### PR TITLE
fix: add locking mechanism for object deletion to prevent race conditions

### DIFF
--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -725,6 +725,13 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 	}
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+
+	// see comment in shard_write_put.go::putObjectLSM
+	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]
+
+	lock.Lock()
+	defer lock.Unlock()
+
 	existing, err := bucket.Get(idBytes)
 	if err != nil {
 		return errors.Wrap(err, "unexpected error on previous lookup")

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -34,6 +34,13 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 	}
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+
+	// see comment in shard_write_put.go::putObjectLSM
+	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]
+
+	lock.Lock()
+	defer lock.Unlock()
+
 	existing, err := bucket.Get([]byte(idBytes))
 	if err != nil {
 		return fmt.Errorf("unexpected error on previous lookup: %w", err)


### PR DESCRIPTION
### What's being changed:

Ensure that operations on the same object ID are synchronized to avoid race conditions.

Concurrency safety fixes:

* [`adapters/repos/db/shard_read.go`](diffhunk://#diff-d08244a2bbe99960c516af6a929befc67a879b42950ca0dadbcde372fb7c8cfaR728-R734): Added a locking mechanism (`docIdLock`) in the `batchDeleteObject` method to synchronize access to object IDs during deletion.
* [`adapters/repos/db/shard_write_delete.go`](diffhunk://#diff-376997473eb6b2027022d40be79fe7bcb354aec352d3b066d99092b1c3f60deeR37-R43): Added a locking mechanism (`docIdLock`) in the `DeleteObject` method to synchronize access to object IDs during deletion.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
