### PR TITLE
refact(usage): lock during upload only

### DIFF
--- a/usecases/modulecomponents/usage/base_module.go
+++ b/usecases/modulecomponents/usage/base_module.go
@@ -207,9 +207,6 @@ func (b *BaseModule) collectAndUploadPeriodically(ctx context.Context) {
 }
 
 func (b *BaseModule) collectAndUploadUsage(ctx context.Context) error {
-	b.mu.Lock()
-	defer b.mu.Unlock()
-
 	start := time.Now()
 	now := start.UTC()
 	collectionTime := time.Date(now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute(), 0, 0, time.UTC).Format("2006-01-02T15-04-05Z")
@@ -230,9 +227,12 @@ func (b *BaseModule) collectAndUploadUsage(ctx context.Context) error {
 	}
 
 	// Set version on usage data
+	// Lock to protect shared fields and upload operation
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	usage.Version = b.policyVersion
-
 	usage.CollectingTIme = collectionTime
+
 	return b.storage.UploadUsageData(ctx, usage)
 }
 


### PR DESCRIPTION
### What's being changed:
we don't need the lock to be held for collecting data but instead  for setting the values in usage report and upload the file

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
