### PR TITLE
Make shard init less verbose, allow runtime override

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -416,6 +416,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		QuerySlowLogThreshold:       appState.ServerConfig.Config.QuerySlowLogThreshold,
 		InvertedSorterDisabled:      appState.ServerConfig.Config.InvertedSorterDisabled,
 		MaintenanceModeEnabled:      appState.Cluster.MaintenanceModeEnabledForLocalhost,
+		ShardInitLogLevel:           appState.ServerConfig.Config.ShardInitLogLevel,
 	}, remoteIndexClient, appState.Cluster, remoteNodesClient, replicationClient, appState.Metrics, appState.MemWatch) // TODO client
 	if err != nil {
 		appState.Logger.
@@ -1729,6 +1730,7 @@ func initRuntimeOverrides(appState *state.State) {
 		registered.QuerySlowLogEnabled = appState.ServerConfig.Config.QuerySlowLogEnabled
 		registered.QuerySlowLogThreshold = appState.ServerConfig.Config.QuerySlowLogThreshold
 		registered.InvertedSorterDisabled = appState.ServerConfig.Config.InvertedSorterDisabled
+		registered.ShardInitLogLevel = appState.ServerConfig.Config.ShardInitLogLevel
 
 		hooks := make(map[string]func() error)
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -677,6 +677,7 @@ type IndexConfig struct {
 	QuerySlowLogThreshold               *configRuntime.DynamicValue[time.Duration]
 	InvertedSorterDisabled              *configRuntime.DynamicValue[bool]
 	MaintenanceModeEnabled              func() bool
+	ShardInitLogLevel                   *configRuntime.DynamicValue[string]
 }
 
 func indexID(class schema.ClassName) string {

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -115,6 +115,7 @@ func (db *DB) init(ctx context.Context) error {
 				QuerySlowLogThreshold:               db.config.QuerySlowLogThreshold,
 				InvertedSorterDisabled:              db.config.InvertedSorterDisabled,
 				MaintenanceModeEnabled:              db.config.MaintenanceModeEnabled,
+				ShardInitLogLevel:                   db.config.ShardInitLogLevel,
 			}, db.schemaGetter.CopyShardingState(class.Class),
 				inverted.ConfigFromModel(invertedConfig),
 				convertToVectorIndexConfig(class.VectorIndexConfig),

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -141,6 +141,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 			QuerySlowLogEnabled:                 m.db.config.QuerySlowLogEnabled,
 			QuerySlowLogThreshold:               m.db.config.QuerySlowLogThreshold,
 			InvertedSorterDisabled:              m.db.config.InvertedSorterDisabled,
+			ShardInitLogLevel:                   m.db.config.ShardInitLogLevel,
 		},
 		shardState,
 		// no backward-compatibility check required, since newly added classes will

--- a/adapters/repos/db/migrator_test.go
+++ b/adapters/repos/db/migrator_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
@@ -89,6 +90,7 @@ func TestUpdateIndexTenants(t *testing.T) {
 				RootPath:          t.TempDir(),
 				ReplicationFactor: 1,
 				ShardLoadLimiter:  NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
+				ShardInitLogLevel: configRuntime.NewDynamicValue("debug"),
 			}, originalSS, inverted.ConfigFromModel(class.InvertedIndexConfig),
 				hnsw.NewDefaultUserConfig(), nil, mockSchemaGetter, nil, logger, nil, nil, nil, nil, nil, class, nil, scheduler, nil, nil, NewShardReindexerV3Noop())
 			require.NoError(t, err)
@@ -218,6 +220,7 @@ func TestUpdateIndexShards(t *testing.T) {
 				RootPath:          t.TempDir(),
 				ReplicationFactor: 1,
 				ShardLoadLimiter:  NewShardLoadLimiter(monitoring.NoopRegisterer, 1),
+				ShardInitLogLevel: configRuntime.NewDynamicValue("debug"),
 			}, initialState, inverted.ConfigFromModel(class.InvertedIndexConfig),
 				hnsw.NewDefaultUserConfig(), nil, mockSchemaGetter, nil, logger, nil, nil, nil, nil, nil, class, nil, scheduler, nil, memwatch.NewDummyMonitor(), NewShardReindexerV3Noop())
 			require.NoError(t, err)

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -232,6 +232,7 @@ type Config struct {
 	QuerySlowLogThreshold               *configRuntime.DynamicValue[time.Duration]
 	InvertedSorterDisabled              *configRuntime.DynamicValue[bool]
 	MaintenanceModeEnabled              func() bool
+	ShardInitLogLevel                   *configRuntime.DynamicValue[string]
 }
 
 // GetIndex returns the index if it exists or nil if it doesn't

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
@@ -197,6 +198,7 @@ type Shard struct {
 	propertyIndices   propertyspecific.Indices
 	propLenTracker    *inverted.JsonShardMetaData
 	versioner         *shardVersioner
+	initLogLevel      logrus.Level
 
 	vectorIndexMu sync.RWMutex
 	vectorIndex   VectorIndex

--- a/adapters/repos/db/shard_debug.go
+++ b/adapters/repos/db/shard_debug.go
@@ -51,7 +51,7 @@ func (s *Shard) DebugResetVectorIndex(ctx context.Context, targetVector string) 
 		newConfig = s.index.vectorIndexUserConfigs[targetVector]
 	}
 
-	vidx, err = s.initVectorIndex(ctx, targetVector, newConfig)
+	vidx, err = s.initVectorIndex(ctx, targetVector, newConfig, s.initLogLevel)
 	if err != nil {
 		return errors.Wrap(err, "init vector index")
 	}

--- a/adapters/repos/db/shard_init_lsm.go
+++ b/adapters/repos/db/shard_init_lsm.go
@@ -37,7 +37,8 @@ func (s *Shard) initNonVector(ctx context.Context, class *models.Class) error {
 		s.index.logger.WithFields(logrus.Fields{
 			"action":   "init_shard_non_vector",
 			"duration": took,
-		}).Debugf("loaded non-vector (lsm, object, inverted) in %s for shard %q", took, s.ID())
+			"shard":    s.ID(),
+		}).Logf(s.initLogLevel, "loaded non-vector (lsm, object, inverted) in %s for shard %q", took, s.ID())
 	}()
 
 	// the shard versioner is also dependency of some of the bucket
@@ -101,7 +102,7 @@ func (s *Shard) initNonVector(ctx context.Context, class *models.Class) error {
 			return fmt.Errorf("init async replication on shard %q: %w", s.ID(), err)
 		}
 	} else if s.index.replicationEnabled() {
-		s.index.logger.Infof("async replication disabled on shard %q", s.ID())
+		s.index.logger.WithField("shard", s.ID()).Logf(s.initLogLevel, "async replication disabled on shard %q", s.ID())
 	}
 
 	// check if we need to set Inverted Index config to use BlockMax inverted format for new properties

--- a/adapters/repos/db/vector/hnsw/config.go
+++ b/adapters/repos/db/vector/hnsw/config.go
@@ -47,6 +47,7 @@ type Config struct {
 	ClassName string
 
 	VisitedListPoolMaxSize int
+	InitLogLevel           logrus.Level
 }
 
 func (c Config) Validate() error {

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -189,6 +189,8 @@ type hnsw struct {
 	docIDVectors map[uint64][]uint64
 	vecIDcounter uint64
 	maxDocID     uint64
+
+	initLogLevel logrus.Level
 }
 
 type CommitLogger interface {
@@ -237,6 +239,10 @@ func New(cfg Config, uc ent.UserConfig,
 		logger := logrus.New()
 		logger.Out = io.Discard
 		cfg.Logger = logger
+	}
+
+	if cfg.InitLogLevel == 0 {
+		cfg.InitLogLevel = logrus.DebugLevel
 	}
 
 	normalizeOnRead := false
@@ -291,8 +297,9 @@ func New(cfg Config, uc ent.UserConfig,
 		efMax:    int64(uc.DynamicEFMax),
 		efFactor: int64(uc.DynamicEFFactor),
 
-		metrics:   NewMetrics(cfg.PrometheusMetrics, cfg.ClassName, cfg.ShardName),
-		shardName: cfg.ShardName,
+		metrics:      NewMetrics(cfg.PrometheusMetrics, cfg.ClassName, cfg.ShardName),
+		shardName:    cfg.ShardName,
+		initLogLevel: cfg.InitLogLevel,
 
 		randFunc:                  rand.Float64,
 		compressActionLock:        &sync.RWMutex{},

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -380,13 +380,13 @@ func (h *hnsw) prefillCache() {
 		h.logger.WithFields(logrus.Fields{
 			"action":                 "hnsw_prefill_cache_sync",
 			"wait_for_cache_prefill": true,
-		}).Info("waiting for vector cache prefill to complete")
+		}).Logf(h.initLogLevel, "waiting for vector cache prefill to complete")
 		f()
 	} else {
 		h.logger.WithFields(logrus.Fields{
 			"action":                 "hnsw_prefill_cache_async",
 			"wait_for_cache_prefill": false,
-		}).Info("not waiting for vector cache prefill, running in background")
+		}).Logf(h.initLogLevel, "not waiting for vector cache prefill, running in background")
 		enterrors.GoWrapper(f, h.logger)
 	}
 }

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller.go
@@ -113,7 +113,7 @@ func (pf *vectorCachePrefiller[T]) logTotal(count, limit int, before time.Time) 
 		"count":    count,
 		"took":     time.Since(before),
 		"index_id": pf.index.id,
-	}).Info("prefilled vector cache")
+	}).Logf(pf.index.initLogLevel, "prefilled vector cache")
 }
 
 func levelOfNode(node *vertex) int {

--- a/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
+++ b/adapters/repos/db/vector/hnsw/vector_cache_prefiller_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
@@ -26,6 +27,7 @@ func TestVectorCachePrefilling(t *testing.T) {
 		nodes:               generateDummyVertices(100),
 		currentMaximumLayer: 3,
 		shardedNodeLocks:    common.NewDefaultShardedRWLocks(),
+		initLogLevel:        logrus.DebugLevel,
 	}
 
 	logger, _ := test.NewNullLogger()

--- a/tools/dev/config.runtime-overrides.yaml
+++ b/tools/dev/config.runtime-overrides.yaml
@@ -6,6 +6,7 @@ tenant_activity_write_log_level: info
 query_slow_log_enabled: true
 query_slow_log_threshold: 100ms
 inverted_sorter_disabled: false
+shard_init_log_level: debug
 
 # exp_oidc_username_claim: "sub"
 # exp_oidc_client_id: "<client_id>"

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -204,6 +204,14 @@ type Config struct {
 	//
 	// This flat may be removed in the future.
 	InvertedSorterDisabled *runtime.DynamicValue[bool] `json:"inverted_sorter_disabled" yaml:"inverted_sorter_disabled"`
+
+	// ShardInitLogLevel is 'debug' by default as every single shard initialization
+	// will log something (e.g. shard ready, async replication state, etc.)
+	// However, this may temporarily be desired, e.g. for analysis or debugging
+	// purposes. In this case the log level can be elevated, e.g. to 'info'. This
+	// is overall less noisy than changing the global log level, but still allows
+	// to see all tenant write activity.
+	ShardInitLogLevel *runtime.DynamicValue[string] `json:"shard_init_log_level" yaml:"shard_init_log_level"`
 }
 
 type MapToBlockamaxConfig struct {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -579,6 +579,12 @@ func FromEnv(config *Config) error {
 	}
 	config.TenantActivityWriteLogLevel = runtime.NewDynamicValue(tenantActivityWriteLogLevel)
 
+	shardInitLogLevel := "debug"
+	if v := os.Getenv("SHARD_INIT_LOG_LEVEL"); v != "" {
+		shardInitLogLevel = v
+	}
+	config.ShardInitLogLevel = runtime.NewDynamicValue(shardInitLogLevel)
+
 	ru, err := parseResourceUsageEnvVars()
 	if err != nil {
 		return err

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -37,6 +37,7 @@ type WeaviateRuntimeConfig struct {
 	QuerySlowLogEnabled            *runtime.DynamicValue[bool]          `json:"query_slow_log_enabled" yaml:"query_slow_log_enabled"`
 	QuerySlowLogThreshold          *runtime.DynamicValue[time.Duration] `json:"query_slow_log_threshold" yaml:"query_slow_log_threshold"`
 	InvertedSorterDisabled         *runtime.DynamicValue[bool]          `json:"inverted_sorter_disabled" yaml:"inverted_sorter_disabled"`
+	ShardInitLogLevel              *runtime.DynamicValue[string]        `json:"shard_init_log_level" yaml:"shard_init_log_level"`
 
 	// Experimental configs. Will be removed in the future.
 	OIDCIssuer            *runtime.DynamicValue[string]   `json:"exp_oidc_issuer" yaml:"exp_oidc_issuer"`


### PR DESCRIPTION
### What's being changed:

- Previously, shard initialization logs were all over the place, some were `debug`, some were `info` etc. 
- The overall impression was that they were noisy
- This PR sets all init logs to `debug` by default
- Additionally the initialization log level can be changed at runtime (without restarts) by setting `shard_init_log_level: info` in the runtime config. This would elevate all init-related logs to `info` level 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
