### PR TITLE
Add requantize debug handler

### DIFF
--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -619,6 +619,46 @@ func setupDebugHandlers(appState *state.State) {
 		w.WriteHeader(http.StatusAccepted)
 	}))
 
+	http.HandleFunc("/debug/index/requantize/vector", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		colName := r.URL.Query().Get("collection")
+		shardName := r.URL.Query().Get("shard")
+		targetVector := r.URL.Query().Get("vector")
+
+		if colName == "" || shardName == "" {
+			http.Error(w, "collection and shard are required", http.StatusBadRequest)
+			return
+		}
+
+		idx := appState.DB.GetIndex(schema.ClassName(colName))
+		if idx == nil {
+			logger.WithField("collection", colName).Error("collection not found")
+			http.Error(w, "collection not found", http.StatusNotFound)
+			return
+		}
+
+		err := idx.DebugRepairIndex(context.Background(), shardName, targetVector)
+		if err != nil {
+			logger.
+				WithField("shard", shardName).
+				WithField("targetVector", targetVector).
+				WithError(err).
+				Error("failed to requantize vector index")
+			if errTxt := err.Error(); strings.Contains(errTxt, "not found") {
+				http.Error(w, "shard not found", http.StatusNotFound)
+			}
+
+			http.Error(w, "failed to requantize vector index", http.StatusInternalServerError)
+			return
+		}
+
+		logger.
+			WithField("shard", shardName).
+			WithField("targetVector", targetVector).
+			Info("requantize started")
+
+		w.WriteHeader(http.StatusAccepted)
+	}))
+
 	http.HandleFunc("/debug/stats/collection/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		path := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/debug/stats/collection/"))
 		parts := strings.Split(path, "/")

--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -636,7 +636,7 @@ func setupDebugHandlers(appState *state.State) {
 			return
 		}
 
-		err := idx.DebugRepairIndex(context.Background(), shardName, targetVector)
+		err := idx.DebugRequantizeIndex(context.Background(), shardName, targetVector)
 		if err != nil {
 			logger.
 				WithField("shard", shardName).

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -172,6 +172,7 @@ type ShardLike interface {
 	// Debug methods
 	DebugResetVectorIndex(ctx context.Context, targetVector string) error
 	RepairIndex(ctx context.Context, targetVector string) error
+	RequantizeIndex(ctx context.Context, targetVector string) error
 }
 
 type onAddToPropertyValueIndex func(shard *Shard, docID uint64, property *inverted.Property) error

--- a/adapters/repos/db/shard_async.go
+++ b/adapters/repos/db/shard_async.go
@@ -418,7 +418,6 @@ func (s *Shard) RepairIndex(ctx context.Context, targetVector string) error {
 // it also removes any indexed vector that is not in the LSM store.
 // It it safe to call or interrupt this method at any time.
 func (s *Shard) RequantizeIndex(ctx context.Context, targetVector string) error {
-
 	start := time.Now()
 
 	vectorIndex, ok := s.GetVectorIndex(targetVector)

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -472,6 +472,11 @@ func (l *LazyLoadShard) RepairIndex(ctx context.Context, targetVector string) er
 	return l.shard.RepairIndex(ctx, targetVector)
 }
 
+func (l *LazyLoadShard) RequantizeIndex(ctx context.Context, targetVector string) error {
+	l.mustLoad()
+	return l.shard.RequantizeIndex(ctx, targetVector)
+}
+
 func (l *LazyLoadShard) Shutdown(ctx context.Context) error {
 	if !l.isLoaded() {
 		return nil

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -805,6 +805,164 @@ func TestShard_UpgradeIndex(t *testing.T) {
 	}, 300*time.Second, 1*time.Second)
 }
 
+func TestShard_RequantizeIndex(t *testing.T) {
+	hnswConfig := hnsw.NewDefaultUserConfig()
+	hnswConfig.BQ = hnsw.BQConfig{Enabled: true}
+
+	flatConfig := flat.NewDefaultUserConfig()
+	flatConfig.BQ = flat.CompressionUserConfig{Enabled: true, Cache: true}
+
+	tests := []struct {
+		name                   string
+		targetVector           string
+		multiVector            bool
+		cfg                    schemaConfig.VectorIndexConfig
+		idxOpt                 func(*Index)
+		getVectorIndexAndQueue func(ShardLike) (VectorIndex, *VectorIndexQueue)
+	}{
+		{
+			name:         "hnsw",
+			cfg:          hnswConfig,
+			targetVector: "",
+			getVectorIndexAndQueue: func(shd ShardLike) (VectorIndex, *VectorIndexQueue) {
+				return getVectorIndexAndQueue(t, shd, "")
+			},
+		},
+		{
+			name:         "hnsw with target vectors",
+			targetVector: "foo",
+			cfg:          hnswConfig,
+			idxOpt: func(i *Index) {
+				i.vectorIndexUserConfigs = make(map[string]schemaConfig.VectorIndexConfig)
+				i.vectorIndexUserConfigs["foo"] = hnswConfig
+			},
+			getVectorIndexAndQueue: func(shd ShardLike) (VectorIndex, *VectorIndexQueue) {
+				return getVectorIndexAndQueue(t, shd, "foo")
+			},
+		},
+		{
+			name:         "flat",
+			cfg:          flatConfig,
+			targetVector: "",
+			getVectorIndexAndQueue: func(shd ShardLike) (VectorIndex, *VectorIndexQueue) {
+				return getVectorIndexAndQueue(t, shd, "")
+			},
+		},
+		{
+			name:         "flat with target vectors",
+			targetVector: "foo",
+			cfg:          flatConfig,
+			idxOpt: func(i *Index) {
+				i.vectorIndexUserConfigs = make(map[string]schemaConfig.VectorIndexConfig)
+				i.vectorIndexUserConfigs["foo"] = flatConfig
+			},
+			getVectorIndexAndQueue: func(shd ShardLike) (VectorIndex, *VectorIndexQueue) {
+				return getVectorIndexAndQueue(t, shd, "foo")
+			},
+		},
+	}
+
+	for testIndex, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			className := fmt.Sprintf("TestClass%d", testIndex)
+			var opts []func(*Index)
+			if test.idxOpt != nil {
+				opts = append(opts, test.idxOpt)
+			}
+			shd, idx := testShardWithSettings(t, ctx, &models.Class{Class: className}, test.cfg, false, true, opts...)
+
+			amount := 50
+
+			defer func(path string) {
+				err := os.RemoveAll(path)
+				if err != nil {
+					fmt.Println(err)
+				}
+			}(shd.Index().Config.RootPath)
+
+			var objs []*storobj.Object
+			for i := 0; i < amount; i++ {
+				obj := testObject(className)
+				if test.targetVector != "" {
+					obj.Vectors = map[string][]float32{
+						test.targetVector: randVector(3),
+					}
+				} else {
+					obj.Vector = randVector(3)
+				}
+				objs = append(objs, obj)
+			}
+
+			errs := shd.PutObjectBatch(ctx, objs)
+			for _, err := range errs {
+				require.Nil(t, err)
+			}
+
+			vidx, _ := test.getVectorIndexAndQueue(shd)
+
+			// For HNSW, the compressed bucket name uses the index name, not the target vector
+			var compressedBucketName string
+			if test.name == "hnsw" || test.name == "hnsw with target vectors" {
+				// HNSW uses the index name for the compressed bucket
+				// For default vector, the index name is "main"
+				if test.targetVector == "" {
+					compressedBucketName = helpers.GetCompressedBucketName("main")
+				} else {
+					compressedBucketName = helpers.GetCompressedBucketName(test.targetVector)
+				}
+			} else {
+				// Flat uses the target vector directly
+				compressedBucketName = helpers.GetCompressedBucketName(test.targetVector)
+			}
+			compressedBucket := shd.Store().Bucket(compressedBucketName)
+			require.NotNil(t, compressedBucket)
+
+			// store original vectors for comparison
+			originalVectors := make(map[uint64][]byte)
+			for i := 10; i < amount; i++ {
+				idBytes := make([]byte, 8)
+				binary.BigEndian.PutUint64(idBytes, uint64(i))
+				compressedVector, err := compressedBucket.Get(idBytes)
+				require.NoError(t, err)
+				require.NotEmpty(t, compressedVector)
+				originalVectors[uint64(i)] = compressedVector
+			}
+
+			// delete those IDs from the vector index
+			for i := 10; i < amount; i++ {
+				if test.multiVector {
+					err := vidx.DeleteMulti(uint64(i))
+					require.NoError(t, err)
+				} else {
+					err := vidx.Delete(uint64(i))
+					require.NoError(t, err)
+				}
+			}
+
+			// run requantize index
+			err := shd.RequantizeIndex(ctx, test.targetVector)
+			require.NoError(t, err)
+
+			// check that vectors are identical after requantization
+			for i := 10; i < amount; i++ {
+				idBytes := make([]byte, 8)
+				binary.BigEndian.PutUint64(idBytes, uint64(i))
+				compressedVector, err := compressedBucket.Get(idBytes)
+				require.NoError(t, err)
+				require.NotEmpty(t, compressedVector)
+
+				originalVector, exists := originalVectors[uint64(i)]
+				require.True(t, exists, "original vector should exist for ID %d", i)
+				require.Equal(t, originalVector, compressedVector, "vectors should be identical for ID %d", i)
+			}
+
+			require.Nil(t, idx.drop())
+			require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+		})
+	}
+}
+
 func getVectorIndexAndQueue(t *testing.T, shard ShardLike, targetVector string) (VectorIndex, *VectorIndexQueue) {
 	idx, vok := shard.GetVectorIndex(targetVector)
 	q, qok := shard.GetVectorIndexQueue(targetVector)

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -902,19 +902,7 @@ func TestShard_RequantizeIndex(t *testing.T) {
 			vidx, _ := test.getVectorIndexAndQueue(shd)
 
 			// For HNSW, the compressed bucket name uses the index name, not the target vector
-			var compressedBucketName string
-			if test.name == "hnsw" || test.name == "hnsw with target vectors" {
-				// HNSW uses the index name for the compressed bucket
-				// For default vector, the index name is "main"
-				if test.targetVector == "" {
-					compressedBucketName = helpers.GetCompressedBucketName("main")
-				} else {
-					compressedBucketName = helpers.GetCompressedBucketName(test.targetVector)
-				}
-			} else {
-				// Flat uses the target vector directly
-				compressedBucketName = helpers.GetCompressedBucketName(test.targetVector)
-			}
+			compressedBucketName := helpers.GetCompressedBucketName(test.targetVector)
 			compressedBucket := shd.Store().Bucket(compressedBucketName)
 			require.NotNil(t, compressedBucket)
 

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -79,6 +79,7 @@ type VectorIndex interface {
 	ValidateBeforeInsert(vector []float32) error
 	DistanceBetweenVectors(x, y []float32) (float32, error)
 	ContainsDoc(docID uint64) bool
+	Preload(id uint64, vector []float32)
 	DistancerProvider() distancer.Provider
 	AlreadyIndexed() uint64
 	QueryVectorDistancer(queryVector []float32) common.QueryVectorDistancer
@@ -441,6 +442,12 @@ func (dynamic *dynamic) ContainsDoc(docID uint64) bool {
 	dynamic.RLock()
 	defer dynamic.RUnlock()
 	return dynamic.index.ContainsDoc(docID)
+}
+
+func (dynamic *dynamic) Preload(id uint64, vector []float32) {
+	dynamic.RLock()
+	defer dynamic.RUnlock()
+	dynamic.index.Preload(id, vector)
 }
 
 func (dynamic *dynamic) AlreadyIndexed() uint64 {

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -334,7 +334,7 @@ func (index *flat) Add(ctx context.Context, id uint64, vector []float32) error {
 	slice := make([]byte, len(vector)*4)
 	index.storeVector(id, byteSliceFromFloat32Slice(vector, slice))
 
-	index.preloadNormalized(id, vector, false)
+	index.Preload(id, vector)
 	newCount := atomic.LoadUint64(&index.count)
 	atomic.StoreUint64(&index.count, newCount+1)
 	return nil
@@ -793,14 +793,6 @@ func (i *flat) ValidateMultiBeforeInsert(vector [][]float32) error {
 }
 
 func (index *flat) Preload(id uint64, vector []float32) {
-	index.preloadNormalized(id, vector, true)
-}
-
-func (index *flat) preloadNormalized(id uint64, vector []float32, shouldNormalize bool) {
-	if shouldNormalize {
-		vector = index.normalized(vector)
-	}
-
 	if index.isBQ() {
 		vectorBQ := index.bq.Encode(vector)
 		if index.isBQCached() {

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -334,15 +334,7 @@ func (index *flat) Add(ctx context.Context, id uint64, vector []float32) error {
 	slice := make([]byte, len(vector)*4)
 	index.storeVector(id, byteSliceFromFloat32Slice(vector, slice))
 
-	if index.isBQ() {
-		vectorBQ := index.bq.Encode(vector)
-		if index.isBQCached() {
-			index.bqCache.Grow(id)
-			index.bqCache.Preload(id, vectorBQ)
-		}
-		slice = make([]byte, len(vectorBQ)*8)
-		index.storeCompressedVector(id, byteSliceFromUint64Slice(vectorBQ, slice))
-	}
+	index.preloadNormalized(id, vector, false)
 	newCount := atomic.LoadUint64(&index.count)
 	atomic.StoreUint64(&index.count, newCount+1)
 	return nil
@@ -800,7 +792,24 @@ func (i *flat) ValidateMultiBeforeInsert(vector [][]float32) error {
 	return nil
 }
 
-func (i *flat) Preload(id uint64, vector []float32) {
+func (index *flat) Preload(id uint64, vector []float32) {
+	index.preloadNormalized(id, vector, true)
+}
+
+func (index *flat) preloadNormalized(id uint64, vector []float32, shouldNormalize bool) {
+	if shouldNormalize {
+		vector = index.normalized(vector)
+	}
+
+	if index.isBQ() {
+		vectorBQ := index.bq.Encode(vector)
+		if index.isBQCached() {
+			index.bqCache.Grow(id)
+			index.bqCache.Preload(id, vectorBQ)
+		}
+		slice := make([]byte, len(vectorBQ)*8)
+		index.storeCompressedVector(id, byteSliceFromUint64Slice(vectorBQ, slice))
+	}
 }
 
 func (index *flat) PostStartup() {

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -800,6 +800,9 @@ func (i *flat) ValidateMultiBeforeInsert(vector [][]float32) error {
 	return nil
 }
 
+func (i *flat) Preload(id uint64, vector []float32) {
+}
+
 func (index *flat) PostStartup() {
 	if !index.isBQCached() {
 		return

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -321,6 +321,76 @@ func TestFlat_QueryVectorDistancer(t *testing.T) {
 	}
 }
 
+func TestFlat_Preload(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	cases := []struct {
+		name     string
+		distance string
+		bq       bool
+		cache    bool
+	}{
+		{name: "euclidean", distance: "l2-squared"},
+		{name: "cosine_with_bq_cache", distance: "cosine-dot"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			dirName := t.TempDir()
+
+			var distanceProvider distancer.Provider
+			if tt.distance == "cosine-dot" {
+				distanceProvider = distancer.NewCosineDistanceProvider()
+			} else {
+				distanceProvider = distancer.NewL2SquaredProvider()
+			}
+
+			bq := flatent.CompressionUserConfig{
+				Enabled: true, Cache: true, RescoreLimit: 10,
+			}
+			store, err := lsmkv.New(dirName, dirName, logger, nil,
+				cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop())
+			require.Nil(t, err)
+			defer store.Shutdown(context.Background())
+
+			index, err := New(Config{
+				ID:               "test-preload",
+				RootPath:         dirName,
+				DistanceProvider: distanceProvider,
+			}, flatent.UserConfig{
+				BQ: bq,
+			}, store)
+			require.Nil(t, err)
+			defer index.Shutdown(context.Background())
+
+			rawVector1 := []float32{1, -1, 1}
+			id1 := uint64(1)
+
+			ctx := context.Background()
+			err = index.Add(ctx, id1, rawVector1)
+			require.Nil(t, err)
+
+			vec1, err := index.bqCache.Get(ctx, id1)
+			require.NoError(t, err)
+			require.NotNil(t, vec1)
+
+			// Ensure deleting removes the cached vector
+			index.Delete(id1)
+			vec, err := index.bqCache.Get(ctx, id1)
+			require.NoError(t, err)
+			require.Nil(t, vec)
+
+			// Preload and check binary vector is identical to original
+			index.Preload(id1, rawVector1)
+			vec2, err := index.bqCache.Get(ctx, id1)
+			require.NoError(t, err)
+			require.InDeltaSlice(t, vec1, vec2, 0.0001)
+		})
+	}
+}
+
 func TestConcurrentReads(t *testing.T) {
 	ctx := context.Background()
 	dirName := t.TempDir()

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -365,7 +365,7 @@ func TestFlat_Preload(t *testing.T) {
 			require.Nil(t, err)
 			defer index.Shutdown(context.Background())
 
-			rawVector1 := []float32{1, -1, 1}
+			rawVector1 := []float32{4, -1, 4}
 			id1 := uint64(1)
 
 			ctx := context.Background()

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -334,13 +334,7 @@ func (h *hnsw) addOne(ctx context.Context, vector []float32, node *vertex) error
 	h.nodes[nodeId] = node
 	h.shardedNodeLocks.Unlock(nodeId)
 
-	if h.compressed.Load() && !h.multivector.Load() {
-		h.compressor.Preload(node.id, vector)
-	} else {
-		if !h.multivector.Load() {
-			h.cache.Preload(node.id, vector)
-		}
-	}
+	h.Preload(node.id, vector)
 
 	h.insertMetrics.prepareAndInsertNode(before)
 	before = time.Now()
@@ -439,4 +433,14 @@ func (h *hnsw) insertInitialElement(node *vertex, nodeVec []float32) error {
 
 	// go h.insertHook(node.id, 0, node.connections)
 	return nil
+}
+
+func (h *hnsw) Preload(id uint64, vector []float32) {
+	if h.compressed.Load() && !h.multivector.Load() {
+		h.compressor.Preload(id, vector)
+	} else {
+		if !h.multivector.Load() {
+			h.cache.Preload(id, vector)
+		}
+	}
 }

--- a/adapters/repos/db/vector/noop/index.go
+++ b/adapters/repos/db/vector/noop/index.go
@@ -141,6 +141,9 @@ func (i *Index) ContainsDoc(docID uint64) bool {
 	return false
 }
 
+func (i *Index) Preload(id uint64, vector []float32) {
+}
+
 func (i *Index) Iterate(fn func(id uint64) bool) {}
 
 func (i *Index) DistancerProvider() distancer.Provider {

--- a/adapters/repos/db/vector_index.go
+++ b/adapters/repos/db/vector_index.go
@@ -53,6 +53,7 @@ type VectorIndex interface {
 	// It must return false if the document does not exist, or has a tombstone.
 	ContainsDoc(docID uint64) bool
 	AlreadyIndexed() uint64
+	Preload(id uint64, vector []float32)
 	// Iterate over all indexed document ids in the index.
 	// Consistency or order is not guaranteed, as the index may be concurrently modified.
 	// If the callback returns false, the iteration will stop.


### PR DESCRIPTION
### What's being changed:
- This handle requantizes the compressed buckets in HNSW.
- Intended to be used together with https://github.com/weaviate/weaviate/pull/9240 if multiple named vectors and quantization were used.
- In tests this restores recall back to 99%+ in the scenarios.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
