### PR TITLE
Avoid repeated checks on long gone vectors

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -346,7 +346,7 @@ func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 	} else if !ok {
 		return executed, nil
 	}
-	h.reassignNeighbor(h.shutdownCtx, h.getEntrypoint(), deleteList, breakCleanUpTombstonedNodes)
+	h.reassignNeighbor(h.shutdownCtx, h.getEntrypoint(), deleteList, breakCleanUpTombstonedNodes, nil)
 
 	if ok, err := h.replaceDeletedEntrypoint(deleteList, breakCleanUpTombstonedNodes); err != nil {
 		return executed, err
@@ -458,6 +458,8 @@ func (h *hnsw) reassignNeighborsOf(ctx context.Context, deleteList helpers.Allow
 	ch := make(chan uint64)
 	var cancelled atomic.Bool
 
+	processedIDs := &sync.Map{}
+
 	for i := 0; i < tombstoneDeletionConcurrency(); i++ {
 		g.Go(func() error {
 			for {
@@ -473,6 +475,11 @@ func (h *hnsw) reassignNeighborsOf(ctx context.Context, deleteList helpers.Allow
 					if !ok {
 						return nil
 					}
+					// Check if already COMPLETED processing
+					if _, alreadyProcessed := processedIDs.Load(deletedID); alreadyProcessed {
+						continue
+					}
+
 					h.shardedNodeLocks.RLock(deletedID)
 					if deletedID >= uint64(size) || deletedID >= uint64(len(h.nodes)) || h.nodes[deletedID] == nil {
 						h.shardedNodeLocks.RUnlock(deletedID)
@@ -481,7 +488,7 @@ func (h *hnsw) reassignNeighborsOf(ctx context.Context, deleteList helpers.Allow
 					h.shardedNodeLocks.RUnlock(deletedID)
 					h.resetLock.RLock()
 					if h.getEntrypoint() != deletedID {
-						if _, err := h.reassignNeighbor(ctx, deletedID, deleteList, breakCleanUpTombstonedNodes); err != nil {
+						if _, err := h.reassignNeighbor(ctx, deletedID, deleteList, breakCleanUpTombstonedNodes, processedIDs); err != nil {
 							h.logger.WithError(err).WithField("action", "hnsw_tombstone_cleanup_error").
 								Errorf("class %s: shard %s: reassign neighbor", h.className, h.shardName)
 						}
@@ -540,6 +547,7 @@ func (h *hnsw) reassignNeighbor(
 	neighbor uint64,
 	deleteList helpers.AllowList,
 	breakCleanUpTombstonedNodes breakCleanUpTombstonedNodesFunc,
+	processedIDs *sync.Map,
 ) (ok bool, err error) {
 	if breakCleanUpTombstonedNodes() {
 		return false, nil
@@ -596,7 +604,7 @@ func (h *hnsw) reassignNeighbor(
 	// just pass this dummy value to make the neighborFinderConnector happy
 	dummyEntrypoint := uint64(0)
 	if err := h.reconnectNeighboursOf(ctx, neighborNode, dummyEntrypoint, neighborVec, compressorDistancer,
-		neighborLevel, currentMaximumLayer, deleteList); err != nil {
+		neighborLevel, currentMaximumLayer, deleteList, processedIDs); err != nil {
 		return false, errors.Wrap(err, "find and connect neighbors")
 	}
 	neighborNode.unmarkAsMaintenance()

--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -31,17 +32,17 @@ func (h *hnsw) findAndConnectNeighbors(ctx context.Context, node *vertex,
 	denyList helpers.AllowList,
 ) error {
 	nfc := newNeighborFinderConnector(h, node, entryPointID, nodeVec, distancer, targetLevel,
-		currentMaxLevel, denyList, false)
+		currentMaxLevel, denyList, false, nil)
 
 	return nfc.Do(ctx)
 }
 
 func (h *hnsw) reconnectNeighboursOf(ctx context.Context, node *vertex,
 	entryPointID uint64, nodeVec []float32, distancer compressionhelpers.CompressorDistancer, targetLevel, currentMaxLevel int,
-	denyList helpers.AllowList,
+	denyList helpers.AllowList, processedIDs *sync.Map,
 ) error {
 	nfc := newNeighborFinderConnector(h, node, entryPointID, nodeVec, distancer, targetLevel,
-		currentMaxLevel, denyList, true)
+		currentMaxLevel, denyList, true, processedIDs)
 
 	return nfc.Do(ctx)
 }
@@ -59,11 +60,12 @@ type neighborFinderConnector struct {
 	denyList        helpers.AllowList
 	// bufLinksLog     BufferedLinksLogger
 	tombstoneCleanupNodes bool
+	processedIDs          *sync.Map
 }
 
 func newNeighborFinderConnector(graph *hnsw, node *vertex, entryPointID uint64,
 	nodeVec []float32, distancer compressionhelpers.CompressorDistancer, targetLevel, currentMaxLevel int,
-	denyList helpers.AllowList, tombstoneCleanupNodes bool,
+	denyList helpers.AllowList, tombstoneCleanupNodes bool, processedIDs *sync.Map,
 ) *neighborFinderConnector {
 	return &neighborFinderConnector{
 		ctx:                   graph.shutdownCtx,
@@ -76,6 +78,7 @@ func newNeighborFinderConnector(graph *hnsw, node *vertex, entryPointID uint64,
 		currentMaxLevel:       currentMaxLevel,
 		denyList:              denyList,
 		tombstoneCleanupNodes: tombstoneCleanupNodes,
+		processedIDs:          processedIDs,
 	}
 }
 
@@ -124,11 +127,22 @@ func (n *neighborFinderConnector) processRecursively(from uint64, results *prior
 	nodesLen := uint64(len(n.graph.nodes))
 	n.graph.RUnlock()
 	var pending []uint64
+	// Check if already completed (not just started)
+	if _, alreadyProcessed := n.processedIDs.Load(from); alreadyProcessed {
+		return nil
+	}
+
 	// lock the nodes slice
-	n.graph.shardedNodeLocks.RLock(from)
+	n.graph.shardedNodeLocks.Lock(from)
+	// Double-check after acquiring lock
+	if _, alreadyProcessed := n.processedIDs.Load(from); alreadyProcessed {
+		n.graph.shardedNodeLocks.Unlock(from)
+		return nil
+	}
 	if nodesLen < from || n.graph.nodes[from] == nil {
 		n.graph.handleDeletedNode(from, "processRecursively")
-		n.graph.shardedNodeLocks.RUnlock(from)
+		n.processedIDs.Store(from, struct{}{})
+		n.graph.shardedNodeLocks.Unlock(from)
 		return nil
 	}
 	// lock the node itself


### PR DESCRIPTION
### What's being changed:

During the tombstone cleanup, if a node has been long gone, it cannot be used to reconnect the neighbours. Still, every path leading to it, will go to the store and check if it exists. This will hammer the store and make the cleanup process to take forever. This pull request keeps track of those ids of the long gone nodes so if one thread finds it, the others will ignore it.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
