### PR TITLE
Add filter support for cursor

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -368,7 +368,9 @@ func (p *Parser) Search(req *pb.SearchRequest, config *config.Config) (dto.GetPa
 	}
 
 	if len(req.After) > 0 || req.AfterPresent {
-		// important for iterator to set the cursor even if after is empty
+		// important for iterator to set the cursor even if after is empty. Otherwise the first request of
+		// filter+cursor with empty (but set) after parameter would do a pure filtered search which returns the object in
+		// a different order than a filtered+cursor search, leading to missing and/or duplicate results.
 		out.Cursor = &filters.Cursor{After: req.After, Limit: out.Pagination.Limit}
 	}
 

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -367,7 +367,8 @@ func (p *Parser) Search(req *pb.SearchRequest, config *config.Config) (dto.GetPa
 		out.AdditionalProperties.ModuleParams["rerank"] = extractRerank(req)
 	}
 
-	if len(req.After) > 0 {
+	if len(req.After) > 0 || req.AfterPresent {
+		// important for iterator to set the cursor even if after is empty
 		out.Cursor = &filters.Cursor{After: req.After, Limit: out.Pagination.Limit}
 	}
 

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -367,11 +367,11 @@ func (p *Parser) Search(req *pb.SearchRequest, config *config.Config) (dto.GetPa
 		out.AdditionalProperties.ModuleParams["rerank"] = extractRerank(req)
 	}
 
-	if len(req.After) > 0 || req.AfterPresent {
+	if req.After != nil {
 		// important for iterator to set the cursor even if after is empty. Otherwise the first request of
 		// filter+cursor with empty (but set) after parameter would do a pure filtered search which returns the object in
 		// a different order than a filtered+cursor search, leading to missing and/or duplicate results.
-		out.Cursor = &filters.Cursor{After: req.After, Limit: out.Pagination.Limit}
+		out.Cursor = &filters.Cursor{After: *req.After, Limit: out.Pagination.Limit}
 	}
 
 	if req.Filters != nil {

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -33,6 +33,8 @@ import (
 
 	hashtree "github.com/weaviate/weaviate/usecases/replica/hashtree"
 
+	helpers "github.com/weaviate/weaviate/adapters/repos/db/helpers"
+
 	indexcounter "github.com/weaviate/weaviate/adapters/repos/db/indexcounter"
 
 	inverted "github.com/weaviate/weaviate/adapters/repos/db/inverted"
@@ -2017,9 +2019,9 @@ func (_c *MockShardLike_ObjectDigestsInRange_Call) RunAndReturn(run func(context
 	return _c
 }
 
-// ObjectList provides a mock function with given fields: ctx, limit, sort, cursor, _a4, className
-func (_m *MockShardLike) ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor, _a4 additional.Properties, className schema.ClassName) ([]*storobj.Object, error) {
-	ret := _m.Called(ctx, limit, sort, cursor, _a4, className)
+// ObjectList provides a mock function with given fields: ctx, limit, sort, cursor, _a4, className, allowlist
+func (_m *MockShardLike) ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor, _a4 additional.Properties, className schema.ClassName, allowlist helpers.AllowList) ([]*storobj.Object, error) {
+	ret := _m.Called(ctx, limit, sort, cursor, _a4, className, allowlist)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ObjectList")
@@ -2027,19 +2029,19 @@ func (_m *MockShardLike) ObjectList(ctx context.Context, limit int, sort []filte
 
 	var r0 []*storobj.Object
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, int, []filters.Sort, *filters.Cursor, additional.Properties, schema.ClassName) ([]*storobj.Object, error)); ok {
-		return rf(ctx, limit, sort, cursor, _a4, className)
+	if rf, ok := ret.Get(0).(func(context.Context, int, []filters.Sort, *filters.Cursor, additional.Properties, schema.ClassName, helpers.AllowList) ([]*storobj.Object, error)); ok {
+		return rf(ctx, limit, sort, cursor, _a4, className, allowlist)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, int, []filters.Sort, *filters.Cursor, additional.Properties, schema.ClassName) []*storobj.Object); ok {
-		r0 = rf(ctx, limit, sort, cursor, _a4, className)
+	if rf, ok := ret.Get(0).(func(context.Context, int, []filters.Sort, *filters.Cursor, additional.Properties, schema.ClassName, helpers.AllowList) []*storobj.Object); ok {
+		r0 = rf(ctx, limit, sort, cursor, _a4, className, allowlist)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*storobj.Object)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, int, []filters.Sort, *filters.Cursor, additional.Properties, schema.ClassName) error); ok {
-		r1 = rf(ctx, limit, sort, cursor, _a4, className)
+	if rf, ok := ret.Get(1).(func(context.Context, int, []filters.Sort, *filters.Cursor, additional.Properties, schema.ClassName, helpers.AllowList) error); ok {
+		r1 = rf(ctx, limit, sort, cursor, _a4, className, allowlist)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -2059,13 +2061,14 @@ type MockShardLike_ObjectList_Call struct {
 //   - cursor *filters.Cursor
 //   - _a4 additional.Properties
 //   - className schema.ClassName
-func (_e *MockShardLike_Expecter) ObjectList(ctx interface{}, limit interface{}, sort interface{}, cursor interface{}, _a4 interface{}, className interface{}) *MockShardLike_ObjectList_Call {
-	return &MockShardLike_ObjectList_Call{Call: _e.mock.On("ObjectList", ctx, limit, sort, cursor, _a4, className)}
+//   - allowlist helpers.AllowList
+func (_e *MockShardLike_Expecter) ObjectList(ctx interface{}, limit interface{}, sort interface{}, cursor interface{}, _a4 interface{}, className interface{}, allowlist interface{}) *MockShardLike_ObjectList_Call {
+	return &MockShardLike_ObjectList_Call{Call: _e.mock.On("ObjectList", ctx, limit, sort, cursor, _a4, className, allowlist)}
 }
 
-func (_c *MockShardLike_ObjectList_Call) Run(run func(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor, _a4 additional.Properties, className schema.ClassName)) *MockShardLike_ObjectList_Call {
+func (_c *MockShardLike_ObjectList_Call) Run(run func(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor, _a4 additional.Properties, className schema.ClassName, allowlist helpers.AllowList)) *MockShardLike_ObjectList_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(int), args[2].([]filters.Sort), args[3].(*filters.Cursor), args[4].(additional.Properties), args[5].(schema.ClassName))
+		run(args[0].(context.Context), args[1].(int), args[2].([]filters.Sort), args[3].(*filters.Cursor), args[4].(additional.Properties), args[5].(schema.ClassName), args[6].(helpers.AllowList))
 	})
 	return _c
 }
@@ -2075,7 +2078,7 @@ func (_c *MockShardLike_ObjectList_Call) Return(_a0 []*storobj.Object, _a1 error
 	return _c
 }
 
-func (_c *MockShardLike_ObjectList_Call) RunAndReturn(run func(context.Context, int, []filters.Sort, *filters.Cursor, additional.Properties, schema.ClassName) ([]*storobj.Object, error)) *MockShardLike_ObjectList_Call {
+func (_c *MockShardLike_ObjectList_Call) RunAndReturn(run func(context.Context, int, []filters.Sort, *filters.Cursor, additional.Properties, schema.ClassName, helpers.AllowList) ([]*storobj.Object, error)) *MockShardLike_ObjectList_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -5033,7 +5036,8 @@ func (_c *MockShardLike_uuidFromDocID_Call) RunAndReturn(run func(uint64) (strfm
 func NewMockShardLike(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockShardLike {
+},
+) *MockShardLike {
 	mock := &MockShardLike{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -118,7 +118,7 @@ type ShardLike interface {
 
 	// TODO tests only
 	ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor,
-		additional additional.Properties, className schema.ClassName) ([]*storobj.Object, error) // Search and return objects
+		additional additional.Properties, className schema.ClassName, allowlist helpers.AllowList) ([]*storobj.Object, error) // Search and return objects
 	WasDeleted(ctx context.Context, id strfmt.UUID) (bool, time.Time, error) // Check if an object was deleted
 	GetVectorIndexQueue(targetVector string) (*VectorIndexQueue, bool)
 	GetVectorIndex(targetVector string) (VectorIndex, bool)

--- a/adapters/repos/db/shard_autoresume_maintenance_test.go
+++ b/adapters/repos/db/shard_autoresume_maintenance_test.go
@@ -46,7 +46,7 @@ func TestShard_IllegalStateForTransfer(t *testing.T) {
 			require.Nil(t, err)
 		}
 
-		objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName)
+		objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName, nil)
 		require.Nil(t, err)
 		require.Equal(t, amount, len(objs))
 	})
@@ -143,7 +143,7 @@ func TestShard_HaltingBeforeTransfer(t *testing.T) {
 			require.Nil(t, err)
 		}
 
-		objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName)
+		objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName, nil)
 		require.Nil(t, err)
 		require.Equal(t, amount, len(objs))
 	})
@@ -203,7 +203,7 @@ func TestShard_ConcurrentTransfers(t *testing.T) {
 			require.Nil(t, err)
 		}
 
-		objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName)
+		objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName, nil)
 		require.Nil(t, err)
 		require.Equal(t, amount, len(objs))
 	})

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
@@ -623,11 +624,11 @@ func (l *LazyLoadShard) HashTreeLevel(ctx context.Context, level int, discrimina
 	return l.shard.HashTreeLevel(ctx, level, discriminant)
 }
 
-func (l *LazyLoadShard) ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor, additional additional.Properties, className schema.ClassName) ([]*storobj.Object, error) {
+func (l *LazyLoadShard) ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor, additional additional.Properties, className schema.ClassName, allowlist helpers.AllowList) ([]*storobj.Object, error) {
 	if err := l.Load(ctx); err != nil {
 		return nil, err
 	}
-	return l.shard.ObjectList(ctx, limit, sort, cursor, additional, className)
+	return l.shard.ObjectList(ctx, limit, sort, cursor, additional, className, allowlist)
 }
 
 func (l *LazyLoadShard) WasDeleted(ctx context.Context, id strfmt.UUID) (bool, time.Time, error) {

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -24,8 +24,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-
-	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
 	"github.com/weaviate/weaviate/adapters/repos/db/indexcounter"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"

--- a/adapters/repos/db/shard_path_test.go
+++ b/adapters/repos/db/shard_path_test.go
@@ -40,7 +40,7 @@ func TestShardFileSanitize(t *testing.T) {
 		require.Nil(t, err)
 	}
 
-	objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName)
+	objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName, nil)
 	require.Nil(t, err)
 	require.Equal(t, amount, len(objs))
 

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -660,7 +660,7 @@ func (s *Shard) cursorObjectList(ctx context.Context, c *filters.Cursor, allowli
 
 	for ; key != nil && i < c.Limit; key, val = cursor.Next() {
 		if allowlist != nil {
-			docId, err := storobj.FromBinaryDocIDOnly(val)
+			docId, err := storobj.DocIDFromBinary(val)
 			if err != nil {
 				return nil, errors.Wrapf(err, "unmarshal doc id from item")
 			}

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -659,6 +659,9 @@ func (s *Shard) cursorObjectList(ctx context.Context, c *filters.Cursor, allowli
 	out := make([]*storobj.Object, c.Limit)
 
 	for ; key != nil && i < c.Limit; key, val = cursor.Next() {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
 		if allowlist != nil {
 			docId, err := storobj.DocIDFromBinary(val)
 			if err != nil {

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -66,7 +66,7 @@ func TestShard_UpdateStatus(t *testing.T) {
 			require.Nil(t, err)
 		}
 
-		objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName)
+		objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName, nil)
 		require.Nil(t, err)
 		require.Equal(t, amount, len(objs))
 	})
@@ -788,7 +788,7 @@ func TestShard_resetDimensionsLSM(t *testing.T) {
 			require.Nil(t, err)
 		}
 
-		objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName)
+		objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName, nil)
 		require.Nil(t, err)
 		require.Equal(t, amount, len(objs))
 	})
@@ -819,7 +819,7 @@ func TestShard_resetDimensionsLSM(t *testing.T) {
 			require.Nil(t, err)
 		}
 
-		objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName)
+		objs, err := shd.ObjectList(ctx, amount, nil, nil, additional.Properties{}, shd.Index().Config.ClassName, nil)
 		require.Nil(t, err)
 		require.Equal(t, amount, len(objs))
 	})

--- a/entities/filters/cursor_validator.go
+++ b/entities/filters/cursor_validator.go
@@ -24,13 +24,10 @@ func ValidateCursor(className schema.ClassName, cursor *Cursor, offset int, filt
 	if className == "" {
 		return fmt.Errorf("class parameter cannot be empty")
 	}
-	if offset > 0 || filters != nil || sort != nil {
+	if offset > 0 || sort != nil {
 		var params []string
 		if offset > 0 {
 			params = append(params, "offset")
-		}
-		if filters != nil {
-			params = append(params, "where")
 		}
 		if sort != nil {
 			params = append(params, "sort")

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -116,6 +116,16 @@ func FromBinary(data []byte) (*Object, error) {
 	return ko, nil
 }
 
+func FromBinaryDocIDOnly(data []byte) (uint64, error) {
+	rw := byteops.NewReadWriter(data)
+	version := rw.ReadUint8()
+	if version != 1 {
+		return 0, errors.Errorf("unsupported binary marshaller version %d", version)
+	}
+
+	return rw.ReadUint64(), nil
+}
+
 func FromBinaryUUIDOnly(data []byte) (*Object, error) {
 	ko := &Object{}
 

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -116,16 +116,6 @@ func FromBinary(data []byte) (*Object, error) {
 	return ko, nil
 }
 
-func FromBinaryDocIDOnly(data []byte) (uint64, error) {
-	rw := byteops.NewReadWriter(data)
-	version := rw.ReadUint8()
-	if version != 1 {
-		return 0, errors.Errorf("unsupported binary marshaller version %d", version)
-	}
-
-	return rw.ReadUint64(), nil
-}
-
 func FromBinaryUUIDOnly(data []byte) (*Object, error) {
 	ko := &Object{}
 

--- a/grpc/generated/protocol/v1/search_get.pb.go
+++ b/grpc/generated/protocol/v1/search_get.pb.go
@@ -30,13 +30,12 @@ type SearchRequest struct {
 	Metadata   *MetadataRequest   `protobuf:"bytes,21,opt,name=metadata,proto3,oneof" json:"metadata,omitempty"`
 	GroupBy    *GroupBy           `protobuf:"bytes,22,opt,name=group_by,json=groupBy,proto3,oneof" json:"group_by,omitempty"`
 	// affects order and length of results. 0/empty (default value) means disabled
-	Limit   uint32 `protobuf:"varint,30,opt,name=limit,proto3" json:"limit,omitempty"`
-	Offset  uint32 `protobuf:"varint,31,opt,name=offset,proto3" json:"offset,omitempty"`
-	Autocut uint32 `protobuf:"varint,32,opt,name=autocut,proto3" json:"autocut,omitempty"`
-	After   string `protobuf:"bytes,33,opt,name=after,proto3" json:"after,omitempty"`
+	Limit   uint32  `protobuf:"varint,30,opt,name=limit,proto3" json:"limit,omitempty"`
+	Offset  uint32  `protobuf:"varint,31,opt,name=offset,proto3" json:"offset,omitempty"`
+	Autocut uint32  `protobuf:"varint,32,opt,name=autocut,proto3" json:"autocut,omitempty"`
+	After   *string `protobuf:"bytes,33,opt,name=after,proto3,oneof" json:"after,omitempty"`
 	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
-	SortBy       []*SortBy `protobuf:"bytes,34,rep,name=sort_by,json=sortBy,proto3" json:"sort_by,omitempty"`
-	AfterPresent bool      `protobuf:"varint,35,opt,name=after_present,json=afterPresent,proto3" json:"after_present,omitempty"`
+	SortBy []*SortBy `protobuf:"bytes,34,rep,name=sort_by,json=sortBy,proto3" json:"sort_by,omitempty"`
 	// matches/searches for objects
 	Filters      *Filters           `protobuf:"bytes,40,opt,name=filters,proto3,oneof" json:"filters,omitempty"`
 	HybridSearch *Hybrid            `protobuf:"bytes,41,opt,name=hybrid_search,json=hybridSearch,proto3,oneof" json:"hybrid_search,omitempty"`
@@ -155,8 +154,8 @@ func (x *SearchRequest) GetAutocut() uint32 {
 }
 
 func (x *SearchRequest) GetAfter() string {
-	if x != nil {
-		return x.After
+	if x != nil && x.After != nil {
+		return *x.After
 	}
 	return ""
 }
@@ -166,13 +165,6 @@ func (x *SearchRequest) GetSortBy() []*SortBy {
 		return x.SortBy
 	}
 	return nil
-}
-
-func (x *SearchRequest) GetAfterPresent() bool {
-	if x != nil {
-		return x.AfterPresent
-	}
-	return false
 }
 
 func (x *SearchRequest) GetFilters() *Filters {
@@ -1423,7 +1415,7 @@ var File_v1_search_get_proto protoreflect.FileDescriptor
 
 const file_v1_search_get_proto_rawDesc = "" +
 	"\n" +
-	"\x13v1/search_get.proto\x12\vweaviate.v1\x1a\rv1/base.proto\x1a\x14v1/base_search.proto\x1a\x13v1/generative.proto\x1a\x13v1/properties.proto\"\xec\r\n" +
+	"\x13v1/search_get.proto\x12\vweaviate.v1\x1a\rv1/base.proto\x1a\x14v1/base_search.proto\x1a\x13v1/generative.proto\x1a\x13v1/properties.proto\"\xd6\r\n" +
 	"\rSearchRequest\x12\x1e\n" +
 	"\n" +
 	"collection\x18\x01 \x01(\tR\n" +
@@ -1438,34 +1430,33 @@ const file_v1_search_get_proto_rawDesc = "" +
 	"\bgroup_by\x18\x16 \x01(\v2\x14.weaviate.v1.GroupByH\x03R\agroupBy\x88\x01\x01\x12\x14\n" +
 	"\x05limit\x18\x1e \x01(\rR\x05limit\x12\x16\n" +
 	"\x06offset\x18\x1f \x01(\rR\x06offset\x12\x18\n" +
-	"\aautocut\x18  \x01(\rR\aautocut\x12\x14\n" +
-	"\x05after\x18! \x01(\tR\x05after\x12,\n" +
-	"\asort_by\x18\" \x03(\v2\x13.weaviate.v1.SortByR\x06sortBy\x12#\n" +
-	"\rafter_present\x18# \x01(\bR\fafterPresent\x123\n" +
-	"\afilters\x18( \x01(\v2\x14.weaviate.v1.FiltersH\x04R\afilters\x88\x01\x01\x12=\n" +
-	"\rhybrid_search\x18) \x01(\v2\x13.weaviate.v1.HybridH\x05R\fhybridSearch\x88\x01\x01\x127\n" +
-	"\vbm25_search\x18* \x01(\v2\x11.weaviate.v1.BM25H\x06R\n" +
+	"\aautocut\x18  \x01(\rR\aautocut\x12\x19\n" +
+	"\x05after\x18! \x01(\tH\x04R\x05after\x88\x01\x01\x12,\n" +
+	"\asort_by\x18\" \x03(\v2\x13.weaviate.v1.SortByR\x06sortBy\x123\n" +
+	"\afilters\x18( \x01(\v2\x14.weaviate.v1.FiltersH\x05R\afilters\x88\x01\x01\x12=\n" +
+	"\rhybrid_search\x18) \x01(\v2\x13.weaviate.v1.HybridH\x06R\fhybridSearch\x88\x01\x01\x127\n" +
+	"\vbm25_search\x18* \x01(\v2\x11.weaviate.v1.BM25H\aR\n" +
 	"bm25Search\x88\x01\x01\x12=\n" +
-	"\vnear_vector\x18+ \x01(\v2\x17.weaviate.v1.NearVectorH\aR\n" +
+	"\vnear_vector\x18+ \x01(\v2\x17.weaviate.v1.NearVectorH\bR\n" +
 	"nearVector\x88\x01\x01\x12=\n" +
-	"\vnear_object\x18, \x01(\v2\x17.weaviate.v1.NearObjectH\bR\n" +
+	"\vnear_object\x18, \x01(\v2\x17.weaviate.v1.NearObjectH\tR\n" +
 	"nearObject\x88\x01\x01\x12=\n" +
-	"\tnear_text\x18- \x01(\v2\x1b.weaviate.v1.NearTextSearchH\tR\bnearText\x88\x01\x01\x12@\n" +
+	"\tnear_text\x18- \x01(\v2\x1b.weaviate.v1.NearTextSearchH\n" +
+	"R\bnearText\x88\x01\x01\x12@\n" +
 	"\n" +
-	"near_image\x18. \x01(\v2\x1c.weaviate.v1.NearImageSearchH\n" +
-	"R\tnearImage\x88\x01\x01\x12@\n" +
+	"near_image\x18. \x01(\v2\x1c.weaviate.v1.NearImageSearchH\vR\tnearImage\x88\x01\x01\x12@\n" +
 	"\n" +
-	"near_audio\x18/ \x01(\v2\x1c.weaviate.v1.NearAudioSearchH\vR\tnearAudio\x88\x01\x01\x12@\n" +
+	"near_audio\x18/ \x01(\v2\x1c.weaviate.v1.NearAudioSearchH\fR\tnearAudio\x88\x01\x01\x12@\n" +
 	"\n" +
-	"near_video\x180 \x01(\v2\x1c.weaviate.v1.NearVideoSearchH\fR\tnearVideo\x88\x01\x01\x12@\n" +
+	"near_video\x180 \x01(\v2\x1c.weaviate.v1.NearVideoSearchH\rR\tnearVideo\x88\x01\x01\x12@\n" +
 	"\n" +
-	"near_depth\x181 \x01(\v2\x1c.weaviate.v1.NearDepthSearchH\rR\tnearDepth\x88\x01\x01\x12F\n" +
-	"\fnear_thermal\x182 \x01(\v2\x1e.weaviate.v1.NearThermalSearchH\x0eR\vnearThermal\x88\x01\x01\x12:\n" +
-	"\bnear_imu\x183 \x01(\v2\x1a.weaviate.v1.NearIMUSearchH\x0fR\anearImu\x88\x01\x01\x12B\n" +
+	"near_depth\x181 \x01(\v2\x1c.weaviate.v1.NearDepthSearchH\x0eR\tnearDepth\x88\x01\x01\x12F\n" +
+	"\fnear_thermal\x182 \x01(\v2\x1e.weaviate.v1.NearThermalSearchH\x0fR\vnearThermal\x88\x01\x01\x12:\n" +
+	"\bnear_imu\x183 \x01(\v2\x1a.weaviate.v1.NearIMUSearchH\x10R\anearImu\x88\x01\x01\x12B\n" +
 	"\n" +
-	"generative\x18< \x01(\v2\x1d.weaviate.v1.GenerativeSearchH\x10R\n" +
+	"generative\x18< \x01(\v2\x1d.weaviate.v1.GenerativeSearchH\x11R\n" +
 	"generative\x88\x01\x01\x120\n" +
-	"\x06rerank\x18= \x01(\v2\x13.weaviate.v1.RerankH\x11R\x06rerank\x88\x01\x01\x12$\n" +
+	"\x06rerank\x18= \x01(\v2\x13.weaviate.v1.RerankH\x12R\x06rerank\x88\x01\x01\x12$\n" +
 	"\fuses_123_api\x18d \x01(\bB\x02\x18\x01R\n" +
 	"uses123Api\x12$\n" +
 	"\fuses_125_api\x18e \x01(\bB\x02\x18\x01R\n" +
@@ -1475,7 +1466,8 @@ const file_v1_search_get_proto_rawDesc = "" +
 	"\x12_consistency_levelB\r\n" +
 	"\v_propertiesB\v\n" +
 	"\t_metadataB\v\n" +
-	"\t_group_byB\n" +
+	"\t_group_byB\b\n" +
+	"\x06_afterB\n" +
 	"\n" +
 	"\b_filtersB\x10\n" +
 	"\x0e_hybrid_searchB\x0e\n" +
@@ -1619,42 +1611,45 @@ func file_v1_search_get_proto_rawDescGZIP() []byte {
 	return file_v1_search_get_proto_rawDescData
 }
 
-var file_v1_search_get_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
-var file_v1_search_get_proto_goTypes = []any{
-	(*SearchRequest)(nil),           // 0: weaviate.v1.SearchRequest
-	(*GroupBy)(nil),                 // 1: weaviate.v1.GroupBy
-	(*SortBy)(nil),                  // 2: weaviate.v1.SortBy
-	(*MetadataRequest)(nil),         // 3: weaviate.v1.MetadataRequest
-	(*PropertiesRequest)(nil),       // 4: weaviate.v1.PropertiesRequest
-	(*ObjectPropertiesRequest)(nil), // 5: weaviate.v1.ObjectPropertiesRequest
-	(*RefPropertiesRequest)(nil),    // 6: weaviate.v1.RefPropertiesRequest
-	(*Rerank)(nil),                  // 7: weaviate.v1.Rerank
-	(*SearchReply)(nil),             // 8: weaviate.v1.SearchReply
-	(*RerankReply)(nil),             // 9: weaviate.v1.RerankReply
-	(*GroupByResult)(nil),           // 10: weaviate.v1.GroupByResult
-	(*SearchResult)(nil),            // 11: weaviate.v1.SearchResult
-	(*MetadataResult)(nil),          // 12: weaviate.v1.MetadataResult
-	(*PropertiesResult)(nil),        // 13: weaviate.v1.PropertiesResult
-	(*RefPropertiesResult)(nil),     // 14: weaviate.v1.RefPropertiesResult
-	(ConsistencyLevel)(0),           // 15: weaviate.v1.ConsistencyLevel
-	(*Filters)(nil),                 // 16: weaviate.v1.Filters
-	(*Hybrid)(nil),                  // 17: weaviate.v1.Hybrid
-	(*BM25)(nil),                    // 18: weaviate.v1.BM25
-	(*NearVector)(nil),              // 19: weaviate.v1.NearVector
-	(*NearObject)(nil),              // 20: weaviate.v1.NearObject
-	(*NearTextSearch)(nil),          // 21: weaviate.v1.NearTextSearch
-	(*NearImageSearch)(nil),         // 22: weaviate.v1.NearImageSearch
-	(*NearAudioSearch)(nil),         // 23: weaviate.v1.NearAudioSearch
-	(*NearVideoSearch)(nil),         // 24: weaviate.v1.NearVideoSearch
-	(*NearDepthSearch)(nil),         // 25: weaviate.v1.NearDepthSearch
-	(*NearThermalSearch)(nil),       // 26: weaviate.v1.NearThermalSearch
-	(*NearIMUSearch)(nil),           // 27: weaviate.v1.NearIMUSearch
-	(*GenerativeSearch)(nil),        // 28: weaviate.v1.GenerativeSearch
-	(*GenerativeResult)(nil),        // 29: weaviate.v1.GenerativeResult
-	(*GenerativeReply)(nil),         // 30: weaviate.v1.GenerativeReply
-	(*Vectors)(nil),                 // 31: weaviate.v1.Vectors
-	(*Properties)(nil),              // 32: weaviate.v1.Properties
-}
+var (
+	file_v1_search_get_proto_msgTypes = make([]protoimpl.MessageInfo, 15)
+	file_v1_search_get_proto_goTypes  = []any{
+		(*SearchRequest)(nil),           // 0: weaviate.v1.SearchRequest
+		(*GroupBy)(nil),                 // 1: weaviate.v1.GroupBy
+		(*SortBy)(nil),                  // 2: weaviate.v1.SortBy
+		(*MetadataRequest)(nil),         // 3: weaviate.v1.MetadataRequest
+		(*PropertiesRequest)(nil),       // 4: weaviate.v1.PropertiesRequest
+		(*ObjectPropertiesRequest)(nil), // 5: weaviate.v1.ObjectPropertiesRequest
+		(*RefPropertiesRequest)(nil),    // 6: weaviate.v1.RefPropertiesRequest
+		(*Rerank)(nil),                  // 7: weaviate.v1.Rerank
+		(*SearchReply)(nil),             // 8: weaviate.v1.SearchReply
+		(*RerankReply)(nil),             // 9: weaviate.v1.RerankReply
+		(*GroupByResult)(nil),           // 10: weaviate.v1.GroupByResult
+		(*SearchResult)(nil),            // 11: weaviate.v1.SearchResult
+		(*MetadataResult)(nil),          // 12: weaviate.v1.MetadataResult
+		(*PropertiesResult)(nil),        // 13: weaviate.v1.PropertiesResult
+		(*RefPropertiesResult)(nil),     // 14: weaviate.v1.RefPropertiesResult
+		(ConsistencyLevel)(0),           // 15: weaviate.v1.ConsistencyLevel
+		(*Filters)(nil),                 // 16: weaviate.v1.Filters
+		(*Hybrid)(nil),                  // 17: weaviate.v1.Hybrid
+		(*BM25)(nil),                    // 18: weaviate.v1.BM25
+		(*NearVector)(nil),              // 19: weaviate.v1.NearVector
+		(*NearObject)(nil),              // 20: weaviate.v1.NearObject
+		(*NearTextSearch)(nil),          // 21: weaviate.v1.NearTextSearch
+		(*NearImageSearch)(nil),         // 22: weaviate.v1.NearImageSearch
+		(*NearAudioSearch)(nil),         // 23: weaviate.v1.NearAudioSearch
+		(*NearVideoSearch)(nil),         // 24: weaviate.v1.NearVideoSearch
+		(*NearDepthSearch)(nil),         // 25: weaviate.v1.NearDepthSearch
+		(*NearThermalSearch)(nil),       // 26: weaviate.v1.NearThermalSearch
+		(*NearIMUSearch)(nil),           // 27: weaviate.v1.NearIMUSearch
+		(*GenerativeSearch)(nil),        // 28: weaviate.v1.GenerativeSearch
+		(*GenerativeResult)(nil),        // 29: weaviate.v1.GenerativeResult
+		(*GenerativeReply)(nil),         // 30: weaviate.v1.GenerativeReply
+		(*Vectors)(nil),                 // 31: weaviate.v1.Vectors
+		(*Properties)(nil),              // 32: weaviate.v1.Properties
+	}
+)
+
 var file_v1_search_get_proto_depIdxs = []int32{
 	15, // 0: weaviate.v1.SearchRequest.consistency_level:type_name -> weaviate.v1.ConsistencyLevel
 	4,  // 1: weaviate.v1.SearchRequest.properties:type_name -> weaviate.v1.PropertiesRequest

--- a/grpc/generated/protocol/v1/search_get.pb.go
+++ b/grpc/generated/protocol/v1/search_get.pb.go
@@ -35,7 +35,8 @@ type SearchRequest struct {
 	Autocut uint32 `protobuf:"varint,32,opt,name=autocut,proto3" json:"autocut,omitempty"`
 	After   string `protobuf:"bytes,33,opt,name=after,proto3" json:"after,omitempty"`
 	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
-	SortBy []*SortBy `protobuf:"bytes,34,rep,name=sort_by,json=sortBy,proto3" json:"sort_by,omitempty"`
+	SortBy       []*SortBy `protobuf:"bytes,34,rep,name=sort_by,json=sortBy,proto3" json:"sort_by,omitempty"`
+	AfterPresent bool      `protobuf:"varint,35,opt,name=after_present,json=afterPresent,proto3" json:"after_present,omitempty"`
 	// matches/searches for objects
 	Filters      *Filters           `protobuf:"bytes,40,opt,name=filters,proto3,oneof" json:"filters,omitempty"`
 	HybridSearch *Hybrid            `protobuf:"bytes,41,opt,name=hybrid_search,json=hybridSearch,proto3,oneof" json:"hybrid_search,omitempty"`
@@ -165,6 +166,13 @@ func (x *SearchRequest) GetSortBy() []*SortBy {
 		return x.SortBy
 	}
 	return nil
+}
+
+func (x *SearchRequest) GetAfterPresent() bool {
+	if x != nil {
+		return x.AfterPresent
+	}
+	return false
 }
 
 func (x *SearchRequest) GetFilters() *Filters {
@@ -1415,7 +1423,7 @@ var File_v1_search_get_proto protoreflect.FileDescriptor
 
 const file_v1_search_get_proto_rawDesc = "" +
 	"\n" +
-	"\x13v1/search_get.proto\x12\vweaviate.v1\x1a\rv1/base.proto\x1a\x14v1/base_search.proto\x1a\x13v1/generative.proto\x1a\x13v1/properties.proto\"\xc7\r\n" +
+	"\x13v1/search_get.proto\x12\vweaviate.v1\x1a\rv1/base.proto\x1a\x14v1/base_search.proto\x1a\x13v1/generative.proto\x1a\x13v1/properties.proto\"\xec\r\n" +
 	"\rSearchRequest\x12\x1e\n" +
 	"\n" +
 	"collection\x18\x01 \x01(\tR\n" +
@@ -1432,7 +1440,8 @@ const file_v1_search_get_proto_rawDesc = "" +
 	"\x06offset\x18\x1f \x01(\rR\x06offset\x12\x18\n" +
 	"\aautocut\x18  \x01(\rR\aautocut\x12\x14\n" +
 	"\x05after\x18! \x01(\tR\x05after\x12,\n" +
-	"\asort_by\x18\" \x03(\v2\x13.weaviate.v1.SortByR\x06sortBy\x123\n" +
+	"\asort_by\x18\" \x03(\v2\x13.weaviate.v1.SortByR\x06sortBy\x12#\n" +
+	"\rafter_present\x18# \x01(\bR\fafterPresent\x123\n" +
 	"\afilters\x18( \x01(\v2\x14.weaviate.v1.FiltersH\x04R\afilters\x88\x01\x01\x12=\n" +
 	"\rhybrid_search\x18) \x01(\v2\x13.weaviate.v1.HybridH\x05R\fhybridSearch\x88\x01\x01\x127\n" +
 	"\vbm25_search\x18* \x01(\v2\x11.weaviate.v1.BM25H\x06R\n" +

--- a/grpc/proto/v1/search_get.proto
+++ b/grpc/proto/v1/search_get.proto
@@ -31,6 +31,7 @@ message SearchRequest {
   string after = 33;
   // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
   repeated SortBy sort_by = 34;
+  bool after_present = 35;  // can be used to distinguish between unset and set to ""
 
   // matches/searches for objects
   optional Filters filters = 40;

--- a/grpc/proto/v1/search_get.proto
+++ b/grpc/proto/v1/search_get.proto
@@ -28,10 +28,9 @@ message SearchRequest {
   uint32 limit = 30;
   uint32 offset = 31;
   uint32 autocut = 32;
-  string after = 33;
+  optional string after = 33;
   // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
   repeated SortBy sort_by = 34;
-  bool after_present = 35;  // can be used to distinguish between unset and set to ""
 
   // matches/searches for objects
   optional Filters filters = 40;

--- a/test/acceptance/graphql_resolvers/local_get_cursor_test.go
+++ b/test/acceptance/graphql_resolvers/local_get_cursor_test.go
@@ -97,12 +97,6 @@ func getWithCursorSearch(t *testing.T) {
 				expectedErrorMsg: "cursor api: invalid 'after' parameter: sort cannot be set with after and limit parameters",
 			},
 			{
-				name:             "error with where",
-				className:        "CursorClass",
-				filter:           `limit: 1 after: "" where:{path:"id" operator:Like valueText:"*"}`,
-				expectedErrorMsg: "cursor api: invalid 'after' parameter: where cannot be set with after and limit parameters",
-			},
-			{
 				name:             "error with bm25, hybrid and offset",
 				className:        "CursorClass",
 				filter:           `limit: 1 after: "" bm25:{query:"cursor api"} hybrid:{query:"cursor api"} offset:1`,

--- a/test/acceptance/search_optimization/search_vector_transmission_test.go
+++ b/test/acceptance/search_optimization/search_vector_transmission_test.go
@@ -1587,7 +1587,7 @@ func testGRPCCursorPagination(t *testing.T, grpcClient protocol.WeaviateClient) 
 		resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
 			Collection: className,
 			Limit:      2,
-			After:      "",
+			After:      nil,
 			Properties: &protocol.PropertiesRequest{
 				ReturnAllNonrefProperties: true,
 			},
@@ -1614,7 +1614,7 @@ func testGRPCCursorPagination(t *testing.T, grpcClient protocol.WeaviateClient) 
 		resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
 			Collection: className,
 			Limit:      3,
-			After:      "",
+			After:      nil,
 			Properties: &protocol.PropertiesRequest{
 				NonRefProperties: []string{"title"},
 			},
@@ -1641,7 +1641,7 @@ func testGRPCCursorPagination(t *testing.T, grpcClient protocol.WeaviateClient) 
 		resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
 			Collection: className,
 			Limit:      2,
-			After:      "",
+			After:      nil,
 			Metadata: &protocol.MetadataRequest{
 				Uuid:   true,
 				Vector: true,
@@ -1661,7 +1661,7 @@ func testGRPCCursorPagination(t *testing.T, grpcClient protocol.WeaviateClient) 
 		resp2, err := grpcClient.Search(ctx, &protocol.SearchRequest{
 			Collection: className,
 			Limit:      2,
-			After:      lastID,
+			After:      &lastID,
 			Metadata: &protocol.MetadataRequest{
 				Uuid:   true,
 				Vector: true,
@@ -1682,7 +1682,7 @@ func testGRPCCursorPagination(t *testing.T, grpcClient protocol.WeaviateClient) 
 		resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
 			Collection: className,
 			Limit:      2,
-			After:      "",
+			After:      nil,
 			Metadata: &protocol.MetadataRequest{
 				Uuid: true,
 			},
@@ -1701,7 +1701,7 @@ func testGRPCCursorPagination(t *testing.T, grpcClient protocol.WeaviateClient) 
 		resp2, err := grpcClient.Search(ctx, &protocol.SearchRequest{
 			Collection: className,
 			Limit:      2,
-			After:      lastID,
+			After:      &lastID,
 			Metadata: &protocol.MetadataRequest{
 				Uuid: true,
 			},
@@ -1720,7 +1720,7 @@ func testGRPCCursorPagination(t *testing.T, grpcClient protocol.WeaviateClient) 
 		resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
 			Collection: className,
 			Limit:      2,
-			After:      "",
+			After:      nil,
 			Properties: &protocol.PropertiesRequest{
 				NonRefProperties: []string{"title"}, // Only title, not description
 			},

--- a/test/acceptance_with_go_client/client_helper.go
+++ b/test/acceptance_with_go_client/client_helper.go
@@ -1,1 +1,20 @@
 package acceptance_with_go_client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	client "github.com/weaviate/weaviate-go-client/v5/weaviate"
+)
+
+func createClientWithClassName(t *testing.T) (*client.Client, string) {
+	c, err := client.NewClient(client.Config{Scheme: "http", Host: "localhost:8080"})
+	require.Nil(t, err)
+
+	ctx := context.Background()
+	className := t.Name()
+	require.NoError(t, c.Schema().ClassDeleter().WithClassName(className).Do(ctx))
+
+	return c, className
+}

--- a/test/acceptance_with_go_client/client_helper.go
+++ b/test/acceptance_with_go_client/client_helper.go
@@ -1,0 +1,1 @@
+package acceptance_with_go_client

--- a/test/acceptance_with_go_client/iterator_test.go
+++ b/test/acceptance_with_go_client/iterator_test.go
@@ -1,0 +1,90 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package acceptance_with_go_client
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	client "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/filters"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+func TestIteratorWithFilter(t *testing.T) {
+	ctx := context.Background()
+	c, err := client.NewClient(client.Config{Scheme: "http", Host: "localhost:8080"})
+	require.Nil(t, err)
+
+	className := "GoldenSunsetFlower"
+	require.NoError(t, c.Schema().ClassDeleter().WithClassName(className).Do(ctx))
+
+	class := models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{Name: "bool", DataType: []string{string(schema.DataTypeBoolean)}},
+			{Name: "counter", DataType: []string{string(schema.DataTypeInt)}},
+		},
+		Vectorizer: "none",
+	}
+	require.NoError(t, c.Schema().ClassCreator().WithClass(&class).Do(ctx))
+
+	trueUUIDs := make(map[string]struct{}, 0)
+	numObjs := 100
+	for i := 0; i < numObjs; i++ {
+		obj, err := c.Data().Creator().WithClassName(className).WithProperties(
+			map[string]interface{}{"counter": i, "bool": i%2 == 0},
+		).Do(ctx)
+		require.NoError(t, err)
+		if i%2 == 0 {
+			trueUUIDs[string(obj.Object.ID)] = struct{}{}
+		}
+	}
+
+	found := 0
+	var after string
+	for {
+		get, err := c.GraphQL().Get().WithClassName(className).WithWhere(filters.Where().
+			WithPath([]string{"bool"}).
+			WithOperator(filters.Equal).
+			WithValueBoolean(true)).WithLimit(10).
+			WithFields(
+				graphql.Field{
+					Name: "_additional", Fields: []graphql.Field{{Name: "id"}},
+				},
+				graphql.Field{Name: "counter"},
+			).WithAfter(after).Do(ctx)
+		require.NoError(t, err)
+		require.Nil(t, get.Errors)
+		objs := get.Data["Get"].(map[string]interface{})[className].([]interface{})
+		if len(objs) == 0 {
+			break
+		}
+		found += len(objs)
+
+		for _, obj := range objs {
+			props := obj.(map[string]interface{})
+			require.True(t, int(props["counter"].(float64))%2 == 0)
+			id := props["_additional"].(map[string]interface{})["id"].(string)
+			_, ok := trueUUIDs[id]
+			require.True(t, ok, "Expected to find UUID %s in trueUUIDs")
+			delete(trueUUIDs, id) // Make sure each object is only counted once
+		}
+
+		after = objs[len(objs)-1].(map[string]interface{})["_additional"].(map[string]interface{})["id"].(string)
+	}
+
+	require.Equal(t, numObjs/2, found)
+}

--- a/test/acceptance_with_go_client/iterator_test.go
+++ b/test/acceptance_with_go_client/iterator_test.go
@@ -23,6 +23,50 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
+func TestAfterUnsetVsEmpty(t *testing.T) {
+	c, className := createClientWithClassName(t)
+
+	class := models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{Name: "bool", DataType: []string{string(schema.DataTypeBoolean)}},
+			{Name: "counter", DataType: []string{string(schema.DataTypeInt)}},
+		},
+		Vectorizer: "none",
+	}
+	require.NoError(t, c.Schema().ClassCreator().WithClass(&class).Do(ctx))
+
+	numObjs := 100
+	for i := 0; i < numObjs; i++ {
+		_, err := c.Data().Creator().WithClassName(className).WithProperties(
+			map[string]interface{}{"counter": i, "bool": i%2 == 0},
+		).Do(ctx)
+		require.NoError(t, err)
+	}
+
+	getExplicitEmpty, err := c.GraphQL().Get().WithClassName(className).WithLimit(10).WithFields(
+		graphql.Field{
+			Name: "_additional", Fields: []graphql.Field{{Name: "id"}},
+		},
+		graphql.Field{Name: "counter"},
+	).WithAfter("").Do(ctx)
+	require.NoError(t, err)
+	require.Nil(t, getExplicitEmpty.Errors)
+	objExplicitEmpty := getExplicitEmpty.Data["Get"].(map[string]interface{})[className].([]interface{})
+
+	getUnset, err := c.GraphQL().Get().WithClassName(className).WithLimit(10).WithFields(
+		graphql.Field{
+			Name: "_additional", Fields: []graphql.Field{{Name: "id"}},
+		},
+		graphql.Field{Name: "counter"},
+	).Do(ctx)
+	require.NoError(t, err)
+	require.Nil(t, getUnset.Errors)
+	objUnset := getUnset.Data["Get"].(map[string]interface{})[className].([]interface{})
+
+	require.Equal(t, objExplicitEmpty, objUnset)
+}
+
 func TestIteratorWithFilter(t *testing.T) {
 	ctx := context.Background()
 	c, err := client.NewClient(client.Config{Scheme: "http", Host: "localhost:8080"})


### PR DESCRIPTION
### What's being changed:

Adds support for filters with the cursor API.
The GRPC needs a new parameter to distinguish between `after` being unset and empty, GQL does that by default.

e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/17137286173
chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17137288747

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
