### PR TITLE
chore: add compaction pause/resume cycle management to ApplyToObjectDigests

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	entcfg "github.com/weaviate/weaviate/entities/config"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/models"
 
 	"github.com/pkg/errors"
@@ -325,9 +326,45 @@ func (b *Bucket) IterateObjects(ctx context.Context, f func(object *storobj.Obje
 	return nil
 }
 
+func (b *Bucket) pauseCompaction(ctx context.Context) error {
+	return b.disk.pauseCompaction(ctx)
+}
+
+func (b *Bucket) resumeCompaction(ctx context.Context) error {
+	return b.disk.resumeCompaction(ctx)
+}
+
+// ApplyToObjectDigests iterates over all objects in the bucket, both in memtable
+// and on disk, and applies the given function to each object.
+// The afterInMemCallback is called after the in-memory memtable has been processed.
+// This allows the caller to perform actions that need to happen after the in-memory
+// objects have been processed.
+// The function f is called for each object, and if it returns an error, the
+// processing is stopped and the error is returned.
+// Note: this function pauses compaction while it is running, to ensure a consistent view of the data.
 func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 	afterInMemCallback func(), f func(object *storobj.Object) error,
 ) error {
+	err := b.pauseCompaction(ctx)
+	if err != nil {
+		afterInMemCallback()
+		return fmt.Errorf("pausing compaction: %w", err)
+	}
+	defer func() {
+		ec := errorcompounder.New()
+
+		if err != nil {
+			ec.AddWrap(err, "during ApplyToObjectDigests")
+		}
+
+		err = b.resumeCompaction(ctx)
+		if err != nil {
+			ec.AddWrap(err, "resuming compaction after ApplyToObjectDigests")
+		}
+
+		err = ec.ToError()
+	}()
+
 	// note: it's important to first create the on disk cursor so to avoid potential double scanning over flushing memtable
 	onDiskCursor := b.CursorOnDisk()
 	defer onDiskCursor.Close()
@@ -335,7 +372,7 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 	inmemProcessedDocIDs := make(map[uint64]struct{})
 
 	// note: read-write access to active and flushing memtable will be blocked only during the scope of this inner function
-	err := func() error {
+	err = func() error {
 		defer afterInMemCallback()
 
 		inMemCursor := b.CursorInMem()

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -475,6 +475,14 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 	return sg, nil
 }
 
+func (sg *SegmentGroup) pauseCompaction(ctx context.Context) error {
+	return sg.compactionCallbackCtrl.Deactivate(ctx)
+}
+
+func (sg *SegmentGroup) resumeCompaction(_ context.Context) error {
+	return sg.compactionCallbackCtrl.Activate()
+}
+
 func (sg *SegmentGroup) makeExistsOn(segments []*segment) existsOnLowerSegmentsFn {
 	return func(key []byte) (bool, error) {
 		if len(segments) == 0 {

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -367,17 +367,10 @@ func (s *Shard) initHashtree(ctx context.Context, config asyncReplicationConfig,
 		close(s.minimalHashtreeInitializationCh)
 	}
 
-	err := s.store.PauseCompaction(ctx)
-	if err != nil {
-		releaseInitialization()
-		return fmt.Errorf("pausing compaction: %w", err)
-	}
-	defer s.store.ResumeCompaction(ctx)
-
 	objCount := 0
 	prevProgressLogging := time.Now()
 
-	err = bucket.ApplyToObjectDigests(ctx, releaseInitialization, func(object *storobj.Object) error {
+	err := bucket.ApplyToObjectDigests(ctx, releaseInitialization, func(object *storobj.Object) error {
 		if time.Since(prevProgressLogging) >= config.loggingFrequency {
 			s.index.logger.
 				WithField("action", "async_replication").


### PR DESCRIPTION
### What's being changed:

This pull request introduces a mechanism to safely pause and resume compaction in the LSMKV storage engine while iterating over all objects in a bucket. The main goal is to ensure a consistent view of the data during operations that require scanning all objects, such as in async replication. The changes add new methods for pausing and resuming compaction, update the object iteration logic to use them, and refactor code that previously handled compaction pausing at a higher level.

Compaction control improvements:

* Added `pauseCompaction` and `resumeCompaction` methods to the `Bucket` and `SegmentGroup` types to allow pausing and resuming compaction at the bucket and segment group levels. (`bucket.go` [[1]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28R328-R363) `segment_group.go` [[2]](diffhunk://#diff-a7dbc361d25c3552363566fb26607efa70f0a5c2abe790bb82ad0bf6aaa8cf3cR478-R485)
* The `ApplyToObjectDigests` method in `Bucket` now pauses compaction before iterating over objects and resumes it afterward, ensuring a consistent view during iteration. (`bucket.go` [adapters/repos/db/lsmkv/bucket.goR328-R363](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28R328-R363))

Async replication refactor:

* Removed explicit calls to `PauseCompaction` and `ResumeCompaction` in the `Shard`'s async replication initialization, since compaction control is now handled within `ApplyToObjectDigests`. (`shard_async_replication.go` [adapters/repos/db/shard_async_replication.goL370-R373](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L370-R373))

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
