### PR TITLE
Add support for jina-embeddings-v4 model

### DIFF
--- a/modules/text2vec-jinaai/config.go
+++ b/modules/text2vec-jinaai/config.go
@@ -27,7 +27,6 @@ func (m *JinaAIModule) ClassConfigDefaults() map[string]interface{} {
 		"vectorizeClassName": ent.DefaultVectorizeClassName,
 		"model":              ent.DefaultJinaAIModel,
 		"baseURL":            ent.DefaultBaseURL,
-		"dimensions":         &ent.DefaultDimensions,
 	}
 }
 

--- a/modules/text2vec-jinaai/ent/class_settings.go
+++ b/modules/text2vec-jinaai/ent/class_settings.go
@@ -20,15 +20,13 @@ import (
 const (
 	// Default values for URL (model is ok) cannot be changed before we solve how old classes that have the defaults
 	// NOT set will handle the change
-	DefaultJinaAIModel           = "jina-embeddings-v2-base-en"
-	DefaultVectorizeClassName    = true
+	DefaultJinaAIModel           = "jina-embeddings-v4"
+	DefaultVectorizeClassName    = false
 	DefaultPropertyIndexed       = true
 	DefaultVectorizePropertyName = false
 	DefaultBaseURL               = "https://api.jina.ai"
 	LowerCaseInput               = false
 )
-
-var DefaultDimensions int64 = 1024
 
 type classSettings struct {
 	basesettings.BaseClassSettings
@@ -48,7 +46,7 @@ func (cs *classSettings) BaseURL() string {
 }
 
 func (cs *classSettings) Dimensions() *int64 {
-	return cs.BaseClassSettings.GetPropertyAsInt64("dimensions", &DefaultDimensions)
+	return cs.BaseClassSettings.GetPropertyAsInt64("dimensions", nil)
 }
 
 func (cs *classSettings) Validate(class *models.Class) error {

--- a/test/modules/multi2vec-jinaai/multi2vec_jinaai_test.go
+++ b/test/modules/multi2vec-jinaai/multi2vec_jinaai_test.go
@@ -26,61 +26,95 @@ func testMulti2VecJinaAI(host string) func(t *testing.T) {
 		helper.SetupClient(host)
 		// Define path to test/helper/sample-schema/multimodal/data folder
 		dataFolderPath := "../../../test/helper/sample-schema/multimodal/data"
-		// Define class
-		vectorizerName := "multi2vec-jinaai"
-		className := "ClipTest"
-		class := multimodal.BaseClass(className, false)
-		class.VectorConfig = map[string]models.VectorConfig{
-			"clip": {
-				Vectorizer: map[string]interface{}{
-					vectorizerName: map[string]interface{}{
-						"imageFields":        []interface{}{multimodal.PropertyImage},
-						"vectorizeClassName": false,
-						"dimensions":         600,
-					},
-				},
-				VectorIndexType: "flat",
+		tests := []struct {
+			name                  string
+			model                 string
+			clipWeightsDimensions int
+		}{
+			{
+				name: "default settings",
 			},
-			"clip_weights": {
-				Vectorizer: map[string]interface{}{
-					vectorizerName: map[string]interface{}{
-						"textFields":  []interface{}{multimodal.PropertyImageTitle, multimodal.PropertyImageDescription},
-						"imageFields": []interface{}{multimodal.PropertyImage},
-						"weights": map[string]interface{}{
-							"textFields":  []interface{}{0.05, 0.05},
-							"imageFields": []interface{}{0.9},
-						},
-						"vectorizeClassName": false,
-					},
-				},
-				VectorIndexType: "flat",
+			{
+				name:                  "jina-embeddings-v4",
+				model:                 "jina-embeddings-v4",
+				clipWeightsDimensions: 2048,
 			},
 		}
-		// create schema
-		helper.CreateClass(t, class)
-		defer helper.DeleteClass(t, class.Class)
-
-		t.Run("import data", func(t *testing.T) {
-			multimodal.InsertObjects(t, dataFolderPath, class.Class, false)
-		})
-
-		t.Run("nearImage", func(t *testing.T) {
-			blob, err := multimodal.GetImageBlob(dataFolderPath, 2)
-			require.NoError(t, err)
-			targetVector := "clip"
-			nearMediaArgument := fmt.Sprintf(`
-				nearImage: {
-					image: "%s"
-					targetVectors: ["%s"]
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				// Define settings
+				clipSettings := map[string]interface{}{
+					"imageFields":        []interface{}{multimodal.PropertyImage},
+					"vectorizeClassName": false,
+					"dimensions":         600,
 				}
-			`, blob, targetVector)
-			titleProperty := multimodal.PropertyImageTitle
-			titlePropertyValue := "waterfalls"
-			targetVectors := map[string]int{
-				"clip":         600,
-				"clip_weights": 1024,
-			}
-			multimodal.TestQuery(t, class.Class, nearMediaArgument, titleProperty, titlePropertyValue, targetVectors)
-		})
+				if tt.model != "" {
+					clipSettings["model"] = tt.model
+				}
+				clipWeightsSettings := map[string]interface{}{
+					"textFields":  []interface{}{multimodal.PropertyImageTitle, multimodal.PropertyImageDescription},
+					"imageFields": []interface{}{multimodal.PropertyImage},
+					"weights": map[string]interface{}{
+						"textFields":  []interface{}{0.05, 0.05},
+						"imageFields": []interface{}{0.9},
+					},
+					"vectorizeClassName": false,
+				}
+				if tt.model != "" {
+					clipWeightsSettings["model"] = tt.model
+				}
+				if tt.clipWeightsDimensions > 0 {
+					clipWeightsSettings["dimensions"] = tt.clipWeightsDimensions
+				}
+				// Define class
+				vectorizerName := "multi2vec-jinaai"
+				className := "ClipTest"
+				class := multimodal.BaseClass(className, false)
+				class.VectorConfig = map[string]models.VectorConfig{
+					"clip": {
+						Vectorizer: map[string]interface{}{
+							vectorizerName: clipSettings,
+						},
+						VectorIndexType: "flat",
+					},
+					"clip_weights": {
+						Vectorizer: map[string]interface{}{
+							vectorizerName: clipWeightsSettings,
+						},
+						VectorIndexType: "flat",
+					},
+				}
+				// create schema
+				helper.CreateClass(t, class)
+				defer helper.DeleteClass(t, class.Class)
+
+				t.Run("import data", func(t *testing.T) {
+					multimodal.InsertObjects(t, dataFolderPath, class.Class, false)
+				})
+
+				t.Run("nearImage", func(t *testing.T) {
+					blob, err := multimodal.GetImageBlob(dataFolderPath, 2)
+					require.NoError(t, err)
+					targetVector := "clip"
+					nearMediaArgument := fmt.Sprintf(`
+						nearImage: {
+							image: "%s"
+							targetVectors: ["%s"]
+						}
+					`, blob, targetVector)
+					titleProperty := multimodal.PropertyImageTitle
+					titlePropertyValue := "waterfalls"
+					clipWeightsDimensions := 1024
+					if tt.clipWeightsDimensions > 0 {
+						clipWeightsDimensions = tt.clipWeightsDimensions
+					}
+					targetVectors := map[string]int{
+						"clip":         600,
+						"clip_weights": clipWeightsDimensions,
+					}
+					multimodal.TestQuery(t, class.Class, nearMediaArgument, titleProperty, titlePropertyValue, targetVectors)
+				})
+			})
+		}
 	}
 }

--- a/test/modules/text2vec-jinaai/text2vec_jinaai_test.go
+++ b/test/modules/text2vec-jinaai/text2vec_jinaai_test.go
@@ -29,26 +29,45 @@ func testText2VecJinaAI(rest, grpc string) func(t *testing.T) {
 		data := companies.Companies
 		class := companies.BaseClass(className)
 		tests := []struct {
-			name  string
-			model string
+			name       string
+			model      string
+			dimensions int
 		}{
 			{
-				name:  "jina-embeddings-v3",
-				model: "jina-embeddings-v3",
+				name:  "jina-embeddings-v2-base-en",
+				model: "jina-embeddings-v2-base-en",
+			},
+			{
+				name:       "jina-embeddings-v3",
+				model:      "jina-embeddings-v3",
+				dimensions: 64,
+			},
+			{
+				name:  "jina-embeddings-v4",
+				model: "jina-embeddings-v4",
+			},
+			{
+				name: "default settings",
 			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
+				// Define module settings
+				settings := map[string]interface{}{
+					"properties":         []interface{}{"description"},
+					"vectorizeClassName": false,
+				}
+				if tt.model != "" {
+					settings["model"] = tt.model
+				}
+				if tt.dimensions > 0 {
+					settings["dimensions"] = tt.dimensions
+				}
 				// Define class
 				class.VectorConfig = map[string]models.VectorConfig{
 					"description": {
 						Vectorizer: map[string]interface{}{
-							"text2vec-jinaai": map[string]interface{}{
-								"properties":         []interface{}{"description"},
-								"vectorizeClassName": false,
-								"model":              tt.model,
-								"dimensions":         64,
-							},
+							"text2vec-jinaai": settings,
 						},
 						VectorIndexType: "flat",
 					},


### PR DESCRIPTION
### What's being changed:

This PR:
- adds e2e tests for `jina-embeddings-v4` model in both `text2vec-jinaai` and `multi2vec-jinaai` modules
- removes default dimensions setting from `text2vec-jinaai` module
- changes default model in `text2vec-jinaai` module to `jina-embeddings-v4`
- changes default `DefaultVectorizeClassName` setting to `false`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
