### PR TITLE
Wait for cache prefill before async indexing can trigger an upgrade

### DIFF
--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -111,6 +111,7 @@ type hnsw struct {
 
 	cache               cache.Cache[float32]
 	waitForCachePrefill bool
+	cachePrefilled      atomic.Bool
 
 	commitLog CommitLogger
 
@@ -305,6 +306,7 @@ func New(cfg Config, uc ent.UserConfig,
 		nodes:                 make([]*vertex, cache.InitialSize),
 		cache:                 vectorCache,
 		waitForCachePrefill:   cfg.WaitForCachePrefill,
+		cachePrefilled:        atomic.Bool{}, // Will be set appropriately in init()
 		vectorForID:           vectorCache.Get,
 		multiVectorForID:      vectorCache.MultiGet,
 		id:                    cfg.ID,
@@ -821,6 +823,11 @@ func (h *hnsw) DistancerProvider() distancer.Provider {
 }
 
 func (h *hnsw) ShouldUpgrade() (bool, int) {
+	// Don't upgrade if cache is not prefilled yet
+	if !h.cachePrefilled.Load() {
+		return false, 0
+	}
+
 	if h.sqConfig.Enabled {
 		return h.sqConfig.Enabled, h.sqConfig.TrainingLimit
 	}

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -368,9 +368,6 @@ func (h *hnsw) prefillCache() {
 		}
 
 		h.cachePrefilled.Store(true)
-		h.logger.WithFields(logrus.Fields{
-			"action": "prefill_cache",
-		}).Info("cache prefill completed")
 	}
 
 	if h.waitForCachePrefill {

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -105,6 +105,8 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 		return errors.Wrap(err, "load commit logger state")
 	}
 
+	h.cachePrefilled.Store(state == nil)
+
 	if state == nil {
 		// nothing to do
 		return nil
@@ -350,14 +352,6 @@ func (h *hnsw) prefillCache() {
 	}
 
 	f := func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Minute)
-		defer cancel()
-
-		h.logger.WithFields(logrus.Fields{
-			"action":   "prefill_cache",
-			"duration": 60 * time.Minute,
-		}).Debug("context.WithTimeout")
-
 		var err error
 		if h.compressed.Load() {
 			if !h.multivector.Load() || h.muvera.Load() {
@@ -366,12 +360,17 @@ func (h *hnsw) prefillCache() {
 				h.compressor.PrefillMultiCache(h.docIDVectors)
 			}
 		} else {
-			err = newVectorCachePrefiller(h.cache, h, h.logger).Prefill(ctx, limit)
+			err = newVectorCachePrefiller(h.cache, h, h.logger).Prefill(context.Background(), limit)
 		}
 
 		if err != nil {
 			h.logger.WithError(err).Error("prefill vector cache")
 		}
+
+		h.cachePrefilled.Store(true)
+		h.logger.WithFields(logrus.Fields{
+			"action": "prefill_cache",
+		}).Info("cache prefill completed")
 	}
 
 	if h.waitForCachePrefill {


### PR DESCRIPTION
### What's being changed:
- Async indexing looks at `ShouldUpgrade` to determine when to upgrade
- This change makes `ShouldUpgrade` also wait for the cache to be prefilled
- It also removes the historical 60 minutes pre-filler timeout for unquantized vectors.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
