### PR TITLE
refact(usage): auto enable TrackVectorDimensions for usage without Prometheus  metrics pushing

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -415,6 +415,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		QueryNestedRefLimit:                 appState.ServerConfig.Config.QueryNestedCrossReferenceLimit,
 		MaxImportGoroutinesFactor:           appState.ServerConfig.Config.MaxImportGoroutinesFactor,
 		TrackVectorDimensions:               appState.ServerConfig.Config.TrackVectorDimensions || appState.Modules.UsageEnabled(),
+		UsageEnabled:                        appState.Modules.UsageEnabled(),
 		ResourceUsage:                       appState.ServerConfig.Config.ResourceUsage,
 		AvoidMMap:                           appState.ServerConfig.Config.AvoidMmap,
 		DisableLazyLoadShards:               appState.ServerConfig.Config.DisableLazyLoadShards,

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -414,7 +414,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 		QueryHybridMaximumResults:           appState.ServerConfig.Config.QueryHybridMaximumResults,
 		QueryNestedRefLimit:                 appState.ServerConfig.Config.QueryNestedCrossReferenceLimit,
 		MaxImportGoroutinesFactor:           appState.ServerConfig.Config.MaxImportGoroutinesFactor,
-		TrackVectorDimensions:               appState.ServerConfig.Config.TrackVectorDimensions,
+		TrackVectorDimensions:               appState.ServerConfig.Config.TrackVectorDimensions || appState.Modules.UsageEnabled(),
 		ResourceUsage:                       appState.ServerConfig.Config.ResourceUsage,
 		AvoidMMap:                           appState.ServerConfig.Config.AvoidMmap,
 		DisableLazyLoadShards:               appState.ServerConfig.Config.DisableLazyLoadShards,
@@ -730,7 +730,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 	configureServer = makeConfigureServer(appState)
 
 	// Add dimensions to all the objects in the database, if requested by the user
-	if appState.ServerConfig.Config.ReindexVectorDimensionsAtStartup {
+	if appState.ServerConfig.Config.ReindexVectorDimensionsAtStartup || appState.Modules.UsageEnabled() {
 		appState.Logger.
 			WithField("action", "startup").
 			Info("Reindexing dimensions")

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -730,7 +730,7 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 	configureServer = makeConfigureServer(appState)
 
 	// Add dimensions to all the objects in the database, if requested by the user
-	if appState.ServerConfig.Config.ReindexVectorDimensionsAtStartup || appState.Modules.UsageEnabled() {
+	if appState.ServerConfig.Config.ReindexVectorDimensionsAtStartup && repo.GetConfig().TrackVectorDimensions {
 		appState.Logger.
 			WithField("action", "startup").
 			Info("Reindexing dimensions")

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -707,6 +707,7 @@ type IndexConfig struct {
 	TransferInactivityTimeout           time.Duration
 	LSMEnableSegmentsChecksumValidation bool
 	TrackVectorDimensions               bool
+	UsageEnabled                        bool
 	ShardLoadLimiter                    ShardLoadLimiter
 
 	HNSWMaxLogSize                               int64

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -18,11 +18,11 @@ import (
 	"path"
 	"time"
 
-	"github.com/weaviate/weaviate/cluster/router"
-
 	"github.com/pkg/errors"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/cluster/router"
 	"github.com/weaviate/weaviate/entities/diskio"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
@@ -111,6 +111,7 @@ func (db *DB) init(ctx context.Context) error {
 				IndexRangeableInMemory:                       db.config.IndexRangeableInMemory,
 				MaxSegmentSize:                               db.config.MaxSegmentSize,
 				TrackVectorDimensions:                        db.config.TrackVectorDimensions,
+				UsageEnabled:                                 db.config.UsageEnabled,
 				AvoidMMap:                                    db.config.AvoidMMap,
 				DisableLazyLoadShards:                        db.config.DisableLazyLoadShards,
 				ForceFullReplicasSearch:                      db.config.ForceFullReplicasSearch,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -17,8 +17,6 @@ import (
 	"slices"
 	"time"
 
-	"github.com/weaviate/weaviate/cluster/router"
-
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
@@ -28,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/flat"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	command "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/router"
 	"github.com/weaviate/weaviate/cluster/types"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -138,6 +137,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class,
 			IndexRangeableInMemory:                       m.db.config.IndexRangeableInMemory,
 			MaxSegmentSize:                               m.db.config.MaxSegmentSize,
 			TrackVectorDimensions:                        m.db.config.TrackVectorDimensions,
+			UsageEnabled:                                 m.db.config.UsageEnabled,
 			AvoidMMap:                                    m.db.config.AvoidMMap,
 			DisableLazyLoadShards:                        m.db.config.DisableLazyLoadShards,
 			ForceFullReplicasSearch:                      m.db.config.ForceFullReplicasSearch,

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -235,6 +235,7 @@ type Config struct {
 	SeparateObjectsCompactions          bool
 	MaxSegmentSize                      int64
 	TrackVectorDimensions               bool
+	UsageEnabled                        bool
 	ServerVersion                       string
 	GitHash                             string
 	AvoidMMap                           bool

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -145,7 +145,6 @@ type ShardLike interface {
 	// Dimensions returns the total number of dimensions for a given vector
 	Dimensions(ctx context.Context, targetVector string) (int, error)
 	// DimensionsUsage returns the total number of dimensions and the number of objects for a given vector
-	// TODO: rename to DimensionsUsage struct and find a better way because of import cycle
 	DimensionsUsage(ctx context.Context, targetVector string) (usagetypes.Dimensionality, error)
 	QuantizedDimensions(ctx context.Context, targetVector string, segments int) int
 

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -88,13 +88,15 @@ func (s *Shard) calcTargetVectorDimensions(ctx context.Context, targetVector str
 	return calcTargetVectorDimensionsFromStore(ctx, s.store, targetVector, calcEntry), nil
 }
 
+// initDimensionTracking initializes the dimension tracking for a shard.
+// it's no op if the trackVectorDimensions is disabled or the usage is enabled
 func (s *Shard) initDimensionTracking() {
 	// do not use the context passed from NewShard, as that one is only meant for
 	// initialization. However, this goroutine keeps running forever, so if the
 	// startup context expires, this would error.
 	// https://github.com/weaviate/weaviate/issues/5091
 	rootCtx := context.Background()
-	if s.index.Config.TrackVectorDimensions {
+	if s.index.Config.TrackVectorDimensions && !s.index.Config.UsageEnabled {
 		s.dimensionTrackingInitialized.Store(true)
 
 		// The timeout is rather arbitrary, it's just meant to prevent a context

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -15,8 +15,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/cluster/usage/types"
@@ -103,10 +101,6 @@ func (s *Shard) initDimensionTracking() {
 		// leak. The actual work should be much faster.
 		ctx, cancel := context.WithTimeout(rootCtx, 30*time.Minute)
 		defer cancel()
-		s.index.logger.WithFields(logrus.Fields{
-			"action":   "init_dimension_tracking",
-			"duration": 30 * time.Minute,
-		}).Debug("context.WithTimeout")
 
 		// always send vector dimensions at startup if tracking is enabled
 		s.publishDimensionMetrics(ctx)
@@ -125,10 +119,6 @@ func (s *Shard) initDimensionTracking() {
 						// leak. The actual work should be much faster.
 						ctx, cancel := context.WithTimeout(rootCtx, 30*time.Minute)
 						defer cancel()
-						s.index.logger.WithFields(logrus.Fields{
-							"action":   "init_dimension_tracking",
-							"duration": 30 * time.Minute,
-						}).Debug("context.WithTimeout")
 						s.publishDimensionMetrics(ctx)
 					}()
 				}

--- a/cluster/usage/types/types.go
+++ b/cluster/usage/types/types.go
@@ -74,9 +74,6 @@ type VectorUsage struct {
 	// The compression ratio achieved
 	VectorCompressionRatio float64 `json:"vector_compression_ratio"`
 
-	// The actual memory storage bytes used by vectors
-	VectorStorageBytes int64 `json:"vector_storage_bytes"`
-
 	// List of dimensionalities and their metrics
 	Dimensionalities []*Dimensionality `json:"dimensionalities"`
 }

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -915,7 +915,7 @@ local-usage-gcs)
       BACKUP_GCS_BUCKET=weaviate-backups \
       USAGE_GCS_BUCKET=weaviate-usage \
       USAGE_GCS_PREFIX=billing-usage \
-      TRACK_VECTOR_DIMENSIONS=true \
+      TRACK_VECTOR_DIMENSIONS=false \
       USAGE_SCRAPE_INTERVAL=1s \
       USAGE_POLICY_VERSION=2025-06-01 \
       RUNTIME_OVERRIDES_LOAD_INTERVAL=3s \
@@ -956,7 +956,7 @@ local-usage-s3)
       BACKUP_S3_ENDPOINT=localhost:9000 \
       BACKUP_S3_BUCKET=weaviate-backups \
       BACKUP_S3_USE_SSL=false \
-      TRACK_VECTOR_DIMENSIONS=true \
+      TRACK_VECTOR_DIMENSIONS=false \
       USAGE_S3_BUCKET=weaviate-usage \
       USAGE_S3_PREFIX=billing-usage \
       USAGE_SCRAPE_INTERVAL=1s \

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -90,9 +90,7 @@ func FromEnv(config *Config) error {
 	}
 
 	if entcfg.Enabled(os.Getenv("REINDEX_VECTOR_DIMENSIONS_AT_STARTUP")) {
-		if config.TrackVectorDimensions {
-			config.ReindexVectorDimensionsAtStartup = true
-		}
+		config.ReindexVectorDimensionsAtStartup = true
 	}
 
 	if entcfg.Enabled(os.Getenv("DISABLE_LAZY_LOAD_SHARDS")) {


### PR DESCRIPTION
### What's being changed:
this PR removes the dependency between usage module and `TRACK_VECTOR_DIMENSIONS`, by enabling the track vector dimensions functionality without pushing to Prometheus given the fact this is not needed for the usage module. 

this is change is necessary because  pushing the metric to promethous has high cardinality at the moment and with this change we avoid pushing the metric to Prometheus and the need to configure `TRACK_VECTOR_DIMENSIONS` at all 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
