### PR TITLE
debug: :construction: allow locking and unlocking maintenanceLock manually

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -1876,3 +1876,26 @@ func (b *Bucket) MetadataSize() int64 {
 	}
 	return b.disk.MetadataSize()
 }
+
+func (b *Bucket) Lock() {
+	if b.disk != nil {
+		b.disk.maintenanceLock.Lock()
+	}
+}
+
+func (b *Bucket) Unlock() {
+	if b.disk != nil {
+		b.disk.maintenanceLock.Unlock()
+	}
+}
+
+func (b *Bucket) GetLockStatus() string {
+	if b.disk == nil {
+		return "no segment group found"
+	}
+	if b.disk.maintenanceLock.TryLock() {
+		b.disk.maintenanceLock.Unlock()
+		return "is unlocked"
+	}
+	return "is locked"
+}


### PR DESCRIPTION
### What's being changed:

- **Lock:** `curl -X POST "http://localhost:6060/debug/index/deadlock_lsm?collection=<collection_name>&shards=<optional, comma separated>"`

`{"shards":{"dwqdaffwe":{"message":"shard dwqdaffwe was locked","shard":"dwqdaffwe","status":"was locked"}}}%`

- **Unlock:** `curl -X DELETE  "http://localhost:6060/debug/index/deadlock_lsm?collection=<collection_name>&shards=<optional, comma separated>"`

`{"shards":{"dwqdaffwe":{"message":"shard dwqdaffwe was unlocked","shard":"dwqdaffwe","status":"was unlocked"}}}% `

- **Get status:** `curl http://localhost:6060/debug/index/deadlock_lsm?collection=<collection_name>&shards=<optional, comma separated>"`

`{"shards":{"dwqdaffwe":{"message":"shard dwqdaffwe is unlocked","shard":"dwqdaffwe","status":"is unlocked"}}}`


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
