### PR TITLE
chore(metrics): ensure init counter and gauge metrics

### DIFF
--- a/adapters/repos/db/lsmkv/memtable_metrics.go
+++ b/adapters/repos/db/lsmkv/memtable_metrics.go
@@ -66,6 +66,7 @@ func newMemtableMetrics(metrics *Metrics, path, strategy string) (*memtableMetri
 	if err != nil {
 		return nil, fmt.Errorf("register lsm_memtable_flush_total: %w", err)
 	}
+	monitoring.InitCounterVec(flushingCount, bucketStrategiesLabels)
 
 	flushingInProgress, err := monitoring.EnsureRegisteredMetric(metrics.register,
 		prometheus.NewGaugeVec(
@@ -79,6 +80,7 @@ func newMemtableMetrics(metrics *Metrics, path, strategy string) (*memtableMetri
 	if err != nil {
 		return nil, fmt.Errorf("register lsm_memtable_flush_in_progress: %w", err)
 	}
+	monitoring.InitGaugeVec(flushingInProgress, bucketStrategiesLabels)
 
 	flushingFailureCount, err := monitoring.EnsureRegisteredMetric(metrics.register,
 		prometheus.NewCounterVec(
@@ -92,6 +94,7 @@ func newMemtableMetrics(metrics *Metrics, path, strategy string) (*memtableMetri
 	if err != nil {
 		return nil, fmt.Errorf("register lsm_memtable_flush_failures_total: %w", err)
 	}
+	monitoring.InitCounterVec(flushingFailureCount, bucketStrategiesLabels)
 
 	flushingDuration, err := monitoring.EnsureRegisteredMetric(metrics.register,
 		prometheus.NewHistogramVec(

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -399,6 +399,18 @@ func EnsureRegisteredMetric[T prometheus.Collector](reg prometheus.Registerer, m
 	return metric, nil
 }
 
+func InitCounterVec(vec *prometheus.CounterVec, labelNames [][]string) {
+	for _, labels := range labelNames {
+		vec.WithLabelValues(labels...).Add(0)
+	}
+}
+
+func InitGaugeVec(vec *prometheus.GaugeVec, labelNames [][]string) {
+	for _, labels := range labelNames {
+		vec.WithLabelValues(labels...).Set(0)
+	}
+}
+
 func newPrometheusMetrics() *PrometheusMetrics {
 	return &PrometheusMetrics{
 		Registerer: prometheus.DefaultRegisterer,


### PR DESCRIPTION
### What's being changed:

This pull request enhances the initialization of Prometheus metrics for LSMKV buckets and memtables by ensuring all expected label values are pre-initialized. This helps avoid missing time series in monitoring systems and makes metric reporting more robust and predictable.

Key changes include:

**Metrics Initialization Improvements:**

* Introduced helper functions `InitCounterVec` and `InitGaugeVec` in `usecases/monitoring/prometheus.go` to pre-initialize all metric vectors with the defined bucket strategies as label values.
* Defined a centralized `bucketStrategies` list in `adapters/repos/db/lsmkv/metrics.go` to ensure consistency in label initialization across all metrics.

**Application of Initialization Helpers:**

* Updated the `NewMetrics` and `newMemtableMetrics` functions in `adapters/repos/db/lsmkv/metrics.go` and `adapters/repos/db/lsmkv/memtable_metrics.go` to call the new initialization helpers for all relevant `CounterVec` and `GaugeVec` metrics, ensuring all expected label combinations are present from startup. [[1]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR137) [[2]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR151) [[3]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR165) [[4]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR193) [[5]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR207) [[6]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR234) [[7]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR248) [[8]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR262) [[9]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR290) [[10]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR304) [[11]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR318) [[12]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR346) [[13]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR360) [[14]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR374) [[15]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR403) [[16]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR432) [[17]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR458) [[18]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR487) [[19]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR500) [[20]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR514) [[21]](diffhunk://#diff-72c9096a1556e261cad2fe5c7e6c6825667e0eb3f54f1f1f06f580e2744444fdR528) [[22]](diffhunk://#diff-96e873a84c04c981c0c8111f65926fd117b67054882de52db8e4d98c81e1d8b7R69) [[23]](diffhunk://#diff-96e873a84c04c981c0c8111f65926fd117b67054882de52db8e4d98c81e1d8b7R83) [[24]](diffhunk://#diff-96e873a84c04c981c0c8111f65926fd117b67054882de52db8e4d98c81e1d8b7R97)

These changes improve the reliability and completeness of exported metrics, making it easier for monitoring tools to display all possible metric series, even before any events have occurred.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
