### PR TITLE
fix: use blocking cursor to list object digests

### DIFF
--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -127,12 +127,6 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 	initialUUID, finalUUID strfmt.UUID, limit int) (
 	objs []replica.RepairResponse, err error,
 ) {
-	err = s.store.PauseCompaction(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("pausing compaction: %w", err)
-	}
-	defer s.store.ResumeCompaction(ctx)
-
 	initialUUIDBytes, err := uuid.MustParse(initialUUID.String()).MarshalBinary()
 	if err != nil {
 		return nil, err
@@ -145,75 +139,31 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 
-	// note: it's important to first create the on disk cursor so to avoid potential double scanning over flushing memtable
-	cursor := bucket.CursorOnDisk()
+	cursor := bucket.Cursor()
 	defer cursor.Close()
-
-	inmemProcessedDocIDs := make(map[uint64]struct{})
 
 	n := 0
 
-	// note: read-write access to active and flushing memtable will be blocked only during the scope of this inner function
-	err = func() error {
-		inMemCursor := bucket.CursorInMem()
-		defer inMemCursor.Close()
-
-		for k, v := inMemCursor.Seek(initialUUIDBytes); n < limit && k != nil && bytes.Compare(k, finalUUIDBytes) < 1; k, v = inMemCursor.Next() {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			default:
-				obj, err := storobj.FromBinaryUUIDOnly(v)
-				if err != nil {
-					return fmt.Errorf("cannot unmarshal object: %w", err)
-				}
-
-				replicaObj := replica.RepairResponse{
-					ID:         obj.ID().String(),
-					UpdateTime: obj.LastUpdateTimeUnix(),
-					// TODO: use version when supported
-					Version: 0,
-				}
-
-				objs = append(objs, replicaObj)
-
-				inmemProcessedDocIDs[obj.DocID] = struct{}{}
-
-				n++
-			}
-		}
-
-		return nil
-	}()
-	if err != nil {
-		return nil, err
-	}
-
 	for k, v := cursor.Seek(initialUUIDBytes); n < limit && k != nil && bytes.Compare(k, finalUUIDBytes) < 1; k, v = cursor.Next() {
-		select {
-		case <-ctx.Done():
+		if ctx.Err() != nil {
 			return objs, ctx.Err()
-		default:
-			obj, err := storobj.FromBinaryUUIDOnly(v)
-			if err != nil {
-				return objs, fmt.Errorf("cannot unmarshal object: %w", err)
-			}
-
-			if _, ok := inmemProcessedDocIDs[obj.DocID]; ok {
-				continue
-			}
-
-			replicaObj := replica.RepairResponse{
-				ID:         obj.ID().String(),
-				UpdateTime: obj.LastUpdateTimeUnix(),
-				// TODO: use version when supported
-				Version: 0,
-			}
-
-			objs = append(objs, replicaObj)
-
-			n++
 		}
+
+		obj, err := storobj.FromBinaryUUIDOnly(v)
+		if err != nil {
+			return objs, fmt.Errorf("cannot unmarshal object: %w", err)
+		}
+
+		replicaObj := replica.RepairResponse{
+			ID:         obj.ID().String(),
+			UpdateTime: obj.LastUpdateTimeUnix(),
+			// TODO: use version when supported
+			Version: 0,
+		}
+
+		objs = append(objs, replicaObj)
+
+		n++
 	}
 
 	return objs, nil


### PR DESCRIPTION
### What's being changed:

Revert #8430 as it could lead to a deadlock with ongoing segment compaction.

e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/16881465587

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
