### PR TITLE
chore(tests): move named vectors tetsts to use model2vec module

### DIFF
--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_add_vectors.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_add_vectors.go
@@ -103,18 +103,18 @@ func testMixedVectorsAddNewVectors(endpoint string) func(t *testing.T) {
 			require.NoError(t, err)
 
 			obj1 := fetchObject(t, UUID1)
-			require.Len(t, obj1.Vector, 300)
+			require.Len(t, obj1.Vector, 512)
 			require.Len(t, obj1.Vectors, 0)
 
 			obj2 := fetchObject(t, UUID2)
-			require.Len(t, obj2.Vector, 300)
+			require.Len(t, obj2.Vector, 512)
 			require.Len(t, obj2.Vectors, 1)
 			require.Equal(t, obj2.Vectors[contextionary].([]float32), []float32(obj2.Vector))
 
 			obj3 := fetchObject(t, UUID3)
-			require.Len(t, obj3.Vector, 300)
+			require.Len(t, obj3.Vector, 512)
 			require.Len(t, obj3.Vectors, 2)
-			require.Len(t, obj3.Vectors[transformers], 384)
+			require.Len(t, obj3.Vectors[transformers], 256)
 		})
 
 		t.Run("add vector to schema with named vector", func(t *testing.T) {
@@ -166,13 +166,13 @@ func testMixedVectorsAddNewVectors(endpoint string) func(t *testing.T) {
 			obj1 := fetchObject(t, UUID1)
 			require.Len(t, obj1.Vector, 0)
 			require.Len(t, obj1.Vectors, 1)
-			require.Len(t, obj1.Vectors[contextionary], 300)
+			require.Len(t, obj1.Vectors[contextionary], 512)
 
 			obj2 := fetchObject(t, UUID2)
 			require.Len(t, obj2.Vector, 0)
 			require.Len(t, obj2.Vectors, 2)
-			require.Len(t, obj2.Vectors[contextionary], 300)
-			require.Len(t, obj2.Vectors[transformers], 384)
+			require.Len(t, obj2.Vectors[contextionary], 512)
+			require.Len(t, obj2.Vectors[transformers], 256)
 		})
 
 		t.Run("add colbert vector to a schema with legacy vector", func(t *testing.T) {
@@ -228,11 +228,11 @@ func testMixedVectorsAddNewVectors(endpoint string) func(t *testing.T) {
 			require.NoError(t, err)
 
 			obj1 := fetchObject(t, UUID1)
-			require.Len(t, obj1.Vector, 300)
+			require.Len(t, obj1.Vector, 512)
 			require.Len(t, obj1.Vectors, 0)
 
 			obj2 := fetchObject(t, UUID2)
-			require.Len(t, obj2.Vector, 300)
+			require.Len(t, obj2.Vector, 512)
 			require.Len(t, obj2.Vectors, 1)
 			require.Equal(t, multiVec, obj2.Vectors["multi"].([][]float32))
 

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/mixed_vectors_objects.go
@@ -76,22 +76,22 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 			obj := objWrappers[0]
 			require.NotNil(t, obj)
 
-			assert.Len(t, obj.Vector, 300)
+			assert.Len(t, obj.Vector, 512)
 
 			require.Len(t, obj.Vectors, 3)
 			assert.Equal(t, []float32(obj.Vector), obj.Vectors["contextionary"].([]float32))
-			assert.Len(t, obj.Vectors["contextionary_with_class_name"], 300)
-			assert.Len(t, obj.Vectors["transformers"], 384)
+			assert.Len(t, obj.Vectors["contextionary_with_class_name"], 512)
+			assert.Len(t, obj.Vectors["transformers"], 256)
 
 			// as these vectors were made using different module parameters, they should be different
-			assert.NotEqual(t, obj.Vector, obj.Vectors["contextionary_with_class_name"], 300)
+			assert.NotEqual(t, obj.Vector, obj.Vectors["contextionary_with_class_name"], 512)
 		})
 
 		t.Run("GraphQL get vectors", func(t *testing.T) {
 			resultVectors := getVectors(t, client, class.Class, id1, "", transformers)
 			require.Len(t, resultVectors, 2)
-			require.Len(t, resultVectors[""], 300)
-			require.Len(t, resultVectors[transformers], 384)
+			require.Len(t, resultVectors[""], 512)
+			require.Len(t, resultVectors[transformers], 256)
 		})
 
 		for _, targetVector := range []string{"", modelsext.DefaultNamedVectorName, contextionary} {
@@ -99,7 +99,7 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 				t.Run("nearText search", func(t *testing.T) {
 					nearText := client.GraphQL().NearTextArgBuilder().
 						WithConcepts([]string{"book"}).
-						WithCertainty(0.9)
+						WithCertainty(0.8)
 
 					if targetVector != "" {
 						nearText = nearText.WithTargetVectors(targetVector)
@@ -131,7 +131,7 @@ func testMixedVectorsObject(host string) func(t *testing.T) {
 				t.Run("nearVector search", func(t *testing.T) {
 					vectors := getVectors(t, client, class.Class, id1, contextionary)
 					require.Len(t, vectors, 1)
-					require.Len(t, vectors[contextionary], 300)
+					require.Len(t, vectors[contextionary], 512)
 					obj1C11YVector := vectors[contextionary].([]float32)
 
 					nearVector := client.GraphQL().NearVectorArgBuilder().
@@ -255,7 +255,7 @@ func testMixedVectorsBatchBYOV(host string) func(t *testing.T) {
 			require.Len(t, vectors, 3)
 			require.Equal(t, []float32(obj.Vector), vectors[""].([]float32))
 			require.Equal(t, []float32(obj.Vector), vectors[contextionary].([]float32))
-			require.Len(t, vectors[transformers], 384)
+			require.Len(t, vectors[transformers], 256)
 		}
 	}
 }

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors.go
@@ -40,8 +40,8 @@ func AllTests(endpoint string, asyncIndexingEnabled bool) func(t *testing.T) {
 
 func ComposeModules() (composeModules *docker.Compose) {
 	composeModules = docker.New().
-		WithText2VecContextionary().
-		WithText2VecTransformers().
+		WithText2VecModel2Vec().
+		WithText2VecTransformersImage("semitechnologies/model2vec-inference:minishlab-potion-base-8M-1.0.0").
 		WithText2VecOpenAI(os.Getenv("OPENAI_APIKEY"), os.Getenv("OPENAI_ORGANIZATION"), os.Getenv("AZURE_APIKEY")).
 		WithText2VecCohere(os.Getenv("COHERE_APIKEY")).
 		WithGenerativeOpenAI(os.Getenv("OPENAI_APIKEY"), os.Getenv("OPENAI_ORGANIZATION"), os.Getenv("AZURE_APIKEY")).

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_aggregate.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_aggregate.go
@@ -60,7 +60,7 @@ func testAggregate(host string) func(t *testing.T) {
 			VectorConfig: map[string]models.VectorConfig{
 				"first": {
 					Vectorizer: map[string]interface{}{
-						"text2vec-contextionary": map[string]interface{}{
+						"text2vec-model2vec": map[string]interface{}{
 							"vectorizeClassName": false,
 							"properties":         []string{"first"},
 						},
@@ -69,7 +69,7 @@ func testAggregate(host string) func(t *testing.T) {
 				},
 				"second": {
 					Vectorizer: map[string]interface{}{
-						"text2vec-contextionary": map[string]interface{}{
+						"text2vec-model2vec": map[string]interface{}{
 							"vectorizeClassName": false,
 							"properties":         []string{"second"},
 						},

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_byov_with_vectorizer.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_byov_with_vectorizer.go
@@ -52,7 +52,7 @@ func testCreateSchemaWithVectorizerAndBYOV(host string) func(t *testing.T) {
 			VectorConfig: map[string]models.VectorConfig{
 				"byov": {
 					Vectorizer: map[string]interface{}{
-						"text2vec-contextionary": map[string]interface{}{
+						"text2vec-model2vec": map[string]interface{}{
 							"vectorizeClassName": false,
 						},
 					},
@@ -60,7 +60,7 @@ func testCreateSchemaWithVectorizerAndBYOV(host string) func(t *testing.T) {
 				},
 				"generate": {
 					Vectorizer: map[string]interface{}{
-						"text2vec-contextionary": map[string]interface{}{
+						"text2vec-model2vec": map[string]interface{}{
 							"vectorizeClassName": false,
 						},
 					},
@@ -87,7 +87,7 @@ func testCreateSchemaWithVectorizerAndBYOV(host string) func(t *testing.T) {
 			Do(ctx)
 		require.NoError(t, err)
 		require.Len(t, objWithoutVector, 1)
-		require.Len(t, objWithoutVector[0].Vectors["byov"], 300)
+		require.Len(t, objWithoutVector[0].Vectors["byov"], 512)
 
 		// add an object with the same vector but different properties
 		_, err = client.Data().Creator().

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_colbert.go
@@ -555,7 +555,7 @@ func testColBERT(host string, asyncIndexingEnabled bool) func(t *testing.T) {
 				}
 				err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
 				require.Error(t, err)
-				assert.ErrorContains(t, err, `parse vector config for c11y: multi vector index configured but vectorizer: \"text2vec-contextionary\" doesn't support multi vectors`)
+				assert.ErrorContains(t, err, `parse vector config for c11y: multi vector index configured but vectorizer: \"text2vec-model2vec\" doesn't support multi vectors`)
 			})
 			t.Run("named vector is colbert vectorizer with regular vector index", func(t *testing.T) {
 				cleanup()

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_generative.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_generative.go
@@ -53,7 +53,7 @@ func testNamedVectorsWithGenerativeModules(host string) func(t *testing.T) {
 				VectorConfig: map[string]models.VectorConfig{
 					"title": {
 						Vectorizer: map[string]interface{}{
-							"text2vec-contextionary": map[string]interface{}{
+							"text2vec-model2vec": map[string]interface{}{
 								"properties":         []interface{}{"title"},
 								"vectorizeClassName": false,
 							},

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_objects.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_objects.go
@@ -137,7 +137,7 @@ func testCreateObject(host string) func(t *testing.T) {
 				nearText := client.GraphQL().NearTextArgBuilder().
 					WithTargetVectors(c11y).
 					WithConcepts([]string{"book"}).
-					WithCertainty(0.9)
+					WithCertainty(0.8)
 
 				res, err := client.GraphQL().Get().
 					WithClassName(className).

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_test_data.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_test_data.go
@@ -43,7 +43,7 @@ var (
 	transformers_pq                     = "transformers_pq"
 	transformers_bq                     = "transformers_bq"
 	transformers_bq_very_long_230_chars = "transformers_bq_b9mgu3N7rCUWufddpfCqaVvr4IUjB9xpMBrmiQFIqyuUxKx5s8wCTD7iWb5gPkwNhECumphBMWXD67G9gvN4CQkylG3bDrR8p9sK02RLOGvE96jcaSKjpZrIRvjJuQliGf8BMNmzXEqH39UWGGt4zPNnZNvdPP6pIzxWG5zNpymGmJJLCHk6yP1eO3QgSdXMt0arzfcrAA1L9uZNIVT7tM"
-	text2vecContextionary               = "text2vec-contextionary"
+	text2vecContextionary               = "text2vec-model2vec"
 	text2vecTransformers                = "text2vec-transformers"
 	id1                                 = "00000000-0000-0000-0000-000000000001"
 	id2                                 = "00000000-0000-0000-0000-000000000002"

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -110,6 +110,7 @@ type Compose struct {
 	withBackendAzure           bool
 	withBackendAzureContainer  string
 	withTransformers           bool
+	withTransformersImage      string
 	withModel2Vec              bool
 	withContextionary          bool
 	withQnATransformers        bool
@@ -166,6 +167,14 @@ func (d *Compose) WithAzurite() *Compose {
 
 func (d *Compose) WithText2VecTransformers() *Compose {
 	d.withTransformers = true
+	d.enableModules = append(d.enableModules, Text2VecTransformers)
+	d.defaultVectorizerModule = Text2VecTransformers
+	return d
+}
+
+func (d *Compose) WithText2VecTransformersImage(image string) *Compose {
+	d.withTransformers = true
+	d.withTransformersImage = image
 	d.enableModules = append(d.enableModules, Text2VecTransformers)
 	d.defaultVectorizerModule = Text2VecTransformers
 	return d
@@ -679,6 +688,9 @@ func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 	}
 	if d.withTransformers {
 		image := os.Getenv(envTestText2vecTransformersImage)
+		if d.withTransformersImage != "" {
+			image = d.withTransformersImage
+		}
 		container, err := startT2VTransformers(ctx, networkName, image)
 		if err != nil {
 			return nil, errors.Wrapf(err, "start %s", Text2VecTransformers)


### PR DESCRIPTION
### What's being changed:

This PR moves all of the named vectors tests to use `model2vec` module instead of `contextionary`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
