### PR TITLE
refact(memberlist-raft): remove locks to avoid lock contention

### DIFF
--- a/cluster/resolver/raft.go
+++ b/cluster/resolver/raft.go
@@ -19,6 +19,7 @@ import (
 
 	raftImpl "github.com/hashicorp/raft"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/cluster/log"
 )
 
@@ -42,8 +43,7 @@ type raft struct {
 	// keep in memory which node uses which port.
 	NodeNameToPortMap map[string]int
 
-	nodesLock        sync.Mutex
-	notResolvedNodes map[raftImpl.ServerID]struct{}
+	notResolvedNodes sync.Map
 }
 
 func NewRaft(cfg RaftConfig) *raft {
@@ -52,23 +52,22 @@ func NewRaft(cfg RaftConfig) *raft {
 		RaftPort:           cfg.RaftPort,
 		IsLocalCluster:     cfg.IsLocalHost,
 		NodeNameToPortMap:  cfg.NodeNameToPortMap,
-		notResolvedNodes:   make(map[raftImpl.ServerID]struct{}),
+		notResolvedNodes:   sync.Map{},
 	}
 }
 
 // ServerAddr resolves server ID to a RAFT address
+// it's thread safe see https://github.com/hashicorp/raft/blob/main/net_transport.go#L389-L391
 func (a *raft) ServerAddr(id raftImpl.ServerID) (raftImpl.ServerAddress, error) {
 	// Get the address from the node id
 	addr := a.ClusterStateReader.NodeAddress(string(id))
 
 	// Update the internal notResolvedNodes if the addr if empty, otherwise delete it from the map
-	a.nodesLock.Lock()
-	defer a.nodesLock.Unlock()
 	if addr == "" {
-		a.notResolvedNodes[id] = struct{}{}
+		a.notResolvedNodes.Store(id, struct{}{})
 		return raftImpl.ServerAddress(invalidAddr), nil
 	}
-	delete(a.notResolvedNodes, id)
+	a.notResolvedNodes.Delete(id)
 
 	// If we are not running a local cluster we can immediately return, otherwise we need to lookup the port of the node
 	// as we can't use the default raft port locally.
@@ -98,12 +97,10 @@ func (a *raft) NewTCPTransport(
 }
 
 func (a *raft) NotResolvedNodes() map[raftImpl.ServerID]struct{} {
-	a.nodesLock.Lock()
-	defer a.nodesLock.Unlock()
-
-	newMap := make(map[raftImpl.ServerID]struct{})
-	for k, v := range a.notResolvedNodes {
-		newMap[k] = v
-	}
-	return newMap
+	notResolvedNodes := make(map[raftImpl.ServerID]struct{})
+	a.notResolvedNodes.Range(func(key, value any) bool {
+		notResolvedNodes[key.(raftImpl.ServerID)] = struct{}{}
+		return true
+	})
+	return notResolvedNodes
 }

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -18,7 +18,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/cluster/distributedtask"
 	"github.com/weaviate/weaviate/cluster/dynusers"
 	"github.com/weaviate/weaviate/cluster/fsm"
@@ -216,8 +216,7 @@ type Store struct {
 	logCache *raft.LogCache
 
 	// cluster bootstrap related attributes
-	bootstrapMutex sync.Mutex
-	candidates     map[string]string
+	candidates map[string]string
 	// bootstrapped is set once the node has either bootstrapped or recovered from RAFT log entries
 	bootstrapped atomic.Bool
 

--- a/cluster/store_cluster_rpc.go
+++ b/cluster/store_cluster_rpc.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/raft"
 	"github.com/sirupsen/logrus"
+
 	"github.com/weaviate/weaviate/cluster/types"
 )
 
@@ -60,9 +61,6 @@ func (st *Store) Notify(id, addr string) (err error) {
 	if !st.cfg.Voter || st.cfg.BootstrapExpect == 0 || st.bootstrapped.Load() || st.Leader() != "" {
 		return nil
 	}
-
-	st.bootstrapMutex.Lock()
-	defer st.bootstrapMutex.Unlock()
 
 	st.candidates[id] = addr
 	if len(st.candidates) < st.cfg.BootstrapExpect {

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -108,7 +108,7 @@ func Init(userConfig Config, raftBootstrapExpect int, dataPath string, nonStorag
 		},
 	}
 	if err := state.delegate.init(diskSpace); err != nil {
-		logger.WithField("action", "init_state.delete_init").WithError(err).
+		logger.WithField("action", "init_state.delegate_init").WithError(err).
 			Error("delegate init failed")
 	}
 	cfg.Delegate = &state.delegate
@@ -135,7 +135,7 @@ func Init(userConfig Config, raftBootstrapExpect int, dataPath string, nonStorag
 			"hostname":  userConfig.Hostname,
 			"bind_port": userConfig.GossipBindPort,
 		}).WithError(err).Error("memberlist not created")
-		return nil, errors.Wrap(err, "create member list")
+		return nil, errors.Wrap(err, "create memberlist")
 	}
 	var joinAddr []string
 	if userConfig.Join != "" {

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -45,8 +45,8 @@ type NodeSelector interface {
 
 type State struct {
 	config Config
-	// that lock to serialize access to memberlist
-	listLock             sync.RWMutex
+	// memberlist methods are thread safe
+	// see https://github.com/hashicorp/memberlist/blob/master/memberlist.go#L502-L503
 	list                 *memberlist.Memberlist
 	nonStorageNodes      map[string]struct{}
 	delegate             delegate
@@ -169,9 +169,6 @@ func Init(userConfig Config, raftBootstrapExpect int, dataPath string, nonStorag
 // Hostnames for all live members, except self. Use AllHostnames to include
 // self, prefixes the data port.
 func (s *State) Hostnames() []string {
-	s.listLock.RLock()
-	defer s.listLock.RUnlock()
-
 	mem := s.list.Members()
 	out := make([]string, len(mem))
 
@@ -191,9 +188,6 @@ func (s *State) Hostnames() []string {
 
 // AllHostnames for live members, including self.
 func (s *State) AllHostnames() []string {
-	s.listLock.RLock()
-	defer s.listLock.RUnlock()
-
 	if s.list == nil {
 		return []string{}
 	}
@@ -212,9 +206,6 @@ func (s *State) AllHostnames() []string {
 
 // All node names (not their hostnames!) for live members, including self.
 func (s *State) AllNames() []string {
-	s.listLock.RLock()
-	defer s.listLock.RUnlock()
-
 	mem := s.list.Members()
 	out := make([]string, len(mem))
 
@@ -230,9 +221,6 @@ func (s *State) storageNodes() []string {
 	if len(s.nonStorageNodes) == 0 {
 		return s.AllNames()
 	}
-
-	s.listLock.RLock()
-	defer s.listLock.RUnlock()
 
 	members := s.list.Members()
 	out := make([]string, len(members))
@@ -273,31 +261,19 @@ func (s *State) SortCandidates(nodes []string) []string {
 
 // All node names (not their hostnames!) for live members, including self.
 func (s *State) NodeCount() int {
-	s.listLock.RLock()
-	defer s.listLock.RUnlock()
-
 	return s.list.NumMembers()
 }
 
 // LocalName() return local node name
 func (s *State) LocalName() string {
-	s.listLock.RLock()
-	defer s.listLock.RUnlock()
-
 	return s.list.LocalNode().Name
 }
 
 func (s *State) ClusterHealthScore() int {
-	s.listLock.RLock()
-	defer s.listLock.RUnlock()
-
 	return s.list.GetHealthScore()
 }
 
 func (s *State) NodeHostname(nodeName string) (string, bool) {
-	s.listLock.RLock()
-	defer s.listLock.RUnlock()
-
 	for _, mem := range s.list.Members() {
 		if mem.Name == nodeName {
 			// TODO: how can we find out the actual data port as opposed to relying on
@@ -312,9 +288,6 @@ func (s *State) NodeHostname(nodeName string) (string, bool) {
 // NodeAddress is used to resolve the node name into an ip address without the port
 // TODO-RAFT-DB-63 : shall be replaced by Members() which returns members in the list
 func (s *State) NodeAddress(id string) string {
-	s.listLock.RLock()
-	defer s.listLock.RUnlock()
-
 	// network interruption detection which can cause a single node to be isolated from the cluster (split brain)
 	nodeCount := s.list.NumMembers()
 	var joinAddr []string


### PR DESCRIPTION
### What's being changed:
remove unnecessarily locks from raft & memberlist to avoid locks contentions. 
w.r.t 
- https://github.com/hashicorp/memberlist/blob/master/memberlist.go#L502-L503
- https://github.com/hashicorp/raft/blob/main/net_transport.go#L389-L391

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17585027646
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
