### PR TITLE
ensure localResults has enough space

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
@@ -316,6 +316,11 @@ func (cpi *parallelIterator[T]) cleanUpTempAllocs(localResults []VecAndID[T], lo
 	// order is important. To get the correct mapping we need to iterated:
 	// - localResults from the back
 	// - fittingLocalBuf from the front
+
+	// make sure we don't go out of bounds.
+	// Note: this assumes localResults has enough capacity
+	localResults = localResults[:len(localResults)+entriesToRecopy]
+
 	for i := 0; i < entriesToRecopy; i++ {
 		localResults[len(localResults)-i-1].Vec = fittingLocalBuf[:lengthOneVec]
 		fittingLocalBuf = fittingLocalBuf[lengthOneVec:]

--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
@@ -116,7 +116,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 			localResults = append(localResults, extract(k, v, &localBuf))
 			cpi.trackIndividual(len(localResults))
 		}
-		cpi.cleanUpTempAllocs(localResults, &localBuf)
+		localResults = cpi.cleanUpTempAllocs(localResults, &localBuf)
 
 		out <- localResults
 	}, cpi.logger)
@@ -149,7 +149,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 				localResults = append(localResults, extract(k, v, &localBuf))
 				cpi.trackIndividual(len(localResults))
 			}
-			cpi.cleanUpTempAllocs(localResults, &localBuf)
+			localResults = cpi.cleanUpTempAllocs(localResults, &localBuf)
 
 			out <- localResults
 		}, cpi.logger)
@@ -180,7 +180,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 			localResults = append(localResults, extract(k, v, &localBuf))
 			cpi.trackIndividual(len(localResults))
 		}
-		cpi.cleanUpTempAllocs(localResults, &localBuf)
+		localResults = cpi.cleanUpTempAllocs(localResults, &localBuf)
 
 		out <- localResults
 	}, cpi.logger)
@@ -290,10 +290,10 @@ type VecAndID[T uint64 | byte] struct {
 	Vec []T
 }
 
-func (cpi *parallelIterator[T]) cleanUpTempAllocs(localResults []VecAndID[T], localBuf *[]T) {
+func (cpi *parallelIterator[T]) cleanUpTempAllocs(localResults []VecAndID[T], localBuf *[]T) []VecAndID[T] {
 	usedSpaceInBuffer := cap(*localBuf) - len(*localBuf)
 	if len(localResults) == 0 || usedSpaceInBuffer == cap(*localBuf) {
-		return
+		return localResults
 	}
 
 	// We allocate localBuf in chunks of 1000 vectors to avoid allocations for every single vector we load, which is a
@@ -313,14 +313,16 @@ func (cpi *parallelIterator[T]) cleanUpTempAllocs(localResults []VecAndID[T], lo
 	*localBuf = (*localBuf)[:cap(*localBuf)]
 	copy(fittingLocalBuf, (*localBuf)[unusedLength:])
 
+	// make sure we don't go out of bounds.
+	if entriesToRecopy > cap(localResults) {
+		cp := make([]VecAndID[T], entriesToRecopy)
+		copy(cp, localResults)
+		localResults = cp
+	}
+
 	// order is important. To get the correct mapping we need to iterated:
 	// - localResults from the back
 	// - fittingLocalBuf from the front
-
-	// make sure we don't go out of bounds.
-	// Note: this assumes localResults has enough capacity
-	localResults = localResults[:len(localResults)+entriesToRecopy]
-
 	for i := 0; i < entriesToRecopy; i++ {
 		localResults[len(localResults)-i-1].Vec = fittingLocalBuf[:lengthOneVec]
 		fittingLocalBuf = fittingLocalBuf[lengthOneVec:]
@@ -328,4 +330,6 @@ func (cpi *parallelIterator[T]) cleanUpTempAllocs(localResults []VecAndID[T], lo
 
 	// explicitly tell GC that the old buffer can go away
 	*localBuf = nil
+
+	return localResults
 }


### PR DESCRIPTION
### What's being changed:

This fixes a panic where the number of entries to copy is larger than `localResults`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
