### PR TITLE
chore(log): change err log level to warn as is not actionable

### DIFF
--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -104,7 +104,7 @@ func (o *nodeWideMetricsObserver) observeUnlocked() {
 		index.ForEachShard(func(name string, shard ShardLike) error {
 			objectCount, err := shard.ObjectCountAsync(context.Background())
 			if err != nil {
-				o.db.logger.Errorf("error while getting object count for shard %s: %w", shard.Name(), err)
+				o.db.logger.Warnf("error while getting object count for shard %s: %w", shard.Name(), err)
 			}
 			totalObjectCount += objectCount
 			return nil

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -206,7 +206,7 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 
 		objectCount, err := shard.ObjectCountAsync(ctx)
 		if err != nil {
-			i.logger.Errorf("error while getting object count for shard %s: %w", shard.Name(), err)
+			i.logger.Warnf("error while getting object count for shard %s: %w", shard.Name(), err)
 		}
 
 		totalCount += int64(objectCount)


### PR DESCRIPTION
### What's being changed:
we have seen in case of offloading tenants this log appear as error but it's not, so for now will convert it to `Warn()` instead 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
