### PR TITLE
Fix case of a missing user prefix

### DIFF
--- a/cluster/rbac/manager.go
+++ b/cluster/rbac/manager.go
@@ -199,7 +199,10 @@ func (m *Manager) AddRolesForUser(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	reqs := migrateAssignRoles(req, m.authNconfig)
+	reqs, err := migrateAssignRoles(req, m.authNconfig)
+	if err != nil {
+		return err
+	}
 	for _, req := range reqs {
 		if err := m.authZ.AddRolesForUser(req.User, req.Roles); err != nil {
 			return err
@@ -242,7 +245,10 @@ func (m *Manager) RevokeRolesForUser(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	reqs := migrateRevokeRoles(req)
+	reqs, err := migrateRevokeRoles(req)
+	if err != nil {
+		return err
+	}
 	for _, req := range reqs {
 		if err := m.authZ.RevokeRolesForUser(req.User, req.Roles...); err != nil {
 			return err

--- a/cluster/rbac/manager.go
+++ b/cluster/rbac/manager.go
@@ -201,7 +201,7 @@ func (m *Manager) AddRolesForUser(c *cmd.ApplyRequest) error {
 
 	reqs, err := migrateAssignRoles(req, m.authNconfig)
 	if err != nil {
-		return err
+		return fmt.Errorf("migrateAssign: %w", err)
 	}
 	for _, req := range reqs {
 		if err := m.authZ.AddRolesForUser(req.User, req.Roles); err != nil {
@@ -247,7 +247,7 @@ func (m *Manager) RevokeRolesForUser(c *cmd.ApplyRequest) error {
 
 	reqs, err := migrateRevokeRoles(req)
 	if err != nil {
-		return err
+		return fmt.Errorf("migrateRevoke: %w", err)
 	}
 	for _, req := range reqs {
 		if err := m.authZ.RevokeRolesForUser(req.User, req.Roles...); err != nil {

--- a/cluster/rbac/migration.go
+++ b/cluster/rbac/migration.go
@@ -237,16 +237,18 @@ func migrateRemoveRolesPermissionsV3(permissions []*authorization.Policy) []*aut
 	return permissions
 }
 
-func migrateRevokeRoles(req *cmd.RevokeRolesForUserRequest) []*cmd.RevokeRolesForUserRequest {
+func migrateRevokeRoles(req *cmd.RevokeRolesForUserRequest) ([]*cmd.RevokeRolesForUserRequest, error) {
 	if req.Version == cmd.RBACAssignRevokeCommandPolicyVersionV0 {
 		return migrateRevokeRolesV0(req)
 	}
-	return []*cmd.RevokeRolesForUserRequest{req}
+	return []*cmd.RevokeRolesForUserRequest{req}, nil
 }
 
-func migrateRevokeRolesV0(req *cmd.RevokeRolesForUserRequest) []*cmd.RevokeRolesForUserRequest {
-	user, _ := conv.GetUserAndPrefix(req.User)
-
+func migrateRevokeRolesV0(req *cmd.RevokeRolesForUserRequest) ([]*cmd.RevokeRolesForUserRequest, error) {
+	user, _, err := conv.GetUserAndPrefix(req.User)
+	if err != nil {
+		return nil, err
+	}
 	req1 := &cmd.RevokeRolesForUserRequest{
 		Version: req.Version + 1,
 		Roles:   req.Roles,
@@ -258,19 +260,21 @@ func migrateRevokeRolesV0(req *cmd.RevokeRolesForUserRequest) []*cmd.RevokeRoles
 		User:    conv.UserNameWithTypeFromId(user, models.UserTypeInputOidc),
 	}
 
-	return []*cmd.RevokeRolesForUserRequest{req1, req2}
+	return []*cmd.RevokeRolesForUserRequest{req1, req2}, nil
 }
 
-func migrateAssignRoles(req *cmd.AddRolesForUsersRequest, authNconfig config.Authentication) []*cmd.AddRolesForUsersRequest {
+func migrateAssignRoles(req *cmd.AddRolesForUsersRequest, authNconfig config.Authentication) ([]*cmd.AddRolesForUsersRequest, error) {
 	if req.Version == cmd.RBACAssignRevokeCommandPolicyVersionV0 {
 		return migrateAssignRolesV0(req, authNconfig)
 	}
-	return []*cmd.AddRolesForUsersRequest{req}
+	return []*cmd.AddRolesForUsersRequest{req}, nil
 }
 
-func migrateAssignRolesV0(req *cmd.AddRolesForUsersRequest, authNconfig config.Authentication) []*cmd.AddRolesForUsersRequest {
-	user, _ := conv.GetUserAndPrefix(req.User)
-
+func migrateAssignRolesV0(req *cmd.AddRolesForUsersRequest, authNconfig config.Authentication) ([]*cmd.AddRolesForUsersRequest, error) {
+	user, _, err := conv.GetUserAndPrefix(req.User)
+	if err != nil {
+		return nil, err
+	}
 	var reqs []*cmd.AddRolesForUsersRequest
 	if authNconfig.APIKey.Enabled && slices.Contains(authNconfig.APIKey.Users, user) {
 		reqs = append(reqs, &cmd.AddRolesForUsersRequest{
@@ -288,5 +292,5 @@ func migrateAssignRolesV0(req *cmd.AddRolesForUsersRequest, authNconfig config.A
 		})
 	}
 
-	return reqs
+	return reqs, nil
 }

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -445,7 +445,10 @@ func TrimRoleNamePrefix(name string) string {
 	return strings.TrimPrefix(name, ROLE_NAME_PREFIX)
 }
 
-func GetUserAndPrefix(name string) (string, string) {
+func GetUserAndPrefix(name string) (string, string, error) {
 	splits := strings.Split(name, PREFIX_SEPARATOR)
-	return splits[1], splits[0]
+	if len(splits) != 2 {
+		return "", "", fmt.Errorf("invalid name: %s", name)
+	}
+	return splits[1], splits[0], nil
 }

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -257,7 +257,10 @@ func (m *Manager) GetUsersForRole(roleName string, userType models.UserTypeInput
 	}
 	users := make([]string, 0, len(pusers))
 	for idx := range pusers {
-		user, prefix := conv.GetUserAndPrefix(pusers[idx])
+		user, prefix, err := conv.GetUserAndPrefix(pusers[idx])
+		if err != nil {
+			return nil, fmt.Errorf("GetUserAndPrefix: %w", err)
+		}
 		if user == conv.InternalPlaceHolder {
 			continue
 		}


### PR DESCRIPTION
### What's being changed:

Handle the case that the username a role is assigned to does not contain a prefix - this should never happen but it did in the wild

```
msg="Recovered from panic: runtime error: index out of range [1] with length 1" build_git_commit=2f77b4d build_go_version=go1.24.6 build_image_tag=v1.30.17 build_wv_version=1.30.17
goroutine 495 [running]:
runtime/debug.Stack()
	/usr/local/go/src/runtime/debug/stack.go:26 +0x5e
runtime/debug.PrintStack()
	/usr/local/go/src/runtime/debug/stack.go:18 +0x13
github.com/weaviate/weaviate/entities/errors.GoWrapper.func1.1()
	/go/src/github.com/weaviate/weaviate/entities/errors/go_wrapper.go:32 +0x14f
panic({0x2b64da0?, 0xc005196750?})
	/usr/local/go/src/runtime/panic.go:792 +0x132
github.com/weaviate/weaviate/usecases/auth/authorization/conv.GetUserAndPrefix(...)
	/go/src/github.com/weaviate/weaviate/usecases/auth/authorization/conv/casbin_types.go:450
github.com/weaviate/weaviate/cluster/rbac.migrateAssignRolesV0(0xc0034b0060, {{0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0}, ...})
	/go/src/github.com/weaviate/weaviate/cluster/rbac/migration.go:272 +0x427
github.com/weaviate/weaviate/cluster/rbac.migrateAssignRoles(...)
	/go/src/github.com/weaviate/weaviate/cluster/rbac/migration.go:266
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
