### PR TITLE
rbac: Require `read=true,collection=*` permission for get alias by name

### DIFF
--- a/test/acceptance/authz/rbac_auto_admin_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_admin_permissions_test.go
@@ -38,7 +38,6 @@ func TestAuthzAllEndpointsAdminDynamically(t *testing.T) {
 	var endpointStats endpointStatsSlice
 
 	className := "ABC"
-	aliasName := "AliasABC"
 	tenantNames := []string{
 		"Tenant1", "Tenant2", "Tenant3",
 	}

--- a/test/acceptance/authz/rbac_auto_admin_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_admin_permissions_test.go
@@ -51,10 +51,6 @@ func TestAuthzAllEndpointsAdminDynamically(t *testing.T) {
 	}
 	helper.CreateTenantsAuth(t, className, tenants, adminKey)
 
-	helper.CreateAliasAuth(t, &models.Alias{
-		Class: className,
-		Alias: aliasName,
-	}, adminKey)
 	col, err := newCollector()
 	require.Nil(t, err)
 
@@ -75,7 +71,7 @@ func TestAuthzAllEndpointsAdminDynamically(t *testing.T) {
 		url = strings.ReplaceAll(url, "{user_id}", "random-user")
 		url = strings.ReplaceAll(url, "{userType}", "db")
 		url = strings.ReplaceAll(url, "{groupType}", "oidc")
-		url = strings.ReplaceAll(url, "{aliasName}", aliasName)
+		url = strings.ReplaceAll(url, "{aliasName}", "aliasName")
 
 		t.Run(url+"("+strings.ToUpper(endpoint.method)+")", func(t *testing.T) {
 			require.NotContains(t, url, "{")

--- a/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
@@ -51,11 +51,6 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 	}
 	helper.CreateTenantsAuth(t, className, tenants, adminKey)
 
-	helper.CreateAliasAuth(t, &models.Alias{
-		Class: className,
-		Alias: aliasName,
-	}, adminKey)
-
 	col, err := newCollector()
 	require.Nil(t, err)
 
@@ -87,7 +82,7 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 		url = strings.ReplaceAll(url, "{user_id}", "admin-user")
 		url = strings.ReplaceAll(url, "{userType}", "db")
 		url = strings.ReplaceAll(url, "{groupType}", "oidc")
-		url = strings.ReplaceAll(url, "{aliasName}", aliasName)
+		url = strings.ReplaceAll(url, "{aliasName}", "aliasName")
 
 		t.Run(url+"("+strings.ToUpper(endpoint.method)+")", func(t *testing.T) {
 			require.NotContains(t, url, "{")

--- a/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
@@ -35,7 +35,6 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 
 	// create class via admin
 	className := "ABC"
-	aliasName := "AliasABC"
 	tenantNames := []string{
 		"Tenant1", "Tenant2", "Tenant3",
 	}


### PR DESCRIPTION

### What's being changed:
This is basically reverting the changes we made in other PR #8949

Rationale:
1. When RBAC is enabled, if we try to access any resource without knowing what collection it belongs to we make sure the user need to have read permission on all collections.
2. This is consistent with RBAC model for other resources (shards, tenants, nodes, etc)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
