### PR TITLE
refact(usage):  replace gcp client to service for better client defaults initialization 

### DIFF
--- a/modules/usage-gcs/storage.go
+++ b/modules/usage-gcs/storage.go
@@ -120,7 +120,8 @@ func (g *GCSStorage) UploadUsageData(ctx context.Context, usage *types.Report) e
 // Close cleans up resources
 func (g *GCSStorage) Close() error {
 	// storageapi.Service doesn't have a Close method
-	// The HTTP client will be cleaned up by Go's garbage collector
+	// requests are handled by the HTTP client
+	// see https://github.com/googleapis/google-cloud-go/blob/storage/v1.56.1/storage/storage.go#L154-L161
 	return nil
 }
 


### PR DESCRIPTION
### What's being changed:
we would like to have the ability to deploy across clouds, using clients were overriding GCP reading defaults,  this change make sure sure to user service instead of client for better clients initialization 

see : https://github.com/googleapis/google-cloud-go/blob/storage/v1.56.1/storage/storage.go#L154-L160 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
