### PR TITLE
chore(alias): Improve error message when creating class.

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -125,10 +125,16 @@ func (s *SchemaManager) PreApplyFilter(req *command.ApplyRequest) error {
 
 	// Discard adding class if the name already exists or a similar one exists
 	if req.Type == command.ApplyRequest_TYPE_ADD_CLASS {
-		if other := s.schema.ClassEqual(req.Class); other == req.Class {
-			return fmt.Errorf("class name %s already exists", req.Class)
+		other, is_alias := s.schema.ClassEqual(req.Class)
+		item := "class"
+		if is_alias {
+			item = "alias"
+		}
+
+		if other == req.Class {
+			return fmt.Errorf("%s name %s already exists", item, req.Class)
 		} else if other != "" {
-			return fmt.Errorf("%w: found similar class %q", ErrClassExists, other)
+			return fmt.Errorf("%w: found similar %s %q", ErrClassExists, item, other)
 		}
 	}
 

--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -125,9 +125,9 @@ func (s *SchemaManager) PreApplyFilter(req *command.ApplyRequest) error {
 
 	// Discard adding class if the name already exists or a similar one exists
 	if req.Type == command.ApplyRequest_TYPE_ADD_CLASS {
-		other, is_alias := s.schema.ClassEqual(req.Class)
+		other, isAlias := s.schema.ClassEqual(req.Class)
 		item := "class"
-		if is_alias {
+		if isAlias {
 			item = "alias"
 		}
 

--- a/cluster/schema/reader.go
+++ b/cluster/schema/reader.go
@@ -68,7 +68,8 @@ func (rs SchemaReader) ClassInfo(class string) (ci ClassInfo) {
 // ClassEqual returns the name of an existing class with a similar name, and "" otherwise
 // strings.EqualFold is used to compare classes
 func (rs SchemaReader) ClassEqual(name string) string {
-	return rs.schema.ClassEqual(name)
+	x, _ := rs.schema.ClassEqual(name)
+	return x
 }
 
 func (rs SchemaReader) MultiTenancy(class string) models.MultiTenancyConfig {

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -645,9 +645,9 @@ func (s *schema) createAlias(class, alias string) error {
 		return fmt.Errorf("create alias: class %s does not exist", class)
 	}
 	// trying to check if any class exists with passed 'alias' name
-	other, is_alias := s.unsafeClassEqual(alias)
+	other, isAlias := s.unsafeClassEqual(alias)
 	item := "class"
-	if is_alias {
+	if isAlias {
 		item = "alias"
 	}
 

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -106,24 +106,25 @@ func (s *schema) ClassInfo(class string) ClassInfo {
 
 // ClassEqual returns the name of an existing class with a similar name, and "" otherwise
 // strings.EqualFold is used to compare classes
-func (s *schema) ClassEqual(name string) string {
+// additional bool return true if it's a alias match
+func (s *schema) ClassEqual(name string) (string, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 	return s.unsafeClassEqual(name)
 }
 
-func (s *schema) unsafeClassEqual(name string) string {
+func (s *schema) unsafeClassEqual(name string) (string, bool) {
 	for alias := range s.aliases {
 		if strings.EqualFold(alias, name) {
-			return alias
+			return alias, true
 		}
 	}
 	for k := range s.classes {
 		if strings.EqualFold(k, name) {
-			return k
+			return k, false
 		}
 	}
-	return ""
+	return "", false
 }
 
 func (s *schema) MultiTenancy(class string) models.MultiTenancyConfig {
@@ -644,8 +645,14 @@ func (s *schema) createAlias(class, alias string) error {
 		return fmt.Errorf("create alias: class %s does not exist", class)
 	}
 	// trying to check if any class exists with passed 'alias' name
-	if other := s.unsafeClassEqual(alias); other == alias {
-		return fmt.Errorf("create alias: class %s already exists", alias)
+	other, is_alias := s.unsafeClassEqual(alias)
+	item := "class"
+	if is_alias {
+		item = "alias"
+	}
+
+	if other == alias {
+		return fmt.Errorf("create alias: %s %s already exists", item, alias)
 	}
 	s.aliases[alias] = class
 	return nil

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -38,8 +38,9 @@ func TestCollectionNameConflictWithAlias(t *testing.T) {
 	require.NoError(t, err)
 
 	// checking to see if class exists should consider the existing alias as well
-	got := sc.ClassEqual("MyCar")
+	got, is_alias := sc.ClassEqual("MyCar")
 	assert.NotEmpty(t, got)
+	assert.True(t, is_alias)
 }
 
 func Test_schemaCollectionMetrics(t *testing.T) {

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -38,9 +38,9 @@ func TestCollectionNameConflictWithAlias(t *testing.T) {
 	require.NoError(t, err)
 
 	// checking to see if class exists should consider the existing alias as well
-	got, is_alias := sc.ClassEqual("MyCar")
+	got, isAlias := sc.ClassEqual("MyCar")
 	assert.NotEmpty(t, got)
-	assert.True(t, is_alias)
+	assert.True(t, isAlias)
 }
 
 func Test_schemaCollectionMetrics(t *testing.T) {

--- a/cluster/schema/schema_thread_safety_test.go
+++ b/cluster/schema/schema_thread_safety_test.go
@@ -281,7 +281,7 @@ func testConcurrentSchemaOperations(t *testing.T, s *schema) {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
 				className := fmt.Sprintf("Class%d_%d", id, j)
-				_ = s.ClassEqual(className)
+				_, _ = s.ClassEqual(className)
 				time.Sleep(time.Microsecond)
 			}
 		}(i)
@@ -553,7 +553,7 @@ func testConcurrentClassInfoOperations(t *testing.T, s *schema) {
 		go func() {
 			defer wg.Done()
 			for j := 0; j < iterations; j++ {
-				name := s.ClassEqual("testclass") // Testing case-insensitive match
+				name, _ := s.ClassEqual("testclass") // Testing case-insensitive match
 				if name != "" {
 					assert.Equal(t, "TestClass", name)
 				}

--- a/cluster/schema/versioned_reader.go
+++ b/cluster/schema/versioned_reader.go
@@ -151,9 +151,3 @@ func (s VersionedSchemaReader) CopyShardingState(ctx context.Context,
 }
 
 func (s VersionedSchemaReader) Len() int { return s.schema.len() }
-
-// ClassEqual returns the name of an existing class with a similar name, and "" otherwise
-// strings.EqualFold is used to compare classes
-func (s VersionedSchemaReader) ClassEqual(name string) string {
-	return s.schema.ClassEqual(name)
-}

--- a/test/acceptance/aliases/aliases_api_test.go
+++ b/test/acceptance/aliases/aliases_api_test.go
@@ -252,18 +252,23 @@ func Test_AliasesAPI(t *testing.T) {
 					// trying to create class with existing class name.
 					name:             "with existing class name",
 					class:            books.ClassModel2VecVectorizerWithName(books.DefaultClassName),
-					expectedErrorMsg: fmt.Sprintf("create class: class %s already exists", books.DefaultClassName),
+					expectedErrorMsg: fmt.Sprintf("class name %s already exists", books.DefaultClassName),
 				},
 				// trying to create class with existing alias name.
 				{
 					name:             "with existing alias name",
 					class:            books.ClassModel2VecVectorizerWithName("BookAlias"),
-					expectedErrorMsg: fmt.Sprintf("create class: alias %s already exists", "BookAlias"),
+					expectedErrorMsg: fmt.Sprintf("alias name %s already exists", "BookAlias"),
 				},
 			}
 			for _, tt := range tests {
 				t.Run(tt.name, func(t *testing.T) {
-					helper.CreateClass(t, tt.class)
+					params := schema.NewSchemaObjectsCreateParams().WithObjectClass(tt.class)
+					resp, err := helper.Client(t).Schema.SchemaObjectsCreate(params, nil)
+					require.Error(t, err)
+					assert.Nil(t, resp)
+					errorPayload, _ := json.MarshalIndent(err, "", " ")
+					assert.Contains(t, string(errorPayload), tt.expectedErrorMsg)
 				})
 			}
 		})
@@ -299,7 +304,7 @@ func Test_AliasesAPI(t *testing.T) {
 			require.Nil(t, resp)
 			require.Error(t, err)
 			errorPayload, _ := json.MarshalIndent(err, "", " ")
-			assert.Contains(t, string(errorPayload), fmt.Sprintf("class name %s already exists", class.Class))
+			assert.Contains(t, string(errorPayload), fmt.Sprintf("alias name %s already exists", class.Class))
 		})
 		t.Run("GraphQL Get query with alias", func(t *testing.T) {
 			getQuery := `

--- a/test/acceptance/aliases/aliases_api_test.go
+++ b/test/acceptance/aliases/aliases_api_test.go
@@ -242,6 +242,31 @@ func Test_AliasesAPI(t *testing.T) {
 				})
 			}
 		})
+		t.Run("create class", func(t *testing.T) {
+			tests := []struct {
+				name             string
+				class            *models.Class
+				expectedErrorMsg string
+			}{
+				{
+					// trying to create class with existing class name.
+					name:             "with existing class name",
+					class:            books.ClassModel2VecVectorizerWithName(books.DefaultClassName),
+					expectedErrorMsg: fmt.Sprintf("create class: class %s already exists", books.DefaultClassName),
+				},
+				// trying to create class with existing alias name.
+				{
+					name:             "with existing alias name",
+					class:            books.ClassModel2VecVectorizerWithName("BookAlias"),
+					expectedErrorMsg: fmt.Sprintf("create class: alias %s already exists", "BookAlias"),
+				},
+			}
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					helper.CreateClass(t, tt.class)
+				})
+			}
+		})
 	})
 
 	t.Run("create alias to non existing collection", func(t *testing.T) {


### PR DESCRIPTION

### What's being changed:
Currently classEqual check does both alias and class checks which is sometimes hard to provide clear error message to the end user.

This PR, fixes some core method to differentiate if it's alias or class

Before 
when trying to create collection with existing alias name
```
class name Movies already exists
```

After:
```
alias name Movies already exists
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
