### PR TITLE
fix: :bug: fix shard selection on empty string

### DIFF
--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -102,14 +102,18 @@ func setupDebugHandlers(appState *state.State) {
 
 	http.HandleFunc("/debug/index/rebuild/inverted/reload", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		colName := r.URL.Query().Get("collection")
-		shardsToMigrateString := r.URL.Query().Get("shards")
 
 		if colName == "" {
 			http.Error(w, "collection name is required", http.StatusBadRequest)
 			return
 		}
 
-		shardsToMigrate := strings.Split(shardsToMigrateString, ",")[1:]
+		shardsToMigrateString := strings.TrimSpace(r.URL.Query().Get("shards"))
+
+		shardsToMigrate := []string{}
+		if shardsToMigrateString != "" {
+			shardsToMigrate = strings.Split(shardsToMigrateString, ",")
+		}
 
 		className := schema.ClassName(colName)
 		idx := appState.DB.GetIndex(className)
@@ -145,6 +149,13 @@ func setupDebugHandlers(appState *state.State) {
 						"shardStatus": shard.GetStatusNoLoad().String(),
 						"status":      "reinit",
 						"message":     "reinit shard started",
+					}
+				} else {
+					output[shardName] = map[string]string{
+						"shard":       shardName,
+						"shardStatus": shard.GetStatusNoLoad().String(),
+						"status":      "skipped",
+						"message":     fmt.Sprintf("shard %s not selected", shardName),
 					}
 				}
 				return nil
@@ -375,6 +386,11 @@ func setupDebugHandlers(appState *state.State) {
 							"status":    "success",
 							"overrides": overrides,
 						}
+					} else {
+						response[shardName] = map[string]string{
+							"status":  "skipped",
+							"message": fmt.Sprintf("shard %s not selected", shardName),
+						}
 					}
 					return nil
 				},
@@ -451,6 +467,11 @@ func setupDebugHandlers(appState *state.State) {
 						response[shardName] = map[string]interface{}{
 							"status": "success",
 							"wrote":  overrides,
+						}
+					} else {
+						response[shardName] = map[string]string{
+							"status":  "skipped",
+							"message": fmt.Sprintf("shard %s not selected", shardName),
 						}
 					}
 					return nil

--- a/adapters/handlers/rest/handlers_debug_bmw_aux.go
+++ b/adapters/handlers/rest/handlers_debug_bmw_aux.go
@@ -26,13 +26,17 @@ import (
 )
 
 func parseIndexAndShards(appState *state.State, r *http.Request) (string, []string, *db.Index, error) {
-	colName := r.URL.Query().Get("collection")
+	colName := strings.TrimSpace(r.URL.Query().Get("collection"))
 	if colName == "" {
 		return "", nil, nil, fmt.Errorf("collection is required")
 	}
 
-	shardsToMigrateString := r.URL.Query().Get("shards")
-	shardsToMigrate := strings.Split(shardsToMigrateString, ",")
+	shardsToMigrateString := strings.TrimSpace(r.URL.Query().Get("shards"))
+
+	shardsToMigrate := []string{}
+	if shardsToMigrateString != "" {
+		shardsToMigrate = strings.Split(shardsToMigrateString, ",")
+	}
 
 	className := schema.ClassName(colName)
 	classNameString := strings.ToLower(className.String())
@@ -61,13 +65,13 @@ func changeFile(filename string, delete bool, logger *logrus.Entry, appState *st
 			func(shardName string, shard db.ShardLike) error {
 				alreadyDid := false
 				if len(shardsToMigrate) == 0 || slices.Contains(shardsToMigrate, shardName) {
-					shardPath := rootPath + "/" + classNameString + "/" + shardName + "/lsm/"
-					_, err := os.Stat(shardPath + ".migrations/searchable_map_to_blockmax")
+					shardPath := rootPath + "/" + classNameString + "/" + shardName + "/lsm/.migrations/searchable_map_to_blockmax/"
+					_, err := os.Stat(shardPath)
 					if err != nil {
 						return fmt.Errorf("shard not found or not ready")
 					}
 					if delete {
-						err = os.Remove(shardPath + ".migrations/searchable_map_to_blockmax/" + filename)
+						err = os.Remove(shardPath + filename)
 						if os.IsNotExist(err) {
 							alreadyDid = true
 						} else if err != nil {
@@ -75,11 +79,11 @@ func changeFile(filename string, delete bool, logger *logrus.Entry, appState *st
 						}
 					} else {
 						// check if the file already exists
-						_, err = os.Stat(shardPath + ".migrations/searchable_map_to_blockmax/" + filename)
+						_, err = os.Stat(shardPath + filename)
 						if err == nil {
 							alreadyDid = true
 						} else {
-							file, err := os.Create(shardPath + ".migrations/searchable_map_to_blockmax/" + filename)
+							file, err := os.Create(shardPath + filename)
 							if os.IsExist(err) {
 								alreadyDid = true
 							} else if err != nil {
@@ -88,25 +92,30 @@ func changeFile(filename string, delete bool, logger *logrus.Entry, appState *st
 							defer file.Close()
 						}
 					}
+					response[shardName] = map[string]string{
+						"status": "success",
+						"message": fmt.Sprintf("file %s %s in shard %s", filename,
+							func() string {
+								if delete {
+									if alreadyDid {
+										return "already deleted"
+									}
+									return "deleted"
+								} else {
+									if alreadyDid {
+										return "already created"
+									}
+								}
+								return "created"
+							}(), shardName),
+					}
+				} else {
+					response[shardName] = map[string]string{
+						"status":  "skipped",
+						"message": fmt.Sprintf("shard %s not selected", shardName),
+					}
+				}
 
-				}
-				response[shardName] = map[string]string{
-					"status": "success",
-					"message": fmt.Sprintf("file %s %s in shard %s", filename,
-						func() string {
-							if delete {
-								if alreadyDid {
-									return "already deleted"
-								}
-								return "deleted"
-							} else {
-								if alreadyDid {
-									return "already created"
-								}
-							}
-							return "created"
-						}(), shardName),
-				}
 				return nil
 			},
 		)


### PR DESCRIPTION
### What's being changed:

Fix shard selection on empty string for the BMW migrator.
By default, it should apply operations to all shards if the parameter is empty, but it was applying it to no shards.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
