### PR TITLE
fix(async-replication): use thread safe shuffler for Finder()

### DIFF
--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -20,14 +20,14 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
-
-	"github.com/go-openapi/strfmt"
-	"github.com/sirupsen/logrus"
-	"github.com/weaviate/weaviate/cluster/router/types"
-	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
@@ -69,8 +69,6 @@ type Finder struct {
 	// control the op backoffs in the coordinator's Pull
 	coordinatorPullBackoffInitialInterval time.Duration
 	coordinatorPullBackoffMaxElapsedTime  time.Duration
-
-	rand *rand.Rand // random number generator for shufflings
 }
 
 // NewFinder constructs a new finder instance
@@ -98,7 +96,6 @@ func NewFinder(className string,
 		},
 		coordinatorPullBackoffInitialInterval: coordinatorPullBackoffInitialInterval,
 		coordinatorPullBackoffMaxElapsedTime:  coordinatorPullBackoffMaxElapsedTime,
-		rand:                                  rand.New(rand.NewSource(time.Now().UnixNano())),
 	}
 }
 
@@ -405,7 +402,8 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 
 	// shuffle the replicas to randomize the order in which we look for differences
 	if len(replicasHostAddrs) > 1 {
-		f.rand.Shuffle(len(replicasHostAddrs), func(i, j int) {
+		// Use the global rand package which is thread-safe
+		rand.Shuffle(len(replicasHostAddrs), func(i, j int) {
 			replicasHostAddrs[i], replicasHostAddrs[j] = replicasHostAddrs[j], replicasHostAddrs[i]
 		})
 	}


### PR DESCRIPTION
### What's being changed:
we  have seen panic in some clusters and multiple go routines try to access the same `rand`. 

this PR avoid struct wide rand and instead use `rand.Shuffle()` directly which is thread safe 

```
goroutine 5794826571 [running]:

runtime/debug.Stack()

	/usr/local/go/src/runtime/debug/stack.go:26 +0x5e

runtime/debug.PrintStack()

	/usr/local/go/src/runtime/debug/stack.go:18 +0x13

github.com/weaviate/weaviate/entities/errors.GoWrapper.func1.1()

	/go/src/github.com/weaviate/weaviate/entities/errors/go_wrapper.go:32 +0x14f

panic({0x2c0f240?, 0xdf3980eca8?})

	/usr/local/go/src/runtime/panic.go:792 +0x132

math/rand.(*rngSource).Uint64(...)

	/usr/local/go/src/math/rand/rng.go:249

math/rand.(*rngSource).Int63(0x26feca0?)

	/usr/local/go/src/math/rand/rng.go:234 +0x85

math/rand.(*Rand).Int63(...)

	/usr/local/go/src/math/rand/rand.go:96

math/rand.(*Rand).Uint32(...)

	/usr/local/go/src/math/rand/rand.go:99

math/rand.(*Rand).int31n(0xc0061940c0, 0x3)

	/usr/local/go/src/math/rand/rand.go:168 +0x82

math/rand.(*Rand).Shuffle(0xc0061940c0, 0xd23e2ba2e0?, 0xc00f350328)

	/usr/local/go/src/math/rand/rand.go:264 +0x79

github.com/weaviate/weaviate/usecases/replica.(*Finder).CollectShardDifferences(0xc00439e100, {0x40710d0, 0xc707001720}, {0xd871a3ce20, 0x1c}, {0x4084250, 0xc707001770}, 0x2540be400, {0x0, 0x0, ...})

	/go/src/github.com/weaviate/weaviate/usecases/replica/finder.go:408 +0x9b2

github.com/weaviate/weaviate/adapters/repos/db.(*Shard).hashBeat(0xcabef80e08, {0x40710d0, 0xc707001720}, {0x10, 0x6fc23ac00, 0xb2d05e00, 0x12a05f200, 0xdf8475800, 0x3e8, 0x3e8, ...})

	/go/src/github.com/weaviate/weaviate/adapters/repos/db/shard_async_replication.go:860 +0x16a

github.com/weaviate/weaviate/adapters/repos/db.(*Shard).initHashBeater.func1()

	/go/src/github.com/weaviate/weaviate/adapters/repos/db/shard_async_replication.go:677 +0x851

github.com/weaviate/weaviate/entities/errors.GoWrapper.func1()

	/go/src/github.com/weaviate/weaviate/entities/errors/go_wrapper.go:36 +0x53

created by github.com/weaviate/weaviate/entities/errors.GoWrapper in goroutine 5794826513

	/go/src/github.com/weaviate/weaviate/entities/errors/go_wrapper.go:26 +0x74
``` 
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
