### PR TITLE
feat: enhance remote shard search with consistency level handling

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1679,7 +1679,7 @@ func (i *Index) localShardSearch(ctx context.Context, searchVectors []models.Vec
 func (i *Index) remoteShardSearch(ctx context.Context, searchVectors []models.Vector,
 	targetVectors []string, distance float32, limit int, localFilters *filters.LocalFilter,
 	sort []filters.Sort, groupBy *searchparams.GroupBy, additional additional.Properties,
-	targetCombination *dto.TargetCombination, properties []string, shardName string,
+	level int, targetCombination *dto.TargetCombination, properties []string, shardName string,
 ) ([]*storobj.Object, []float32, error) {
 	var outObjects []*storobj.Object
 	var outScores []float32
@@ -1696,7 +1696,7 @@ func (i *Index) remoteShardSearch(ctx context.Context, searchVectors []models.Ve
 		// Force a search on all the replicas for the shard
 		remoteSearchResults, err := i.remote.SearchAllReplicas(ctx,
 			i.logger, shardName, searchVectors, targetVectors, distance, limit, localFilters,
-			nil, sort, nil, groupBy, additional, i.replicationEnabled(), i.getSchema.NodeName(), targetCombination, properties)
+			nil, sort, nil, groupBy, additional, i.replicationEnabled(), level, i.getSchema.NodeName(), targetCombination, properties)
 		// Only return an error if we failed to query remote shards AND we had no local shard to query
 		if err != nil && shard == nil {
 			return nil, nil, errors.Wrapf(err, "remote shard %s", shardName)
@@ -1802,10 +1802,43 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors []models.V
 		}
 
 		if shard == nil || i.Config.ForceFullReplicasSearch {
+			var level int
+
+			if i.replicationEnabled() {
+				if replProps == nil {
+					replProps = defaultConsistency()
+				}
+
+				// direct candidate is not supported for remote searches
+				state, err := i.replicator.State(shardName, replica.ConsistencyLevel(replProps.ConsistencyLevel), "")
+				if err != nil {
+					return nil, nil, fmt.Errorf("%w : class %q shard %q", err, i.Config.ClassName, shardName)
+				}
+
+				level = state.Level
+			} else {
+				replicas, err := i.getSchema.ShardReplicas(i.getClass().Class, shardName)
+				if err != nil || len(replicas) == 0 {
+					return nil, nil, fmt.Errorf("class %q has no physical shard %q: %w", i.getClass().Class, shardName, err)
+				}
+
+				level = len(replicas)
+			}
+
+			if shard != nil {
+				// If we have a local shard, we can reduce the consistency level
+				// to one, because we already have a local shard that will answer the request
+				level--
+			}
+
+			if level <= 0 {
+				continue // no need to search in remote shards if we have a local shard and the consistency level is one
+			}
+
 			remoteSearches++
 			eg.Go(func() error {
 				// If we have no local shard or if we force the query to reach all replicas
-				remoteShardObject, remoteShardScores, err2 := i.remoteShardSearch(ctx, searchVectors, targetVectors, dist, limit, localFilters, sort, groupBy, additionalProps, targetCombination, properties, shardName)
+				remoteShardObject, remoteShardScores, err2 := i.remoteShardSearch(ctx, searchVectors, targetVectors, dist, limit, localFilters, sort, groupBy, additionalProps, level, targetCombination, properties, shardName)
 				if err2 != nil {
 					return fmt.Errorf(
 						"remote shard object search %s: %w", shardName, err2)

--- a/usecases/replica/replicator.go
+++ b/usecases/replica/replicator.go
@@ -95,6 +95,10 @@ func (r *Replicator) AllHostnames() []string {
 	return r.resolver.AllHostnames()
 }
 
+func (r *Replicator) State(shardName string, cl ConsistencyLevel, directCandidate string) (res rState, err error) {
+	return r.resolver.State(shardName, cl, directCandidate)
+}
+
 func (r *Replicator) PutObject(ctx context.Context,
 	shard string,
 	obj *storobj.Object,


### PR DESCRIPTION
### What's being changed:

This pull request introduces improvements to how remote shard searches handle consistency levels and efficiently query replicas. The main change is the addition of a consistency `level` parameter, which controls how many replica responses are needed before returning results. This helps optimize search performance and reliability, especially when both local and remote shards are involved.

**Consistency Level Handling and Replica Query Optimization:**

* Added logic in `objectVectorSearch` (in `index.go`) to determine the required consistency level for remote searches, reducing unnecessary remote queries when a local shard is available.
* Updated `remoteShardSearch` and its callers to accept a `level` parameter, ensuring that only the required number of replica responses are collected. [[1]](diffhunk://#diff-d080e5efa621477a1d974bced14c39a8912fcb7a649eb4a0fb219647728dbc3dL1682-R1682) [[2]](diffhunk://#diff-d080e5efa621477a1d974bced14c39a8912fcb7a649eb4a0fb219647728dbc3dL1699-R1699)
* Modified `RemoteIndex.SearchAllReplicas` and `queryAllReplicas` (in `remote_index.go`) to propagate and use the `level` parameter, allowing early cancellation of replica queries once enough responses are received. [[1]](diffhunk://#diff-77d62686c1015b0d1e0d2398bce6610ca837a4f8a658146e0810d7e9ee88432eR270-R283) [[2]](diffhunk://#diff-77d62686c1015b0d1e0d2398bce6610ca837a4f8a658146e0810d7e9ee88432eL419-R446) [[3]](diffhunk://#diff-77d62686c1015b0d1e0d2398bce6610ca837a4f8a658146e0810d7e9ee88432eL454-R477) [[4]](diffhunk://#diff-77d62686c1015b0d1e0d2398bce6610ca837a4f8a658146e0810d7e9ee88432eL484-R496)

**Replicator API Extension:**

* Added a new `State` method to the `Replicator` type, enabling retrieval of consistency information for a shard.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
