### PR TITLE
Revert "fix(raft-transport): avoid invalid ports to avoid rollout errors"

### DIFF
--- a/cluster/resolver/raft.go
+++ b/cluster/resolver/raft.go
@@ -19,7 +19,6 @@ import (
 
 	raftImpl "github.com/hashicorp/raft"
 	"github.com/sirupsen/logrus"
-
 	"github.com/weaviate/weaviate/cluster/log"
 )
 
@@ -67,7 +66,7 @@ func (a *raft) ServerAddr(id raftImpl.ServerID) (raftImpl.ServerAddress, error) 
 	defer a.nodesLock.Unlock()
 	if addr == "" {
 		a.notResolvedNodes[id] = struct{}{}
-		return "", fmt.Errorf("could not resolve server id %s", id)
+		return raftImpl.ServerAddress(invalidAddr), nil
 	}
 	delete(a.notResolvedNodes, id)
 

--- a/cluster/resolver/types.go
+++ b/cluster/resolver/types.go
@@ -11,6 +11,10 @@
 
 package resolver
 
+const (
+	invalidAddr = "256.256.256.256:99999999"
+)
+
 // NodeToAddress allows the resolver to compute node-id to ip addresses.
 type NodeToAddress interface {
 	// NodeAddress resolves node id into an ip address without the port.

--- a/test/acceptance/recovery/network_isolation_test.go
+++ b/test/acceptance/recovery/network_isolation_test.go
@@ -25,7 +25,8 @@ import (
 )
 
 func TestNetworkIsolationSplitBrain(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
 
 	compose, err := docker.New().
 		With3NodeCluster().


### PR DESCRIPTION
Reverts weaviate/weaviate#8946

Chaos : https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17215745499