### PR TITLE
Requantize api should skip uncompressed vectors

### DIFF
--- a/adapters/repos/db/shard_async.go
+++ b/adapters/repos/db/shard_async.go
@@ -429,6 +429,11 @@ func (s *Shard) RequantizeIndex(ctx context.Context, targetVector string) error 
 		return nil
 	}
 
+	if !vectorIndex.Compressed() {
+		s.index.logger.WithField("targetVector", targetVector).WithField("action", "requantize").Info("vector index is not compressed, skipping requantizing")
+		return nil
+	}
+
 	normalize := false
 	if vectorIndex.DistancerProvider().Type() == "cosine-dot" {
 		normalize = true


### PR DESCRIPTION
### What's being changed:
- `RequantizeIndex` should terminate early if the vector is uncompressed

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
