### PR TITLE
feat(metrics): memtable flushing metrics

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -29,12 +29,7 @@ import (
 
 var logOnceWhenRecoveringFromWAL sync.Once
 
-func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup, files map[string]int64) error {
-	beforeAll := time.Now()
-	defer b.metrics.TrackStartupBucketRecovery(beforeAll)
-
-	recovered := false
-
+func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup, files map[string]int64) (err error) {
 	// the context is only ever checked once at the beginning, as there is no
 	// point in aborting an ongoing recovery. It makes more sense to let it
 	// complete and have the next recovery (this is called once per bucket) run
@@ -65,13 +60,34 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup,
 		walFileNames = append(walFileNames, file)
 	}
 
-	if len(walFileNames) > 0 {
-		logOnceWhenRecoveringFromWAL.Do(func() {
-			b.logger.WithField("action", "lsm_recover_from_active_wal").
-				WithField("path", b.dir).
-				Debug("active write-ahead-log found")
-		})
+	if len(walFileNames) == 0 {
+		// nothing to do
+		return nil
 	}
+
+	logOnceWhenRecoveringFromWAL.Do(func() {
+		b.logger.WithField("action", "lsm_recover_from_active_wal").
+			WithField("path", b.dir).
+			Debug("active write-ahead-log found")
+	})
+
+	start := time.Now()
+
+	b.metrics.IncWalRecoveryCount(b.strategy)
+	b.metrics.IncWalRecoveryInProgress(b.strategy)
+
+	defer func() {
+		b.metrics.DecWalRecoveryInProgress(b.strategy)
+
+		if err != nil {
+			b.metrics.IncWalRecoveryFailureCount(b.strategy)
+			return
+		}
+
+		b.metrics.ObserveWalRecoveryDuration(b.strategy, time.Since(start))
+	}()
+
+	recovered := false
 
 	// recover from each log
 	for i, fname := range walFileNames {

--- a/adapters/repos/db/lsmkv/memtable_metrics.go
+++ b/adapters/repos/db/lsmkv/memtable_metrics.go
@@ -11,7 +11,30 @@
 
 package lsmkv
 
+import (
+	"fmt"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+var (
+	flushingDurationBuckets = prometheus.ExponentialBuckets(0.01, 2, 15)    // from 10ms up to ~2min 44s
+	flushingSizeBuckets     = prometheus.ExponentialBuckets(64*1024, 2, 15) // 64KB → ~1GB
+)
+
 type memtableMetrics struct {
+	// flushing metrics
+	flushingCount        *prometheus.CounterVec
+	flushingInProgress   *prometheus.GaugeVec
+	flushingFailureCount *prometheus.CounterVec
+	flushingDuration     *prometheus.HistogramVec
+	flushMemtableSize    *prometheus.HistogramVec
+
+	flushMemtableBytesWritten BytesWriteObserver
+
+	// per-operation metrics (old-style, to be migrated)
 	put             NsObserver
 	setTombstone    NsObserver
 	append          NsObserver
@@ -21,14 +44,92 @@ type memtableMetrics struct {
 	getMap          NsObserver
 	getCollection   NsObserver
 	size            Setter
-	writeMemtable   BytesWriteObserver
 }
 
 // newMemtableMetrics curries the prometheus-functions just once to make sure
 // they don't have to be curried on the hotpath where we this would lead to a
 // lot of allocations.
-func newMemtableMetrics(metrics *Metrics, path, strategy string) *memtableMetrics {
+func newMemtableMetrics(metrics *Metrics, path, strategy string) (*memtableMetrics, error) {
+	if metrics == nil {
+		return nil, nil
+	}
+
+	flushingCount, err := monitoring.EnsureRegisteredMetric(metrics.register,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_memtable_flush_total",
+				Help:      "Total number of LSM memtable flushes, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_memtable_flush_total: %w", err)
+	}
+
+	flushingInProgress, err := monitoring.EnsureRegisteredMetric(metrics.register,
+		prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_memtable_flush_in_progress",
+				Help:      "Number of LSM memtable flushes in progress, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_memtable_flush_in_progress: %w", err)
+	}
+
+	flushingFailureCount, err := monitoring.EnsureRegisteredMetric(metrics.register,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_memtable_flush_failures_total",
+				Help:      "Total number of failed LSM memtable flushes, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_memtable_flush_failures_total: %w", err)
+	}
+
+	flushingDuration, err := monitoring.EnsureRegisteredMetric(metrics.register,
+		prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_memtable_flush_duration_seconds",
+				Help:      "Duration of LSM memtable flush in seconds, labeled by segment strategy",
+				Buckets:   flushingDurationBuckets,
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_memtable_flush_duration_seconds: %w", err)
+	}
+
+	flushMemtableSize, err := monitoring.EnsureRegisteredMetric(metrics.register,
+		prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_memtable_flush_size_bytes",
+				Help:      "Size of LSM memtable at flushing time, in bytes",
+				Buckets:   flushingSizeBuckets,
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_memtable_flush_size_bytes: %w", err)
+	}
+
 	return &memtableMetrics{
+		flushingCount:        flushingCount,
+		flushingInProgress:   flushingInProgress,
+		flushingFailureCount: flushingFailureCount,
+		flushingDuration:     flushingDuration,
+		flushMemtableSize:    flushMemtableSize,
+
+		flushMemtableBytesWritten: metrics.MemtableWriteObserver(strategy, "flushMemtable"),
+
 		put:             metrics.MemtableOpObserver(path, strategy, "put"),
 		setTombstone:    metrics.MemtableOpObserver(path, strategy, "setTombstone"),
 		append:          metrics.MemtableOpObserver(path, strategy, "append"),
@@ -38,6 +139,117 @@ func newMemtableMetrics(metrics *Metrics, path, strategy string) *memtableMetric
 		getMap:          metrics.MemtableOpObserver(path, strategy, "getMap"),
 		getCollection:   metrics.MemtableOpObserver(path, strategy, "getCollection"),
 		size:            metrics.MemtableSizeSetter(path, strategy),
-		writeMemtable:   metrics.MemtableWriteObserver(strategy, "flushMemtable"),
+	}, nil
+}
+
+func (m *memtableMetrics) incFlushingCount(strategy string) {
+	if m == nil {
+		return
 	}
+	m.flushingCount.WithLabelValues(strategy).Inc()
+}
+
+func (m *memtableMetrics) incFlushingInProgress(strategy string) {
+	if m == nil {
+		return
+	}
+	m.flushingInProgress.WithLabelValues(strategy).Inc()
+}
+
+func (m *memtableMetrics) decFlushingInProgress(strategy string) {
+	if m == nil {
+		return
+	}
+	m.flushingInProgress.WithLabelValues(strategy).Dec()
+}
+
+func (m *memtableMetrics) incFlushingFailureCount(strategy string) {
+	if m == nil {
+		return
+	}
+	m.flushingFailureCount.WithLabelValues(strategy).Inc()
+}
+
+func (m *memtableMetrics) observeFlushingDuration(strategy string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.flushingDuration.WithLabelValues(strategy).Observe(duration.Seconds())
+}
+
+func (m *memtableMetrics) observeFlushMemtableSize(strategy string, size uint64) {
+	if m == nil {
+		return
+	}
+	m.flushMemtableSize.WithLabelValues(strategy).Observe(float64(size))
+}
+
+func (m *memtableMetrics) observeFlushMemtableBytesWritten(n int64) {
+	if m == nil {
+		return
+	}
+	m.flushMemtableBytesWritten(n)
+}
+
+func (m *memtableMetrics) observePut(ns int64) {
+	if m == nil {
+		return
+	}
+	m.put(ns)
+}
+
+func (m *memtableMetrics) observeSetTombstone(ns int64) {
+	if m == nil {
+		return
+	}
+	m.setTombstone(ns)
+}
+
+func (m *memtableMetrics) observeAppend(ns int64) {
+	if m == nil {
+		return
+	}
+	m.append(ns)
+}
+
+func (m *memtableMetrics) observeAppendMapSorted(ns int64) {
+	if m == nil {
+		return
+	}
+	m.appendMapSorted(ns)
+}
+
+func (m *memtableMetrics) observeGet(ns int64) {
+	if m == nil {
+		return
+	}
+	m.get(ns)
+}
+
+func (m *memtableMetrics) observeGetBySecondary(ns int64) {
+	if m == nil {
+		return
+	}
+	m.getBySecondary(ns)
+}
+
+func (m *memtableMetrics) observeGetMap(ns int64) {
+	if m == nil {
+		return
+	}
+	m.getMap(ns)
+}
+
+func (m *memtableMetrics) observeGetCollection(ns int64) {
+	if m == nil {
+		return
+	}
+	m.getCollection(ns)
+}
+
+func (m *memtableMetrics) observeSize(size uint64) {
+	if m == nil {
+		return
+	}
+	m.size(size)
 }

--- a/adapters/repos/db/lsmkv/memtable_roaring_set.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set.go
@@ -135,7 +135,7 @@ func (m *Memtable) roaringSetAdjustMeta(entriesChanged int) {
 	// estimation is therefore to take the changed entries and multiply them by
 	// 2.
 	m.size += uint64(entriesChanged * 2)
-	m.metrics.size(m.size)
+	m.metrics.observeSize(m.size)
 	m.updateDirtyAt()
 }
 

--- a/adapters/repos/db/lsmkv/memtable_roaring_set_range.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set_range.go
@@ -80,7 +80,7 @@ func (m *Memtable) roaringSetRangeAdjustMeta(entriesChanged int) {
 	// estimation is therefore to take the changed entries and multiply them by
 	// 2.
 	m.size += uint64(entriesChanged * 2)
-	m.metrics.size(m.size)
+	m.metrics.observeSize(m.size)
 	m.updateDirtyAt()
 }
 

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -32,6 +32,12 @@ var compactionDurationBuckets = prometheus.ExponentialBuckets(0.01, 2, 18) // 0.
 type Metrics struct {
 	register prometheus.Registerer
 
+	// wal recovery metrics
+	walRecoveryCount        *prometheus.CounterVec
+	walRecoveryInProgress   *prometheus.GaugeVec
+	walRecoveryFailureCount *prometheus.CounterVec
+	walRecoveryDuration     *prometheus.HistogramVec
+
 	// compaction-related metrics
 	compactionCount        *prometheus.CounterVec
 	compactionInProgress   *prometheus.GaugeVec
@@ -73,6 +79,59 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 	}
 
 	register := promMetrics.Registerer
+
+	// wal recovery metrics
+	walRecoveryCount, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_wal_recovery_count",
+				Help:      "Total number of LSM bucket WAL recoveries requested, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_wal_recovery_count: %w", err)
+	}
+
+	walRecoveryInProgress, err := monitoring.EnsureRegisteredMetric(register, prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "weaviate",
+			Name:      "lsm_bucket_wal_recovery_in_progress",
+			Help:      "Number of LSM bucket WAL recoveries currently in progress",
+		},
+		[]string{"strategy"},
+	))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_wal_recovery_in_progress: %w", err)
+	}
+
+	walRecoveryFailureCount, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_wal_recovery_failure_count",
+				Help:      "Number of failed LSM bucket WAL recoveries, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_wal_recovery_failure_count: %w", err)
+	}
+
+	walRecoveryDuration, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_wal_recovery_duration_seconds",
+				Help:      "Duration of LSM bucket WAL recovery in seconds, labeled by segment strategy",
+				Buckets:   compactionDurationBuckets,
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_wal_recovery_duration_seconds: %w", err)
+	}
 
 	// compaction-related metrics
 	compactionCount, err := monitoring.EnsureRegisteredMetric(register,
@@ -174,6 +233,13 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		groupClasses:        promMetrics.Group,
 		criticalBucketsOnly: promMetrics.LSMCriticalBucketsOnly,
 
+		// wal recovery metrics
+		walRecoveryCount:        walRecoveryCount,
+		walRecoveryInProgress:   walRecoveryInProgress,
+		walRecoveryFailureCount: walRecoveryFailureCount,
+		walRecoveryDuration:     walRecoveryDuration,
+
+		// compaction-related metrics
 		compactionNoOpCount:    compactionNoOpCount,
 		compactionCount:        compactionCount,
 		compactionInProgress:   compactionInProgress,
@@ -242,8 +308,43 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 	}, nil
 }
 
-// compaction metrics
+// wal recovery metrics
+func (m *Metrics) IncWalRecoveryCount(strategy string) {
+	if m == nil {
+		return
+	}
+	m.walRecoveryCount.WithLabelValues(strategy).Inc()
+}
 
+func (m *Metrics) IncWalRecoveryInProgress(strategy string) {
+	if m == nil {
+		return
+	}
+	m.walRecoveryInProgress.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) DecWalRecoveryInProgress(strategy string) {
+	if m == nil {
+		return
+	}
+	m.walRecoveryInProgress.WithLabelValues(strategy).Dec()
+}
+
+func (m *Metrics) IncWalRecoveryFailureCount(strategy string) {
+	if m == nil {
+		return
+	}
+	m.walRecoveryFailureCount.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) ObserveWalRecoveryDuration(strategy string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.walRecoveryDuration.WithLabelValues(strategy).Observe(duration.Seconds())
+}
+
+// compaction metrics
 func (m *Metrics) IncCompactionCount(strategy string) {
 	if m == nil {
 		return
@@ -380,15 +481,6 @@ func (m *Metrics) TrackStartupBucket(start time.Time) {
 
 	took := float64(time.Since(start)) / float64(time.Millisecond)
 	m.startupDurations.With(prometheus.Labels{"operation": "lsm_startup_bucket"}).Observe(took)
-}
-
-func (m *Metrics) TrackStartupBucketRecovery(start time.Time) {
-	if m == nil {
-		return
-	}
-
-	took := float64(time.Since(start)) / float64(time.Millisecond)
-	m.startupDurations.With(prometheus.Labels{"operation": "lsm_startup_bucket_recovery"}).Observe(took)
 }
 
 func (m *Metrics) ObjectCount(count int) {

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -30,6 +30,8 @@ type (
 var compactionDurationBuckets = prometheus.ExponentialBuckets(0.01, 2, 18) // 0.01s → 0.02s → ... → ~163.84s
 
 type Metrics struct {
+	register prometheus.Registerer
+
 	// compaction-related metrics
 	compactionCount        *prometheus.CounterVec
 	compactionInProgress   *prometheus.GaugeVec
@@ -70,8 +72,10 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		shardName = "n/a"
 	}
 
+	register := promMetrics.Registerer
+
 	// compaction-related metrics
-	compactionCount, err := monitoring.EnsureRegisteredMetric(promMetrics.Registerer,
+	compactionCount, err := monitoring.EnsureRegisteredMetric(register,
 		prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: "weaviate",
@@ -84,7 +88,7 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		return nil, fmt.Errorf("register lsm_bucket_compaction_count: %w", err)
 	}
 
-	compactionInProgress, err := monitoring.EnsureRegisteredMetric(promMetrics.Registerer, prometheus.NewGaugeVec(
+	compactionInProgress, err := monitoring.EnsureRegisteredMetric(register, prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: "weaviate",
 			Name:      "lsm_bucket_compaction_in_progress",
@@ -96,7 +100,7 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		return nil, fmt.Errorf("register lsm_bucket_compaction_in_progress: %w", err)
 	}
 
-	compactionFailureCount, err := monitoring.EnsureRegisteredMetric(promMetrics.Registerer,
+	compactionFailureCount, err := monitoring.EnsureRegisteredMetric(register,
 		prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: "weaviate",
@@ -109,7 +113,7 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		return nil, fmt.Errorf("register lsm_bucket_compaction_failure_count: %w", err)
 	}
 
-	compactionNoOpCount, err := monitoring.EnsureRegisteredMetric(promMetrics.Registerer,
+	compactionNoOpCount, err := monitoring.EnsureRegisteredMetric(register,
 		prometheus.NewCounterVec(
 			prometheus.CounterOpts{
 				Namespace: "weaviate",
@@ -122,7 +126,7 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		return nil, fmt.Errorf("register lsm_bucket_compaction_noop_count: %w", err)
 	}
 
-	compactionDuration, err := monitoring.EnsureRegisteredMetric(promMetrics.Registerer,
+	compactionDuration, err := monitoring.EnsureRegisteredMetric(register,
 		prometheus.NewHistogramVec(
 			prometheus.HistogramOpts{
 				Namespace: "weaviate",
@@ -166,6 +170,7 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 	})
 
 	return &Metrics{
+		register:            register,
 		groupClasses:        promMetrics.Group,
 		criticalBucketsOnly: promMetrics.LSMCriticalBucketsOnly,
 


### PR DESCRIPTION
### What's being changed:

This pull request introduces comprehensive improvements to the metrics collected during LSM memtable flush operations. It adds new Prometheus metrics for tracking flush counts, durations, failures, and bytes written. Additionally, it updates the `Metrics` struct to consistently use a shared Prometheus registerer, ensuring all metrics are registered in a unified way.

**Memtable flush metrics enhancements:**

* Introduced new Prometheus metrics for memtable flush operations: total flush count, in-progress flushes, flush failures, flush duration (with exponential buckets), and bytes written during flush. These are now tracked per segment strategy in `memtable_metrics.go`. [[1]](diffhunk://#diff-96e873a84c04c981c0c8111f65926fd117b67054882de52db8e4d98c81e1d8b7R14-R32) [[2]](diffhunk://#diff-96e873a84c04c981c0c8111f65926fd117b67054882de52db8e4d98c81e1d8b7L24-R107)
* Refactored the `flush()` method in `memtable_flush.go` to increment/decrement in-progress counters, record failures, and observe flush durations using the new metrics.
* Updated the bytes-written metric observation to use the new observer function in `memtable_flush.go`.

**Metrics registration and struct improvements:**

* Changed the `Metrics` struct to store a `prometheus.Registerer` and refactored all metric registrations in `metrics.go` to use this shared registerer for consistency and efficiency. [[1]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR33-R34) [[2]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR75-R78) [[3]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdL87-R91) [[4]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdL99-R103) [[5]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdL112-R116) [[6]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdL125-R129) [[7]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR173)
* Updated the `newMemtableMetrics` function to return errors on registration failures and to be used safely in `newMemtable`, improving error handling and initialization. [[1]](diffhunk://#diff-ca11b815febc0d71d1d980756eaae1fd653eae49008155365cad67716732203fR68-R72) [[2]](diffhunk://#diff-ca11b815febc0d71d1d980756eaae1fd653eae49008155365cad67716732203fL81-R86) [[3]](diffhunk://#diff-96e873a84c04c981c0c8111f65926fd117b67054882de52db8e4d98c81e1d8b7L41-R156)

**Other improvements:**

* Added utility methods to `memtableMetrics` for incrementing and observing the new metrics, and refactored existing code to use these helpers.
* Added missing import for `time` in `memtable_flush.go` to support flush duration measurement.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
