### PR TITLE
feat(usage-module): treat loading shards as cold tenants to avoid blocking usage

### DIFF
--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	entschema "github.com/weaviate/weaviate/entities/schema"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
+	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/usecases/backup"
 	"github.com/weaviate/weaviate/usecases/schema"
 )
@@ -90,9 +91,9 @@ func (m *service) Usage(ctx context.Context) (*types.Report, error) {
 		index := m.db.GetIndexLike(entschema.ClassName(collection.Class))
 		if index != nil {
 			// First, collect cold tenants from sharding state
-			for tenantName, physical := range shardingState.Physical {
+			for shardName, physical := range shardingState.Physical {
 				// skip non-local shards
-				if !shardingState.IsLocalShard(tenantName) {
+				if !shardingState.IsLocalShard(shardName) {
 					continue
 				}
 
@@ -103,43 +104,9 @@ func (m *service) Usage(ctx context.Context) (*types.Report, error) {
 						m.addJitter()
 					}
 
-					// Cold tenant: calculate from disk without loading
-					objectUsage, err := index.CalculateUnloadedObjectsMetrics(ctx, tenantName)
+					shardUsage, err := calculateUnloadedShardUsage(ctx, index, shardName, collection.VectorConfig)
 					if err != nil {
 						return nil, err
-					}
-
-					vectorStorageSize, err := index.CalculateUnloadedVectorsMetrics(ctx, tenantName)
-					if err != nil {
-						return nil, err
-					}
-
-					shardUsage := &types.ShardUsage{
-						Name:                tenantName,
-						ObjectsCount:        objectUsage.Count,
-						Status:              strings.ToLower(models.TenantActivityStatusINACTIVE),
-						ObjectsStorageBytes: uint64(objectUsage.StorageBytes),
-						VectorStorageBytes:  uint64(vectorStorageSize),
-					}
-
-					// Get named vector data for cold shards from schema configuration
-					for targetVector, vectorConfig := range collection.VectorConfig {
-						if vectorIndexConfig, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig); ok {
-							category, _ := db.GetDimensionCategory(vectorIndexConfig)
-							indexType := vectorIndexConfig.IndexType()
-
-							// For cold shards, we can't get actual dimensionality from disk without loading
-							// So we'll use a placeholder or estimate based on the schema
-							vectorUsage := &types.VectorUsage{
-								Name:                   targetVector,
-								Compression:            category.String(),
-								VectorIndexType:        indexType,
-								IsDynamic:              common.IsDynamic(common.IndexType(indexType)),
-								VectorCompressionRatio: 1.0, // Default ratio for cold shards
-							}
-
-							shardUsage.NamedVectors = append(shardUsage.NamedVectors, vectorUsage)
-						}
 					}
 
 					collectionUsage.Shards = append(collectionUsage.Shards, shardUsage)
@@ -147,15 +114,25 @@ func (m *service) Usage(ctx context.Context) (*types.Report, error) {
 			}
 
 			// Then, collect hot tenants from loaded shards
-			index.ForEachShard(func(name string, shard db.ShardLike) error {
+			index.ForEachShard(func(shardName string, shard db.ShardLike) error {
 				// skip non-local shards
-				if !shardingState.IsLocalShard(name) {
+				if !shardingState.IsLocalShard(shardName) {
 					return nil
 				}
 
 				// Add jitter between hot shard processing (except for the first one)
 				if len(collectionUsage.Shards) > 0 {
 					m.addJitter()
+				}
+
+				// Check shard status without forcing load
+				if shard.GetStatusNoLoad() == storagestate.StatusLoading {
+					shardUsage, err := calculateUnloadedShardUsage(ctx, index, shardName, collection.VectorConfig)
+					if err != nil {
+						return err
+					}
+					collectionUsage.Shards = append(collectionUsage.Shards, shardUsage)
+					return nil
 				}
 
 				objectStorageSize, err := shard.ObjectStorageSize(ctx)
@@ -173,7 +150,7 @@ func (m *service) Usage(ctx context.Context) (*types.Report, error) {
 				}
 
 				shardUsage := &types.ShardUsage{
-					Name:                name,
+					Name:                shardName,
 					Status:              strings.ToLower(models.TenantActivityStatusACTIVE),
 					ObjectsCount:        objectCount,
 					ObjectsStorageBytes: uint64(objectStorageSize),
@@ -252,4 +229,46 @@ func (m *service) Usage(ctx context.Context) (*types.Report, error) {
 		}
 	}
 	return usage, nil
+}
+
+func calculateUnloadedShardUsage(ctx context.Context, index db.IndexLike, tenantName string, vectorConfig map[string]models.VectorConfig) (*types.ShardUsage, error) {
+	// Cold tenant: calculate from disk without loading
+	objectUsage, err := index.CalculateUnloadedObjectsMetrics(ctx, tenantName)
+	if err != nil {
+		return nil, err
+	}
+
+	vectorStorageSize, err := index.CalculateUnloadedVectorsMetrics(ctx, tenantName)
+	if err != nil {
+		return nil, err
+	}
+
+	shardUsage := &types.ShardUsage{
+		Name:                tenantName,
+		ObjectsCount:        objectUsage.Count,
+		Status:              strings.ToLower(models.TenantActivityStatusINACTIVE),
+		ObjectsStorageBytes: uint64(objectUsage.StorageBytes),
+		VectorStorageBytes:  uint64(vectorStorageSize),
+	}
+
+	// Get named vector data for cold shards from schema configuration
+	for targetVector, vectorConfig := range vectorConfig {
+		if vectorIndexConfig, ok := vectorConfig.VectorIndexConfig.(schemaConfig.VectorIndexConfig); ok {
+			category, _ := db.GetDimensionCategory(vectorIndexConfig)
+			indexType := vectorIndexConfig.IndexType()
+
+			// For cold shards, we can't get actual dimensionality from disk without loading
+			// So we'll use a placeholder or estimate based on the schema
+			vectorUsage := &types.VectorUsage{
+				Name:                   targetVector,
+				Compression:            category.String(),
+				VectorIndexType:        indexType,
+				IsDynamic:              common.IsDynamic(common.IndexType(indexType)),
+				VectorCompressionRatio: 1.0, // Default ratio for cold shards
+			}
+
+			shardUsage.NamedVectors = append(shardUsage.NamedVectors, vectorUsage)
+		}
+	}
+	return shardUsage, err
 }

--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -186,7 +186,7 @@ func (m *service) Usage(ctx context.Context) (*types.Report, error) {
 					}
 
 					// Only add dimensionalities if there's valid data
-					if dimensionality.Count > 0 && dimensionality.Dimensions > 0 {
+					if dimensionality.Count > 0 || dimensionality.Dimensions > 0 {
 						vectorUsage.Dimensionalities = append(vectorUsage.Dimensionalities, &types.Dimensionality{
 							Dimensions: dimensionality.Dimensions,
 							Count:      dimensionality.Count,

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	modulecapabilities "github.com/weaviate/weaviate/entities/modulecapabilities"
 	entschema "github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	backupusecase "github.com/weaviate/weaviate/usecases/backup"
 	"github.com/weaviate/weaviate/usecases/schema"
@@ -87,6 +88,7 @@ func TestService_Usage_SingleTenant(t *testing.T) {
 	mockDB.EXPECT().GetIndexLike(entschema.ClassName(className)).Return(mockIndex)
 
 	mockShard := db.NewMockShardLike(t)
+	mockShard.EXPECT().GetStatusNoLoad().Return(storagestate.StatusReady)
 	mockShard.EXPECT().ObjectCountAsync(ctx).Return(int64(objectCount), nil)
 	mockShard.EXPECT().ObjectStorageSize(ctx).Return(storageSize, nil)
 	mockShard.EXPECT().VectorStorageSize(ctx).Return(int64(0), nil)
@@ -213,6 +215,7 @@ func TestService_Usage_MultiTenant_HotAndCold(t *testing.T) {
 	mockDB.EXPECT().GetIndexLike(entschema.ClassName(className)).Return(mockIndex)
 
 	mockShard := db.NewMockShardLike(t)
+	mockShard.EXPECT().GetStatusNoLoad().Return(storagestate.StatusReady)
 	mockShard.EXPECT().ObjectCountAsync(ctx).Return(int64(hotObjectCount), nil)
 	mockShard.EXPECT().ObjectStorageSize(ctx).Return(hotStorageSize, nil)
 	mockShard.EXPECT().VectorStorageSize(ctx).Return(int64(0), nil)
@@ -431,6 +434,7 @@ func TestService_Usage_WithNamedVectors(t *testing.T) {
 	mockDB.EXPECT().GetIndexLike(entschema.ClassName(className)).Return(mockIndex)
 
 	mockShard := db.NewMockShardLike(t)
+	mockShard.EXPECT().GetStatusNoLoad().Return(storagestate.StatusReady)
 	mockShard.EXPECT().ObjectCountAsync(ctx).Return(int64(objectCount), nil)
 	mockShard.EXPECT().ObjectStorageSize(ctx).Return(storageSize, nil)
 	mockShard.EXPECT().VectorStorageSize(ctx).Return(int64(0), nil)
@@ -644,6 +648,7 @@ func TestService_Usage_VectorIndexError(t *testing.T) {
 	mockDB.EXPECT().GetIndexLike(entschema.ClassName(className)).Return(mockIndex)
 
 	mockShard := db.NewMockShardLike(t)
+	mockShard.EXPECT().GetStatusNoLoad().Return(storagestate.StatusReady)
 	mockShard.EXPECT().ObjectCountAsync(ctx).Return(int64(objectCount), nil)
 	mockShard.EXPECT().ObjectStorageSize(ctx).Return(storageSize, nil)
 	mockShard.EXPECT().VectorStorageSize(ctx).Return(int64(0), nil)
@@ -746,6 +751,7 @@ func TestService_Usage_NilVectorIndexConfig(t *testing.T) {
 	mockDB.EXPECT().GetIndexLike(entschema.ClassName(className)).Return(mockIndex)
 
 	mockShard := db.NewMockShardLike(t)
+	mockShard.EXPECT().GetStatusNoLoad().Return(storagestate.StatusReady)
 	mockShard.EXPECT().ObjectCountAsync(ctx).Return(int64(objectCount), nil)
 	mockShard.EXPECT().ObjectStorageSize(ctx).Return(storageSize, nil)
 	mockShard.EXPECT().VectorStorageSize(ctx).Return(int64(0), nil)
@@ -877,6 +883,7 @@ func TestService_Usage_VectorStorageSize(t *testing.T) {
 
 	// Mock hot tenant shard
 	mockHotShard := db.NewMockShardLike(t)
+	mockHotShard.EXPECT().GetStatusNoLoad().Return(storagestate.StatusReady)
 	mockHotShard.EXPECT().ObjectCountAsync(ctx).Return(int64(hotObjectCount), nil)
 	mockHotShard.EXPECT().ObjectStorageSize(ctx).Return(hotStorageSize, nil)
 	mockHotShard.EXPECT().VectorStorageSize(ctx).Return(hotVectorStorageSize, nil) // Test actual vector storage size
@@ -1125,6 +1132,7 @@ func TestService_JitterFunctionality(t *testing.T) {
 
 		// Simple shard mock
 		mockShard := db.NewMockShardLike(t)
+		mockShard.EXPECT().GetStatusNoLoad().Return(storagestate.StatusReady)
 		mockShard.EXPECT().ObjectCountAsync(ctx).Return(int64(100), nil).Times(2)
 		mockShard.EXPECT().ObjectStorageSize(ctx).Return(int64(1000), nil).Times(2)
 		mockShard.EXPECT().VectorStorageSize(ctx).Return(int64(0), nil).Times(2)
@@ -1217,6 +1225,7 @@ func TestService_JitterFunctionality(t *testing.T) {
 
 		// Simple shard mock
 		mockShard := db.NewMockShardLike(t)
+		mockShard.EXPECT().GetStatusNoLoad().Return(storagestate.StatusReady)
 		mockShard.EXPECT().ObjectCountAsync(ctx).Return(int64(100), nil)
 		mockShard.EXPECT().ObjectStorageSize(ctx).Return(int64(1000), nil)
 		mockShard.EXPECT().VectorStorageSize(ctx).Return(int64(0), nil)


### PR DESCRIPTION
### What's being changed:
This PR addresses a blocking issue in the usage module by treating loading shards as cold tenants, preventing usage collection from being blocked during shard loading operations.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
