### PR TITLE
fix(memberlist-raft) gracefully leave on shutdown and raft shutdown order

### DIFF
--- a/usecases/cluster/delegate_test.go
+++ b/usecases/cluster/delegate_test.go
@@ -212,10 +212,12 @@ func TestDelegateSort(t *testing.T) {
 }
 
 func TestDelegateCleanUp(t *testing.T) {
+	logger, _ := test.NewNullLogger()
 	st := State{
 		delegate: delegate{
 			Name:     "N0",
 			dataPath: ".",
+			log:      logger,
 		},
 	}
 	diskSpace := func(path string) (DiskUsage, error) {

--- a/usecases/cluster/log_workaround.go
+++ b/usecases/cluster/log_workaround.go
@@ -24,7 +24,7 @@ type logParser struct {
 
 func newLogParser(logrus logrus.FieldLogger) *logParser {
 	return &logParser{
-		logrus: logrus,
+		logrus: logrus.WithField("action", "memberlist"),
 		regexp: regexp.MustCompile(`(.*)\[(DEBUG|ERR|ERROR|INFO|WARNING|WARN)](.*)`),
 	}
 }

--- a/usecases/cluster/mocks/node_selector.go
+++ b/usecases/cluster/mocks/node_selector.go
@@ -45,6 +45,14 @@ func (m memberlist) AllOtherClusterMembers(port int) map[string]string {
 	return map[string]string{}
 }
 
+func (m memberlist) Leave() error {
+	return nil
+}
+
+func (m memberlist) Shutdown() error {
+	return nil
+}
+
 func (m memberlist) LocalName() string {
 	if len(m.nodes) == 0 {
 		return ""


### PR DESCRIPTION
### What's being changed:
this PR 
- Ensure nodes gracefully leave memberlist on shutdown and clarify why both leave and shutdown are used.
- Adjust Raft shutdown order to avoid transport-related errors and ensure clean termination.
- shall resolve many of the memberlist and raft errors during rollout 
- Improve inline docs to explain the sequencing and rationale.

**Before 1.31.15** 
- Server Errors: 1814
- Latency: Increase observed for ingestion
<img width="1712" height="613" alt="1 31 15-sims" src="https://github.com/user-attachments/assets/a20b4c52-1189-4181-8096-03d5f0dbf95d" />
<img width="1712" height="204" alt="1 31 15-logs" src="https://github.com/user-attachments/assets/7e64e127-32e5-4c41-b6b7-74de1583b2ab" />


**After those changes**
- Server Errors: 96
- Latency: No increase for ingestion
<img width="1719" height="609" alt="fixes-sims" src="https://github.com/user-attachments/assets/9b58e775-b49b-4267-87de-9846571d61ac" />
<img width="1706" height="202" alt="fixes-logs" src="https://github.com/user-attachments/assets/a7b25953-1df5-440b-94dd-d45591136859" />



### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17794361596
- [x] e2e run  https://github.com/weaviate/weaviate-e2e-tests/actions/runs/17794355777
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
