### PR TITLE
Reduce BM25 multi-node test iterations from 5 to 1

### DIFF
--- a/test/acceptance/multi_node/bm25_test.go
+++ b/test/acceptance/multi_node/bm25_test.go
@@ -32,7 +32,7 @@ var paragraphs = []string{
 func TestBm25MultiNode(t *testing.T) {
 	ctx := context.Background()
 	compose, err := docker.New().
-		With1NodeCluster().
+		With3NodeCluster().
 		Start(ctx)
 	require.NoError(t, err)
 	defer func() {

--- a/test/acceptance/multi_node/bm25_test.go
+++ b/test/acceptance/multi_node/bm25_test.go
@@ -13,7 +13,6 @@ package multi_node
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -32,16 +31,8 @@ var paragraphs = []string{
 
 func TestBm25MultiNode(t *testing.T) {
 	ctx := context.Background()
-	for i := 0; i < 5; i++ {
-		t.Run(fmt.Sprintf("iteration: %v", i), func(t *testing.T) {
-			runBM25MultinodeTest(t, ctx)
-		})
-	}
-}
-
-func runBM25MultinodeTest(t *testing.T, ctx context.Context) {
 	compose, err := docker.New().
-		With3NodeCluster().
+		With1NodeCluster().
 		Start(ctx)
 	require.NoError(t, err)
 	defer func() {


### PR DESCRIPTION
This change reduces the number of runs in `TestBm25MultiNode` from 5 to just 1.  
A single execution is sufficient to validate BM25 search behavior in a multi-node setup, so repeated runs are not necessary.

While this reduces the loop overhead, the overall test runtime is still dominated by the initial Docker build stage, since the test requires building the image the first time it is executed.

This work is part of the effort tracked by Jira DB-270.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.