### PR TITLE
fix(alias): return alias as target collection in gRPC Search

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -58,14 +58,17 @@ type generativeParser interface {
 type Parser struct {
 	generative         generativeParser
 	authorizedGetClass classGetterWithAuthzFunc
+	aliasGetter        aliasGetter
 }
 
 func NewParser(uses127Api bool,
 	authorizedGetClass classGetterWithAuthzFunc,
+	aliasGetter aliasGetter,
 ) *Parser {
 	return &Parser{
 		generative:         generative.NewParser(uses127Api),
 		authorizedGetClass: authorizedGetClass,
+		aliasGetter:        aliasGetter,
 	}
 }
 
@@ -76,6 +79,7 @@ func (p *Parser) Search(req *pb.SearchRequest, config *config.Config) (dto.GetPa
 		return out, err
 	}
 
+	out.Alias = p.aliasGetter(req.Collection)
 	out.ClassName = class.Class
 	out.ReplicationProperties = extractReplicationProperties(req.ConsistencyLevel)
 

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -2337,7 +2337,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 		},
 	}
 
-	parser := NewParser(false, getClass)
+	parser := NewParser(false, getClass, getAlias)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out, err := parser.Search(tt.req, &config.Config{QueryDefaults: config.QueryDefaults{Limit: 10}})
@@ -2362,6 +2362,10 @@ func getClass(name string) (*models.Class, error) {
 		return nil, fmt.Errorf("class %s not found", name)
 	}
 	return class, nil
+}
+
+func getAlias(name string) string {
+	return ""
 }
 
 func sortNamedVecs(vecs []string) {

--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -115,7 +115,7 @@ func (r *Replier) extractObjectsToResults(res []interface{}, searchParams dto.Ge
 		var props *pb.PropertiesResult
 		var err error
 
-		props, err = r.extractPropertiesAnswer(scheme, asMap, searchParams.Properties, searchParams.ClassName, searchParams.AdditionalProperties)
+		props, err = r.extractPropertiesAnswer(scheme, asMap, searchParams.Properties, searchParams.ClassName, searchParams.Alias, searchParams.AdditionalProperties)
 		if err != nil {
 			return nil, "", nil, err
 		}
@@ -472,7 +472,7 @@ func (r *Replier) extractGroup(raw any, searchParams dto.GetParams, scheme schem
 	return ret, groupedGenerativeResults, nil
 }
 
-func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[string]interface{}, properties search.SelectProperties, className string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
+func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[string]interface{}, properties search.SelectProperties, className, alias string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
 	nonRefProps := &pb.Properties{
 		Fields: make(map[string]*pb.Value, 0),
 	}
@@ -528,7 +528,7 @@ func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[stri
 			if !ok {
 				continue
 			}
-			extractedRefProp, err := r.extractPropertiesAnswer(scheme, refLocal.Fields, prop.Refs[0].RefProperties, refLocal.Class, additionalPropsParams)
+			extractedRefProp, err := r.extractPropertiesAnswer(scheme, refLocal.Fields, prop.Refs[0].RefProperties, refLocal.Class, "", additionalPropsParams)
 			if err != nil {
 				continue
 			}
@@ -554,7 +554,11 @@ func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[stri
 		props.RefProps = refProps
 	}
 	props.RefPropsRequested = properties.HasRefs()
-	props.TargetCollection = className
+	if alias != "" {
+		props.TargetCollection = alias
+	} else {
+		props.TargetCollection = className
+	}
 	return &props, nil
 }
 

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -309,6 +309,7 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	parser := NewParser(
 		req.Uses_127Api,
 		s.classGetterWithAuthzFunc(ctx, principal, req.Tenant),
+		s.aliasGetter(),
 	)
 	replier := NewReplier(
 		req.Uses_125Api || req.Uses_127Api,
@@ -375,6 +376,17 @@ func (s *Service) classGetterWithAuthzFunc(ctx context.Context, principal *model
 			return nil, fmt.Errorf("could not find class %s in schema", name)
 		}
 		return class, nil
+	}
+}
+
+type aliasGetter func(string) string
+
+func (s *Service) aliasGetter() aliasGetter {
+	return func(name string) string {
+		if cls := s.schemaManager.ResolveAlias(name); cls != "" {
+			return name // name is an alias
+		}
+		return ""
 	}
 }
 

--- a/entities/dto/dto.go
+++ b/entities/dto/dto.go
@@ -65,7 +65,8 @@ type GetParams struct {
 	AdditionalProperties    additional.Properties
 	ReplicationProperties   *additional.ReplicationProperties
 	Tenant                  string
-	IsRefOrigin             bool // is created by ref filter
+	IsRefOrigin             bool   // is created by ref filter
+	Alias                   string // used only to transfer alias passed in search request, not used for actual search
 }
 
 type Embedding interface {

--- a/test/acceptance/aliases/aliases_api_grpc_test.go
+++ b/test/acceptance/aliases/aliases_api_grpc_test.go
@@ -73,6 +73,13 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 		require.NotEmpty(t, resp.Aliases)
 	})
 
+	assertTargetCollectionName := func(res []*pb.SearchResult, collection string) {
+		for _, r := range res {
+			require.NotNil(t, r.GetProperties())
+			assert.Equal(t, collection, r.GetProperties().GetTargetCollection())
+		}
+	}
+
 	tests := []struct {
 		name       string
 		collection string
@@ -99,6 +106,7 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 					require.NoError(t, err)
 					require.NotNil(t, resp)
 					assert.Len(t, resp.Results, 3)
+					assertTargetCollectionName(resp.Results, tt.collection)
 				})
 				t.Run("get with filters", func(t *testing.T) {
 					resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
@@ -118,6 +126,7 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 					assert.Len(t, resp.Results, 1)
 					assert.Equal(t, resp.Results[0].Metadata.Id, books.Dune.String())
 					assert.NotEmpty(t, resp.Results[0].Metadata.GetVectorBytes())
+					assertTargetCollectionName(resp.Results, tt.collection)
 				})
 				t.Run("nearText", func(t *testing.T) {
 					resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
@@ -134,6 +143,7 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 					require.NotNil(t, resp)
 					assert.Len(t, resp.Results, 3)
 					assert.Equal(t, resp.Results[0].Metadata.Id, books.Dune.String())
+					assertTargetCollectionName(resp.Results, tt.collection)
 				})
 				t.Run("bm25", func(t *testing.T) {
 					resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
@@ -151,6 +161,7 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 					require.NotNil(t, resp)
 					assert.Len(t, resp.Results, 1)
 					assert.Equal(t, resp.Results[0].Metadata.Id, books.Dune.String())
+					assertTargetCollectionName(resp.Results, tt.collection)
 				})
 				t.Run("hybrid", func(t *testing.T) {
 					resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
@@ -171,6 +182,7 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 					require.NotNil(t, resp)
 					assert.Len(t, resp.Results, 3)
 					assert.Equal(t, resp.Results[0].Metadata.Id, books.ProjectHailMary.String())
+					assertTargetCollectionName(resp.Results, tt.collection)
 				})
 			})
 			t.Run("aggregate using alias", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

This PR fixes the target collection returned in gRPC Search. It sets the `Alias` as `TargetCollection` if a search request is made using an `Alias`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
