### PR TITLE
spfresh: unbounded channels

### DIFF
--- a/adapters/repos/db/vector/common/unbounded_channel.go
+++ b/adapters/repos/db/vector/common/unbounded_channel.go
@@ -1,0 +1,154 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package common
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+)
+
+// MakeUnboundedChannel creates a channel with unbounded capacity.
+// Any push is guaranteed to succeed without blocking, regardless of the
+// number of pending reads on `out`. The implementation uses a background goroutine
+// that continuously drains an internal queue to the output channel.
+// If the channel is empty, the goroutine sleeps until a new item is added.
+// This channel doesn't implement backpressure and should be used with caution
+// to avoid excessive memory usage.
+func MakeUnboundedChannel[T any]() *UnboundedChannel[T] {
+	u := UnboundedChannel[T]{
+		ch: make(chan T, 64),
+	}
+	u.cond = sync.NewCond(&u.mu)
+
+	enterrors.GoWrapper(u.run, logrus.New())
+	return &u
+}
+
+type UnboundedChannel[T any] struct {
+	ch        chan T
+	ctx       context.Context
+	mu        sync.RWMutex
+	q         []T
+	cond      *sync.Cond
+	closeOnce sync.Once
+	closed    bool
+}
+
+// Push adds a value to the channel. This operation does not wait for
+// a corresponding read and buffers the value internally until it can be sent.
+// If the channel has been closed, Push returns false.
+func (u *UnboundedChannel[T]) Push(v T) bool {
+	u.mu.Lock()
+	if u.closed {
+		u.mu.Unlock()
+		return false
+	}
+
+	wasEmpty := len(u.q) == 0
+	u.q = append(u.q, v)
+	u.mu.Unlock()
+	if wasEmpty {
+		u.cond.Signal()
+	}
+
+	return true
+}
+
+// Out returns a read-only channel from which values can be received.
+func (u *UnboundedChannel[T]) Out() <-chan T {
+	return u.ch
+}
+
+// Close the channel and initiates the shutdown of the background
+// goroutine. The provided context can be used to cancel the draining of
+// remaining items to the output channel.
+func (u *UnboundedChannel[T]) Close(ctx context.Context) {
+	u.closeOnce.Do(func() {
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		u.mu.Lock()
+		u.ctx = ctx
+		u.closed = true
+		u.cond.Broadcast()
+		u.mu.Unlock()
+	})
+}
+
+func (u *UnboundedChannel[T]) run() {
+	defer close(u.ch)
+
+	bgCtx := context.Background()
+
+	for {
+		// sleep until we have something to send
+		u.mu.Lock()
+		for len(u.q) == 0 && !u.closed {
+			u.cond.Wait()
+		}
+		// If closed and empty, we're done
+		if len(u.q) == 0 && u.closed {
+			u.mu.Unlock()
+			return
+		}
+
+		// pop head
+		v := u.pop()
+
+		ctx := u.ctx
+		if ctx == nil {
+			ctx = bgCtx
+		}
+		u.mu.Unlock()
+
+		select {
+		case u.ch <- v:
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+func (u *UnboundedChannel[T]) pop() T {
+	var zero T
+
+	// pop head
+	v := u.q[0]
+	u.q[0] = zero // prevent memory leak
+	u.q = u.q[1:]
+
+	// shrink the queue if necessary
+	if len(u.q) == 0 {
+		if cap(u.q) > 1024 {
+			u.q = nil // release underlying array
+		} else {
+			u.q = u.q[:0] // reset to zero length
+		}
+	} else if cap(u.q) > 1024 && len(u.q) < cap(u.q)/4 {
+		// if the queue is less than 25% full, shrink it to half the capacity
+		newQ := make([]T, len(u.q), cap(u.q)/2)
+		copy(newQ, u.q)
+		u.q = newQ
+	}
+
+	return v
+}
+
+// Len returns the number of items currently buffered in the channel.
+func (u *UnboundedChannel[T]) Len() int {
+	u.mu.RLock()
+	defer u.mu.RUnlock()
+	return len(u.q) + len(u.ch)
+}

--- a/adapters/repos/db/vector/common/unbounded_channel_test.go
+++ b/adapters/repos/db/vector/common/unbounded_channel_test.go
@@ -32,10 +32,6 @@ func TestMakeUnboundedChannel(t *testing.T) {
 		j++
 	}
 
-	ch.Close(t.Context())
-
-	require.Equal(t, 1000, ch.Len())
-
 	for range 1000 {
 		v := <-ch.Out()
 		require.Equal(t, j, v)
@@ -43,6 +39,8 @@ func TestMakeUnboundedChannel(t *testing.T) {
 	}
 
 	require.Zero(t, ch.Len())
+
+	ch.Close(t.Context())
 }
 
 func BenchmarkUnboundedChannel(b *testing.B) {

--- a/adapters/repos/db/vector/common/unbounded_channel_test.go
+++ b/adapters/repos/db/vector/common/unbounded_channel_test.go
@@ -1,0 +1,89 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package common
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeUnboundedChannel(t *testing.T) {
+	ch := MakeUnboundedChannel[int]()
+
+	var j int
+	for i := 0; i < 2000; i += 2 {
+		// two writes per read
+		ch.Push(i)
+		ch.Push(i + 1)
+
+		v := <-ch.Out()
+		require.Equal(t, j, v)
+		j++
+	}
+
+	ch.Close(t.Context())
+
+	require.Equal(t, 1000, ch.Len())
+
+	for range 1000 {
+		v := <-ch.Out()
+		require.Equal(t, j, v)
+		j++
+	}
+
+	require.Zero(t, ch.Len())
+}
+
+func BenchmarkUnboundedChannel(b *testing.B) {
+	b.Run("Push", func(b *testing.B) {
+		ch := MakeUnboundedChannel[int]()
+		for b.Loop() {
+			ch.Push(1)
+		}
+		b.StopTimer()
+		ctx, cancel := context.WithCancel(b.Context())
+		cancel()
+		ch.Close(ctx)
+	})
+
+	b.Run("InThenOut", func(b *testing.B) {
+		ch := MakeUnboundedChannel[int]()
+
+		for b.Loop() {
+			for j := range 1000 {
+				ch.Push(j)
+			}
+			for range 1000 {
+				<-ch.Out()
+			}
+		}
+		b.StopTimer()
+		ctx, cancel := context.WithCancel(b.Context())
+		cancel()
+		ch.Close(ctx)
+	})
+
+	b.Run("STD/InThenOut", func(b *testing.B) {
+		ch := make(chan int, 1000)
+
+		for b.Loop() {
+			for j := range 1000 {
+				ch <- j
+			}
+			for range 1000 {
+				<-ch
+			}
+		}
+	})
+}

--- a/adapters/repos/db/vector/spfresh/config.go
+++ b/adapters/repos/db/vector/spfresh/config.go
@@ -55,13 +55,10 @@ func DefaultConfig() *Config {
 		Distancer: distancer.NewL2SquaredProvider(),
 		// TODO: make the MaxPostingSize dynamic and dependent on the
 		// vector size and compression method
-		MaxPostingSize: 128,
-		MinPostingSize: 10,
-		// TODO: the number of goroutines is way too big,
-		// create unbounded channels to avoid having to create
-		// too many workers.
-		SplitWorkers:              64,
-		ReassignWorkers:           128,
+		MaxPostingSize:            128,
+		MinPostingSize:            10,
+		SplitWorkers:              8,
+		ReassignWorkers:           16,
 		InternalPostingCandidates: 64,
 		ReassignNeighbors:         64,
 		Replicas:                  8,

--- a/adapters/repos/db/vector/spfresh/spfresh_test.go
+++ b/adapters/repos/db/vector/spfresh/spfresh_test.go
@@ -42,7 +42,7 @@ func TestSPFreshRecall(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 
-	vectors_size := 10_000
+	vectors_size := 100_000
 	queries_size := 100
 	dimensions := 64
 	k := 100
@@ -77,7 +77,13 @@ func TestSPFreshRecall(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	fmt.Printf("indexing done, took: %s\n", time.Since(before))
+	fmt.Printf("indexing done, took: %s, waiting for background tasks...\n", time.Since(before))
+
+	for index.splitCh.Len() > 0 || index.reassignCh.Len() > 0 || index.mergeCh.Len() > 0 {
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	fmt.Printf("all background tasks done,took: %s\n", time.Since(before))
 
 	recall, latency := testinghelpers.RecallAndLatency(t.Context(), queries, k, index, truths)
 	fmt.Println(recall, latency)


### PR DESCRIPTION
### What's being changed:

This replaces the large buffered channels for split, merge and reassign operations with an unbounded channel implementation.
The goal is to enqueue tasks in-memory while they are being processed by the workers. This allows us to avoid deadlocks because the workers act as both producers and consumers.
Previous PR avoid this by using very large buffered channels, which is not reasonable.

The unbounded channels implementation uses a goroutine that acts as buffer between producer and consumer and stores all tasks in-memory.
It also makes sure it frees up memory during long running spikes by releasing large queues.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
