### PR TITLE
fix: calculating unloaded object metrics of empty inactive tenant

### DIFF
--- a/adapters/repos/db/index_object_storage_test.go
+++ b/adapters/repos/db/index_object_storage_test.go
@@ -233,7 +233,8 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	className := "TestClass"
-	tenantName := "test-tenant"
+	tenantNamePopulated := "test-tenant"
+	tenantNameEmpty := "empty-tenant"
 	objectCount := 50
 	objectSize := 500 // ~500 bytes per object
 
@@ -268,10 +269,15 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	// Create sharding state with multi-tenancy enabled
 	shardState := &sharding.State{
 		Physical: map[string]sharding.Physical{
-			tenantName: {
-				Name:           tenantName,
+			tenantNamePopulated: {
+				Name:           tenantNamePopulated,
 				BelongsToNodes: []string{"test-node"},
 				Status:         models.TenantActivityStatusHOT,
+			},
+			tenantNameEmpty: {
+				Name:           tenantNameEmpty,
+				BelongsToNodes: []string{"test-node"},
+				Status:         models.TenantActivityStatusCOLD,
 			},
 		},
 		PartitioningEnabled: true,
@@ -290,9 +296,9 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	mockSchema.EXPECT().ReadOnlyClass(className).Maybe().Return(class)
 	mockSchema.EXPECT().CopyShardingState(className).Maybe().Return(shardState)
 	mockSchema.EXPECT().NodeName().Maybe().Return("test-node")
-	mockSchema.EXPECT().ShardFromUUID("TestClass", mock.Anything).Return(tenantName).Maybe()
-	mockSchema.EXPECT().ShardOwner(className, tenantName).Maybe().Return("test-node", nil)
-	mockSchema.EXPECT().TenantsShards(ctx, className, tenantName).Maybe().Return(map[string]string{tenantName: models.TenantActivityStatusHOT}, nil)
+	mockSchema.EXPECT().ShardOwner(className, tenantNamePopulated).Maybe().Return("test-node", nil)
+	mockSchema.EXPECT().TenantsShards(ctx, className, tenantNamePopulated).Maybe().
+		Return(map[string]string{tenantNamePopulated: models.TenantActivityStatusHOT}, nil)
 
 	// Create index with lazy loading disabled to test active calculation methods
 	index, err := NewIndex(ctx, IndexConfig{
@@ -315,11 +321,11 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	}
 
 	// Add test objects
-	for i := 0; i < objectCount; i++ {
+	for i := range objectCount {
 		obj := &models.Object{
 			Class:  className,
 			ID:     strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", i)),
-			Tenant: tenantName,
+			Tenant: tenantNamePopulated,
 			Properties: map[string]interface{}{
 				"name":        fmt.Sprintf("test-object-%d", i),
 				"description": generateStringOfSize(objectSize - 50), // Leave room for other properties
@@ -334,7 +340,7 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// Test active shard object storage size
-	activeShard, release, err := index.GetShard(ctx, tenantName)
+	activeShard, release, err := index.GetShard(ctx, tenantNamePopulated)
 	require.NoError(t, err)
 	require.NotNil(t, activeShard)
 
@@ -366,7 +372,7 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	time.Sleep(1 * time.Second)
 
 	// Unload the shard from memory to test inactive calculation methods
-	index.shards.LoadAndDelete(tenantName)
+	index.shards.LoadAndDelete(tenantNamePopulated)
 
 	// Shut down the entire index to ensure all store metadata is persisted
 	require.NoError(t, index.Shutdown(ctx))
@@ -391,13 +397,18 @@ func TestIndex_CalculateUnloadedObjectsMetrics_ActiveVsUnloaded(t *testing.T) {
 	require.NoError(t, newIndex.ForEachShard(func(name string, shard ShardLike) error {
 		return shard.Shutdown(ctx)
 	}))
-	newIndex.shards.LoadAndDelete(tenantName)
+	newIndex.shards.LoadAndDelete(tenantNamePopulated)
 
-	inactiveObjectUsage, err := newIndex.CalculateUnloadedObjectsMetrics(ctx, tenantName)
+	inactiveObjectUsageOfPopulatedTenant, err := newIndex.CalculateUnloadedObjectsMetrics(ctx, tenantNamePopulated)
 	require.NoError(t, err)
 	// Compare active and inactive metrics
-	assert.Equal(t, int64(activeObjectCount), inactiveObjectUsage.Count, "Active and inactive object count should match")
-	assert.InDelta(t, activeObjectStorageSize, inactiveObjectUsage.StorageBytes, 1024, "Active and inactive object storage size should be close")
+	assert.Equal(t, int64(activeObjectCount), inactiveObjectUsageOfPopulatedTenant.Count, "Active and inactive object count should match")
+	assert.InDelta(t, activeObjectStorageSize, inactiveObjectUsageOfPopulatedTenant.StorageBytes, 1024, "Active and inactive object storage size should be close")
+
+	inactiveObjectUsageOfEmptyTenant, err := newIndex.CalculateUnloadedObjectsMetrics(ctx, tenantNameEmpty)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), inactiveObjectUsageOfEmptyTenant.Count)
+	assert.Equal(t, int64(0), inactiveObjectUsageOfEmptyTenant.StorageBytes)
 
 	// Verify all mock expectations were met
 	mockSchema.AssertExpectations(t)


### PR DESCRIPTION
### What's being changed:
Tenant that is created, but not yet populated does not have its directory created. That was cause of `failed to get usage data: lstat /var/lib/weaviate/{class}/{tenant}/lsm/objects: no such file or directory` messages when object metrics of inactive empty tenant were fetched.
Introduced fix checks if tenant's directory exists before trying to read from it.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
