### PR TITLE
fix: Remove nil check for maintenance mode in async replication config

### DIFF
--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -179,9 +179,6 @@ func (s *Shard) getAsyncReplicationConfig() (config asyncReplicationConfig, err 
 	}
 
 	config.maintenanceModeEnabled = s.index.Config.MaintenanceModeEnabled
-	if config.maintenanceModeEnabled == nil {
-		return asyncReplicationConfig{}, fmt.Errorf("maintenance mode enabled function is not set")
-	}
 
 	return
 }


### PR DESCRIPTION
### What's being changed:

Remove nil check for maintenance mode in async replication config, as it may not be set for tests.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
