### PR TITLE
fix: :bug: handle empty keys on inverted segments

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
+++ b/adapters/repos/db/lsmkv/cursor_segment_inverted_reusable.go
@@ -114,17 +114,19 @@ func (s *segmentCursorInvertedReusable) parseInvertedNodeInto(offset nodeOffset)
 
 	offset.start = offset.end
 	offset.end += uint64(keyLen)
-	r, err = s.segment.newNodeReader(offset, "segmentCursorInvertedReusable")
-	if err != nil {
-		return err
-	}
-
 	key := make([]byte, keyLen)
-	_, err = r.Read(key)
-	if err != nil {
-		return err
-	}
 
+	// empty keys are possible if using non-word tokenizers, so let's handle them
+	if keyLen > 0 {
+		r, err = s.segment.newNodeReader(offset, "segmentCursorInvertedReusable")
+		if err != nil {
+			return err
+		}
+		_, err = r.Read(key)
+		if err != nil {
+			return err
+		}
+	}
 	s.nodeBuf.key = key
 	s.nodeBuf.values = nodes
 

--- a/adapters/repos/db/lsmkv/segment_serialization_inverted.go
+++ b/adapters/repos/db/lsmkv/segment_serialization_inverted.go
@@ -433,9 +433,12 @@ func ParseInvertedNode(r io.Reader) (segmentCollectionNode, error) {
 	keyLen := binary.LittleEndian.Uint32(allBytes[len(allBytes)-4:])
 
 	key := make([]byte, keyLen)
-	_, err := r.Read(key)
-	if err != nil {
-		return out, err
+
+	if keyLen > 0 {
+		_, err := r.Read(key)
+		if err != nil {
+			return out, err
+		}
 	}
 
 	out.offset += int(keyLen)


### PR DESCRIPTION
### What's being changed:

- Fix edge case where, for tokenizers where empty chars are allow, they were not being properly handled on compaction

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
