### PR TITLE
Make bucket min reuse default in line with weaviate default

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/weaviate/weaviate/entities/diskio"
+	"github.com/weaviate/weaviate/usecases/config"
 
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
@@ -215,6 +216,7 @@ func (*Bucket) NewBucket(ctx context.Context, dir, rootDir string, logger logrus
 		calcCountNetAdditions:        false,
 		haltedFlushTimer:             interval.NewBackoffTimer(),
 		writeSegmentInfoIntoFileName: false,
+		minWalThreshold:              config.DefaultPersistenceMaxReuseWalSize,
 	}
 
 	for _, opt := range opts {

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -332,7 +332,7 @@ func TestBucketWalReload(t *testing.T) {
 			// initial bucket, always create segment, even if it is just a single entry
 			b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount), WithMinWalThreshold(4096),
+				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount),
 				WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 			require.NoError(t, err)
 
@@ -362,7 +362,7 @@ func TestBucketWalReload(t *testing.T) {
 			// start fresh with a new memtable, new entries will stay in wal until size is reached
 			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount), WithMinWalThreshold(4096),
+				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount),
 				WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 			require.NoError(t, err)
 
@@ -391,7 +391,7 @@ func TestBucketWalReload(t *testing.T) {
 			// will load wal and reuse memtable
 			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-				WithStrategy(strategy), WithSecondaryIndices(1), WithMinWalThreshold(4096),
+				WithStrategy(strategy), WithSecondaryIndices(1),
 				WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 			require.NoError(t, err)
 
@@ -423,7 +423,7 @@ func TestBucketWalReload(t *testing.T) {
 			// now add a lot of entries to hit .wal file limit
 			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount), WithMinWalThreshold(4096),
+				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount),
 				WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 			require.NoError(t, err)
 
@@ -457,7 +457,7 @@ func TestBucketWalReload(t *testing.T) {
 
 			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
 				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
-				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount), WithMinWalThreshold(4096),
+				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount),
 				WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 			require.NoError(t, err)
 
@@ -617,7 +617,7 @@ func TestBucketRecovery(t *testing.T) {
 	dirName := t.TempDir()
 	tmpDir := t.TempDir()
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(true), WithMinWalThreshold(4096),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(true),
 	)
 	require.NoError(t, err)
 	require.NoError(t, b.Put([]byte("hello1"), []byte("world1"), WithSecondaryKey(0, []byte("bonjour1"))))
@@ -641,7 +641,7 @@ func TestBucketRecovery(t *testing.T) {
 	require.Equal(t, walFiles, 0)
 
 	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(true), WithMinWalThreshold(4096),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(true),
 	)
 	require.NoError(t, err)
 	require.NoError(t, b.Put([]byte("hello2"), []byte("world2"), WithSecondaryKey(0, []byte("bonjour2"))))
@@ -654,7 +654,7 @@ func TestBucketRecovery(t *testing.T) {
 	require.NoError(t, os.Rename(tmpPath, oldPath))
 
 	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(true), WithMinWalThreshold(4096),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(true),
 	)
 	require.NoError(t, err)
 	get, err := b.Get([]byte("hello1"))
@@ -668,7 +668,7 @@ func TestNetCountComputationAtInit(t *testing.T) {
 	ctx := context.Background()
 	dirName := t.TempDir()
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithCalcCountNetAdditions(true),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithCalcCountNetAdditions(true), WithMinWalThreshold(0),
 	)
 	require.NoError(t, err)
 

--- a/adapters/repos/db/lsmkv/segment_group_loading_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_loading_test.go
@@ -200,7 +200,7 @@ func TestWalFilePresent(t *testing.T) {
 	ctx := context.Background()
 	dirName := t.TempDir()
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(true), WithMinWalThreshold(4096),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(true),
 	)
 
 	// create "incomplete" segment
@@ -237,7 +237,7 @@ func TestWalFilePresent(t *testing.T) {
 
 	// incomplete segment will be deleted and memtable is reconstructed from .wal
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(true), WithMinWalThreshold(4096),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(true),
 	)
 	require.NoError(t, err)
 
@@ -312,7 +312,7 @@ func createSegmentFiles(t *testing.T, ctx context.Context, logger logrus.FieldLo
 	}
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo[0]), WithMinWalThreshold(4096),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo[0]),
 	)
 	require.NoError(t, err)
 	for i := 0; i < 10; i++ {
@@ -325,7 +325,7 @@ func createSegmentFiles(t *testing.T, ctx context.Context, logger logrus.FieldLo
 	require.NoError(t, b.Shutdown(ctx))
 
 	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo[1]), WithMinWalThreshold(4096),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo[1]),
 	)
 	require.NoError(t, err)
 

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -33,6 +33,7 @@ func TestReplaceStrategy(t *testing.T) {
 			opts: []BucketOption{
 				WithStrategy(StrategyReplace),
 				WithCalcCountNetAdditions(true),
+				WithMinWalThreshold(0),
 			},
 		},
 		{


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
