### PR TITLE
chore: Make sure ErrAliasNotFound is in the ResolveAlias error chain

### DIFF
--- a/cluster/schema/manager_alias.go
+++ b/cluster/schema/manager_alias.go
@@ -75,7 +75,7 @@ func (s *SchemaManager) ResolveAlias(req *command.QueryRequest) ([]byte, error) 
 
 	rootClass := s.schema.ResolveAlias(subCommand.Alias)
 	if rootClass == "" {
-		return nil, fmt.Errorf("resolve alias: alias %q not found", subCommand.Alias)
+		return nil, fmt.Errorf("resolve alias: %s, %w", subCommand.Alias, ErrAliasNotFound)
 	}
 
 	response := command.QueryResolveAliasResponse{


### PR DESCRIPTION


### What's being changed:

Without this specific sentinal errors, it's hard to return correct status code say (404 not found) to the users in http api handlers

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
