### PR TITLE
fix(modules): remove model validation in generative-cohere module

### DIFF
--- a/modules/generative-cohere/config/class_settings.go
+++ b/modules/generative-cohere/config/class_settings.go
@@ -27,16 +27,10 @@ const (
 	stopSequencesProperty = "stopSequences"
 )
 
-var availableCohereModels = []string{
-	"command-r-plus", "command-r", "command-xlarge-beta",
-	"command-xlarge", "command-medium", "command-xlarge-nightly", "command-medium-nightly", "xlarge", "medium",
-	"command", "command-light", "command-nightly", "command-light-nightly", "base", "base-light",
-}
-
 // note it might not like this -- might want int values for e.g. MaxTokens
 var (
 	DefaultBaseURL                     = "https://api.cohere.ai"
-	DefaultCohereModel                 = "command-r"
+	DefaultCohereModel                 = "command-a-03-2025"
 	DefaultCohereTemperature   float64 = 0
 	DefaultCohereMaxTokens             = 2048
 	DefaultCohereK                     = 0
@@ -57,11 +51,6 @@ func (ic *classSettings) Validate(class *models.Class) error {
 		// we would receive a nil-config on cross-class requests, such as Explore{}
 		return errors.New("empty config")
 	}
-	model := ic.getStringProperty(modelProperty, DefaultCohereModel)
-	if model == nil || !ic.validateModel(*model) {
-		return errors.Errorf("wrong Cohere model name, available model names are: %v", availableCohereModels)
-	}
-
 	return nil
 }
 
@@ -100,10 +89,6 @@ func (ic *classSettings) getListOfStringsProperty(name string, defaultValue []st
 
 func (ic *classSettings) GetMaxTokensForModel(model string) int {
 	return DefaultCohereMaxTokens
-}
-
-func (ic *classSettings) validateModel(model string) bool {
-	return basesettings.ValidateSetting(model, availableCohereModels)
 }
 
 func (ic *classSettings) BaseURL() string {

--- a/modules/generative-cohere/config/class_settings_test.go
+++ b/modules/generative-cohere/config/class_settings_test.go
@@ -14,7 +14,6 @@ package config
 import (
 	"testing"
 
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -38,7 +37,7 @@ func Test_classSettings_Validate(t *testing.T) {
 			cfg: fakeClassConfig{
 				classConfig: map[string]interface{}{},
 			},
-			wantModel:         "command-r",
+			wantModel:         "command-a-03-2025",
 			wantMaxTokens:     2048,
 			wantTemperature:   0,
 			wantK:             0,
@@ -64,17 +63,6 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantStopSequences: []string{"stop1", "stop2"},
 			wantBaseURL:       "https://api.cohere.ai",
 			wantErr:           nil,
-		},
-		{
-			name: "wrong model configured",
-			cfg: fakeClassConfig{
-				classConfig: map[string]interface{}{
-					"model": "wrong-model",
-				},
-			},
-			wantErr: errors.Errorf("wrong Cohere model name, available model names are: " +
-				"[command-r-plus command-r command-xlarge-beta command-xlarge command-medium command-xlarge-nightly " +
-				"command-medium-nightly xlarge medium command command-light command-nightly command-light-nightly base base-light]"),
 		},
 		{
 			name: "default settings with command-light-nightly",

--- a/test/modules/generative-cohere/generative_cohere_test.go
+++ b/test/modules/generative-cohere/generative_cohere_test.go
@@ -50,16 +50,12 @@ func testGenerativeCohere(rest, grpc string) func(t *testing.T) {
 			absentModuleConfig bool
 		}{
 			{
-				name:            "command-r-plus",
-				generativeModel: "command-r-plus",
-			},
-			{
-				name:            "command-r",
-				generativeModel: "command-r",
+				name:            "command-r-08-2024",
+				generativeModel: "command-r-08-2024",
 			},
 			{
 				name:               "absent module config",
-				generativeModel:    "command-r",
+				generativeModel:    "command-a-03-2025",
 				absentModuleConfig: true,
 			},
 		}


### PR DESCRIPTION
### What's being changed:

Removed model name validation in `generative-cohere` module.

Changed the default model to `command-a-03-2025` (`command-r` model is deprecated sing 15th of Sept)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
