### PR TITLE
Fix order of segment initialization for compaction crashes

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -19,7 +19,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -150,8 +149,6 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 
 	segmentIndex := 0
 
-	segmentsAlreadyRecoveredFromCompaction := make(map[string]struct{})
-
 	// Note: it's important to process first the compacted segments
 	// TODO: a single iteration may be possible
 
@@ -280,42 +277,12 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 			return nil, fmt.Errorf("rename compacted segment file %q as %q: %w", entry, newRightSegmentFileName, err)
 		}
 
-		var segment Segment
-		var err error
-		sgConf := segmentConfig{
-			mmapContents:             sg.mmapContents,
-			useBloomFilter:           sg.useBloomFilter,
-			calcCountNetAdditions:    sg.calcCountNetAdditions,
-			overwriteDerived:         true,
-			enableChecksumValidation: sg.enableChecksumValidation,
-			MinMMapSize:              sg.MinMMapSize,
-			allocChecker:             sg.allocChecker,
-			fileList:                 files,
-			writeMetadata:            sg.writeMetadata,
-		}
-		if b.lazySegmentLoading {
-			segment, err = newLazySegment(newRightSegmentPath, logger,
-				metrics, sg.makeExistsOn(sg.segments[:segmentIndex]), sgConf,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("init lazy segment %s: %w", newRightSegmentFileName, err)
-			}
-		} else {
-			segment, err = newSegment(newRightSegmentPath, logger,
-				metrics, sg.makeExistsOn(sg.segments[:segmentIndex]), sgConf,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("init segment %s: %w", newRightSegmentFileName, err)
-			}
-		}
-
-		sg.segments[segmentIndex] = segment
-		segmentIndex++
-
-		segmentsAlreadyRecoveredFromCompaction[newRightSegmentFileName] = struct{}{}
+		// initialize in correct order in the next iteration
+		files[newRightSegmentFileName] = files[entry]
+		delete(files, entry)
 	}
 
-	// segments need to be initialised in order of their timestamp to ensure that net additions are calculated correctly
+	// segments need to be initialised in order of their timestamp to ensure that various computations are correct (CNA etc)
 	fileList := make([]string, 0, len(files))
 	for entry := range files {
 		fileList = append(fileList, entry)
@@ -339,12 +306,6 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 
 		if filepath.Ext(entry) != ".db" {
 			// skip, this could be commit log, etc.
-			continue
-		}
-
-		_, alreadyRecoveredFromCompaction := segmentsAlreadyRecoveredFromCompaction[entry]
-		if alreadyRecoveredFromCompaction {
-			// the .db file was already removed and restored from a compacted segment
 			continue
 		}
 
@@ -403,19 +364,6 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 	}
 
 	sg.segments = sg.segments[:segmentIndex]
-
-	// segment load order is as follows:
-	// - find .tmp files and recover them first
-	// - find .db files and load them
-	//   - if there is a .wal file exists for a .db, remove the .db file
-	// - find .wal files and load them into a memtable
-	//   - flush the memtable to a segment file
-	// Thus, files may be loaded in a different order than they were created,
-	// and we need to re-sort them to ensure the order is correct, as compations
-	// and other operations are based on the creation order of the segments
-	sort.Slice(sg.segments, func(i, j int) bool {
-		return sg.segments[i].getPath() < sg.segments[j].getPath()
-	})
 
 	// Actual strategy is stored in segment files. In case it is SetCollection,
 	// while new implementation uses bitmaps and supposed to be RoaringSet,


### PR DESCRIPTION
### What's being changed:

Currently we are doing two iterations to initialize objects:
1. one to recover potential leftovers from compations after crashes
2. initialize all "normal" segments

However, if we recover from a compaction `sg.makeExistsOn(sg.segments[:segmentIndex])` does not contain all previous segments and the computed object count will be wrong.

To fix this, the segment to be recovered is renamed and added to the list of known files. This will be sorted before it is initialized and all segments will be initialised in the correct order.

Follow up to https://github.com/weaviate/weaviate/pull/9169

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
