### PR TITLE
chore: remove async replication target overrides endpoint from debug handlers

### DIFF
--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -31,57 +31,6 @@ import (
 func setupDebugHandlers(appState *state.State) {
 	logger := appState.Logger.WithField("handler", "debug")
 
-	http.HandleFunc(
-		"/debug/async-replication/remove-target-overrides",
-		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			collectionName := r.URL.Query().Get("collection")
-			if collectionName == "" {
-				http.Error(w, "collection is required", http.StatusBadRequest)
-				return
-			}
-			shardNamesStr := r.URL.Query().Get("shardNames")
-			if shardNamesStr == "" {
-				http.Error(w, "shardNames is required", http.StatusBadRequest)
-				return
-			}
-			shardNames := strings.Split(shardNamesStr, ",")
-			if len(shardNames) == 0 {
-				http.Error(w, "shardNames len > 0 is required", http.StatusBadRequest)
-				return
-			}
-			timeoutStr := r.URL.Query().Get("timeout")
-			timeoutDuration := time.Hour
-			var err error
-			if timeoutStr != "" {
-				timeoutDuration, err = time.ParseDuration(timeoutStr)
-				if err != nil {
-					http.Error(w, "timeout duration has invalid format", http.StatusBadRequest)
-					return
-				}
-			}
-			ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
-			defer cancel()
-
-			idx := appState.DB.GetIndex(schema.ClassName(collectionName))
-			if idx == nil {
-				logger.WithField("collection", collectionName).Error("collection not found")
-				http.Error(w, "collection not found", http.StatusNotFound)
-				return
-			}
-			for _, shardName := range shardNames {
-				err = idx.IncomingRemoveAllAsyncReplicationTargetNodes(ctx, shardName)
-				if err != nil {
-					logger.WithError(err).WithField("collection", collectionName).WithField("shard", shardName).
-						Warn("debug endpoint failed to remove all async replication target nodes")
-					http.Error(w, "failed to remove all async replication target nodes", http.StatusInternalServerError)
-					return
-				}
-				logger.WithField("collection", collectionName).WithField("shard", shardName).
-					Info("debug endpoint removed all async replication target nodes")
-			}
-			w.WriteHeader(http.StatusAccepted)
-		}))
-
 	http.HandleFunc("/debug/index/rebuild/inverted", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		colName := r.URL.Query().Get("collection")
 		if colName == "" {


### PR DESCRIPTION
### What's being changed:

This pull request removes a debug handler responsible for removing async replication target overrides. The change simplifies the `setupDebugHandlers` function by eliminating this specific endpoint.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
