### PR TITLE
chore(alias): Make alias name case-insenstive similar to collection.

### DIFF
--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -113,11 +113,6 @@ func (s *schema) ClassEqual(name string) string {
 }
 
 func (s *schema) unsafeClassEqual(name string) string {
-	for alias := range s.aliases {
-		if strings.EqualFold(alias, name) {
-			return alias
-		}
-	}
 	for k := range s.classes {
 		if strings.EqualFold(k, name) {
 			return k
@@ -667,8 +662,12 @@ func (s *schema) replaceAlias(newClass, alias string) error {
 
 // unsafeAliasExists is not concurrency-safe! Lock s.aliases before calling
 func (s *schema) unsafeAliasExists(alias string) bool {
-	_, ok := s.aliases[alias]
-	return ok
+	for v := range s.aliases {
+		if strings.EqualFold(v, alias) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *schema) canonicalAlias(alias string) string {

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -113,6 +113,11 @@ func (s *schema) ClassEqual(name string) string {
 }
 
 func (s *schema) unsafeClassEqual(name string) string {
+	for alias := range s.aliases {
+		if strings.EqualFold(alias, name) {
+			return alias
+		}
+	}
 	for k := range s.classes {
 		if strings.EqualFold(k, name) {
 			return k

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -26,6 +26,22 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
+func TestCollectionNameConflictWithAlias(t *testing.T) {
+	var (
+		sc = NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+		ss = &sharding.State{Physical: make(map[string]sharding.Physical)}
+	)
+
+	require.Nil(t, sc.addClass(&models.Class{Class: "CoolCar"}, ss, 1))
+
+	err := sc.createAlias("CoolCar", "MyCar")
+	require.NoError(t, err)
+
+	// checking to see if class exists should consider the existing alias as well
+	got := sc.ClassEqual("MyCar")
+	assert.NotEmpty(t, got)
+}
+
 func Test_schemaCollectionMetrics(t *testing.T) {
 	r := prometheus.NewPedanticRegistry()
 

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -26,37 +26,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
-func TestSchemaAliasCasing(t *testing.T) {
-	// Alias name should be case-insensitive similar to collection.
-	// Meaning, MyCar, MYCar, myCar all same.
-
-	var (
-		sc = NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
-		ss = &sharding.State{Physical: make(map[string]sharding.Physical)}
-	)
-
-	require.Nil(t, sc.addClass(&models.Class{Class: "CoolCar"}, ss, 1))
-	err := sc.createAlias("CoolCar", "MyCar")
-	require.Nil(t, err)
-
-	// Try creating it with different cases.
-	err = sc.createAlias("CoolCar", "MYCar")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already exists")
-
-	err = sc.createAlias("CoolCar", "mYCar")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already exists")
-
-	err = sc.createAlias("CoolCar", "mycar")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already exists")
-
-	err = sc.createAlias("CoolCar", "MYCAR")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "already exists")
-}
-
 func Test_schemaCollectionMetrics(t *testing.T) {
 	r := prometheus.NewPedanticRegistry()
 
@@ -419,6 +388,37 @@ func TestCreateAlias(t *testing.T) {
 		err := sc.createAlias("C", "AnotherClass")
 		require.EqualError(t, err, "create alias: class AnotherClass already exists")
 	})
+}
+
+func TestSchemaAliasCasing(t *testing.T) {
+	// Alias name should be case-insensitive similar to collection.
+	// Meaning, MyCar, MYCar, myCar all same.
+
+	var (
+		sc = NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+		ss = &sharding.State{Physical: make(map[string]sharding.Physical)}
+	)
+
+	require.Nil(t, sc.addClass(&models.Class{Class: "CoolCar"}, ss, 1))
+	err := sc.createAlias("CoolCar", "MyCar")
+	require.Nil(t, err)
+
+	// Try creating it with different cases.
+	err = sc.createAlias("CoolCar", "MYCar")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+
+	err = sc.createAlias("CoolCar", "mYCar")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+
+	err = sc.createAlias("CoolCar", "mycar")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
+
+	err = sc.createAlias("CoolCar", "MYCAR")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already exists")
 }
 
 func TestReplaceAlias(t *testing.T) {


### PR DESCRIPTION
### What's being changed:
The collection name is case-insensitive (e.g: coolCAR, CoolCAR, etc) are all same.
Where alias name is case-sensitive (e.g: myCar, MyCar, MYCar are all different)

This PR make it consistent.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
