### PR TITLE
Writable Shard With Context

### DIFF
--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -165,8 +165,8 @@ func (db *DB) replicatedIndex(name string) (idx *Index, resp *replica.SimpleResp
 	return
 }
 
-func (i *Index) writableShard(name string) (ShardLike, func(), *replica.SimpleResponse) {
-	localShard, release, err := i.getOrInitShard(context.Background(), name)
+func (i *Index) writableShard(name string, ctx context.Context) (ShardLike, func(), *replica.SimpleResponse) {
+	localShard, release, err := i.getOrInitShard(ctx, name)
 	if err != nil {
 		return nil, func() {}, &replica.SimpleResponse{Errors: []replica.Error{
 			{Code: replica.StatusShardNotFound, Msg: name},
@@ -183,7 +183,7 @@ func (i *Index) writableShard(name string) (ShardLike, func(), *replica.SimpleRe
 }
 
 func (i *Index) ReplicateObject(ctx context.Context, shard, requestID string, object *storobj.Object) replica.SimpleResponse {
-	localShard, release, pr := i.writableShard(shard)
+	localShard, release, pr := i.writableShard(shard, ctx)
 	if pr != nil {
 		return *pr
 	}
@@ -194,7 +194,7 @@ func (i *Index) ReplicateObject(ctx context.Context, shard, requestID string, ob
 }
 
 func (i *Index) ReplicateUpdate(ctx context.Context, shard, requestID string, doc *objects.MergeDocument) replica.SimpleResponse {
-	localShard, release, pr := i.writableShard(shard)
+	localShard, release, pr := i.writableShard(shard, ctx)
 	if pr != nil {
 		return *pr
 	}
@@ -205,7 +205,7 @@ func (i *Index) ReplicateUpdate(ctx context.Context, shard, requestID string, do
 }
 
 func (i *Index) ReplicateDeletion(ctx context.Context, shard, requestID string, uuid strfmt.UUID, deletionTime time.Time) replica.SimpleResponse {
-	localShard, release, pr := i.writableShard(shard)
+	localShard, release, pr := i.writableShard(shard, ctx)
 	if pr != nil {
 		return *pr
 	}
@@ -216,7 +216,7 @@ func (i *Index) ReplicateDeletion(ctx context.Context, shard, requestID string, 
 }
 
 func (i *Index) ReplicateObjects(ctx context.Context, shard, requestID string, objects []*storobj.Object, schemaVersion uint64) replica.SimpleResponse {
-	localShard, release, pr := i.writableShard(shard)
+	localShard, release, pr := i.writableShard(shard, ctx)
 	if pr != nil {
 		return *pr
 	}
@@ -229,7 +229,7 @@ func (i *Index) ReplicateObjects(ctx context.Context, shard, requestID string, o
 func (i *Index) ReplicateDeletions(ctx context.Context, shard, requestID string,
 	uuids []strfmt.UUID, deletionTime time.Time, dryRun bool, schemaVersion uint64,
 ) replica.SimpleResponse {
-	localShard, release, pr := i.writableShard(shard)
+	localShard, release, pr := i.writableShard(shard, ctx)
 	if pr != nil {
 		return *pr
 	}
@@ -240,7 +240,7 @@ func (i *Index) ReplicateDeletions(ctx context.Context, shard, requestID string,
 }
 
 func (i *Index) ReplicateReferences(ctx context.Context, shard, requestID string, refs []objects.BatchReference) replica.SimpleResponse {
-	localShard, release, pr := i.writableShard(shard)
+	localShard, release, pr := i.writableShard(shard, ctx)
 	if pr != nil {
 		return *pr
 	}


### PR DESCRIPTION
### What's being changed:

Passes through the request context into `writableShard`

 - [ ] TODO consider having initShard call use a background and/or very long context still?

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
