### PR TITLE
test: split go client acceptance tests into balanced groups for CI

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -370,7 +370,8 @@ jobs:
           "--acceptance-only-async-replication",
           "--acceptance-only-replica-replication-fast",
           "--acceptance-only-replica-replication-slow",
-          "--acceptance-go-client-only-fast",
+          "--acceptance-go-client-only-fast-group-1",
+          "--acceptance-go-client-only-fast-group-2",
           "--acceptance-only-python",
         ]
     steps:

--- a/test/run.sh
+++ b/test/run.sh
@@ -12,7 +12,8 @@ function main() {
   run_acceptance_only_fast_group_4=false
   run_acceptance_only_authz=false
   run_acceptance_only_python=false
-  run_acceptance_go_client=false
+  run_acceptance_go_client_only_fast_group_1=false
+  run_acceptance_go_client_only_fast_group_2=false
   run_acceptance_graphql_tests=false
   run_acceptance_replication_tests=false
   run_acceptance_replica_replication_fast_tests=false
@@ -54,7 +55,9 @@ function main() {
           --acceptance-only-fast-group-4|-aof-g4) run_all_tests=false; run_acceptance_only_fast_group_4=true;;
           --acceptance-only-python|-aop) run_all_tests=false; run_acceptance_only_python=true;;
           --acceptance-go-client|-ag) run_all_tests=false; run_acceptance_go_client=true;;
-          --acceptance-go-client-only-fast|-agof) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_only_fast=true;;
+          --acceptance-go-client-only-fast|-agof) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_only_fast_group_1=true; run_acceptance_go_client_only_fast_group_2=true;;
+          --acceptance-go-client-only-fast-group-1|-agof-g1) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_only_fast_group_1=true;;
+          --acceptance-go-client-only-fast-group-2|-agof-g2) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_only_fast_group_2=true;;
           --acceptance-go-client-named-vectors-single-node|-agnvsn) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_named_vectors_single_node=true;;
           --acceptance-go-client-named-vectors-cluster|-agnvc) run_all_tests=false; run_acceptance_go_client=false; run_acceptance_go_client_named_vectors_cluster=true;;
           --acceptance-only-graphql|-aog) run_all_tests=false; run_acceptance_graphql_tests=true ;;
@@ -88,6 +91,8 @@ function main() {
               "--acceptance-only-python | -aop"\
               "--acceptance-go-client | -ag"\
               "--acceptance-go-client-only-fast | -agof"\
+              "--acceptance-go-client-only-fast-group-1 | -agof-g1"\
+              "--acceptance-go-client-only-fast-group-2 | -agof-g2"\
               "--acceptance-go-client-named-vectors-single-node | -agnvsn"\
               "--acceptance-go-client-named-vectors-cluster | -agnvc"\
               "--acceptance-only-graphql | -aog"\
@@ -135,7 +140,7 @@ function main() {
     echo_green "Integration tests successful"
   fi
 
-  if $run_acceptance_tests  || $run_acceptance_only_fast_group_1 || $run_acceptance_only_fast_group_2 || $run_acceptance_only_fast_group_3 || $run_acceptance_only_fast_group_4 || $run_acceptance_only_authz || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_only_python || $run_all_tests || $run_benchmark || $run_acceptance_go_client_only_fast || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $only_acceptance || $run_acceptance_objects
+  if $run_acceptance_tests  || $run_acceptance_only_fast_group_1 || $run_acceptance_only_fast_group_2 || $run_acceptance_only_fast_group_3 || $run_acceptance_only_fast_group_4 || $run_acceptance_only_authz || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_only_python || $run_all_tests || $run_benchmark || $run_acceptance_go_client_only_fast_group_1 || $run_acceptance_go_client_only_fast_group_2 || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $only_acceptance || $run_acceptance_objects
   then
     echo "Start docker container needed for acceptance and/or benchmark test"
     echo_green "Stop any running docker-compose containers..."
@@ -163,7 +168,7 @@ function main() {
       ./test/benchmark/run_performance_tracker.sh
     fi
 
-    if $run_acceptance_tests || $run_acceptance_only_fast_group_1 || $run_acceptance_only_fast_group_2 || $run_acceptance_only_fast_group_3 || $run_acceptance_only_fast_group_4 || $run_acceptance_only_authz || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_go_client_only_fast || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $run_all_tests || $only_acceptance || $run_acceptance_objects
+    if $run_acceptance_tests || $run_acceptance_only_fast_group_1 || $run_acceptance_only_fast_group_2 || $run_acceptance_only_fast_group_3 || $run_acceptance_only_fast_group_4 || $run_acceptance_only_authz || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_go_client_only_fast_group_1 || $run_acceptance_go_client_only_fast_group_2 || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $run_all_tests || $only_acceptance || $run_acceptance_objects
     then
       echo_green "Run acceptance tests..."
       run_acceptance_tests "$@"
@@ -320,10 +325,14 @@ function run_acceptance_tests() {
   echo "running only acceptance"
     run_acceptance_only_tests
   fi
-  if $run_acceptance_go_client_only_fast || $run_acceptance_go_client || $run_acceptance_tests || $run_all_tests; then
-  echo "running acceptance go client only fast"
-    run_acceptance_go_client_only_fast "$@"
-  fi
+  if $run_acceptance_go_client_only_fast_group_1 || $run_acceptance_go_client || $run_acceptance_tests || $run_all_tests; then
+    echo "running acceptance go client only fast group 1"
+      run_acceptance_go_client_only_fast_group 1
+    fi
+    if $run_acceptance_go_client_only_fast_group_2 || $run_acceptance_go_client || $run_acceptance_tests || $run_all_tests; then
+    echo "running acceptance go client only fast group 2"
+      run_acceptance_go_client_only_fast_group 2
+    fi
   if $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client || $run_acceptance_tests || $run_all_tests; then
   echo "running acceptance go client named vectors for single node"
     run_acceptance_go_client_named_vectors_single_node "$@"
@@ -468,17 +477,52 @@ function run_acceptance_only_fast_group() {
   esac
 }
 
-function run_acceptance_go_client_only_fast() {
+# get_go_client_group returns the package patterns for the specified group number (1-2).
+function get_go_client_group() {
+  case "$1" in
+    1) echo "acceptance_tests_with_client/multi_tenancy_tests acceptance_tests_with_client/filters_tests" ;;
+    2) echo "acceptance_tests_with_client acceptance_tests_with_client/compression acceptance_tests_with_client/grpc_tests acceptance_tests_with_client/auth_tests acceptance_tests_with_client/object_property_tests" ;;
+    *) echo "" ;;
+  esac
+}
+
+# run_acceptance_go_client_only_fast_group runs a specific group of go client tests.
+# Parameters:
+#   $1: GROUP - group number to run (1-2)
+function run_acceptance_go_client_only_fast_group() {
   export TEST_WEAVIATE_IMAGE=weaviate/test-server
-    # tests with go client are in a separate package with its own dependencies to isolate them
-    cd 'test/acceptance_with_go_client'
-    for pkg in $(go list ./... | grep -v 'acceptance_tests_with_client/named_vectors_tests'); do
+  local GROUP="$1"
+
+  echo_green "acceptance-go-client-only-fast — group $GROUP/2"
+
+  local group_packages
+  group_packages=$(get_go_client_group "$GROUP")
+
+  if [[ -z "$group_packages" ]]; then
+    echo_red "Invalid group: $GROUP (must be 1 or 2)"
+    return 1
+  fi
+
+  echo "Group $GROUP packages: $group_packages"
+
+  # tests with go client are in a separate package with its own dependencies to isolate them
+  cd 'test/acceptance_with_go_client'
+
+  local testFailed=0
+  for pattern in $group_packages; do
+    for pkg in $(go list ./... | grep -v 'acceptance_tests_with_client/named_vectors_tests' | grep "${pattern}$"); do
+      echo_green "Running $pkg"
       if ! go test -count 1 -race "$pkg"; then
         echo "Test for $pkg failed" >&2
-        return 1
+        testFailed=1
       fi
     done
-    cd -
+  done
+
+  cd -
+
+  [[ $testFailed -eq 1 ]] && return 1
+  return 0
 }
 
 function run_acceptance_go_client_named_vectors_single_node() {


### PR DESCRIPTION
Go client acceptance tests currently run as a single job taking about 10 minutes, creating CI bottlenecks when multiple PRs are active. With limited GitHub runners and multiple jobs per PR, inefficient job scheduling leads to queueing and wasted runner capacity.

Here we split go client tests into two balanced groups following the same pattern as some existing acceptance test groups:

- **Group 1** (~5 minutes): `multi_tenancy_tests` + `filters_tests`
- **Group 2** (~4-5 minutes): main package + `compression` + `grpc_tests` + `auth_tests` + `object_property_tests`

- Added `--acceptance-go-client-only-fast-group-1` and `--acceptance-go-client-only-fast-group-2` flags
- Modified `--acceptance-go-client-only-fast` to run both groups sequentially (backward compatibility)
- Updated GitHub Actions matrix to run groups in parallel instead of sequential single job
- Added load-balanced package assignment to groups based on historical execution times

- **45% faster CI**: Pipeline completion time reduced from 10 mins to 5 mins
- **Better runner utilization**: Both parallel jobs finish at similar times, reducing idle capacity
- **Reduced queue pressure**: Faster pipeline completion frees runners for other queued jobs
- **Backward compatibility**: Existing `--acceptance-go-client-only-fast` flag still works

Verified all three execution modes work correctly:
- Individual groups: `./test/run.sh --acceptance-go-client-only-fast-group-1`
- Combined: `./test/run.sh --acceptance-go-client-only-fast`
- CI matrix integration confirmed

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.