### PR TITLE
Enable metadata and segment info in filename

### DIFF
--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -369,11 +369,15 @@ func FromEnv(config *Config) error {
 		config.Persistence.LazySegmentsDisabled = true
 	}
 
-	if entcfg.Enabled(os.Getenv("PERSISTENCE_SEGMENT_INFO_FROM_FILE_ENABLED")) {
+	if entcfg.Enabled(os.Getenv("PERSISTENCE_SEGMENT_INFO_FROM_FILE_DISABLED")) {
+		config.Persistence.SegmentInfoIntoFileNameEnabled = false
+	} else {
 		config.Persistence.SegmentInfoIntoFileNameEnabled = true
 	}
 
-	if entcfg.Enabled(os.Getenv("PERSISTENCE_WRITE_METADATA_FILES_ENABLED")) {
+	if entcfg.Enabled(os.Getenv("PERSISTENCE_WRITE_METADATA_FILES_DISABLED")) {
+		config.Persistence.WriteMetadataFilesEnabled = false
+	} else {
 		config.Persistence.WriteMetadataFilesEnabled = true
 	}
 


### PR DESCRIPTION
### What's being changed:

Enable new performance features by default. 

This includes:
- single .metadata file instead of separate (primary+secondary) .bloom + .cna files
- Adds some metadata info about segment into the filename to avoid the need to load the segment for these infos

Older versions support _reading_ these new changes but writing them is off by default

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
