### PR TITLE
ux(alias): improve error message for alias not allowed operations

### DIFF
--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -63,11 +63,9 @@ func (s *schemaHandlers) updateClass(params schema.SchemaObjectsUpdateParams,
 		params.ObjectClass)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
-		if errors.Is(err, schemaUC.ErrNotFound) {
-			return schema.NewSchemaObjectsUpdateNotFound()
-		}
-
 		switch {
+		case errors.Is(err, schemaUC.ErrNotFound):
+			return schema.NewSchemaObjectsUpdateNotFound().WithPayload(errCheckClassAndPermission(params.ClassName))
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsUpdateForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
@@ -132,6 +130,8 @@ func (s *schemaHandlers) addClassProperty(params schema.SchemaObjectsPropertiesA
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		switch {
+		case errors.Is(err, schemaUC.ErrNotFound):
+			return schema.NewSchemaObjectsUpdateNotFound().WithPayload(errCheckClassAndPermission(params.ClassName))
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsPropertiesAddForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
@@ -203,6 +203,8 @@ func (s *schemaHandlers) updateShardStatus(params schema.SchemaObjectsShardsUpda
 	if err != nil {
 		s.metricRequestsTotal.logError("", err)
 		switch {
+		case errors.Is(err, schemaUC.ErrNotFound):
+			return schema.NewSchemaObjectsUpdateNotFound().WithPayload(errCheckClassAndPermission(params.ClassName))
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsShardsGetForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
@@ -227,6 +229,8 @@ func (s *schemaHandlers) createTenants(params schema.TenantsCreateParams,
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		switch {
+		case errors.Is(err, schemaUC.ErrNotFound):
+			return schema.NewSchemaObjectsUpdateNotFound().WithPayload(errCheckClassAndPermission(params.ClassName))
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewTenantsCreateForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
@@ -249,6 +253,8 @@ func (s *schemaHandlers) updateTenants(params schema.TenantsUpdateParams,
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		switch {
+		case errors.Is(err, schemaUC.ErrNotFound):
+			return schema.NewSchemaObjectsUpdateNotFound().WithPayload(errCheckClassAndPermission(params.ClassName))
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewTenantsUpdateForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
@@ -271,6 +277,8 @@ func (s *schemaHandlers) deleteTenants(params schema.TenantsDeleteParams,
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		switch {
+		case errors.Is(err, schemaUC.ErrNotFound):
+			return schema.NewSchemaObjectsUpdateNotFound().WithPayload(errCheckClassAndPermission(params.ClassName))
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewTenantsDeleteForbidden().
 				WithPayload(errPayloadFromSingleErr(err))

--- a/adapters/handlers/rest/helpers.go
+++ b/adapters/handlers/rest/helpers.go
@@ -37,3 +37,13 @@ func errPayloadFromSingleErr(err error) *models.ErrorResponse {
 		Message: fmt.Sprintf("%s", err),
 	}}}
 }
+
+func errCheckClassAndPermission(class string) *models.ErrorResponse {
+	return &models.ErrorResponse{
+		Error: []*models.ErrorResponseErrorItems0{
+			{
+				Message: fmt.Sprintf("collection %s not found or collection alias is used for operations that are not allowed", class),
+			},
+		},
+	}
+}


### PR DESCRIPTION
### What's being changed:

One of the several attempts to improve the UX of error message for misusing alias name instead of collection name.

Context: You can only use alias for specific collection related operations
1. Getting Collection object itself.
2. Getting shard status
3. Getting collection tenants

None of the update/delete operations on collections are not allowed with alias name. You still need original collection name to do these "mutation" operation on collection.

But sometimes the error message can be confusing. e.g: User try to update collection via alias and we would report "Collection not found" (because schema checks if any collection found with given alias name)

Given our current error handling (and constructing error chain) design that interacts with different layers (http, grpc, endpoints, schema, etc), It's not always possible to know if given string is "alias" or "class". So this PR try to improve the error message little to avoid any confusion and help user with right next action item.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
