### PR TITLE
fix panic in Dynamic index when mixing different compression types

### DIFF
--- a/adapters/repos/db/vector/dynamic/config.go
+++ b/adapters/repos/db/vector/dynamic/config.go
@@ -28,25 +28,26 @@ import (
 )
 
 type Config struct {
-	ID                    string
-	TargetVector          string
-	Logger                logrus.FieldLogger
-	RootPath              string
-	ShardName             string
-	ClassName             string
-	PrometheusMetrics     *monitoring.PrometheusMetrics
-	VectorForIDThunk      common.VectorForID[float32]
-	TempVectorForIDThunk  common.TempVectorForID[float32]
-	DistanceProvider      distancer.Provider
-	MakeCommitLoggerThunk hnsw.MakeCommitLogger
-	TombstoneCallbacks    cyclemanager.CycleCallbackGroup
-	SharedDB              *bolt.DB
-	HNSWDisableSnapshots  bool
-	HNSWSnapshotOnStartup bool
-	MinMMapSize           int64
-	MaxWalReuseSize       int64
-	LazyLoadSegments      bool
-	AllocChecker          memwatch.AllocChecker
+	ID                      string
+	TargetVector            string
+	Logger                  logrus.FieldLogger
+	RootPath                string
+	ShardName               string
+	ClassName               string
+	PrometheusMetrics       *monitoring.PrometheusMetrics
+	VectorForIDThunk        common.VectorForID[float32]
+	TempVectorForIDThunk    common.TempVectorForID[float32]
+	DistanceProvider        distancer.Provider
+	MakeCommitLoggerThunk   hnsw.MakeCommitLogger
+	TombstoneCallbacks      cyclemanager.CycleCallbackGroup
+	SharedDB                *bolt.DB
+	HNSWDisableSnapshots    bool
+	HNSWSnapshotOnStartup   bool
+	HNSWWaitForCachePrefill bool
+	MinMMapSize             int64
+	MaxWalReuseSize         int64
+	LazyLoadSegments        bool
+	AllocChecker            memwatch.AllocChecker
 }
 
 func (c Config) Validate() error {

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -131,7 +131,13 @@ func upgradeBucket(path, targetVector string) {
 	path = filepath.Join(path, "lsm")
 	newPath := filepath.Join(path, fmt.Sprintf("%s_%s", helpers.VectorsCompressedBucketLSM, targetVector))
 	path = filepath.Join(path, helpers.VectorsCompressedBucketLSM)
-	info, err := os.Stat(path)
+
+	info, err := os.Stat(newPath)
+	if info != nil && info.IsDir() {
+		return
+	}
+
+	info, err = os.Stat(path)
 	if err != nil {
 		return
 	}

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -132,13 +132,13 @@ func upgradeBucket(path, targetVector string) {
 	newPath := filepath.Join(path, fmt.Sprintf("%s_%s", helpers.VectorsCompressedBucketLSM, targetVector))
 	path = filepath.Join(path, helpers.VectorsCompressedBucketLSM)
 
-	info, err := os.Stat(newPath)
+	info, _ := os.Stat(newPath)
 	if info != nil && info.IsDir() {
 		return
 	}
 
-	info, err = os.Stat(path)
-	if err != nil {
+	info, _ = os.Stat(path)
+	if info == nil {
 		return
 	}
 

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -42,7 +42,10 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
-const composerUpgradedKey = "upgraded"
+const (
+	composerUpgradedKey = "upgraded"
+	flatPostfix         = "flat"
+)
 
 var dynamicBucket = []byte("dynamic")
 
@@ -139,10 +142,14 @@ func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
 		logger = l
 	}
 
+	targetVector := cfg.TargetVector
+	if len(targetVector) == 0 {
+		targetVector = flatPostfix
+	}
 	flatConfig := flat.Config{
 		ID:               cfg.ID,
 		RootPath:         cfg.RootPath,
-		TargetVector:     cfg.TargetVector,
+		TargetVector:     targetVector,
 		Logger:           cfg.Logger,
 		DistanceProvider: cfg.DistanceProvider,
 		MinMMapSize:      cfg.MinMMapSize,
@@ -260,7 +267,7 @@ func (dynamic *dynamic) getBucketName() string {
 		return fmt.Sprintf("%s_%s", helpers.VectorsBucketLSM, dynamic.targetVector)
 	}
 
-	return helpers.VectorsBucketLSM
+	return fmt.Sprintf("%s_%s", helpers.VectorsBucketLSM, flatPostfix)
 }
 
 func (dynamic *dynamic) Compressed() bool {

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -438,7 +438,17 @@ func (dynamic *dynamic) ValidateMultiBeforeInsert(vector [][]float32) error {
 func (dynamic *dynamic) PostStartup() {
 	dynamic.Lock()
 	defer dynamic.Unlock()
+	dynamic.upgradeBucket()
 	dynamic.index.PostStartup()
+}
+
+func (dynamic *dynamic) upgradeBucket() {
+	if len(dynamic.targetVector) == 0 {
+		bucket := dynamic.store.Bucket(dynamic.getBucketName())
+		if bucket == nil {
+			dynamic.store.RenameBucket(context.Background(), helpers.VectorsBucketLSM, dynamic.getBucketName())
+		}
+	}
 }
 
 func (dynamic *dynamic) DistanceBetweenVectors(x, y []float32) (float32, error) {

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -97,30 +97,31 @@ type upgradableIndexer interface {
 
 type dynamic struct {
 	sync.RWMutex
-	id                    string
-	targetVector          string
-	store                 *lsmkv.Store
-	logger                logrus.FieldLogger
-	rootPath              string
-	shardName             string
-	className             string
-	prometheusMetrics     *monitoring.PrometheusMetrics
-	vectorForIDThunk      common.VectorForID[float32]
-	tempVectorForIDThunk  common.TempVectorForID[float32]
-	distanceProvider      distancer.Provider
-	makeCommitLoggerThunk hnsw.MakeCommitLogger
-	threshold             uint64
-	index                 VectorIndex
-	upgraded              atomic.Bool
-	upgradeOnce           sync.Once
-	tombstoneCallbacks    cyclemanager.CycleCallbackGroup
-	hnswUC                hnswent.UserConfig
-	db                    *bbolt.DB
-	ctx                   context.Context
-	cancel                context.CancelFunc
-	hnswDisableSnapshots  bool
-	hnswSnapshotOnStartup bool
-	LazyLoadSegments      bool
+	id                      string
+	targetVector            string
+	store                   *lsmkv.Store
+	logger                  logrus.FieldLogger
+	rootPath                string
+	shardName               string
+	className               string
+	prometheusMetrics       *monitoring.PrometheusMetrics
+	vectorForIDThunk        common.VectorForID[float32]
+	tempVectorForIDThunk    common.TempVectorForID[float32]
+	distanceProvider        distancer.Provider
+	makeCommitLoggerThunk   hnsw.MakeCommitLogger
+	threshold               uint64
+	index                   VectorIndex
+	upgraded                atomic.Bool
+	upgradeOnce             sync.Once
+	tombstoneCallbacks      cyclemanager.CycleCallbackGroup
+	hnswUC                  hnswent.UserConfig
+	db                      *bbolt.DB
+	ctx                     context.Context
+	cancel                  context.CancelFunc
+	hnswDisableSnapshots    bool
+	hnswSnapshotOnStartup   bool
+	hnswWaitForCachePrefill bool
+	LazyLoadSegments        bool
 }
 
 func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
@@ -153,27 +154,28 @@ func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	index := &dynamic{
-		id:                    cfg.ID,
-		targetVector:          cfg.TargetVector,
-		logger:                logger,
-		rootPath:              cfg.RootPath,
-		shardName:             cfg.ShardName,
-		className:             cfg.ClassName,
-		prometheusMetrics:     cfg.PrometheusMetrics,
-		vectorForIDThunk:      cfg.VectorForIDThunk,
-		tempVectorForIDThunk:  cfg.TempVectorForIDThunk,
-		distanceProvider:      cfg.DistanceProvider,
-		makeCommitLoggerThunk: cfg.MakeCommitLoggerThunk,
-		store:                 store,
-		threshold:             uc.Threshold,
-		tombstoneCallbacks:    cfg.TombstoneCallbacks,
-		hnswUC:                uc.HnswUC,
-		db:                    cfg.SharedDB,
-		ctx:                   ctx,
-		cancel:                cancel,
-		hnswDisableSnapshots:  cfg.HNSWDisableSnapshots,
-		hnswSnapshotOnStartup: cfg.HNSWSnapshotOnStartup,
-		LazyLoadSegments:      cfg.LazyLoadSegments,
+		id:                      cfg.ID,
+		targetVector:            cfg.TargetVector,
+		logger:                  logger,
+		rootPath:                cfg.RootPath,
+		shardName:               cfg.ShardName,
+		className:               cfg.ClassName,
+		prometheusMetrics:       cfg.PrometheusMetrics,
+		vectorForIDThunk:        cfg.VectorForIDThunk,
+		tempVectorForIDThunk:    cfg.TempVectorForIDThunk,
+		distanceProvider:        cfg.DistanceProvider,
+		makeCommitLoggerThunk:   cfg.MakeCommitLoggerThunk,
+		store:                   store,
+		threshold:               uc.Threshold,
+		tombstoneCallbacks:      cfg.TombstoneCallbacks,
+		hnswUC:                  uc.HnswUC,
+		db:                      cfg.SharedDB,
+		ctx:                     ctx,
+		cancel:                  cancel,
+		hnswDisableSnapshots:    cfg.HNSWDisableSnapshots,
+		hnswSnapshotOnStartup:   cfg.HNSWSnapshotOnStartup,
+		hnswWaitForCachePrefill: cfg.HNSWWaitForCachePrefill,
+		LazyLoadSegments:        cfg.LazyLoadSegments,
 	}
 
 	err := cfg.SharedDB.Update(func(tx *bbolt.Tx) error {
@@ -218,6 +220,7 @@ func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
 				DisableSnapshots:      index.hnswDisableSnapshots,
 				SnapshotOnStartup:     index.hnswSnapshotOnStartup,
 				LazyLoadSegments:      index.LazyLoadSegments,
+				WaitForCachePrefill:   index.hnswWaitForCachePrefill,
 			},
 			index.hnswUC,
 			index.tombstoneCallbacks,
@@ -535,6 +538,7 @@ func (dynamic *dynamic) doUpgrade() error {
 			MakeCommitLoggerThunk: dynamic.makeCommitLoggerThunk,
 			DisableSnapshots:      dynamic.hnswDisableSnapshots,
 			SnapshotOnStartup:     dynamic.hnswSnapshotOnStartup,
+			WaitForCachePrefill:   dynamic.hnswWaitForCachePrefill,
 		},
 		dynamic.hnswUC,
 		dynamic.tombstoneCallbacks,

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -448,6 +448,7 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	require.NoError(t, err)
 	err = dynamic.Shutdown(t.Context())
 	require.NoError(t, err)
+	dummyStore.FlushMemtables(t.Context())
 
 	// open the db again
 	db, err = bbolt.Open(filepath.Join(tempDir, "index.db"), 0o666, nil)
@@ -459,4 +460,5 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	dynamic.PostStartup()
 	recall2, _ := testinghelpers.RecallAndLatency(ctx, queries, k, dynamic, truths)
 	assert.Equal(t, recall, recall2)
+	assert.True(t, false)
 }

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -338,7 +338,7 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("ASYNC_INDEXING", "true")
 	dimensions := 20
-	vectors_size := 4_000
+	vectors_size := 10_000
 	threshold := 2_000
 	queries_size := 10
 	k := 10

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -338,8 +338,8 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("ASYNC_INDEXING", "true")
 	dimensions := 20
-	vectors_size := 10_000
-	threshold := 2000
+	vectors_size := 4_000
+	threshold := 2_000
 	queries_size := 10
 	k := 10
 
@@ -459,5 +459,4 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	dynamic.PostStartup()
 	recall2, _ := testinghelpers.RecallAndLatency(ctx, queries, k, dynamic, truths)
 	assert.Equal(t, recall, recall2)
-	assert.True(t, false)
 }

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -425,7 +425,7 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(1)
 
-	//flat -> hnsw
+	// flat -> hnsw
 	err = dynamic.Upgrade(func() {
 		wg.Done()
 	})
@@ -433,7 +433,7 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	wg.Wait()
 	wg.Add(1)
 
-	//PQ
+	// PQ
 	err = dynamic.Upgrade(func() {
 		wg.Done()
 	})

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -359,13 +359,12 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 		truths[i], _ = testinghelpers.BruteForce(logger, vectors, queries[i], k, testinghelpers.DistanceWrapper(distancer))
 	})
 	noopCallback := cyclemanager.NewCallbackGroupNoop()
-	fuc := flatent.UserConfig{
-		BQ: flatent.CompressionUserConfig{
-			Enabled: true,
-			Cache:   true,
-		},
-	}
+	fuc := flatent.UserConfig{}
 	fuc.SetDefaults()
+	fuc.BQ = flatent.CompressionUserConfig{
+		Enabled: true,
+		Cache:   true,
+	}
 	hnswuc := hnswent.UserConfig{
 		MaxConnections:        30,
 		EFConstruction:        64,
@@ -385,7 +384,7 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	}
 
 	config := Config{
-		TargetVector: "target_0",
+		TargetVector: "",
 		RootPath:     rootPath,
 		ID:           "vector-test_0",
 		MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -424,14 +424,18 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	assert.False(t, dynamic.Upgraded())
 	var wg sync.WaitGroup
 	wg.Add(1)
+
+	//flat -> hnsw
 	err = dynamic.Upgrade(func() {
-		wg.Done() //flat -> hnsw
+		wg.Done()
 	})
 	require.NoError(t, err)
 	wg.Wait()
 	wg.Add(1)
+
+	//PQ
 	err = dynamic.Upgrade(func() {
-		wg.Done() //PQ
+		wg.Done()
 	})
 	require.NoError(t, err)
 	wg.Wait()

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -4,7 +4,7 @@
 //  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
 //   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
 //
-//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
 //
 //  CONTACT: hello@weaviate.io
 //

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -1051,6 +1051,16 @@ func (index *flat) Stats() (common.IndexStats, error) {
 	return &FlatStats{}, errors.New("Stats() is not implemented for flat index")
 }
 
+func (index *flat) VectorStorageSize() int64 {
+	// TODO-usage: Implement this
+	return 0
+}
+
+func (index *flat) CompressionStats() (compressionhelpers.CompressionStats, error) {
+	// Flat index doesn't have detailed compression stats, return uncompressed stats
+	return compressionhelpers.UncompressedStats{}, nil
+}
+
 type FlatStats struct{}
 
 func (s *FlatStats) IndexType() common.IndexType {


### PR DESCRIPTION
### What's being changed:

When using dynamic index with BQ enabled for flat and PQ enabled for hnsw and an empty targetVector, the two under the hood indices share the same bucket and mix different endianness which end up in panics when refilling the compressed cache. This PR decouple both even when targetVector is empty.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
