### PR TITLE
fix: context-aware propagation triggering

### DIFF
--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -707,7 +707,12 @@ func (s *Shard) initHashBeater(ctx context.Context, config asyncReplicationConfi
 				slices.Sort(aliveHosts)
 
 				if !slices.Equal(comparedHosts, aliveHosts) {
-					propagationRequired <- struct{}{}
+					select {
+					case <-ctx.Done():
+						return
+					case propagationRequired <- struct{}{}:
+					}
+
 					s.setLastComparedNodes(aliveHosts)
 				}
 			case <-ft.C:
@@ -718,7 +723,11 @@ func (s *Shard) initHashBeater(ctx context.Context, config asyncReplicationConfi
 				lastHashbeatMux.Unlock()
 
 				if shouldHashbeat {
-					propagationRequired <- struct{}{}
+					select {
+					case <-ctx.Done():
+						return
+					case propagationRequired <- struct{}{}:
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### What's being changed:

This pull request improves the robustness of the `initHashBeater` function in `shard_async_replication.go` by ensuring that signals sent to the `propagationRequired` channel are context-aware. This prevents potential goroutine leaks or deadlocks when the context is canceled.

Concurrency and context handling improvements:

* Updated the logic for sending to the `propagationRequired` channel to use a `select` statement, ensuring that if the context is canceled, the function returns early instead of blocking on the channel. This change is applied in two places within the `initHashBeater` function. [[1]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L710-R715) [[2]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L721-R730)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
