### PR TITLE
Snapshots/add lock

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -53,6 +53,7 @@ type hnswCommitLogger struct {
 
 	allocChecker memwatch.AllocChecker
 
+	snapshotLock   sync.Mutex
 	snapshotLogger logrus.FieldLogger
 	// whether snapshots are disabled
 	snapshotDisabled bool

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -62,6 +62,9 @@ func snapshotDirectory(rootPath, name string) string {
 
 // Loads state of last available snapshot. Returns nil if no snaphshot was found.
 func (l *hnswCommitLogger) LoadSnapshot() (state *DeserializationResult, createdAt int64, err error) {
+	l.snapshotLock.Lock()
+	defer l.snapshotLock.Unlock()
+
 	logger, onFinish := l.setupSnapshotLogger(logrus.Fields{"method": "load_snapshot"})
 	defer func() { onFinish(err) }()
 
@@ -87,6 +90,9 @@ func (l *hnswCommitLogger) LoadSnapshot() (state *DeserializationResult, created
 // or from the entire commit log if there is no previous snapshot.
 // The snapshot state contains all but last commitlog (may still be in use and mutable).
 func (l *hnswCommitLogger) CreateSnapshot() (created bool, createdAt int64, err error) {
+	l.snapshotLock.Lock()
+	defer l.snapshotLock.Unlock()
+
 	logger, onFinish := l.setupSnapshotLogger(logrus.Fields{"method": "create_snapshot"})
 	defer func() { onFinish(err) }()
 
@@ -98,6 +104,9 @@ func (l *hnswCommitLogger) CreateSnapshot() (created bool, createdAt int64, err 
 // last snapshot. It is used at startup to automatically create a snapshot
 // while loading the commit log, to avoid having to load the commit log again.
 func (l *hnswCommitLogger) CreateAndLoadSnapshot() (state *DeserializationResult, createdAt int64, err error) {
+	l.snapshotLock.Lock()
+	defer l.snapshotLock.Unlock()
+
 	logger, onFinish := l.setupSnapshotLogger(logrus.Fields{"method": "create_and_load_snapshot"})
 	defer func() { onFinish(err) }()
 


### PR DESCRIPTION
### What's being changed:

This adds a mutex to prevent accidental concurrent snapshot creation. This could happen if `PERSISTENCE_HNSW_SNAPSHOT_INTERVAL_SECONDS` is very short and startup snapshot creation takes more time than that interval.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
