### PR TITLE
feature: RoaringSet as default strategy for dimensions bucket

### DIFF
--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -40,10 +40,11 @@ const (
 	DimensionCategoryRQ
 )
 
-// since v1.34 StrategyRoaringSet will be default strategy for dimensions bucket
+// since v1.34 StrategyRoaringSet is default strategy for dimensions bucket,
+// StrategyMapCollection is left as backward compatibility for buckets created earlier
 var DimensionsBucketPrioritizedStrategies = []string{
-	lsmkv.StrategyMapCollection,
 	lsmkv.StrategyRoaringSet,
+	lsmkv.StrategyMapCollection,
 }
 
 func (c DimensionCategory) String() string {


### PR DESCRIPTION
### What's being changed:
- Changes strategy of dimensions bucket to `RoaringSet` (from `MapCollection`) to provide better performance for querying bucket and compacting its segment files.To ensure backward compatibility with buckets created before the change, buckets of `MapCollection` strategy will still be supported. 
- Introduces `lsmkv.DetermineUnloadedBucketStrategy(...)` and `lsmkv.DetermineUnloadedBucketStrategyAmong(...)` methods inferring unloaded bucket's actual strategy based on segment files or commit logs to ensure backward compatibility with buckets created with `MapCollection` strategy.

REMARK: migrations of existing buckets from `MapCollection` to `RoaringSet` strategy is not (yet) supported. Change will affect only newly added collections. Buckets created with `MapCollection` strategy will continue to work as before.


chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17916850508
~~https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17679756937~~
e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/17916888901
~~https://github.com/weaviate/weaviate-e2e-tests/actions/runs/17679765659~~

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
