### PR TITLE
Fix flaky compression status test by extracting shard compression check

### DIFF
--- a/test/acceptance/nodes/nodes_api_test.go
+++ b/test/acceptance/nodes/nodes_api_test.go
@@ -365,6 +365,18 @@ func TestNodesApi_Compression_AsyncIndexing(t *testing.T) {
 }
 
 func TestNodesApi_Compression_SyncIndexing(t *testing.T) {
+	ctx := context.Background()
+	compose, err := docker.New().
+		WithWeaviate().
+		WithText2VecContextionary().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	defer helper.SetupClient(fmt.Sprintf("%s:%s", helper.ServerHost, helper.ServerPort))
+	helper.SetupClient(compose.GetWeaviate().URI())
 	t.Run("validate flat compression status", func(t *testing.T) {
 		booksClass := books.ClassContextionaryVectorizer()
 		booksClass.VectorIndexType = "flat"


### PR DESCRIPTION
### What's being changed:

This change addresses a flaky test issue where the compression status of shards was inconsistently reported depending on whether the shard was lazy-loaded or not.
The problem was in the `getShardsNodeStatus` function where the logic for determining if any vector index in a shard is compressed was only being executed for loaded shards. For lazy-loaded shards, the compression status field was being set but the actual compression check wasn't happening, leading to inconsistent behavior that made tests fail unpredictably.

The test works by repeatedly calling the nodes API at regular intervals for a short period of time and checking the compression status until the expected condition is met. However, because the compression status calculation was missing for lazy-loaded shards, the test would sometimes never reach the expected state, causing it to fail intermittently based on the timing of when shards were loaded and whether they are lazy or not.

The fix extracts the compression checking logic into a dedicated `isAnyVectorIndexCompressed` function and calls it consistently for both loaded and lazy-loaded shards. This ensures that the compression status is always calculated regardless of the shard's loading state, making the polling-based test reliable.

Additionally, the `TestNodesApi_Compression_SyncIndexing` test has been updated with proper Docker compose setup . This test environment setup was missing, which meant the test was running against an unpredictable or incomplete environment. The new setup ensures the test runs in a controlled, isolated and dedicated environment with all necessary components properly initialized, which is essential for reliable compression status testing since the behavior depends on having actual vector indexes and shards in known states.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

