### PR TITLE
chore(alias): Tweak error message on create alias.

### DIFF
--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -643,8 +643,9 @@ func (s *schema) createAlias(class, alias string) error {
 	if cls, _ := s.unsafeReadOnlyClass(class); cls == nil {
 		return fmt.Errorf("create alias: class %s does not exist", class)
 	}
+	// trying to check if any class exists with passed 'alias' name
 	if other := s.unsafeClassEqual(alias); other == alias {
-		return fmt.Errorf("create alias: class %s already exists", class)
+		return fmt.Errorf("create alias: class %s already exists", alias)
 	}
 	s.aliases[alias] = class
 	return nil

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -360,6 +360,7 @@ func TestCreateAlias(t *testing.T) {
 	)
 
 	require.Nil(t, sc.addClass(&models.Class{Class: "C"}, ss, 1))
+	require.Nil(t, sc.addClass(&models.Class{Class: "AnotherClass"}, ss, 1))
 
 	t.Run("successfully create alias", func(t *testing.T) {
 		err := sc.createAlias("C", "A1")
@@ -379,6 +380,13 @@ func TestCreateAlias(t *testing.T) {
 	t.Run("fail on non-existing alias", func(t *testing.T) {
 		err := sc.createAlias("D", "A1")
 		require.EqualError(t, err, "create alias: alias A1 already exists")
+	})
+	t.Run("fail on creating alias with existing class name", func(t *testing.T) {
+		// We have two collection. "C" and "AnotherClass"
+		// 1. We try to create alias with name "AnotherClass" to class "C".
+		// 2. Should fail saying class with "AnotherClass" already exists.
+		err := sc.createAlias("C", "AnotherClass")
+		require.EqualError(t, err, "create alias: class AnotherClass already exists")
 	})
 }
 


### PR DESCRIPTION
When trying to create alias with collection name that already exists as collection, make error message more clear.

Say we have following collection
1. A
2. B

And you try to create alias with name "A" to collection "B".

Before:
```
create alias: class B already exists
```

After:
```
create alias: Class A already exists
```

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
