### PR TITLE
Check for correct shard status in usage module

### DIFF
--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -165,6 +165,9 @@ func (l *LazyLoadShard) NotifyReady() {
 }
 
 func (l *LazyLoadShard) GetStatus() storagestate.Status {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+
 	if l.loaded {
 		return l.shard.GetStatus()
 	}

--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -143,7 +143,7 @@ func (m *service) Usage(ctx context.Context) (*types.Report, error) {
 			}
 
 			// Check shard status without forcing load
-			if shard.GetStatus() == storagestate.StatusLoading {
+			if shard.GetStatus() == storagestate.StatusLoading || shard.GetStatus() == storagestate.StatusLazyLoading {
 				shardUsage, err := calculateUnloadedShardUsage(ctx, index, shardName, collection.VectorConfig)
 				if err != nil {
 					return err

--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -13,16 +13,17 @@ package usage
 
 import (
 	"context"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
-
 	"github.com/weaviate/weaviate/adapters/repos/db"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
 	"github.com/weaviate/weaviate/cluster/usage/types"
 	backupent "github.com/weaviate/weaviate/entities/backup"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/models"
 	entschema "github.com/weaviate/weaviate/entities/schema"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
@@ -73,6 +74,14 @@ func (s *service) addJitter() {
 // Usage service collects usage metrics for the node and shall return error in case of any error
 // to avoid reporting partial data
 func (m *service) Usage(ctx context.Context) (*types.Report, error) {
+	defer func() {
+		if !entcfg.Enabled(os.Getenv("RECOVERY_IN_USAGE_MODULE_DISABLED")) {
+			if r := recover(); r != nil {
+				m.logger.Warn("Could not collect usage data")
+			}
+		}
+	}()
+
 	schema := m.schemaManager.GetSchemaSkipAuth().Objects
 	collections := schema.Classes
 	usage := &types.Report{


### PR DESCRIPTION
### What's being changed:

Lazy shards have the status `StatusLazyLoading` and not `StatusLoading`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
