### PR TITLE
Fix error message for wrong api key

### DIFF
--- a/usecases/auth/authentication/apikey/client.go
+++ b/usecases/auth/authentication/apikey/client.go
@@ -16,7 +16,6 @@ import (
 	"crypto/subtle"
 	"fmt"
 
-	errors "github.com/go-openapi/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/config"
 )
@@ -81,13 +80,9 @@ func (c *StaticApiKey) validateConfig() error {
 }
 
 func (c *StaticApiKey) ValidateAndExtract(token string, scopes []string) (*models.Principal, error) {
-	if !c.config.Enabled {
-		return nil, errors.New(401, "apikey auth is not configured, please try another auth scheme or set up weaviate with apikey configured")
-	}
-
 	tokenPos, ok := c.isTokenAllowed(token)
 	if !ok {
-		return nil, errors.New(401, "invalid api key, please provide a valid api key")
+		return nil, fmt.Errorf("invalid api key")
 	}
 
 	return &models.Principal{

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -65,6 +65,7 @@ type DBUser struct {
 	data           dbUserdata
 	memoryOnlyData memoryOnlyData
 	path           string
+	enabled        bool
 }
 
 type DBUserSnapshot struct {
@@ -141,6 +142,7 @@ func NewDBUser(path string, enabled bool, logger logrus.FieldLogger) (*DBUser, e
 			weakKeyStorageById:     make(map[string][sha256.Size]byte),
 			importedApiKeysBlocked: make([][sha256.Size]byte, 0),
 		},
+		enabled: enabled,
 	}
 
 	// we save every change to file after a request is done, EXCEPT the lastUsedAt time as we do not want to write to a

--- a/usecases/auth/authentication/apikey/wrapper.go
+++ b/usecases/auth/authentication/apikey/wrapper.go
@@ -12,6 +12,8 @@
 package apikey
 
 import (
+	"fmt"
+
 	"github.com/go-openapi/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/models"
@@ -41,23 +43,35 @@ func New(cfg config.Config, logger logrus.FieldLogger) (*ApiKey, error) {
 }
 
 func (a *ApiKey) ValidateAndExtract(token string, scopes []string) (*models.Principal, error) {
-	if randomKey, userIdentifier, err := keys.DecodeApiKey(token); err == nil {
-		principal, err := a.Dynamic.ValidateAndExtract(randomKey, userIdentifier)
-		if err != nil {
-			return nil, errors.New(401, "unauthorized: %v", err)
+	validate := func(token string, scopes []string) (*models.Principal, error) {
+		if a.Dynamic.enabled {
+			if randomKey, userIdentifier, err := keys.DecodeApiKey(token); err == nil {
+				principal, err := a.Dynamic.ValidateAndExtract(randomKey, userIdentifier)
+				if err != nil {
+					return nil, fmt.Errorf("invalid api key: %w", err)
+				}
+				return principal, nil
+			}
+			principal, err := a.Dynamic.ValidateImportedKey(token)
+			if err != nil {
+				return nil, fmt.Errorf("invalid api key: %w", err)
+			}
+			if principal != nil {
+				return principal, nil
+			} else if a.Dynamic.IsBlockedKey(token) {
+				// make sure static keys do not work after import and key rotation
+				return nil, fmt.Errorf("invalid api key")
+			}
 		}
-		return principal, nil
+		if a.static.config.Enabled {
+			return a.static.ValidateAndExtract(token, scopes)
+		}
+		return nil, fmt.Errorf("invalid api key")
 	}
-	principal, err := a.Dynamic.ValidateImportedKey(token)
+
+	principal, err := validate(token, scopes)
 	if err != nil {
 		return nil, errors.New(401, "unauthorized: %v", err)
 	}
-	if principal != nil {
-		return principal, nil
-	} else if a.Dynamic.IsBlockedKey(token) {
-		// make sure static keys do not work after import and key rotation
-		return nil, errors.New(401, "unauthorized: invalid token")
-	} else {
-		return a.static.ValidateAndExtract(token, scopes)
-	}
+	return principal, nil
 }

--- a/usecases/auth/authentication/apikey/wrapper_test.go
+++ b/usecases/auth/authentication/apikey/wrapper_test.go
@@ -1,0 +1,148 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package apikey
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey/keys"
+	"github.com/weaviate/weaviate/usecases/config"
+
+	"github.com/sirupsen/logrus/hooks/test"
+)
+
+func TestInvalidApiKey(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := test.NewNullLogger()
+
+	testCases := []struct {
+		staticEnabled bool
+		dbEnabled     bool
+	}{
+		{staticEnabled: true, dbEnabled: false},
+		{staticEnabled: false, dbEnabled: true},
+		{staticEnabled: true, dbEnabled: true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("staticEnabled="+boolToStr(testCase.staticEnabled)+",dbEnabled="+boolToStr(testCase.dbEnabled), func(t *testing.T) {
+			conf := config.Config{
+				Persistence: config.Persistence{DataPath: t.TempDir()},
+				Authentication: config.Authentication{
+					DBUsers: config.DbUsers{Enabled: testCase.dbEnabled},
+					APIKey:  config.StaticAPIKey{Enabled: testCase.staticEnabled, AllowedKeys: []string{"valid-key"}, Users: []string{"user1"}},
+				},
+			}
+			wrapper, err := New(conf, logger)
+			require.NoError(t, err)
+
+			_, err = wrapper.ValidateAndExtract("invalid-key", nil)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "unauthorized: invalid api key")
+		})
+	}
+}
+
+func TestValidStaticKey(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := test.NewNullLogger()
+
+	testCases := []struct {
+		staticEnabled bool
+		dbEnabled     bool
+		expectError   bool
+	}{
+		{staticEnabled: true, dbEnabled: false, expectError: false},
+		{staticEnabled: false, dbEnabled: true, expectError: true},
+		{staticEnabled: true, dbEnabled: true, expectError: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("staticEnabled="+boolToStr(testCase.staticEnabled)+",dbEnabled="+boolToStr(testCase.dbEnabled), func(t *testing.T) {
+			conf := config.Config{
+				Persistence: config.Persistence{DataPath: t.TempDir()},
+				Authentication: config.Authentication{
+					DBUsers: config.DbUsers{Enabled: testCase.dbEnabled},
+					APIKey:  config.StaticAPIKey{Enabled: testCase.staticEnabled, AllowedKeys: []string{"valid-key"}, Users: []string{"user1"}},
+				},
+			}
+			wrapper, err := New(conf, logger)
+			require.NoError(t, err)
+
+			principal, err := wrapper.ValidateAndExtract("valid-key", nil)
+			if testCase.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unauthorized: invalid api key")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, principal)
+			}
+		})
+	}
+}
+
+func TestValidDynamicKey(t *testing.T) {
+	t.Parallel()
+
+	logger, _ := test.NewNullLogger()
+
+	testCases := []struct {
+		staticEnabled bool
+		dbEnabled     bool
+		expectError   bool
+	}{
+		{staticEnabled: true, dbEnabled: false, expectError: true},
+		{staticEnabled: false, dbEnabled: true, expectError: false},
+		{staticEnabled: true, dbEnabled: true, expectError: false},
+	}
+
+	for _, testCase := range testCases {
+		t.Run("staticEnabled="+boolToStr(testCase.staticEnabled)+",dbEnabled="+boolToStr(testCase.dbEnabled), func(t *testing.T) {
+			conf := config.Config{
+				Persistence: config.Persistence{DataPath: t.TempDir()},
+				Authentication: config.Authentication{
+					DBUsers: config.DbUsers{Enabled: testCase.dbEnabled},
+					APIKey:  config.StaticAPIKey{Enabled: testCase.staticEnabled, AllowedKeys: []string{"valid-key"}, Users: []string{"user1"}},
+				},
+			}
+			wrapper, err := New(conf, logger)
+			require.NoError(t, err)
+
+			userId := "id"
+
+			apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
+			require.NoError(t, err)
+
+			require.NoError(t, wrapper.Dynamic.CreateUser(userId, hash, identifier, "", time.Now()))
+
+			principal, err := wrapper.ValidateAndExtract(apiKey, nil)
+			if testCase.expectError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "unauthorized: invalid api key")
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, principal)
+			}
+		})
+	}
+}
+
+func boolToStr(enabled bool) string {
+	if enabled {
+		return "true"
+	}
+	return "false"
+}


### PR DESCRIPTION
### What's being changed:

When dynamic users are enabled but static API keys are disabled, the error was
```
{'code': 401, 'message': 'apikey auth is not configured, please try another auth scheme or set up weaviate with apikey configured'}.
```

This returns the correct error in all cases that starts with "invalid api key" and may contain more information

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
