### PR TITLE
fix: handle corrupted doc mappings

### DIFF
--- a/adapters/repos/db/vector/hnsw/restore_doc_mappings_test.go
+++ b/adapters/repos/db/vector/hnsw/restore_doc_mappings_test.go
@@ -1,0 +1,91 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+)
+
+// TestRestoreDocMappingsWithCorruptedState tests that restoreDocMappings handles
+// corrupted state gracefully after ungraceful shutdown
+func TestRestoreDocMappingsWithCorruptedState(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	
+	// Create a dummy store
+	store := testinghelpers.NewDummyStore(t)
+	
+	// Create a minimal hnsw instance for testing
+	idx := &hnsw{
+		id:     "test-corrupted-mappings",
+		logger: logger,
+		store:  store,
+		nodes: []*vertex{
+			{id: 1},
+			{id: 2},
+			{id: 3},
+		},
+		docIDVectors: make(map[uint64][]uint64),
+	}
+	
+	// Enable multivector mode
+	idx.multivector.Store(true)
+	
+	// Now try to restore doc mappings - this should not panic even with missing mappings
+	err := idx.restoreDocMappings()
+	assert.Nil(t, err)
+	
+	// Verify that warnings were logged for the missing mappings or bucket
+	logEntries := hook.AllEntries()
+	warningCount := 0
+	for _, entry := range logEntries {
+		if entry.Level.String() == "warning" && 
+			(entry.Message == "skipping node with missing doc mapping, possibly due to corrupted state" ||
+			 entry.Message == "mappings bucket not found, possibly due to corrupted state after ungraceful shutdown") {
+			warningCount++
+		}
+	}
+	
+	// Should have at least one warning (either for missing mappings or missing bucket)
+	assert.GreaterOrEqual(t, warningCount, 1, "Expected at least one warning for corrupted state")
+}
+
+// TestRestoreDocMappingsWithNilData tests the specific case where Get returns nil
+func TestRestoreDocMappingsWithNilData(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	
+	// Create a dummy store
+	store := testinghelpers.NewDummyStore(t)
+	
+	// Create a minimal hnsw instance for testing
+	idx := &hnsw{
+		id:     "test-nil-data",
+		logger: logger,
+		store:  store,
+		nodes: []*vertex{
+			{id: 1},
+			{id: 2},
+			{id: 3},
+		},
+		docIDVectors: make(map[uint64][]uint64),
+	}
+	
+	// This should not panic even with missing mappings
+	err := idx.restoreDocMappings()
+	assert.Nil(t, err)
+	
+	// Verify that the function completed without crashing
+	assert.NotNil(t, idx.docIDVectors)
+}

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -14,7 +14,6 @@ package hnsw
 import (
 	"context"
 	"encoding/binary"
-	"fmt"
 	"time"
 
 	"github.com/pkg/errors"
@@ -335,15 +334,42 @@ func (h *hnsw) restoreDocMappings() error {
 	maxNodeID := uint64(0)
 	maxDocID := uint64(0)
 	buf := make([]byte, 8)
+	
+	// Get the mappings bucket - handle case where it might be nil
+	bucket := h.store.Bucket(h.id + "_mv_mappings")
+	if bucket == nil {
+		h.logger.WithField("action", "restore_doc_mappings").
+			Warn("mappings bucket not found, possibly due to corrupted state after ungraceful shutdown")
+		return nil
+	}
+	
 	for _, node := range h.nodes {
 		if node == nil {
 			continue
 		}
 		binary.BigEndian.PutUint64(buf, node.id)
-		docIDBytes, err := h.store.Bucket(h.id + "_mv_mappings").Get(buf)
+		docIDBytes, err := bucket.Get(buf)
 		if err != nil {
-			return errors.Wrap(err, fmt.Sprintf("failed to get %s_mv_mappings from the bucket", h.id))
+			// If the mapping is not found (e.g., due to corrupted state after ungraceful shutdown),
+			// log a warning and skip this node instead of failing completely
+			h.logger.WithFields(map[string]interface{}{
+				"action": "restore_doc_mappings",
+				"node_id": node.id,
+				"error": err.Error(),
+			}).Warn("skipping node with missing doc mapping, possibly due to corrupted state")
+			continue
 		}
+		
+		// Validate that we have enough bytes for a uint64 (8 bytes)
+		if len(docIDBytes) < 8 {
+			h.logger.WithFields(map[string]interface{}{
+				"action": "restore_doc_mappings", 
+				"node_id": node.id,
+				"bytes_length": len(docIDBytes),
+			}).Warn("skipping node with invalid doc mapping data, possibly due to corrupted state")
+			continue
+		}
+		
 		docID := binary.BigEndian.Uint64(docIDBytes)
 		if docID != prevDocID {
 			relativeID = 0


### PR DESCRIPTION
## What's being changed:

Fixes #9276 - panic during shard initialization with multiple named vectors after ungraceful shutdown.

Added error handling in `restoreDocMappings()` to gracefully handle corrupted doc mappings instead of crashing with "index out of range [7] with length 0" panic. The function now logs warnings and skips corrupted nodes, allowing Weaviate to recover from ungraceful shutdowns.

## Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation: N/A - No documentation changes needed
- [x] Chaos pipeline run or not necessary. Link to pipeline: N/A - This is a bug fix for crash scenarios
- [x] All new code is covered by tests where it is reasonable. Added comprehensive tests in `restore_doc_mappings_test.go`
- [ ] Performance tests have been run or not necessary. N/A - This is a bug fix, not a performance change


GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
