### PR TITLE
fix: increase IdLockPoolSize and improve uuidToIdLockPoolId calculation

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -13,6 +13,7 @@ package db
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"path"
@@ -54,7 +55,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
-const IdLockPoolSize = 128
+const IdLockPoolSize uint64 = 1024
 
 var (
 	errAlreadyShutdown    = errors.New("already shut or dropped")
@@ -294,10 +295,19 @@ func (s *Shard) vectorIndexID(targetVector string) string {
 	return "main"
 }
 
-func (s *Shard) uuidToIdLockPoolId(idBytes []byte) uint8 {
-	// use the last byte of the uuid to determine which locking-pool a given object should use. The last byte is used
-	// as uuids probably often have some kind of order and the last byte will in general be the one that changes the most
-	return idBytes[15] % IdLockPoolSize
+// uuidToIdLockPoolId computes a lock pool id for a given uuid. The lock pool
+// is used to synchronize access to the same uuid. The pool size is fixed and
+// defined by IdLockPoolSize.
+// The function uses the XOR of the two halves of the UUID to ensure a good
+// distribution of UUIDs to lock pool ids. This helps to minimize lock
+// contention when multiple goroutines are accessing different UUIDs.
+// The result is then taken modulo the pool size to ensure it fits within the
+// bounds of the lock pool array.
+func (s *Shard) uuidToIdLockPoolId(uuidBytes []byte) uint {
+	lo := binary.LittleEndian.Uint64(uuidBytes[:8])
+	hi := binary.LittleEndian.Uint64(uuidBytes[8:16])
+
+	return uint((lo ^ hi) % IdLockPoolSize)
 }
 
 func (s *Shard) memtableDirtyConfig() lsmkv.BucketOption {


### PR DESCRIPTION
### What's being changed:

This pull request updates the locking mechanism for UUID-based object access in the `Shard` implementation to improve lock distribution and reduce contention. The main change is an improved hashing algorithm for mapping UUIDs to lock pool indices, along with an increase in the lock pool size for better concurrency.

**Locking improvements:**

* Increased the `IdLockPoolSize` constant from 128 to 1024 to allow for finer-grained locking and reduced contention.
* Updated the `uuidToIdLockPoolId` function to use a hash of both halves of the UUID (using XOR and modulo) instead of just the last byte, improving the distribution of UUIDs across the lock pool. The function now returns a `uint` instead of `uint8`.
* Added the `encoding/binary` import to support the new hashing logic for UUIDs.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
