### PR TITLE
fix(alias): backup recovery error when using alias + overwrite_alias flag

### DIFF
--- a/test/acceptance/aliases/aliases_api_backup_test.go
+++ b/test/acceptance/aliases/aliases_api_backup_test.go
@@ -73,8 +73,14 @@ func Test_AliasesAPI_Backup(t *testing.T) {
 	// Three options for the test:
 	// 1. full: backup and restore collection after deleting both collection and the alias, will pass as of 1.32
 	// 2. overwrite: backup and restore after deleting the collection but not the alias, should pass only if "overwrite option is set"
-	for _, options := range []string{"full", "overwrite"} {
-		t.Run("backup with "+options, func(t *testing.T) {
+	tests := []struct {
+		option string
+	}{
+		{option: "full"},
+		{option: "overwrite"},
+	}
+	for _, tt := range tests {
+		t.Run("backup with "+tt.option, func(t *testing.T) {
 			t.Run("create schema", func(t *testing.T) {
 				t.Run("Books", func(t *testing.T) {
 					booksClass := books.ClassModel2VecVectorizer()
@@ -99,6 +105,10 @@ func Test_AliasesAPI_Backup(t *testing.T) {
 					{
 						name:  books.DefaultClassName,
 						alias: &models.Alias{Alias: "BookAliasToBeDeleted", Class: books.DefaultClassName},
+					},
+					{
+						name:  books.DefaultClassName,
+						alias: &models.Alias{Alias: "BookAliasOverwrite", Class: books.DefaultClassName},
 					},
 				}
 				for _, tt := range tests {
@@ -135,13 +145,13 @@ func Test_AliasesAPI_Backup(t *testing.T) {
 					require.NotEmpty(t, resp.Aliases)
 					require.Equal(t, count, len(resp.Aliases))
 				}
-				checkAliasesCount(t, 2)
+				checkAliasesCount(t, 3)
 				helper.DeleteAlias(t, "BookAliasToBeDeleted")
-				checkAliasesCount(t, 1)
+				checkAliasesCount(t, 2)
 			})
 
 			backend := "filesystem"
-			backupID := options + "-backup-id"
+			backupID := tt.option + "-backup-id"
 
 			t.Run("backup with local filesystem backend", func(t *testing.T) {
 				backupResp, err := helper.CreateBackup(t, helper.DefaultBackupConfig(), books.DefaultClassName, backend, backupID)
@@ -150,13 +160,29 @@ func Test_AliasesAPI_Backup(t *testing.T) {
 				waitForBackup(t, backupID, backend)
 			})
 
+			if tt.option == "overwrite" {
+				t.Run("reassign BookAliasOverwrite from Books to Books2 class", func(t *testing.T) {
+					alias := helper.GetAlias(t, "BookAliasOverwrite")
+					assert.Equal(t, "Books", alias.Class)
+					// create Books2 class
+					books2Class := books.ClassModel2VecVectorizerWithName("Books2")
+					helper.CreateClass(t, books2Class)
+					for _, book := range books.ObjectsWithName("Books2") {
+						helper.CreateObject(t, book)
+						helper.AssertGetObjectEventually(t, book.Class, book.ID)
+					}
+					helper.UpdateAlias(t, "BookAliasOverwrite", "Books2")
+				})
+			}
+
 			t.Run("delete collection", func(t *testing.T) {
 				helper.DeleteClass(t, books.DefaultClassName)
 			})
 
-			if options != "overwrite" {
+			if tt.option != "overwrite" {
 				t.Run("delete alias", func(t *testing.T) {
 					helper.DeleteAlias(t, "BookAlias")
+					helper.DeleteAlias(t, "BookAliasOverwrite")
 				})
 
 				t.Run("check alias count after deletion", func(t *testing.T) {
@@ -166,9 +192,16 @@ func Test_AliasesAPI_Backup(t *testing.T) {
 				})
 			}
 
+			if tt.option == "overwrite" {
+				t.Run("check BookAliasOverwrite alias that it points to Books2 before restore", func(t *testing.T) {
+					alias := helper.GetAlias(t, "BookAliasOverwrite")
+					assert.Equal(t, "Books2", alias.Class)
+				})
+			}
+
 			t.Run("restore with local filesystem backend", func(t *testing.T) {
 				var overwriteAlias bool
-				if options == "overwrite" {
+				if tt.option == "overwrite" {
 					overwriteAlias = true
 				}
 
@@ -190,7 +223,12 @@ func Test_AliasesAPI_Backup(t *testing.T) {
 					require.NotEmpty(t, resp.Aliases)
 					require.Equal(t, count, len(resp.Aliases))
 				}
-				checkAliasesCount(t, 1)
+				checkAliasesCount(t, 2)
+			})
+
+			t.Run("check BookAliasOverwrite alias that it points to Books", func(t *testing.T) {
+				alias := helper.GetAlias(t, "BookAliasOverwrite")
+				assert.Equal(t, books.DefaultClassName, alias.Class)
 			})
 		})
 	}

--- a/tools/dev/run_dev_server.sh
+++ b/tools/dev/run_dev_server.sh
@@ -720,7 +720,6 @@ case $CONFIG in
       CONTEXTIONARY_URL=localhost:9999 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       PERSISTENCE_DATA_PATH="./${PERSISTENCE_DATA_PATH}-weaviate-0" \
-      BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-0" \
       DEFAULT_VECTORIZER_MODULE=text2vec-contextionary \
       ENABLE_MODULES="text2vec-contextionary,backup-s3,offload-s3" \
       BACKUP_S3_BUCKET="weaviate-backups" \
@@ -748,7 +747,6 @@ case $CONFIG in
       CONTEXTIONARY_URL=localhost:9999 \
       AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
       PERSISTENCE_DATA_PATH="./${PERSISTENCE_DATA_PATH}-weaviate-1" \
-      BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-1" \
       BACKUP_S3_BUCKET="weaviate-backups" \
       BACKUP_S3_USE_SSL="false" \
       BACKUP_S3_ENDPOINT="localhost:9000" \
@@ -782,7 +780,6 @@ case $CONFIG in
         CONTEXTIONARY_URL=localhost:9999 \
         AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED=true \
         PERSISTENCE_DATA_PATH="./${PERSISTENCE_DATA_PATH}-weaviate-2" \
-        BACKUP_FILESYSTEM_PATH="${PWD}/backups-weaviate-2" \
         BACKUP_S3_BUCKET="weaviate-backups" \
         BACKUP_S3_USE_SSL="false" \
         BACKUP_S3_ENDPOINT="localhost:9000" \

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -26,7 +26,6 @@ import (
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
-	cschema "github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/classcache"
 	entcfg "github.com/weaviate/weaviate/entities/config"
@@ -289,29 +288,23 @@ func (h *Handler) RestoreClass(ctx context.Context, d *backup.ClassDescriptor, m
 	}
 
 	for _, alias := range aliases {
-		var err error
-		_, err = h.schemaManager.CreateAlias(ctx, alias.Alias, class)
-		if errors.Is(err, cschema.ErrAliasExists) {
-			// Overwrite if user asks to during restore
-			if overwriteAlias {
-				_, err = h.schemaManager.DeleteAlias(ctx, alias.Alias)
-				if err != nil {
-					return fmt.Errorf("failed to restore alias for class: delete alias failed: %w", err)
-				}
-				// retry again
-				_, err = h.schemaManager.CreateAlias(ctx, alias.Alias, class)
-				if err != nil {
-					return fmt.Errorf("failed to restore alias for class: create alias failed: %w", err)
-				}
-				return nil
-			}
-			// Schema returned alias already exists error. So let user know
-			// that there is a "flag overwrite" if she want's to overwrite alias.
-			return fmt.Errorf("failed to restore alias for class: alias already exists. You can overwrite using `overwrite_alias` param when restoring")
+		resolved := h.schemaReader.ResolveAlias(alias.Alias)
+
+		// Alias do exist and don't want to overwrite
+		if resolved != "" && !overwriteAlias {
+			continue
 		}
 
+		if resolved != "" {
+			_, err := h.schemaManager.DeleteAlias(ctx, alias.Alias)
+			if err != nil {
+				return fmt.Errorf("failed to restore alias for class: delete alias %s failed: %w", alias.Alias, err)
+			}
+		}
+
+		_, err := h.schemaManager.CreateAlias(ctx, alias.Alias, class)
 		if err != nil {
-			return fmt.Errorf("failed to restore alias for class: %w", err)
+			return fmt.Errorf("failed to restore alias for class: create alias %s failed: %w", alias.Alias, err)
 		}
 	}
 


### PR DESCRIPTION
### What's being changed:

To find if alias really exists use ResolveAlias instead of trusting on sentinal error during restore.

@jfrancoa and @antas-marcin have all the context related to this issue.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/17764144164
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
