### PR TITLE
raft: Fix skipping the error return from leader

### DIFF
--- a/cluster/raft_query_endpoints.go
+++ b/cluster/raft_query_endpoints.go
@@ -392,6 +392,7 @@ func (s *Raft) Query(ctx context.Context, req *cmd.QueryRequest) (*cmd.QueryResp
 	resp, err := s.cl.Query(ctx, leader, req)
 	if err != nil {
 		s.log.WithField("leader", leader).Errorf("query: failed to query leader: %s", err)
+		return &cmd.QueryResponse{}, err
 	}
 	return resp, err
 }


### PR DESCRIPTION


### What's being changed:

If query forwarded to leader from the follower failes in leader, those errors are skipped to be propaged to the follower.

Identified this issue when testing alias with RBAC + OIDC. Thanks to @Jose :)

Basically, on the follower side, we should stop as soon as alias is not found. but Follower ignores this error (NOT FOUND) from the leader

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
