### PR TITLE
chore(e2e-tests): introduce timeout in api based module tests

### DIFF
--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/strfmt"
@@ -117,6 +118,14 @@ func UpdateClass(t *testing.T, class *models.Class) {
 func CreateObject(t *testing.T, object *models.Object) error {
 	t.Helper()
 	params := objects.NewObjectsCreateParams().WithBody(object)
+	resp, err := Client(t).Objects.ObjectsCreate(params, nil)
+	AssertRequestOk(t, resp, err, nil)
+	return err
+}
+
+func CreateObjectWithTimeout(t *testing.T, object *models.Object, timeout time.Duration) error {
+	t.Helper()
+	params := objects.NewObjectsCreateParamsWithTimeout(timeout).WithBody(object)
 	resp, err := Client(t).Objects.ObjectsCreate(params, nil)
 	AssertRequestOk(t, resp, err, nil)
 	return err

--- a/test/helper/sample-schema/multimodal/multimodal.go
+++ b/test/helper/sample-schema/multimodal/multimodal.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
@@ -28,6 +29,8 @@ import (
 	"github.com/weaviate/weaviate/test/helper"
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 )
+
+const DefaultTimeout = 2 * time.Minute
 
 const (
 	PropertyImageTitle       = "image_title"
@@ -114,8 +117,10 @@ func InsertObjects(t *testing.T, dataFolderPath, className string, withVideo boo
 		i++
 	}
 	for _, obj := range objs {
-		helper.CreateObject(t, obj)
-		helper.AssertGetObjectEventually(t, obj.Class, obj.ID)
+		err := helper.CreateObjectWithTimeout(t, obj, DefaultTimeout)
+		require.NoError(t, err)
+		obj := helper.AssertGetObjectEventually(t, obj.Class, obj.ID)
+		require.NotNil(t, obj)
 	}
 }
 
@@ -158,7 +163,7 @@ func TestQuery(t *testing.T,
 			}
 		`, className, nearMediaArgument, titleProperty, strings.Join(targetVectorsList, ","))
 
-	result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, query)
+	result := graphqlhelper.AssertGraphQLWithTimeout(t, helper.RootAuth, DefaultTimeout, query)
 	objs := result.Get("Get", className).AsSlice()
 	require.Len(t, objs, 2)
 	title := objs[0].(map[string]interface{})[titleProperty]

--- a/test/modules/multi2vec-jinaai/setup_test.go
+++ b/test/modules/multi2vec-jinaai/setup_test.go
@@ -13,11 +13,13 @@ package test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/multimodal"
 )
 
 func TestMulti2VecJinaAI_SingleNode(t *testing.T) {
@@ -29,6 +31,7 @@ func TestMulti2VecJinaAI_SingleNode(t *testing.T) {
 	compose, err := docker.New().
 		WithWeaviate().
 		WithMulti2VecJinaAI(apiKey).
+		WithWeaviateEnv("MODULES_CLIENT_TIMEOUT", fmt.Sprintf("%.0fs", multimodal.DefaultTimeout.Seconds())).
 		Start(ctx)
 	require.NoError(t, err)
 	defer func() {

--- a/test/modules/text2vec-jinaai/setup_test.go
+++ b/test/modules/text2vec-jinaai/setup_test.go
@@ -13,11 +13,13 @@ package tests
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/companies"
 )
 
 func TestText2VecJinaAI(t *testing.T) {
@@ -42,6 +44,7 @@ func createSingleNodeEnvironment(ctx context.Context, jinaApiKey string,
 	compose, err = composeModules(jinaApiKey).
 		WithWeaviate().
 		WithWeaviateWithGRPC().
+		WithWeaviateEnv("MODULES_CLIENT_TIMEOUT", fmt.Sprintf("%.0fs", companies.DefaultTimeout.Seconds())).
 		Start(ctx)
 	return
 }


### PR DESCRIPTION
### What's being changed:

Introduce timeout in API based module tests.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
