### PR TITLE
fix(vector metrics): group dimensions metric to avoid high cardinality

### DIFF
--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -140,11 +140,18 @@ func (s *Shard) publishDimensionMetrics(ctx context.Context) {
 	if s.promMetrics != nil {
 		var (
 			className = s.index.Config.ClassName.String()
+			shardName = s.name
 			configs   = s.index.GetVectorIndexConfigs()
 
 			sumSegments   = 0
 			sumDimensions = 0
 		)
+
+		// Apply grouping logic when PROMETHEUS_MONITORING_GROUP is enabled
+		if s.promMetrics.Group {
+			className = "n/a"
+			shardName = "n/a"
+		}
 
 		for targetVector, config := range configs {
 			metrics := s.calcDimensionMetrics(ctx, config, targetVector)
@@ -152,8 +159,8 @@ func (s *Shard) publishDimensionMetrics(ctx context.Context) {
 			sumSegments += metrics.Compressed
 		}
 
-		sendVectorSegmentsMetric(s.promMetrics, className, s.name, sumSegments)
-		sendVectorDimensionsMetric(s.promMetrics, className, s.name, sumDimensions)
+		sendVectorSegmentsMetric(s.promMetrics, className, shardName, sumSegments)
+		sendVectorDimensionsMetric(s.promMetrics, className, shardName, sumDimensions)
 	}
 }
 
@@ -197,6 +204,11 @@ func (s *Shard) clearDimensionMetrics() {
 
 func clearDimensionMetrics(promMetrics *monitoring.PrometheusMetrics, className, shardName string) {
 	if promMetrics != nil {
+		// Apply grouping logic when PROMETHEUS_MONITORING_GROUP is enabled
+		if promMetrics.Group {
+			className = "n/a"
+			shardName = "n/a"
+		}
 		sendVectorDimensionsMetric(promMetrics, className, shardName, 0)
 		sendVectorSegmentsMetric(promMetrics, className, shardName, 0)
 	}
@@ -205,6 +217,12 @@ func clearDimensionMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 func sendVectorSegmentsMetric(promMetrics *monitoring.PrometheusMetrics,
 	className, shardName string, count int,
 ) {
+	// Apply grouping logic when PROMETHEUS_MONITORING_GROUP is enabled
+	if promMetrics != nil && promMetrics.Group {
+		className = "n/a"
+		shardName = "n/a"
+	}
+
 	metric, err := promMetrics.VectorSegmentsSum.
 		GetMetricWithLabelValues(className, shardName)
 	if err == nil {
@@ -215,14 +233,12 @@ func sendVectorSegmentsMetric(promMetrics *monitoring.PrometheusMetrics,
 func sendVectorDimensionsMetric(promMetrics *monitoring.PrometheusMetrics,
 	className, shardName string, count int,
 ) {
-	// Important: Never group classes/shards for this metric. We need the
-	// granularity here as this tracks an absolute value per shard that changes
-	// independently over time.
-	//
-	// If we need to reduce metrics further, an alternative could be to not
-	// make dimension tracking shard-centric, but rather make it node-centric.
-	// Then have a single metric that aggregates all dimensions first, then
-	// observes only the sum
+	// Apply grouping logic when PROMETHEUS_MONITORING_GROUP is enabled
+	if promMetrics != nil && promMetrics.Group {
+		className = "n/a"
+		shardName = "n/a"
+	}
+
 	metric, err := promMetrics.VectorDimensionsSum.
 		GetMetricWithLabelValues(className, shardName)
 	if err == nil {


### PR DESCRIPTION
### What's being changed:
to avoid high cardinality this PR makes sure if `PROMETHEUS_MONITORING_GROUP=true` to report vector dimensions metrics with labels `n/a` to decrease cardinality for clusters in MT with huge amount of shards/tenants or collections 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
