### PR TITLE
fix: ensure consistent shuffling of replica node names during shard difference collection

### DIFF
--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -404,6 +404,7 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 	if len(replicasHostAddrs) > 1 {
 		// Use the global rand package which is thread-safe
 		rand.Shuffle(len(replicasHostAddrs), func(i, j int) {
+			replicaNodeNames[i], replicaNodeNames[j] = replicaNodeNames[j], replicaNodeNames[i]
 			replicasHostAddrs[i], replicasHostAddrs[j] = replicasHostAddrs[j], replicasHostAddrs[i]
 		})
 	}


### PR DESCRIPTION
### What's being changed:

The change ensures that both `replicaNodeNames` and `replicasHostAddrs` are shuffled together, maintaining their association and preventing mismatches between node names and host addresses.

* Ensured that `replicaNodeNames` is shuffled in sync with `replicasHostAddrs` during the randomization step in `CollectShardDifferences`, preserving correct mapping between node names and addresses.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
