### PR TITLE
refact(memberlist-config): re-name env var to MEMBERLIST_FAST_FAILURE_DETECTION

### DIFF
--- a/test/acceptance/replication/read_repair/scale_test.go
+++ b/test/acceptance/replication/read_repair/scale_test.go
@@ -37,6 +37,7 @@ func (suite *ReplicationTestSuite) TestReplicationFactorIncrease() {
 	compose, err := docker.New().
 		With3NodeCluster().
 		WithText2VecContextionary().
+		WithWeaviateEnv("RAFT_TIMEOUTS_MULTIPLIER", "10").
 		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {

--- a/test/acceptance/replication/read_repair/scale_test.go
+++ b/test/acceptance/replication/read_repair/scale_test.go
@@ -37,7 +37,7 @@ func (suite *ReplicationTestSuite) TestReplicationFactorIncrease() {
 	compose, err := docker.New().
 		With3NodeCluster().
 		WithText2VecContextionary().
-		WithWeaviateEnv("RAFT_TIMEOUTS_MULTIPLIER", "10").
+		WithWeaviateEnv("RAFT_TIMEOUTS_MULTIPLIER", "5").
 		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -95,7 +95,7 @@ func (d *DockerCompose) StopAt(ctx context.Context, nodeIndex int, timeout *time
 	}
 
 	// sleep to make sure that the off node is detected by memberlist and marked failed
-	// it shall be used with combination of "FAST_FAILURE_DETECTION" env flag
+	// it shall be used with combination of "MEMBERLIST_FAST_FAILURE_DETECTION" env flag
 	time.Sleep(3 * time.Second)
 
 	return nil

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -78,14 +78,14 @@ func startWeaviate(ctx context.Context,
 	}
 	env := map[string]string{
 		"AUTHENTICATION_ANONYMOUS_ACCESS_ENABLED": "true",
-		"LOG_LEVEL":                 "debug",
-		"QUERY_DEFAULTS_LIMIT":      "20",
-		"PERSISTENCE_DATA_PATH":     "./data",
-		"DEFAULT_VECTORIZER_MODULE": "none",
-		"FAST_FAILURE_DETECTION":    "true",
-		"DISABLE_TELEMETRY":         "true",
-		"RAFT_DRAIN_SLEEP":          "1ms", // almost as no sleep, no 0 because will fail validation
-		"RAFT_TIMEOUTS_MULTIPLIER":  "3",
+		"LOG_LEVEL":                         "debug",
+		"QUERY_DEFAULTS_LIMIT":              "20",
+		"PERSISTENCE_DATA_PATH":             "./data",
+		"DEFAULT_VECTORIZER_MODULE":         "none",
+		"MEMBERLIST_FAST_FAILURE_DETECTION": "true",
+		"DISABLE_TELEMETRY":                 "true",
+		"RAFT_DRAIN_SLEEP":                  "1ms", // almost as no sleep, no 0 because will fail validation
+		"RAFT_TIMEOUTS_MULTIPLIER":          "3",
 	}
 	if len(enableModules) > 0 {
 		env["ENABLE_MODULES"] = strings.Join(enableModules, ",")

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -72,9 +72,9 @@ type Config struct {
 	AuthConfig              AuthConfig `json:"auth" yaml:"auth"`
 	AdvertiseAddr           string     `json:"advertiseAddr" yaml:"advertiseAddr"`
 	AdvertisePort           int        `json:"advertisePort" yaml:"advertisePort"`
-	// FastFailureDetection mostly for testing purpose, it will make memberlist sensitive and detect
+	// MemberlistFastFailureDetection mostly for testing purpose, it will make memberlist sensitive and detect
 	// failures (down nodes) faster.
-	FastFailureDetection bool `json:"fastFailureDetection" yaml:"fastFailureDetection"`
+	MemberlistFastFailureDetection bool `json:"memberlistFastFailureDetection" yaml:"memberlistFastFailureDetection"`
 	// LocalHost flag enables running a multi-node setup with the same localhost and different ports
 	Localhost bool `json:"localhost" yaml:"localhost"`
 	// MaintenanceNodes is experimental. You should not use this directly, but should use the
@@ -137,7 +137,7 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 		cfg.AdvertisePort = userConfig.AdvertisePort
 	}
 
-	if userConfig.FastFailureDetection {
+	if userConfig.MemberlistFastFailureDetection {
 		cfg.SuspicionMult = 1
 		cfg.DeadNodeReclaimTime = 5 * time.Second
 	}

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1426,7 +1426,7 @@ func parseClusterConfig() (cluster.Config, error) {
 		},
 	}
 
-	cfg.MemberlistFastFailureDetection = entcfg.Enabled(os.Getenv("MEMBERLIST_FAST_FAILURE_DETECTION")) || entcfg.Enabled(os.Getenv("FAST_FAILURE_DETECTION")) // ackward compatibility
+	cfg.MemberlistFastFailureDetection = entcfg.Enabled(os.Getenv("MEMBERLIST_FAST_FAILURE_DETECTION")) || entcfg.Enabled(os.Getenv("FAST_FAILURE_DETECTION")) // backward compatibility
 
 	// MAINTENANCE_NODES is experimental and subject to removal/change. It is an optional, comma
 	// separated list of hostnames that are in maintenance mode. In maintenance mode, the node will

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1426,7 +1426,7 @@ func parseClusterConfig() (cluster.Config, error) {
 		},
 	}
 
-	cfg.FastFailureDetection = entcfg.Enabled(os.Getenv("FAST_FAILURE_DETECTION"))
+	cfg.MemberlistFastFailureDetection = entcfg.Enabled(os.Getenv("MEMBERLIST_FAST_FAILURE_DETECTION")) || entcfg.Enabled(os.Getenv("FAST_FAILURE_DETECTION")) // ackward compatibility
 
 	// MAINTENANCE_NODES is experimental and subject to removal/change. It is an optional, comma
 	// separated list of hostnames that are in maintenance mode. In maintenance mode, the node will


### PR DESCRIPTION
this  PR rename env var from `FAST_FAILURE_DETECTION` to be `MEMBERLIST_FAST_FAILURE_DETECTION` to give more context to the config. i's backward compatiable because the config checks for both. 


**NOTE**: this config used for testing purposes or tweaking our pipelines 
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/17862493868
- [x] e2e tests: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/17860498084
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
