### PR TITLE
Actual reentries

### DIFF
--- a/adapters/repos/db/priorityqueue/queue.go
+++ b/adapters/repos/db/priorityqueue/queue.go
@@ -100,6 +100,10 @@ func (q *Queue[T]) Len() int {
 	return len(q.items)
 }
 
+func (q *Queue[T]) Elements() []Item[T] {
+	return q.items
+}
+
 // Cap returns the remaining capacity of the queue
 func (q *Queue[T]) Cap() int {
 	return cap(q.items)

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -790,7 +790,7 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 					currentNode = h.nodes[nextId]
 					h.shardedNodeLocks.RUnlock(nextId)
 					if currentNode == nil {
-						return nil, nil, fmt.Errorf("knn search: search layer at level 0")
+						break
 					}
 					currentDist = maxDist
 				}

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -33,6 +33,14 @@ import (
 
 const defaultAcornMaxFilterPercentage = 0.4
 
+type FilterStrategy int
+
+const (
+	SWEEPING FilterStrategy = iota
+	ACORN
+	RRE
+)
+
 func (h *hnsw) searchTimeEF(k int) int {
 	// load atomically, so we can get away with concurrent updates of the
 	// userconfig without having to set a lock each time we try to read - which
@@ -177,26 +185,37 @@ func (h *hnsw) cacheSize() int64 {
 	return size
 }
 
-func (h *hnsw) acornParams(allowList helpers.AllowList) (bool, int) {
-	useAcorn := h.acornSearch.Load()
-	var M int
-
-	if allowList != nil && useAcorn {
-		cacheSize := h.cacheSize()
-		allowListSize := allowList.Len()
-		if cacheSize != 0 && float32(allowListSize)/float32(cacheSize) > defaultAcornMaxFilterPercentage {
-			useAcorn = false
-		}
-		M = int(cacheSize / int64(max(1, allowListSize)))
-		M = min(M, 8)
+func (h *hnsw) acornParams(allowList helpers.AllowList) bool {
+	if allowList == nil || !h.acornSearch.Load() {
+		return false
 	}
-	return useAcorn, M
+
+	cacheSize := h.cacheSize()
+	allowListSize := allowList.Len()
+	if cacheSize != 0 && float32(allowListSize)/float32(cacheSize) > defaultAcornMaxFilterPercentage {
+		return false
+	}
+
+	return true
 }
 
 func (h *hnsw) searchLayerByVectorWithDistancer(ctx context.Context,
 	queryVector []float32,
 	entrypoints *priorityqueue.Queue[any], ef int, level int,
-	allowList helpers.AllowList, compressorDistancer compressionhelpers.CompressorDistancer) (*priorityqueue.Queue[any], error,
+	allowList helpers.AllowList, compressorDistancer compressionhelpers.CompressorDistancer,
+) (*priorityqueue.Queue[any], error,
+) {
+	if h.acornParams(allowList) {
+		return h.searchLayerByVectorWithDistancerWithStrategy(ctx, queryVector, entrypoints, ef, level, allowList, compressorDistancer, ACORN)
+	}
+	return h.searchLayerByVectorWithDistancerWithStrategy(ctx, queryVector, entrypoints, ef, level, allowList, compressorDistancer, SWEEPING)
+}
+
+func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
+	queryVector []float32,
+	entrypoints *priorityqueue.Queue[any], ef int, level int,
+	allowList helpers.AllowList, compressorDistancer compressionhelpers.CompressorDistancer,
+	strategy FilterStrategy) (*priorityqueue.Queue[any], error,
 ) {
 	start := time.Now()
 	defer func() {
@@ -207,8 +226,6 @@ func (h *hnsw) searchLayerByVectorWithDistancer(ctx context.Context,
 	visited := h.pools.visitedLists.Borrow()
 	visitedExp := h.pools.visitedLists.Borrow()
 	h.pools.visitedListsLock.RUnlock()
-
-	useAcorn, M := h.acornParams(allowList)
 
 	candidates := h.pools.pqCandidates.GetMin(ef)
 	results := h.pools.pqResults.GetMax(ef)
@@ -237,13 +254,15 @@ func (h *hnsw) searchLayerByVectorWithDistancer(ctx context.Context,
 		return nil, errors.Wrapf(err, "calculate distance of current last result")
 	}
 	var connectionsReusable []uint64
-
 	var sliceConnectionsReusable *common.VectorUint64Slice
 	var slicePendingNextRound *common.VectorUint64Slice
 	var slicePendingThisRound *common.VectorUint64Slice
 
-	if allowList != nil && useAcorn {
-		sliceConnectionsReusable = h.pools.tempVectorsUint64.Get(M * h.maximumConnectionsLayerZero)
+	if allowList == nil {
+		strategy = SWEEPING
+	}
+	if strategy == ACORN {
+		sliceConnectionsReusable = h.pools.tempVectorsUint64.Get(8 * h.maximumConnectionsLayerZero)
 		slicePendingNextRound = h.pools.tempVectorsUint64.Get(h.maximumConnectionsLayerZero)
 		slicePendingThisRound = h.pools.tempVectorsUint64.Get(h.maximumConnectionsLayerZero)
 	} else {
@@ -287,7 +306,7 @@ func (h *hnsw) searchLayerByVectorWithDistancer(ctx context.Context,
 			continue
 		}
 
-		if allowList == nil || !useAcorn {
+		if strategy != ACORN {
 			if len(candidateNode.connections[level]) > h.maximumConnectionsLayerZero {
 				// How is it possible that we could ever have more connections than the
 				// allowed maximum? It is not anymore, but there was a bug that allowed
@@ -317,7 +336,7 @@ func (h *hnsw) searchLayerByVectorWithDistancer(ctx context.Context,
 			copy(pendingNextRound, candidateNode.connections[level])
 			hop := 1
 			maxHops := 2
-			for hop <= maxHops && realLen < M*h.maximumConnectionsLayerZero && len(pendingNextRound) > 0 {
+			for hop <= maxHops && realLen < 8*h.maximumConnectionsLayerZero && len(pendingNextRound) > 0 {
 				if cap(pendingThisRound) >= len(pendingNextRound) {
 					pendingThisRound = pendingThisRound[:len(pendingNextRound)]
 				} else {
@@ -326,7 +345,7 @@ func (h *hnsw) searchLayerByVectorWithDistancer(ctx context.Context,
 				}
 				copy(pendingThisRound, pendingNextRound)
 				pendingNextRound = pendingNextRound[:0]
-				for index < len(pendingThisRound) && realLen < M*h.maximumConnectionsLayerZero {
+				for index < len(pendingThisRound) && realLen < 8*h.maximumConnectionsLayerZero {
 					nodeId := pendingThisRound[index]
 					index++
 					if ok := visited.Visited(nodeId); ok {
@@ -361,7 +380,7 @@ func (h *hnsw) searchLayerByVectorWithDistancer(ctx context.Context,
 							continue
 						}
 
-						if realLen >= M*h.maximumConnectionsLayerZero {
+						if realLen >= 8*h.maximumConnectionsLayerZero {
 							break
 						}
 
@@ -390,6 +409,12 @@ func (h *hnsw) searchLayerByVectorWithDistancer(ctx context.Context,
 
 			// make sure we never visit this neighbor again
 			visited.Visit(neighborID)
+
+			if strategy == RRE && level == 0 {
+				if !allowList.Contains(neighborID) {
+					continue
+				}
+			}
 			var distance float32
 			var err error
 			if h.compressed.Load() {
@@ -413,7 +438,7 @@ func (h *hnsw) searchLayerByVectorWithDistancer(ctx context.Context,
 
 			if distance < worstResultDistance || results.Len() < ef {
 				candidates.Insert(neighborID, distance)
-				if !useAcorn && level == 0 && allowList != nil {
+				if strategy == SWEEPING && level == 0 && allowList != nil {
 					// we are on the lowest level containing the actual candidates and we
 					// have an allow list (i.e. the user has probably set some sort of a
 					// filter restricting this search further. As a result we have to
@@ -447,7 +472,7 @@ func (h *hnsw) searchLayerByVectorWithDistancer(ctx context.Context,
 		}
 	}
 
-	if allowList != nil && useAcorn {
+	if strategy == ACORN {
 		h.pools.tempVectorsUint64.Put(sliceConnectionsReusable)
 		h.pools.tempVectorsUint64.Put(slicePendingNextRound)
 		h.pools.tempVectorsUint64.Put(slicePendingThisRound)
@@ -594,111 +619,11 @@ func (h *hnsw) handleDeletedNode(docID uint64, operation string) {
 			"tombstone was added", docID)
 }
 
-type FastSet struct {
-	boolSet []bool
-	size    int
-}
-
-func NewFastSet(allow helpers.AllowList) *FastSet {
-	bools := make([]bool, allow.Max()+1)
-	it := allow.Iterator()
-	for docID, ok := it.Next(); ok; docID, ok = it.Next() {
-		bools[docID] = true
-	}
-	return &FastSet{
-		boolSet: bools,
-		size:    allow.Len(),
-	}
-}
-
-func (s *FastSet) Contains(node uint64) bool {
-	return uint64(len(s.boolSet)) > node && s.boolSet[node]
-}
-
-func (s *FastSet) DeepCopy() helpers.AllowList {
-	panic("DeepCopy")
-}
-
-func (s *FastSet) Insert(ids ...uint64) {
-	panic("DeepCopy")
-}
-
-func (s *FastSet) WrapOnWrite() helpers.AllowList {
-	panic("DeepCopy")
-}
-
-func (s *FastSet) Slice() []uint64 {
-	panic("DeepCopy")
-}
-
-func (s *FastSet) IsEmpty() bool {
-	panic("DeepCopy")
-}
-
-func (s *FastSet) Len() int {
-	return s.size
-}
-
-func (s *FastSet) Min() uint64 {
-	panic("DeepCopy")
-}
-
-func (s *FastSet) Max() uint64 {
-	panic("DeepCopy")
-}
-
-func (s *FastSet) Size() uint64 {
-	panic("DeepCopy")
-}
-
-func (s *FastSet) Truncate(uint64) helpers.AllowList {
-	panic("DeepCopy")
-}
-
-func (s *FastSet) Close() {
-}
-
-func (s *FastSet) Iterator() helpers.AllowListIterator {
-	return &fastIterator{
-		source:  s,
-		current: 0,
-	}
-}
-
-func (s *FastSet) LimitedIterator(limit int) helpers.AllowListIterator {
-	panic("DeepCopy")
-}
-
-type fastIterator struct {
-	current uint64
-	source  *FastSet
-}
-
-func (s *fastIterator) Len() int {
-	return s.source.Len()
-}
-
-func (s *fastIterator) Next() (uint64, bool) {
-	index := s.current
-	size := uint64(len(s.source.boolSet))
-	for index < size && !s.source.boolSet[index] {
-		index++
-	}
-	s.current = index + 1
-	return index, index < size
-}
-
 func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int,
 	ef int, allowList helpers.AllowList,
 ) ([]uint64, []float32, error) {
 	if h.isEmpty() {
 		return nil, nil, nil
-	}
-
-	useAcorn, _ := h.acornParams(allowList)
-
-	if allowList != nil && useAcorn {
-		allowList = NewFastSet(allowList)
 	}
 
 	if k < 0 {
@@ -775,24 +700,40 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 
 	eps := priorityqueue.NewMin[any](10)
 	eps.Insert(entryPointID, entryPointDistance)
-	if allowList != nil && useAcorn {
-		size := h.maximumConnectionsLayerZero
-		if size >= ef {
-			size = ef - 1
+	var strategy FilterStrategy
+	h.shardedNodeLocks.RLock(entryPointID)
+	entryPointNode := h.nodes[entryPointID]
+	h.shardedNodeLocks.RUnlock(entryPointID)
+	useAcorn := h.acornParams(allowList)
+	if useAcorn {
+		if entryPointNode == nil {
+			strategy = RRE
+		} else {
+			counter := float32(0)
+			entryPointNode.Lock()
+			for _, id := range entryPointNode.connections[0] {
+				if allowList.Contains(id) {
+					counter++
+				}
+			}
+			entryPointNode.Unlock()
+			if counter/float32(len(h.nodes[entryPointID].connections[0])) > defaultAcornMaxFilterPercentage {
+				strategy = RRE
+			} else {
+				strategy = ACORN
+			}
 		}
-		it := allowList.Iterator()
-		i := 0
-		seeds := make([]uint64, size)
-		for idx, ok := it.Next(); ok && i < size; idx, ok = it.Next() {
-			seeds[i] = idx
-			i++
-		}
-		for _, entryPoint := range seeds {
-			entryPointDistance, _ := h.distToNode(compressorDistancer, entryPoint, searchVec)
-			eps.Insert(entryPoint, entryPointDistance)
-		}
+	} else {
+		strategy = SWEEPING
 	}
-	res, err := h.searchLayerByVectorWithDistancer(ctx, searchVec, eps, ef, 0, allowList, compressorDistancer)
+
+	if allowList != nil && useAcorn {
+		it := allowList.Iterator()
+		idx, _ := it.Next()
+		entryPointDistance, _ := h.distToNode(compressorDistancer, idx, searchVec)
+		eps.Insert(idx, entryPointDistance)
+	}
+	res, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, ef, 0, allowList, compressorDistancer, strategy)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
 	}

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -723,12 +723,13 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		h.pools.visitedLists.Return(visitedExp)
 		h.pools.visitedListsLock.RUnlock()
 	}()
+
 	res, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, ef, 0, allowList, compressorDistancer, strategy, visited, visitedExp)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
 	}
 
-	if strategy == RRE {
+	if strategy == ACORN {
 		h.pools.visitedListsLock.RLock()
 		visitedRRE := h.pools.visitedLists.Borrow()
 		visitedRes := h.pools.visitedLists.Borrow()
@@ -743,10 +744,14 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 
 		eps.Reset()
 		eps.Insert(entryPointID, entryPointDistance)
+		visited.Reset()
 		//entryPoint without filter
 		resEntryPoint, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, 1, 0, nil, compressorDistancer, strategy, visited, visitedExp)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
+		}
+		for resEntryPoint.Len() > 1 {
+			resEntryPoint.Pop()
 		}
 		elem := resEntryPoint.Pop()
 		h.pools.pqResults.Put(resEntryPoint)
@@ -758,18 +763,19 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		if unfilteredEntryPointNode == nil {
 			return nil, nil, fmt.Errorf("knn search: search layer at level 0")
 		}
+		unfilteredVector, _ := h.cache.Get(ctx, unfilteredEntryPointID)
 
 		//init visitedRes
 		for _, elem := range res.Elements() {
 			visitedRes.Visit(elem.ID)
 		}
 
-		for i := 0; i < 10; i++ {
+		for i := 0; i < 32; i++ {
 			//search next seed
 			currentNode := unfilteredEntryPointNode
 			currentDist := unfilteredEntryPointDist
 			moreToVisit := true
-			for currentDist < res.Top().Dist && moreToVisit && (!allowList.Contains(currentNode.id) || h.hasTombstone(currentNode.id)) {
+			for currentDist < res.Top().Dist*1.2 && moreToVisit && (!allowList.Contains(currentNode.id) || h.hasTombstone(currentNode.id)) {
 				moreToVisit = false
 				maxDist := float32(-math.MaxFloat32)
 				var nextId uint64
@@ -778,14 +784,14 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 						continue
 					}
 					moreToVisit = true
-					visitedRRE.Visit(conn)
-					dist, _ := h.distToNode(compressorDistancer, conn, searchVec)
+					dist, _ := h.distToNode(compressorDistancer, conn, unfilteredVector)
 					if dist > maxDist {
 						maxDist = dist
 						nextId = conn
 					}
 				}
 				if moreToVisit {
+					visitedRRE.Visit(nextId)
 					h.shardedNodeLocks.RLock(nextId)
 					currentNode = h.nodes[nextId]
 					h.shardedNodeLocks.RUnlock(nextId)
@@ -798,7 +804,9 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 
 			//if valid seed, search again
 			if allowList.Contains(currentNode.id) && !h.hasTombstone(currentNode.id) {
-				resTemp, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, ef, 0, allowList, compressorDistancer, strategy, visited, visitedExp)
+				eps.Reset()
+				eps.Insert(currentNode.id, currentDist)
+				resTemp, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, ef, 0, allowList, compressorDistancer, RRE, visited, visitedExp)
 				if err != nil {
 					return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
 				}

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -205,28 +205,35 @@ func (h *hnsw) searchLayerByVectorWithDistancer(ctx context.Context,
 	allowList helpers.AllowList, compressorDistancer compressionhelpers.CompressorDistancer,
 ) (*priorityqueue.Queue[any], error,
 ) {
+	h.pools.visitedListsLock.RLock()
+	visited := h.pools.visitedLists.Borrow()
+	visitedExp := h.pools.visitedLists.Borrow()
+	h.pools.visitedListsLock.RUnlock()
+
+	defer func() {
+		h.pools.visitedListsLock.RLock()
+		h.pools.visitedLists.Return(visited)
+		h.pools.visitedLists.Return(visitedExp)
+		h.pools.visitedListsLock.RUnlock()
+	}()
+
 	if h.acornParams(allowList) {
-		return h.searchLayerByVectorWithDistancerWithStrategy(ctx, queryVector, entrypoints, ef, level, allowList, compressorDistancer, ACORN)
+		return h.searchLayerByVectorWithDistancerWithStrategy(ctx, queryVector, entrypoints, ef, level, allowList, compressorDistancer, ACORN, visited, visitedExp)
 	}
-	return h.searchLayerByVectorWithDistancerWithStrategy(ctx, queryVector, entrypoints, ef, level, allowList, compressorDistancer, SWEEPING)
+	return h.searchLayerByVectorWithDistancerWithStrategy(ctx, queryVector, entrypoints, ef, level, allowList, compressorDistancer, SWEEPING, visited, visitedExp)
 }
 
 func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 	queryVector []float32,
 	entrypoints *priorityqueue.Queue[any], ef int, level int,
 	allowList helpers.AllowList, compressorDistancer compressionhelpers.CompressorDistancer,
-	strategy FilterStrategy) (*priorityqueue.Queue[any], error,
+	strategy FilterStrategy, visited visited.ListSet, visitedExp visited.ListSet) (*priorityqueue.Queue[any], error,
 ) {
 	start := time.Now()
 	defer func() {
 		took := time.Since(start)
 		helpers.AnnotateSlowQueryLog(ctx, fmt.Sprintf("knn_search_layer_%d_took", level), took)
 	}()
-	h.pools.visitedListsLock.RLock()
-	visited := h.pools.visitedLists.Borrow()
-	visitedExp := h.pools.visitedLists.Borrow()
-	h.pools.visitedListsLock.RUnlock()
-
 	candidates := h.pools.pqCandidates.GetMin(ef)
 	results := h.pools.pqResults.GetMax(ef)
 	var floatDistancer distancer.Distancer
@@ -271,10 +278,6 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 
 	for candidates.Len() > 0 {
 		if err := ctx.Err(); err != nil {
-			h.pools.visitedListsLock.RLock()
-			h.pools.visitedLists.Return(visited)
-			h.pools.visitedListsLock.RUnlock()
-
 			helpers.AnnotateSlowQueryLog(ctx, "context_error", "knn_search_layer")
 			return nil, err
 		}
@@ -428,10 +431,6 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 					h.handleDeletedNode(e.DocID, "searchLayerByVectorWithDistancer")
 					continue
 				} else {
-					h.pools.visitedListsLock.RLock()
-					h.pools.visitedLists.Return(visited)
-					h.pools.visitedLists.Return(visitedExp)
-					h.pools.visitedListsLock.RUnlock()
 					return nil, errors.Wrap(err, "calculate distance between candidate and query")
 				}
 			}
@@ -479,11 +478,6 @@ func (h *hnsw) searchLayerByVectorWithDistancerWithStrategy(ctx context.Context,
 	}
 
 	h.pools.pqCandidates.Put(candidates)
-
-	h.pools.visitedListsLock.RLock()
-	h.pools.visitedLists.Return(visited)
-	h.pools.visitedLists.Return(visitedExp)
-	h.pools.visitedListsLock.RUnlock()
 
 	return results, nil
 }
@@ -735,12 +729,113 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		}
 		h.shardedNodeLocks.RUnlockAll()
 
-		entryPointDistance, _ := h.distToNode(compressorDistancer, idx, searchVec)
-		eps.Insert(idx, entryPointDistance)
+		idxDistance, _ := h.distToNode(compressorDistancer, idx, searchVec)
+		eps.Insert(idx, idxDistance)
 	}
-	res, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, ef, 0, allowList, compressorDistancer, strategy)
+	h.pools.visitedListsLock.RLock()
+	visited := h.pools.visitedLists.Borrow()
+	visitedExp := h.pools.visitedLists.Borrow()
+	h.pools.visitedListsLock.RUnlock()
+
+	defer func() {
+		h.pools.visitedListsLock.RLock()
+		h.pools.visitedLists.Return(visited)
+		h.pools.visitedLists.Return(visitedExp)
+		h.pools.visitedListsLock.RUnlock()
+	}()
+	res, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, ef, 0, allowList, compressorDistancer, strategy, visited, visitedExp)
 	if err != nil {
 		return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
+	}
+
+	if strategy == RRE {
+		h.pools.visitedListsLock.RLock()
+		visitedRRE := h.pools.visitedLists.Borrow()
+		visitedRes := h.pools.visitedLists.Borrow()
+		h.pools.visitedListsLock.RUnlock()
+
+		defer func() {
+			h.pools.visitedListsLock.RLock()
+			h.pools.visitedLists.Return(visitedRRE)
+			h.pools.visitedLists.Return(visitedRes)
+			h.pools.visitedListsLock.RUnlock()
+		}()
+
+		eps.Reset()
+		eps.Insert(entryPointID, entryPointDistance)
+		//entryPoint without filter
+		resEntryPoint, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, 1, 0, nil, compressorDistancer, strategy, visited, visitedExp)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
+		}
+		elem := resEntryPoint.Pop()
+		h.pools.pqResults.Put(resEntryPoint)
+		unfilteredEntryPointID := elem.ID
+		unfilteredEntryPointDist := elem.Dist
+		h.shardedNodeLocks.RLock(unfilteredEntryPointID)
+		unfilteredEntryPointNode := h.nodes[unfilteredEntryPointID]
+		h.shardedNodeLocks.RUnlock(unfilteredEntryPointID)
+		if unfilteredEntryPointNode == nil {
+			return nil, nil, fmt.Errorf("knn search: search layer at level 0")
+		}
+
+		//init visitedRes
+		for _, elem := range res.Elements() {
+			visitedRes.Visit(elem.ID)
+		}
+
+		for i := 0; i < 10; i++ {
+			//search next seed
+			currentNode := unfilteredEntryPointNode
+			currentDist := unfilteredEntryPointDist
+			moreToVisit := true
+			for currentDist < res.Top().Dist && moreToVisit && (!allowList.Contains(currentNode.id) || h.hasTombstone(currentNode.id)) {
+				moreToVisit = false
+				maxDist := float32(-math.MaxFloat32)
+				var nextId uint64
+				for _, conn := range currentNode.connections[0] {
+					if visitedRRE.Visited(conn) {
+						continue
+					}
+					moreToVisit = true
+					visitedRRE.Visit(conn)
+					dist, _ := h.distToNode(compressorDistancer, conn, searchVec)
+					if dist > maxDist {
+						maxDist = dist
+						nextId = conn
+					}
+				}
+				if moreToVisit {
+					h.shardedNodeLocks.RLock(nextId)
+					currentNode = h.nodes[nextId]
+					h.shardedNodeLocks.RUnlock(nextId)
+					if currentNode == nil {
+						return nil, nil, fmt.Errorf("knn search: search layer at level 0")
+					}
+					currentDist = maxDist
+				}
+			}
+
+			//if valid seed, search again
+			if allowList.Contains(currentNode.id) && !h.hasTombstone(currentNode.id) {
+				resTemp, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, ef, 0, allowList, compressorDistancer, strategy, visited, visitedExp)
+				if err != nil {
+					return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
+				}
+
+				//and merge results
+				for resTemp.Len() > 0 {
+					elem = resTemp.Pop()
+					if visitedRes.Visited(elem.ID) {
+						continue
+					}
+					visitedRes.Visit(elem.ID)
+					res.Pop()
+					res.Insert(elem.ID, elem.Dist)
+				}
+				h.pools.pqResults.Put(resTemp)
+			}
+		}
 	}
 
 	beforeRescore := time.Now()

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -175,28 +175,8 @@ func (h *hnsw) shouldRescore() bool {
 	return h.compressed.Load() && !h.doNotRescore
 }
 
-func (h *hnsw) cacheSize() int64 {
-	var size int64
-	if h.compressed.Load() {
-		size = h.compressor.CountVectors()
-	} else {
-		size = h.cache.CountVectors()
-	}
-	return size
-}
-
 func (h *hnsw) acornParams(allowList helpers.AllowList) bool {
-	if allowList == nil || !h.acornSearch.Load() {
-		return false
-	}
-
-	cacheSize := h.cacheSize()
-	allowListSize := allowList.Len()
-	if cacheSize != 0 && float32(allowListSize)/float32(cacheSize) > defaultAcornMaxFilterPercentage {
-		return false
-	}
-
-	return true
+	return allowList != nil && h.acornSearch.Load()
 }
 
 func (h *hnsw) searchLayerByVectorWithDistancer(ctx context.Context,

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -712,31 +712,21 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		idxDistance, _ := h.distToNode(compressorDistancer, idx, searchVec)
 		eps.Insert(idx, idxDistance)
 	}
-	h.pools.visitedListsLock.RLock()
-	visited := h.pools.visitedLists.Borrow()
-	visitedExp := h.pools.visitedLists.Borrow()
-	h.pools.visitedListsLock.RUnlock()
 
-	defer func() {
-		h.pools.visitedListsLock.RLock()
-		h.pools.visitedLists.Return(visited)
-		h.pools.visitedLists.Return(visitedExp)
-		h.pools.visitedListsLock.RUnlock()
-	}()
-
-	res, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, ef, 0, allowList, compressorDistancer, strategy, visited, visitedExp)
-	if err != nil {
-		return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
-	}
+	var res *priorityqueue.Queue[any]
 
 	if strategy == ACORN {
 		h.pools.visitedListsLock.RLock()
+		visited := h.pools.visitedLists.Borrow()
+		visitedExp := h.pools.visitedLists.Borrow()
 		visitedRRE := h.pools.visitedLists.Borrow()
 		visitedRes := h.pools.visitedLists.Borrow()
 		h.pools.visitedListsLock.RUnlock()
 
 		defer func() {
 			h.pools.visitedListsLock.RLock()
+			h.pools.visitedLists.Return(visited)
+			h.pools.visitedLists.Return(visitedExp)
 			h.pools.visitedLists.Return(visitedRRE)
 			h.pools.visitedLists.Return(visitedRes)
 			h.pools.visitedListsLock.RUnlock()
@@ -746,7 +736,7 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		eps.Insert(entryPointID, entryPointDistance)
 		visited.Reset()
 		//entryPoint without filter
-		resEntryPoint, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, 1, 0, nil, compressorDistancer, strategy, visited, visitedExp)
+		resEntryPoint, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, 1, 0, nil, compressorDistancer, SWEEPING, visited, visitedExp)
 		if err != nil {
 			return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
 		}
@@ -756,73 +746,203 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		elem := resEntryPoint.Pop()
 		h.pools.pqResults.Put(resEntryPoint)
 		unfilteredEntryPointID := elem.ID
-		unfilteredEntryPointDist := elem.Dist
 		h.shardedNodeLocks.RLock(unfilteredEntryPointID)
 		unfilteredEntryPointNode := h.nodes[unfilteredEntryPointID]
 		h.shardedNodeLocks.RUnlock(unfilteredEntryPointID)
 		if unfilteredEntryPointNode == nil {
 			return nil, nil, fmt.Errorf("knn search: search layer at level 0")
 		}
-		unfilteredVector, _ := h.cache.Get(ctx, unfilteredEntryPointID)
 
-		//init visitedRes
-		for _, elem := range res.Elements() {
-			visitedRes.Visit(elem.ID)
+		start := []uint64{unfilteredEntryPointID}
+		visitedRRE.Reset()
+		visitedRRE.Visit(start[0])
+		radius := float32(0)
+		res = h.pools.pqResults.GetMax(k)
+		limitHit := false
+		for len(start) > 0 && (res.Len() < k || radius < res.Top().Dist*2) {
+			for _, id := range h.nodes[start[0]].connections[0] {
+				if visitedRRE.Visited(id) {
+					continue
+				}
+				visitedRRE.Visit(id)
+				if limitHit {
+					vec, _ := h.cache.Get(ctx, id)
+					d, _ := h.distancerProvider.SingleDist(searchVec, vec)
+					if d < res.Top().Dist*1.1 {
+						start = append(start, id)
+					}
+				} else {
+					start = append(start, id)
+				}
+
+				if !allowList.Contains(id) {
+					continue
+				}
+				if visitedRes.Visited(id) {
+					continue
+				}
+				visitedRes.Visit(id)
+				vec, _ := h.cache.Get(ctx, id)
+				d, _ := h.distancerProvider.SingleDist(searchVec, vec)
+				if res.Len() < k || d < res.Top().Dist {
+					if res.Len() >= k {
+						limitHit = true
+						res.Pop()
+					}
+					res.Insert(id, d)
+				}
+				if d > radius {
+					radius = d
+				}
+			}
+			start = start[1:]
 		}
-
-		for i := 0; i < 32; i++ {
-			//search next seed
-			currentNode := unfilteredEntryPointNode
-			currentDist := unfilteredEntryPointDist
-			moreToVisit := true
-			for currentDist < res.Top().Dist*1.2 && moreToVisit && (!allowList.Contains(currentNode.id) || h.hasTombstone(currentNode.id)) {
-				moreToVisit = false
-				maxDist := float32(-math.MaxFloat32)
-				var nextId uint64
-				for _, conn := range currentNode.connections[0] {
-					if visitedRRE.Visited(conn) {
-						continue
+		/*
+			for i := 0; i < 32; i++ {
+				//search next seed
+				currentNode := unfilteredEntryPointNode
+				currentDist := unfilteredEntryPointDist
+				moreToVisit := true
+				for currentDist < res.Top().Dist*1.3 && moreToVisit && (!allowList.Contains(currentNode.id) || h.hasTombstone(currentNode.id)) {
+					moreToVisit = false
+					maxDist := float32(-math.MaxFloat32)
+					var nextId uint64
+					for _, conn := range currentNode.connections[0] {
+						if visitedRRE.Visited(conn) {
+							continue
+						}
+						moreToVisit = true
+						dist, _ := h.distToNode(compressorDistancer, conn, unfilteredVector)
+						if dist > maxDist {
+							maxDist = dist
+							nextId = conn
+						}
 					}
-					moreToVisit = true
-					dist, _ := h.distToNode(compressorDistancer, conn, unfilteredVector)
-					if dist > maxDist {
-						maxDist = dist
-						nextId = conn
+					if moreToVisit {
+						visitedRRE.Visit(nextId)
+						h.shardedNodeLocks.RLock(nextId)
+						currentNode = h.nodes[nextId]
+						h.shardedNodeLocks.RUnlock(nextId)
+						if currentNode == nil {
+							break
+						}
+						currentDist = maxDist
 					}
-				}
-				if moreToVisit {
-					visitedRRE.Visit(nextId)
-					h.shardedNodeLocks.RLock(nextId)
-					currentNode = h.nodes[nextId]
-					h.shardedNodeLocks.RUnlock(nextId)
-					if currentNode == nil {
-						break
-					}
-					currentDist = maxDist
-				}
-			}
-
-			//if valid seed, search again
-			if allowList.Contains(currentNode.id) && !h.hasTombstone(currentNode.id) {
-				eps.Reset()
-				eps.Insert(currentNode.id, currentDist)
-				resTemp, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, ef, 0, allowList, compressorDistancer, RRE, visited, visitedExp)
-				if err != nil {
-					return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
 				}
 
-				//and merge results
-				for resTemp.Len() > 0 {
-					elem = resTemp.Pop()
-					if visitedRes.Visited(elem.ID) {
-						continue
+				//if valid seed, search again
+				if allowList.Contains(currentNode.id) && !h.hasTombstone(currentNode.id) {
+					eps.Reset()
+					eps.Insert(currentNode.id, currentDist)
+					resTemp, err := h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, ef, 0, allowList, compressorDistancer, strategy, visited, visitedExp)
+					if err != nil {
+						return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
 					}
-					visitedRes.Visit(elem.ID)
-					res.Pop()
-					res.Insert(elem.ID, elem.Dist)
+
+					//and merge results
+					for resTemp.Len() > 0 {
+						elem = resTemp.Pop()
+						if visitedRes.Visited(elem.ID) {
+							continue
+						}
+						visitedRes.Visit(elem.ID)
+						res.Pop()
+						res.Insert(elem.ID, elem.Dist)
+					}
+					h.pools.pqResults.Put(resTemp)
+					//******************************
+					found := make([]bool, 0)
+					for _, id := range []uint64{439708, 717792, 580594, 692599, 38375, 259502, 287888, 564593, 524850, 667339} {
+						found = append(found, visitedRes.Visited(id))
+					}
+					h.logger.Error(i, currentNode.id, found)
+					for _, id := range []uint64{121359, 55458, 271902, 127946} {
+						v0, _ := h.cache.Get(ctx, id)
+						dists := make([]float32, 0)
+						for _, id := range []uint64{439708, 717792} {
+							v1, _ := h.cache.Get(ctx, id)
+							d, _ := h.distancerProvider.SingleDist(v0, v1)
+							dists = append(dists, d)
+						}
+						h.logger.Error(dists)
+					}
+
+					currentNodeT := unfilteredEntryPointNode
+					currentDistT := unfilteredEntryPointDist
+					moreToVisitT := true
+					unfilteredVectorT, _ := h.cache.Get(ctx, 439708)
+					for currentDistT < res.Top().Dist*1.3 && moreToVisitT && (!allowList.Contains(currentNodeT.id) || h.hasTombstone(currentNodeT.id)) {
+						moreToVisitT = false
+						minDist := float32(math.MaxFloat32)
+						var nextIdT uint64
+						for _, conn := range currentNodeT.connections[0] {
+							dist, _ := h.distToNode(compressorDistancer, conn, unfilteredVectorT)
+							if dist < minDist {
+								minDist = dist
+								nextIdT = conn
+							}
+						}
+						if moreToVisitT {
+							currentNodeT = h.nodes[nextIdT]
+							if currentNode == nil {
+								break
+							}
+							currentDistT = minDist
+						}
+					}
+					eps.Reset()
+					eps.Insert(currentNodeT.id, currentDistT)
+					visited.Reset()
+					visitedExp.Reset()
+					resTempT, _ := h.searchLayerByVectorWithDistancerWithStrategy(ctx, unfilteredVectorT, eps, ef, 0, allowList, compressorDistancer, strategy, visited, visitedExp)
+					foundT := false
+					countT := resTempT.Len()
+					worstDistT := resTempT.Top().Dist
+					for resTempT.Len() > 0 {
+						if resTemp.Pop().ID == 439708 {
+							foundT = true
+						}
+					}
+					dist, _ := h.distToNode(compressorDistancer, 439708, searchVec)
+					h.logger.Error(currentNodeT.id, currentDistT, foundT, countT, worstDistT, dist)
+
+					start := []uint64{439708}
+					visitedRRE.Reset()
+					visitedRRE.Visit(start[0])
+					count := 0
+					for len(start) > 0 {
+						count++
+						for _, id := range h.nodes[start[0]].connections[0] {
+							if !allowList.Contains(id) {
+								continue
+							}
+							if visitedRRE.Visited(id) {
+								continue
+							}
+							visitedRRE.Visit(id)
+							start = append(start, id)
+						}
+						start = start[1:]
+					}
+					h.logger.Error(count, allowList.Len())
 				}
-				h.pools.pqResults.Put(resTemp)
-			}
+			}*/
+	} else {
+		h.pools.visitedListsLock.RLock()
+		visited := h.pools.visitedLists.Borrow()
+		visitedExp := h.pools.visitedLists.Borrow()
+		h.pools.visitedListsLock.RUnlock()
+
+		defer func() {
+			h.pools.visitedListsLock.RLock()
+			h.pools.visitedLists.Return(visited)
+			h.pools.visitedLists.Return(visitedExp)
+			h.pools.visitedListsLock.RUnlock()
+		}()
+
+		res, err = h.searchLayerByVectorWithDistancerWithStrategy(ctx, searchVec, eps, ef, 0, allowList, compressorDistancer, strategy, visited, visitedExp)
+		if err != nil {
+			return nil, nil, errors.Wrapf(err, "knn search: search layer at level %d", 0)
 		}
 	}
 
@@ -855,6 +975,7 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		i--
 	}
 	h.pools.pqResults.Put(res)
+
 	return ids, dists, nil
 }
 

--- a/adapters/repos/db/vector/hnsw/search_test.go
+++ b/adapters/repos/db/vector/hnsw/search_test.go
@@ -171,23 +171,20 @@ func TestAcornPercentage(t *testing.T) {
 	t.Run("check acorn params on different filter percentags", func(t *testing.T) {
 		vectorIndex.acornSearch.Store(false)
 		allowList := helpers.NewAllowList(1, 2, 3)
-		useAcorn, M := vectorIndex.acornParams(allowList)
+		useAcorn := vectorIndex.acornParams(allowList)
 		assert.False(t, useAcorn)
-		assert.Equal(t, 0, M)
 
 		vectorIndex.acornSearch.Store(true)
 
-		useAcorn, M = vectorIndex.acornParams(allowList)
+		useAcorn = vectorIndex.acornParams(allowList)
 		assert.True(t, useAcorn)
-		assert.Equal(t, 3, M)
 
 		vectorIndex.acornSearch.Store(true)
 
 		largerAllowList := helpers.NewAllowList(1, 2, 3, 4, 5)
-		useAcorn, M = vectorIndex.acornParams(largerAllowList)
+		useAcorn = vectorIndex.acornParams(largerAllowList)
 		// should be false as allow list percentage is 50%
 		assert.False(t, useAcorn)
-		assert.Equal(t, 2, M)
 	})
 }
 


### PR DESCRIPTION
### What's being changed:

This PR introduces the smart seeding mechanism that addresses ACORN's fundamental limitation. Standard ACORN with two-hop searches fails when restrictive filters create isolated graph regions - some filtered points become unreachable from others within the hop limit. To overcome this limitations, we seed some entry points to start our search from better informed regions. The seeding is based on the graph topology. We perform a breadth-first graph traversal from the unfiltered entry point, using graph hops as distance heuristic (no expensive distance calculations), to collect ef nodes that pass the filter and are well-distributed across the graph topology.

In the process we have added a new structure to the common folder (Queue) implementing a simple queue (first in first out). The new code is covered with tests.

The image shows the new results in the super beir dataset. Sweeping (blue) represents the old sweeping strategy, capable of good recall but extremely slow. Acorn (orange) represents the pure Acorn capable of much faster search but with limited recall. The unnamed curve (green) represents Acorn with smart seeding, capable of both, fast search with no recall loss.
<img width="959" height="703" alt="output" src="https://github.com/user-attachments/assets/7ddfa45a-e854-4940-bf5e-d9377e79b74d" />


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [X] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
