### PR TITLE
fix: prevent double processing of object digests

### DIFF
--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -143,6 +143,8 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 	cursor := bucket.CursorOnDisk()
 	defer cursor.Close()
 
+	inmemProcessedDocIDs := make(map[uint64]struct{})
+
 	n := 0
 
 	// note: read-write access to active and flushing memtable will be blocked only during the scope of this inner function
@@ -169,6 +171,8 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 
 				objs = append(objs, replicaObj)
 
+				inmemProcessedDocIDs[obj.DocID] = struct{}{}
+
 				n++
 			}
 		}
@@ -187,6 +191,10 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 			obj, err := storobj.FromBinaryUUIDOnly(v)
 			if err != nil {
 				return objs, fmt.Errorf("cannot unmarshal object: %w", err)
+			}
+
+			if _, ok := inmemProcessedDocIDs[obj.DocID]; ok {
+				continue
 			}
 
 			replicaObj := replica.RepairResponse{


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
