### PR TITLE
Move tokeniser module out of db

### DIFF
--- a/adapters/repos/db/inverted/analyzer.go
+++ b/adapters/repos/db/inverted/analyzer.go
@@ -16,7 +16,7 @@ import (
 	"encoding/binary"
 
 	"github.com/google/uuid"
-	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/packages/tokenizer"
 	ent "github.com/weaviate/weaviate/entities/inverted"
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -77,7 +77,7 @@ func (a *Analyzer) Text(tokenization, in string) []Countable {
 func (a *Analyzer) TextArray(tokenization string, inArr []string) []Countable {
 	var terms []string
 	for _, in := range inArr {
-		terms = append(terms, helpers.Tokenize(tokenization, in)...)
+		terms = append(terms, tokenizer.Tokenize(tokenization, in)...)
 	}
 
 	counts := map[string]uint64{}

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -39,6 +39,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/packages/tokenizer"
 )
 
 type BM25Searcher struct {
@@ -143,8 +144,8 @@ func (b *BM25Searcher) generateQueryTermsAndStats(class *models.Class, params se
 	propNamesByTokenization := map[string][]string{}
 	propertyBoosts := make(map[string]float32, len(params.Properties))
 
-	for _, tokenization := range helpers.Tokenizations {
-		queryTerms, dupBoosts := helpers.TokenizeAndCountDuplicates(tokenization, params.Query)
+	for _, tokenization := range tokenizer.Tokenizations {
+		queryTerms, dupBoosts := tokenizer.TokenizeAndCountDuplicates(tokenization, params.Query)
 		queryTermsByTokenization[tokenization] = queryTerms
 		duplicateBoostsByTokenization[tokenization] = dupBoosts
 
@@ -235,7 +236,7 @@ func (b *BM25Searcher) wand(
 	allQueryTerms := make([]string, 0, 1000)
 	minimumOrTokensMatch := math.MaxInt64
 
-	for _, tokenization := range helpers.Tokenizations {
+	for _, tokenization := range tokenizer.Tokenizations {
 		propNames := propNamesByTokenization[tokenization]
 		if len(propNames) > 0 {
 			queryTerms, duplicateBoosts := queryTermsByTokenization[tokenization], duplicateBoostsByTokenization[tokenization]

--- a/adapters/repos/db/inverted/bm25_searcher_block.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block.go
@@ -33,6 +33,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/searchparams"
 	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/packages/tokenizer"
 )
 
 // var metrics = lsmkv.BlockMetrics{}
@@ -87,7 +88,7 @@ func (b *BM25Searcher) wandBlock(
 		}
 	}()
 
-	for _, tokenization := range helpers.Tokenizations {
+	for _, tokenization := range tokenizer.Tokenizations {
 		propNames := propNamesByTokenization[tokenization]
 		if len(propNames) > 0 {
 			lenAllResults := len(allResults)

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -38,6 +38,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/config/runtime"
+	"github.com/weaviate/weaviate/packages/tokenizer"
 )
 
 type Searcher struct {
@@ -578,9 +579,9 @@ func (s *Searcher) extractTokenizableProp(prop *models.Property, propType schema
 		// if the operator is like, we cannot apply the regular text-splitting
 		// logic as it would remove all wildcard symbols
 		if operator == filters.OperatorLike {
-			terms = helpers.TokenizeWithWildcards(prop.Tokenization, valueString)
+			terms = tokenizer.TokenizeWithWildcards(prop.Tokenization, valueString)
 		} else {
-			terms = helpers.Tokenize(prop.Tokenization, valueString)
+			terms = tokenizer.Tokenize(prop.Tokenization, valueString)
 		}
 	default:
 		return nil, fmt.Errorf("expected value type to be text, got %v", propType)

--- a/packages/tokenizer/tokenizer.go
+++ b/packages/tokenizer/tokenizer.go
@@ -9,7 +9,7 @@
 //  CONTACT: hello@weaviate.io
 //
 
-package helpers
+package tokenizer
 
 import (
 	"os"

--- a/packages/tokenizer/tokenizer_test.go
+++ b/packages/tokenizer/tokenizer_test.go
@@ -9,7 +9,7 @@
 //  CONTACT: hello@weaviate.io
 //
 
-package helpers
+package tokenizer
 
 import (
 	"testing"

--- a/test/run.sh
+++ b/test/run.sh
@@ -57,6 +57,7 @@ function main() {
           --acceptance-only-replica-replication-slow|-aorrs) run_all_tests=false; run_acceptance_replica_replication_slow_tests=true ;;
           --acceptance-only-async-replication|-aoar) run_all_tests=false; run_acceptance_async_replication_tests=true ;;
           --acceptance-only-objects|-aoob) run_all_tests=false; run_acceptance_objects=true ;;
+          --packages-only) run_packages_tests=true; run_all_tests=false ;;
           --only-acceptance-*|-oa)run_all_tests=false; only_acceptance=true;only_acceptance_value=$1;;
           --only-module-*|-om)run_all_tests=false; only_module=true;only_module_value=$1;;
           --acceptance-module-tests-only|--modules-only|-m) run_all_tests=false; run_module_tests=true; run_module_only_backup_tests=true; run_module_except_backup_tests=true;run_module_only_offload_tests=true;run_module_except_offload_tests=true;;
@@ -121,6 +122,13 @@ function main() {
     echo_green "Run integration tests..."
     run_integration_tests "$@"
     echo_green "Integration tests successful"
+  fi
+
+  if $run_packages_tests ||  $run_unit_and_integration_tests || $run_integration_tests || $run_all_tests
+  then
+    echo_green "Run package tests..."
+    run_packages_tests "$@"
+    echo_green "Package tests successful"
   fi
 
   if $run_acceptance_tests  || $run_acceptance_only_fast || $run_acceptance_only_authz || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_only_python || $run_all_tests || $run_benchmark || $run_acceptance_go_client_only_fast || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $only_acceptance || $run_acceptance_objects
@@ -245,6 +253,18 @@ function run_integration_tests() {
     ./test/integration/run.sh --include-slow
   fi
 }
+
+function run_packages_tests() {
+  if [[ "$*" == *--acceptance-only* ]]; then
+    echo "Skipping packages tests"
+    return
+  fi
+
+  # Run `go test` only on ./packages and its submodules
+  go test -race -coverprofile=coverage-packages.txt -covermode=atomic -count 1 ./packages/... \
+    | grep -v '\[no test files\]'
+}
+
 
 function run_acceptance_lsmkv() {
     echo "This test runs without the race detector because it asserts performance"

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -283,7 +283,7 @@ func Test_AddClass(t *testing.T) {
 			for _, dataType := range []schema.DataType{
 				schema.DataTypeText, schema.DataTypeTextArray,
 			} {
-				for _, tokenization := range append(helpers.Tokenizations, "") {
+				for _, tokenization := range append(tokenizer.Tokenizations, "") {
 					testCases = append(testCases, testCase{
 						propName:       propName(dataType, tokenization),
 						dataType:       dataType.PropString(),
@@ -319,7 +319,7 @@ func Test_AddClass(t *testing.T) {
 						expectedErrMsg: "",
 					})
 
-					for _, tokenization := range append(helpers.Tokenizations, "non_existing") {
+					for _, tokenization := range append(tokenizer.Tokenizations, "non_existing") {
 						testCases = append(testCases, testCase{
 							propName:       propName(dataType, tokenization),
 							dataType:       dataType.PropString(),
@@ -347,7 +347,7 @@ func Test_AddClass(t *testing.T) {
 					callReadOnly:   true,
 				})
 
-				for _, tokenization := range append(helpers.Tokenizations, "non_existing") {
+				for _, tokenization := range append(tokenizer.Tokenizations, "non_existing") {
 					testCases = append(testCases, testCase{
 						propName:       fmt.Sprintf("RefProp_%d_%s", i, tokenization),
 						dataType:       dataType,
@@ -377,7 +377,7 @@ func Test_AddClass(t *testing.T) {
 					})
 				}
 
-				for _, tokenization := range append(helpers.Tokenizations, "non_existing") {
+				for _, tokenization := range append(tokenizer.Tokenizations, "non_existing") {
 					switch tokenization {
 					case models.PropertyTokenizationWord, models.PropertyTokenizationField:
 						continue
@@ -589,7 +589,7 @@ func Test_AddClass_DefaultsAndMigration(t *testing.T) {
 		for _, dataType := range []schema.DataType{
 			schema.DataTypeText, schema.DataTypeTextArray,
 		} {
-			for _, tokenization := range helpers.Tokenizations {
+			for _, tokenization := range tokenizer.Tokenizations {
 				testCases = append(testCases, testCase{
 					propName:             propName(dataType, tokenization),
 					dataType:             dataType,

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -231,7 +231,7 @@ func TestHandler_AddProperty_Tokenization(t *testing.T) {
 		testCases := []testCase{}
 		for _, dataType := range dataTypes {
 			// all tokenizations
-			for _, tokenization := range helpers.Tokenizations {
+			for _, tokenization := range tokenizer.Tokenizations {
 				testCases = append(testCases, testCase{
 					dataType:             dataType,
 					tokenization:         tokenization,
@@ -266,7 +266,7 @@ func TestHandler_AddProperty_Tokenization(t *testing.T) {
 		testCases := []testCase{}
 		for _, dataType := range dataTypes {
 			// all tokenizations
-			for _, tokenization := range helpers.Tokenizations {
+			for _, tokenization := range tokenizer.Tokenizations {
 				switch tokenization {
 				case models.PropertyTokenizationWord:
 					testCases = append(testCases, testCase{
@@ -328,7 +328,7 @@ func TestHandler_AddProperty_Tokenization(t *testing.T) {
 		testCases := []testCase{}
 		for _, dataType := range dataTypes {
 			// all tokenizations
-			for _, tokenization := range helpers.Tokenizations {
+			for _, tokenization := range tokenizer.Tokenizations {
 				testCases = append(testCases, testCase{
 					dataType:     dataType,
 					tokenization: tokenization,
@@ -366,7 +366,7 @@ func TestHandler_AddProperty_Tokenization(t *testing.T) {
 		testCases := []testCase{}
 		for _, dataType := range dataTypes {
 			// all tokenizations
-			for _, tokenization := range helpers.Tokenizations {
+			for _, tokenization := range tokenizer.Tokenizations {
 				testCases = append(testCases, testCase{
 					dataType:     dataType,
 					tokenization: tokenization,
@@ -424,7 +424,7 @@ func TestHandler_AddProperty_Reference_Tokenization(t *testing.T) {
 	dataType := []string{refClass.Class}
 
 	// all tokenizations
-	for _, tokenization := range helpers.Tokenizations {
+	for _, tokenization := range tokenizer.Tokenizations {
 		propName := fmt.Sprintf("ref_%s", tokenization)
 		t.Run(propName, func(t *testing.T) {
 			_, _, err := handler.AddClassProperty(ctx, nil, &class, class.Class, false,
@@ -499,7 +499,7 @@ func Test_Validation_PropertyTokenization(t *testing.T) {
 		for _, dataType := range []schema.DataType{
 			schema.DataTypeText, schema.DataTypeTextArray,
 		} {
-			for _, tokenization := range helpers.Tokenizations {
+			for _, tokenization := range tokenizer.Tokenizations {
 				testCases = append(testCases, testCase{
 					name:             fmt.Sprintf("%s + '%s'", dataType, tokenization),
 					propertyDataType: newFakePrimitivePDT(dataType),
@@ -535,7 +535,7 @@ func Test_Validation_PropertyTokenization(t *testing.T) {
 					expectedErrMsg:   "",
 				})
 
-				for _, tokenization := range append(helpers.Tokenizations, "non_existing") {
+				for _, tokenization := range append(tokenizer.Tokenizations, "non_existing") {
 					testCases = append(testCases, testCase{
 						name:             fmt.Sprintf("%s + '%s'", dataType, tokenization),
 						propertyDataType: newFakePrimitivePDT(dataType),
@@ -559,7 +559,7 @@ func Test_Validation_PropertyTokenization(t *testing.T) {
 				expectedErrMsg:   "",
 			})
 
-			for _, tokenization := range append(helpers.Tokenizations, "non_existent") {
+			for _, tokenization := range append(tokenizer.Tokenizations, "non_existent") {
 				testCases = append(testCases, testCase{
 					name:             fmt.Sprintf("%s + '%s'", dataType, tokenization),
 					propertyDataType: newFakeNestedPDT(dataType),
@@ -582,7 +582,7 @@ func Test_Validation_PropertyTokenization(t *testing.T) {
 			expectedErrMsg:   "",
 		})
 
-		for _, tokenization := range append(helpers.Tokenizations, "non_existing") {
+		for _, tokenization := range append(tokenizer.Tokenizations, "non_existing") {
 			testCases = append(testCases, testCase{
 				name:             fmt.Sprintf("ref + '%s'", tokenization),
 				propertyDataType: newFakePrimitivePDT(""),
@@ -599,7 +599,7 @@ func Test_Validation_PropertyTokenization(t *testing.T) {
 		for _, dataType := range []schema.DataType{
 			schema.DataTypeString, schema.DataTypeStringArray,
 		} {
-			for _, tokenization := range append(helpers.Tokenizations, "non_existing") {
+			for _, tokenization := range append(tokenizer.Tokenizations, "non_existing") {
 				switch tokenization {
 				case models.PropertyTokenizationWord, models.PropertyTokenizationField:
 					testCases = append(testCases, testCase{


### PR DESCRIPTION
### What's being changed:

The tokeniser has no connection at all with the database, so this moves it to its own module.

Tests have been updated appropriately., with a new option --packages-only to focus on these tests.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
