### PR TITLE
chore(modules): remove jina-embeddings-v2-base-en from text2vec-jinaai e2e tests

### DIFF
--- a/test/modules/text2vec-jinaai/text2vec_jinaai_test.go
+++ b/test/modules/text2vec-jinaai/text2vec_jinaai_test.go
@@ -34,10 +34,6 @@ func testText2VecJinaAI(rest, grpc string) func(t *testing.T) {
 			dimensions int
 		}{
 			{
-				name:  "jina-embeddings-v2-base-en",
-				model: "jina-embeddings-v2-base-en",
-			},
-			{
 				name:       "jina-embeddings-v3",
 				model:      "jina-embeddings-v3",
 				dimensions: 64,


### PR DESCRIPTION
### What's being changed:

This PR removes `jina-embeddings-v2-base-en` from `text2vec-jinaai` e2e tests.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
