### PR TITLE
Improvements to vector index tests

### DIFF
--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -45,7 +45,7 @@ func TestDynamic(t *testing.T) {
 	os.Setenv("ASYNC_INDEXING", "true")
 	defer os.Setenv("ASYNC_INDEXING", currentIndexing)
 	dimensions := 20
-	vectors_size := 10_000
+	vectors_size := 1_000
 	queries_size := 10
 	k := 10
 
@@ -169,7 +169,7 @@ func TestDynamicWithTargetVectors(t *testing.T) {
 	os.Setenv("ASYNC_INDEXING", "true")
 	defer os.Setenv("ASYNC_INDEXING", currentIndexing)
 	dimensions := 20
-	vectors_size := 10_000
+	vectors_size := 1_000
 	queries_size := 10
 	k := 10
 
@@ -257,7 +257,7 @@ func TestDynamicUpgradeCancelation(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("ASYNC_INDEXING", "true")
 	dimensions := 20
-	vectors_size := 10_000
+	vectors_size := 1_000
 	queries_size := 10
 	k := 10
 
@@ -338,7 +338,7 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	ctx := context.Background()
 	t.Setenv("ASYNC_INDEXING", "true")
 	dimensions := 20
-	vectors_size := 10_000
+	vectors_size := 1_000
 	threshold := 2_000
 	queries_size := 10
 	k := 10

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -339,7 +339,7 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	t.Setenv("ASYNC_INDEXING", "true")
 	dimensions := 20
 	vectors_size := 1_000
-	threshold := 2_000
+	threshold := 600
 	queries_size := 10
 	k := 10
 

--- a/adapters/repos/db/vector/dynamic/restore_integration_test.go
+++ b/adapters/repos/db/vector/dynamic/restore_integration_test.go
@@ -39,7 +39,7 @@ func TestBackup_Integration(t *testing.T) {
 	os.Setenv("ASYNC_INDEXING", "true")
 	defer os.Setenv("ASYNC_INDEXING", currentIndexing)
 	dimensions := 20
-	vectors_size := 10_000
+	vectors_size := 1_000
 	queries_size := 10
 	k := 10
 

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -352,7 +352,7 @@ func TestDelete_WithCleaningUpTombstonesTwiceConcurrently(t *testing.T) {
 
 func TestDelete_WithConcurrentEntrypointDeletionAndTombstoneCleanup(t *testing.T) {
 	var vectors [][]float32
-	for i := 0; i < 10000; i++ {
+	for i := 0; i < 1000; i++ {
 		vectors = append(vectors, []float32{rand.Float32(), rand.Float32(), rand.Float32()})
 	}
 	var vectorIndex *hnsw
@@ -652,7 +652,7 @@ func genStopAtFunc(i int) func() bool {
 
 func TestDelete_WithCleaningUpTombstonesStopped(t *testing.T) {
 	ctx := context.Background()
-	vectors := vectorsForDeleteTest()
+	vectors := vectorsForDeleteTest()[:50]
 	var index *hnsw
 	var possibleStopsCount int
 	// due to not yet resolved bug (https://semi-technology.atlassian.net/browse/WEAVIATE-179)
@@ -1031,8 +1031,8 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce_DoesNotCrash(t *t
 		vectors    = vectorsForDeleteTest()
 		rootPath   = t.TempDir()
 		userConfig = ent.UserConfig{
-			MaxConnections: 30,
-			EFConstruction: 128,
+			MaxConnections: 16,
+			EFConstruction: 32,
 
 			// The actual size does not matter for this test, but if it defaults to
 			// zero it will constantly think it's full and needs to be deleted - even
@@ -1074,8 +1074,8 @@ func TestDelete_InCompressedIndex_WithCleaningUpTombstonesOnce_DoesNotCrash(t *t
 		cfg := ent.PQConfig{
 			Enabled: true,
 			Encoder: ent.PQEncoder{
-				Type:         ent.PQEncoderTypeTile,
-				Distribution: ent.PQEncoderDistributionLogNormal,
+				Type:         ent.PQEncoderTypeKMeans,
+				Distribution: ent.PQEncoderDistributionNormal,
 			},
 			BitCompression: false,
 			Segments:       3,
@@ -1623,7 +1623,7 @@ func neverStop() bool {
 }
 
 func slowNeverStop() bool {
-	time.Sleep(time.Millisecond * 10)
+	time.Sleep(time.Millisecond * 3)
 	return false
 }
 
@@ -1836,7 +1836,7 @@ func TestDelete_WithCleaningUpTombstonesWithHighConcurrency(t *testing.T) {
 	os.Setenv("TOMBSTONE_DELETION_CONCURRENCY", "100")
 	defer os.Unsetenv("TOMBSTONE_DELETION_CONCURRENCY")
 	// there is a single bulk clean event after all the deletes
-	vectors, _ := testinghelpers.RandomVecs(3_000, 1, 1536)
+	vectors, _ := testinghelpers.RandomVecs(1_000, 1, 64)
 	var vectorIndex *hnsw
 
 	store := testinghelpers.NewDummyStore(t)

--- a/adapters/repos/db/vector/hnsw/distancer/dot_product_amd64_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/dot_product_amd64_test.go
@@ -42,7 +42,7 @@ var dotFloatByteImpl func(a []float32, b []byte) float32 = func(a []float32, b [
 }
 
 func testDotProductFixedValue(t *testing.T, size uint, dotFn func(x []float32, y []float32) float32) {
-	count := 10000
+	count := 100
 	countFailed := 0
 	for i := 0; i < count; i++ {
 		vec1 := make([]float32, size)
@@ -75,7 +75,7 @@ func testDotProductFixedValue(t *testing.T, size uint, dotFn func(x []float32, y
 
 func testDotProductRandomValue(t *testing.T, size uint, dotFn func(x []float32, y []float32) float32) {
 	r := getRandomSeed()
-	count := 10000
+	count := 100
 	countFailed := 0
 
 	vec1s := make([][]float32, count)
@@ -176,7 +176,7 @@ func testDotProductByteFixedValue(t *testing.T, size uint, dotFn func(x []uint8,
 
 func testDotProductByteRandomValue(t *testing.T, size uint, dotFn func(x []byte, y []byte) uint32) {
 	r := getRandomSeed()
-	count := 10000
+	count := 100
 
 	vec1s := make([][]byte, count)
 	vec2s := make([][]byte, count)
@@ -292,7 +292,7 @@ func testDotProductFloatByteFixedValue(t *testing.T, size uint, dotFn func(x []f
 
 func testDotProductFloatByteRandomValue(t *testing.T, size uint, dotFn func(x []float32, y []byte) float32) {
 	r := getRandomSeed()
-	count := 10000
+	count := 100
 
 	vec1s := make([][]float32, count)
 	vec2s := make([][]byte, count)

--- a/adapters/repos/db/vector/hnsw/distancer/dot_product_arm64_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/dot_product_arm64_test.go
@@ -42,7 +42,7 @@ func dotFloatByteImpl(a []float32, b []byte) float32 {
 }
 
 func testDotProductFixedValue(t *testing.T, size uint) {
-	count := 10000
+	count := 100
 	countFailed := 0
 	for i := 0; i < count; i++ {
 		vec1 := make([]float32, size)
@@ -78,7 +78,7 @@ func testDotProductFixedValue(t *testing.T, size uint) {
 
 func testDotProductRandomValue(t *testing.T, size uint) {
 	r := getRandomSeed()
-	count := 10000
+	count := 100
 	countFailed := 0
 
 	vec1s := make([][]float32, count)
@@ -168,7 +168,7 @@ func testDotProductByteFixedValue(t *testing.T, size uint, dotFn func(x []uint8,
 
 func testDotProductByteRandomValue(t *testing.T, size uint, dotFn func(x []byte, y []byte) uint32) {
 	r := getRandomSeed()
-	count := 10000
+	count := 100
 
 	vec1s := make([][]byte, count)
 	vec2s := make([][]byte, count)
@@ -286,7 +286,7 @@ func testDotProductFloatByteFixedValue(t *testing.T, size uint, dotFn func(x []f
 
 func testDotProductFloatByteRandomValue(t *testing.T, size uint, dotFn func(x []float32, y []byte) float32) {
 	r := getRandomSeed()
-	count := 10000
+	count := 100
 
 	vec1s := make([][]float32, count)
 	vec2s := make([][]byte, count)

--- a/adapters/repos/db/vector/hnsw/distancer/hamming_amd64_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/hamming_amd64_test.go
@@ -48,7 +48,7 @@ func testHammingBitwiseFixedValue(t *testing.T, size uint, hammingBitwiseFn func
 
 func testHammingBitwiseRandomValue(t *testing.T, size uint, hammingBitwiseFn func(x []uint64, y []uint64) float32) {
 	r := getRandomSeed()
-	count := 10000
+	count := 100
 
 	vec1s := make([][]uint64, count)
 	vec2s := make([][]uint64, count)

--- a/adapters/repos/db/vector/hnsw/distancer/hamming_arm64_test.go
+++ b/adapters/repos/db/vector/hnsw/distancer/hamming_arm64_test.go
@@ -48,7 +48,7 @@ func testHammingBitwiseFixedValue(t *testing.T, size uint, hammingBitwiseFn func
 
 func testHammingBitwiseRandomValue(t *testing.T, size uint, hammingBitwiseFn func(x []uint64, y []uint64) float32) {
 	r := getRandomSeed()
-	count := 10000
+	count := 100
 
 	vec1s := make([][]uint64, count)
 	vec2s := make([][]uint64, count)

--- a/adapters/repos/db/vector/hnsw/restore_test.go
+++ b/adapters/repos/db/vector/hnsw/restore_test.go
@@ -50,7 +50,7 @@ func Test_RestartFromZeroSegments(t *testing.T) {
 	ef := 32
 	maxNeighbors := 32
 	dimensions := 20
-	vectors_size := 10000
+	vectors_size := 1000
 	queries_size := 1
 	vectors, _ := testinghelpers.RandomVecs(vectors_size, queries_size, dimensions)
 	distancer := distancer.NewL2SquaredProvider()
@@ -84,7 +84,7 @@ func Test_RestartFromZeroSegments(t *testing.T) {
 func TestBackup_IntegrationHnsw(t *testing.T) {
 	ctx := context.Background()
 	dimensions := 20
-	vectors_size := 10_000
+	vectors_size := 1_000
 	queries_size := 100
 	k := 10
 


### PR DESCRIPTION
### What's being changed:

A few changes to improve speed of tests:

- The dynamic index now using 1000 instead of 10,000 vectors for each upgrade test
- The distancer comparison tests use less rounds
- Some HNSW calculations are reduced

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
