### PR TITLE
feat(metrics): enhance async replication metrics

### DIFF
--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -357,6 +357,7 @@ func (s *Shard) initAsyncReplication() (err error) {
 func (s *Shard) initHashtree(ctx context.Context, config asyncReplicationConfig, bucket *lsmkv.Bucket) (err error) {
 	start := time.Now()
 
+	s.metrics.IncAsyncReplicationHashTreeInitCount()
 	s.metrics.IncAsyncReplicationHashTreeInitRunning()
 
 	defer func() {
@@ -596,8 +597,8 @@ func (s *Shard) getAsyncReplicationStats(ctx context.Context) []*models.AsyncRep
 	asyncReplicationStatsToReturn := make([]*models.AsyncReplicationStatus, 0, len(s.asyncReplicationStatsByTargetNode))
 	for targetNodeName, asyncReplicationStats := range s.asyncReplicationStatsByTargetNode {
 		asyncReplicationStatsToReturn = append(asyncReplicationStatsToReturn, &models.AsyncReplicationStatus{
-			ObjectsPropagated:       uint64(asyncReplicationStats.objectsPropagated),
-			StartDiffTimeUnixMillis: asyncReplicationStats.diffStartTime.UnixMilli(),
+			ObjectsPropagated:       uint64(asyncReplicationStats.localObjectsPropagationCount),
+			StartDiffTimeUnixMillis: asyncReplicationStats.hashtreeDiffStartTime.UnixMilli(),
 			TargetNode:              targetNodeName,
 		})
 	}
@@ -676,8 +677,8 @@ func (s *Shard) initHashBeater(ctx context.Context, config asyncReplicationConfi
 	var lastHashbeatMux sync.Mutex
 
 	enterrors.GoWrapper(func() {
-		s.metrics.IncAsyncReplicationGoroutinesRunning()
-		defer s.metrics.DecAsyncReplicationGoroutinesRunning()
+		s.metrics.IncAsyncReplicationHashbeaterRunning()
+		defer s.metrics.DecAsyncReplicationHashbeaterRunning()
 
 		s.index.logger.
 			WithField("action", "async_replication").
@@ -742,15 +743,14 @@ func (s *Shard) initHashBeater(ctx context.Context, config asyncReplicationConfi
 						for _, stat := range stats {
 							if stat != nil {
 								s.index.logger.WithFields(logrus.Fields{
-									"source_shard":                s.name,
-									"target_shard":                s.name,
-									"target_node":                 stat.targetNodeName,
-									"objects_propagated":          stat.objectsPropagated,
-									"start_diff_time_unix_millis": stat.diffStartTime.UnixMilli(),
-									"diff_calculation_took":       stat.diffCalculationTook.String(),
-									"local_objects":               stat.localObjects,
-									"remote_objects":              stat.remoteObjects,
-									"object_progation_took":       stat.objectProgationTook.String(),
+									"shard_name":                      s.name,
+									"target_node_name":                stat.targetNodeName,
+									"hashtree_diff_took":              stat.hashtreeDiffTook,
+									"object_digests_diff_took":        stat.objectDigestsDiffTook,
+									"local_object_digests_count":      stat.localObjectDigestsCount,
+									"remote_object_digests_count":     stat.remoteObjectDigestsCount,
+									"local_objects_propagation_count": stat.localObjectsPropagationCount,
+									"local_objects_propagation_took":  stat.localObjectsPropagationTook,
 								}).Info("updating async replication stats")
 								s.asyncReplicationStatsByTargetNode[stat.targetNodeName] = stat
 							}
@@ -811,13 +811,14 @@ func (s *Shard) initHashBeater(ctx context.Context, config asyncReplicationConfi
 							WithField("class_name", s.class.Class).
 							WithField("shard_name", s.name).
 							WithField("target_node_name", stat.targetNodeName).
-							WithField("diff_calculation_took", stat.diffCalculationTook.String()).
-							WithField("local_objects", stat.localObjects).
-							WithField("remote_objects", stat.remoteObjects).
-							WithField("objects_propagated", stat.objectsPropagated).
-							WithField("object_progation_took", stat.objectProgationTook.String()).
+							WithField("hashtree_diff_took", stat.hashtreeDiffTook).
+							WithField("object_digests_diff_took", stat.objectDigestsDiffTook).
+							WithField("local_object_digests_count", stat.localObjectDigestsCount).
+							WithField("remote_object_digests_count", stat.remoteObjectDigestsCount).
+							WithField("local_objects_propagation_count", stat.localObjectsPropagationCount).
+							WithField("local_objects_propagation_took", stat.localObjectsPropagationTook).
 							Info("hashbeat iteration successfully completed")
-						if stat.objectsPropagated > 0 {
+						if stat.localObjectDigestsCount > 0 {
 							statsHaveObjectsPropagated = true
 						}
 					}
@@ -832,7 +833,20 @@ func (s *Shard) initHashBeater(ctx context.Context, config asyncReplicationConfi
 		}
 	}, s.index.logger)
 
+	// goroutine to monitor changes in alive nodes and time since last hashbeat
+	// and "wake up" the hashbeater when necessary
+	// e.g. when a node goes down or comes back up, or when frequency time has elapsed
+	// since last hashbeat
+	// this ensures that changes in cluster topology are quickly detected and propagated
+	// without having to wait for the next frequency tick
+	// note that the hashbeater itself also has a frequency ticker to ensure that
+	// propagation occurs at least every frequency interval even if no changes in
+	// alive nodes occur
+	propagationRequired <- struct{}{}
 	enterrors.GoWrapper(func() {
+		s.metrics.IncAsyncReplicationHashbeatTriggerRunning()
+		defer s.metrics.DecAsyncReplicationHashbeatTriggerRunning()
+
 		nt := time.NewTicker(config.aliveNodesCheckingFrequency)
 		defer nt.Stop()
 
@@ -888,13 +902,14 @@ func (s *Shard) allAliveHostnames() []string {
 }
 
 type hashBeatHostStats struct {
-	targetNodeName      string
-	diffStartTime       time.Time
-	diffCalculationTook time.Duration
-	localObjects        int
-	remoteObjects       int
-	objectsPropagated   int
-	objectProgationTook time.Duration
+	targetNodeName               string
+	hashtreeDiffStartTime        time.Time
+	hashtreeDiffTook             time.Duration
+	objectDigestsDiffTook        time.Duration
+	localObjectDigestsCount      int
+	remoteObjectDigestsCount     int
+	localObjectsPropagationCount int
+	localObjectsPropagationTook  time.Duration
 }
 
 func (s *Shard) hashBeat(ctx context.Context, config asyncReplicationConfig) (stats []*hashBeatHostStats, err error) {
@@ -922,7 +937,7 @@ func (s *Shard) hashBeat(ctx context.Context, config asyncReplicationConfig) (st
 	ht = s.hashtree
 	s.asyncReplicationRWMux.RUnlock()
 
-	diffCalculationStart := time.Now()
+	hashtreeDiffStart := time.Now()
 
 	shardDiffReader, err := s.index.replicator.CollectShardDifferences(ctx, s.name, ht, config.diffPerNodeTimeout, config.targetNodeOverrides)
 	if err != nil {
@@ -930,33 +945,33 @@ func (s *Shard) hashBeat(ctx context.Context, config asyncReplicationConfig) (st
 			stats := make([]*hashBeatHostStats, 0, len(config.targetNodeOverrides))
 			for _, o := range config.targetNodeOverrides {
 				stats = append(stats, &hashBeatHostStats{
-					targetNodeName:    o.TargetNode,
-					diffStartTime:     diffCalculationStart,
-					objectsPropagated: 0,
+					targetNodeName:        o.TargetNode,
+					hashtreeDiffStartTime: hashtreeDiffStart,
 				})
 			}
 			return stats, err
 		}
-		return nil, fmt.Errorf("collecting differences: %w", err)
+		return nil, fmt.Errorf("collecting hashtree differences: %w", err)
 	}
 
-	diffCalculationTook := time.Since(diffCalculationStart)
+	hashtreeDiffTook := time.Since(hashtreeDiffStart)
+	s.metrics.ObserveAsyncReplicationHashtreeDiffDuration(hashtreeDiffTook)
 
 	rangeReader := shardDiffReader.RangeReader
 
-	objectProgationStart := time.Now()
+	objectDigestsDiffStart := time.Now()
 
-	localObjectsCount := 0
-	remoteObjectsCount := 0
+	localObjectDigestsCount := 0
+	remoteObjectDigestsCount := 0
 
-	objectsToPropagate := make([]strfmt.UUID, 0, config.propagationLimit)
+	localObjectsToPropagate := make([]strfmt.UUID, 0, config.propagationLimit)
 	localUpdateTimeByUUID := make(map[strfmt.UUID]int64, config.propagationLimit)
 	remoteStaleUpdateTimeByUUID := make(map[strfmt.UUID]int64, config.propagationLimit)
 
-	prepropagationCtx, cancel := context.WithTimeout(ctx, config.prePropagationTimeout)
+	objectDigestsDiffCtx, cancel := context.WithTimeout(ctx, config.prePropagationTimeout)
 	defer cancel()
 
-	for len(objectsToPropagate) < config.propagationLimit {
+	for len(localObjectsToPropagate) < config.propagationLimit {
 		initialLeaf, finalLeaf, err := rangeReader.Next()
 		if err != nil {
 			if errors.Is(err, hashtree.ErrNoMoreRanges) {
@@ -966,16 +981,16 @@ func (s *Shard) hashBeat(ctx context.Context, config asyncReplicationConfig) (st
 		}
 
 		localObjsCountWithinRange, remoteObjsCountWithinRange, objsToPropagateWithinRange, err := s.objectsToPropagateWithinRange(
-			prepropagationCtx,
+			objectDigestsDiffCtx,
 			config,
 			shardDiffReader.TargetNodeAddress,
 			shardDiffReader.TargetNodeName,
 			initialLeaf,
 			finalLeaf,
-			config.propagationLimit-len(objectsToPropagate),
+			config.propagationLimit-len(localObjectsToPropagate),
 		)
 		if err != nil {
-			if prepropagationCtx.Err() != nil {
+			if objectDigestsDiffCtx.Err() != nil {
 				// it may be the case that just pre propagation timeout was reached
 				// and some objects could be propagated
 				break
@@ -984,21 +999,26 @@ func (s *Shard) hashBeat(ctx context.Context, config asyncReplicationConfig) (st
 			return nil, fmt.Errorf("collecting local objects to be propagated: %w", err)
 		}
 
-		localObjectsCount += localObjsCountWithinRange
-		remoteObjectsCount += remoteObjsCountWithinRange
+		localObjectDigestsCount += localObjsCountWithinRange
+		remoteObjectDigestsCount += remoteObjsCountWithinRange
 
 		for _, obj := range objsToPropagateWithinRange {
-			objectsToPropagate = append(objectsToPropagate, obj.uuid)
+			localObjectsToPropagate = append(localObjectsToPropagate, obj.uuid)
 			localUpdateTimeByUUID[obj.uuid] = obj.lastUpdateTime
 			remoteStaleUpdateTimeByUUID[obj.uuid] = obj.remoteStaleUpdateTime
 		}
 	}
 
-	if len(objectsToPropagate) > 0 {
+	objectDigestsDiffTook := time.Since(objectDigestsDiffStart)
+	s.metrics.ObserveAsyncReplicationObjectDigestsDiffDuration(objectDigestsDiffTook)
+
+	objectsPropagationStart := time.Now()
+
+	if len(localObjectsToPropagate) > 0 {
 		propagationCtx, cancel := context.WithTimeout(ctx, config.propagationTimeout)
 		defer cancel()
 
-		resp, err := s.propagateObjects(propagationCtx, config, shardDiffReader.TargetNodeAddress, objectsToPropagate, remoteStaleUpdateTimeByUUID)
+		resp, err := s.propagateObjects(propagationCtx, config, shardDiffReader.TargetNodeAddress, localObjectsToPropagate, remoteStaleUpdateTimeByUUID)
 		if err != nil {
 			return nil, fmt.Errorf("propagating local objects: %w", err)
 		}
@@ -1027,13 +1047,14 @@ func (s *Shard) hashBeat(ctx context.Context, config asyncReplicationConfig) (st
 
 	return []*hashBeatHostStats{
 		{
-			targetNodeName:      shardDiffReader.TargetNodeName,
-			diffStartTime:       diffCalculationStart,
-			diffCalculationTook: diffCalculationTook,
-			localObjects:        localObjectsCount,
-			remoteObjects:       remoteObjectsCount,
-			objectsPropagated:   len(objectsToPropagate),
-			objectProgationTook: time.Since(objectProgationStart),
+			targetNodeName:               shardDiffReader.TargetNodeName,
+			hashtreeDiffStartTime:        hashtreeDiffStart,
+			hashtreeDiffTook:             hashtreeDiffTook,
+			objectDigestsDiffTook:        objectDigestsDiffTook,
+			localObjectDigestsCount:      localObjectDigestsCount,
+			remoteObjectDigestsCount:     remoteObjectDigestsCount,
+			localObjectsPropagationCount: len(localObjectsToPropagate),
+			localObjectsPropagationTook:  time.Since(objectsPropagationStart),
 		},
 	}, nil
 }


### PR DESCRIPTION
### What's being changed:

This pull request refactors and extends the async replication metrics. The changes improve observability by adding more granular Prometheus metrics, refactor metric registration for consistency, and update async replication status reporting and logging to provide more detailed and accurate information.

**Metrics and Monitoring Enhancements:**

* Refactored the async replication metrics in the `Metrics` struct to use more granular and labeled Prometheus metric types (e.g., `GaugeVec` with a `type` label for goroutines, new counters and histograms for specific replication stages). Added new metrics for hash tree initialization count, hashtree diff duration, and object digests diff duration. All metrics are now registered using a consistent helper function. [[1]](diffhunk://#diff-dbe663b64f56c7bffb7d93a808f0665b8a6509177fcde88e91ee91d3a0bc3400L47-R49) [[2]](diffhunk://#diff-dbe663b64f56c7bffb7d93a808f0665b8a6509177fcde88e91ee91d3a0bc3400R58-R60) [[3]](diffhunk://#diff-dbe663b64f56c7bffb7d93a808f0665b8a6509177fcde88e91ee91d3a0bc3400L172-R343)
* Added new metric methods to increment/decrement goroutines by type (`hashbeater`, `hashbeat_trigger`) and to observe durations for hashtree diff and object digests diff. [[1]](diffhunk://#diff-dbe663b64f56c7bffb7d93a808f0665b8a6509177fcde88e91ee91d3a0bc3400L553-R617) [[2]](diffhunk://#diff-dbe663b64f56c7bffb7d93a808f0665b8a6509177fcde88e91ee91d3a0bc3400R662-R673)

**Async Replication Status and Logging Improvements:**

* Updated the async replication status reporting to use more descriptive and accurate field names (e.g., `localObjectsPropagationCount`, `hashtreeDiffStartTime`) and updated logging to reflect these new fields, providing clearer insights into the replication process. [[1]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L599-R601) [[2]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L745-R753) [[3]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L814-R821) [[4]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L892-R912)
* Refactored the `hashBeatHostStats` struct and related logic to track and report more granular timing and count statistics for each phase of the replication process, including hashtree diff, object digests diff, and propagation. [[1]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L892-R912) [[2]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L925-R940) [[3]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L934-R974)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
