### PR TITLE
bug(alias): Fix case inconsistency with GET /alias endpoint

### DIFF
--- a/usecases/schema/alias.go
+++ b/usecases/schema/alias.go
@@ -47,6 +47,7 @@ func (h *Handler) GetAliases(ctx context.Context, principal *models.Principal, a
 }
 
 func (h *Handler) GetAlias(ctx context.Context, principal *models.Principal, alias string) ([]*models.Alias, error) {
+	alias = schema.UppercaseClassName(alias)
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.READ, authorization.Aliases("", alias)...); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What's being changed:

Normally, both class and alias is case-insensitivity to first letter. e.g: TigerLion, tigerLion are same.

The GET /alias endpoint violated this invariant. This PR fixes it.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
