### PR TITLE
feat(usage-module): expose the shard status to the report

### DIFF
--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -13,6 +13,7 @@ package usage
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -116,6 +117,7 @@ func (m *service) Usage(ctx context.Context) (*types.Report, error) {
 					shardUsage := &types.ShardUsage{
 						Name:                tenantName,
 						ObjectsCount:        objectUsage.Count,
+						Status:              strings.ToLower(models.TenantActivityStatusINACTIVE),
 						ObjectsStorageBytes: uint64(objectUsage.StorageBytes),
 						VectorStorageBytes:  uint64(vectorStorageSize),
 						NamedVectors:        make([]*types.VectorUsage, 0), // Empty for cold tenants
@@ -152,6 +154,7 @@ func (m *service) Usage(ctx context.Context) (*types.Report, error) {
 
 				shardUsage := &types.ShardUsage{
 					Name:                name,
+					Status:              strings.ToLower(models.TenantActivityStatusACTIVE),
 					ObjectsCount:        objectCount,
 					ObjectsStorageBytes: uint64(objectStorageSize),
 					VectorStorageBytes:  uint64(vectorStorageSize),

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -14,6 +14,7 @@ package usage
 import (
 	"context"
 	"sort"
+	"strings"
 	"testing"
 	"time"
 
@@ -272,11 +273,13 @@ func TestService_Usage_MultiTenant_HotAndCold(t *testing.T) {
 	require.NotNil(t, hotShard)
 	assert.Equal(t, int64(hotObjectCount), hotShard.ObjectsCount)
 	assert.Equal(t, uint64(hotStorageSize), hotShard.ObjectsStorageBytes)
+	assert.Equal(t, strings.ToLower(models.TenantActivityStatusACTIVE), hotShard.Status)
 	assert.Len(t, hotShard.NamedVectors, 1)
 
 	require.NotNil(t, coldShard)
 	assert.Equal(t, int64(coldObjectCount), coldShard.ObjectsCount)
 	assert.Equal(t, uint64(coldStorageSize), coldShard.ObjectsStorageBytes)
+	assert.Equal(t, strings.ToLower(models.TenantActivityStatusINACTIVE), coldShard.Status)
 	assert.Len(t, coldShard.NamedVectors, 0)
 
 	vector := hotShard.NamedVectors[0]
@@ -938,6 +941,7 @@ func TestService_Usage_VectorStorageSize(t *testing.T) {
 	require.NotNil(t, hotShard)
 	assert.Equal(t, int64(hotObjectCount), hotShard.ObjectsCount)
 	assert.Equal(t, uint64(hotStorageSize), hotShard.ObjectsStorageBytes)
+	assert.Equal(t, strings.ToLower(models.TenantActivityStatusACTIVE), hotShard.Status)
 	assert.Equal(t, uint64(hotVectorStorageSize), hotShard.VectorStorageBytes) // Verify hot tenant vector storage
 	assert.Len(t, hotShard.NamedVectors, 1)
 
@@ -945,6 +949,7 @@ func TestService_Usage_VectorStorageSize(t *testing.T) {
 	require.NotNil(t, coldShard)
 	assert.Equal(t, int64(coldObjectCount), coldShard.ObjectsCount)
 	assert.Equal(t, uint64(coldStorageSize), coldShard.ObjectsStorageBytes)
+	assert.Equal(t, strings.ToLower(models.TenantActivityStatusINACTIVE), coldShard.Status)
 	assert.Equal(t, uint64(coldVectorStorageSize), coldShard.VectorStorageBytes) // Verify cold tenant vector storage
 	assert.Len(t, coldShard.NamedVectors, 0)                                     // Cold tenants don't have named vectors
 

--- a/cluster/usage/types/types.go
+++ b/cluster/usage/types/types.go
@@ -47,6 +47,9 @@ type ShardUsage struct {
 	// The name of the shard
 	Name string `json:"name"`
 
+	// The status of the shard (ACTIVE, INACTIVE)
+	Status string `json:"status"`
+
 	// The number of objects in the shard
 	ObjectsCount int64 `json:"objects_count"`
 


### PR DESCRIPTION
### What's being changed:
we need the shard status in the metric 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
