### PR TITLE
Remove error check that makes extending the message impossible

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices_payloads.go
+++ b/adapters/handlers/rest/clusterapi/indices_payloads.go
@@ -402,10 +402,6 @@ func (p vectorDistanceResultsPayload) Unmarshal(in []byte) ([]float32, error) {
 		read += 4
 	}
 
-	if read != uint64(len(in)) {
-		return nil, errors.Errorf("corrupt read: %d != %d", read, len(in))
-	}
-
 	return dists, nil
 }
 
@@ -569,10 +565,6 @@ func (p searchResultsPayload) Unmarshal(in []byte) ([]*storobj.Object, []float32
 	for i := range dists {
 		dists[i] = math.Float32frombits(binary.LittleEndian.Uint32(in[read : read+4]))
 		read += 4
-	}
-
-	if read != uint64(len(in)) {
-		return nil, nil, errors.Errorf("corrupt read: %d != %d", read, len(in))
 	}
 
 	return objs, dists, nil


### PR DESCRIPTION
### What's being changed:

Extending the message(s) would trigger the error in older versions in a cluster, which would be a problem during rolling updates of a multi-node cluster.

Only two out of 20+ Unmarshall methods had this check

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
