### PR TITLE
Split `acceptance-only-fast` into 4 parallel groups

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -352,6 +352,32 @@ jobs:
           ANTHROPIC_APIKEY: ${{ secrets.ANTHROPIC_APIKEY }}
           JINAAI_APIKEY: ${{ secrets.JINAAI_APIKEY }}
         run: ./test/run.sh ${{ matrix.test }}
+  Acceptance-Only-Fast:
+    timeout-minutes: 30
+    name: acceptance-only-fast (group ${{ matrix.group }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        group: [ 1, 2, 3, 4 ]
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          cache: true
+      - uses: docker/login-action@v3
+        if: ${{ !github.event.pull_request.head.repo.fork && github.triggering_actor != 'dependabot[bot]' }}
+        with:
+          username: ${{secrets.DOCKER_USERNAME}}
+          password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Run acceptance-only-fast group ${{ matrix.group }}
+        env:
+          WCS_DUMMY_CI_PW: ${{ secrets.WCS_DUMMY_CI_PW }}
+          WCS_DUMMY_CI_PW_2: ${{ secrets.WCS_DUMMY_CI_PW_2 }}
+          ACCEPTANCE_FAST_GROUP: ${{ matrix.group }}
+        run: ./test/run.sh --acceptance-only-fast
   Acceptance-Tests:
     name: acceptance-tests
     runs-on: ubuntu-latest
@@ -359,7 +385,6 @@ jobs:
       fail-fast: false
       matrix:
         test: [
-          "--acceptance-only-fast",
           "--acceptance-only-graphql",
           "--acceptance-only-authz",
           "--acceptance-only-replication",


### PR DESCRIPTION
This PR reduces CI wall-clock for the `acceptance-only-fast` suite by splitting it into **four groups** that run concurrently on separate runners. The workflow adds a dedicated matrix job, `acceptance-only-fast (group 1..4)` with `max-parallel: 4`. The test runner (`test/run.sh`) now accepts `ACCEPTANCE_FAST_GROUP=1..4` to run a specific group; if the variable is **unset**, behavior remains identical (the full suite runs sequentially). The previous single entry for `--acceptance-only-fast` is removed from the general acceptance matrix to avoid duplicate execution.

This is a pure scheduling change—no test logic or dependencies changed. The motivation is to shorten the critical path and free runners sooner, improving throughput when multiple PRs are in flight. Aggregate runner minutes stay approximately the same while wall-clock time drops significantly.

### Local benchmark (predicting CI wall-clock as the max group)
```
| Run                                   | Time (s) | Time (min) |
|--------------------------------------:|---------:|-----------:|
| Baseline (no grouping)                | 1292.309 | 21.54      |
| Group 1                               | 260.080  | 4.33       |
| Group 2                               | 398.933  | 6.65       |
| Group 3                               | 271.536  | 4.53       |
| Group 4                               | 395.198  | 6.59       |
| **Predicted CI wall-clock** (max)     | **398.933** | **6.65**  |
| Sum of groups (runner-min proxy)      | 1325.747 | 22.10      |
| **Improvement vs baseline**           | —        | **~69% faster** |
```

If we observe drift as tests evolve, we can later switch from static lists to a deterministic hash-based assignment with a few pinned heavy suites; for now, the static grouping is simple and effective.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
