### PR TITLE
fix: prevent nil pointer panic in BatchDelete findUUIDs

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2758,7 +2758,7 @@ func (i *Index) findUUIDs(ctx context.Context,
 		var err error
 
 		if i.shardHasMultipleReplicasRead(tenant, shardName) {
-			results[shardName], err = i.replicator.FindUUIDs(ctx, className, shardName, filters, routerTypes.ConsistencyLevel(repl.ConsistencyLevel))
+			results[shardName], err = i.replicator.FindUUIDs(ctx, className, shardName, filters, cl)
 		} else {
 			// anonymous func is here to ensure release is executed after each loop iteration
 			func() {


### PR DESCRIPTION
### What's being changed:

The `findUUIDs` method in `index.go` was experiencing nil pointer dereferences during batch delete operations when `repl.ConsistencyLevel` was accessed directly without checking if the `repl` parameter was nil.

Here we use the already computed consistency level `cl` (derived from `i.consistencyLevel(repl)`) instead of directly accessing `repl.ConsistencyLevel`. The `consistencyLevel` method safely handles nil replication properties.

Currently `service.go`, which includes multiple APIs like `BatchDelete`, is not covered by any tests. As an exception this critical bug fix is being merged without accompanying tests to ensure rapid deployment and followup testing. A follow-up PR will be created to add comprehensive test coverage for at least all public methods in `service.go`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.