### PR TITLE
fix(file_replication.proto): use unique java_outer_classname

### DIFF
--- a/grpc/proto/v1/file_replication.proto
+++ b/grpc/proto/v1/file_replication.proto
@@ -4,7 +4,7 @@ package weaviate.v1;
 
 option go_package = "github.com/weaviate/weaviate/grpc/generated;protocol";
 option java_package = "io.weaviate.client.grpc.protocol.v1";
-option java_outer_classname = "WeaviateProto";
+option java_outer_classname = "WeaviateProtoFileReplication";
 
 enum CompressionType {
   COMPRESSION_TYPE_UNSPECIFIED = 0;     // No compression


### PR DESCRIPTION
WeaviateProto is already reserved for the stub generated out of weaviate.proto.

This naming follows the `Weaviate<FileName>Proto` naming convention.

### What's being changed:

`option java_outer_classname` is set to `WeaviateFileReplicationProto`.