### PR TITLE
refact(backup): expose create and completed timestamps

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -5426,6 +5426,11 @@ func init() {
           "description": "Backup backend name e.g. filesystem, gcs, s3.",
           "type": "string"
         },
+        "completedAt": {
+          "description": "Timestamp when the backup process completed (successfully or with failure)",
+          "type": "string",
+          "format": "date-time"
+        },
         "error": {
           "description": "error message if creation failed",
           "type": "string"
@@ -5437,6 +5442,11 @@ func init() {
         "path": {
           "description": "destination path of backup files proper to selected backend",
           "type": "string"
+        },
+        "startedAt": {
+          "description": "Timestamp when the backup process started",
+          "type": "string",
+          "format": "date-time"
         },
         "status": {
           "description": "phase of backup creation process",
@@ -5466,9 +5476,19 @@ func init() {
               "type": "string"
             }
           },
+          "completedAt": {
+            "description": "Timestamp when the backup process completed (successfully or with failure)",
+            "type": "string",
+            "format": "date-time"
+          },
           "id": {
             "description": "The ID of the backup. Must be URL-safe and work as a filesystem path, only lowercase, numbers, underscore, minus characters allowed.",
             "type": "string"
+          },
+          "startedAt": {
+            "description": "Timestamp when the backup process started",
+            "type": "string",
+            "format": "date-time"
           },
           "status": {
             "description": "status of backup process",
@@ -13812,6 +13832,11 @@ func init() {
           "description": "Backup backend name e.g. filesystem, gcs, s3.",
           "type": "string"
         },
+        "completedAt": {
+          "description": "Timestamp when the backup process completed (successfully or with failure)",
+          "type": "string",
+          "format": "date-time"
+        },
         "error": {
           "description": "error message if creation failed",
           "type": "string"
@@ -13823,6 +13848,11 @@ func init() {
         "path": {
           "description": "destination path of backup files proper to selected backend",
           "type": "string"
+        },
+        "startedAt": {
+          "description": "Timestamp when the backup process started",
+          "type": "string",
+          "format": "date-time"
         },
         "status": {
           "description": "phase of backup creation process",
@@ -13856,9 +13886,19 @@ func init() {
             "type": "string"
           }
         },
+        "completedAt": {
+          "description": "Timestamp when the backup process completed (successfully or with failure)",
+          "type": "string",
+          "format": "date-time"
+        },
         "id": {
           "description": "The ID of the backup. Must be URL-safe and work as a filesystem path, only lowercase, numbers, underscore, minus characters allowed.",
           "type": "string"
+        },
+        "startedAt": {
+          "description": "Timestamp when the backup process started",
+          "type": "string",
+          "format": "date-time"
         },
         "status": {
           "description": "status of backup process",

--- a/adapters/handlers/rest/handlers_backup.go
+++ b/adapters/handlers/rest/handlers_backup.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations"
@@ -161,11 +162,13 @@ func (s *backupHandlers) createBackupStatus(params backups.BackupsCreateStatusPa
 
 	strStatus := string(status.Status)
 	payload := models.BackupCreateStatusResponse{
-		Status:  &strStatus,
-		ID:      params.ID,
-		Path:    status.Path,
-		Backend: params.Backend,
-		Error:   status.Err,
+		Status:      &strStatus,
+		ID:          params.ID,
+		Path:        status.Path,
+		Backend:     params.Backend,
+		Error:       status.Err,
+		StartedAt:   strfmt.DateTime(status.StartedAt.UTC()),
+		CompletedAt: strfmt.DateTime(status.CompletedAt.UTC()),
 	}
 	s.metricRequestsTotal.logOk("")
 	return backups.NewBackupsCreateStatusOK().WithPayload(&payload)

--- a/entities/models/backup_create_status_response.go
+++ b/entities/models/backup_create_status_response.go
@@ -34,6 +34,10 @@ type BackupCreateStatusResponse struct {
 	// Backup backend name e.g. filesystem, gcs, s3.
 	Backend string `json:"backend,omitempty"`
 
+	// Timestamp when the backup process completed (successfully or with failure)
+	// Format: date-time
+	CompletedAt strfmt.DateTime `json:"completedAt,omitempty"`
+
 	// error message if creation failed
 	Error string `json:"error,omitempty"`
 
@@ -42,6 +46,10 @@ type BackupCreateStatusResponse struct {
 
 	// destination path of backup files proper to selected backend
 	Path string `json:"path,omitempty"`
+
+	// Timestamp when the backup process started
+	// Format: date-time
+	StartedAt strfmt.DateTime `json:"startedAt,omitempty"`
 
 	// phase of backup creation process
 	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED CANCELED]
@@ -52,6 +60,14 @@ type BackupCreateStatusResponse struct {
 func (m *BackupCreateStatusResponse) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateCompletedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateStartedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateStatus(formats); err != nil {
 		res = append(res, err)
 	}
@@ -59,6 +75,30 @@ func (m *BackupCreateStatusResponse) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *BackupCreateStatusResponse) validateCompletedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.CompletedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("completedAt", "body", "date-time", m.CompletedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *BackupCreateStatusResponse) validateStartedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.StartedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("startedAt", "body", "date-time", m.StartedAt.String(), formats); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/entities/models/backup_list_response.go
+++ b/entities/models/backup_list_response.go
@@ -93,8 +93,16 @@ type BackupListResponseItems0 struct {
 	// The list of classes for which the existed backup process
 	Classes []string `json:"classes"`
 
+	// Timestamp when the backup process completed (successfully or with failure)
+	// Format: date-time
+	CompletedAt strfmt.DateTime `json:"completedAt,omitempty"`
+
 	// The ID of the backup. Must be URL-safe and work as a filesystem path, only lowercase, numbers, underscore, minus characters allowed.
 	ID string `json:"id,omitempty"`
+
+	// Timestamp when the backup process started
+	// Format: date-time
+	StartedAt strfmt.DateTime `json:"startedAt,omitempty"`
 
 	// status of backup process
 	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED CANCELED]
@@ -105,6 +113,14 @@ type BackupListResponseItems0 struct {
 func (m *BackupListResponseItems0) Validate(formats strfmt.Registry) error {
 	var res []error
 
+	if err := m.validateCompletedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateStartedAt(formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.validateStatus(formats); err != nil {
 		res = append(res, err)
 	}
@@ -112,6 +128,30 @@ func (m *BackupListResponseItems0) Validate(formats strfmt.Registry) error {
 	if len(res) > 0 {
 		return errors.CompositeValidationError(res...)
 	}
+	return nil
+}
+
+func (m *BackupListResponseItems0) validateCompletedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.CompletedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("completedAt", "body", "date-time", m.CompletedAt.String(), formats); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *BackupListResponseItems0) validateStartedAt(formats strfmt.Registry) error {
+	if swag.IsZero(m.StartedAt) { // not required
+		return nil
+	}
+
+	if err := validate.FormatOf("startedAt", "body", "date-time", m.StartedAt.String(), formats); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1496,6 +1496,16 @@
             "FAILED",
             "CANCELED"
           ]
+        },
+        "startedAt": {
+          "description": "Timestamp when the backup process started",
+          "type": "string",
+          "format": "date-time"
+        },
+        "completedAt": {
+          "description": "Timestamp when the backup process completed (successfully or with failure)",
+          "type": "string",
+          "format": "date-time"
         }
       }
     },
@@ -1723,6 +1733,16 @@
               "FAILED",
               "CANCELED"
             ]
+          },
+          "startedAt": {
+            "description": "Timestamp when the backup process started",
+            "type": "string",
+            "format": "date-time"
+          },
+          "completedAt": {
+            "description": "Timestamp when the backup process completed (successfully or with failure)",
+            "type": "string",
+            "format": "date-time"
           }
         }
       }

--- a/test/helper/journey/backup_and_restore_journey.go
+++ b/test/helper/journey/backup_and_restore_journey.go
@@ -152,6 +152,10 @@ func backupAndRestoreJourneyTest(t *testing.T, weaviateEndpoint, backend string,
 			WithID(backupID).
 			WithBucket(&overrideName).
 			WithPath(&overridePath)
+
+		var startTime time.Time
+		var completedTime time.Time
+
 		for {
 			resp, err := helper.Client(t).Backups.BackupsCreateStatus(params, nil)
 			require.Nil(t, err)
@@ -159,6 +163,13 @@ func backupAndRestoreJourneyTest(t *testing.T, weaviateEndpoint, backend string,
 
 			meta := resp.GetPayload()
 			require.NotNil(t, meta)
+			require.NotNil(t, meta.StartedAt)
+
+			// Capture start time on first iteration
+			if startTime.IsZero() {
+				startTime = time.Time(meta.StartedAt)
+				t.Logf("Backup started at: %v", startTime)
+			}
 
 			if err != nil {
 				t.Logf("failed to get backup status: %+v", err)
@@ -166,6 +177,21 @@ func backupAndRestoreJourneyTest(t *testing.T, weaviateEndpoint, backend string,
 
 			switch *meta.Status {
 			case models.BackupCreateStatusResponseStatusSUCCESS:
+				require.NotNil(t, meta.CompletedAt)
+				completedTime = time.Time(meta.CompletedAt)
+				t.Logf("Backup completed at: %v", completedTime)
+
+				// Verify timestamps are reasonable
+				require.True(t, !startTime.IsZero(), "Start time should not be zero")
+				require.True(t, !completedTime.IsZero(), "Completed time should not be zero")
+				require.True(t, completedTime.After(startTime), "Completed time should be after start time")
+
+				// Verify timestamps are recent (within last hour)
+				now := time.Now()
+				require.True(t, startTime.After(now.Add(-1*time.Hour)), "Start time should be within the last hour")
+				require.True(t, completedTime.After(now.Add(-1*time.Hour)), "Completed time should be within the last hour")
+
+				t.Logf("Backup duration: %v", completedTime.Sub(startTime))
 				return
 			case models.BackupCreateStatusResponseStatusFAILED:
 				t.Errorf("failed to create backup, got response: %+v", meta)

--- a/test/helper/journey/backup_journey.go
+++ b/test/helper/journey/backup_journey.go
@@ -332,6 +332,26 @@ wait:
 				found = true
 				assert.Equal(t, string(backup.Success), b.Status)
 				assert.Contains(t, b.Classes, className)
+
+				// Validate timestamp fields
+				require.NotNil(t, b.StartedAt, "StartedAt should not be nil")
+				require.NotNil(t, b.CompletedAt, "CompletedAt should not be nil")
+
+				startTime := time.Time(b.StartedAt)
+				completedTime := time.Time(b.CompletedAt)
+
+				// Verify timestamps are reasonable
+				assert.False(t, startTime.IsZero(), "Start time should not be zero")
+				assert.False(t, completedTime.IsZero(), "Completed time should not be zero")
+				assert.True(t, completedTime.After(startTime), "Completed time should be after start time")
+
+				// Verify timestamps are recent (within last hour)
+				now := time.Now()
+				assert.True(t, startTime.After(now.Add(-1*time.Hour)), "Start time should be within the last hour")
+				assert.True(t, completedTime.After(now.Add(-1*time.Hour)), "Completed time should be within the last hour")
+
+				t.Logf("Backup %s: started at %v, completed at %v, duration: %v",
+					b.ID, startTime, completedTime, completedTime.Sub(startTime))
 				break
 			}
 		}

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/entities/backup"
@@ -328,9 +329,11 @@ func (s *Scheduler) List(ctx context.Context, principal *models.Principal, backe
 	response := make(models.BackupListResponse, len(backups))
 	for i, b := range backups {
 		response[i] = &models.BackupListResponseItems0{
-			ID:      b.ID,
-			Status:  string(b.Status),
-			Classes: b.Classes(),
+			ID:          b.ID,
+			Classes:     b.Classes(),
+			Status:      string(b.Status),
+			StartedAt:   strfmt.DateTime(b.StartedAt.UTC()),
+			CompletedAt: strfmt.DateTime(b.CompletedAt.UTC()),
 		}
 	}
 


### PR DESCRIPTION
### What's being changed:
we need to expose creation and completion timestamps as metadata for backup status or list in order to help for decsions if there is a need to trigger backups based on the creation time window  


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
