### PR TITLE
Spfresh: add as vector indexes option

### DIFF
--- a/adapters/repos/db/vector/hnsw/visited/list_set.go
+++ b/adapters/repos/db/vector/hnsw/visited/list_set.go
@@ -11,6 +11,8 @@
 
 package visited
 
+import "fmt"
+
 // ListSet is a reusable list with very efficient resets. Inspired by the C++
 // implementation in hnswlib it can be reset with zero memory writes in the
 // array by moving the match target instead of altering the list. Only after a
@@ -40,6 +42,7 @@ func NewList(size int) ListSet {
 // Visit sets element at node to the marker value
 func (l *ListSet) Visit(node uint64) {
 	if int(node) >= l.Len() { // resize
+		fmt.Println("NATEE ListSet.Visit resize", growth(len(l.set), int(node)+1024))
 		newset := make([]uint8, growth(len(l.set), int(node)+1024))
 		copy(newset, l.set)
 		l.set = newset

--- a/adapters/repos/db/vector/spfresh/spfresh_test.go
+++ b/adapters/repos/db/vector/spfresh/spfresh_test.go
@@ -1,0 +1,108 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package spfresh
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+func Test_SPFresh_Add_Search(t *testing.T) {
+	userConfig := UserConfig{
+		MaxPostingSize:            100,
+		MinPostingSize:            10,
+		SplitWorkers:              5,
+		ReassignWorkers:           5,
+		InternalPostingCandidates: 4,
+		ReassignNeighbors:         4,
+		Replicas:                  1,
+		RNGFactor:                 1.5,
+		MaxDistanceRatio:          1.5,
+	}
+	logger, _ := test.NewNullLogger()
+	promMetrics := monitoring.GetMetrics()
+	className := "class"
+	shardName := "shard"
+	metrics := lsmkv.NewMetrics(promMetrics, className, shardName)
+	shardCompactionCallbacks := cyclemanager.NewCallbackGroup("shard-compaction", logger, 1)
+	shardFlushCallbacks := cyclemanager.NewCallbackGroup("shard-flush", logger, 1)
+	store, err := lsmkv.New(t.TempDir(), t.TempDir(), logger, metrics, shardCompactionCallbacks, shardCompactionCallbacks, shardFlushCallbacks)
+	require.NoError(t, err)
+	vectorSize := 2
+	storeBucketName := "bucket"
+	distancer := distancer.NewCosineDistanceProvider()
+	quantizer := compressionhelpers.NewRotationalQuantizer(vectorSize, 42, 8, distancer)
+	bytesInRqOutput := quantizer.OutputDimension()
+	lsmStore, err := NewLSMStore(store, int32(bytesInRqOutput), storeBucketName)
+	require.NoError(t, err)
+	pages := uint64(512)
+	pageSize := uint64(8192)
+	versionMap := NewVersionMap(pages, pageSize)
+	idGenerator := common.NewUint64Counter(0)
+	sptag := NewBruteForceSPTAG(quantizer)
+	spfresh := SPFresh{
+		Logger:             logrus.NewEntry(logger),
+		UserConfig:         &userConfig,
+		SPTAG:              sptag,
+		Store:              lsmStore,
+		VersionMap:         versionMap,
+		IDs:                idGenerator,
+		PostingSizes:       NewPostingSizes(pages, pageSize),
+		Quantizer:          quantizer,
+		Distancer:          distancer,
+		vectorSize:         int32(bytesInRqOutput),
+		initialPostingLock: &sync.Mutex{},
+	}
+	ctx := t.Context()
+	spfresh.Start(ctx)
+	type testVector struct {
+		id     uint64
+		vector []float32
+	}
+	testVectors := []testVector{
+		{id: 1, vector: []float32{0.9, 0.9}},
+		{id: 2, vector: []float32{0.1, 0.1}},
+		{id: 3, vector: []float32{0.5, 0.5}},
+	}
+	for _, testVector := range testVectors {
+		err = spfresh.Add(ctx, testVector.id, testVector.vector)
+		require.NoError(t, err)
+	}
+	ids := []uint64{}
+	for _, testVector := range testVectors {
+		ids = append(ids, testVector.id)
+	}
+	allowList := helpers.NewAllowList(ids...)
+	verifyOrderOfResults := func(searchVector []float32, expectedIds []uint64) {
+		results, _, err := spfresh.SearchByVector(ctx, searchVector, len(expectedIds), allowList)
+		require.NoError(t, err)
+		require.Equal(t, len(expectedIds), len(results))
+		for i, id := range results {
+			require.Equal(t, id, expectedIds[i], "search vector: ", searchVector, " expected ids: ", expectedIds, " results: ", results)
+		}
+	}
+	verifyOrderOfResults([]float32{0.9, 0.9}, []uint64{1, 3, 2})
+	verifyOrderOfResults([]float32{0.1, 0.1}, []uint64{2, 3, 1})
+	verifyOrderOfResults([]float32{0.5, 0.5}, []uint64{3, 1, 2})
+	verifyOrderOfResults([]float32{0.0, 0.0}, []uint64{2, 3, 1})
+}

--- a/entities/vectorindex/common/my_spfresh.py
+++ b/entities/vectorindex/common/my_spfresh.py
@@ -1,0 +1,37 @@
+import weaviate
+
+COLLECTION_NAME = 'MyCollection'
+
+with weaviate.connect_to_local() as client:
+    if client.collections.exists(COLLECTION_NAME):
+        client.collections.delete(COLLECTION_NAME)
+
+    my_collection = client.collections.create(
+        name=COLLECTION_NAME,
+        properties=[
+            weaviate.classes.config.Property(name='my_property', data_type=weaviate.classes.config.DataType.TEXT)
+        ],
+        vectorizer_config=weaviate.classes.config.Configure.Vectorizer.none(),
+        replication_config=weaviate.classes.config.Configure.replication(
+            factor=1,
+        ),
+        sharding_config=weaviate.classes.config.Configure.sharding(
+            desired_count=1,
+        ),
+        vector_config=weaviate.classes.config.Configure.Vectors.self_provided(
+            vector_index_config=weaviate.classes.config.Configure.VectorIndex.flat(
+                # TODO
+            ),
+        ),
+    )
+    my_col = my_collection.with_consistency_level(weaviate.classes.config.ConsistencyLevel.ALL)
+    for i in range(20):
+        o = my_col.data.insert(
+            properties={
+                'my_property': f'blue elephant {i}',
+            },
+            vector=[0.1] * 1536,
+        )
+    r = my_col.query.fetch_objects()
+    for o in r.objects:
+        print(o)

--- a/entities/vectorindex/config.go
+++ b/entities/vectorindex/config.go
@@ -38,8 +38,8 @@ func ParseAndValidateConfig(input interface{}, vectorIndexType string, isMultiVe
 		vectorIndexType = DefaultVectorIndexType
 	}
 
-	if os.Getenv("SPFRESH_ENABLED") == "true" && vectorIndexType == VectorIndexTypeSPFRESH {
-		return nil, errors.New("spfresh is not enabled via SPFRESH_ENABLED=true")
+	if os.Getenv("EXPERIMENT_SPFRESH") == "true" && vectorIndexType == VectorIndexTypeSPFRESH {
+		return nil, errors.New("spfresh is not enabled via EXPERIMENT_SPFRESH=true")
 	}
 
 	switch vectorIndexType {

--- a/entities/vectorindex/config.go
+++ b/entities/vectorindex/config.go
@@ -12,12 +12,15 @@
 package vectorindex
 
 import (
+	"errors"
 	"fmt"
+	"os"
 
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/vectorindex/dynamic"
 	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/entities/vectorindex/spfresh"
 )
 
 const (
@@ -25,6 +28,7 @@ const (
 	VectorIndexTypeHNSW    = "hnsw"
 	VectorIndexTypeFLAT    = "flat"
 	VectorIndexTypeDYNAMIC = "dynamic"
+	VectorIndexTypeSPFRESH = "spfresh"
 )
 
 // ParseAndValidateConfig from an unknown input value, as this is not further
@@ -34,6 +38,10 @@ func ParseAndValidateConfig(input interface{}, vectorIndexType string, isMultiVe
 		vectorIndexType = DefaultVectorIndexType
 	}
 
+	if os.Getenv("SPFRESH_ENABLED") == "true" && vectorIndexType == VectorIndexTypeSPFRESH {
+		return nil, errors.New("spfresh is not enabled via SPFRESH_ENABLED=true")
+	}
+
 	switch vectorIndexType {
 	case VectorIndexTypeHNSW:
 		return hnsw.ParseAndValidateConfig(input, isMultiVector)
@@ -41,6 +49,8 @@ func ParseAndValidateConfig(input interface{}, vectorIndexType string, isMultiVe
 		return flat.ParseAndValidateConfig(input)
 	case VectorIndexTypeDYNAMIC:
 		return dynamic.ParseAndValidateConfig(input, isMultiVector)
+	case VectorIndexTypeSPFRESH:
+		return spfresh.ParseAndValidateConfig(input)
 	default:
 		return nil, fmt.Errorf("invalid vector index %q. Supported types are hnsw and flat", vectorIndexType)
 	}

--- a/entities/vectorindex/spfresh/config.go
+++ b/entities/vectorindex/spfresh/config.go
@@ -1,0 +1,175 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package spfresh
+
+import (
+	"fmt"
+
+	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
+	vectorindexcommon "github.com/weaviate/weaviate/entities/vectorindex/common"
+)
+
+const (
+	DefaultMaxPostingSize            = 100
+	DefaultMinPostingSize            = 10
+	DefaultSplitWorkers              = 5
+	DefaultReassignWorkers           = 5
+	DefaultInternalPostingCandidates = 4
+	DefaultReassignNeighbors         = 4
+	DefaultReplicas                  = 1
+	DefaultRNGFactor                 = 1.5
+	DefaultMaxDistanceRatio          = 1.5
+)
+
+type UserConfig struct {
+	// public
+	Distance string `json:"distance"`
+	// TODO make these private when spfresh goes GA
+	MaxPostingSize            uint32  `json:"maxPostingSize,omitempty"`            // Maximum number of vectors in a posting
+	MinPostingSize            uint32  `json:"minPostingSize,omitempty"`            // Minimum number of vectors in a posting
+	SplitWorkers              int     `json:"splitWorkers,omitempty"`              // Number of concurrent workers for split operations
+	ReassignWorkers           int     `json:"reassignWorkers,omitempty"`           // Number of concurrent workers for reassign operations
+	InternalPostingCandidates int     `json:"internalPostingCandidates,omitempty"` // Number of candidates to consider when running a centroid search internally
+	ReassignNeighbors         int     `json:"reassignNeighbors,omitempty"`         // Number of neighboring centroids to consider for reassigning vectors
+	Replicas                  int     `json:"replicas,omitempty"`                  // Number of closure replicas to maintain
+	RNGFactor                 float32 `json:"rngFactor,omitempty"`                 // Distance factor used by the RNG rule to determine how spread out replica selections are
+	MaxDistanceRatio          float32 `json:"maxDistanceRatio,omitempty"`          // Maximum distance ratio for the search, used to filter out candidates that are too far away
+}
+
+// IndexType returns the type of the underlying vector index, thus making sure
+// the schema.VectorIndexConfig interface is implemented
+func (u UserConfig) IndexType() string {
+	return "spfresh"
+}
+
+func (u UserConfig) DistanceName() string {
+	return u.Distance
+}
+
+func (u UserConfig) IsMultiVector() bool {
+	return false
+}
+
+// SetDefaults in the user-specifyable part of the config
+func (u *UserConfig) SetDefaults() {
+	u.Distance = vectorindexcommon.DefaultDistanceMetric
+	u.MaxPostingSize = DefaultMaxPostingSize
+	u.MinPostingSize = DefaultMinPostingSize
+	u.SplitWorkers = DefaultSplitWorkers
+	u.ReassignWorkers = DefaultReassignWorkers
+	u.InternalPostingCandidates = DefaultInternalPostingCandidates
+	u.ReassignNeighbors = DefaultReassignNeighbors
+	u.Replicas = DefaultReplicas
+	u.RNGFactor = DefaultRNGFactor
+	u.MaxDistanceRatio = DefaultMaxDistanceRatio
+}
+
+// ParseAndValidateConfig from an unknown input value, as this is not further
+// specified in the API to allow of exchanging the index type
+func ParseAndValidateConfig(input interface{}) (schemaConfig.VectorIndexConfig, error) {
+	uc := UserConfig{}
+	uc.SetDefaults()
+
+	if input == nil {
+		return uc, nil
+	}
+
+	asMap, ok := input.(map[string]interface{})
+	if !ok || asMap == nil {
+		return uc, fmt.Errorf("input must be a non-nil map")
+	}
+
+	if err := vectorindexcommon.OptionalStringFromMap(asMap, "distance", func(v string) {
+		uc.Distance = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := validateCompression(asMap); err != nil {
+		return uc, err
+	}
+
+	if err := vectorindexcommon.OptionalIntFromMap(asMap, "maxPostingSize", func(v int) {
+		uc.MaxPostingSize = uint32(v)
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorindexcommon.OptionalIntFromMap(asMap, "minPostingSize", func(v int) {
+		uc.MinPostingSize = uint32(v)
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorindexcommon.OptionalIntFromMap(asMap, "splitWorkers", func(v int) {
+		uc.SplitWorkers = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorindexcommon.OptionalIntFromMap(asMap, "reassignWorkers", func(v int) {
+		uc.ReassignWorkers = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorindexcommon.OptionalIntFromMap(asMap, "internalPostingCandidates", func(v int) {
+		uc.InternalPostingCandidates = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorindexcommon.OptionalIntFromMap(asMap, "reassignNeighbors", func(v int) {
+		uc.ReassignNeighbors = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorindexcommon.OptionalIntFromMap(asMap, "replicas", func(v int) {
+		uc.Replicas = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorindexcommon.OptionalFloat32FromMap(asMap, "rngFactor", func(v float32) {
+		uc.RNGFactor = v
+	}); err != nil {
+		return uc, err
+	}
+
+	if err := vectorindexcommon.OptionalFloat32FromMap(asMap, "maxDistanceRatio", func(v float32) {
+		uc.MaxDistanceRatio = v
+	}); err != nil {
+		return uc, err
+	}
+
+	return uc, nil
+}
+
+func validateCompression(in map[string]interface{}) error {
+	_, pqOk := in["pq"]
+	_, bqOk := in["bq"]
+	_, sqOk := in["sq"]
+	_, rqOk := in["rq"]
+
+	if pqOk || bqOk || sqOk || rqOk {
+		return fmt.Errorf("BQ, PQ, RQ, and SQ are not currently supported for spfresh indices")
+	}
+
+	return nil
+}
+
+func NewDefaultUserConfig() UserConfig {
+	uc := UserConfig{}
+	uc.SetDefaults()
+	return uc
+}

--- a/entities/vectorindex/spfresh/config_test.go
+++ b/entities/vectorindex/spfresh/config_test.go
@@ -1,0 +1,107 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package spfresh
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/vectorindex/common"
+)
+
+func Test_FlatUserConfig(t *testing.T) {
+	type test struct {
+		name         string
+		input        interface{}
+		expected     UserConfig
+		expectErr    bool
+		expectErrMsg string
+	}
+
+	tests := []test{
+		{
+			name:  "nothing specified, all defaults",
+			input: nil,
+			expected: UserConfig{
+				Distance:                  common.DefaultDistanceMetric,
+				MaxPostingSize:            DefaultMaxPostingSize,
+				MinPostingSize:            DefaultMinPostingSize,
+				SplitWorkers:              DefaultSplitWorkers,
+				ReassignWorkers:           DefaultReassignWorkers,
+				InternalPostingCandidates: DefaultInternalPostingCandidates,
+				ReassignNeighbors:         DefaultReassignNeighbors,
+				Replicas:                  DefaultReplicas,
+				RNGFactor:                 DefaultRNGFactor,
+				MaxDistanceRatio:          DefaultMaxDistanceRatio,
+			},
+		},
+		{
+			name: "all specified",
+			input: map[string]interface{}{
+				"distance":                  "cosine",
+				"maxPostingSize":            json.Number("1"),
+				"minPostingSize":            json.Number("2"),
+				"splitWorkers":              json.Number("3"),
+				"reassignWorkers":           float64(4),
+				"internalPostingCandidates": float64(5),
+				"reassignNeighbors":         float64(6),
+				"replicas":                  float64(7),
+				"rngFactor":                 json.Number("1.1"),
+				"maxDistanceRatio":          float64(1.2),
+			},
+			expected: UserConfig{
+				Distance:                  "cosine",
+				MaxPostingSize:            1,
+				MinPostingSize:            2,
+				SplitWorkers:              3,
+				ReassignWorkers:           4,
+				InternalPostingCandidates: 5,
+				ReassignNeighbors:         6,
+				Replicas:                  7,
+				RNGFactor:                 1.1,
+				MaxDistanceRatio:          1.2,
+			},
+			expectErr:    false,
+			expectErrMsg: "",
+		},
+		{
+			name: "pq enabled",
+			input: map[string]interface{}{
+				"vectorCacheMaxObjects": float64(100),
+				"distance":              "cosine",
+				"pq": map[string]interface{}{
+					"enabled":      true,
+					"rescoreLimit": float64(100),
+					"cache":        true,
+				},
+			},
+			expectErr:    true,
+			expectErrMsg: "BQ, PQ, RQ, and SQ are not currently supported for spfresh indices",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			cfg, err := ParseAndValidateConfig(test.input)
+			if test.expectErr {
+				require.NotNil(t, err)
+				assert.Contains(t, err.Error(), test.expectErrMsg)
+				return
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, test.expected, cfg)
+			}
+		})
+	}
+}

--- a/my_spfresh.py
+++ b/my_spfresh.py
@@ -1,0 +1,42 @@
+import weaviate
+
+COLLECTION_NAME = 'MyCollection'
+
+with weaviate.connect_to_local() as client:
+    if client.collections.exists(COLLECTION_NAME):
+        client.collections.delete(COLLECTION_NAME)
+
+    my_collection = client.collections.create_from_dict({
+        'invertedIndexConfig': {'bm25': {'b': 0.75, 'k1': 1.2}, 'cleanupIntervalSeconds': 60, 'indexNullState': False, 'indexPropertyLength': False, 'indexTimestamps': False, 'stopwords': {'preset': 'en'}}, 
+        'multiTenancyConfig': {'enabled': False, 'autoTenantCreation': False, 'autoTenantActivation': False}, 
+        'properties': [{'name': 'my_property', 'dataType': ['text'], 'indexFilterable': True, 'indexSearchable': True, 'indexRangeFilters': False, 'tokenization': 'word'}], 
+        'replicationConfig': {'factor': 1, 'asyncEnabled': False, 'deletionStrategy': 'NoAutomatedResolution'}, 
+        'shardingConfig': {'virtualPerPhysical': 128, 'desiredCount': 1, 'actualCount': 1, 'desiredVirtualCount': 128, 'actualVirtualCount': 128, 'key': '_id', 'strategy': 'hash', 'function': 'murmur3'}, 
+        'vectorConfig': {
+            'default': {
+                'vectorizer': {'none': {}}, 
+                'vectorIndexConfig': {
+                    'distanceMetric': 'cosine', 
+                    'vectorCacheMaxObjects': 1000000000000,
+                },
+                'vectorIndexType': 'spfresh',
+            },
+        },
+        'class': 'MyCollection', 
+        'moduleConfig': {},
+    })
+    my_col = my_collection.with_consistency_level(weaviate.classes.config.ConsistencyLevel.ALL)
+    for i in range(20):
+        o = my_col.data.insert(
+            properties={
+                'my_property': f'blue elephant {i}',
+            },
+            vector=[0.1] * 768,
+        )
+    v = my_col.query.near_vector(
+        near_vector=[0.1] * 768,
+        distance=2,
+        limit=30,
+    )
+    for o in v.objects:
+        print(o)

--- a/usecases/modules/vectorizer.go
+++ b/usecases/modules/vectorizer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaviate/weaviate/entities/vectorindex/dynamic"
 	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/entities/vectorindex/spfresh"
 	"github.com/weaviate/weaviate/usecases/config"
 )
 
@@ -516,7 +517,9 @@ func (p *Provider) getVectorIndexConfig(class *models.Class, targetVector string
 	hnswConfig, okHnsw := vectorIndexConfig.(hnsw.UserConfig)
 	_, okFlat := vectorIndexConfig.(flat.UserConfig)
 	_, okDynamic := vectorIndexConfig.(dynamic.UserConfig)
-	if !(okHnsw || okFlat || okDynamic) {
+	// TODO why return hnsw instead of spfresh?
+	_, okSpfresh := vectorIndexConfig.(spfresh.UserConfig)
+	if !(okHnsw || okFlat || okDynamic || okSpfresh) {
 		return hnsw.UserConfig{}, fmt.Errorf(errorVectorIndexType, vectorIndexConfig)
 	}
 	return hnswConfig, nil

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -808,8 +808,8 @@ func (h *Handler) validateVectorizer(vectorizer string) error {
 }
 
 func (h *Handler) validateVectorIndexType(vectorIndexType string) error {
-	if os.Getenv("SPFRESH_ENABLED") == "true" && vectorIndexType == vectorindex.VectorIndexTypeSPFRESH {
-		return errors.New("spfresh is not enabled via SPFRESH_ENABLED=true")
+	if os.Getenv("EXPERIMENT_SPFRESH") == "true" && vectorIndexType == vectorindex.VectorIndexTypeSPFRESH {
+		return errors.New("spfresh is not enabled via EXPERIMENT_SPFRESH=true")
 	}
 	// TODO async indexing allowed for spfresh?
 	switch vectorIndexType {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -808,8 +808,12 @@ func (h *Handler) validateVectorizer(vectorizer string) error {
 }
 
 func (h *Handler) validateVectorIndexType(vectorIndexType string) error {
+	if os.Getenv("SPFRESH_ENABLED") == "true" && vectorIndexType == vectorindex.VectorIndexTypeSPFRESH {
+		return errors.New("spfresh is not enabled via SPFRESH_ENABLED=true")
+	}
+	// TODO async indexing allowed for spfresh?
 	switch vectorIndexType {
-	case vectorindex.VectorIndexTypeHNSW, vectorindex.VectorIndexTypeFLAT:
+	case vectorindex.VectorIndexTypeHNSW, vectorindex.VectorIndexTypeFLAT, vectorindex.VectorIndexTypeSPFRESH:
 		return nil
 	case vectorindex.VectorIndexTypeDYNAMIC:
 		if !h.asyncIndexingEnabled {

--- a/usecases/schema/parser.go
+++ b/usecases/schema/parser.go
@@ -14,6 +14,7 @@ package schema
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"reflect"
 	"sort"
 	"strings"
@@ -209,7 +210,13 @@ func (p *Parser) parseTargetVectorsIndexConfig(class *models.Class) error {
 func (p *Parser) parseGivenVectorIndexConfig(vectorIndexType string,
 	vectorIndexConfig interface{}, isMultiVector bool,
 ) (schemaConfig.VectorIndexConfig, error) {
-	if vectorIndexType != vectorindex.VectorIndexTypeHNSW && vectorIndexType != vectorindex.VectorIndexTypeFLAT && vectorIndexType != vectorindex.VectorIndexTypeDYNAMIC {
+	if os.Getenv("SPFRESH_ENABLED") == "true" && vectorIndexType == vectorindex.VectorIndexTypeSPFRESH {
+		return nil, errors.New("spfresh is not enabled via SPFRESH_ENABLED=true")
+	}
+	if vectorIndexType != vectorindex.VectorIndexTypeHNSW &&
+		vectorIndexType != vectorindex.VectorIndexTypeFLAT &&
+		vectorIndexType != vectorindex.VectorIndexTypeDYNAMIC &&
+		vectorIndexType != vectorindex.VectorIndexTypeSPFRESH {
 		return nil, errors.Errorf(
 			"parse vector index config: unsupported vector index type: %q",
 			vectorIndexType)

--- a/usecases/schema/parser.go
+++ b/usecases/schema/parser.go
@@ -210,8 +210,8 @@ func (p *Parser) parseTargetVectorsIndexConfig(class *models.Class) error {
 func (p *Parser) parseGivenVectorIndexConfig(vectorIndexType string,
 	vectorIndexConfig interface{}, isMultiVector bool,
 ) (schemaConfig.VectorIndexConfig, error) {
-	if os.Getenv("SPFRESH_ENABLED") == "true" && vectorIndexType == vectorindex.VectorIndexTypeSPFRESH {
-		return nil, errors.New("spfresh is not enabled via SPFRESH_ENABLED=true")
+	if os.Getenv("EXPERIMENT_SPFRESH") == "true" && vectorIndexType == vectorindex.VectorIndexTypeSPFRESH {
+		return nil, errors.New("spfresh is not enabled via EXPERIMENT_SPFRESH=true")
 	}
 	if vectorIndexType != vectorindex.VectorIndexTypeHNSW &&
 		vectorIndexType != vectorindex.VectorIndexTypeFLAT &&


### PR DESCRIPTION
### What's being changed:

Adds spfresh as a vector index option (if env var `EXPERIMENT_SPFRESH=true` exists).

Not quite working yet, need to figure out visited, knowing ndim at index creation, distance calcs, etc.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
