### PR TITLE
fix: :bug: reuse segments during iteration

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -92,7 +92,7 @@ func (sg *SegmentGroup) findCompactionCandidates() (pair []int, level uint16) {
 		left, right := sg.segments[leftId], sg.segments[leftId+1]
 
 		if left.getLevel() == right.getLevel() {
-			leftS, rightS := sg.segments[leftId].getSegment(), sg.segments[leftId+1].getSegment()
+			leftS, rightS := left.getSegment(), right.getSegment()
 			if leftS.secondaryIndexCount != rightS.secondaryIndexCount {
 				// only pair of segments with the same secondary indexes are compacted
 				continue
@@ -125,7 +125,7 @@ func (sg *SegmentGroup) findCompactionCandidates() (pair []int, level uint16) {
 				break
 			}
 			if sg.compactLeftOverSegments && !leftoverPairFound {
-				leftS, rightS := sg.segments[leftId].getSegment(), sg.segments[leftId+1].getSegment()
+				leftS, rightS := left.getSegment(), right.getSegment()
 				if leftS.secondaryIndexCount != rightS.secondaryIndexCount {
 					// only pair of segments with the same secondary indexes are compacted
 					continue


### PR DESCRIPTION
### What's being changed:

Revert to old behavior where segments are selected at start of iteration to avoid issues with underlying order of `sg.segments`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
