### PR TITLE
fix: extract all grpc multi ref targets

### DIFF
--- a/adapters/handlers/grpc/v1/batch/parse.go
+++ b/adapters/handlers/grpc/v1/batch/parse.go
@@ -170,7 +170,11 @@ func extractMultiRefTarget(class *models.Class, properties []*pb.BatchObject_Mul
 		for j, uid := range refMulti.Uuids {
 			beacons[j] = map[string]interface{}{"beacon": BEACON_START + refMulti.TargetCollection + "/" + uid}
 		}
-		props[propName] = beacons
+		if props[propName] == nil {
+			props[propName] = beacons
+		} else {
+			props[propName] = append(props[propName].([]interface{}), beacons...)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
### What's being changed:
If `BatchObject_MultiTargetRefProps` contained multiple references of same property, latter reference used to overwrite previous one resulting in only latest reference being extracted and stored. Now all references are extracted.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
