### PR TITLE
feat(metrics): lsm wal recovery metrics

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_from_wal.go
@@ -29,12 +29,7 @@ import (
 
 var logOnceWhenRecoveringFromWAL sync.Once
 
-func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup, files map[string]int64) error {
-	beforeAll := time.Now()
-	defer b.metrics.TrackStartupBucketRecovery(beforeAll)
-
-	recovered := false
-
+func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup, files map[string]int64) (err error) {
 	// the context is only ever checked once at the beginning, as there is no
 	// point in aborting an ongoing recovery. It makes more sense to let it
 	// complete and have the next recovery (this is called once per bucket) run
@@ -65,13 +60,34 @@ func (b *Bucket) mayRecoverFromCommitLogs(ctx context.Context, sg *SegmentGroup,
 		walFileNames = append(walFileNames, file)
 	}
 
-	if len(walFileNames) > 0 {
-		logOnceWhenRecoveringFromWAL.Do(func() {
-			b.logger.WithField("action", "lsm_recover_from_active_wal").
-				WithField("path", b.dir).
-				Debug("active write-ahead-log found")
-		})
+	if len(walFileNames) == 0 {
+		// nothing to do
+		return nil
 	}
+
+	logOnceWhenRecoveringFromWAL.Do(func() {
+		b.logger.WithField("action", "lsm_recover_from_active_wal").
+			WithField("path", b.dir).
+			Debug("active write-ahead-log found")
+	})
+
+	start := time.Now()
+
+	b.metrics.IncWalRecoveryCount(b.strategy)
+	b.metrics.IncWalRecoveryInProgress(b.strategy)
+
+	defer func() {
+		b.metrics.DecWalRecoveryInProgress(b.strategy)
+
+		if err != nil {
+			b.metrics.IncWalRecoveryFailureCount(b.strategy)
+			return
+		}
+
+		b.metrics.ObserveWalRecoveryDuration(b.strategy, time.Since(start))
+	}()
+
+	recovered := false
 
 	// recover from each log
 	for i, fname := range walFileNames {

--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -32,6 +32,12 @@ var compactionDurationBuckets = prometheus.ExponentialBuckets(0.01, 2, 18) // 0.
 type Metrics struct {
 	register prometheus.Registerer
 
+	// wal recovery metrics
+	walRecoveryCount        *prometheus.CounterVec
+	walRecoveryInProgress   *prometheus.GaugeVec
+	walRecoveryFailureCount *prometheus.CounterVec
+	walRecoveryDuration     *prometheus.HistogramVec
+
 	// compaction-related metrics
 	compactionCount        *prometheus.CounterVec
 	compactionInProgress   *prometheus.GaugeVec
@@ -73,6 +79,59 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 	}
 
 	register := promMetrics.Registerer
+
+	// wal recovery metrics
+	walRecoveryCount, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_wal_recovery_count",
+				Help:      "Total number of LSM bucket WAL recoveries requested, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_wal_recovery_count: %w", err)
+	}
+
+	walRecoveryInProgress, err := monitoring.EnsureRegisteredMetric(register, prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: "weaviate",
+			Name:      "lsm_bucket_wal_recovery_in_progress",
+			Help:      "Number of LSM bucket WAL recoveries currently in progress",
+		},
+		[]string{"strategy"},
+	))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_wal_recovery_in_progress: %w", err)
+	}
+
+	walRecoveryFailureCount, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_wal_recovery_failure_count",
+				Help:      "Number of failed LSM bucket WAL recoveries, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_wal_recovery_failure_count: %w", err)
+	}
+
+	walRecoveryDuration, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_wal_recovery_duration_seconds",
+				Help:      "Duration of LSM bucket WAL recovery in seconds, labeled by segment strategy",
+				Buckets:   compactionDurationBuckets,
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_wal_recovery_duration_seconds: %w", err)
+	}
 
 	// compaction-related metrics
 	compactionCount, err := monitoring.EnsureRegisteredMetric(register,
@@ -174,6 +233,13 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		groupClasses:        promMetrics.Group,
 		criticalBucketsOnly: promMetrics.LSMCriticalBucketsOnly,
 
+		// wal recovery metrics
+		walRecoveryCount:        walRecoveryCount,
+		walRecoveryInProgress:   walRecoveryInProgress,
+		walRecoveryFailureCount: walRecoveryFailureCount,
+		walRecoveryDuration:     walRecoveryDuration,
+
+		// compaction-related metrics
 		compactionNoOpCount:    compactionNoOpCount,
 		compactionCount:        compactionCount,
 		compactionInProgress:   compactionInProgress,
@@ -242,8 +308,43 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 	}, nil
 }
 
-// compaction metrics
+// wal recovery metrics
+func (m *Metrics) IncWalRecoveryCount(strategy string) {
+	if m == nil {
+		return
+	}
+	m.walRecoveryCount.WithLabelValues(strategy).Inc()
+}
 
+func (m *Metrics) IncWalRecoveryInProgress(strategy string) {
+	if m == nil {
+		return
+	}
+	m.walRecoveryInProgress.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) DecWalRecoveryInProgress(strategy string) {
+	if m == nil {
+		return
+	}
+	m.walRecoveryInProgress.WithLabelValues(strategy).Dec()
+}
+
+func (m *Metrics) IncWalRecoveryFailureCount(strategy string) {
+	if m == nil {
+		return
+	}
+	m.walRecoveryFailureCount.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) ObserveWalRecoveryDuration(strategy string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.walRecoveryDuration.WithLabelValues(strategy).Observe(duration.Seconds())
+}
+
+// compaction metrics
 func (m *Metrics) IncCompactionCount(strategy string) {
 	if m == nil {
 		return
@@ -380,15 +481,6 @@ func (m *Metrics) TrackStartupBucket(start time.Time) {
 
 	took := float64(time.Since(start)) / float64(time.Millisecond)
 	m.startupDurations.With(prometheus.Labels{"operation": "lsm_startup_bucket"}).Observe(took)
-}
-
-func (m *Metrics) TrackStartupBucketRecovery(start time.Time) {
-	if m == nil {
-		return
-	}
-
-	took := float64(time.Since(start)) / float64(time.Millisecond)
-	m.startupDurations.With(prometheus.Labels{"operation": "lsm_startup_bucket_recovery"}).Observe(took)
 }
 
 func (m *Metrics) ObjectCount(count int) {


### PR DESCRIPTION
### What's being changed:

This pull request adds detailed Prometheus metrics for tracking the recovery of LSM bucket Write-Ahead Logs (WAL). It introduces new counters, gauges, and histograms to monitor the number, status, failures, and duration of WAL recoveries, and integrates their usage into the WAL recovery code path. Additionally, it removes the old generic startup recovery metric in favor of these more granular metrics.

**WAL recovery metrics instrumentation:**

* Added new Prometheus metrics in `Metrics` (`lsm_bucket_wal_recovery_count`, `lsm_bucket_wal_recovery_in_progress`, `lsm_bucket_wal_recovery_failure_count`, and `lsm_bucket_wal_recovery_duration_seconds`) to track WAL recovery events, failures, in-progress status, and durations, all labeled by segment strategy. [[1]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR35-R40) [[2]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR83-R135) [[3]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR236-R242)
* Implemented helper methods on `Metrics` to increment and observe these new WAL recovery metrics.

**Integration into WAL recovery flow:**

* Updated `mayRecoverFromCommitLogs` in `bucket_recover_from_wal.go` to record WAL recovery metrics at appropriate points: when recovery starts, finishes, or fails, including tracking recovery duration. [[1]](diffhunk://#diff-f48216371fffcd0b62084c85ed39a1995091a2c20198dde9569db24d3150b84bL32-R32) [[2]](diffhunk://#diff-f48216371fffcd0b62084c85ed39a1995091a2c20198dde9569db24d3150b84bL68-R91)

**Cleanup:**

* Removed the old `TrackStartupBucketRecovery` metric and its usages, as it is superseded by the new, more specific WAL recovery metrics.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
