### PR TITLE
fix(raft): schema collection deletion case sensitivity 

### DIFF
--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -102,6 +102,8 @@ func (st *Store) Apply(l *raft.Log) any {
 	// If we don't have any last applied index on start, schema only is always false.
 	// we check for index !=0 to force apply of the 1st index in both db and schema
 	catchingUp := l.Index != 0 && l.Index <= st.lastAppliedIndexToDB.Load()
+	// TODO: get rid off schema only as it causes more trouble than it's worth
+	// T-Nr: DB-306
 	schemaOnly := catchingUp || st.cfg.MetadataOnlyVoters
 	defer func() {
 		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as
@@ -184,15 +186,23 @@ func (st *Store) Apply(l *raft.Log) any {
 	case api.ApplyRequest_TYPE_DELETE_CLASS:
 		f = func() {
 			// During RAFT log replay (schemaOnly=true), apply case-insensitive handling
-			// to prevent silent failures due to case mismatches in log entries
+			// to prevent silent failures due to case mismatches in log entries.
+			// This ensures we capture the correct class name as stored in memory,
+			// regardless of what the user used in the original request.
+			//
+			// Example scenario:
+			// - Old RAFT entry: add Class "FooBar"
+			// - New RAFT entry: delete Class "foobar"
+			//
+			// Without case-insensitive handling, we would never delete "FooBar"
+			// because the new log entry contains "foobar", leading to class
+			// reappearance during rollout.
 			if schemaOnly {
 				existingClass := st.SchemaReader().ClassEqual(cmd.Class)
 				if existingClass != "" {
 					cmd.Class = existingClass
 				}
 			}
-			// For regular operations (schemaOnly=false), maintain strict case-sensitivity
-			// to preserve GraphQL naming conventions and test expectations
 			ret.Error = st.schemaManager.DeleteClass(&cmd, schemaOnly, !catchingUp)
 		}
 


### PR DESCRIPTION
### What's being changed:
During RAFT log replay (schemaOnly mode), class deletion operations were case-sensitive, which could lead to class reappearance during cluster rollout when there were case mismatches between RAFT log entries and the in-memory schema which was causing **collection re-appearance on restarts**.

e.g. 
```
Old RAFT entry: add Class "FooBar"
New RAFT entry: delete Class "foobar"

Without fix: "FooBar" would never be deleted, causing class reappearance
With fix: "foobar" deletion correctly removes "FooBar" from memory schema
```

This PR handles this by implementing case-insensitive matching to find and delete the correct class from the in-memory schema, preventing silent failures due to case mismatches and class reappearance on restarts.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
