### PR TITLE
fix: delete redundant 'validation' step

### DIFF
--- a/usecases/modules/module_config_init_and_validate.go
+++ b/usecases/modules/module_config_init_and_validate.go
@@ -273,26 +273,5 @@ func (p *Provider) validateClassModuleConfig(ctx context.Context,
 	if err != nil {
 		return errors.Wrapf(err, "module '%s'", moduleName)
 	}
-
-	p.validateVectorConfig(class, moduleName, targetVector)
-
 	return nil
-}
-
-func (p *Provider) validateVectorConfig(class *models.Class, moduleName string, targetVector string) {
-	mod := p.GetByName(moduleName)
-
-	if class.VectorConfig == nil || !p.implementsVectorizer(mod) {
-		return
-	}
-
-	// named vector props need to be a string array
-	props, ok := class.VectorConfig[targetVector].Vectorizer.(map[string]interface{})[moduleName].(map[string]interface{})["properties"]
-	if ok {
-		propsTyped := make([]string, len(props.([]interface{})))
-		for i, v := range props.([]interface{}) {
-			propsTyped[i] = v.(string) // was validated by the module
-		}
-		class.VectorConfig[targetVector].Vectorizer.(map[string]interface{})[moduleName].(map[string]interface{})["properties"] = propsTyped
-	}
 }


### PR DESCRIPTION
In version 1.32.0 (build_commit: 7cebee0), probably earlier versions too, this causes a panic when relying on auto-schema:

```
interface conversion: interface {} is nil, not map[string]interface {}
```

See full traceback below:

<details>

```sh
{"action":"requests_total","api":"rest","build_git_commit":"7cebee0","build_go_version":"go1.24.5","build_imag
e_tag":"v1.32.0","build_wv_version":"1.32.0","class_name":"","error":"interface conversion: interface {} is ni
l, not map[string]interface {}","level":"error","msg":"unexpected error","query_type":"","time":"2025-07-26T13
:35:07Z"}
goroutine 104442 [running]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:26 +0x64
runtime/debug.PrintStack()
        /usr/local/go/src/runtime/debug/stack.go:18 +0x1c
github.com/weaviate/weaviate/adapters/handlers/rest.handlePanics({0x3cd1450, 0x40031a3a80}, {0x3caa068, 0x4000
1115b8}, 0x400273ec80)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/panics_middleware.go:85 +0x2e8
panic({0x240bb20?, 0x400311a840?})
        /usr/local/go/src/runtime/panic.go:792 +0x124
github.com/weaviate/weaviate/usecases/modules.(*Provider).validateVectorConfig(0x4002c71008, 0x400259e420, {0x
40000780da, 0x16}, {0x0, 0x0})
        /go/src/github.com/weaviate/weaviate/usecases/modules/module_config_init_and_validate.go:290 +0x340
github.com/weaviate/weaviate/usecases/modules.(*Provider).validateClassModuleConfig(0x4002c71008, {0x3caa5f8, 
0x40031c9470}, 0x400259e420, {0x40000780da, 0x16}, {0x0, 0x0})
        /go/src/github.com/weaviate/weaviate/usecases/modules/module_config_init_and_validate.go:277 +0x1f4
github.com/weaviate/weaviate/usecases/modules.(*Provider).validateClassesModuleConfig(0x4002c71008, {0x3caa5f8
, 0x40031c9470}, 0x400259e420, {0x249dfc0?, 0x40031c9530})
        /go/src/github.com/weaviate/weaviate/usecases/modules/module_config_init_and_validate.go:241 +0x130
github.com/weaviate/weaviate/usecases/modules.(*Provider).ValidateClass(0x400302cd70?, {0x3caa5f8?, 0x40031c94
70?}, 0x4?)
        /go/src/github.com/weaviate/weaviate/usecases/modules/module_config_init_and_validate.go:166 +0xc8
github.com/weaviate/weaviate/usecases/schema.(*Handler).validateClassInvariants(0x400302cd70, {0x3caa5f8, 0x40
031c9470}, 0x400259e420, 0x4000020a90, 0x0)
        /go/src/github.com/weaviate/weaviate/usecases/schema/class.go:675 +0x170
github.com/weaviate/weaviate/usecases/schema.(*Handler).validateCanAddClass(0x400302cd70?, {0x3caa5f8?, 0x4003
1c9470?}, 0x27d6c?, 0x0?, 0x0?)
        /go/src/github.com/weaviate/weaviate/usecases/schema/class.go:652 +0x80
github.com/weaviate/weaviate/usecases/schema.(*Handler).AddClass(0x400302cd70, {0x3caa5f8, 0x40031c9470}, 0x0,
 0x400259e420)
        /go/src/github.com/weaviate/weaviate/usecases/schema/class.go:117 +0x1dc
github.com/weaviate/weaviate/adapters/handlers/rest.(*schemaHandlers).addClass(0x40034ee9f0, {0x400273edc0?, 0
x400259e420?}, 0x0)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/handlers_schema.go:41 +0x9c
github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema.SchemaObjectsCreateHandlerFunc.Handle(0x
400339a780?, {0x400273edc0?, 0x400259e420?}, 0x3c74920?)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema/schema_objects_create.go
:32 +0x38
github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema.(*SchemaObjectsCreate).ServeHTTP(0x40034
ef3f8, {0x3ca46a0, 0x4004bc3260}, 0x400273edc0)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema/schema_objects_create.go
:81 +0x1fc
github.com/go-openapi/runtime/middleware.(*Context).RoutesHandler.NewOperationExecutor.func1({0x3ca46a0, 0x400
4bc3260}, 0x400273edc0)
        /go/pkg/mod/github.com/go-openapi/runtime@v0.24.2/middleware/operation.go:28 +0x58
net/http.HandlerFunc.ServeHTTP(0x40041b3710?, {0x3ca46a0?, 0x4004bc3260?}, 0x40031c9080?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/weaviate/weaviate/adapters/handlers/rest.configureAPI.makeSetupMiddlewares.func8.1({0x3ca46a0, 0x40
04bc3260}, 0x400273edc0)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/middlewares.go:48 +0xf0
net/http.HandlerFunc.ServeHTTP(0x400339a780?, {0x3ca46a0?, 0x4004bc3260?}, 0x8920c?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/go-openapi/runtime/middleware.NewRouter.func1({0x3ca46a0, 0x4004bc3260}, 0x400273ec80)
        /go/pkg/mod/github.com/go-openapi/runtime@v0.24.2/middleware/router.go:78 +0x1c0
net/http.HandlerFunc.ServeHTTP(0x4002eed068?, {0x3ca46a0?, 0x4004bc3260?}, 0xf75f4f2db868?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/go-openapi/runtime/middleware.Redoc.func1({0x3ca46a0, 0x4004bc3260}, 0x1?)
        /go/pkg/mod/github.com/go-openapi/runtime@v0.24.2/middleware/redoc.go:72 +0x1f4
net/http.HandlerFunc.ServeHTTP(0x0?, {0x3ca46a0?, 0x4004bc3260?}, 0x0?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/go-openapi/runtime/middleware.Spec.func1({0x3ca46a0, 0x4004bc3260}, 0x4002eed128?)
        /go/pkg/mod/github.com/go-openapi/runtime@v0.24.2/middleware/spec.go:46 +0x164
net/http.HandlerFunc.ServeHTTP(0x40036c5c20?, {0x3ca46a0?, 0x4004bc3260?}, 0x400273ec80?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/rs/cors.(*Cors).Handler-fm.(*Cors).Handler.func1({0x3ca46a0, 0x4004bc3260}, 0x400273ec80)
        /go/pkg/mod/github.com/rs/cors@v1.5.0/cors.go:200 +0x19c
net/http.HandlerFunc.ServeHTTP(0x4000110020?, {0x3ca46a0?, 0x4004bc3260?}, 0x2543600?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/weaviate/weaviate/adapters/handlers/rest/swagger_middleware.AddMiddleware.func1({0x3ca46a0, 0x4004b
c3260}, 0x400273ec80)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/swagger_middleware/swagger_middleware.go:3
7 +0x21c
net/http.HandlerFunc.ServeHTTP(0x400242a460?, {0x3ca46a0?, 0x4004bc3260?}, 0x3?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/weaviate/weaviate/adapters/handlers/rest.makeAddLogging.func1.1({0x3ca46a0, 0x4004bc3260}, 0x400273
ec80)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/middlewares.go:188 +0x228
net/http.HandlerFunc.ServeHTTP(0x275d7e0?, {0x3ca46a0?, 0x4004bc3260?}, 0x1c?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/weaviate/weaviate/adapters/handlers/rest.addPreflight.func1({0x3ca46a0, 0x4004bc3260}, 0x400273ec80
)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/middlewares.go:225 +0x310
net/http.HandlerFunc.ServeHTTP(0x40041b3710?, {0x3ca46a0?, 0x4004bc3260?}, 0x18?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/weaviate/weaviate/adapters/handlers/rest.addLiveAndReadyness.func1({0x3ca46a0, 0x4004bc3260}, 0x400
273ec80)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/middlewares.go:273 +0xa4
net/http.HandlerFunc.ServeHTTP(0x40041b3710?, {0x3ca46a0?, 0x4004bc3260?}, 0x8b460?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/weaviate/weaviate/adapters/handlers/rest.addHandleRoot.func1({0x3ca46a0, 0x4004bc3260}, 0x400273ec8
0)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/middlewares.go:63 +0x1c8
net/http.HandlerFunc.ServeHTTP(0x40041b3710?, {0x3ca46a0?, 0x4004bc3260?}, 0x284bc?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/weaviate/weaviate/adapters/handlers/rest.makeAddModuleHandlers.func1.1({0x3ca46a0, 0x4004bc3260}, 0
x400273ec80)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/middlewares.go:105 +0x88
net/http.HandlerFunc.ServeHTTP(0x4002e91868?, {0x3ca46a0?, 0x4004bc3260?}, 0x0?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/weaviate/weaviate/adapters/handlers/rest.addInjectHeadersIntoContext.func1({0x3ca46a0, 0x4004bc3260
}, 0x400273ec80)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/middlewares.go:243 +0x248
net/http.HandlerFunc.ServeHTTP(0x1400000030?, {0x3ca46a0?, 0x4004bc3260?}, 0x140?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/weaviate/weaviate/adapters/handlers/rest.makeCatchPanics.func1.1({0x3ca46a0?, 0x4004bc3260?}, 0x400
2e919d8?)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/panics_middleware.go:31 +0x88
net/http.HandlerFunc.ServeHTTP(0x3caa630?, {0x3ca46a0?, 0x4004bc3260?}, 0x3c60a50?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/weaviate/weaviate/adapters/handlers/rest.addSourceIpToContext.func1({0x3ca46a0, 0x4004bc3260}, 0x40
029eca00)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/source_ip_middleware.go:28 +0x13c
net/http.HandlerFunc.ServeHTTP(0x4002e91ab8?, {0x3ca46a0?, 0x4004bc3260?}, 0x0?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
github.com/weaviate/weaviate/adapters/handlers/rest.addClusterHandlerMiddleware.func1({0x3ca46a0, 0x4004bc3260
}, 0x40029eca00)
        /go/src/github.com/weaviate/weaviate/adapters/handlers/rest/middlewares.go:83 +0xe8
net/http.HandlerFunc.ServeHTTP(0x10?, {0x3ca46a0?, 0x4004bc3260?}, 0x4004bc3260?)
        /usr/local/go/src/net/http/server.go:2294 +0x38
net/http.serverHandler.ServeHTTP({0x3c95b58?}, {0x3ca46a0?, 0x4004bc3260?}, 0x1?)
        /usr/local/go/src/net/http/server.go:3301 +0xbc
net/http.(*conn).serve(0x400378d830, {0x3caa5f8, 0x400332ed20})
        /usr/local/go/src/net/http/server.go:2102 +0x52c
created by net/http.(*Server).Serve in goroutine 183
        /usr/local/go/src/net/http/server.go:3454 +0x3d8
```

</details>

This panic is non-fatal and does not affect Weaviate at all, because the 'validation' is a noop:

1. It never returns an error. There's no return value at all.
2. The typed []string is put back to an interface{} variable, which negates the previous type assertion.

### What's being changed:

Let's delete the method causing the panic. All the tests should pass, as this is a noop.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
