### PR TITLE
feat(metrics): lsm cursor metrics

### DIFF
--- a/adapters/repos/db/lsmkv/cursor_bucket_replace.go
+++ b/adapters/repos/db/lsmkv/cursor_bucket_replace.go
@@ -13,6 +13,7 @@ package lsmkv
 
 import (
 	"bytes"
+	"time"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/lsmkv"
@@ -42,11 +43,15 @@ type cursorStateReplace struct {
 // Cursor holds a RLock for the flushing state. It needs to be closed using the
 // .Close() methods or otherwise the lock will never be released
 func (b *Bucket) Cursor() *CursorReplace {
-	b.flushLock.RLock()
-
 	if b.strategy != StrategyReplace {
 		panic("Cursor() called on strategy other than 'replace'")
 	}
+
+	cursorOpenedAt := time.Now()
+	b.metrics.IncBucketOpenedCursorsByStrategy(b.strategy)
+	b.metrics.IncBucketOpenCursorsByStrategy(b.strategy)
+
+	b.flushLock.RLock()
 
 	innerCursors, unlockSegmentGroup := b.disk.newCursors()
 
@@ -66,6 +71,9 @@ func (b *Bucket) Cursor() *CursorReplace {
 		unlock: func() {
 			unlockSegmentGroup()
 			b.flushLock.RUnlock()
+
+			b.metrics.DecBucketOpenCursorsByStrategy(b.strategy)
+			b.metrics.ObserveBucketCursorDurationByStrategy(b.strategy, time.Since(cursorOpenedAt))
 		},
 	}
 }


### PR DESCRIPTION
### What's being changed:

This pull request adds detailed Prometheus metrics for tracking LSM bucket cursor usage, including counts of opened and currently open cursors, as well as the duration cursors are held open. These metrics are implemented across all cursor types and are labeled by segment strategy for granular observability. Additionally, new histogram buckets are introduced for cursor duration, and related metric registration and update logic is added to the codebase.

**Metrics instrumentation for LSM bucket cursors:**

* Introduced three new Prometheus metrics in `metrics.go` to track LSM bucket cursors: a counter for the number of opened cursors (`lsm_bucket_opened_cursors`), a gauge for currently open cursors (`lsm_bucket_open_cursors`), and a histogram for cursor open duration (`lsm_bucket_cursor_duration_seconds`), all labeled by segment strategy. [[1]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR51-R54) [[2]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR214-R253) [[3]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR446-R449) [[4]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR600-R627)
* Added logic to increment, decrement, and observe these metrics in all cursor-opening methods (`MapCursor`, `Cursor`, and `cursorRoaringSet`) in their respective files, ensuring metrics are updated on cursor open and close. [[1]](diffhunk://#diff-5eeb528077bbbef9a42b8ccb69db43ba454e531197326773e63066ee17682ddbR46-R49) [[2]](diffhunk://#diff-5eeb528077bbbef9a42b8ccb69db43ba454e531197326773e63066ee17682ddbR72-R74) [[3]](diffhunk://#diff-761fba551e5ea5011447c61f0df84bbbad84e4eccb865fad1060e5db5b14cb69L45-R55) [[4]](diffhunk://#diff-761fba551e5ea5011447c61f0df84bbbad84e4eccb865fad1060e5db5b14cb69R74-R76) [[5]](diffhunk://#diff-998a180d08001ba52771bd0c72f2121f1a64413ab80bce088e276461430ead14R60-R63) [[6]](diffhunk://#diff-998a180d08001ba52771bd0c72f2121f1a64413ab80bce088e276461430ead14R83-R85)
* Updated imports in relevant files to include the `time` package for measuring cursor durations. [[1]](diffhunk://#diff-5eeb528077bbbef9a42b8ccb69db43ba454e531197326773e63066ee17682ddbR20) [[2]](diffhunk://#diff-761fba551e5ea5011447c61f0df84bbbad84e4eccb865fad1060e5db5b14cb69R16) [[3]](diffhunk://#diff-998a180d08001ba52771bd0c72f2121f1a64413ab80bce088e276461430ead14R15-R16)

**Prometheus histogram configuration:**

* Added a new exponential bucket configuration for cursor duration histograms, and slightly reduced the number of buckets for other duration metrics for efficiency.

These changes provide improved visibility into cursor usage patterns and potential bottlenecks in the LSM storage layer.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
