### PR TITLE
[chore] Remove direct member variable access for db.indices

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -44,12 +44,9 @@ func (db *DB) Backupable(ctx context.Context, classes []string) error {
 
 // ListBackupable returns a list of all classes which can be backed up.
 func (db *DB) ListBackupable() []string {
-	db.indexLock.RLock()
-	defer db.indexLock.RUnlock()
+	cs := make([]string, 0, len(db.Indices()))
 
-	cs := make([]string, 0, len(db.indices))
-
-	for _, idx := range db.indices {
+	for _, idx := range db.Indices() {
 		cls := string(idx.Config.ClassName)
 		cs = append(cs, cls)
 	}

--- a/adapters/repos/db/batch.go
+++ b/adapters/repos/db/batch.go
@@ -60,11 +60,8 @@ func (db *DB) BatchPutObjects(ctx context.Context, objs objects.BatchObjects,
 
 	// wrapped by func to acquire and safely release indexLock only for duration of loop
 	func() {
-		db.indexLock.RLock()
-		defer db.indexLock.RUnlock()
-
 		for class, queue := range objectByClass {
-			index, ok := db.indices[indexID(schema.ClassName(class))]
+			index, ok := db.Indices()[indexID(schema.ClassName(class))]
 			if !ok {
 				msg := fmt.Sprintf("could not find index for class %v. It might have been deleted in the meantime", class)
 				db.logger.Warn(msg)
@@ -128,11 +125,8 @@ func (db *DB) AddBatchReferences(ctx context.Context, references objects.BatchRe
 
 	// wrapped by func to acquire and safely release indexLock only for duration of loop
 	func() {
-		db.indexLock.RLock()
-		defer db.indexLock.RUnlock()
-
 		for class, queue := range refByClass {
-			index, ok := db.indices[indexID(class)]
+			index, ok := db.Indices()[indexID(class)]
 			if !ok {
 				for _, item := range queue {
 					references[item.OriginalIndex].Err = fmt.Errorf("could not find index for class %v. It might have been deleted in the meantime", class)

--- a/adapters/repos/db/bm25f_block_test.go
+++ b/adapters/repos/db/bm25f_block_test.go
@@ -299,7 +299,7 @@ func TestBM25FJourneyBlock(t *testing.T) {
 			EqualFloats(t, float32(0.50612706), autocutscores[1], 5)
 		})
 
-		for _, index := range repo.indices {
+		for _, index := range repo.Indices() {
 			index.ForEachShard(func(name string, shard ShardLike) error {
 				err := shard.Store().FlushMemtables(context.Background())
 				require.Nil(t, err)
@@ -366,7 +366,7 @@ func TestBM25FSinglePropBlock(t *testing.T) {
 			EqualFloats(t, float32(0.6178051), scores[1], 5)
 		})
 
-		for _, index := range repo.indices {
+		for _, index := range repo.Indices() {
 			index.ForEachShard(func(name string, shard ShardLike) error {
 				err := shard.Store().FlushMemtables(context.Background())
 				require.Nil(t, err)
@@ -481,7 +481,7 @@ func TestBM25FWithFiltersBlock(t *testing.T) {
 			require.True(t, len(res) == 0)
 		})
 
-		for _, index := range repo.indices {
+		for _, index := range repo.Indices() {
 			index.ForEachShard(func(name string, shard ShardLike) error {
 				err := shard.Store().FlushMemtables(context.Background())
 				require.Nil(t, err)
@@ -564,7 +564,7 @@ func TestBM25FWithFilters_ScoreIsIdenticalWithOrWithoutFilterBlock(t *testing.T)
 			assert.Equal(t, filteredScores[0], unfilteredScores[0])
 		})
 
-		for _, index := range repo.indices {
+		for _, index := range repo.Indices() {
 			index.ForEachShard(func(name string, shard ShardLike) error {
 				err := shard.Store().FlushMemtables(context.Background())
 				require.Nil(t, err)
@@ -640,7 +640,7 @@ func TestBM25FDifferentParamsJourneyBlock(t *testing.T) {
 			EqualFloats(t, float32(1.7730504), scores[1], 2)
 		})
 
-		for _, index := range repo.indices {
+		for _, index := range repo.Indices() {
 			index.ForEachShard(func(name string, shard ShardLike) error {
 				err := shard.Store().FlushMemtables(context.Background())
 				require.Nil(t, err)
@@ -738,7 +738,7 @@ func TestBM25FCompareBlock(t *testing.T) {
 			}
 		})
 
-		for _, index := range repo.indices {
+		for _, index := range repo.Indices() {
 			index.ForEachShard(func(name string, shard ShardLike) error {
 				err := shard.Store().FlushMemtables(context.Background())
 				require.Nil(t, err)
@@ -846,7 +846,7 @@ func TestBM25F_ComplexDocumentsBlock(t *testing.T) {
 			}
 		})
 
-		for _, index := range repo.indices {
+		for _, index := range repo.Indices() {
 			index.ForEachShard(func(name string, shard ShardLike) error {
 				err := shard.Store().FlushMemtables(context.Background())
 				require.Nil(t, err)
@@ -938,7 +938,7 @@ func TestBM25F_SortMultiPropBlock(t *testing.T) {
 			require.True(t, strings.Contains(explanationString, "BM25F_banana_propLength:1"))
 		})
 
-		for _, index := range repo.indices {
+		for _, index := range repo.Indices() {
 			index.ForEachShard(func(name string, shard ShardLike) error {
 				err := shard.Store().FlushMemtables(context.Background())
 				require.Nil(t, err)
@@ -1020,7 +1020,7 @@ func TestBM25FWithFiltersMemtable(t *testing.T) {
 			}
 		})
 
-		for _, index := range repo.indices {
+		for _, index := range repo.Indices() {
 			index.ForEachShard(func(name string, shard ShardLike) error {
 				err := shard.Store().FlushMemtables(context.Background())
 				require.Nil(t, err)

--- a/adapters/repos/db/idempotent_integration_test.go
+++ b/adapters/repos/db/idempotent_integration_test.go
@@ -307,7 +307,7 @@ func TestMigrator_UpdateIndex(t *testing.T) {
 		}()
 
 		t.Run("before index update", func(t *testing.T) {
-			idx, ok := localMigrator.db.indices[strings.ToLower(class1Name)]
+			idx, ok := localMigrator.db.Indices()[strings.ToLower(class1Name)]
 			require.True(t, ok)
 			shardCount := 0
 			idx.ForEachShard(func(_ string, shard ShardLike) error {
@@ -335,8 +335,8 @@ func TestMigrator_UpdateIndex(t *testing.T) {
 		})
 
 		t.Run("after index update", func(t *testing.T) {
-			require.Len(t, localMigrator.db.indices, 1)
-			idx, ok := localMigrator.db.indices[strings.ToLower(class1Name)]
+			require.Len(t, localMigrator.db.Indices(), 1)
+			idx, ok := localMigrator.db.Indices()[strings.ToLower(class1Name)]
 			require.True(t, ok)
 
 			shardCount := 0
@@ -395,7 +395,7 @@ func TestMigrator_UpdateIndex(t *testing.T) {
 		})
 
 		t.Run("before index update", func(t *testing.T) {
-			idx, ok := localMigrator.db.indices[strings.ToLower(class1Name)]
+			idx, ok := localMigrator.db.Indices()[strings.ToLower(class1Name)]
 			require.True(t, ok)
 			shardCount := 0
 			idx.ForEachShard(func(_ string, shard ShardLike) error {
@@ -423,8 +423,8 @@ func TestMigrator_UpdateIndex(t *testing.T) {
 		})
 
 		t.Run("after index update", func(t *testing.T) {
-			require.Len(t, localMigrator.db.indices, 1)
-			idx, ok := localMigrator.db.indices[strings.ToLower(class1Name)]
+			require.Len(t, localMigrator.db.Indices(), 1)
+			idx, ok := localMigrator.db.Indices()[strings.ToLower(class1Name)]
 			require.True(t, ok)
 
 			shardCount := 0
@@ -474,7 +474,7 @@ func TestMigrator_UpdateIndex(t *testing.T) {
 		})
 
 		t.Run("before index update", func(t *testing.T) {
-			idx, ok := localMigrator.db.indices[strings.ToLower(class1Name)]
+			idx, ok := localMigrator.db.Indices()[strings.ToLower(class1Name)]
 			require.True(t, ok)
 			for _, tenant := range initialTenants {
 				require.NotNil(t, idx.shards.Load(tenant))
@@ -491,8 +491,8 @@ func TestMigrator_UpdateIndex(t *testing.T) {
 		})
 
 		t.Run("after index update", func(t *testing.T) {
-			require.Len(t, localMigrator.db.indices, 1)
-			idx, ok := localMigrator.db.indices[strings.ToLower(class1Name)]
+			require.Len(t, localMigrator.db.Indices(), 1)
+			idx, ok := localMigrator.db.Indices()[strings.ToLower(class1Name)]
 			require.True(t, ok)
 
 			shardCount := 0

--- a/adapters/repos/db/inverted_index_integration_test.go
+++ b/adapters/repos/db/inverted_index_integration_test.go
@@ -130,7 +130,7 @@ func TestIndexByTimestampsNullStatePropLength_AddClass(t *testing.T) {
 	}))
 
 	t.Run("check for additional buckets", func(t *testing.T) {
-		for _, idx := range migrator.db.indices {
+		for _, idx := range migrator.db.Indices() {
 			idx.ForEachShard(func(_ string, shd ShardLike) error {
 				createBucket := shd.Store().Bucket("property__creationTimeUnix")
 				assert.NotNil(t, createBucket)
@@ -187,7 +187,7 @@ func TestIndexByTimestampsNullStatePropLength_AddClass(t *testing.T) {
 
 	t.Run("delete class", func(t *testing.T) {
 		require.Nil(t, migrator.DropClass(context.Background(), class.Class, false))
-		for _, idx := range migrator.db.indices {
+		for _, idx := range migrator.db.Indices() {
 			idx.ForEachShard(func(name string, shd ShardLike) error {
 				require.Nil(t, shd.Store().Bucket("property__creationTimeUnix"))
 				require.Nil(t, shd.Store().Bucket("property_name"+filters.InternalNullIndex))
@@ -337,7 +337,7 @@ func TestIndexNullState_GetClass(t *testing.T) {
 	})
 
 	t.Run("check buckets exist", func(t *testing.T) {
-		index := repo.indices["testclass"]
+		index := repo.Indices()["testclass"]
 		n := 0
 		index.ForEachShard(func(_ string, shard ShardLike) error {
 			bucketNull := shard.Store().Bucket(helpers.BucketFromPropNameNullLSM("name"))
@@ -620,7 +620,7 @@ func TestIndexPropLength_GetClass(t *testing.T) {
 	})
 
 	t.Run("check buckets exist", func(t *testing.T) {
-		index := repo.indices["testclass"]
+		index := repo.Indices()["testclass"]
 		n := 0
 		index.ForEachShard(func(_ string, shard ShardLike) error {
 			bucketPropLengthName := shard.Store().Bucket(helpers.BucketFromPropNameLengthLSM("name"))
@@ -985,7 +985,7 @@ func TestIndexByTimestamps_GetClass(t *testing.T) {
 	})
 
 	t.Run("check buckets exist", func(t *testing.T) {
-		index := repo.indices["testclass"]
+		index := repo.Indices()["testclass"]
 		n := 0
 		index.ForEachShard(func(_ string, shard ShardLike) error {
 			bucketCreated := shard.Store().Bucket("property_" + filters.InternalPropCreationTimeUnix)

--- a/adapters/repos/db/inverted_migrator_filter_to_search.go
+++ b/adapters/repos/db/inverted_migrator_filter_to_search.go
@@ -44,7 +44,7 @@ func newFilterableToSearchableMigrator(migrator *Migrator) *filterableToSearchab
 		logger:       migrator.logger,
 		files:        newFilterableToSearchableMigrationFiles(migrator.db.config.RootPath),
 		schemaGetter: migrator.db.schemaGetter,
-		indexes:      migrator.db.indices,
+		indexes:      migrator.db.Indices(),
 	}
 }
 

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -798,11 +798,8 @@ func (m *Migrator) RecalculateVectorDimensions(ctx context.Context) error {
 		WithField("action", "reindex").
 		Info("Reindexing dimensions, this may take a while")
 
-	m.db.indexLock.Lock()
-	defer m.db.indexLock.Unlock()
-
 	// Iterate over all indexes
-	for _, index := range m.db.indices {
+	for _, index := range m.db.Indices() {
 		err := index.ForEachShard(func(name string, shard ShardLike) error {
 			return shard.resetDimensionsLSM()
 		})
@@ -845,10 +842,8 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 		WithField("action", "recount").
 		Info("Recounting properties, this may take a while")
 
-	m.db.indexLock.Lock()
-	defer m.db.indexLock.Unlock()
 	// Iterate over all indexes
-	for _, index := range m.db.indices {
+	for _, index := range m.db.Indices() {
 
 		// Clear the shards before counting
 		err := index.IterateShards(ctx, func(index *Index, shard ShardLike) error {
@@ -943,7 +938,7 @@ func (m *Migrator) doInvertedReindex(ctx context.Context, taskNamesWithArgs map[
 
 	eg := enterrors.NewErrorGroupWrapper(m.logger)
 	eg.SetLimit(_NUMCPU)
-	for _, index := range m.db.indices {
+	for _, index := range m.db.Indices() {
 		index.ForEachShard(func(name string, shard ShardLike) error {
 			eg.Go(func() error {
 				reindexer := NewShardInvertedReindexer(shard, m.logger)
@@ -989,7 +984,7 @@ func (m *Migrator) doInvertedIndexMissingTextFilterable(ctx context.Context, tas
 
 	eg := enterrors.NewErrorGroupWrapper(m.logger)
 	eg.SetLimit(_NUMCPU * 2)
-	for _, index := range m.db.indices {
+	for _, index := range m.db.Indices() {
 		index := index
 		className := index.Config.ClassName.String()
 

--- a/adapters/repos/db/node_wide_metrics_test.go
+++ b/adapters/repos/db/node_wide_metrics_test.go
@@ -46,22 +46,22 @@ func TestShardActivity(t *testing.T) {
 		},
 	}
 
-	db.indices["Col1"].shards.Store("t1_overflow", &Shard{})
-	db.indices["Col1"].shards.Store("t2_only_reads", &Shard{})
-	db.indices["Col1"].shards.Store("t3_no_reads_and_writes", &Shard{})
-	db.indices["Col1"].shards.Store("t4_only_writes", &Shard{})
-	db.indices["Col1"].shards.Store("t5_reads_and_writes", &Shard{})
+	db.Indices()["Col1"].shards.Store("t1_overflow", &Shard{})
+	db.Indices()["Col1"].shards.Store("t2_only_reads", &Shard{})
+	db.Indices()["Col1"].shards.Store("t3_no_reads_and_writes", &Shard{})
+	db.Indices()["Col1"].shards.Store("t4_only_writes", &Shard{})
+	db.Indices()["Col1"].shards.Store("t5_reads_and_writes", &Shard{})
 	o := newNodeWideMetricsObserver(db)
 
 	o.observeActivity()
 
 	// show activity on two tenants
 	time.Sleep(10 * time.Millisecond)
-	db.indices["Col1"].shards.Load("t1_overflow").(*Shard).activityTrackerRead.Store(math.MaxInt32)
-	db.indices["Col1"].shards.Load("t2_only_reads").(*Shard).activityTrackerRead.Add(1)
-	db.indices["Col1"].shards.Load("t4_only_writes").(*Shard).activityTrackerWrite.Add(1)
-	db.indices["Col1"].shards.Load("t5_reads_and_writes").(*Shard).activityTrackerRead.Add(1)
-	db.indices["Col1"].shards.Load("t5_reads_and_writes").(*Shard).activityTrackerWrite.Add(1)
+	db.Indices()["Col1"].shards.Load("t1_overflow").(*Shard).activityTrackerRead.Store(math.MaxInt32)
+	db.Indices()["Col1"].shards.Load("t2_only_reads").(*Shard).activityTrackerRead.Add(1)
+	db.Indices()["Col1"].shards.Load("t4_only_writes").(*Shard).activityTrackerWrite.Add(1)
+	db.Indices()["Col1"].shards.Load("t5_reads_and_writes").(*Shard).activityTrackerRead.Add(1)
+	db.Indices()["Col1"].shards.Load("t5_reads_and_writes").(*Shard).activityTrackerWrite.Add(1)
 
 	// observe to update timestamps
 	o.observeActivity()
@@ -70,7 +70,7 @@ func TestShardActivity(t *testing.T) {
 	time.Sleep(10 * time.Millisecond)
 	// previous value was math.MaxInt32, so this counter will overflow now.
 	// Assert that everything still works as expected
-	db.indices["Col1"].shards.Load("t1_overflow").(*Shard).activityTrackerRead.Add(1)
+	db.Indices()["Col1"].shards.Load("t1_overflow").(*Shard).activityTrackerRead.Add(1)
 	o.observeActivity()
 
 	t.Run("total usage", func(t *testing.T) {
@@ -128,7 +128,7 @@ func TestShardActivity(t *testing.T) {
 		assert.True(t, ok, "t5 should be contained")
 
 		// write into t5 again
-		db.indices["Col1"].shards.Load("t5_reads_and_writes").(*Shard).activityTrackerWrite.Add(1)
+		db.Indices()["Col1"].shards.Load("t5_reads_and_writes").(*Shard).activityTrackerWrite.Add(1)
 		time.Sleep(10 * time.Millisecond)
 		o.observeActivity()
 

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -124,9 +124,7 @@ func (db *DB) localNodeShardStats(ctx context.Context,
 ) *models.NodeStats {
 	var objectCount, shardCount int64
 	if className == "" {
-		db.indexLock.RLock()
-		defer db.indexLock.RUnlock()
-		for name, idx := range db.indices {
+		for name, idx := range db.Indices() {
 			if idx == nil {
 				db.logger.WithField("action", "local_node_status_for_all").
 					Warningf("no resource found for index %q", name)

--- a/adapters/repos/db/resource_use.go
+++ b/adapters/repos/db/resource_use.go
@@ -152,8 +152,7 @@ func (db *DB) memUseReadonly(mon *memwatch.Monitor) {
 }
 
 func (db *DB) setShardsReadOnly(reason string) {
-	db.indexLock.Lock()
-	for _, index := range db.indices {
+	for _, index := range db.Indices() {
 		index.ForEachShard(func(name string, shard ShardLike) error {
 			err := shard.SetStatusReadonly(reason)
 			if err != nil {
@@ -165,6 +164,5 @@ func (db *DB) setShardsReadOnly(reason string) {
 			return nil
 		})
 	}
-	db.indexLock.Unlock()
 	db.resourceScanState.isReadOnly = true
 }


### PR DESCRIPTION
### What's being changed:

Removes all direct member access to db.indices, and replaces it with a member function, that also checks the data.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
