### PR TITLE
fix(schema): panic in NumberOfReplicas()

### DIFF
--- a/usecases/sharding/state.go
+++ b/usecases/sharding/state.go
@@ -193,6 +193,9 @@ func (s *State) DeleteReplicaFromShard(shard string, replica string) error {
 }
 
 func (s *State) NumberOfReplicas(shard string) (int64, error) {
+	if len(s.Physical) == 0 {
+		return 0, fmt.Errorf("could not find shard %s", shard)
+	}
 	phys, ok := s.Physical[shard]
 	if !ok {
 		return 0, fmt.Errorf("could not find shard %s", shard)


### PR DESCRIPTION
### What's being changed:
this PR fix possible panics in `schema.NumberOfReplicas()` and adds unittest
e.g 
```
mp/post_upgrade_weaviate_pods.log:weaviate-2 weaviate 2025/09/09 09:50:37 http: panic serving 10.244.3.20:42438: runtime error: invalid memory address or nil pointer dereference
/tmp/post_upgrade_weaviate_pods.log:weaviate-2 weaviate goroutine 83197 [running]:
Error: Found panic in weaviate logs
Panic context:
/tmp/post_upgrade_weaviate_pods.log:weaviate-1 weaviate panic: runtime error: invalid memory address or nil pointer dereference
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate [signal SIGSEGV: segmentation violation code=0x1 addr=0x68 pc=0xf30c55]
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate 
/tmp/post_upgrade_weaviate_pods.log:weaviate-1 weaviate goroutine 472312 [running]:
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate github.com/weaviate/weaviate/usecases/sharding.(*State).NumberOfReplicas(0xc00f025b60?, {0xc00f031100, 0xc})
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate 	/go/src/github.com/weaviate/weaviate/usecases/sharding/state.go:196 +0x55
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*Index).getShardsNodeStatus.func1({0xc00f031100, 0xc}, {0x40d9678, 0xc00f025b60})
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate 	/go/src/github.com/weaviate/weaviate/adapters/repos/db/nodes.go:225 +0x2eb
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*shardMap).Range.func1({0x2723160?, 0xc00f409a80?}, {0x2e0d8e0?, 0xc00f025b60?})
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate 	/go/src/github.com/weaviate/weaviate/adapters/repos/db/index.go:95 +0xcf
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate internal/sync.(*HashTrieMap[...]).iter(0x40dfaa0, 0xc00e6ec780, 0xc006635ac8)
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate 	/usr/local/go/src/internal/sync/hashtriemap.go:512 +0xea
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate internal/sync.(*HashTrieMap[...]).Range(0x7265880?, 0xc00008c008?)
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate 	/usr/local/go/src/internal/sync/hashtriemap.go:495 +0x57
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate sync.(*Map).Range(...)
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate 	/usr/local/go/src/sync/hashtriemap.go:115
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*shardMap).Range(0xc0022b3008?, 0xc0022b3548?)
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate 	/go/src/github.com/weaviate/weaviate/adapters/repos/db/index.go:94 +0x45
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*Index).ForEachShard(...)
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate 	/go/src/github.com/weaviate/weaviate/adapters/repos/db/index.go:505
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*Index).getShardsNodeStatus(0xc00050715c?, {0x409fe00?, 0xc00060c4d0?}, 0xe8a93c245b83be63?, {0x0?, 0x73827b?})
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate 	/go/src/github.com/weaviate/weaviate/adapters/repos/db/nodes.go:175 +0xa8
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate github.com/weaviate/weaviate/adapters/repos/db.(*DB).localNodeShardStats(0xc000506f08, {0x409fe00, 0xc00060c4d0}, 0xc006635cd0, {0x0?, 0x34bf435f12be6a?}, {0x0, 0x0})
/tmp/post_upgrade_weaviate_pods.log-weaviate-1 weaviate 	/go/src/github.com/weaviate/weaviate/adapters/repos/db/nodes.go:135 +0x2ba
--
/tmp/post_upgrade_weaviate_pods.log:weaviate-2 weaviate 2025/09/09 09:50:37 http: panic serving 10.244.3.20:42438: runtime error: invalid memory address or nil pointer dereference
/tmp/post_upgrade_weaviate_pods.log:weaviate-2 weaviate goroutine 83197 [running]:
/tmp/post_upgrade_weaviate_pods.log-weaviate-2 weaviate net/http.(*conn).serve.func1()
/tmp/post_upgrade_weaviate_pods.log-weaviate-2 weaviate 	/usr/local/go/src/net/http/server.go:1947 +0xbe
/tmp/post_upgrade_weaviate_pods.log-weaviate-2 weaviate panic({0x288e5c0?, 0x71dd910?})
/tmp/post_upgrade_weaviate_pods.log-weaviate-2 weaviate 	/usr/local/go/src/runtime/panic.go:792 +0x132
/tmp/post_upgrade_weaviate_pods.log-weaviate-2 weaviate github.com/weaviate/weaviate/usecases/sharding.(*State).NumberOfReplicas(0xc00161acc0?, {0xc000f619a0, 0xc})
/tmp/post_upgrade_weaviate_pods.log-weaviate-2 weaviate 	/go/src/github.com/weaviate/weaviate/usecases/sharding/state.go:196 +0x55
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
