### PR TITLE
feat: override bmw migration props

### DIFF
--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -100,6 +100,14 @@ func setupDebugHandlers(appState *state.State) {
 		changeFile("start.mig", true, nil, logger, appState, r, w)
 	}))
 
+	http.HandleFunc("/debug/index/rebuild/inverted/reset", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		changeFile("reset.mig", false, nil, logger, appState, r, w)
+	}))
+
+	http.HandleFunc("/debug/index/rebuild/inverted/unreset", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		changeFile("reset.mig", true, nil, logger, appState, r, w)
+	}))
+
 	http.HandleFunc("/debug/index/rebuild/inverted/setProperties", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		propertiesToMigrateString := strings.TrimSpace(r.URL.Query().Get("properties"))
 

--- a/adapters/handlers/rest/handlers_debug_bmw_aux.go
+++ b/adapters/handlers/rest/handlers_debug_bmw_aux.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 
@@ -65,13 +66,14 @@ func changeFile(filename string, delete bool, content []byte, logger *logrus.Ent
 			func(shardName string, shard db.ShardLike) error {
 				alreadyDid := false
 				if len(shardsToMigrate) == 0 || slices.Contains(shardsToMigrate, shardName) {
-					shardPath := rootPath + "/" + classNameString + "/" + shardName + "/lsm/.migrations/searchable_map_to_blockmax/"
+					shardPath := filepath.Join(rootPath, classNameString, shardName, "lsm", ".migrations", "searchable_map_to_blockmax")
+					filename = filepath.Join(shardPath, filename)
 					_, err := os.Stat(shardPath)
 					if err != nil {
 						return fmt.Errorf("shard not found or not ready")
 					}
 					if delete {
-						err = os.Remove(shardPath + filename)
+						err = os.Remove(filename)
 						if os.IsNotExist(err) {
 							alreadyDid = true
 						} else if err != nil {
@@ -79,11 +81,11 @@ func changeFile(filename string, delete bool, content []byte, logger *logrus.Ent
 						}
 					} else {
 						// check if the file already exists
-						_, err = os.Stat(shardPath + filename)
+						_, err = os.Stat(filename)
 						if err == nil {
 							alreadyDid = true
 						} else {
-							file, err := os.Create(shardPath + filename)
+							file, err := os.Create(filename)
 							if os.IsExist(err) {
 								alreadyDid = true
 							} else if err != nil {
@@ -93,7 +95,7 @@ func changeFile(filename string, delete bool, content []byte, logger *logrus.Ent
 						}
 
 						if content != nil {
-							file, err := os.Create(shardPath + filename)
+							file, err := os.Create(filename)
 							if err != nil {
 								return fmt.Errorf("failed to create %s: %w", filename, err)
 							}

--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -179,6 +179,12 @@ func (t *ShardReindexTask_MapToBlockmax) OnBeforeLsmInit(ctx context.Context, sh
 		t.config.rollback = true
 	}
 
+	if rt.IsReset() && rt.IsTidied() {
+		rt.reset()
+		err = fmt.Errorf("reset was manually triggered")
+		return
+	}
+
 	if t.config.conditionalStart && !rt.HasStartCondition() {
 		err = fmt.Errorf("conditional start is set, but file trigger is not found")
 		return
@@ -1317,6 +1323,7 @@ type mapToBlockmaxReindexTracker interface {
 
 	IsPaused() bool
 	IsRollback() bool
+	IsReset() bool
 
 	reset() error
 
@@ -1337,6 +1344,7 @@ func NewFileMapToBlockmaxReindexTracker(lsmPath string, keyParser indexKeyParser
 			filenameTidied:     "tidied.mig",
 			filenameProperties: "properties.mig",
 			filenameRollback:   "rollback.mig",
+			filenameReset:      "reset.mig",
 			filenamePaused:     "paused.mig",
 			filenameOverrides:  "overrides.mig",
 			migrationPath:      filepath.Join(lsmPath, ".migrations", "searchable_map_to_blockmax"),
@@ -1360,6 +1368,7 @@ type fileReindexTrackerConfig struct {
 	filenameTidied     string
 	filenameProperties string
 	filenameRollback   string
+	filenameReset      string
 	filenamePaused     string
 	filenameOverrides  string
 	migrationPath      string
@@ -1684,6 +1693,10 @@ func (t *fileMapToBlockmaxReindexTracker) GetProps() ([]string, error) {
 		return []string{}, nil
 	}
 	return strings.Split(string(content), ","), nil
+}
+
+func (t *fileMapToBlockmaxReindexTracker) IsReset() bool {
+	return t.fileExists(t.config.filenameReset)
 }
 
 func (t *fileMapToBlockmaxReindexTracker) reset() error {


### PR DESCRIPTION
### What's being changed:

- Allow for overriding the BMW migration props to allow to rebuild index for properties already using BMW
- Allow for reset migration folder after tidy to run process again without having to delete folder manually

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
