### PR TITLE
vector index: Add type method

### DIFF
--- a/adapters/repos/db/mock_vector_index.go
+++ b/adapters/repos/db/mock_vector_index.go
@@ -1270,6 +1270,51 @@ func (_c *MockVectorIndex_SwitchCommitLogs_Call) RunAndReturn(run func(context.C
 	return _c
 }
 
+// Type provides a mock function with no fields
+func (_m *MockVectorIndex) Type() common.IndexType {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Type")
+	}
+
+	var r0 common.IndexType
+	if rf, ok := ret.Get(0).(func() common.IndexType); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(common.IndexType)
+	}
+
+	return r0
+}
+
+// MockVectorIndex_Type_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Type'
+type MockVectorIndex_Type_Call struct {
+	*mock.Call
+}
+
+// Type is a helper method to define mock.On call
+func (_e *MockVectorIndex_Expecter) Type() *MockVectorIndex_Type_Call {
+	return &MockVectorIndex_Type_Call{Call: _e.mock.On("Type")}
+}
+
+func (_c *MockVectorIndex_Type_Call) Run(run func()) *MockVectorIndex_Type_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockVectorIndex_Type_Call) Return(_a0 common.IndexType) *MockVectorIndex_Type_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockVectorIndex_Type_Call) RunAndReturn(run func() common.IndexType) *MockVectorIndex_Type_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateUserConfig provides a mock function with given fields: updated, callback
 func (_m *MockVectorIndex) UpdateUserConfig(updated config.VectorIndexConfig, callback func()) error {
 	ret := _m.Called(updated, callback)

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -254,6 +254,10 @@ func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
 	return index, nil
 }
 
+func (dynamic *dynamic) Type() common.IndexType {
+	return common.IndexTypeDynamic
+}
+
 func (dynamic *dynamic) dbKey() []byte {
 	var key []byte
 	if dynamic.targetVector == "fef" {

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -23,6 +23,7 @@ import (
 // VectorIndex is anything that indexes vectors efficiently. For an example
 // look at ./vector/hnsw/index.go
 type VectorIndex interface {
+	Type() common.IndexType
 	Add(ctx context.Context, id uint64, vector []float32) error
 	AddMulti(ctx context.Context, docId uint64, vector [][]float32) error
 	AddBatch(ctx context.Context, ids []uint64, vector [][]float32) error


### PR DESCRIPTION
### What's being changed:

This adds the Type() method to the VectorIndex interface.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
