### PR TITLE
Skip snapshot if muvera is enabled

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -724,6 +724,10 @@ func (l *hnswCommitLogger) writeMetadataTo(state *DeserializationResult, w io.Wr
 	}
 	offset += writeByteSize
 
+	if state.MuveraEnabled {
+		return 0, errors.New("muvera is not supported in snapshots")
+	}
+
 	if state.Compressed && state.CompressionPQData != nil { // PQ
 		// first byte is the compression type
 		if err := writeByte(w, byte(SnapshotCompressionTypePQ)); err != nil {


### PR DESCRIPTION
### What's being changed:
The following PR does not allow to use snapshots if MUVERA is enabled. This happened due to a bug in which when working with MUVERA + snapshotting some information are lost and is not possible to recovery MUVERA parameters. The bug has been fixed in 1.32 taking advantage of the new snapshot v2.

The scope for 1.31 is to skip the creation of snapshot and relying on commit logger if MUVERA is on.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
