### PR TITLE
chore: handle conflict when local object was deleted at the same time of the incoming update

### DIFF
--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -394,6 +394,19 @@ func (idx *Index) OverwriteObjects(ctx context.Context,
 		if currUpdateTime != u.StaleUpdateTime {
 
 			if currUpdateTime == u.LastUpdateTimeUnixMilli {
+				if locallyDeleted && !u.Deleted {
+					// local object was deleted at the same time as the incoming update
+					r := replica.RepairResponse{
+						ID:         id.String(),
+						Deleted:    locallyDeleted,
+						UpdateTime: currUpdateTime,
+						Err:        "conflict",
+					}
+
+					result = append(result, r)
+					continue
+				}
+
 				// local object was updated in the mean time, no need to do anything
 				continue
 			}


### PR DESCRIPTION
### What's being changed:

This pull request adds improved conflict handling to the replication logic in the `OverwriteObjects` method. Specifically, it addresses a scenario where a local object is deleted at the same time as an incoming update, ensuring that this conflict is detected and reported.

Conflict handling improvements:

* Added logic to detect and report a conflict when a local object is deleted at the same time as an incoming update, by appending a `RepairResponse` with an error message to the result. (`adapters/repos/db/replication.go`)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
