### PR TITLE
feat(metrics): add new compaction metrics

### DIFF
--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -12,6 +12,7 @@
 package lsmkv
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -26,12 +27,17 @@ type (
 	TimeObserver       func(start time.Time)
 )
 
+var compactionDurationBuckets = prometheus.ExponentialBuckets(0.01, 2, 18) // 0.01s → 0.02s → ... → ~163.84s
+
 type Metrics struct {
-	CompactionReplace            *prometheus.GaugeVec
-	CompactionSet                *prometheus.GaugeVec
-	CompactionMap                *prometheus.GaugeVec
-	CompactionRoaringSet         *prometheus.GaugeVec
-	CompactionRoaringSetRange    *prometheus.GaugeVec
+	// compaction-related metrics
+	compactionCount        *prometheus.CounterVec
+	compactionInProgress   *prometheus.GaugeVec
+	compactionFailureCount *prometheus.CounterVec
+	compactionNoOpCount    *prometheus.CounterVec
+	compactionDuration     *prometheus.HistogramVec
+
+	// old-style metrics, to be migrated
 	ActiveSegments               *prometheus.GaugeVec
 	ObjectsBucketSegments        *prometheus.GaugeVec
 	CompressedVecsBucketSegments *prometheus.GaugeVec
@@ -58,41 +64,79 @@ type Metrics struct {
 
 func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 	shardName string,
-) *Metrics {
+) (*Metrics, error) {
 	if promMetrics.Group {
 		className = "n/a"
 		shardName = "n/a"
 	}
 
-	replace := promMetrics.AsyncOperations.MustCurryWith(prometheus.Labels{
-		"operation":  "compact_lsm_segments_stratreplace",
-		"class_name": className,
-		"shard_name": shardName,
-	})
+	// compaction-related metrics
+	compactionCount, err := monitoring.EnsureRegisteredMetric(promMetrics.Registerer,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_compaction_count",
+				Help:      "Total number of LSM bucket compactions requested, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_compaction_count: %w", err)
+	}
 
-	set := promMetrics.AsyncOperations.MustCurryWith(prometheus.Labels{
-		"operation":  "compact_lsm_segments_stratset",
-		"class_name": className,
-		"shard_name": shardName,
-	})
+	compactionInProgress, err := monitoring.EnsureRegisteredMetric(promMetrics.Registerer, prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "weaviate",
+			Name:      "lsm_bucket_compaction_in_progress",
+			Help:      "Number of LSM bucket compactions currently in progress, labeled by segment strategy",
+		},
+		[]string{"strategy"},
+	))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_compaction_in_progress: %w", err)
+	}
 
-	roaringSet := promMetrics.AsyncOperations.MustCurryWith(prometheus.Labels{
-		"operation":  "compact_lsm_segments_stratroaringset",
-		"class_name": className,
-		"shard_name": shardName,
-	})
+	compactionFailureCount, err := monitoring.EnsureRegisteredMetric(promMetrics.Registerer,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_compaction_failure_count",
+				Help:      "Number of failed LSM bucket compactions, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_compaction_failure_count: %w", err)
+	}
 
-	roaringSetRange := promMetrics.AsyncOperations.MustCurryWith(prometheus.Labels{
-		"operation":  "compact_lsm_segments_stratroaringsetrange",
-		"class_name": className,
-		"shard_name": shardName,
-	})
+	compactionNoOpCount, err := monitoring.EnsureRegisteredMetric(promMetrics.Registerer,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_compaction_noop_count",
+				Help:      "Number of times the periodic LSM bucket compaction task ran but found nothing to compact, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_compaction_noop_count: %w", err)
+	}
 
-	stratMap := promMetrics.AsyncOperations.MustCurryWith(prometheus.Labels{
-		"operation":  "compact_lsm_segments_stratmap",
-		"class_name": className,
-		"shard_name": shardName,
-	})
+	compactionDuration, err := monitoring.EnsureRegisteredMetric(promMetrics.Registerer,
+		prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_compaction_duration_seconds",
+				Help:      "Duration of LSM bucket compaction in seconds, labeled by segment strategy",
+				Buckets:   compactionDurationBuckets,
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_compaction_duration_seconds: %w", err)
+	}
+
+	// old-style metrics, to be migrated
 
 	lazySegmentInit := monitoring.GetMetrics().AsyncOperations.With(prometheus.Labels{
 		"operation":  "lazySegmentInit",
@@ -122,13 +166,16 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 	})
 
 	return &Metrics{
-		groupClasses:              promMetrics.Group,
-		criticalBucketsOnly:       promMetrics.LSMCriticalBucketsOnly,
-		CompactionReplace:         replace,
-		CompactionSet:             set,
-		CompactionMap:             stratMap,
-		CompactionRoaringSet:      roaringSet,
-		CompactionRoaringSetRange: roaringSetRange,
+		groupClasses:        promMetrics.Group,
+		criticalBucketsOnly: promMetrics.LSMCriticalBucketsOnly,
+
+		compactionNoOpCount:    compactionNoOpCount,
+		compactionCount:        compactionCount,
+		compactionInProgress:   compactionInProgress,
+		compactionFailureCount: compactionFailureCount,
+		compactionDuration:     compactionDuration,
+
+		// old-style metrics, to be migrated
 		ActiveSegments: promMetrics.LSMSegmentCount.MustCurryWith(prometheus.Labels{
 			"class_name": className,
 			"shard_name": shardName,
@@ -187,7 +234,51 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		LazySegmentClose:  lazySegmentClose,
 		LazySegmentInit:   lazySegmentInit,
 		LazySegmentUnLoad: lazySegmentUnload,
+	}, nil
+}
+
+// compaction metrics
+
+func (m *Metrics) IncCompactionCount(strategy string) {
+	if m == nil {
+		return
 	}
+	m.compactionCount.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) IncCompactionInProgress(strategy string) {
+	if m == nil {
+		return
+	}
+	m.compactionInProgress.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) DecCompactionInProgress(strategy string) {
+	if m == nil {
+		return
+	}
+	m.compactionInProgress.WithLabelValues(strategy).Dec()
+}
+
+func (m *Metrics) IncCompactionNoOp(strategy string) {
+	if m == nil {
+		return
+	}
+	m.compactionNoOpCount.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) IncCompactionFailureCount(strategy string) {
+	if m == nil {
+		return
+	}
+	m.compactionFailureCount.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) ObserveCompactionDuration(strategy string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.compactionDuration.WithLabelValues(strategy).Observe(duration.Seconds())
 }
 
 func noOpNsObserver(startNs int64) {

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -211,13 +211,33 @@ func segmentExtraInfo(level uint16, strategy segmentindex.Strategy) string {
 	return fmt.Sprintf(".l%d.s%d", level, strategy)
 }
 
-func (sg *SegmentGroup) compactOnce() (bool, error) {
+func (sg *SegmentGroup) compactOnce() (compacted bool, err error) {
 	// Is it safe to only occasionally lock instead of the entire duration? Yes,
 	// because other than compaction the only change to the segments array could
 	// be an append because of a new flush cycle, so we do not need to guarantee
 	// that the array contents stay stable over the duration of an entire
 	// compaction. We do however need to protect against a read-while-write (race
 	// condition) on the array. Thus any read from sg.segments need to protected
+	start := time.Now()
+
+	sg.metrics.IncCompactionCount(sg.strategy)
+	sg.metrics.IncCompactionInProgress(sg.strategy)
+
+	defer func() {
+		sg.metrics.DecCompactionInProgress(sg.strategy)
+
+		if err != nil {
+			sg.metrics.IncCompactionFailureCount(sg.strategy)
+			return
+		}
+
+		if !compacted {
+			sg.metrics.IncCompactionNoOp(sg.strategy)
+			return
+		}
+
+		sg.metrics.ObserveCompactionDuration(sg.strategy, time.Since(start))
+	}()
 
 	pair, level := sg.findCompactionCandidates()
 	if pair == nil {
@@ -247,6 +267,7 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 
 	leftSegment := sg.segmentAtPos(pair[0])
 	rightSegment := sg.segmentAtPos(pair[1])
+
 	var path string
 	if sg.writeSegmentInfoIntoFileName {
 		path = filepath.Join(sg.dir, "segment-"+segmentID(leftSegment.path)+"_"+segmentID(rightSegment.path)+segmentExtraInfo(level, leftSegment.strategy)+".db.tmp")
@@ -265,11 +286,6 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 	secondaryIndices := leftSegment.secondaryIndexCount
 	cleanupTombstones := !sg.keepTombstones && pair[0] == 0
 
-	pathLabel := "n/a"
-	if sg.metrics != nil && !sg.metrics.groupClasses {
-		pathLabel = sg.dir
-	}
-
 	maxNewFileSize := leftSegment.size + rightSegment.size
 
 	switch strategy {
@@ -277,15 +293,9 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 	// TODO: call metrics just once with variable strategy label
 
 	case segmentindex.StrategyReplace:
-
 		c := newCompactorReplace(f, leftSegment.newCursor(),
 			rightSegment.newCursor(), level, secondaryIndices,
 			scratchSpacePath, cleanupTombstones, sg.enableChecksumValidation, maxNewFileSize, sg.allocChecker)
-
-		if sg.metrics != nil {
-			sg.metrics.CompactionReplace.With(prometheus.Labels{"path": pathLabel}).Inc()
-			defer sg.metrics.CompactionReplace.With(prometheus.Labels{"path": pathLabel}).Dec()
-		}
 
 		if err := c.do(); err != nil {
 			return false, err
@@ -294,11 +304,6 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 		c := newCompactorSetCollection(f, leftSegment.newCollectionCursor(),
 			rightSegment.newCollectionCursor(), level, secondaryIndices,
 			scratchSpacePath, cleanupTombstones, sg.enableChecksumValidation, maxNewFileSize, sg.allocChecker)
-
-		if sg.metrics != nil {
-			sg.metrics.CompactionSet.With(prometheus.Labels{"path": pathLabel}).Inc()
-			defer sg.metrics.CompactionSet.With(prometheus.Labels{"path": pathLabel}).Dec()
-		}
 
 		if err := c.do(); err != nil {
 			return false, err
@@ -311,11 +316,6 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 			sg.mapRequiresSorting, cleanupTombstones,
 			sg.enableChecksumValidation, maxNewFileSize, sg.allocChecker)
 
-		if sg.metrics != nil {
-			sg.metrics.CompactionMap.With(prometheus.Labels{"path": pathLabel}).Inc()
-			defer sg.metrics.CompactionMap.With(prometheus.Labels{"path": pathLabel}).Dec()
-		}
-
 		if err := c.do(); err != nil {
 			return false, err
 		}
@@ -327,10 +327,6 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 			level, scratchSpacePath, cleanupTombstones,
 			sg.enableChecksumValidation, maxNewFileSize, sg.allocChecker)
 
-		if sg.metrics != nil {
-			sg.metrics.CompactionRoaringSet.With(prometheus.Labels{"path": pathLabel}).Set(1)
-			defer sg.metrics.CompactionRoaringSet.With(prometheus.Labels{"path": pathLabel}).Set(0)
-		}
 		if err := c.Do(); err != nil {
 			return false, err
 		}
@@ -341,11 +337,6 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 
 		c := roaringsetrange.NewCompactor(f, leftCursor, rightCursor,
 			level, cleanupTombstones, sg.enableChecksumValidation, maxNewFileSize)
-
-		if sg.metrics != nil {
-			sg.metrics.CompactionRoaringSetRange.With(prometheus.Labels{"path": pathLabel}).Set(1)
-			defer sg.metrics.CompactionRoaringSetRange.With(prometheus.Labels{"path": pathLabel}).Set(0)
-		}
 
 		if err := c.Do(); err != nil {
 			return false, err
@@ -363,11 +354,6 @@ func (sg *SegmentGroup) compactOnce() (bool, error) {
 			leftSegment.newInvertedCursorReusable(),
 			rightSegment.newInvertedCursorReusable(),
 			level, secondaryIndices, scratchSpacePath, cleanupTombstones, k1, b, avgPropLen, maxNewFileSize, sg.allocChecker)
-
-		if sg.metrics != nil {
-			sg.metrics.CompactionMap.With(prometheus.Labels{"path": pathLabel}).Inc()
-			defer sg.metrics.CompactionMap.With(prometheus.Labels{"path": pathLabel}).Dec()
-		}
 
 		if err := c.do(); err != nil {
 			return false, err

--- a/adapters/repos/db/shard_init_lsm.go
+++ b/adapters/repos/db/shard_init_lsm.go
@@ -121,9 +121,15 @@ func (s *Shard) initLSMStore() error {
 		"index": s.index.ID(),
 		"class": s.index.Config.ClassName,
 	})
+
 	var metrics *lsmkv.Metrics
+	var err error
+
 	if s.promMetrics != nil {
-		metrics = lsmkv.NewMetrics(s.promMetrics, string(s.index.Config.ClassName), s.name)
+		metrics, err = lsmkv.NewMetrics(s.promMetrics, string(s.index.Config.ClassName), s.name)
+		if err != nil {
+			return fmt.Errorf("init lsmkv metrics: %w", err)
+		}
 	}
 
 	store, err := lsmkv.New(s.pathLSM(), s.path(), annotatedLogger, metrics,


### PR DESCRIPTION
### What's being changed:

This pull request introduces a new, more robust set of Prometheus metrics for LSM bucket compaction in the `lsmkv` storage engine, replacing the previous metrics implementation. The changes add new counters, gauges, and histograms for tracking compaction operations, failures, durations, and no-op events, and migrate the code to use these new metrics throughout the compaction process. Additionally, a generic utility is introduced to safely register Prometheus metrics.

**Key changes:**

### Compaction Metrics Overhaul

- Replaced the old per-strategy compaction metrics (`CompactionReplace`, `CompactionSet`, etc.) in `Metrics` with a new set of metrics: `compactionCount`, `compactionsInProgress`, `compactionFailureCount`, `compactionNoOpCount`, and `compactionDuration`, all labeled by compaction strategy. These provide more granular and meaningful observability for compaction operations. [[1]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR30-R40) [[2]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdL61-R139) [[3]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdL127-R178)
- Added new methods to the `Metrics` struct for incrementing and observing these new compaction metrics, such as `IncCompactionCount`, `IncCompactionsInProgress`, `IncCompactionFailureCount`, and `ObserveCompactionDuration`.

### Integration of New Metrics in Compaction Logic

- Updated the `SegmentGroup.compactOnce` method to use the new metrics, tracking the start and end of compactions, failures, no-ops, and durations, and removed all usage of the old metrics. [[1]](diffhunk://#diff-01936e06b48aae163f73aba0025ad1039f927e616f0d3df2418f9bfdc002f18aL214-R240) [[2]](diffhunk://#diff-01936e06b48aae163f73aba0025ad1039f927e616f0d3df2418f9bfdc002f18aL268-L289) [[3]](diffhunk://#diff-01936e06b48aae163f73aba0025ad1039f927e616f0d3df2418f9bfdc002f18aL298-L302) [[4]](diffhunk://#diff-01936e06b48aae163f73aba0025ad1039f927e616f0d3df2418f9bfdc002f18aL314-L318) [[5]](diffhunk://#diff-01936e06b48aae163f73aba0025ad1039f927e616f0d3df2418f9bfdc002f18aL330-L333) [[6]](diffhunk://#diff-01936e06b48aae163f73aba0025ad1039f927e616f0d3df2418f9bfdc002f18aL345-L349) [[7]](diffhunk://#diff-01936e06b48aae163f73aba0025ad1039f927e616f0d3df2418f9bfdc002f18aL367-L371)

### Metrics Initialization and Error Handling

- Modified `NewMetrics` to return an error if metric registration fails, and updated all call sites (e.g., in `Shard.initLSMStore`) to handle errors appropriately. [[1]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdL61-R139) [[2]](diffhunk://#diff-33a390aa39739210c0aa6601fafbf81e2bfa6a11b2709ea8579ad9457df17d14R124-R132)

### Prometheus Utility

- Added a generic `EnsureRegisteredMetric` utility function to safely register Prometheus metrics, handling the case where a metric is already registered and returning the existing collector.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
