### PR TITLE
Add parsing of oidc group claim from string

### DIFF
--- a/usecases/auth/authentication/oidc/middleware.go
+++ b/usecases/auth/authentication/oidc/middleware.go
@@ -196,6 +196,10 @@ func (c *Client) extractGroups(claims map[string]interface{}) []string {
 
 	groupsSlice, ok := groupsUntyped.([]interface{})
 	if !ok {
+		groupAsString, ok := groupsUntyped.(string)
+		if ok {
+			return []string{groupAsString}
+		}
 		return groups
 	}
 


### PR DESCRIPTION
### What's being changed:

Support OIDC tokens where the group claim is a string

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
