### PR TITLE
hnsw: prevent race between UpdateUserConfig and ShouldUpgrade

### DIFF
--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -111,9 +111,11 @@ func (h *hnsw) UpdateUserConfig(updated config.VectorIndexConfig, callback func(
 		return nil
 	}
 
+	h.compressActionLock.Lock()
 	h.pqConfig = parsed.PQ
 	h.sqConfig = parsed.SQ
 	h.bqConfig = parsed.BQ
+	h.compressActionLock.Unlock()
 	if asyncEnabled() {
 		callback()
 		return nil

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -794,6 +794,9 @@ func (h *hnsw) DistancerProvider() distancer.Provider {
 }
 
 func (h *hnsw) ShouldUpgrade() (bool, int) {
+	h.compressActionLock.RLock()
+	defer h.compressActionLock.RUnlock()
+
 	if h.sqConfig.Enabled {
 		return h.sqConfig.Enabled, h.sqConfig.TrainingLimit
 	}


### PR DESCRIPTION
### What's being changed:

This adds a simple lock to prevent a race between `UpdateUserConfig` and `ShouldUpgrade` when async indexing is enabled.

`ShouldUpgrade` is called periodically by the queue to determine if it needs to trigger compression. If a client calls `UpdateUserConfig` at that moment, a race can occur.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
