### PR TITLE
Extend minimum timeout based on environment variable

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -147,6 +147,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 	"github.com/weaviate/weaviate/usecases/telemetry"
 	"github.com/weaviate/weaviate/usecases/traverser"
+	entconfig "github.com/weaviate/weaviate/entities/config"
 )
 
 const MinimumRequiredContextionaryVersion = "1.0.2"
@@ -1723,7 +1724,7 @@ func reasonableHttpClient(authConfig cluster.AuthConfig) *http.Client {
 	t := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
 		DialContext: (&net.Dialer{
-			Timeout:   30 * time.Second,
+			Timeout:   entconfig.MinimumTimeout(),
 			KeepAlive: 120 * time.Second,
 		}).DialContext,
 		MaxIdleConnsPerHost:   100,

--- a/entities/config/helpers.go
+++ b/entities/config/helpers.go
@@ -26,16 +26,19 @@ func Enabled(value string) bool {
 		return false
 	}
 }
-
+var defaultMinimumTimeout = -1 * time.Second
 func MinimumTimeout() time.Duration {
-	timeout := 30 * time.Second
+	if defaultMinimumTimeout > 0 {
+		return defaultMinimumTimeout
+	}
+	defaultMinimumTimeout = 30 * time.Second // default minimum timeout is 30 seconds
 	opt := os.Getenv("WEAVIATE_MINIMUM_TIMEOUT")
 	if opt != "" {
 		if parsed, err := time.ParseDuration(opt); err == nil {
-			timeout = parsed
+			defaultMinimumTimeout = parsed
 		} else {
-			fmt.Printf("Invalid WEAVIATE_MINIMUM_TIMEOUT value: %s, using default %s\n", opt, timeout)
+			fmt.Printf("Invalid WEAVIATE_MINIMUM_TIMEOUT value: %s, using default %s\n", opt, defaultMinimumTimeout)
 		}
 	}
-	return timeout
+	return defaultMinimumTimeout
 }

--- a/entities/config/helpers.go
+++ b/entities/config/helpers.go
@@ -11,7 +11,12 @@
 
 package config
 
-import "strings"
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
 
 func Enabled(value string) bool {
 	switch strings.ToLower(value) {
@@ -20,4 +25,17 @@ func Enabled(value string) bool {
 	default:
 		return false
 	}
+}
+
+func MinimumTimeout() time.Duration {
+	timeout := 30 * time.Second
+	opt := os.Getenv("WEAVIATE_MINIMUM_TIMEOUT")
+	if opt != "" {
+		if parsed, err := time.ParseDuration(opt); err == nil {
+			timeout = parsed
+		} else {
+			fmt.Printf("Invalid WEAVIATE_MINIMUM_TIMEOUT value: %s, using default %s\n", opt, timeout)
+		}
+	}
+	return timeout
 }

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -90,7 +90,7 @@ func (m *Manager) GetNodeStatus(ctx context.Context,
 func (m *Manager) GetNodeStatistics(ctx context.Context,
 	principal *models.Principal,
 ) ([]*models.Statistics, error) {
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, GetNodeStatusTimeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, config.MinimumTimeout())
 	defer cancel()
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Cluster()); err != nil {

--- a/usecases/nodes/handler.go
+++ b/usecases/nodes/handler.go
@@ -13,11 +13,11 @@ package nodes
 
 import (
 	"context"
-	"time"
 
 	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac/rbacconf"
 
+	"github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/verbosity"
 
 	"github.com/sirupsen/logrus"
@@ -25,8 +25,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 )
-
-const GetNodeStatusTimeout = 30 * time.Second
 
 type db interface {
 	GetNodeStatus(ctx context.Context, className, shardName, verbosity string) ([]*models.NodeStatus, error)
@@ -52,7 +50,7 @@ func NewManager(logger logrus.FieldLogger, authorizer authorization.Authorizer,
 func (m *Manager) GetNodeStatus(ctx context.Context,
 	principal *models.Principal, className, shardName, verbosityString string,
 ) ([]*models.NodeStatus, error) {
-	ctxWithTimeout, cancel := context.WithTimeout(ctx, GetNodeStatusTimeout)
+	ctxWithTimeout, cancel := context.WithTimeout(ctx, config.MinimumTimeout())
 	defer cancel()
 
 	// filter output after getting results if info about all shards is requested


### PR DESCRIPTION
### What's being changed:

Adds an environment variable, WEAVIATE_MINIMUM_TIMEOUT, that allows users to increase the default query timeout above 30s.  This allows long running calls such as node status to succeed.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
