### PR TITLE
fix: :bug: force segments to be sorted inside segment group

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -18,6 +18,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -415,6 +416,12 @@ func newSegmentGroup(logger logrus.FieldLogger, metrics *Metrics,
 	// TODO AL: use separate cycle callback for cleanup?
 	id := "segmentgroup/compaction/" + sg.dir
 	sg.compactionCallbackCtrl = compactionCallbacks.Register(id, sg.compactOrCleanup)
+
+	// The following Inverted segment type assumes segments are sorted by their path
+	// As we are passing an unordered map instead of a sorted slice, we need to sort the segments first.
+	sort.Slice(sg.segments, func(i, j int) bool {
+		return sg.segments[i].getPath() < sg.segments[j].getPath()
+	})
 
 	// if a segment exists of the map collection strategy, we need to
 	// convert the inverted strategy to a map collection strategy


### PR DESCRIPTION
### What's being changed:

Force segments to be sorted inside segment group, as they are passed as an ordered map, instead of a sorted slice

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
