### PR TITLE
feat: allow changing vectorizer configuration

### DIFF
--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -1244,12 +1244,10 @@ func Test_UpdateClass(t *testing.T) {
 						"attempted change from \"InitialName\" to \"UpdatedName\""),
 			},
 			{
-				name:    "ModifyVectorizer",
-				initial: &models.Class{Class: "InitialName", Vectorizer: "model1", ReplicationConfig: &models.ReplicationConfig{Factor: 1}},
-				update:  &models.Class{Class: "InitialName", Vectorizer: "model2", ReplicationConfig: &models.ReplicationConfig{Factor: 1}},
-				expectedError: fmt.Errorf(
-					"vectorizer is immutable: " +
-						"attempted change from \"model1\" to \"model2\""),
+				name:          "ModifyVectorizer",
+				initial:       &models.Class{Class: "InitialName", Vectorizer: "model1", ReplicationConfig: &models.ReplicationConfig{Factor: 1}},
+				update:        &models.Class{Class: "InitialName", Vectorizer: "model2", ReplicationConfig: &models.ReplicationConfig{Factor: 1}},
+				expectedError: nil, // Vectorizer is now mutable to allow switching between providers
 			},
 			{
 				name:    "ModifyVectorIndexType",
@@ -1835,7 +1833,7 @@ func Test_UpdateClass(t *testing.T) {
 					},
 					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 				},
-				expectedError: fmt.Errorf("vectorizer is immutable"),
+				expectedError: nil, // Vectorizer is now mutable
 			},
 			{
 				name: "removing existing named vector",
@@ -1883,7 +1881,7 @@ func Test_UpdateClass(t *testing.T) {
 					Class:             "InitialName",
 					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 				},
-				expectedError: fmt.Errorf("vectorizer is immutable"),
+				expectedError: nil, // Vectorizer is now mutable - users can remove it
 			},
 			{
 				name: "adding named vector with reserved named on a collection with legacy index",

--- a/usecases/schema/parser.go
+++ b/usecases/schema/parser.go
@@ -259,7 +259,7 @@ func (p *Parser) ParseClassUpdate(class, update *models.Class) (*models.Class, e
 		return nil, err
 	}
 
-	if class.VectorIndexConfig != nil || update.VectorIndexConfig != nil {
+	if class.VectorIndexConfig != nil && update.VectorIndexConfig != nil {
 		vIdxConfig, ok1 := class.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
 		vIdxConfigU, ok2 := update.VectorIndexConfig.(schemaConfig.VectorIndexConfig)
 		if !ok1 || !ok2 {
@@ -517,27 +517,8 @@ func (p *Parser) validateNamedVectorConfigsParityAndImmutables(initial, updated 
 				vecName, initialCfg.VectorIndexType, updatedCfg.VectorIndexType)
 		}
 
-		// immutable vectorizer
-		if imap, ok := initialCfg.Vectorizer.(map[string]interface{}); ok && len(imap) == 1 {
-			umap, ok := updatedCfg.Vectorizer.(map[string]interface{})
-			if !ok || len(umap) != 1 {
-				return fmt.Errorf("invalid vectorizer config for vector %q", vecName)
-			}
-
-			ivectorizer := ""
-			for k := range imap {
-				ivectorizer = k
-			}
-			uvectorizer := ""
-			for k := range umap {
-				uvectorizer = k
-			}
-
-			if ivectorizer != uvectorizer {
-				return fmt.Errorf("vectorizer of vector %q is immutable: attempted change from %q to %q",
-					vecName, ivectorizer, uvectorizer)
-			}
-		}
+		// Vectorizer is now mutable to allow switching between providers
+		// Users can change vectorizers for the same embedding model across different providers
 	}
 	return nil
 }


### PR DESCRIPTION
Remove immutability constraint on vectorizer to enable switching between different providers offering the same embedding model.

Changes:
- Remove vectorizer immutability check in validateImmutableFields
- Remove vectorizer immutability check in validateNamedVectorConfigsParityAndImmutables
- Keep vector index type immutable for data consistency
- Allow adding vector config when none existed before
- Update tests to reflect mutable vectorizer behavior

This addresses issue #9333 by enabling users to switch between vectorizer providers (e.g., different hosting of same open-weight models) without recreating their collections.

