### PR TITLE
chore: remove un-used metric

### DIFF
--- a/adapters/repos/db/metrics.go
+++ b/adapters/repos/db/metrics.go
@@ -44,8 +44,7 @@ type Metrics struct {
 	shardStatusUpdateDurationsSeconds *prometheus.HistogramVec
 
 	// async replication metrics
-	asyncReplicationGoroutinesRunning      prometheus.Gauge
-	asyncReplicationGoroutinesFailureCount prometheus.Counter
+	asyncReplicationGoroutinesRunning prometheus.Gauge
 
 	asyncReplicationHashTreeInitRunning      prometheus.Gauge
 	asyncReplicationHashTreeInitFailureCount prometheus.Counter
@@ -173,13 +172,6 @@ func NewMetrics(
 	m.asyncReplicationGoroutinesRunning, err = newGauge(prom.Registerer,
 		"async_replication_goroutines_running",
 		"Number of currently running async replication goroutines")
-	if err != nil {
-		return nil, err
-	}
-
-	m.asyncReplicationGoroutinesFailureCount, err = newCounter(prom.Registerer,
-		"async_replication_goroutines_failure_count",
-		"Count of async replication goroutines initialization failures")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
### What's being changed:

This pull request makes a minor change to the metrics tracking in the async replication logic. Specifically, it removes the counter for tracking async replication goroutine failures from the `Metrics` struct and its initialization.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
