### PR TITLE
Fix filtered search multivector and quantization

### DIFF
--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -766,13 +766,11 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 			} else {
 				for _, id := range entryPointNode.connections[0] {
 					if isMultivec {
-						var docID uint64
 						if h.compressed.Load() {
-							docID, _ = h.compressor.GetKeys(id)
+							id, _ = h.compressor.GetKeys(id)
 						} else {
-							docID, _ = h.cache.GetKeys(id)
+							id, _ = h.cache.GetKeys(id)
 						}
-						id = docID
 					}
 					if allowList.Contains(id) {
 						counter++

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -334,7 +334,12 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 								continue
 							}
 						} else {
-							docID, _ := h.cache.GetKeys(nodeId)
+							var docID uint64
+							if h.compressed.Load() {
+								docID, _ = h.compressor.GetKeys(nodeId)
+							} else {
+								docID, _ = h.cache.GetKeys(nodeId)
+							}
 							if allowList.Contains(docID) {
 								connectionsReusable[realLen] = nodeId
 								realLen++
@@ -377,7 +382,12 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 								pendingNextRound = append(pendingNextRound, expId)
 							}
 						} else {
-							docID, _ := h.cache.GetKeys(expId)
+							var docID uint64
+							if h.compressed.Load() {
+								docID, _ = h.compressor.GetKeys(expId)
+							} else {
+								docID, _ = h.cache.GetKeys(expId)
+							}
 							if allowList.Contains(docID) {
 								visitedExp.Visit(expId)
 								connectionsReusable[realLen] = expId
@@ -407,7 +417,12 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 
 			if strategy == RRE && level == 0 {
 				if isMultivec {
-					docID, _ := h.cache.GetKeys(neighborID)
+					var docID uint64
+					if h.compressed.Load() {
+						docID, _ = h.compressor.GetKeys(neighborID)
+					} else {
+						docID, _ = h.cache.GetKeys(neighborID)
+					}
 					if !allowList.Contains(docID) {
 						continue
 					}
@@ -444,7 +459,12 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 					// filter restricting this search further. As a result we have to
 					// ignore items not on the list
 					if isMultivec {
-						docID, _ := h.cache.GetKeys(neighborID)
+						var docID uint64
+						if h.compressed.Load() {
+							docID, _ = h.compressor.GetKeys(neighborID)
+						} else {
+							docID, _ = h.cache.GetKeys(neighborID)
+						}
 						if !allowList.Contains(docID) {
 							continue
 						}
@@ -508,7 +528,12 @@ func (h *hnsw) insertViableEntrypointsAsCandidatesAndResults(
 			// filter restricting this search further. As a result we have to
 			// ignore items not on the list
 			if isMultivec {
-				docID, _ := h.cache.GetKeys(ep.ID)
+				var docID uint64
+				if h.compressed.Load() {
+					docID, _ = h.compressor.GetKeys(ep.ID)
+				} else {
+					docID, _ = h.cache.GetKeys(ep.ID)
+				}
 				if !allowList.Contains(docID) {
 					continue
 				}
@@ -741,7 +766,13 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 			} else {
 				for _, id := range entryPointNode.connections[0] {
 					if isMultivec {
-						id, _ = h.cache.GetKeys(id)
+						var docID uint64
+						if h.compressed.Load() {
+							docID, _ = h.compressor.GetKeys(id)
+						} else {
+							docID, _ = h.cache.GetKeys(id)
+						}
+						id = docID
 					}
 					if allowList.Contains(id) {
 						counter++


### PR DESCRIPTION
### What's being changed:
This PR fixes filtered search on multivector + quantization when the elements in the allow list are above the cutoff. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
