### PR TITLE
chore(alias): Fix DELETE and GET response types and status codes

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -264,7 +264,7 @@ func init() {
           "200": {
             "description": "Successfully retrieved the alias details.",
             "schema": {
-              "$ref": "#/definitions/AliasResponse"
+              "$ref": "#/definitions/Alias"
             }
           },
           "401": {
@@ -272,6 +272,12 @@ func init() {
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Not Found - Alias does not exist",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -379,6 +385,12 @@ func init() {
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Not Found - Alias does not exist",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -8858,7 +8870,7 @@ func init() {
           "200": {
             "description": "Successfully retrieved the alias details.",
             "schema": {
-              "$ref": "#/definitions/AliasResponse"
+              "$ref": "#/definitions/Alias"
             }
           },
           "401": {
@@ -8866,6 +8878,12 @@ func init() {
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Not Found - Alias does not exist",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -8973,6 +8991,12 @@ func init() {
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Not Found - Alias does not exist",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }

--- a/adapters/handlers/rest/handlers_aliases.go
+++ b/adapters/handlers/rest/handlers_aliases.go
@@ -75,11 +75,21 @@ func (s *aliasesHandlers) getAlias(params schema.AliasesGetAliasParams,
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
-
-	aliasesResponse := &models.AliasResponse{Aliases: aliases}
+	if len(aliases) == 0 {
+		return schema.NewAliasesGetAliasNotFound()
+	}
+	if len(aliases) > 1 {
+		return schema.NewAliasesGetAliasInternalServerError().WithPayload(&models.ErrorResponse{
+			Error: []*models.ErrorResponseErrorItems0{
+				{
+					Message: "get alias returned more than one alias",
+				},
+			},
+		})
+	}
 
 	s.metricRequestsTotal.logOk("")
-	return schema.NewAliasesGetAliasOK().WithPayload(aliasesResponse)
+	return schema.NewAliasesGetAliasOK().WithPayload(aliases[0])
 }
 
 func (s *aliasesHandlers) addAlias(params schema.AliasesCreateParams,
@@ -131,6 +141,9 @@ func (s *aliasesHandlers) deleteAlias(params schema.AliasesDeleteParams, princip
 	err := s.manager.DeleteAlias(params.HTTPRequest.Context(), principal, params.AliasName)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.AliasName, err)
+		if errors.Is(err, schemaUC.ErrNotFound) {
+			return schema.NewAliasesDeleteNotFound()
+		}
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewAliasesDeleteForbidden().

--- a/adapters/handlers/rest/operations/schema/aliases_delete_responses.go
+++ b/adapters/handlers/rest/operations/schema/aliases_delete_responses.go
@@ -119,6 +119,51 @@ func (o *AliasesDeleteForbidden) WriteResponse(rw http.ResponseWriter, producer 
 	}
 }
 
+// AliasesDeleteNotFoundCode is the HTTP code returned for type AliasesDeleteNotFound
+const AliasesDeleteNotFoundCode int = 404
+
+/*
+AliasesDeleteNotFound Not Found - Alias does not exist
+
+swagger:response aliasesDeleteNotFound
+*/
+type AliasesDeleteNotFound struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewAliasesDeleteNotFound creates AliasesDeleteNotFound with default headers values
+func NewAliasesDeleteNotFound() *AliasesDeleteNotFound {
+
+	return &AliasesDeleteNotFound{}
+}
+
+// WithPayload adds the payload to the aliases delete not found response
+func (o *AliasesDeleteNotFound) WithPayload(payload *models.ErrorResponse) *AliasesDeleteNotFound {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the aliases delete not found response
+func (o *AliasesDeleteNotFound) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *AliasesDeleteNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(404)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // AliasesDeleteUnprocessableEntityCode is the HTTP code returned for type AliasesDeleteUnprocessableEntity
 const AliasesDeleteUnprocessableEntityCode int = 422
 

--- a/adapters/handlers/rest/operations/schema/aliases_get_alias_responses.go
+++ b/adapters/handlers/rest/operations/schema/aliases_get_alias_responses.go
@@ -37,7 +37,7 @@ type AliasesGetAliasOK struct {
 	/*
 	  In: Body
 	*/
-	Payload *models.AliasResponse `json:"body,omitempty"`
+	Payload *models.Alias `json:"body,omitempty"`
 }
 
 // NewAliasesGetAliasOK creates AliasesGetAliasOK with default headers values
@@ -47,13 +47,13 @@ func NewAliasesGetAliasOK() *AliasesGetAliasOK {
 }
 
 // WithPayload adds the payload to the aliases get alias o k response
-func (o *AliasesGetAliasOK) WithPayload(payload *models.AliasResponse) *AliasesGetAliasOK {
+func (o *AliasesGetAliasOK) WithPayload(payload *models.Alias) *AliasesGetAliasOK {
 	o.Payload = payload
 	return o
 }
 
 // SetPayload sets the payload to the aliases get alias o k response
-func (o *AliasesGetAliasOK) SetPayload(payload *models.AliasResponse) {
+func (o *AliasesGetAliasOK) SetPayload(payload *models.Alias) {
 	o.Payload = payload
 }
 
@@ -131,6 +131,51 @@ func (o *AliasesGetAliasForbidden) SetPayload(payload *models.ErrorResponse) {
 func (o *AliasesGetAliasForbidden) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.WriteHeader(403)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
+// AliasesGetAliasNotFoundCode is the HTTP code returned for type AliasesGetAliasNotFound
+const AliasesGetAliasNotFoundCode int = 404
+
+/*
+AliasesGetAliasNotFound Not Found - Alias does not exist
+
+swagger:response aliasesGetAliasNotFound
+*/
+type AliasesGetAliasNotFound struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewAliasesGetAliasNotFound creates AliasesGetAliasNotFound with default headers values
+func NewAliasesGetAliasNotFound() *AliasesGetAliasNotFound {
+
+	return &AliasesGetAliasNotFound{}
+}
+
+// WithPayload adds the payload to the aliases get alias not found response
+func (o *AliasesGetAliasNotFound) WithPayload(payload *models.ErrorResponse) *AliasesGetAliasNotFound {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the aliases get alias not found response
+func (o *AliasesGetAliasNotFound) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *AliasesGetAliasNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(404)
 	if o.Payload != nil {
 		payload := o.Payload
 		if err := producer.Produce(rw, payload); err != nil {

--- a/client/schema/aliases_delete_responses.go
+++ b/client/schema/aliases_delete_responses.go
@@ -52,6 +52,12 @@ func (o *AliasesDeleteReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return nil, result
+	case 404:
+		result := NewAliasesDeleteNotFound()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewAliasesDeleteUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -238,6 +244,74 @@ func (o *AliasesDeleteForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesDeleteForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAliasesDeleteNotFound creates a AliasesDeleteNotFound with default headers values
+func NewAliasesDeleteNotFound() *AliasesDeleteNotFound {
+	return &AliasesDeleteNotFound{}
+}
+
+/*
+AliasesDeleteNotFound describes a response with status code 404, with default header values.
+
+Not Found - Alias does not exist
+*/
+type AliasesDeleteNotFound struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this aliases delete not found response has a 2xx status code
+func (o *AliasesDeleteNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this aliases delete not found response has a 3xx status code
+func (o *AliasesDeleteNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this aliases delete not found response has a 4xx status code
+func (o *AliasesDeleteNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this aliases delete not found response has a 5xx status code
+func (o *AliasesDeleteNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this aliases delete not found response a status code equal to that given
+func (o *AliasesDeleteNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the aliases delete not found response
+func (o *AliasesDeleteNotFound) Code() int {
+	return 404
+}
+
+func (o *AliasesDeleteNotFound) Error() string {
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteNotFound  %+v", 404, o.Payload)
+}
+
+func (o *AliasesDeleteNotFound) String() string {
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteNotFound  %+v", 404, o.Payload)
+}
+
+func (o *AliasesDeleteNotFound) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *AliasesDeleteNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.ErrorResponse)
 

--- a/client/schema/aliases_get_alias_responses.go
+++ b/client/schema/aliases_get_alias_responses.go
@@ -52,6 +52,12 @@ func (o *AliasesGetAliasReader) ReadResponse(response runtime.ClientResponse, co
 			return nil, err
 		}
 		return nil, result
+	case 404:
+		result := NewAliasesGetAliasNotFound()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewAliasesGetAliasUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -80,7 +86,7 @@ AliasesGetAliasOK describes a response with status code 200, with default header
 Successfully retrieved the alias details.
 */
 type AliasesGetAliasOK struct {
-	Payload *models.AliasResponse
+	Payload *models.Alias
 }
 
 // IsSuccess returns true when this aliases get alias o k response has a 2xx status code
@@ -121,13 +127,13 @@ func (o *AliasesGetAliasOK) String() string {
 	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasOK  %+v", 200, o.Payload)
 }
 
-func (o *AliasesGetAliasOK) GetPayload() *models.AliasResponse {
+func (o *AliasesGetAliasOK) GetPayload() *models.Alias {
 	return o.Payload
 }
 
 func (o *AliasesGetAliasOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
-	o.Payload = new(models.AliasResponse)
+	o.Payload = new(models.Alias)
 
 	// response payload
 	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
@@ -250,6 +256,74 @@ func (o *AliasesGetAliasForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesGetAliasForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewAliasesGetAliasNotFound creates a AliasesGetAliasNotFound with default headers values
+func NewAliasesGetAliasNotFound() *AliasesGetAliasNotFound {
+	return &AliasesGetAliasNotFound{}
+}
+
+/*
+AliasesGetAliasNotFound describes a response with status code 404, with default header values.
+
+Not Found - Alias does not exist
+*/
+type AliasesGetAliasNotFound struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this aliases get alias not found response has a 2xx status code
+func (o *AliasesGetAliasNotFound) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this aliases get alias not found response has a 3xx status code
+func (o *AliasesGetAliasNotFound) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this aliases get alias not found response has a 4xx status code
+func (o *AliasesGetAliasNotFound) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this aliases get alias not found response has a 5xx status code
+func (o *AliasesGetAliasNotFound) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this aliases get alias not found response a status code equal to that given
+func (o *AliasesGetAliasNotFound) IsCode(code int) bool {
+	return code == 404
+}
+
+// Code gets the status code for the aliases get alias not found response
+func (o *AliasesGetAliasNotFound) Code() int {
+	return 404
+}
+
+func (o *AliasesGetAliasNotFound) Error() string {
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasNotFound  %+v", 404, o.Payload)
+}
+
+func (o *AliasesGetAliasNotFound) String() string {
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasNotFound  %+v", 404, o.Payload)
+}
+
+func (o *AliasesGetAliasNotFound) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *AliasesGetAliasNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.ErrorResponse)
 

--- a/entities/schema/schema.go
+++ b/entities/schema/schema.go
@@ -60,15 +60,7 @@ func (s *Schema) SemanticSchemaFor() *models.Schema {
 }
 
 func UppercaseClassName(name string) string {
-	if len(name) < 1 {
-		return name
-	}
-
-	if len(name) == 1 {
-		return strings.ToUpper(name)
-	}
-
-	return strings.ToUpper(string(name[0])) + name[1:]
+	return strings.ToTitle(name)
 }
 
 func UppercaseClassesNames(names ...string) []string {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -7738,7 +7738,7 @@
           "200": {
             "description": "Successfully retrieved the alias details.",
             "schema": {
-              "$ref": "#/definitions/AliasResponse"
+              "$ref": "#/definitions/Alias"
             }
           },
           "401": {
@@ -7746,6 +7746,12 @@
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "404": {
+            "description": "Not Found - Alias does not exist",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -7853,6 +7859,12 @@
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+	  "404": {
+            "description": "Not Found - Alias does not exist",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }


### PR DESCRIPTION
### What's being changed:
1. GET /aliases/{aliase} now returns single alias object instead of list. And returns 404 if resource doesn't exist (previously returns empty list with 200)
2. DELETE /aliases/{alias} now returns 404 when resource doesn't exist
3. Minor cleanups

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
