### PR TITLE
refact(track-vector): adjust reported RQ 1 and 8 bits 

### DIFF
--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -405,6 +405,17 @@ func TestTotalDimensionTrackingMetrics(t *testing.T) {
 		expectSegments   float64
 	}{
 		{
+			name: "named_with_rq_8bit",
+			namedVectorConfig: func() enthnsw.UserConfig {
+				cfg := enthnsw.NewDefaultUserConfig()
+				cfg.RQ.Enabled = true
+				cfg.RQ.Bits = 8
+				return cfg
+			},
+
+			expectDimensions: dimensionsPerVector * objectCount,
+		},
+		{
 			name:         "legacy",
 			vectorConfig: func() enthnsw.UserConfig { return enthnsw.NewDefaultUserConfig() },
 

--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -405,17 +405,6 @@ func TestTotalDimensionTrackingMetrics(t *testing.T) {
 		expectSegments   float64
 	}{
 		{
-			name: "named_with_rq_8bit",
-			namedVectorConfig: func() enthnsw.UserConfig {
-				cfg := enthnsw.NewDefaultUserConfig()
-				cfg.RQ.Enabled = true
-				cfg.RQ.Bits = 8
-				return cfg
-			},
-
-			expectDimensions: dimensionsPerVector * objectCount,
-		},
-		{
 			name:         "legacy",
 			vectorConfig: func() enthnsw.UserConfig { return enthnsw.NewDefaultUserConfig() },
 
@@ -480,6 +469,17 @@ func TestTotalDimensionTrackingMetrics(t *testing.T) {
 			multiVectorConfig: func() enthnsw.UserConfig { return enthnsw.NewDefaultUserConfig() },
 			expectDimensions:  multiVecCard * dimensionsPerVector * objectCount,
 			expectSegments:    (dimensionsPerVector / 8) * objectCount,
+		},
+		{
+			name: "named_with_rq_8bit",
+			namedVectorConfig: func() enthnsw.UserConfig {
+				cfg := enthnsw.NewDefaultUserConfig()
+				cfg.RQ.Enabled = true
+				cfg.RQ.Bits = 8
+				return cfg
+			},
+
+			expectDimensions: dimensionsPerVector * objectCount,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
@@ -113,8 +114,12 @@ func (h *hnsw) AddBatch(ctx context.Context, ids []uint64, vectors [][]float32) 
 				h.allocChecker, int(h.rqConfig.Bits), int(h.dims))
 
 			if err == nil {
+				h.Lock()
+				defer h.Unlock()
 				h.compressed.Store(true)
-				h.cache.Drop()
+				if h.cache != nil {
+					h.cache.Drop()
+				}
 				h.cache = nil
 				h.compressor.PersistCompression(h.commitLog)
 			}


### PR DESCRIPTION
### What's being changed:
this PR address for legacy billing 
RQ 8 Bit
Legacy billing provides no discount (the same as SQ)
RQ 1 Bit
Legacy billing provides same discount as BQ but provides metric `vector_dimensions_sum` instead of `vector_segments_sum`



### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
