### PR TITLE
refact(offloading): delete frozen shards from index no matter closed or not

### DIFF
--- a/adapters/repos/db/migrator_shard_status_ops.go
+++ b/adapters/repos/db/migrator_shard_status_ops.go
@@ -39,17 +39,12 @@ func (m *Migrator) frozen(ctx context.Context, idx *Index, frozen []string, ec *
 	eg.SetLimit(_NUMCPU * 2)
 
 	for _, name := range frozen {
-		name := name
 		eg.Go(func() error {
-			shard, release, err := idx.getOrInitShard(ctx, name)
-			if err != nil {
-				ec.Add(err)
-				return nil
-			}
+			idx.shardCreateLocks.Lock(name)
+			defer idx.shardCreateLocks.Unlock(name)
 
-			defer release()
-
-			if shard == nil {
+			shard, ok := idx.shards.LoadAndDelete(name)
+			if !ok {
 				// shard already does not exist or inactive, so remove local files if exists
 				// this pass will happen if the shard was COLD for example
 				if err := os.RemoveAll(fmt.Sprintf("%s/%s", idx.path(), name)); err != nil {
@@ -59,11 +54,6 @@ func (m *Migrator) frozen(ctx context.Context, idx *Index, frozen []string, ec *
 				}
 				return nil
 			}
-
-			idx.shardCreateLocks.Lock(name)
-			defer idx.shardCreateLocks.Unlock(name)
-
-			idx.shards.LoadAndDelete(name)
 
 			if err := shard.drop(); err != nil {
 				ec.Add(err)


### PR DESCRIPTION
### What's being changed:
this PR remove unnecessary init for shards on offloading 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
