### PR TITLE
Ensure Unlock called on all code paths of SPFresh.append

### DIFF
--- a/adapters/repos/db/vector/spfresh/insert.go
+++ b/adapters/repos/db/vector/spfresh/insert.go
@@ -91,12 +91,12 @@ func (s *SPFresh) append(ctx context.Context, vector Vector, postingID uint64, r
 		// might happen if we are reassigning
 		if s.VersionMap.Get(vector.ID()) == vector.Version() {
 			err := s.enqueueReassign(ctx, postingID, vector)
-			s.postingLocks.Unlock(postingID)
 			if err != nil {
+				s.postingLocks.Unlock(postingID)
 				return false, err
 			}
 		}
-
+		s.postingLocks.Unlock(postingID)
 		return false, nil
 	}
 


### PR DESCRIPTION
### What's being changed:

Without this change, if the posting still exists but the vector version is different, we could return without unlocking postingLocks. This change ensures we always unlock before returning from append.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
