### PR TITLE
chore(modules): add support for debug param in grouped generative search

### DIFF
--- a/adapters/handlers/grpc/v1/generative/parser.go
+++ b/adapters/handlers/grpc/v1/generative/parser.go
@@ -34,10 +34,15 @@ type Parser struct {
 	uses127Api     bool
 	providerName   string
 	returnMetadata returnMetadata
-	debug          bool
+	returnDebug    returnDebug
 }
 
 type returnMetadata struct {
+	single  bool
+	grouped bool
+}
+
+type returnDebug struct {
 	single  bool
 	grouped bool
 }
@@ -72,8 +77,12 @@ func (p *Parser) ReturnMetadataForGrouped() bool {
 	return p.returnMetadata.grouped
 }
 
-func (p *Parser) Debug() bool {
-	return p.debug
+func (p *Parser) ReturnDebugForSingle() bool {
+	return p.returnDebug.single
+}
+
+func (p *Parser) ReturnDebugForGrouped() bool {
+	return p.returnDebug.grouped
 }
 
 func (p *Parser) extractDeprecated(req *pb.GenerativeSearch, class *models.Class) *generate.Params {
@@ -166,7 +175,7 @@ func (p *Parser) extract(req *pb.GenerativeSearch, class *models.Class) *generat
 		generative.Prompt = &req.Single.Prompt
 		p.returnMetadata.single = p.extractFromQuery(&generative, req.Single.Queries)
 
-		p.debug = req.Single.Debug
+		p.returnDebug.single = req.Single.Debug
 		generative.Debug = req.Single.Debug
 
 		singleResultPrompts := generate.ExtractPropsFromPrompt(generative.Prompt)
@@ -175,6 +184,10 @@ func (p *Parser) extract(req *pb.GenerativeSearch, class *models.Class) *generat
 	if req.Grouped != nil {
 		generative.Task = &req.Grouped.Task
 		p.returnMetadata.grouped = p.extractFromQuery(&generative, req.Grouped.Queries) // populates generative.Properties with any values in provider.ImageProperties (if supported)
+
+		p.returnDebug.grouped = req.Grouped.Debug
+		generative.Debug = req.Grouped.Debug
+
 		if len(generative.Properties) == 0 && len(req.Grouped.GetProperties().GetValues()) == 0 {
 			// if users do not supply any properties, all properties need to be extracted
 			generative.PropertiesToExtract = append(generative.PropertiesToExtract, schema.GetPropertyNamesFromClass(class, false)...)

--- a/adapters/handlers/grpc/v1/generative/replier.go
+++ b/adapters/handlers/grpc/v1/generative/replier.go
@@ -53,7 +53,8 @@ type queryParams interface {
 	ProviderName() string
 	ReturnMetadataForSingle() bool
 	ReturnMetadataForGrouped() bool
-	Debug() bool
+	ReturnDebugForSingle() bool
+	ReturnDebugForGrouped() bool
 }
 
 func NewReplier(logger logrus.FieldLogger, queryParams queryParams, uses127Api bool) *Replier {
@@ -356,10 +357,15 @@ func (r *Replier) extractGenerativeReply(_additional map[string]any, params any)
 				return nil, nil, err
 			}
 		}
-		if generateResults["debug"] != nil && r.queryParams.Debug() {
+		if generateResults["debug"] != nil && (r.queryParams.ReturnDebugForSingle() || r.queryParams.ReturnDebugForGrouped()) {
 			if debug, ok := generateResults["debug"].(*modulecapabilities.GenerateDebugInformation); ok && debug != nil {
 				prompt := debug.Prompt
-				reply.Debug = &pb.GenerativeDebug{FullPrompt: &prompt}
+				if r.queryParams.ReturnDebugForSingle() {
+					reply.Debug = &pb.GenerativeDebug{FullPrompt: &prompt}
+				}
+				if r.queryParams.ReturnDebugForGrouped() {
+					grouped.Debug = &pb.GenerativeDebug{FullPrompt: &prompt}
+				}
 			}
 		}
 		if r.queryParams.ReturnMetadataForSingle() || r.queryParams.ReturnMetadataForGrouped() {

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -52,7 +52,8 @@ type generativeParser interface {
 	ProviderName() string
 	ReturnMetadataForSingle() bool
 	ReturnMetadataForGrouped() bool
-	Debug() bool
+	ReturnDebugForSingle() bool
+	ReturnDebugForGrouped() bool
 }
 
 type Parser struct {

--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -54,7 +54,8 @@ type generativeQueryParams interface {
 	ProviderName() string
 	ReturnMetadataForSingle() bool
 	ReturnMetadataForGrouped() bool
-	Debug() bool
+	ReturnDebugForSingle() bool
+	ReturnDebugForGrouped() bool
 }
 
 func NewReplier(

--- a/adapters/handlers/grpc/v1/prepare_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_reply_test.go
@@ -1400,6 +1400,10 @@ func (f fakeGenerativeParams) ReturnMetadataForGrouped() bool {
 	return false
 }
 
-func (f fakeGenerativeParams) Debug() bool {
+func (f fakeGenerativeParams) ReturnDebugForSingle() bool {
+	return false
+}
+
+func (f fakeGenerativeParams) ReturnDebugForGrouped() bool {
 	return false
 }

--- a/grpc/generated/protocol/v1/generative.pb.go
+++ b/grpc/generated/protocol/v1/generative.pb.go
@@ -2663,6 +2663,7 @@ type GenerativeSearch_Grouped struct {
 	Properties *TextArray             `protobuf:"bytes,2,opt,name=properties,proto3,oneof" json:"properties,omitempty"`
 	// only allow one at the beginning, but multiple in the future
 	Queries       []*GenerativeProvider `protobuf:"bytes,3,rep,name=queries,proto3" json:"queries,omitempty"`
+	Debug         bool                  `protobuf:"varint,4,opt,name=debug,proto3" json:"debug,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -2716,6 +2717,13 @@ func (x *GenerativeSearch_Grouped) GetQueries() []*GenerativeProvider {
 		return x.Queries
 	}
 	return nil
+}
+
+func (x *GenerativeSearch_Grouped) GetDebug() bool {
+	if x != nil {
+		return x.Debug
+	}
+	return false
 }
 
 type GenerativeAnthropicMetadata_Usage struct {
@@ -3522,7 +3530,7 @@ var File_v1_generative_proto protoreflect.FileDescriptor
 
 const file_v1_generative_proto_rawDesc = "" +
 	"\n" +
-	"\x13v1/generative.proto\x12\vweaviate.v1\x1a\rv1/base.proto\"\xd0\x04\n" +
+	"\x13v1/generative.proto\x12\vweaviate.v1\x1a\rv1/base.proto\"\xe6\x04\n" +
 	"\x10GenerativeSearch\x128\n" +
 	"\x16single_response_prompt\x18\x01 \x01(\tB\x02\x18\x01R\x14singleResponsePrompt\x126\n" +
 	"\x15grouped_response_task\x18\x02 \x01(\tB\x02\x18\x01R\x13groupedResponseTask\x121\n" +
@@ -3532,13 +3540,14 @@ const file_v1_generative_proto_rawDesc = "" +
 	"\x06Single\x12\x16\n" +
 	"\x06prompt\x18\x01 \x01(\tR\x06prompt\x12\x14\n" +
 	"\x05debug\x18\x02 \x01(\bR\x05debug\x129\n" +
-	"\aqueries\x18\x03 \x03(\v2\x1f.weaviate.v1.GenerativeProviderR\aqueries\x1a\xa4\x01\n" +
+	"\aqueries\x18\x03 \x03(\v2\x1f.weaviate.v1.GenerativeProviderR\aqueries\x1a\xba\x01\n" +
 	"\aGrouped\x12\x12\n" +
 	"\x04task\x18\x01 \x01(\tR\x04task\x12;\n" +
 	"\n" +
 	"properties\x18\x02 \x01(\v2\x16.weaviate.v1.TextArrayH\x00R\n" +
 	"properties\x88\x01\x01\x129\n" +
-	"\aqueries\x18\x03 \x03(\v2\x1f.weaviate.v1.GenerativeProviderR\aqueriesB\r\n" +
+	"\aqueries\x18\x03 \x03(\v2\x1f.weaviate.v1.GenerativeProviderR\aqueries\x12\x14\n" +
+	"\x05debug\x18\x04 \x01(\bR\x05debugB\r\n" +
 	"\v_properties\"\xbf\x06\n" +
 	"\x12GenerativeProvider\x12'\n" +
 	"\x0freturn_metadata\x18\x01 \x01(\bR\x0ereturnMetadata\x12@\n" +

--- a/grpc/proto/v1/generative.proto
+++ b/grpc/proto/v1/generative.proto
@@ -21,6 +21,7 @@ message GenerativeSearch {
     optional TextArray properties = 2;
     // only allow one at the beginning, but multiple in the future
     repeated GenerativeProvider queries = 3;
+    bool debug = 4;
   }
 
   string single_response_prompt = 1 [deprecated = true];

--- a/test/modules/reranker-transformers/reranker_transformers_test.go
+++ b/test/modules/reranker-transformers/reranker_transformers_test.go
@@ -273,6 +273,7 @@ func testRerankerTransformers(rest, grpc, ollamaEndpoint string) func(t *testing
 						req.Generative = &pb.GenerativeSearch{
 							Grouped: &pb.GenerativeSearch_Grouped{
 								Task:       "Write a short tweet about this content",
+								Debug:      true,
 								Properties: &pb.TextArray{Values: []string{"title", "description"}},
 								Queries: []*pb.GenerativeProvider{{
 									ReturnMetadata: false, // no metadata for ollama
@@ -297,7 +298,9 @@ func testRerankerTransformers(rest, grpc, ollamaEndpoint string) func(t *testing
 						require.NotNil(t, resp.GenerativeGroupedResults)
 						require.NotEmpty(t, resp.GenerativeGroupedResults.Values)
 						require.NotEmpty(t, resp.GenerativeGroupedResults.Values[0].Result)
-						t.Logf("---------------\nGroupedResult: %v\n---------------\n", resp.GenerativeGroupedResults.Values[0].Result)
+						require.NotNil(t, resp.GenerativeGroupedResults.Values[0].Debug)
+						require.NotEmpty(t, *resp.GenerativeGroupedResults.Values[0].Debug.FullPrompt)
+						t.Logf("---------------\nDebug.Prompt: %v\n\nGroupedResult: %v\n---------------\n", *resp.GenerativeGroupedResults.Values[0].Debug.FullPrompt, resp.GenerativeGroupedResults.Values[0].Result)
 					}
 				})
 			}


### PR DESCRIPTION
### What's being changed:

Added missing support for debug param in grouped generative search gRPC message.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
