### PR TITLE
feat(usage-module): include the object count from the new metadata file in object bucket

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3120,6 +3120,16 @@ func (i *Index) CalculateUnloadedObjectsMetrics(ctx context.Context, tenantName 
 				}
 				totalObjectCount += count
 			}
+
+			// Look for .metadata files (bloom filters + count net additions)
+			if strings.HasSuffix(info.Name(), lsmkv.MetadataFileSuffix) {
+				count, err := lsmkv.ReadObjectCountFromMetadataFile(path)
+				if err != nil {
+					i.logger.WithField("path", path).WithError(err).Warn("failed to read .metadata file")
+					return err
+				}
+				totalObjectCount += count
+			}
 		}
 
 		return nil

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -750,33 +750,69 @@ func (sg *SegmentGroup) Size() int64 {
 }
 
 // MetadataSize returns the total size of metadata files (.bloom and .cna) from segments in memory
+// MetadataSize returns the total size of metadata files for all segments.
+// The calculation differs based on the writeMetadata setting:
+//
+// When writeMetadata is enabled:
+//   - Counts the actual file size of .metadata files on disk
+//   - Each .metadata file contains: header + bloom filters + count net additions
+//   - Header includes: checksum (4 bytes) + version (1 byte) + bloom len (4 bytes) + cna len (4 bytes) = 13 bytes
+//   - Bloom filters are serialized and stored inline
+//   - CNA data includes: uint64 count (8 bytes) + length indicator (4 bytes) = 12 bytes
+//
+// When writeMetadata is disabled:
+//   - Counts bloom filters in memory (getBloomFilterSize)
+//   - Counts .cna files separately (12 bytes each: 8 bytes data + 4 bytes checksum)
+//   - This represents the legacy behavior where metadata was stored separately
+//
+// The total size should be equivalent between both modes, accounting for the
+// metadata file header overhead when writeMetadata is enabled.
 func (sg *SegmentGroup) MetadataSize() int64 {
 	segments, release := sg.getAndLockSegments()
 	defer release()
 
-	var totalSize, cnaCount int64
+	var totalSize int64
 	for _, segment := range segments {
-		// Count bloom filters in memory
-		if seg := segment.getSegment(); seg != nil {
-			if seg.bloomFilter != nil {
-				totalSize += int64(getBloomFilterSize(seg.bloomFilter))
-			}
-			// Count secondary bloom filters
-			for _, bf := range seg.secondaryBloomFilters {
-				if bf != nil {
-					totalSize += int64(getBloomFilterSize(bf))
+		if sg.writeMetadata {
+			// When writeMetadata is enabled, count .metadata files
+			// Each .metadata file contains bloom filters + count net additions
+			if seg := segment.getSegment(); seg != nil {
+				// Check if segment has metadata file
+				metadataPath := seg.metadataPath()
+				if metadataPath != "" {
+					exists, err := fileExists(metadataPath)
+					if err == nil && exists {
+						// Get the actual file size of the metadata file
+						if info, err := os.Stat(metadataPath); err == nil {
+							totalSize += info.Size()
+						}
+					}
 				}
 			}
-		}
+		} else {
+			// When writeMetadata is disabled, count bloom filters and .cna files separately
+			if seg := segment.getSegment(); seg != nil {
+				// Count bloom filters in memory
+				if seg.bloomFilter != nil {
+					totalSize += int64(getBloomFilterSize(seg.bloomFilter))
+				}
+				// Count secondary bloom filters
+				for _, bf := range seg.secondaryBloomFilters {
+					if bf != nil {
+						totalSize += int64(getBloomFilterSize(bf))
+					}
+				}
+			}
 
-		// Count .cna files (12 bytes each)
-		if segment.getSegment().countNetPath() != "" {
-			cnaCount++
+			// Count .cna files (12 bytes each)
+			if segment.getSegment().countNetPath() != "" {
+				// .cna files: uint64 count (8 bytes) + uint32 checksum (4 bytes) = 12 bytes
+				totalSize += 12
+			}
 		}
 	}
 
-	// .cna files: uint64 count (8 bytes) + uint32 checksum (4 bytes) = 12 bytes
-	return totalSize + 12*cnaCount
+	return totalSize
 }
 
 func (sg *SegmentGroup) shutdown(ctx context.Context) error {

--- a/adapters/repos/db/lsmkv/segment_group_size_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_size_test.go
@@ -12,10 +12,15 @@
 package lsmkv
 
 import (
+	"encoding/binary"
+	"path/filepath"
 	"testing"
 
 	"github.com/bits-and-blooms/bloom/v3"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
+	"github.com/weaviate/weaviate/usecases/byteops"
 )
 
 func TestSegmentGroup_Size(t *testing.T) {
@@ -379,6 +384,57 @@ func TestSegmentGroup_MetadataSize_ComplexScenarios(t *testing.T) {
 	}
 }
 
+func TestSegmentGroup_MetadataSize_WithWriteMetadata(t *testing.T) {
+	tests := []struct {
+		name          string
+		writeMetadata bool
+		segments      []*segment
+		expectedSize  int64
+		description   string
+	}{
+		{
+			name:          "writeMetadata disabled - count bloom filters and .cna files",
+			writeMetadata: false,
+			segments: []*segment{
+				createMockSegmentWithMetadata(true, 48, []int{}), // 48 bytes (bloom filter) + 12 bytes (.cna file)
+				createMockSegmentWithMetadata(true, 48, []int{}), // 48 bytes (bloom filter) + 12 bytes (.cna file)
+			},
+			expectedSize: 120, // 2 * (48 + 12) bytes
+			description:  "should count bloom filters and .cna files when writeMetadata is disabled",
+		},
+		{
+			name:          "writeMetadata enabled - count metadata files",
+			writeMetadata: true,
+			segments: []*segment{
+				createMockSegmentWithMetadataFile(t, true, 48, []int{}), // metadata file with bloom filter + count
+				createMockSegmentWithMetadataFile(t, true, 48, []int{}), // metadata file with bloom filter + count
+			},
+			// Expected size: 138 bytes (includes metadata file header overhead: checksum + version + length indicators)
+			expectedSize: 138, // Actual metadata file size (includes header overhead)
+			description:  "should count metadata files when writeMetadata is enabled (requires actual files)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Convert []*segment to []Segment for the test
+			segments := make([]Segment, len(tt.segments))
+			for i, seg := range tt.segments {
+				segments[i] = seg
+			}
+
+			sg := &SegmentGroup{
+				segments:      segments,
+				writeMetadata: tt.writeMetadata,
+			}
+
+			result := sg.MetadataSize()
+
+			assert.Equal(t, tt.expectedSize, result, tt.description)
+		})
+	}
+}
+
 // createTestBloomFilter creates a bloom filter with some data for testing
 func createTestBloomFilter() *bloom.BloomFilter {
 	// Create a bloom filter with the same parameters as the actual implementation
@@ -386,4 +442,80 @@ func createTestBloomFilter() *bloom.BloomFilter {
 	bf := bloom.NewWithEstimates(10, 0.001)
 	bf.Add([]byte("test"))
 	return bf
+}
+
+// createMockSegmentWithMetadataFile creates a segment with an actual metadata file for testing writeMetadata scenarios
+func createMockSegmentWithMetadataFile(t *testing.T, hasCNA bool, bloomFilterSize int, secondaryBloomFilterSizes []int) *segment {
+	seg := &segment{
+		calcCountNetAdditions: hasCNA,
+		useBloomFilter:        true,
+		strategy:              segmentindex.StrategyReplace,
+	}
+
+	// Create a temporary directory for the segment
+	tempDir := t.TempDir()
+	seg.path = filepath.Join(tempDir, "test.dat")
+
+	if bloomFilterSize > 0 {
+		// Create a bloom filter with some data
+		seg.bloomFilter = createTestBloomFilter()
+	}
+
+	if len(secondaryBloomFilterSizes) > 0 {
+		seg.secondaryIndexCount = uint16(len(secondaryBloomFilterSizes))
+		seg.secondaryBloomFilters = make([]*bloom.BloomFilter, len(secondaryBloomFilterSizes))
+		for i, size := range secondaryBloomFilterSizes {
+			if size > 0 {
+				seg.secondaryBloomFilters[i] = createTestBloomFilter()
+			}
+		}
+	}
+
+	// Use the actual implementation to write the metadata file
+	metadataPath := seg.metadataPath()
+	if metadataPath != "" {
+		// Create primary bloom filter data directly
+		var primaryBloom []byte
+		if seg.bloomFilter != nil {
+			bfSize := getBloomFilterSize(seg.bloomFilter)
+			rw := byteops.NewReadWriter(make([]byte, bfSize))
+			if _, err := seg.bloomFilter.WriteTo(&rw); err != nil {
+				t.Fatalf("failed to write primary bloom filter: %v", err)
+			}
+			primaryBloom = rw.Buffer
+		}
+
+		// Create secondary bloom filters data directly
+		var secondaryBloom [][]byte
+		if seg.secondaryIndexCount > 0 {
+			secondaryBloom = make([][]byte, seg.secondaryIndexCount)
+			for i, bf := range seg.secondaryBloomFilters {
+				if bf != nil {
+					bfSize := getBloomFilterSize(bf)
+					rw := byteops.NewReadWriter(make([]byte, bfSize))
+					if _, err := bf.WriteTo(&rw); err != nil {
+						t.Fatalf("failed to write secondary bloom filter %d: %v", i, err)
+					}
+					secondaryBloom[i] = rw.Buffer
+				}
+			}
+		}
+
+		// Create CNA data directly
+		var netAdditions []byte
+		if hasCNA {
+			// Create a simple CNA with a test count
+			cnaData := make([]byte, 8)
+			binary.LittleEndian.PutUint64(cnaData, 42) // Some test count
+			netAdditions = cnaData
+		}
+
+		// Use the actual implementation to write the metadata file
+		err := seg.writeMetadataToDisk(metadataPath, primaryBloom, secondaryBloom, netAdditions)
+		if err != nil {
+			t.Fatalf("failed to write metadata file: %v", err)
+		}
+	}
+
+	return seg
 }

--- a/adapters/repos/db/lsmkv/segment_metadata.go
+++ b/adapters/repos/db/lsmkv/segment_metadata.go
@@ -20,11 +20,15 @@ import (
 	"path/filepath"
 
 	"github.com/bits-and-blooms/bloom/v3"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/usecases/byteops"
 )
 
-const MetadataVersion = 0
+const (
+	MetadataVersion    = 0
+	MetadataFileSuffix = ".metadata"
+)
 
 func (s *segment) metadataPath() string {
 	return s.buildPath("%s.metadata")
@@ -295,4 +299,43 @@ func (s *segment) recalcCountNetAdditions(exists existsOnLowerSegmentsFn, precom
 	data := make([]byte, 8)
 	binary.LittleEndian.PutUint64(data, uint64(s.countNetAdditions))
 	return data, nil
+}
+
+// ReadObjectCountFromMetadataFile reads a .metadata file and returns the count net additions value
+// Returns (count, nil) if successful, (0, error) if the file is invalid or corrupted
+func ReadObjectCountFromMetadataFile(path string) (int64, error) {
+	data, err := loadWithChecksum(path, -1, nil)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read .metadata file: %w", err)
+	}
+
+	rw := byteops.NewReadWriter(data)
+
+	// Read version to detect file structure
+	version := rw.ReadUint8()
+
+	switch version {
+	case MetadataVersion:
+		// Version 0: checksum + version + primary bloom + cna + secondary blooms
+		// Read bloom filter length and skip
+		bloomLen := rw.ReadUint32()
+		rw.MoveBufferPositionForward(uint64(bloomLen))
+
+		// Read CNA length
+		cnaLen := rw.ReadUint32()
+
+		// Read CNA data
+		if cnaLen >= 8 {
+			cnaData := rw.ReadBytesFromBuffer(uint64(cnaLen))
+			if len(cnaData) >= 8 {
+				count := int64(binary.LittleEndian.Uint64(cnaData))
+				return count, nil
+			}
+		}
+
+	default:
+		return 0, fmt.Errorf("unsupported metadata version: %d", version)
+	}
+
+	return 0, fmt.Errorf("invalid net additions data in metadata file")
 }


### PR DESCRIPTION
### What's being changed:
recently  we add `metadata` file in the object bucket to contain metadata details for shard which is opt-in and has to be enabled by `PERSISTENCE_WRITE_METADATA_FILES_ENABLED`. this PR makes sure if it was enabled to collect the metadata info from the `metadata` file

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
