### PR TITLE
Disable metadata writing by default

### DIFF
--- a/adapters/repos/db/lsmkv/segment_metadata.go
+++ b/adapters/repos/db/lsmkv/segment_metadata.go
@@ -240,9 +240,8 @@ func (s *segment) initBloomFiltersFromData(primary []byte, secondary [][]byte) e
 		s.secondaryBloomFilters[i] = new(bloom.BloomFilter)
 		_, err := s.secondaryBloomFilters[i].ReadFrom(bytes.NewReader(secondary[i]))
 		if err != nil {
-			return fmt.Errorf("read bloom filter: %w", err)
+			return fmt.Errorf("read secondary bloom filter %d with byte length %d: %w", i, len(secondary[i]), err)
 		}
-
 	}
 	return nil
 }

--- a/adapters/repos/db/lsmkv/segment_metadata_test.go
+++ b/adapters/repos/db/lsmkv/segment_metadata_test.go
@@ -55,6 +55,7 @@ func TestMetadataNoWrites(t *testing.T) {
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
 				WithWriteMetadata(tt.writeMetadata), WithUseBloomFilter(tt.bloomFilter), WithCalcCountNetAdditions(tt.cna), WithSecondaryIndices(uint16(secondaryIndexCount)))
 			require.NoError(t, err)
+			require.NoError(t, b.Shutdown(ctx))
 
 			require.NoError(t, b.Put([]byte("key"), []byte("value")))
 			require.NoError(t, b.FlushMemtable())
@@ -67,6 +68,12 @@ func TestMetadataNoWrites(t *testing.T) {
 					require.Equal(t, fileTypes[expectedFile], 1)
 				}
 			}
+
+			// read again
+			_, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				WithWriteMetadata(tt.writeMetadata), WithUseBloomFilter(tt.bloomFilter), WithCalcCountNetAdditions(tt.cna), WithSecondaryIndices(uint16(secondaryIndexCount)))
+			require.NoError(t, err)
 		})
 	}
 }
@@ -142,6 +149,52 @@ func TestSecondaryBloomNoCna(t *testing.T) {
 	require.True(t, b.disk.segments[0].getSegment().secondaryBloomFilters[1].Test([]byte("key1")))
 	require.False(t, b.disk.segments[0].getSegment().secondaryBloomFilters[1].Test([]byte("key0")))
 	require.NoError(t, b.Shutdown(ctx))
+}
+
+func TestMarkMetadataAsDeleted(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	dirName := t.TempDir()
+
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithUseBloomFilter(true), WithWriteMetadata(true), WithCalcCountNetAdditions(true), WithSecondaryIndices(2))
+	require.NoError(t, err)
+	require.NoError(t, b.Put([]byte("key"), []byte("value"), WithSecondaryKey(0, []byte("key0")), WithSecondaryKey(1, []byte("key1"))))
+	require.NoError(t, b.FlushMemtable())
+	fileTypes := countFileTypes(t, dirName)
+	require.Len(t, fileTypes, 2)
+	require.Equal(t, fileTypes[".db"], 1)
+	require.Equal(t, fileTypes[".metadata"], 1)
+
+	sgment := b.disk.segments[0]
+	require.NoError(t, sgment.markForDeletion())
+	fileTypes = countFileTypes(t, dirName)
+	require.Len(t, fileTypes, 1)
+	require.Equal(t, fileTypes[DeleteMarkerSuffix], 2)
+}
+
+func TestDropImmediately(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	dirName := t.TempDir()
+
+	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		WithUseBloomFilter(true), WithWriteMetadata(true), WithCalcCountNetAdditions(true), WithSecondaryIndices(2))
+	require.NoError(t, err)
+	require.NoError(t, b.Put([]byte("key"), []byte("value"), WithSecondaryKey(0, []byte("key0")), WithSecondaryKey(1, []byte("key1"))))
+	require.NoError(t, b.FlushMemtable())
+	fileTypes := countFileTypes(t, dirName)
+	require.Len(t, fileTypes, 2)
+	require.Equal(t, fileTypes[".db"], 1)
+	require.Equal(t, fileTypes[".metadata"], 1)
+
+	lazySgment := b.disk.segments[0]
+	sgment := lazySgment.getSegment()
+	require.NoError(t, sgment.dropImmediately())
+	fileTypes = countFileTypes(t, dirName)
+	require.Len(t, fileTypes, 0)
 }
 
 func TestCorruptFile(t *testing.T) {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -387,10 +387,10 @@ func FromEnv(config *Config) error {
 		config.Persistence.SegmentInfoIntoFileNameEnabled = true
 	}
 
-	if entcfg.Enabled(os.Getenv("PERSISTENCE_WRITE_METADATA_FILES_DISABLED")) {
-		config.Persistence.WriteMetadataFilesEnabled = false
-	} else {
+	if entcfg.Enabled(os.Getenv("PERSISTENCE_WRITE_METADATA_FILES_ENABLED")) {
 		config.Persistence.WriteMetadataFilesEnabled = true
+	} else {
+		config.Persistence.WriteMetadataFilesEnabled = false
 	}
 
 	if v := os.Getenv("PERSISTENCE_MAX_REUSE_WAL_SIZE"); v != "" {


### PR DESCRIPTION
### What's being changed:

Note that v1.32 had the `PERSISTENCE_WRITE_METADATA_FILES_ENABLED` env var

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
