### PR TITLE
feat bucket lifecycle metrics

### DIFF
--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -28,12 +28,24 @@ type (
 )
 
 var (
+	lifecycleDurationBuckets  = prometheus.ExponentialBuckets(0.01, 2, 18)     // 0.01s → 0.02s → ... → ~163.84s
 	segmentSizeBuckets        = prometheus.ExponentialBuckets(100*1024, 2, 20) // 100KB → 200KB → 400KB → ... → ~52GB
 	compactionDurationBuckets = prometheus.ExponentialBuckets(0.01, 2, 18)     // 0.01s → 0.02s → ... → ~163.84s
 )
 
 type Metrics struct {
 	register prometheus.Registerer
+
+	// bucket metrics
+	bucketInitCountByStrategy        *prometheus.CounterVec
+	bucketInitInProgressByStrategy   *prometheus.GaugeVec
+	bucketInitFailureCountByStrategy *prometheus.CounterVec
+	bucketInitDurationByStrategy     *prometheus.HistogramVec
+
+	bucketShutdownCountByStrategy        *prometheus.CounterVec
+	bucketShutdownInProgressByStrategy   *prometheus.GaugeVec
+	bucketShutdownDurationByStrategy     *prometheus.HistogramVec
+	bucketShutdownFailureCountByStrategy *prometheus.CounterVec
 
 	// segment metrics
 	segmentTotalByStrategy *prometheus.GaugeVec
@@ -86,6 +98,113 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 	}
 
 	register := promMetrics.Registerer
+
+	// bucket metrics
+
+	bucketInitCountByStrategy, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_init_count",
+				Help:      "Total number of LSM bucket initializations requested, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_init_count: %w", err)
+	}
+
+	bucketInitInProgressByStrategy, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_init_in_progress",
+				Help:      "Number of LSM bucket initializations currently in progress, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_init_in_progress: %w", err)
+	}
+
+	bucketInitFailureCountByStrategy, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_init_failure_count",
+				Help:      "Number of failed LSM bucket initializations, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_init_failure_count: %w", err)
+	}
+
+	bucketInitDurationByStrategy, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_init_duration_seconds",
+				Help:      "Duration of LSM bucket initialization in seconds, labeled by segment strategy",
+				Buckets:   lifecycleDurationBuckets,
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_init_duration_seconds: %w", err)
+	}
+
+	bucketShutdownCountByStrategy, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_shutdown_count",
+				Help:      "Total number of LSM bucket shutdowns requested, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_shutdown_count: %w", err)
+	}
+
+	bucketShutdownInProgressByStrategy, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_shutdown_in_progress",
+				Help:      "Number of LSM bucket shutdowns currently in progress, labeled by segment strategy",
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_shutdown_in_progress: %w", err)
+	}
+
+	bucketShutdownDurationByStrategy, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_shutdown_duration_seconds",
+				Help:      "Duration of LSM bucket shutdown in seconds, labeled by segment strategy",
+				Buckets:   lifecycleDurationBuckets,
+			},
+			[]string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_shutdown_duration_seconds: %w", err)
+	}
+
+	bucketShutdownFailureCountByStrategy, err := monitoring.EnsureRegisteredMetric(register,
+		prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Namespace: "weaviate",
+				Name:      "lsm_bucket_shutdown_failure_count",
+				Help:      "Number of failed LSM bucket shutdowns, labeled by segment strategy",
+			}, []string{"strategy"},
+		))
+	if err != nil {
+		return nil, fmt.Errorf("register lsm_bucket_shutdown_failure_count: %w", err)
+	}
 
 	// segment metrics
 	segmentTotalByStrategy, err := monitoring.EnsureRegisteredMetric(register,
@@ -268,6 +387,17 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		groupClasses:        promMetrics.Group,
 		criticalBucketsOnly: promMetrics.LSMCriticalBucketsOnly,
 
+		// bucket metrics
+		bucketInitCountByStrategy:        bucketInitCountByStrategy,
+		bucketInitInProgressByStrategy:   bucketInitInProgressByStrategy,
+		bucketInitFailureCountByStrategy: bucketInitFailureCountByStrategy,
+		bucketInitDurationByStrategy:     bucketInitDurationByStrategy,
+
+		bucketShutdownCountByStrategy:        bucketShutdownCountByStrategy,
+		bucketShutdownInProgressByStrategy:   bucketShutdownInProgressByStrategy,
+		bucketShutdownDurationByStrategy:     bucketShutdownDurationByStrategy,
+		bucketShutdownFailureCountByStrategy: bucketShutdownFailureCountByStrategy,
+
 		// segment metrics
 		segmentTotalByStrategy: segmentTotalByStrategy,
 		segmentSizeByStrategy:  segmentSizeByStrategy,
@@ -345,6 +475,77 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		LazySegmentInit:   lazySegmentInit,
 		LazySegmentUnLoad: lazySegmentUnload,
 	}, nil
+}
+
+// bucket metrics
+func (m *Metrics) IncBucketInitCountByStrategy(strategy string) {
+	if m == nil {
+		return
+	}
+	m.bucketInitCountByStrategy.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) IncBucketInitInProgressByStrategy(strategy string) {
+	if m == nil {
+		return
+	}
+	m.bucketInitInProgressByStrategy.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) DecBucketInitInProgressByStrategy(strategy string) {
+	if m == nil {
+		return
+	}
+	m.bucketInitInProgressByStrategy.WithLabelValues(strategy).Dec()
+}
+
+func (m *Metrics) IncBucketInitFailureCountByStrategy(strategy string) {
+	if m == nil {
+		return
+	}
+	m.bucketInitFailureCountByStrategy.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) ObserveBucketInitDurationByStrategy(strategy string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.bucketInitDurationByStrategy.WithLabelValues(strategy).Observe(duration.Seconds())
+}
+
+func (m *Metrics) IncBucketShutdownCountByStrategy(strategy string) {
+	if m == nil {
+		return
+	}
+	m.bucketShutdownCountByStrategy.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) IncBucketShutdownInProgressByStrategy(strategy string) {
+	if m == nil {
+		return
+	}
+	m.bucketShutdownInProgressByStrategy.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) DecBucketShutdownInProgressByStrategy(strategy string) {
+	if m == nil {
+		return
+	}
+	m.bucketShutdownInProgressByStrategy.WithLabelValues(strategy).Dec()
+}
+
+func (m *Metrics) IncBucketShutdownFailureCountByStrategy(strategy string) {
+	if m == nil {
+		return
+	}
+	m.bucketShutdownFailureCountByStrategy.WithLabelValues(strategy).Inc()
+}
+
+func (m *Metrics) ObserveBucketShutdownDurationByStrategy(strategy string, duration time.Duration) {
+	if m == nil {
+		return
+	}
+	m.bucketShutdownDurationByStrategy.WithLabelValues(strategy).Observe(duration.Seconds())
 }
 
 // segment metrics

--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -43,7 +43,7 @@ type Segment interface {
 	getStrategy() segmentindex.Strategy
 	getSecondaryIndexCount() uint16
 	getLevel() uint16
-	getSize() int64
+	Size() int64
 	setSize(size int64)
 
 	PayloadSize() int
@@ -494,8 +494,8 @@ func (s *segment) markForDeletion() error {
 
 // Size returns the total size of the segment in bytes, including the header
 // and index
-func (s *segment) Size() int {
-	return int(s.size)
+func (s *segment) Size() int64 {
+	return s.size
 }
 
 func (s *segment) getPath() string {
@@ -520,10 +520,6 @@ func (s *segment) getCountNetAdditions() int {
 
 func (s *segment) getLevel() uint16 {
 	return s.level
-}
-
-func (s *segment) getSize() int64 {
-	return s.size
 }
 
 func (s *segment) setSize(size int64) {

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -361,6 +361,9 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 		}
 		sg.segments[segmentIndex] = segment
 		segmentIndex++
+
+		sg.metrics.IncSegmentTotalByStrategy(sg.strategy)
+		sg.metrics.ObserveSegmentSize(sg.strategy, segment.Size())
 	}
 
 	sg.segments = sg.segments[:segmentIndex]
@@ -517,6 +520,9 @@ func (sg *SegmentGroup) add(path string) error {
 	}
 
 	sg.segments = append(sg.segments, segment)
+	sg.metrics.IncSegmentTotalByStrategy(sg.strategy)
+	sg.metrics.ObserveSegmentSize(sg.strategy, segment.Size())
+
 	return nil
 }
 
@@ -542,7 +548,15 @@ func (sg *SegmentGroup) getAndLockSegments() (segments []Segment, release func()
 	}
 }
 
-func (sg *SegmentGroup) addInitializedSegment(segment *segment) error {
+func (sg *SegmentGroup) addInitializedSegment(segment *segment) (err error) {
+	defer func() {
+		if err != nil {
+			return
+		}
+		sg.metrics.IncSegmentTotalByStrategy(sg.strategy)
+		sg.metrics.ObserveSegmentSize(sg.strategy, segment.Size())
+	}()
+
 	sg.cursorsLock.Lock()
 	defer sg.cursorsLock.Unlock()
 
@@ -555,6 +569,7 @@ func (sg *SegmentGroup) addInitializedSegment(segment *segment) error {
 	defer sg.maintenanceLock.Unlock()
 
 	sg.segments = append(sg.segments, segment)
+
 	return nil
 }
 

--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -213,7 +213,7 @@ func (c *segmentCleanerCommon) getSegmentIdsAndSizes() ([]int64, []int64, error)
 				return nil, nil, fmt.Errorf("parse segment id %q: %w", idStr, err)
 			}
 			ids[i] = id
-			sizes[i] = seg.getSize()
+			sizes[i] = seg.Size()
 		}
 	}
 

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -427,6 +427,9 @@ func (sg *SegmentGroup) replaceCompactedSegments(old1, old2 int,
 		}).Error("failed to delete file already marked for deletion")
 	}
 
+	sg.metrics.DecSegmentTotalByStrategy(sg.strategy)
+	sg.metrics.ObserveSegmentSize(sg.strategy, seg.Size())
+
 	return nil
 }
 

--- a/adapters/repos/db/lsmkv/segment_group_compaction_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction_test.go
@@ -2366,7 +2366,7 @@ func compactSegments(sg *SegmentGroup, pair []int, newLevel uint16, resizeFactor
 
 	seg := &segment{
 		path:             left.getPath() + "+" + right.getPath(),
-		size:             int64(float32(left.getSize()+right.getSize()) * resizeFactor),
+		size:             int64(float32(left.Size()+right.Size()) * resizeFactor),
 		level:            newLevel,
 		observeMetaWrite: func(n int64) {},
 	}


### PR DESCRIPTION
### What's being changed:

This pull request adds comprehensive Prometheus-based metrics for tracking the lifecycle of LSM bucket initialization and shutdown in the `lsmkv` package. It introduces new counters, gauges, and histograms to monitor bucket creation and shutdown events, their durations, failures, and in-progress operations, all labeled by segment strategy. The `Bucket` implementation is updated to increment, decrement, and observe these metrics at appropriate points in the lifecycle.

**Lifecycle Metrics Instrumentation:**

* Added new bucket lifecycle metrics (counters, gauges, histograms) to the `Metrics` struct in `metrics.go` for tracking initialization and shutdown counts, failures, durations, and in-progress operations, all labeled by strategy. [[1]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR31-R49) [[2]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR102-R208) [[3]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR390-R400)
* Implemented methods on the `Metrics` struct to increment, decrement, and observe these new metrics.

**Bucket Initialization and Shutdown Integration:**

* Updated the `NewBucket` and `Shutdown` methods in `bucket.go` to record metric events at the start, end, and failure points of initialization and shutdown, using `defer` to ensure proper metric handling. [[1]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28L192-R200) [[2]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28R232-R254) [[3]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28L1223-R1256)

These changes improve observability of bucket lifecycle events, making it easier to monitor and troubleshoot LSM bucket operations in production systems.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
