### PR TITLE
refact(usage): introduce Loaded() and handle concurrency calls for cold tenant object storage calc and add unit test

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2971,7 +2971,6 @@ func (i *Index) CalculateUnloadedObjectsMetrics(ctx context.Context, tenantName 
 					return err
 				}
 				totalObjectCount += count
-				i.logger.WithField("path", path).WithField("count", count).Info("found .cna file mooga")
 			}
 		}
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -119,7 +119,7 @@ func (m *shardMap) RangeConcurrently(logger logrus.FieldLogger, f func(name stri
 
 // Load returns the shard or nil if no shard is present.
 // NOTE: this method does not check if the shard is loaded or not and it could
-// return a lazy shard that is not loaded which could result to loading it if
+// return a lazy shard that is not loaded which could result in loading it if
 // the returned shard is used.
 // Use Loaded if you want to check if the shard is loaded without loading it.
 func (m *shardMap) Load(name string) ShardLike {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2945,6 +2945,11 @@ func (i *Index) CalculateUnloadedObjectsMetrics(ctx context.Context, tenantName 
 	i.shardCreateLocks.Lock(tenantName)
 	defer i.shardCreateLocks.Unlock(tenantName)
 
+	// check if created in the meantime by concurrent call
+	if shard := i.shards.Load(tenantName); shard != nil {
+		return int64(shard.ObjectCount()), shard.ObjectStorageSize(ctx)
+	}
+
 	// Locate the tenant on disk
 	shardPath := shardPathObjectsLSM(i.path(), tenantName)
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2964,8 +2964,8 @@ func (i *Index) CalculateUnloadedObjectsMetrics(ctx context.Context, tenantName 
 			totalDiskSize += info.Size()
 
 			// Look for .cna files (net count additions)
-			if strings.HasSuffix(info.Name(), lsmkv.CNAFileSuffix) {
-				count, err := lsmkv.ReadCNAFileCount(path)
+			if strings.HasSuffix(info.Name(), lsmkv.CountNetAdditionsFileSuffix) {
+				count, err := lsmkv.ReadCountNetAdditionsFile(path)
 				if err != nil {
 					i.logger.WithField("path", path).WithError(err).Warn("failed to read .cna file")
 					return err

--- a/adapters/repos/db/index_object_storage_test.go
+++ b/adapters/repos/db/index_object_storage_test.go
@@ -1,0 +1,438 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/queue"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/replication"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+func TestIndex_ObjectStorageSize_Comprehensive(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	tests := []struct {
+		name                   string
+		className              string
+		shardName              string
+		objectCount            int
+		objectSize             int // approximate size in bytes per object
+		expectedObjectCount    int
+		expectedStorageSizeMin int64 // minimum expected storage size
+		expectedStorageSizeMax int64 // maximum expected storage size (allowing for overhead)
+		setupData              bool
+		description            string
+	}{
+		{
+			name:        "empty shard",
+			className:   "TestClass",
+			shardName:   "test-shard-empty",
+			setupData:   false,
+			description: "Empty shard should have zero storage size",
+		},
+		{
+			name:                   "shard with small objects",
+			className:              "TestClass",
+			shardName:              "test-shard-small",
+			objectCount:            10,
+			objectSize:             100, // ~100 bytes per object
+			expectedObjectCount:    10,
+			expectedStorageSizeMin: int64(10 * 100),     // minimum: just the data
+			expectedStorageSizeMax: int64(10 * 100 * 5), // maximum: data + overhead (increased to 5x)
+			setupData:              true,
+			description:            "Shard with small objects should have proportional storage size",
+		},
+		{
+			name:                   "shard with medium objects",
+			className:              "TestClass",
+			shardName:              "test-shard-medium",
+			objectCount:            50,
+			objectSize:             500, // ~500 bytes per object
+			expectedObjectCount:    50,
+			expectedStorageSizeMin: int64(50 * 500),     // minimum: just the data
+			expectedStorageSizeMax: int64(50 * 500 * 3), // maximum: data + overhead
+			setupData:              true,
+			description:            "Shard with medium objects should have proportional storage size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test class
+			class := &models.Class{
+				Class: tt.className,
+				Properties: []*models.Property{
+					{
+						Name:         "name",
+						DataType:     schema.DataTypeText.PropString(),
+						Tokenization: models.PropertyTokenizationWhitespace,
+					},
+					{
+						Name:         "description",
+						DataType:     schema.DataTypeText.PropString(),
+						Tokenization: models.PropertyTokenizationWhitespace,
+					},
+					{
+						Name:     "count",
+						DataType: schema.DataTypeInt.PropString(),
+					},
+				},
+				InvertedIndexConfig: &models.InvertedIndexConfig{},
+			}
+
+			// Create fake schema
+			fakeSchema := schema.Schema{
+				Objects: &models.Schema{
+					Classes: []*models.Class{class},
+				},
+			}
+
+			// Create sharding state
+			shardState := &sharding.State{
+				Physical: map[string]sharding.Physical{
+					tt.shardName: {
+						Name:           tt.shardName,
+						BelongsToNodes: []string{"test-node"},
+						Status:         models.TenantActivityStatusHOT,
+					},
+				},
+			}
+			shardState.SetLocalName("test-node")
+
+			// Create scheduler
+			scheduler := queue.NewScheduler(queue.SchedulerOptions{
+				Logger:  logger,
+				Workers: 1,
+			})
+
+			// Create mock schema getter
+			mockSchema := schemaUC.NewMockSchemaGetter(t)
+			mockSchema.EXPECT().GetSchemaSkipAuth().Maybe().Return(fakeSchema)
+			mockSchema.EXPECT().ReadOnlyClass(tt.className).Maybe().Return(class)
+			mockSchema.EXPECT().CopyShardingState(tt.className).Maybe().Return(shardState)
+			mockSchema.EXPECT().NodeName().Maybe().Return("test-node")
+			mockSchema.EXPECT().ShardFromUUID("TestClass", mock.Anything).Return(tt.shardName).Maybe()
+			mockSchema.EXPECT().ShardOwner(tt.className, tt.shardName).Maybe().Return("test-node", nil)
+
+			// Create index
+			index, err := NewIndex(ctx, IndexConfig{
+				RootPath:              dirName,
+				ClassName:             schema.ClassName(tt.className),
+				ReplicationFactor:     1,
+				ShardLoadLimiter:      NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
+				TrackVectorDimensions: true,
+			}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
+				enthnsw.UserConfig{
+					VectorCacheMaxObjects: 1000,
+				}, nil, nil, mockSchema, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil, class, nil, scheduler, nil, nil, NewShardReindexerV3Noop())
+			require.NoError(t, err)
+			defer index.Shutdown(ctx)
+
+			// Add properties
+			for _, prop := range class.Properties {
+				err = index.addProperty(ctx, prop)
+				require.NoError(t, err)
+			}
+
+			if tt.setupData {
+				// Create objects with varying sizes
+				for i := 0; i < tt.objectCount; i++ {
+					// Create object with properties that approximate the desired size
+					obj := &models.Object{
+						Class: tt.className,
+						ID:    strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", i)),
+						Properties: map[string]interface{}{
+							"name":        fmt.Sprintf("test-object-%d", i),
+							"description": generateStringOfSize(tt.objectSize - 50), // Leave room for other properties
+							"count":       i,
+						},
+					}
+					storageObj := storobj.FromObject(obj, nil, nil, nil)
+					err := index.putObject(ctx, storageObj, nil, 0)
+					require.NoError(t, err)
+				}
+
+				// Wait for indexing to complete
+				time.Sleep(2 * time.Second)
+
+				// Test object storage size
+				shard, release, err := index.GetShard(ctx, tt.shardName)
+				require.NoError(t, err)
+				require.NotNil(t, shard)
+				defer release()
+
+				objectStorageSize := shard.ObjectStorageSize(ctx)
+				objectCount := shard.ObjectCount()
+
+				// Verify object count
+				assert.Equal(t, tt.expectedObjectCount, objectCount, "Object count should match expected")
+
+				// Verify storage size is within expected range
+				assert.GreaterOrEqual(t, objectStorageSize, tt.expectedStorageSizeMin,
+					"Storage size should be at least the minimum expected size")
+				assert.LessOrEqual(t, objectStorageSize, tt.expectedStorageSizeMax,
+					"Storage size should not exceed the maximum expected size")
+
+			} else {
+				// Test empty shard
+				shard, release, err := index.GetShard(ctx, tt.shardName)
+				require.NoError(t, err)
+				require.NotNil(t, shard)
+				defer release()
+
+				objectStorageSize := shard.ObjectStorageSize(ctx)
+				objectCount := shard.ObjectCount()
+
+				assert.Equal(t, tt.expectedObjectCount, objectCount, "Empty shard should have 0 objects")
+				assert.Equal(t, tt.expectedStorageSizeMin, objectStorageSize, "Empty shard should have 0 storage size")
+			}
+			mockSchema.AssertExpectations(t)
+		})
+	}
+}
+
+func TestIndex_ObjectStorageSize_ActiveVsUnloaded(t *testing.T) {
+	ctx := context.Background()
+	dirName := t.TempDir()
+	logger, _ := test.NewNullLogger()
+
+	tests := []struct {
+		name                   string
+		className              string
+		shardName              string
+		objectCount            int
+		objectSize             int
+		expectedObjectCount    int
+		expectedStorageSizeMin int64
+		expectedStorageSizeMax int64
+		setupData              bool
+		description            string
+	}{
+		{
+			name:                   "active shard with objects",
+			className:              "TestClass",
+			shardName:              "test-shard-active",
+			objectCount:            100,
+			objectSize:             200, // ~200 bytes per object
+			expectedObjectCount:    100,
+			expectedStorageSizeMin: int64(100 * 200),     // minimum: just the data
+			expectedStorageSizeMax: int64(100 * 200 * 5), // maximum: data + overhead
+			setupData:              true,
+			description:            "Active shard should have accurate object storage size",
+		},
+		{
+			name:                   "unloaded shard with objects",
+			className:              "TestClass",
+			shardName:              "test-shard-unloaded",
+			objectCount:            100,
+			objectSize:             200, // ~200 bytes per object
+			expectedObjectCount:    100,
+			expectedStorageSizeMin: int64(100 * 200),     // minimum: just the data
+			expectedStorageSizeMax: int64(100 * 200 * 5), // maximum: data + overhead
+			setupData:              true,
+			description:            "Unloaded shard should have accurate object storage size",
+		},
+		{
+			name:                   "active shard with large objects",
+			className:              "TestClass",
+			shardName:              "test-shard-active-large",
+			objectCount:            50,
+			objectSize:             1000, // ~1000 bytes per object
+			expectedObjectCount:    50,
+			expectedStorageSizeMin: int64(50 * 1000),     // minimum: just the data
+			expectedStorageSizeMax: int64(50 * 1000 * 5), // maximum: data + overhead
+			setupData:              true,
+			description:            "Active shard with large objects should have accurate storage size",
+		},
+		{
+			name:                   "unloaded shard with large objects",
+			className:              "TestClass",
+			shardName:              "test-shard-unloaded-large",
+			objectCount:            50,
+			objectSize:             1000, // ~1000 bytes per object
+			expectedObjectCount:    50,
+			expectedStorageSizeMin: int64(50 * 1000),     // minimum: just the data
+			expectedStorageSizeMax: int64(50 * 1000 * 5), // maximum: data + overhead
+			setupData:              true,
+			description:            "Unloaded shard with large objects should have accurate storage size",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create test class
+			class := &models.Class{
+				Class: tt.className,
+				Properties: []*models.Property{
+					{
+						Name:         "name",
+						DataType:     schema.DataTypeText.PropString(),
+						Tokenization: models.PropertyTokenizationWhitespace,
+					},
+					{
+						Name:         "description",
+						DataType:     schema.DataTypeText.PropString(),
+						Tokenization: models.PropertyTokenizationWhitespace,
+					},
+					{
+						Name:     "count",
+						DataType: schema.DataTypeInt.PropString(),
+					},
+				},
+				InvertedIndexConfig: &models.InvertedIndexConfig{},
+			}
+
+			// Create fake schema
+			fakeSchema := schema.Schema{
+				Objects: &models.Schema{
+					Classes: []*models.Class{class},
+				},
+			}
+
+			// Create sharding state
+			shardState := &sharding.State{
+				Physical: map[string]sharding.Physical{
+					tt.shardName: {
+						Name:           tt.shardName,
+						BelongsToNodes: []string{"test-node"},
+						Status:         models.TenantActivityStatusHOT,
+					},
+				},
+			}
+			shardState.SetLocalName("test-node")
+
+			// Create scheduler
+			scheduler := queue.NewScheduler(queue.SchedulerOptions{
+				Logger:  logger,
+				Workers: 1,
+			})
+
+			// Create mock schema getter
+			mockSchema := schemaUC.NewMockSchemaGetter(t)
+			mockSchema.EXPECT().GetSchemaSkipAuth().Maybe().Return(fakeSchema)
+			mockSchema.EXPECT().ReadOnlyClass(tt.className).Maybe().Return(class)
+			mockSchema.EXPECT().CopyShardingState(tt.className).Maybe().Return(shardState)
+			mockSchema.EXPECT().NodeName().Maybe().Return("test-node")
+			mockSchema.EXPECT().ShardFromUUID("TestClass", mock.Anything).Return(tt.shardName).Maybe()
+			mockSchema.EXPECT().ShardOwner(tt.className, tt.shardName).Maybe().Return("test-node", nil)
+
+			// Create index
+			index, err := NewIndex(ctx, IndexConfig{
+				RootPath:              dirName,
+				ClassName:             schema.ClassName(tt.className),
+				ReplicationFactor:     1,
+				ShardLoadLimiter:      NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
+				TrackVectorDimensions: true,
+			}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
+				enthnsw.UserConfig{
+					VectorCacheMaxObjects: 1000,
+				}, nil, nil, mockSchema, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil, class, nil, scheduler, nil, nil, NewShardReindexerV3Noop())
+			require.NoError(t, err)
+			defer index.Shutdown(ctx)
+
+			// Add properties
+			for _, prop := range class.Properties {
+				err = index.addProperty(ctx, prop)
+				require.NoError(t, err)
+			}
+
+			if tt.setupData {
+				// Create objects with varying sizes
+				for i := 0; i < tt.objectCount; i++ {
+					// Create object with properties that approximate the desired size
+					obj := &models.Object{
+						Class: tt.className,
+						ID:    strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", i)),
+						Properties: map[string]interface{}{
+							"name":        fmt.Sprintf("test-object-%d", i),
+							"description": generateStringOfSize(tt.objectSize - 50), // Leave room for other properties
+							"count":       i,
+						},
+					}
+					storageObj := storobj.FromObject(obj, nil, nil, nil)
+					err := index.putObject(ctx, storageObj, nil, 0)
+					require.NoError(t, err)
+				}
+
+				// Wait for indexing to complete
+				time.Sleep(2 * time.Second)
+
+				// Test object storage size for active shard
+				shard, release, err := index.GetShard(ctx, tt.shardName)
+				require.NoError(t, err)
+				require.NotNil(t, shard)
+				defer release()
+
+				objectStorageSize := shard.ObjectStorageSize(ctx)
+				objectCount := shard.ObjectCount()
+
+				// Verify object count
+				assert.Equal(t, tt.expectedObjectCount, objectCount, "Object count should match expected")
+
+				// Verify storage size is within expected range
+				assert.GreaterOrEqual(t, objectStorageSize, tt.expectedStorageSizeMin,
+					"Storage size should be at least the minimum expected size")
+				assert.LessOrEqual(t, objectStorageSize, tt.expectedStorageSizeMax,
+					"Storage size should not exceed the maximum expected size")
+
+				// Test that unloaded shard returns the same storage size
+				// This simulates what happens when a shard is unloaded but we still need to measure its storage
+				unloadedStorageSize := shard.ObjectStorageSize(ctx)
+				assert.Equal(t, objectStorageSize, unloadedStorageSize,
+					"Unloaded shard should return the same storage size as active shard")
+			}
+			mockSchema.AssertExpectations(t)
+		})
+	}
+}
+
+// Helper function to generate a string of approximately the given size
+func generateStringOfSize(size int) string {
+	if size <= 0 {
+		return ""
+	}
+
+	// Use a repeating pattern to create a string of approximately the desired size
+	pattern := "abcdefghijklmnopqrstuvwxyz0123456789"
+	repeats := size / len(pattern)
+	remainder := size % len(pattern)
+
+	result := ""
+	for i := 0; i < repeats; i++ {
+		result += pattern
+	}
+	if remainder > 0 {
+		result += pattern[:remainder]
+	}
+
+	return result
+}

--- a/adapters/repos/db/index_object_storage_test.go
+++ b/adapters/repos/db/index_object_storage_test.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -403,16 +404,9 @@ func generateStringOfSize(size int) string {
 
 	// Use a repeating pattern to create a string of approximately the desired size
 	pattern := "abcdefghijklmnopqrstuvwxyz0123456789"
-	repeats := size / len(pattern)
-	remainder := size % len(pattern)
-
-	result := ""
-	for i := 0; i < repeats; i++ {
-		result += pattern
-	}
-	if remainder > 0 {
+	result := strings.Repeat(pattern, size/len(pattern))
+	if remainder := size % len(pattern); remainder > 0 {
 		result += pattern[:remainder]
 	}
-
 	return result
 }

--- a/adapters/repos/db/index_object_storage_test.go
+++ b/adapters/repos/db/index_object_storage_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/queue"
 	"github.com/weaviate/weaviate/entities/models"
@@ -220,199 +221,178 @@ func TestIndex_ObjectStorageSize_Comprehensive(t *testing.T) {
 	}
 }
 
-func TestIndex_ObjectStorageSize_ActiveVsUnloaded(t *testing.T) {
+func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	ctx := context.Background()
 	dirName := t.TempDir()
 	logger, _ := test.NewNullLogger()
 
-	tests := []struct {
-		name                   string
-		className              string
-		shardName              string
-		objectCount            int
-		objectSize             int
-		expectedObjectCount    int
-		expectedStorageSizeMin int64
-		expectedStorageSizeMax int64
-		setupData              bool
-		description            string
-	}{
-		{
-			name:                   "active shard with objects",
-			className:              "TestClass",
-			shardName:              "test-shard-active",
-			objectCount:            100,
-			objectSize:             200, // ~200 bytes per object
-			expectedObjectCount:    100,
-			expectedStorageSizeMin: int64(100 * 200),     // minimum: just the data
-			expectedStorageSizeMax: int64(100 * 200 * 5), // maximum: data + overhead
-			setupData:              true,
-			description:            "Active shard should have accurate object storage size",
+	className := "TestClass"
+	tenantName := "test-tenant"
+	objectCount := 50
+	objectSize := 500 // ~500 bytes per object
+
+	// Create test class with multi-tenancy enabled
+	class := &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{
+				Name:         "name",
+				DataType:     schema.DataTypeText.PropString(),
+				Tokenization: models.PropertyTokenizationWhitespace,
+			},
+			{
+				Name:         "description",
+				DataType:     schema.DataTypeText.PropString(),
+				Tokenization: models.PropertyTokenizationWhitespace,
+			},
 		},
-		{
-			name:                   "unloaded shard with objects",
-			className:              "TestClass",
-			shardName:              "test-shard-unloaded",
-			objectCount:            100,
-			objectSize:             200, // ~200 bytes per object
-			expectedObjectCount:    100,
-			expectedStorageSizeMin: int64(100 * 200),     // minimum: just the data
-			expectedStorageSizeMax: int64(100 * 200 * 5), // maximum: data + overhead
-			setupData:              true,
-			description:            "Unloaded shard should have accurate object storage size",
-		},
-		{
-			name:                   "active shard with large objects",
-			className:              "TestClass",
-			shardName:              "test-shard-active-large",
-			objectCount:            50,
-			objectSize:             1000, // ~1000 bytes per object
-			expectedObjectCount:    50,
-			expectedStorageSizeMin: int64(50 * 1000),     // minimum: just the data
-			expectedStorageSizeMax: int64(50 * 1000 * 5), // maximum: data + overhead
-			setupData:              true,
-			description:            "Active shard with large objects should have accurate storage size",
-		},
-		{
-			name:                   "unloaded shard with large objects",
-			className:              "TestClass",
-			shardName:              "test-shard-unloaded-large",
-			objectCount:            50,
-			objectSize:             1000, // ~1000 bytes per object
-			expectedObjectCount:    50,
-			expectedStorageSizeMin: int64(50 * 1000),     // minimum: just the data
-			expectedStorageSizeMax: int64(50 * 1000 * 5), // maximum: data + overhead
-			setupData:              true,
-			description:            "Unloaded shard with large objects should have accurate storage size",
+		InvertedIndexConfig: &models.InvertedIndexConfig{},
+		MultiTenancyConfig: &models.MultiTenancyConfig{
+			Enabled: true,
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Create test class
-			class := &models.Class{
-				Class: tt.className,
-				Properties: []*models.Property{
-					{
-						Name:         "name",
-						DataType:     schema.DataTypeText.PropString(),
-						Tokenization: models.PropertyTokenizationWhitespace,
-					},
-					{
-						Name:         "description",
-						DataType:     schema.DataTypeText.PropString(),
-						Tokenization: models.PropertyTokenizationWhitespace,
-					},
-					{
-						Name:     "count",
-						DataType: schema.DataTypeInt.PropString(),
-					},
-				},
-				InvertedIndexConfig: &models.InvertedIndexConfig{},
-			}
-
-			// Create fake schema
-			fakeSchema := schema.Schema{
-				Objects: &models.Schema{
-					Classes: []*models.Class{class},
-				},
-			}
-
-			// Create sharding state
-			shardState := &sharding.State{
-				Physical: map[string]sharding.Physical{
-					tt.shardName: {
-						Name:           tt.shardName,
-						BelongsToNodes: []string{"test-node"},
-						Status:         models.TenantActivityStatusHOT,
-					},
-				},
-			}
-			shardState.SetLocalName("test-node")
-
-			// Create scheduler
-			scheduler := queue.NewScheduler(queue.SchedulerOptions{
-				Logger:  logger,
-				Workers: 1,
-			})
-
-			// Create mock schema getter
-			mockSchema := schemaUC.NewMockSchemaGetter(t)
-			mockSchema.EXPECT().GetSchemaSkipAuth().Maybe().Return(fakeSchema)
-			mockSchema.EXPECT().ReadOnlyClass(tt.className).Maybe().Return(class)
-			mockSchema.EXPECT().CopyShardingState(tt.className).Maybe().Return(shardState)
-			mockSchema.EXPECT().NodeName().Maybe().Return("test-node")
-			mockSchema.EXPECT().ShardFromUUID("TestClass", mock.Anything).Return(tt.shardName).Maybe()
-			mockSchema.EXPECT().ShardOwner(tt.className, tt.shardName).Maybe().Return("test-node", nil)
-
-			// Create index
-			index, err := NewIndex(ctx, IndexConfig{
-				RootPath:              dirName,
-				ClassName:             schema.ClassName(tt.className),
-				ReplicationFactor:     1,
-				ShardLoadLimiter:      NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
-				TrackVectorDimensions: true,
-			}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
-				enthnsw.UserConfig{
-					VectorCacheMaxObjects: 1000,
-				}, nil, nil, mockSchema, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil, class, nil, scheduler, nil, nil, NewShardReindexerV3Noop())
-			require.NoError(t, err)
-			defer index.Shutdown(ctx)
-
-			// Add properties
-			for _, prop := range class.Properties {
-				err = index.addProperty(ctx, prop)
-				require.NoError(t, err)
-			}
-
-			if tt.setupData {
-				// Create objects with varying sizes
-				for i := 0; i < tt.objectCount; i++ {
-					// Create object with properties that approximate the desired size
-					obj := &models.Object{
-						Class: tt.className,
-						ID:    strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", i)),
-						Properties: map[string]interface{}{
-							"name":        fmt.Sprintf("test-object-%d", i),
-							"description": generateStringOfSize(tt.objectSize - 50), // Leave room for other properties
-							"count":       i,
-						},
-					}
-					storageObj := storobj.FromObject(obj, nil, nil, nil)
-					err := index.putObject(ctx, storageObj, nil, 0)
-					require.NoError(t, err)
-				}
-
-				// Wait for indexing to complete
-				time.Sleep(2 * time.Second)
-
-				// Test object storage size for active shard
-				shard, release, err := index.GetShard(ctx, tt.shardName)
-				require.NoError(t, err)
-				require.NotNil(t, shard)
-				defer release()
-
-				objectStorageSize := shard.ObjectStorageSize(ctx)
-				objectCount := shard.ObjectCount()
-
-				// Verify object count
-				assert.Equal(t, tt.expectedObjectCount, objectCount, "Object count should match expected")
-
-				// Verify storage size is within expected range
-				assert.GreaterOrEqual(t, objectStorageSize, tt.expectedStorageSizeMin,
-					"Storage size should be at least the minimum expected size")
-				assert.LessOrEqual(t, objectStorageSize, tt.expectedStorageSizeMax,
-					"Storage size should not exceed the maximum expected size")
-
-				// Test that unloaded shard returns the same storage size
-				// This simulates what happens when a shard is unloaded but we still need to measure its storage
-				unloadedStorageSize := shard.ObjectStorageSize(ctx)
-				assert.Equal(t, objectStorageSize, unloadedStorageSize,
-					"Unloaded shard should return the same storage size as active shard")
-			}
-			mockSchema.AssertExpectations(t)
-		})
+	// Create fake schema
+	fakeSchema := schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{class},
+		},
 	}
+
+	// Create sharding state with multi-tenancy enabled
+	shardState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			tenantName: {
+				Name:           tenantName,
+				BelongsToNodes: []string{"test-node"},
+				Status:         models.TenantActivityStatusHOT,
+			},
+		},
+		PartitioningEnabled: true,
+	}
+	shardState.SetLocalName("test-node")
+
+	// Create scheduler
+	scheduler := queue.NewScheduler(queue.SchedulerOptions{
+		Logger:  logger,
+		Workers: 1,
+	})
+
+	// Create mock schema getter
+	mockSchema := schemaUC.NewMockSchemaGetter(t)
+	mockSchema.EXPECT().GetSchemaSkipAuth().Maybe().Return(fakeSchema)
+	mockSchema.EXPECT().ReadOnlyClass(className).Maybe().Return(class)
+	mockSchema.EXPECT().CopyShardingState(className).Maybe().Return(shardState)
+	mockSchema.EXPECT().NodeName().Maybe().Return("test-node")
+	mockSchema.EXPECT().ShardFromUUID("TestClass", mock.Anything).Return(tenantName).Maybe()
+	mockSchema.EXPECT().ShardOwner(className, tenantName).Maybe().Return("test-node", nil)
+	mockSchema.EXPECT().TenantsShards(ctx, className, tenantName).Maybe().Return(map[string]string{tenantName: models.TenantActivityStatusHOT}, nil)
+
+	// Create index with lazy loading disabled to test active calculation methods
+	index, err := NewIndex(ctx, IndexConfig{
+		RootPath:              dirName,
+		ClassName:             schema.ClassName(className),
+		ReplicationFactor:     1,
+		ShardLoadLimiter:      NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
+		TrackVectorDimensions: true,
+		DisableLazyLoadShards: true, // we have to make sure lazyload shard disabled to load directly
+	}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
+		enthnsw.UserConfig{
+			VectorCacheMaxObjects: 1000,
+		}, nil, nil, mockSchema, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil, class, nil, scheduler, nil, nil, NewShardReindexerV3Noop())
+	require.NoError(t, err)
+
+	// Add properties
+	for _, prop := range class.Properties {
+		err = index.addProperty(ctx, prop)
+		require.NoError(t, err)
+	}
+
+	// Add test objects
+	for i := 0; i < objectCount; i++ {
+		obj := &models.Object{
+			Class:  className,
+			ID:     strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", i)),
+			Tenant: tenantName,
+			Properties: map[string]interface{}{
+				"name":        fmt.Sprintf("test-object-%d", i),
+				"description": generateStringOfSize(objectSize - 50), // Leave room for other properties
+			},
+		}
+		storageObj := storobj.FromObject(obj, nil, nil, nil)
+		err := index.putObject(ctx, storageObj, nil, 0)
+		require.NoError(t, err)
+	}
+
+	// Wait for indexing to complete
+	time.Sleep(1 * time.Second)
+
+	// Test active shard object storage size
+	activeShard, release, err := index.GetShard(ctx, tenantName)
+	require.NoError(t, err)
+	require.NotNil(t, activeShard)
+
+	// Force flush to ensure .cna files are created
+	objectsBucket := activeShard.Store().Bucket(helpers.ObjectsBucketLSM)
+	require.NotNil(t, objectsBucket)
+	require.NoError(t, objectsBucket.FlushMemtable())
+
+	activeObjectStorageSize := activeShard.ObjectStorageSize(ctx)
+	activeObjectCount := activeShard.ObjectCount()
+	assert.Greater(t, activeObjectStorageSize, int64(0), "Active shard calculation should have object storage size > 0")
+
+	// Test that active calculations are correct
+	assert.Equal(t, objectCount, activeObjectCount, "Active shard object count should match")
+	assert.Greater(t, activeObjectStorageSize, int64(objectCount*objectSize/2), "Active object storage size should be reasonable")
+
+	// Release the shard (this will flush all data to disk)
+	release()
+
+	// Explicitly shutdown all shards to ensure data is flushed to disk
+	err = index.ForEachShard(func(name string, shard ShardLike) error {
+		return shard.Shutdown(ctx)
+	})
+	require.NoError(t, err)
+
+	// Wait a bit for all shards to complete shutdown and data to be flushed
+	time.Sleep(1 * time.Second)
+
+	// Unload the shard from memory to test inactive calculation methods
+	index.shards.LoadAndDelete(tenantName)
+
+	// Shut down the entire index to ensure all store metadata is persisted
+	require.NoError(t, index.Shutdown(ctx))
+
+	// Create a new index instance to test inactive calculation methods
+	// This ensures we're testing the inactive methods on a fresh index that reads from disk
+	newIndex, err := NewIndex(ctx, IndexConfig{
+		RootPath:              dirName,
+		ClassName:             schema.ClassName(className),
+		ReplicationFactor:     1,
+		ShardLoadLimiter:      NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
+		TrackVectorDimensions: true,
+		DisableLazyLoadShards: false, // we have to make sure lazyload enabled
+	}, shardState, inverted.ConfigFromModel(class.InvertedIndexConfig),
+		enthnsw.UserConfig{
+			VectorCacheMaxObjects: 1000,
+		}, index.GetVectorIndexConfigs(), nil, mockSchema, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil, class, nil, scheduler, nil, nil, NewShardReindexerV3Noop())
+	require.NoError(t, err)
+	defer newIndex.Shutdown(ctx)
+
+	// Explicitly shutdown all shards to ensure data is flushed to disk
+	require.NoError(t, newIndex.ForEachShard(func(name string, shard ShardLike) error {
+		return shard.Shutdown(ctx)
+	}))
+	newIndex.shards.LoadAndDelete(tenantName)
+
+	inactiveObjectCount, inactiveObjectStorageSize := newIndex.CalculateUnloadedObjectsMetrics(ctx, tenantName)
+
+	// Compare active and inactive metrics
+	assert.Equal(t, activeObjectCount, int(inactiveObjectCount), "Active and inactive object count should match")
+	assert.InDelta(t, activeObjectStorageSize, inactiveObjectStorageSize, 1024, "Active and inactive object storage size should be close")
+
+	// Verify all mock expectations were met
+	mockSchema.AssertExpectations(t)
 }
 
 // Helper function to generate a string of approximately the given size

--- a/adapters/repos/db/lsmkv/segment_net_count_additions.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions.go
@@ -28,7 +28,7 @@ import (
 // re-computed at read-time.
 var ErrInvalidChecksum = errors.New("invalid checksum")
 
-const CNAFileSuffix = ".cna"
+const CountNetAdditionsFileSuffix = ".cna"
 
 // existOnLowerSegments is a simple function that can be passed at segment
 // initialization time to check if any of the keys are truly new or previously
@@ -136,9 +136,9 @@ func (s *segment) loadCountNetFromDisk() error {
 	return nil
 }
 
-// ReadCNAFileCount reads a .cna file and returns the count net additions value
+// ReadCountNetAdditionsFile reads a .cna file and returns the count net additions value
 // Returns (count, nil) if successful, (0, error) if the file is invalid or corrupted
-func ReadCNAFileCount(path string) (int64, error) {
+func ReadCountNetAdditionsFile(path string) (int64, error) {
 	data, err := loadWithChecksum(path, 12, nil)
 	if err != nil {
 		return 0, fmt.Errorf("failed to read .cna file: %w", err)

--- a/adapters/repos/db/lsmkv/segment_net_count_additions.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions.go
@@ -18,16 +18,17 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/weaviate/weaviate/usecases/byteops"
-
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/entities/diskio"
+	"github.com/weaviate/weaviate/usecases/byteops"
 )
 
 // ErrInvalidChecksum indicates that the read file should not be trusted. For
 // any pre-computed data this is a recoverable issue, as the data can simply be
 // re-computed at read-time.
 var ErrInvalidChecksum = errors.New("invalid checksum")
+
+const CNAFileSuffix = ".cna"
 
 // existOnLowerSegments is a simple function that can be passed at segment
 // initialization time to check if any of the keys are truly new or previously
@@ -133,6 +134,20 @@ func (s *segment) loadCountNetFromDisk() error {
 	s.countNetAdditions = int(binary.LittleEndian.Uint64(data[0:8]))
 
 	return nil
+}
+
+// ReadCNAFileCount reads a .cna file and returns the count net additions value
+// Returns (count, nil) if successful, (0, error) if the file is invalid or corrupted
+func ReadCNAFileCount(path string) (int64, error) {
+	data, err := loadWithChecksum(path, 12, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read .cna file: %w", err)
+	}
+
+	// Extract count value (first 8 bytes, uint64 little-endian)
+	count := int64(binary.LittleEndian.Uint64(data[0:8]))
+
+	return count, nil
 }
 
 func (s *segment) precomputeCountNetAdditions(updatedCountNetAdditions int) ([]string, error) {


### PR DESCRIPTION
### What's being changed:
- introduce func (m *shardMap) Loaded(name string) ShardLike 
- handle concurrency of loaded shards for objects calculations 
- add unit test

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
