### PR TITLE
chore(alias): Objects api response will have original class name

### DIFF
--- a/test/acceptance/aliases/aliases_api_test.go
+++ b/test/acceptance/aliases/aliases_api_test.go
@@ -478,7 +478,8 @@ func Test_AliasesAPI(t *testing.T) {
 			}
 			created, err := helper.CreateObjectWithResponse(t, obj)
 			require.NoError(t, err)
-			assert.Equal(t, aliasName, created.Class)
+			// should still return original class name in the response (not alias)
+			assert.Equal(t, books.DefaultClassName, created.Class)
 			assertGetObject(t, objID)
 		})
 
@@ -494,7 +495,8 @@ func Test_AliasesAPI(t *testing.T) {
 			}
 			updated, err := helper.UpdateObjectWithResponse(t, obj)
 			require.NoError(t, err)
-			assert.Equal(t, aliasName, updated.Class)
+			// should still return original class name in the response (not alias)
+			assert.Equal(t, books.DefaultClassName, updated.Class)
 			assertGetObject(t, objID)
 		})
 
@@ -555,7 +557,8 @@ func Test_AliasesAPI(t *testing.T) {
 			}
 			resp := helper.CreateObjectsBatchWithResponse(t, []*models.Object{obj1, obj2})
 			for _, obj := range resp {
-				assert.Equal(t, aliasName, obj.Class)
+				// should still return original class name in the response (not alias)
+				assert.Equal(t, books.DefaultClassName, obj.Class)
 			}
 			assertGetObject(t, objID1)
 			assertGetObject(t, objID2)
@@ -576,7 +579,8 @@ func Test_AliasesAPI(t *testing.T) {
 			resp := helper.DeleteObjectsBatchWithResponse(t, batchDelete, types.ConsistencyLevelAll)
 			require.NotNil(t, resp)
 			require.NotNil(t, resp.Match)
-			assert.Equal(t, aliasName, resp.Match.Class)
+			// should still return original class name in the response (not alias)
+			assert.Equal(t, books.DefaultClassName, resp.Match.Class)
 		})
 	})
 }

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -39,7 +39,7 @@ func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, ob
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
 	className := schema.UppercaseClassName(object.Class)
-	className, aliasName := m.resolveAlias(className)
+	className, _ = m.resolveAlias(className)
 	object.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.ShardsData(className, object.Tenant)...); err != nil {
@@ -66,9 +66,6 @@ func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, ob
 		return nil, err
 	}
 
-	if aliasName != "" {
-		return m.classNameToAlias(obj, aliasName), nil
-	}
 	return obj, nil
 }
 

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -50,19 +50,11 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal,
 		return nil, err
 	}
 
-	var alias string
-	if res.ClassName != class {
-		alias = class
-	}
-
 	if additional.Vector {
 		m.trackUsageSingle(res)
 	}
 
 	obj := res.ObjectWithVector(additional.Vector)
-	if alias != "" {
-		obj.Class = alias
-	}
 	return obj, nil
 }
 

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -187,14 +187,6 @@ func (m *Manager) resolveAlias(class string) (className, aliasName string) {
 	return alias.ResolveAlias(m.schemaManager, class)
 }
 
-func (m *Manager) classNameToAlias(obj *models.Object, aliasName string) *models.Object {
-	return alias.ClassNameToAlias(obj, aliasName)
-}
-
-func (m *Manager) classNamesToAliases(objs []*models.Object, aliasName string) []*models.Object {
-	return alias.ClassNamesToAliases(objs, aliasName)
-}
-
 func generateUUID() (strfmt.UUID, error) {
 	id, err := uuid.NewRandom()
 	if err != nil {

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -69,10 +69,9 @@ func (q *QueryParams) inputs(m *Manager) (*QueryInput, error) {
 func (m *Manager) Query(ctx context.Context, principal *models.Principal, params *QueryParams,
 ) ([]*models.Object, *Error) {
 	class := "*"
-	aliasName := ""
 
 	if params != nil && params.Class != "" {
-		params.Class, aliasName = m.resolveAlias(params.Class)
+		params.Class, _ = m.resolveAlias(params.Class)
 		class = params.Class
 	}
 
@@ -119,8 +118,5 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 		m.trackUsageList(res)
 	}
 
-	if aliasName != "" {
-		return m.classNamesToAliases(res.ObjectsWithVector(q.Additional.Vector), aliasName), nil
-	}
 	return res.ObjectsWithVector(q.Additional.Vector), nil
 }

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -35,7 +35,7 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
 	className := schema.UppercaseClassName(updates.Class)
-	className, aliasName := m.resolveAlias(className)
+	className, _ = m.resolveAlias(className)
 	updates.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Objects(updates.Class, updates.Tenant, updates.ID)); err != nil {
@@ -57,10 +57,6 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 		return nil, fmt.Errorf("cannot process update object: %w", err)
 	}
 
-	if aliasName != "" {
-		obj, err := m.updateObjectToConnectorAndSchema(ctx, principal, class, id, updates, repl, fetchedClasses)
-		return m.classNameToAlias(obj, aliasName), err
-	}
 	return m.updateObjectToConnectorAndSchema(ctx, principal, class, id, updates, repl, fetchedClasses)
 }
 


### PR DESCRIPTION
### What's being changed:
Currently, when objects were create/updated/delete/listed via alias name, that will contain `class` key with value as alias name but that is confusing and we decided not a best approach. It's better to have original class name as value for `class` key no matter how we access the objects (source of truth).

This PR make that class key consistent in all those objects endpoints

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
