### PR TITLE
dynamic index: prevent store locking during upgrades

### DIFF
--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -42,7 +42,10 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
-const composerUpgradedKey = "upgraded"
+const (
+	composerUpgradedKey = "upgraded"
+	batchSize           = 100
+)
 
 var dynamicBucket = []byte("dynamic")
 
@@ -568,30 +571,11 @@ func (dynamic *dynamic) doUpgrade() error {
 		return err
 	}
 
-	bucket := dynamic.store.Bucket(dynamic.getBucketName())
-
-	cursor := bucket.Cursor()
-
-	for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
-		if dynamic.ctx.Err() != nil {
-			cursor.Close()
-			// context was cancelled, stop processing
-			dynamic.RUnlock()
-			return dynamic.ctx.Err()
-		}
-
-		id := binary.BigEndian.Uint64(k)
-		vc := make([]float32, len(v)/4)
-		float32SliceFromByteSlice(v, vc)
-
-		err := index.Add(dynamic.ctx, id, vc)
-		if err != nil {
-			dynamic.logger.WithField("id", id).WithError(err).Error("failed to add vector")
-			continue
-		}
+	err = dynamic.copyToVectorIndex(index)
+	if err != nil {
+		dynamic.RUnlock()
+		return err
 	}
-
-	cursor.Close()
 
 	// end of read-only zone
 	dynamic.RUnlock()
@@ -641,6 +625,63 @@ func (dynamic *dynamic) doUpgrade() error {
 	}
 	if len(errs) > 0 {
 		dynamic.logger.Warn(simpleErrors.Join(errs...))
+	}
+
+	return nil
+}
+
+// Loop over the store and add each vector to the HNSW.
+// This can take a while, so we use short-lived cursors to not block
+// other operations on the KV store (e.g. flush)
+func (dynamic *dynamic) copyToVectorIndex(index VectorIndex) error {
+	bucket := dynamic.store.Bucket(dynamic.getBucketName())
+
+	var k, v []byte
+
+	var ids []uint64
+	var vectors [][]float32
+
+	for {
+		ids = ids[:0]
+		vectors = vectors[:0]
+
+		cursor := bucket.Cursor()
+
+		if len(k) == 0 {
+			k, v = cursor.First()
+		} else {
+			k, v = cursor.Seek(k)
+		}
+
+		var i int
+		for k != nil && i < batchSize {
+			if err := dynamic.ctx.Err(); err != nil {
+				cursor.Close()
+				// context was cancelled, stop processing
+				return err
+			}
+
+			id := binary.BigEndian.Uint64(k)
+			vc := make([]float32, len(v)/4)
+			float32SliceFromByteSlice(v, vc)
+
+			ids = append(ids, id)
+			vectors = append(vectors, vc)
+
+			k, v = cursor.Next()
+			i++
+		}
+
+		cursor.Close()
+
+		err := index.AddBatch(dynamic.ctx, ids, vectors)
+		if err != nil {
+			dynamic.logger.WithField("ids", ids).WithError(err).Error("failed to add vectors")
+		}
+
+		if k == nil {
+			break
+		}
 	}
 
 	return nil

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -44,7 +44,7 @@ import (
 
 const (
 	composerUpgradedKey = "upgraded"
-	batchSize           = 100
+	batchSize           = 500
 )
 
 var dynamicBucket = []byte("dynamic")
@@ -676,7 +676,7 @@ func (dynamic *dynamic) copyToVectorIndex(index VectorIndex) error {
 
 		err := index.AddBatch(dynamic.ctx, ids, vectors)
 		if err != nil {
-			dynamic.logger.WithField("ids", ids).WithError(err).Error("failed to add vectors")
+			dynamic.logger.WithError(err).Error("failed to add vectors")
 		}
 
 		if k == nil {

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -553,6 +553,4 @@ func TestDynamicAndStoreOperations(t *testing.T) {
 	}
 
 	close(ch)
-
-	require.True(t, false)
 }

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/noop"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -463,4 +464,95 @@ func TestDynamicWithDifferentCompressionSchema(t *testing.T) {
 	dynamic.PostStartup()
 	recall2, _ := testinghelpers.RecallAndLatency(ctx, queries, k, dynamic, truths)
 	assert.Equal(t, recall, recall2)
+}
+
+func TestDynamicAndStoreOperations(t *testing.T) {
+	ctx := context.Background()
+	currentIndexing := os.Getenv("ASYNC_INDEXING")
+	os.Setenv("ASYNC_INDEXING", "true")
+	defer os.Setenv("ASYNC_INDEXING", currentIndexing)
+	dimensions := 20
+	vectors_size := 1_000
+	queries_size := 10
+	k := 10
+
+	db, err := bbolt.Open(filepath.Join(t.TempDir(), "index.db"), 0o666, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	vectors, queries := testinghelpers.RandomVecs(vectors_size, queries_size, dimensions)
+	rootPath := t.TempDir()
+	distancer := distancer.NewL2SquaredProvider()
+	truths := make([][]uint64, queries_size)
+	compressionhelpers.Concurrently(logger, uint64(len(queries)), func(i uint64) {
+		truths[i], _ = testinghelpers.BruteForce(logger, vectors, queries[i], k, testinghelpers.DistanceWrapper(distancer))
+	})
+	noopCallback := cyclemanager.NewCallbackGroupNoop()
+	fuc := flatent.UserConfig{}
+	fuc.SetDefaults()
+	hnswuc := hnswent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        64,
+		EF:                    32,
+		VectorCacheMaxObjects: 1_000_000,
+	}
+	dynamic, err := New(Config{
+		RootPath:              rootPath,
+		ID:                    "nil-vector-test",
+		MakeCommitLoggerThunk: hnsw.MakeNoopCommitLogger,
+		DistanceProvider:      distancer,
+		VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+			vec := vectors[int(id)]
+			if vec == nil {
+				return nil, storobj.NewErrNotFoundf(id, "nil vec")
+			}
+			return vec, nil
+		},
+		TempVectorForIDThunk: TempVectorForIDThunk(vectors),
+		TombstoneCallbacks:   noopCallback,
+		SharedDB:             db,
+	}, ent.UserConfig{
+		Threshold: uint64(vectors_size),
+		Distance:  distancer.Type(),
+		HnswUC:    hnswuc,
+		FlatUC:    fuc,
+	}, testinghelpers.NewDummyStore(t))
+	assert.Nil(t, err)
+
+	compressionhelpers.Concurrently(logger, uint64(vectors_size), func(i uint64) {
+		err := dynamic.Add(ctx, i, vectors[i])
+		require.NoError(t, err)
+	})
+
+	shouldUpgrade, at := dynamic.ShouldUpgrade()
+	assert.True(t, shouldUpgrade)
+	assert.Equal(t, vectors_size, at)
+	assert.False(t, dynamic.Upgraded())
+
+	ch := make(chan struct{})
+	idx := noop.Index{
+		AddFn: func(ctx context.Context, id uint64, vector []float32) error {
+			<-ch
+			return nil
+		},
+	}
+
+	go func() {
+		err = dynamic.copyToVectorIndex(&idx)
+		require.NoError(t, err)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	for i := 0; i < 100; i++ {
+		err = dynamic.store.Bucket(dynamic.getBucketName()).FlushAndSwitch()
+		time.Sleep(1 * time.Millisecond)
+		require.NoError(t, err)
+	}
+
+	close(ch)
+
+	require.True(t, false)
 }

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -540,7 +540,7 @@ func TestDynamicAndStoreOperations(t *testing.T) {
 	}
 
 	go func() {
-		err = dynamic.copyToVectorIndex(&idx)
+		err := dynamic.copyToVectorIndex(&idx)
 		require.NoError(t, err)
 	}()
 

--- a/adapters/repos/db/vector/noop/index.go
+++ b/adapters/repos/db/vector/noop/index.go
@@ -24,13 +24,19 @@ import (
 	hnswconf "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
-type Index struct{}
+type Index struct {
+	AddFn      func(ctx context.Context, id uint64, vector []float32) error
+	AddBatchFn func(ctx context.Context, id []uint64, vector [][]float32) error
+}
 
 func NewIndex() *Index {
 	return &Index{}
 }
 
 func (i *Index) AddBatch(ctx context.Context, id []uint64, vector [][]float32) error {
+	if i.AddBatchFn != nil {
+		return i.AddBatchFn(ctx, id, vector)
+	}
 	// silently ignore
 	return nil
 }
@@ -41,6 +47,9 @@ func (i *Index) AddMultiBatch(ctx context.Context, docIds []uint64, vectors [][]
 }
 
 func (i *Index) Add(ctx context.Context, id uint64, vector []float32) error {
+	if i.AddFn != nil {
+		return i.AddFn(ctx, id, vector)
+	}
 	// silently ignore
 	return nil
 }


### PR DESCRIPTION
### What's being changed:

During upgrades on the dynamic index, we keep a bucket cursor open to copy/index data from the flat index to HNSW.
Since this operation can take a very long time (e.g. 4min for 100k vectors), it prevents other scheduled LSM store operations that require a write lock on the bucket (in this case, `bucket.FlushAndSwitch`).
Because mutexes in Go are write-preferring, any subsequent RLock gets blocked until the write Lock succeeds.
This in turns prevents regular import operations when they are trying to flush the buckets (RLock).

This makes it impossible to import data to a dynamic index while it's being upgraded.

This PR fixes this by using short-term cursors and indexing in batch, instead of streaming the vectors from one vector index to another.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17395019230
- [x] E2E pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/17395017483
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
