### PR TITLE
chore(modules): remove end of life models from generative-aws module tests

### DIFF
--- a/test/modules/generative-aws/generative_aws_test.go
+++ b/test/modules/generative-aws/generative_aws_test.go
@@ -98,18 +98,6 @@ func testGenerativeAWS(rest, grpc, region string) func(t *testing.T) {
 				generativeModel: "anthropic.claude-3-haiku-20240307-v1:0",
 				withImages:      true,
 			},
-			{
-				name:            "anthropic.claude-v2:1",
-				generativeModel: "anthropic.claude-v2:1",
-			},
-			{
-				name:            "anthropic.claude-v2",
-				generativeModel: "anthropic.claude-v2",
-			},
-			{
-				name:            "anthropic.claude-instant-v1",
-				generativeModel: "anthropic.claude-instant-v1",
-			},
 			// Cohere
 			{
 				name:            "cohere.command-r-v1:0",


### PR DESCRIPTION
### What's being changed:

This PR removes models that reached end of life in AWS Bedrock:
- `anthropic.claude-v2:1`
- `anthropic.claude-v2`
- `anthropic.claude-instant-v1`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
