### PR TITLE
test: rename CI GitHub Actions to better fit the UI

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -415,6 +415,7 @@ jobs:
             test: "--acceptance-go-client-only-fast-group-2"
           - name: "python"
             test: "--acceptance-only-python"
+    steps:
       - uses: actions/checkout@v5
       - name: Set up Go
         uses: actions/setup-go@v6


### PR DESCRIPTION
CI job names in GitHub Actions are too verbose and get truncated in the UI. Job names like `modules-acceptance-tests-large` and matrix test names like `--acceptance-only-fast-group-1` make it hard to quickly scan CI results.

This PR shortens job display names (`modules` instead of `modules-acceptance-tests`) and converts matrix arrays to use include strategy with descriptive names. Jobs now display as `modules (backup-azure)` instead of `modules-acceptance-tests (--only-module-backup-azure)`.

The changes improve CI dashboard scanning and fit better in GitHub Actions UI without changing any test functionality. All command-line flags are preserved in the `test` parameter so execution remains identical.

Examples:
- `acceptance (go-client-1)` vs `acceptance-tests (--acceptance-go-client-only-fast-group-1)`
- `modules (text2vec-transformers)` vs `modules-acceptance-tests (--only-module-text2vec-transformers)`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
