### PR TITLE
fix(raft): pass  local node name and address to store to use it in discovery

### DIFF
--- a/cluster/resolver/types.go
+++ b/cluster/resolver/types.go
@@ -32,10 +32,3 @@ type RaftConfig struct {
 	LocalName          string
 	LocalAddress       string
 }
-
-type FQDNConfig struct {
-	RaftPort          int
-	IsLocalHost       bool
-	NodeNameToPortMap map[string]int
-	TLD               string
-}

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -321,6 +321,8 @@ func NewFSM(cfg Config, authZController authorization.Controller, snapshotter fs
 			RaftPort:           cfg.RaftPort,
 			IsLocalHost:        cfg.IsLocalHost,
 			NodeNameToPortMap:  cfg.NodeNameToPortMap,
+			LocalName:          cfg.NodeID,
+			LocalAddress:       fmt.Sprintf("%s:%d", cfg.Host, cfg.RaftPort),
 		}),
 		schemaManager:      schemaManager,
 		snapshotter:        snapshotter,


### PR DESCRIPTION
### What's being changed:
this is a follow up PR for  https://github.com/weaviate/weaviate/pull/9230 to init local name and address

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17807569174
- [x] e2e run :https://github.com/weaviate/weaviate-e2e-tests/actions/runs/17807581454
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
