### PR TITLE
Fix loading of broken compaction segments with metadata in filenames

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -204,14 +204,6 @@ func segmentID(path string) string {
 	return strings.TrimPrefix(filename, "segment-")
 }
 
-func strategyAndLevelFromFileName(path string) (uint16, segmentindex.Strategy) {
-	// is not used, only the filename parsing
-	ls := lazySegment{path: path}
-	level := ls.getLevel()
-	strategy := ls.getStrategy()
-	return level, strategy
-}
-
 func segmentExtraInfo(level uint16, strategy segmentindex.Strategy) string {
 	return fmt.Sprintf(".l%d.s%d", level, strategy)
 }

--- a/adapters/repos/db/lsmkv/segment_group_loading_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_loading_test.go
@@ -20,6 +20,8 @@ import (
 	"sort"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -51,68 +53,7 @@ func TestCompactionCleanupBothSegmentsPresent(t *testing.T) {
 		for _, addFileInfo := range []bool{true, false} {
 			dirName := t.TempDir()
 			tmpDir := t.TempDir()
-			b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo), WithMinWalThreshold(4096),
-			)
-			require.NoError(t, err)
-			for i := 0; i < 10; i++ {
-				require.NoError(t, b.Put([]byte(fmt.Sprintf("hello%d", i)), []byte(fmt.Sprintf("world%d", i))))
-			}
-			require.NoError(t, b.FlushMemtable())
-			dbFiles, walFiles := countDbAndWalFiles(t, dirName)
-			require.Equal(t, dbFiles, 1)
-			require.Equal(t, walFiles, 0)
-
-			for i := 10; i < 20; i++ {
-				require.NoError(t, b.Put([]byte(fmt.Sprintf("hello%d", i)), []byte(fmt.Sprintf("world%d", i))))
-			}
-			require.NoError(t, b.Put([]byte("hello1"), []byte("newworld")))
-			require.NoError(t, b.FlushMemtable())
-			dbFiles, walFiles = countDbAndWalFiles(t, dirName)
-			require.Equal(t, dbFiles, 2)
-			require.Equal(t, walFiles, 0)
-
-			// copy segments to safe place
-			var segments []string
-			entriesTmp, err := os.ReadDir(dirName)
-			require.NoError(t, err)
-			for _, entry := range entriesTmp {
-				if filepath.Ext(entry.Name()) == ".db" {
-					copyFile(t, dirName+"/"+entry.Name(), tmpDir+"/"+entry.Name())
-					segments = append(segments, segmentID(entry.Name()))
-				}
-			}
-
-			once, err := b.disk.compactOnce()
-			require.NoError(t, err)
-			require.True(t, once)
-			dbFiles, walFiles = countDbAndWalFiles(t, dirName)
-			require.Equal(t, dbFiles, 1)
-			require.Equal(t, walFiles, 0)
-			require.NoError(t, b.Shutdown(ctx))
-
-			// move compacted segment to safe place
-			entries, err := os.ReadDir(dirName)
-			require.NoError(t, err)
-			for _, entry := range entries {
-				if filepath.Ext(entry.Name()) == ".db" {
-					ext := ".db.tmp"
-					if addFileInfo {
-						ext = ".l1.s0" + ext
-					}
-					require.NoError(t, os.Rename(dirName+"/"+entry.Name(), tmpDir+"/"+"segment-"+segments[0]+"_"+segments[1]+ext))
-				}
-			}
-
-			// order after sorting is:
-			// 0: left segment
-			// 1: combined segment
-			// 2: right segment
-			entriesTmp, err = os.ReadDir(tmpDir)
-			sort.Slice(entriesTmp, func(i, j int) bool {
-				return entriesTmp[i].Name() < entriesTmp[j].Name()
-			})
-			require.NoError(t, err)
+			entriesTmp := createSegmentFiles(t, ctx, logger, dirName, tmpDir, []bool{addFileInfo})
 			t.Run(tt.name, func(t *testing.T) {
 				testDir := t.TempDir()
 				if tt.copyLeft {
@@ -126,6 +67,86 @@ func TestCompactionCleanupBothSegmentsPresent(t *testing.T) {
 
 				b2, err := NewBucketCreator().NewBucket(ctx, testDir, "", logger, nil,
 					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo), WithCalcCountNetAdditions(true),
+				)
+				if tt.expectErr {
+					require.Error(t, err)
+				} else {
+					require.NoError(t, err)
+					require.Equal(t, 20, b2.Count())
+					entries, err := os.ReadDir(testDir)
+					require.NoError(t, err)
+					for _, entry := range entries {
+						if filepath.Ext(entry.Name()) == ".db" {
+							require.NotContains(t, entry.Name(), "_")
+						}
+					}
+					require.Len(t, b2.disk.segments, tt.expectedSegments)
+					for _, segment := range b2.disk.segments {
+						path := segment.getPath()
+						file := filepath.Base(path)
+						require.NotContains(t, file, "_")
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestCompactionCleanupBothSegmentsPresentUpgrade(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	ctx := context.Background()
+
+	// Tests that various states of the compaction being aborted are handled correctly
+	// There are 3 files involved:
+	// 1. The combined segment that is still a tmp file
+	// 2+3. The two source segment files
+	tests := []struct {
+		name             string
+		copyLeft         bool
+		copyRight        bool
+		expectErr        bool
+		expectedSegments int
+	}{
+		{name: "only left present", copyLeft: true, copyRight: false, expectErr: true},
+		{name: "only right present", copyLeft: false, copyRight: true, expectErr: false, expectedSegments: 1},
+		{name: "nothing present", copyLeft: false, copyRight: false, expectErr: false, expectedSegments: 1},
+		{name: "both present", copyLeft: true, copyRight: true, expectErr: false, expectedSegments: 2},
+	}
+
+	for _, tt := range tests {
+		fileInfos := []struct {
+			sourceFileLeft   bool
+			sourceFileRight  bool
+			compactedTmpFile bool
+			loadingBucket    bool
+		}{
+			{sourceFileLeft: true, sourceFileRight: true, compactedTmpFile: false, loadingBucket: false},
+			{sourceFileLeft: true, sourceFileRight: true, compactedTmpFile: true, loadingBucket: false},
+			{sourceFileLeft: false, sourceFileRight: false, compactedTmpFile: true, loadingBucket: false},
+			{sourceFileLeft: false, sourceFileRight: true, compactedTmpFile: true, loadingBucket: false},
+			{sourceFileLeft: false, sourceFileRight: true, compactedTmpFile: false, loadingBucket: true},
+			{sourceFileLeft: false, sourceFileRight: false, compactedTmpFile: true, loadingBucket: true},
+			{sourceFileLeft: false, sourceFileRight: false, compactedTmpFile: false, loadingBucket: true},
+			{sourceFileLeft: true, sourceFileRight: false, compactedTmpFile: true, loadingBucket: true},
+		}
+		for _, fileInfo := range fileInfos {
+			dirName := t.TempDir()
+			tmpDir := t.TempDir()
+			entriesTmp := createSegmentFiles(t, ctx, logger, dirName, tmpDir, []bool{fileInfo.sourceFileLeft, fileInfo.sourceFileRight, fileInfo.compactedTmpFile})
+			t.Run(tt.name, func(t *testing.T) {
+				testDir := t.TempDir()
+				if tt.copyLeft {
+					copyFile(t, tmpDir+"/"+entriesTmp[0].Name(), testDir+"/"+entriesTmp[0].Name())
+				}
+				if tt.copyRight {
+					copyFile(t, tmpDir+"/"+entriesTmp[2].Name(), testDir+"/"+entriesTmp[2].Name())
+				}
+				// always copy the combined file
+				copyFile(t, tmpDir+"/"+entriesTmp[1].Name(), testDir+"/"+entriesTmp[1].Name())
+
+				b2, err := NewBucketCreator().NewBucket(ctx, testDir, "", logger, nil,
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(fileInfo.loadingBucket), WithCalcCountNetAdditions(true),
 				)
 				if tt.expectErr {
 					require.Error(t, err)
@@ -221,4 +242,81 @@ func TestWalFilePresent(t *testing.T) {
 	dbFiles, walFiles = countDbAndWalFiles(t, dirName)
 	require.Equal(t, dbFiles, 0)
 	require.Equal(t, walFiles, 1)
+}
+
+func createSegmentFiles(t *testing.T, ctx context.Context, logger logrus.FieldLogger, dirName, tmpDir string, addFileInfo []bool) []os.DirEntry {
+	t.Helper()
+	if len(addFileInfo) == 1 {
+		addFileInfo = []bool{addFileInfo[0], addFileInfo[0], addFileInfo[0]}
+	}
+
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo[0]), WithMinWalThreshold(4096),
+	)
+	require.NoError(t, err)
+	for i := 0; i < 10; i++ {
+		require.NoError(t, b.Put([]byte(fmt.Sprintf("hello%d", i)), []byte(fmt.Sprintf("world%d", i))))
+	}
+	require.NoError(t, b.FlushMemtable())
+	dbFiles, walFiles := countDbAndWalFiles(t, dirName)
+	require.Equal(t, dbFiles, 1)
+	require.Equal(t, walFiles, 0)
+	require.NoError(t, b.Shutdown(ctx))
+
+	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo[1]), WithMinWalThreshold(4096),
+	)
+	require.NoError(t, err)
+
+	for i := 10; i < 20; i++ {
+		require.NoError(t, b.Put([]byte(fmt.Sprintf("hello%d", i)), []byte(fmt.Sprintf("world%d", i))))
+	}
+	require.NoError(t, b.Put([]byte("hello1"), []byte("newworld")))
+	require.NoError(t, b.FlushMemtable())
+	dbFiles, walFiles = countDbAndWalFiles(t, dirName)
+	require.Equal(t, dbFiles, 2)
+	require.Equal(t, walFiles, 0)
+
+	// copy segments to safe place
+	var segments []string
+	entriesTmp, err := os.ReadDir(dirName)
+	require.NoError(t, err)
+	for _, entry := range entriesTmp {
+		if filepath.Ext(entry.Name()) == ".db" {
+			copyFile(t, dirName+"/"+entry.Name(), tmpDir+"/"+entry.Name())
+			segments = append(segments, segmentID(entry.Name()))
+		}
+	}
+
+	once, err := b.disk.compactOnce()
+	require.NoError(t, err)
+	require.True(t, once)
+	dbFiles, walFiles = countDbAndWalFiles(t, dirName)
+	require.Equal(t, dbFiles, 1)
+	require.Equal(t, walFiles, 0)
+	require.NoError(t, b.Shutdown(ctx))
+
+	// move compacted segment to safe place
+	entries, err := os.ReadDir(dirName)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		if filepath.Ext(entry.Name()) == ".db" {
+			ext := ".db.tmp"
+			if addFileInfo[2] {
+				ext = ".l1.s0" + ext
+			}
+			require.NoError(t, os.Rename(dirName+"/"+entry.Name(), tmpDir+"/"+"segment-"+segments[0]+"_"+segments[1]+ext))
+		}
+	}
+
+	// order after sorting is:
+	// 0: left segment
+	// 1: combined segment
+	// 2: right segment
+	entriesTmp, err = os.ReadDir(tmpDir)
+	sort.Slice(entriesTmp, func(i, j int) bool {
+		return entriesTmp[i].Name() < entriesTmp[j].Name()
+	})
+	require.NoError(t, err)
+	return entriesTmp
 }


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
