### PR TITLE
fix(raft): joiner avoid self join dials

### DIFF
--- a/cluster/bootstrap/joiner.go
+++ b/cluster/bootstrap/joiner.go
@@ -61,7 +61,7 @@ func (j *Joiner) Do(ctx context.Context, lg *logrus.Logger, remoteNodes map[stri
 
 	// For each server, try to join.
 	// If we have no error then we have a leader
-	// If we have an error check for err == NOT_FOUND and leader != "" -> we contacted a non-leader node part of the
+	// If we have an error check for err == NotLeaderRPCCode and leader != "" -> we contacted a non-leader node part of the
 	// cluster, let's join the leader.
 	// If no server allows us to join a cluster, return an error
 	for name, addr := range remoteNodes {

--- a/cluster/bootstrap/joiner.go
+++ b/cluster/bootstrap/joiner.go
@@ -92,7 +92,7 @@ func (j *Joiner) Do(ctx context.Context, lg *logrus.Logger, remoteNodes map[stri
 		lg.WithFields(logrus.Fields{
 			"action":                  "join",
 			"trying_remote_node_addr": addr,
-			"leader":                  leaderAddr,
+			"leader_address":          leaderAddr,
 			"rpc_status_code":         rpcStatusCode,
 		}).Info("attempted to join and failed")
 
@@ -103,7 +103,11 @@ func (j *Joiner) Do(ctx context.Context, lg *logrus.Logger, remoteNodes map[stri
 			if err == nil {
 				return leaderAddr, nil
 			}
-			lg.WithField("leader", leaderAddr).WithError(err).Info("attempted to follow to leader and failed")
+			lg.WithFields(logrus.Fields{
+				"action":          "join",
+				"leader_address":  leaderAddr,
+				"rpc_status_code": rpcStatusCode,
+			}).Info("attempted to follow to leader and failed")
 		}
 	}
 	return "", fmt.Errorf("could not join a cluster from %v", remoteNodes)

--- a/cluster/bootstrap/joiner_test.go
+++ b/cluster/bootstrap/joiner_test.go
@@ -1,0 +1,230 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package bootstrap
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/status"
+
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/rpc"
+)
+
+func TestJoiner_DoesNotAttemptSelfJoin(t *testing.T) {
+	t.Parallel()
+
+	logger := logrus.New()
+	ctx := context.Background()
+
+	localID := "weaviate-0"
+	localAddr := "127.0.0.1:8300"
+
+	// remoteNodes includes the local node (which must not be dialed) and a peer
+	remoteNodes := map[string]string{
+		"weaviate-0": localAddr,        // self
+		"weaviate-1": "127.0.0.2:8300", // peer
+	}
+
+	mpj := &mockPeerJoiner{results: map[string]struct {
+		resp *cmd.JoinPeerResponse
+		err  error
+	}{
+		// Simulate peer responds as leader and accepts join
+		"127.0.0.2:8300": {resp: &cmd.JoinPeerResponse{}, err: nil},
+		// If self were called, the test will fail before checking results
+	}}
+
+	j := NewJoiner(mpj, localID, localAddr, true)
+
+	leader, err := j.Do(ctx, logger, remoteNodes)
+	assert.NoError(t, err)
+	assert.NotEqual(t, localAddr, leader)
+
+	// Assert self address was never used in Join calls
+	for _, called := range mpj.calls {
+		assert.NotEqual(t, localAddr, called)
+	}
+	// And specifically verify zero self-join attempts
+	selfCalls := 0
+	for _, c := range mpj.calls {
+		if c == localAddr {
+			selfCalls++
+		}
+	}
+	assert.Equal(t, 0, selfCalls, "self-join must never be dialed")
+
+	// Sanity: ensure we attempted to join at least one remote
+	assert.NotEmpty(t, mpj.calls)
+}
+
+func TestJoiner_FollowsLeaderRedirection(t *testing.T) {
+	t.Parallel()
+
+	logger := logrus.New()
+	ctx := context.Background()
+
+	localID := "weaviate-0"
+	localAddr := "127.0.0.1:8300"
+	leaderAddr := "127.0.0.3:8300"
+
+	remoteNodes := map[string]string{
+		"weaviate-1": "127.0.0.2:8300",
+	}
+
+	mpj := &mockPeerJoiner{results: map[string]struct {
+		resp *cmd.JoinPeerResponse
+		err  error
+	}{
+		// First remote returns NotLeader with a leader address
+		"127.0.0.2:8300": {resp: &cmd.JoinPeerResponse{Leader: leaderAddr}, err: status.Error(rpc.NotLeaderRPCCode, "not leader")},
+		// Following the leader succeeds
+		leaderAddr: {resp: &cmd.JoinPeerResponse{}, err: nil},
+	}}
+
+	j := NewJoiner(mpj, localID, localAddr, true)
+
+	gotLeader, err := j.Do(ctx, logger, remoteNodes)
+	assert.NoError(t, err)
+	assert.Equal(t, leaderAddr, gotLeader)
+}
+
+func TestJoiner_ContinuesOnEmptyLeaderAndSucceedsNext(t *testing.T) {
+	t.Parallel()
+
+	logger := logrus.New()
+	ctx := context.Background()
+
+	localID := "weaviate-0"
+	localAddr := "127.0.0.1:8300"
+
+	remote1 := "127.0.0.2:8300"
+	remote2 := "127.0.0.3:8300"
+
+	remoteNodes := map[string]string{
+		"weaviate-1": remote1,
+		"weaviate-2": remote2,
+	}
+
+	mpj := &mockPeerJoiner{results: map[string]struct {
+		resp *cmd.JoinPeerResponse
+		err  error
+	}{
+		// First remote says NotLeader but with empty leader -> should continue
+		remote1: {resp: &cmd.JoinPeerResponse{Leader: ""}, err: status.Error(rpc.NotLeaderRPCCode, "not leader")},
+		// Second remote succeeds
+		remote2: {resp: &cmd.JoinPeerResponse{}, err: nil},
+	}}
+
+	j := NewJoiner(mpj, localID, localAddr, true)
+
+	gotLeader, err := j.Do(ctx, logger, remoteNodes)
+	assert.NoError(t, err)
+	assert.Equal(t, remote2, gotLeader)
+}
+
+func TestJoiner_ReturnsErrorWhenAllFail(t *testing.T) {
+	t.Parallel()
+
+	logger := logrus.New()
+	ctx := context.Background()
+
+	localID := "weaviate-0"
+	localAddr := "127.0.0.1:8300"
+
+	remoteNodes := map[string]string{
+		"weaviate-1": "127.0.0.2:8300",
+		"weaviate-2": "127.0.0.3:8300",
+	}
+
+	mpj := &mockPeerJoiner{results: map[string]struct {
+		resp *cmd.JoinPeerResponse
+		err  error
+	}{
+		// Both remotes fail with NotLeader but no leader provided -> nothing to follow
+		"127.0.0.2:8300": {resp: &cmd.JoinPeerResponse{Leader: ""}, err: status.Error(rpc.NotLeaderRPCCode, "not leader")},
+		"127.0.0.3:8300": {resp: &cmd.JoinPeerResponse{Leader: ""}, err: status.Error(rpc.NotLeaderRPCCode, "not leader")},
+	}}
+
+	j := NewJoiner(mpj, localID, localAddr, true)
+
+	_, err := j.Do(ctx, logger, remoteNodes)
+	assert.Error(t, err)
+}
+
+// Ensures that when a remote redirects us to the local node as leader,
+// the joiner does NOT attempt to dial the local raft address (no self-dial),
+// even indirectly through leader-follow logic.
+func TestJoiner_DoesNotDialSelfOnLeaderRedirection(t *testing.T) {
+	t.Parallel()
+
+	logger := logrus.New()
+	ctx := context.Background()
+
+	localID := "weaviate-0"
+	localAddr := "127.0.0.1:8300"
+	remote := "127.0.0.2:8300"
+
+	remoteNodes := map[string]string{
+		"weaviate-1": remote,
+	}
+
+	mpj := &mockPeerJoiner{results: map[string]struct {
+		resp *cmd.JoinPeerResponse
+		err  error
+	}{
+		// Remote says not leader and points to the local node as leader
+		remote: {resp: &cmd.JoinPeerResponse{Leader: localAddr}, err: status.Error(rpc.NotLeaderRPCCode, "not leader")},
+		// If self were dialed, we would need an entry for localAddr; absence asserts we never dial it
+	}}
+
+	j := NewJoiner(mpj, localID, localAddr, true)
+
+	gotLeader, err := j.Do(ctx, logger, remoteNodes)
+	// Current behavior: treat redirect-to-self as success without dialing self
+	assert.NoError(t, err)
+	assert.Equal(t, localAddr, gotLeader)
+
+	// Verify no dial to localAddr happened
+	for _, c := range mpj.calls {
+		assert.NotEqual(t, localAddr, c, "must not dial local leader address")
+	}
+	// And there should be exactly one call to the remote
+	assert.ElementsMatch(t, []string{remote}, mpj.calls)
+}
+
+// mockPeerJoiner implements PeerJoiner and records Join calls
+type mockPeerJoiner struct {
+	calls []string
+	// map of addr -> result (resp, err)
+	results map[string]struct {
+		resp *cmd.JoinPeerResponse
+		err  error
+	}
+}
+
+func (m *mockPeerJoiner) Join(_ context.Context, leaderAddr string, _ *cmd.JoinPeerRequest) (*cmd.JoinPeerResponse, error) {
+	m.calls = append(m.calls, leaderAddr)
+	if m.results != nil {
+		if r, ok := m.results[leaderAddr]; ok {
+			return r.resp, r.err
+		}
+	}
+	return &cmd.JoinPeerResponse{}, nil
+}
+
+func (m *mockPeerJoiner) Notify(_ context.Context, _ string, _ *cmd.NotifyPeerRequest) (*cmd.NotifyPeerResponse, error) {
+	return &cmd.NotifyPeerResponse{}, nil
+}


### PR DESCRIPTION
### What's being changed:
- Prevents nodes from repeatedly attempting to join themselves during bootstrap/restarts, which increased startup flakiness in our testing 
- Improves join clarity and leader redirection handling.
- add unit tests 
- improve logging 


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17822574973
- [x] E2E run : https://github.com/weaviate/weaviate-e2e-tests/actions/runs/17822593917
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
