### PR TITLE
fix: check s.index.metrics is configured before accessing

### DIFF
--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -112,7 +112,7 @@ func (dm DimensionMetrics) Add(add DimensionMetrics) DimensionMetrics {
 // its dimension metrics on its own iff it is being shut down or dropped
 // and metrics grouping is disatbled.
 func (s *Shard) clearDimensionMetrics() {
-	if s.index.metrics.baseMetrics == nil || s.index.metrics.baseMetrics.Group {
+	if s.index.metrics == nil || s.index.metrics.baseMetrics == nil || s.index.metrics.baseMetrics.Group {
 		return
 	}
 


### PR DESCRIPTION
Fixes nil pointer dereference panic here:

```sh
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*Shard).clearDimensionMetrics(0xc000590808?)
weaviate-0 weaviate 	/go/src/github.com/weaviate/weaviate/adapters/repos/db/shard_dimension_tracking.go:115 +0x1a
...
```

<details>

```sh
weaviate-0 weaviate {"action":"startup","auto_schema_enabled":true,"build_git_commit":"ba6cc25","build_go_version":"go1.24.5","build_image_tag":"","build_wv_version":"1.33.0-dev","level":"info","msg":"auto schema enabled setting is set to \"true\"","time":"2025-08-01T08:27:10Z"}
weaviate-0 weaviate {"OFFLOAD_S3_BUCKET":"weaviate-offload","OFFLOAD_S3_CONCURRENCY":25,"OFFLOAD_S3_ENDPOINT":"http://minio:9000/","OFFLOAD_TIMEOUT":120000000000,"PERSISTENCE_DATA_PATH":"/var/lib/weaviate","build_git_commit":"ba6cc25","build_go_version":"go1.24.5","build_image_tag":"","build_wv_version":"1.33.0-dev","level":"info","msg":"offload module loaded","time":"2025-08-01T08:27:11Z"}
weaviate-0 weaviate ERROR "mb s3://weaviate-offload": BucketAlreadyOwnedByYou: Your previous request to create the named bucket succeeded and you already own it. status code: 409, request id: 18579734875359CE, host id: dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8
weaviate-0 weaviate {"action":"startup_check_contextionary","build_git_commit":"ba6cc25","build_go_version":"go1.24.5","build_image_tag":"","build_wv_version":"1.33.0-dev","contextionaryVersion":"en0.16.0-v1.2.1","level":"info","msg":"found a valid contextionary version","requiredMinimumContextionaryVersion":"1.0.0","time":"2025-08-01T08:27:12Z"}
--
weaviate-0 weaviate panic: runtime error: invalid memory address or nil pointer dereference
weaviate-0 weaviate [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x170c55a]
weaviate-0 weaviate 
weaviate-0 weaviate goroutine 1733 [running]:
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*Shard).clearDimensionMetrics(0xc000590808?)
weaviate-0 weaviate 	/go/src/github.com/weaviate/weaviate/adapters/repos/db/shard_dimension_tracking.go:115 +0x1a
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*LazyLoadShard).drop(0xc0017b03c0)
weaviate-0 weaviate 	/go/src/github.com/weaviate/weaviate/adapters/repos/db/shard_lazyloader.go:398 +0x125
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*Index).dropShards.func1()
weaviate-0 weaviate 	/go/src/github.com/weaviate/weaviate/adapters/repos/db/index.go:2496 +0xe4
weaviate-0 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*Index).dropShards.(*ErrorGroupWrapper).Go.func2()
weaviate-0 weaviate 	/go/src/github.com/weaviate/weaviate/entities/errors/error_group_wrapper.go:102 +0x8b
weaviate-0 weaviate golang.org/x/sync/errgroup.(*Group).Go.func1()
weaviate-0 weaviate 	/go/pkg/mod/golang.org/x/sync@v0.16.0/errgroup/errgroup.go:93 +0x50
weaviate-0 weaviate created by golang.org/x/sync/errgroup.(*Group).Go in goroutine 1732
weaviate-0 weaviate 	/go/pkg/mod/golang.org/x/sync@v0.16.0/errgroup/errgroup.go:78 +0x93
```

</details>

If no metrics tracking is configured for a shard we shouldn't publish/clear any.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
