### PR TITLE
fix: release segment buffered reader when no error

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_segment_collection.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_collection.go
@@ -92,7 +92,6 @@ func (s *segmentCursorCollection) parseCollectionNode(offset nodeOffset) (segmen
 	if err != nil {
 		return segmentCollectionNode{}, err
 	}
-
 	defer r.Release()
 
 	return ParseCollectionNode(r)

--- a/adapters/repos/db/lsmkv/cursor_segment_collection_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_collection_reusable.go
@@ -109,7 +109,6 @@ func (c *cacheReader) loadDataIntoCache(readLength int) error {
 	if err != nil {
 		return err
 	}
-
 	defer at.Release()
 
 	// Restore the original buffer capacity before reading

--- a/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
@@ -102,7 +102,6 @@ func (s *segmentCursorInvertedReusable) parseInvertedNodeInto(offset nodeOffset)
 	if err != nil {
 		return err
 	}
-
 	defer r.Release()
 
 	allBytes := make([]byte, offset.end-offset.start)
@@ -119,11 +118,10 @@ func (s *segmentCursorInvertedReusable) parseInvertedNodeInto(offset nodeOffset)
 	offset.start = offset.end
 	offset.end += uint64(keyLen)
 	r, err = s.segment.newNodeReader(offset, "segmentCursorInvertedReusable")
-
-	defer r.Release()
 	if err != nil {
 		return err
 	}
+	defer r.Release()
 
 	key := make([]byte, keyLen)
 	_, err = r.Read(key)

--- a/adapters/repos/db/lsmkv/cursor_segment_map.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_map.go
@@ -152,6 +152,7 @@ func (s *segmentCursorMap) parseCollectionNode(offset nodeOffset) (segmentCollec
 		return segmentCollectionNode{}, err
 	}
 	defer r.Release()
+
 	return ParseCollectionNode(r)
 }
 
@@ -161,5 +162,6 @@ func (s *segmentCursorMap) parseInvertedNode(offset nodeOffset) (segmentCollecti
 		return segmentCollectionNode{}, err
 	}
 	defer r.Release()
+
 	return ParseInvertedNode(r)
 }

--- a/adapters/repos/db/lsmkv/cursor_segment_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_replace.go
@@ -251,6 +251,7 @@ func (s *segmentCursorReplace) parseReplaceNode(offset nodeOffset) (segmentRepla
 		return segmentReplaceNode{}, err
 	}
 	defer r.Release()
+
 	out, err := ParseReplaceNode(r, s.segment.secondaryIndexCount)
 	if out.tombstone {
 		return out, lsmkv.Deleted
@@ -264,10 +265,10 @@ func (s *segmentCursorReplace) parseReplaceNodeInto(offset nodeOffset, buf []byt
 	}
 
 	r, err := s.segment.newNodeReader(offset, "segmentCursorReplace")
-	defer r.Release()
 	if err != nil {
 		return err
 	}
+	defer r.Release()
 
 	err = ParseReplaceNodeIntoPread(r, s.segment.secondaryIndexCount, s.reusableNode)
 	if err != nil {

--- a/adapters/repos/db/lsmkv/segment_blockmax.go
+++ b/adapters/repos/db/lsmkv/segment_blockmax.go
@@ -37,7 +37,6 @@ func (s *segment) loadBlockEntries(node segmentindex.Node) ([]*terms.BlockEntry,
 		if err != nil {
 			return nil, 0, nil, err
 		}
-
 		defer r.Release()
 
 		_, err = r.Read(buf)
@@ -73,7 +72,6 @@ func (s *segment) loadBlockEntries(node segmentindex.Node) ([]*terms.BlockEntry,
 		if err != nil {
 			return nil, 0, nil, err
 		}
-
 		defer r.Release()
 
 		buf = make([]byte, blockCount*20)


### PR DESCRIPTION
### What's being changed:
`defer reader.Release()` called only after error check to ensure it is not executed on `nil` instance


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
