### PR TITLE
fix TestTotalDimensionTrackingMetrics race

### DIFF
--- a/adapters/repos/db/shard_dimension_tracking_test.go
+++ b/adapters/repos/db/shard_dimension_tracking_test.go
@@ -575,6 +575,8 @@ func TestTotalDimensionTrackingMetrics(t *testing.T) {
 			assertTotalMetrics(0, 0)
 			insertData()
 			assertTotalMetrics(tt.expectDimensions, tt.expectSegments)
+			err := db.GetIndex(schema.ClassName(class.Class)).drop()
+			require.NoError(t, err)
 			require.NoError(t, db.DeleteIndex(schema.ClassName(class.Class)))
 			assertTotalMetrics(0, 0)
 		})


### PR DESCRIPTION
### What's being changed:

This fixes a race `TestTotalDimensionTrackingMetrics` where were deleting an index without properly closing it.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
