### PR TITLE
Descriptive error message on malformed reference property

### DIFF
--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -175,7 +175,7 @@ func removeReference(obj *models.Object, prop string, remove *models.SingleRef) 
 
 	refs, ok := properties[prop].(models.MultipleRef)
 	if !ok {
-		return false, fmt.Sprintf("property %q with type %T is not a valid cross-reference", prop, refs)
+		return false, fmt.Sprintf("property %s of type %T is not a valid cross-reference", prop, refs)
 	}
 
 	var removed bool


### PR DESCRIPTION
### What's being changed:

During `DELETE /objects/.../references` call, if the property is not `models.MultipleRef`, Weaviate returns a cryptic message: `"source list is not well formed"`.

This PR provides a more descriptive error message instead.

Additionally, I used `slices.DeleteFunc` to remove a reference from the list, because it does so without allocating a new slice.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
