### PR TITLE
fix(nodes endpoint): avoid loading lazy loaded shards if not loaded while getting status

### DIFF
--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -177,7 +177,7 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 				shardStatus := &models.NodeShardStatus{
 					Name:                 name,
 					Class:                shard.Index().Config.ClassName.String(),
-					VectorIndexingStatus: shard.GetStatus().String(),
+					VectorIndexingStatus: shard.GetStatusNoLoad().String(),
 					Loaded:               false,
 				}
 				*status = append(*status, shardStatus)


### PR DESCRIPTION
### What's being changed:
calling `GetStatus()` on `LazyLoadedShard` force loading the shard, we need to make sure calling nodes endpoint doesn't force loading the shard 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
