### PR TITLE
Add buffer queue to the replicated indices handler

### DIFF
--- a/adapters/handlers/rest/clusterapi/fake_replicator_test.go
+++ b/adapters/handlers/rest/clusterapi/fake_replicator_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package clusterapi_test
 
 import (
@@ -48,9 +59,7 @@ func (f *fakeReplicator) ReplicateReferences(ctx context.Context, indexName, sha
 }
 
 func (f *fakeReplicator) CommitReplication(indexName, shardName, requestID string) interface{} {
-	select {
-	case <-f.commitBlock:
-	}
+	<-f.commitBlock
 	return map[string]string{"status": "committed"}
 }
 

--- a/adapters/handlers/rest/clusterapi/fake_replicator_test.go
+++ b/adapters/handlers/rest/clusterapi/fake_replicator_test.go
@@ -1,0 +1,83 @@
+package clusterapi_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/objects"
+	"github.com/weaviate/weaviate/usecases/replica"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+)
+
+// fakeReplicator is a mock implementation of the replicator interface for testing
+type fakeReplicator struct {
+	commitBlock chan struct{}
+}
+
+// newFakeReplicator creates a new controllable fake replicator
+func newFakeReplicator() *fakeReplicator {
+	return &fakeReplicator{
+		commitBlock: make(chan struct{}),
+	}
+}
+
+func (f *fakeReplicator) ReplicateObject(ctx context.Context, indexName, shardName, requestID string, object *storobj.Object, schemaVersion uint64) replica.SimpleResponse {
+	return replica.SimpleResponse{}
+}
+
+func (f *fakeReplicator) ReplicateObjects(ctx context.Context, indexName, shardName, requestID string, objects []*storobj.Object, schemaVersion uint64) replica.SimpleResponse {
+	return replica.SimpleResponse{}
+}
+
+func (f *fakeReplicator) ReplicateUpdate(ctx context.Context, indexName, shardName, requestID string, mergeDoc *objects.MergeDocument, schemaVersion uint64) replica.SimpleResponse {
+	return replica.SimpleResponse{}
+}
+
+func (f *fakeReplicator) ReplicateDeletion(ctx context.Context, indexName, shardName, requestID string, uuid strfmt.UUID, deletionTime time.Time, schemaVersion uint64) replica.SimpleResponse {
+	return replica.SimpleResponse{}
+}
+
+func (f *fakeReplicator) ReplicateDeletions(ctx context.Context, indexName, shardName, requestID string, uuids []strfmt.UUID, deletionTime time.Time, dryRun bool, schemaVersion uint64) replica.SimpleResponse {
+	return replica.SimpleResponse{}
+}
+
+func (f *fakeReplicator) ReplicateReferences(ctx context.Context, indexName, shardName, requestID string, refs []objects.BatchReference, schemaVersion uint64) replica.SimpleResponse {
+	return replica.SimpleResponse{}
+}
+
+func (f *fakeReplicator) CommitReplication(indexName, shardName, requestID string) interface{} {
+	select {
+	case <-f.commitBlock:
+	}
+	return map[string]string{"status": "committed"}
+}
+
+func (f *fakeReplicator) AbortReplication(indexName, shardName, requestID string) interface{} {
+	return map[string]string{"status": "aborted"}
+}
+
+func (f *fakeReplicator) OverwriteObjects(ctx context.Context, index, shard string, vobjects []*objects.VObject) ([]replica.RepairResponse, error) {
+	return []replica.RepairResponse{}, nil
+}
+
+func (f *fakeReplicator) FetchObject(ctx context.Context, indexName, shardName string, id strfmt.UUID) (objects.Replica, error) {
+	return objects.Replica{}, nil
+}
+
+func (f *fakeReplicator) FetchObjects(ctx context.Context, class, shardName string, ids []strfmt.UUID) ([]objects.Replica, error) {
+	return []objects.Replica{}, nil
+}
+
+func (f *fakeReplicator) DigestObjects(ctx context.Context, class, shardName string, ids []strfmt.UUID) (result []replica.RepairResponse, err error) {
+	return []replica.RepairResponse{}, nil
+}
+
+func (f *fakeReplicator) DigestObjectsInRange(ctx context.Context, class, shardName string, initialUUID, finalUUID strfmt.UUID, limit int) (result []replica.RepairResponse, err error) {
+	return []replica.RepairResponse{}, nil
+}
+
+func (f *fakeReplicator) HashTreeLevel(ctx context.Context, index, shard string, level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error) {
+	return []hashtree.Digest{}, nil
+}

--- a/adapters/handlers/rest/clusterapi/fake_replicator_test.go
+++ b/adapters/handlers/rest/clusterapi/fake_replicator_test.go
@@ -58,6 +58,7 @@ func (f *fakeReplicator) ReplicateReferences(ctx context.Context, indexName, sha
 	return replica.SimpleResponse{}
 }
 
+// CommitReplication waits to return until a message is received on the commitBlock channel
 func (f *fakeReplicator) CommitReplication(indexName, shardName, requestID string) interface{} {
 	<-f.commitBlock
 	return map[string]string{"status": "committed"}

--- a/adapters/handlers/rest/clusterapi/fake_replicator_test.go
+++ b/adapters/handlers/rest/clusterapi/fake_replicator_test.go
@@ -24,13 +24,15 @@ import (
 
 // fakeReplicator is a mock implementation of the replicator interface for testing
 type fakeReplicator struct {
-	commitBlock chan struct{}
+	useCommitBlock bool
+	commitBlock    chan struct{}
 }
 
 // newFakeReplicator creates a new controllable fake replicator
-func newFakeReplicator() *fakeReplicator {
+func newFakeReplicator(useCommitBlock bool) *fakeReplicator {
 	return &fakeReplicator{
-		commitBlock: make(chan struct{}),
+		commitBlock:    make(chan struct{}),
+		useCommitBlock: useCommitBlock,
 	}
 }
 
@@ -60,7 +62,10 @@ func (f *fakeReplicator) ReplicateReferences(ctx context.Context, indexName, sha
 
 // CommitReplication waits to return until a message is received on the commitBlock channel
 func (f *fakeReplicator) CommitReplication(indexName, shardName, requestID string) interface{} {
-	<-f.commitBlock
+	if f.useCommitBlock {
+		<-f.commitBlock
+	}
+	// fmt.Println("NATEE commit replication")
 	return map[string]string{"status": "committed"}
 }
 

--- a/adapters/handlers/rest/clusterapi/fake_replicator_test.go
+++ b/adapters/handlers/rest/clusterapi/fake_replicator_test.go
@@ -24,9 +24,9 @@ import (
 
 // fakeReplicator is a mock implementation of the replicator interface for testing
 type fakeReplicator struct {
-	useCommitBlock bool
-	commitBlock    chan struct{}
-	startedChan    chan struct{} // Signal when operation has started
+	useCommitBlock bool          // Enables/disables if commit will block or not
+	commitBlock    chan struct{} // Used to allow the tester to block/unblock the commit operation
+	startedChan    chan struct{} // Signal to the tester when operations have started
 }
 
 // newFakeReplicator creates a new controllable fake replicator

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -268,7 +268,6 @@ func (i *replicatedIndices) waitToAcquireWorkerSlot(ctx context.Context) (succes
 	case <-ctx.Done():
 		return false, func() {}
 	}
-
 }
 
 func (i *replicatedIndices) executeCommitPhase() http.Handler {

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -263,7 +263,6 @@ func (i *replicatedIndices) indicesHandler() http.HandlerFunc {
 			return
 		}
 		wg.Wait()
-
 	}
 }
 

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -246,8 +246,6 @@ func NewReplicatedIndices(
 		workQueueConfig:        workQueueConfig,
 	}
 
-	// TODO graceful shutdown? later? Server.Close in clusterapi/serve.go
-	// TODO stop/wait for workers?
 	for j := 0; j < max(1, workQueueConfig.NumWorkers); j++ {
 		enterrors.GoWrapper(func() {
 			for workItem := range i.workQueue {

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -85,8 +85,9 @@ type replicatedIndices struct {
 	requestQueueConfig cluster.RequestQueueConfig
 	// requestQueue buffers requests until they're picked up by a worker, goal is to avoid
 	// overwhelming the system with requests during spikes (also allows for backpressure)
+	requestQueue chan queuedRequest
+	// startWorkersOnce ensures that the workers are started only once
 	startWorkersOnce sync.Once
-	requestQueue     chan queuedRequest
 	// set to true when shutting down
 	isShutdown atomic.Bool
 	// workerWg waits for all workers to finish

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -84,10 +84,11 @@ type replicatedIndices struct {
 	// requestQueue buffers requests until they're picked up by a worker, goal is to avoid
 	// overwhelming the system with requests during spikes (also allows for backpressure)
 	requestQueue chan queuedRequest
-
 	// shutdown management
-	shutdown     chan struct{}
-	workerWg     sync.WaitGroup
+	shutdown chan struct{}
+	// workerWg waits for all workers to finish
+	workerWg sync.WaitGroup
+	// shutdownOnce ensures that the shutdown is only done once
 	shutdownOnce sync.Once
 }
 
@@ -996,7 +997,7 @@ func (i *replicatedIndices) Close(ctx context.Context) error {
 		// Set a timeout for graceful shutdown
 		shutdownTimeout := i.requestQueueConfig.QueueShutdownTimeout
 		if shutdownTimeout == 0 {
-			shutdownTimeout = 30 * time.Second // default timeout
+			shutdownTimeout = 30 * time.Second // default timeout if not set
 		}
 
 		// Create a context with timeout for shutdown

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -218,9 +218,9 @@ func (i *replicatedIndices) handleRequest(qr queuedRequest) {
 	w := qr.w
 	path := r.URL.Path
 
-	i.dummySleepLock.Lock()
-	defer i.dummySleepLock.Unlock()
 	if os.Getenv("REPLICATED_INDICES_SLEEP") != "" {
+		i.dummySleepLock.Lock()
+		defer i.dummySleepLock.Unlock()
 		s := os.Getenv("REPLICATED_INDICES_SLEEP")
 		duration, err := time.ParseDuration(s)
 		if err != nil {

--- a/adapters/handlers/rest/clusterapi/indices_replicas_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas_test.go
@@ -15,16 +15,19 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
+	"github.com/weaviate/weaviate/usecases/replica"
 )
 
 func TestMaintenanceModeReplicatedIndices(t *testing.T) {
 	noopAuth := clusterapi.NewNoopAuthHandler()
-	// NOTE leaving shards and scaler nil for now, fill in when needed
-	indices := clusterapi.NewReplicatedIndices(nil, nil, noopAuth, func() bool { return true })
+	fakeReplicator := newFakeReplicator()
+	indices := clusterapi.NewReplicatedIndices(fakeReplicator, nil, noopAuth, func() bool { return true }, clusterapi.WorkQueueConfig{})
 	mux := http.NewServeMux()
 	mux.Handle("/replicas/indices/", indices.Indices())
 	server := httptest.NewServer(mux)
@@ -57,6 +60,176 @@ func TestMaintenanceModeReplicatedIndices(t *testing.T) {
 			assert.Nil(t, err)
 			defer res.Body.Close()
 			assert.True(t, res.StatusCode == maintenanceModeExpectedHTTPStatus, "expected %d, got %d", maintenanceModeExpectedHTTPStatus, res.StatusCode)
+		})
+	}
+}
+
+func TestReplicatedIndicesWorkQueue(t *testing.T) {
+	testCases := []struct {
+		name             string
+		workQueueConfig  clusterapi.WorkQueueConfig
+		numRequests      int
+		expectedAccepted int
+		expectedRejected int
+	}{
+		{
+			name:             "empty_config",
+			workQueueConfig:  clusterapi.WorkQueueConfig{},
+			numRequests:      10,
+			expectedAccepted: 10,
+			expectedRejected: 0,
+		},
+		{
+			name: "disabled_10reqs",
+			workQueueConfig: clusterapi.WorkQueueConfig{
+				IsEnabled: configRuntime.NewDynamicValue(false),
+			},
+			numRequests:      10,
+			expectedAccepted: 10,
+			expectedRejected: 0,
+		},
+		{
+			name: "disabled_10reqs_0config",
+			workQueueConfig: clusterapi.WorkQueueConfig{
+				IsEnabled:            configRuntime.NewDynamicValue(false),
+				NumWorkers:           0,
+				BufferSize:           0,
+				BufferFullHttpStatus: 0,
+			},
+			numRequests:      10,
+			expectedAccepted: 10,
+			expectedRejected: 0,
+		},
+		{
+			name: "disabled_10reqs_1config",
+			workQueueConfig: clusterapi.WorkQueueConfig{
+				IsEnabled:            configRuntime.NewDynamicValue(false),
+				NumWorkers:           1,
+				BufferSize:           1,
+				BufferFullHttpStatus: 1,
+			},
+			numRequests:      10,
+			expectedAccepted: 10,
+			expectedRejected: 0,
+		},
+		{
+			// the implementation ensures that at least one worker is running
+			name: "enabled_10reqs_0workers_1buffer_429",
+			workQueueConfig: clusterapi.WorkQueueConfig{
+				IsEnabled:            configRuntime.NewDynamicValue(true),
+				NumWorkers:           0,
+				BufferSize:           1,
+				BufferFullHttpStatus: http.StatusTooManyRequests,
+			},
+			numRequests:      10,
+			expectedAccepted: 2,
+			expectedRejected: 8,
+		},
+		{
+			name: "enabled_10reqs_2workers_3buffer_429",
+			workQueueConfig: clusterapi.WorkQueueConfig{
+				IsEnabled:            configRuntime.NewDynamicValue(true),
+				NumWorkers:           2,
+				BufferSize:           3,
+				BufferFullHttpStatus: http.StatusTooManyRequests,
+			},
+			numRequests:      10,
+			expectedAccepted: 5,
+			expectedRejected: 5,
+		},
+		{
+			name:        "enabled_10reqs_32workers_1024buffer_429",
+			numRequests: 10,
+			workQueueConfig: clusterapi.WorkQueueConfig{
+				IsEnabled:            configRuntime.NewDynamicValue(true),
+				NumWorkers:           32,
+				BufferSize:           1024,
+				BufferFullHttpStatus: http.StatusTooManyRequests,
+			},
+			expectedAccepted: 10,
+			expectedRejected: 0,
+		},
+		{
+			name: "enabled_10reqs_5workers_0buffer_429",
+			workQueueConfig: clusterapi.WorkQueueConfig{
+				IsEnabled:            configRuntime.NewDynamicValue(true),
+				NumWorkers:           5,
+				BufferSize:           0,
+				BufferFullHttpStatus: http.StatusTooManyRequests,
+			},
+			numRequests:      10,
+			expectedAccepted: 5,
+			expectedRejected: 5,
+		},
+		{
+			name: "enabled_10reqs_1workers_1buffer_504",
+			workQueueConfig: clusterapi.WorkQueueConfig{
+				IsEnabled:            configRuntime.NewDynamicValue(true),
+				NumWorkers:           1,
+				BufferSize:           1,
+				BufferFullHttpStatus: http.StatusGatewayTimeout,
+			},
+			numRequests:      10,
+			expectedAccepted: 2,
+			expectedRejected: 8,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			noopAuth := clusterapi.NewNoopAuthHandler()
+			fakeReplicator := newFakeReplicator()
+			indices := clusterapi.NewReplicatedIndices(fakeReplicator, nil, noopAuth, func() bool { return false }, tc.workQueueConfig)
+			mux := http.NewServeMux()
+			mux.Handle("/replicas/indices/", indices.Indices())
+			server := httptest.NewServer(mux)
+			defer server.Close()
+
+			requestKey := fmt.Sprintf("%s=%s", replica.RequestKey, "test_request_id")
+			req, err := http.NewRequest("POST", fmt.Sprintf("%s/replicas/indices/MyClass/shards/myshard:commit?%s", server.URL, requestKey), nil)
+			assert.Nil(t, err)
+			wgAccepted := sync.WaitGroup{}
+			wgRejected := sync.WaitGroup{}
+			wgAccepted.Add(tc.expectedAccepted)
+			wgRejected.Add(tc.expectedRejected)
+			httpStatuses := make(chan int, tc.numRequests)
+			for i := 0; i < tc.numRequests; i++ {
+				go func() {
+					res, err := http.DefaultClient.Do(req)
+					assert.Nil(t, err)
+					defer res.Body.Close()
+					httpStatuses <- res.StatusCode
+					if res.StatusCode == http.StatusOK {
+						wgAccepted.Done()
+					} else if res.StatusCode == tc.workQueueConfig.BufferFullHttpStatus {
+						wgRejected.Done()
+					} else {
+						// unexpected status code received
+						fmt.Println("unexpected status code: ", res.StatusCode)
+						t.Fail()
+					}
+				}()
+			}
+			wgRejected.Wait()
+			for i := 0; i < tc.expectedAccepted; i++ {
+				fakeReplicator.commitBlock <- struct{}{}
+			}
+			wgAccepted.Wait()
+			close(httpStatuses)
+
+			actualAccepted := 0
+			actualRejected := 0
+			for httpStatus := range httpStatuses {
+				if httpStatus == http.StatusOK {
+					actualAccepted++
+				} else if httpStatus == tc.workQueueConfig.BufferFullHttpStatus {
+					actualRejected++
+				} else {
+					fmt.Println("unexpected status code: ", httpStatus)
+					t.Fail()
+				}
+			}
+			assert.Equal(t, tc.expectedAccepted, actualAccepted)
+			assert.Equal(t, tc.expectedRejected, actualRejected)
 		})
 	}
 }

--- a/adapters/handlers/rest/clusterapi/indices_replicas_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas_test.go
@@ -268,10 +268,10 @@ func TestReplicatedIndicesShutdown(t *testing.T) {
 		{
 			name: "shutdown_with_pending_requests",
 			requestQueueConfig: cluster.RequestQueueConfig{
-				IsEnabled:            configRuntime.NewDynamicValue(true),
-				NumWorkers:           1,
-				QueueSize:            5,
-				QueueShutdownTimeout: 1 * time.Second,
+				IsEnabled:                   configRuntime.NewDynamicValue(true),
+				NumWorkers:                  1,
+				QueueSize:                   5,
+				QueueShutdownTimeoutSeconds: 1,
 			},
 			numRequests:     3,
 			shutdownTimeout: 2 * time.Second,
@@ -395,10 +395,10 @@ func TestReplicatedIndicesShutdownWithStuckRequests(t *testing.T) {
 		noopAuth,
 		func() bool { return false },
 		cluster.RequestQueueConfig{
-			IsEnabled:            configRuntime.NewDynamicValue(true),
-			NumWorkers:           1,
-			QueueSize:            5,
-			QueueShutdownTimeout: 500 * time.Millisecond, // Short timeout to test timeout handling
+			IsEnabled:                   configRuntime.NewDynamicValue(true),
+			NumWorkers:                  1,
+			QueueSize:                   5,
+			QueueShutdownTimeoutSeconds: 1,
 		},
 		logger,
 	)

--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -130,7 +130,7 @@ func (s *Server) Close(ctx context.Context) error {
 		}
 	}
 
-	// Now shutdown the HTTP server after the business logic has been drained
+	// Now shutdown the HTTP server after the replicated indices have been closed
 	if err := s.server.Shutdown(ctx); err != nil {
 		s.appState.Logger.WithField("action", "cluster_api_shutdown").
 			WithError(err).

--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/types"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
@@ -44,7 +45,13 @@ func NewServer(appState *state.State) *Server {
 		Debugf("serving cluster api on port %d", port)
 
 	indices := NewIndices(appState.RemoteIndexIncoming, appState.DB, auth, appState.Cluster.MaintenanceModeEnabledForLocalhost, appState.Logger)
-	replicatedIndices := NewReplicatedIndices(appState.RemoteReplicaIncoming, appState.Scaler, auth, appState.Cluster.MaintenanceModeEnabledForLocalhost)
+	workQueueConfig := WorkQueueConfig{
+		IsEnabled:            configRuntime.NewDynamicValue(true),
+		NumWorkers:           32,
+		BufferSize:           1024,
+		BufferFullHttpStatus: http.StatusTooManyRequests,
+	}
+	replicatedIndices := NewReplicatedIndices(appState.RemoteReplicaIncoming, appState.Scaler, auth, appState.Cluster.MaintenanceModeEnabledForLocalhost, workQueueConfig)
 	classifications := NewClassifications(appState.ClassificationRepo.TxManager(), auth)
 	nodes := NewNodes(appState.RemoteNodeIncoming, auth)
 	backups := NewBackups(appState.BackupManager, auth)

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1730,6 +1730,7 @@ func initRuntimeOverrides(appState *state.State) {
 		registered.QuerySlowLogEnabled = appState.ServerConfig.Config.QuerySlowLogEnabled
 		registered.QuerySlowLogThreshold = appState.ServerConfig.Config.QuerySlowLogThreshold
 		registered.InvertedSorterDisabled = appState.ServerConfig.Config.InvertedSorterDisabled
+		registered.ReplicatedIndicesRequestQueueEnabled = appState.ServerConfig.Config.Cluster.RequestQueueConfig.IsEnabled
 
 		hooks := make(map[string]func() error)
 

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -77,7 +77,8 @@ type Config struct {
 	// RaftBootstrapExpect is used to detect split-brain scenarios and attempt to rejoin the cluster
 	// TODO-RAFT-DB-63 : shall be removed once NodeAddress() is moved under raft cluster package
 	RaftBootstrapExpect int
-	RequestQueueConfig  RequestQueueConfig `json:"requestQueueConfig" yaml:"requestQueueConfig"`
+	// RequestQueueConfig is used to configure the request queue buffer for the replicated indices
+	RequestQueueConfig RequestQueueConfig `json:"requestQueueConfig" yaml:"requestQueueConfig"`
 }
 
 type AuthConfig struct {
@@ -98,11 +99,17 @@ const (
 	DefaultRequestQueueFullHttpStatus = http.StatusTooManyRequests
 )
 
+// RequestQueueConfig is used to configure the request queue buffer for the replicated indices
 type RequestQueueConfig struct {
-	IsEnabled           *configRuntime.DynamicValue[bool] `json:"isEnabled" yaml:"isEnabled"`
-	NumWorkers          int                               `json:"numWorkers" yaml:"numWorkers"`
-	QueueSize           int                               `json:"queueSize" yaml:"queueSize"`
-	QueueFullHttpStatus int                               `json:"queueFullHttpStatus" yaml:"queueFullHttpStatus"`
+	// IsEnabled is used to enable/disable the request queue, can be modified at runtime
+	IsEnabled *configRuntime.DynamicValue[bool] `json:"isEnabled" yaml:"isEnabled"`
+	// NumWorkers is used to configure the number of workers that handle requests from the queue
+	NumWorkers int `json:"numWorkers" yaml:"numWorkers"`
+	// QueueSize is used to configure the size of the request queue buffer
+	QueueSize int `json:"queueSize" yaml:"queueSize"`
+	// QueueFullHttpStatus is used to configure the http status code that is returned when the request queue is full
+	// Should usually be set to 429 or 504 (429 will be retried by the coordinator, 504 will not)
+	QueueFullHttpStatus int `json:"queueFullHttpStatus" yaml:"queueFullHttpStatus"`
 }
 
 func Init(userConfig Config, raftBootstrapExpect int, dataPath string, nonStorageNodes map[string]struct{}, logger logrus.FieldLogger) (_ *State, err error) {

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -95,8 +95,9 @@ func (ba BasicAuth) Enabled() bool {
 }
 
 const (
-	DefaultRequestQueueSize           = 10000
-	DefaultRequestQueueFullHttpStatus = http.StatusTooManyRequests
+	DefaultRequestQueueSize                   = 2000
+	DefaultRequestQueueFullHttpStatus         = http.StatusTooManyRequests
+	DefaultRequestQueueShutdownTimeoutSeconds = 90
 )
 
 // RequestQueueConfig is used to configure the request queue buffer for the replicated indices
@@ -110,6 +111,11 @@ type RequestQueueConfig struct {
 	// QueueFullHttpStatus is used to configure the http status code that is returned when the request queue is full
 	// Should usually be set to 429 or 504 (429 will be retried by the coordinator, 504 will not)
 	QueueFullHttpStatus int `json:"queueFullHttpStatus" yaml:"queueFullHttpStatus"`
+	// QueueShutdownTimeoutSeconds is used to configure the timeout for the request queue shutdown.
+	// This is the timeout for the workers to finish processing the requests in the queue
+	// and for the request queue to be drained.
+	// Should usually be set to 90 seconds, based on coordinator's timeout
+	QueueShutdownTimeoutSeconds int `json:"queueShutdownTimeoutSeconds" yaml:"queueShutdownTimeoutSeconds"`
 }
 
 func Init(userConfig Config, raftBootstrapExpect int, dataPath string, nonStorageNodes map[string]struct{}, logger logrus.FieldLogger) (_ *State, err error) {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1267,6 +1267,7 @@ func parseClusterConfig() (cluster.Config, error) {
 
 	requestQueueIsEnabled := entcfg.Enabled(os.Getenv("REPLICATED_INDICES_REQUEST_QUEUE_ENABLED"))
 	cfg.RequestQueueConfig.IsEnabled = configRuntime.NewDynamicValue(requestQueueIsEnabled)
+	// choosing runtime.GOMAXPROCS(0)*2 for the number of workers as a reasonable default, but can be overridden
 	parsePositiveInt("REPLICATED_INDICES_REQUEST_QUEUE_NUM_WORKERS",
 		func(val int) { cfg.RequestQueueConfig.NumWorkers = val },
 		runtime.GOMAXPROCS(0)*2)

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1277,6 +1277,9 @@ func parseClusterConfig() (cluster.Config, error) {
 	parsePositiveInt("REPLICATED_INDICES_REQUEST_QUEUE_FULL_HTTP_STATUS",
 		func(val int) { cfg.RequestQueueConfig.QueueFullHttpStatus = val },
 		cluster.DefaultRequestQueueFullHttpStatus)
+	parsePositiveInt("REPLICATED_INDICES_REQUEST_QUEUE_SHUTDOWN_TIMEOUT_SECONDS",
+		func(val int) { cfg.RequestQueueConfig.QueueShutdownTimeoutSeconds = val },
+		cluster.DefaultRequestQueueShutdownTimeoutSeconds)
 
 	return cfg, nil
 }

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -16,6 +16,7 @@ import (
 	"math"
 	"os"
 	"regexp"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -27,7 +28,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/sentry"
 	"github.com/weaviate/weaviate/usecases/cluster"
-	"github.com/weaviate/weaviate/usecases/config/runtime"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
 const (
@@ -191,14 +192,14 @@ func FromEnv(config *Config) error {
 			jwksUrl = v
 		}
 
-		config.Authentication.OIDC.SkipClientIDCheck = runtime.NewDynamicValue(skipClientCheck)
-		config.Authentication.OIDC.Issuer = runtime.NewDynamicValue(issuer)
-		config.Authentication.OIDC.ClientID = runtime.NewDynamicValue(clientID)
-		config.Authentication.OIDC.Scopes = runtime.NewDynamicValue(scopes)
-		config.Authentication.OIDC.UsernameClaim = runtime.NewDynamicValue(userClaim)
-		config.Authentication.OIDC.GroupsClaim = runtime.NewDynamicValue(groupsClaim)
-		config.Authentication.OIDC.Certificate = runtime.NewDynamicValue(certificate)
-		config.Authentication.OIDC.JWKSUrl = runtime.NewDynamicValue(jwksUrl)
+		config.Authentication.OIDC.SkipClientIDCheck = configRuntime.NewDynamicValue(skipClientCheck)
+		config.Authentication.OIDC.Issuer = configRuntime.NewDynamicValue(issuer)
+		config.Authentication.OIDC.ClientID = configRuntime.NewDynamicValue(clientID)
+		config.Authentication.OIDC.Scopes = configRuntime.NewDynamicValue(scopes)
+		config.Authentication.OIDC.UsernameClaim = configRuntime.NewDynamicValue(userClaim)
+		config.Authentication.OIDC.GroupsClaim = configRuntime.NewDynamicValue(groupsClaim)
+		config.Authentication.OIDC.Certificate = configRuntime.NewDynamicValue(certificate)
+		config.Authentication.OIDC.JWKSUrl = configRuntime.NewDynamicValue(jwksUrl)
 	}
 
 	if entcfg.Enabled(os.Getenv("AUTHENTICATION_DB_USERS_ENABLED")) {
@@ -581,7 +582,7 @@ func FromEnv(config *Config) error {
 	if v := os.Getenv("AUTOSCHEMA_ENABLED"); v != "" {
 		autoSchemaEnabled = !(strings.ToLower(v) == "false")
 	}
-	config.AutoSchema.Enabled = runtime.NewDynamicValue(autoSchemaEnabled)
+	config.AutoSchema.Enabled = configRuntime.NewDynamicValue(autoSchemaEnabled)
 
 	config.AutoSchema.DefaultString = schema.DataTypeText.String()
 	if v := os.Getenv("AUTOSCHEMA_DEFAULT_STRING"); v != "" {
@@ -600,13 +601,13 @@ func FromEnv(config *Config) error {
 	if v := os.Getenv("TENANT_ACTIVITY_READ_LOG_LEVEL"); v != "" {
 		tenantActivityReadLogLevel = v
 	}
-	config.TenantActivityReadLogLevel = runtime.NewDynamicValue(tenantActivityReadLogLevel)
+	config.TenantActivityReadLogLevel = configRuntime.NewDynamicValue(tenantActivityReadLogLevel)
 
 	tenantActivityWriteLogLevel := "debug"
 	if v := os.Getenv("TENANT_ACTIVITY_WRITE_LOG_LEVEL"); v != "" {
 		tenantActivityWriteLogLevel = v
 	}
-	config.TenantActivityWriteLogLevel = runtime.NewDynamicValue(tenantActivityWriteLogLevel)
+	config.TenantActivityWriteLogLevel = configRuntime.NewDynamicValue(tenantActivityWriteLogLevel)
 
 	ru, err := parseResourceUsageEnvVars()
 	if err != nil {
@@ -687,7 +688,7 @@ func FromEnv(config *Config) error {
 		return err
 	}
 
-	config.Replication.AsyncReplicationDisabled = runtime.NewDynamicValue(entcfg.Enabled(os.Getenv("ASYNC_REPLICATION_DISABLED")))
+	config.Replication.AsyncReplicationDisabled = configRuntime.NewDynamicValue(entcfg.Enabled(os.Getenv("ASYNC_REPLICATION_DISABLED")))
 
 	if v := os.Getenv("REPLICATION_FORCE_DELETION_STRATEGY"); v != "" {
 		config.Replication.DeletionStrategy = v
@@ -705,7 +706,7 @@ func FromEnv(config *Config) error {
 	if err := parseInt(
 		"MAXIMUM_ALLOWED_COLLECTIONS_COUNT",
 		func(val int) {
-			config.SchemaHandlerConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(val)
+			config.SchemaHandlerConfig.MaximumAllowedCollectionsCount = configRuntime.NewDynamicValue(val)
 		},
 		DefaultMaximumAllowedCollectionsCount,
 	); err != nil {
@@ -754,10 +755,10 @@ func FromEnv(config *Config) error {
 	if v := os.Getenv("REVECTORIZE_CHECK_DISABLED"); v != "" {
 		revoctorizeCheckDisabled = !(strings.ToLower(v) == "false")
 	}
-	config.RevectorizeCheckDisabled = runtime.NewDynamicValue(revoctorizeCheckDisabled)
+	config.RevectorizeCheckDisabled = configRuntime.NewDynamicValue(revoctorizeCheckDisabled)
 
 	querySlowLogEnabled := entcfg.Enabled(os.Getenv("QUERY_SLOW_LOG_ENABLED"))
-	config.QuerySlowLogEnabled = runtime.NewDynamicValue(querySlowLogEnabled)
+	config.QuerySlowLogEnabled = configRuntime.NewDynamicValue(querySlowLogEnabled)
 
 	querySlowLogThreshold := dbhelpers.DefaultSlowLogThreshold
 	if v := os.Getenv("QUERY_SLOW_LOG_THRESHOLD"); v != "" {
@@ -767,13 +768,13 @@ func FromEnv(config *Config) error {
 		}
 		querySlowLogThreshold = threshold
 	}
-	config.QuerySlowLogThreshold = runtime.NewDynamicValue(querySlowLogThreshold)
+	config.QuerySlowLogThreshold = configRuntime.NewDynamicValue(querySlowLogThreshold)
 
 	invertedSorterDisabled := false
 	if v := os.Getenv("INVERTED_SORTER_DISABLED"); v != "" {
 		invertedSorterDisabled = !(strings.ToLower(v) == "false")
 	}
-	config.InvertedSorterDisabled = runtime.NewDynamicValue(invertedSorterDisabled)
+	config.InvertedSorterDisabled = configRuntime.NewDynamicValue(invertedSorterDisabled)
 
 	return nil
 }
@@ -1263,6 +1264,18 @@ func parseClusterConfig() (cluster.Config, error) {
 			}
 		}
 	}
+
+	requestQueueIsEnabled := entcfg.Enabled(os.Getenv("REPLICATED_INDICES_REQUEST_QUEUE_ENABLED"))
+	cfg.RequestQueueConfig.IsEnabled = configRuntime.NewDynamicValue(requestQueueIsEnabled)
+	parsePositiveInt("REPLICATED_INDICES_REQUEST_QUEUE_NUM_WORKERS",
+		func(val int) { cfg.RequestQueueConfig.NumWorkers = val },
+		runtime.GOMAXPROCS(0)*2)
+	parseNonNegativeInt("REPLICATED_INDICES_REQUEST_QUEUE_SIZE",
+		func(val int) { cfg.RequestQueueConfig.QueueSize = val },
+		cluster.DefaultRequestQueueSize)
+	parsePositiveInt("REPLICATED_INDICES_REQUEST_QUEUE_FULL_HTTP_STATUS",
+		func(val int) { cfg.RequestQueueConfig.QueueFullHttpStatus = val },
+		cluster.DefaultRequestQueueFullHttpStatus)
 
 	return cfg, nil
 }

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -15,13 +15,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/usecases/cluster"
-	"github.com/weaviate/weaviate/usecases/config/runtime"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
 const DefaultGoroutineFactor = 1.5
@@ -259,6 +260,12 @@ func TestEnvironmentMemtable_MaxDuration(t *testing.T) {
 
 func TestEnvironmentParseClusterConfig(t *testing.T) {
 	hostname, _ := os.Hostname()
+	defaultRequestQueueConfig := cluster.RequestQueueConfig{
+		IsEnabled:           configRuntime.NewDynamicValue(false),
+		NumWorkers:          runtime.GOMAXPROCS(0) * 2,
+		QueueSize:           10000,
+		QueueFullHttpStatus: 429,
+	}
 	tests := []struct {
 		name           string
 		envVars        map[string]string
@@ -274,22 +281,24 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 				"CLUSTER_ADVERTISE_PORT":   "9999",
 			},
 			expectedResult: cluster.Config{
-				Hostname:         hostname,
-				GossipBindPort:   7100,
-				DataBindPort:     7101,
-				AdvertiseAddr:    "193.0.0.1",
-				AdvertisePort:    9999,
-				MaintenanceNodes: make([]string, 0),
+				Hostname:           hostname,
+				GossipBindPort:     7100,
+				DataBindPort:       7101,
+				AdvertiseAddr:      "193.0.0.1",
+				AdvertisePort:      9999,
+				MaintenanceNodes:   make([]string, 0),
+				RequestQueueConfig: defaultRequestQueueConfig,
 			},
 		},
 		{
 			name: "valid cluster config - no ports and advertiseaddr provided",
 			expectedResult: cluster.Config{
-				Hostname:         hostname,
-				GossipBindPort:   DefaultGossipBindPort,
-				DataBindPort:     DefaultGossipBindPort + 1,
-				AdvertiseAddr:    "",
-				MaintenanceNodes: make([]string, 0),
+				Hostname:           hostname,
+				GossipBindPort:     DefaultGossipBindPort,
+				DataBindPort:       DefaultGossipBindPort + 1,
+				AdvertiseAddr:      "",
+				MaintenanceNodes:   make([]string, 0),
+				RequestQueueConfig: defaultRequestQueueConfig,
 			},
 		},
 		{
@@ -298,10 +307,11 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 				"CLUSTER_GOSSIP_BIND_PORT": "7777",
 			},
 			expectedResult: cluster.Config{
-				Hostname:         hostname,
-				GossipBindPort:   7777,
-				DataBindPort:     7778,
-				MaintenanceNodes: make([]string, 0),
+				Hostname:           hostname,
+				GossipBindPort:     7777,
+				DataBindPort:       7778,
+				MaintenanceNodes:   make([]string, 0),
+				RequestQueueConfig: defaultRequestQueueConfig,
 			},
 		},
 		{
@@ -332,6 +342,28 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 				DataBindPort:            7947,
 				IgnoreStartupSchemaSync: true,
 				MaintenanceNodes:        make([]string, 0),
+				RequestQueueConfig:      defaultRequestQueueConfig,
+			},
+		},
+		{
+			name: "request queue enabled with custom config",
+			envVars: map[string]string{
+				"REPLICATED_INDICES_REQUEST_QUEUE_ENABLED":          "true",
+				"REPLICATED_INDICES_REQUEST_QUEUE_NUM_WORKERS":      "10",
+				"REPLICATED_INDICES_REQUEST_QUEUE_SIZE":             "100",
+				"REPLICATED_INDICES_REQUEST_QUEUE_FULL_HTTP_STATUS": "504",
+			},
+			expectedResult: cluster.Config{
+				Hostname:         hostname,
+				GossipBindPort:   7946,
+				DataBindPort:     7947,
+				MaintenanceNodes: make([]string, 0),
+				RequestQueueConfig: cluster.RequestQueueConfig{
+					IsEnabled:           configRuntime.NewDynamicValue(true),
+					NumWorkers:          10,
+					QueueSize:           100,
+					QueueFullHttpStatus: 504,
+				},
 			},
 		},
 	}
@@ -725,14 +757,14 @@ func TestEnvironmentAuthentication(t *testing.T) {
 			expected: Authentication{
 				OIDC: OIDC{
 					Enabled:           true,
-					Issuer:            runtime.NewDynamicValue(""),
-					ClientID:          runtime.NewDynamicValue(""),
-					SkipClientIDCheck: runtime.NewDynamicValue(false),
-					UsernameClaim:     runtime.NewDynamicValue(""),
-					GroupsClaim:       runtime.NewDynamicValue(""),
-					Scopes:            runtime.NewDynamicValue([]string(nil)),
-					Certificate:       runtime.NewDynamicValue(""),
-					JWKSUrl:           runtime.NewDynamicValue(""),
+					Issuer:            configRuntime.NewDynamicValue(""),
+					ClientID:          configRuntime.NewDynamicValue(""),
+					SkipClientIDCheck: configRuntime.NewDynamicValue(false),
+					UsernameClaim:     configRuntime.NewDynamicValue(""),
+					GroupsClaim:       configRuntime.NewDynamicValue(""),
+					Scopes:            configRuntime.NewDynamicValue([]string(nil)),
+					Certificate:       configRuntime.NewDynamicValue(""),
+					JWKSUrl:           configRuntime.NewDynamicValue(""),
 				},
 			},
 		},

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -263,7 +263,7 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 	defaultRequestQueueConfig := cluster.RequestQueueConfig{
 		IsEnabled:                   configRuntime.NewDynamicValue(false),
 		NumWorkers:                  runtime.GOMAXPROCS(0) * 2,
-		QueueSize:                   5000,
+		QueueSize:                   2000,
 		QueueFullHttpStatus:         429,
 		QueueShutdownTimeoutSeconds: 90,
 	}

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -261,10 +261,11 @@ func TestEnvironmentMemtable_MaxDuration(t *testing.T) {
 func TestEnvironmentParseClusterConfig(t *testing.T) {
 	hostname, _ := os.Hostname()
 	defaultRequestQueueConfig := cluster.RequestQueueConfig{
-		IsEnabled:           configRuntime.NewDynamicValue(false),
-		NumWorkers:          runtime.GOMAXPROCS(0) * 2,
-		QueueSize:           10000,
-		QueueFullHttpStatus: 429,
+		IsEnabled:                   configRuntime.NewDynamicValue(false),
+		NumWorkers:                  runtime.GOMAXPROCS(0) * 2,
+		QueueSize:                   5000,
+		QueueFullHttpStatus:         429,
+		QueueShutdownTimeoutSeconds: 90,
 	}
 	tests := []struct {
 		name           string
@@ -348,10 +349,11 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 		{
 			name: "request queue enabled with custom config",
 			envVars: map[string]string{
-				"REPLICATED_INDICES_REQUEST_QUEUE_ENABLED":          "true",
-				"REPLICATED_INDICES_REQUEST_QUEUE_NUM_WORKERS":      "10",
-				"REPLICATED_INDICES_REQUEST_QUEUE_SIZE":             "100",
-				"REPLICATED_INDICES_REQUEST_QUEUE_FULL_HTTP_STATUS": "504",
+				"REPLICATED_INDICES_REQUEST_QUEUE_ENABLED":                  "true",
+				"REPLICATED_INDICES_REQUEST_QUEUE_NUM_WORKERS":              "10",
+				"REPLICATED_INDICES_REQUEST_QUEUE_SIZE":                     "100",
+				"REPLICATED_INDICES_REQUEST_QUEUE_FULL_HTTP_STATUS":         "504",
+				"REPLICATED_INDICES_REQUEST_QUEUE_SHUTDOWN_TIMEOUT_SECONDS": "120",
 			},
 			expectedResult: cluster.Config{
 				Hostname:         hostname,
@@ -359,10 +361,11 @@ func TestEnvironmentParseClusterConfig(t *testing.T) {
 				DataBindPort:     7947,
 				MaintenanceNodes: make([]string, 0),
 				RequestQueueConfig: cluster.RequestQueueConfig{
-					IsEnabled:           configRuntime.NewDynamicValue(true),
-					NumWorkers:          10,
-					QueueSize:           100,
-					QueueFullHttpStatus: 504,
+					IsEnabled:                   configRuntime.NewDynamicValue(true),
+					NumWorkers:                  10,
+					QueueSize:                   100,
+					QueueFullHttpStatus:         504,
+					QueueShutdownTimeoutSeconds: 120,
 				},
 			},
 		},

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -28,15 +28,16 @@ import (
 // WeaviateRuntimeConfig is the collection all the supported configs that is
 // managed dynamically and can be overridden during runtime.
 type WeaviateRuntimeConfig struct {
-	MaximumAllowedCollectionsCount *runtime.DynamicValue[int]           `json:"maximum_allowed_collections_count" yaml:"maximum_allowed_collections_count"`
-	AutoschemaEnabled              *runtime.DynamicValue[bool]          `json:"autoschema_enabled" yaml:"autoschema_enabled"`
-	AsyncReplicationDisabled       *runtime.DynamicValue[bool]          `json:"async_replication_disabled" yaml:"async_replication_disabled"`
-	TenantActivityReadLogLevel     *runtime.DynamicValue[string]        `json:"tenant_activity_read_log_level" yaml:"tenant_activity_read_log_level"`
-	TenantActivityWriteLogLevel    *runtime.DynamicValue[string]        `json:"tenant_activity_write_log_level" yaml:"tenant_activity_write_log_level"`
-	RevectorizeCheckDisabled       *runtime.DynamicValue[bool]          `json:"revectorize_check_disabled" yaml:"revectorize_check_disabled"`
-	QuerySlowLogEnabled            *runtime.DynamicValue[bool]          `json:"query_slow_log_enabled" yaml:"query_slow_log_enabled"`
-	QuerySlowLogThreshold          *runtime.DynamicValue[time.Duration] `json:"query_slow_log_threshold" yaml:"query_slow_log_threshold"`
-	InvertedSorterDisabled         *runtime.DynamicValue[bool]          `json:"inverted_sorter_disabled" yaml:"inverted_sorter_disabled"`
+	MaximumAllowedCollectionsCount       *runtime.DynamicValue[int]           `json:"maximum_allowed_collections_count" yaml:"maximum_allowed_collections_count"`
+	AutoschemaEnabled                    *runtime.DynamicValue[bool]          `json:"autoschema_enabled" yaml:"autoschema_enabled"`
+	AsyncReplicationDisabled             *runtime.DynamicValue[bool]          `json:"async_replication_disabled" yaml:"async_replication_disabled"`
+	TenantActivityReadLogLevel           *runtime.DynamicValue[string]        `json:"tenant_activity_read_log_level" yaml:"tenant_activity_read_log_level"`
+	TenantActivityWriteLogLevel          *runtime.DynamicValue[string]        `json:"tenant_activity_write_log_level" yaml:"tenant_activity_write_log_level"`
+	RevectorizeCheckDisabled             *runtime.DynamicValue[bool]          `json:"revectorize_check_disabled" yaml:"revectorize_check_disabled"`
+	QuerySlowLogEnabled                  *runtime.DynamicValue[bool]          `json:"query_slow_log_enabled" yaml:"query_slow_log_enabled"`
+	QuerySlowLogThreshold                *runtime.DynamicValue[time.Duration] `json:"query_slow_log_threshold" yaml:"query_slow_log_threshold"`
+	InvertedSorterDisabled               *runtime.DynamicValue[bool]          `json:"inverted_sorter_disabled" yaml:"inverted_sorter_disabled"`
+	ReplicatedIndicesRequestQueueEnabled *runtime.DynamicValue[bool]          `json:"replicated_indices_request_queue_enabled" yaml:"replicated_indices_request_queue_enabled"`
 
 	// Experimental configs. Will be removed in the future.
 	OIDCIssuer            *runtime.DynamicValue[string]   `json:"exp_oidc_issuer" yaml:"exp_oidc_issuer"`


### PR DESCRIPTION
### What's being changed:

Adds a buffer queue queue to limit concurrent replicated index requests. This only adds the queue to the replicated indices handlers, though this pattern may be generally useful for other endpoints in the future. The goal of these changes is to avoid a slow/locked node having millions of goroutines piling up on the slow section/lock.

The queue can be enabled/disabled at runtime (though the parameters in the config are only modifiable via env vars at startup for simplicity of implementation).

The environment variables are:

```sh
REPLICATED_INDICES_REQUEST_QUEUE_ENABLED
REPLICATED_INDICES_REQUEST_QUEUE_NUM_WORKERS
REPLICATED_INDICES_REQUEST_QUEUE_SIZE
REPLICATED_INDICES_REQUEST_QUEUE_FULL_HTTP_STATUS
REPLICATED_INDICES_REQUEST_QUEUE_SHUTDOWN_TIMEOUT_SECONDS
```

`REPLICATED_INDICES_REQUEST_QUEUE_ENABLED` defaults to `false`, can be set to `true` via env var or dynamic config to turn on.

`REPLICATED_INDICES_REQUEST_QUEUE_NUM_WORKERS` defaults to `runtime.GOMAXPROCS(0)*2` but can be set via env var to any int `>=`1`.

`REPLICATED_INDICES_REQUEST_QUEUE_SIZE` default to `10000`, but can be set to any int `>=0`

`REPLICATED_INDICES_REQUEST_QUEUE_FULL_HTTP_STATUS` defaults to `429` and should usually only be set to `429` (retryable by the coordinator node) or `504` (not retryable by the coordinator node).

`REPLICATED_INDICES_REQUEST_QUEUE_SHUTDOWN_TIMEOUT_SECONDS` defaults to `90` and is used to decide how long to wait for the replicated indices/workers to shut themselves down gracefully (if this time is exceeded, an error is returned).

TODO
- [x] make the sizes configurable (and make the queues opt-in?)
- [x] test/verify how retries work with/without queues and decide if we should return retryable status codes or not
- [ ] add observability (logs, metrics, etc)
- [ ] generally test the whole thing

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
