### PR TITLE
Fix/Improve Concurrency Control for nested callstacks

### DIFF
--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/weaviate/weaviate/entities/concurrency"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 
 	"github.com/google/uuid"
@@ -81,6 +82,7 @@ func (s *Searcher) Objects(ctx context.Context, limit int,
 	className schema.ClassName, properties []string,
 	disableInvertedSorter *runtime.DynamicValue[bool],
 ) ([]*storobj.Object, error) {
+	ctx = concurrency.CtxWithBudget(ctx, concurrency.TimesNUMCPU(2))
 	beforeFilters := time.Now()
 	allowList, err := s.docIDs(ctx, filter, additional, className, limit)
 	if err != nil {
@@ -202,6 +204,7 @@ func (s *Searcher) objectsByDocID(ctx context.Context, it docIDsIterator,
 func (s *Searcher) DocIDs(ctx context.Context, filter *filters.LocalFilter,
 	additional additional.Properties, className schema.ClassName,
 ) (helpers.AllowList, error) {
+	ctx = concurrency.CtxWithBudget(ctx, concurrency.TimesNUMCPU(2))
 	return s.docIDs(ctx, filter, additional, className, 0)
 }
 
@@ -209,7 +212,7 @@ func (s *Searcher) docIDs(ctx context.Context, filter *filters.LocalFilter,
 	additional additional.Properties, className schema.ClassName,
 	limit int,
 ) (helpers.AllowList, error) {
-	pv, err := s.extractPropValuePair(filter.Root, className)
+	pv, err := s.extractPropValuePair(ctx, filter.Root, className)
 	if err != nil {
 		return nil, err
 	}
@@ -229,8 +232,8 @@ func (s *Searcher) docIDs(ctx context.Context, filter *filters.LocalFilter,
 	return helpers.NewAllowListCloseableFromBitmap(dbm.docIDs, dbm.release), nil
 }
 
-func (s *Searcher) extractPropValuePair(filter *filters.Clause,
-	className schema.ClassName,
+func (s *Searcher) extractPropValuePair(
+	ctx context.Context, filter *filters.Clause, className schema.ClassName,
 ) (*propValuePair, error) {
 	class := s.getClass(className.String())
 	if class == nil {
@@ -242,7 +245,7 @@ func (s *Searcher) extractPropValuePair(filter *filters.Clause,
 	}
 	if filter.Operands != nil {
 		// nested filter
-		children, err := s.extractPropValuePairs(filter.Operands, className)
+		children, err := s.extractPropValuePairs(ctx, filter.Operands, className)
 		if err != nil {
 			return nil, err
 		}
@@ -252,7 +255,7 @@ func (s *Searcher) extractPropValuePair(filter *filters.Clause,
 	}
 
 	if filter.Operator == filters.ContainsAny || filter.Operator == filters.ContainsAll {
-		return s.extractContains(filter.On, filter.Value.Type, filter.Value.Value, filter.Operator, class)
+		return s.extractContains(ctx, filter.On, filter.Value.Type, filter.Value.Value, filter.Operator, class)
 	}
 
 	// on value or non-nested filter
@@ -310,17 +313,21 @@ func (s *Searcher) extractPropValuePair(filter *filters.Clause,
 	return s.extractPrimitiveProp(property, filter.Value.Type, filter.Value.Value, filter.Operator, class)
 }
 
-func (s *Searcher) extractPropValuePairs(operands []filters.Clause, className schema.ClassName) ([]*propValuePair, error) {
+func (s *Searcher) extractPropValuePairs(ctx context.Context,
+	operands []filters.Clause, className schema.ClassName,
+) ([]*propValuePair, error) {
 	children := make([]*propValuePair, len(operands))
 	eg := enterrors.NewErrorGroupWrapper(s.logger)
-	// prevent unbounded concurrency, see
-	// https://github.com/weaviate/weaviate/issues/3179 for details
-	eg.SetLimit(2 * _NUMCPU)
+	outerConcurrencyLimit := concurrency.BudgetFromCtx(ctx, concurrency.NUMCPU)
+	eg.SetLimit(outerConcurrencyLimit)
+
+	concurrencyReductionFactor := min(len(operands), outerConcurrencyLimit)
 
 	for i, clause := range operands {
 		i, clause := i, clause
 		eg.Go(func() error {
-			child, err := s.extractPropValuePair(&clause, className)
+			ctx := concurrency.ContextWithFractionalBudget(ctx, concurrencyReductionFactor, concurrency.NUMCPU)
+			child, err := s.extractPropValuePair(ctx, &clause, className)
 			if err != nil {
 				return fmt.Errorf("nested clause at pos %d: %w", i, err)
 			}
@@ -672,7 +679,8 @@ func (s *Searcher) extractPropertyNull(prop *models.Property, propType schema.Da
 	}, nil
 }
 
-func (s *Searcher) extractContains(path *filters.Path, propType schema.DataType, value interface{},
+func (s *Searcher) extractContains(ctx context.Context,
+	path *filters.Path, propType schema.DataType, value interface{},
 	operator filters.Operator, class *models.Class,
 ) (*propValuePair, error) {
 	var operands []filters.Clause
@@ -711,7 +719,7 @@ func (s *Searcher) extractContains(path *filters.Path, propType schema.DataType,
 		return nil, fmt.Errorf("unsupported type '%T' for '%v' operator", propType, operator)
 	}
 
-	children, err := s.extractPropValuePairs(operands, schema.ClassName(class.Class))
+	children, err := s.extractPropValuePairs(ctx, operands, schema.ClassName(class.Class))
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -86,7 +86,8 @@ func (s *Searcher) docBitmapInvertedRoaringSet(ctx context.Context, b *lsmkv.Buc
 			out.release = release
 			isEmpty = false
 		} else {
-			out.docIDs.OrConc(docIDs, concurrency.SROAR_MERGE)
+			concurrencyBudget := concurrency.BudgetFromCtx(ctx, concurrency.SROAR_MERGE)
+			out.docIDs.OrConc(docIDs, concurrencyBudget)
 			release()
 		}
 
@@ -144,7 +145,8 @@ func (s *Searcher) docBitmapInvertedSet(ctx context.Context, b *lsmkv.Bucket,
 			out.release = release
 			isEmpty = false
 		} else {
-			out.docIDs.OrConc(ids, concurrency.SROAR_MERGE)
+			concurrencyBudget := concurrency.BudgetFromCtx(ctx, concurrency.SROAR_MERGE)
+			out.docIDs.OrConc(ids, concurrencyBudget)
 			release()
 		}
 
@@ -181,7 +183,8 @@ func (s *Searcher) docBitmapInvertedMap(ctx context.Context, b *lsmkv.Bucket,
 			out.release = release
 			isEmpty = false
 		} else {
-			out.docIDs.OrConc(ids, concurrency.SROAR_MERGE)
+			concurrencyBudget := concurrency.BudgetFromCtx(ctx, concurrency.SROAR_MERGE)
+			out.docIDs.OrConc(ids, concurrencyBudget)
 			release()
 		}
 

--- a/entities/concurrency/budget.go
+++ b/entities/concurrency/budget.go
@@ -1,6 +1,8 @@
 package concurrency
 
-import "context"
+import (
+	"context"
+)
 
 type budgetKey struct{}
 

--- a/entities/concurrency/budget.go
+++ b/entities/concurrency/budget.go
@@ -1,0 +1,29 @@
+package concurrency
+
+import "context"
+
+type budgetKey struct{}
+
+func (budgetKey) String() string {
+	return "concurrency_budget"
+}
+
+func CtxWithBudget(ctx context.Context, budget int) context.Context {
+	return context.WithValue(ctx, budgetKey{}, budget)
+}
+
+func BudgetFromCtx(ctx context.Context, fallback int) int {
+	budget, ok := ctx.Value(budgetKey{}).(int)
+	if !ok {
+		return fallback
+	}
+
+	return budget
+}
+
+func ContextWithFractionalBudget(ctx context.Context, factor, fallback int) context.Context {
+	budget := BudgetFromCtx(ctx, fallback)
+	newBudget := FractionOf(budget, factor)
+
+	return CtxWithBudget(ctx, newBudget)
+}

--- a/entities/concurrency/budget.go
+++ b/entities/concurrency/budget.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package concurrency
 
 import (

--- a/entities/concurrency/budget_test.go
+++ b/entities/concurrency/budget_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package concurrency
 
 import (

--- a/entities/concurrency/budget_test.go
+++ b/entities/concurrency/budget_test.go
@@ -1,0 +1,32 @@
+package concurrency
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBudget(t *testing.T) {
+	fallback := 12
+
+	ctx := context.Background()
+	budget := BudgetFromCtx(ctx, fallback)
+	// no budget set
+	assert.Equal(t, fallback, budget)
+
+	// extract previously set budget
+	ctx = CtxWithBudget(ctx, 32)
+	budget = BudgetFromCtx(ctx, fallback)
+	assert.Equal(t, 32, budget)
+
+	// reduce budget by factor
+	ctx = ContextWithFractionalBudget(ctx, 2, fallback)
+	budget = BudgetFromCtx(ctx, fallback)
+	assert.Equal(t, 16, budget)
+
+	// fractional reduction of fallback
+	ctx = ContextWithFractionalBudget(context.Background(), 3, fallback)
+	budget = BudgetFromCtx(ctx, fallback)
+	assert.Equal(t, 4, budget)
+}

--- a/entities/concurrency/numcpu.go
+++ b/entities/concurrency/numcpu.go
@@ -83,3 +83,15 @@ func timesFloatNUMCPU(factor float64, numcpu int) int {
 
 	return int(math.Max(1, math.Round(factor*float64(numcpu))))
 }
+
+func FractionOf(original, factor int) int {
+	if factor <= 0 {
+		return original
+	}
+
+	result := original / factor
+	if result < 1 {
+		return 1
+	}
+	return result
+}

--- a/entities/concurrency/numcpu_test.go
+++ b/entities/concurrency/numcpu_test.go
@@ -169,3 +169,51 @@ func TestTimesFloatNumcpu(t *testing.T) {
 		})
 	}
 }
+
+func TestFractionOf(t *testing.T) {
+	type testCase struct {
+		original int
+		factor   int
+		expected int
+	}
+
+	testCases := []testCase{
+		{
+			original: 10,
+			factor:   -1,
+			expected: 10,
+		},
+		{
+			original: 10,
+			factor:   0,
+			expected: 10,
+		},
+		{
+			original: 10,
+			factor:   1,
+			expected: 10,
+		},
+		{
+			original: 10,
+			factor:   2,
+			expected: 5,
+		},
+		{
+			original: 10,
+			factor:   3,
+			expected: 3,
+		},
+		{
+			original: 10,
+			factor:   24,
+			expected: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("fraction of %d factor %d", tc.original, tc.factor), func(t *testing.T) {
+			n := FractionOf(tc.original, tc.factor)
+			assert.Equal(t, tc.expected, n)
+		})
+	}
+}


### PR DESCRIPTION
## Concept

Treats "concurrency budget" as a tree where the root is the full budget (`e.g. 2*NUMCPU`). Every situation where new goroutines are spawned, the number of concurrent branches (`min(number_of_branches, concurrency_limit`) determine how to reduce the concurrency budget for the remainder of the call stack. 

Example with fewer child routines than budget:
- root routine has budget 32
- it spawns 4 new routines
- each routine has budget 8

Example with more child routines than budget
- root routine has budget 32
- it spawns 64 new routines, however concurrency limit cannot exceed 32
- each child routine has budget 1

## Implementation

Currently only used for filters (searcher / prop value pairs), but the same concept can be applied anywhere we spawn new routines.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
