### PR TITLE
Truncate old condensed files to avoid data corruption

### DIFF
--- a/adapters/repos/db/vector/hnsw/condensor.go
+++ b/adapters/repos/db/vector/hnsw/condensor.go
@@ -50,7 +50,7 @@ func (c *MemoryCondensor) Do(fileName string) error {
 	}
 
 	newLogFile, err := os.OpenFile(fmt.Sprintf("%s.condensed", fileName),
-		os.O_WRONLY|os.O_APPEND|os.O_CREATE, 0o666)
+		os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0o666)
 	if err != nil {
 		return errors.Wrap(err, "open new commit log file for writing")
 	}
@@ -148,6 +148,10 @@ func (c *MemoryCondensor) Do(fileName string) error {
 
 	if err := c.newLog.Flush(); err != nil {
 		return errors.Wrap(err, "close new commit log")
+	}
+
+	if err := newLogFile.Sync(); err != nil {
+		return errors.Wrap(err, "fsync new commit log")
 	}
 
 	if err := c.newLogFile.Close(); err != nil {

--- a/adapters/repos/db/vector/hnsw/corrupt_commit_logs_fixer_test.go
+++ b/adapters/repos/db/vector/hnsw/corrupt_commit_logs_fixer_test.go
@@ -1,0 +1,57 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCorruptCommitLogFixer_Do(t *testing.T) {
+	t.Run("keeps normal files without condensed counterpart", func(t *testing.T) {
+		tmp := t.TempDir()
+		f1 := filepath.Join(tmp, "commit1.log")
+		require.Nil(t, os.WriteFile(f1, []byte("test"), 0644))
+
+		fixer := NewCorruptedCommitLogFixer()
+		files, err := fixer.Do([]string{f1})
+		require.Nil(t, err)
+		require.Equal(t, []string{f1}, files)
+	})
+
+	t.Run("keeps .condensed files", func(t *testing.T) {
+		tmp := t.TempDir()
+		f := filepath.Join(tmp, "commit3.log.condensed")
+		require.Nil(t, os.WriteFile(f, []byte("condensed"), 0644))
+
+		fixer := NewCorruptedCommitLogFixer()
+		files, err := fixer.Do([]string{f})
+		require.Nil(t, err)
+		require.Equal(t, []string{f}, files)
+	})
+
+	t.Run("removes uncondensed file if condensed exists", func(t *testing.T) {
+		tmp := t.TempDir()
+		f := filepath.Join(tmp, "commit4.log")
+		cf := filepath.Join(tmp, "commit4.log.condensed")
+		require.Nil(t, os.WriteFile(f, []byte("uncondensed"), 0644))
+		require.Nil(t, os.WriteFile(cf, []byte("condensed"), 0644))
+
+		fixer := NewCorruptedCommitLogFixer()
+		files, err := fixer.Do([]string{f, cf})
+		require.Nil(t, err)
+		require.Equal(t, []string{f}, files)
+	})
+}


### PR DESCRIPTION
### What's being changed:

Do not append to existing corrupted condensed files to avoid panics in the booting process.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
