### PR TITLE
fix(raft-transport): avoid invalid ports to avoid rollout errors

### DIFF
--- a/cluster/resolver/raft.go
+++ b/cluster/resolver/raft.go
@@ -19,6 +19,7 @@ import (
 
 	raftImpl "github.com/hashicorp/raft"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/cluster/log"
 )
 
@@ -66,7 +67,7 @@ func (a *raft) ServerAddr(id raftImpl.ServerID) (raftImpl.ServerAddress, error) 
 	defer a.nodesLock.Unlock()
 	if addr == "" {
 		a.notResolvedNodes[id] = struct{}{}
-		return raftImpl.ServerAddress(invalidAddr), nil
+		return "", fmt.Errorf("could not resolve server id %s", id)
 	}
 	delete(a.notResolvedNodes, id)
 

--- a/cluster/resolver/types.go
+++ b/cluster/resolver/types.go
@@ -11,10 +11,6 @@
 
 package resolver
 
-const (
-	invalidAddr = "256.256.256.256:99999999"
-)
-
 // NodeToAddress allows the resolver to compute node-id to ip addresses.
 type NodeToAddress interface {
 	// NodeAddress resolves node id into an ip address without the port.

--- a/test/acceptance/recovery/network_isolation_test.go
+++ b/test/acceptance/recovery/network_isolation_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestNetworkIsolationSplitBrain(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
 	compose, err := docker.New().
 		With3NodeCluster().


### PR DESCRIPTION
### What's being changed:
a while back we had an issue where serveless clusters were merging and we introduced a [hot fix](https://github.com/weaviate/weaviate/pull/5668) which instead of reporting an error we were reporting an invalid port and this caused Raft to think that the node is alive but actually it wasn't in rollouts case. the hot fix did serve us well, however now we rolled out mTLS everywhere so we won't need this hot fix any more.

this PR fallback to original behaviour by reporting an error on transport if the cluster ID doesn't exists in memberlist and we shall not see `"error":"dial tcp: address 99999999: invalid port"` anymore , err count dropped from `~300` -> `~88`

**errors count before** 
<img width="1707" height="209" alt="Screenshot 2025-08-19 at 17 21 49" src="https://github.com/user-attachments/assets/9d94eb63-9517-45ee-8170-ecc23980807a" />

**errors count after** 
<img width="1715" height="240" alt="Screenshot 2025-08-19 at 17 23 23" src="https://github.com/user-attachments/assets/a4cdbb53-27c2-4492-83ff-7530ce87fde8" />


### Review checklist
- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
