### PR TITLE
chore(alias): Refactor to keep resolve alias isolated only in schema layer

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1073,6 +1073,11 @@ func startupRoutine(ctx context.Context, options *swag.CommandLineOptionsGroup) 
 		logger.Exit(1)
 	}
 
+	// Configure RBAC alias resolver if RBAC is enabled
+	if appState.RBAC != nil && appState.SchemaManager != nil {
+		appState.RBAC.SetAliasResolver(appState.SchemaManager.ResolveAlias)
+	}
+
 	logger.WithField("action", "startup").WithField("startup_time_left", timeTillDeadline(ctx)).
 		Debug("configured OIDC and anonymous access client")
 

--- a/usecases/auth/authorization/authorizer.go
+++ b/usecases/auth/authorization/authorizer.go
@@ -17,6 +17,10 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
+// AliasResolver is a function type that resolves an alias to its actual class name.
+// It returns the resolved class name if the alias exists, otherwise returns empty string.
+type AliasResolver func(alias string) string
+
 // Authorizer always makes a yes/no decision on a specific resource. Which
 // authorization technique is used in the background (e.g. RBAC, adminlist,
 // ...) is hidden through this interface

--- a/usecases/auth/authorization/rbac/authorizer.go
+++ b/usecases/auth/authorization/rbac/authorizer.go
@@ -50,10 +50,13 @@ func (m *Manager) authorize(ctx context.Context, principal *models.Principal, ve
 		logger = logger.WithField("groups", principal.Groups)
 	}
 
+	// Resolve aliases in resource paths before authorization
+	resolvedResources := m.resolveAliasesInResources(resources)
+	
 	// Create a map to aggregate resources and their counts while preserving order
 	resourceCounts := make(map[string]int)
 	var uniqueResources []string
-	for _, resource := range resources {
+	for _, resource := range resolvedResources {
 		if _, exists := resourceCounts[resource]; !exists {
 			uniqueResources = append(uniqueResources, resource)
 		}
@@ -131,12 +134,14 @@ func (m *Manager) FilterAuthorizedResources(ctx context.Context, principal *mode
 		logger = logger.WithField("groups", principal.Groups)
 	}
 
-	allowedResources := make([]string, 0, len(resources))
+	// Resolve aliases in resource paths before authorization
+	resolvedResources := m.resolveAliasesInResources(resources)
+	allowedResources := make([]string, 0, len(resolvedResources))
 
 	// Create a map to aggregate resources and their counts while preserving order
 	resourceCounts := make(map[string]int)
 	var uniqueResources []string
-	for _, resource := range resources {
+	for _, resource := range resolvedResources {
 		if _, exists := resourceCounts[resource]; !exists {
 			uniqueResources = append(uniqueResources, resource)
 		}

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -171,7 +171,7 @@ func (b *BatchManager) classGetterFunc(ctx context.Context, principal *models.Pr
 		if err := b.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Collections(name)...); err != nil {
 			return nil, err
 		}
-		class := b.schemaManager.ReadOnlyClass(name)
+		class := b.schemaManager.ReadOnlyClassResolvingAlias(name)
 		if class == nil {
 			return nil, fmt.Errorf("could not find class %s in schema", name)
 		}

--- a/usecases/objects/head.go
+++ b/usecases/objects/head.go
@@ -26,7 +26,7 @@ import (
 func (m *Manager) HeadObject(ctx context.Context, principal *models.Principal, className string,
 	id strfmt.UUID, repl *additional.ReplicationProperties, tenant string,
 ) (bool, *Error) {
-	className, _ = m.resolveAlias(className)
+	// RBAC will resolve alias internally using its configured resolver
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(className, tenant, id)); err != nil {
 		return false, &Error{err.Error(), StatusForbidden, err}
 	}
@@ -34,10 +34,7 @@ func (m *Manager) HeadObject(ctx context.Context, principal *models.Principal, c
 	m.metrics.HeadObjectInc()
 	defer m.metrics.HeadObjectDec()
 
-	if cls := m.schemaManager.ResolveAlias(className); cls != "" {
-		className = cls
-	}
-
+	// Pass class as-is to repository - schema layer will resolve alias internally
 	ok, err := m.vectorRepo.Exists(ctx, className, id, repl, tenant)
 	if err != nil {
 		switch {

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -44,6 +44,8 @@ type schemaManager interface {
 	GetClass(ctx context.Context, principal *models.Principal, name string) (*models.Class, error)
 	// ReadOnlyClass return class model.
 	ReadOnlyClass(name string) *models.Class
+	// ReadOnlyClassResolvingAlias returns class model, resolving alias internally if needed.
+	ReadOnlyClassResolvingAlias(classOrAlias string) *models.Class
 	// AddClassProperty it is upsert operation. it adds properties to a class and updates
 	// existing properties if the merge bool passed true.
 	AddClassProperty(ctx context.Context, principal *models.Principal, class *models.Class, className string, merge bool, prop ...*models.Property) (*models.Class, uint64, error)

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -103,6 +103,14 @@ type SchemaReader interface {
 	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
 	ResolveAlias(alias string) string
 
+	// Alias-resolving methods - these handle alias resolution internally
+	ReadOnlyClassResolvingAlias(classOrAlias string) *models.Class
+	ClassInfoResolvingAlias(classOrAlias string) clusterSchema.ClassInfo
+	ClassExistsResolvingAlias(classOrAlias string) bool
+	ReadResolvingAlias(classOrAlias string, reader func(*models.Class, *sharding.State) error) error
+	MultiTenancyResolvingAlias(classOrAlias string) models.MultiTenancyConfig
+	GetRealClassName(classOrAlias string) string
+
 	// These schema reads function (...WithVersion) return the metadata once the local schema has caught up to the
 	// version parameter. If version is 0 is behaves exactly the same as eventual consistent reads.
 	// For details about each endpoint see [github.com/weaviate/weaviate/cluster/schema.VersionedSchemaReader].


### PR DESCRIPTION
### What's being changed:
Two major changes
1. RBAC layer resolves alias internally and abstracts away from it's consumers
2. All the resolve alias is handled at schema layer so that we don't have to resolve alias in other layers including, db, rest, grpc, graphql, etc.

basically trying to refactor changes introduced in this PR #8524 

This helps a lot because, now any consumer of RBAC and Schema doesn't have to know about alias hence no need to worry about resolving the alias. Because that can be error prone, e.g: what if failed to check RBAC on resolved collection? what if new apis forget to resolve alias?

This PR abstracts the alias into just schema layer.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
