### PR TITLE
fix(modules): relax model name validation in text2vec-aws module

### DIFF
--- a/modules/text2vec-aws/clients/aws.go
+++ b/modules/text2vec-aws/clients/aws.go
@@ -337,19 +337,11 @@ func extractHostAndPath(endpointUrl string) (string, string, error) {
 }
 
 func createRequestBody(model string, texts []string, operation operationType) (interface{}, error) {
-	modelParts := strings.Split(model, ".")
-	if len(modelParts) == 0 {
-		return nil, fmt.Errorf("invalid model: %s", model)
-	}
-
-	modelProvider := modelParts[0]
-
-	switch modelProvider {
-	case "amazon":
+	if strings.Contains(model, "amazon.") {
 		return bedrockEmbeddingsRequest{
 			InputText: texts[0],
 		}, nil
-	case "cohere":
+	} else if strings.Contains(model, "cohere.") {
 		inputType := "search_document"
 		if operation == vectorizeQuery {
 			inputType = "search_query"
@@ -358,7 +350,7 @@ func createRequestBody(model string, texts []string, operation operationType) (i
 			Texts:     texts,
 			InputType: inputType,
 		}, nil
-	default:
-		return nil, fmt.Errorf("unknown model provider: %s", modelProvider)
+	} else {
+		return nil, fmt.Errorf("unknown model provider: %s", model)
 	}
 }

--- a/modules/text2vec-aws/vectorizer/class_settings.go
+++ b/modules/text2vec-aws/vectorizer/class_settings.go
@@ -15,11 +15,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
-
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/moduletools"
-	"github.com/weaviate/weaviate/entities/schema"
 	basesettings "github.com/weaviate/weaviate/usecases/modulecomponents/settings"
 )
 
@@ -44,13 +41,6 @@ const (
 var availableAWSServices = []string{
 	"bedrock",
 	"sagemaker",
-}
-
-var availableAWSBedrockModels = []string{
-	"amazon.titan-embed-text-v1",
-	"amazon.titan-embed-text-v2:0",
-	"cohere.embed-english-v3",
-	"cohere.embed-multilingual-v3",
 }
 
 type classSettings struct {
@@ -79,8 +69,8 @@ func (ic *classSettings) Validate(class *models.Class) error {
 
 	if isBedrock(service) {
 		model := ic.Model()
-		if model == "" || !ic.validatAvailableAWSSetting(model, availableAWSBedrockModels) {
-			errorMessages = append(errorMessages, fmt.Sprintf("wrong %s, available models are: %v", modelProperty, availableAWSBedrockModels))
+		if model == "" {
+			errorMessages = append(errorMessages, fmt.Sprintf("%s has to be defined", modelProperty))
 		}
 		endpoint := ic.Endpoint()
 		if endpoint != "" {
@@ -103,11 +93,6 @@ func (ic *classSettings) Validate(class *models.Class) error {
 		return fmt.Errorf("%s", strings.Join(errorMessages, ", "))
 	}
 
-	err := ic.validateIndexState(class, ic)
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -122,43 +107,6 @@ func (ic *classSettings) validatAvailableAWSSetting(value string, availableValue
 
 func (ic *classSettings) getStringProperty(name, defaultValue string) string {
 	return ic.BaseClassSettings.GetPropertyAsString(name, defaultValue)
-}
-
-func (cv *classSettings) validateIndexState(class *models.Class, settings ClassSettings) error {
-	if settings.VectorizeClassName() {
-		// if the user chooses to vectorize the classname, vector-building will
-		// always be possible, no need to investigate further
-
-		return nil
-	}
-
-	// search if there is at least one indexed, string/text prop. If found pass
-	// validation
-	for _, prop := range class.Properties {
-		if len(prop.DataType) < 1 {
-			return errors.Errorf("property %s must have at least one datatype: "+
-				"got %v", prop.Name, prop.DataType)
-		}
-
-		if prop.DataType[0] != string(schema.DataTypeString) &&
-			prop.DataType[0] != string(schema.DataTypeText) {
-			// we can only vectorize text-like props
-			continue
-		}
-
-		if settings.PropertyIndexed(prop.Name) {
-			// found at least one, this is a valid schema
-			return nil
-		}
-	}
-
-	return fmt.Errorf("invalid properties: didn't find a single property which is " +
-		"of type string or text and is not excluded from indexing. In addition the " +
-		"class name is excluded from vectorization as well, meaning that it cannot be " +
-		"used to determine the vector position. To fix this, set 'vectorizeClassName' " +
-		"to true if the class name is contextionary-valid. Alternatively add at least " +
-		"contextionary-valid text/string property which is not excluded from " +
-		"indexing")
 }
 
 // Aws params

--- a/modules/text2vec-aws/vectorizer/class_settings_test.go
+++ b/modules/text2vec-aws/vectorizer/class_settings_test.go
@@ -84,15 +84,29 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantErr: errors.Errorf("region cannot be empty"),
 		},
 		{
-			name: "wrong model",
+			name: "any model name",
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{
 					"service": "bedrock",
 					"region":  "us-west-1",
-					"model":   "wrong-model",
+					"model":   "any-model-name",
 				},
 			},
-			wantErr: errors.Errorf("wrong model, available models are: [amazon.titan-embed-text-v1 amazon.titan-embed-text-v2:0 cohere.embed-english-v3 cohere.embed-multilingual-v3]"),
+			wantService: "bedrock",
+			wantRegion:  "us-west-1",
+			wantModel:   "any-model-name",
+			wantErr:     nil,
+		},
+		{
+			name: "empty model",
+			cfg: fakeClassConfig{
+				classConfig: map[string]interface{}{
+					"service": "bedrock",
+					"region":  "us-west-1",
+					"model":   "",
+				},
+			},
+			wantErr: errors.Errorf("model has to be defined"),
 		},
 		{
 			name: "all wrong",


### PR DESCRIPTION
### What's being changed:

Relax model name validation in `text2vec-aws` module:

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
