### PR TITLE
fix: implement coordinated shutdown to prevent serving APIs during shutdown

### DIFF
--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"google.golang.org/grpc/health"
 	"google.golang.org/grpc/peer"
 
 	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
@@ -46,7 +47,7 @@ import (
 )
 
 // CreateGRPCServer creates *grpc.Server with optional grpc.Serveroption passed.
-func CreateGRPCServer(state *state.State, shutdown *batch.Shutdown, options ...grpc.ServerOption) *grpc.Server {
+func CreateGRPCServer(state *state.State, shutdown *batch.Shutdown, options ...grpc.ServerOption) (*grpc.Server, *health.Server) {
 	o := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(state.ServerConfig.Config.GRPC.MaxMsgSize),
 		grpc.MaxSendMsgSize(state.ServerConfig.Config.GRPC.MaxMsgSize),
@@ -117,9 +118,10 @@ func CreateGRPCServer(state *state.State, shutdown *batch.Shutdown, options ...g
 	weaviateV1FileReplicationService := v1.NewFileReplicationService(state.DB, state.ClusterService.SchemaReader())
 	pbv1.RegisterFileReplicationServiceServer(s, weaviateV1FileReplicationService)
 
-	grpc_health_v1.RegisterHealthServer(s, weaviateV1)
+	healthServer := health.NewServer()
+	grpc_health_v1.RegisterHealthServer(s, healthServer)
 
-	return s
+	return s, healthServer
 }
 
 func makeMetricsInterceptor(logger logrus.FieldLogger, metrics *monitoring.PrometheusMetrics) grpc.UnaryServerInterceptor {

--- a/adapters/handlers/rest/grpc.go
+++ b/adapters/handlers/rest/grpc.go
@@ -17,9 +17,10 @@ import (
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
 )
 
-func createGrpcServer(state *state.State, shutdown *batch.Shutdown, options ...grpc.ServerOption) *grpc.Server {
+func createGrpcServer(state *state.State, shutdown *batch.Shutdown, options ...grpc.ServerOption) (*grpc.Server, *health.Server) {
 	return grpcHandler.CreateGRPCServer(state, shutdown, options...)
 }
 

--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -124,6 +124,7 @@ func makeSetupGlobalMiddleware(appState *state.State, context *middleware.Contex
 		if appState.ServerConfig.Config.Monitoring.Enabled {
 			handler = makeAddMonitoring(appState.Metrics)(handler)
 		}
+		handler = makeShutdownMiddleware(appState)(handler)
 		handler = addPreflight(handler, appState.ServerConfig.Config.CORS)
 		handler = addLiveAndReadyness(appState, handler)
 		handler = addHandleRoot(handler)
@@ -175,6 +176,28 @@ func staticRoute(context *middleware.Context) monitoring.StaticRouteLabel {
 
 func addSentryHandler(next http.Handler) http.Handler {
 	return sentryhttp.New(sentryhttp.Options{}).Handle(next)
+}
+
+func makeShutdownMiddleware(s *state.State) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if s.IsShuttingDown() {
+				s.Logger.WithField("method", r.Method).
+					WithField("path", r.URL.Path).
+					Debug("rejecting request during shutdown")
+
+				w.Header().Set("Connection", "close")
+				w.WriteHeader(http.StatusServiceUnavailable)
+				_, err := w.Write([]byte("Service is shutting down"))
+				if err != nil {
+					s.Logger.WithError(err).Error("failed to write response")
+					return
+				}
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
 }
 
 func makeAddLogging(logger logrus.FieldLogger) func(http.Handler) http.Handler {
@@ -247,16 +270,19 @@ func addInjectHeadersIntoContext(next http.Handler) http.Handler {
 
 func addLiveAndReadyness(state *state.State, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.String() == "/v1/.well-known/live" {
+		switch r.URL.Path {
+		case "/v1/.well-known/live":
 			w.WriteHeader(http.StatusOK)
 			return
-		}
 
-		if r.URL.String() == "/v1/.well-known/ready" {
+		case "/v1/.well-known/ready":
 			code := http.StatusOK
-			// if this node is in maintenance mode, we want to return live but not ready
-			// so that kubernetes will allow this pod to run but not send traffic to it
-			if state.Cluster.MaintenanceModeEnabledForLocalhost() {
+
+			w.Header().Set("Cache-Control", "no-store")
+
+			if state.IsShuttingDown() {
+				code = http.StatusServiceUnavailable
+			} else if state.Cluster.MaintenanceModeEnabledForLocalhost() {
 				code = http.StatusServiceUnavailable
 			} else if !state.ClusterService.Ready() || state.Cluster.ClusterHealthScore() != 0 {
 				code = http.StatusServiceUnavailable
@@ -266,10 +292,11 @@ func addLiveAndReadyness(state *state.State, next http.Handler) http.Handler {
 					code = http.StatusServiceUnavailable
 				}
 			}
+
+			state.Logger.WithField("response_code", code).Debug("readiness probe response")
 			w.WriteHeader(code)
 			return
 		}
-
 		next.ServeHTTP(w, r)
 	})
 }

--- a/adapters/handlers/rest/server.go
+++ b/adapters/handlers/rest/server.go
@@ -65,7 +65,7 @@ func NewServer(api *operations.WeaviateAPI) *Server {
 // ConfigureAPI configures the API and handlers.
 func (s *Server) ConfigureAPI() {
 	if s.api != nil {
-		s.handler = configureAPI(s.api)
+		s.handler = s.configureAPI(s.api)
 	}
 }
 
@@ -143,7 +143,7 @@ func (s *Server) SetAPI(api *operations.WeaviateAPI) {
 	}
 
 	s.api = api
-	s.handler = configureAPI(api)
+	s.handler = s.configureAPI(api)
 }
 
 func (s *Server) hasScheme(scheme string) bool {
@@ -427,8 +427,15 @@ func (s *Server) handleShutdown(wg *sync.WaitGroup, serversPtr *[]*http.Server) 
 	ctx, cancel := context.WithTimeout(context.TODO(), s.GracefulTimeout)
 	defer cancel()
 
+	s.Logf("Starting coordinated shutdown process")
+
 	// first execute the pre-shutdown hook
 	s.api.PreServerShutdown()
+
+	// NOTE: add a small additional delay to ensure health checks have propagated
+	// This gives load balancers more time to detect pods are shutting down
+	time.Sleep(500 * time.Millisecond)
+	s.Logf("Starting HTTP server shutdown")
 
 	shutdownChan := make(chan bool)
 	for i := range servers {
@@ -453,8 +460,12 @@ func (s *Server) handleShutdown(wg *sync.WaitGroup, serversPtr *[]*http.Server) 
 		success = success && <-shutdownChan
 	}
 	if success {
-		s.api.ServerShutdown()
+		s.Logf("All HTTP servers shut down successfully")
+	} else {
+		s.Logf("Some HTTP servers failed to shut down gracefully")
 	}
+
+	s.api.ServerShutdown()
 }
 
 // GetHandler returns a handler useful for testing
@@ -515,4 +526,8 @@ func handleInterrupt(once *sync.Once, s *Server) {
 
 func signalNotify(interrupt chan<- os.Signal) {
 	signal.Notify(interrupt, syscall.SIGINT, syscall.SIGTERM)
+}
+
+func (s *Server) IsShuttingDown() bool {
+	return atomic.LoadInt32(&s.shuttingDown) == 1
 }

--- a/adapters/handlers/rest/state/state.go
+++ b/adapters/handlers/rest/state/state.go
@@ -16,10 +16,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac"
-
 	"github.com/sirupsen/logrus"
-
 	"github.com/weaviate/weaviate/adapters/handlers/graphql"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/tenantactivity"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/types"
@@ -32,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/oidc"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac"
 	"github.com/weaviate/weaviate/usecases/backup"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -45,6 +43,10 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 	"github.com/weaviate/weaviate/usecases/traverser"
 )
+
+type ShutdownChecker interface {
+	IsShuttingDown() bool
+}
 
 // State is the only source of application-wide state
 // NOTE: This is not true yet, see gh-723
@@ -90,6 +92,8 @@ type State struct {
 
 	DistributedTaskScheduler *distributedtask.Scheduler
 	Migrator                 *db.Migrator
+	restShutdownChecker      ShutdownChecker
+	grpcShutdownChecker      ShutdownChecker
 }
 
 // GetGraphQL is the safe way to retrieve GraphQL from the state as it can be
@@ -108,4 +112,27 @@ func (s *State) SetGraphQL(gql graphql.GraphQL) {
 	s.gqlMutex.Lock()
 	s.GraphQL = gql
 	s.gqlMutex.Unlock()
+}
+
+func (s *State) SetShutdownRestChecker(checker ShutdownChecker) {
+	s.restShutdownChecker = checker
+	s.Logger.Debug("REST ShutdownChecker set successfully")
+}
+
+func (s *State) SetShutdownGrpcChecker(checker ShutdownChecker) {
+	s.grpcShutdownChecker = checker
+	s.Logger.Debug("GRPC ShutdownChecker set successfully")
+}
+
+func (s *State) IsShuttingDown() bool {
+	isRestShutdown := s.restShutdownChecker != nil && s.restShutdownChecker.IsShuttingDown()
+	isGrpcShutdown := s.grpcShutdownChecker != nil && s.grpcShutdownChecker.IsShuttingDown()
+	isShuttingDown := isRestShutdown || isGrpcShutdown
+
+	s.Logger.WithField("is_shutting_down", isShuttingDown).
+		WithField("is_rest_shutdown", isRestShutdown).
+		WithField("is_grpc_shutdown", isGrpcShutdown).
+		Trace("checking rest and grpc shutdown state")
+
+	return isShuttingDown
 }

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -40,10 +40,11 @@ const (
 	DimensionCategoryRQ
 )
 
-// since v1.34 StrategyRoaringSet will be default strategy for dimensions bucket
+// since v1.34 StrategyRoaringSet is default strategy for dimensions bucket,
+// StrategyMapCollection is left as backward compatibility for buckets created earlier
 var DimensionsBucketPrioritizedStrategies = []string{
-	lsmkv.StrategyMapCollection,
 	lsmkv.StrategyRoaringSet,
+	lsmkv.StrategyMapCollection,
 }
 
 func (c DimensionCategory) String() string {


### PR DESCRIPTION
APIs continued serving requests during shutdown due to **uncoordinated shutdown between HTTP servers, gRPC servers, and health checks** - creating race conditions and timing issues.

### Root Cause: Readiness Probe Not Shutdown-Aware

- Kubernetes relies on readiness probes to stop routing traffic during shutdown
- Our readiness probe continued returning `200 OK` while servers were shutting down  
- Load balancers thought pods were healthy and kept routing requests to partially shutdown services

### Additional Fix: Readiness Probe URL Bug

Fixed readiness probe handler from `r.URL.String()` to `r.URL.Path` - previously probes with query parameters (e.g., `?timeout=5s`) fell through to main application handlers instead of being handled correctly.

## Solution: Coordinated Shutdown Phases

**Phase 1: Mark Unhealthy**
- Set shutdown flags for HTTP/gRPC, readiness probe returns 503
- Shutdown middleware rejects new requests, gRPC health marked `NOT_SERVING`

**Phase 2: Health Check Propagation**
- Wait for load balancers to detect unhealthy state and stop routing traffic

**Phase 3: Drain Connections**  
- Start draining gRPC connections, additional buffer for health check propagation

**Phase 4: Shutdown Servers**
- Gracefully shutdown all HTTP/gRPC servers concurrently with timeout fallback

## Key Changes

- **Shutdown State Tracking**: Proper shutdown state reporting for both HTTP and gRPC
- **Readiness Probe Integration**: Returns 503 during shutdown + fixed URL path matching
- **Shutdown Middleware**: Safety net rejecting requests during shutdown
- **Coordinated Timing**: Proper delays for Kubernetes health check propagation  
- **Error Resilience**: Always proceed to cleanup even if servers fail to shutdown gracefully
- **Enhanced Logging**: Comprehensive logging throughout all shutdown phases

## Critical: Timing Configuration Required

**Shutdown detection requires coordination between server and health check monitors via readiness probes.** This fix only works with proper timing:

- **Readiness probe interval must be ≤ 2 seconds** to work with our `ReadinessProbeLeadTime`
- **Load balancer health check intervals** must align with probe timing
- **Pod termination grace period** must allow time for full shutdown sequence

**We cannot fix coordination issues if monitoring infrastructure timing is misconfigured.** If our probe interval > 2 seconds, either we need to reduce it or increase the `ReadinessProbeLeadTime` constant accordingly.

## Testing

This eliminates race conditions by ensuring:
1. Load balancers stop routing before servers shut down
2. Readiness probes work correctly with query parameters  
3. Both HTTP and gRPC servers shut down in coordinated fashion
4. Proper cleanup occurs even with shutdown errors

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.