### PR TITLE
fixing out of range when bq is on

### DIFF
--- a/adapters/repos/db/vector/hnsw/restore_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/restore_integration_test.go
@@ -1,0 +1,108 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storobj"
+	hnswent "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"go.etcd.io/bbolt"
+)
+
+func TempVectorForIDThunk(vectors [][]float32) func(context.Context, uint64, *common.VectorSlice) ([]float32, error) {
+	return func(ctx context.Context, id uint64, container *common.VectorSlice) ([]float32, error) {
+		copy(container.Slice, vectors[int(id)])
+		return vectors[int(id)], nil
+	}
+}
+
+func TestRestorBQ_Integration(t *testing.T) {
+	ctx := context.Background()
+	dimensions := 20
+	vectors_size := 3_000
+	queries_size := 100
+	k := 10
+
+	vectors, queries := testinghelpers.RandomVecs(vectors_size, queries_size, dimensions)
+	distancer := distancer.NewL2SquaredProvider()
+	logger, _ := test.NewNullLogger()
+
+	dirName := t.TempDir()
+	indexID := "restore-bq-integration-test"
+	noopCallback := cyclemanager.NewCallbackGroupNoop()
+	uc := hnswent.UserConfig{}
+	uc.SetDefaults()
+	uc.MaxConnections = 30
+	uc.EFConstruction = 64
+	uc.EF = 32
+	uc.VectorCacheMaxObjects = 1_000_000
+	uc.BQ = hnswent.BQConfig{
+		Enabled: true,
+	}
+
+	tmpDir := t.TempDir()
+	dbPath := filepath.Join(tmpDir, "index.db")
+	db, err := bbolt.Open(dbPath, 0o666, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	config := hnsw.Config{
+		RootPath:         dirName,
+		ID:               indexID,
+		Logger:           logger,
+		DistanceProvider: distancer,
+		MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
+			return hnsw.NewCommitLogger(dirName, indexID, logger, noopCallback)
+		},
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			vec := vectors[int(id)]
+			if vec == nil {
+				return nil, storobj.NewErrNotFoundf(id, "nil vec")
+			}
+			return vec, nil
+		},
+		TempVectorForIDThunk: TempVectorForIDThunk(vectors),
+	}
+
+	idx, err := hnsw.New(config, uc, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+	require.Nil(t, err)
+	idx.PostStartup()
+
+	compressionhelpers.Concurrently(logger, uint64(vectors_size), func(i uint64) {
+		idx.Add(ctx, i, vectors[i])
+	})
+
+	assert.Nil(t, idx.Flush())
+	assert.Nil(t, idx.Shutdown(context.Background()))
+
+	idx, err = hnsw.New(config, uc, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+	require.Nil(t, err)
+	idx.PostStartup()
+
+	for i := range queries {
+		idx.SearchByVector(ctx, queries[i], k, nil)
+	}
+}

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -135,7 +135,6 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 			h.muvera.Store(true)
 		}
 	}
-
 	if state.Compressed {
 		h.compressed.Store(state.Compressed)
 		h.cache.Drop()
@@ -230,6 +229,8 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 				h.dims = int32(len(vec))
 			}
 		}
+	} else {
+		h.compressor.GrowCache(uint64(len(h.nodes)))
 	}
 
 	if h.compressed.Load() && h.multivector.Load() && !h.muvera.Load() {


### PR DESCRIPTION
### What's being changed:

When BQ is on, the compressed cache is not grown properly at startup. This means that if queries come before the prefill is finished, we could hit node ids higher than the size of the cache ending up in panics. This PR corrects this problem.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
