### PR TITLE
Add vector index types tests with restart

### DIFF
--- a/test/acceptance_with_go_client/named_vectors_tests/singlenode/singlenode_test.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/singlenode/singlenode_test.go
@@ -34,6 +34,7 @@ func TestNamedVectors_SingleNode(t *testing.T) {
 	t.Run("tests", test_suits.AllTests(endpoint, false))
 	t.Run("legacy tests", test_suits.AllLegacyTests(endpoint))
 	t.Run("mixed vector tests", test_suits.AllMixedVectorsTests(endpoint))
+	t.Run("restart", test_suits.AllWithRestart(compose))
 }
 
 func TestNamedVectors_SingleNode_AsyncIndexing(t *testing.T) {
@@ -48,16 +49,7 @@ func TestNamedVectors_SingleNode_AsyncIndexing(t *testing.T) {
 	t.Run("legacy tests", test_suits.AllLegacyTests(endpoint))
 	t.Run("mixed vector tests", test_suits.AllMixedVectorsTests(endpoint))
 	t.Run("async indexing tests", test_suits.AsyncIndexigTests(endpoint))
-}
-
-func TestNamedVectors_SingleNode_Restart(t *testing.T) {
-	ctx := context.Background()
-	compose, err := createSingleNodeEnvironment(ctx)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, compose.Terminate(ctx))
-	}()
-	t.Run("restart", test_suits.TestRestart(compose))
+	t.Run("restart", test_suits.AllWithRestart(compose))
 }
 
 func TestNamedVectors_VectorCanNotBeAddedWithoutEnvFlag(t *testing.T) {

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/helpers.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/helpers.go
@@ -12,8 +12,15 @@
 package test_suits
 
 import (
+	"context"
 	"math/rand"
+	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	"github.com/weaviate/weaviate/entities/models"
 )
 
 func generateRandomVector(dimensionality int) []float32 {
@@ -29,4 +36,25 @@ func generateRandomVector(dimensionality int) []float32 {
 		slice[i] = r.Float32()
 	}
 	return slice
+}
+
+func generateRandomMultiVector(dimensionality, len int) [][]float32 {
+	multiVector := make([][]float32, len)
+	for i := range len {
+		multiVector[i] = generateRandomVector(dimensionality)
+	}
+	return multiVector
+}
+
+func batchInsertObjects(t *testing.T, client *wvt.Client, objs []*models.Object) {
+	resp, err := client.Batch().ObjectsBatcher().
+		WithObjects(objs...).
+		Do(context.TODO())
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	for _, r := range resp {
+		require.NotNil(t, r.Result)
+		require.NotNil(t, r.Result.Status)
+		assert.Equal(t, models.ObjectsGetResponseAO2ResultStatusSUCCESS, *r.Result.Status)
+	}
 }

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_restart.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_restart.go
@@ -24,7 +24,7 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 )
 
-func TestRestart(compose *docker.DockerCompose) func(t *testing.T) {
+func testNamedVectorsRestart(compose *docker.DockerCompose) func(t *testing.T) {
 	return func(t *testing.T) {
 		ctx := context.Background()
 		host := compose.GetWeaviate().URI()

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_test_data.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_test_data.go
@@ -216,6 +216,37 @@ func sqVectorIndexConfig() map[string]interface{} {
 	}
 }
 
+func pq(trainingLimit int) map[string]interface{} {
+	return map[string]interface{}{
+		"pq": map[string]interface{}{
+			"enabled":       true,
+			"trainingLimit": trainingLimit,
+		},
+	}
+}
+
+func sq(trainingLimit int) map[string]interface{} {
+	return map[string]interface{}{
+		"pq": map[string]interface{}{
+			"enabled":       true,
+			"trainingLimit": trainingLimit,
+			"cache":         true,
+		},
+	}
+}
+
+func bq(multiVector bool) map[string]interface{} {
+	bq := map[string]interface{}{
+		"bq": map[string]interface{}{
+			"enabled": true,
+		},
+	}
+	if multiVector {
+		bq["multivector"] = map[string]interface{}{"enabled": true}
+	}
+	return bq
+}
+
 func getVectorsWithNearText(t *testing.T, client *wvt.Client,
 	className, id string, nearText *graphql.NearTextArgumentBuilder, targetVectors ...string,
 ) map[string]models.Vector {

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_vector_index_dynamic.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_vector_index_dynamic.go
@@ -77,20 +77,11 @@ func testCompressedDynamicVectorIndex(host string) func(t *testing.T) {
 				}
 				objs = append(objs, obj)
 			}
-
-			resp, err := client.Batch().ObjectsBatcher().
-				WithObjects(objs...).
-				Do(ctx)
-			require.NoError(t, err)
-			require.NotNil(t, resp)
+			batchInsertObjects(t, client, objs)
 		}
 
 		queryAllTargetVectors := func(t *testing.T) {
-			var targetVectors []string
 			for targetVector := range targetVectorDimensions {
-				targetVectors = append(targetVectors, targetVector)
-			}
-			for _, targetVector := range targetVectors {
 				nearVector := client.GraphQL().NearVectorArgBuilder().
 					WithVector(generateRandomVector(targetVectorDimensions[targetVector])).
 					WithTargetVectors(targetVector)

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_vector_index_restart.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_vector_index_restart.go
@@ -1,0 +1,239 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test_suits
+
+import (
+	acceptance_with_go_client "acceptance_tests_with_client"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	"github.com/weaviate/weaviate-go-client/v5/weaviate/graphql"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/docker"
+)
+
+func testCompresseVectorTypesRestart(compose *docker.DockerCompose) func(t *testing.T) {
+	return func(t *testing.T) {
+		ctx := context.Background()
+		className := "NamedVectorsCompressedIndexTypeRestart"
+
+		host := compose.GetWeaviate().URI()
+		client, err := wvt.NewClient(wvt.Config{Scheme: "http", Host: host})
+		require.Nil(t, err)
+
+		client.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+
+		numberOfObjects := 10
+
+		targetVectorDimensions := map[string]int{
+			"uncompressed":    800,
+			"hnsw_bq":         1280,
+			"hnsw_pq":         256,
+			"hnsw_sq":         796,
+			"flat":            512,
+			"flat_bq":         1024,
+			"mv_uncompressed": 64,
+			"mv_bq":           128,
+		}
+
+		vectorConfig := map[string]models.VectorConfig{
+			"uncompressed": {
+				Vectorizer: map[string]any{
+					"none": map[string]any{},
+				},
+				VectorIndexType: "hnsw",
+			},
+			"hnsw_bq": {
+				Vectorizer: map[string]any{
+					"none": map[string]any{},
+				},
+				VectorIndexType:   "hnsw",
+				VectorIndexConfig: bq(false),
+			},
+			"hnsw_pq": {
+				Vectorizer: map[string]any{
+					"none": map[string]any{},
+				},
+				VectorIndexType: "hnsw",
+			},
+			"hnsw_sq": {
+				Vectorizer: map[string]any{
+					"none": map[string]any{},
+				},
+				VectorIndexType: "hnsw",
+			},
+			"flat": {
+				Vectorizer: map[string]any{
+					"none": map[string]any{},
+				},
+				VectorIndexType: "flat",
+			},
+			"flat_bq": {
+				Vectorizer: map[string]any{
+					"none": map[string]any{},
+				},
+				VectorIndexType:   "flat",
+				VectorIndexConfig: bq(false),
+			},
+			"mv_uncompressed": {
+				Vectorizer: map[string]any{
+					"none": map[string]any{},
+				},
+				VectorIndexType: "hnsw",
+				VectorIndexConfig: map[string]interface{}{
+					"multivector": map[string]interface{}{
+						"enabled": true,
+					},
+				},
+			},
+			"mv_bq": {
+				Vectorizer: map[string]any{
+					"none": map[string]any{},
+				},
+				VectorIndexType:   "hnsw",
+				VectorIndexConfig: bq(true),
+			},
+		}
+
+		class := &models.Class{
+			Class: className,
+			Properties: []*models.Property{
+				{
+					Name: "name", DataType: []string{schema.DataTypeText.String()},
+				},
+				{
+					Name: "description", DataType: []string{schema.DataTypeText.String()},
+				},
+			},
+			VectorConfig: vectorConfig,
+		}
+
+		generateVector := func(targetVector string) models.Vector {
+			dimensions := targetVectorDimensions[targetVector]
+			if strings.HasPrefix(targetVector, "mv_") {
+				return generateRandomMultiVector(dimensions, 5)
+			}
+			return generateRandomVector(dimensions)
+		}
+
+		generateVectors := func() models.Vectors {
+			vectors := models.Vectors{}
+			for targetVector := range targetVectorDimensions {
+				vectors[targetVector] = generateVector(targetVector)
+			}
+			return vectors
+		}
+
+		insertObjects := func(t *testing.T, n int) {
+			objs := []*models.Object{}
+			for i := range n {
+				obj := &models.Object{
+					Class: className,
+					ID:    strfmt.UUID(uuid.NewString()),
+					Properties: map[string]any{
+						"name":        fmt.Sprintf("name %v", i),
+						"description": fmt.Sprintf("some description %v", i),
+					},
+					Vectors: generateVectors(),
+				}
+				objs = append(objs, obj)
+			}
+			batchInsertObjects(t, client, objs)
+		}
+
+		queryAllTargetVectors := func(t *testing.T, expectedResults int) {
+			for targetVector := range targetVectorDimensions {
+				nearVector := client.GraphQL().NearVectorArgBuilder().
+					WithVector(generateVector(targetVector)).
+					WithTargetVectors(targetVector)
+				get := client.GraphQL().Get().
+					WithClassName(className).
+					WithNearVector(nearVector).
+					WithLimit(1000).
+					WithFields(graphql.Field{
+						Name: "_additional",
+						Fields: []graphql.Field{
+							{Name: "id"},
+						},
+					})
+				require.EventuallyWithT(t, func(ct *assert.CollectT) {
+					resp, err := get.Do(context.Background())
+					require.NoError(t, err)
+					require.NotNil(t, resp)
+					if len(resp.Data) == 0 {
+						return
+					}
+
+					ids := acceptance_with_go_client.GetIds(t, resp, className)
+					assert.Equal(ct, expectedResults, len(ids), fmt.Sprintf("targetVector: %s", targetVector))
+				}, 5*time.Second, 1*time.Millisecond)
+			}
+		}
+
+		t.Run("create schema", func(t *testing.T) {
+			err := client.Schema().ClassCreator().WithClass(class).Do(ctx)
+			require.NoError(t, err)
+		})
+
+		t.Run("batch create objects", func(t *testing.T) {
+			insertObjects(t, numberOfObjects)
+			testAllObjectsIndexed(t, client, className)
+		})
+
+		t.Run("query all target vectors", func(t *testing.T) {
+			queryAllTargetVectors(t, numberOfObjects)
+		})
+
+		t.Run("enable quantization", func(t *testing.T) {
+			vectorConfig["hnsw_sq"] = models.VectorConfig{
+				Vectorizer: map[string]any{
+					"none": map[string]any{},
+				},
+				VectorIndexType:   "hnsw",
+				VectorIndexConfig: sq(9),
+			}
+			class.VectorConfig = vectorConfig
+			err := client.Schema().ClassUpdater().WithClass(class).Do(ctx)
+			require.NoError(t, err)
+		})
+
+		t.Run("query all target vectors after quantization enabled", func(t *testing.T) {
+			queryAllTargetVectors(t, numberOfObjects)
+		})
+
+		t.Run("wait 5 seconds for all of the indexes to settle", func(t *testing.T) {
+			time.Sleep(5 * time.Second)
+		})
+
+		t.Run("restart", func(t *testing.T) {
+			err := compose.Stop(ctx, compose.GetWeaviate().Name(), nil)
+			require.NoError(t, err)
+
+			err = compose.Start(ctx, compose.GetWeaviate().Name())
+			require.NoError(t, err)
+
+			host := compose.GetWeaviate().URI()
+			client, err = wvt.NewClient(wvt.Config{Scheme: "http", Host: host})
+			require.NoError(t, err)
+			queryAllTargetVectors(t, numberOfObjects)
+		})
+	}
+}

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/restart.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/restart.go
@@ -1,0 +1,25 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test_suits
+
+import (
+	"testing"
+
+	"github.com/weaviate/weaviate/test/docker"
+)
+
+func AllWithRestart(compose *docker.DockerCompose) func(t *testing.T) {
+	return func(t *testing.T) {
+		t.Run("named vectors", testNamedVectorsRestart(compose))
+		t.Run("vector search", testCompresseVectorTypesRestart(compose))
+	}
+}


### PR DESCRIPTION
### What's being changed:

Add vector index types tests with restart

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
