### PR TITLE
fix: nil panic on empty sharding state while calling DeepCopy

### DIFF
--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -649,35 +649,37 @@ func generateShardName() string {
 }
 
 func (s State) DeepCopy() State {
-	var virtualCopy []Virtual
-
-	physicalCopy := make(map[string]Physical, len(s.Physical))
-	for name, shard := range s.Physical {
-		physicalCopy[name] = shard.DeepCopy()
-	}
-
-	if len(s.Virtual) > 0 {
-		virtualCopy = make([]Virtual, len(s.Virtual))
-	}
-	for i, virtual := range s.Virtual {
-		virtualCopy[i] = virtual.DeepCopy()
-	}
-
 	state := State{
 		localNodeName:       s.localNodeName,
 		IndexID:             s.IndexID,
 		Config:              s.Config.DeepCopy(),
-		Physical:            physicalCopy,
-		Virtual:             virtualCopy,
+		Physical:            make(map[string]Physical, len(s.Physical)),
+		Virtual:             make([]Virtual, len(s.Virtual)),
 		PartitioningEnabled: s.PartitioningEnabled,
 		ReplicationFactor:   s.ReplicationFactor,
 	}
 
-	// TODO: in case of error we return an empty sharding state temporarily. The plan is to remove this
-	// DeepCopy method in a followup PR.
-	err := state.MigrateShardingStateReplicationFactor()
-	if err != nil {
-		return State{}
+	for name, physicalShard := range s.Physical {
+		state.Physical[name] = physicalShard.DeepCopy()
+	}
+	for i, virtualShard := range s.Virtual {
+		state.Virtual[i] = virtualShard.DeepCopy()
+	}
+
+	// TODO: currently we ignore migration errors by returning an empty State with
+	// initialized but empty maps/slices. This avoids panics in callers, but hides the
+	// underlying issue and may cause misleading replica counts or missing shard info.
+	// In the future, change DeepCopy to return (State, error) so the error can be
+	// propagated to callers, who can then decide what to do with it.
+	if err := state.MigrateShardingStateReplicationFactor(); err != nil {
+		return State{
+			localNodeName: s.localNodeName,
+			IndexID:       s.IndexID,
+			Config:        s.Config.DeepCopy(),
+			Physical:      make(map[string]Physical),
+			Virtual:       make([]Virtual, 0),
+			// PartitioningEnabled and ReplicationFactor default to zero values here.
+		}
 	}
 
 	return state


### PR DESCRIPTION
Fix a panic in `(*State).NumberOfReplicas` caused by `DeepCopy` returning an
invalid empty state when migration detects shard replication inconsistencies.

When `MigrateShardingStateReplicationFactor` encounters inconsistent replication
factors across shards, it returns an error. `DeepCopy` currently swallows this
error and returns an empty `State{}` with nil maps and slices. Later calls to
`NumberOfReplicas` dereference this invalid state, triggering a panic.

- Ensure `DeepCopy` always returns a zero-safe state with non-nil maps/slices.
- Callers (e.g. the Nodes API) will now see `0` values for number of replicas
  and replication factor instead of panicking.
- Updated the TODO to clarify that the proper long-term fix is returning
  `(State, error)` so migration errors can be propagated instead of ignored.

In a follow-up, change `DeepCopy` to return `(State, error)` and update callers
to handle migration errors explicitly.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.