### PR TITLE
feat(backup): Add support to backup aliases as part of collection

### DIFF
--- a/cluster/schema/reader.go
+++ b/cluster/schema/reader.go
@@ -99,6 +99,10 @@ func (rs SchemaReader) ReadOnlyClass(class string) (cls *models.Class) {
 	return res
 }
 
+func (rs SchemaReader) GetAliasesForClass(class string) []*models.Alias {
+	return rs.schema.GetAliasesForClass(class)
+}
+
 // ReadOnlyVersionedClass returns a shallow copy of a class along with its version.
 // The copy is read-only and should not be modified.
 func (rs SchemaReader) ReadOnlyVersionedClass(className string) versioned.Class {

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -694,6 +694,24 @@ func (s *schema) canonicalAlias(alias string) string {
 	return strings.ToUpper(string(alias[0])) + alias[1:]
 }
 
+func (s *schema) GetAliasesForClass(class string) []*models.Alias {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	res := make([]*models.Alias, 0)
+	if class == "" {
+		return res
+	}
+	for alias, className := range s.aliases {
+		if className == class {
+			res = append(res, &models.Alias{
+				Alias: alias,
+				Class: className,
+			})
+		}
+	}
+	return res
+}
 func (s *schema) getAliases(alias, class string) map[string]string {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/entities/backup/descriptor.go
+++ b/entities/backup/descriptor.go
@@ -247,6 +247,7 @@ type ClassDescriptor struct {
 	Shards                  []*ShardDescriptor `json:"shards"`
 	ShardingState           []byte             `json:"shardingState"`
 	Schema                  []byte             `json:"schema"`
+	Aliases                 []byte             `json:"aliases"`
 	Chunks                  map[int32][]string `json:"chunks,omitempty"`
 	Error                   error              `json:"-"`
 	PreCompressionSizeBytes int64              `json:"preCompressionSizeBytes"` // Size of this class's backup in bytes before compression

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -162,13 +162,25 @@ func (h *Handler) RestoreClass(ctx context.Context, d *backup.ClassDescriptor, m
 	// get schema and sharding state
 	class := &models.Class{}
 	if err := json.Unmarshal(d.Schema, &class); err != nil {
-		return fmt.Errorf("marshal class schema: %w", err)
+		return fmt.Errorf("unmarshal class schema: %w", err)
 	}
 	var shardingState sharding.State
 	if d.ShardingState != nil {
 		err := json.Unmarshal(d.ShardingState, &shardingState)
 		if err != nil {
-			return fmt.Errorf("marshal sharding state: %w", err)
+			return fmt.Errorf("unmarshal sharding state: %w", err)
+		}
+	}
+
+	aliases := make([]*models.Alias, 0)
+	if err := json.Unmarshal(d.Aliases, &aliases); err != nil {
+		return fmt.Errorf("unmarshal aliases: %w", err)
+	}
+
+	for _, alias := range aliases {
+		_, err := h.schemaManager.CreateAlias(ctx, alias.Alias, class)
+		if err != nil {
+			return fmt.Errorf("failed to restore alias for class: %w", err)
 		}
 	}
 

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -102,6 +102,7 @@ type SchemaReader interface {
 	Read(class string, reader func(*models.Class, *sharding.State) error) error
 	GetShardsStatus(class, tenant string) (models.ShardStatusList, error)
 	ResolveAlias(alias string) string
+	GetAliasesForClass(class string) []*models.Alias
 
 	// These schema reads function (...WithVersion) return the metadata once the local schema has caught up to the
 	// version parameter. If version is 0 is behaves exactly the same as eventual consistent reads.

--- a/usecases/schema/manager.go
+++ b/usecases/schema/manager.go
@@ -59,6 +59,7 @@ type SchemaGetter interface {
 	GetSchemaSkipAuth() schema.Schema
 	ReadOnlyClass(string) *models.Class
 	ResolveAlias(string) string
+	GetAliasesForClass(class string) []*models.Alias
 	Nodes() []string
 	NodeName() string
 	ClusterHealthScore() int

--- a/usecases/schema/mock_schema_getter.go
+++ b/usecases/schema/mock_schema_getter.go
@@ -130,6 +130,54 @@ func (_c *MockSchemaGetter_CopyShardingState_Call) RunAndReturn(run func(string)
 	return _c
 }
 
+// GetAliasesForClass provides a mock function with given fields: class
+func (_m *MockSchemaGetter) GetAliasesForClass(class string) []*models.Alias {
+	ret := _m.Called(class)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAliasesForClass")
+	}
+
+	var r0 []*models.Alias
+	if rf, ok := ret.Get(0).(func(string) []*models.Alias); ok {
+		r0 = rf(class)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*models.Alias)
+		}
+	}
+
+	return r0
+}
+
+// MockSchemaGetter_GetAliasesForClass_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAliasesForClass'
+type MockSchemaGetter_GetAliasesForClass_Call struct {
+	*mock.Call
+}
+
+// GetAliasesForClass is a helper method to define mock.On call
+//   - class string
+func (_e *MockSchemaGetter_Expecter) GetAliasesForClass(class interface{}) *MockSchemaGetter_GetAliasesForClass_Call {
+	return &MockSchemaGetter_GetAliasesForClass_Call{Call: _e.mock.On("GetAliasesForClass", class)}
+}
+
+func (_c *MockSchemaGetter_GetAliasesForClass_Call) Run(run func(class string)) *MockSchemaGetter_GetAliasesForClass_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockSchemaGetter_GetAliasesForClass_Call) Return(_a0 []*models.Alias) *MockSchemaGetter_GetAliasesForClass_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockSchemaGetter_GetAliasesForClass_Call) RunAndReturn(run func(string) []*models.Alias) *MockSchemaGetter_GetAliasesForClass_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetSchemaSkipAuth provides a mock function with no fields
 func (_m *MockSchemaGetter) GetSchemaSkipAuth() entitiesschema.Schema {
 	ret := _m.Called()


### PR DESCRIPTION
### What's being changed:
This PR add support to take backup of alias along with collection.

Changes:
1. Added aliases support in core `backup.ClassDescriptor`
2. Marshal as JSON the alias list as part of backup
3. Unmarshal and mutate the class during `schema.RestoreClass` method.

Also updated other tests, mocks and fakes alongside.

TODO:
Still need to fix some tests and add more tests for backup alias backup/restore behavior

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
