### PR TITLE
vector index: Remove AlreadyIndexed

### DIFF
--- a/adapters/repos/db/mock_vector_index.go
+++ b/adapters/repos/db/mock_vector_index.go
@@ -231,51 +231,6 @@ func (_c *MockVectorIndex_AddMultiBatch_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
-// AlreadyIndexed provides a mock function with no fields
-func (_m *MockVectorIndex) AlreadyIndexed() uint64 {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for AlreadyIndexed")
-	}
-
-	var r0 uint64
-	if rf, ok := ret.Get(0).(func() uint64); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint64)
-	}
-
-	return r0
-}
-
-// MockVectorIndex_AlreadyIndexed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AlreadyIndexed'
-type MockVectorIndex_AlreadyIndexed_Call struct {
-	*mock.Call
-}
-
-// AlreadyIndexed is a helper method to define mock.On call
-func (_e *MockVectorIndex_Expecter) AlreadyIndexed() *MockVectorIndex_AlreadyIndexed_Call {
-	return &MockVectorIndex_AlreadyIndexed_Call{Call: _e.mock.On("AlreadyIndexed")}
-}
-
-func (_c *MockVectorIndex_AlreadyIndexed_Call) Run(run func()) *MockVectorIndex_AlreadyIndexed_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockVectorIndex_AlreadyIndexed_Call) Return(_a0 uint64) *MockVectorIndex_AlreadyIndexed_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockVectorIndex_AlreadyIndexed_Call) RunAndReturn(run func() uint64) *MockVectorIndex_AlreadyIndexed_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Compressed provides a mock function with no fields
 func (_m *MockVectorIndex) Compressed() bool {
 	ret := _m.Called()

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -81,7 +81,6 @@ type VectorIndex interface {
 	Multivector() bool
 	ValidateBeforeInsert(vector []float32) error
 	ContainsDoc(docID uint64) bool
-	AlreadyIndexed() uint64
 	QueryVectorDistancer(queryVector []float32) common.QueryVectorDistancer
 	QueryMultiVectorDistancer(queryVector [][]float32) common.QueryVectorDistancer
 	// Iterate over all indexed document ids in the index.
@@ -96,6 +95,7 @@ type upgradableIndexer interface {
 	Upgraded() bool
 	Upgrade(callback func()) error
 	ShouldUpgrade() (bool, int)
+	AlreadyIndexed() uint64
 }
 
 type dynamic struct {
@@ -457,7 +457,7 @@ func (dynamic *dynamic) ContainsDoc(docID uint64) bool {
 func (dynamic *dynamic) AlreadyIndexed() uint64 {
 	dynamic.RLock()
 	defer dynamic.RUnlock()
-	return dynamic.index.AlreadyIndexed()
+	return (dynamic.index).(upgradableIndexer).AlreadyIndexed()
 }
 
 func (dynamic *dynamic) QueryVectorDistancer(queryVector []float32) common.QueryVectorDistancer {

--- a/adapters/repos/db/vector/dynamic/mock_vector_index.go
+++ b/adapters/repos/db/vector/dynamic/mock_vector_index.go
@@ -229,51 +229,6 @@ func (_c *MockVectorIndex_AddMultiBatch_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
-// AlreadyIndexed provides a mock function with no fields
-func (_m *MockVectorIndex) AlreadyIndexed() uint64 {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for AlreadyIndexed")
-	}
-
-	var r0 uint64
-	if rf, ok := ret.Get(0).(func() uint64); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint64)
-	}
-
-	return r0
-}
-
-// MockVectorIndex_AlreadyIndexed_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AlreadyIndexed'
-type MockVectorIndex_AlreadyIndexed_Call struct {
-	*mock.Call
-}
-
-// AlreadyIndexed is a helper method to define mock.On call
-func (_e *MockVectorIndex_Expecter) AlreadyIndexed() *MockVectorIndex_AlreadyIndexed_Call {
-	return &MockVectorIndex_AlreadyIndexed_Call{Call: _e.mock.On("AlreadyIndexed")}
-}
-
-func (_c *MockVectorIndex_AlreadyIndexed_Call) Run(run func()) *MockVectorIndex_AlreadyIndexed_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run()
-	})
-	return _c
-}
-
-func (_c *MockVectorIndex_AlreadyIndexed_Call) Return(_a0 uint64) *MockVectorIndex_AlreadyIndexed_Call {
-	_c.Call.Return(_a0)
-	return _c
-}
-
-func (_c *MockVectorIndex_AlreadyIndexed_Call) RunAndReturn(run func() uint64) *MockVectorIndex_AlreadyIndexed_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // Compressed provides a mock function with no fields
 func (_m *MockVectorIndex) Compressed() bool {
 	ret := _m.Called()

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -49,7 +49,6 @@ type VectorIndex interface {
 	// ContainsDoc returns true if the index has indexed document with a given id.
 	// It must return false if the document does not exist, or has a tombstone.
 	ContainsDoc(docID uint64) bool
-	AlreadyIndexed() uint64
 	// Iterate over all indexed document ids in the index.
 	// Consistency or order is not guaranteed, as the index may be concurrently modified.
 	// If the callback returns false, the iteration will stop.

--- a/adapters/repos/db/vector_index_queue.go
+++ b/adapters/repos/db/vector_index_queue.go
@@ -257,6 +257,7 @@ type upgradableIndexer interface {
 	Upgraded() bool
 	Upgrade(callback func()) error
 	ShouldUpgrade() (bool, int)
+	AlreadyIndexed() uint64
 }
 
 // triggers compression if the index is ready to be upgraded
@@ -271,7 +272,7 @@ func (iq *VectorIndexQueue) checkCompressionSettings() (skip bool) {
 		return false
 	}
 
-	if iq.vectorIndex.AlreadyIndexed() > uint64(shouldUpgradeAt) {
+	if ci.AlreadyIndexed() > uint64(shouldUpgradeAt) {
 		iq.scheduler.PauseQueue(iq.DiskQueue.ID())
 
 		err := ci.Upgrade(func() {


### PR DESCRIPTION
### What's being changed:

This removes the AlreadyIndexed method from the VectorIndex interface.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
