### PR TITLE
bug(runtime): Fix default YAML marshaling values

### DIFF
--- a/usecases/config/runtime/values.go
+++ b/usecases/config/runtime/values.go
@@ -102,7 +102,7 @@ func (dv *DynamicValue[T]) UnmarshalYAML(node *yaml.Node) error {
 	dv.mu.Lock()
 	defer dv.mu.Unlock()
 
-	dv.val = &val
+	dv.def = val
 	return nil
 }
 
@@ -126,7 +126,7 @@ func (dv *DynamicValue[T]) UnmarshalJSON(data []byte) error {
 	}
 	dv.mu.Lock()
 	defer dv.mu.Unlock()
-	dv.val = &val
+	dv.def = val
 	return nil
 }
 

--- a/usecases/config/runtime/values_test.go
+++ b/usecases/config/runtime/values_test.go
@@ -232,7 +232,6 @@ func TestDyanamicValue_Reset(t *testing.T) {
 	assert.Equal(t, []string{"a", "b"}, *slice.val)
 	slice.Reset() // reset should only reset val. not default
 	assert.Nil(t, slice.val)
-
 }
 
 func Test_String(t *testing.T) {

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -179,7 +179,6 @@ maximum_allowed_collections_count: 13`) // leaving out `asyncRep` config
 		assert.Equal(t, "INFO", source.TenantActivityReadLogLevel.Get())
 		assert.Equal(t, "INFO", source.TenantActivityWriteLogLevel.Get())
 		assert.Equal(t, true, source.RevectorizeCheckDisabled.Get())
-
 	})
 
 	t.Run("Reset() of non-exist config values in parsed yaml shouldn't panic", func(t *testing.T) {

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -72,16 +72,6 @@ func TestParseRuntimeConfig(t *testing.T) {
 	})
 }
 
-// assertConfigKey asserts if the `yaml` key is standard `lower_snake_case` (e.g: not `UPPER_CASE`)
-func assertConfigKey(t *testing.T, key string) {
-	t.Helper()
-
-	re := regexp.MustCompile(`^[a-z]+(_[a-z]+)*$`)
-	if !re.MatchString(key) {
-		t.Fatalf("given key %v is not lower snake case. The json/yaml tag for runtime config should be all lower snake case (e.g my_key, not MY_KEY)", key)
-	}
-}
-
 func TestUpdateRuntimeConfig(t *testing.T) {
 	log := logrus.New()
 	log.SetOutput(io.Discard)
@@ -120,6 +110,76 @@ maximum_allowed_collections_count: 13`)
 		// after update (reflect from parsed values)
 		assert.Equal(t, true, autoSchema.Get())
 		assert.Equal(t, 13, colCount.Get())
+	})
+
+	t.Run("Add and remove workflow", func(t *testing.T) {
+		// 1. We start with empty overrides and see it doesn't change the .Get() value of source configs.
+		// 2. We add some overrides. Check .Get() value
+		// 3. Remove the overrides. check .Get() value goes back to default
+
+		source := &WeaviateRuntimeConfig{
+			MaximumAllowedCollectionsCount: runtime.NewDynamicValue(10),
+			AutoschemaEnabled:              runtime.NewDynamicValue(true),
+			AsyncReplicationDisabled:       runtime.NewDynamicValue(true),
+			TenantActivityReadLogLevel:     runtime.NewDynamicValue("INFO"),
+			TenantActivityWriteLogLevel:    runtime.NewDynamicValue("INFO"),
+			RevectorizeCheckDisabled:       runtime.NewDynamicValue(true),
+		}
+
+		assert.Equal(t, 10, source.MaximumAllowedCollectionsCount.Get())
+		assert.Equal(t, true, source.AutoschemaEnabled.Get())
+		assert.Equal(t, true, source.AsyncReplicationDisabled.Get())
+		assert.Equal(t, "INFO", source.TenantActivityReadLogLevel.Get())
+		assert.Equal(t, "INFO", source.TenantActivityWriteLogLevel.Get())
+		assert.Equal(t, true, source.RevectorizeCheckDisabled.Get())
+
+		// Empty Parsing
+		buf := []byte("")
+		parsed, err := ParseRuntimeConfig(buf)
+		require.NoError(t, err)
+
+		assert.Nil(t, parsed.AsyncReplicationDisabled)
+		assert.Nil(t, parsed.MaximumAllowedCollectionsCount)
+		assert.Nil(t, parsed.AutoschemaEnabled)
+		assert.Nil(t, parsed.TenantActivityReadLogLevel)
+		assert.Nil(t, parsed.TenantActivityWriteLogLevel)
+		assert.Nil(t, parsed.RevectorizeCheckDisabled)
+
+		require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil))
+		assert.Equal(t, 10, source.MaximumAllowedCollectionsCount.Get())
+		assert.Equal(t, true, source.AutoschemaEnabled.Get())
+		assert.Equal(t, true, source.AsyncReplicationDisabled.Get())
+		assert.Equal(t, "INFO", source.TenantActivityReadLogLevel.Get())
+		assert.Equal(t, "INFO", source.TenantActivityWriteLogLevel.Get())
+		assert.Equal(t, true, source.RevectorizeCheckDisabled.Get())
+
+		// Non-empty parsing
+		buf = []byte(`autoschema_enabled: false
+maximum_allowed_collections_count: 13`) // leaving out `asyncRep` config
+		parsed, err = ParseRuntimeConfig(buf)
+		require.NoError(t, err)
+
+		require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil))
+		assert.Equal(t, 13, source.MaximumAllowedCollectionsCount.Get()) // changed
+		assert.Equal(t, false, source.AutoschemaEnabled.Get())           // changed
+		assert.Equal(t, true, source.AsyncReplicationDisabled.Get())
+		assert.Equal(t, "INFO", source.TenantActivityReadLogLevel.Get())
+		assert.Equal(t, "INFO", source.TenantActivityWriteLogLevel.Get())
+		assert.Equal(t, true, source.RevectorizeCheckDisabled.Get())
+
+		// Empty parsing again. Should go back to default values
+		buf = []byte("")
+		parsed, err = ParseRuntimeConfig(buf)
+		require.NoError(t, err)
+
+		require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil))
+		assert.Equal(t, 10, source.MaximumAllowedCollectionsCount.Get())
+		assert.Equal(t, true, source.AutoschemaEnabled.Get())
+		assert.Equal(t, true, source.AsyncReplicationDisabled.Get())
+		assert.Equal(t, "INFO", source.TenantActivityReadLogLevel.Get())
+		assert.Equal(t, "INFO", source.TenantActivityWriteLogLevel.Get())
+		assert.Equal(t, true, source.RevectorizeCheckDisabled.Get())
+
 	})
 
 	t.Run("Reset() of non-exist config values in parsed yaml shouldn't panic", func(t *testing.T) {
@@ -260,4 +320,15 @@ maximum_allowed_collections_count: 13`)
 		assert.Equal(t, 0, colCount.Get())     // this should still return `default` value. not old value
 		assert.Equal(t, false, asyncRep.Get()) // this field doesn't exist in original config file, should return default value.
 	})
+}
+
+// helpers
+// assertConfigKey asserts if the `yaml` key is standard `lower_snake_case` (e.g: not `UPPER_CASE`)
+func assertConfigKey(t *testing.T, key string) {
+	t.Helper()
+
+	re := regexp.MustCompile(`^[a-z]+(_[a-z]+)*$`)
+	if !re.MatchString(key) {
+		t.Fatalf("given key %v is not lower snake case. The json/yaml tag for runtime config should be all lower snake case (e.g my_key, not MY_KEY)", key)
+	}
 }


### PR DESCRIPTION

### What's being changed:

Before the fix, any unmarshaling from JSON or YAML of runtime config struct sets the `val` field. 
This PR makes it to set only `def` (default) field. 
Rationale being when looking "if any config changed" during runtime we check if new config is nil and try to Reset() (case where config is removed). But this causes `val` field to set empty loosing the original default value.

This bug was not possible if config is set via ENV variable where we initialize the `default` value correctly. But if these configs are parsed by YAML during start, then this buggy case can happen.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
