### PR TITLE
chore(alias): Make alias name validation same as class name validation

### DIFF
--- a/entities/schema/validation.go
+++ b/entities/schema/validation.go
@@ -55,14 +55,15 @@ const (
 
 // ValidateClassName validates that this string is a valid class name (format wise)
 func ValidateClassName(name string) (ClassName, error) {
-	if len(name) > classNameMaxLength {
-		return "", fmt.Errorf("'%s' is not a valid class name. Name should not be longer than %d characters",
-			name, classNameMaxLength)
+	c, err := validateClassOrAliasName(name, false)
+	if err != nil {
+		return "", err
 	}
-	if !validateClassNameRegex.MatchString(name) {
-		return "", fmt.Errorf("'%s' is not a valid class name", name)
-	}
-	return ClassName(name), nil
+	return ClassName(c), nil
+}
+
+func ValidateAliasName(name string) (string, error) {
+	return validateClassOrAliasName(name, true)
 }
 
 // ValidateClassNameIncludesRegex validates that this string is a valid class name (format wise)
@@ -76,6 +77,22 @@ func ValidateClassNameIncludesRegex(name string) (ClassName, error) {
 		return "", fmt.Errorf("'%s' is not a valid class name", name)
 	}
 	return ClassName(name), nil
+}
+
+func validateClassOrAliasName(name string, isAlias bool) (string, error) {
+	typ := "class"
+	if isAlias {
+		typ = "alias"
+	}
+
+	if len(name) > classNameMaxLength {
+		return "", fmt.Errorf("'%s' is not a valid %s name. Name should not be longer than %d characters",
+			name, typ, classNameMaxLength)
+	}
+	if !validateClassNameRegex.MatchString(name) {
+		return "", fmt.Errorf("'%s' is not a valid %s name", name, typ)
+	}
+	return name, nil
 }
 
 // ValidateTenantName validates that this string is a valid tenant name (format wise)

--- a/test/acceptance/aliases/aliases_api_test.go
+++ b/test/acceptance/aliases/aliases_api_test.go
@@ -14,6 +14,7 @@ package test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -154,8 +155,9 @@ func Test_AliasesAPI(t *testing.T) {
 				resp, err := helper.Client(t).Schema.AliasesCreate(p, nil)
 				require.Error(t, err)
 				assert.Nil(t, resp)
-				cerr, ok := err.(*schema.AliasesCreateUnprocessableEntity)
-				assert.True(t, ok) // returned error should be of this concrete type.
+				var cerr *schema.AliasesCreateUnprocessableEntity
+				ok := errors.As(err, &cerr) // convert to concrete error type
+				assert.True(t, ok)
 				assert.Contains(t, cerr.Payload.Error[0].Message, "is not a valid alias name")
 			})
 		}

--- a/test/acceptance/aliases/aliases_api_test.go
+++ b/test/acceptance/aliases/aliases_api_test.go
@@ -139,13 +139,15 @@ func Test_AliasesAPI(t *testing.T) {
 
 	t.Run("create alias with invalid char", func(t *testing.T) {
 		cases := []struct {
-			name string
+			name  string
+			input string
 		}{
-			{name: "invalid_alias_!#"},
-			{name: "invalid_alias_@"},
-			{name: "!invalid_alias_@"},
-			{name: "#invalid_alias_*"},
-			{name: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, // more than max 255 chars
+			{name: "symbols1", input: "invalid_alias_!#"},
+			{name: "symbols2", input: "invalid_alias_@"},
+			{name: "symbols3", input: "!invalid_alias_@"},
+			{name: "symbols4", input: "#invalid_alias_*"},
+			{name: "empty", input: ""},
+			{name: "maxlength", input: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}, // more than max 255 chars
 		}
 
 		for _, tc := range cases {

--- a/usecases/schema/alias.go
+++ b/usecases/schema/alias.go
@@ -60,6 +60,11 @@ func (h *Handler) AddAlias(ctx context.Context, principal *models.Principal,
 	alias.Class = schema.UppercaseClassName(alias.Class)
 	alias.Alias = schema.UppercaseClassName(alias.Alias)
 
+	err := h.Authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.Aliases(alias.Class, alias.Alias)...)
+	if err != nil {
+		return nil, 0, err
+	}
+
 	// alias should have same validation as collection.
 	al, err := schema.ValidateAliasName(alias.Alias)
 	if err != nil {
@@ -67,10 +72,6 @@ func (h *Handler) AddAlias(ctx context.Context, principal *models.Principal,
 	}
 	alias.Alias = al
 
-	err = h.Authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.Aliases(alias.Class, alias.Alias)...)
-	if err != nil {
-		return nil, 0, err
-	}
 	class := h.schemaReader.ReadOnlyClass(alias.Class)
 	version, err := h.schemaManager.CreateAlias(ctx, alias.Alias, class)
 	if err != nil {

--- a/usecases/schema/alias.go
+++ b/usecases/schema/alias.go
@@ -59,7 +59,15 @@ func (h *Handler) AddAlias(ctx context.Context, principal *models.Principal,
 ) (*models.Alias, uint64, error) {
 	alias.Class = schema.UppercaseClassName(alias.Class)
 	alias.Alias = schema.UppercaseClassName(alias.Alias)
-	err := h.Authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.Aliases(alias.Class, alias.Alias)...)
+
+	// alias should have same validation as collection.
+	al, err := schema.ValidateAliasName(alias.Alias)
+	if err != nil {
+		return nil, 0, err
+	}
+	alias.Alias = al
+
+	err = h.Authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.Aliases(alias.Class, alias.Alias)...)
 	if err != nil {
 		return nil, 0, err
 	}

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -126,9 +126,9 @@ func Test_Schema_Authorization(t *testing.T) {
 		},
 		{
 			methodName:        "AddAlias",
-			additionalArgs:    []interface{}{&models.Alias{Class: "classname"}},
+			additionalArgs:    []interface{}{&models.Alias{Class: "classname", Alias: "aliasName"}},
 			expectedVerb:      authorization.CREATE,
-			expectedResources: authorization.Aliases("Classname"),
+			expectedResources: authorization.Aliases("Classname", "AliasName"),
 		},
 		{
 			methodName:        "UpdateAlias",


### PR DESCRIPTION
### What's being changed:
Currently we let alias name contains non-alphanumeric characters(e.g: @#!) which conflicts with how validation done on class names

This PR fixes it by making it consistent with class name validation.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
