### PR TITLE
fix(raft): joiner was checking for wrong status code

### DIFF
--- a/cluster/bootstrap/bootstrap_test.go
+++ b/cluster/bootstrap/bootstrap_test.go
@@ -19,11 +19,11 @@ import (
 
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/mock"
-	"github.com/weaviate/weaviate/usecases/cluster/mocks"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/rpc"
+	"github.com/weaviate/weaviate/usecases/cluster/mocks"
 )
 
 var errAny = errors.New("any error")
@@ -82,7 +82,7 @@ func TestBootstrapper(t *testing.T) {
 				// This test performs a join request to the leader, but the leader is not
 				// available. The bootstrapper should retry the join request until it is
 				// successful.
-				errLeaderElected := status.Error(codes.NotFound, "follow the leader")
+				errLeaderElected := status.Error(rpc.NotLeaderRPCCode, "follow the leader")
 				count := 0
 				m.On("Join", anything, anything, anything).
 					Run(func(args mock.Arguments) {

--- a/cluster/bootstrap/joiner.go
+++ b/cluster/bootstrap/joiner.go
@@ -17,10 +17,11 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/sirupsen/logrus"
-	cmd "github.com/weaviate/weaviate/cluster/proto/api"
-	entSentry "github.com/weaviate/weaviate/entities/sentry"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/rpc"
+	entSentry "github.com/weaviate/weaviate/entities/sentry"
 )
 
 type Joiner struct {
@@ -72,7 +73,7 @@ func (j *Joiner) Do(ctx context.Context, lg *logrus.Logger, remoteNodes map[stri
 		st := status.Convert(err)
 		lg.WithField("remoteNode", addr).WithField("status", st.Code()).Info("attempted to join and failed")
 		// Get the leader from response and if not empty try to join it
-		if leader := resp.GetLeader(); st.Code() == codes.NotFound && leader != "" {
+		if leader := resp.GetLeader(); st.Code() == rpc.NotLeaderRPCCode && leader != "" {
 			_, err = j.peerJoiner.Join(ctx, leader, req)
 			if err == nil {
 				return leader, nil

--- a/cluster/rpc/server_test.go
+++ b/cluster/rpc/server_test.go
@@ -13,6 +13,7 @@ package rpc
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"testing"
@@ -21,13 +22,15 @@ import (
 	"github.com/sirupsen/logrus"
 	logrustest "github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/cluster/types"
 	"github.com/weaviate/weaviate/cluster/utils"
 	"github.com/weaviate/weaviate/usecases/fakes"
 	"github.com/weaviate/weaviate/usecases/monitoring"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
 
 const raftGrpcMessageMaxSize = 1024 * 1024 * 1024
@@ -368,6 +371,67 @@ func TestApply(t *testing.T) {
 			leaderAddr := fmt.Sprintf("localhost:%v", utils.MustGetFreeTCPPort())
 			test.members.leader = leaderAddr
 			test.testFunc(t, leaderAddr, test.members, test.executor)
+		})
+	}
+}
+
+func TestToRPCError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected codes.Code
+	}{
+		{
+			name:     "ErrNotLeader maps to NotLeaderRPCCode",
+			err:      types.ErrNotLeader,
+			expected: NotLeaderRPCCode,
+		},
+		{
+			name:     "ErrLeaderNotFound maps to NotLeaderRPCCode",
+			err:      types.ErrLeaderNotFound,
+			expected: NotLeaderRPCCode,
+		},
+		{
+			name:     "ErrNotOpen maps to Unavailable",
+			err:      types.ErrNotOpen,
+			expected: codes.Unavailable,
+		},
+		{
+			name:     "ErrMTDisabled maps to FailedPrecondition",
+			err:      schema.ErrMTDisabled,
+			expected: codes.FailedPrecondition,
+		},
+		{
+			name:     "ErrNotFound maps to NotFound",
+			err:      types.ErrNotFound,
+			expected: codes.NotFound,
+		},
+		{
+			name:     "Unknown error maps to Internal",
+			err:      errors.New("unknown error"),
+			expected: codes.Internal,
+		},
+		{
+			name:     "Nil error returns nil",
+			err:      nil,
+			expected: codes.OK,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := toRPCError(tt.err)
+
+			if tt.err == nil {
+				assert.Nil(t, result)
+				return
+			}
+
+			assert.NotNil(t, result)
+			st, ok := status.FromError(result)
+			assert.True(t, ok)
+			assert.Equal(t, tt.expected, st.Code())
+			assert.Contains(t, st.Message(), tt.err.Error())
 		})
 	}
 }


### PR DESCRIPTION
### What's being changed:
joiner was checking for for `NotFound` which was the incorrect status code, this PR changes the returned RPC code in state of there is no leader or node hit follower node. the new constant will make sure in future if we had changed the underlying rpc status code shall not affect the joiner code. also adding unit test for `toRPCError()`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17576996821
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
