### PR TITLE
fix(raft-transport): avoid invalid ports to avoid rollout errors and tweak memberlist config

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1045,7 +1045,7 @@ func startupRoutine(ctx context.Context, options *swag.CommandLineOptionsGroup) 
 	if cfg := serverConfig.Config.Raft; cfg.MetadataOnlyVoters {
 		nonStorageNodes = parseVotersNames(cfg)
 	}
-	clusterState, err := cluster.Init(serverConfig.Config.Cluster, serverConfig.Config.Raft.BootstrapExpect, dataPath, nonStorageNodes, logger)
+	clusterState, err := cluster.Init(serverConfig.Config.Cluster, serverConfig.Config.Raft.TimeoutsMultiplier, dataPath, nonStorageNodes, logger)
 	if err != nil {
 		logger.WithField("action", "startup").WithError(err).
 			Error("could not init cluster state")

--- a/cluster/bootstrap/bootstrap.go
+++ b/cluster/bootstrap/bootstrap.go
@@ -19,9 +19,11 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/sirupsen/logrus"
+
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/resolver"
 	entSentry "github.com/weaviate/weaviate/entities/sentry"
+	"github.com/weaviate/weaviate/usecases/config"
 )
 
 // PeerJoiner is the interface we expect to be able to talk to the other peers to either Join or Notify them
@@ -149,12 +151,22 @@ func (b *Bootstrapper) notify(ctx context.Context, remoteNodes map[string]string
 }
 
 // ResolveRemoteNodes returns a list of remoteNodes addresses resolved using addrResolver. The nodes id used are
-// taken from serverPortMap keys and ports from the values
+// taken from serverPortMap keys and ports from the values. Additionally, it includes nodes discovered via memberlist
+// to handle cases where the join config is incomplete.
 func ResolveRemoteNodes(addrResolver resolver.ClusterStateReader, serverPortMap map[string]int) map[string]string {
 	candidates := make(map[string]string, len(serverPortMap))
 	for name, raftPort := range serverPortMap {
 		if addr := addrResolver.NodeAddress(name); addr != "" {
 			candidates[name] = fmt.Sprintf("%s:%d", addr, raftPort)
+		}
+	}
+
+	// this is a fallback for cases where the join config is incomplete
+	memberlistNodes := addrResolver.AllClusterMembers(config.DefaultRaftPort)
+	for name, addr := range memberlistNodes {
+		// Only add memberlist nodes that are NOT already in the join configuration
+		if _, exists := serverPortMap[name]; !exists {
+			candidates[name] = addr
 		}
 	}
 	return candidates

--- a/cluster/bootstrap/bootstrap.go
+++ b/cluster/bootstrap/bootstrap.go
@@ -162,7 +162,7 @@ func ResolveRemoteNodes(addrResolver resolver.ClusterStateReader, serverPortMap 
 	}
 
 	// this is a fallback for cases where the join config is incomplete
-	memberlistNodes := addrResolver.AllClusterMembers(config.DefaultRaftPort)
+	memberlistNodes := addrResolver.AllOtherClusterMembers(config.DefaultRaftPort)
 	for name, addr := range memberlistNodes {
 		// Only add memberlist nodes that are NOT already in the join configuration
 		if _, exists := serverPortMap[name]; !exists {

--- a/cluster/bootstrap/joiner.go
+++ b/cluster/bootstrap/joiner.go
@@ -58,14 +58,19 @@ func (j *Joiner) Do(ctx context.Context, lg *logrus.Logger, remoteNodes map[stri
 	var resp *cmd.JoinPeerResponse
 	var err error
 	req := &cmd.JoinPeerRequest{Id: j.localNodeID, Address: j.localRaftAddr, Voter: j.voter}
-	lg.WithField("remoteNodes", remoteNodes).Info("attempting to join")
 
 	// For each server, try to join.
 	// If we have no error then we have a leader
 	// If we have an error check for err == NOT_FOUND and leader != "" -> we contacted a non-leader node part of the
 	// cluster, let's join the leader.
 	// If no server allows us to join a cluster, return an error
-	for _, addr := range remoteNodes {
+	for name, addr := range remoteNodes {
+		lg.WithFields(logrus.Fields{
+			"action":         "join",
+			"node":           name,
+			"local_address":  j.localRaftAddr,
+			"remote_address": addr,
+		}).Info("attempting to join")
 		resp, err = j.peerJoiner.Join(ctx, addr, req)
 		if err == nil {
 			return addr, nil

--- a/cluster/resolver/raft.go
+++ b/cluster/resolver/raft.go
@@ -23,13 +23,6 @@ import (
 	"github.com/weaviate/weaviate/cluster/log"
 )
 
-const (
-	// RaftTcpMaxPool controls how many connections raft transport will pool
-	raftTcpMaxPool = 3
-	// RaftTcpTimeout is used to apply I/O deadlines.
-	raftTcpTimeout = 10 * time.Second
-)
-
 type raft struct {
 	// ClusterStateReader allows the raft to also be used to the current cluster state
 	ClusterStateReader
@@ -65,7 +58,7 @@ func (a *raft) ServerAddr(id raftImpl.ServerID) (raftImpl.ServerAddress, error) 
 	// Update the internal notResolvedNodes if the addr if empty, otherwise delete it from the map
 	if addr == "" {
 		a.notResolvedNodes.Store(id, struct{}{})
-		return raftImpl.ServerAddress(invalidAddr), nil
+		return "", fmt.Errorf("could not resolve server id %s", id)
 	}
 	a.notResolvedNodes.Delete(id)
 
@@ -74,7 +67,12 @@ func (a *raft) ServerAddr(id raftImpl.ServerID) (raftImpl.ServerAddress, error) 
 	if !a.IsLocalCluster {
 		return raftImpl.ServerAddress(fmt.Sprintf("%s:%d", addr, a.RaftPort)), nil
 	}
-	return raftImpl.ServerAddress(fmt.Sprintf("%s:%d", addr, a.NodeNameToPortMap[string(id)])), nil
+	port, exists := a.NodeNameToPortMap[string(id)]
+	if !exists {
+		// if does not exist, use the default raft port, self healing from bad config
+		port = a.RaftPort
+	}
+	return raftImpl.ServerAddress(fmt.Sprintf("%s:%d", addr, port)), nil
 }
 
 // NewTCPTransport returns a new raft.NetworkTransportConfig that utilizes
@@ -89,8 +87,8 @@ func (a *raft) NewTCPTransport(
 ) (*raftImpl.NetworkTransport, error) {
 	cfg := &raftImpl.NetworkTransportConfig{
 		ServerAddressProvider: a,
-		MaxPool:               raftTcpMaxPool,
-		Timeout:               raftTcpTimeout,
+		MaxPool:               maxPool,
+		Timeout:               timeout,
 		Logger:                log.NewHCLogrusLogger("raft-net", logger),
 	}
 	return raftImpl.NewTCPTransportWithConfig(bindAddr, advertise, cfg)
@@ -103,4 +101,9 @@ func (a *raft) NotResolvedNodes() map[raftImpl.ServerID]struct{} {
 		return true
 	})
 	return notResolvedNodes
+}
+
+// AllClusterMembers returns all cluster members discovered via memberlist with their raft addresses
+func (a *raft) AllClusterMembers(raftPort int) map[string]string {
+	return a.ClusterStateReader.AllClusterMembers(raftPort)
 }

--- a/cluster/resolver/raft.go
+++ b/cluster/resolver/raft.go
@@ -103,7 +103,7 @@ func (a *raft) NotResolvedNodes() map[raftImpl.ServerID]struct{} {
 	return notResolvedNodes
 }
 
-// AllClusterMembers returns all cluster members discovered via memberlist with their raft addresses
-func (a *raft) AllClusterMembers(raftPort int) map[string]string {
-	return a.ClusterStateReader.AllClusterMembers(raftPort)
+// AllOtherClusterMembers returns all cluster members discovered via memberlist with their raft addresses
+func (a *raft) AllOtherClusterMembers(raftPort int) map[string]string {
+	return a.ClusterStateReader.AllOtherClusterMembers(raftPort)
 }

--- a/cluster/resolver/types.go
+++ b/cluster/resolver/types.go
@@ -11,10 +11,6 @@
 
 package resolver
 
-const (
-	invalidAddr = "256.256.256.256:99999999"
-)
-
 // ClusterStateReader allows the resolver to compute node-id to ip addresses.
 type ClusterStateReader interface {
 	// NodeAddress resolves node id into an ip address without the port.
@@ -23,6 +19,9 @@ type ClusterStateReader interface {
 	NodeHostname(nodeName string) (string, bool)
 	// LocalName returns the local node name
 	LocalName() string
+	// AllClusterMembers returns all cluster members discovered via memberlist with their addresses
+	// This is useful for bootstrap when the join config is incomplete
+	AllClusterMembers(port int) map[string]string
 }
 
 type RaftConfig struct {

--- a/cluster/resolver/types.go
+++ b/cluster/resolver/types.go
@@ -19,9 +19,9 @@ type ClusterStateReader interface {
 	NodeHostname(nodeName string) (string, bool)
 	// LocalName returns the local node name
 	LocalName() string
-	// AllClusterMembers returns all cluster members discovered via memberlist with their addresses
+	// AllOtherClusterMembers returns all cluster members discovered via memberlist with their addresses
 	// This is useful for bootstrap when the join config is incomplete
-	AllClusterMembers(port int) map[string]string
+	AllOtherClusterMembers(port int) map[string]string
 }
 
 type RaftConfig struct {

--- a/cluster/rpc/server.go
+++ b/cluster/rpc/server.go
@@ -178,7 +178,7 @@ func (s *Server) Open() error {
 // Close closes the server and free any used ressources.
 func (s *Server) Close() {
 	if s.grpcServer != nil {
-		s.grpcServer.Stop()
+		s.grpcServer.GracefulStop()
 	}
 }
 

--- a/test/acceptance/recovery/network_isolation_test.go
+++ b/test/acceptance/recovery/network_isolation_test.go
@@ -25,8 +25,7 @@ import (
 )
 
 func TestNetworkIsolationSplitBrain(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	defer cancel()
+	ctx := context.Background()
 
 	compose, err := docker.New().
 		With3NodeCluster().

--- a/usecases/cluster/mocks/node_selector.go
+++ b/usecases/cluster/mocks/node_selector.go
@@ -41,6 +41,10 @@ func (m memberlist) NodeHostname(name string) (string, bool) {
 	return "", false
 }
 
+func (m memberlist) AllClusterMembers(port int) map[string]string {
+	return map[string]string{}
+}
+
 func (m memberlist) LocalName() string {
 	if len(m.nodes) == 0 {
 		return ""

--- a/usecases/cluster/mocks/node_selector.go
+++ b/usecases/cluster/mocks/node_selector.go
@@ -41,7 +41,7 @@ func (m memberlist) NodeHostname(name string) (string, bool) {
 	return "", false
 }
 
-func (m memberlist) AllClusterMembers(port int) map[string]string {
+func (m memberlist) AllOtherClusterMembers(port int) map[string]string {
 	return map[string]string{}
 }
 

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -42,10 +42,10 @@ type NodeSelector interface {
 	// NodeHostname return hosts address for a specific node name
 	NodeHostname(name string) (string, bool)
 	AllHostnames() []string
-	// AllClusterMembers returns all cluster members discovered via memberlist with their raft addresses
+	// AllOtherClusterMembers returns all cluster members discovered via memberlist with their raft addresses
 	// This is useful for bootstrap when the join config is incomplete
 	// TODO-RAFT: shall be removed once unifying with raft package
-	AllClusterMembers(port int) map[string]string
+	AllOtherClusterMembers(port int) map[string]string
 }
 
 type State struct {
@@ -305,9 +305,9 @@ func (s *State) NodeAddress(id string) string {
 	return strings.Split(addr, ":")[0] // get address without port
 }
 
-// AllClusterMembers returns all cluster members discovered via memberlist with their raft addresses
+// AllOtherClusterMembers returns all cluster members discovered via memberlist with their raft addresses
 // This is useful for bootstrap when the join config is incomplete
-func (s *State) AllClusterMembers(port int) map[string]string {
+func (s *State) AllOtherClusterMembers(port int) map[string]string {
 	if s.list == nil {
 		return map[string]string{}
 	}

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/hashicorp/memberlist"
 	"github.com/pkg/errors"
@@ -41,6 +42,10 @@ type NodeSelector interface {
 	// NodeHostname return hosts address for a specific node name
 	NodeHostname(name string) (string, bool)
 	AllHostnames() []string
+	// AllClusterMembers returns all cluster members discovered via memberlist with their raft addresses
+	// This is useful for bootstrap when the join config is incomplete
+	// TODO-RAFT: shall be removed once unifying with raft package
+	AllClusterMembers(port int) map[string]string
 }
 
 type State struct {
@@ -75,9 +80,6 @@ type Config struct {
 	// them in maintenance mode. In addition, we may want to have the cluster nodes not in
 	// maintenance mode be aware of which nodes are in maintenance mode in the future.
 	MaintenanceNodes []string `json:"maintenanceNodes" yaml:"maintenanceNodes"`
-	// RaftBootstrapExpect is used to detect split-brain scenarios and attempt to rejoin the cluster
-	// TODO-RAFT-DB-63 : shall be removed once NodeAddress() is moved under raft cluster package
-	RaftBootstrapExpect int
 }
 
 type AuthConfig struct {
@@ -93,9 +95,15 @@ func (ba BasicAuth) Enabled() bool {
 	return ba.Username != "" || ba.Password != ""
 }
 
-func Init(userConfig Config, raftBootstrapExpect int, dataPath string, nonStorageNodes map[string]struct{}, logger logrus.FieldLogger) (_ *State, err error) {
-	userConfig.RaftBootstrapExpect = raftBootstrapExpect
+func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonStorageNodes map[string]struct{}, logger logrus.FieldLogger) (_ *State, err error) {
 	cfg := memberlist.DefaultLANConfig()
+	// DeadNodeReclaimTime controls the time before a dead node's name can be
+	// reclaimed by one with a different address or port. By default, this is 0,
+	// meaning nodes cannot be reclaimed this way.
+	cfg.DeadNodeReclaimTime = 30 * time.Second
+	// TCPTimeout default is 10, however in case of rollouts we need to increase it
+	// to avoid timeouts during the rollout
+	cfg.TCPTimeout = 10 * time.Second * time.Duration(raftTimeoutsMultiplier)
 	cfg.LogOutput = newLogParser(logger)
 	cfg.Name = userConfig.Hostname
 	state := State{
@@ -127,6 +135,7 @@ func Init(userConfig Config, raftBootstrapExpect int, dataPath string, nonStorag
 
 	if userConfig.FastFailureDetection {
 		cfg.SuspicionMult = 1
+		cfg.DeadNodeReclaimTime = 5 * time.Second
 	}
 
 	if state.list, err = memberlist.Create(cfg); err != nil {
@@ -288,38 +297,29 @@ func (s *State) NodeHostname(nodeName string) (string, bool) {
 // NodeAddress is used to resolve the node name into an ip address without the port
 // TODO-RAFT-DB-63 : shall be replaced by Members() which returns members in the list
 func (s *State) NodeAddress(id string) string {
-	// network interruption detection which can cause a single node to be isolated from the cluster (split brain)
-	nodeCount := s.list.NumMembers()
-	var joinAddr []string
-	if s.config.Join != "" {
-		joinAddr = strings.Split(s.config.Join, ",")
-	}
-	if nodeCount == 1 && len(joinAddr) > 0 && s.config.RaftBootstrapExpect > 1 {
-		s.delegate.log.WithFields(logrus.Fields{
-			"action":     "memberlist_rejoin",
-			"node_count": nodeCount,
-		}).Warn("detected single node split-brain, attempting to rejoin memberlist cluster")
-		// Only attempt rejoin if we're supposed to be part of a larger cluster
-		_, err := s.list.Join(joinAddr)
-		if err != nil {
-			s.delegate.log.WithFields(logrus.Fields{
-				"action":          "memberlist_rejoin",
-				"remote_hostname": joinAddr,
-			}).WithError(err).Error("memberlist rejoin not successful")
-		} else {
-			s.delegate.log.WithFields(logrus.Fields{
-				"action":     "memberlist_rejoin",
-				"node_count": s.list.NumMembers(),
-			}).Info("Successfully rejoined the memberlist cluster")
-		}
+	addr, ok := s.NodeHostname(id)
+	if !ok {
+		return ""
 	}
 
-	for _, mem := range s.list.Members() {
-		if mem.Name == id {
-			return mem.Addr.String()
-		}
+	return strings.Split(addr, ":")[0] // get address without port
+}
+
+// AllClusterMembers returns all cluster members discovered via memberlist with their raft addresses
+// This is useful for bootstrap when the join config is incomplete
+func (s *State) AllClusterMembers(port int) map[string]string {
+	if s.list == nil {
+		return map[string]string{}
 	}
-	return ""
+
+	members := s.list.Members()
+	result := make(map[string]string, len(members))
+
+	for _, m := range members {
+		result[m.Name] = fmt.Sprintf("%s:%d", m.Addr.String(), port)
+	}
+
+	return result
 }
 
 func (s *State) SchemaSyncIgnored() bool {

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -316,6 +316,10 @@ func (s *State) AllClusterMembers(port int) map[string]string {
 	result := make(map[string]string, len(members))
 
 	for _, m := range members {
+		if m.Name == s.list.LocalNode().Name {
+			// skip self
+			continue
+		}
 		result[m.Name] = fmt.Sprintf("%s:%d", m.Addr.String(), port)
 	}
 


### PR DESCRIPTION
### What's being changed:
a while back we had an issue where serveless clusters were merging and we introduced a [hot fix](https://github.com/weaviate/weaviate/pull/5668) which instead of reporting an error we were reporting an invalid port and this caused Raft to think that the node is alive but actually it wasn't in rollouts case. the hot fix did serve us well, however now we rolled out mTLS everywhere so we won't need this hot fix any more.

this PR fallback to original behaviour by reporting an error on transport if the cluster ID doesn't exists in memberlist and we shall not see `"error":"dial tcp: address 99999999: invalid port"` anymore , err count dropped from `~300` -> `~88`

**errors count before** 
<img width="1707" height="209" alt="Screenshot 2025-08-19 at 17 21 49" src="https://github.com/user-attachments/assets/9d94eb63-9517-45ee-8170-ecc23980807a" />

**errors count after** 
<img width="1715" height="240" alt="Screenshot 2025-08-19 at 17 23 23" src="https://github.com/user-attachments/assets/a4cdbb53-27c2-4492-83ff-7530ce87fde8" />


this PR is one of multiple PRs and has follow up 
- https://github.com/weaviate/weaviate/pull/9010
- https://github.com/weaviate/weaviate/pull/9065
- https://github.com/weaviate/weaviate/pull/9200
- https://github.com/weaviate/weaviate/pull/9230
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
