### PR TITLE
Fixing hybrid index collision buckets

### DIFF
--- a/adapters/repos/db/vector/dynamic/config.go
+++ b/adapters/repos/db/vector/dynamic/config.go
@@ -28,25 +28,26 @@ import (
 )
 
 type Config struct {
-	ID                    string
-	TargetVector          string
-	Logger                logrus.FieldLogger
-	RootPath              string
-	ShardName             string
-	ClassName             string
-	PrometheusMetrics     *monitoring.PrometheusMetrics
-	VectorForIDThunk      common.VectorForID[float32]
-	TempVectorForIDThunk  common.TempVectorForID[float32]
-	DistanceProvider      distancer.Provider
-	MakeCommitLoggerThunk hnsw.MakeCommitLogger
-	TombstoneCallbacks    cyclemanager.CycleCallbackGroup
-	SharedDB              *bolt.DB
-	HNSWDisableSnapshots  bool
-	HNSWSnapshotOnStartup bool
-	MinMMapSize           int64
-	MaxWalReuseSize       int64
-	LazyLoadSegments      bool
-	AllocChecker          memwatch.AllocChecker
+	ID                      string
+	TargetVector            string
+	Logger                  logrus.FieldLogger
+	RootPath                string
+	ShardName               string
+	ClassName               string
+	PrometheusMetrics       *monitoring.PrometheusMetrics
+	VectorForIDThunk        common.VectorForID[float32]
+	TempVectorForIDThunk    common.TempVectorForID[float32]
+	DistanceProvider        distancer.Provider
+	MakeCommitLoggerThunk   hnsw.MakeCommitLogger
+	TombstoneCallbacks      cyclemanager.CycleCallbackGroup
+	SharedDB                *bolt.DB
+	HNSWDisableSnapshots    bool
+	HNSWSnapshotOnStartup   bool
+	HNSWWaitForCachePrefill bool
+	MinMMapSize             int64
+	MaxWalReuseSize         int64
+	LazyLoadSegments        bool
+	AllocChecker            memwatch.AllocChecker
 }
 
 func (c Config) Validate() error {

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -608,11 +608,13 @@ func (dynamic *dynamic) doUpgrade() error {
 	dynamic.index = index
 	dynamic.upgraded.Store(true)
 
+	bDir := dynamic.store.Bucket(dynamic.getBucketName()).GetDir()
 	dynamic.store.ShutdownBucket(ctx, dynamic.getBucketName())
-	os.RemoveAll(filepath.Join(dynamic.rootPath, "lsm", dynamic.getBucketName()))
+	os.RemoveAll(bDir)
 	if dynamic.flatBQ && !dynamic.hnswUC.BQ.Enabled {
+		bDir = dynamic.store.Bucket(dynamic.getCompressedBucketName()).GetDir()
 		dynamic.store.ShutdownBucket(ctx, dynamic.getCompressedBucketName())
-		os.RemoveAll(filepath.Join(dynamic.rootPath, "lsm", dynamic.getCompressedBucketName()))
+		os.RemoveAll(bDir)
 	}
 
 	return nil

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -262,6 +262,13 @@ func (dynamic *dynamic) getBucketName() string {
 	return helpers.VectorsBucketLSM
 }
 
+func (dynamic *dynamic) getCompressedBucketName() string {
+	if dynamic.targetVector != "" {
+		return fmt.Sprintf("%s_%s", helpers.VectorsCompressedBucketLSM, dynamic.targetVector)
+	}
+	return helpers.VectorsCompressedBucketLSM
+}
+
 func (dynamic *dynamic) Compressed() bool {
 	dynamic.RLock()
 	defer dynamic.RUnlock()
@@ -594,8 +601,9 @@ func (dynamic *dynamic) doUpgrade() error {
 		return errors.Wrap(err, "update dynamic")
 	}
 
-	dynamic.index = index
 	dynamic.upgraded.Store(true)
+	os.RemoveAll(filepath.Join(dynamic.rootPath, "lsm", dynamic.getBucketName()))
+	os.RemoveAll(filepath.Join(dynamic.rootPath, "lsm", dynamic.getCompressedBucketName()))
 
 	return nil
 }

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -338,7 +338,7 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("ASYNC_INDEXING", "true")
 	dimensions := 20
-	vectors_size := 3_000
+	vectors_size := 10_000
 	threshold := 2_000
 	queries_size := 10
 	k := 10

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -333,3 +333,134 @@ func TestDynamicUpgradeCancelation(t *testing.T) {
 		t.Fatal("upgrade callback was not called")
 	}
 }
+
+func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
+	ctx := context.Background()
+	t.Setenv("ASYNC_INDEXING", "true")
+	dimensions := 20
+	vectors_size := 10_000
+	threshold := 2_000
+	queries_size := 10
+	k := 10
+
+	tempDir := t.TempDir()
+
+	db, err := bbolt.Open(filepath.Join(tempDir, "index.db"), 0o666, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	vectors, queries := testinghelpers.RandomVecs(vectors_size, queries_size, dimensions)
+	rootPath := tempDir
+	distancer := distancer.NewL2SquaredProvider()
+	truths := make([][]uint64, queries_size)
+	compressionhelpers.Concurrently(logger, uint64(len(queries)), func(i uint64) {
+		truths[i], _ = testinghelpers.BruteForce(logger, vectors, queries[i], k, testinghelpers.DistanceWrapper(distancer))
+	})
+	noopCallback := cyclemanager.NewCallbackGroupNoop()
+	fuc := flatent.UserConfig{}
+	fuc.SetDefaults()
+	fuc.BQ = flatent.CompressionUserConfig{
+		Enabled: true,
+		Cache:   true,
+	}
+	hnswuc := hnswent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        64,
+		EF:                    32,
+		VectorCacheMaxObjects: 1_000_000,
+		PQ: hnswent.PQConfig{
+			Enabled:        true,
+			BitCompression: false,
+			Segments:       5,
+			Centroids:      255,
+			TrainingLimit:  threshold - 1,
+			Encoder: hnswent.PQEncoder{
+				Type:         hnswent.PQEncoderTypeKMeans,
+				Distribution: hnswent.PQEncoderDistributionLogNormal,
+			},
+		},
+	}
+
+	config := Config{
+		TargetVector: "",
+		RootPath:     rootPath,
+		ID:           "vector-test_0",
+		MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
+			return hnsw.NewCommitLogger(tempDir, "vector-test_0", logger, noopCallback)
+		},
+		DistanceProvider: distancer,
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			vec := vectors[int(id)]
+			if vec == nil {
+				return nil, storobj.NewErrNotFoundf(id, "nil vec")
+			}
+			return vec, nil
+		},
+		TempVectorForIDThunk:    TempVectorForIDThunk(vectors),
+		TombstoneCallbacks:      noopCallback,
+		SharedDB:                db,
+		HNSWWaitForCachePrefill: true,
+	}
+	uc := ent.UserConfig{
+		Threshold: uint64(threshold),
+		Distance:  distancer.Type(),
+		HnswUC:    hnswuc,
+		FlatUC:    fuc,
+	}
+
+	dummyStore := testinghelpers.NewDummyStore(t)
+	dynamic, err := New(config, uc, dummyStore)
+	require.NoError(t, err)
+
+	compressionhelpers.Concurrently(logger, uint64(threshold), func(i uint64) {
+		err := dynamic.Add(ctx, i, vectors[i])
+		require.NoError(t, err)
+	})
+	shouldUpgrade, at := dynamic.ShouldUpgrade()
+	assert.True(t, shouldUpgrade)
+	assert.Equal(t, threshold, at)
+	assert.False(t, dynamic.Upgraded())
+	var wg sync.WaitGroup
+	wg.Add(1)
+
+	// flat -> hnsw
+	err = dynamic.Upgrade(func() {
+		wg.Done()
+	})
+	require.NoError(t, err)
+	wg.Wait()
+	wg.Add(1)
+
+	// PQ
+	err = dynamic.Upgrade(func() {
+		wg.Done()
+	})
+	require.NoError(t, err)
+	wg.Wait()
+	compressionhelpers.Concurrently(logger, uint64(vectors_size-threshold), func(i uint64) {
+		err := dynamic.Add(ctx, uint64(threshold)+i, vectors[threshold+int(i)])
+		require.NoError(t, err)
+	})
+
+	recall, latency := testinghelpers.RecallAndLatency(ctx, queries, k, dynamic, truths)
+	fmt.Println(recall, latency)
+
+	err = dynamic.Flush()
+	require.NoError(t, err)
+	err = dynamic.Shutdown(t.Context())
+	require.NoError(t, err)
+	dummyStore.FlushMemtables(t.Context())
+
+	// open the db again
+	db, err = bbolt.Open(filepath.Join(tempDir, "index.db"), 0o666, nil)
+	require.NoError(t, err)
+	config.SharedDB = db
+
+	dynamic, err = New(config, uc, dummyStore)
+	require.NoError(t, err)
+	dynamic.PostStartup()
+	recall2, _ := testinghelpers.RecallAndLatency(ctx, queries, k, dynamic, truths)
+	assert.Equal(t, recall, recall2)
+}

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -338,7 +338,7 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("ASYNC_INDEXING", "true")
 	dimensions := 20
-	vectors_size := 5_000
+	vectors_size := 3_000
 	threshold := 2_000
 	queries_size := 10
 	k := 10

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -338,7 +338,7 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("ASYNC_INDEXING", "true")
 	dimensions := 20
-	vectors_size := 10_000
+	vectors_size := 5_000
 	threshold := 2_000
 	queries_size := 10
 	k := 10

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -1056,3 +1056,15 @@ type FlatStats struct{}
 func (s *FlatStats) IndexType() common.IndexType {
 	return common.IndexTypeFlat
 }
+
+func (h *flat) ShouldUpgrade() (bool, int) {
+	return false, 0
+}
+
+func (h *flat) Upgrade(callback func()) error {
+	return nil
+}
+
+func (h *flat) Upgraded() bool {
+	return false
+}


### PR DESCRIPTION
### What's being changed:

When using dynamic index with BQ enabled for flat and PQ enabled for hnsw and an empty targetVector, the two under the hood indices share the same bucket and mix different endianness which end up in panics when refilling the compressed cache. Furthermore, both buckets (uncompressed and compressed) used during the flat index are no longer needed, but they are kept on disk. This PR cleans the buckets before upgrading to HNSW.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
