### PR TITLE
no need telemetry_mock_api in dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,13 +35,6 @@ RUN GOOS=linux GOARCH=$TARGETARCH go build $EXTRA_BUILD_ARGS \
       -o /weaviate-server ./cmd/weaviate-server
 
 ###############################################################################
-
-# This creates an image that can be used to fake an api for telemetry acceptance test purposes
-FROM build_base AS telemetry_mock_api
-COPY . .
-ENTRYPOINT ["./tools/dev/telemetry_mock_api.sh"]
-
-###############################################################################
 # Weaviate (no differentiation between dev/test/prod - 12 factor!)
 FROM alpine AS weaviate
 ENTRYPOINT ["/bin/weaviate"]


### PR DESCRIPTION
### What's being changed:
telemetry_mock_api.sh has been deleted, so dockerfile should clean ...

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
