### PR TITLE
update: bump `go-swagger` version to `0.32.3` and generate code

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -8896,8 +8896,8 @@ func init() {
 }`))
 	FlatSwaggerJSON = json.RawMessage([]byte(`{
   "consumes": [
-    "application/json",
-    "application/yaml"
+    "application/yaml",
+    "application/json"
   ],
   "produces": [
     "application/json"

--- a/adapters/handlers/rest/operations/authz/add_permissions.go
+++ b/adapters/handlers/rest/operations/authz/add_permissions.go
@@ -63,7 +63,7 @@ func (o *AddPermissions) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if rCtx != nil {
 		*r = *rCtx
 	}
-	var Params = NewAddPermissionsParams()
+	Params := NewAddPermissionsParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -84,14 +84,12 @@ func (o *AddPermissions) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
-
 }
 
 // AddPermissionsBody add permissions body
 //
 // swagger:model AddPermissionsBody
 type AddPermissionsBody struct {
-
 	// permissions to be added to the role
 	// Required: true
 	Permissions []*models.Permission `json:"permissions" yaml:"permissions"`
@@ -112,7 +110,6 @@ func (o *AddPermissionsBody) Validate(formats strfmt.Registry) error {
 }
 
 func (o *AddPermissionsBody) validatePermissions(formats strfmt.Registry) error {
-
 	if err := validate.Required("body"+"."+"permissions", "body", o.Permissions); err != nil {
 		return err
 	}
@@ -153,10 +150,13 @@ func (o *AddPermissionsBody) ContextValidate(ctx context.Context, formats strfmt
 }
 
 func (o *AddPermissionsBody) contextValidatePermissions(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(o.Permissions); i++ {
-
 		if o.Permissions[i] != nil {
+
+			if swag.IsZero(o.Permissions[i]) { // not required
+				return nil
+			}
+
 			if err := o.Permissions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("body" + "." + "permissions" + "." + strconv.Itoa(i))
@@ -166,7 +166,6 @@ func (o *AddPermissionsBody) contextValidatePermissions(ctx context.Context, for
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/adapters/handlers/rest/operations/authz/assign_role_to_group.go
+++ b/adapters/handlers/rest/operations/authz/assign_role_to_group.go
@@ -61,7 +61,7 @@ func (o *AssignRoleToGroup) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if rCtx != nil {
 		*r = *rCtx
 	}
-	var Params = NewAssignRoleToGroupParams()
+	Params := NewAssignRoleToGroupParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -82,14 +82,12 @@ func (o *AssignRoleToGroup) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
-
 }
 
 // AssignRoleToGroupBody assign role to group body
 //
 // swagger:model AssignRoleToGroupBody
 type AssignRoleToGroupBody struct {
-
 	// group type
 	GroupType models.GroupType `json:"groupType,omitempty" yaml:"groupType,omitempty"`
 
@@ -143,6 +141,9 @@ func (o *AssignRoleToGroupBody) ContextValidate(ctx context.Context, formats str
 }
 
 func (o *AssignRoleToGroupBody) contextValidateGroupType(ctx context.Context, formats strfmt.Registry) error {
+	if swag.IsZero(o.GroupType) { // not required
+		return nil
+	}
 
 	if err := o.GroupType.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/adapters/handlers/rest/operations/authz/assign_role_to_user.go
+++ b/adapters/handlers/rest/operations/authz/assign_role_to_user.go
@@ -61,7 +61,7 @@ func (o *AssignRoleToUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if rCtx != nil {
 		*r = *rCtx
 	}
-	var Params = NewAssignRoleToUserParams()
+	Params := NewAssignRoleToUserParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -82,14 +82,12 @@ func (o *AssignRoleToUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
-
 }
 
 // AssignRoleToUserBody assign role to user body
 //
 // swagger:model AssignRoleToUserBody
 type AssignRoleToUserBody struct {
-
 	// the roles that assigned to user
 	Roles []string `json:"roles" yaml:"roles"`
 
@@ -143,6 +141,9 @@ func (o *AssignRoleToUserBody) ContextValidate(ctx context.Context, formats strf
 }
 
 func (o *AssignRoleToUserBody) contextValidateUserType(ctx context.Context, formats strfmt.Registry) error {
+	if swag.IsZero(o.UserType) { // not required
+		return nil
+	}
 
 	if err := o.UserType.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/adapters/handlers/rest/operations/authz/get_groups_for_role.go
+++ b/adapters/handlers/rest/operations/authz/get_groups_for_role.go
@@ -64,7 +64,7 @@ func (o *GetGroupsForRole) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if rCtx != nil {
 		*r = *rCtx
 	}
-	var Params = NewGetGroupsForRoleParams()
+	Params := NewGetGroupsForRoleParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -85,14 +85,12 @@ func (o *GetGroupsForRole) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
-
 }
 
 // GetGroupsForRoleOKBodyItems0 get groups for role o k body items0
 //
 // swagger:model GetGroupsForRoleOKBodyItems0
 type GetGroupsForRoleOKBodyItems0 struct {
-
 	// group Id
 	GroupID string `json:"groupId,omitempty" yaml:"groupId,omitempty"`
 
@@ -116,7 +114,6 @@ func (o *GetGroupsForRoleOKBodyItems0) Validate(formats strfmt.Registry) error {
 }
 
 func (o *GetGroupsForRoleOKBodyItems0) validateGroupType(formats strfmt.Registry) error {
-
 	if err := validate.Required("groupType", "body", o.GroupType); err != nil {
 		return err
 	}
@@ -154,7 +151,6 @@ func (o *GetGroupsForRoleOKBodyItems0) ContextValidate(ctx context.Context, form
 }
 
 func (o *GetGroupsForRoleOKBodyItems0) contextValidateGroupType(ctx context.Context, formats strfmt.Registry) error {
-
 	if o.GroupType != nil {
 		if err := o.GroupType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {

--- a/adapters/handlers/rest/operations/authz/get_users_for_role.go
+++ b/adapters/handlers/rest/operations/authz/get_users_for_role.go
@@ -62,7 +62,7 @@ func (o *GetUsersForRole) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if rCtx != nil {
 		*r = *rCtx
 	}
-	var Params = NewGetUsersForRoleParams()
+	Params := NewGetUsersForRoleParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -83,14 +83,12 @@ func (o *GetUsersForRole) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
-
 }
 
 // GetUsersForRoleOKBodyItems0 get users for role o k body items0
 //
 // swagger:model GetUsersForRoleOKBodyItems0
 type GetUsersForRoleOKBodyItems0 struct {
-
 	// user Id
 	UserID string `json:"userId,omitempty" yaml:"userId,omitempty"`
 
@@ -114,7 +112,6 @@ func (o *GetUsersForRoleOKBodyItems0) Validate(formats strfmt.Registry) error {
 }
 
 func (o *GetUsersForRoleOKBodyItems0) validateUserType(formats strfmt.Registry) error {
-
 	if err := validate.Required("userType", "body", o.UserType); err != nil {
 		return err
 	}
@@ -152,7 +149,6 @@ func (o *GetUsersForRoleOKBodyItems0) ContextValidate(ctx context.Context, forma
 }
 
 func (o *GetUsersForRoleOKBodyItems0) contextValidateUserType(ctx context.Context, formats strfmt.Registry) error {
-
 	if o.UserType != nil {
 		if err := o.UserType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {

--- a/adapters/handlers/rest/operations/authz/remove_permissions.go
+++ b/adapters/handlers/rest/operations/authz/remove_permissions.go
@@ -63,7 +63,7 @@ func (o *RemovePermissions) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if rCtx != nil {
 		*r = *rCtx
 	}
-	var Params = NewRemovePermissionsParams()
+	Params := NewRemovePermissionsParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -84,14 +84,12 @@ func (o *RemovePermissions) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
-
 }
 
 // RemovePermissionsBody remove permissions body
 //
 // swagger:model RemovePermissionsBody
 type RemovePermissionsBody struct {
-
 	// permissions to remove from the role
 	// Required: true
 	Permissions []*models.Permission `json:"permissions" yaml:"permissions"`
@@ -112,7 +110,6 @@ func (o *RemovePermissionsBody) Validate(formats strfmt.Registry) error {
 }
 
 func (o *RemovePermissionsBody) validatePermissions(formats strfmt.Registry) error {
-
 	if err := validate.Required("body"+"."+"permissions", "body", o.Permissions); err != nil {
 		return err
 	}
@@ -153,10 +150,13 @@ func (o *RemovePermissionsBody) ContextValidate(ctx context.Context, formats str
 }
 
 func (o *RemovePermissionsBody) contextValidatePermissions(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(o.Permissions); i++ {
-
 		if o.Permissions[i] != nil {
+
+			if swag.IsZero(o.Permissions[i]) { // not required
+				return nil
+			}
+
 			if err := o.Permissions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("body" + "." + "permissions" + "." + strconv.Itoa(i))
@@ -166,7 +166,6 @@ func (o *RemovePermissionsBody) contextValidatePermissions(ctx context.Context, 
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/adapters/handlers/rest/operations/authz/revoke_role_from_group.go
+++ b/adapters/handlers/rest/operations/authz/revoke_role_from_group.go
@@ -61,7 +61,7 @@ func (o *RevokeRoleFromGroup) ServeHTTP(rw http.ResponseWriter, r *http.Request)
 	if rCtx != nil {
 		*r = *rCtx
 	}
-	var Params = NewRevokeRoleFromGroupParams()
+	Params := NewRevokeRoleFromGroupParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -82,14 +82,12 @@ func (o *RevokeRoleFromGroup) ServeHTTP(rw http.ResponseWriter, r *http.Request)
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
-
 }
 
 // RevokeRoleFromGroupBody revoke role from group body
 //
 // swagger:model RevokeRoleFromGroupBody
 type RevokeRoleFromGroupBody struct {
-
 	// group type
 	GroupType models.GroupType `json:"groupType,omitempty" yaml:"groupType,omitempty"`
 
@@ -143,6 +141,9 @@ func (o *RevokeRoleFromGroupBody) ContextValidate(ctx context.Context, formats s
 }
 
 func (o *RevokeRoleFromGroupBody) contextValidateGroupType(ctx context.Context, formats strfmt.Registry) error {
+	if swag.IsZero(o.GroupType) { // not required
+		return nil
+	}
 
 	if err := o.GroupType.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/adapters/handlers/rest/operations/authz/revoke_role_from_user.go
+++ b/adapters/handlers/rest/operations/authz/revoke_role_from_user.go
@@ -61,7 +61,7 @@ func (o *RevokeRoleFromUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 	if rCtx != nil {
 		*r = *rCtx
 	}
-	var Params = NewRevokeRoleFromUserParams()
+	Params := NewRevokeRoleFromUserParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -82,14 +82,12 @@ func (o *RevokeRoleFromUser) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
-
 }
 
 // RevokeRoleFromUserBody revoke role from user body
 //
 // swagger:model RevokeRoleFromUserBody
 type RevokeRoleFromUserBody struct {
-
 	// the roles that revoked from the key or user
 	Roles []string `json:"roles" yaml:"roles"`
 
@@ -143,6 +141,9 @@ func (o *RevokeRoleFromUserBody) ContextValidate(ctx context.Context, formats st
 }
 
 func (o *RevokeRoleFromUserBody) contextValidateUserType(ctx context.Context, formats strfmt.Registry) error {
+	if swag.IsZero(o.UserType) { // not required
+		return nil
+	}
 
 	if err := o.UserType.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/adapters/handlers/rest/operations/batch/batch_objects_create.go
+++ b/adapters/handlers/rest/operations/batch/batch_objects_create.go
@@ -66,7 +66,7 @@ func (o *BatchObjectsCreate) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 	if rCtx != nil {
 		*r = *rCtx
 	}
-	var Params = NewBatchObjectsCreateParams()
+	Params := NewBatchObjectsCreateParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -87,14 +87,12 @@ func (o *BatchObjectsCreate) ServeHTTP(rw http.ResponseWriter, r *http.Request) 
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
-
 }
 
 // BatchObjectsCreateBody batch objects create body
 //
 // swagger:model BatchObjectsCreateBody
 type BatchObjectsCreateBody struct {
-
 	// Define which fields need to be returned. Default value is ALL
 	Fields []*string `json:"fields" yaml:"fields"`
 
@@ -200,10 +198,13 @@ func (o *BatchObjectsCreateBody) ContextValidate(ctx context.Context, formats st
 }
 
 func (o *BatchObjectsCreateBody) contextValidateObjects(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(o.Objects); i++ {
-
 		if o.Objects[i] != nil {
+
+			if swag.IsZero(o.Objects[i]) { // not required
+				return nil
+			}
+
 			if err := o.Objects[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("body" + "." + "objects" + "." + strconv.Itoa(i))
@@ -213,7 +214,6 @@ func (o *BatchObjectsCreateBody) contextValidateObjects(ctx context.Context, for
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/adapters/handlers/rest/operations/weaviate_api.go
+++ b/adapters/handlers/rest/operations/weaviate_api.go
@@ -996,7 +996,6 @@ func (o *WeaviateAPI) AuthenticatorsFor(schemes map[string]spec.SecurityScheme) 
 			result[name] = o.BearerAuthenticator(name, func(token string, scopes []string) (interface{}, error) {
 				return o.OidcAuth(token, scopes)
 			})
-
 		}
 	}
 	return result
@@ -1491,6 +1490,6 @@ func (o *WeaviateAPI) AddMiddlewareFor(method, path string, builder middleware.B
 	}
 	o.Init()
 	if h, ok := o.handlers[um][path]; ok {
-		o.handlers[method][path] = builder(h)
+		o.handlers[um][path] = builder(h)
 	}
 }

--- a/adapters/handlers/rest/operations/weaviate_root.go
+++ b/adapters/handlers/rest/operations/weaviate_root.go
@@ -64,7 +64,7 @@ func (o *WeaviateRoot) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if rCtx != nil {
 		*r = *rCtx
 	}
-	var Params = NewWeaviateRootParams()
+	Params := NewWeaviateRootParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -85,14 +85,12 @@ func (o *WeaviateRoot) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
-
 }
 
 // WeaviateRootOKBody weaviate root o k body
 //
 // swagger:model WeaviateRootOKBody
 type WeaviateRootOKBody struct {
-
 	// links
 	Links []*models.Link `json:"links" yaml:"links"`
 }
@@ -152,10 +150,13 @@ func (o *WeaviateRootOKBody) ContextValidate(ctx context.Context, formats strfmt
 }
 
 func (o *WeaviateRootOKBody) contextValidateLinks(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(o.Links); i++ {
-
 		if o.Links[i] != nil {
+
+			if swag.IsZero(o.Links[i]) { // not required
+				return nil
+			}
+
 			if err := o.Links[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("weaviateRootOK" + "." + "links" + "." + strconv.Itoa(i))
@@ -165,7 +166,6 @@ func (o *WeaviateRootOKBody) contextValidateLinks(ctx context.Context, formats s
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/adapters/handlers/rest/server.go
+++ b/adapters/handlers/rest/server.go
@@ -91,7 +91,7 @@ type Server struct {
 	ListenLimit  int           `long:"listen-limit" description:"limit the number of outstanding requests"`
 	KeepAlive    time.Duration `long:"keep-alive" description:"sets the TCP keep-alive timeouts on accepted connections. It prunes dead TCP connections ( e.g. closing laptop mid-download)" default:"3m"`
 	ReadTimeout  time.Duration `long:"read-timeout" description:"maximum duration before timing out read of the request" default:"30s"`
-	WriteTimeout time.Duration `long:"write-timeout" description:"maximum duration before timing out write of the response" default:"60s"`
+	WriteTimeout time.Duration `long:"write-timeout" description:"maximum duration before timing out write of the response" default:"30s"`
 	httpServerL  net.Listener
 
 	TLSHost           string         `long:"tls-host" description:"the IP to listen on for tls, when not specified it's the same as --host" env:"TLS_HOST"`

--- a/client/authz/add_permissions_responses.go
+++ b/client/authz/add_permissions_responses.go
@@ -18,6 +18,7 @@ package authz
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -82,7 +83,7 @@ func (o *AddPermissionsReader) ReadResponse(response runtime.ClientResponse, con
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /authz/roles/{id}/add-permissions] addPermissions", response, response.Code())
 	}
 }
 
@@ -96,8 +97,7 @@ AddPermissionsOK describes a response with status code 200, with default header 
 
 Permissions added successfully
 */
-type AddPermissionsOK struct {
-}
+type AddPermissionsOK struct{}
 
 // IsSuccess returns true when this add permissions o k response has a 2xx status code
 func (o *AddPermissionsOK) IsSuccess() bool {
@@ -130,15 +130,14 @@ func (o *AddPermissionsOK) Code() int {
 }
 
 func (o *AddPermissionsOK) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsOK ", 200)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsOK", 200)
 }
 
 func (o *AddPermissionsOK) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsOK ", 200)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsOK", 200)
 }
 
 func (o *AddPermissionsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -187,11 +186,13 @@ func (o *AddPermissionsBadRequest) Code() int {
 }
 
 func (o *AddPermissionsBadRequest) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsBadRequest %s", 400, payload)
 }
 
 func (o *AddPermissionsBadRequest) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsBadRequest %s", 400, payload)
 }
 
 func (o *AddPermissionsBadRequest) GetPayload() *models.ErrorResponse {
@@ -199,7 +200,6 @@ func (o *AddPermissionsBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AddPermissionsBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -220,8 +220,7 @@ AddPermissionsUnauthorized describes a response with status code 401, with defau
 
 Unauthorized or invalid credentials.
 */
-type AddPermissionsUnauthorized struct {
-}
+type AddPermissionsUnauthorized struct{}
 
 // IsSuccess returns true when this add permissions unauthorized response has a 2xx status code
 func (o *AddPermissionsUnauthorized) IsSuccess() bool {
@@ -254,15 +253,14 @@ func (o *AddPermissionsUnauthorized) Code() int {
 }
 
 func (o *AddPermissionsUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsUnauthorized", 401)
 }
 
 func (o *AddPermissionsUnauthorized) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsUnauthorized", 401)
 }
 
 func (o *AddPermissionsUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -311,11 +309,13 @@ func (o *AddPermissionsForbidden) Code() int {
 }
 
 func (o *AddPermissionsForbidden) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsForbidden %s", 403, payload)
 }
 
 func (o *AddPermissionsForbidden) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsForbidden %s", 403, payload)
 }
 
 func (o *AddPermissionsForbidden) GetPayload() *models.ErrorResponse {
@@ -323,7 +323,6 @@ func (o *AddPermissionsForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AddPermissionsForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -344,8 +343,7 @@ AddPermissionsNotFound describes a response with status code 404, with default h
 
 no role found
 */
-type AddPermissionsNotFound struct {
-}
+type AddPermissionsNotFound struct{}
 
 // IsSuccess returns true when this add permissions not found response has a 2xx status code
 func (o *AddPermissionsNotFound) IsSuccess() bool {
@@ -378,15 +376,14 @@ func (o *AddPermissionsNotFound) Code() int {
 }
 
 func (o *AddPermissionsNotFound) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsNotFound ", 404)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsNotFound", 404)
 }
 
 func (o *AddPermissionsNotFound) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsNotFound ", 404)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsNotFound", 404)
 }
 
 func (o *AddPermissionsNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -435,11 +432,13 @@ func (o *AddPermissionsUnprocessableEntity) Code() int {
 }
 
 func (o *AddPermissionsUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *AddPermissionsUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *AddPermissionsUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -447,7 +446,6 @@ func (o *AddPermissionsUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AddPermissionsUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -503,11 +501,13 @@ func (o *AddPermissionsInternalServerError) Code() int {
 }
 
 func (o *AddPermissionsInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsInternalServerError %s", 500, payload)
 }
 
 func (o *AddPermissionsInternalServerError) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/add-permissions][%d] addPermissionsInternalServerError %s", 500, payload)
 }
 
 func (o *AddPermissionsInternalServerError) GetPayload() *models.ErrorResponse {
@@ -515,7 +515,6 @@ func (o *AddPermissionsInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AddPermissionsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -531,7 +530,6 @@ AddPermissionsBody add permissions body
 swagger:model AddPermissionsBody
 */
 type AddPermissionsBody struct {
-
 	// permissions to be added to the role
 	// Required: true
 	Permissions []*models.Permission `json:"permissions"`
@@ -552,7 +550,6 @@ func (o *AddPermissionsBody) Validate(formats strfmt.Registry) error {
 }
 
 func (o *AddPermissionsBody) validatePermissions(formats strfmt.Registry) error {
-
 	if err := validate.Required("body"+"."+"permissions", "body", o.Permissions); err != nil {
 		return err
 	}
@@ -593,10 +590,13 @@ func (o *AddPermissionsBody) ContextValidate(ctx context.Context, formats strfmt
 }
 
 func (o *AddPermissionsBody) contextValidatePermissions(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(o.Permissions); i++ {
-
 		if o.Permissions[i] != nil {
+
+			if swag.IsZero(o.Permissions[i]) { // not required
+				return nil
+			}
+
 			if err := o.Permissions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("body" + "." + "permissions" + "." + strconv.Itoa(i))
@@ -606,7 +606,6 @@ func (o *AddPermissionsBody) contextValidatePermissions(ctx context.Context, for
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/client/authz/assign_role_to_group_responses.go
+++ b/client/authz/assign_role_to_group_responses.go
@@ -18,6 +18,7 @@ package authz
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -74,7 +75,7 @@ func (o *AssignRoleToGroupReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /authz/groups/{id}/assign] assignRoleToGroup", response, response.Code())
 	}
 }
 
@@ -88,8 +89,7 @@ AssignRoleToGroupOK describes a response with status code 200, with default head
 
 Role assigned successfully
 */
-type AssignRoleToGroupOK struct {
-}
+type AssignRoleToGroupOK struct{}
 
 // IsSuccess returns true when this assign role to group o k response has a 2xx status code
 func (o *AssignRoleToGroupOK) IsSuccess() bool {
@@ -122,15 +122,14 @@ func (o *AssignRoleToGroupOK) Code() int {
 }
 
 func (o *AssignRoleToGroupOK) Error() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupOK ", 200)
+	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupOK", 200)
 }
 
 func (o *AssignRoleToGroupOK) String() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupOK ", 200)
+	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupOK", 200)
 }
 
 func (o *AssignRoleToGroupOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -179,11 +178,13 @@ func (o *AssignRoleToGroupBadRequest) Code() int {
 }
 
 func (o *AssignRoleToGroupBadRequest) Error() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupBadRequest %s", 400, payload)
 }
 
 func (o *AssignRoleToGroupBadRequest) String() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupBadRequest %s", 400, payload)
 }
 
 func (o *AssignRoleToGroupBadRequest) GetPayload() *models.ErrorResponse {
@@ -191,7 +192,6 @@ func (o *AssignRoleToGroupBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AssignRoleToGroupBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -212,8 +212,7 @@ AssignRoleToGroupUnauthorized describes a response with status code 401, with de
 
 Unauthorized or invalid credentials.
 */
-type AssignRoleToGroupUnauthorized struct {
-}
+type AssignRoleToGroupUnauthorized struct{}
 
 // IsSuccess returns true when this assign role to group unauthorized response has a 2xx status code
 func (o *AssignRoleToGroupUnauthorized) IsSuccess() bool {
@@ -246,15 +245,14 @@ func (o *AssignRoleToGroupUnauthorized) Code() int {
 }
 
 func (o *AssignRoleToGroupUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupUnauthorized", 401)
 }
 
 func (o *AssignRoleToGroupUnauthorized) String() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupUnauthorized", 401)
 }
 
 func (o *AssignRoleToGroupUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -303,11 +301,13 @@ func (o *AssignRoleToGroupForbidden) Code() int {
 }
 
 func (o *AssignRoleToGroupForbidden) Error() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupForbidden %s", 403, payload)
 }
 
 func (o *AssignRoleToGroupForbidden) String() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupForbidden %s", 403, payload)
 }
 
 func (o *AssignRoleToGroupForbidden) GetPayload() *models.ErrorResponse {
@@ -315,7 +315,6 @@ func (o *AssignRoleToGroupForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AssignRoleToGroupForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -336,8 +335,7 @@ AssignRoleToGroupNotFound describes a response with status code 404, with defaul
 
 role or group is not found.
 */
-type AssignRoleToGroupNotFound struct {
-}
+type AssignRoleToGroupNotFound struct{}
 
 // IsSuccess returns true when this assign role to group not found response has a 2xx status code
 func (o *AssignRoleToGroupNotFound) IsSuccess() bool {
@@ -370,15 +368,14 @@ func (o *AssignRoleToGroupNotFound) Code() int {
 }
 
 func (o *AssignRoleToGroupNotFound) Error() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupNotFound ", 404)
+	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupNotFound", 404)
 }
 
 func (o *AssignRoleToGroupNotFound) String() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupNotFound ", 404)
+	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupNotFound", 404)
 }
 
 func (o *AssignRoleToGroupNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -427,11 +424,13 @@ func (o *AssignRoleToGroupInternalServerError) Code() int {
 }
 
 func (o *AssignRoleToGroupInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupInternalServerError %s", 500, payload)
 }
 
 func (o *AssignRoleToGroupInternalServerError) String() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/groups/{id}/assign][%d] assignRoleToGroupInternalServerError %s", 500, payload)
 }
 
 func (o *AssignRoleToGroupInternalServerError) GetPayload() *models.ErrorResponse {
@@ -439,7 +438,6 @@ func (o *AssignRoleToGroupInternalServerError) GetPayload() *models.ErrorRespons
 }
 
 func (o *AssignRoleToGroupInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -455,7 +453,6 @@ AssignRoleToGroupBody assign role to group body
 swagger:model AssignRoleToGroupBody
 */
 type AssignRoleToGroupBody struct {
-
 	// group type
 	GroupType models.GroupType `json:"groupType,omitempty"`
 
@@ -509,6 +506,9 @@ func (o *AssignRoleToGroupBody) ContextValidate(ctx context.Context, formats str
 }
 
 func (o *AssignRoleToGroupBody) contextValidateGroupType(ctx context.Context, formats strfmt.Registry) error {
+	if swag.IsZero(o.GroupType) { // not required
+		return nil
+	}
 
 	if err := o.GroupType.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/client/authz/assign_role_to_user_responses.go
+++ b/client/authz/assign_role_to_user_responses.go
@@ -18,6 +18,7 @@ package authz
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -74,7 +75,7 @@ func (o *AssignRoleToUserReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /authz/users/{id}/assign] assignRoleToUser", response, response.Code())
 	}
 }
 
@@ -88,8 +89,7 @@ AssignRoleToUserOK describes a response with status code 200, with default heade
 
 Role assigned successfully
 */
-type AssignRoleToUserOK struct {
-}
+type AssignRoleToUserOK struct{}
 
 // IsSuccess returns true when this assign role to user o k response has a 2xx status code
 func (o *AssignRoleToUserOK) IsSuccess() bool {
@@ -122,15 +122,14 @@ func (o *AssignRoleToUserOK) Code() int {
 }
 
 func (o *AssignRoleToUserOK) Error() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserOK ", 200)
+	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserOK", 200)
 }
 
 func (o *AssignRoleToUserOK) String() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserOK ", 200)
+	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserOK", 200)
 }
 
 func (o *AssignRoleToUserOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -179,11 +178,13 @@ func (o *AssignRoleToUserBadRequest) Code() int {
 }
 
 func (o *AssignRoleToUserBadRequest) Error() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserBadRequest %s", 400, payload)
 }
 
 func (o *AssignRoleToUserBadRequest) String() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserBadRequest %s", 400, payload)
 }
 
 func (o *AssignRoleToUserBadRequest) GetPayload() *models.ErrorResponse {
@@ -191,7 +192,6 @@ func (o *AssignRoleToUserBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AssignRoleToUserBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -212,8 +212,7 @@ AssignRoleToUserUnauthorized describes a response with status code 401, with def
 
 Unauthorized or invalid credentials.
 */
-type AssignRoleToUserUnauthorized struct {
-}
+type AssignRoleToUserUnauthorized struct{}
 
 // IsSuccess returns true when this assign role to user unauthorized response has a 2xx status code
 func (o *AssignRoleToUserUnauthorized) IsSuccess() bool {
@@ -246,15 +245,14 @@ func (o *AssignRoleToUserUnauthorized) Code() int {
 }
 
 func (o *AssignRoleToUserUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserUnauthorized", 401)
 }
 
 func (o *AssignRoleToUserUnauthorized) String() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserUnauthorized", 401)
 }
 
 func (o *AssignRoleToUserUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -303,11 +301,13 @@ func (o *AssignRoleToUserForbidden) Code() int {
 }
 
 func (o *AssignRoleToUserForbidden) Error() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserForbidden %s", 403, payload)
 }
 
 func (o *AssignRoleToUserForbidden) String() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserForbidden %s", 403, payload)
 }
 
 func (o *AssignRoleToUserForbidden) GetPayload() *models.ErrorResponse {
@@ -315,7 +315,6 @@ func (o *AssignRoleToUserForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AssignRoleToUserForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -371,11 +370,13 @@ func (o *AssignRoleToUserNotFound) Code() int {
 }
 
 func (o *AssignRoleToUserNotFound) Error() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserNotFound %s", 404, payload)
 }
 
 func (o *AssignRoleToUserNotFound) String() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserNotFound %s", 404, payload)
 }
 
 func (o *AssignRoleToUserNotFound) GetPayload() *models.ErrorResponse {
@@ -383,7 +384,6 @@ func (o *AssignRoleToUserNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AssignRoleToUserNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -439,11 +439,13 @@ func (o *AssignRoleToUserInternalServerError) Code() int {
 }
 
 func (o *AssignRoleToUserInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserInternalServerError %s", 500, payload)
 }
 
 func (o *AssignRoleToUserInternalServerError) String() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/assign][%d] assignRoleToUserInternalServerError %s", 500, payload)
 }
 
 func (o *AssignRoleToUserInternalServerError) GetPayload() *models.ErrorResponse {
@@ -451,7 +453,6 @@ func (o *AssignRoleToUserInternalServerError) GetPayload() *models.ErrorResponse
 }
 
 func (o *AssignRoleToUserInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -467,7 +468,6 @@ AssignRoleToUserBody assign role to user body
 swagger:model AssignRoleToUserBody
 */
 type AssignRoleToUserBody struct {
-
 	// the roles that assigned to user
 	Roles []string `json:"roles"`
 
@@ -521,6 +521,9 @@ func (o *AssignRoleToUserBody) ContextValidate(ctx context.Context, formats strf
 }
 
 func (o *AssignRoleToUserBody) contextValidateUserType(ctx context.Context, formats strfmt.Registry) error {
+	if swag.IsZero(o.UserType) { // not required
+		return nil
+	}
 
 	if err := o.UserType.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/client/authz/authz_client.go
+++ b/client/authz/authz_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new authz API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new authz API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new authz API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -93,7 +143,7 @@ func (a *Client) AddPermissions(params *AddPermissionsParams, authInfo runtime.C
 		Method:             "POST",
 		PathPattern:        "/authz/roles/{id}/add-permissions",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &AddPermissionsReader{formats: a.formats},
@@ -132,7 +182,7 @@ func (a *Client) AssignRoleToGroup(params *AssignRoleToGroupParams, authInfo run
 		Method:             "POST",
 		PathPattern:        "/authz/groups/{id}/assign",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &AssignRoleToGroupReader{formats: a.formats},
@@ -171,7 +221,7 @@ func (a *Client) AssignRoleToUser(params *AssignRoleToUserParams, authInfo runti
 		Method:             "POST",
 		PathPattern:        "/authz/users/{id}/assign",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &AssignRoleToUserReader{formats: a.formats},
@@ -210,7 +260,7 @@ func (a *Client) CreateRole(params *CreateRoleParams, authInfo runtime.ClientAut
 		Method:             "POST",
 		PathPattern:        "/authz/roles",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &CreateRoleReader{formats: a.formats},
@@ -249,7 +299,7 @@ func (a *Client) DeleteRole(params *DeleteRoleParams, authInfo runtime.ClientAut
 		Method:             "DELETE",
 		PathPattern:        "/authz/roles/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &DeleteRoleReader{formats: a.formats},
@@ -290,7 +340,7 @@ func (a *Client) GetGroups(params *GetGroupsParams, authInfo runtime.ClientAuthI
 		Method:             "GET",
 		PathPattern:        "/authz/groups/{groupType}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetGroupsReader{formats: a.formats},
@@ -331,7 +381,7 @@ func (a *Client) GetGroupsForRole(params *GetGroupsForRoleParams, authInfo runti
 		Method:             "GET",
 		PathPattern:        "/authz/roles/{id}/group-assignments",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetGroupsForRoleReader{formats: a.formats},
@@ -370,7 +420,7 @@ func (a *Client) GetRole(params *GetRoleParams, authInfo runtime.ClientAuthInfoW
 		Method:             "GET",
 		PathPattern:        "/authz/roles/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetRoleReader{formats: a.formats},
@@ -409,7 +459,7 @@ func (a *Client) GetRoles(params *GetRolesParams, authInfo runtime.ClientAuthInf
 		Method:             "GET",
 		PathPattern:        "/authz/roles",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetRolesReader{formats: a.formats},
@@ -450,7 +500,7 @@ func (a *Client) GetRolesForGroup(params *GetRolesForGroupParams, authInfo runti
 		Method:             "GET",
 		PathPattern:        "/authz/groups/{id}/roles/{groupType}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetRolesForGroupReader{formats: a.formats},
@@ -489,7 +539,7 @@ func (a *Client) GetRolesForUser(params *GetRolesForUserParams, authInfo runtime
 		Method:             "GET",
 		PathPattern:        "/authz/users/{id}/roles/{userType}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetRolesForUserReader{formats: a.formats},
@@ -528,7 +578,7 @@ func (a *Client) GetRolesForUserDeprecated(params *GetRolesForUserDeprecatedPara
 		Method:             "GET",
 		PathPattern:        "/authz/users/{id}/roles",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetRolesForUserDeprecatedReader{formats: a.formats},
@@ -567,7 +617,7 @@ func (a *Client) GetUsersForRole(params *GetUsersForRoleParams, authInfo runtime
 		Method:             "GET",
 		PathPattern:        "/authz/roles/{id}/user-assignments",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetUsersForRoleReader{formats: a.formats},
@@ -606,7 +656,7 @@ func (a *Client) GetUsersForRoleDeprecated(params *GetUsersForRoleDeprecatedPara
 		Method:             "GET",
 		PathPattern:        "/authz/roles/{id}/users",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetUsersForRoleDeprecatedReader{formats: a.formats},
@@ -645,7 +695,7 @@ func (a *Client) HasPermission(params *HasPermissionParams, authInfo runtime.Cli
 		Method:             "POST",
 		PathPattern:        "/authz/roles/{id}/has-permission",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &HasPermissionReader{formats: a.formats},
@@ -684,7 +734,7 @@ func (a *Client) RemovePermissions(params *RemovePermissionsParams, authInfo run
 		Method:             "POST",
 		PathPattern:        "/authz/roles/{id}/remove-permissions",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &RemovePermissionsReader{formats: a.formats},
@@ -723,7 +773,7 @@ func (a *Client) RevokeRoleFromGroup(params *RevokeRoleFromGroupParams, authInfo
 		Method:             "POST",
 		PathPattern:        "/authz/groups/{id}/revoke",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &RevokeRoleFromGroupReader{formats: a.formats},
@@ -762,7 +812,7 @@ func (a *Client) RevokeRoleFromUser(params *RevokeRoleFromUserParams, authInfo r
 		Method:             "POST",
 		PathPattern:        "/authz/users/{id}/revoke",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &RevokeRoleFromUserReader{formats: a.formats},

--- a/client/authz/create_role_responses.go
+++ b/client/authz/create_role_responses.go
@@ -17,6 +17,7 @@ package authz
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *CreateRoleReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /authz/roles] createRole", response, response.Code())
 	}
 }
 
@@ -91,8 +92,7 @@ CreateRoleCreated describes a response with status code 201, with default header
 
 Role created successfully
 */
-type CreateRoleCreated struct {
-}
+type CreateRoleCreated struct{}
 
 // IsSuccess returns true when this create role created response has a 2xx status code
 func (o *CreateRoleCreated) IsSuccess() bool {
@@ -125,15 +125,14 @@ func (o *CreateRoleCreated) Code() int {
 }
 
 func (o *CreateRoleCreated) Error() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleCreated ", 201)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleCreated", 201)
 }
 
 func (o *CreateRoleCreated) String() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleCreated ", 201)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleCreated", 201)
 }
 
 func (o *CreateRoleCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -182,11 +181,13 @@ func (o *CreateRoleBadRequest) Code() int {
 }
 
 func (o *CreateRoleBadRequest) Error() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleBadRequest %s", 400, payload)
 }
 
 func (o *CreateRoleBadRequest) String() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleBadRequest %s", 400, payload)
 }
 
 func (o *CreateRoleBadRequest) GetPayload() *models.ErrorResponse {
@@ -194,7 +195,6 @@ func (o *CreateRoleBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateRoleBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -215,8 +215,7 @@ CreateRoleUnauthorized describes a response with status code 401, with default h
 
 Unauthorized or invalid credentials.
 */
-type CreateRoleUnauthorized struct {
-}
+type CreateRoleUnauthorized struct{}
 
 // IsSuccess returns true when this create role unauthorized response has a 2xx status code
 func (o *CreateRoleUnauthorized) IsSuccess() bool {
@@ -249,15 +248,14 @@ func (o *CreateRoleUnauthorized) Code() int {
 }
 
 func (o *CreateRoleUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleUnauthorized", 401)
 }
 
 func (o *CreateRoleUnauthorized) String() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleUnauthorized", 401)
 }
 
 func (o *CreateRoleUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -306,11 +304,13 @@ func (o *CreateRoleForbidden) Code() int {
 }
 
 func (o *CreateRoleForbidden) Error() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleForbidden %s", 403, payload)
 }
 
 func (o *CreateRoleForbidden) String() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleForbidden %s", 403, payload)
 }
 
 func (o *CreateRoleForbidden) GetPayload() *models.ErrorResponse {
@@ -318,7 +318,6 @@ func (o *CreateRoleForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateRoleForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -374,11 +373,13 @@ func (o *CreateRoleConflict) Code() int {
 }
 
 func (o *CreateRoleConflict) Error() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleConflict  %+v", 409, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleConflict %s", 409, payload)
 }
 
 func (o *CreateRoleConflict) String() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleConflict  %+v", 409, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleConflict %s", 409, payload)
 }
 
 func (o *CreateRoleConflict) GetPayload() *models.ErrorResponse {
@@ -386,7 +387,6 @@ func (o *CreateRoleConflict) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateRoleConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -442,11 +442,13 @@ func (o *CreateRoleUnprocessableEntity) Code() int {
 }
 
 func (o *CreateRoleUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleUnprocessableEntity %s", 422, payload)
 }
 
 func (o *CreateRoleUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleUnprocessableEntity %s", 422, payload)
 }
 
 func (o *CreateRoleUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -454,7 +456,6 @@ func (o *CreateRoleUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateRoleUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -510,11 +511,13 @@ func (o *CreateRoleInternalServerError) Code() int {
 }
 
 func (o *CreateRoleInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleInternalServerError %s", 500, payload)
 }
 
 func (o *CreateRoleInternalServerError) String() string {
-	return fmt.Sprintf("[POST /authz/roles][%d] createRoleInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles][%d] createRoleInternalServerError %s", 500, payload)
 }
 
 func (o *CreateRoleInternalServerError) GetPayload() *models.ErrorResponse {
@@ -522,7 +525,6 @@ func (o *CreateRoleInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateRoleInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/authz/delete_role_responses.go
+++ b/client/authz/delete_role_responses.go
@@ -17,6 +17,7 @@ package authz
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *DeleteRoleReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /authz/roles/{id}] deleteRole", response, response.Code())
 	}
 }
 
@@ -79,8 +80,7 @@ DeleteRoleNoContent describes a response with status code 204, with default head
 
 Successfully deleted.
 */
-type DeleteRoleNoContent struct {
-}
+type DeleteRoleNoContent struct{}
 
 // IsSuccess returns true when this delete role no content response has a 2xx status code
 func (o *DeleteRoleNoContent) IsSuccess() bool {
@@ -113,15 +113,14 @@ func (o *DeleteRoleNoContent) Code() int {
 }
 
 func (o *DeleteRoleNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleNoContent ", 204)
+	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleNoContent", 204)
 }
 
 func (o *DeleteRoleNoContent) String() string {
-	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleNoContent ", 204)
+	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleNoContent", 204)
 }
 
 func (o *DeleteRoleNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -170,11 +169,13 @@ func (o *DeleteRoleBadRequest) Code() int {
 }
 
 func (o *DeleteRoleBadRequest) Error() string {
-	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleBadRequest %s", 400, payload)
 }
 
 func (o *DeleteRoleBadRequest) String() string {
-	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleBadRequest %s", 400, payload)
 }
 
 func (o *DeleteRoleBadRequest) GetPayload() *models.ErrorResponse {
@@ -182,7 +183,6 @@ func (o *DeleteRoleBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeleteRoleBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -203,8 +203,7 @@ DeleteRoleUnauthorized describes a response with status code 401, with default h
 
 Unauthorized or invalid credentials.
 */
-type DeleteRoleUnauthorized struct {
-}
+type DeleteRoleUnauthorized struct{}
 
 // IsSuccess returns true when this delete role unauthorized response has a 2xx status code
 func (o *DeleteRoleUnauthorized) IsSuccess() bool {
@@ -237,15 +236,14 @@ func (o *DeleteRoleUnauthorized) Code() int {
 }
 
 func (o *DeleteRoleUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleUnauthorized", 401)
 }
 
 func (o *DeleteRoleUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleUnauthorized", 401)
 }
 
 func (o *DeleteRoleUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -294,11 +292,13 @@ func (o *DeleteRoleForbidden) Code() int {
 }
 
 func (o *DeleteRoleForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleForbidden %s", 403, payload)
 }
 
 func (o *DeleteRoleForbidden) String() string {
-	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleForbidden %s", 403, payload)
 }
 
 func (o *DeleteRoleForbidden) GetPayload() *models.ErrorResponse {
@@ -306,7 +306,6 @@ func (o *DeleteRoleForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeleteRoleForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -362,11 +361,13 @@ func (o *DeleteRoleInternalServerError) Code() int {
 }
 
 func (o *DeleteRoleInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleInternalServerError %s", 500, payload)
 }
 
 func (o *DeleteRoleInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /authz/roles/{id}][%d] deleteRoleInternalServerError %s", 500, payload)
 }
 
 func (o *DeleteRoleInternalServerError) GetPayload() *models.ErrorResponse {
@@ -374,7 +375,6 @@ func (o *DeleteRoleInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeleteRoleInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/authz/get_groups_for_role_responses.go
+++ b/client/authz/get_groups_for_role_responses.go
@@ -18,6 +18,7 @@ package authz
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -75,7 +76,7 @@ func (o *GetGroupsForRoleReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /authz/roles/{id}/group-assignments] getGroupsForRole", response, response.Code())
 	}
 }
 
@@ -124,11 +125,13 @@ func (o *GetGroupsForRoleOK) Code() int {
 }
 
 func (o *GetGroupsForRoleOK) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleOK %s", 200, payload)
 }
 
 func (o *GetGroupsForRoleOK) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleOK %s", 200, payload)
 }
 
 func (o *GetGroupsForRoleOK) GetPayload() []*GetGroupsForRoleOKBodyItems0 {
@@ -136,7 +139,6 @@ func (o *GetGroupsForRoleOK) GetPayload() []*GetGroupsForRoleOKBodyItems0 {
 }
 
 func (o *GetGroupsForRoleOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -190,11 +192,13 @@ func (o *GetGroupsForRoleBadRequest) Code() int {
 }
 
 func (o *GetGroupsForRoleBadRequest) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleBadRequest %s", 400, payload)
 }
 
 func (o *GetGroupsForRoleBadRequest) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleBadRequest %s", 400, payload)
 }
 
 func (o *GetGroupsForRoleBadRequest) GetPayload() *models.ErrorResponse {
@@ -202,7 +206,6 @@ func (o *GetGroupsForRoleBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetGroupsForRoleBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -223,8 +226,7 @@ GetGroupsForRoleUnauthorized describes a response with status code 401, with def
 
 Unauthorized or invalid credentials.
 */
-type GetGroupsForRoleUnauthorized struct {
-}
+type GetGroupsForRoleUnauthorized struct{}
 
 // IsSuccess returns true when this get groups for role unauthorized response has a 2xx status code
 func (o *GetGroupsForRoleUnauthorized) IsSuccess() bool {
@@ -257,15 +259,14 @@ func (o *GetGroupsForRoleUnauthorized) Code() int {
 }
 
 func (o *GetGroupsForRoleUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleUnauthorized", 401)
 }
 
 func (o *GetGroupsForRoleUnauthorized) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleUnauthorized", 401)
 }
 
 func (o *GetGroupsForRoleUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -314,11 +315,13 @@ func (o *GetGroupsForRoleForbidden) Code() int {
 }
 
 func (o *GetGroupsForRoleForbidden) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleForbidden %s", 403, payload)
 }
 
 func (o *GetGroupsForRoleForbidden) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleForbidden %s", 403, payload)
 }
 
 func (o *GetGroupsForRoleForbidden) GetPayload() *models.ErrorResponse {
@@ -326,7 +329,6 @@ func (o *GetGroupsForRoleForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetGroupsForRoleForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -347,8 +349,7 @@ GetGroupsForRoleNotFound describes a response with status code 404, with default
 
 The specified role was not found.
 */
-type GetGroupsForRoleNotFound struct {
-}
+type GetGroupsForRoleNotFound struct{}
 
 // IsSuccess returns true when this get groups for role not found response has a 2xx status code
 func (o *GetGroupsForRoleNotFound) IsSuccess() bool {
@@ -381,15 +382,14 @@ func (o *GetGroupsForRoleNotFound) Code() int {
 }
 
 func (o *GetGroupsForRoleNotFound) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleNotFound", 404)
 }
 
 func (o *GetGroupsForRoleNotFound) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleNotFound", 404)
 }
 
 func (o *GetGroupsForRoleNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -438,11 +438,13 @@ func (o *GetGroupsForRoleInternalServerError) Code() int {
 }
 
 func (o *GetGroupsForRoleInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleInternalServerError %s", 500, payload)
 }
 
 func (o *GetGroupsForRoleInternalServerError) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/group-assignments][%d] getGroupsForRoleInternalServerError %s", 500, payload)
 }
 
 func (o *GetGroupsForRoleInternalServerError) GetPayload() *models.ErrorResponse {
@@ -450,7 +452,6 @@ func (o *GetGroupsForRoleInternalServerError) GetPayload() *models.ErrorResponse
 }
 
 func (o *GetGroupsForRoleInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -466,7 +467,6 @@ GetGroupsForRoleOKBodyItems0 get groups for role o k body items0
 swagger:model GetGroupsForRoleOKBodyItems0
 */
 type GetGroupsForRoleOKBodyItems0 struct {
-
 	// group Id
 	GroupID string `json:"groupId,omitempty"`
 
@@ -490,7 +490,6 @@ func (o *GetGroupsForRoleOKBodyItems0) Validate(formats strfmt.Registry) error {
 }
 
 func (o *GetGroupsForRoleOKBodyItems0) validateGroupType(formats strfmt.Registry) error {
-
 	if err := validate.Required("groupType", "body", o.GroupType); err != nil {
 		return err
 	}
@@ -528,7 +527,6 @@ func (o *GetGroupsForRoleOKBodyItems0) ContextValidate(ctx context.Context, form
 }
 
 func (o *GetGroupsForRoleOKBodyItems0) contextValidateGroupType(ctx context.Context, formats strfmt.Registry) error {
-
 	if o.GroupType != nil {
 		if err := o.GroupType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {

--- a/client/authz/get_groups_responses.go
+++ b/client/authz/get_groups_responses.go
@@ -17,6 +17,7 @@ package authz
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *GetGroupsReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /authz/groups/{groupType}] getGroups", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *GetGroupsOK) Code() int {
 }
 
 func (o *GetGroupsOK) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsOK %s", 200, payload)
 }
 
 func (o *GetGroupsOK) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsOK %s", 200, payload)
 }
 
 func (o *GetGroupsOK) GetPayload() []string {
@@ -132,7 +135,6 @@ func (o *GetGroupsOK) GetPayload() []string {
 }
 
 func (o *GetGroupsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -186,11 +188,13 @@ func (o *GetGroupsBadRequest) Code() int {
 }
 
 func (o *GetGroupsBadRequest) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsBadRequest %s", 400, payload)
 }
 
 func (o *GetGroupsBadRequest) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsBadRequest %s", 400, payload)
 }
 
 func (o *GetGroupsBadRequest) GetPayload() *models.ErrorResponse {
@@ -198,7 +202,6 @@ func (o *GetGroupsBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetGroupsBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -219,8 +222,7 @@ GetGroupsUnauthorized describes a response with status code 401, with default he
 
 Unauthorized or invalid credentials.
 */
-type GetGroupsUnauthorized struct {
-}
+type GetGroupsUnauthorized struct{}
 
 // IsSuccess returns true when this get groups unauthorized response has a 2xx status code
 func (o *GetGroupsUnauthorized) IsSuccess() bool {
@@ -253,15 +255,14 @@ func (o *GetGroupsUnauthorized) Code() int {
 }
 
 func (o *GetGroupsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsUnauthorized", 401)
 }
 
 func (o *GetGroupsUnauthorized) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsUnauthorized", 401)
 }
 
 func (o *GetGroupsUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -310,11 +311,13 @@ func (o *GetGroupsForbidden) Code() int {
 }
 
 func (o *GetGroupsForbidden) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsForbidden %s", 403, payload)
 }
 
 func (o *GetGroupsForbidden) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsForbidden %s", 403, payload)
 }
 
 func (o *GetGroupsForbidden) GetPayload() *models.ErrorResponse {
@@ -322,7 +325,6 @@ func (o *GetGroupsForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetGroupsForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -378,11 +380,13 @@ func (o *GetGroupsUnprocessableEntity) Code() int {
 }
 
 func (o *GetGroupsUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GetGroupsUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GetGroupsUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -390,7 +394,6 @@ func (o *GetGroupsUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetGroupsUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -446,11 +449,13 @@ func (o *GetGroupsInternalServerError) Code() int {
 }
 
 func (o *GetGroupsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsInternalServerError %s", 500, payload)
 }
 
 func (o *GetGroupsInternalServerError) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{groupType}][%d] getGroupsInternalServerError %s", 500, payload)
 }
 
 func (o *GetGroupsInternalServerError) GetPayload() *models.ErrorResponse {
@@ -458,7 +463,6 @@ func (o *GetGroupsInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetGroupsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/authz/get_role_responses.go
+++ b/client/authz/get_role_responses.go
@@ -17,6 +17,7 @@ package authz
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *GetRoleReader) ReadResponse(response runtime.ClientResponse, consumer r
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /authz/roles/{id}] getRole", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *GetRoleOK) Code() int {
 }
 
 func (o *GetRoleOK) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleOK %s", 200, payload)
 }
 
 func (o *GetRoleOK) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleOK %s", 200, payload)
 }
 
 func (o *GetRoleOK) GetPayload() *models.Role {
@@ -132,7 +135,6 @@ func (o *GetRoleOK) GetPayload() *models.Role {
 }
 
 func (o *GetRoleOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Role)
 
 	// response payload
@@ -188,11 +190,13 @@ func (o *GetRoleBadRequest) Code() int {
 }
 
 func (o *GetRoleBadRequest) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleBadRequest %s", 400, payload)
 }
 
 func (o *GetRoleBadRequest) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleBadRequest %s", 400, payload)
 }
 
 func (o *GetRoleBadRequest) GetPayload() *models.ErrorResponse {
@@ -200,7 +204,6 @@ func (o *GetRoleBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetRoleBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -221,8 +224,7 @@ GetRoleUnauthorized describes a response with status code 401, with default head
 
 Unauthorized or invalid credentials.
 */
-type GetRoleUnauthorized struct {
-}
+type GetRoleUnauthorized struct{}
 
 // IsSuccess returns true when this get role unauthorized response has a 2xx status code
 func (o *GetRoleUnauthorized) IsSuccess() bool {
@@ -255,15 +257,14 @@ func (o *GetRoleUnauthorized) Code() int {
 }
 
 func (o *GetRoleUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleUnauthorized", 401)
 }
 
 func (o *GetRoleUnauthorized) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleUnauthorized", 401)
 }
 
 func (o *GetRoleUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -312,11 +313,13 @@ func (o *GetRoleForbidden) Code() int {
 }
 
 func (o *GetRoleForbidden) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleForbidden %s", 403, payload)
 }
 
 func (o *GetRoleForbidden) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleForbidden %s", 403, payload)
 }
 
 func (o *GetRoleForbidden) GetPayload() *models.ErrorResponse {
@@ -324,7 +327,6 @@ func (o *GetRoleForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetRoleForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -345,8 +347,7 @@ GetRoleNotFound describes a response with status code 404, with default header v
 
 no role found
 */
-type GetRoleNotFound struct {
-}
+type GetRoleNotFound struct{}
 
 // IsSuccess returns true when this get role not found response has a 2xx status code
 func (o *GetRoleNotFound) IsSuccess() bool {
@@ -379,15 +380,14 @@ func (o *GetRoleNotFound) Code() int {
 }
 
 func (o *GetRoleNotFound) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleNotFound", 404)
 }
 
 func (o *GetRoleNotFound) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleNotFound", 404)
 }
 
 func (o *GetRoleNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -436,11 +436,13 @@ func (o *GetRoleInternalServerError) Code() int {
 }
 
 func (o *GetRoleInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleInternalServerError %s", 500, payload)
 }
 
 func (o *GetRoleInternalServerError) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}][%d] getRoleInternalServerError %s", 500, payload)
 }
 
 func (o *GetRoleInternalServerError) GetPayload() *models.ErrorResponse {
@@ -448,7 +450,6 @@ func (o *GetRoleInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetRoleInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/authz/get_roles_for_group_responses.go
+++ b/client/authz/get_roles_for_group_responses.go
@@ -17,6 +17,7 @@ package authz
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *GetRolesForGroupReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /authz/groups/{id}/roles/{groupType}] getRolesForGroup", response, response.Code())
 	}
 }
 
@@ -126,11 +127,13 @@ func (o *GetRolesForGroupOK) Code() int {
 }
 
 func (o *GetRolesForGroupOK) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupOK %s", 200, payload)
 }
 
 func (o *GetRolesForGroupOK) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupOK %s", 200, payload)
 }
 
 func (o *GetRolesForGroupOK) GetPayload() models.RolesListResponse {
@@ -138,7 +141,6 @@ func (o *GetRolesForGroupOK) GetPayload() models.RolesListResponse {
 }
 
 func (o *GetRolesForGroupOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -192,11 +194,13 @@ func (o *GetRolesForGroupBadRequest) Code() int {
 }
 
 func (o *GetRolesForGroupBadRequest) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupBadRequest %s", 400, payload)
 }
 
 func (o *GetRolesForGroupBadRequest) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupBadRequest %s", 400, payload)
 }
 
 func (o *GetRolesForGroupBadRequest) GetPayload() *models.ErrorResponse {
@@ -204,7 +208,6 @@ func (o *GetRolesForGroupBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetRolesForGroupBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -225,8 +228,7 @@ GetRolesForGroupUnauthorized describes a response with status code 401, with def
 
 Unauthorized or invalid credentials.
 */
-type GetRolesForGroupUnauthorized struct {
-}
+type GetRolesForGroupUnauthorized struct{}
 
 // IsSuccess returns true when this get roles for group unauthorized response has a 2xx status code
 func (o *GetRolesForGroupUnauthorized) IsSuccess() bool {
@@ -259,15 +261,14 @@ func (o *GetRolesForGroupUnauthorized) Code() int {
 }
 
 func (o *GetRolesForGroupUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupUnauthorized", 401)
 }
 
 func (o *GetRolesForGroupUnauthorized) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupUnauthorized", 401)
 }
 
 func (o *GetRolesForGroupUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -316,11 +317,13 @@ func (o *GetRolesForGroupForbidden) Code() int {
 }
 
 func (o *GetRolesForGroupForbidden) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupForbidden %s", 403, payload)
 }
 
 func (o *GetRolesForGroupForbidden) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupForbidden %s", 403, payload)
 }
 
 func (o *GetRolesForGroupForbidden) GetPayload() *models.ErrorResponse {
@@ -328,7 +331,6 @@ func (o *GetRolesForGroupForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetRolesForGroupForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -349,8 +351,7 @@ GetRolesForGroupNotFound describes a response with status code 404, with default
 
 The specified group was not found.
 */
-type GetRolesForGroupNotFound struct {
-}
+type GetRolesForGroupNotFound struct{}
 
 // IsSuccess returns true when this get roles for group not found response has a 2xx status code
 func (o *GetRolesForGroupNotFound) IsSuccess() bool {
@@ -383,15 +384,14 @@ func (o *GetRolesForGroupNotFound) Code() int {
 }
 
 func (o *GetRolesForGroupNotFound) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupNotFound", 404)
 }
 
 func (o *GetRolesForGroupNotFound) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupNotFound", 404)
 }
 
 func (o *GetRolesForGroupNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -440,11 +440,13 @@ func (o *GetRolesForGroupUnprocessableEntity) Code() int {
 }
 
 func (o *GetRolesForGroupUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GetRolesForGroupUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GetRolesForGroupUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -452,7 +454,6 @@ func (o *GetRolesForGroupUnprocessableEntity) GetPayload() *models.ErrorResponse
 }
 
 func (o *GetRolesForGroupUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -508,11 +509,13 @@ func (o *GetRolesForGroupInternalServerError) Code() int {
 }
 
 func (o *GetRolesForGroupInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupInternalServerError %s", 500, payload)
 }
 
 func (o *GetRolesForGroupInternalServerError) String() string {
-	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/groups/{id}/roles/{groupType}][%d] getRolesForGroupInternalServerError %s", 500, payload)
 }
 
 func (o *GetRolesForGroupInternalServerError) GetPayload() *models.ErrorResponse {
@@ -520,7 +523,6 @@ func (o *GetRolesForGroupInternalServerError) GetPayload() *models.ErrorResponse
 }
 
 func (o *GetRolesForGroupInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/authz/get_roles_for_user_deprecated_responses.go
+++ b/client/authz/get_roles_for_user_deprecated_responses.go
@@ -17,6 +17,7 @@ package authz
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *GetRolesForUserDeprecatedReader) ReadResponse(response runtime.ClientRe
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /authz/users/{id}/roles] getRolesForUserDeprecated", response, response.Code())
 	}
 }
 
@@ -126,11 +127,13 @@ func (o *GetRolesForUserDeprecatedOK) Code() int {
 }
 
 func (o *GetRolesForUserDeprecatedOK) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedOK %s", 200, payload)
 }
 
 func (o *GetRolesForUserDeprecatedOK) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedOK %s", 200, payload)
 }
 
 func (o *GetRolesForUserDeprecatedOK) GetPayload() models.RolesListResponse {
@@ -138,7 +141,6 @@ func (o *GetRolesForUserDeprecatedOK) GetPayload() models.RolesListResponse {
 }
 
 func (o *GetRolesForUserDeprecatedOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -192,11 +194,13 @@ func (o *GetRolesForUserDeprecatedBadRequest) Code() int {
 }
 
 func (o *GetRolesForUserDeprecatedBadRequest) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedBadRequest %s", 400, payload)
 }
 
 func (o *GetRolesForUserDeprecatedBadRequest) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedBadRequest %s", 400, payload)
 }
 
 func (o *GetRolesForUserDeprecatedBadRequest) GetPayload() *models.ErrorResponse {
@@ -204,7 +208,6 @@ func (o *GetRolesForUserDeprecatedBadRequest) GetPayload() *models.ErrorResponse
 }
 
 func (o *GetRolesForUserDeprecatedBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -225,8 +228,7 @@ GetRolesForUserDeprecatedUnauthorized describes a response with status code 401,
 
 Unauthorized or invalid credentials.
 */
-type GetRolesForUserDeprecatedUnauthorized struct {
-}
+type GetRolesForUserDeprecatedUnauthorized struct{}
 
 // IsSuccess returns true when this get roles for user deprecated unauthorized response has a 2xx status code
 func (o *GetRolesForUserDeprecatedUnauthorized) IsSuccess() bool {
@@ -259,15 +261,14 @@ func (o *GetRolesForUserDeprecatedUnauthorized) Code() int {
 }
 
 func (o *GetRolesForUserDeprecatedUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedUnauthorized", 401)
 }
 
 func (o *GetRolesForUserDeprecatedUnauthorized) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedUnauthorized", 401)
 }
 
 func (o *GetRolesForUserDeprecatedUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -316,11 +317,13 @@ func (o *GetRolesForUserDeprecatedForbidden) Code() int {
 }
 
 func (o *GetRolesForUserDeprecatedForbidden) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedForbidden %s", 403, payload)
 }
 
 func (o *GetRolesForUserDeprecatedForbidden) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedForbidden %s", 403, payload)
 }
 
 func (o *GetRolesForUserDeprecatedForbidden) GetPayload() *models.ErrorResponse {
@@ -328,7 +331,6 @@ func (o *GetRolesForUserDeprecatedForbidden) GetPayload() *models.ErrorResponse 
 }
 
 func (o *GetRolesForUserDeprecatedForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -349,8 +351,7 @@ GetRolesForUserDeprecatedNotFound describes a response with status code 404, wit
 
 no role found for user
 */
-type GetRolesForUserDeprecatedNotFound struct {
-}
+type GetRolesForUserDeprecatedNotFound struct{}
 
 // IsSuccess returns true when this get roles for user deprecated not found response has a 2xx status code
 func (o *GetRolesForUserDeprecatedNotFound) IsSuccess() bool {
@@ -383,15 +384,14 @@ func (o *GetRolesForUserDeprecatedNotFound) Code() int {
 }
 
 func (o *GetRolesForUserDeprecatedNotFound) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedNotFound", 404)
 }
 
 func (o *GetRolesForUserDeprecatedNotFound) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedNotFound", 404)
 }
 
 func (o *GetRolesForUserDeprecatedNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -440,11 +440,13 @@ func (o *GetRolesForUserDeprecatedUnprocessableEntity) Code() int {
 }
 
 func (o *GetRolesForUserDeprecatedUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GetRolesForUserDeprecatedUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GetRolesForUserDeprecatedUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -452,7 +454,6 @@ func (o *GetRolesForUserDeprecatedUnprocessableEntity) GetPayload() *models.Erro
 }
 
 func (o *GetRolesForUserDeprecatedUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -508,11 +509,13 @@ func (o *GetRolesForUserDeprecatedInternalServerError) Code() int {
 }
 
 func (o *GetRolesForUserDeprecatedInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedInternalServerError %s", 500, payload)
 }
 
 func (o *GetRolesForUserDeprecatedInternalServerError) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles][%d] getRolesForUserDeprecatedInternalServerError %s", 500, payload)
 }
 
 func (o *GetRolesForUserDeprecatedInternalServerError) GetPayload() *models.ErrorResponse {
@@ -520,7 +523,6 @@ func (o *GetRolesForUserDeprecatedInternalServerError) GetPayload() *models.Erro
 }
 
 func (o *GetRolesForUserDeprecatedInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/authz/get_roles_for_user_responses.go
+++ b/client/authz/get_roles_for_user_responses.go
@@ -17,6 +17,7 @@ package authz
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *GetRolesForUserReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /authz/users/{id}/roles/{userType}] getRolesForUser", response, response.Code())
 	}
 }
 
@@ -126,11 +127,13 @@ func (o *GetRolesForUserOK) Code() int {
 }
 
 func (o *GetRolesForUserOK) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserOK %s", 200, payload)
 }
 
 func (o *GetRolesForUserOK) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserOK %s", 200, payload)
 }
 
 func (o *GetRolesForUserOK) GetPayload() models.RolesListResponse {
@@ -138,7 +141,6 @@ func (o *GetRolesForUserOK) GetPayload() models.RolesListResponse {
 }
 
 func (o *GetRolesForUserOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -192,11 +194,13 @@ func (o *GetRolesForUserBadRequest) Code() int {
 }
 
 func (o *GetRolesForUserBadRequest) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserBadRequest %s", 400, payload)
 }
 
 func (o *GetRolesForUserBadRequest) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserBadRequest %s", 400, payload)
 }
 
 func (o *GetRolesForUserBadRequest) GetPayload() *models.ErrorResponse {
@@ -204,7 +208,6 @@ func (o *GetRolesForUserBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetRolesForUserBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -225,8 +228,7 @@ GetRolesForUserUnauthorized describes a response with status code 401, with defa
 
 Unauthorized or invalid credentials.
 */
-type GetRolesForUserUnauthorized struct {
-}
+type GetRolesForUserUnauthorized struct{}
 
 // IsSuccess returns true when this get roles for user unauthorized response has a 2xx status code
 func (o *GetRolesForUserUnauthorized) IsSuccess() bool {
@@ -259,15 +261,14 @@ func (o *GetRolesForUserUnauthorized) Code() int {
 }
 
 func (o *GetRolesForUserUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserUnauthorized", 401)
 }
 
 func (o *GetRolesForUserUnauthorized) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserUnauthorized", 401)
 }
 
 func (o *GetRolesForUserUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -316,11 +317,13 @@ func (o *GetRolesForUserForbidden) Code() int {
 }
 
 func (o *GetRolesForUserForbidden) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserForbidden %s", 403, payload)
 }
 
 func (o *GetRolesForUserForbidden) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserForbidden %s", 403, payload)
 }
 
 func (o *GetRolesForUserForbidden) GetPayload() *models.ErrorResponse {
@@ -328,7 +331,6 @@ func (o *GetRolesForUserForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetRolesForUserForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -349,8 +351,7 @@ GetRolesForUserNotFound describes a response with status code 404, with default 
 
 no role found for user
 */
-type GetRolesForUserNotFound struct {
-}
+type GetRolesForUserNotFound struct{}
 
 // IsSuccess returns true when this get roles for user not found response has a 2xx status code
 func (o *GetRolesForUserNotFound) IsSuccess() bool {
@@ -383,15 +384,14 @@ func (o *GetRolesForUserNotFound) Code() int {
 }
 
 func (o *GetRolesForUserNotFound) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserNotFound", 404)
 }
 
 func (o *GetRolesForUserNotFound) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserNotFound", 404)
 }
 
 func (o *GetRolesForUserNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -440,11 +440,13 @@ func (o *GetRolesForUserUnprocessableEntity) Code() int {
 }
 
 func (o *GetRolesForUserUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GetRolesForUserUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GetRolesForUserUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -452,7 +454,6 @@ func (o *GetRolesForUserUnprocessableEntity) GetPayload() *models.ErrorResponse 
 }
 
 func (o *GetRolesForUserUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -508,11 +509,13 @@ func (o *GetRolesForUserInternalServerError) Code() int {
 }
 
 func (o *GetRolesForUserInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserInternalServerError %s", 500, payload)
 }
 
 func (o *GetRolesForUserInternalServerError) String() string {
-	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/users/{id}/roles/{userType}][%d] getRolesForUserInternalServerError %s", 500, payload)
 }
 
 func (o *GetRolesForUserInternalServerError) GetPayload() *models.ErrorResponse {
@@ -520,7 +523,6 @@ func (o *GetRolesForUserInternalServerError) GetPayload() *models.ErrorResponse 
 }
 
 func (o *GetRolesForUserInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/authz/get_roles_responses.go
+++ b/client/authz/get_roles_responses.go
@@ -17,6 +17,7 @@ package authz
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *GetRolesReader) ReadResponse(response runtime.ClientResponse, consumer 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /authz/roles] getRoles", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *GetRolesOK) Code() int {
 }
 
 func (o *GetRolesOK) Error() string {
-	return fmt.Sprintf("[GET /authz/roles][%d] getRolesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles][%d] getRolesOK %s", 200, payload)
 }
 
 func (o *GetRolesOK) String() string {
-	return fmt.Sprintf("[GET /authz/roles][%d] getRolesOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles][%d] getRolesOK %s", 200, payload)
 }
 
 func (o *GetRolesOK) GetPayload() models.RolesListResponse {
@@ -126,7 +129,6 @@ func (o *GetRolesOK) GetPayload() models.RolesListResponse {
 }
 
 func (o *GetRolesOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -180,11 +182,13 @@ func (o *GetRolesBadRequest) Code() int {
 }
 
 func (o *GetRolesBadRequest) Error() string {
-	return fmt.Sprintf("[GET /authz/roles][%d] getRolesBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles][%d] getRolesBadRequest %s", 400, payload)
 }
 
 func (o *GetRolesBadRequest) String() string {
-	return fmt.Sprintf("[GET /authz/roles][%d] getRolesBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles][%d] getRolesBadRequest %s", 400, payload)
 }
 
 func (o *GetRolesBadRequest) GetPayload() *models.ErrorResponse {
@@ -192,7 +196,6 @@ func (o *GetRolesBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetRolesBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -213,8 +216,7 @@ GetRolesUnauthorized describes a response with status code 401, with default hea
 
 Unauthorized or invalid credentials.
 */
-type GetRolesUnauthorized struct {
-}
+type GetRolesUnauthorized struct{}
 
 // IsSuccess returns true when this get roles unauthorized response has a 2xx status code
 func (o *GetRolesUnauthorized) IsSuccess() bool {
@@ -247,15 +249,14 @@ func (o *GetRolesUnauthorized) Code() int {
 }
 
 func (o *GetRolesUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /authz/roles][%d] getRolesUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/roles][%d] getRolesUnauthorized", 401)
 }
 
 func (o *GetRolesUnauthorized) String() string {
-	return fmt.Sprintf("[GET /authz/roles][%d] getRolesUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/roles][%d] getRolesUnauthorized", 401)
 }
 
 func (o *GetRolesUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -304,11 +305,13 @@ func (o *GetRolesForbidden) Code() int {
 }
 
 func (o *GetRolesForbidden) Error() string {
-	return fmt.Sprintf("[GET /authz/roles][%d] getRolesForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles][%d] getRolesForbidden %s", 403, payload)
 }
 
 func (o *GetRolesForbidden) String() string {
-	return fmt.Sprintf("[GET /authz/roles][%d] getRolesForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles][%d] getRolesForbidden %s", 403, payload)
 }
 
 func (o *GetRolesForbidden) GetPayload() *models.ErrorResponse {
@@ -316,7 +319,6 @@ func (o *GetRolesForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetRolesForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -372,11 +374,13 @@ func (o *GetRolesInternalServerError) Code() int {
 }
 
 func (o *GetRolesInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /authz/roles][%d] getRolesInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles][%d] getRolesInternalServerError %s", 500, payload)
 }
 
 func (o *GetRolesInternalServerError) String() string {
-	return fmt.Sprintf("[GET /authz/roles][%d] getRolesInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles][%d] getRolesInternalServerError %s", 500, payload)
 }
 
 func (o *GetRolesInternalServerError) GetPayload() *models.ErrorResponse {
@@ -384,7 +388,6 @@ func (o *GetRolesInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetRolesInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/authz/get_users_for_role_deprecated_responses.go
+++ b/client/authz/get_users_for_role_deprecated_responses.go
@@ -17,6 +17,7 @@ package authz
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *GetUsersForRoleDeprecatedReader) ReadResponse(response runtime.ClientRe
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /authz/roles/{id}/users] getUsersForRoleDeprecated", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *GetUsersForRoleDeprecatedOK) Code() int {
 }
 
 func (o *GetUsersForRoleDeprecatedOK) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedOK %s", 200, payload)
 }
 
 func (o *GetUsersForRoleDeprecatedOK) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedOK %s", 200, payload)
 }
 
 func (o *GetUsersForRoleDeprecatedOK) GetPayload() []string {
@@ -132,7 +135,6 @@ func (o *GetUsersForRoleDeprecatedOK) GetPayload() []string {
 }
 
 func (o *GetUsersForRoleDeprecatedOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -186,11 +188,13 @@ func (o *GetUsersForRoleDeprecatedBadRequest) Code() int {
 }
 
 func (o *GetUsersForRoleDeprecatedBadRequest) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedBadRequest %s", 400, payload)
 }
 
 func (o *GetUsersForRoleDeprecatedBadRequest) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedBadRequest %s", 400, payload)
 }
 
 func (o *GetUsersForRoleDeprecatedBadRequest) GetPayload() *models.ErrorResponse {
@@ -198,7 +202,6 @@ func (o *GetUsersForRoleDeprecatedBadRequest) GetPayload() *models.ErrorResponse
 }
 
 func (o *GetUsersForRoleDeprecatedBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -219,8 +222,7 @@ GetUsersForRoleDeprecatedUnauthorized describes a response with status code 401,
 
 Unauthorized or invalid credentials.
 */
-type GetUsersForRoleDeprecatedUnauthorized struct {
-}
+type GetUsersForRoleDeprecatedUnauthorized struct{}
 
 // IsSuccess returns true when this get users for role deprecated unauthorized response has a 2xx status code
 func (o *GetUsersForRoleDeprecatedUnauthorized) IsSuccess() bool {
@@ -253,15 +255,14 @@ func (o *GetUsersForRoleDeprecatedUnauthorized) Code() int {
 }
 
 func (o *GetUsersForRoleDeprecatedUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedUnauthorized", 401)
 }
 
 func (o *GetUsersForRoleDeprecatedUnauthorized) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedUnauthorized", 401)
 }
 
 func (o *GetUsersForRoleDeprecatedUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -310,11 +311,13 @@ func (o *GetUsersForRoleDeprecatedForbidden) Code() int {
 }
 
 func (o *GetUsersForRoleDeprecatedForbidden) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedForbidden %s", 403, payload)
 }
 
 func (o *GetUsersForRoleDeprecatedForbidden) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedForbidden %s", 403, payload)
 }
 
 func (o *GetUsersForRoleDeprecatedForbidden) GetPayload() *models.ErrorResponse {
@@ -322,7 +325,6 @@ func (o *GetUsersForRoleDeprecatedForbidden) GetPayload() *models.ErrorResponse 
 }
 
 func (o *GetUsersForRoleDeprecatedForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -343,8 +345,7 @@ GetUsersForRoleDeprecatedNotFound describes a response with status code 404, wit
 
 no role found
 */
-type GetUsersForRoleDeprecatedNotFound struct {
-}
+type GetUsersForRoleDeprecatedNotFound struct{}
 
 // IsSuccess returns true when this get users for role deprecated not found response has a 2xx status code
 func (o *GetUsersForRoleDeprecatedNotFound) IsSuccess() bool {
@@ -377,15 +378,14 @@ func (o *GetUsersForRoleDeprecatedNotFound) Code() int {
 }
 
 func (o *GetUsersForRoleDeprecatedNotFound) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedNotFound", 404)
 }
 
 func (o *GetUsersForRoleDeprecatedNotFound) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedNotFound", 404)
 }
 
 func (o *GetUsersForRoleDeprecatedNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -434,11 +434,13 @@ func (o *GetUsersForRoleDeprecatedInternalServerError) Code() int {
 }
 
 func (o *GetUsersForRoleDeprecatedInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedInternalServerError %s", 500, payload)
 }
 
 func (o *GetUsersForRoleDeprecatedInternalServerError) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/users][%d] getUsersForRoleDeprecatedInternalServerError %s", 500, payload)
 }
 
 func (o *GetUsersForRoleDeprecatedInternalServerError) GetPayload() *models.ErrorResponse {
@@ -446,7 +448,6 @@ func (o *GetUsersForRoleDeprecatedInternalServerError) GetPayload() *models.Erro
 }
 
 func (o *GetUsersForRoleDeprecatedInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/authz/get_users_for_role_responses.go
+++ b/client/authz/get_users_for_role_responses.go
@@ -18,6 +18,7 @@ package authz
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -75,7 +76,7 @@ func (o *GetUsersForRoleReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /authz/roles/{id}/user-assignments] getUsersForRole", response, response.Code())
 	}
 }
 
@@ -124,11 +125,13 @@ func (o *GetUsersForRoleOK) Code() int {
 }
 
 func (o *GetUsersForRoleOK) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleOK %s", 200, payload)
 }
 
 func (o *GetUsersForRoleOK) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleOK %s", 200, payload)
 }
 
 func (o *GetUsersForRoleOK) GetPayload() []*GetUsersForRoleOKBodyItems0 {
@@ -136,7 +139,6 @@ func (o *GetUsersForRoleOK) GetPayload() []*GetUsersForRoleOKBodyItems0 {
 }
 
 func (o *GetUsersForRoleOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -190,11 +192,13 @@ func (o *GetUsersForRoleBadRequest) Code() int {
 }
 
 func (o *GetUsersForRoleBadRequest) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleBadRequest %s", 400, payload)
 }
 
 func (o *GetUsersForRoleBadRequest) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleBadRequest %s", 400, payload)
 }
 
 func (o *GetUsersForRoleBadRequest) GetPayload() *models.ErrorResponse {
@@ -202,7 +206,6 @@ func (o *GetUsersForRoleBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetUsersForRoleBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -223,8 +226,7 @@ GetUsersForRoleUnauthorized describes a response with status code 401, with defa
 
 Unauthorized or invalid credentials.
 */
-type GetUsersForRoleUnauthorized struct {
-}
+type GetUsersForRoleUnauthorized struct{}
 
 // IsSuccess returns true when this get users for role unauthorized response has a 2xx status code
 func (o *GetUsersForRoleUnauthorized) IsSuccess() bool {
@@ -257,15 +259,14 @@ func (o *GetUsersForRoleUnauthorized) Code() int {
 }
 
 func (o *GetUsersForRoleUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleUnauthorized", 401)
 }
 
 func (o *GetUsersForRoleUnauthorized) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleUnauthorized ", 401)
+	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleUnauthorized", 401)
 }
 
 func (o *GetUsersForRoleUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -314,11 +315,13 @@ func (o *GetUsersForRoleForbidden) Code() int {
 }
 
 func (o *GetUsersForRoleForbidden) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleForbidden %s", 403, payload)
 }
 
 func (o *GetUsersForRoleForbidden) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleForbidden %s", 403, payload)
 }
 
 func (o *GetUsersForRoleForbidden) GetPayload() *models.ErrorResponse {
@@ -326,7 +329,6 @@ func (o *GetUsersForRoleForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetUsersForRoleForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -347,8 +349,7 @@ GetUsersForRoleNotFound describes a response with status code 404, with default 
 
 no role found
 */
-type GetUsersForRoleNotFound struct {
-}
+type GetUsersForRoleNotFound struct{}
 
 // IsSuccess returns true when this get users for role not found response has a 2xx status code
 func (o *GetUsersForRoleNotFound) IsSuccess() bool {
@@ -381,15 +382,14 @@ func (o *GetUsersForRoleNotFound) Code() int {
 }
 
 func (o *GetUsersForRoleNotFound) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleNotFound", 404)
 }
 
 func (o *GetUsersForRoleNotFound) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleNotFound ", 404)
+	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleNotFound", 404)
 }
 
 func (o *GetUsersForRoleNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -438,11 +438,13 @@ func (o *GetUsersForRoleInternalServerError) Code() int {
 }
 
 func (o *GetUsersForRoleInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleInternalServerError %s", 500, payload)
 }
 
 func (o *GetUsersForRoleInternalServerError) String() string {
-	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /authz/roles/{id}/user-assignments][%d] getUsersForRoleInternalServerError %s", 500, payload)
 }
 
 func (o *GetUsersForRoleInternalServerError) GetPayload() *models.ErrorResponse {
@@ -450,7 +452,6 @@ func (o *GetUsersForRoleInternalServerError) GetPayload() *models.ErrorResponse 
 }
 
 func (o *GetUsersForRoleInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -466,7 +467,6 @@ GetUsersForRoleOKBodyItems0 get users for role o k body items0
 swagger:model GetUsersForRoleOKBodyItems0
 */
 type GetUsersForRoleOKBodyItems0 struct {
-
 	// user Id
 	UserID string `json:"userId,omitempty"`
 
@@ -490,7 +490,6 @@ func (o *GetUsersForRoleOKBodyItems0) Validate(formats strfmt.Registry) error {
 }
 
 func (o *GetUsersForRoleOKBodyItems0) validateUserType(formats strfmt.Registry) error {
-
 	if err := validate.Required("userType", "body", o.UserType); err != nil {
 		return err
 	}
@@ -528,7 +527,6 @@ func (o *GetUsersForRoleOKBodyItems0) ContextValidate(ctx context.Context, forma
 }
 
 func (o *GetUsersForRoleOKBodyItems0) contextValidateUserType(ctx context.Context, formats strfmt.Registry) error {
-
 	if o.UserType != nil {
 		if err := o.UserType.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {

--- a/client/authz/has_permission_responses.go
+++ b/client/authz/has_permission_responses.go
@@ -17,6 +17,7 @@ package authz
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *HasPermissionReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /authz/roles/{id}/has-permission] hasPermission", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *HasPermissionOK) Code() int {
 }
 
 func (o *HasPermissionOK) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionOK %s", 200, payload)
 }
 
 func (o *HasPermissionOK) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionOK %s", 200, payload)
 }
 
 func (o *HasPermissionOK) GetPayload() bool {
@@ -132,7 +135,6 @@ func (o *HasPermissionOK) GetPayload() bool {
 }
 
 func (o *HasPermissionOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -186,11 +188,13 @@ func (o *HasPermissionBadRequest) Code() int {
 }
 
 func (o *HasPermissionBadRequest) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionBadRequest %s", 400, payload)
 }
 
 func (o *HasPermissionBadRequest) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionBadRequest %s", 400, payload)
 }
 
 func (o *HasPermissionBadRequest) GetPayload() *models.ErrorResponse {
@@ -198,7 +202,6 @@ func (o *HasPermissionBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *HasPermissionBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -219,8 +222,7 @@ HasPermissionUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type HasPermissionUnauthorized struct {
-}
+type HasPermissionUnauthorized struct{}
 
 // IsSuccess returns true when this has permission unauthorized response has a 2xx status code
 func (o *HasPermissionUnauthorized) IsSuccess() bool {
@@ -253,15 +255,14 @@ func (o *HasPermissionUnauthorized) Code() int {
 }
 
 func (o *HasPermissionUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionUnauthorized", 401)
 }
 
 func (o *HasPermissionUnauthorized) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionUnauthorized", 401)
 }
 
 func (o *HasPermissionUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -310,11 +311,13 @@ func (o *HasPermissionForbidden) Code() int {
 }
 
 func (o *HasPermissionForbidden) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionForbidden %s", 403, payload)
 }
 
 func (o *HasPermissionForbidden) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionForbidden %s", 403, payload)
 }
 
 func (o *HasPermissionForbidden) GetPayload() *models.ErrorResponse {
@@ -322,7 +325,6 @@ func (o *HasPermissionForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *HasPermissionForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -378,11 +380,13 @@ func (o *HasPermissionUnprocessableEntity) Code() int {
 }
 
 func (o *HasPermissionUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionUnprocessableEntity %s", 422, payload)
 }
 
 func (o *HasPermissionUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionUnprocessableEntity %s", 422, payload)
 }
 
 func (o *HasPermissionUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -390,7 +394,6 @@ func (o *HasPermissionUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *HasPermissionUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -446,11 +449,13 @@ func (o *HasPermissionInternalServerError) Code() int {
 }
 
 func (o *HasPermissionInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionInternalServerError %s", 500, payload)
 }
 
 func (o *HasPermissionInternalServerError) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/has-permission][%d] hasPermissionInternalServerError %s", 500, payload)
 }
 
 func (o *HasPermissionInternalServerError) GetPayload() *models.ErrorResponse {
@@ -458,7 +463,6 @@ func (o *HasPermissionInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *HasPermissionInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/authz/remove_permissions_responses.go
+++ b/client/authz/remove_permissions_responses.go
@@ -18,6 +18,7 @@ package authz
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -82,7 +83,7 @@ func (o *RemovePermissionsReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /authz/roles/{id}/remove-permissions] removePermissions", response, response.Code())
 	}
 }
 
@@ -96,8 +97,7 @@ RemovePermissionsOK describes a response with status code 200, with default head
 
 Permissions removed successfully
 */
-type RemovePermissionsOK struct {
-}
+type RemovePermissionsOK struct{}
 
 // IsSuccess returns true when this remove permissions o k response has a 2xx status code
 func (o *RemovePermissionsOK) IsSuccess() bool {
@@ -130,15 +130,14 @@ func (o *RemovePermissionsOK) Code() int {
 }
 
 func (o *RemovePermissionsOK) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsOK ", 200)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsOK", 200)
 }
 
 func (o *RemovePermissionsOK) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsOK ", 200)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsOK", 200)
 }
 
 func (o *RemovePermissionsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -187,11 +186,13 @@ func (o *RemovePermissionsBadRequest) Code() int {
 }
 
 func (o *RemovePermissionsBadRequest) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsBadRequest %s", 400, payload)
 }
 
 func (o *RemovePermissionsBadRequest) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsBadRequest %s", 400, payload)
 }
 
 func (o *RemovePermissionsBadRequest) GetPayload() *models.ErrorResponse {
@@ -199,7 +200,6 @@ func (o *RemovePermissionsBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *RemovePermissionsBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -220,8 +220,7 @@ RemovePermissionsUnauthorized describes a response with status code 401, with de
 
 Unauthorized or invalid credentials.
 */
-type RemovePermissionsUnauthorized struct {
-}
+type RemovePermissionsUnauthorized struct{}
 
 // IsSuccess returns true when this remove permissions unauthorized response has a 2xx status code
 func (o *RemovePermissionsUnauthorized) IsSuccess() bool {
@@ -254,15 +253,14 @@ func (o *RemovePermissionsUnauthorized) Code() int {
 }
 
 func (o *RemovePermissionsUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsUnauthorized", 401)
 }
 
 func (o *RemovePermissionsUnauthorized) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsUnauthorized", 401)
 }
 
 func (o *RemovePermissionsUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -311,11 +309,13 @@ func (o *RemovePermissionsForbidden) Code() int {
 }
 
 func (o *RemovePermissionsForbidden) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsForbidden %s", 403, payload)
 }
 
 func (o *RemovePermissionsForbidden) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsForbidden %s", 403, payload)
 }
 
 func (o *RemovePermissionsForbidden) GetPayload() *models.ErrorResponse {
@@ -323,7 +323,6 @@ func (o *RemovePermissionsForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *RemovePermissionsForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -344,8 +343,7 @@ RemovePermissionsNotFound describes a response with status code 404, with defaul
 
 no role found
 */
-type RemovePermissionsNotFound struct {
-}
+type RemovePermissionsNotFound struct{}
 
 // IsSuccess returns true when this remove permissions not found response has a 2xx status code
 func (o *RemovePermissionsNotFound) IsSuccess() bool {
@@ -378,15 +376,14 @@ func (o *RemovePermissionsNotFound) Code() int {
 }
 
 func (o *RemovePermissionsNotFound) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsNotFound ", 404)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsNotFound", 404)
 }
 
 func (o *RemovePermissionsNotFound) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsNotFound ", 404)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsNotFound", 404)
 }
 
 func (o *RemovePermissionsNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -435,11 +432,13 @@ func (o *RemovePermissionsUnprocessableEntity) Code() int {
 }
 
 func (o *RemovePermissionsUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *RemovePermissionsUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *RemovePermissionsUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -447,7 +446,6 @@ func (o *RemovePermissionsUnprocessableEntity) GetPayload() *models.ErrorRespons
 }
 
 func (o *RemovePermissionsUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -503,11 +501,13 @@ func (o *RemovePermissionsInternalServerError) Code() int {
 }
 
 func (o *RemovePermissionsInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsInternalServerError %s", 500, payload)
 }
 
 func (o *RemovePermissionsInternalServerError) String() string {
-	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/roles/{id}/remove-permissions][%d] removePermissionsInternalServerError %s", 500, payload)
 }
 
 func (o *RemovePermissionsInternalServerError) GetPayload() *models.ErrorResponse {
@@ -515,7 +515,6 @@ func (o *RemovePermissionsInternalServerError) GetPayload() *models.ErrorRespons
 }
 
 func (o *RemovePermissionsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -531,7 +530,6 @@ RemovePermissionsBody remove permissions body
 swagger:model RemovePermissionsBody
 */
 type RemovePermissionsBody struct {
-
 	// permissions to remove from the role
 	// Required: true
 	Permissions []*models.Permission `json:"permissions"`
@@ -552,7 +550,6 @@ func (o *RemovePermissionsBody) Validate(formats strfmt.Registry) error {
 }
 
 func (o *RemovePermissionsBody) validatePermissions(formats strfmt.Registry) error {
-
 	if err := validate.Required("body"+"."+"permissions", "body", o.Permissions); err != nil {
 		return err
 	}
@@ -593,10 +590,13 @@ func (o *RemovePermissionsBody) ContextValidate(ctx context.Context, formats str
 }
 
 func (o *RemovePermissionsBody) contextValidatePermissions(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(o.Permissions); i++ {
-
 		if o.Permissions[i] != nil {
+
+			if swag.IsZero(o.Permissions[i]) { // not required
+				return nil
+			}
+
 			if err := o.Permissions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("body" + "." + "permissions" + "." + strconv.Itoa(i))
@@ -606,7 +606,6 @@ func (o *RemovePermissionsBody) contextValidatePermissions(ctx context.Context, 
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/client/authz/revoke_role_from_group_responses.go
+++ b/client/authz/revoke_role_from_group_responses.go
@@ -18,6 +18,7 @@ package authz
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -74,7 +75,7 @@ func (o *RevokeRoleFromGroupReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /authz/groups/{id}/revoke] revokeRoleFromGroup", response, response.Code())
 	}
 }
 
@@ -88,8 +89,7 @@ RevokeRoleFromGroupOK describes a response with status code 200, with default he
 
 Role revoked successfully
 */
-type RevokeRoleFromGroupOK struct {
-}
+type RevokeRoleFromGroupOK struct{}
 
 // IsSuccess returns true when this revoke role from group o k response has a 2xx status code
 func (o *RevokeRoleFromGroupOK) IsSuccess() bool {
@@ -122,15 +122,14 @@ func (o *RevokeRoleFromGroupOK) Code() int {
 }
 
 func (o *RevokeRoleFromGroupOK) Error() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupOK ", 200)
+	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupOK", 200)
 }
 
 func (o *RevokeRoleFromGroupOK) String() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupOK ", 200)
+	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupOK", 200)
 }
 
 func (o *RevokeRoleFromGroupOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -179,11 +178,13 @@ func (o *RevokeRoleFromGroupBadRequest) Code() int {
 }
 
 func (o *RevokeRoleFromGroupBadRequest) Error() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupBadRequest %s", 400, payload)
 }
 
 func (o *RevokeRoleFromGroupBadRequest) String() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupBadRequest %s", 400, payload)
 }
 
 func (o *RevokeRoleFromGroupBadRequest) GetPayload() *models.ErrorResponse {
@@ -191,7 +192,6 @@ func (o *RevokeRoleFromGroupBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *RevokeRoleFromGroupBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -212,8 +212,7 @@ RevokeRoleFromGroupUnauthorized describes a response with status code 401, with 
 
 Unauthorized or invalid credentials.
 */
-type RevokeRoleFromGroupUnauthorized struct {
-}
+type RevokeRoleFromGroupUnauthorized struct{}
 
 // IsSuccess returns true when this revoke role from group unauthorized response has a 2xx status code
 func (o *RevokeRoleFromGroupUnauthorized) IsSuccess() bool {
@@ -246,15 +245,14 @@ func (o *RevokeRoleFromGroupUnauthorized) Code() int {
 }
 
 func (o *RevokeRoleFromGroupUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupUnauthorized", 401)
 }
 
 func (o *RevokeRoleFromGroupUnauthorized) String() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupUnauthorized", 401)
 }
 
 func (o *RevokeRoleFromGroupUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -303,11 +301,13 @@ func (o *RevokeRoleFromGroupForbidden) Code() int {
 }
 
 func (o *RevokeRoleFromGroupForbidden) Error() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupForbidden %s", 403, payload)
 }
 
 func (o *RevokeRoleFromGroupForbidden) String() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupForbidden %s", 403, payload)
 }
 
 func (o *RevokeRoleFromGroupForbidden) GetPayload() *models.ErrorResponse {
@@ -315,7 +315,6 @@ func (o *RevokeRoleFromGroupForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *RevokeRoleFromGroupForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -336,8 +335,7 @@ RevokeRoleFromGroupNotFound describes a response with status code 404, with defa
 
 role or group is not found.
 */
-type RevokeRoleFromGroupNotFound struct {
-}
+type RevokeRoleFromGroupNotFound struct{}
 
 // IsSuccess returns true when this revoke role from group not found response has a 2xx status code
 func (o *RevokeRoleFromGroupNotFound) IsSuccess() bool {
@@ -370,15 +368,14 @@ func (o *RevokeRoleFromGroupNotFound) Code() int {
 }
 
 func (o *RevokeRoleFromGroupNotFound) Error() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupNotFound ", 404)
+	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupNotFound", 404)
 }
 
 func (o *RevokeRoleFromGroupNotFound) String() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupNotFound ", 404)
+	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupNotFound", 404)
 }
 
 func (o *RevokeRoleFromGroupNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -427,11 +424,13 @@ func (o *RevokeRoleFromGroupInternalServerError) Code() int {
 }
 
 func (o *RevokeRoleFromGroupInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupInternalServerError %s", 500, payload)
 }
 
 func (o *RevokeRoleFromGroupInternalServerError) String() string {
-	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/groups/{id}/revoke][%d] revokeRoleFromGroupInternalServerError %s", 500, payload)
 }
 
 func (o *RevokeRoleFromGroupInternalServerError) GetPayload() *models.ErrorResponse {
@@ -439,7 +438,6 @@ func (o *RevokeRoleFromGroupInternalServerError) GetPayload() *models.ErrorRespo
 }
 
 func (o *RevokeRoleFromGroupInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -455,7 +453,6 @@ RevokeRoleFromGroupBody revoke role from group body
 swagger:model RevokeRoleFromGroupBody
 */
 type RevokeRoleFromGroupBody struct {
-
 	// group type
 	GroupType models.GroupType `json:"groupType,omitempty"`
 
@@ -509,6 +506,9 @@ func (o *RevokeRoleFromGroupBody) ContextValidate(ctx context.Context, formats s
 }
 
 func (o *RevokeRoleFromGroupBody) contextValidateGroupType(ctx context.Context, formats strfmt.Registry) error {
+	if swag.IsZero(o.GroupType) { // not required
+		return nil
+	}
 
 	if err := o.GroupType.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/client/authz/revoke_role_from_user_responses.go
+++ b/client/authz/revoke_role_from_user_responses.go
@@ -18,6 +18,7 @@ package authz
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -74,7 +75,7 @@ func (o *RevokeRoleFromUserReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /authz/users/{id}/revoke] revokeRoleFromUser", response, response.Code())
 	}
 }
 
@@ -88,8 +89,7 @@ RevokeRoleFromUserOK describes a response with status code 200, with default hea
 
 Role revoked successfully
 */
-type RevokeRoleFromUserOK struct {
-}
+type RevokeRoleFromUserOK struct{}
 
 // IsSuccess returns true when this revoke role from user o k response has a 2xx status code
 func (o *RevokeRoleFromUserOK) IsSuccess() bool {
@@ -122,15 +122,14 @@ func (o *RevokeRoleFromUserOK) Code() int {
 }
 
 func (o *RevokeRoleFromUserOK) Error() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserOK ", 200)
+	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserOK", 200)
 }
 
 func (o *RevokeRoleFromUserOK) String() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserOK ", 200)
+	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserOK", 200)
 }
 
 func (o *RevokeRoleFromUserOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -179,11 +178,13 @@ func (o *RevokeRoleFromUserBadRequest) Code() int {
 }
 
 func (o *RevokeRoleFromUserBadRequest) Error() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserBadRequest %s", 400, payload)
 }
 
 func (o *RevokeRoleFromUserBadRequest) String() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserBadRequest %s", 400, payload)
 }
 
 func (o *RevokeRoleFromUserBadRequest) GetPayload() *models.ErrorResponse {
@@ -191,7 +192,6 @@ func (o *RevokeRoleFromUserBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *RevokeRoleFromUserBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -212,8 +212,7 @@ RevokeRoleFromUserUnauthorized describes a response with status code 401, with d
 
 Unauthorized or invalid credentials.
 */
-type RevokeRoleFromUserUnauthorized struct {
-}
+type RevokeRoleFromUserUnauthorized struct{}
 
 // IsSuccess returns true when this revoke role from user unauthorized response has a 2xx status code
 func (o *RevokeRoleFromUserUnauthorized) IsSuccess() bool {
@@ -246,15 +245,14 @@ func (o *RevokeRoleFromUserUnauthorized) Code() int {
 }
 
 func (o *RevokeRoleFromUserUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserUnauthorized", 401)
 }
 
 func (o *RevokeRoleFromUserUnauthorized) String() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserUnauthorized ", 401)
+	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserUnauthorized", 401)
 }
 
 func (o *RevokeRoleFromUserUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -303,11 +301,13 @@ func (o *RevokeRoleFromUserForbidden) Code() int {
 }
 
 func (o *RevokeRoleFromUserForbidden) Error() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserForbidden %s", 403, payload)
 }
 
 func (o *RevokeRoleFromUserForbidden) String() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserForbidden %s", 403, payload)
 }
 
 func (o *RevokeRoleFromUserForbidden) GetPayload() *models.ErrorResponse {
@@ -315,7 +315,6 @@ func (o *RevokeRoleFromUserForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *RevokeRoleFromUserForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -371,11 +370,13 @@ func (o *RevokeRoleFromUserNotFound) Code() int {
 }
 
 func (o *RevokeRoleFromUserNotFound) Error() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserNotFound %s", 404, payload)
 }
 
 func (o *RevokeRoleFromUserNotFound) String() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserNotFound %s", 404, payload)
 }
 
 func (o *RevokeRoleFromUserNotFound) GetPayload() *models.ErrorResponse {
@@ -383,7 +384,6 @@ func (o *RevokeRoleFromUserNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *RevokeRoleFromUserNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -439,11 +439,13 @@ func (o *RevokeRoleFromUserInternalServerError) Code() int {
 }
 
 func (o *RevokeRoleFromUserInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserInternalServerError %s", 500, payload)
 }
 
 func (o *RevokeRoleFromUserInternalServerError) String() string {
-	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /authz/users/{id}/revoke][%d] revokeRoleFromUserInternalServerError %s", 500, payload)
 }
 
 func (o *RevokeRoleFromUserInternalServerError) GetPayload() *models.ErrorResponse {
@@ -451,7 +453,6 @@ func (o *RevokeRoleFromUserInternalServerError) GetPayload() *models.ErrorRespon
 }
 
 func (o *RevokeRoleFromUserInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -467,7 +468,6 @@ RevokeRoleFromUserBody revoke role from user body
 swagger:model RevokeRoleFromUserBody
 */
 type RevokeRoleFromUserBody struct {
-
 	// the roles that revoked from the key or user
 	Roles []string `json:"roles"`
 
@@ -521,6 +521,9 @@ func (o *RevokeRoleFromUserBody) ContextValidate(ctx context.Context, formats st
 }
 
 func (o *RevokeRoleFromUserBody) contextValidateUserType(ctx context.Context, formats strfmt.Registry) error {
+	if swag.IsZero(o.UserType) { // not required
+		return nil
+	}
 
 	if err := o.UserType.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/client/backups/backups_cancel_responses.go
+++ b/client/backups/backups_cancel_responses.go
@@ -17,6 +17,7 @@ package backups
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *BackupsCancelReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /backups/{backend}/{id}] backups.cancel", response, response.Code())
 	}
 }
 
@@ -79,8 +80,7 @@ BackupsCancelNoContent describes a response with status code 204, with default h
 
 Successfully deleted.
 */
-type BackupsCancelNoContent struct {
-}
+type BackupsCancelNoContent struct{}
 
 // IsSuccess returns true when this backups cancel no content response has a 2xx status code
 func (o *BackupsCancelNoContent) IsSuccess() bool {
@@ -113,15 +113,14 @@ func (o *BackupsCancelNoContent) Code() int {
 }
 
 func (o *BackupsCancelNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelNoContent ", 204)
+	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelNoContent", 204)
 }
 
 func (o *BackupsCancelNoContent) String() string {
-	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelNoContent ", 204)
+	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelNoContent", 204)
 }
 
 func (o *BackupsCancelNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -135,8 +134,7 @@ BackupsCancelUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type BackupsCancelUnauthorized struct {
-}
+type BackupsCancelUnauthorized struct{}
 
 // IsSuccess returns true when this backups cancel unauthorized response has a 2xx status code
 func (o *BackupsCancelUnauthorized) IsSuccess() bool {
@@ -169,15 +167,14 @@ func (o *BackupsCancelUnauthorized) Code() int {
 }
 
 func (o *BackupsCancelUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelUnauthorized", 401)
 }
 
 func (o *BackupsCancelUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelUnauthorized", 401)
 }
 
 func (o *BackupsCancelUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -226,11 +223,13 @@ func (o *BackupsCancelForbidden) Code() int {
 }
 
 func (o *BackupsCancelForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelForbidden %s", 403, payload)
 }
 
 func (o *BackupsCancelForbidden) String() string {
-	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelForbidden %s", 403, payload)
 }
 
 func (o *BackupsCancelForbidden) GetPayload() *models.ErrorResponse {
@@ -238,7 +237,6 @@ func (o *BackupsCancelForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsCancelForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -294,11 +292,13 @@ func (o *BackupsCancelUnprocessableEntity) Code() int {
 }
 
 func (o *BackupsCancelUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BackupsCancelUnprocessableEntity) String() string {
-	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BackupsCancelUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -306,7 +306,6 @@ func (o *BackupsCancelUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsCancelUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -362,11 +361,13 @@ func (o *BackupsCancelInternalServerError) Code() int {
 }
 
 func (o *BackupsCancelInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelInternalServerError %s", 500, payload)
 }
 
 func (o *BackupsCancelInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /backups/{backend}/{id}][%d] backupsCancelInternalServerError %s", 500, payload)
 }
 
 func (o *BackupsCancelInternalServerError) GetPayload() *models.ErrorResponse {
@@ -374,7 +375,6 @@ func (o *BackupsCancelInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsCancelInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/backups/backups_client.go
+++ b/client/backups/backups_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new backups API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new backups API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new backups API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -71,7 +121,7 @@ func (a *Client) BackupsCancel(params *BackupsCancelParams, authInfo runtime.Cli
 		Method:             "DELETE",
 		PathPattern:        "/backups/{backend}/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &BackupsCancelReader{formats: a.formats},
@@ -112,7 +162,7 @@ func (a *Client) BackupsCreate(params *BackupsCreateParams, authInfo runtime.Cli
 		Method:             "POST",
 		PathPattern:        "/backups/{backend}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &BackupsCreateReader{formats: a.formats},
@@ -153,7 +203,7 @@ func (a *Client) BackupsCreateStatus(params *BackupsCreateStatusParams, authInfo
 		Method:             "GET",
 		PathPattern:        "/backups/{backend}/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &BackupsCreateStatusReader{formats: a.formats},
@@ -194,7 +244,7 @@ func (a *Client) BackupsList(params *BackupsListParams, authInfo runtime.ClientA
 		Method:             "GET",
 		PathPattern:        "/backups/{backend}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &BackupsListReader{formats: a.formats},
@@ -235,7 +285,7 @@ func (a *Client) BackupsRestore(params *BackupsRestoreParams, authInfo runtime.C
 		Method:             "POST",
 		PathPattern:        "/backups/{backend}/{id}/restore",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &BackupsRestoreReader{formats: a.formats},
@@ -276,7 +326,7 @@ func (a *Client) BackupsRestoreStatus(params *BackupsRestoreStatusParams, authIn
 		Method:             "GET",
 		PathPattern:        "/backups/{backend}/{id}/restore",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &BackupsRestoreStatusReader{formats: a.formats},

--- a/client/backups/backups_create_responses.go
+++ b/client/backups/backups_create_responses.go
@@ -17,6 +17,7 @@ package backups
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *BackupsCreateReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /backups/{backend}] backups.create", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *BackupsCreateOK) Code() int {
 }
 
 func (o *BackupsCreateOK) Error() string {
-	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateOK %s", 200, payload)
 }
 
 func (o *BackupsCreateOK) String() string {
-	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateOK %s", 200, payload)
 }
 
 func (o *BackupsCreateOK) GetPayload() *models.BackupCreateResponse {
@@ -126,7 +129,6 @@ func (o *BackupsCreateOK) GetPayload() *models.BackupCreateResponse {
 }
 
 func (o *BackupsCreateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.BackupCreateResponse)
 
 	// response payload
@@ -147,8 +149,7 @@ BackupsCreateUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type BackupsCreateUnauthorized struct {
-}
+type BackupsCreateUnauthorized struct{}
 
 // IsSuccess returns true when this backups create unauthorized response has a 2xx status code
 func (o *BackupsCreateUnauthorized) IsSuccess() bool {
@@ -181,15 +182,14 @@ func (o *BackupsCreateUnauthorized) Code() int {
 }
 
 func (o *BackupsCreateUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateUnauthorized", 401)
 }
 
 func (o *BackupsCreateUnauthorized) String() string {
-	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateUnauthorized", 401)
 }
 
 func (o *BackupsCreateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -238,11 +238,13 @@ func (o *BackupsCreateForbidden) Code() int {
 }
 
 func (o *BackupsCreateForbidden) Error() string {
-	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateForbidden %s", 403, payload)
 }
 
 func (o *BackupsCreateForbidden) String() string {
-	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateForbidden %s", 403, payload)
 }
 
 func (o *BackupsCreateForbidden) GetPayload() *models.ErrorResponse {
@@ -250,7 +252,6 @@ func (o *BackupsCreateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsCreateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -306,11 +307,13 @@ func (o *BackupsCreateUnprocessableEntity) Code() int {
 }
 
 func (o *BackupsCreateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BackupsCreateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BackupsCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -318,7 +321,6 @@ func (o *BackupsCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsCreateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -374,11 +376,13 @@ func (o *BackupsCreateInternalServerError) Code() int {
 }
 
 func (o *BackupsCreateInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateInternalServerError %s", 500, payload)
 }
 
 func (o *BackupsCreateInternalServerError) String() string {
-	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}][%d] backupsCreateInternalServerError %s", 500, payload)
 }
 
 func (o *BackupsCreateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -386,7 +390,6 @@ func (o *BackupsCreateInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsCreateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/backups/backups_create_status_responses.go
+++ b/client/backups/backups_create_status_responses.go
@@ -17,6 +17,7 @@ package backups
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *BackupsCreateStatusReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /backups/{backend}/{id}] backups.create.status", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *BackupsCreateStatusOK) Code() int {
 }
 
 func (o *BackupsCreateStatusOK) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusOK %s", 200, payload)
 }
 
 func (o *BackupsCreateStatusOK) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusOK %s", 200, payload)
 }
 
 func (o *BackupsCreateStatusOK) GetPayload() *models.BackupCreateStatusResponse {
@@ -132,7 +135,6 @@ func (o *BackupsCreateStatusOK) GetPayload() *models.BackupCreateStatusResponse 
 }
 
 func (o *BackupsCreateStatusOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.BackupCreateStatusResponse)
 
 	// response payload
@@ -153,8 +155,7 @@ BackupsCreateStatusUnauthorized describes a response with status code 401, with 
 
 Unauthorized or invalid credentials.
 */
-type BackupsCreateStatusUnauthorized struct {
-}
+type BackupsCreateStatusUnauthorized struct{}
 
 // IsSuccess returns true when this backups create status unauthorized response has a 2xx status code
 func (o *BackupsCreateStatusUnauthorized) IsSuccess() bool {
@@ -187,15 +188,14 @@ func (o *BackupsCreateStatusUnauthorized) Code() int {
 }
 
 func (o *BackupsCreateStatusUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusUnauthorized ", 401)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusUnauthorized", 401)
 }
 
 func (o *BackupsCreateStatusUnauthorized) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusUnauthorized ", 401)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusUnauthorized", 401)
 }
 
 func (o *BackupsCreateStatusUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +244,13 @@ func (o *BackupsCreateStatusForbidden) Code() int {
 }
 
 func (o *BackupsCreateStatusForbidden) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusForbidden %s", 403, payload)
 }
 
 func (o *BackupsCreateStatusForbidden) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusForbidden %s", 403, payload)
 }
 
 func (o *BackupsCreateStatusForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +258,6 @@ func (o *BackupsCreateStatusForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsCreateStatusForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -312,11 +313,13 @@ func (o *BackupsCreateStatusNotFound) Code() int {
 }
 
 func (o *BackupsCreateStatusNotFound) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusNotFound %s", 404, payload)
 }
 
 func (o *BackupsCreateStatusNotFound) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusNotFound %s", 404, payload)
 }
 
 func (o *BackupsCreateStatusNotFound) GetPayload() *models.ErrorResponse {
@@ -324,7 +327,6 @@ func (o *BackupsCreateStatusNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsCreateStatusNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -380,11 +382,13 @@ func (o *BackupsCreateStatusUnprocessableEntity) Code() int {
 }
 
 func (o *BackupsCreateStatusUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BackupsCreateStatusUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BackupsCreateStatusUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -392,7 +396,6 @@ func (o *BackupsCreateStatusUnprocessableEntity) GetPayload() *models.ErrorRespo
 }
 
 func (o *BackupsCreateStatusUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -448,11 +451,13 @@ func (o *BackupsCreateStatusInternalServerError) Code() int {
 }
 
 func (o *BackupsCreateStatusInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusInternalServerError %s", 500, payload)
 }
 
 func (o *BackupsCreateStatusInternalServerError) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}][%d] backupsCreateStatusInternalServerError %s", 500, payload)
 }
 
 func (o *BackupsCreateStatusInternalServerError) GetPayload() *models.ErrorResponse {
@@ -460,7 +465,6 @@ func (o *BackupsCreateStatusInternalServerError) GetPayload() *models.ErrorRespo
 }
 
 func (o *BackupsCreateStatusInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/backups/backups_list_responses.go
+++ b/client/backups/backups_list_responses.go
@@ -17,6 +17,7 @@ package backups
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *BackupsListReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /backups/{backend}] backups.list", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *BackupsListOK) Code() int {
 }
 
 func (o *BackupsListOK) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListOK %s", 200, payload)
 }
 
 func (o *BackupsListOK) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListOK %s", 200, payload)
 }
 
 func (o *BackupsListOK) GetPayload() models.BackupListResponse {
@@ -126,7 +129,6 @@ func (o *BackupsListOK) GetPayload() models.BackupListResponse {
 }
 
 func (o *BackupsListOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -145,8 +147,7 @@ BackupsListUnauthorized describes a response with status code 401, with default 
 
 Unauthorized or invalid credentials.
 */
-type BackupsListUnauthorized struct {
-}
+type BackupsListUnauthorized struct{}
 
 // IsSuccess returns true when this backups list unauthorized response has a 2xx status code
 func (o *BackupsListUnauthorized) IsSuccess() bool {
@@ -179,15 +180,14 @@ func (o *BackupsListUnauthorized) Code() int {
 }
 
 func (o *BackupsListUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListUnauthorized ", 401)
+	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListUnauthorized", 401)
 }
 
 func (o *BackupsListUnauthorized) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListUnauthorized ", 401)
+	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListUnauthorized", 401)
 }
 
 func (o *BackupsListUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -236,11 +236,13 @@ func (o *BackupsListForbidden) Code() int {
 }
 
 func (o *BackupsListForbidden) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListForbidden %s", 403, payload)
 }
 
 func (o *BackupsListForbidden) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListForbidden %s", 403, payload)
 }
 
 func (o *BackupsListForbidden) GetPayload() *models.ErrorResponse {
@@ -248,7 +250,6 @@ func (o *BackupsListForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsListForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -304,11 +305,13 @@ func (o *BackupsListUnprocessableEntity) Code() int {
 }
 
 func (o *BackupsListUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BackupsListUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BackupsListUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -316,7 +319,6 @@ func (o *BackupsListUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsListUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -372,11 +374,13 @@ func (o *BackupsListInternalServerError) Code() int {
 }
 
 func (o *BackupsListInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListInternalServerError %s", 500, payload)
 }
 
 func (o *BackupsListInternalServerError) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}][%d] backupsListInternalServerError %s", 500, payload)
 }
 
 func (o *BackupsListInternalServerError) GetPayload() *models.ErrorResponse {
@@ -384,7 +388,6 @@ func (o *BackupsListInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsListInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/backups/backups_restore_responses.go
+++ b/client/backups/backups_restore_responses.go
@@ -17,6 +17,7 @@ package backups
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *BackupsRestoreReader) ReadResponse(response runtime.ClientResponse, con
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /backups/{backend}/{id}/restore] backups.restore", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *BackupsRestoreOK) Code() int {
 }
 
 func (o *BackupsRestoreOK) Error() string {
-	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreOK %s", 200, payload)
 }
 
 func (o *BackupsRestoreOK) String() string {
-	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreOK %s", 200, payload)
 }
 
 func (o *BackupsRestoreOK) GetPayload() *models.BackupRestoreResponse {
@@ -132,7 +135,6 @@ func (o *BackupsRestoreOK) GetPayload() *models.BackupRestoreResponse {
 }
 
 func (o *BackupsRestoreOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.BackupRestoreResponse)
 
 	// response payload
@@ -153,8 +155,7 @@ BackupsRestoreUnauthorized describes a response with status code 401, with defau
 
 Unauthorized or invalid credentials.
 */
-type BackupsRestoreUnauthorized struct {
-}
+type BackupsRestoreUnauthorized struct{}
 
 // IsSuccess returns true when this backups restore unauthorized response has a 2xx status code
 func (o *BackupsRestoreUnauthorized) IsSuccess() bool {
@@ -187,15 +188,14 @@ func (o *BackupsRestoreUnauthorized) Code() int {
 }
 
 func (o *BackupsRestoreUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreUnauthorized ", 401)
+	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreUnauthorized", 401)
 }
 
 func (o *BackupsRestoreUnauthorized) String() string {
-	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreUnauthorized ", 401)
+	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreUnauthorized", 401)
 }
 
 func (o *BackupsRestoreUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +244,13 @@ func (o *BackupsRestoreForbidden) Code() int {
 }
 
 func (o *BackupsRestoreForbidden) Error() string {
-	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreForbidden %s", 403, payload)
 }
 
 func (o *BackupsRestoreForbidden) String() string {
-	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreForbidden %s", 403, payload)
 }
 
 func (o *BackupsRestoreForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +258,6 @@ func (o *BackupsRestoreForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsRestoreForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -312,11 +313,13 @@ func (o *BackupsRestoreNotFound) Code() int {
 }
 
 func (o *BackupsRestoreNotFound) Error() string {
-	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreNotFound %s", 404, payload)
 }
 
 func (o *BackupsRestoreNotFound) String() string {
-	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreNotFound %s", 404, payload)
 }
 
 func (o *BackupsRestoreNotFound) GetPayload() *models.ErrorResponse {
@@ -324,7 +327,6 @@ func (o *BackupsRestoreNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsRestoreNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -380,11 +382,13 @@ func (o *BackupsRestoreUnprocessableEntity) Code() int {
 }
 
 func (o *BackupsRestoreUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BackupsRestoreUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BackupsRestoreUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -392,7 +396,6 @@ func (o *BackupsRestoreUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsRestoreUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -448,11 +451,13 @@ func (o *BackupsRestoreInternalServerError) Code() int {
 }
 
 func (o *BackupsRestoreInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreInternalServerError %s", 500, payload)
 }
 
 func (o *BackupsRestoreInternalServerError) String() string {
-	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /backups/{backend}/{id}/restore][%d] backupsRestoreInternalServerError %s", 500, payload)
 }
 
 func (o *BackupsRestoreInternalServerError) GetPayload() *models.ErrorResponse {
@@ -460,7 +465,6 @@ func (o *BackupsRestoreInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsRestoreInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/backups/backups_restore_status_responses.go
+++ b/client/backups/backups_restore_status_responses.go
@@ -17,6 +17,7 @@ package backups
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *BackupsRestoreStatusReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /backups/{backend}/{id}/restore] backups.restore.status", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *BackupsRestoreStatusOK) Code() int {
 }
 
 func (o *BackupsRestoreStatusOK) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusOK %s", 200, payload)
 }
 
 func (o *BackupsRestoreStatusOK) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusOK %s", 200, payload)
 }
 
 func (o *BackupsRestoreStatusOK) GetPayload() *models.BackupRestoreStatusResponse {
@@ -126,7 +129,6 @@ func (o *BackupsRestoreStatusOK) GetPayload() *models.BackupRestoreStatusRespons
 }
 
 func (o *BackupsRestoreStatusOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.BackupRestoreStatusResponse)
 
 	// response payload
@@ -147,8 +149,7 @@ BackupsRestoreStatusUnauthorized describes a response with status code 401, with
 
 Unauthorized or invalid credentials.
 */
-type BackupsRestoreStatusUnauthorized struct {
-}
+type BackupsRestoreStatusUnauthorized struct{}
 
 // IsSuccess returns true when this backups restore status unauthorized response has a 2xx status code
 func (o *BackupsRestoreStatusUnauthorized) IsSuccess() bool {
@@ -181,15 +182,14 @@ func (o *BackupsRestoreStatusUnauthorized) Code() int {
 }
 
 func (o *BackupsRestoreStatusUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusUnauthorized ", 401)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusUnauthorized", 401)
 }
 
 func (o *BackupsRestoreStatusUnauthorized) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusUnauthorized ", 401)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusUnauthorized", 401)
 }
 
 func (o *BackupsRestoreStatusUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -238,11 +238,13 @@ func (o *BackupsRestoreStatusForbidden) Code() int {
 }
 
 func (o *BackupsRestoreStatusForbidden) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusForbidden %s", 403, payload)
 }
 
 func (o *BackupsRestoreStatusForbidden) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusForbidden %s", 403, payload)
 }
 
 func (o *BackupsRestoreStatusForbidden) GetPayload() *models.ErrorResponse {
@@ -250,7 +252,6 @@ func (o *BackupsRestoreStatusForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsRestoreStatusForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -306,11 +307,13 @@ func (o *BackupsRestoreStatusNotFound) Code() int {
 }
 
 func (o *BackupsRestoreStatusNotFound) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusNotFound %s", 404, payload)
 }
 
 func (o *BackupsRestoreStatusNotFound) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusNotFound %s", 404, payload)
 }
 
 func (o *BackupsRestoreStatusNotFound) GetPayload() *models.ErrorResponse {
@@ -318,7 +321,6 @@ func (o *BackupsRestoreStatusNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BackupsRestoreStatusNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -374,11 +376,13 @@ func (o *BackupsRestoreStatusInternalServerError) Code() int {
 }
 
 func (o *BackupsRestoreStatusInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusInternalServerError %s", 500, payload)
 }
 
 func (o *BackupsRestoreStatusInternalServerError) String() string {
-	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /backups/{backend}/{id}/restore][%d] backupsRestoreStatusInternalServerError %s", 500, payload)
 }
 
 func (o *BackupsRestoreStatusInternalServerError) GetPayload() *models.ErrorResponse {
@@ -386,7 +390,6 @@ func (o *BackupsRestoreStatusInternalServerError) GetPayload() *models.ErrorResp
 }
 
 func (o *BackupsRestoreStatusInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/batch/batch_client.go
+++ b/client/batch/batch_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new batch API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new batch API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new batch API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -65,7 +115,7 @@ func (a *Client) BatchObjectsCreate(params *BatchObjectsCreateParams, authInfo r
 		Method:             "POST",
 		PathPattern:        "/batch/objects",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &BatchObjectsCreateReader{formats: a.formats},
@@ -106,7 +156,7 @@ func (a *Client) BatchObjectsDelete(params *BatchObjectsDeleteParams, authInfo r
 		Method:             "DELETE",
 		PathPattern:        "/batch/objects",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &BatchObjectsDeleteReader{formats: a.formats},
@@ -147,7 +197,7 @@ func (a *Client) BatchReferencesCreate(params *BatchReferencesCreateParams, auth
 		Method:             "POST",
 		PathPattern:        "/batch/references",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &BatchReferencesCreateReader{formats: a.formats},

--- a/client/batch/batch_objects_create_responses.go
+++ b/client/batch/batch_objects_create_responses.go
@@ -77,7 +77,7 @@ func (o *BatchObjectsCreateReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /batch/objects] batch.objects.create", response, response.Code())
 	}
 }
 
@@ -126,11 +126,13 @@ func (o *BatchObjectsCreateOK) Code() int {
 }
 
 func (o *BatchObjectsCreateOK) Error() string {
-	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateOK %s", 200, payload)
 }
 
 func (o *BatchObjectsCreateOK) String() string {
-	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateOK %s", 200, payload)
 }
 
 func (o *BatchObjectsCreateOK) GetPayload() []*models.ObjectsGetResponse {
@@ -138,7 +140,6 @@ func (o *BatchObjectsCreateOK) GetPayload() []*models.ObjectsGetResponse {
 }
 
 func (o *BatchObjectsCreateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -192,11 +193,13 @@ func (o *BatchObjectsCreateBadRequest) Code() int {
 }
 
 func (o *BatchObjectsCreateBadRequest) Error() string {
-	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateBadRequest %s", 400, payload)
 }
 
 func (o *BatchObjectsCreateBadRequest) String() string {
-	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateBadRequest %s", 400, payload)
 }
 
 func (o *BatchObjectsCreateBadRequest) GetPayload() *models.ErrorResponse {
@@ -204,7 +207,6 @@ func (o *BatchObjectsCreateBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BatchObjectsCreateBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -225,8 +227,7 @@ BatchObjectsCreateUnauthorized describes a response with status code 401, with d
 
 Unauthorized or invalid credentials.
 */
-type BatchObjectsCreateUnauthorized struct {
-}
+type BatchObjectsCreateUnauthorized struct{}
 
 // IsSuccess returns true when this batch objects create unauthorized response has a 2xx status code
 func (o *BatchObjectsCreateUnauthorized) IsSuccess() bool {
@@ -259,15 +260,14 @@ func (o *BatchObjectsCreateUnauthorized) Code() int {
 }
 
 func (o *BatchObjectsCreateUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateUnauthorized", 401)
 }
 
 func (o *BatchObjectsCreateUnauthorized) String() string {
-	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateUnauthorized", 401)
 }
 
 func (o *BatchObjectsCreateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -316,11 +316,13 @@ func (o *BatchObjectsCreateForbidden) Code() int {
 }
 
 func (o *BatchObjectsCreateForbidden) Error() string {
-	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateForbidden %s", 403, payload)
 }
 
 func (o *BatchObjectsCreateForbidden) String() string {
-	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateForbidden %s", 403, payload)
 }
 
 func (o *BatchObjectsCreateForbidden) GetPayload() *models.ErrorResponse {
@@ -328,7 +330,6 @@ func (o *BatchObjectsCreateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BatchObjectsCreateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -384,11 +385,13 @@ func (o *BatchObjectsCreateUnprocessableEntity) Code() int {
 }
 
 func (o *BatchObjectsCreateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BatchObjectsCreateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BatchObjectsCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -396,7 +399,6 @@ func (o *BatchObjectsCreateUnprocessableEntity) GetPayload() *models.ErrorRespon
 }
 
 func (o *BatchObjectsCreateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -452,11 +454,13 @@ func (o *BatchObjectsCreateInternalServerError) Code() int {
 }
 
 func (o *BatchObjectsCreateInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateInternalServerError %s", 500, payload)
 }
 
 func (o *BatchObjectsCreateInternalServerError) String() string {
-	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/objects][%d] batchObjectsCreateInternalServerError %s", 500, payload)
 }
 
 func (o *BatchObjectsCreateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -464,7 +468,6 @@ func (o *BatchObjectsCreateInternalServerError) GetPayload() *models.ErrorRespon
 }
 
 func (o *BatchObjectsCreateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -480,7 +483,6 @@ BatchObjectsCreateBody batch objects create body
 swagger:model BatchObjectsCreateBody
 */
 type BatchObjectsCreateBody struct {
-
 	// Define which fields need to be returned. Default value is ALL
 	Fields []*string `json:"fields"`
 
@@ -586,10 +588,13 @@ func (o *BatchObjectsCreateBody) ContextValidate(ctx context.Context, formats st
 }
 
 func (o *BatchObjectsCreateBody) contextValidateObjects(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(o.Objects); i++ {
-
 		if o.Objects[i] != nil {
+
+			if swag.IsZero(o.Objects[i]) { // not required
+				return nil
+			}
+
 			if err := o.Objects[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("body" + "." + "objects" + "." + strconv.Itoa(i))
@@ -599,7 +604,6 @@ func (o *BatchObjectsCreateBody) contextValidateObjects(ctx context.Context, for
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/client/batch/batch_objects_delete_responses.go
+++ b/client/batch/batch_objects_delete_responses.go
@@ -17,6 +17,7 @@ package batch
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *BatchObjectsDeleteReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /batch/objects] batch.objects.delete", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *BatchObjectsDeleteOK) Code() int {
 }
 
 func (o *BatchObjectsDeleteOK) Error() string {
-	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteOK %s", 200, payload)
 }
 
 func (o *BatchObjectsDeleteOK) String() string {
-	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteOK %s", 200, payload)
 }
 
 func (o *BatchObjectsDeleteOK) GetPayload() *models.BatchDeleteResponse {
@@ -132,7 +135,6 @@ func (o *BatchObjectsDeleteOK) GetPayload() *models.BatchDeleteResponse {
 }
 
 func (o *BatchObjectsDeleteOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.BatchDeleteResponse)
 
 	// response payload
@@ -188,11 +190,13 @@ func (o *BatchObjectsDeleteBadRequest) Code() int {
 }
 
 func (o *BatchObjectsDeleteBadRequest) Error() string {
-	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteBadRequest %s", 400, payload)
 }
 
 func (o *BatchObjectsDeleteBadRequest) String() string {
-	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteBadRequest %s", 400, payload)
 }
 
 func (o *BatchObjectsDeleteBadRequest) GetPayload() *models.ErrorResponse {
@@ -200,7 +204,6 @@ func (o *BatchObjectsDeleteBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BatchObjectsDeleteBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -221,8 +224,7 @@ BatchObjectsDeleteUnauthorized describes a response with status code 401, with d
 
 Unauthorized or invalid credentials.
 */
-type BatchObjectsDeleteUnauthorized struct {
-}
+type BatchObjectsDeleteUnauthorized struct{}
 
 // IsSuccess returns true when this batch objects delete unauthorized response has a 2xx status code
 func (o *BatchObjectsDeleteUnauthorized) IsSuccess() bool {
@@ -255,15 +257,14 @@ func (o *BatchObjectsDeleteUnauthorized) Code() int {
 }
 
 func (o *BatchObjectsDeleteUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteUnauthorized", 401)
 }
 
 func (o *BatchObjectsDeleteUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteUnauthorized", 401)
 }
 
 func (o *BatchObjectsDeleteUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -312,11 +313,13 @@ func (o *BatchObjectsDeleteForbidden) Code() int {
 }
 
 func (o *BatchObjectsDeleteForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteForbidden %s", 403, payload)
 }
 
 func (o *BatchObjectsDeleteForbidden) String() string {
-	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteForbidden %s", 403, payload)
 }
 
 func (o *BatchObjectsDeleteForbidden) GetPayload() *models.ErrorResponse {
@@ -324,7 +327,6 @@ func (o *BatchObjectsDeleteForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BatchObjectsDeleteForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -380,11 +382,13 @@ func (o *BatchObjectsDeleteUnprocessableEntity) Code() int {
 }
 
 func (o *BatchObjectsDeleteUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BatchObjectsDeleteUnprocessableEntity) String() string {
-	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BatchObjectsDeleteUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -392,7 +396,6 @@ func (o *BatchObjectsDeleteUnprocessableEntity) GetPayload() *models.ErrorRespon
 }
 
 func (o *BatchObjectsDeleteUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -448,11 +451,13 @@ func (o *BatchObjectsDeleteInternalServerError) Code() int {
 }
 
 func (o *BatchObjectsDeleteInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *BatchObjectsDeleteInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /batch/objects][%d] batchObjectsDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *BatchObjectsDeleteInternalServerError) GetPayload() *models.ErrorResponse {
@@ -460,7 +465,6 @@ func (o *BatchObjectsDeleteInternalServerError) GetPayload() *models.ErrorRespon
 }
 
 func (o *BatchObjectsDeleteInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/batch/batch_references_create_responses.go
+++ b/client/batch/batch_references_create_responses.go
@@ -17,6 +17,7 @@ package batch
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *BatchReferencesCreateReader) ReadResponse(response runtime.ClientRespon
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /batch/references] batch.references.create", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *BatchReferencesCreateOK) Code() int {
 }
 
 func (o *BatchReferencesCreateOK) Error() string {
-	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateOK %s", 200, payload)
 }
 
 func (o *BatchReferencesCreateOK) String() string {
-	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateOK %s", 200, payload)
 }
 
 func (o *BatchReferencesCreateOK) GetPayload() []*models.BatchReferenceResponse {
@@ -132,7 +135,6 @@ func (o *BatchReferencesCreateOK) GetPayload() []*models.BatchReferenceResponse 
 }
 
 func (o *BatchReferencesCreateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -186,11 +188,13 @@ func (o *BatchReferencesCreateBadRequest) Code() int {
 }
 
 func (o *BatchReferencesCreateBadRequest) Error() string {
-	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateBadRequest %s", 400, payload)
 }
 
 func (o *BatchReferencesCreateBadRequest) String() string {
-	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateBadRequest %s", 400, payload)
 }
 
 func (o *BatchReferencesCreateBadRequest) GetPayload() *models.ErrorResponse {
@@ -198,7 +202,6 @@ func (o *BatchReferencesCreateBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BatchReferencesCreateBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -219,8 +222,7 @@ BatchReferencesCreateUnauthorized describes a response with status code 401, wit
 
 Unauthorized or invalid credentials.
 */
-type BatchReferencesCreateUnauthorized struct {
-}
+type BatchReferencesCreateUnauthorized struct{}
 
 // IsSuccess returns true when this batch references create unauthorized response has a 2xx status code
 func (o *BatchReferencesCreateUnauthorized) IsSuccess() bool {
@@ -253,15 +255,14 @@ func (o *BatchReferencesCreateUnauthorized) Code() int {
 }
 
 func (o *BatchReferencesCreateUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateUnauthorized", 401)
 }
 
 func (o *BatchReferencesCreateUnauthorized) String() string {
-	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateUnauthorized", 401)
 }
 
 func (o *BatchReferencesCreateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -310,11 +311,13 @@ func (o *BatchReferencesCreateForbidden) Code() int {
 }
 
 func (o *BatchReferencesCreateForbidden) Error() string {
-	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateForbidden %s", 403, payload)
 }
 
 func (o *BatchReferencesCreateForbidden) String() string {
-	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateForbidden %s", 403, payload)
 }
 
 func (o *BatchReferencesCreateForbidden) GetPayload() *models.ErrorResponse {
@@ -322,7 +325,6 @@ func (o *BatchReferencesCreateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *BatchReferencesCreateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -378,11 +380,13 @@ func (o *BatchReferencesCreateUnprocessableEntity) Code() int {
 }
 
 func (o *BatchReferencesCreateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BatchReferencesCreateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *BatchReferencesCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -390,7 +394,6 @@ func (o *BatchReferencesCreateUnprocessableEntity) GetPayload() *models.ErrorRes
 }
 
 func (o *BatchReferencesCreateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -446,11 +449,13 @@ func (o *BatchReferencesCreateInternalServerError) Code() int {
 }
 
 func (o *BatchReferencesCreateInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateInternalServerError %s", 500, payload)
 }
 
 func (o *BatchReferencesCreateInternalServerError) String() string {
-	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /batch/references][%d] batchReferencesCreateInternalServerError %s", 500, payload)
 }
 
 func (o *BatchReferencesCreateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -458,7 +463,6 @@ func (o *BatchReferencesCreateInternalServerError) GetPayload() *models.ErrorRes
 }
 
 func (o *BatchReferencesCreateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/classifications/classifications_client.go
+++ b/client/classifications/classifications_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new classifications API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new classifications API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new classifications API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -63,7 +113,7 @@ func (a *Client) ClassificationsGet(params *ClassificationsGetParams, authInfo r
 		Method:             "GET",
 		PathPattern:        "/classifications/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ClassificationsGetReader{formats: a.formats},
@@ -104,7 +154,7 @@ func (a *Client) ClassificationsPost(params *ClassificationsPostParams, authInfo
 		Method:             "POST",
 		PathPattern:        "/classifications/",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ClassificationsPostReader{formats: a.formats},

--- a/client/classifications/classifications_get_responses.go
+++ b/client/classifications/classifications_get_responses.go
@@ -17,6 +17,7 @@ package classifications
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *ClassificationsGetReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /classifications/{id}] classifications.get", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *ClassificationsGetOK) Code() int {
 }
 
 func (o *ClassificationsGetOK) Error() string {
-	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetOK %s", 200, payload)
 }
 
 func (o *ClassificationsGetOK) String() string {
-	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetOK %s", 200, payload)
 }
 
 func (o *ClassificationsGetOK) GetPayload() *models.Classification {
@@ -126,7 +129,6 @@ func (o *ClassificationsGetOK) GetPayload() *models.Classification {
 }
 
 func (o *ClassificationsGetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Classification)
 
 	// response payload
@@ -147,8 +149,7 @@ ClassificationsGetUnauthorized describes a response with status code 401, with d
 
 Unauthorized or invalid credentials.
 */
-type ClassificationsGetUnauthorized struct {
-}
+type ClassificationsGetUnauthorized struct{}
 
 // IsSuccess returns true when this classifications get unauthorized response has a 2xx status code
 func (o *ClassificationsGetUnauthorized) IsSuccess() bool {
@@ -181,15 +182,14 @@ func (o *ClassificationsGetUnauthorized) Code() int {
 }
 
 func (o *ClassificationsGetUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetUnauthorized", 401)
 }
 
 func (o *ClassificationsGetUnauthorized) String() string {
-	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetUnauthorized", 401)
 }
 
 func (o *ClassificationsGetUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -238,11 +238,13 @@ func (o *ClassificationsGetForbidden) Code() int {
 }
 
 func (o *ClassificationsGetForbidden) Error() string {
-	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetForbidden %s", 403, payload)
 }
 
 func (o *ClassificationsGetForbidden) String() string {
-	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetForbidden %s", 403, payload)
 }
 
 func (o *ClassificationsGetForbidden) GetPayload() *models.ErrorResponse {
@@ -250,7 +252,6 @@ func (o *ClassificationsGetForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ClassificationsGetForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -271,8 +272,7 @@ ClassificationsGetNotFound describes a response with status code 404, with defau
 
 Not Found - Classification does not exist
 */
-type ClassificationsGetNotFound struct {
-}
+type ClassificationsGetNotFound struct{}
 
 // IsSuccess returns true when this classifications get not found response has a 2xx status code
 func (o *ClassificationsGetNotFound) IsSuccess() bool {
@@ -305,15 +305,14 @@ func (o *ClassificationsGetNotFound) Code() int {
 }
 
 func (o *ClassificationsGetNotFound) Error() string {
-	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetNotFound ", 404)
+	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetNotFound", 404)
 }
 
 func (o *ClassificationsGetNotFound) String() string {
-	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetNotFound ", 404)
+	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetNotFound", 404)
 }
 
 func (o *ClassificationsGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -362,11 +361,13 @@ func (o *ClassificationsGetInternalServerError) Code() int {
 }
 
 func (o *ClassificationsGetInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetInternalServerError %s", 500, payload)
 }
 
 func (o *ClassificationsGetInternalServerError) String() string {
-	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetInternalServerError %s", 500, payload)
 }
 
 func (o *ClassificationsGetInternalServerError) GetPayload() *models.ErrorResponse {
@@ -374,7 +375,6 @@ func (o *ClassificationsGetInternalServerError) GetPayload() *models.ErrorRespon
 }
 
 func (o *ClassificationsGetInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/classifications/classifications_post_responses.go
+++ b/client/classifications/classifications_post_responses.go
@@ -17,6 +17,7 @@ package classifications
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *ClassificationsPostReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /classifications/] classifications.post", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *ClassificationsPostCreated) Code() int {
 }
 
 func (o *ClassificationsPostCreated) Error() string {
-	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostCreated  %+v", 201, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostCreated %s", 201, payload)
 }
 
 func (o *ClassificationsPostCreated) String() string {
-	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostCreated  %+v", 201, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostCreated %s", 201, payload)
 }
 
 func (o *ClassificationsPostCreated) GetPayload() *models.Classification {
@@ -126,7 +129,6 @@ func (o *ClassificationsPostCreated) GetPayload() *models.Classification {
 }
 
 func (o *ClassificationsPostCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Classification)
 
 	// response payload
@@ -182,11 +184,13 @@ func (o *ClassificationsPostBadRequest) Code() int {
 }
 
 func (o *ClassificationsPostBadRequest) Error() string {
-	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostBadRequest %s", 400, payload)
 }
 
 func (o *ClassificationsPostBadRequest) String() string {
-	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostBadRequest %s", 400, payload)
 }
 
 func (o *ClassificationsPostBadRequest) GetPayload() *models.ErrorResponse {
@@ -194,7 +198,6 @@ func (o *ClassificationsPostBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ClassificationsPostBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -215,8 +218,7 @@ ClassificationsPostUnauthorized describes a response with status code 401, with 
 
 Unauthorized or invalid credentials.
 */
-type ClassificationsPostUnauthorized struct {
-}
+type ClassificationsPostUnauthorized struct{}
 
 // IsSuccess returns true when this classifications post unauthorized response has a 2xx status code
 func (o *ClassificationsPostUnauthorized) IsSuccess() bool {
@@ -249,15 +251,14 @@ func (o *ClassificationsPostUnauthorized) Code() int {
 }
 
 func (o *ClassificationsPostUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostUnauthorized ", 401)
+	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostUnauthorized", 401)
 }
 
 func (o *ClassificationsPostUnauthorized) String() string {
-	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostUnauthorized ", 401)
+	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostUnauthorized", 401)
 }
 
 func (o *ClassificationsPostUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -306,11 +307,13 @@ func (o *ClassificationsPostForbidden) Code() int {
 }
 
 func (o *ClassificationsPostForbidden) Error() string {
-	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostForbidden %s", 403, payload)
 }
 
 func (o *ClassificationsPostForbidden) String() string {
-	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostForbidden %s", 403, payload)
 }
 
 func (o *ClassificationsPostForbidden) GetPayload() *models.ErrorResponse {
@@ -318,7 +321,6 @@ func (o *ClassificationsPostForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ClassificationsPostForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -374,11 +376,13 @@ func (o *ClassificationsPostInternalServerError) Code() int {
 }
 
 func (o *ClassificationsPostInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostInternalServerError %s", 500, payload)
 }
 
 func (o *ClassificationsPostInternalServerError) String() string {
-	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostInternalServerError %s", 500, payload)
 }
 
 func (o *ClassificationsPostInternalServerError) GetPayload() *models.ErrorResponse {
@@ -386,7 +390,6 @@ func (o *ClassificationsPostInternalServerError) GetPayload() *models.ErrorRespo
 }
 
 func (o *ClassificationsPostInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/cluster/cluster_client.go
+++ b/client/cluster/cluster_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new cluster API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new cluster API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new cluster API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -61,7 +111,7 @@ func (a *Client) ClusterGetStatistics(params *ClusterGetStatisticsParams, authIn
 		Method:             "GET",
 		PathPattern:        "/cluster/statistics",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ClusterGetStatisticsReader{formats: a.formats},

--- a/client/cluster/cluster_get_statistics_responses.go
+++ b/client/cluster/cluster_get_statistics_responses.go
@@ -17,6 +17,7 @@ package cluster
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *ClusterGetStatisticsReader) ReadResponse(response runtime.ClientRespons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /cluster/statistics] cluster.get.statistics", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *ClusterGetStatisticsOK) Code() int {
 }
 
 func (o *ClusterGetStatisticsOK) Error() string {
-	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsOK %s", 200, payload)
 }
 
 func (o *ClusterGetStatisticsOK) String() string {
-	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsOK %s", 200, payload)
 }
 
 func (o *ClusterGetStatisticsOK) GetPayload() *models.ClusterStatisticsResponse {
@@ -126,7 +129,6 @@ func (o *ClusterGetStatisticsOK) GetPayload() *models.ClusterStatisticsResponse 
 }
 
 func (o *ClusterGetStatisticsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ClusterStatisticsResponse)
 
 	// response payload
@@ -147,8 +149,7 @@ ClusterGetStatisticsUnauthorized describes a response with status code 401, with
 
 Unauthorized or invalid credentials.
 */
-type ClusterGetStatisticsUnauthorized struct {
-}
+type ClusterGetStatisticsUnauthorized struct{}
 
 // IsSuccess returns true when this cluster get statistics unauthorized response has a 2xx status code
 func (o *ClusterGetStatisticsUnauthorized) IsSuccess() bool {
@@ -181,15 +182,14 @@ func (o *ClusterGetStatisticsUnauthorized) Code() int {
 }
 
 func (o *ClusterGetStatisticsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsUnauthorized ", 401)
+	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsUnauthorized", 401)
 }
 
 func (o *ClusterGetStatisticsUnauthorized) String() string {
-	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsUnauthorized ", 401)
+	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsUnauthorized", 401)
 }
 
 func (o *ClusterGetStatisticsUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -238,11 +238,13 @@ func (o *ClusterGetStatisticsForbidden) Code() int {
 }
 
 func (o *ClusterGetStatisticsForbidden) Error() string {
-	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsForbidden %s", 403, payload)
 }
 
 func (o *ClusterGetStatisticsForbidden) String() string {
-	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsForbidden %s", 403, payload)
 }
 
 func (o *ClusterGetStatisticsForbidden) GetPayload() *models.ErrorResponse {
@@ -250,7 +252,6 @@ func (o *ClusterGetStatisticsForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ClusterGetStatisticsForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -306,11 +307,13 @@ func (o *ClusterGetStatisticsUnprocessableEntity) Code() int {
 }
 
 func (o *ClusterGetStatisticsUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ClusterGetStatisticsUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ClusterGetStatisticsUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -318,7 +321,6 @@ func (o *ClusterGetStatisticsUnprocessableEntity) GetPayload() *models.ErrorResp
 }
 
 func (o *ClusterGetStatisticsUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -374,11 +376,13 @@ func (o *ClusterGetStatisticsInternalServerError) Code() int {
 }
 
 func (o *ClusterGetStatisticsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsInternalServerError %s", 500, payload)
 }
 
 func (o *ClusterGetStatisticsInternalServerError) String() string {
-	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /cluster/statistics][%d] clusterGetStatisticsInternalServerError %s", 500, payload)
 }
 
 func (o *ClusterGetStatisticsInternalServerError) GetPayload() *models.ErrorResponse {
@@ -386,7 +390,6 @@ func (o *ClusterGetStatisticsInternalServerError) GetPayload() *models.ErrorResp
 }
 
 func (o *ClusterGetStatisticsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/distributed_tasks/distributed_tasks_client.go
+++ b/client/distributed_tasks/distributed_tasks_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new distributed tasks API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new distributed tasks API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new distributed tasks API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -59,7 +109,7 @@ func (a *Client) DistributedTasksGet(params *DistributedTasksGetParams, authInfo
 		Method:             "GET",
 		PathPattern:        "/tasks",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &DistributedTasksGetReader{formats: a.formats},

--- a/client/distributed_tasks/distributed_tasks_get_responses.go
+++ b/client/distributed_tasks/distributed_tasks_get_responses.go
@@ -17,6 +17,7 @@ package distributed_tasks
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -53,7 +54,7 @@ func (o *DistributedTasksGetReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /tasks] distributedTasks.get", response, response.Code())
 	}
 }
 
@@ -102,11 +103,13 @@ func (o *DistributedTasksGetOK) Code() int {
 }
 
 func (o *DistributedTasksGetOK) Error() string {
-	return fmt.Sprintf("[GET /tasks][%d] distributedTasksGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /tasks][%d] distributedTasksGetOK %s", 200, payload)
 }
 
 func (o *DistributedTasksGetOK) String() string {
-	return fmt.Sprintf("[GET /tasks][%d] distributedTasksGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /tasks][%d] distributedTasksGetOK %s", 200, payload)
 }
 
 func (o *DistributedTasksGetOK) GetPayload() models.DistributedTasks {
@@ -114,7 +117,6 @@ func (o *DistributedTasksGetOK) GetPayload() models.DistributedTasks {
 }
 
 func (o *DistributedTasksGetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -168,11 +170,13 @@ func (o *DistributedTasksGetForbidden) Code() int {
 }
 
 func (o *DistributedTasksGetForbidden) Error() string {
-	return fmt.Sprintf("[GET /tasks][%d] distributedTasksGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /tasks][%d] distributedTasksGetForbidden %s", 403, payload)
 }
 
 func (o *DistributedTasksGetForbidden) String() string {
-	return fmt.Sprintf("[GET /tasks][%d] distributedTasksGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /tasks][%d] distributedTasksGetForbidden %s", 403, payload)
 }
 
 func (o *DistributedTasksGetForbidden) GetPayload() *models.ErrorResponse {
@@ -180,7 +184,6 @@ func (o *DistributedTasksGetForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DistributedTasksGetForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -236,11 +239,13 @@ func (o *DistributedTasksGetInternalServerError) Code() int {
 }
 
 func (o *DistributedTasksGetInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /tasks][%d] distributedTasksGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /tasks][%d] distributedTasksGetInternalServerError %s", 500, payload)
 }
 
 func (o *DistributedTasksGetInternalServerError) String() string {
-	return fmt.Sprintf("[GET /tasks][%d] distributedTasksGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /tasks][%d] distributedTasksGetInternalServerError %s", 500, payload)
 }
 
 func (o *DistributedTasksGetInternalServerError) GetPayload() *models.ErrorResponse {
@@ -248,7 +253,6 @@ func (o *DistributedTasksGetInternalServerError) GetPayload() *models.ErrorRespo
 }
 
 func (o *DistributedTasksGetInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/graphql/graphql_batch_responses.go
+++ b/client/graphql/graphql_batch_responses.go
@@ -17,6 +17,7 @@ package graphql
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *GraphqlBatchReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /graphql/batch] graphql.batch", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *GraphqlBatchOK) Code() int {
 }
 
 func (o *GraphqlBatchOK) Error() string {
-	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchOK %s", 200, payload)
 }
 
 func (o *GraphqlBatchOK) String() string {
-	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchOK %s", 200, payload)
 }
 
 func (o *GraphqlBatchOK) GetPayload() models.GraphQLResponses {
@@ -126,7 +129,6 @@ func (o *GraphqlBatchOK) GetPayload() models.GraphQLResponses {
 }
 
 func (o *GraphqlBatchOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -145,8 +147,7 @@ GraphqlBatchUnauthorized describes a response with status code 401, with default
 
 Unauthorized or invalid credentials.
 */
-type GraphqlBatchUnauthorized struct {
-}
+type GraphqlBatchUnauthorized struct{}
 
 // IsSuccess returns true when this graphql batch unauthorized response has a 2xx status code
 func (o *GraphqlBatchUnauthorized) IsSuccess() bool {
@@ -179,15 +180,14 @@ func (o *GraphqlBatchUnauthorized) Code() int {
 }
 
 func (o *GraphqlBatchUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchUnauthorized ", 401)
+	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchUnauthorized", 401)
 }
 
 func (o *GraphqlBatchUnauthorized) String() string {
-	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchUnauthorized ", 401)
+	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchUnauthorized", 401)
 }
 
 func (o *GraphqlBatchUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -236,11 +236,13 @@ func (o *GraphqlBatchForbidden) Code() int {
 }
 
 func (o *GraphqlBatchForbidden) Error() string {
-	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchForbidden %s", 403, payload)
 }
 
 func (o *GraphqlBatchForbidden) String() string {
-	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchForbidden %s", 403, payload)
 }
 
 func (o *GraphqlBatchForbidden) GetPayload() *models.ErrorResponse {
@@ -248,7 +250,6 @@ func (o *GraphqlBatchForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GraphqlBatchForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -304,11 +305,13 @@ func (o *GraphqlBatchUnprocessableEntity) Code() int {
 }
 
 func (o *GraphqlBatchUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GraphqlBatchUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GraphqlBatchUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -316,7 +319,6 @@ func (o *GraphqlBatchUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GraphqlBatchUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -372,11 +374,13 @@ func (o *GraphqlBatchInternalServerError) Code() int {
 }
 
 func (o *GraphqlBatchInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchInternalServerError %s", 500, payload)
 }
 
 func (o *GraphqlBatchInternalServerError) String() string {
-	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchInternalServerError %s", 500, payload)
 }
 
 func (o *GraphqlBatchInternalServerError) GetPayload() *models.ErrorResponse {
@@ -384,7 +388,6 @@ func (o *GraphqlBatchInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GraphqlBatchInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/graphql/graphql_client.go
+++ b/client/graphql/graphql_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new graphql API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new graphql API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new graphql API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -63,7 +113,7 @@ func (a *Client) GraphqlBatch(params *GraphqlBatchParams, authInfo runtime.Clien
 		Method:             "POST",
 		PathPattern:        "/graphql/batch",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GraphqlBatchReader{formats: a.formats},
@@ -104,7 +154,7 @@ func (a *Client) GraphqlPost(params *GraphqlPostParams, authInfo runtime.ClientA
 		Method:             "POST",
 		PathPattern:        "/graphql",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GraphqlPostReader{formats: a.formats},

--- a/client/graphql/graphql_post_responses.go
+++ b/client/graphql/graphql_post_responses.go
@@ -17,6 +17,7 @@ package graphql
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *GraphqlPostReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /graphql] graphql.post", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *GraphqlPostOK) Code() int {
 }
 
 func (o *GraphqlPostOK) Error() string {
-	return fmt.Sprintf("[POST /graphql][%d] graphqlPostOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql][%d] graphqlPostOK %s", 200, payload)
 }
 
 func (o *GraphqlPostOK) String() string {
-	return fmt.Sprintf("[POST /graphql][%d] graphqlPostOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql][%d] graphqlPostOK %s", 200, payload)
 }
 
 func (o *GraphqlPostOK) GetPayload() *models.GraphQLResponse {
@@ -126,7 +129,6 @@ func (o *GraphqlPostOK) GetPayload() *models.GraphQLResponse {
 }
 
 func (o *GraphqlPostOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.GraphQLResponse)
 
 	// response payload
@@ -147,8 +149,7 @@ GraphqlPostUnauthorized describes a response with status code 401, with default 
 
 Unauthorized or invalid credentials.
 */
-type GraphqlPostUnauthorized struct {
-}
+type GraphqlPostUnauthorized struct{}
 
 // IsSuccess returns true when this graphql post unauthorized response has a 2xx status code
 func (o *GraphqlPostUnauthorized) IsSuccess() bool {
@@ -181,15 +182,14 @@ func (o *GraphqlPostUnauthorized) Code() int {
 }
 
 func (o *GraphqlPostUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /graphql][%d] graphqlPostUnauthorized ", 401)
+	return fmt.Sprintf("[POST /graphql][%d] graphqlPostUnauthorized", 401)
 }
 
 func (o *GraphqlPostUnauthorized) String() string {
-	return fmt.Sprintf("[POST /graphql][%d] graphqlPostUnauthorized ", 401)
+	return fmt.Sprintf("[POST /graphql][%d] graphqlPostUnauthorized", 401)
 }
 
 func (o *GraphqlPostUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -238,11 +238,13 @@ func (o *GraphqlPostForbidden) Code() int {
 }
 
 func (o *GraphqlPostForbidden) Error() string {
-	return fmt.Sprintf("[POST /graphql][%d] graphqlPostForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql][%d] graphqlPostForbidden %s", 403, payload)
 }
 
 func (o *GraphqlPostForbidden) String() string {
-	return fmt.Sprintf("[POST /graphql][%d] graphqlPostForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql][%d] graphqlPostForbidden %s", 403, payload)
 }
 
 func (o *GraphqlPostForbidden) GetPayload() *models.ErrorResponse {
@@ -250,7 +252,6 @@ func (o *GraphqlPostForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GraphqlPostForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -306,11 +307,13 @@ func (o *GraphqlPostUnprocessableEntity) Code() int {
 }
 
 func (o *GraphqlPostUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /graphql][%d] graphqlPostUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql][%d] graphqlPostUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GraphqlPostUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /graphql][%d] graphqlPostUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql][%d] graphqlPostUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GraphqlPostUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -318,7 +321,6 @@ func (o *GraphqlPostUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GraphqlPostUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -374,11 +376,13 @@ func (o *GraphqlPostInternalServerError) Code() int {
 }
 
 func (o *GraphqlPostInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /graphql][%d] graphqlPostInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql][%d] graphqlPostInternalServerError %s", 500, payload)
 }
 
 func (o *GraphqlPostInternalServerError) String() string {
-	return fmt.Sprintf("[POST /graphql][%d] graphqlPostInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /graphql][%d] graphqlPostInternalServerError %s", 500, payload)
 }
 
 func (o *GraphqlPostInternalServerError) GetPayload() *models.ErrorResponse {
@@ -386,7 +390,6 @@ func (o *GraphqlPostInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GraphqlPostInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/meta/meta_client.go
+++ b/client/meta/meta_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new meta API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new meta API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new meta API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -61,7 +111,7 @@ func (a *Client) MetaGet(params *MetaGetParams, authInfo runtime.ClientAuthInfoW
 		Method:             "GET",
 		PathPattern:        "/meta",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &MetaGetReader{formats: a.formats},

--- a/client/meta/meta_get_responses.go
+++ b/client/meta/meta_get_responses.go
@@ -17,6 +17,7 @@ package meta
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -59,7 +60,7 @@ func (o *MetaGetReader) ReadResponse(response runtime.ClientResponse, consumer r
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /meta] meta.get", response, response.Code())
 	}
 }
 
@@ -108,11 +109,13 @@ func (o *MetaGetOK) Code() int {
 }
 
 func (o *MetaGetOK) Error() string {
-	return fmt.Sprintf("[GET /meta][%d] metaGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /meta][%d] metaGetOK %s", 200, payload)
 }
 
 func (o *MetaGetOK) String() string {
-	return fmt.Sprintf("[GET /meta][%d] metaGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /meta][%d] metaGetOK %s", 200, payload)
 }
 
 func (o *MetaGetOK) GetPayload() *models.Meta {
@@ -120,7 +123,6 @@ func (o *MetaGetOK) GetPayload() *models.Meta {
 }
 
 func (o *MetaGetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Meta)
 
 	// response payload
@@ -141,8 +143,7 @@ MetaGetUnauthorized describes a response with status code 401, with default head
 
 Unauthorized or invalid credentials.
 */
-type MetaGetUnauthorized struct {
-}
+type MetaGetUnauthorized struct{}
 
 // IsSuccess returns true when this meta get unauthorized response has a 2xx status code
 func (o *MetaGetUnauthorized) IsSuccess() bool {
@@ -175,15 +176,14 @@ func (o *MetaGetUnauthorized) Code() int {
 }
 
 func (o *MetaGetUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /meta][%d] metaGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /meta][%d] metaGetUnauthorized", 401)
 }
 
 func (o *MetaGetUnauthorized) String() string {
-	return fmt.Sprintf("[GET /meta][%d] metaGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /meta][%d] metaGetUnauthorized", 401)
 }
 
 func (o *MetaGetUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -232,11 +232,13 @@ func (o *MetaGetForbidden) Code() int {
 }
 
 func (o *MetaGetForbidden) Error() string {
-	return fmt.Sprintf("[GET /meta][%d] metaGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /meta][%d] metaGetForbidden %s", 403, payload)
 }
 
 func (o *MetaGetForbidden) String() string {
-	return fmt.Sprintf("[GET /meta][%d] metaGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /meta][%d] metaGetForbidden %s", 403, payload)
 }
 
 func (o *MetaGetForbidden) GetPayload() *models.ErrorResponse {
@@ -244,7 +246,6 @@ func (o *MetaGetForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *MetaGetForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -300,11 +301,13 @@ func (o *MetaGetInternalServerError) Code() int {
 }
 
 func (o *MetaGetInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /meta][%d] metaGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /meta][%d] metaGetInternalServerError %s", 500, payload)
 }
 
 func (o *MetaGetInternalServerError) String() string {
-	return fmt.Sprintf("[GET /meta][%d] metaGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /meta][%d] metaGetInternalServerError %s", 500, payload)
 }
 
 func (o *MetaGetInternalServerError) GetPayload() *models.ErrorResponse {
@@ -312,7 +315,6 @@ func (o *MetaGetInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *MetaGetInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/nodes/nodes_client.go
+++ b/client/nodes/nodes_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new nodes API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new nodes API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new nodes API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -63,7 +113,7 @@ func (a *Client) NodesGet(params *NodesGetParams, authInfo runtime.ClientAuthInf
 		Method:             "GET",
 		PathPattern:        "/nodes",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &NodesGetReader{formats: a.formats},
@@ -104,7 +154,7 @@ func (a *Client) NodesGetClass(params *NodesGetClassParams, authInfo runtime.Cli
 		Method:             "GET",
 		PathPattern:        "/nodes/{className}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &NodesGetClassReader{formats: a.formats},

--- a/client/nodes/nodes_get_class_responses.go
+++ b/client/nodes/nodes_get_class_responses.go
@@ -17,6 +17,7 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *NodesGetClassReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /nodes/{className}] nodes.get.class", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *NodesGetClassOK) Code() int {
 }
 
 func (o *NodesGetClassOK) Error() string {
-	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassOK %s", 200, payload)
 }
 
 func (o *NodesGetClassOK) String() string {
-	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassOK %s", 200, payload)
 }
 
 func (o *NodesGetClassOK) GetPayload() *models.NodesStatusResponse {
@@ -132,7 +135,6 @@ func (o *NodesGetClassOK) GetPayload() *models.NodesStatusResponse {
 }
 
 func (o *NodesGetClassOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.NodesStatusResponse)
 
 	// response payload
@@ -153,8 +155,7 @@ NodesGetClassUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type NodesGetClassUnauthorized struct {
-}
+type NodesGetClassUnauthorized struct{}
 
 // IsSuccess returns true when this nodes get class unauthorized response has a 2xx status code
 func (o *NodesGetClassUnauthorized) IsSuccess() bool {
@@ -187,15 +188,14 @@ func (o *NodesGetClassUnauthorized) Code() int {
 }
 
 func (o *NodesGetClassUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassUnauthorized ", 401)
+	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassUnauthorized", 401)
 }
 
 func (o *NodesGetClassUnauthorized) String() string {
-	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassUnauthorized ", 401)
+	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassUnauthorized", 401)
 }
 
 func (o *NodesGetClassUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +244,13 @@ func (o *NodesGetClassForbidden) Code() int {
 }
 
 func (o *NodesGetClassForbidden) Error() string {
-	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassForbidden %s", 403, payload)
 }
 
 func (o *NodesGetClassForbidden) String() string {
-	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassForbidden %s", 403, payload)
 }
 
 func (o *NodesGetClassForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +258,6 @@ func (o *NodesGetClassForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *NodesGetClassForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -312,11 +313,13 @@ func (o *NodesGetClassNotFound) Code() int {
 }
 
 func (o *NodesGetClassNotFound) Error() string {
-	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassNotFound %s", 404, payload)
 }
 
 func (o *NodesGetClassNotFound) String() string {
-	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassNotFound %s", 404, payload)
 }
 
 func (o *NodesGetClassNotFound) GetPayload() *models.ErrorResponse {
@@ -324,7 +327,6 @@ func (o *NodesGetClassNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *NodesGetClassNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -380,11 +382,13 @@ func (o *NodesGetClassUnprocessableEntity) Code() int {
 }
 
 func (o *NodesGetClassUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassUnprocessableEntity %s", 422, payload)
 }
 
 func (o *NodesGetClassUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassUnprocessableEntity %s", 422, payload)
 }
 
 func (o *NodesGetClassUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -392,7 +396,6 @@ func (o *NodesGetClassUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *NodesGetClassUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -448,11 +451,13 @@ func (o *NodesGetClassInternalServerError) Code() int {
 }
 
 func (o *NodesGetClassInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassInternalServerError %s", 500, payload)
 }
 
 func (o *NodesGetClassInternalServerError) String() string {
-	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes/{className}][%d] nodesGetClassInternalServerError %s", 500, payload)
 }
 
 func (o *NodesGetClassInternalServerError) GetPayload() *models.ErrorResponse {
@@ -460,7 +465,6 @@ func (o *NodesGetClassInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *NodesGetClassInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/nodes/nodes_get_responses.go
+++ b/client/nodes/nodes_get_responses.go
@@ -17,6 +17,7 @@ package nodes
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *NodesGetReader) ReadResponse(response runtime.ClientResponse, consumer 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /nodes] nodes.get", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *NodesGetOK) Code() int {
 }
 
 func (o *NodesGetOK) Error() string {
-	return fmt.Sprintf("[GET /nodes][%d] nodesGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes][%d] nodesGetOK %s", 200, payload)
 }
 
 func (o *NodesGetOK) String() string {
-	return fmt.Sprintf("[GET /nodes][%d] nodesGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes][%d] nodesGetOK %s", 200, payload)
 }
 
 func (o *NodesGetOK) GetPayload() *models.NodesStatusResponse {
@@ -132,7 +135,6 @@ func (o *NodesGetOK) GetPayload() *models.NodesStatusResponse {
 }
 
 func (o *NodesGetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.NodesStatusResponse)
 
 	// response payload
@@ -153,8 +155,7 @@ NodesGetUnauthorized describes a response with status code 401, with default hea
 
 Unauthorized or invalid credentials.
 */
-type NodesGetUnauthorized struct {
-}
+type NodesGetUnauthorized struct{}
 
 // IsSuccess returns true when this nodes get unauthorized response has a 2xx status code
 func (o *NodesGetUnauthorized) IsSuccess() bool {
@@ -187,15 +188,14 @@ func (o *NodesGetUnauthorized) Code() int {
 }
 
 func (o *NodesGetUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /nodes][%d] nodesGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /nodes][%d] nodesGetUnauthorized", 401)
 }
 
 func (o *NodesGetUnauthorized) String() string {
-	return fmt.Sprintf("[GET /nodes][%d] nodesGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /nodes][%d] nodesGetUnauthorized", 401)
 }
 
 func (o *NodesGetUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +244,13 @@ func (o *NodesGetForbidden) Code() int {
 }
 
 func (o *NodesGetForbidden) Error() string {
-	return fmt.Sprintf("[GET /nodes][%d] nodesGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes][%d] nodesGetForbidden %s", 403, payload)
 }
 
 func (o *NodesGetForbidden) String() string {
-	return fmt.Sprintf("[GET /nodes][%d] nodesGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes][%d] nodesGetForbidden %s", 403, payload)
 }
 
 func (o *NodesGetForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +258,6 @@ func (o *NodesGetForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *NodesGetForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -312,11 +313,13 @@ func (o *NodesGetNotFound) Code() int {
 }
 
 func (o *NodesGetNotFound) Error() string {
-	return fmt.Sprintf("[GET /nodes][%d] nodesGetNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes][%d] nodesGetNotFound %s", 404, payload)
 }
 
 func (o *NodesGetNotFound) String() string {
-	return fmt.Sprintf("[GET /nodes][%d] nodesGetNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes][%d] nodesGetNotFound %s", 404, payload)
 }
 
 func (o *NodesGetNotFound) GetPayload() *models.ErrorResponse {
@@ -324,7 +327,6 @@ func (o *NodesGetNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *NodesGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -380,11 +382,13 @@ func (o *NodesGetUnprocessableEntity) Code() int {
 }
 
 func (o *NodesGetUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /nodes][%d] nodesGetUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes][%d] nodesGetUnprocessableEntity %s", 422, payload)
 }
 
 func (o *NodesGetUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /nodes][%d] nodesGetUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes][%d] nodesGetUnprocessableEntity %s", 422, payload)
 }
 
 func (o *NodesGetUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -392,7 +396,6 @@ func (o *NodesGetUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *NodesGetUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -448,11 +451,13 @@ func (o *NodesGetInternalServerError) Code() int {
 }
 
 func (o *NodesGetInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /nodes][%d] nodesGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes][%d] nodesGetInternalServerError %s", 500, payload)
 }
 
 func (o *NodesGetInternalServerError) String() string {
-	return fmt.Sprintf("[GET /nodes][%d] nodesGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /nodes][%d] nodesGetInternalServerError %s", 500, payload)
 }
 
 func (o *NodesGetInternalServerError) GetPayload() *models.ErrorResponse {
@@ -460,7 +465,6 @@ func (o *NodesGetInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *NodesGetInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_class_delete_responses.go
+++ b/client/objects/objects_class_delete_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *ObjectsClassDeleteReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /objects/{className}/{id}] objects.class.delete", response, response.Code())
 	}
 }
 
@@ -91,8 +92,7 @@ ObjectsClassDeleteNoContent describes a response with status code 204, with defa
 
 Successfully deleted.
 */
-type ObjectsClassDeleteNoContent struct {
-}
+type ObjectsClassDeleteNoContent struct{}
 
 // IsSuccess returns true when this objects class delete no content response has a 2xx status code
 func (o *ObjectsClassDeleteNoContent) IsSuccess() bool {
@@ -125,15 +125,14 @@ func (o *ObjectsClassDeleteNoContent) Code() int {
 }
 
 func (o *ObjectsClassDeleteNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteNoContent ", 204)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteNoContent", 204)
 }
 
 func (o *ObjectsClassDeleteNoContent) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteNoContent ", 204)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteNoContent", 204)
 }
 
 func (o *ObjectsClassDeleteNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -182,11 +181,13 @@ func (o *ObjectsClassDeleteBadRequest) Code() int {
 }
 
 func (o *ObjectsClassDeleteBadRequest) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsClassDeleteBadRequest) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsClassDeleteBadRequest) GetPayload() *models.ErrorResponse {
@@ -194,7 +195,6 @@ func (o *ObjectsClassDeleteBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsClassDeleteBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -215,8 +215,7 @@ ObjectsClassDeleteUnauthorized describes a response with status code 401, with d
 
 Unauthorized or invalid credentials.
 */
-type ObjectsClassDeleteUnauthorized struct {
-}
+type ObjectsClassDeleteUnauthorized struct{}
 
 // IsSuccess returns true when this objects class delete unauthorized response has a 2xx status code
 func (o *ObjectsClassDeleteUnauthorized) IsSuccess() bool {
@@ -249,15 +248,14 @@ func (o *ObjectsClassDeleteUnauthorized) Code() int {
 }
 
 func (o *ObjectsClassDeleteUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteUnauthorized", 401)
 }
 
 func (o *ObjectsClassDeleteUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteUnauthorized", 401)
 }
 
 func (o *ObjectsClassDeleteUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -306,11 +304,13 @@ func (o *ObjectsClassDeleteForbidden) Code() int {
 }
 
 func (o *ObjectsClassDeleteForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassDeleteForbidden) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassDeleteForbidden) GetPayload() *models.ErrorResponse {
@@ -318,7 +318,6 @@ func (o *ObjectsClassDeleteForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsClassDeleteForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -339,8 +338,7 @@ ObjectsClassDeleteNotFound describes a response with status code 404, with defau
 
 Successful query result but no resource was found.
 */
-type ObjectsClassDeleteNotFound struct {
-}
+type ObjectsClassDeleteNotFound struct{}
 
 // IsSuccess returns true when this objects class delete not found response has a 2xx status code
 func (o *ObjectsClassDeleteNotFound) IsSuccess() bool {
@@ -373,15 +371,14 @@ func (o *ObjectsClassDeleteNotFound) Code() int {
 }
 
 func (o *ObjectsClassDeleteNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteNotFound ", 404)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteNotFound", 404)
 }
 
 func (o *ObjectsClassDeleteNotFound) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteNotFound ", 404)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteNotFound", 404)
 }
 
 func (o *ObjectsClassDeleteNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -430,11 +427,13 @@ func (o *ObjectsClassDeleteUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsClassDeleteUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassDeleteUnprocessableEntity) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassDeleteUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -442,7 +441,6 @@ func (o *ObjectsClassDeleteUnprocessableEntity) GetPayload() *models.ErrorRespon
 }
 
 func (o *ObjectsClassDeleteUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -498,11 +496,13 @@ func (o *ObjectsClassDeleteInternalServerError) Code() int {
 }
 
 func (o *ObjectsClassDeleteInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassDeleteInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}][%d] objectsClassDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassDeleteInternalServerError) GetPayload() *models.ErrorResponse {
@@ -510,7 +510,6 @@ func (o *ObjectsClassDeleteInternalServerError) GetPayload() *models.ErrorRespon
 }
 
 func (o *ObjectsClassDeleteInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_class_get_responses.go
+++ b/client/objects/objects_class_get_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *ObjectsClassGetReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /objects/{className}/{id}] objects.class.get", response, response.Code())
 	}
 }
 
@@ -126,11 +127,13 @@ func (o *ObjectsClassGetOK) Code() int {
 }
 
 func (o *ObjectsClassGetOK) Error() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetOK %s", 200, payload)
 }
 
 func (o *ObjectsClassGetOK) String() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetOK %s", 200, payload)
 }
 
 func (o *ObjectsClassGetOK) GetPayload() *models.Object {
@@ -138,7 +141,6 @@ func (o *ObjectsClassGetOK) GetPayload() *models.Object {
 }
 
 func (o *ObjectsClassGetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Object)
 
 	// response payload
@@ -194,11 +196,13 @@ func (o *ObjectsClassGetBadRequest) Code() int {
 }
 
 func (o *ObjectsClassGetBadRequest) Error() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsClassGetBadRequest) String() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsClassGetBadRequest) GetPayload() *models.ErrorResponse {
@@ -206,7 +210,6 @@ func (o *ObjectsClassGetBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsClassGetBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -227,8 +230,7 @@ ObjectsClassGetUnauthorized describes a response with status code 401, with defa
 
 Unauthorized or invalid credentials.
 */
-type ObjectsClassGetUnauthorized struct {
-}
+type ObjectsClassGetUnauthorized struct{}
 
 // IsSuccess returns true when this objects class get unauthorized response has a 2xx status code
 func (o *ObjectsClassGetUnauthorized) IsSuccess() bool {
@@ -261,15 +263,14 @@ func (o *ObjectsClassGetUnauthorized) Code() int {
 }
 
 func (o *ObjectsClassGetUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetUnauthorized", 401)
 }
 
 func (o *ObjectsClassGetUnauthorized) String() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetUnauthorized", 401)
 }
 
 func (o *ObjectsClassGetUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -318,11 +319,13 @@ func (o *ObjectsClassGetForbidden) Code() int {
 }
 
 func (o *ObjectsClassGetForbidden) Error() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassGetForbidden) String() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassGetForbidden) GetPayload() *models.ErrorResponse {
@@ -330,7 +333,6 @@ func (o *ObjectsClassGetForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsClassGetForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -351,8 +353,7 @@ ObjectsClassGetNotFound describes a response with status code 404, with default 
 
 Successful query result but no resource was found.
 */
-type ObjectsClassGetNotFound struct {
-}
+type ObjectsClassGetNotFound struct{}
 
 // IsSuccess returns true when this objects class get not found response has a 2xx status code
 func (o *ObjectsClassGetNotFound) IsSuccess() bool {
@@ -385,15 +386,14 @@ func (o *ObjectsClassGetNotFound) Code() int {
 }
 
 func (o *ObjectsClassGetNotFound) Error() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetNotFound ", 404)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetNotFound", 404)
 }
 
 func (o *ObjectsClassGetNotFound) String() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetNotFound ", 404)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetNotFound", 404)
 }
 
 func (o *ObjectsClassGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -442,11 +442,13 @@ func (o *ObjectsClassGetUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsClassGetUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassGetUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassGetUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -454,7 +456,6 @@ func (o *ObjectsClassGetUnprocessableEntity) GetPayload() *models.ErrorResponse 
 }
 
 func (o *ObjectsClassGetUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -510,11 +511,13 @@ func (o *ObjectsClassGetInternalServerError) Code() int {
 }
 
 func (o *ObjectsClassGetInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassGetInternalServerError) String() string {
-	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{className}/{id}][%d] objectsClassGetInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassGetInternalServerError) GetPayload() *models.ErrorResponse {
@@ -522,7 +525,6 @@ func (o *ObjectsClassGetInternalServerError) GetPayload() *models.ErrorResponse 
 }
 
 func (o *ObjectsClassGetInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_class_head_responses.go
+++ b/client/objects/objects_class_head_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *ObjectsClassHeadReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[HEAD /objects/{className}/{id}] objects.class.head", response, response.Code())
 	}
 }
 
@@ -85,8 +86,7 @@ ObjectsClassHeadNoContent describes a response with status code 204, with defaul
 
 Object exists.
 */
-type ObjectsClassHeadNoContent struct {
-}
+type ObjectsClassHeadNoContent struct{}
 
 // IsSuccess returns true when this objects class head no content response has a 2xx status code
 func (o *ObjectsClassHeadNoContent) IsSuccess() bool {
@@ -119,15 +119,14 @@ func (o *ObjectsClassHeadNoContent) Code() int {
 }
 
 func (o *ObjectsClassHeadNoContent) Error() string {
-	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadNoContent ", 204)
+	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadNoContent", 204)
 }
 
 func (o *ObjectsClassHeadNoContent) String() string {
-	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadNoContent ", 204)
+	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadNoContent", 204)
 }
 
 func (o *ObjectsClassHeadNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -141,8 +140,7 @@ ObjectsClassHeadUnauthorized describes a response with status code 401, with def
 
 Unauthorized or invalid credentials.
 */
-type ObjectsClassHeadUnauthorized struct {
-}
+type ObjectsClassHeadUnauthorized struct{}
 
 // IsSuccess returns true when this objects class head unauthorized response has a 2xx status code
 func (o *ObjectsClassHeadUnauthorized) IsSuccess() bool {
@@ -175,15 +173,14 @@ func (o *ObjectsClassHeadUnauthorized) Code() int {
 }
 
 func (o *ObjectsClassHeadUnauthorized) Error() string {
-	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadUnauthorized ", 401)
+	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadUnauthorized", 401)
 }
 
 func (o *ObjectsClassHeadUnauthorized) String() string {
-	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadUnauthorized ", 401)
+	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadUnauthorized", 401)
 }
 
 func (o *ObjectsClassHeadUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -232,11 +229,13 @@ func (o *ObjectsClassHeadForbidden) Code() int {
 }
 
 func (o *ObjectsClassHeadForbidden) Error() string {
-	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassHeadForbidden) String() string {
-	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassHeadForbidden) GetPayload() *models.ErrorResponse {
@@ -244,7 +243,6 @@ func (o *ObjectsClassHeadForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsClassHeadForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -265,8 +263,7 @@ ObjectsClassHeadNotFound describes a response with status code 404, with default
 
 Object doesn't exist.
 */
-type ObjectsClassHeadNotFound struct {
-}
+type ObjectsClassHeadNotFound struct{}
 
 // IsSuccess returns true when this objects class head not found response has a 2xx status code
 func (o *ObjectsClassHeadNotFound) IsSuccess() bool {
@@ -299,15 +296,14 @@ func (o *ObjectsClassHeadNotFound) Code() int {
 }
 
 func (o *ObjectsClassHeadNotFound) Error() string {
-	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadNotFound ", 404)
+	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadNotFound", 404)
 }
 
 func (o *ObjectsClassHeadNotFound) String() string {
-	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadNotFound ", 404)
+	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadNotFound", 404)
 }
 
 func (o *ObjectsClassHeadNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -356,11 +352,13 @@ func (o *ObjectsClassHeadUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsClassHeadUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassHeadUnprocessableEntity) String() string {
-	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassHeadUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -368,7 +366,6 @@ func (o *ObjectsClassHeadUnprocessableEntity) GetPayload() *models.ErrorResponse
 }
 
 func (o *ObjectsClassHeadUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -424,11 +421,13 @@ func (o *ObjectsClassHeadInternalServerError) Code() int {
 }
 
 func (o *ObjectsClassHeadInternalServerError) Error() string {
-	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassHeadInternalServerError) String() string {
-	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /objects/{className}/{id}][%d] objectsClassHeadInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassHeadInternalServerError) GetPayload() *models.ErrorResponse {
@@ -436,7 +435,6 @@ func (o *ObjectsClassHeadInternalServerError) GetPayload() *models.ErrorResponse
 }
 
 func (o *ObjectsClassHeadInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_class_patch_responses.go
+++ b/client/objects/objects_class_patch_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *ObjectsClassPatchReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PATCH /objects/{className}/{id}] objects.class.patch", response, response.Code())
 	}
 }
 
@@ -91,8 +92,7 @@ ObjectsClassPatchNoContent describes a response with status code 204, with defau
 
 Successfully applied. No content provided.
 */
-type ObjectsClassPatchNoContent struct {
-}
+type ObjectsClassPatchNoContent struct{}
 
 // IsSuccess returns true when this objects class patch no content response has a 2xx status code
 func (o *ObjectsClassPatchNoContent) IsSuccess() bool {
@@ -125,15 +125,14 @@ func (o *ObjectsClassPatchNoContent) Code() int {
 }
 
 func (o *ObjectsClassPatchNoContent) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchNoContent ", 204)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchNoContent", 204)
 }
 
 func (o *ObjectsClassPatchNoContent) String() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchNoContent ", 204)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchNoContent", 204)
 }
 
 func (o *ObjectsClassPatchNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -182,11 +181,13 @@ func (o *ObjectsClassPatchBadRequest) Code() int {
 }
 
 func (o *ObjectsClassPatchBadRequest) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsClassPatchBadRequest) String() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsClassPatchBadRequest) GetPayload() *models.ErrorResponse {
@@ -194,7 +195,6 @@ func (o *ObjectsClassPatchBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsClassPatchBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -215,8 +215,7 @@ ObjectsClassPatchUnauthorized describes a response with status code 401, with de
 
 Unauthorized or invalid credentials.
 */
-type ObjectsClassPatchUnauthorized struct {
-}
+type ObjectsClassPatchUnauthorized struct{}
 
 // IsSuccess returns true when this objects class patch unauthorized response has a 2xx status code
 func (o *ObjectsClassPatchUnauthorized) IsSuccess() bool {
@@ -249,15 +248,14 @@ func (o *ObjectsClassPatchUnauthorized) Code() int {
 }
 
 func (o *ObjectsClassPatchUnauthorized) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchUnauthorized ", 401)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchUnauthorized", 401)
 }
 
 func (o *ObjectsClassPatchUnauthorized) String() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchUnauthorized ", 401)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchUnauthorized", 401)
 }
 
 func (o *ObjectsClassPatchUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -306,11 +304,13 @@ func (o *ObjectsClassPatchForbidden) Code() int {
 }
 
 func (o *ObjectsClassPatchForbidden) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassPatchForbidden) String() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassPatchForbidden) GetPayload() *models.ErrorResponse {
@@ -318,7 +318,6 @@ func (o *ObjectsClassPatchForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsClassPatchForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -339,8 +338,7 @@ ObjectsClassPatchNotFound describes a response with status code 404, with defaul
 
 Successful query result but no resource was found.
 */
-type ObjectsClassPatchNotFound struct {
-}
+type ObjectsClassPatchNotFound struct{}
 
 // IsSuccess returns true when this objects class patch not found response has a 2xx status code
 func (o *ObjectsClassPatchNotFound) IsSuccess() bool {
@@ -373,15 +371,14 @@ func (o *ObjectsClassPatchNotFound) Code() int {
 }
 
 func (o *ObjectsClassPatchNotFound) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchNotFound ", 404)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchNotFound", 404)
 }
 
 func (o *ObjectsClassPatchNotFound) String() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchNotFound ", 404)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchNotFound", 404)
 }
 
 func (o *ObjectsClassPatchNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -430,11 +427,13 @@ func (o *ObjectsClassPatchUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsClassPatchUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassPatchUnprocessableEntity) String() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassPatchUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -442,7 +441,6 @@ func (o *ObjectsClassPatchUnprocessableEntity) GetPayload() *models.ErrorRespons
 }
 
 func (o *ObjectsClassPatchUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -498,11 +496,13 @@ func (o *ObjectsClassPatchInternalServerError) Code() int {
 }
 
 func (o *ObjectsClassPatchInternalServerError) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassPatchInternalServerError) String() string {
-	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{className}/{id}][%d] objectsClassPatchInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassPatchInternalServerError) GetPayload() *models.ErrorResponse {
@@ -510,7 +510,6 @@ func (o *ObjectsClassPatchInternalServerError) GetPayload() *models.ErrorRespons
 }
 
 func (o *ObjectsClassPatchInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_class_put_responses.go
+++ b/client/objects/objects_class_put_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *ObjectsClassPutReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /objects/{className}/{id}] objects.class.put", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *ObjectsClassPutOK) Code() int {
 }
 
 func (o *ObjectsClassPutOK) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutOK %s", 200, payload)
 }
 
 func (o *ObjectsClassPutOK) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutOK %s", 200, payload)
 }
 
 func (o *ObjectsClassPutOK) GetPayload() *models.Object {
@@ -132,7 +135,6 @@ func (o *ObjectsClassPutOK) GetPayload() *models.Object {
 }
 
 func (o *ObjectsClassPutOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Object)
 
 	// response payload
@@ -153,8 +155,7 @@ ObjectsClassPutUnauthorized describes a response with status code 401, with defa
 
 Unauthorized or invalid credentials.
 */
-type ObjectsClassPutUnauthorized struct {
-}
+type ObjectsClassPutUnauthorized struct{}
 
 // IsSuccess returns true when this objects class put unauthorized response has a 2xx status code
 func (o *ObjectsClassPutUnauthorized) IsSuccess() bool {
@@ -187,15 +188,14 @@ func (o *ObjectsClassPutUnauthorized) Code() int {
 }
 
 func (o *ObjectsClassPutUnauthorized) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutUnauthorized", 401)
 }
 
 func (o *ObjectsClassPutUnauthorized) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutUnauthorized", 401)
 }
 
 func (o *ObjectsClassPutUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +244,13 @@ func (o *ObjectsClassPutForbidden) Code() int {
 }
 
 func (o *ObjectsClassPutForbidden) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassPutForbidden) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassPutForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +258,6 @@ func (o *ObjectsClassPutForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsClassPutForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -277,8 +278,7 @@ ObjectsClassPutNotFound describes a response with status code 404, with default 
 
 Successful query result but no resource was found.
 */
-type ObjectsClassPutNotFound struct {
-}
+type ObjectsClassPutNotFound struct{}
 
 // IsSuccess returns true when this objects class put not found response has a 2xx status code
 func (o *ObjectsClassPutNotFound) IsSuccess() bool {
@@ -311,15 +311,14 @@ func (o *ObjectsClassPutNotFound) Code() int {
 }
 
 func (o *ObjectsClassPutNotFound) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutNotFound ", 404)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutNotFound", 404)
 }
 
 func (o *ObjectsClassPutNotFound) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutNotFound ", 404)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutNotFound", 404)
 }
 
 func (o *ObjectsClassPutNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -368,11 +367,13 @@ func (o *ObjectsClassPutUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsClassPutUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassPutUnprocessableEntity) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassPutUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -380,7 +381,6 @@ func (o *ObjectsClassPutUnprocessableEntity) GetPayload() *models.ErrorResponse 
 }
 
 func (o *ObjectsClassPutUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -436,11 +436,13 @@ func (o *ObjectsClassPutInternalServerError) Code() int {
 }
 
 func (o *ObjectsClassPutInternalServerError) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassPutInternalServerError) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}][%d] objectsClassPutInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassPutInternalServerError) GetPayload() *models.ErrorResponse {
@@ -448,7 +450,6 @@ func (o *ObjectsClassPutInternalServerError) GetPayload() *models.ErrorResponse 
 }
 
 func (o *ObjectsClassPutInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_class_references_create_responses.go
+++ b/client/objects/objects_class_references_create_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *ObjectsClassReferencesCreateReader) ReadResponse(response runtime.Clien
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /objects/{className}/{id}/references/{propertyName}] objects.class.references.create", response, response.Code())
 	}
 }
 
@@ -91,8 +92,7 @@ ObjectsClassReferencesCreateOK describes a response with status code 200, with d
 
 Successfully added the reference.
 */
-type ObjectsClassReferencesCreateOK struct {
-}
+type ObjectsClassReferencesCreateOK struct{}
 
 // IsSuccess returns true when this objects class references create o k response has a 2xx status code
 func (o *ObjectsClassReferencesCreateOK) IsSuccess() bool {
@@ -125,15 +125,14 @@ func (o *ObjectsClassReferencesCreateOK) Code() int {
 }
 
 func (o *ObjectsClassReferencesCreateOK) Error() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateOK ", 200)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateOK", 200)
 }
 
 func (o *ObjectsClassReferencesCreateOK) String() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateOK ", 200)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateOK", 200)
 }
 
 func (o *ObjectsClassReferencesCreateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -182,11 +181,13 @@ func (o *ObjectsClassReferencesCreateBadRequest) Code() int {
 }
 
 func (o *ObjectsClassReferencesCreateBadRequest) Error() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsClassReferencesCreateBadRequest) String() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsClassReferencesCreateBadRequest) GetPayload() *models.ErrorResponse {
@@ -194,7 +195,6 @@ func (o *ObjectsClassReferencesCreateBadRequest) GetPayload() *models.ErrorRespo
 }
 
 func (o *ObjectsClassReferencesCreateBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -215,8 +215,7 @@ ObjectsClassReferencesCreateUnauthorized describes a response with status code 4
 
 Unauthorized or invalid credentials.
 */
-type ObjectsClassReferencesCreateUnauthorized struct {
-}
+type ObjectsClassReferencesCreateUnauthorized struct{}
 
 // IsSuccess returns true when this objects class references create unauthorized response has a 2xx status code
 func (o *ObjectsClassReferencesCreateUnauthorized) IsSuccess() bool {
@@ -249,15 +248,14 @@ func (o *ObjectsClassReferencesCreateUnauthorized) Code() int {
 }
 
 func (o *ObjectsClassReferencesCreateUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateUnauthorized", 401)
 }
 
 func (o *ObjectsClassReferencesCreateUnauthorized) String() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateUnauthorized", 401)
 }
 
 func (o *ObjectsClassReferencesCreateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -306,11 +304,13 @@ func (o *ObjectsClassReferencesCreateForbidden) Code() int {
 }
 
 func (o *ObjectsClassReferencesCreateForbidden) Error() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassReferencesCreateForbidden) String() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassReferencesCreateForbidden) GetPayload() *models.ErrorResponse {
@@ -318,7 +318,6 @@ func (o *ObjectsClassReferencesCreateForbidden) GetPayload() *models.ErrorRespon
 }
 
 func (o *ObjectsClassReferencesCreateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -339,8 +338,7 @@ ObjectsClassReferencesCreateNotFound describes a response with status code 404, 
 
 Source object doesn't exist.
 */
-type ObjectsClassReferencesCreateNotFound struct {
-}
+type ObjectsClassReferencesCreateNotFound struct{}
 
 // IsSuccess returns true when this objects class references create not found response has a 2xx status code
 func (o *ObjectsClassReferencesCreateNotFound) IsSuccess() bool {
@@ -373,15 +371,14 @@ func (o *ObjectsClassReferencesCreateNotFound) Code() int {
 }
 
 func (o *ObjectsClassReferencesCreateNotFound) Error() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateNotFound ", 404)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateNotFound", 404)
 }
 
 func (o *ObjectsClassReferencesCreateNotFound) String() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateNotFound ", 404)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateNotFound", 404)
 }
 
 func (o *ObjectsClassReferencesCreateNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -430,11 +427,13 @@ func (o *ObjectsClassReferencesCreateUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsClassReferencesCreateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassReferencesCreateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassReferencesCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -442,7 +441,6 @@ func (o *ObjectsClassReferencesCreateUnprocessableEntity) GetPayload() *models.E
 }
 
 func (o *ObjectsClassReferencesCreateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -498,11 +496,13 @@ func (o *ObjectsClassReferencesCreateInternalServerError) Code() int {
 }
 
 func (o *ObjectsClassReferencesCreateInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassReferencesCreateInternalServerError) String() string {
-	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesCreateInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassReferencesCreateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -510,7 +510,6 @@ func (o *ObjectsClassReferencesCreateInternalServerError) GetPayload() *models.E
 }
 
 func (o *ObjectsClassReferencesCreateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_class_references_delete_responses.go
+++ b/client/objects/objects_class_references_delete_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *ObjectsClassReferencesDeleteReader) ReadResponse(response runtime.Clien
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /objects/{className}/{id}/references/{propertyName}] objects.class.references.delete", response, response.Code())
 	}
 }
 
@@ -91,8 +92,7 @@ ObjectsClassReferencesDeleteNoContent describes a response with status code 204,
 
 Successfully deleted.
 */
-type ObjectsClassReferencesDeleteNoContent struct {
-}
+type ObjectsClassReferencesDeleteNoContent struct{}
 
 // IsSuccess returns true when this objects class references delete no content response has a 2xx status code
 func (o *ObjectsClassReferencesDeleteNoContent) IsSuccess() bool {
@@ -125,15 +125,14 @@ func (o *ObjectsClassReferencesDeleteNoContent) Code() int {
 }
 
 func (o *ObjectsClassReferencesDeleteNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteNoContent ", 204)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteNoContent", 204)
 }
 
 func (o *ObjectsClassReferencesDeleteNoContent) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteNoContent ", 204)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteNoContent", 204)
 }
 
 func (o *ObjectsClassReferencesDeleteNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -182,11 +181,13 @@ func (o *ObjectsClassReferencesDeleteBadRequest) Code() int {
 }
 
 func (o *ObjectsClassReferencesDeleteBadRequest) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsClassReferencesDeleteBadRequest) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsClassReferencesDeleteBadRequest) GetPayload() *models.ErrorResponse {
@@ -194,7 +195,6 @@ func (o *ObjectsClassReferencesDeleteBadRequest) GetPayload() *models.ErrorRespo
 }
 
 func (o *ObjectsClassReferencesDeleteBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -215,8 +215,7 @@ ObjectsClassReferencesDeleteUnauthorized describes a response with status code 4
 
 Unauthorized or invalid credentials.
 */
-type ObjectsClassReferencesDeleteUnauthorized struct {
-}
+type ObjectsClassReferencesDeleteUnauthorized struct{}
 
 // IsSuccess returns true when this objects class references delete unauthorized response has a 2xx status code
 func (o *ObjectsClassReferencesDeleteUnauthorized) IsSuccess() bool {
@@ -249,15 +248,14 @@ func (o *ObjectsClassReferencesDeleteUnauthorized) Code() int {
 }
 
 func (o *ObjectsClassReferencesDeleteUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteUnauthorized", 401)
 }
 
 func (o *ObjectsClassReferencesDeleteUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteUnauthorized", 401)
 }
 
 func (o *ObjectsClassReferencesDeleteUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -306,11 +304,13 @@ func (o *ObjectsClassReferencesDeleteForbidden) Code() int {
 }
 
 func (o *ObjectsClassReferencesDeleteForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassReferencesDeleteForbidden) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassReferencesDeleteForbidden) GetPayload() *models.ErrorResponse {
@@ -318,7 +318,6 @@ func (o *ObjectsClassReferencesDeleteForbidden) GetPayload() *models.ErrorRespon
 }
 
 func (o *ObjectsClassReferencesDeleteForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -374,11 +373,13 @@ func (o *ObjectsClassReferencesDeleteNotFound) Code() int {
 }
 
 func (o *ObjectsClassReferencesDeleteNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteNotFound %s", 404, payload)
 }
 
 func (o *ObjectsClassReferencesDeleteNotFound) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteNotFound %s", 404, payload)
 }
 
 func (o *ObjectsClassReferencesDeleteNotFound) GetPayload() *models.ErrorResponse {
@@ -386,7 +387,6 @@ func (o *ObjectsClassReferencesDeleteNotFound) GetPayload() *models.ErrorRespons
 }
 
 func (o *ObjectsClassReferencesDeleteNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -442,11 +442,13 @@ func (o *ObjectsClassReferencesDeleteUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsClassReferencesDeleteUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassReferencesDeleteUnprocessableEntity) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassReferencesDeleteUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -454,7 +456,6 @@ func (o *ObjectsClassReferencesDeleteUnprocessableEntity) GetPayload() *models.E
 }
 
 func (o *ObjectsClassReferencesDeleteUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -510,11 +511,13 @@ func (o *ObjectsClassReferencesDeleteInternalServerError) Code() int {
 }
 
 func (o *ObjectsClassReferencesDeleteInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassReferencesDeleteInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassReferencesDeleteInternalServerError) GetPayload() *models.ErrorResponse {
@@ -522,7 +525,6 @@ func (o *ObjectsClassReferencesDeleteInternalServerError) GetPayload() *models.E
 }
 
 func (o *ObjectsClassReferencesDeleteInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_class_references_put_responses.go
+++ b/client/objects/objects_class_references_put_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *ObjectsClassReferencesPutReader) ReadResponse(response runtime.ClientRe
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /objects/{className}/{id}/references/{propertyName}] objects.class.references.put", response, response.Code())
 	}
 }
 
@@ -91,8 +92,7 @@ ObjectsClassReferencesPutOK describes a response with status code 200, with defa
 
 Successfully replaced all the references.
 */
-type ObjectsClassReferencesPutOK struct {
-}
+type ObjectsClassReferencesPutOK struct{}
 
 // IsSuccess returns true when this objects class references put o k response has a 2xx status code
 func (o *ObjectsClassReferencesPutOK) IsSuccess() bool {
@@ -125,15 +125,14 @@ func (o *ObjectsClassReferencesPutOK) Code() int {
 }
 
 func (o *ObjectsClassReferencesPutOK) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutOK ", 200)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutOK", 200)
 }
 
 func (o *ObjectsClassReferencesPutOK) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutOK ", 200)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutOK", 200)
 }
 
 func (o *ObjectsClassReferencesPutOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -182,11 +181,13 @@ func (o *ObjectsClassReferencesPutBadRequest) Code() int {
 }
 
 func (o *ObjectsClassReferencesPutBadRequest) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsClassReferencesPutBadRequest) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsClassReferencesPutBadRequest) GetPayload() *models.ErrorResponse {
@@ -194,7 +195,6 @@ func (o *ObjectsClassReferencesPutBadRequest) GetPayload() *models.ErrorResponse
 }
 
 func (o *ObjectsClassReferencesPutBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -215,8 +215,7 @@ ObjectsClassReferencesPutUnauthorized describes a response with status code 401,
 
 Unauthorized or invalid credentials.
 */
-type ObjectsClassReferencesPutUnauthorized struct {
-}
+type ObjectsClassReferencesPutUnauthorized struct{}
 
 // IsSuccess returns true when this objects class references put unauthorized response has a 2xx status code
 func (o *ObjectsClassReferencesPutUnauthorized) IsSuccess() bool {
@@ -249,15 +248,14 @@ func (o *ObjectsClassReferencesPutUnauthorized) Code() int {
 }
 
 func (o *ObjectsClassReferencesPutUnauthorized) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutUnauthorized", 401)
 }
 
 func (o *ObjectsClassReferencesPutUnauthorized) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutUnauthorized", 401)
 }
 
 func (o *ObjectsClassReferencesPutUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -306,11 +304,13 @@ func (o *ObjectsClassReferencesPutForbidden) Code() int {
 }
 
 func (o *ObjectsClassReferencesPutForbidden) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassReferencesPutForbidden) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutForbidden %s", 403, payload)
 }
 
 func (o *ObjectsClassReferencesPutForbidden) GetPayload() *models.ErrorResponse {
@@ -318,7 +318,6 @@ func (o *ObjectsClassReferencesPutForbidden) GetPayload() *models.ErrorResponse 
 }
 
 func (o *ObjectsClassReferencesPutForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -339,8 +338,7 @@ ObjectsClassReferencesPutNotFound describes a response with status code 404, wit
 
 Source object doesn't exist.
 */
-type ObjectsClassReferencesPutNotFound struct {
-}
+type ObjectsClassReferencesPutNotFound struct{}
 
 // IsSuccess returns true when this objects class references put not found response has a 2xx status code
 func (o *ObjectsClassReferencesPutNotFound) IsSuccess() bool {
@@ -373,15 +371,14 @@ func (o *ObjectsClassReferencesPutNotFound) Code() int {
 }
 
 func (o *ObjectsClassReferencesPutNotFound) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutNotFound ", 404)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutNotFound", 404)
 }
 
 func (o *ObjectsClassReferencesPutNotFound) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutNotFound ", 404)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutNotFound", 404)
 }
 
 func (o *ObjectsClassReferencesPutNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -430,11 +427,13 @@ func (o *ObjectsClassReferencesPutUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsClassReferencesPutUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassReferencesPutUnprocessableEntity) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsClassReferencesPutUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -442,7 +441,6 @@ func (o *ObjectsClassReferencesPutUnprocessableEntity) GetPayload() *models.Erro
 }
 
 func (o *ObjectsClassReferencesPutUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -498,11 +496,13 @@ func (o *ObjectsClassReferencesPutInternalServerError) Code() int {
 }
 
 func (o *ObjectsClassReferencesPutInternalServerError) Error() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassReferencesPutInternalServerError) String() string {
-	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{className}/{id}/references/{propertyName}][%d] objectsClassReferencesPutInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsClassReferencesPutInternalServerError) GetPayload() *models.ErrorResponse {
@@ -510,7 +510,6 @@ func (o *ObjectsClassReferencesPutInternalServerError) GetPayload() *models.Erro
 }
 
 func (o *ObjectsClassReferencesPutInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_client.go
+++ b/client/objects/objects_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new objects API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new objects API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new objects API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -97,7 +147,7 @@ func (a *Client) ObjectsClassDelete(params *ObjectsClassDeleteParams, authInfo r
 		Method:             "DELETE",
 		PathPattern:        "/objects/{className}/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsClassDeleteReader{formats: a.formats},
@@ -138,7 +188,7 @@ func (a *Client) ObjectsClassGet(params *ObjectsClassGetParams, authInfo runtime
 		Method:             "GET",
 		PathPattern:        "/objects/{className}/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsClassGetReader{formats: a.formats},
@@ -179,7 +229,7 @@ func (a *Client) ObjectsClassHead(params *ObjectsClassHeadParams, authInfo runti
 		Method:             "HEAD",
 		PathPattern:        "/objects/{className}/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsClassHeadReader{formats: a.formats},
@@ -220,7 +270,7 @@ func (a *Client) ObjectsClassPatch(params *ObjectsClassPatchParams, authInfo run
 		Method:             "PATCH",
 		PathPattern:        "/objects/{className}/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsClassPatchReader{formats: a.formats},
@@ -261,7 +311,7 @@ func (a *Client) ObjectsClassPut(params *ObjectsClassPutParams, authInfo runtime
 		Method:             "PUT",
 		PathPattern:        "/objects/{className}/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsClassPutReader{formats: a.formats},
@@ -302,7 +352,7 @@ func (a *Client) ObjectsClassReferencesCreate(params *ObjectsClassReferencesCrea
 		Method:             "POST",
 		PathPattern:        "/objects/{className}/{id}/references/{propertyName}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsClassReferencesCreateReader{formats: a.formats},
@@ -343,7 +393,7 @@ func (a *Client) ObjectsClassReferencesDelete(params *ObjectsClassReferencesDele
 		Method:             "DELETE",
 		PathPattern:        "/objects/{className}/{id}/references/{propertyName}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsClassReferencesDeleteReader{formats: a.formats},
@@ -384,7 +434,7 @@ func (a *Client) ObjectsClassReferencesPut(params *ObjectsClassReferencesPutPara
 		Method:             "PUT",
 		PathPattern:        "/objects/{className}/{id}/references/{propertyName}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsClassReferencesPutReader{formats: a.formats},
@@ -425,7 +475,7 @@ func (a *Client) ObjectsCreate(params *ObjectsCreateParams, authInfo runtime.Cli
 		Method:             "POST",
 		PathPattern:        "/objects",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsCreateReader{formats: a.formats},
@@ -466,7 +516,7 @@ func (a *Client) ObjectsDelete(params *ObjectsDeleteParams, authInfo runtime.Cli
 		Method:             "DELETE",
 		PathPattern:        "/objects/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsDeleteReader{formats: a.formats},
@@ -507,7 +557,7 @@ func (a *Client) ObjectsGet(params *ObjectsGetParams, authInfo runtime.ClientAut
 		Method:             "GET",
 		PathPattern:        "/objects/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsGetReader{formats: a.formats},
@@ -548,7 +598,7 @@ func (a *Client) ObjectsHead(params *ObjectsHeadParams, authInfo runtime.ClientA
 		Method:             "HEAD",
 		PathPattern:        "/objects/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsHeadReader{formats: a.formats},
@@ -589,7 +639,7 @@ func (a *Client) ObjectsList(params *ObjectsListParams, authInfo runtime.ClientA
 		Method:             "GET",
 		PathPattern:        "/objects",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsListReader{formats: a.formats},
@@ -630,7 +680,7 @@ func (a *Client) ObjectsPatch(params *ObjectsPatchParams, authInfo runtime.Clien
 		Method:             "PATCH",
 		PathPattern:        "/objects/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsPatchReader{formats: a.formats},
@@ -671,7 +721,7 @@ func (a *Client) ObjectsReferencesCreate(params *ObjectsReferencesCreateParams, 
 		Method:             "POST",
 		PathPattern:        "/objects/{id}/references/{propertyName}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsReferencesCreateReader{formats: a.formats},
@@ -712,7 +762,7 @@ func (a *Client) ObjectsReferencesDelete(params *ObjectsReferencesDeleteParams, 
 		Method:             "DELETE",
 		PathPattern:        "/objects/{id}/references/{propertyName}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsReferencesDeleteReader{formats: a.formats},
@@ -753,7 +803,7 @@ func (a *Client) ObjectsReferencesUpdate(params *ObjectsReferencesUpdateParams, 
 		Method:             "PUT",
 		PathPattern:        "/objects/{id}/references/{propertyName}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsReferencesUpdateReader{formats: a.formats},
@@ -794,7 +844,7 @@ func (a *Client) ObjectsUpdate(params *ObjectsUpdateParams, authInfo runtime.Cli
 		Method:             "PUT",
 		PathPattern:        "/objects/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsUpdateReader{formats: a.formats},
@@ -835,7 +885,7 @@ func (a *Client) ObjectsValidate(params *ObjectsValidateParams, authInfo runtime
 		Method:             "POST",
 		PathPattern:        "/objects/validate",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ObjectsValidateReader{formats: a.formats},

--- a/client/objects/objects_create_responses.go
+++ b/client/objects/objects_create_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *ObjectsCreateReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /objects] objects.create", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *ObjectsCreateOK) Code() int {
 }
 
 func (o *ObjectsCreateOK) Error() string {
-	return fmt.Sprintf("[POST /objects][%d] objectsCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects][%d] objectsCreateOK %s", 200, payload)
 }
 
 func (o *ObjectsCreateOK) String() string {
-	return fmt.Sprintf("[POST /objects][%d] objectsCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects][%d] objectsCreateOK %s", 200, payload)
 }
 
 func (o *ObjectsCreateOK) GetPayload() *models.Object {
@@ -132,7 +135,6 @@ func (o *ObjectsCreateOK) GetPayload() *models.Object {
 }
 
 func (o *ObjectsCreateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Object)
 
 	// response payload
@@ -188,11 +190,13 @@ func (o *ObjectsCreateBadRequest) Code() int {
 }
 
 func (o *ObjectsCreateBadRequest) Error() string {
-	return fmt.Sprintf("[POST /objects][%d] objectsCreateBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects][%d] objectsCreateBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsCreateBadRequest) String() string {
-	return fmt.Sprintf("[POST /objects][%d] objectsCreateBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects][%d] objectsCreateBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsCreateBadRequest) GetPayload() *models.ErrorResponse {
@@ -200,7 +204,6 @@ func (o *ObjectsCreateBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsCreateBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -221,8 +224,7 @@ ObjectsCreateUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type ObjectsCreateUnauthorized struct {
-}
+type ObjectsCreateUnauthorized struct{}
 
 // IsSuccess returns true when this objects create unauthorized response has a 2xx status code
 func (o *ObjectsCreateUnauthorized) IsSuccess() bool {
@@ -255,15 +257,14 @@ func (o *ObjectsCreateUnauthorized) Code() int {
 }
 
 func (o *ObjectsCreateUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /objects][%d] objectsCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /objects][%d] objectsCreateUnauthorized", 401)
 }
 
 func (o *ObjectsCreateUnauthorized) String() string {
-	return fmt.Sprintf("[POST /objects][%d] objectsCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /objects][%d] objectsCreateUnauthorized", 401)
 }
 
 func (o *ObjectsCreateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -312,11 +313,13 @@ func (o *ObjectsCreateForbidden) Code() int {
 }
 
 func (o *ObjectsCreateForbidden) Error() string {
-	return fmt.Sprintf("[POST /objects][%d] objectsCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects][%d] objectsCreateForbidden %s", 403, payload)
 }
 
 func (o *ObjectsCreateForbidden) String() string {
-	return fmt.Sprintf("[POST /objects][%d] objectsCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects][%d] objectsCreateForbidden %s", 403, payload)
 }
 
 func (o *ObjectsCreateForbidden) GetPayload() *models.ErrorResponse {
@@ -324,7 +327,6 @@ func (o *ObjectsCreateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsCreateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -380,11 +382,13 @@ func (o *ObjectsCreateUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsCreateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /objects][%d] objectsCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects][%d] objectsCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsCreateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /objects][%d] objectsCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects][%d] objectsCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -392,7 +396,6 @@ func (o *ObjectsCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsCreateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -448,11 +451,13 @@ func (o *ObjectsCreateInternalServerError) Code() int {
 }
 
 func (o *ObjectsCreateInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /objects][%d] objectsCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects][%d] objectsCreateInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsCreateInternalServerError) String() string {
-	return fmt.Sprintf("[POST /objects][%d] objectsCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects][%d] objectsCreateInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsCreateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -460,7 +465,6 @@ func (o *ObjectsCreateInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsCreateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_delete_responses.go
+++ b/client/objects/objects_delete_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *ObjectsDeleteReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /objects/{id}] objects.delete", response, response.Code())
 	}
 }
 
@@ -79,8 +80,7 @@ ObjectsDeleteNoContent describes a response with status code 204, with default h
 
 Successfully deleted.
 */
-type ObjectsDeleteNoContent struct {
-}
+type ObjectsDeleteNoContent struct{}
 
 // IsSuccess returns true when this objects delete no content response has a 2xx status code
 func (o *ObjectsDeleteNoContent) IsSuccess() bool {
@@ -113,15 +113,14 @@ func (o *ObjectsDeleteNoContent) Code() int {
 }
 
 func (o *ObjectsDeleteNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteNoContent ", 204)
+	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteNoContent", 204)
 }
 
 func (o *ObjectsDeleteNoContent) String() string {
-	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteNoContent ", 204)
+	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteNoContent", 204)
 }
 
 func (o *ObjectsDeleteNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -135,8 +134,7 @@ ObjectsDeleteUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type ObjectsDeleteUnauthorized struct {
-}
+type ObjectsDeleteUnauthorized struct{}
 
 // IsSuccess returns true when this objects delete unauthorized response has a 2xx status code
 func (o *ObjectsDeleteUnauthorized) IsSuccess() bool {
@@ -169,15 +167,14 @@ func (o *ObjectsDeleteUnauthorized) Code() int {
 }
 
 func (o *ObjectsDeleteUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteUnauthorized", 401)
 }
 
 func (o *ObjectsDeleteUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteUnauthorized", 401)
 }
 
 func (o *ObjectsDeleteUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -226,11 +223,13 @@ func (o *ObjectsDeleteForbidden) Code() int {
 }
 
 func (o *ObjectsDeleteForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteForbidden %s", 403, payload)
 }
 
 func (o *ObjectsDeleteForbidden) String() string {
-	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteForbidden %s", 403, payload)
 }
 
 func (o *ObjectsDeleteForbidden) GetPayload() *models.ErrorResponse {
@@ -238,7 +237,6 @@ func (o *ObjectsDeleteForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsDeleteForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -259,8 +257,7 @@ ObjectsDeleteNotFound describes a response with status code 404, with default he
 
 Successful query result but no resource was found.
 */
-type ObjectsDeleteNotFound struct {
-}
+type ObjectsDeleteNotFound struct{}
 
 // IsSuccess returns true when this objects delete not found response has a 2xx status code
 func (o *ObjectsDeleteNotFound) IsSuccess() bool {
@@ -293,15 +290,14 @@ func (o *ObjectsDeleteNotFound) Code() int {
 }
 
 func (o *ObjectsDeleteNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteNotFound ", 404)
+	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteNotFound", 404)
 }
 
 func (o *ObjectsDeleteNotFound) String() string {
-	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteNotFound ", 404)
+	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteNotFound", 404)
 }
 
 func (o *ObjectsDeleteNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -350,11 +346,13 @@ func (o *ObjectsDeleteInternalServerError) Code() int {
 }
 
 func (o *ObjectsDeleteInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsDeleteInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsDeleteInternalServerError) GetPayload() *models.ErrorResponse {
@@ -362,7 +360,6 @@ func (o *ObjectsDeleteInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsDeleteInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_get_responses.go
+++ b/client/objects/objects_get_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *ObjectsGetReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /objects/{id}] objects.get", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *ObjectsGetOK) Code() int {
 }
 
 func (o *ObjectsGetOK) Error() string {
-	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetOK %s", 200, payload)
 }
 
 func (o *ObjectsGetOK) String() string {
-	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetOK %s", 200, payload)
 }
 
 func (o *ObjectsGetOK) GetPayload() *models.Object {
@@ -132,7 +135,6 @@ func (o *ObjectsGetOK) GetPayload() *models.Object {
 }
 
 func (o *ObjectsGetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Object)
 
 	// response payload
@@ -188,11 +190,13 @@ func (o *ObjectsGetBadRequest) Code() int {
 }
 
 func (o *ObjectsGetBadRequest) Error() string {
-	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsGetBadRequest) String() string {
-	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsGetBadRequest) GetPayload() *models.ErrorResponse {
@@ -200,7 +204,6 @@ func (o *ObjectsGetBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsGetBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -221,8 +224,7 @@ ObjectsGetUnauthorized describes a response with status code 401, with default h
 
 Unauthorized or invalid credentials.
 */
-type ObjectsGetUnauthorized struct {
-}
+type ObjectsGetUnauthorized struct{}
 
 // IsSuccess returns true when this objects get unauthorized response has a 2xx status code
 func (o *ObjectsGetUnauthorized) IsSuccess() bool {
@@ -255,15 +257,14 @@ func (o *ObjectsGetUnauthorized) Code() int {
 }
 
 func (o *ObjectsGetUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetUnauthorized", 401)
 }
 
 func (o *ObjectsGetUnauthorized) String() string {
-	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetUnauthorized", 401)
 }
 
 func (o *ObjectsGetUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -312,11 +313,13 @@ func (o *ObjectsGetForbidden) Code() int {
 }
 
 func (o *ObjectsGetForbidden) Error() string {
-	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetForbidden %s", 403, payload)
 }
 
 func (o *ObjectsGetForbidden) String() string {
-	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetForbidden %s", 403, payload)
 }
 
 func (o *ObjectsGetForbidden) GetPayload() *models.ErrorResponse {
@@ -324,7 +327,6 @@ func (o *ObjectsGetForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsGetForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -345,8 +347,7 @@ ObjectsGetNotFound describes a response with status code 404, with default heade
 
 Successful query result but no resource was found.
 */
-type ObjectsGetNotFound struct {
-}
+type ObjectsGetNotFound struct{}
 
 // IsSuccess returns true when this objects get not found response has a 2xx status code
 func (o *ObjectsGetNotFound) IsSuccess() bool {
@@ -379,15 +380,14 @@ func (o *ObjectsGetNotFound) Code() int {
 }
 
 func (o *ObjectsGetNotFound) Error() string {
-	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetNotFound ", 404)
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetNotFound", 404)
 }
 
 func (o *ObjectsGetNotFound) String() string {
-	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetNotFound ", 404)
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetNotFound", 404)
 }
 
 func (o *ObjectsGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -436,11 +436,13 @@ func (o *ObjectsGetInternalServerError) Code() int {
 }
 
 func (o *ObjectsGetInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsGetInternalServerError) String() string {
-	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsGetInternalServerError) GetPayload() *models.ErrorResponse {
@@ -448,7 +450,6 @@ func (o *ObjectsGetInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsGetInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_head_responses.go
+++ b/client/objects/objects_head_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *ObjectsHeadReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[HEAD /objects/{id}] objects.head", response, response.Code())
 	}
 }
 
@@ -79,8 +80,7 @@ ObjectsHeadNoContent describes a response with status code 204, with default hea
 
 Object exists.
 */
-type ObjectsHeadNoContent struct {
-}
+type ObjectsHeadNoContent struct{}
 
 // IsSuccess returns true when this objects head no content response has a 2xx status code
 func (o *ObjectsHeadNoContent) IsSuccess() bool {
@@ -113,15 +113,14 @@ func (o *ObjectsHeadNoContent) Code() int {
 }
 
 func (o *ObjectsHeadNoContent) Error() string {
-	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadNoContent ", 204)
+	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadNoContent", 204)
 }
 
 func (o *ObjectsHeadNoContent) String() string {
-	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadNoContent ", 204)
+	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadNoContent", 204)
 }
 
 func (o *ObjectsHeadNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -135,8 +134,7 @@ ObjectsHeadUnauthorized describes a response with status code 401, with default 
 
 Unauthorized or invalid credentials.
 */
-type ObjectsHeadUnauthorized struct {
-}
+type ObjectsHeadUnauthorized struct{}
 
 // IsSuccess returns true when this objects head unauthorized response has a 2xx status code
 func (o *ObjectsHeadUnauthorized) IsSuccess() bool {
@@ -169,15 +167,14 @@ func (o *ObjectsHeadUnauthorized) Code() int {
 }
 
 func (o *ObjectsHeadUnauthorized) Error() string {
-	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadUnauthorized ", 401)
+	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadUnauthorized", 401)
 }
 
 func (o *ObjectsHeadUnauthorized) String() string {
-	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadUnauthorized ", 401)
+	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadUnauthorized", 401)
 }
 
 func (o *ObjectsHeadUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -226,11 +223,13 @@ func (o *ObjectsHeadForbidden) Code() int {
 }
 
 func (o *ObjectsHeadForbidden) Error() string {
-	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadForbidden %s", 403, payload)
 }
 
 func (o *ObjectsHeadForbidden) String() string {
-	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadForbidden %s", 403, payload)
 }
 
 func (o *ObjectsHeadForbidden) GetPayload() *models.ErrorResponse {
@@ -238,7 +237,6 @@ func (o *ObjectsHeadForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsHeadForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -259,8 +257,7 @@ ObjectsHeadNotFound describes a response with status code 404, with default head
 
 Object doesn't exist.
 */
-type ObjectsHeadNotFound struct {
-}
+type ObjectsHeadNotFound struct{}
 
 // IsSuccess returns true when this objects head not found response has a 2xx status code
 func (o *ObjectsHeadNotFound) IsSuccess() bool {
@@ -293,15 +290,14 @@ func (o *ObjectsHeadNotFound) Code() int {
 }
 
 func (o *ObjectsHeadNotFound) Error() string {
-	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadNotFound ", 404)
+	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadNotFound", 404)
 }
 
 func (o *ObjectsHeadNotFound) String() string {
-	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadNotFound ", 404)
+	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadNotFound", 404)
 }
 
 func (o *ObjectsHeadNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -350,11 +346,13 @@ func (o *ObjectsHeadInternalServerError) Code() int {
 }
 
 func (o *ObjectsHeadInternalServerError) Error() string {
-	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsHeadInternalServerError) String() string {
-	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsHeadInternalServerError) GetPayload() *models.ErrorResponse {
@@ -362,7 +360,6 @@ func (o *ObjectsHeadInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsHeadInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_list_responses.go
+++ b/client/objects/objects_list_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *ObjectsListReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /objects] objects.list", response, response.Code())
 	}
 }
 
@@ -126,11 +127,13 @@ func (o *ObjectsListOK) Code() int {
 }
 
 func (o *ObjectsListOK) Error() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects][%d] objectsListOK %s", 200, payload)
 }
 
 func (o *ObjectsListOK) String() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects][%d] objectsListOK %s", 200, payload)
 }
 
 func (o *ObjectsListOK) GetPayload() *models.ObjectsListResponse {
@@ -138,7 +141,6 @@ func (o *ObjectsListOK) GetPayload() *models.ObjectsListResponse {
 }
 
 func (o *ObjectsListOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ObjectsListResponse)
 
 	// response payload
@@ -194,11 +196,13 @@ func (o *ObjectsListBadRequest) Code() int {
 }
 
 func (o *ObjectsListBadRequest) Error() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects][%d] objectsListBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsListBadRequest) String() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects][%d] objectsListBadRequest %s", 400, payload)
 }
 
 func (o *ObjectsListBadRequest) GetPayload() *models.ErrorResponse {
@@ -206,7 +210,6 @@ func (o *ObjectsListBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsListBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -227,8 +230,7 @@ ObjectsListUnauthorized describes a response with status code 401, with default 
 
 Unauthorized or invalid credentials.
 */
-type ObjectsListUnauthorized struct {
-}
+type ObjectsListUnauthorized struct{}
 
 // IsSuccess returns true when this objects list unauthorized response has a 2xx status code
 func (o *ObjectsListUnauthorized) IsSuccess() bool {
@@ -261,15 +263,14 @@ func (o *ObjectsListUnauthorized) Code() int {
 }
 
 func (o *ObjectsListUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListUnauthorized ", 401)
+	return fmt.Sprintf("[GET /objects][%d] objectsListUnauthorized", 401)
 }
 
 func (o *ObjectsListUnauthorized) String() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListUnauthorized ", 401)
+	return fmt.Sprintf("[GET /objects][%d] objectsListUnauthorized", 401)
 }
 
 func (o *ObjectsListUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -318,11 +319,13 @@ func (o *ObjectsListForbidden) Code() int {
 }
 
 func (o *ObjectsListForbidden) Error() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects][%d] objectsListForbidden %s", 403, payload)
 }
 
 func (o *ObjectsListForbidden) String() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects][%d] objectsListForbidden %s", 403, payload)
 }
 
 func (o *ObjectsListForbidden) GetPayload() *models.ErrorResponse {
@@ -330,7 +333,6 @@ func (o *ObjectsListForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsListForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -351,8 +353,7 @@ ObjectsListNotFound describes a response with status code 404, with default head
 
 Successful query result but no resource was found.
 */
-type ObjectsListNotFound struct {
-}
+type ObjectsListNotFound struct{}
 
 // IsSuccess returns true when this objects list not found response has a 2xx status code
 func (o *ObjectsListNotFound) IsSuccess() bool {
@@ -385,15 +386,14 @@ func (o *ObjectsListNotFound) Code() int {
 }
 
 func (o *ObjectsListNotFound) Error() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListNotFound ", 404)
+	return fmt.Sprintf("[GET /objects][%d] objectsListNotFound", 404)
 }
 
 func (o *ObjectsListNotFound) String() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListNotFound ", 404)
+	return fmt.Sprintf("[GET /objects][%d] objectsListNotFound", 404)
 }
 
 func (o *ObjectsListNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -442,11 +442,13 @@ func (o *ObjectsListUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsListUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects][%d] objectsListUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsListUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects][%d] objectsListUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsListUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -454,7 +456,6 @@ func (o *ObjectsListUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsListUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -510,11 +511,13 @@ func (o *ObjectsListInternalServerError) Code() int {
 }
 
 func (o *ObjectsListInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects][%d] objectsListInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsListInternalServerError) String() string {
-	return fmt.Sprintf("[GET /objects][%d] objectsListInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /objects][%d] objectsListInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsListInternalServerError) GetPayload() *models.ErrorResponse {
@@ -522,7 +525,6 @@ func (o *ObjectsListInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsListInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_patch_responses.go
+++ b/client/objects/objects_patch_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *ObjectsPatchReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PATCH /objects/{id}] objects.patch", response, response.Code())
 	}
 }
 
@@ -91,8 +92,7 @@ ObjectsPatchNoContent describes a response with status code 204, with default he
 
 Successfully applied. No content provided.
 */
-type ObjectsPatchNoContent struct {
-}
+type ObjectsPatchNoContent struct{}
 
 // IsSuccess returns true when this objects patch no content response has a 2xx status code
 func (o *ObjectsPatchNoContent) IsSuccess() bool {
@@ -125,15 +125,14 @@ func (o *ObjectsPatchNoContent) Code() int {
 }
 
 func (o *ObjectsPatchNoContent) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchNoContent ", 204)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchNoContent", 204)
 }
 
 func (o *ObjectsPatchNoContent) String() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchNoContent ", 204)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchNoContent", 204)
 }
 
 func (o *ObjectsPatchNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -147,8 +146,7 @@ ObjectsPatchBadRequest describes a response with status code 400, with default h
 
 The patch-JSON is malformed.
 */
-type ObjectsPatchBadRequest struct {
-}
+type ObjectsPatchBadRequest struct{}
 
 // IsSuccess returns true when this objects patch bad request response has a 2xx status code
 func (o *ObjectsPatchBadRequest) IsSuccess() bool {
@@ -181,15 +179,14 @@ func (o *ObjectsPatchBadRequest) Code() int {
 }
 
 func (o *ObjectsPatchBadRequest) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchBadRequest ", 400)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchBadRequest", 400)
 }
 
 func (o *ObjectsPatchBadRequest) String() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchBadRequest ", 400)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchBadRequest", 400)
 }
 
 func (o *ObjectsPatchBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -203,8 +200,7 @@ ObjectsPatchUnauthorized describes a response with status code 401, with default
 
 Unauthorized or invalid credentials.
 */
-type ObjectsPatchUnauthorized struct {
-}
+type ObjectsPatchUnauthorized struct{}
 
 // IsSuccess returns true when this objects patch unauthorized response has a 2xx status code
 func (o *ObjectsPatchUnauthorized) IsSuccess() bool {
@@ -237,15 +233,14 @@ func (o *ObjectsPatchUnauthorized) Code() int {
 }
 
 func (o *ObjectsPatchUnauthorized) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchUnauthorized ", 401)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchUnauthorized", 401)
 }
 
 func (o *ObjectsPatchUnauthorized) String() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchUnauthorized ", 401)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchUnauthorized", 401)
 }
 
 func (o *ObjectsPatchUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -294,11 +289,13 @@ func (o *ObjectsPatchForbidden) Code() int {
 }
 
 func (o *ObjectsPatchForbidden) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchForbidden %s", 403, payload)
 }
 
 func (o *ObjectsPatchForbidden) String() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchForbidden %s", 403, payload)
 }
 
 func (o *ObjectsPatchForbidden) GetPayload() *models.ErrorResponse {
@@ -306,7 +303,6 @@ func (o *ObjectsPatchForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsPatchForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -327,8 +323,7 @@ ObjectsPatchNotFound describes a response with status code 404, with default hea
 
 Successful query result but no resource was found.
 */
-type ObjectsPatchNotFound struct {
-}
+type ObjectsPatchNotFound struct{}
 
 // IsSuccess returns true when this objects patch not found response has a 2xx status code
 func (o *ObjectsPatchNotFound) IsSuccess() bool {
@@ -361,15 +356,14 @@ func (o *ObjectsPatchNotFound) Code() int {
 }
 
 func (o *ObjectsPatchNotFound) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchNotFound ", 404)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchNotFound", 404)
 }
 
 func (o *ObjectsPatchNotFound) String() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchNotFound ", 404)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchNotFound", 404)
 }
 
 func (o *ObjectsPatchNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -418,11 +412,13 @@ func (o *ObjectsPatchUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsPatchUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsPatchUnprocessableEntity) String() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsPatchUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -430,7 +426,6 @@ func (o *ObjectsPatchUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsPatchUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -486,11 +481,13 @@ func (o *ObjectsPatchInternalServerError) Code() int {
 }
 
 func (o *ObjectsPatchInternalServerError) Error() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsPatchInternalServerError) String() string {
-	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsPatchInternalServerError) GetPayload() *models.ErrorResponse {
@@ -498,7 +495,6 @@ func (o *ObjectsPatchInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsPatchInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_references_create_responses.go
+++ b/client/objects/objects_references_create_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *ObjectsReferencesCreateReader) ReadResponse(response runtime.ClientResp
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /objects/{id}/references/{propertyName}] objects.references.create", response, response.Code())
 	}
 }
 
@@ -79,8 +80,7 @@ ObjectsReferencesCreateOK describes a response with status code 200, with defaul
 
 Successfully added the reference.
 */
-type ObjectsReferencesCreateOK struct {
-}
+type ObjectsReferencesCreateOK struct{}
 
 // IsSuccess returns true when this objects references create o k response has a 2xx status code
 func (o *ObjectsReferencesCreateOK) IsSuccess() bool {
@@ -113,15 +113,14 @@ func (o *ObjectsReferencesCreateOK) Code() int {
 }
 
 func (o *ObjectsReferencesCreateOK) Error() string {
-	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateOK ", 200)
+	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateOK", 200)
 }
 
 func (o *ObjectsReferencesCreateOK) String() string {
-	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateOK ", 200)
+	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateOK", 200)
 }
 
 func (o *ObjectsReferencesCreateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -135,8 +134,7 @@ ObjectsReferencesCreateUnauthorized describes a response with status code 401, w
 
 Unauthorized or invalid credentials.
 */
-type ObjectsReferencesCreateUnauthorized struct {
-}
+type ObjectsReferencesCreateUnauthorized struct{}
 
 // IsSuccess returns true when this objects references create unauthorized response has a 2xx status code
 func (o *ObjectsReferencesCreateUnauthorized) IsSuccess() bool {
@@ -169,15 +167,14 @@ func (o *ObjectsReferencesCreateUnauthorized) Code() int {
 }
 
 func (o *ObjectsReferencesCreateUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateUnauthorized", 401)
 }
 
 func (o *ObjectsReferencesCreateUnauthorized) String() string {
-	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateUnauthorized", 401)
 }
 
 func (o *ObjectsReferencesCreateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -226,11 +223,13 @@ func (o *ObjectsReferencesCreateForbidden) Code() int {
 }
 
 func (o *ObjectsReferencesCreateForbidden) Error() string {
-	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateForbidden %s", 403, payload)
 }
 
 func (o *ObjectsReferencesCreateForbidden) String() string {
-	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateForbidden %s", 403, payload)
 }
 
 func (o *ObjectsReferencesCreateForbidden) GetPayload() *models.ErrorResponse {
@@ -238,7 +237,6 @@ func (o *ObjectsReferencesCreateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsReferencesCreateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -294,11 +292,13 @@ func (o *ObjectsReferencesCreateUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsReferencesCreateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsReferencesCreateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsReferencesCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -306,7 +306,6 @@ func (o *ObjectsReferencesCreateUnprocessableEntity) GetPayload() *models.ErrorR
 }
 
 func (o *ObjectsReferencesCreateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -362,11 +361,13 @@ func (o *ObjectsReferencesCreateInternalServerError) Code() int {
 }
 
 func (o *ObjectsReferencesCreateInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsReferencesCreateInternalServerError) String() string {
-	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsReferencesCreateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -374,7 +375,6 @@ func (o *ObjectsReferencesCreateInternalServerError) GetPayload() *models.ErrorR
 }
 
 func (o *ObjectsReferencesCreateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_references_delete_responses.go
+++ b/client/objects/objects_references_delete_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *ObjectsReferencesDeleteReader) ReadResponse(response runtime.ClientResp
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /objects/{id}/references/{propertyName}] objects.references.delete", response, response.Code())
 	}
 }
 
@@ -79,8 +80,7 @@ ObjectsReferencesDeleteNoContent describes a response with status code 204, with
 
 Successfully deleted.
 */
-type ObjectsReferencesDeleteNoContent struct {
-}
+type ObjectsReferencesDeleteNoContent struct{}
 
 // IsSuccess returns true when this objects references delete no content response has a 2xx status code
 func (o *ObjectsReferencesDeleteNoContent) IsSuccess() bool {
@@ -113,15 +113,14 @@ func (o *ObjectsReferencesDeleteNoContent) Code() int {
 }
 
 func (o *ObjectsReferencesDeleteNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteNoContent ", 204)
+	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteNoContent", 204)
 }
 
 func (o *ObjectsReferencesDeleteNoContent) String() string {
-	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteNoContent ", 204)
+	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteNoContent", 204)
 }
 
 func (o *ObjectsReferencesDeleteNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -135,8 +134,7 @@ ObjectsReferencesDeleteUnauthorized describes a response with status code 401, w
 
 Unauthorized or invalid credentials.
 */
-type ObjectsReferencesDeleteUnauthorized struct {
-}
+type ObjectsReferencesDeleteUnauthorized struct{}
 
 // IsSuccess returns true when this objects references delete unauthorized response has a 2xx status code
 func (o *ObjectsReferencesDeleteUnauthorized) IsSuccess() bool {
@@ -169,15 +167,14 @@ func (o *ObjectsReferencesDeleteUnauthorized) Code() int {
 }
 
 func (o *ObjectsReferencesDeleteUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteUnauthorized", 401)
 }
 
 func (o *ObjectsReferencesDeleteUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteUnauthorized", 401)
 }
 
 func (o *ObjectsReferencesDeleteUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -226,11 +223,13 @@ func (o *ObjectsReferencesDeleteForbidden) Code() int {
 }
 
 func (o *ObjectsReferencesDeleteForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteForbidden %s", 403, payload)
 }
 
 func (o *ObjectsReferencesDeleteForbidden) String() string {
-	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteForbidden %s", 403, payload)
 }
 
 func (o *ObjectsReferencesDeleteForbidden) GetPayload() *models.ErrorResponse {
@@ -238,7 +237,6 @@ func (o *ObjectsReferencesDeleteForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsReferencesDeleteForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -294,11 +292,13 @@ func (o *ObjectsReferencesDeleteNotFound) Code() int {
 }
 
 func (o *ObjectsReferencesDeleteNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteNotFound %s", 404, payload)
 }
 
 func (o *ObjectsReferencesDeleteNotFound) String() string {
-	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteNotFound %s", 404, payload)
 }
 
 func (o *ObjectsReferencesDeleteNotFound) GetPayload() *models.ErrorResponse {
@@ -306,7 +306,6 @@ func (o *ObjectsReferencesDeleteNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsReferencesDeleteNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -362,11 +361,13 @@ func (o *ObjectsReferencesDeleteInternalServerError) Code() int {
 }
 
 func (o *ObjectsReferencesDeleteInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsReferencesDeleteInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsReferencesDeleteInternalServerError) GetPayload() *models.ErrorResponse {
@@ -374,7 +375,6 @@ func (o *ObjectsReferencesDeleteInternalServerError) GetPayload() *models.ErrorR
 }
 
 func (o *ObjectsReferencesDeleteInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_references_update_responses.go
+++ b/client/objects/objects_references_update_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *ObjectsReferencesUpdateReader) ReadResponse(response runtime.ClientResp
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /objects/{id}/references/{propertyName}] objects.references.update", response, response.Code())
 	}
 }
 
@@ -79,8 +80,7 @@ ObjectsReferencesUpdateOK describes a response with status code 200, with defaul
 
 Successfully replaced all the references.
 */
-type ObjectsReferencesUpdateOK struct {
-}
+type ObjectsReferencesUpdateOK struct{}
 
 // IsSuccess returns true when this objects references update o k response has a 2xx status code
 func (o *ObjectsReferencesUpdateOK) IsSuccess() bool {
@@ -113,15 +113,14 @@ func (o *ObjectsReferencesUpdateOK) Code() int {
 }
 
 func (o *ObjectsReferencesUpdateOK) Error() string {
-	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateOK ", 200)
+	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateOK", 200)
 }
 
 func (o *ObjectsReferencesUpdateOK) String() string {
-	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateOK ", 200)
+	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateOK", 200)
 }
 
 func (o *ObjectsReferencesUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -135,8 +134,7 @@ ObjectsReferencesUpdateUnauthorized describes a response with status code 401, w
 
 Unauthorized or invalid credentials.
 */
-type ObjectsReferencesUpdateUnauthorized struct {
-}
+type ObjectsReferencesUpdateUnauthorized struct{}
 
 // IsSuccess returns true when this objects references update unauthorized response has a 2xx status code
 func (o *ObjectsReferencesUpdateUnauthorized) IsSuccess() bool {
@@ -169,15 +167,14 @@ func (o *ObjectsReferencesUpdateUnauthorized) Code() int {
 }
 
 func (o *ObjectsReferencesUpdateUnauthorized) Error() string {
-	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateUnauthorized", 401)
 }
 
 func (o *ObjectsReferencesUpdateUnauthorized) String() string {
-	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateUnauthorized", 401)
 }
 
 func (o *ObjectsReferencesUpdateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -226,11 +223,13 @@ func (o *ObjectsReferencesUpdateForbidden) Code() int {
 }
 
 func (o *ObjectsReferencesUpdateForbidden) Error() string {
-	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateForbidden %s", 403, payload)
 }
 
 func (o *ObjectsReferencesUpdateForbidden) String() string {
-	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateForbidden %s", 403, payload)
 }
 
 func (o *ObjectsReferencesUpdateForbidden) GetPayload() *models.ErrorResponse {
@@ -238,7 +237,6 @@ func (o *ObjectsReferencesUpdateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsReferencesUpdateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -294,11 +292,13 @@ func (o *ObjectsReferencesUpdateUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsReferencesUpdateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsReferencesUpdateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsReferencesUpdateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -306,7 +306,6 @@ func (o *ObjectsReferencesUpdateUnprocessableEntity) GetPayload() *models.ErrorR
 }
 
 func (o *ObjectsReferencesUpdateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -362,11 +361,13 @@ func (o *ObjectsReferencesUpdateInternalServerError) Code() int {
 }
 
 func (o *ObjectsReferencesUpdateInternalServerError) Error() string {
-	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsReferencesUpdateInternalServerError) String() string {
-	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsReferencesUpdateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -374,7 +375,6 @@ func (o *ObjectsReferencesUpdateInternalServerError) GetPayload() *models.ErrorR
 }
 
 func (o *ObjectsReferencesUpdateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_update_responses.go
+++ b/client/objects/objects_update_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *ObjectsUpdateReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /objects/{id}] objects.update", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *ObjectsUpdateOK) Code() int {
 }
 
 func (o *ObjectsUpdateOK) Error() string {
-	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateOK %s", 200, payload)
 }
 
 func (o *ObjectsUpdateOK) String() string {
-	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateOK %s", 200, payload)
 }
 
 func (o *ObjectsUpdateOK) GetPayload() *models.Object {
@@ -132,7 +135,6 @@ func (o *ObjectsUpdateOK) GetPayload() *models.Object {
 }
 
 func (o *ObjectsUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Object)
 
 	// response payload
@@ -153,8 +155,7 @@ ObjectsUpdateUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type ObjectsUpdateUnauthorized struct {
-}
+type ObjectsUpdateUnauthorized struct{}
 
 // IsSuccess returns true when this objects update unauthorized response has a 2xx status code
 func (o *ObjectsUpdateUnauthorized) IsSuccess() bool {
@@ -187,15 +188,14 @@ func (o *ObjectsUpdateUnauthorized) Code() int {
 }
 
 func (o *ObjectsUpdateUnauthorized) Error() string {
-	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateUnauthorized", 401)
 }
 
 func (o *ObjectsUpdateUnauthorized) String() string {
-	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateUnauthorized", 401)
 }
 
 func (o *ObjectsUpdateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +244,13 @@ func (o *ObjectsUpdateForbidden) Code() int {
 }
 
 func (o *ObjectsUpdateForbidden) Error() string {
-	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateForbidden %s", 403, payload)
 }
 
 func (o *ObjectsUpdateForbidden) String() string {
-	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateForbidden %s", 403, payload)
 }
 
 func (o *ObjectsUpdateForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +258,6 @@ func (o *ObjectsUpdateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsUpdateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -277,8 +278,7 @@ ObjectsUpdateNotFound describes a response with status code 404, with default he
 
 Successful query result but no resource was found.
 */
-type ObjectsUpdateNotFound struct {
-}
+type ObjectsUpdateNotFound struct{}
 
 // IsSuccess returns true when this objects update not found response has a 2xx status code
 func (o *ObjectsUpdateNotFound) IsSuccess() bool {
@@ -311,15 +311,14 @@ func (o *ObjectsUpdateNotFound) Code() int {
 }
 
 func (o *ObjectsUpdateNotFound) Error() string {
-	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateNotFound ", 404)
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateNotFound", 404)
 }
 
 func (o *ObjectsUpdateNotFound) String() string {
-	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateNotFound ", 404)
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateNotFound", 404)
 }
 
 func (o *ObjectsUpdateNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -368,11 +367,13 @@ func (o *ObjectsUpdateUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsUpdateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsUpdateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsUpdateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -380,7 +381,6 @@ func (o *ObjectsUpdateUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsUpdateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -436,11 +436,13 @@ func (o *ObjectsUpdateInternalServerError) Code() int {
 }
 
 func (o *ObjectsUpdateInternalServerError) Error() string {
-	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsUpdateInternalServerError) String() string {
-	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsUpdateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -448,7 +450,6 @@ func (o *ObjectsUpdateInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsUpdateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/objects/objects_validate_responses.go
+++ b/client/objects/objects_validate_responses.go
@@ -17,6 +17,7 @@ package objects
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *ObjectsValidateReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /objects/validate] objects.validate", response, response.Code())
 	}
 }
 
@@ -79,8 +80,7 @@ ObjectsValidateOK describes a response with status code 200, with default header
 
 Successfully validated.
 */
-type ObjectsValidateOK struct {
-}
+type ObjectsValidateOK struct{}
 
 // IsSuccess returns true when this objects validate o k response has a 2xx status code
 func (o *ObjectsValidateOK) IsSuccess() bool {
@@ -113,15 +113,14 @@ func (o *ObjectsValidateOK) Code() int {
 }
 
 func (o *ObjectsValidateOK) Error() string {
-	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateOK ", 200)
+	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateOK", 200)
 }
 
 func (o *ObjectsValidateOK) String() string {
-	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateOK ", 200)
+	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateOK", 200)
 }
 
 func (o *ObjectsValidateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -135,8 +134,7 @@ ObjectsValidateUnauthorized describes a response with status code 401, with defa
 
 Unauthorized or invalid credentials.
 */
-type ObjectsValidateUnauthorized struct {
-}
+type ObjectsValidateUnauthorized struct{}
 
 // IsSuccess returns true when this objects validate unauthorized response has a 2xx status code
 func (o *ObjectsValidateUnauthorized) IsSuccess() bool {
@@ -169,15 +167,14 @@ func (o *ObjectsValidateUnauthorized) Code() int {
 }
 
 func (o *ObjectsValidateUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateUnauthorized", 401)
 }
 
 func (o *ObjectsValidateUnauthorized) String() string {
-	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateUnauthorized", 401)
 }
 
 func (o *ObjectsValidateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -226,11 +223,13 @@ func (o *ObjectsValidateForbidden) Code() int {
 }
 
 func (o *ObjectsValidateForbidden) Error() string {
-	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateForbidden %s", 403, payload)
 }
 
 func (o *ObjectsValidateForbidden) String() string {
-	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateForbidden %s", 403, payload)
 }
 
 func (o *ObjectsValidateForbidden) GetPayload() *models.ErrorResponse {
@@ -238,7 +237,6 @@ func (o *ObjectsValidateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsValidateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -294,11 +292,13 @@ func (o *ObjectsValidateUnprocessableEntity) Code() int {
 }
 
 func (o *ObjectsValidateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsValidateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ObjectsValidateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -306,7 +306,6 @@ func (o *ObjectsValidateUnprocessableEntity) GetPayload() *models.ErrorResponse 
 }
 
 func (o *ObjectsValidateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -362,11 +361,13 @@ func (o *ObjectsValidateInternalServerError) Code() int {
 }
 
 func (o *ObjectsValidateInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsValidateInternalServerError) String() string {
-	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /objects/validate][%d] objectsValidateInternalServerError %s", 500, payload)
 }
 
 func (o *ObjectsValidateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -374,7 +375,6 @@ func (o *ObjectsValidateInternalServerError) GetPayload() *models.ErrorResponse 
 }
 
 func (o *ObjectsValidateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/operations/operations_client.go
+++ b/client/operations/operations_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new operations API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new operations API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new operations API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -65,7 +115,7 @@ func (a *Client) WeaviateRoot(params *WeaviateRootParams, authInfo runtime.Clien
 		Method:             "GET",
 		PathPattern:        "/",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &WeaviateRootReader{formats: a.formats},
@@ -106,7 +156,7 @@ func (a *Client) WeaviateWellknownLiveness(params *WeaviateWellknownLivenessPara
 		Method:             "GET",
 		PathPattern:        "/.well-known/live",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &WeaviateWellknownLivenessReader{formats: a.formats},
@@ -147,7 +197,7 @@ func (a *Client) WeaviateWellknownReadiness(params *WeaviateWellknownReadinessPa
 		Method:             "GET",
 		PathPattern:        "/.well-known/ready",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &WeaviateWellknownReadinessReader{formats: a.formats},

--- a/client/operations/weaviate_root_responses.go
+++ b/client/operations/weaviate_root_responses.go
@@ -18,6 +18,7 @@ package operations
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strconv"
@@ -45,7 +46,7 @@ func (o *WeaviateRootReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /] weaviate.root", response, response.Code())
 	}
 }
 
@@ -94,11 +95,13 @@ func (o *WeaviateRootOK) Code() int {
 }
 
 func (o *WeaviateRootOK) Error() string {
-	return fmt.Sprintf("[GET /][%d] weaviateRootOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /][%d] weaviateRootOK %s", 200, payload)
 }
 
 func (o *WeaviateRootOK) String() string {
-	return fmt.Sprintf("[GET /][%d] weaviateRootOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /][%d] weaviateRootOK %s", 200, payload)
 }
 
 func (o *WeaviateRootOK) GetPayload() *WeaviateRootOKBody {
@@ -106,7 +109,6 @@ func (o *WeaviateRootOK) GetPayload() *WeaviateRootOKBody {
 }
 
 func (o *WeaviateRootOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(WeaviateRootOKBody)
 
 	// response payload
@@ -122,7 +124,6 @@ WeaviateRootOKBody weaviate root o k body
 swagger:model WeaviateRootOKBody
 */
 type WeaviateRootOKBody struct {
-
 	// links
 	Links []*models.Link `json:"links"`
 }
@@ -182,10 +183,13 @@ func (o *WeaviateRootOKBody) ContextValidate(ctx context.Context, formats strfmt
 }
 
 func (o *WeaviateRootOKBody) contextValidateLinks(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(o.Links); i++ {
-
 		if o.Links[i] != nil {
+
+			if swag.IsZero(o.Links[i]) { // not required
+				return nil
+			}
+
 			if err := o.Links[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("weaviateRootOK" + "." + "links" + "." + strconv.Itoa(i))
@@ -195,7 +199,6 @@ func (o *WeaviateRootOKBody) contextValidateLinks(ctx context.Context, formats s
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/client/operations/weaviate_wellknown_liveness_responses.go
+++ b/client/operations/weaviate_wellknown_liveness_responses.go
@@ -38,7 +38,7 @@ func (o *WeaviateWellknownLivenessReader) ReadResponse(response runtime.ClientRe
 		}
 		return result, nil
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /.well-known/live] weaviate.wellknown.liveness", response, response.Code())
 	}
 }
 
@@ -52,8 +52,7 @@ WeaviateWellknownLivenessOK describes a response with status code 200, with defa
 
 The application is able to respond to HTTP requests
 */
-type WeaviateWellknownLivenessOK struct {
-}
+type WeaviateWellknownLivenessOK struct{}
 
 // IsSuccess returns true when this weaviate wellknown liveness o k response has a 2xx status code
 func (o *WeaviateWellknownLivenessOK) IsSuccess() bool {
@@ -86,14 +85,13 @@ func (o *WeaviateWellknownLivenessOK) Code() int {
 }
 
 func (o *WeaviateWellknownLivenessOK) Error() string {
-	return fmt.Sprintf("[GET /.well-known/live][%d] weaviateWellknownLivenessOK ", 200)
+	return fmt.Sprintf("[GET /.well-known/live][%d] weaviateWellknownLivenessOK", 200)
 }
 
 func (o *WeaviateWellknownLivenessOK) String() string {
-	return fmt.Sprintf("[GET /.well-known/live][%d] weaviateWellknownLivenessOK ", 200)
+	return fmt.Sprintf("[GET /.well-known/live][%d] weaviateWellknownLivenessOK", 200)
 }
 
 func (o *WeaviateWellknownLivenessOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }

--- a/client/operations/weaviate_wellknown_readiness_responses.go
+++ b/client/operations/weaviate_wellknown_readiness_responses.go
@@ -44,7 +44,7 @@ func (o *WeaviateWellknownReadinessReader) ReadResponse(response runtime.ClientR
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /.well-known/ready] weaviate.wellknown.readiness", response, response.Code())
 	}
 }
 
@@ -58,8 +58,7 @@ WeaviateWellknownReadinessOK describes a response with status code 200, with def
 
 The application has completed its start-up routine and is ready to accept traffic.
 */
-type WeaviateWellknownReadinessOK struct {
-}
+type WeaviateWellknownReadinessOK struct{}
 
 // IsSuccess returns true when this weaviate wellknown readiness o k response has a 2xx status code
 func (o *WeaviateWellknownReadinessOK) IsSuccess() bool {
@@ -92,15 +91,14 @@ func (o *WeaviateWellknownReadinessOK) Code() int {
 }
 
 func (o *WeaviateWellknownReadinessOK) Error() string {
-	return fmt.Sprintf("[GET /.well-known/ready][%d] weaviateWellknownReadinessOK ", 200)
+	return fmt.Sprintf("[GET /.well-known/ready][%d] weaviateWellknownReadinessOK", 200)
 }
 
 func (o *WeaviateWellknownReadinessOK) String() string {
-	return fmt.Sprintf("[GET /.well-known/ready][%d] weaviateWellknownReadinessOK ", 200)
+	return fmt.Sprintf("[GET /.well-known/ready][%d] weaviateWellknownReadinessOK", 200)
 }
 
 func (o *WeaviateWellknownReadinessOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -114,8 +112,7 @@ WeaviateWellknownReadinessServiceUnavailable describes a response with status co
 
 The application is currently not able to serve traffic. If other horizontal replicas of weaviate are available and they are capable of receiving traffic, all traffic should be redirected there instead.
 */
-type WeaviateWellknownReadinessServiceUnavailable struct {
-}
+type WeaviateWellknownReadinessServiceUnavailable struct{}
 
 // IsSuccess returns true when this weaviate wellknown readiness service unavailable response has a 2xx status code
 func (o *WeaviateWellknownReadinessServiceUnavailable) IsSuccess() bool {
@@ -148,14 +145,13 @@ func (o *WeaviateWellknownReadinessServiceUnavailable) Code() int {
 }
 
 func (o *WeaviateWellknownReadinessServiceUnavailable) Error() string {
-	return fmt.Sprintf("[GET /.well-known/ready][%d] weaviateWellknownReadinessServiceUnavailable ", 503)
+	return fmt.Sprintf("[GET /.well-known/ready][%d] weaviateWellknownReadinessServiceUnavailable", 503)
 }
 
 func (o *WeaviateWellknownReadinessServiceUnavailable) String() string {
-	return fmt.Sprintf("[GET /.well-known/ready][%d] weaviateWellknownReadinessServiceUnavailable ", 503)
+	return fmt.Sprintf("[GET /.well-known/ready][%d] weaviateWellknownReadinessServiceUnavailable", 503)
 }
 
 func (o *WeaviateWellknownReadinessServiceUnavailable) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }

--- a/client/replication/cancel_replication_responses.go
+++ b/client/replication/cancel_replication_responses.go
@@ -17,6 +17,7 @@ package replication
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -83,7 +84,7 @@ func (o *CancelReplicationReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /replication/replicate/{id}/cancel] cancelReplication", response, response.Code())
 	}
 }
 
@@ -97,8 +98,7 @@ CancelReplicationNoContent describes a response with status code 204, with defau
 
 Successfully cancelled.
 */
-type CancelReplicationNoContent struct {
-}
+type CancelReplicationNoContent struct{}
 
 // IsSuccess returns true when this cancel replication no content response has a 2xx status code
 func (o *CancelReplicationNoContent) IsSuccess() bool {
@@ -131,15 +131,14 @@ func (o *CancelReplicationNoContent) Code() int {
 }
 
 func (o *CancelReplicationNoContent) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationNoContent ", 204)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationNoContent", 204)
 }
 
 func (o *CancelReplicationNoContent) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationNoContent ", 204)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationNoContent", 204)
 }
 
 func (o *CancelReplicationNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -153,8 +152,7 @@ CancelReplicationUnauthorized describes a response with status code 401, with de
 
 Unauthorized or invalid credentials.
 */
-type CancelReplicationUnauthorized struct {
-}
+type CancelReplicationUnauthorized struct{}
 
 // IsSuccess returns true when this cancel replication unauthorized response has a 2xx status code
 func (o *CancelReplicationUnauthorized) IsSuccess() bool {
@@ -187,15 +185,14 @@ func (o *CancelReplicationUnauthorized) Code() int {
 }
 
 func (o *CancelReplicationUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationUnauthorized ", 401)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationUnauthorized", 401)
 }
 
 func (o *CancelReplicationUnauthorized) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationUnauthorized ", 401)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationUnauthorized", 401)
 }
 
 func (o *CancelReplicationUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +241,13 @@ func (o *CancelReplicationForbidden) Code() int {
 }
 
 func (o *CancelReplicationForbidden) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationForbidden %s", 403, payload)
 }
 
 func (o *CancelReplicationForbidden) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationForbidden %s", 403, payload)
 }
 
 func (o *CancelReplicationForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +255,6 @@ func (o *CancelReplicationForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CancelReplicationForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -277,8 +275,7 @@ CancelReplicationNotFound describes a response with status code 404, with defaul
 
 Shard replica operation not found.
 */
-type CancelReplicationNotFound struct {
-}
+type CancelReplicationNotFound struct{}
 
 // IsSuccess returns true when this cancel replication not found response has a 2xx status code
 func (o *CancelReplicationNotFound) IsSuccess() bool {
@@ -311,15 +308,14 @@ func (o *CancelReplicationNotFound) Code() int {
 }
 
 func (o *CancelReplicationNotFound) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationNotFound ", 404)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationNotFound", 404)
 }
 
 func (o *CancelReplicationNotFound) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationNotFound ", 404)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationNotFound", 404)
 }
 
 func (o *CancelReplicationNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -368,11 +364,13 @@ func (o *CancelReplicationConflict) Code() int {
 }
 
 func (o *CancelReplicationConflict) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationConflict  %+v", 409, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationConflict %s", 409, payload)
 }
 
 func (o *CancelReplicationConflict) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationConflict  %+v", 409, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationConflict %s", 409, payload)
 }
 
 func (o *CancelReplicationConflict) GetPayload() *models.ErrorResponse {
@@ -380,7 +378,6 @@ func (o *CancelReplicationConflict) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CancelReplicationConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -436,11 +433,13 @@ func (o *CancelReplicationUnprocessableEntity) Code() int {
 }
 
 func (o *CancelReplicationUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationUnprocessableEntity %s", 422, payload)
 }
 
 func (o *CancelReplicationUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationUnprocessableEntity %s", 422, payload)
 }
 
 func (o *CancelReplicationUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -448,7 +447,6 @@ func (o *CancelReplicationUnprocessableEntity) GetPayload() *models.ErrorRespons
 }
 
 func (o *CancelReplicationUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -504,11 +502,13 @@ func (o *CancelReplicationInternalServerError) Code() int {
 }
 
 func (o *CancelReplicationInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationInternalServerError %s", 500, payload)
 }
 
 func (o *CancelReplicationInternalServerError) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationInternalServerError %s", 500, payload)
 }
 
 func (o *CancelReplicationInternalServerError) GetPayload() *models.ErrorResponse {
@@ -516,7 +516,6 @@ func (o *CancelReplicationInternalServerError) GetPayload() *models.ErrorRespons
 }
 
 func (o *CancelReplicationInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -572,11 +571,13 @@ func (o *CancelReplicationNotImplemented) Code() int {
 }
 
 func (o *CancelReplicationNotImplemented) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationNotImplemented %s", 501, payload)
 }
 
 func (o *CancelReplicationNotImplemented) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/{id}/cancel][%d] cancelReplicationNotImplemented %s", 501, payload)
 }
 
 func (o *CancelReplicationNotImplemented) GetPayload() *models.ErrorResponse {
@@ -584,7 +585,6 @@ func (o *CancelReplicationNotImplemented) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CancelReplicationNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/replication/delete_all_replications_responses.go
+++ b/client/replication/delete_all_replications_responses.go
@@ -17,6 +17,7 @@ package replication
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *DeleteAllReplicationsReader) ReadResponse(response runtime.ClientRespon
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /replication/replicate] deleteAllReplications", response, response.Code())
 	}
 }
 
@@ -91,8 +92,7 @@ DeleteAllReplicationsNoContent describes a response with status code 204, with d
 
 Replication operation registered successfully
 */
-type DeleteAllReplicationsNoContent struct {
-}
+type DeleteAllReplicationsNoContent struct{}
 
 // IsSuccess returns true when this delete all replications no content response has a 2xx status code
 func (o *DeleteAllReplicationsNoContent) IsSuccess() bool {
@@ -125,15 +125,14 @@ func (o *DeleteAllReplicationsNoContent) Code() int {
 }
 
 func (o *DeleteAllReplicationsNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsNoContent ", 204)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsNoContent", 204)
 }
 
 func (o *DeleteAllReplicationsNoContent) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsNoContent ", 204)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsNoContent", 204)
 }
 
 func (o *DeleteAllReplicationsNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -182,11 +181,13 @@ func (o *DeleteAllReplicationsBadRequest) Code() int {
 }
 
 func (o *DeleteAllReplicationsBadRequest) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsBadRequest %s", 400, payload)
 }
 
 func (o *DeleteAllReplicationsBadRequest) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsBadRequest %s", 400, payload)
 }
 
 func (o *DeleteAllReplicationsBadRequest) GetPayload() *models.ErrorResponse {
@@ -194,7 +195,6 @@ func (o *DeleteAllReplicationsBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeleteAllReplicationsBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -215,8 +215,7 @@ DeleteAllReplicationsUnauthorized describes a response with status code 401, wit
 
 Unauthorized or invalid credentials.
 */
-type DeleteAllReplicationsUnauthorized struct {
-}
+type DeleteAllReplicationsUnauthorized struct{}
 
 // IsSuccess returns true when this delete all replications unauthorized response has a 2xx status code
 func (o *DeleteAllReplicationsUnauthorized) IsSuccess() bool {
@@ -249,15 +248,14 @@ func (o *DeleteAllReplicationsUnauthorized) Code() int {
 }
 
 func (o *DeleteAllReplicationsUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsUnauthorized", 401)
 }
 
 func (o *DeleteAllReplicationsUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsUnauthorized", 401)
 }
 
 func (o *DeleteAllReplicationsUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -306,11 +304,13 @@ func (o *DeleteAllReplicationsForbidden) Code() int {
 }
 
 func (o *DeleteAllReplicationsForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsForbidden %s", 403, payload)
 }
 
 func (o *DeleteAllReplicationsForbidden) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsForbidden %s", 403, payload)
 }
 
 func (o *DeleteAllReplicationsForbidden) GetPayload() *models.ErrorResponse {
@@ -318,7 +318,6 @@ func (o *DeleteAllReplicationsForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeleteAllReplicationsForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -374,11 +373,13 @@ func (o *DeleteAllReplicationsUnprocessableEntity) Code() int {
 }
 
 func (o *DeleteAllReplicationsUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *DeleteAllReplicationsUnprocessableEntity) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *DeleteAllReplicationsUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -386,7 +387,6 @@ func (o *DeleteAllReplicationsUnprocessableEntity) GetPayload() *models.ErrorRes
 }
 
 func (o *DeleteAllReplicationsUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -442,11 +442,13 @@ func (o *DeleteAllReplicationsInternalServerError) Code() int {
 }
 
 func (o *DeleteAllReplicationsInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsInternalServerError %s", 500, payload)
 }
 
 func (o *DeleteAllReplicationsInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsInternalServerError %s", 500, payload)
 }
 
 func (o *DeleteAllReplicationsInternalServerError) GetPayload() *models.ErrorResponse {
@@ -454,7 +456,6 @@ func (o *DeleteAllReplicationsInternalServerError) GetPayload() *models.ErrorRes
 }
 
 func (o *DeleteAllReplicationsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -510,11 +511,13 @@ func (o *DeleteAllReplicationsNotImplemented) Code() int {
 }
 
 func (o *DeleteAllReplicationsNotImplemented) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsNotImplemented %s", 501, payload)
 }
 
 func (o *DeleteAllReplicationsNotImplemented) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate][%d] deleteAllReplicationsNotImplemented %s", 501, payload)
 }
 
 func (o *DeleteAllReplicationsNotImplemented) GetPayload() *models.ErrorResponse {
@@ -522,7 +525,6 @@ func (o *DeleteAllReplicationsNotImplemented) GetPayload() *models.ErrorResponse
 }
 
 func (o *DeleteAllReplicationsNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/replication/delete_replication_responses.go
+++ b/client/replication/delete_replication_responses.go
@@ -17,6 +17,7 @@ package replication
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -83,7 +84,7 @@ func (o *DeleteReplicationReader) ReadResponse(response runtime.ClientResponse, 
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /replication/replicate/{id}] deleteReplication", response, response.Code())
 	}
 }
 
@@ -97,8 +98,7 @@ DeleteReplicationNoContent describes a response with status code 204, with defau
 
 Successfully deleted.
 */
-type DeleteReplicationNoContent struct {
-}
+type DeleteReplicationNoContent struct{}
 
 // IsSuccess returns true when this delete replication no content response has a 2xx status code
 func (o *DeleteReplicationNoContent) IsSuccess() bool {
@@ -131,15 +131,14 @@ func (o *DeleteReplicationNoContent) Code() int {
 }
 
 func (o *DeleteReplicationNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationNoContent ", 204)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationNoContent", 204)
 }
 
 func (o *DeleteReplicationNoContent) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationNoContent ", 204)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationNoContent", 204)
 }
 
 func (o *DeleteReplicationNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -153,8 +152,7 @@ DeleteReplicationUnauthorized describes a response with status code 401, with de
 
 Unauthorized or invalid credentials.
 */
-type DeleteReplicationUnauthorized struct {
-}
+type DeleteReplicationUnauthorized struct{}
 
 // IsSuccess returns true when this delete replication unauthorized response has a 2xx status code
 func (o *DeleteReplicationUnauthorized) IsSuccess() bool {
@@ -187,15 +185,14 @@ func (o *DeleteReplicationUnauthorized) Code() int {
 }
 
 func (o *DeleteReplicationUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationUnauthorized", 401)
 }
 
 func (o *DeleteReplicationUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationUnauthorized", 401)
 }
 
 func (o *DeleteReplicationUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +241,13 @@ func (o *DeleteReplicationForbidden) Code() int {
 }
 
 func (o *DeleteReplicationForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationForbidden %s", 403, payload)
 }
 
 func (o *DeleteReplicationForbidden) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationForbidden %s", 403, payload)
 }
 
 func (o *DeleteReplicationForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +255,6 @@ func (o *DeleteReplicationForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeleteReplicationForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -277,8 +275,7 @@ DeleteReplicationNotFound describes a response with status code 404, with defaul
 
 Shard replica operation not found.
 */
-type DeleteReplicationNotFound struct {
-}
+type DeleteReplicationNotFound struct{}
 
 // IsSuccess returns true when this delete replication not found response has a 2xx status code
 func (o *DeleteReplicationNotFound) IsSuccess() bool {
@@ -311,15 +308,14 @@ func (o *DeleteReplicationNotFound) Code() int {
 }
 
 func (o *DeleteReplicationNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationNotFound ", 404)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationNotFound", 404)
 }
 
 func (o *DeleteReplicationNotFound) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationNotFound ", 404)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationNotFound", 404)
 }
 
 func (o *DeleteReplicationNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -368,11 +364,13 @@ func (o *DeleteReplicationConflict) Code() int {
 }
 
 func (o *DeleteReplicationConflict) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationConflict  %+v", 409, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationConflict %s", 409, payload)
 }
 
 func (o *DeleteReplicationConflict) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationConflict  %+v", 409, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationConflict %s", 409, payload)
 }
 
 func (o *DeleteReplicationConflict) GetPayload() *models.ErrorResponse {
@@ -380,7 +378,6 @@ func (o *DeleteReplicationConflict) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeleteReplicationConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -436,11 +433,13 @@ func (o *DeleteReplicationUnprocessableEntity) Code() int {
 }
 
 func (o *DeleteReplicationUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationUnprocessableEntity %s", 422, payload)
 }
 
 func (o *DeleteReplicationUnprocessableEntity) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationUnprocessableEntity %s", 422, payload)
 }
 
 func (o *DeleteReplicationUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -448,7 +447,6 @@ func (o *DeleteReplicationUnprocessableEntity) GetPayload() *models.ErrorRespons
 }
 
 func (o *DeleteReplicationUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -504,11 +502,13 @@ func (o *DeleteReplicationInternalServerError) Code() int {
 }
 
 func (o *DeleteReplicationInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationInternalServerError %s", 500, payload)
 }
 
 func (o *DeleteReplicationInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationInternalServerError %s", 500, payload)
 }
 
 func (o *DeleteReplicationInternalServerError) GetPayload() *models.ErrorResponse {
@@ -516,7 +516,6 @@ func (o *DeleteReplicationInternalServerError) GetPayload() *models.ErrorRespons
 }
 
 func (o *DeleteReplicationInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -572,11 +571,13 @@ func (o *DeleteReplicationNotImplemented) Code() int {
 }
 
 func (o *DeleteReplicationNotImplemented) Error() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationNotImplemented %s", 501, payload)
 }
 
 func (o *DeleteReplicationNotImplemented) String() string {
-	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /replication/replicate/{id}][%d] deleteReplicationNotImplemented %s", 501, payload)
 }
 
 func (o *DeleteReplicationNotImplemented) GetPayload() *models.ErrorResponse {
@@ -584,7 +585,6 @@ func (o *DeleteReplicationNotImplemented) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeleteReplicationNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/replication/force_delete_replications_responses.go
+++ b/client/replication/force_delete_replications_responses.go
@@ -17,6 +17,7 @@ package replication
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *ForceDeleteReplicationsReader) ReadResponse(response runtime.ClientResp
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /replication/replicate/force-delete] forceDeleteReplications", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *ForceDeleteReplicationsOK) Code() int {
 }
 
 func (o *ForceDeleteReplicationsOK) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsOK %s", 200, payload)
 }
 
 func (o *ForceDeleteReplicationsOK) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsOK %s", 200, payload)
 }
 
 func (o *ForceDeleteReplicationsOK) GetPayload() *models.ReplicationReplicateForceDeleteResponse {
@@ -132,7 +135,6 @@ func (o *ForceDeleteReplicationsOK) GetPayload() *models.ReplicationReplicateFor
 }
 
 func (o *ForceDeleteReplicationsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ReplicationReplicateForceDeleteResponse)
 
 	// response payload
@@ -188,11 +190,13 @@ func (o *ForceDeleteReplicationsBadRequest) Code() int {
 }
 
 func (o *ForceDeleteReplicationsBadRequest) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsBadRequest %s", 400, payload)
 }
 
 func (o *ForceDeleteReplicationsBadRequest) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsBadRequest %s", 400, payload)
 }
 
 func (o *ForceDeleteReplicationsBadRequest) GetPayload() *models.ErrorResponse {
@@ -200,7 +204,6 @@ func (o *ForceDeleteReplicationsBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ForceDeleteReplicationsBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -221,8 +224,7 @@ ForceDeleteReplicationsUnauthorized describes a response with status code 401, w
 
 Unauthorized or invalid credentials.
 */
-type ForceDeleteReplicationsUnauthorized struct {
-}
+type ForceDeleteReplicationsUnauthorized struct{}
 
 // IsSuccess returns true when this force delete replications unauthorized response has a 2xx status code
 func (o *ForceDeleteReplicationsUnauthorized) IsSuccess() bool {
@@ -255,15 +257,14 @@ func (o *ForceDeleteReplicationsUnauthorized) Code() int {
 }
 
 func (o *ForceDeleteReplicationsUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsUnauthorized ", 401)
+	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsUnauthorized", 401)
 }
 
 func (o *ForceDeleteReplicationsUnauthorized) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsUnauthorized ", 401)
+	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsUnauthorized", 401)
 }
 
 func (o *ForceDeleteReplicationsUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -312,11 +313,13 @@ func (o *ForceDeleteReplicationsForbidden) Code() int {
 }
 
 func (o *ForceDeleteReplicationsForbidden) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsForbidden %s", 403, payload)
 }
 
 func (o *ForceDeleteReplicationsForbidden) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsForbidden %s", 403, payload)
 }
 
 func (o *ForceDeleteReplicationsForbidden) GetPayload() *models.ErrorResponse {
@@ -324,7 +327,6 @@ func (o *ForceDeleteReplicationsForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ForceDeleteReplicationsForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -380,11 +382,13 @@ func (o *ForceDeleteReplicationsUnprocessableEntity) Code() int {
 }
 
 func (o *ForceDeleteReplicationsUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ForceDeleteReplicationsUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ForceDeleteReplicationsUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -392,7 +396,6 @@ func (o *ForceDeleteReplicationsUnprocessableEntity) GetPayload() *models.ErrorR
 }
 
 func (o *ForceDeleteReplicationsUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -448,11 +451,13 @@ func (o *ForceDeleteReplicationsInternalServerError) Code() int {
 }
 
 func (o *ForceDeleteReplicationsInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsInternalServerError %s", 500, payload)
 }
 
 func (o *ForceDeleteReplicationsInternalServerError) String() string {
-	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate/force-delete][%d] forceDeleteReplicationsInternalServerError %s", 500, payload)
 }
 
 func (o *ForceDeleteReplicationsInternalServerError) GetPayload() *models.ErrorResponse {
@@ -460,7 +465,6 @@ func (o *ForceDeleteReplicationsInternalServerError) GetPayload() *models.ErrorR
 }
 
 func (o *ForceDeleteReplicationsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/replication/get_collection_sharding_state_responses.go
+++ b/client/replication/get_collection_sharding_state_responses.go
@@ -17,6 +17,7 @@ package replication
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *GetCollectionShardingStateReader) ReadResponse(response runtime.ClientR
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /replication/sharding-state] getCollectionShardingState", response, response.Code())
 	}
 }
 
@@ -126,11 +127,13 @@ func (o *GetCollectionShardingStateOK) Code() int {
 }
 
 func (o *GetCollectionShardingStateOK) Error() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateOK %s", 200, payload)
 }
 
 func (o *GetCollectionShardingStateOK) String() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateOK %s", 200, payload)
 }
 
 func (o *GetCollectionShardingStateOK) GetPayload() *models.ReplicationShardingStateResponse {
@@ -138,7 +141,6 @@ func (o *GetCollectionShardingStateOK) GetPayload() *models.ReplicationShardingS
 }
 
 func (o *GetCollectionShardingStateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ReplicationShardingStateResponse)
 
 	// response payload
@@ -194,11 +196,13 @@ func (o *GetCollectionShardingStateBadRequest) Code() int {
 }
 
 func (o *GetCollectionShardingStateBadRequest) Error() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateBadRequest %s", 400, payload)
 }
 
 func (o *GetCollectionShardingStateBadRequest) String() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateBadRequest %s", 400, payload)
 }
 
 func (o *GetCollectionShardingStateBadRequest) GetPayload() *models.ErrorResponse {
@@ -206,7 +210,6 @@ func (o *GetCollectionShardingStateBadRequest) GetPayload() *models.ErrorRespons
 }
 
 func (o *GetCollectionShardingStateBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -227,8 +230,7 @@ GetCollectionShardingStateUnauthorized describes a response with status code 401
 
 Unauthorized or invalid credentials.
 */
-type GetCollectionShardingStateUnauthorized struct {
-}
+type GetCollectionShardingStateUnauthorized struct{}
 
 // IsSuccess returns true when this get collection sharding state unauthorized response has a 2xx status code
 func (o *GetCollectionShardingStateUnauthorized) IsSuccess() bool {
@@ -261,15 +263,14 @@ func (o *GetCollectionShardingStateUnauthorized) Code() int {
 }
 
 func (o *GetCollectionShardingStateUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateUnauthorized ", 401)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateUnauthorized", 401)
 }
 
 func (o *GetCollectionShardingStateUnauthorized) String() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateUnauthorized ", 401)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateUnauthorized", 401)
 }
 
 func (o *GetCollectionShardingStateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -318,11 +319,13 @@ func (o *GetCollectionShardingStateForbidden) Code() int {
 }
 
 func (o *GetCollectionShardingStateForbidden) Error() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateForbidden %s", 403, payload)
 }
 
 func (o *GetCollectionShardingStateForbidden) String() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateForbidden %s", 403, payload)
 }
 
 func (o *GetCollectionShardingStateForbidden) GetPayload() *models.ErrorResponse {
@@ -330,7 +333,6 @@ func (o *GetCollectionShardingStateForbidden) GetPayload() *models.ErrorResponse
 }
 
 func (o *GetCollectionShardingStateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -386,11 +388,13 @@ func (o *GetCollectionShardingStateNotFound) Code() int {
 }
 
 func (o *GetCollectionShardingStateNotFound) Error() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateNotFound %s", 404, payload)
 }
 
 func (o *GetCollectionShardingStateNotFound) String() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateNotFound %s", 404, payload)
 }
 
 func (o *GetCollectionShardingStateNotFound) GetPayload() *models.ErrorResponse {
@@ -398,7 +402,6 @@ func (o *GetCollectionShardingStateNotFound) GetPayload() *models.ErrorResponse 
 }
 
 func (o *GetCollectionShardingStateNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -454,11 +457,13 @@ func (o *GetCollectionShardingStateInternalServerError) Code() int {
 }
 
 func (o *GetCollectionShardingStateInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateInternalServerError %s", 500, payload)
 }
 
 func (o *GetCollectionShardingStateInternalServerError) String() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateInternalServerError %s", 500, payload)
 }
 
 func (o *GetCollectionShardingStateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -466,7 +471,6 @@ func (o *GetCollectionShardingStateInternalServerError) GetPayload() *models.Err
 }
 
 func (o *GetCollectionShardingStateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -522,11 +526,13 @@ func (o *GetCollectionShardingStateNotImplemented) Code() int {
 }
 
 func (o *GetCollectionShardingStateNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateNotImplemented %s", 501, payload)
 }
 
 func (o *GetCollectionShardingStateNotImplemented) String() string {
-	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/sharding-state][%d] getCollectionShardingStateNotImplemented %s", 501, payload)
 }
 
 func (o *GetCollectionShardingStateNotImplemented) GetPayload() *models.ErrorResponse {
@@ -534,7 +540,6 @@ func (o *GetCollectionShardingStateNotImplemented) GetPayload() *models.ErrorRes
 }
 
 func (o *GetCollectionShardingStateNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/replication/list_replication_responses.go
+++ b/client/replication/list_replication_responses.go
@@ -17,6 +17,7 @@ package replication
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *ListReplicationReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /replication/replicate/list] listReplication", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *ListReplicationOK) Code() int {
 }
 
 func (o *ListReplicationOK) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationOK %s", 200, payload)
 }
 
 func (o *ListReplicationOK) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationOK %s", 200, payload)
 }
 
 func (o *ListReplicationOK) GetPayload() []*models.ReplicationReplicateDetailsReplicaResponse {
@@ -132,7 +135,6 @@ func (o *ListReplicationOK) GetPayload() []*models.ReplicationReplicateDetailsRe
 }
 
 func (o *ListReplicationOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -186,11 +188,13 @@ func (o *ListReplicationBadRequest) Code() int {
 }
 
 func (o *ListReplicationBadRequest) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationBadRequest %s", 400, payload)
 }
 
 func (o *ListReplicationBadRequest) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationBadRequest %s", 400, payload)
 }
 
 func (o *ListReplicationBadRequest) GetPayload() *models.ErrorResponse {
@@ -198,7 +202,6 @@ func (o *ListReplicationBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ListReplicationBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -219,8 +222,7 @@ ListReplicationUnauthorized describes a response with status code 401, with defa
 
 Unauthorized or invalid credentials.
 */
-type ListReplicationUnauthorized struct {
-}
+type ListReplicationUnauthorized struct{}
 
 // IsSuccess returns true when this list replication unauthorized response has a 2xx status code
 func (o *ListReplicationUnauthorized) IsSuccess() bool {
@@ -253,15 +255,14 @@ func (o *ListReplicationUnauthorized) Code() int {
 }
 
 func (o *ListReplicationUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationUnauthorized ", 401)
+	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationUnauthorized", 401)
 }
 
 func (o *ListReplicationUnauthorized) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationUnauthorized ", 401)
+	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationUnauthorized", 401)
 }
 
 func (o *ListReplicationUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -310,11 +311,13 @@ func (o *ListReplicationForbidden) Code() int {
 }
 
 func (o *ListReplicationForbidden) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationForbidden %s", 403, payload)
 }
 
 func (o *ListReplicationForbidden) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationForbidden %s", 403, payload)
 }
 
 func (o *ListReplicationForbidden) GetPayload() *models.ErrorResponse {
@@ -322,7 +325,6 @@ func (o *ListReplicationForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ListReplicationForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -378,11 +380,13 @@ func (o *ListReplicationInternalServerError) Code() int {
 }
 
 func (o *ListReplicationInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationInternalServerError %s", 500, payload)
 }
 
 func (o *ListReplicationInternalServerError) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationInternalServerError %s", 500, payload)
 }
 
 func (o *ListReplicationInternalServerError) GetPayload() *models.ErrorResponse {
@@ -390,7 +394,6 @@ func (o *ListReplicationInternalServerError) GetPayload() *models.ErrorResponse 
 }
 
 func (o *ListReplicationInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -446,11 +449,13 @@ func (o *ListReplicationNotImplemented) Code() int {
 }
 
 func (o *ListReplicationNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationNotImplemented %s", 501, payload)
 }
 
 func (o *ListReplicationNotImplemented) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/list][%d] listReplicationNotImplemented %s", 501, payload)
 }
 
 func (o *ListReplicationNotImplemented) GetPayload() *models.ErrorResponse {
@@ -458,7 +463,6 @@ func (o *ListReplicationNotImplemented) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ListReplicationNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/replication/replicate_responses.go
+++ b/client/replication/replicate_responses.go
@@ -17,6 +17,7 @@ package replication
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *ReplicateReader) ReadResponse(response runtime.ClientResponse, consumer
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /replication/replicate] replicate", response, response.Code())
 	}
 }
 
@@ -126,11 +127,13 @@ func (o *ReplicateOK) Code() int {
 }
 
 func (o *ReplicateOK) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateOK %s", 200, payload)
 }
 
 func (o *ReplicateOK) String() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateOK %s", 200, payload)
 }
 
 func (o *ReplicateOK) GetPayload() *models.ReplicationReplicateReplicaResponse {
@@ -138,7 +141,6 @@ func (o *ReplicateOK) GetPayload() *models.ReplicationReplicateReplicaResponse {
 }
 
 func (o *ReplicateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ReplicationReplicateReplicaResponse)
 
 	// response payload
@@ -194,11 +196,13 @@ func (o *ReplicateBadRequest) Code() int {
 }
 
 func (o *ReplicateBadRequest) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateBadRequest %s", 400, payload)
 }
 
 func (o *ReplicateBadRequest) String() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateBadRequest %s", 400, payload)
 }
 
 func (o *ReplicateBadRequest) GetPayload() *models.ErrorResponse {
@@ -206,7 +210,6 @@ func (o *ReplicateBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ReplicateBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -227,8 +230,7 @@ ReplicateUnauthorized describes a response with status code 401, with default he
 
 Unauthorized or invalid credentials.
 */
-type ReplicateUnauthorized struct {
-}
+type ReplicateUnauthorized struct{}
 
 // IsSuccess returns true when this replicate unauthorized response has a 2xx status code
 func (o *ReplicateUnauthorized) IsSuccess() bool {
@@ -261,15 +263,14 @@ func (o *ReplicateUnauthorized) Code() int {
 }
 
 func (o *ReplicateUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateUnauthorized", 401)
 }
 
 func (o *ReplicateUnauthorized) String() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateUnauthorized", 401)
 }
 
 func (o *ReplicateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -318,11 +319,13 @@ func (o *ReplicateForbidden) Code() int {
 }
 
 func (o *ReplicateForbidden) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateForbidden %s", 403, payload)
 }
 
 func (o *ReplicateForbidden) String() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateForbidden %s", 403, payload)
 }
 
 func (o *ReplicateForbidden) GetPayload() *models.ErrorResponse {
@@ -330,7 +333,6 @@ func (o *ReplicateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ReplicateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -386,11 +388,13 @@ func (o *ReplicateUnprocessableEntity) Code() int {
 }
 
 func (o *ReplicateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ReplicateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ReplicateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -398,7 +402,6 @@ func (o *ReplicateUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ReplicateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -454,11 +457,13 @@ func (o *ReplicateInternalServerError) Code() int {
 }
 
 func (o *ReplicateInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateInternalServerError %s", 500, payload)
 }
 
 func (o *ReplicateInternalServerError) String() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateInternalServerError %s", 500, payload)
 }
 
 func (o *ReplicateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -466,7 +471,6 @@ func (o *ReplicateInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ReplicateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -522,11 +526,13 @@ func (o *ReplicateNotImplemented) Code() int {
 }
 
 func (o *ReplicateNotImplemented) Error() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateNotImplemented %s", 501, payload)
 }
 
 func (o *ReplicateNotImplemented) String() string {
-	return fmt.Sprintf("[POST /replication/replicate][%d] replicateNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /replication/replicate][%d] replicateNotImplemented %s", 501, payload)
 }
 
 func (o *ReplicateNotImplemented) GetPayload() *models.ErrorResponse {
@@ -534,7 +540,6 @@ func (o *ReplicateNotImplemented) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ReplicateNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/replication/replication_client.go
+++ b/client/replication/replication_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new replication API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new replication API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new replication API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -75,7 +125,7 @@ func (a *Client) CancelReplication(params *CancelReplicationParams, authInfo run
 		Method:             "POST",
 		PathPattern:        "/replication/replicate/{id}/cancel",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &CancelReplicationReader{formats: a.formats},
@@ -114,7 +164,7 @@ func (a *Client) DeleteAllReplications(params *DeleteAllReplicationsParams, auth
 		Method:             "DELETE",
 		PathPattern:        "/replication/replicate",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &DeleteAllReplicationsReader{formats: a.formats},
@@ -155,7 +205,7 @@ func (a *Client) DeleteReplication(params *DeleteReplicationParams, authInfo run
 		Method:             "DELETE",
 		PathPattern:        "/replication/replicate/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &DeleteReplicationReader{formats: a.formats},
@@ -196,7 +246,7 @@ func (a *Client) ForceDeleteReplications(params *ForceDeleteReplicationsParams, 
 		Method:             "POST",
 		PathPattern:        "/replication/replicate/force-delete",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ForceDeleteReplicationsReader{formats: a.formats},
@@ -237,7 +287,7 @@ func (a *Client) GetCollectionShardingState(params *GetCollectionShardingStatePa
 		Method:             "GET",
 		PathPattern:        "/replication/sharding-state",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetCollectionShardingStateReader{formats: a.formats},
@@ -278,7 +328,7 @@ func (a *Client) ListReplication(params *ListReplicationParams, authInfo runtime
 		Method:             "GET",
 		PathPattern:        "/replication/replicate/list",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ListReplicationReader{formats: a.formats},
@@ -319,7 +369,7 @@ func (a *Client) Replicate(params *ReplicateParams, authInfo runtime.ClientAuthI
 		Method:             "POST",
 		PathPattern:        "/replication/replicate",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ReplicateReader{formats: a.formats},
@@ -360,7 +410,7 @@ func (a *Client) ReplicationDetails(params *ReplicationDetailsParams, authInfo r
 		Method:             "GET",
 		PathPattern:        "/replication/replicate/{id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ReplicationDetailsReader{formats: a.formats},

--- a/client/replication/replication_details_responses.go
+++ b/client/replication/replication_details_responses.go
@@ -17,6 +17,7 @@ package replication
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *ReplicationDetailsReader) ReadResponse(response runtime.ClientResponse,
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /replication/replicate/{id}] replicationDetails", response, response.Code())
 	}
 }
 
@@ -126,11 +127,13 @@ func (o *ReplicationDetailsOK) Code() int {
 }
 
 func (o *ReplicationDetailsOK) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsOK %s", 200, payload)
 }
 
 func (o *ReplicationDetailsOK) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsOK %s", 200, payload)
 }
 
 func (o *ReplicationDetailsOK) GetPayload() *models.ReplicationReplicateDetailsReplicaResponse {
@@ -138,7 +141,6 @@ func (o *ReplicationDetailsOK) GetPayload() *models.ReplicationReplicateDetailsR
 }
 
 func (o *ReplicationDetailsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ReplicationReplicateDetailsReplicaResponse)
 
 	// response payload
@@ -159,8 +161,7 @@ ReplicationDetailsUnauthorized describes a response with status code 401, with d
 
 Unauthorized or invalid credentials.
 */
-type ReplicationDetailsUnauthorized struct {
-}
+type ReplicationDetailsUnauthorized struct{}
 
 // IsSuccess returns true when this replication details unauthorized response has a 2xx status code
 func (o *ReplicationDetailsUnauthorized) IsSuccess() bool {
@@ -193,15 +194,14 @@ func (o *ReplicationDetailsUnauthorized) Code() int {
 }
 
 func (o *ReplicationDetailsUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsUnauthorized ", 401)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsUnauthorized", 401)
 }
 
 func (o *ReplicationDetailsUnauthorized) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsUnauthorized ", 401)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsUnauthorized", 401)
 }
 
 func (o *ReplicationDetailsUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -250,11 +250,13 @@ func (o *ReplicationDetailsForbidden) Code() int {
 }
 
 func (o *ReplicationDetailsForbidden) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsForbidden %s", 403, payload)
 }
 
 func (o *ReplicationDetailsForbidden) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsForbidden %s", 403, payload)
 }
 
 func (o *ReplicationDetailsForbidden) GetPayload() *models.ErrorResponse {
@@ -262,7 +264,6 @@ func (o *ReplicationDetailsForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ReplicationDetailsForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -283,8 +284,7 @@ ReplicationDetailsNotFound describes a response with status code 404, with defau
 
 Shard replica operation not found.
 */
-type ReplicationDetailsNotFound struct {
-}
+type ReplicationDetailsNotFound struct{}
 
 // IsSuccess returns true when this replication details not found response has a 2xx status code
 func (o *ReplicationDetailsNotFound) IsSuccess() bool {
@@ -317,15 +317,14 @@ func (o *ReplicationDetailsNotFound) Code() int {
 }
 
 func (o *ReplicationDetailsNotFound) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsNotFound ", 404)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsNotFound", 404)
 }
 
 func (o *ReplicationDetailsNotFound) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsNotFound ", 404)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsNotFound", 404)
 }
 
 func (o *ReplicationDetailsNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -374,11 +373,13 @@ func (o *ReplicationDetailsUnprocessableEntity) Code() int {
 }
 
 func (o *ReplicationDetailsUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ReplicationDetailsUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ReplicationDetailsUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -386,7 +387,6 @@ func (o *ReplicationDetailsUnprocessableEntity) GetPayload() *models.ErrorRespon
 }
 
 func (o *ReplicationDetailsUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -442,11 +442,13 @@ func (o *ReplicationDetailsInternalServerError) Code() int {
 }
 
 func (o *ReplicationDetailsInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsInternalServerError %s", 500, payload)
 }
 
 func (o *ReplicationDetailsInternalServerError) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsInternalServerError %s", 500, payload)
 }
 
 func (o *ReplicationDetailsInternalServerError) GetPayload() *models.ErrorResponse {
@@ -454,7 +456,6 @@ func (o *ReplicationDetailsInternalServerError) GetPayload() *models.ErrorRespon
 }
 
 func (o *ReplicationDetailsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -510,11 +511,13 @@ func (o *ReplicationDetailsNotImplemented) Code() int {
 }
 
 func (o *ReplicationDetailsNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsNotImplemented %s", 501, payload)
 }
 
 func (o *ReplicationDetailsNotImplemented) String() string {
-	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /replication/replicate/{id}][%d] replicationDetailsNotImplemented %s", 501, payload)
 }
 
 func (o *ReplicationDetailsNotImplemented) GetPayload() *models.ErrorResponse {
@@ -522,7 +525,6 @@ func (o *ReplicationDetailsNotImplemented) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ReplicationDetailsNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/aliases_create_responses.go
+++ b/client/schema/aliases_create_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *AliasesCreateReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /aliases] aliases.create", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *AliasesCreateOK) Code() int {
 }
 
 func (o *AliasesCreateOK) Error() string {
-	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateOK %s", 200, payload)
 }
 
 func (o *AliasesCreateOK) String() string {
-	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateOK %s", 200, payload)
 }
 
 func (o *AliasesCreateOK) GetPayload() *models.Alias {
@@ -126,7 +129,6 @@ func (o *AliasesCreateOK) GetPayload() *models.Alias {
 }
 
 func (o *AliasesCreateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Alias)
 
 	// response payload
@@ -147,8 +149,7 @@ AliasesCreateUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type AliasesCreateUnauthorized struct {
-}
+type AliasesCreateUnauthorized struct{}
 
 // IsSuccess returns true when this aliases create unauthorized response has a 2xx status code
 func (o *AliasesCreateUnauthorized) IsSuccess() bool {
@@ -181,15 +182,14 @@ func (o *AliasesCreateUnauthorized) Code() int {
 }
 
 func (o *AliasesCreateUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateUnauthorized", 401)
 }
 
 func (o *AliasesCreateUnauthorized) String() string {
-	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateUnauthorized", 401)
 }
 
 func (o *AliasesCreateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -238,11 +238,13 @@ func (o *AliasesCreateForbidden) Code() int {
 }
 
 func (o *AliasesCreateForbidden) Error() string {
-	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateForbidden %s", 403, payload)
 }
 
 func (o *AliasesCreateForbidden) String() string {
-	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateForbidden %s", 403, payload)
 }
 
 func (o *AliasesCreateForbidden) GetPayload() *models.ErrorResponse {
@@ -250,7 +252,6 @@ func (o *AliasesCreateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesCreateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -306,11 +307,13 @@ func (o *AliasesCreateUnprocessableEntity) Code() int {
 }
 
 func (o *AliasesCreateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *AliasesCreateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *AliasesCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -318,7 +321,6 @@ func (o *AliasesCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesCreateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -374,11 +376,13 @@ func (o *AliasesCreateInternalServerError) Code() int {
 }
 
 func (o *AliasesCreateInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateInternalServerError %s", 500, payload)
 }
 
 func (o *AliasesCreateInternalServerError) String() string {
-	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /aliases][%d] aliasesCreateInternalServerError %s", 500, payload)
 }
 
 func (o *AliasesCreateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -386,7 +390,6 @@ func (o *AliasesCreateInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesCreateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/aliases_delete_responses.go
+++ b/client/schema/aliases_delete_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *AliasesDeleteReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /aliases/{aliasName}] aliases.delete", response, response.Code())
 	}
 }
 
@@ -85,8 +86,7 @@ AliasesDeleteNoContent describes a response with status code 204, with default h
 
 Successfully deleted the alias.
 */
-type AliasesDeleteNoContent struct {
-}
+type AliasesDeleteNoContent struct{}
 
 // IsSuccess returns true when this aliases delete no content response has a 2xx status code
 func (o *AliasesDeleteNoContent) IsSuccess() bool {
@@ -119,15 +119,14 @@ func (o *AliasesDeleteNoContent) Code() int {
 }
 
 func (o *AliasesDeleteNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteNoContent ", 204)
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteNoContent", 204)
 }
 
 func (o *AliasesDeleteNoContent) String() string {
-	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteNoContent ", 204)
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteNoContent", 204)
 }
 
 func (o *AliasesDeleteNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -141,8 +140,7 @@ AliasesDeleteUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type AliasesDeleteUnauthorized struct {
-}
+type AliasesDeleteUnauthorized struct{}
 
 // IsSuccess returns true when this aliases delete unauthorized response has a 2xx status code
 func (o *AliasesDeleteUnauthorized) IsSuccess() bool {
@@ -175,15 +173,14 @@ func (o *AliasesDeleteUnauthorized) Code() int {
 }
 
 func (o *AliasesDeleteUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteUnauthorized", 401)
 }
 
 func (o *AliasesDeleteUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteUnauthorized", 401)
 }
 
 func (o *AliasesDeleteUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -232,11 +229,13 @@ func (o *AliasesDeleteForbidden) Code() int {
 }
 
 func (o *AliasesDeleteForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteForbidden %s", 403, payload)
 }
 
 func (o *AliasesDeleteForbidden) String() string {
-	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteForbidden %s", 403, payload)
 }
 
 func (o *AliasesDeleteForbidden) GetPayload() *models.ErrorResponse {
@@ -244,7 +243,6 @@ func (o *AliasesDeleteForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesDeleteForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -300,11 +298,13 @@ func (o *AliasesDeleteNotFound) Code() int {
 }
 
 func (o *AliasesDeleteNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteNotFound %s", 404, payload)
 }
 
 func (o *AliasesDeleteNotFound) String() string {
-	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteNotFound %s", 404, payload)
 }
 
 func (o *AliasesDeleteNotFound) GetPayload() *models.ErrorResponse {
@@ -312,7 +312,6 @@ func (o *AliasesDeleteNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesDeleteNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -368,11 +367,13 @@ func (o *AliasesDeleteUnprocessableEntity) Code() int {
 }
 
 func (o *AliasesDeleteUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteUnprocessableEntity %s", 422, payload)
 }
 
 func (o *AliasesDeleteUnprocessableEntity) String() string {
-	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteUnprocessableEntity %s", 422, payload)
 }
 
 func (o *AliasesDeleteUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -380,7 +381,6 @@ func (o *AliasesDeleteUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesDeleteUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -436,11 +436,13 @@ func (o *AliasesDeleteInternalServerError) Code() int {
 }
 
 func (o *AliasesDeleteInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *AliasesDeleteInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /aliases/{aliasName}][%d] aliasesDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *AliasesDeleteInternalServerError) GetPayload() *models.ErrorResponse {
@@ -448,7 +450,6 @@ func (o *AliasesDeleteInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesDeleteInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/aliases_get_alias_responses.go
+++ b/client/schema/aliases_get_alias_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *AliasesGetAliasReader) ReadResponse(response runtime.ClientResponse, co
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /aliases/{aliasName}] aliases.get.alias", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *AliasesGetAliasOK) Code() int {
 }
 
 func (o *AliasesGetAliasOK) Error() string {
-	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasOK %s", 200, payload)
 }
 
 func (o *AliasesGetAliasOK) String() string {
-	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasOK %s", 200, payload)
 }
 
 func (o *AliasesGetAliasOK) GetPayload() *models.Alias {
@@ -132,7 +135,6 @@ func (o *AliasesGetAliasOK) GetPayload() *models.Alias {
 }
 
 func (o *AliasesGetAliasOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Alias)
 
 	// response payload
@@ -153,8 +155,7 @@ AliasesGetAliasUnauthorized describes a response with status code 401, with defa
 
 Unauthorized or invalid credentials.
 */
-type AliasesGetAliasUnauthorized struct {
-}
+type AliasesGetAliasUnauthorized struct{}
 
 // IsSuccess returns true when this aliases get alias unauthorized response has a 2xx status code
 func (o *AliasesGetAliasUnauthorized) IsSuccess() bool {
@@ -187,15 +188,14 @@ func (o *AliasesGetAliasUnauthorized) Code() int {
 }
 
 func (o *AliasesGetAliasUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasUnauthorized ", 401)
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasUnauthorized", 401)
 }
 
 func (o *AliasesGetAliasUnauthorized) String() string {
-	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasUnauthorized ", 401)
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasUnauthorized", 401)
 }
 
 func (o *AliasesGetAliasUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +244,13 @@ func (o *AliasesGetAliasForbidden) Code() int {
 }
 
 func (o *AliasesGetAliasForbidden) Error() string {
-	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasForbidden %s", 403, payload)
 }
 
 func (o *AliasesGetAliasForbidden) String() string {
-	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasForbidden %s", 403, payload)
 }
 
 func (o *AliasesGetAliasForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +258,6 @@ func (o *AliasesGetAliasForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesGetAliasForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -312,11 +313,13 @@ func (o *AliasesGetAliasNotFound) Code() int {
 }
 
 func (o *AliasesGetAliasNotFound) Error() string {
-	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasNotFound %s", 404, payload)
 }
 
 func (o *AliasesGetAliasNotFound) String() string {
-	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasNotFound %s", 404, payload)
 }
 
 func (o *AliasesGetAliasNotFound) GetPayload() *models.ErrorResponse {
@@ -324,7 +327,6 @@ func (o *AliasesGetAliasNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesGetAliasNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -380,11 +382,13 @@ func (o *AliasesGetAliasUnprocessableEntity) Code() int {
 }
 
 func (o *AliasesGetAliasUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasUnprocessableEntity %s", 422, payload)
 }
 
 func (o *AliasesGetAliasUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasUnprocessableEntity %s", 422, payload)
 }
 
 func (o *AliasesGetAliasUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -392,7 +396,6 @@ func (o *AliasesGetAliasUnprocessableEntity) GetPayload() *models.ErrorResponse 
 }
 
 func (o *AliasesGetAliasUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -448,11 +451,13 @@ func (o *AliasesGetAliasInternalServerError) Code() int {
 }
 
 func (o *AliasesGetAliasInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasInternalServerError %s", 500, payload)
 }
 
 func (o *AliasesGetAliasInternalServerError) String() string {
-	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases/{aliasName}][%d] aliasesGetAliasInternalServerError %s", 500, payload)
 }
 
 func (o *AliasesGetAliasInternalServerError) GetPayload() *models.ErrorResponse {
@@ -460,7 +465,6 @@ func (o *AliasesGetAliasInternalServerError) GetPayload() *models.ErrorResponse 
 }
 
 func (o *AliasesGetAliasInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/aliases_get_responses.go
+++ b/client/schema/aliases_get_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *AliasesGetReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /aliases] aliases.get", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *AliasesGetOK) Code() int {
 }
 
 func (o *AliasesGetOK) Error() string {
-	return fmt.Sprintf("[GET /aliases][%d] aliasesGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases][%d] aliasesGetOK %s", 200, payload)
 }
 
 func (o *AliasesGetOK) String() string {
-	return fmt.Sprintf("[GET /aliases][%d] aliasesGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases][%d] aliasesGetOK %s", 200, payload)
 }
 
 func (o *AliasesGetOK) GetPayload() *models.AliasResponse {
@@ -126,7 +129,6 @@ func (o *AliasesGetOK) GetPayload() *models.AliasResponse {
 }
 
 func (o *AliasesGetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.AliasResponse)
 
 	// response payload
@@ -147,8 +149,7 @@ AliasesGetUnauthorized describes a response with status code 401, with default h
 
 Unauthorized or invalid credentials.
 */
-type AliasesGetUnauthorized struct {
-}
+type AliasesGetUnauthorized struct{}
 
 // IsSuccess returns true when this aliases get unauthorized response has a 2xx status code
 func (o *AliasesGetUnauthorized) IsSuccess() bool {
@@ -181,15 +182,14 @@ func (o *AliasesGetUnauthorized) Code() int {
 }
 
 func (o *AliasesGetUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /aliases][%d] aliasesGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /aliases][%d] aliasesGetUnauthorized", 401)
 }
 
 func (o *AliasesGetUnauthorized) String() string {
-	return fmt.Sprintf("[GET /aliases][%d] aliasesGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /aliases][%d] aliasesGetUnauthorized", 401)
 }
 
 func (o *AliasesGetUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -238,11 +238,13 @@ func (o *AliasesGetForbidden) Code() int {
 }
 
 func (o *AliasesGetForbidden) Error() string {
-	return fmt.Sprintf("[GET /aliases][%d] aliasesGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases][%d] aliasesGetForbidden %s", 403, payload)
 }
 
 func (o *AliasesGetForbidden) String() string {
-	return fmt.Sprintf("[GET /aliases][%d] aliasesGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases][%d] aliasesGetForbidden %s", 403, payload)
 }
 
 func (o *AliasesGetForbidden) GetPayload() *models.ErrorResponse {
@@ -250,7 +252,6 @@ func (o *AliasesGetForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesGetForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -306,11 +307,13 @@ func (o *AliasesGetUnprocessableEntity) Code() int {
 }
 
 func (o *AliasesGetUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /aliases][%d] aliasesGetUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases][%d] aliasesGetUnprocessableEntity %s", 422, payload)
 }
 
 func (o *AliasesGetUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /aliases][%d] aliasesGetUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases][%d] aliasesGetUnprocessableEntity %s", 422, payload)
 }
 
 func (o *AliasesGetUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -318,7 +321,6 @@ func (o *AliasesGetUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesGetUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -374,11 +376,13 @@ func (o *AliasesGetInternalServerError) Code() int {
 }
 
 func (o *AliasesGetInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /aliases][%d] aliasesGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases][%d] aliasesGetInternalServerError %s", 500, payload)
 }
 
 func (o *AliasesGetInternalServerError) String() string {
-	return fmt.Sprintf("[GET /aliases][%d] aliasesGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /aliases][%d] aliasesGetInternalServerError %s", 500, payload)
 }
 
 func (o *AliasesGetInternalServerError) GetPayload() *models.ErrorResponse {
@@ -386,7 +390,6 @@ func (o *AliasesGetInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesGetInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/aliases_update_responses.go
+++ b/client/schema/aliases_update_responses.go
@@ -18,6 +18,7 @@ package schema
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -73,7 +74,7 @@ func (o *AliasesUpdateReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /aliases/{aliasName}] aliases.update", response, response.Code())
 	}
 }
 
@@ -122,11 +123,13 @@ func (o *AliasesUpdateOK) Code() int {
 }
 
 func (o *AliasesUpdateOK) Error() string {
-	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateOK %s", 200, payload)
 }
 
 func (o *AliasesUpdateOK) String() string {
-	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateOK %s", 200, payload)
 }
 
 func (o *AliasesUpdateOK) GetPayload() *models.Alias {
@@ -134,7 +137,6 @@ func (o *AliasesUpdateOK) GetPayload() *models.Alias {
 }
 
 func (o *AliasesUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Alias)
 
 	// response payload
@@ -155,8 +157,7 @@ AliasesUpdateUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type AliasesUpdateUnauthorized struct {
-}
+type AliasesUpdateUnauthorized struct{}
 
 // IsSuccess returns true when this aliases update unauthorized response has a 2xx status code
 func (o *AliasesUpdateUnauthorized) IsSuccess() bool {
@@ -189,15 +190,14 @@ func (o *AliasesUpdateUnauthorized) Code() int {
 }
 
 func (o *AliasesUpdateUnauthorized) Error() string {
-	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateUnauthorized", 401)
 }
 
 func (o *AliasesUpdateUnauthorized) String() string {
-	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateUnauthorized", 401)
 }
 
 func (o *AliasesUpdateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -246,11 +246,13 @@ func (o *AliasesUpdateForbidden) Code() int {
 }
 
 func (o *AliasesUpdateForbidden) Error() string {
-	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateForbidden %s", 403, payload)
 }
 
 func (o *AliasesUpdateForbidden) String() string {
-	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateForbidden %s", 403, payload)
 }
 
 func (o *AliasesUpdateForbidden) GetPayload() *models.ErrorResponse {
@@ -258,7 +260,6 @@ func (o *AliasesUpdateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesUpdateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -314,11 +315,13 @@ func (o *AliasesUpdateNotFound) Code() int {
 }
 
 func (o *AliasesUpdateNotFound) Error() string {
-	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateNotFound %s", 404, payload)
 }
 
 func (o *AliasesUpdateNotFound) String() string {
-	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateNotFound %s", 404, payload)
 }
 
 func (o *AliasesUpdateNotFound) GetPayload() *models.ErrorResponse {
@@ -326,7 +329,6 @@ func (o *AliasesUpdateNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesUpdateNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -382,11 +384,13 @@ func (o *AliasesUpdateUnprocessableEntity) Code() int {
 }
 
 func (o *AliasesUpdateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *AliasesUpdateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *AliasesUpdateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -394,7 +398,6 @@ func (o *AliasesUpdateUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesUpdateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -450,11 +453,13 @@ func (o *AliasesUpdateInternalServerError) Code() int {
 }
 
 func (o *AliasesUpdateInternalServerError) Error() string {
-	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateInternalServerError %s", 500, payload)
 }
 
 func (o *AliasesUpdateInternalServerError) String() string {
-	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /aliases/{aliasName}][%d] aliasesUpdateInternalServerError %s", 500, payload)
 }
 
 func (o *AliasesUpdateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -462,7 +467,6 @@ func (o *AliasesUpdateInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *AliasesUpdateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -478,7 +482,6 @@ AliasesUpdateBody aliases update body
 swagger:model AliasesUpdateBody
 */
 type AliasesUpdateBody struct {
-
 	// The new collection (class) that the alias should point to.
 	Class string `json:"class,omitempty"`
 }

--- a/client/schema/schema_client.go
+++ b/client/schema/schema_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new schema API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new schema API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new schema API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -97,7 +147,7 @@ func (a *Client) AliasesCreate(params *AliasesCreateParams, authInfo runtime.Cli
 		Method:             "POST",
 		PathPattern:        "/aliases",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &AliasesCreateReader{formats: a.formats},
@@ -138,7 +188,7 @@ func (a *Client) AliasesDelete(params *AliasesDeleteParams, authInfo runtime.Cli
 		Method:             "DELETE",
 		PathPattern:        "/aliases/{aliasName}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &AliasesDeleteReader{formats: a.formats},
@@ -179,7 +229,7 @@ func (a *Client) AliasesGet(params *AliasesGetParams, authInfo runtime.ClientAut
 		Method:             "GET",
 		PathPattern:        "/aliases",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &AliasesGetReader{formats: a.formats},
@@ -220,7 +270,7 @@ func (a *Client) AliasesGetAlias(params *AliasesGetAliasParams, authInfo runtime
 		Method:             "GET",
 		PathPattern:        "/aliases/{aliasName}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &AliasesGetAliasReader{formats: a.formats},
@@ -261,7 +311,7 @@ func (a *Client) AliasesUpdate(params *AliasesUpdateParams, authInfo runtime.Cli
 		Method:             "PUT",
 		PathPattern:        "/aliases/{aliasName}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &AliasesUpdateReader{formats: a.formats},
@@ -302,7 +352,7 @@ func (a *Client) SchemaDump(params *SchemaDumpParams, authInfo runtime.ClientAut
 		Method:             "GET",
 		PathPattern:        "/schema",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &SchemaDumpReader{formats: a.formats},
@@ -343,7 +393,7 @@ func (a *Client) SchemaObjectsCreate(params *SchemaObjectsCreateParams, authInfo
 		Method:             "POST",
 		PathPattern:        "/schema",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &SchemaObjectsCreateReader{formats: a.formats},
@@ -384,7 +434,7 @@ func (a *Client) SchemaObjectsDelete(params *SchemaObjectsDeleteParams, authInfo
 		Method:             "DELETE",
 		PathPattern:        "/schema/{className}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &SchemaObjectsDeleteReader{formats: a.formats},
@@ -423,7 +473,7 @@ func (a *Client) SchemaObjectsGet(params *SchemaObjectsGetParams, authInfo runti
 		Method:             "GET",
 		PathPattern:        "/schema/{className}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &SchemaObjectsGetReader{formats: a.formats},
@@ -462,7 +512,7 @@ func (a *Client) SchemaObjectsPropertiesAdd(params *SchemaObjectsPropertiesAddPa
 		Method:             "POST",
 		PathPattern:        "/schema/{className}/properties",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &SchemaObjectsPropertiesAddReader{formats: a.formats},
@@ -503,7 +553,7 @@ func (a *Client) SchemaObjectsShardsGet(params *SchemaObjectsShardsGetParams, au
 		Method:             "GET",
 		PathPattern:        "/schema/{className}/shards",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &SchemaObjectsShardsGetReader{formats: a.formats},
@@ -544,7 +594,7 @@ func (a *Client) SchemaObjectsShardsUpdate(params *SchemaObjectsShardsUpdatePara
 		Method:             "PUT",
 		PathPattern:        "/schema/{className}/shards/{shardName}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &SchemaObjectsShardsUpdateReader{formats: a.formats},
@@ -585,7 +635,7 @@ func (a *Client) SchemaObjectsUpdate(params *SchemaObjectsUpdateParams, authInfo
 		Method:             "PUT",
 		PathPattern:        "/schema/{className}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &SchemaObjectsUpdateReader{formats: a.formats},
@@ -626,7 +676,7 @@ func (a *Client) TenantExists(params *TenantExistsParams, authInfo runtime.Clien
 		Method:             "HEAD",
 		PathPattern:        "/schema/{className}/tenants/{tenantName}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &TenantExistsReader{formats: a.formats},
@@ -667,7 +717,7 @@ func (a *Client) TenantsCreate(params *TenantsCreateParams, authInfo runtime.Cli
 		Method:             "POST",
 		PathPattern:        "/schema/{className}/tenants",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &TenantsCreateReader{formats: a.formats},
@@ -706,7 +756,7 @@ func (a *Client) TenantsDelete(params *TenantsDeleteParams, authInfo runtime.Cli
 		Method:             "DELETE",
 		PathPattern:        "/schema/{className}/tenants",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &TenantsDeleteReader{formats: a.formats},
@@ -747,7 +797,7 @@ func (a *Client) TenantsGet(params *TenantsGetParams, authInfo runtime.ClientAut
 		Method:             "GET",
 		PathPattern:        "/schema/{className}/tenants",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &TenantsGetReader{formats: a.formats},
@@ -788,7 +838,7 @@ func (a *Client) TenantsGetOne(params *TenantsGetOneParams, authInfo runtime.Cli
 		Method:             "GET",
 		PathPattern:        "/schema/{className}/tenants/{tenantName}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &TenantsGetOneReader{formats: a.formats},
@@ -829,7 +879,7 @@ func (a *Client) TenantsUpdate(params *TenantsUpdateParams, authInfo runtime.Cli
 		Method:             "PUT",
 		PathPattern:        "/schema/{className}/tenants",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &TenantsUpdateReader{formats: a.formats},

--- a/client/schema/schema_dump_responses.go
+++ b/client/schema/schema_dump_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -59,7 +60,7 @@ func (o *SchemaDumpReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /schema] schema.dump", response, response.Code())
 	}
 }
 
@@ -108,11 +109,13 @@ func (o *SchemaDumpOK) Code() int {
 }
 
 func (o *SchemaDumpOK) Error() string {
-	return fmt.Sprintf("[GET /schema][%d] schemaDumpOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema][%d] schemaDumpOK %s", 200, payload)
 }
 
 func (o *SchemaDumpOK) String() string {
-	return fmt.Sprintf("[GET /schema][%d] schemaDumpOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema][%d] schemaDumpOK %s", 200, payload)
 }
 
 func (o *SchemaDumpOK) GetPayload() *models.Schema {
@@ -120,7 +123,6 @@ func (o *SchemaDumpOK) GetPayload() *models.Schema {
 }
 
 func (o *SchemaDumpOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Schema)
 
 	// response payload
@@ -141,8 +143,7 @@ SchemaDumpUnauthorized describes a response with status code 401, with default h
 
 Unauthorized or invalid credentials.
 */
-type SchemaDumpUnauthorized struct {
-}
+type SchemaDumpUnauthorized struct{}
 
 // IsSuccess returns true when this schema dump unauthorized response has a 2xx status code
 func (o *SchemaDumpUnauthorized) IsSuccess() bool {
@@ -175,15 +176,14 @@ func (o *SchemaDumpUnauthorized) Code() int {
 }
 
 func (o *SchemaDumpUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /schema][%d] schemaDumpUnauthorized ", 401)
+	return fmt.Sprintf("[GET /schema][%d] schemaDumpUnauthorized", 401)
 }
 
 func (o *SchemaDumpUnauthorized) String() string {
-	return fmt.Sprintf("[GET /schema][%d] schemaDumpUnauthorized ", 401)
+	return fmt.Sprintf("[GET /schema][%d] schemaDumpUnauthorized", 401)
 }
 
 func (o *SchemaDumpUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -232,11 +232,13 @@ func (o *SchemaDumpForbidden) Code() int {
 }
 
 func (o *SchemaDumpForbidden) Error() string {
-	return fmt.Sprintf("[GET /schema][%d] schemaDumpForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema][%d] schemaDumpForbidden %s", 403, payload)
 }
 
 func (o *SchemaDumpForbidden) String() string {
-	return fmt.Sprintf("[GET /schema][%d] schemaDumpForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema][%d] schemaDumpForbidden %s", 403, payload)
 }
 
 func (o *SchemaDumpForbidden) GetPayload() *models.ErrorResponse {
@@ -244,7 +246,6 @@ func (o *SchemaDumpForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *SchemaDumpForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -300,11 +301,13 @@ func (o *SchemaDumpInternalServerError) Code() int {
 }
 
 func (o *SchemaDumpInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /schema][%d] schemaDumpInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema][%d] schemaDumpInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaDumpInternalServerError) String() string {
-	return fmt.Sprintf("[GET /schema][%d] schemaDumpInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema][%d] schemaDumpInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaDumpInternalServerError) GetPayload() *models.ErrorResponse {
@@ -312,7 +315,6 @@ func (o *SchemaDumpInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *SchemaDumpInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/schema_objects_create_responses.go
+++ b/client/schema/schema_objects_create_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *SchemaObjectsCreateReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /schema] schema.objects.create", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *SchemaObjectsCreateOK) Code() int {
 }
 
 func (o *SchemaObjectsCreateOK) Error() string {
-	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateOK %s", 200, payload)
 }
 
 func (o *SchemaObjectsCreateOK) String() string {
-	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateOK %s", 200, payload)
 }
 
 func (o *SchemaObjectsCreateOK) GetPayload() *models.Class {
@@ -126,7 +129,6 @@ func (o *SchemaObjectsCreateOK) GetPayload() *models.Class {
 }
 
 func (o *SchemaObjectsCreateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Class)
 
 	// response payload
@@ -147,8 +149,7 @@ SchemaObjectsCreateUnauthorized describes a response with status code 401, with 
 
 Unauthorized or invalid credentials.
 */
-type SchemaObjectsCreateUnauthorized struct {
-}
+type SchemaObjectsCreateUnauthorized struct{}
 
 // IsSuccess returns true when this schema objects create unauthorized response has a 2xx status code
 func (o *SchemaObjectsCreateUnauthorized) IsSuccess() bool {
@@ -181,15 +182,14 @@ func (o *SchemaObjectsCreateUnauthorized) Code() int {
 }
 
 func (o *SchemaObjectsCreateUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateUnauthorized", 401)
 }
 
 func (o *SchemaObjectsCreateUnauthorized) String() string {
-	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateUnauthorized", 401)
 }
 
 func (o *SchemaObjectsCreateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -238,11 +238,13 @@ func (o *SchemaObjectsCreateForbidden) Code() int {
 }
 
 func (o *SchemaObjectsCreateForbidden) Error() string {
-	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsCreateForbidden) String() string {
-	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsCreateForbidden) GetPayload() *models.ErrorResponse {
@@ -250,7 +252,6 @@ func (o *SchemaObjectsCreateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *SchemaObjectsCreateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -306,11 +307,13 @@ func (o *SchemaObjectsCreateUnprocessableEntity) Code() int {
 }
 
 func (o *SchemaObjectsCreateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *SchemaObjectsCreateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *SchemaObjectsCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -318,7 +321,6 @@ func (o *SchemaObjectsCreateUnprocessableEntity) GetPayload() *models.ErrorRespo
 }
 
 func (o *SchemaObjectsCreateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -374,11 +376,13 @@ func (o *SchemaObjectsCreateInternalServerError) Code() int {
 }
 
 func (o *SchemaObjectsCreateInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsCreateInternalServerError) String() string {
-	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema][%d] schemaObjectsCreateInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsCreateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -386,7 +390,6 @@ func (o *SchemaObjectsCreateInternalServerError) GetPayload() *models.ErrorRespo
 }
 
 func (o *SchemaObjectsCreateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/schema_objects_delete_responses.go
+++ b/client/schema/schema_objects_delete_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *SchemaObjectsDeleteReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /schema/{className}] schema.objects.delete", response, response.Code())
 	}
 }
 
@@ -79,8 +80,7 @@ SchemaObjectsDeleteOK describes a response with status code 200, with default he
 
 Removed the Object class from the schema.
 */
-type SchemaObjectsDeleteOK struct {
-}
+type SchemaObjectsDeleteOK struct{}
 
 // IsSuccess returns true when this schema objects delete o k response has a 2xx status code
 func (o *SchemaObjectsDeleteOK) IsSuccess() bool {
@@ -113,15 +113,14 @@ func (o *SchemaObjectsDeleteOK) Code() int {
 }
 
 func (o *SchemaObjectsDeleteOK) Error() string {
-	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteOK ", 200)
+	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteOK", 200)
 }
 
 func (o *SchemaObjectsDeleteOK) String() string {
-	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteOK ", 200)
+	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteOK", 200)
 }
 
 func (o *SchemaObjectsDeleteOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -170,11 +169,13 @@ func (o *SchemaObjectsDeleteBadRequest) Code() int {
 }
 
 func (o *SchemaObjectsDeleteBadRequest) Error() string {
-	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteBadRequest %s", 400, payload)
 }
 
 func (o *SchemaObjectsDeleteBadRequest) String() string {
-	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteBadRequest %s", 400, payload)
 }
 
 func (o *SchemaObjectsDeleteBadRequest) GetPayload() *models.ErrorResponse {
@@ -182,7 +183,6 @@ func (o *SchemaObjectsDeleteBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *SchemaObjectsDeleteBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -203,8 +203,7 @@ SchemaObjectsDeleteUnauthorized describes a response with status code 401, with 
 
 Unauthorized or invalid credentials.
 */
-type SchemaObjectsDeleteUnauthorized struct {
-}
+type SchemaObjectsDeleteUnauthorized struct{}
 
 // IsSuccess returns true when this schema objects delete unauthorized response has a 2xx status code
 func (o *SchemaObjectsDeleteUnauthorized) IsSuccess() bool {
@@ -237,15 +236,14 @@ func (o *SchemaObjectsDeleteUnauthorized) Code() int {
 }
 
 func (o *SchemaObjectsDeleteUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteUnauthorized", 401)
 }
 
 func (o *SchemaObjectsDeleteUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteUnauthorized", 401)
 }
 
 func (o *SchemaObjectsDeleteUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -294,11 +292,13 @@ func (o *SchemaObjectsDeleteForbidden) Code() int {
 }
 
 func (o *SchemaObjectsDeleteForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsDeleteForbidden) String() string {
-	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsDeleteForbidden) GetPayload() *models.ErrorResponse {
@@ -306,7 +306,6 @@ func (o *SchemaObjectsDeleteForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *SchemaObjectsDeleteForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -362,11 +361,13 @@ func (o *SchemaObjectsDeleteInternalServerError) Code() int {
 }
 
 func (o *SchemaObjectsDeleteInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsDeleteInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}][%d] schemaObjectsDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsDeleteInternalServerError) GetPayload() *models.ErrorResponse {
@@ -374,7 +375,6 @@ func (o *SchemaObjectsDeleteInternalServerError) GetPayload() *models.ErrorRespo
 }
 
 func (o *SchemaObjectsDeleteInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/schema_objects_get_responses.go
+++ b/client/schema/schema_objects_get_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *SchemaObjectsGetReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /schema/{className}] schema.objects.get", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *SchemaObjectsGetOK) Code() int {
 }
 
 func (o *SchemaObjectsGetOK) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetOK %s", 200, payload)
 }
 
 func (o *SchemaObjectsGetOK) String() string {
-	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetOK %s", 200, payload)
 }
 
 func (o *SchemaObjectsGetOK) GetPayload() *models.Class {
@@ -126,7 +129,6 @@ func (o *SchemaObjectsGetOK) GetPayload() *models.Class {
 }
 
 func (o *SchemaObjectsGetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Class)
 
 	// response payload
@@ -147,8 +149,7 @@ SchemaObjectsGetUnauthorized describes a response with status code 401, with def
 
 Unauthorized or invalid credentials.
 */
-type SchemaObjectsGetUnauthorized struct {
-}
+type SchemaObjectsGetUnauthorized struct{}
 
 // IsSuccess returns true when this schema objects get unauthorized response has a 2xx status code
 func (o *SchemaObjectsGetUnauthorized) IsSuccess() bool {
@@ -181,15 +182,14 @@ func (o *SchemaObjectsGetUnauthorized) Code() int {
 }
 
 func (o *SchemaObjectsGetUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetUnauthorized", 401)
 }
 
 func (o *SchemaObjectsGetUnauthorized) String() string {
-	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetUnauthorized", 401)
 }
 
 func (o *SchemaObjectsGetUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -238,11 +238,13 @@ func (o *SchemaObjectsGetForbidden) Code() int {
 }
 
 func (o *SchemaObjectsGetForbidden) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsGetForbidden) String() string {
-	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsGetForbidden) GetPayload() *models.ErrorResponse {
@@ -250,7 +252,6 @@ func (o *SchemaObjectsGetForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *SchemaObjectsGetForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -271,8 +272,7 @@ SchemaObjectsGetNotFound describes a response with status code 404, with default
 
 This class does not exist
 */
-type SchemaObjectsGetNotFound struct {
-}
+type SchemaObjectsGetNotFound struct{}
 
 // IsSuccess returns true when this schema objects get not found response has a 2xx status code
 func (o *SchemaObjectsGetNotFound) IsSuccess() bool {
@@ -305,15 +305,14 @@ func (o *SchemaObjectsGetNotFound) Code() int {
 }
 
 func (o *SchemaObjectsGetNotFound) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetNotFound ", 404)
+	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetNotFound", 404)
 }
 
 func (o *SchemaObjectsGetNotFound) String() string {
-	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetNotFound ", 404)
+	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetNotFound", 404)
 }
 
 func (o *SchemaObjectsGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -362,11 +361,13 @@ func (o *SchemaObjectsGetInternalServerError) Code() int {
 }
 
 func (o *SchemaObjectsGetInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsGetInternalServerError) String() string {
-	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsGetInternalServerError) GetPayload() *models.ErrorResponse {
@@ -374,7 +375,6 @@ func (o *SchemaObjectsGetInternalServerError) GetPayload() *models.ErrorResponse
 }
 
 func (o *SchemaObjectsGetInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/schema_objects_properties_add_responses.go
+++ b/client/schema/schema_objects_properties_add_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *SchemaObjectsPropertiesAddReader) ReadResponse(response runtime.ClientR
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /schema/{className}/properties] schema.objects.properties.add", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *SchemaObjectsPropertiesAddOK) Code() int {
 }
 
 func (o *SchemaObjectsPropertiesAddOK) Error() string {
-	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddOK %s", 200, payload)
 }
 
 func (o *SchemaObjectsPropertiesAddOK) String() string {
-	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddOK %s", 200, payload)
 }
 
 func (o *SchemaObjectsPropertiesAddOK) GetPayload() *models.Property {
@@ -126,7 +129,6 @@ func (o *SchemaObjectsPropertiesAddOK) GetPayload() *models.Property {
 }
 
 func (o *SchemaObjectsPropertiesAddOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Property)
 
 	// response payload
@@ -147,8 +149,7 @@ SchemaObjectsPropertiesAddUnauthorized describes a response with status code 401
 
 Unauthorized or invalid credentials.
 */
-type SchemaObjectsPropertiesAddUnauthorized struct {
-}
+type SchemaObjectsPropertiesAddUnauthorized struct{}
 
 // IsSuccess returns true when this schema objects properties add unauthorized response has a 2xx status code
 func (o *SchemaObjectsPropertiesAddUnauthorized) IsSuccess() bool {
@@ -181,15 +182,14 @@ func (o *SchemaObjectsPropertiesAddUnauthorized) Code() int {
 }
 
 func (o *SchemaObjectsPropertiesAddUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddUnauthorized ", 401)
+	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddUnauthorized", 401)
 }
 
 func (o *SchemaObjectsPropertiesAddUnauthorized) String() string {
-	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddUnauthorized ", 401)
+	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddUnauthorized", 401)
 }
 
 func (o *SchemaObjectsPropertiesAddUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -238,11 +238,13 @@ func (o *SchemaObjectsPropertiesAddForbidden) Code() int {
 }
 
 func (o *SchemaObjectsPropertiesAddForbidden) Error() string {
-	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsPropertiesAddForbidden) String() string {
-	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsPropertiesAddForbidden) GetPayload() *models.ErrorResponse {
@@ -250,7 +252,6 @@ func (o *SchemaObjectsPropertiesAddForbidden) GetPayload() *models.ErrorResponse
 }
 
 func (o *SchemaObjectsPropertiesAddForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -306,11 +307,13 @@ func (o *SchemaObjectsPropertiesAddUnprocessableEntity) Code() int {
 }
 
 func (o *SchemaObjectsPropertiesAddUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddUnprocessableEntity %s", 422, payload)
 }
 
 func (o *SchemaObjectsPropertiesAddUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddUnprocessableEntity %s", 422, payload)
 }
 
 func (o *SchemaObjectsPropertiesAddUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -318,7 +321,6 @@ func (o *SchemaObjectsPropertiesAddUnprocessableEntity) GetPayload() *models.Err
 }
 
 func (o *SchemaObjectsPropertiesAddUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -374,11 +376,13 @@ func (o *SchemaObjectsPropertiesAddInternalServerError) Code() int {
 }
 
 func (o *SchemaObjectsPropertiesAddInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsPropertiesAddInternalServerError) String() string {
-	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/properties][%d] schemaObjectsPropertiesAddInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsPropertiesAddInternalServerError) GetPayload() *models.ErrorResponse {
@@ -386,7 +390,6 @@ func (o *SchemaObjectsPropertiesAddInternalServerError) GetPayload() *models.Err
 }
 
 func (o *SchemaObjectsPropertiesAddInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/schema_objects_shards_get_responses.go
+++ b/client/schema/schema_objects_shards_get_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *SchemaObjectsShardsGetReader) ReadResponse(response runtime.ClientRespo
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /schema/{className}/shards] schema.objects.shards.get", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *SchemaObjectsShardsGetOK) Code() int {
 }
 
 func (o *SchemaObjectsShardsGetOK) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetOK %s", 200, payload)
 }
 
 func (o *SchemaObjectsShardsGetOK) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetOK %s", 200, payload)
 }
 
 func (o *SchemaObjectsShardsGetOK) GetPayload() models.ShardStatusList {
@@ -126,7 +129,6 @@ func (o *SchemaObjectsShardsGetOK) GetPayload() models.ShardStatusList {
 }
 
 func (o *SchemaObjectsShardsGetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -145,8 +147,7 @@ SchemaObjectsShardsGetUnauthorized describes a response with status code 401, wi
 
 Unauthorized or invalid credentials.
 */
-type SchemaObjectsShardsGetUnauthorized struct {
-}
+type SchemaObjectsShardsGetUnauthorized struct{}
 
 // IsSuccess returns true when this schema objects shards get unauthorized response has a 2xx status code
 func (o *SchemaObjectsShardsGetUnauthorized) IsSuccess() bool {
@@ -179,15 +180,14 @@ func (o *SchemaObjectsShardsGetUnauthorized) Code() int {
 }
 
 func (o *SchemaObjectsShardsGetUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetUnauthorized", 401)
 }
 
 func (o *SchemaObjectsShardsGetUnauthorized) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetUnauthorized", 401)
 }
 
 func (o *SchemaObjectsShardsGetUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -236,11 +236,13 @@ func (o *SchemaObjectsShardsGetForbidden) Code() int {
 }
 
 func (o *SchemaObjectsShardsGetForbidden) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsShardsGetForbidden) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsShardsGetForbidden) GetPayload() *models.ErrorResponse {
@@ -248,7 +250,6 @@ func (o *SchemaObjectsShardsGetForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *SchemaObjectsShardsGetForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -304,11 +305,13 @@ func (o *SchemaObjectsShardsGetNotFound) Code() int {
 }
 
 func (o *SchemaObjectsShardsGetNotFound) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetNotFound %s", 404, payload)
 }
 
 func (o *SchemaObjectsShardsGetNotFound) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetNotFound %s", 404, payload)
 }
 
 func (o *SchemaObjectsShardsGetNotFound) GetPayload() *models.ErrorResponse {
@@ -316,7 +319,6 @@ func (o *SchemaObjectsShardsGetNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *SchemaObjectsShardsGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -372,11 +374,13 @@ func (o *SchemaObjectsShardsGetInternalServerError) Code() int {
 }
 
 func (o *SchemaObjectsShardsGetInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsShardsGetInternalServerError) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/shards][%d] schemaObjectsShardsGetInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsShardsGetInternalServerError) GetPayload() *models.ErrorResponse {
@@ -384,7 +388,6 @@ func (o *SchemaObjectsShardsGetInternalServerError) GetPayload() *models.ErrorRe
 }
 
 func (o *SchemaObjectsShardsGetInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/schema_objects_shards_update_responses.go
+++ b/client/schema/schema_objects_shards_update_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *SchemaObjectsShardsUpdateReader) ReadResponse(response runtime.ClientRe
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /schema/{className}/shards/{shardName}] schema.objects.shards.update", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *SchemaObjectsShardsUpdateOK) Code() int {
 }
 
 func (o *SchemaObjectsShardsUpdateOK) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateOK %s", 200, payload)
 }
 
 func (o *SchemaObjectsShardsUpdateOK) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateOK %s", 200, payload)
 }
 
 func (o *SchemaObjectsShardsUpdateOK) GetPayload() *models.ShardStatus {
@@ -132,7 +135,6 @@ func (o *SchemaObjectsShardsUpdateOK) GetPayload() *models.ShardStatus {
 }
 
 func (o *SchemaObjectsShardsUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ShardStatus)
 
 	// response payload
@@ -153,8 +155,7 @@ SchemaObjectsShardsUpdateUnauthorized describes a response with status code 401,
 
 Unauthorized or invalid credentials.
 */
-type SchemaObjectsShardsUpdateUnauthorized struct {
-}
+type SchemaObjectsShardsUpdateUnauthorized struct{}
 
 // IsSuccess returns true when this schema objects shards update unauthorized response has a 2xx status code
 func (o *SchemaObjectsShardsUpdateUnauthorized) IsSuccess() bool {
@@ -187,15 +188,14 @@ func (o *SchemaObjectsShardsUpdateUnauthorized) Code() int {
 }
 
 func (o *SchemaObjectsShardsUpdateUnauthorized) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateUnauthorized", 401)
 }
 
 func (o *SchemaObjectsShardsUpdateUnauthorized) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateUnauthorized", 401)
 }
 
 func (o *SchemaObjectsShardsUpdateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +244,13 @@ func (o *SchemaObjectsShardsUpdateForbidden) Code() int {
 }
 
 func (o *SchemaObjectsShardsUpdateForbidden) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsShardsUpdateForbidden) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsShardsUpdateForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +258,6 @@ func (o *SchemaObjectsShardsUpdateForbidden) GetPayload() *models.ErrorResponse 
 }
 
 func (o *SchemaObjectsShardsUpdateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -312,11 +313,13 @@ func (o *SchemaObjectsShardsUpdateNotFound) Code() int {
 }
 
 func (o *SchemaObjectsShardsUpdateNotFound) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateNotFound %s", 404, payload)
 }
 
 func (o *SchemaObjectsShardsUpdateNotFound) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateNotFound %s", 404, payload)
 }
 
 func (o *SchemaObjectsShardsUpdateNotFound) GetPayload() *models.ErrorResponse {
@@ -324,7 +327,6 @@ func (o *SchemaObjectsShardsUpdateNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *SchemaObjectsShardsUpdateNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -380,11 +382,13 @@ func (o *SchemaObjectsShardsUpdateUnprocessableEntity) Code() int {
 }
 
 func (o *SchemaObjectsShardsUpdateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *SchemaObjectsShardsUpdateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *SchemaObjectsShardsUpdateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -392,7 +396,6 @@ func (o *SchemaObjectsShardsUpdateUnprocessableEntity) GetPayload() *models.Erro
 }
 
 func (o *SchemaObjectsShardsUpdateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -448,11 +451,13 @@ func (o *SchemaObjectsShardsUpdateInternalServerError) Code() int {
 }
 
 func (o *SchemaObjectsShardsUpdateInternalServerError) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsShardsUpdateInternalServerError) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/shards/{shardName}][%d] schemaObjectsShardsUpdateInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsShardsUpdateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -460,7 +465,6 @@ func (o *SchemaObjectsShardsUpdateInternalServerError) GetPayload() *models.Erro
 }
 
 func (o *SchemaObjectsShardsUpdateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/schema_objects_update_responses.go
+++ b/client/schema/schema_objects_update_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *SchemaObjectsUpdateReader) ReadResponse(response runtime.ClientResponse
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /schema/{className}] schema.objects.update", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *SchemaObjectsUpdateOK) Code() int {
 }
 
 func (o *SchemaObjectsUpdateOK) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateOK %s", 200, payload)
 }
 
 func (o *SchemaObjectsUpdateOK) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateOK %s", 200, payload)
 }
 
 func (o *SchemaObjectsUpdateOK) GetPayload() *models.Class {
@@ -132,7 +135,6 @@ func (o *SchemaObjectsUpdateOK) GetPayload() *models.Class {
 }
 
 func (o *SchemaObjectsUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Class)
 
 	// response payload
@@ -153,8 +155,7 @@ SchemaObjectsUpdateUnauthorized describes a response with status code 401, with 
 
 Unauthorized or invalid credentials.
 */
-type SchemaObjectsUpdateUnauthorized struct {
-}
+type SchemaObjectsUpdateUnauthorized struct{}
 
 // IsSuccess returns true when this schema objects update unauthorized response has a 2xx status code
 func (o *SchemaObjectsUpdateUnauthorized) IsSuccess() bool {
@@ -187,15 +188,14 @@ func (o *SchemaObjectsUpdateUnauthorized) Code() int {
 }
 
 func (o *SchemaObjectsUpdateUnauthorized) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateUnauthorized", 401)
 }
 
 func (o *SchemaObjectsUpdateUnauthorized) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateUnauthorized", 401)
 }
 
 func (o *SchemaObjectsUpdateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +244,13 @@ func (o *SchemaObjectsUpdateForbidden) Code() int {
 }
 
 func (o *SchemaObjectsUpdateForbidden) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsUpdateForbidden) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateForbidden %s", 403, payload)
 }
 
 func (o *SchemaObjectsUpdateForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +258,6 @@ func (o *SchemaObjectsUpdateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *SchemaObjectsUpdateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -312,11 +313,13 @@ func (o *SchemaObjectsUpdateNotFound) Code() int {
 }
 
 func (o *SchemaObjectsUpdateNotFound) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateNotFound %s", 404, payload)
 }
 
 func (o *SchemaObjectsUpdateNotFound) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateNotFound %s", 404, payload)
 }
 
 func (o *SchemaObjectsUpdateNotFound) GetPayload() *models.ErrorResponse {
@@ -324,7 +327,6 @@ func (o *SchemaObjectsUpdateNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *SchemaObjectsUpdateNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -380,11 +382,13 @@ func (o *SchemaObjectsUpdateUnprocessableEntity) Code() int {
 }
 
 func (o *SchemaObjectsUpdateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *SchemaObjectsUpdateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *SchemaObjectsUpdateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -392,7 +396,6 @@ func (o *SchemaObjectsUpdateUnprocessableEntity) GetPayload() *models.ErrorRespo
 }
 
 func (o *SchemaObjectsUpdateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -448,11 +451,13 @@ func (o *SchemaObjectsUpdateInternalServerError) Code() int {
 }
 
 func (o *SchemaObjectsUpdateInternalServerError) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsUpdateInternalServerError) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}][%d] schemaObjectsUpdateInternalServerError %s", 500, payload)
 }
 
 func (o *SchemaObjectsUpdateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -460,7 +465,6 @@ func (o *SchemaObjectsUpdateInternalServerError) GetPayload() *models.ErrorRespo
 }
 
 func (o *SchemaObjectsUpdateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/tenant_exists_responses.go
+++ b/client/schema/tenant_exists_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *TenantExistsReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[HEAD /schema/{className}/tenants/{tenantName}] tenant.exists", response, response.Code())
 	}
 }
 
@@ -85,8 +86,7 @@ TenantExistsOK describes a response with status code 200, with default header va
 
 The tenant exists in the specified class
 */
-type TenantExistsOK struct {
-}
+type TenantExistsOK struct{}
 
 // IsSuccess returns true when this tenant exists o k response has a 2xx status code
 func (o *TenantExistsOK) IsSuccess() bool {
@@ -119,15 +119,14 @@ func (o *TenantExistsOK) Code() int {
 }
 
 func (o *TenantExistsOK) Error() string {
-	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsOK ", 200)
+	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsOK", 200)
 }
 
 func (o *TenantExistsOK) String() string {
-	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsOK ", 200)
+	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsOK", 200)
 }
 
 func (o *TenantExistsOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -141,8 +140,7 @@ TenantExistsUnauthorized describes a response with status code 401, with default
 
 Unauthorized or invalid credentials.
 */
-type TenantExistsUnauthorized struct {
-}
+type TenantExistsUnauthorized struct{}
 
 // IsSuccess returns true when this tenant exists unauthorized response has a 2xx status code
 func (o *TenantExistsUnauthorized) IsSuccess() bool {
@@ -175,15 +173,14 @@ func (o *TenantExistsUnauthorized) Code() int {
 }
 
 func (o *TenantExistsUnauthorized) Error() string {
-	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsUnauthorized ", 401)
+	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsUnauthorized", 401)
 }
 
 func (o *TenantExistsUnauthorized) String() string {
-	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsUnauthorized ", 401)
+	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsUnauthorized", 401)
 }
 
 func (o *TenantExistsUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -232,11 +229,13 @@ func (o *TenantExistsForbidden) Code() int {
 }
 
 func (o *TenantExistsForbidden) Error() string {
-	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsForbidden %s", 403, payload)
 }
 
 func (o *TenantExistsForbidden) String() string {
-	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsForbidden %s", 403, payload)
 }
 
 func (o *TenantExistsForbidden) GetPayload() *models.ErrorResponse {
@@ -244,7 +243,6 @@ func (o *TenantExistsForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantExistsForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -265,8 +263,7 @@ TenantExistsNotFound describes a response with status code 404, with default hea
 
 The tenant not found
 */
-type TenantExistsNotFound struct {
-}
+type TenantExistsNotFound struct{}
 
 // IsSuccess returns true when this tenant exists not found response has a 2xx status code
 func (o *TenantExistsNotFound) IsSuccess() bool {
@@ -299,15 +296,14 @@ func (o *TenantExistsNotFound) Code() int {
 }
 
 func (o *TenantExistsNotFound) Error() string {
-	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsNotFound ", 404)
+	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsNotFound", 404)
 }
 
 func (o *TenantExistsNotFound) String() string {
-	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsNotFound ", 404)
+	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsNotFound", 404)
 }
 
 func (o *TenantExistsNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -356,11 +352,13 @@ func (o *TenantExistsUnprocessableEntity) Code() int {
 }
 
 func (o *TenantExistsUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *TenantExistsUnprocessableEntity) String() string {
-	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsUnprocessableEntity %s", 422, payload)
 }
 
 func (o *TenantExistsUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -368,7 +366,6 @@ func (o *TenantExistsUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantExistsUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -424,11 +421,13 @@ func (o *TenantExistsInternalServerError) Code() int {
 }
 
 func (o *TenantExistsInternalServerError) Error() string {
-	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsInternalServerError %s", 500, payload)
 }
 
 func (o *TenantExistsInternalServerError) String() string {
-	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[HEAD /schema/{className}/tenants/{tenantName}][%d] tenantExistsInternalServerError %s", 500, payload)
 }
 
 func (o *TenantExistsInternalServerError) GetPayload() *models.ErrorResponse {
@@ -436,7 +435,6 @@ func (o *TenantExistsInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantExistsInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/tenants_create_responses.go
+++ b/client/schema/tenants_create_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *TenantsCreateReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /schema/{className}/tenants] tenants.create", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *TenantsCreateOK) Code() int {
 }
 
 func (o *TenantsCreateOK) Error() string {
-	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateOK %s", 200, payload)
 }
 
 func (o *TenantsCreateOK) String() string {
-	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateOK %s", 200, payload)
 }
 
 func (o *TenantsCreateOK) GetPayload() []*models.Tenant {
@@ -126,7 +129,6 @@ func (o *TenantsCreateOK) GetPayload() []*models.Tenant {
 }
 
 func (o *TenantsCreateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -145,8 +147,7 @@ TenantsCreateUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type TenantsCreateUnauthorized struct {
-}
+type TenantsCreateUnauthorized struct{}
 
 // IsSuccess returns true when this tenants create unauthorized response has a 2xx status code
 func (o *TenantsCreateUnauthorized) IsSuccess() bool {
@@ -179,15 +180,14 @@ func (o *TenantsCreateUnauthorized) Code() int {
 }
 
 func (o *TenantsCreateUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateUnauthorized", 401)
 }
 
 func (o *TenantsCreateUnauthorized) String() string {
-	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateUnauthorized ", 401)
+	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateUnauthorized", 401)
 }
 
 func (o *TenantsCreateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -236,11 +236,13 @@ func (o *TenantsCreateForbidden) Code() int {
 }
 
 func (o *TenantsCreateForbidden) Error() string {
-	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateForbidden %s", 403, payload)
 }
 
 func (o *TenantsCreateForbidden) String() string {
-	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateForbidden %s", 403, payload)
 }
 
 func (o *TenantsCreateForbidden) GetPayload() *models.ErrorResponse {
@@ -248,7 +250,6 @@ func (o *TenantsCreateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsCreateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -304,11 +305,13 @@ func (o *TenantsCreateUnprocessableEntity) Code() int {
 }
 
 func (o *TenantsCreateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *TenantsCreateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *TenantsCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -316,7 +319,6 @@ func (o *TenantsCreateUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsCreateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -372,11 +374,13 @@ func (o *TenantsCreateInternalServerError) Code() int {
 }
 
 func (o *TenantsCreateInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateInternalServerError %s", 500, payload)
 }
 
 func (o *TenantsCreateInternalServerError) String() string {
-	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /schema/{className}/tenants][%d] tenantsCreateInternalServerError %s", 500, payload)
 }
 
 func (o *TenantsCreateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -384,7 +388,6 @@ func (o *TenantsCreateInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsCreateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/tenants_delete_responses.go
+++ b/client/schema/tenants_delete_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *TenantsDeleteReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /schema/{className}/tenants] tenants.delete", response, response.Code())
 	}
 }
 
@@ -79,8 +80,7 @@ TenantsDeleteOK describes a response with status code 200, with default header v
 
 Deleted tenants from specified class.
 */
-type TenantsDeleteOK struct {
-}
+type TenantsDeleteOK struct{}
 
 // IsSuccess returns true when this tenants delete o k response has a 2xx status code
 func (o *TenantsDeleteOK) IsSuccess() bool {
@@ -113,15 +113,14 @@ func (o *TenantsDeleteOK) Code() int {
 }
 
 func (o *TenantsDeleteOK) Error() string {
-	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteOK ", 200)
+	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteOK", 200)
 }
 
 func (o *TenantsDeleteOK) String() string {
-	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteOK ", 200)
+	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteOK", 200)
 }
 
 func (o *TenantsDeleteOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -135,8 +134,7 @@ TenantsDeleteUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type TenantsDeleteUnauthorized struct {
-}
+type TenantsDeleteUnauthorized struct{}
 
 // IsSuccess returns true when this tenants delete unauthorized response has a 2xx status code
 func (o *TenantsDeleteUnauthorized) IsSuccess() bool {
@@ -169,15 +167,14 @@ func (o *TenantsDeleteUnauthorized) Code() int {
 }
 
 func (o *TenantsDeleteUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteUnauthorized", 401)
 }
 
 func (o *TenantsDeleteUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteUnauthorized", 401)
 }
 
 func (o *TenantsDeleteUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -226,11 +223,13 @@ func (o *TenantsDeleteForbidden) Code() int {
 }
 
 func (o *TenantsDeleteForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteForbidden %s", 403, payload)
 }
 
 func (o *TenantsDeleteForbidden) String() string {
-	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteForbidden %s", 403, payload)
 }
 
 func (o *TenantsDeleteForbidden) GetPayload() *models.ErrorResponse {
@@ -238,7 +237,6 @@ func (o *TenantsDeleteForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsDeleteForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -294,11 +292,13 @@ func (o *TenantsDeleteUnprocessableEntity) Code() int {
 }
 
 func (o *TenantsDeleteUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteUnprocessableEntity %s", 422, payload)
 }
 
 func (o *TenantsDeleteUnprocessableEntity) String() string {
-	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteUnprocessableEntity %s", 422, payload)
 }
 
 func (o *TenantsDeleteUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -306,7 +306,6 @@ func (o *TenantsDeleteUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsDeleteUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -362,11 +361,13 @@ func (o *TenantsDeleteInternalServerError) Code() int {
 }
 
 func (o *TenantsDeleteInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *TenantsDeleteInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /schema/{className}/tenants][%d] tenantsDeleteInternalServerError %s", 500, payload)
 }
 
 func (o *TenantsDeleteInternalServerError) GetPayload() *models.ErrorResponse {
@@ -374,7 +375,6 @@ func (o *TenantsDeleteInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsDeleteInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/tenants_get_one_responses.go
+++ b/client/schema/tenants_get_one_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *TenantsGetOneReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /schema/{className}/tenants/{tenantName}] tenants.get.one", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *TenantsGetOneOK) Code() int {
 }
 
 func (o *TenantsGetOneOK) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneOK %s", 200, payload)
 }
 
 func (o *TenantsGetOneOK) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneOK %s", 200, payload)
 }
 
 func (o *TenantsGetOneOK) GetPayload() *models.Tenant {
@@ -132,7 +135,6 @@ func (o *TenantsGetOneOK) GetPayload() *models.Tenant {
 }
 
 func (o *TenantsGetOneOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Tenant)
 
 	// response payload
@@ -153,8 +155,7 @@ TenantsGetOneUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type TenantsGetOneUnauthorized struct {
-}
+type TenantsGetOneUnauthorized struct{}
 
 // IsSuccess returns true when this tenants get one unauthorized response has a 2xx status code
 func (o *TenantsGetOneUnauthorized) IsSuccess() bool {
@@ -187,15 +188,14 @@ func (o *TenantsGetOneUnauthorized) Code() int {
 }
 
 func (o *TenantsGetOneUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneUnauthorized ", 401)
+	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneUnauthorized", 401)
 }
 
 func (o *TenantsGetOneUnauthorized) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneUnauthorized ", 401)
+	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneUnauthorized", 401)
 }
 
 func (o *TenantsGetOneUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +244,13 @@ func (o *TenantsGetOneForbidden) Code() int {
 }
 
 func (o *TenantsGetOneForbidden) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneForbidden %s", 403, payload)
 }
 
 func (o *TenantsGetOneForbidden) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneForbidden %s", 403, payload)
 }
 
 func (o *TenantsGetOneForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +258,6 @@ func (o *TenantsGetOneForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsGetOneForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -277,8 +278,7 @@ TenantsGetOneNotFound describes a response with status code 404, with default he
 
 Tenant not found
 */
-type TenantsGetOneNotFound struct {
-}
+type TenantsGetOneNotFound struct{}
 
 // IsSuccess returns true when this tenants get one not found response has a 2xx status code
 func (o *TenantsGetOneNotFound) IsSuccess() bool {
@@ -311,15 +311,14 @@ func (o *TenantsGetOneNotFound) Code() int {
 }
 
 func (o *TenantsGetOneNotFound) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneNotFound ", 404)
+	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneNotFound", 404)
 }
 
 func (o *TenantsGetOneNotFound) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneNotFound ", 404)
+	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneNotFound", 404)
 }
 
 func (o *TenantsGetOneNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -368,11 +367,13 @@ func (o *TenantsGetOneUnprocessableEntity) Code() int {
 }
 
 func (o *TenantsGetOneUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneUnprocessableEntity %s", 422, payload)
 }
 
 func (o *TenantsGetOneUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneUnprocessableEntity %s", 422, payload)
 }
 
 func (o *TenantsGetOneUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -380,7 +381,6 @@ func (o *TenantsGetOneUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsGetOneUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -436,11 +436,13 @@ func (o *TenantsGetOneInternalServerError) Code() int {
 }
 
 func (o *TenantsGetOneInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneInternalServerError %s", 500, payload)
 }
 
 func (o *TenantsGetOneInternalServerError) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants/{tenantName}][%d] tenantsGetOneInternalServerError %s", 500, payload)
 }
 
 func (o *TenantsGetOneInternalServerError) GetPayload() *models.ErrorResponse {
@@ -448,7 +450,6 @@ func (o *TenantsGetOneInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsGetOneInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/tenants_get_responses.go
+++ b/client/schema/tenants_get_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *TenantsGetReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /schema/{className}/tenants] tenants.get", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *TenantsGetOK) Code() int {
 }
 
 func (o *TenantsGetOK) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetOK %s", 200, payload)
 }
 
 func (o *TenantsGetOK) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetOK %s", 200, payload)
 }
 
 func (o *TenantsGetOK) GetPayload() []*models.Tenant {
@@ -126,7 +129,6 @@ func (o *TenantsGetOK) GetPayload() []*models.Tenant {
 }
 
 func (o *TenantsGetOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -145,8 +147,7 @@ TenantsGetUnauthorized describes a response with status code 401, with default h
 
 Unauthorized or invalid credentials.
 */
-type TenantsGetUnauthorized struct {
-}
+type TenantsGetUnauthorized struct{}
 
 // IsSuccess returns true when this tenants get unauthorized response has a 2xx status code
 func (o *TenantsGetUnauthorized) IsSuccess() bool {
@@ -179,15 +180,14 @@ func (o *TenantsGetUnauthorized) Code() int {
 }
 
 func (o *TenantsGetUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetUnauthorized", 401)
 }
 
 func (o *TenantsGetUnauthorized) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetUnauthorized ", 401)
+	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetUnauthorized", 401)
 }
 
 func (o *TenantsGetUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -236,11 +236,13 @@ func (o *TenantsGetForbidden) Code() int {
 }
 
 func (o *TenantsGetForbidden) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetForbidden %s", 403, payload)
 }
 
 func (o *TenantsGetForbidden) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetForbidden %s", 403, payload)
 }
 
 func (o *TenantsGetForbidden) GetPayload() *models.ErrorResponse {
@@ -248,7 +250,6 @@ func (o *TenantsGetForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsGetForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -304,11 +305,13 @@ func (o *TenantsGetUnprocessableEntity) Code() int {
 }
 
 func (o *TenantsGetUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetUnprocessableEntity %s", 422, payload)
 }
 
 func (o *TenantsGetUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetUnprocessableEntity %s", 422, payload)
 }
 
 func (o *TenantsGetUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -316,7 +319,6 @@ func (o *TenantsGetUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsGetUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -372,11 +374,13 @@ func (o *TenantsGetInternalServerError) Code() int {
 }
 
 func (o *TenantsGetInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetInternalServerError %s", 500, payload)
 }
 
 func (o *TenantsGetInternalServerError) String() string {
-	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /schema/{className}/tenants][%d] tenantsGetInternalServerError %s", 500, payload)
 }
 
 func (o *TenantsGetInternalServerError) GetPayload() *models.ErrorResponse {
@@ -384,7 +388,6 @@ func (o *TenantsGetInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsGetInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/schema/tenants_update_responses.go
+++ b/client/schema/tenants_update_responses.go
@@ -17,6 +17,7 @@ package schema
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -65,7 +66,7 @@ func (o *TenantsUpdateReader) ReadResponse(response runtime.ClientResponse, cons
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[PUT /schema/{className}/tenants] tenants.update", response, response.Code())
 	}
 }
 
@@ -114,11 +115,13 @@ func (o *TenantsUpdateOK) Code() int {
 }
 
 func (o *TenantsUpdateOK) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateOK %s", 200, payload)
 }
 
 func (o *TenantsUpdateOK) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateOK %s", 200, payload)
 }
 
 func (o *TenantsUpdateOK) GetPayload() []*models.Tenant {
@@ -126,7 +129,6 @@ func (o *TenantsUpdateOK) GetPayload() []*models.Tenant {
 }
 
 func (o *TenantsUpdateOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -145,8 +147,7 @@ TenantsUpdateUnauthorized describes a response with status code 401, with defaul
 
 Unauthorized or invalid credentials.
 */
-type TenantsUpdateUnauthorized struct {
-}
+type TenantsUpdateUnauthorized struct{}
 
 // IsSuccess returns true when this tenants update unauthorized response has a 2xx status code
 func (o *TenantsUpdateUnauthorized) IsSuccess() bool {
@@ -179,15 +180,14 @@ func (o *TenantsUpdateUnauthorized) Code() int {
 }
 
 func (o *TenantsUpdateUnauthorized) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateUnauthorized", 401)
 }
 
 func (o *TenantsUpdateUnauthorized) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateUnauthorized ", 401)
+	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateUnauthorized", 401)
 }
 
 func (o *TenantsUpdateUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -236,11 +236,13 @@ func (o *TenantsUpdateForbidden) Code() int {
 }
 
 func (o *TenantsUpdateForbidden) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateForbidden %s", 403, payload)
 }
 
 func (o *TenantsUpdateForbidden) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateForbidden %s", 403, payload)
 }
 
 func (o *TenantsUpdateForbidden) GetPayload() *models.ErrorResponse {
@@ -248,7 +250,6 @@ func (o *TenantsUpdateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsUpdateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -304,11 +305,13 @@ func (o *TenantsUpdateUnprocessableEntity) Code() int {
 }
 
 func (o *TenantsUpdateUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *TenantsUpdateUnprocessableEntity) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateUnprocessableEntity %s", 422, payload)
 }
 
 func (o *TenantsUpdateUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -316,7 +319,6 @@ func (o *TenantsUpdateUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsUpdateUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -372,11 +374,13 @@ func (o *TenantsUpdateInternalServerError) Code() int {
 }
 
 func (o *TenantsUpdateInternalServerError) Error() string {
-	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateInternalServerError %s", 500, payload)
 }
 
 func (o *TenantsUpdateInternalServerError) String() string {
-	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[PUT /schema/{className}/tenants][%d] tenantsUpdateInternalServerError %s", 500, payload)
 }
 
 func (o *TenantsUpdateInternalServerError) GetPayload() *models.ErrorResponse {
@@ -384,7 +388,6 @@ func (o *TenantsUpdateInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *TenantsUpdateInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/users/activate_user_responses.go
+++ b/client/users/activate_user_responses.go
@@ -17,6 +17,7 @@ package users
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -83,7 +84,7 @@ func (o *ActivateUserReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /users/db/{user_id}/activate] activateUser", response, response.Code())
 	}
 }
 
@@ -97,8 +98,7 @@ ActivateUserOK describes a response with status code 200, with default header va
 
 User successfully activated
 */
-type ActivateUserOK struct {
-}
+type ActivateUserOK struct{}
 
 // IsSuccess returns true when this activate user o k response has a 2xx status code
 func (o *ActivateUserOK) IsSuccess() bool {
@@ -131,15 +131,14 @@ func (o *ActivateUserOK) Code() int {
 }
 
 func (o *ActivateUserOK) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserOK ", 200)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserOK", 200)
 }
 
 func (o *ActivateUserOK) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserOK ", 200)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserOK", 200)
 }
 
 func (o *ActivateUserOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -188,11 +187,13 @@ func (o *ActivateUserBadRequest) Code() int {
 }
 
 func (o *ActivateUserBadRequest) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserBadRequest %s", 400, payload)
 }
 
 func (o *ActivateUserBadRequest) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserBadRequest %s", 400, payload)
 }
 
 func (o *ActivateUserBadRequest) GetPayload() *models.ErrorResponse {
@@ -200,7 +201,6 @@ func (o *ActivateUserBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ActivateUserBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -221,8 +221,7 @@ ActivateUserUnauthorized describes a response with status code 401, with default
 
 Unauthorized or invalid credentials.
 */
-type ActivateUserUnauthorized struct {
-}
+type ActivateUserUnauthorized struct{}
 
 // IsSuccess returns true when this activate user unauthorized response has a 2xx status code
 func (o *ActivateUserUnauthorized) IsSuccess() bool {
@@ -255,15 +254,14 @@ func (o *ActivateUserUnauthorized) Code() int {
 }
 
 func (o *ActivateUserUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserUnauthorized ", 401)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserUnauthorized", 401)
 }
 
 func (o *ActivateUserUnauthorized) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserUnauthorized ", 401)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserUnauthorized", 401)
 }
 
 func (o *ActivateUserUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -312,11 +310,13 @@ func (o *ActivateUserForbidden) Code() int {
 }
 
 func (o *ActivateUserForbidden) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserForbidden %s", 403, payload)
 }
 
 func (o *ActivateUserForbidden) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserForbidden %s", 403, payload)
 }
 
 func (o *ActivateUserForbidden) GetPayload() *models.ErrorResponse {
@@ -324,7 +324,6 @@ func (o *ActivateUserForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ActivateUserForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -345,8 +344,7 @@ ActivateUserNotFound describes a response with status code 404, with default hea
 
 user not found
 */
-type ActivateUserNotFound struct {
-}
+type ActivateUserNotFound struct{}
 
 // IsSuccess returns true when this activate user not found response has a 2xx status code
 func (o *ActivateUserNotFound) IsSuccess() bool {
@@ -379,15 +377,14 @@ func (o *ActivateUserNotFound) Code() int {
 }
 
 func (o *ActivateUserNotFound) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserNotFound ", 404)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserNotFound", 404)
 }
 
 func (o *ActivateUserNotFound) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserNotFound ", 404)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserNotFound", 404)
 }
 
 func (o *ActivateUserNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -401,8 +398,7 @@ ActivateUserConflict describes a response with status code 409, with default hea
 
 user already activated
 */
-type ActivateUserConflict struct {
-}
+type ActivateUserConflict struct{}
 
 // IsSuccess returns true when this activate user conflict response has a 2xx status code
 func (o *ActivateUserConflict) IsSuccess() bool {
@@ -435,15 +431,14 @@ func (o *ActivateUserConflict) Code() int {
 }
 
 func (o *ActivateUserConflict) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserConflict ", 409)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserConflict", 409)
 }
 
 func (o *ActivateUserConflict) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserConflict ", 409)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserConflict", 409)
 }
 
 func (o *ActivateUserConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -492,11 +487,13 @@ func (o *ActivateUserUnprocessableEntity) Code() int {
 }
 
 func (o *ActivateUserUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ActivateUserUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserUnprocessableEntity %s", 422, payload)
 }
 
 func (o *ActivateUserUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -504,7 +501,6 @@ func (o *ActivateUserUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ActivateUserUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -560,11 +556,13 @@ func (o *ActivateUserInternalServerError) Code() int {
 }
 
 func (o *ActivateUserInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserInternalServerError %s", 500, payload)
 }
 
 func (o *ActivateUserInternalServerError) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/activate][%d] activateUserInternalServerError %s", 500, payload)
 }
 
 func (o *ActivateUserInternalServerError) GetPayload() *models.ErrorResponse {
@@ -572,7 +570,6 @@ func (o *ActivateUserInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ActivateUserInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/users/create_user_responses.go
+++ b/client/users/create_user_responses.go
@@ -18,6 +18,7 @@ package users
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -87,7 +88,7 @@ func (o *CreateUserReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /users/db/{user_id}] createUser", response, response.Code())
 	}
 }
 
@@ -136,11 +137,13 @@ func (o *CreateUserCreated) Code() int {
 }
 
 func (o *CreateUserCreated) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserCreated  %+v", 201, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserCreated %s", 201, payload)
 }
 
 func (o *CreateUserCreated) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserCreated  %+v", 201, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserCreated %s", 201, payload)
 }
 
 func (o *CreateUserCreated) GetPayload() *models.UserAPIKey {
@@ -148,7 +151,6 @@ func (o *CreateUserCreated) GetPayload() *models.UserAPIKey {
 }
 
 func (o *CreateUserCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.UserAPIKey)
 
 	// response payload
@@ -204,11 +206,13 @@ func (o *CreateUserBadRequest) Code() int {
 }
 
 func (o *CreateUserBadRequest) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserBadRequest %s", 400, payload)
 }
 
 func (o *CreateUserBadRequest) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserBadRequest %s", 400, payload)
 }
 
 func (o *CreateUserBadRequest) GetPayload() *models.ErrorResponse {
@@ -216,7 +220,6 @@ func (o *CreateUserBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateUserBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -237,8 +240,7 @@ CreateUserUnauthorized describes a response with status code 401, with default h
 
 Unauthorized or invalid credentials.
 */
-type CreateUserUnauthorized struct {
-}
+type CreateUserUnauthorized struct{}
 
 // IsSuccess returns true when this create user unauthorized response has a 2xx status code
 func (o *CreateUserUnauthorized) IsSuccess() bool {
@@ -271,15 +273,14 @@ func (o *CreateUserUnauthorized) Code() int {
 }
 
 func (o *CreateUserUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserUnauthorized ", 401)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserUnauthorized", 401)
 }
 
 func (o *CreateUserUnauthorized) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserUnauthorized ", 401)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserUnauthorized", 401)
 }
 
 func (o *CreateUserUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -328,11 +329,13 @@ func (o *CreateUserForbidden) Code() int {
 }
 
 func (o *CreateUserForbidden) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserForbidden %s", 403, payload)
 }
 
 func (o *CreateUserForbidden) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserForbidden %s", 403, payload)
 }
 
 func (o *CreateUserForbidden) GetPayload() *models.ErrorResponse {
@@ -340,7 +343,6 @@ func (o *CreateUserForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateUserForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -396,11 +398,13 @@ func (o *CreateUserNotFound) Code() int {
 }
 
 func (o *CreateUserNotFound) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserNotFound %s", 404, payload)
 }
 
 func (o *CreateUserNotFound) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserNotFound  %+v", 404, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserNotFound %s", 404, payload)
 }
 
 func (o *CreateUserNotFound) GetPayload() *models.ErrorResponse {
@@ -408,7 +412,6 @@ func (o *CreateUserNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateUserNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -464,11 +467,13 @@ func (o *CreateUserConflict) Code() int {
 }
 
 func (o *CreateUserConflict) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserConflict  %+v", 409, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserConflict %s", 409, payload)
 }
 
 func (o *CreateUserConflict) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserConflict  %+v", 409, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserConflict %s", 409, payload)
 }
 
 func (o *CreateUserConflict) GetPayload() *models.ErrorResponse {
@@ -476,7 +481,6 @@ func (o *CreateUserConflict) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateUserConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -532,11 +536,13 @@ func (o *CreateUserUnprocessableEntity) Code() int {
 }
 
 func (o *CreateUserUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserUnprocessableEntity %s", 422, payload)
 }
 
 func (o *CreateUserUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserUnprocessableEntity %s", 422, payload)
 }
 
 func (o *CreateUserUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -544,7 +550,6 @@ func (o *CreateUserUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateUserUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -600,11 +605,13 @@ func (o *CreateUserInternalServerError) Code() int {
 }
 
 func (o *CreateUserInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserInternalServerError %s", 500, payload)
 }
 
 func (o *CreateUserInternalServerError) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}][%d] createUserInternalServerError %s", 500, payload)
 }
 
 func (o *CreateUserInternalServerError) GetPayload() *models.ErrorResponse {
@@ -612,7 +619,6 @@ func (o *CreateUserInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateUserInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -628,7 +634,6 @@ CreateUserBody create user body
 swagger:model CreateUserBody
 */
 type CreateUserBody struct {
-
 	// EXPERIMENTAL, DONT USE. THIS WILL BE REMOVED AGAIN. - set the given time as creation time
 	// Format: date-time
 	CreateTime strfmt.DateTime `json:"createTime,omitempty"`

--- a/client/users/deactivate_user_responses.go
+++ b/client/users/deactivate_user_responses.go
@@ -18,6 +18,7 @@ package users
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -85,7 +86,7 @@ func (o *DeactivateUserReader) ReadResponse(response runtime.ClientResponse, con
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /users/db/{user_id}/deactivate] deactivateUser", response, response.Code())
 	}
 }
 
@@ -99,8 +100,7 @@ DeactivateUserOK describes a response with status code 200, with default header 
 
 users successfully deactivated
 */
-type DeactivateUserOK struct {
-}
+type DeactivateUserOK struct{}
 
 // IsSuccess returns true when this deactivate user o k response has a 2xx status code
 func (o *DeactivateUserOK) IsSuccess() bool {
@@ -133,15 +133,14 @@ func (o *DeactivateUserOK) Code() int {
 }
 
 func (o *DeactivateUserOK) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserOK ", 200)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserOK", 200)
 }
 
 func (o *DeactivateUserOK) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserOK ", 200)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserOK", 200)
 }
 
 func (o *DeactivateUserOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -190,11 +189,13 @@ func (o *DeactivateUserBadRequest) Code() int {
 }
 
 func (o *DeactivateUserBadRequest) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserBadRequest %s", 400, payload)
 }
 
 func (o *DeactivateUserBadRequest) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserBadRequest %s", 400, payload)
 }
 
 func (o *DeactivateUserBadRequest) GetPayload() *models.ErrorResponse {
@@ -202,7 +203,6 @@ func (o *DeactivateUserBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeactivateUserBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -223,8 +223,7 @@ DeactivateUserUnauthorized describes a response with status code 401, with defau
 
 Unauthorized or invalid credentials.
 */
-type DeactivateUserUnauthorized struct {
-}
+type DeactivateUserUnauthorized struct{}
 
 // IsSuccess returns true when this deactivate user unauthorized response has a 2xx status code
 func (o *DeactivateUserUnauthorized) IsSuccess() bool {
@@ -257,15 +256,14 @@ func (o *DeactivateUserUnauthorized) Code() int {
 }
 
 func (o *DeactivateUserUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserUnauthorized ", 401)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserUnauthorized", 401)
 }
 
 func (o *DeactivateUserUnauthorized) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserUnauthorized ", 401)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserUnauthorized", 401)
 }
 
 func (o *DeactivateUserUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -314,11 +312,13 @@ func (o *DeactivateUserForbidden) Code() int {
 }
 
 func (o *DeactivateUserForbidden) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserForbidden %s", 403, payload)
 }
 
 func (o *DeactivateUserForbidden) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserForbidden %s", 403, payload)
 }
 
 func (o *DeactivateUserForbidden) GetPayload() *models.ErrorResponse {
@@ -326,7 +326,6 @@ func (o *DeactivateUserForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeactivateUserForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -347,8 +346,7 @@ DeactivateUserNotFound describes a response with status code 404, with default h
 
 user not found
 */
-type DeactivateUserNotFound struct {
-}
+type DeactivateUserNotFound struct{}
 
 // IsSuccess returns true when this deactivate user not found response has a 2xx status code
 func (o *DeactivateUserNotFound) IsSuccess() bool {
@@ -381,15 +379,14 @@ func (o *DeactivateUserNotFound) Code() int {
 }
 
 func (o *DeactivateUserNotFound) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserNotFound ", 404)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserNotFound", 404)
 }
 
 func (o *DeactivateUserNotFound) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserNotFound ", 404)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserNotFound", 404)
 }
 
 func (o *DeactivateUserNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -403,8 +400,7 @@ DeactivateUserConflict describes a response with status code 409, with default h
 
 user already deactivated
 */
-type DeactivateUserConflict struct {
-}
+type DeactivateUserConflict struct{}
 
 // IsSuccess returns true when this deactivate user conflict response has a 2xx status code
 func (o *DeactivateUserConflict) IsSuccess() bool {
@@ -437,15 +433,14 @@ func (o *DeactivateUserConflict) Code() int {
 }
 
 func (o *DeactivateUserConflict) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserConflict ", 409)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserConflict", 409)
 }
 
 func (o *DeactivateUserConflict) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserConflict ", 409)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserConflict", 409)
 }
 
 func (o *DeactivateUserConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -494,11 +489,13 @@ func (o *DeactivateUserUnprocessableEntity) Code() int {
 }
 
 func (o *DeactivateUserUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserUnprocessableEntity %s", 422, payload)
 }
 
 func (o *DeactivateUserUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserUnprocessableEntity %s", 422, payload)
 }
 
 func (o *DeactivateUserUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -506,7 +503,6 @@ func (o *DeactivateUserUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeactivateUserUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -562,11 +558,13 @@ func (o *DeactivateUserInternalServerError) Code() int {
 }
 
 func (o *DeactivateUserInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserInternalServerError %s", 500, payload)
 }
 
 func (o *DeactivateUserInternalServerError) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/deactivate][%d] deactivateUserInternalServerError %s", 500, payload)
 }
 
 func (o *DeactivateUserInternalServerError) GetPayload() *models.ErrorResponse {
@@ -574,7 +572,6 @@ func (o *DeactivateUserInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeactivateUserInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -590,7 +587,6 @@ DeactivateUserBody deactivate user body
 swagger:model DeactivateUserBody
 */
 type DeactivateUserBody struct {
-
 	// if the key should be revoked when deactivating the user
 	RevokeKey *bool `json:"revoke_key,omitempty"`
 }

--- a/client/users/delete_user_responses.go
+++ b/client/users/delete_user_responses.go
@@ -17,6 +17,7 @@ package users
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *DeleteUserReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[DELETE /users/db/{user_id}] deleteUser", response, response.Code())
 	}
 }
 
@@ -91,8 +92,7 @@ DeleteUserNoContent describes a response with status code 204, with default head
 
 Successfully deleted.
 */
-type DeleteUserNoContent struct {
-}
+type DeleteUserNoContent struct{}
 
 // IsSuccess returns true when this delete user no content response has a 2xx status code
 func (o *DeleteUserNoContent) IsSuccess() bool {
@@ -125,15 +125,14 @@ func (o *DeleteUserNoContent) Code() int {
 }
 
 func (o *DeleteUserNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserNoContent ", 204)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserNoContent", 204)
 }
 
 func (o *DeleteUserNoContent) String() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserNoContent ", 204)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserNoContent", 204)
 }
 
 func (o *DeleteUserNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -182,11 +181,13 @@ func (o *DeleteUserBadRequest) Code() int {
 }
 
 func (o *DeleteUserBadRequest) Error() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserBadRequest %s", 400, payload)
 }
 
 func (o *DeleteUserBadRequest) String() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserBadRequest %s", 400, payload)
 }
 
 func (o *DeleteUserBadRequest) GetPayload() *models.ErrorResponse {
@@ -194,7 +195,6 @@ func (o *DeleteUserBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeleteUserBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -215,8 +215,7 @@ DeleteUserUnauthorized describes a response with status code 401, with default h
 
 Unauthorized or invalid credentials.
 */
-type DeleteUserUnauthorized struct {
-}
+type DeleteUserUnauthorized struct{}
 
 // IsSuccess returns true when this delete user unauthorized response has a 2xx status code
 func (o *DeleteUserUnauthorized) IsSuccess() bool {
@@ -249,15 +248,14 @@ func (o *DeleteUserUnauthorized) Code() int {
 }
 
 func (o *DeleteUserUnauthorized) Error() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserUnauthorized", 401)
 }
 
 func (o *DeleteUserUnauthorized) String() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserUnauthorized ", 401)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserUnauthorized", 401)
 }
 
 func (o *DeleteUserUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -306,11 +304,13 @@ func (o *DeleteUserForbidden) Code() int {
 }
 
 func (o *DeleteUserForbidden) Error() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserForbidden %s", 403, payload)
 }
 
 func (o *DeleteUserForbidden) String() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserForbidden %s", 403, payload)
 }
 
 func (o *DeleteUserForbidden) GetPayload() *models.ErrorResponse {
@@ -318,7 +318,6 @@ func (o *DeleteUserForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeleteUserForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -339,8 +338,7 @@ DeleteUserNotFound describes a response with status code 404, with default heade
 
 user not found
 */
-type DeleteUserNotFound struct {
-}
+type DeleteUserNotFound struct{}
 
 // IsSuccess returns true when this delete user not found response has a 2xx status code
 func (o *DeleteUserNotFound) IsSuccess() bool {
@@ -373,15 +371,14 @@ func (o *DeleteUserNotFound) Code() int {
 }
 
 func (o *DeleteUserNotFound) Error() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserNotFound ", 404)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserNotFound", 404)
 }
 
 func (o *DeleteUserNotFound) String() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserNotFound ", 404)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserNotFound", 404)
 }
 
 func (o *DeleteUserNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -430,11 +427,13 @@ func (o *DeleteUserUnprocessableEntity) Code() int {
 }
 
 func (o *DeleteUserUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserUnprocessableEntity %s", 422, payload)
 }
 
 func (o *DeleteUserUnprocessableEntity) String() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserUnprocessableEntity %s", 422, payload)
 }
 
 func (o *DeleteUserUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -442,7 +441,6 @@ func (o *DeleteUserUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeleteUserUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -498,11 +496,13 @@ func (o *DeleteUserInternalServerError) Code() int {
 }
 
 func (o *DeleteUserInternalServerError) Error() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserInternalServerError %s", 500, payload)
 }
 
 func (o *DeleteUserInternalServerError) String() string {
-	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[DELETE /users/db/{user_id}][%d] deleteUserInternalServerError %s", 500, payload)
 }
 
 func (o *DeleteUserInternalServerError) GetPayload() *models.ErrorResponse {
@@ -510,7 +510,6 @@ func (o *DeleteUserInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *DeleteUserInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/users/get_own_info_responses.go
+++ b/client/users/get_own_info_responses.go
@@ -17,6 +17,7 @@ package users
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -59,7 +60,7 @@ func (o *GetOwnInfoReader) ReadResponse(response runtime.ClientResponse, consume
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /users/own-info] getOwnInfo", response, response.Code())
 	}
 }
 
@@ -108,11 +109,13 @@ func (o *GetOwnInfoOK) Code() int {
 }
 
 func (o *GetOwnInfoOK) Error() string {
-	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoOK %s", 200, payload)
 }
 
 func (o *GetOwnInfoOK) String() string {
-	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoOK %s", 200, payload)
 }
 
 func (o *GetOwnInfoOK) GetPayload() *models.UserOwnInfo {
@@ -120,7 +123,6 @@ func (o *GetOwnInfoOK) GetPayload() *models.UserOwnInfo {
 }
 
 func (o *GetOwnInfoOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.UserOwnInfo)
 
 	// response payload
@@ -141,8 +143,7 @@ GetOwnInfoUnauthorized describes a response with status code 401, with default h
 
 Unauthorized or invalid credentials.
 */
-type GetOwnInfoUnauthorized struct {
-}
+type GetOwnInfoUnauthorized struct{}
 
 // IsSuccess returns true when this get own info unauthorized response has a 2xx status code
 func (o *GetOwnInfoUnauthorized) IsSuccess() bool {
@@ -175,15 +176,14 @@ func (o *GetOwnInfoUnauthorized) Code() int {
 }
 
 func (o *GetOwnInfoUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoUnauthorized ", 401)
+	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoUnauthorized", 401)
 }
 
 func (o *GetOwnInfoUnauthorized) String() string {
-	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoUnauthorized ", 401)
+	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoUnauthorized", 401)
 }
 
 func (o *GetOwnInfoUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -232,11 +232,13 @@ func (o *GetOwnInfoInternalServerError) Code() int {
 }
 
 func (o *GetOwnInfoInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoInternalServerError %s", 500, payload)
 }
 
 func (o *GetOwnInfoInternalServerError) String() string {
-	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoInternalServerError %s", 500, payload)
 }
 
 func (o *GetOwnInfoInternalServerError) GetPayload() *models.ErrorResponse {
@@ -244,7 +246,6 @@ func (o *GetOwnInfoInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetOwnInfoInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -300,11 +301,13 @@ func (o *GetOwnInfoNotImplemented) Code() int {
 }
 
 func (o *GetOwnInfoNotImplemented) Error() string {
-	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoNotImplemented %s", 501, payload)
 }
 
 func (o *GetOwnInfoNotImplemented) String() string {
-	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoNotImplemented  %+v", 501, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/own-info][%d] getOwnInfoNotImplemented %s", 501, payload)
 }
 
 func (o *GetOwnInfoNotImplemented) GetPayload() *models.ErrorResponse {
@@ -312,7 +315,6 @@ func (o *GetOwnInfoNotImplemented) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetOwnInfoNotImplemented) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/users/get_user_info_responses.go
+++ b/client/users/get_user_info_responses.go
@@ -17,6 +17,7 @@ package users
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -71,7 +72,7 @@ func (o *GetUserInfoReader) ReadResponse(response runtime.ClientResponse, consum
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /users/db/{user_id}] getUserInfo", response, response.Code())
 	}
 }
 
@@ -120,11 +121,13 @@ func (o *GetUserInfoOK) Code() int {
 }
 
 func (o *GetUserInfoOK) Error() string {
-	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoOK %s", 200, payload)
 }
 
 func (o *GetUserInfoOK) String() string {
-	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoOK %s", 200, payload)
 }
 
 func (o *GetUserInfoOK) GetPayload() *models.DBUserInfo {
@@ -132,7 +135,6 @@ func (o *GetUserInfoOK) GetPayload() *models.DBUserInfo {
 }
 
 func (o *GetUserInfoOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.DBUserInfo)
 
 	// response payload
@@ -153,8 +155,7 @@ GetUserInfoUnauthorized describes a response with status code 401, with default 
 
 Unauthorized or invalid credentials.
 */
-type GetUserInfoUnauthorized struct {
-}
+type GetUserInfoUnauthorized struct{}
 
 // IsSuccess returns true when this get user info unauthorized response has a 2xx status code
 func (o *GetUserInfoUnauthorized) IsSuccess() bool {
@@ -187,15 +188,14 @@ func (o *GetUserInfoUnauthorized) Code() int {
 }
 
 func (o *GetUserInfoUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoUnauthorized ", 401)
+	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoUnauthorized", 401)
 }
 
 func (o *GetUserInfoUnauthorized) String() string {
-	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoUnauthorized ", 401)
+	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoUnauthorized", 401)
 }
 
 func (o *GetUserInfoUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -244,11 +244,13 @@ func (o *GetUserInfoForbidden) Code() int {
 }
 
 func (o *GetUserInfoForbidden) Error() string {
-	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoForbidden %s", 403, payload)
 }
 
 func (o *GetUserInfoForbidden) String() string {
-	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoForbidden %s", 403, payload)
 }
 
 func (o *GetUserInfoForbidden) GetPayload() *models.ErrorResponse {
@@ -256,7 +258,6 @@ func (o *GetUserInfoForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetUserInfoForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -277,8 +278,7 @@ GetUserInfoNotFound describes a response with status code 404, with default head
 
 user not found
 */
-type GetUserInfoNotFound struct {
-}
+type GetUserInfoNotFound struct{}
 
 // IsSuccess returns true when this get user info not found response has a 2xx status code
 func (o *GetUserInfoNotFound) IsSuccess() bool {
@@ -311,15 +311,14 @@ func (o *GetUserInfoNotFound) Code() int {
 }
 
 func (o *GetUserInfoNotFound) Error() string {
-	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoNotFound ", 404)
+	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoNotFound", 404)
 }
 
 func (o *GetUserInfoNotFound) String() string {
-	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoNotFound ", 404)
+	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoNotFound", 404)
 }
 
 func (o *GetUserInfoNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -368,11 +367,13 @@ func (o *GetUserInfoUnprocessableEntity) Code() int {
 }
 
 func (o *GetUserInfoUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GetUserInfoUnprocessableEntity) String() string {
-	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoUnprocessableEntity %s", 422, payload)
 }
 
 func (o *GetUserInfoUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -380,7 +381,6 @@ func (o *GetUserInfoUnprocessableEntity) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetUserInfoUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -436,11 +436,13 @@ func (o *GetUserInfoInternalServerError) Code() int {
 }
 
 func (o *GetUserInfoInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoInternalServerError %s", 500, payload)
 }
 
 func (o *GetUserInfoInternalServerError) String() string {
-	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db/{user_id}][%d] getUserInfoInternalServerError %s", 500, payload)
 }
 
 func (o *GetUserInfoInternalServerError) GetPayload() *models.ErrorResponse {
@@ -448,7 +450,6 @@ func (o *GetUserInfoInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GetUserInfoInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/users/list_all_users_responses.go
+++ b/client/users/list_all_users_responses.go
@@ -17,6 +17,7 @@ package users
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -59,7 +60,7 @@ func (o *ListAllUsersReader) ReadResponse(response runtime.ClientResponse, consu
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /users/db] listAllUsers", response, response.Code())
 	}
 }
 
@@ -108,11 +109,13 @@ func (o *ListAllUsersOK) Code() int {
 }
 
 func (o *ListAllUsersOK) Error() string {
-	return fmt.Sprintf("[GET /users/db][%d] listAllUsersOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db][%d] listAllUsersOK %s", 200, payload)
 }
 
 func (o *ListAllUsersOK) String() string {
-	return fmt.Sprintf("[GET /users/db][%d] listAllUsersOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db][%d] listAllUsersOK %s", 200, payload)
 }
 
 func (o *ListAllUsersOK) GetPayload() []*models.DBUserInfo {
@@ -120,7 +123,6 @@ func (o *ListAllUsersOK) GetPayload() []*models.DBUserInfo {
 }
 
 func (o *ListAllUsersOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	// response payload
 	if err := consumer.Consume(response.Body(), &o.Payload); err != nil && err != io.EOF {
 		return err
@@ -139,8 +141,7 @@ ListAllUsersUnauthorized describes a response with status code 401, with default
 
 Unauthorized or invalid credentials.
 */
-type ListAllUsersUnauthorized struct {
-}
+type ListAllUsersUnauthorized struct{}
 
 // IsSuccess returns true when this list all users unauthorized response has a 2xx status code
 func (o *ListAllUsersUnauthorized) IsSuccess() bool {
@@ -173,15 +174,14 @@ func (o *ListAllUsersUnauthorized) Code() int {
 }
 
 func (o *ListAllUsersUnauthorized) Error() string {
-	return fmt.Sprintf("[GET /users/db][%d] listAllUsersUnauthorized ", 401)
+	return fmt.Sprintf("[GET /users/db][%d] listAllUsersUnauthorized", 401)
 }
 
 func (o *ListAllUsersUnauthorized) String() string {
-	return fmt.Sprintf("[GET /users/db][%d] listAllUsersUnauthorized ", 401)
+	return fmt.Sprintf("[GET /users/db][%d] listAllUsersUnauthorized", 401)
 }
 
 func (o *ListAllUsersUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -230,11 +230,13 @@ func (o *ListAllUsersForbidden) Code() int {
 }
 
 func (o *ListAllUsersForbidden) Error() string {
-	return fmt.Sprintf("[GET /users/db][%d] listAllUsersForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db][%d] listAllUsersForbidden %s", 403, payload)
 }
 
 func (o *ListAllUsersForbidden) String() string {
-	return fmt.Sprintf("[GET /users/db][%d] listAllUsersForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db][%d] listAllUsersForbidden %s", 403, payload)
 }
 
 func (o *ListAllUsersForbidden) GetPayload() *models.ErrorResponse {
@@ -242,7 +244,6 @@ func (o *ListAllUsersForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ListAllUsersForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -298,11 +299,13 @@ func (o *ListAllUsersInternalServerError) Code() int {
 }
 
 func (o *ListAllUsersInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /users/db][%d] listAllUsersInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db][%d] listAllUsersInternalServerError %s", 500, payload)
 }
 
 func (o *ListAllUsersInternalServerError) String() string {
-	return fmt.Sprintf("[GET /users/db][%d] listAllUsersInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /users/db][%d] listAllUsersInternalServerError %s", 500, payload)
 }
 
 func (o *ListAllUsersInternalServerError) GetPayload() *models.ErrorResponse {
@@ -310,7 +313,6 @@ func (o *ListAllUsersInternalServerError) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ListAllUsersInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/users/rotate_user_api_key_responses.go
+++ b/client/users/rotate_user_api_key_responses.go
@@ -17,6 +17,7 @@ package users
 // Editing this file might prove futile when you re-run the swagger generate command
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -77,7 +78,7 @@ func (o *RotateUserAPIKeyReader) ReadResponse(response runtime.ClientResponse, c
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[POST /users/db/{user_id}/rotate-key] rotateUserApiKey", response, response.Code())
 	}
 }
 
@@ -126,11 +127,13 @@ func (o *RotateUserAPIKeyOK) Code() int {
 }
 
 func (o *RotateUserAPIKeyOK) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyOK %s", 200, payload)
 }
 
 func (o *RotateUserAPIKeyOK) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyOK %s", 200, payload)
 }
 
 func (o *RotateUserAPIKeyOK) GetPayload() *models.UserAPIKey {
@@ -138,7 +141,6 @@ func (o *RotateUserAPIKeyOK) GetPayload() *models.UserAPIKey {
 }
 
 func (o *RotateUserAPIKeyOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.UserAPIKey)
 
 	// response payload
@@ -194,11 +196,13 @@ func (o *RotateUserAPIKeyBadRequest) Code() int {
 }
 
 func (o *RotateUserAPIKeyBadRequest) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyBadRequest %s", 400, payload)
 }
 
 func (o *RotateUserAPIKeyBadRequest) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyBadRequest  %+v", 400, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyBadRequest %s", 400, payload)
 }
 
 func (o *RotateUserAPIKeyBadRequest) GetPayload() *models.ErrorResponse {
@@ -206,7 +210,6 @@ func (o *RotateUserAPIKeyBadRequest) GetPayload() *models.ErrorResponse {
 }
 
 func (o *RotateUserAPIKeyBadRequest) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -227,8 +230,7 @@ RotateUserAPIKeyUnauthorized describes a response with status code 401, with def
 
 Unauthorized or invalid credentials.
 */
-type RotateUserAPIKeyUnauthorized struct {
-}
+type RotateUserAPIKeyUnauthorized struct{}
 
 // IsSuccess returns true when this rotate user Api key unauthorized response has a 2xx status code
 func (o *RotateUserAPIKeyUnauthorized) IsSuccess() bool {
@@ -261,15 +263,14 @@ func (o *RotateUserAPIKeyUnauthorized) Code() int {
 }
 
 func (o *RotateUserAPIKeyUnauthorized) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyUnauthorized ", 401)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyUnauthorized", 401)
 }
 
 func (o *RotateUserAPIKeyUnauthorized) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyUnauthorized ", 401)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyUnauthorized", 401)
 }
 
 func (o *RotateUserAPIKeyUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -318,11 +319,13 @@ func (o *RotateUserAPIKeyForbidden) Code() int {
 }
 
 func (o *RotateUserAPIKeyForbidden) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyForbidden %s", 403, payload)
 }
 
 func (o *RotateUserAPIKeyForbidden) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyForbidden  %+v", 403, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyForbidden %s", 403, payload)
 }
 
 func (o *RotateUserAPIKeyForbidden) GetPayload() *models.ErrorResponse {
@@ -330,7 +333,6 @@ func (o *RotateUserAPIKeyForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *RotateUserAPIKeyForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -351,8 +353,7 @@ RotateUserAPIKeyNotFound describes a response with status code 404, with default
 
 user not found
 */
-type RotateUserAPIKeyNotFound struct {
-}
+type RotateUserAPIKeyNotFound struct{}
 
 // IsSuccess returns true when this rotate user Api key not found response has a 2xx status code
 func (o *RotateUserAPIKeyNotFound) IsSuccess() bool {
@@ -385,15 +386,14 @@ func (o *RotateUserAPIKeyNotFound) Code() int {
 }
 
 func (o *RotateUserAPIKeyNotFound) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyNotFound ", 404)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyNotFound", 404)
 }
 
 func (o *RotateUserAPIKeyNotFound) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyNotFound ", 404)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyNotFound", 404)
 }
 
 func (o *RotateUserAPIKeyNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -442,11 +442,13 @@ func (o *RotateUserAPIKeyUnprocessableEntity) Code() int {
 }
 
 func (o *RotateUserAPIKeyUnprocessableEntity) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyUnprocessableEntity %s", 422, payload)
 }
 
 func (o *RotateUserAPIKeyUnprocessableEntity) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyUnprocessableEntity  %+v", 422, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyUnprocessableEntity %s", 422, payload)
 }
 
 func (o *RotateUserAPIKeyUnprocessableEntity) GetPayload() *models.ErrorResponse {
@@ -454,7 +456,6 @@ func (o *RotateUserAPIKeyUnprocessableEntity) GetPayload() *models.ErrorResponse
 }
 
 func (o *RotateUserAPIKeyUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -510,11 +511,13 @@ func (o *RotateUserAPIKeyInternalServerError) Code() int {
 }
 
 func (o *RotateUserAPIKeyInternalServerError) Error() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyInternalServerError %s", 500, payload)
 }
 
 func (o *RotateUserAPIKeyInternalServerError) String() string {
-	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[POST /users/db/{user_id}/rotate-key][%d] rotateUserApiKeyInternalServerError %s", 500, payload)
 }
 
 func (o *RotateUserAPIKeyInternalServerError) GetPayload() *models.ErrorResponse {
@@ -522,7 +525,6 @@ func (o *RotateUserAPIKeyInternalServerError) GetPayload() *models.ErrorResponse
 }
 
 func (o *RotateUserAPIKeyInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/users/users_client.go
+++ b/client/users/users_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new users API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new users API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new users API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -73,7 +123,7 @@ func (a *Client) ActivateUser(params *ActivateUserParams, authInfo runtime.Clien
 		Method:             "POST",
 		PathPattern:        "/users/db/{user_id}/activate",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ActivateUserReader{formats: a.formats},
@@ -112,7 +162,7 @@ func (a *Client) CreateUser(params *CreateUserParams, authInfo runtime.ClientAut
 		Method:             "POST",
 		PathPattern:        "/users/db/{user_id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &CreateUserReader{formats: a.formats},
@@ -151,7 +201,7 @@ func (a *Client) DeactivateUser(params *DeactivateUserParams, authInfo runtime.C
 		Method:             "POST",
 		PathPattern:        "/users/db/{user_id}/deactivate",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &DeactivateUserReader{formats: a.formats},
@@ -190,7 +240,7 @@ func (a *Client) DeleteUser(params *DeleteUserParams, authInfo runtime.ClientAut
 		Method:             "DELETE",
 		PathPattern:        "/users/db/{user_id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &DeleteUserReader{formats: a.formats},
@@ -229,7 +279,7 @@ func (a *Client) GetOwnInfo(params *GetOwnInfoParams, authInfo runtime.ClientAut
 		Method:             "GET",
 		PathPattern:        "/users/own-info",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetOwnInfoReader{formats: a.formats},
@@ -268,7 +318,7 @@ func (a *Client) GetUserInfo(params *GetUserInfoParams, authInfo runtime.ClientA
 		Method:             "GET",
 		PathPattern:        "/users/db/{user_id}",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetUserInfoReader{formats: a.formats},
@@ -307,7 +357,7 @@ func (a *Client) ListAllUsers(params *ListAllUsersParams, authInfo runtime.Clien
 		Method:             "GET",
 		PathPattern:        "/users/db",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &ListAllUsersReader{formats: a.formats},
@@ -346,7 +396,7 @@ func (a *Client) RotateUserAPIKey(params *RotateUserAPIKeyParams, authInfo runti
 		Method:             "POST",
 		PathPattern:        "/users/db/{user_id}/rotate-key",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &RotateUserAPIKeyReader{formats: a.formats},

--- a/client/well_known/get_well_known_openid_configuration_responses.go
+++ b/client/well_known/get_well_known_openid_configuration_responses.go
@@ -18,6 +18,7 @@ package well_known
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 
@@ -55,7 +56,7 @@ func (o *GetWellKnownOpenidConfigurationReader) ReadResponse(response runtime.Cl
 		}
 		return nil, result
 	default:
-		return nil, runtime.NewAPIError("response status code does not match any response statuses defined for this endpoint in the swagger spec", response, response.Code())
+		return nil, runtime.NewAPIError("[GET /.well-known/openid-configuration] GetWellKnownOpenidConfiguration", response, response.Code())
 	}
 }
 
@@ -104,11 +105,13 @@ func (o *GetWellKnownOpenidConfigurationOK) Code() int {
 }
 
 func (o *GetWellKnownOpenidConfigurationOK) Error() string {
-	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] getWellKnownOpenidConfigurationOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] getWellKnownOpenidConfigurationOK %s", 200, payload)
 }
 
 func (o *GetWellKnownOpenidConfigurationOK) String() string {
-	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] getWellKnownOpenidConfigurationOK  %+v", 200, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] getWellKnownOpenidConfigurationOK %s", 200, payload)
 }
 
 func (o *GetWellKnownOpenidConfigurationOK) GetPayload() *GetWellKnownOpenidConfigurationOKBody {
@@ -116,7 +119,6 @@ func (o *GetWellKnownOpenidConfigurationOK) GetPayload() *GetWellKnownOpenidConf
 }
 
 func (o *GetWellKnownOpenidConfigurationOK) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(GetWellKnownOpenidConfigurationOKBody)
 
 	// response payload
@@ -137,8 +139,7 @@ GetWellKnownOpenidConfigurationNotFound describes a response with status code 40
 
 Not found, no oidc provider present
 */
-type GetWellKnownOpenidConfigurationNotFound struct {
-}
+type GetWellKnownOpenidConfigurationNotFound struct{}
 
 // IsSuccess returns true when this get well known openid configuration not found response has a 2xx status code
 func (o *GetWellKnownOpenidConfigurationNotFound) IsSuccess() bool {
@@ -171,15 +172,14 @@ func (o *GetWellKnownOpenidConfigurationNotFound) Code() int {
 }
 
 func (o *GetWellKnownOpenidConfigurationNotFound) Error() string {
-	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] getWellKnownOpenidConfigurationNotFound ", 404)
+	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] getWellKnownOpenidConfigurationNotFound", 404)
 }
 
 func (o *GetWellKnownOpenidConfigurationNotFound) String() string {
-	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] getWellKnownOpenidConfigurationNotFound ", 404)
+	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] getWellKnownOpenidConfigurationNotFound", 404)
 }
 
 func (o *GetWellKnownOpenidConfigurationNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -228,11 +228,13 @@ func (o *GetWellKnownOpenidConfigurationInternalServerError) Code() int {
 }
 
 func (o *GetWellKnownOpenidConfigurationInternalServerError) Error() string {
-	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] getWellKnownOpenidConfigurationInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] getWellKnownOpenidConfigurationInternalServerError %s", 500, payload)
 }
 
 func (o *GetWellKnownOpenidConfigurationInternalServerError) String() string {
-	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] getWellKnownOpenidConfigurationInternalServerError  %+v", 500, o.Payload)
+	payload, _ := json.Marshal(o.Payload)
+	return fmt.Sprintf("[GET /.well-known/openid-configuration][%d] getWellKnownOpenidConfigurationInternalServerError %s", 500, payload)
 }
 
 func (o *GetWellKnownOpenidConfigurationInternalServerError) GetPayload() *models.ErrorResponse {
@@ -240,7 +242,6 @@ func (o *GetWellKnownOpenidConfigurationInternalServerError) GetPayload() *model
 }
 
 func (o *GetWellKnownOpenidConfigurationInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -256,7 +257,6 @@ GetWellKnownOpenidConfigurationOKBody get well known openid configuration o k bo
 swagger:model GetWellKnownOpenidConfigurationOKBody
 */
 type GetWellKnownOpenidConfigurationOKBody struct {
-
 	// OAuth Client ID
 	ClientID string `json:"clientId,omitempty"`
 

--- a/client/well_known/well_known_client.go
+++ b/client/well_known/well_known_client.go
@@ -20,12 +20,38 @@ import (
 	"fmt"
 
 	"github.com/go-openapi/runtime"
+	httptransport "github.com/go-openapi/runtime/client"
 	"github.com/go-openapi/strfmt"
 )
 
 // New creates a new well known API client.
 func New(transport runtime.ClientTransport, formats strfmt.Registry) ClientService {
 	return &Client{transport: transport, formats: formats}
+}
+
+// New creates a new well known API client with basic auth credentials.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - user: user for basic authentication header.
+// - password: password for basic authentication header.
+func NewClientWithBasicAuth(host, basePath, scheme, user, password string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BasicAuth(user, password)
+	return &Client{transport: transport, formats: strfmt.Default}
+}
+
+// New creates a new well known API client with a bearer token for authentication.
+// It takes the following parameters:
+// - host: http host (github.com).
+// - basePath: any base path for the API client ("/v1", "/v3").
+// - scheme: http scheme ("http", "https").
+// - bearerToken: bearer token for Bearer authentication header.
+func NewClientWithBearerToken(host, basePath, scheme, bearerToken string) ClientService {
+	transport := httptransport.New(host, basePath, []string{scheme})
+	transport.DefaultAuthentication = httptransport.BearerToken(bearerToken)
+	return &Client{transport: transport, formats: strfmt.Default}
 }
 
 /*
@@ -36,8 +62,32 @@ type Client struct {
 	formats   strfmt.Registry
 }
 
-// ClientOption is the option for Client methods
+// ClientOption may be used to customize the behavior of Client methods.
 type ClientOption func(*runtime.ClientOperation)
+
+// This client is generated with a few options you might find useful for your swagger spec.
+//
+// Feel free to add you own set of options.
+
+// WithContentType allows the client to force the Content-Type header
+// to negotiate a specific Consumer from the server.
+//
+// You may use this option to set arbitrary extensions to your MIME media type.
+func WithContentType(mime string) ClientOption {
+	return func(r *runtime.ClientOperation) {
+		r.ConsumesMediaTypes = []string{mime}
+	}
+}
+
+// WithContentTypeApplicationJSON sets the Content-Type header to "application/json".
+func WithContentTypeApplicationJSON(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/json"}
+}
+
+// WithContentTypeApplicationYaml sets the Content-Type header to "application/yaml".
+func WithContentTypeApplicationYaml(r *runtime.ClientOperation) {
+	r.ConsumesMediaTypes = []string{"application/yaml"}
+}
 
 // ClientService is the interface for Client methods
 type ClientService interface {
@@ -61,7 +111,7 @@ func (a *Client) GetWellKnownOpenidConfiguration(params *GetWellKnownOpenidConfi
 		Method:             "GET",
 		PathPattern:        "/.well-known/openid-configuration",
 		ProducesMediaTypes: []string{"application/json"},
-		ConsumesMediaTypes: []string{"application/json", "application/yaml"},
+		ConsumesMediaTypes: []string{"application/yaml", "application/json"},
 		Schemes:            []string{"https"},
 		Params:             params,
 		Reader:             &GetWellKnownOpenidConfigurationReader{formats: a.formats},

--- a/entities/models/alias_response.go
+++ b/entities/models/alias_response.go
@@ -29,7 +29,6 @@ import (
 //
 // swagger:model AliasResponse
 type AliasResponse struct {
-
 	// Array of alias objects, each containing an alias-to-collection mapping.
 	Aliases []*Alias `json:"aliases"`
 }
@@ -89,10 +88,13 @@ func (m *AliasResponse) ContextValidate(ctx context.Context, formats strfmt.Regi
 }
 
 func (m *AliasResponse) contextValidateAliases(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Aliases); i++ {
-
 		if m.Aliases[i] != nil {
+
+			if swag.IsZero(m.Aliases[i]) { // not required
+				return nil
+			}
+
 			if err := m.Aliases[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("aliases" + "." + strconv.Itoa(i))
@@ -102,7 +104,6 @@ func (m *AliasResponse) contextValidateAliases(ctx context.Context, formats strf
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/backup_config.go
+++ b/entities/models/backup_config.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model BackupConfig
 type BackupConfig struct {
-
 	// Name of the bucket, container, volume, etc
 	Bucket string `json:"Bucket,omitempty"`
 
@@ -45,7 +44,7 @@ type BackupConfig struct {
 	ChunkSize int64 `json:"ChunkSize,omitempty"`
 
 	// compression level used by compression algorithm
-	// Enum: [DefaultCompression BestSpeed BestCompression]
+	// Enum: ["DefaultCompression","BestSpeed","BestCompression"]
 	CompressionLevel string `json:"CompressionLevel,omitempty"`
 
 	// name of the endpoint, e.g. s3.amazonaws.com

--- a/entities/models/backup_create_request.go
+++ b/entities/models/backup_create_request.go
@@ -28,7 +28,6 @@ import (
 //
 // swagger:model BackupCreateRequest
 type BackupCreateRequest struct {
-
 	// Custom configuration for the backup creation process
 	Config *BackupConfig `json:"config,omitempty"`
 
@@ -90,8 +89,12 @@ func (m *BackupCreateRequest) ContextValidate(ctx context.Context, formats strfm
 }
 
 func (m *BackupCreateRequest) contextValidateConfig(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Config != nil {
+
+		if swag.IsZero(m.Config) { // not required
+			return nil
+		}
+
 		if err := m.Config.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("config")

--- a/entities/models/backup_create_response.go
+++ b/entities/models/backup_create_response.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model BackupCreateResponse
 type BackupCreateResponse struct {
-
 	// Backup backend name e.g. filesystem, gcs, s3.
 	Backend string `json:"backend,omitempty"`
 
@@ -50,7 +49,7 @@ type BackupCreateResponse struct {
 	Path string `json:"path,omitempty"`
 
 	// phase of backup creation process
-	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED CANCELED]
+	// Enum: ["STARTED","TRANSFERRING","TRANSFERRED","SUCCESS","FAILED","CANCELED"]
 	Status *string `json:"status,omitempty"`
 }
 

--- a/entities/models/backup_create_status_response.go
+++ b/entities/models/backup_create_status_response.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model BackupCreateStatusResponse
 type BackupCreateStatusResponse struct {
-
 	// Backup backend name e.g. filesystem, gcs, s3.
 	Backend string `json:"backend,omitempty"`
 
@@ -52,7 +51,7 @@ type BackupCreateStatusResponse struct {
 	StartedAt strfmt.DateTime `json:"startedAt,omitempty"`
 
 	// phase of backup creation process
-	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED CANCELED]
+	// Enum: ["STARTED","TRANSFERRING","TRANSFERRED","SUCCESS","FAILED","CANCELED"]
 	Status *string `json:"status,omitempty"`
 }
 

--- a/entities/models/backup_list_response.go
+++ b/entities/models/backup_list_response.go
@@ -65,8 +65,12 @@ func (m BackupListResponse) ContextValidate(ctx context.Context, formats strfmt.
 	var res []error
 
 	for i := 0; i < len(m); i++ {
-
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
@@ -76,7 +80,6 @@ func (m BackupListResponse) ContextValidate(ctx context.Context, formats strfmt.
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {
@@ -89,7 +92,6 @@ func (m BackupListResponse) ContextValidate(ctx context.Context, formats strfmt.
 //
 // swagger:model BackupListResponseItems0
 type BackupListResponseItems0 struct {
-
 	// The list of classes for which the existed backup process
 	Classes []string `json:"classes"`
 
@@ -105,7 +107,7 @@ type BackupListResponseItems0 struct {
 	StartedAt strfmt.DateTime `json:"startedAt,omitempty"`
 
 	// status of backup process
-	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED CANCELED]
+	// Enum: ["STARTED","TRANSFERRING","TRANSFERRED","SUCCESS","FAILED","CANCELED"]
 	Status string `json:"status,omitempty"`
 }
 

--- a/entities/models/backup_restore_request.go
+++ b/entities/models/backup_restore_request.go
@@ -28,7 +28,6 @@ import (
 //
 // swagger:model BackupRestoreRequest
 type BackupRestoreRequest struct {
-
 	// Custom configuration for the backup restoration process
 	Config *RestoreConfig `json:"config,omitempty"`
 
@@ -93,8 +92,12 @@ func (m *BackupRestoreRequest) ContextValidate(ctx context.Context, formats strf
 }
 
 func (m *BackupRestoreRequest) contextValidateConfig(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Config != nil {
+
+		if swag.IsZero(m.Config) { // not required
+			return nil
+		}
+
 		if err := m.Config.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("config")

--- a/entities/models/backup_restore_response.go
+++ b/entities/models/backup_restore_response.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model BackupRestoreResponse
 type BackupRestoreResponse struct {
-
 	// Backup backend name e.g. filesystem, gcs, s3.
 	Backend string `json:"backend,omitempty"`
 
@@ -47,7 +46,7 @@ type BackupRestoreResponse struct {
 	Path string `json:"path,omitempty"`
 
 	// phase of backup restoration process
-	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED CANCELED]
+	// Enum: ["STARTED","TRANSFERRING","TRANSFERRED","SUCCESS","FAILED","CANCELED"]
 	Status *string `json:"status,omitempty"`
 }
 

--- a/entities/models/backup_restore_status_response.go
+++ b/entities/models/backup_restore_status_response.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model BackupRestoreStatusResponse
 type BackupRestoreStatusResponse struct {
-
 	// Backup backend name e.g. filesystem, gcs, s3.
 	Backend string `json:"backend,omitempty"`
 
@@ -44,7 +43,7 @@ type BackupRestoreStatusResponse struct {
 	Path string `json:"path,omitempty"`
 
 	// phase of backup restoration process
-	// Enum: [STARTED TRANSFERRING TRANSFERRED SUCCESS FAILED CANCELED]
+	// Enum: ["STARTED","TRANSFERRING","TRANSFERRED","SUCCESS","FAILED","CANCELED"]
 	Status *string `json:"status,omitempty"`
 }
 

--- a/entities/models/batch_delete.go
+++ b/entities/models/batch_delete.go
@@ -28,7 +28,6 @@ import (
 //
 // swagger:model BatchDelete
 type BatchDelete struct {
-
 	// Timestamp of deletion in milliseconds since epoch UTC.
 	DeletionTimeUnixMilli *int64 `json:"deletionTimeUnixMilli,omitempty"`
 
@@ -90,8 +89,12 @@ func (m *BatchDelete) ContextValidate(ctx context.Context, formats strfmt.Regist
 }
 
 func (m *BatchDelete) contextValidateMatch(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Match != nil {
+
+		if swag.IsZero(m.Match) { // not required
+			return nil
+		}
+
 		if err := m.Match.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("match")
@@ -127,7 +130,6 @@ func (m *BatchDelete) UnmarshalBinary(b []byte) error {
 //
 // swagger:model BatchDeleteMatch
 type BatchDeleteMatch struct {
-
 	// Class (name) which objects will be deleted.
 	// Example: City
 	Class string `json:"class,omitempty"`
@@ -184,8 +186,12 @@ func (m *BatchDeleteMatch) ContextValidate(ctx context.Context, formats strfmt.R
 }
 
 func (m *BatchDeleteMatch) contextValidateWhere(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Where != nil {
+
+		if swag.IsZero(m.Where) { // not required
+			return nil
+		}
+
 		if err := m.Where.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("match" + "." + "where")

--- a/entities/models/batch_delete_response.go
+++ b/entities/models/batch_delete_response.go
@@ -31,7 +31,6 @@ import (
 //
 // swagger:model BatchDeleteResponse
 type BatchDeleteResponse struct {
-
 	// Timestamp of deletion in milliseconds since epoch UTC.
 	DeletionTimeUnixMilli *int64 `json:"deletionTimeUnixMilli,omitempty"`
 
@@ -123,8 +122,12 @@ func (m *BatchDeleteResponse) ContextValidate(ctx context.Context, formats strfm
 }
 
 func (m *BatchDeleteResponse) contextValidateMatch(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Match != nil {
+
+		if swag.IsZero(m.Match) { // not required
+			return nil
+		}
+
 		if err := m.Match.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("match")
@@ -139,8 +142,12 @@ func (m *BatchDeleteResponse) contextValidateMatch(ctx context.Context, formats 
 }
 
 func (m *BatchDeleteResponse) contextValidateResults(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Results != nil {
+
+		if swag.IsZero(m.Results) { // not required
+			return nil
+		}
+
 		if err := m.Results.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("results")
@@ -176,7 +183,6 @@ func (m *BatchDeleteResponse) UnmarshalBinary(b []byte) error {
 //
 // swagger:model BatchDeleteResponseMatch
 type BatchDeleteResponseMatch struct {
-
 	// Class (name) which objects will be deleted.
 	// Example: City
 	Class string `json:"class,omitempty"`
@@ -233,8 +239,12 @@ func (m *BatchDeleteResponseMatch) ContextValidate(ctx context.Context, formats 
 }
 
 func (m *BatchDeleteResponseMatch) contextValidateWhere(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Where != nil {
+
+		if swag.IsZero(m.Where) { // not required
+			return nil
+		}
+
 		if err := m.Where.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("match" + "." + "where")
@@ -270,7 +280,6 @@ func (m *BatchDeleteResponseMatch) UnmarshalBinary(b []byte) error {
 //
 // swagger:model BatchDeleteResponseResults
 type BatchDeleteResponseResults struct {
-
 	// How many objects should have been deleted but could not be deleted.
 	Failed int64 `json:"failed"`
 
@@ -342,10 +351,13 @@ func (m *BatchDeleteResponseResults) ContextValidate(ctx context.Context, format
 }
 
 func (m *BatchDeleteResponseResults) contextValidateObjects(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Objects); i++ {
-
 		if m.Objects[i] != nil {
+
+			if swag.IsZero(m.Objects[i]) { // not required
+				return nil
+			}
+
 			if err := m.Objects[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("results" + "." + "objects" + "." + strconv.Itoa(i))
@@ -355,7 +367,6 @@ func (m *BatchDeleteResponseResults) contextValidateObjects(ctx context.Context,
 				return err
 			}
 		}
-
 	}
 
 	return nil
@@ -383,7 +394,6 @@ func (m *BatchDeleteResponseResults) UnmarshalBinary(b []byte) error {
 //
 // swagger:model BatchDeleteResponseResultsObjectsItems0
 type BatchDeleteResponseResultsObjectsItems0 struct {
-
 	// errors
 	Errors *ErrorResponse `json:"errors,omitempty"`
 
@@ -392,7 +402,7 @@ type BatchDeleteResponseResultsObjectsItems0 struct {
 	ID strfmt.UUID `json:"id,omitempty"`
 
 	// status
-	// Enum: [SUCCESS DRYRUN FAILED]
+	// Enum: ["SUCCESS","DRYRUN","FAILED"]
 	Status *string `json:"status,omitempty"`
 }
 
@@ -509,8 +519,12 @@ func (m *BatchDeleteResponseResultsObjectsItems0) ContextValidate(ctx context.Co
 }
 
 func (m *BatchDeleteResponseResultsObjectsItems0) contextValidateErrors(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Errors != nil {
+
+		if swag.IsZero(m.Errors) { // not required
+			return nil
+		}
+
 		if err := m.Errors.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("errors")

--- a/entities/models/batch_reference_response.go
+++ b/entities/models/batch_reference_response.go
@@ -101,7 +101,6 @@ func (m *BatchReferenceResponse) Validate(formats strfmt.Registry) error {
 }
 
 func (m *BatchReferenceResponse) validateResult(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Result) { // not required
 		return nil
 	}
@@ -140,8 +139,12 @@ func (m *BatchReferenceResponse) ContextValidate(ctx context.Context, formats st
 }
 
 func (m *BatchReferenceResponse) contextValidateResult(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Result != nil {
+
+		if swag.IsZero(m.Result) { // not required
+			return nil
+		}
+
 		if err := m.Result.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
@@ -177,12 +180,11 @@ func (m *BatchReferenceResponse) UnmarshalBinary(b []byte) error {
 //
 // swagger:model BatchReferenceResponseAO1Result
 type BatchReferenceResponseAO1Result struct {
-
 	// errors
 	Errors *ErrorResponse `json:"errors,omitempty"`
 
 	// status
-	// Enum: [SUCCESS FAILED]
+	// Enum: ["SUCCESS","FAILED"]
 	Status *string `json:"status,omitempty"`
 }
 
@@ -280,8 +282,12 @@ func (m *BatchReferenceResponseAO1Result) ContextValidate(ctx context.Context, f
 }
 
 func (m *BatchReferenceResponseAO1Result) contextValidateErrors(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Errors != nil {
+
+		if swag.IsZero(m.Errors) { // not required
+			return nil
+		}
+
 		if err := m.Errors.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result" + "." + "errors")

--- a/entities/models/c11y_nearest_neighbors.go
+++ b/entities/models/c11y_nearest_neighbors.go
@@ -63,8 +63,12 @@ func (m C11yNearestNeighbors) ContextValidate(ctx context.Context, formats strfm
 	var res []error
 
 	for i := 0; i < len(m); i++ {
-
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
@@ -74,7 +78,6 @@ func (m C11yNearestNeighbors) ContextValidate(ctx context.Context, formats strfm
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {
@@ -87,7 +90,6 @@ func (m C11yNearestNeighbors) ContextValidate(ctx context.Context, formats strfm
 //
 // swagger:model C11yNearestNeighborsItems0
 type C11yNearestNeighborsItems0 struct {
-
 	// distance
 	Distance float32 `json:"distance,omitempty"`
 

--- a/entities/models/c11y_vector_based_question.go
+++ b/entities/models/c11y_vector_based_question.go
@@ -64,8 +64,12 @@ func (m C11yVectorBasedQuestion) ContextValidate(ctx context.Context, formats st
 	var res []error
 
 	for i := 0; i < len(m); i++ {
-
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
@@ -75,7 +79,6 @@ func (m C11yVectorBasedQuestion) ContextValidate(ctx context.Context, formats st
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {
@@ -88,7 +91,6 @@ func (m C11yVectorBasedQuestion) ContextValidate(ctx context.Context, formats st
 //
 // swagger:model C11yVectorBasedQuestionItems0
 type C11yVectorBasedQuestionItems0 struct {
-
 	// Vectorized properties.
 	// Max Items: 300
 	// Min Items: 300
@@ -187,10 +189,13 @@ func (m *C11yVectorBasedQuestionItems0) ContextValidate(ctx context.Context, for
 }
 
 func (m *C11yVectorBasedQuestionItems0) contextValidateClassProps(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.ClassProps); i++ {
-
 		if m.ClassProps[i] != nil {
+
+			if swag.IsZero(m.ClassProps[i]) { // not required
+				return nil
+			}
+
 			if err := m.ClassProps[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("classProps" + "." + strconv.Itoa(i))
@@ -200,7 +205,6 @@ func (m *C11yVectorBasedQuestionItems0) contextValidateClassProps(ctx context.Co
 				return err
 			}
 		}
-
 	}
 
 	return nil
@@ -228,7 +232,6 @@ func (m *C11yVectorBasedQuestionItems0) UnmarshalBinary(b []byte) error {
 //
 // swagger:model C11yVectorBasedQuestionItems0ClassPropsItems0
 type C11yVectorBasedQuestionItems0ClassPropsItems0 struct {
-
 	// props vectors
 	PropsVectors []float32 `json:"propsVectors"`
 

--- a/entities/models/c11y_words_response.go
+++ b/entities/models/c11y_words_response.go
@@ -29,7 +29,6 @@ import (
 //
 // swagger:model C11yWordsResponse
 type C11yWordsResponse struct {
-
 	// concatenated word
 	ConcatenatedWord *C11yWordsResponseConcatenatedWord `json:"concatenatedWord,omitempty"`
 
@@ -119,8 +118,12 @@ func (m *C11yWordsResponse) ContextValidate(ctx context.Context, formats strfmt.
 }
 
 func (m *C11yWordsResponse) contextValidateConcatenatedWord(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.ConcatenatedWord != nil {
+
+		if swag.IsZero(m.ConcatenatedWord) { // not required
+			return nil
+		}
+
 		if err := m.ConcatenatedWord.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("concatenatedWord")
@@ -135,10 +138,13 @@ func (m *C11yWordsResponse) contextValidateConcatenatedWord(ctx context.Context,
 }
 
 func (m *C11yWordsResponse) contextValidateIndividualWords(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.IndividualWords); i++ {
-
 		if m.IndividualWords[i] != nil {
+
+			if swag.IsZero(m.IndividualWords[i]) { // not required
+				return nil
+			}
+
 			if err := m.IndividualWords[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("individualWords" + "." + strconv.Itoa(i))
@@ -148,7 +154,6 @@ func (m *C11yWordsResponse) contextValidateIndividualWords(ctx context.Context, 
 				return err
 			}
 		}
-
 	}
 
 	return nil
@@ -176,7 +181,6 @@ func (m *C11yWordsResponse) UnmarshalBinary(b []byte) error {
 //
 // swagger:model C11yWordsResponseConcatenatedWord
 type C11yWordsResponseConcatenatedWord struct {
-
 	// concatenated nearest neighbors
 	ConcatenatedNearestNeighbors C11yNearestNeighbors `json:"concatenatedNearestNeighbors,omitempty"`
 
@@ -261,7 +265,6 @@ func (m *C11yWordsResponseConcatenatedWord) ContextValidate(ctx context.Context,
 }
 
 func (m *C11yWordsResponseConcatenatedWord) contextValidateConcatenatedNearestNeighbors(ctx context.Context, formats strfmt.Registry) error {
-
 	if err := m.ConcatenatedNearestNeighbors.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("concatenatedWord" + "." + "concatenatedNearestNeighbors")
@@ -275,7 +278,6 @@ func (m *C11yWordsResponseConcatenatedWord) contextValidateConcatenatedNearestNe
 }
 
 func (m *C11yWordsResponseConcatenatedWord) contextValidateConcatenatedVector(ctx context.Context, formats strfmt.Registry) error {
-
 	if err := m.ConcatenatedVector.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("concatenatedWord" + "." + "concatenatedVector")
@@ -310,7 +312,6 @@ func (m *C11yWordsResponseConcatenatedWord) UnmarshalBinary(b []byte) error {
 //
 // swagger:model C11yWordsResponseIndividualWordsItems0
 type C11yWordsResponseIndividualWordsItems0 struct {
-
 	// info
 	Info *C11yWordsResponseIndividualWordsItems0Info `json:"info,omitempty"`
 
@@ -369,8 +370,12 @@ func (m *C11yWordsResponseIndividualWordsItems0) ContextValidate(ctx context.Con
 }
 
 func (m *C11yWordsResponseIndividualWordsItems0) contextValidateInfo(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Info != nil {
+
+		if swag.IsZero(m.Info) { // not required
+			return nil
+		}
+
 		if err := m.Info.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("info")
@@ -406,7 +411,6 @@ func (m *C11yWordsResponseIndividualWordsItems0) UnmarshalBinary(b []byte) error
 //
 // swagger:model C11yWordsResponseIndividualWordsItems0Info
 type C11yWordsResponseIndividualWordsItems0Info struct {
-
 	// nearest neighbors
 	NearestNeighbors C11yNearestNeighbors `json:"nearestNeighbors,omitempty"`
 
@@ -485,7 +489,6 @@ func (m *C11yWordsResponseIndividualWordsItems0Info) ContextValidate(ctx context
 }
 
 func (m *C11yWordsResponseIndividualWordsItems0Info) contextValidateNearestNeighbors(ctx context.Context, formats strfmt.Registry) error {
-
 	if err := m.NearestNeighbors.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("info" + "." + "nearestNeighbors")
@@ -499,7 +502,6 @@ func (m *C11yWordsResponseIndividualWordsItems0Info) contextValidateNearestNeigh
 }
 
 func (m *C11yWordsResponseIndividualWordsItems0Info) contextValidateVector(ctx context.Context, formats strfmt.Registry) error {
-
 	if err := m.Vector.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("info" + "." + "vector")

--- a/entities/models/class.go
+++ b/entities/models/class.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model Class
 type Class struct {
-
 	// Name of the class (a.k.a. 'collection') (required). Multiple words should be concatenated in CamelCase, e.g. `ArticleAuthor`.
 	Class string `json:"class,omitempty"`
 
@@ -238,8 +237,12 @@ func (m *Class) ContextValidate(ctx context.Context, formats strfmt.Registry) er
 }
 
 func (m *Class) contextValidateInvertedIndexConfig(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.InvertedIndexConfig != nil {
+
+		if swag.IsZero(m.InvertedIndexConfig) { // not required
+			return nil
+		}
+
 		if err := m.InvertedIndexConfig.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("invertedIndexConfig")
@@ -254,8 +257,12 @@ func (m *Class) contextValidateInvertedIndexConfig(ctx context.Context, formats 
 }
 
 func (m *Class) contextValidateMultiTenancyConfig(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.MultiTenancyConfig != nil {
+
+		if swag.IsZero(m.MultiTenancyConfig) { // not required
+			return nil
+		}
+
 		if err := m.MultiTenancyConfig.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("multiTenancyConfig")
@@ -270,10 +277,13 @@ func (m *Class) contextValidateMultiTenancyConfig(ctx context.Context, formats s
 }
 
 func (m *Class) contextValidateProperties(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Properties); i++ {
-
 		if m.Properties[i] != nil {
+
+			if swag.IsZero(m.Properties[i]) { // not required
+				return nil
+			}
+
 			if err := m.Properties[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("properties" + "." + strconv.Itoa(i))
@@ -283,15 +293,18 @@ func (m *Class) contextValidateProperties(ctx context.Context, formats strfmt.Re
 				return err
 			}
 		}
-
 	}
 
 	return nil
 }
 
 func (m *Class) contextValidateReplicationConfig(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.ReplicationConfig != nil {
+
+		if swag.IsZero(m.ReplicationConfig) { // not required
+			return nil
+		}
+
 		if err := m.ReplicationConfig.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("replicationConfig")
@@ -306,15 +319,12 @@ func (m *Class) contextValidateReplicationConfig(ctx context.Context, formats st
 }
 
 func (m *Class) contextValidateVectorConfig(ctx context.Context, formats strfmt.Registry) error {
-
 	for k := range m.VectorConfig {
-
 		if val, ok := m.VectorConfig[k]; ok {
 			if err := val.ContextValidate(ctx, formats); err != nil {
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/classification.go
+++ b/entities/models/classification.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model Classification
 type Classification struct {
-
 	// base the text-based classification on these fields (of type text)
 	// Example: ["description"]
 	BasedOnProperties []string `json:"basedOnProperties"`
@@ -63,7 +62,7 @@ type Classification struct {
 
 	// status of this classification
 	// Example: running
-	// Enum: [running completed failed]
+	// Enum: ["running","completed","failed"]
 	Status string `json:"status,omitempty"`
 
 	// which algorithm to use for classifications
@@ -210,8 +209,12 @@ func (m *Classification) ContextValidate(ctx context.Context, formats strfmt.Reg
 }
 
 func (m *Classification) contextValidateFilters(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Filters != nil {
+
+		if swag.IsZero(m.Filters) { // not required
+			return nil
+		}
+
 		if err := m.Filters.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("filters")
@@ -226,8 +229,12 @@ func (m *Classification) contextValidateFilters(ctx context.Context, formats str
 }
 
 func (m *Classification) contextValidateMeta(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Meta != nil {
+
+		if swag.IsZero(m.Meta) { // not required
+			return nil
+		}
+
 		if err := m.Meta.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("meta")
@@ -263,7 +270,6 @@ func (m *Classification) UnmarshalBinary(b []byte) error {
 //
 // swagger:model ClassificationFilters
 type ClassificationFilters struct {
-
 	// limit the objects to be classified
 	SourceWhere *WhereFilter `json:"sourceWhere,omitempty"`
 
@@ -376,8 +382,12 @@ func (m *ClassificationFilters) ContextValidate(ctx context.Context, formats str
 }
 
 func (m *ClassificationFilters) contextValidateSourceWhere(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.SourceWhere != nil {
+
+		if swag.IsZero(m.SourceWhere) { // not required
+			return nil
+		}
+
 		if err := m.SourceWhere.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("filters" + "." + "sourceWhere")
@@ -392,8 +402,12 @@ func (m *ClassificationFilters) contextValidateSourceWhere(ctx context.Context, 
 }
 
 func (m *ClassificationFilters) contextValidateTargetWhere(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.TargetWhere != nil {
+
+		if swag.IsZero(m.TargetWhere) { // not required
+			return nil
+		}
+
 		if err := m.TargetWhere.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("filters" + "." + "targetWhere")
@@ -408,8 +422,12 @@ func (m *ClassificationFilters) contextValidateTargetWhere(ctx context.Context, 
 }
 
 func (m *ClassificationFilters) contextValidateTrainingSetWhere(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.TrainingSetWhere != nil {
+
+		if swag.IsZero(m.TrainingSetWhere) { // not required
+			return nil
+		}
+
 		if err := m.TrainingSetWhere.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("filters" + "." + "trainingSetWhere")

--- a/entities/models/cluster_statistics_response.go
+++ b/entities/models/cluster_statistics_response.go
@@ -29,7 +29,6 @@ import (
 //
 // swagger:model ClusterStatisticsResponse
 type ClusterStatisticsResponse struct {
-
 	// statistics
 	Statistics []*Statistics `json:"statistics"`
 
@@ -92,10 +91,13 @@ func (m *ClusterStatisticsResponse) ContextValidate(ctx context.Context, formats
 }
 
 func (m *ClusterStatisticsResponse) contextValidateStatistics(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Statistics); i++ {
-
 		if m.Statistics[i] != nil {
+
+			if swag.IsZero(m.Statistics[i]) { // not required
+				return nil
+			}
+
 			if err := m.Statistics[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("statistics" + "." + strconv.Itoa(i))
@@ -105,7 +107,6 @@ func (m *ClusterStatisticsResponse) contextValidateStatistics(ctx context.Contex
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/d_b_user_info.go
+++ b/entities/models/d_b_user_info.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model DBUserInfo
 type DBUserInfo struct {
-
 	// activity status of the returned user
 	// Required: true
 	Active *bool `json:"active"`
@@ -45,7 +44,7 @@ type DBUserInfo struct {
 
 	// type of the returned user
 	// Required: true
-	// Enum: [db_user db_env_user]
+	// Enum: ["db_user","db_env_user"]
 	DbUserType *string `json:"dbUserType"`
 
 	// Date and time in ISO 8601 format (YYYY-MM-DDTHH:MM:SSZ)
@@ -100,7 +99,6 @@ func (m *DBUserInfo) Validate(formats strfmt.Registry) error {
 }
 
 func (m *DBUserInfo) validateActive(formats strfmt.Registry) error {
-
 	if err := validate.Required("active", "body", m.Active); err != nil {
 		return err
 	}
@@ -162,7 +160,6 @@ func (m *DBUserInfo) validateDbUserTypeEnum(path, location string, value string)
 }
 
 func (m *DBUserInfo) validateDbUserType(formats strfmt.Registry) error {
-
 	if err := validate.Required("dbUserType", "body", m.DbUserType); err != nil {
 		return err
 	}
@@ -188,7 +185,6 @@ func (m *DBUserInfo) validateLastUsedAt(formats strfmt.Registry) error {
 }
 
 func (m *DBUserInfo) validateRoles(formats strfmt.Registry) error {
-
 	if err := validate.Required("roles", "body", m.Roles); err != nil {
 		return err
 	}
@@ -197,7 +193,6 @@ func (m *DBUserInfo) validateRoles(formats strfmt.Registry) error {
 }
 
 func (m *DBUserInfo) validateUserID(formats strfmt.Registry) error {
-
 	if err := validate.Required("userId", "body", m.UserID); err != nil {
 		return err
 	}

--- a/entities/models/distributed_tasks.go
+++ b/entities/models/distributed_tasks.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
+	"github.com/go-openapi/swag"
 	"github.com/go-openapi/validate"
 )
 
@@ -41,7 +42,6 @@ func (m DistributedTasks) Validate(formats strfmt.Registry) error {
 		}
 
 		for i := 0; i < len(m[k]); i++ {
-
 			if err := m[k][i].Validate(formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(k + "." + strconv.Itoa(i))
@@ -50,7 +50,6 @@ func (m DistributedTasks) Validate(formats strfmt.Registry) error {
 				}
 				return err
 			}
-
 		}
 
 	}
@@ -66,8 +65,11 @@ func (m DistributedTasks) ContextValidate(ctx context.Context, formats strfmt.Re
 	var res []error
 
 	for k := range m {
-
 		for i := 0; i < len(m[k]); i++ {
+
+			if swag.IsZero(m[k][i]) { // not required
+				return nil
+			}
 
 			if err := m[k][i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
@@ -79,7 +81,6 @@ func (m DistributedTasks) ContextValidate(ctx context.Context, formats strfmt.Re
 			}
 
 		}
-
 	}
 
 	if len(res) > 0 {

--- a/entities/models/error_response.go
+++ b/entities/models/error_response.go
@@ -29,7 +29,6 @@ import (
 //
 // swagger:model ErrorResponse
 type ErrorResponse struct {
-
 	// error
 	Error []*ErrorResponseErrorItems0 `json:"error"`
 }
@@ -89,10 +88,13 @@ func (m *ErrorResponse) ContextValidate(ctx context.Context, formats strfmt.Regi
 }
 
 func (m *ErrorResponse) contextValidateError(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Error); i++ {
-
 		if m.Error[i] != nil {
+
+			if swag.IsZero(m.Error[i]) { // not required
+				return nil
+			}
+
 			if err := m.Error[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("error" + "." + strconv.Itoa(i))
@@ -102,7 +104,6 @@ func (m *ErrorResponse) contextValidateError(ctx context.Context, formats strfmt
 				return err
 			}
 		}
-
 	}
 
 	return nil
@@ -130,7 +131,6 @@ func (m *ErrorResponse) UnmarshalBinary(b []byte) error {
 //
 // swagger:model ErrorResponseErrorItems0
 type ErrorResponseErrorItems0 struct {
-
 	// message
 	Message string `json:"message,omitempty"`
 }

--- a/entities/models/graph_q_l_error.go
+++ b/entities/models/graph_q_l_error.go
@@ -29,7 +29,6 @@ import (
 //
 // swagger:model GraphQLError
 type GraphQLError struct {
-
 	// locations
 	Locations []*GraphQLErrorLocationsItems0 `json:"locations"`
 
@@ -95,10 +94,13 @@ func (m *GraphQLError) ContextValidate(ctx context.Context, formats strfmt.Regis
 }
 
 func (m *GraphQLError) contextValidateLocations(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Locations); i++ {
-
 		if m.Locations[i] != nil {
+
+			if swag.IsZero(m.Locations[i]) { // not required
+				return nil
+			}
+
 			if err := m.Locations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("locations" + "." + strconv.Itoa(i))
@@ -108,7 +110,6 @@ func (m *GraphQLError) contextValidateLocations(ctx context.Context, formats str
 				return err
 			}
 		}
-
 	}
 
 	return nil
@@ -136,7 +137,6 @@ func (m *GraphQLError) UnmarshalBinary(b []byte) error {
 //
 // swagger:model GraphQLErrorLocationsItems0
 type GraphQLErrorLocationsItems0 struct {
-
 	// column
 	Column int64 `json:"column,omitempty"`
 

--- a/entities/models/graph_q_l_queries.go
+++ b/entities/models/graph_q_l_queries.go
@@ -63,8 +63,12 @@ func (m GraphQLQueries) ContextValidate(ctx context.Context, formats strfmt.Regi
 	var res []error
 
 	for i := 0; i < len(m); i++ {
-
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
@@ -74,7 +78,6 @@ func (m GraphQLQueries) ContextValidate(ctx context.Context, formats strfmt.Regi
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {

--- a/entities/models/graph_q_l_response.go
+++ b/entities/models/graph_q_l_response.go
@@ -29,7 +29,6 @@ import (
 //
 // swagger:model GraphQLResponse
 type GraphQLResponse struct {
-
 	// GraphQL data object.
 	Data map[string]JSONObject `json:"data,omitempty"`
 
@@ -92,10 +91,13 @@ func (m *GraphQLResponse) ContextValidate(ctx context.Context, formats strfmt.Re
 }
 
 func (m *GraphQLResponse) contextValidateErrors(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Errors); i++ {
-
 		if m.Errors[i] != nil {
+
+			if swag.IsZero(m.Errors[i]) { // not required
+				return nil
+			}
+
 			if err := m.Errors[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("errors" + "." + strconv.Itoa(i))
@@ -105,7 +107,6 @@ func (m *GraphQLResponse) contextValidateErrors(ctx context.Context, formats str
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/graph_q_l_responses.go
+++ b/entities/models/graph_q_l_responses.go
@@ -63,8 +63,12 @@ func (m GraphQLResponses) ContextValidate(ctx context.Context, formats strfmt.Re
 	var res []error
 
 	for i := 0; i < len(m); i++ {
-
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
@@ -74,7 +78,6 @@ func (m GraphQLResponses) ContextValidate(ctx context.Context, formats strfmt.Re
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {

--- a/entities/models/inverted_index_config.go
+++ b/entities/models/inverted_index_config.go
@@ -28,7 +28,6 @@ import (
 //
 // swagger:model InvertedIndexConfig
 type InvertedIndexConfig struct {
-
 	// bm25
 	Bm25 *BM25Config `json:"bm25,omitempty"`
 
@@ -126,8 +125,12 @@ func (m *InvertedIndexConfig) ContextValidate(ctx context.Context, formats strfm
 }
 
 func (m *InvertedIndexConfig) contextValidateBm25(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Bm25 != nil {
+
+		if swag.IsZero(m.Bm25) { // not required
+			return nil
+		}
+
 		if err := m.Bm25.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("bm25")
@@ -142,8 +145,12 @@ func (m *InvertedIndexConfig) contextValidateBm25(ctx context.Context, formats s
 }
 
 func (m *InvertedIndexConfig) contextValidateStopwords(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Stopwords != nil {
+
+		if swag.IsZero(m.Stopwords) { // not required
+			return nil
+		}
+
 		if err := m.Stopwords.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("stopwords")

--- a/entities/models/multiple_ref.go
+++ b/entities/models/multiple_ref.go
@@ -63,8 +63,12 @@ func (m MultipleRef) ContextValidate(ctx context.Context, formats strfmt.Registr
 	var res []error
 
 	for i := 0; i < len(m); i++ {
-
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
@@ -74,7 +78,6 @@ func (m MultipleRef) ContextValidate(ctx context.Context, formats strfmt.Registr
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {

--- a/entities/models/nested_property.go
+++ b/entities/models/nested_property.go
@@ -31,7 +31,6 @@ import (
 //
 // swagger:model NestedProperty
 type NestedProperty struct {
-
 	// data type
 	DataType []string `json:"dataType"`
 
@@ -54,7 +53,7 @@ type NestedProperty struct {
 	NestedProperties []*NestedProperty `json:"nestedProperties,omitempty"`
 
 	// tokenization
-	// Enum: [word lowercase whitespace field trigram gse kagome_kr kagome_ja gse_ch]
+	// Enum: ["word","lowercase","whitespace","field","trigram","gse","kagome_kr","kagome_ja","gse_ch"]
 	Tokenization string `json:"tokenization,omitempty"`
 }
 
@@ -180,10 +179,13 @@ func (m *NestedProperty) ContextValidate(ctx context.Context, formats strfmt.Reg
 }
 
 func (m *NestedProperty) contextValidateNestedProperties(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.NestedProperties); i++ {
-
 		if m.NestedProperties[i] != nil {
+
+			if swag.IsZero(m.NestedProperties[i]) { // not required
+				return nil
+			}
+
 			if err := m.NestedProperties[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nestedProperties" + "." + strconv.Itoa(i))
@@ -193,7 +195,6 @@ func (m *NestedProperty) contextValidateNestedProperties(ctx context.Context, fo
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/node_shard_status.go
+++ b/entities/models/node_shard_status.go
@@ -29,7 +29,6 @@ import (
 //
 // swagger:model NodeShardStatus
 type NodeShardStatus struct {
-
 	// The status of the async replication.
 	AsyncReplicationStatus []*AsyncReplicationStatus `json:"asyncReplicationStatus"`
 
@@ -116,10 +115,13 @@ func (m *NodeShardStatus) ContextValidate(ctx context.Context, formats strfmt.Re
 }
 
 func (m *NodeShardStatus) contextValidateAsyncReplicationStatus(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.AsyncReplicationStatus); i++ {
-
 		if m.AsyncReplicationStatus[i] != nil {
+
+			if swag.IsZero(m.AsyncReplicationStatus[i]) { // not required
+				return nil
+			}
+
 			if err := m.AsyncReplicationStatus[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("asyncReplicationStatus" + "." + strconv.Itoa(i))
@@ -129,7 +131,6 @@ func (m *NodeShardStatus) contextValidateAsyncReplicationStatus(ctx context.Cont
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/node_status.go
+++ b/entities/models/node_status.go
@@ -31,7 +31,6 @@ import (
 //
 // swagger:model NodeStatus
 type NodeStatus struct {
-
 	// Weaviate batch statistics.
 	BatchStats *BatchStats `json:"batchStats,omitempty"`
 
@@ -48,7 +47,7 @@ type NodeStatus struct {
 	Stats *NodeStats `json:"stats,omitempty"`
 
 	// Node's status.
-	// Enum: [HEALTHY UNHEALTHY UNAVAILABLE TIMEOUT]
+	// Enum: ["HEALTHY","UNHEALTHY","UNAVAILABLE","TIMEOUT"]
 	Status *string `json:"status,omitempty"`
 
 	// The version of Weaviate.
@@ -216,8 +215,12 @@ func (m *NodeStatus) ContextValidate(ctx context.Context, formats strfmt.Registr
 }
 
 func (m *NodeStatus) contextValidateBatchStats(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.BatchStats != nil {
+
+		if swag.IsZero(m.BatchStats) { // not required
+			return nil
+		}
+
 		if err := m.BatchStats.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("batchStats")
@@ -232,10 +235,13 @@ func (m *NodeStatus) contextValidateBatchStats(ctx context.Context, formats strf
 }
 
 func (m *NodeStatus) contextValidateShards(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Shards); i++ {
-
 		if m.Shards[i] != nil {
+
+			if swag.IsZero(m.Shards[i]) { // not required
+				return nil
+			}
+
 			if err := m.Shards[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("shards" + "." + strconv.Itoa(i))
@@ -245,15 +251,18 @@ func (m *NodeStatus) contextValidateShards(ctx context.Context, formats strfmt.R
 				return err
 			}
 		}
-
 	}
 
 	return nil
 }
 
 func (m *NodeStatus) contextValidateStats(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Stats != nil {
+
+		if swag.IsZero(m.Stats) { // not required
+			return nil
+		}
+
 		if err := m.Stats.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("stats")

--- a/entities/models/nodes_status_response.go
+++ b/entities/models/nodes_status_response.go
@@ -29,7 +29,6 @@ import (
 //
 // swagger:model NodesStatusResponse
 type NodesStatusResponse struct {
-
 	// nodes
 	Nodes []*NodeStatus `json:"nodes"`
 }
@@ -89,10 +88,13 @@ func (m *NodesStatusResponse) ContextValidate(ctx context.Context, formats strfm
 }
 
 func (m *NodesStatusResponse) contextValidateNodes(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Nodes); i++ {
-
 		if m.Nodes[i] != nil {
+
+			if swag.IsZero(m.Nodes[i]) { // not required
+				return nil
+			}
+
 			if err := m.Nodes[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nodes" + "." + strconv.Itoa(i))
@@ -102,7 +104,6 @@ func (m *NodesStatusResponse) contextValidateNodes(ctx context.Context, formats 
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/object.go
+++ b/entities/models/object.go
@@ -29,7 +29,6 @@ import (
 //
 // swagger:model Object
 type Object struct {
-
 	// additional
 	Additional AdditionalProperties `json:"additional,omitempty"`
 
@@ -178,6 +177,9 @@ func (m *Object) ContextValidate(ctx context.Context, formats strfmt.Registry) e
 }
 
 func (m *Object) contextValidateAdditional(ctx context.Context, formats strfmt.Registry) error {
+	if swag.IsZero(m.Additional) { // not required
+		return nil
+	}
 
 	if err := m.Additional.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
@@ -192,7 +194,6 @@ func (m *Object) contextValidateAdditional(ctx context.Context, formats strfmt.R
 }
 
 func (m *Object) contextValidateVector(ctx context.Context, formats strfmt.Registry) error {
-
 	if err := m.Vector.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("vector")
@@ -206,6 +207,9 @@ func (m *Object) contextValidateVector(ctx context.Context, formats strfmt.Regis
 }
 
 func (m *Object) contextValidateVectors(ctx context.Context, formats strfmt.Registry) error {
+	if swag.IsZero(m.Vectors) { // not required
+		return nil
+	}
 
 	if err := m.Vectors.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/entities/models/objects_get_response.go
+++ b/entities/models/objects_get_response.go
@@ -130,7 +130,6 @@ func (m *ObjectsGetResponse) Validate(formats strfmt.Registry) error {
 }
 
 func (m *ObjectsGetResponse) validateDeprecations(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Deprecations) { // not required
 		return nil
 	}
@@ -157,7 +156,6 @@ func (m *ObjectsGetResponse) validateDeprecations(formats strfmt.Registry) error
 }
 
 func (m *ObjectsGetResponse) validateResult(formats strfmt.Registry) error {
-
 	if swag.IsZero(m.Result) { // not required
 		return nil
 	}
@@ -200,10 +198,13 @@ func (m *ObjectsGetResponse) ContextValidate(ctx context.Context, formats strfmt
 }
 
 func (m *ObjectsGetResponse) contextValidateDeprecations(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Deprecations); i++ {
-
 		if m.Deprecations[i] != nil {
+
+			if swag.IsZero(m.Deprecations[i]) { // not required
+				return nil
+			}
+
 			if err := m.Deprecations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("deprecations" + "." + strconv.Itoa(i))
@@ -213,15 +214,18 @@ func (m *ObjectsGetResponse) contextValidateDeprecations(ctx context.Context, fo
 				return err
 			}
 		}
-
 	}
 
 	return nil
 }
 
 func (m *ObjectsGetResponse) contextValidateResult(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Result != nil {
+
+		if swag.IsZero(m.Result) { // not required
+			return nil
+		}
+
 		if err := m.Result.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result")
@@ -257,12 +261,11 @@ func (m *ObjectsGetResponse) UnmarshalBinary(b []byte) error {
 //
 // swagger:model ObjectsGetResponseAO2Result
 type ObjectsGetResponseAO2Result struct {
-
 	// errors
 	Errors *ErrorResponse `json:"errors,omitempty"`
 
 	// status
-	// Enum: [SUCCESS FAILED]
+	// Enum: ["SUCCESS","FAILED"]
 	Status *string `json:"status,omitempty"`
 }
 
@@ -360,8 +363,12 @@ func (m *ObjectsGetResponseAO2Result) ContextValidate(ctx context.Context, forma
 }
 
 func (m *ObjectsGetResponseAO2Result) contextValidateErrors(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Errors != nil {
+
+		if swag.IsZero(m.Errors) { // not required
+			return nil
+		}
+
 		if err := m.Errors.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("result" + "." + "errors")

--- a/entities/models/objects_list_response.go
+++ b/entities/models/objects_list_response.go
@@ -29,7 +29,6 @@ import (
 //
 // swagger:model ObjectsListResponse
 type ObjectsListResponse struct {
-
 	// deprecations
 	Deprecations []*Deprecation `json:"deprecations"`
 
@@ -129,10 +128,13 @@ func (m *ObjectsListResponse) ContextValidate(ctx context.Context, formats strfm
 }
 
 func (m *ObjectsListResponse) contextValidateDeprecations(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Deprecations); i++ {
-
 		if m.Deprecations[i] != nil {
+
+			if swag.IsZero(m.Deprecations[i]) { // not required
+				return nil
+			}
+
 			if err := m.Deprecations[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("deprecations" + "." + strconv.Itoa(i))
@@ -142,17 +144,19 @@ func (m *ObjectsListResponse) contextValidateDeprecations(ctx context.Context, f
 				return err
 			}
 		}
-
 	}
 
 	return nil
 }
 
 func (m *ObjectsListResponse) contextValidateObjects(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Objects); i++ {
-
 		if m.Objects[i] != nil {
+
+			if swag.IsZero(m.Objects[i]) { // not required
+				return nil
+			}
+
 			if err := m.Objects[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("objects" + "." + strconv.Itoa(i))
@@ -162,7 +166,6 @@ func (m *ObjectsListResponse) contextValidateObjects(ctx context.Context, format
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/patch_document_action.go
+++ b/entities/models/patch_document_action.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model PatchDocumentAction
 type PatchDocumentAction struct {
-
 	// A string containing a JSON Pointer value.
 	From string `json:"from,omitempty"`
 
@@ -39,7 +38,7 @@ type PatchDocumentAction struct {
 
 	// The operation to be performed.
 	// Required: true
-	// Enum: [add remove replace move copy test]
+	// Enum: ["add","remove","replace","move","copy","test"]
 	Op *string `json:"op"`
 
 	// A JSON-Pointer.
@@ -133,7 +132,6 @@ func (m *PatchDocumentAction) validateOpEnum(path, location string, value string
 }
 
 func (m *PatchDocumentAction) validateOp(formats strfmt.Registry) error {
-
 	if err := validate.Required("op", "body", m.Op); err != nil {
 		return err
 	}
@@ -147,7 +145,6 @@ func (m *PatchDocumentAction) validateOp(formats strfmt.Registry) error {
 }
 
 func (m *PatchDocumentAction) validatePath(formats strfmt.Registry) error {
-
 	if err := validate.Required("path", "body", m.Path); err != nil {
 		return err
 	}
@@ -170,8 +167,12 @@ func (m *PatchDocumentAction) ContextValidate(ctx context.Context, formats strfm
 }
 
 func (m *PatchDocumentAction) contextValidateMerge(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Merge != nil {
+
+		if swag.IsZero(m.Merge) { // not required
+			return nil
+		}
+
 		if err := m.Merge.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("merge")

--- a/entities/models/patch_document_object.go
+++ b/entities/models/patch_document_object.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model PatchDocumentObject
 type PatchDocumentObject struct {
-
 	// A string containing a JSON Pointer value.
 	From string `json:"from,omitempty"`
 
@@ -39,7 +38,7 @@ type PatchDocumentObject struct {
 
 	// The operation to be performed.
 	// Required: true
-	// Enum: [add remove replace move copy test]
+	// Enum: ["add","remove","replace","move","copy","test"]
 	Op *string `json:"op"`
 
 	// A JSON-Pointer.
@@ -133,7 +132,6 @@ func (m *PatchDocumentObject) validateOpEnum(path, location string, value string
 }
 
 func (m *PatchDocumentObject) validateOp(formats strfmt.Registry) error {
-
 	if err := validate.Required("op", "body", m.Op); err != nil {
 		return err
 	}
@@ -147,7 +145,6 @@ func (m *PatchDocumentObject) validateOp(formats strfmt.Registry) error {
 }
 
 func (m *PatchDocumentObject) validatePath(formats strfmt.Registry) error {
-
 	if err := validate.Required("path", "body", m.Path); err != nil {
 		return err
 	}
@@ -170,8 +167,12 @@ func (m *PatchDocumentObject) ContextValidate(ctx context.Context, formats strfm
 }
 
 func (m *PatchDocumentObject) contextValidateMerge(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Merge != nil {
+
+		if swag.IsZero(m.Merge) { // not required
+			return nil
+		}
+
 		if err := m.Merge.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("merge")

--- a/entities/models/peer_update_list.go
+++ b/entities/models/peer_update_list.go
@@ -63,8 +63,12 @@ func (m PeerUpdateList) ContextValidate(ctx context.Context, formats strfmt.Regi
 	var res []error
 
 	for i := 0; i < len(m); i++ {
-
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
@@ -74,7 +78,6 @@ func (m PeerUpdateList) ContextValidate(ctx context.Context, formats strfmt.Regi
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -30,10 +30,9 @@ import (
 //
 // swagger:model Permission
 type Permission struct {
-
 	// allowed actions in weaviate.
 	// Required: true
-	// Enum: [manage_backups read_cluster create_data read_data update_data delete_data read_nodes create_roles read_roles update_roles delete_roles create_collections read_collections update_collections delete_collections assign_and_revoke_users create_users read_users update_users delete_users create_tenants read_tenants update_tenants delete_tenants create_replicate read_replicate update_replicate delete_replicate create_aliases read_aliases update_aliases delete_aliases assign_and_revoke_groups read_groups]
+	// Enum: ["manage_backups","read_cluster","create_data","read_data","update_data","delete_data","read_nodes","create_roles","read_roles","update_roles","delete_roles","create_collections","read_collections","update_collections","delete_collections","assign_and_revoke_users","create_users","read_users","update_users","delete_users","create_tenants","read_tenants","update_tenants","delete_tenants","create_replicate","read_replicate","update_replicate","delete_replicate","create_aliases","read_aliases","update_aliases","delete_aliases","assign_and_revoke_groups","read_groups"]
 	Action *string `json:"action"`
 
 	// aliases
@@ -247,7 +246,6 @@ func (m *Permission) validateActionEnum(path, location string, value string) err
 }
 
 func (m *Permission) validateAction(formats strfmt.Registry) error {
-
 	if err := validate.Required("action", "body", m.Action); err != nil {
 		return err
 	}
@@ -501,8 +499,12 @@ func (m *Permission) ContextValidate(ctx context.Context, formats strfmt.Registr
 }
 
 func (m *Permission) contextValidateAliases(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Aliases != nil {
+
+		if swag.IsZero(m.Aliases) { // not required
+			return nil
+		}
+
 		if err := m.Aliases.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("aliases")
@@ -517,8 +519,12 @@ func (m *Permission) contextValidateAliases(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Backups != nil {
+
+		if swag.IsZero(m.Backups) { // not required
+			return nil
+		}
+
 		if err := m.Backups.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("backups")
@@ -533,8 +539,12 @@ func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateCollections(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Collections != nil {
+
+		if swag.IsZero(m.Collections) { // not required
+			return nil
+		}
+
 		if err := m.Collections.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("collections")
@@ -549,8 +559,12 @@ func (m *Permission) contextValidateCollections(ctx context.Context, formats str
 }
 
 func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Data != nil {
+
+		if swag.IsZero(m.Data) { // not required
+			return nil
+		}
+
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("data")
@@ -565,8 +579,12 @@ func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Reg
 }
 
 func (m *Permission) contextValidateGroups(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Groups != nil {
+
+		if swag.IsZero(m.Groups) { // not required
+			return nil
+		}
+
 		if err := m.Groups.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("groups")
@@ -581,8 +599,12 @@ func (m *Permission) contextValidateGroups(ctx context.Context, formats strfmt.R
 }
 
 func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Nodes != nil {
+
+		if swag.IsZero(m.Nodes) { // not required
+			return nil
+		}
+
 		if err := m.Nodes.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("nodes")
@@ -597,8 +619,12 @@ func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Re
 }
 
 func (m *Permission) contextValidateReplicate(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Replicate != nil {
+
+		if swag.IsZero(m.Replicate) { // not required
+			return nil
+		}
+
 		if err := m.Replicate.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("replicate")
@@ -613,8 +639,12 @@ func (m *Permission) contextValidateReplicate(ctx context.Context, formats strfm
 }
 
 func (m *Permission) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Roles != nil {
+
+		if swag.IsZero(m.Roles) { // not required
+			return nil
+		}
+
 		if err := m.Roles.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("roles")
@@ -629,8 +659,12 @@ func (m *Permission) contextValidateRoles(ctx context.Context, formats strfmt.Re
 }
 
 func (m *Permission) contextValidateTenants(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Tenants != nil {
+
+		if swag.IsZero(m.Tenants) { // not required
+			return nil
+		}
+
 		if err := m.Tenants.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("tenants")
@@ -645,8 +679,12 @@ func (m *Permission) contextValidateTenants(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateUsers(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Users != nil {
+
+		if swag.IsZero(m.Users) { // not required
+			return nil
+		}
+
 		if err := m.Users.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("users")
@@ -682,7 +720,6 @@ func (m *Permission) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionAliases
 type PermissionAliases struct {
-
 	// A string that specifies which aliases this permission applies to. Can be an exact alias name or a regex pattern. The default value `*` applies the permission to all aliases.
 	Alias *string `json:"alias,omitempty"`
 
@@ -722,7 +759,6 @@ func (m *PermissionAliases) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionBackups
 type PermissionBackups struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 }
@@ -759,7 +795,6 @@ func (m *PermissionBackups) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionCollections
 type PermissionCollections struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 }
@@ -796,7 +831,6 @@ func (m *PermissionCollections) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionData
 type PermissionData struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -839,7 +873,6 @@ func (m *PermissionData) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionGroups
 type PermissionGroups struct {
-
 	// A string that specifies which groups this permission applies to. Can be an exact group name or a regex pattern. The default value `*` applies the permission to all groups.
 	Group *string `json:"group,omitempty"`
 
@@ -893,6 +926,9 @@ func (m *PermissionGroups) ContextValidate(ctx context.Context, formats strfmt.R
 }
 
 func (m *PermissionGroups) contextValidateGroupType(ctx context.Context, formats strfmt.Registry) error {
+	if swag.IsZero(m.GroupType) { // not required
+		return nil
+	}
 
 	if err := m.GroupType.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
@@ -928,12 +964,11 @@ func (m *PermissionGroups) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionNodes
 type PermissionNodes struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
 	// whether to allow (verbose) returning shards and stats data in the response
-	// Enum: [verbose minimal]
+	// Enum: ["verbose","minimal"]
 	Verbosity *string `json:"verbosity,omitempty"`
 }
 
@@ -1020,7 +1055,6 @@ func (m *PermissionNodes) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionReplicate
 type PermissionReplicate struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -1060,12 +1094,11 @@ func (m *PermissionReplicate) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionRoles
 type PermissionRoles struct {
-
 	// string or regex. if a specific role name, if left empty it will be ALL or *
 	Role *string `json:"role,omitempty"`
 
 	// set the scope for the manage role permission
-	// Enum: [all match]
+	// Enum: ["all","match"]
 	Scope *string `json:"scope,omitempty"`
 }
 
@@ -1152,7 +1185,6 @@ func (m *PermissionRoles) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionTenants
 type PermissionTenants struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -1192,7 +1224,6 @@ func (m *PermissionTenants) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionUsers
 type PermissionUsers struct {
-
 	// string or regex. if a specific name, if left empty it will be ALL or *
 	Users *string `json:"users,omitempty"`
 }

--- a/entities/models/principal.go
+++ b/entities/models/principal.go
@@ -28,7 +28,6 @@ import (
 //
 // swagger:model Principal
 type Principal struct {
-
 	// groups
 	Groups []string `json:"groups"`
 
@@ -85,6 +84,9 @@ func (m *Principal) ContextValidate(ctx context.Context, formats strfmt.Registry
 }
 
 func (m *Principal) contextValidateUserType(ctx context.Context, formats strfmt.Registry) error {
+	if swag.IsZero(m.UserType) { // not required
+		return nil
+	}
 
 	if err := m.UserType.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {

--- a/entities/models/property.go
+++ b/entities/models/property.go
@@ -31,7 +31,6 @@ import (
 //
 // swagger:model Property
 type Property struct {
-
 	// Data type of the property (required). If it starts with a capital (for example Person), may be a reference to another type.
 	DataType []string `json:"dataType"`
 
@@ -60,7 +59,7 @@ type Property struct {
 	NestedProperties []*NestedProperty `json:"nestedProperties,omitempty"`
 
 	// Determines tokenization of the property as separate words or whole field. Optional. Applies to text and text[] data types. Allowed values are `word` (default; splits on any non-alphanumerical, lowercases), `lowercase` (splits on white spaces, lowercases), `whitespace` (splits on white spaces), `field` (trims). Not supported for remaining data types
-	// Enum: [word lowercase whitespace field trigram gse kagome_kr kagome_ja gse_ch]
+	// Enum: ["word","lowercase","whitespace","field","trigram","gse","kagome_kr","kagome_ja","gse_ch"]
 	Tokenization string `json:"tokenization,omitempty"`
 }
 
@@ -186,10 +185,13 @@ func (m *Property) ContextValidate(ctx context.Context, formats strfmt.Registry)
 }
 
 func (m *Property) contextValidateNestedProperties(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.NestedProperties); i++ {
-
 		if m.NestedProperties[i] != nil {
+
+			if swag.IsZero(m.NestedProperties[i]) { // not required
+				return nil
+			}
+
 			if err := m.NestedProperties[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("nestedProperties" + "." + strconv.Itoa(i))
@@ -199,7 +201,6 @@ func (m *Property) contextValidateNestedProperties(ctx context.Context, formats 
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/replication_config.go
+++ b/entities/models/replication_config.go
@@ -30,12 +30,11 @@ import (
 //
 // swagger:model ReplicationConfig
 type ReplicationConfig struct {
-
 	// Enable asynchronous replication (default: false).
 	AsyncEnabled bool `json:"asyncEnabled"`
 
 	// Conflict resolution strategy for deleted objects.
-	// Enum: [NoAutomatedResolution DeleteOnConflict TimeBasedResolution]
+	// Enum: ["NoAutomatedResolution","DeleteOnConflict","TimeBasedResolution"]
 	DeletionStrategy string `json:"deletionStrategy,omitempty"`
 
 	// Number of times a class is replicated (default: 1).

--- a/entities/models/replication_replicate_details_replica_response.go
+++ b/entities/models/replication_replicate_details_replica_response.go
@@ -31,7 +31,6 @@ import (
 //
 // swagger:model ReplicationReplicateDetailsReplicaResponse
 type ReplicationReplicateDetailsReplicaResponse struct {
-
 	// The name of the collection to which the shard being replicated belongs.
 	// Required: true
 	Collection *string `json:"collection"`
@@ -68,7 +67,7 @@ type ReplicationReplicateDetailsReplicaResponse struct {
 
 	// Indicates whether the operation is a 'COPY' (source replica remains) or a 'MOVE' (source replica is removed after successful transfer).
 	// Required: true
-	// Enum: [COPY MOVE]
+	// Enum: ["COPY","MOVE"]
 	Type *string `json:"type"`
 
 	// Whether the replica operation is uncancelable.
@@ -121,7 +120,6 @@ func (m *ReplicationReplicateDetailsReplicaResponse) Validate(formats strfmt.Reg
 }
 
 func (m *ReplicationReplicateDetailsReplicaResponse) validateCollection(formats strfmt.Registry) error {
-
 	if err := validate.Required("collection", "body", m.Collection); err != nil {
 		return err
 	}
@@ -130,7 +128,6 @@ func (m *ReplicationReplicateDetailsReplicaResponse) validateCollection(formats 
 }
 
 func (m *ReplicationReplicateDetailsReplicaResponse) validateID(formats strfmt.Registry) error {
-
 	if err := validate.Required("id", "body", m.ID); err != nil {
 		return err
 	}
@@ -143,7 +140,6 @@ func (m *ReplicationReplicateDetailsReplicaResponse) validateID(formats strfmt.R
 }
 
 func (m *ReplicationReplicateDetailsReplicaResponse) validateShard(formats strfmt.Registry) error {
-
 	if err := validate.Required("shard", "body", m.Shard); err != nil {
 		return err
 	}
@@ -152,7 +148,6 @@ func (m *ReplicationReplicateDetailsReplicaResponse) validateShard(formats strfm
 }
 
 func (m *ReplicationReplicateDetailsReplicaResponse) validateSourceNode(formats strfmt.Registry) error {
-
 	if err := validate.Required("sourceNode", "body", m.SourceNode); err != nil {
 		return err
 	}
@@ -161,7 +156,6 @@ func (m *ReplicationReplicateDetailsReplicaResponse) validateSourceNode(formats 
 }
 
 func (m *ReplicationReplicateDetailsReplicaResponse) validateStatus(formats strfmt.Registry) error {
-
 	if err := validate.Required("status", "body", m.Status); err != nil {
 		return err
 	}
@@ -207,7 +201,6 @@ func (m *ReplicationReplicateDetailsReplicaResponse) validateStatusHistory(forma
 }
 
 func (m *ReplicationReplicateDetailsReplicaResponse) validateTargetNode(formats strfmt.Registry) error {
-
 	if err := validate.Required("targetNode", "body", m.TargetNode); err != nil {
 		return err
 	}
@@ -245,7 +238,6 @@ func (m *ReplicationReplicateDetailsReplicaResponse) validateTypeEnum(path, loca
 }
 
 func (m *ReplicationReplicateDetailsReplicaResponse) validateType(formats strfmt.Registry) error {
-
 	if err := validate.Required("type", "body", m.Type); err != nil {
 		return err
 	}
@@ -277,7 +269,6 @@ func (m *ReplicationReplicateDetailsReplicaResponse) ContextValidate(ctx context
 }
 
 func (m *ReplicationReplicateDetailsReplicaResponse) contextValidateStatus(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Status != nil {
 		if err := m.Status.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -293,10 +284,13 @@ func (m *ReplicationReplicateDetailsReplicaResponse) contextValidateStatus(ctx c
 }
 
 func (m *ReplicationReplicateDetailsReplicaResponse) contextValidateStatusHistory(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.StatusHistory); i++ {
-
 		if m.StatusHistory[i] != nil {
+
+			if swag.IsZero(m.StatusHistory[i]) { // not required
+				return nil
+			}
+
 			if err := m.StatusHistory[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("statusHistory" + "." + strconv.Itoa(i))
@@ -306,7 +300,6 @@ func (m *ReplicationReplicateDetailsReplicaResponse) contextValidateStatusHistor
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/replication_replicate_details_replica_status.go
+++ b/entities/models/replication_replicate_details_replica_status.go
@@ -31,12 +31,11 @@ import (
 //
 // swagger:model ReplicationReplicateDetailsReplicaStatus
 type ReplicationReplicateDetailsReplicaStatus struct {
-
 	// A list of error messages encountered by this replica during the replication operation, if any.
 	Errors []*ReplicationReplicateDetailsReplicaStatusError `json:"errors"`
 
 	// The current operational state of the replica during the replication process.
-	// Enum: [REGISTERED HYDRATING FINALIZING DEHYDRATING READY CANCELLED]
+	// Enum: ["REGISTERED","HYDRATING","FINALIZING","DEHYDRATING","READY","CANCELLED"]
 	State string `json:"state,omitempty"`
 
 	// The UNIX timestamp in ms when this state was first entered. This is an approximate time and so should not be used for precise timing.
@@ -156,10 +155,13 @@ func (m *ReplicationReplicateDetailsReplicaStatus) ContextValidate(ctx context.C
 }
 
 func (m *ReplicationReplicateDetailsReplicaStatus) contextValidateErrors(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Errors); i++ {
-
 		if m.Errors[i] != nil {
+
+			if swag.IsZero(m.Errors[i]) { // not required
+				return nil
+			}
+
 			if err := m.Errors[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("errors" + "." + strconv.Itoa(i))
@@ -169,7 +171,6 @@ func (m *ReplicationReplicateDetailsReplicaStatus) contextValidateErrors(ctx con
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/replication_replicate_replica_request.go
+++ b/entities/models/replication_replicate_replica_request.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model ReplicationReplicateReplicaRequest
 type ReplicationReplicateReplicaRequest struct {
-
 	// The name of the collection to which the target shard belongs.
 	// Required: true
 	Collection *string `json:"collection"`
@@ -48,7 +47,7 @@ type ReplicationReplicateReplicaRequest struct {
 	TargetNode *string `json:"targetNode"`
 
 	// Specifies the type of replication operation to perform. 'COPY' creates a new replica on the target node while keeping the source replica. 'MOVE' creates a new replica on the target node and then removes the source replica upon successful completion. Defaults to 'COPY' if omitted.
-	// Enum: [COPY MOVE]
+	// Enum: ["COPY","MOVE"]
 	Type *string `json:"type,omitempty"`
 }
 
@@ -83,7 +82,6 @@ func (m *ReplicationReplicateReplicaRequest) Validate(formats strfmt.Registry) e
 }
 
 func (m *ReplicationReplicateReplicaRequest) validateCollection(formats strfmt.Registry) error {
-
 	if err := validate.Required("collection", "body", m.Collection); err != nil {
 		return err
 	}
@@ -92,7 +90,6 @@ func (m *ReplicationReplicateReplicaRequest) validateCollection(formats strfmt.R
 }
 
 func (m *ReplicationReplicateReplicaRequest) validateShard(formats strfmt.Registry) error {
-
 	if err := validate.Required("shard", "body", m.Shard); err != nil {
 		return err
 	}
@@ -101,7 +98,6 @@ func (m *ReplicationReplicateReplicaRequest) validateShard(formats strfmt.Regist
 }
 
 func (m *ReplicationReplicateReplicaRequest) validateSourceNode(formats strfmt.Registry) error {
-
 	if err := validate.Required("sourceNode", "body", m.SourceNode); err != nil {
 		return err
 	}
@@ -110,7 +106,6 @@ func (m *ReplicationReplicateReplicaRequest) validateSourceNode(formats strfmt.R
 }
 
 func (m *ReplicationReplicateReplicaRequest) validateTargetNode(formats strfmt.Registry) error {
-
 	if err := validate.Required("targetNode", "body", m.TargetNode); err != nil {
 		return err
 	}

--- a/entities/models/replication_sharding_state.go
+++ b/entities/models/replication_sharding_state.go
@@ -29,7 +29,6 @@ import (
 //
 // swagger:model ReplicationShardingState
 type ReplicationShardingState struct {
-
 	// The name of the collection.
 	Collection string `json:"collection,omitempty"`
 
@@ -92,10 +91,13 @@ func (m *ReplicationShardingState) ContextValidate(ctx context.Context, formats 
 }
 
 func (m *ReplicationShardingState) contextValidateShards(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Shards); i++ {
-
 		if m.Shards[i] != nil {
+
+			if swag.IsZero(m.Shards[i]) { // not required
+				return nil
+			}
+
 			if err := m.Shards[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("shards" + "." + strconv.Itoa(i))
@@ -105,7 +107,6 @@ func (m *ReplicationShardingState) contextValidateShards(ctx context.Context, fo
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/replication_sharding_state_response.go
+++ b/entities/models/replication_sharding_state_response.go
@@ -28,7 +28,6 @@ import (
 //
 // swagger:model ReplicationShardingStateResponse
 type ReplicationShardingStateResponse struct {
-
 	// sharding state
 	ShardingState *ReplicationShardingState `json:"shardingState,omitempty"`
 }
@@ -81,8 +80,12 @@ func (m *ReplicationShardingStateResponse) ContextValidate(ctx context.Context, 
 }
 
 func (m *ReplicationShardingStateResponse) contextValidateShardingState(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.ShardingState != nil {
+
+		if swag.IsZero(m.ShardingState) { // not required
+			return nil
+		}
+
 		if err := m.ShardingState.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("shardingState")

--- a/entities/models/restore_config.go
+++ b/entities/models/restore_config.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model RestoreConfig
 type RestoreConfig struct {
-
 	// Name of the bucket, container, volume, etc
 	Bucket string `json:"Bucket,omitempty"`
 
@@ -46,11 +45,11 @@ type RestoreConfig struct {
 	Path string `json:"Path,omitempty"`
 
 	// How roles should be restored
-	// Enum: [noRestore all]
+	// Enum: ["noRestore","all"]
 	RolesOptions *string `json:"rolesOptions,omitempty"`
 
 	// How users should be restored
-	// Enum: [noRestore all]
+	// Enum: ["noRestore","all"]
 	UsersOptions *string `json:"usersOptions,omitempty"`
 }
 

--- a/entities/models/role.go
+++ b/entities/models/role.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model Role
 type Role struct {
-
 	// role name
 	// Required: true
 	Name *string `json:"name"`
@@ -59,7 +58,6 @@ func (m *Role) Validate(formats strfmt.Registry) error {
 }
 
 func (m *Role) validateName(formats strfmt.Registry) error {
-
 	if err := validate.Required("name", "body", m.Name); err != nil {
 		return err
 	}
@@ -68,7 +66,6 @@ func (m *Role) validateName(formats strfmt.Registry) error {
 }
 
 func (m *Role) validatePermissions(formats strfmt.Registry) error {
-
 	if err := validate.Required("permissions", "body", m.Permissions); err != nil {
 		return err
 	}
@@ -109,10 +106,13 @@ func (m *Role) ContextValidate(ctx context.Context, formats strfmt.Registry) err
 }
 
 func (m *Role) contextValidatePermissions(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Permissions); i++ {
-
 		if m.Permissions[i] != nil {
+
+			if swag.IsZero(m.Permissions[i]) { // not required
+				return nil
+			}
+
 			if err := m.Permissions[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("permissions" + "." + strconv.Itoa(i))
@@ -122,7 +122,6 @@ func (m *Role) contextValidatePermissions(ctx context.Context, formats strfmt.Re
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/roles_list_response.go
+++ b/entities/models/roles_list_response.go
@@ -63,8 +63,12 @@ func (m RolesListResponse) ContextValidate(ctx context.Context, formats strfmt.R
 	var res []error
 
 	for i := 0; i < len(m); i++ {
-
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
@@ -74,7 +78,6 @@ func (m RolesListResponse) ContextValidate(ctx context.Context, formats strfmt.R
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {

--- a/entities/models/schema.go
+++ b/entities/models/schema.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model Schema
 type Schema struct {
-
 	// Semantic classes that are available.
 	Classes []*Class `json:"classes"`
 
@@ -113,10 +112,13 @@ func (m *Schema) ContextValidate(ctx context.Context, formats strfmt.Registry) e
 }
 
 func (m *Schema) contextValidateClasses(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Classes); i++ {
-
 		if m.Classes[i] != nil {
+
+			if swag.IsZero(m.Classes[i]) { // not required
+				return nil
+			}
+
 			if err := m.Classes[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("classes" + "." + strconv.Itoa(i))
@@ -126,7 +128,6 @@ func (m *Schema) contextValidateClasses(ctx context.Context, formats strfmt.Regi
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/shard_status_list.go
+++ b/entities/models/shard_status_list.go
@@ -63,8 +63,12 @@ func (m ShardStatusList) ContextValidate(ctx context.Context, formats strfmt.Reg
 	var res []error
 
 	for i := 0; i < len(m); i++ {
-
 		if m[i] != nil {
+
+			if swag.IsZero(m[i]) { // not required
+				return nil
+			}
+
 			if err := m[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName(strconv.Itoa(i))
@@ -74,7 +78,6 @@ func (m ShardStatusList) ContextValidate(ctx context.Context, formats strfmt.Reg
 				return err
 			}
 		}
-
 	}
 
 	if len(res) > 0 {

--- a/entities/models/single_ref.go
+++ b/entities/models/single_ref.go
@@ -29,7 +29,6 @@ import (
 //
 // swagger:model SingleRef
 type SingleRef struct {
-
 	// If using a direct reference, specify the URI to point to the cross-ref here. Should be in the form of weaviate://localhost/<uuid> for the example of a local cross-ref to an object
 	// Format: uri
 	Beacon strfmt.URI `json:"beacon,omitempty"`
@@ -145,8 +144,12 @@ func (m *SingleRef) ContextValidate(ctx context.Context, formats strfmt.Registry
 }
 
 func (m *SingleRef) contextValidateClassification(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Classification != nil {
+
+		if swag.IsZero(m.Classification) { // not required
+			return nil
+		}
+
 		if err := m.Classification.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("classification")

--- a/entities/models/statistics.go
+++ b/entities/models/statistics.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model Statistics
 type Statistics struct {
-
 	// bootstrapped
 	Bootstrapped bool `json:"bootstrapped,omitempty"`
 
@@ -68,7 +67,7 @@ type Statistics struct {
 	Ready bool `json:"ready,omitempty"`
 
 	// Node's status.
-	// Enum: [HEALTHY UNHEALTHY UNAVAILABLE TIMEOUT]
+	// Enum: ["HEALTHY","UNHEALTHY","UNAVAILABLE","TIMEOUT"]
 	Status *string `json:"status,omitempty"`
 }
 
@@ -172,8 +171,12 @@ func (m *Statistics) ContextValidate(ctx context.Context, formats strfmt.Registr
 }
 
 func (m *Statistics) contextValidateRaft(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Raft != nil {
+
+		if swag.IsZero(m.Raft) { // not required
+			return nil
+		}
+
 		if err := m.Raft.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("raft")

--- a/entities/models/tenant.go
+++ b/entities/models/tenant.go
@@ -30,9 +30,8 @@ import (
 //
 // swagger:model Tenant
 type Tenant struct {
-
 	// activity status of the tenant's shard. Optional for creating tenant (implicit `ACTIVE`) and required for updating tenant. For creation, allowed values are `ACTIVE` - tenant is fully active and `INACTIVE` - tenant is inactive; no actions can be performed on tenant, tenant's files are stored locally. For updating, `ACTIVE`, `INACTIVE` and also `OFFLOADED` - as INACTIVE, but files are stored on cloud storage. The following values are read-only and are set by the server for internal use: `OFFLOADING` - tenant is transitioning from ACTIVE/INACTIVE to OFFLOADED, `ONLOADING` - tenant is transitioning from OFFLOADED to ACTIVE/INACTIVE. We still accept deprecated names `HOT` (now `ACTIVE`), `COLD` (now `INACTIVE`), `FROZEN` (now `OFFLOADED`), `FREEZING` (now `OFFLOADING`), `UNFREEZING` (now `ONLOADING`).
-	// Enum: [ACTIVE INACTIVE OFFLOADED OFFLOADING ONLOADING HOT COLD FROZEN FREEZING UNFREEZING]
+	// Enum: ["ACTIVE","INACTIVE","OFFLOADED","OFFLOADING","ONLOADING","HOT","COLD","FROZEN","FREEZING","UNFREEZING"]
 	ActivityStatus string `json:"activityStatus,omitempty"`
 
 	// The name of the tenant (required).

--- a/entities/models/user_own_info.go
+++ b/entities/models/user_own_info.go
@@ -30,7 +30,6 @@ import (
 //
 // swagger:model UserOwnInfo
 type UserOwnInfo struct {
-
 	// The groups associated to the user
 	Groups []string `json:"groups"`
 
@@ -87,7 +86,6 @@ func (m *UserOwnInfo) validateRoles(formats strfmt.Registry) error {
 }
 
 func (m *UserOwnInfo) validateUsername(formats strfmt.Registry) error {
-
 	if err := validate.Required("username", "body", m.Username); err != nil {
 		return err
 	}
@@ -110,10 +108,13 @@ func (m *UserOwnInfo) ContextValidate(ctx context.Context, formats strfmt.Regist
 }
 
 func (m *UserOwnInfo) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Roles); i++ {
-
 		if m.Roles[i] != nil {
+
+			if swag.IsZero(m.Roles[i]) { // not required
+				return nil
+			}
+
 			if err := m.Roles[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("roles" + "." + strconv.Itoa(i))
@@ -123,7 +124,6 @@ func (m *UserOwnInfo) contextValidateRoles(ctx context.Context, formats strfmt.R
 				return err
 			}
 		}
-
 	}
 
 	return nil

--- a/entities/models/where_filter.go
+++ b/entities/models/where_filter.go
@@ -31,13 +31,12 @@ import (
 //
 // swagger:model WhereFilter
 type WhereFilter struct {
-
 	// combine multiple where filters, requires 'And' or 'Or' operator
 	Operands []*WhereFilter `json:"operands"`
 
 	// operator to use
 	// Example: GreaterThanEqual
-	// Enum: [And Or Equal Like NotEqual GreaterThan GreaterThanEqual LessThan LessThanEqual WithinGeoRange IsNull ContainsAny ContainsAll ContainsNone Not]
+	// Enum: ["And","Or","Equal","Like","NotEqual","GreaterThan","GreaterThanEqual","LessThan","LessThanEqual","WithinGeoRange","IsNull","ContainsAny","ContainsAll","ContainsNone","Not"]
 	Operator string `json:"operator,omitempty"`
 
 	// path to the property currently being filtered
@@ -263,10 +262,13 @@ func (m *WhereFilter) ContextValidate(ctx context.Context, formats strfmt.Regist
 }
 
 func (m *WhereFilter) contextValidateOperands(ctx context.Context, formats strfmt.Registry) error {
-
 	for i := 0; i < len(m.Operands); i++ {
-
 		if m.Operands[i] != nil {
+
+			if swag.IsZero(m.Operands[i]) { // not required
+				return nil
+			}
+
 			if err := m.Operands[i].ContextValidate(ctx, formats); err != nil {
 				if ve, ok := err.(*errors.Validation); ok {
 					return ve.ValidateName("operands" + "." + strconv.Itoa(i))
@@ -276,15 +278,18 @@ func (m *WhereFilter) contextValidateOperands(ctx context.Context, formats strfm
 				return err
 			}
 		}
-
 	}
 
 	return nil
 }
 
 func (m *WhereFilter) contextValidateValueGeoRange(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.ValueGeoRange != nil {
+
+		if swag.IsZero(m.ValueGeoRange) { // not required
+			return nil
+		}
+
 		if err := m.ValueGeoRange.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("valueGeoRange")

--- a/entities/models/where_filter_geo_range.go
+++ b/entities/models/where_filter_geo_range.go
@@ -28,7 +28,6 @@ import (
 //
 // swagger:model WhereFilterGeoRange
 type WhereFilterGeoRange struct {
-
 	// distance
 	Distance *WhereFilterGeoRangeDistance `json:"distance,omitempty"`
 
@@ -111,8 +110,12 @@ func (m *WhereFilterGeoRange) ContextValidate(ctx context.Context, formats strfm
 }
 
 func (m *WhereFilterGeoRange) contextValidateDistance(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Distance != nil {
+
+		if swag.IsZero(m.Distance) { // not required
+			return nil
+		}
+
 		if err := m.Distance.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("distance")
@@ -127,8 +130,12 @@ func (m *WhereFilterGeoRange) contextValidateDistance(ctx context.Context, forma
 }
 
 func (m *WhereFilterGeoRange) contextValidateGeoCoordinates(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.GeoCoordinates != nil {
+
+		if swag.IsZero(m.GeoCoordinates) { // not required
+			return nil
+		}
+
 		if err := m.GeoCoordinates.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
 				return ve.ValidateName("geoCoordinates")
@@ -164,7 +171,6 @@ func (m *WhereFilterGeoRange) UnmarshalBinary(b []byte) error {
 //
 // swagger:model WhereFilterGeoRangeDistance
 type WhereFilterGeoRangeDistance struct {
-
 	// max
 	Max float64 `json:"max,omitempty"`
 }

--- a/tools/gen-code-from-swagger.sh
+++ b/tools/gen-code-from-swagger.sh
@@ -3,7 +3,7 @@
 set -eou pipefail
 
 # Version of go-swagger to use.
-version=v0.30.4
+version=v0.32.3
 
 # Always points to the directory of this script.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"


### PR DESCRIPTION
### What's being changed:

Here we bump the version of `go-swagger` from `0.30.4` to `0.32.3` and re-run code generation.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.
