### PR TITLE
Add local/remote per-shard and per-replica executor

### DIFF
--- a/adapters/handlers/rest/authz/mock_controller_and_get_users.go
+++ b/adapters/handlers/rest/authz/mock_controller_and_get_users.go
@@ -663,8 +663,7 @@ func (_c *MockControllerAndGetUsers_UpdateRolesPermissions_Call) RunAndReturn(ru
 func NewMockControllerAndGetUsers(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockControllerAndGetUsers {
+}) *MockControllerAndGetUsers {
 	mock := &MockControllerAndGetUsers{}
 	mock.Mock.Test(t)
 

--- a/adapters/handlers/rest/db_users/mock_db_user_and_roles_getter.go
+++ b/adapters/handlers/rest/db_users/mock_db_user_and_roles_getter.go
@@ -577,8 +577,7 @@ func (_c *MockDbUserAndRolesGetter_RotateKey_Call) RunAndReturn(run func(string,
 func NewMockDbUserAndRolesGetter(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockDbUserAndRolesGetter {
+}) *MockDbUserAndRolesGetter {
 	mock := &MockDbUserAndRolesGetter{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/batch_integration_test.go
+++ b/adapters/repos/db/batch_integration_test.go
@@ -105,7 +105,7 @@ func TestBatchPutObjects(t *testing.T) {
 	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}).Maybe()
 	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).Return([]string{"node1"}, nil).Maybe()
 	mockNodeSelector := cluster.NewMockNodeSelector(t)
-	mockNodeSelector.EXPECT().LocalName().Return("node").Maybe()
+	mockNodeSelector.EXPECT().LocalName().Return("node1").Maybe()
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return("node1", true).Maybe()
 	repo, err := New(logger, "node1", Config{
 		MemtablesFlushDirtyAfter:  60,

--- a/adapters/repos/db/lsmkv/mock_bucket_creator.go
+++ b/adapters/repos/db/lsmkv/mock_bucket_creator.go
@@ -119,8 +119,7 @@ func (_c *MockBucketCreator_NewBucket_Call) RunAndReturn(run func(context.Contex
 func NewMockBucketCreator(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockBucketCreator {
+}) *MockBucketCreator {
 	mock := &MockBucketCreator{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/mock_index_getter.go
+++ b/adapters/repos/db/mock_index_getter.go
@@ -84,8 +84,7 @@ func (_c *MockIndexGetter_GetIndexLike_Call) RunAndReturn(run func(schema.ClassN
 func NewMockIndexGetter(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockIndexGetter {
+}) *MockIndexGetter {
 	mock := &MockIndexGetter{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/mock_index_like.go
+++ b/adapters/repos/db/mock_index_like.go
@@ -198,8 +198,7 @@ func (_c *MockIndexLike_ForEachShard_Call) RunAndReturn(run func(func(string, Sh
 func NewMockIndexLike(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockIndexLike {
+}) *MockIndexLike {
 	mock := &MockIndexLike{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -4663,17 +4663,17 @@ func (_c *MockShardLike_removeTargetNodeOverride_Call) RunAndReturn(run func(con
 	return _c
 }
 
-// resetDimensionsLSM provides a mock function with no fields
+// resetDimensionsLSM provides a mock function with given fields: ctx
 func (_m *MockShardLike) resetDimensionsLSM(ctx context.Context) error {
-	ret := _m.Called()
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for resetDimensionsLSM")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r0 = rf(ctx)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -4687,13 +4687,14 @@ type MockShardLike_resetDimensionsLSM_Call struct {
 }
 
 // resetDimensionsLSM is a helper method to define mock.On call
-func (_e *MockShardLike_Expecter) resetDimensionsLSM(ctx context.Context) *MockShardLike_resetDimensionsLSM_Call {
-	return &MockShardLike_resetDimensionsLSM_Call{Call: _e.mock.On("resetDimensionsLSM")}
+//   - ctx context.Context
+func (_e *MockShardLike_Expecter) resetDimensionsLSM(ctx interface{}) *MockShardLike_resetDimensionsLSM_Call {
+	return &MockShardLike_resetDimensionsLSM_Call{Call: _e.mock.On("resetDimensionsLSM", ctx)}
 }
 
-func (_c *MockShardLike_resetDimensionsLSM_Call) Run(run func()) *MockShardLike_resetDimensionsLSM_Call {
+func (_c *MockShardLike_resetDimensionsLSM_Call) Run(run func(ctx context.Context)) *MockShardLike_resetDimensionsLSM_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run()
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -4703,7 +4704,7 @@ func (_c *MockShardLike_resetDimensionsLSM_Call) Return(_a0 error) *MockShardLik
 	return _c
 }
 
-func (_c *MockShardLike_resetDimensionsLSM_Call) RunAndReturn(run func() error) *MockShardLike_resetDimensionsLSM_Call {
+func (_c *MockShardLike_resetDimensionsLSM_Call) RunAndReturn(run func(context.Context) error) *MockShardLike_resetDimensionsLSM_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5040,8 +5041,7 @@ func (_c *MockShardLike_uuidFromDocID_Call) RunAndReturn(run func(uint64) (strfm
 func NewMockShardLike(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockShardLike {
+}) *MockShardLike {
 	mock := &MockShardLike{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/mock_vector_index.go
+++ b/adapters/repos/db/mock_vector_index.go
@@ -1014,8 +1014,7 @@ func (_c *MockVectorIndex_ValidateBeforeInsert_Call) RunAndReturn(run func([]flo
 func NewMockVectorIndex(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockVectorIndex {
+}) *MockVectorIndex {
 	mock := &MockVectorIndex{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/vector/compressionhelpers/mock_compression_stats.go
+++ b/adapters/repos/db/vector/compressionhelpers/mock_compression_stats.go
@@ -124,8 +124,7 @@ func (_c *MockCompressionStats_CompressionType_Call) RunAndReturn(run func() str
 func NewMockCompressionStats(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockCompressionStats {
+}) *MockCompressionStats {
 	mock := &MockCompressionStats{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/vector/dynamic/mock_index.go
+++ b/adapters/repos/db/vector/dynamic/mock_index.go
@@ -81,8 +81,7 @@ func (_c *MockIndex_UnderlyingIndex_Call) RunAndReturn(run func() common.IndexTy
 func NewMockIndex(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockIndex {
+}) *MockIndex {
 	mock := &MockIndex{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/vector/dynamic/mock_vector_index.go
+++ b/adapters/repos/db/vector/dynamic/mock_vector_index.go
@@ -965,8 +965,7 @@ func (_c *MockVectorIndex_ValidateBeforeInsert_Call) RunAndReturn(run func([]flo
 func NewMockVectorIndex(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockVectorIndex {
+}) *MockVectorIndex {
 	mock := &MockVectorIndex{}
 	mock.Mock.Test(t)
 

--- a/cluster/router/executor/executor.go
+++ b/cluster/router/executor/executor.go
@@ -1,0 +1,78 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package executor
+
+import (
+	"fmt"
+
+	"github.com/weaviate/weaviate/cluster/router/types"
+)
+
+type Operation func(types.Replica) error
+
+func validateExecutors(localOperation Operation, remoteOperation Operation) error {
+	if localOperation == nil {
+		return fmt.Errorf("local executor cannot be nil")
+	}
+	if remoteOperation == nil {
+		return fmt.Errorf("remote executor cannot be nil")
+	}
+	return nil
+}
+
+func ExecuteForEachShard(plan types.ReadRoutingPlan, localOperation Operation, remoteOperation Operation) error {
+	if err := validateExecutors(localOperation, remoteOperation); err != nil {
+		return err
+	}
+
+	shardSet := make(map[string]struct{})
+	for _, replica := range plan.ReplicaSet.Replicas {
+		if _, ok := shardSet[replica.ShardName]; ok {
+			continue
+		}
+		shardSet[replica.ShardName] = struct{}{}
+
+		if plan.LocalHostname == replica.NodeName {
+			if err := localOperation(replica); err != nil {
+				return fmt.Errorf("failed to locally execute read plan on replica %s: %w", replica.NodeName, err)
+			}
+		} else {
+			if err := remoteOperation(replica); err != nil {
+				return fmt.Errorf("failed to remotely execute read plan on replica %s at addr %s: %w", replica.NodeName, replica.HostAddr, err)
+			}
+		}
+	}
+	return nil
+}
+
+func ExecuteForEachReplicaOfShard(plan types.ReadRoutingPlan, shardName string, localOperation Operation, remoteOperation Operation) error {
+	if err := validateExecutors(localOperation, remoteOperation); err != nil {
+		return err
+	}
+
+	for _, replica := range plan.ReplicaSet.Replicas {
+		if replica.ShardName != shardName {
+			continue
+		}
+
+		if plan.LocalHostname == replica.NodeName {
+			if err := localOperation(replica); err != nil {
+				return fmt.Errorf("failed to locally execute read plan on replica %s: %w", replica.NodeName, err)
+			}
+		} else {
+			if err := remoteOperation(replica); err != nil {
+				return fmt.Errorf("failed to remotely execute read plan on replica %s at addr %s: %w", replica.NodeName, replica.HostAddr, err)
+			}
+		}
+	}
+	return nil
+}

--- a/cluster/router/executor/executor_test.go
+++ b/cluster/router/executor/executor_test.go
@@ -1,0 +1,356 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package executor_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cluster/router/executor"
+	"github.com/weaviate/weaviate/cluster/router/types"
+)
+
+// mockExecutor creates a mock executor that tracks calls and can simulate errors
+func mockExecutor(expectedCalls map[string]int, expectedErrors map[string]bool) executor.Operation {
+	return func(replica types.Replica) error {
+		expectedCalls[replica.NodeName]++
+		if expectedErrors[replica.NodeName] {
+			return fmt.Errorf("mock error for node %s", replica.NodeName)
+		}
+		return nil
+	}
+}
+
+// createTestPlan creates a test routing plan with the specified replicas
+func createTestPlan(replicas []types.Replica) types.ReadRoutingPlan {
+	return types.ReadRoutingPlan{
+		LocalHostname: "node1", // Default local hostname for tests
+		ReplicaSet: types.ReadReplicaSet{
+			Replicas: replicas,
+		},
+	}
+}
+
+// createTestReplica creates a test replica
+func createTestReplica(nodeName, shardName, hostAddr string) types.Replica {
+	return types.Replica{
+		NodeName:  nodeName,
+		ShardName: shardName,
+		HostAddr:  hostAddr,
+	}
+}
+
+func TestExecuteForEachShard(t *testing.T) {
+	type testCase struct {
+		name           string
+		plan           types.ReadRoutingPlan
+		expectedError  string
+		expectedLocal  map[string]int  // nodeName -> expected local call count
+		expectedRemote map[string]int  // nodeName -> expected remote call count
+		expectedErrors map[string]bool // nodeName -> whether error was expected
+	}
+
+	tests := []testCase{
+		{
+			name: "single local replica",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node1", "shard1", "node1:8080"),
+			}),
+			expectedLocal:  map[string]int{"node1": 1},
+			expectedRemote: map[string]int{},
+		},
+		{
+			name: "single remote replica",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node2", "shard1", "node2:8080"),
+			}),
+			expectedLocal:  map[string]int{},
+			expectedRemote: map[string]int{"node2": 1},
+		},
+		{
+			name: "multiple replicas same shard",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node1", "shard1", "node1:8080"),
+				createTestReplica("node2", "shard1", "node2:8080"),
+				createTestReplica("node3", "shard1", "node3:8080"),
+			}),
+			expectedLocal:  map[string]int{"node1": 1}, // Only first replica of shard should be called
+			expectedRemote: map[string]int{},
+		},
+		{
+			name: "multiple shards",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node1", "shard1", "node1:8080"),
+				createTestReplica("node2", "shard2", "node2:8080"),
+				createTestReplica("node3", "shard3", "node3:8080"),
+			}),
+			expectedLocal:  map[string]int{"node1": 1},
+			expectedRemote: map[string]int{"node2": 1, "node3": 1},
+		},
+		{
+			name: "local executor error",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node1", "shard1", "node1:8080"),
+				createTestReplica("node2", "shard2", "node2:8080"),
+			}),
+			expectedLocal:  map[string]int{"node1": 1},
+			expectedRemote: map[string]int{},
+			expectedErrors: map[string]bool{"node1": true},
+			expectedError:  "failed to locally execute read plan on replica node1: mock error for node node1",
+		},
+		{
+			name: "remote executor error",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node2", "shard1", "node2:8080"),
+				createTestReplica("node3", "shard2", "node3:8080"),
+			}),
+			expectedLocal:  map[string]int{},
+			expectedRemote: map[string]int{"node2": 1},
+			expectedErrors: map[string]bool{"node2": true},
+			expectedError:  "failed to remotely execute read plan on replica node2 at addr node2:8080: mock error for node node2",
+		},
+		{
+			name:           "empty replica set",
+			plan:           createTestPlan([]types.Replica{}),
+			expectedLocal:  map[string]int{},
+			expectedRemote: map[string]int{},
+		},
+		{
+			name: "mixed local and remote replicas",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node1", "shard1", "node1:8080"),
+				createTestReplica("node2", "shard1", "node2:8080"),
+				createTestReplica("node3", "shard2", "node3:8080"),
+			}),
+			expectedLocal:  map[string]int{"node1": 1},
+			expectedRemote: map[string]int{"node3": 1},
+		},
+		{
+			name: "empty local hostname",
+			plan: types.ReadRoutingPlan{
+				LocalHostname: "",
+				ReplicaSet: types.ReadReplicaSet{
+					Replicas: []types.Replica{
+						createTestReplica("node1", "shard1", "node1:8080"),
+					},
+				},
+			},
+			expectedLocal:  map[string]int{},
+			expectedRemote: map[string]int{"node1": 1},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock executors
+			localCalls := make(map[string]int)
+			remoteCalls := make(map[string]int)
+
+			localExecutor := mockExecutor(localCalls, tt.expectedErrors)
+			remoteExecutor := mockExecutor(remoteCalls, tt.expectedErrors)
+
+			// Execute the function
+			err := executor.ExecuteForEachShard(tt.plan, localExecutor, remoteExecutor)
+
+			// Verify results
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Verify local call counts
+			if tt.expectedLocal != nil {
+				for nodeName, expectedCount := range tt.expectedLocal {
+					actualCount := localCalls[nodeName]
+					require.Equal(t, expectedCount, actualCount,
+						"node %s: expected %d local calls, got %d", nodeName, expectedCount, actualCount)
+				}
+			}
+
+			// Verify remote call counts
+			if tt.expectedRemote != nil {
+				for nodeName, expectedCount := range tt.expectedRemote {
+					actualCount := remoteCalls[nodeName]
+					require.Equal(t, expectedCount, actualCount,
+						"node %s: expected %d remote calls, got %d", nodeName, expectedCount, actualCount)
+				}
+			}
+
+			// Verify no unexpected calls
+			for nodeName, actualLocalCount := range localCalls {
+				if expectedLocalCount, exists := tt.expectedLocal[nodeName]; !exists || expectedLocalCount != actualLocalCount {
+					require.Fail(t, "unexpected local calls", "node %s: got %d local calls but expected %d",
+						nodeName, actualLocalCount, expectedLocalCount)
+				}
+			}
+			for nodeName, actualRemoteCount := range remoteCalls {
+				if expectedRemoteCount, exists := tt.expectedRemote[nodeName]; !exists || expectedRemoteCount != actualRemoteCount {
+					require.Fail(t, "unexpected remote calls", "node %s: got %d remote calls but expected %d",
+						nodeName, actualRemoteCount, expectedRemoteCount)
+				}
+			}
+		})
+	}
+}
+
+func TestExecuteForEachReplicaOfShard(t *testing.T) {
+	type testCase struct {
+		name           string
+		plan           types.ReadRoutingPlan
+		shardName      string
+		expectedError  string
+		expectedLocal  map[string]int  // nodeName -> expected local call count
+		expectedRemote map[string]int  // nodeName -> expected remote call count
+		expectedErrors map[string]bool // nodeName -> whether error was expected
+	}
+	tests := []testCase{
+		{
+			name: "single local replica matching shard",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node1", "shard1", "node1:8080"),
+			}),
+			shardName:      "shard1",
+			expectedLocal:  map[string]int{"node1": 1},
+			expectedRemote: map[string]int{},
+		},
+		{
+			name: "single remote replica matching shard",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node2", "shard1", "node2:8080"),
+			}),
+			shardName:      "shard1",
+			expectedLocal:  map[string]int{},
+			expectedRemote: map[string]int{"node2": 1},
+		},
+		{
+			name: "multiple replicas matching shard",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node1", "shard1", "node1:8080"),
+				createTestReplica("node2", "shard1", "node2:8080"),
+				createTestReplica("node3", "shard1", "node3:8080"),
+			}),
+			shardName:      "shard1",
+			expectedLocal:  map[string]int{"node1": 1},
+			expectedRemote: map[string]int{"node2": 1, "node3": 1},
+		},
+		{
+			name: "replicas from different shards",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node1", "shard1", "node1:8080"),
+				createTestReplica("node2", "shard2", "node2:8080"),
+				createTestReplica("node3", "shard3", "node3:8080"),
+			}),
+			shardName:      "shard1",
+			expectedLocal:  map[string]int{"node1": 1},
+			expectedRemote: map[string]int{},
+		},
+		{
+			name: "no replicas matching shard",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node1", "shard1", "node1:8080"),
+				createTestReplica("node2", "shard2", "node2:8080"),
+			}),
+			shardName:      "shard3",
+			expectedLocal:  map[string]int{},
+			expectedRemote: map[string]int{},
+		},
+		{
+			name: "remote executor error with stop on error",
+			plan: createTestPlan([]types.Replica{
+				createTestReplica("node2", "shard1", "node2:8080"),
+				createTestReplica("node3", "shard1", "node3:8080"),
+			}),
+			shardName:      "shard1",
+			expectedLocal:  map[string]int{},
+			expectedRemote: map[string]int{"node2": 1},
+			expectedErrors: map[string]bool{"node2": true},
+			expectedError:  "failed to remotely execute read plan on replica node2 at addr node2:8080: mock error for node node2",
+		},
+		{
+			name:           "empty replica set",
+			plan:           createTestPlan([]types.Replica{}),
+			shardName:      "shard1",
+			expectedLocal:  map[string]int{},
+			expectedRemote: map[string]int{},
+		},
+		{
+			name: "empty local hostname",
+			plan: types.ReadRoutingPlan{
+				LocalHostname: "",
+				ReplicaSet: types.ReadReplicaSet{
+					Replicas: []types.Replica{
+						createTestReplica("node1", "shard1", "node1:8080"),
+					},
+				},
+			},
+			shardName:      "shard1",
+			expectedLocal:  map[string]int{},
+			expectedRemote: map[string]int{"node1": 1}, // Empty local hostname means all replicas are treated as remote
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create mock executors
+			localCalls := make(map[string]int)
+			remoteCalls := make(map[string]int)
+			localExecutor := mockExecutor(localCalls, tt.expectedErrors)
+			remoteExecutor := mockExecutor(remoteCalls, tt.expectedErrors)
+
+			// Execute the function
+			err := executor.ExecuteForEachReplicaOfShard(tt.plan, tt.shardName, localExecutor, remoteExecutor)
+
+			// Verify results
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				require.NoError(t, err)
+			}
+
+			// Verify local call counts
+			if tt.expectedLocal != nil {
+				for nodeName, expectedCount := range tt.expectedLocal {
+					actualCount := localCalls[nodeName]
+					require.Equal(t, expectedCount, actualCount,
+						"node %s: expected %d local calls, got %d", nodeName, expectedCount, actualCount)
+				}
+			}
+
+			// Verify remote call counts
+			if tt.expectedRemote != nil {
+				for nodeName, expectedCount := range tt.expectedRemote {
+					actualCount := remoteCalls[nodeName]
+					require.Equal(t, expectedCount, actualCount,
+						"node %s: expected %d remote calls, got %d", nodeName, expectedCount, actualCount)
+				}
+			}
+
+			// Verify no unexpected calls
+			for nodeName, actualLocalCount := range localCalls {
+				if expectedLocalCount, exists := tt.expectedLocal[nodeName]; !exists || expectedLocalCount != actualLocalCount {
+					require.Fail(t, "unexpected local calls", "node %s: got %d local calls but expected %d",
+						nodeName, actualLocalCount, expectedLocalCount)
+				}
+			}
+			for nodeName, actualRemoteCount := range remoteCalls {
+				if expectedRemoteCount, exists := tt.expectedRemote[nodeName]; !exists || expectedRemoteCount != actualRemoteCount {
+					require.Fail(t, "unexpected remote calls", "node %s: got %d remote calls but expected %d",
+						nodeName, actualRemoteCount, expectedRemoteCount)
+				}
+			}
+		})
+	}
+}

--- a/cluster/router/router.go
+++ b/cluster/router/router.go
@@ -360,8 +360,9 @@ func (r *singleTenantRouter) buildReadRoutingPlan(params types.RoutingPlanBuildO
 	orderedReplicas := sort(readReplicas.Replicas, preferredNode(params.DirectCandidateNode, r.nodeSelector.LocalName()))
 
 	plan := types.ReadRoutingPlan{
-		Shard:  params.Shard,
-		Tenant: params.Tenant,
+		LocalHostname: r.nodeSelector.LocalName(),
+		Shard:         params.Shard,
+		Tenant:        params.Tenant,
 		ReplicaSet: types.ReadReplicaSet{
 			Replicas: orderedReplicas,
 		},
@@ -611,8 +612,9 @@ func (r *multiTenantRouter) buildReadRoutingPlan(params types.RoutingPlanBuildOp
 	orderedReplicas := sort(readReplicas.Replicas, preferredNode(params.DirectCandidateNode, r.nodeSelector.LocalName()))
 
 	return types.ReadRoutingPlan{
-		Shard:  params.Shard,
-		Tenant: params.Tenant,
+		LocalHostname: r.nodeSelector.LocalName(),
+		Shard:         params.Shard,
+		Tenant:        params.Tenant,
 		ReplicaSet: types.ReadReplicaSet{
 			Replicas: orderedReplicas,
 		},

--- a/cluster/router/types/router_plan.go
+++ b/cluster/router/types/router_plan.go
@@ -53,6 +53,7 @@ func (o RoutingPlanBuildOptions) String() string {
 //   - ConsistencyLevel: The user-specified consistency level.
 //   - IntConsistencyLevel: The resolved numeric value for the consistency level.
 type ReadRoutingPlan struct {
+	LocalHostname       string
 	Shard               string
 	Tenant              string
 	ReplicaSet          ReadReplicaSet

--- a/test/acceptance_with_go_client/multi_tenancy_tests/implicit_activation_test.go
+++ b/test/acceptance_with_go_client/multi_tenancy_tests/implicit_activation_test.go
@@ -86,17 +86,15 @@ func autoTenantActivationJourney(t *testing.T,
 		err = client.Schema().ClassUpdater().WithClass(c).Do(ctx)
 		require.Nil(t, err)
 
-		// These kind of schema changes are not expected to be strongly
-		// consistent, so we wait a bit. This is fine as this setting should very
-		// rarely change.
-		time.Sleep(1 * time.Second)
 	})
 
 	t.Run("assert all tenants are queryable despite originally being COLD", func(t *testing.T) {
-		for _, tenantName := range tenantNames {
-			assertActiveTenantObjects(t, client, className, tenantName,
-				[]string{fixtures.PIZZA_FRUTTI_DI_MARE_ID})
-		}
+		assert.EventuallyWithT(t, func(t *assert.CollectT) {
+			for _, tenantName := range tenantNames {
+				assertActiveTenantObjectsNoRequire(t, client, className, tenantName,
+					[]string{fixtures.PIZZA_FRUTTI_DI_MARE_ID})
+			}
+		}, 5*time.Second, 300*time.Millisecond)
 	})
 
 	t.Run("assert all tenants are reporting as HOT now", func(t *testing.T) {

--- a/usecases/auth/authorization/mock_authorizer.go
+++ b/usecases/auth/authorization/mock_authorizer.go
@@ -239,8 +239,7 @@ func (_c *MockAuthorizer_FilterAuthorizedResources_Call) RunAndReturn(run func(c
 func NewMockAuthorizer(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockAuthorizer {
+}) *MockAuthorizer {
 	mock := &MockAuthorizer{}
 	mock.Mock.Test(t)
 

--- a/usecases/auth/authorization/mock_controller.go
+++ b/usecases/auth/authorization/mock_controller.go
@@ -588,8 +588,7 @@ func (_c *MockController_UpdateRolesPermissions_Call) RunAndReturn(run func(map[
 func NewMockController(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockController {
+}) *MockController {
 	mock := &MockController{}
 	mock.Mock.Test(t)
 

--- a/usecases/backup/mock_backup_backend_provider.go
+++ b/usecases/backup/mock_backup_backend_provider.go
@@ -141,8 +141,7 @@ func (_c *MockBackupBackendProvider_EnabledBackupBackends_Call) RunAndReturn(run
 func NewMockBackupBackendProvider(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockBackupBackendProvider {
+}) *MockBackupBackendProvider {
 	mock := &MockBackupBackendProvider{}
 	mock.Mock.Test(t)
 

--- a/usecases/backup/mock_node_resolver.go
+++ b/usecases/backup/mock_node_resolver.go
@@ -226,8 +226,7 @@ func (_c *MockNodeResolver_NodeHostname_Call) RunAndReturn(run func(string) (str
 func NewMockNodeResolver(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockNodeResolver {
+}) *MockNodeResolver {
 	mock := &MockNodeResolver{}
 	mock.Mock.Test(t)
 

--- a/usecases/backup/mock_selector.go
+++ b/usecases/backup/mock_selector.go
@@ -191,8 +191,7 @@ func (_c *MockSelector_Shards_Call) RunAndReturn(run func(context.Context, strin
 func NewMockSelector(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockSelector {
+}) *MockSelector {
 	mock := &MockSelector{}
 	mock.Mock.Test(t)
 

--- a/usecases/cluster/mock_node_selector.go
+++ b/usecases/cluster/mock_node_selector.go
@@ -425,8 +425,7 @@ func (_c *MockNodeSelector_StorageCandidates_Call) RunAndReturn(run func() []str
 func NewMockNodeSelector(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockNodeSelector {
+}) *MockNodeSelector {
 	mock := &MockNodeSelector{}
 	mock.Mock.Test(t)
 

--- a/usecases/modulecomponents/usage/mock_storage_backend.go
+++ b/usecases/modulecomponents/usage/mock_storage_backend.go
@@ -232,8 +232,7 @@ func (_c *MockStorageBackend_VerifyPermissions_Call) RunAndReturn(run func(conte
 func NewMockStorageBackend(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockStorageBackend {
+}) *MockStorageBackend {
 	mock := &MockStorageBackend{}
 	mock.Mock.Test(t)
 

--- a/usecases/schema/mock_schema_getter.go
+++ b/usecases/schema/mock_schema_getter.go
@@ -769,8 +769,7 @@ func (_c *MockSchemaGetter_TenantsShards_Call) RunAndReturn(run func(context.Con
 func NewMockSchemaGetter(t interface {
 	mock.TestingT
 	Cleanup(func())
-},
-) *MockSchemaGetter {
+}) *MockSchemaGetter {
 	mock := &MockSchemaGetter{}
 	mock.Mock.Test(t)
 


### PR DESCRIPTION
### What's being changed:

Add the ability to execute `ForEachShard` and `ForEachReplicasOfShard` on a read plan to reduce the complexity and improve code readability on the index side.
Add tests for the execute functions and update some tests to avoid flakyness/failures due to wrong setup in fakes.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17064253035
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
