### PR TITLE
Support for reading float32 vectors directly from parquet.

### DIFF
--- a/adapters/repos/db/vector/datasets/dataset.go
+++ b/adapters/repos/db/vector/datasets/dataset.go
@@ -12,12 +12,11 @@
 package datasets
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"io"
-	"math"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gomlx/go-huggingface/hub"
@@ -27,59 +26,112 @@ import (
 
 const defaultBatchSize = 1000
 
-func convertBinaryToFloat32(data []byte) ([]float32, error) {
-	if len(data)%4 != 0 {
-		return nil, fmt.Errorf("binary data length %d is not divisible by 4 (float32 size)", len(data))
-	}
-
-	result := make([]float32, len(data)/4)
-	for i := 0; i < len(result); i++ {
-		offset := i * 4
-		bits := binary.LittleEndian.Uint32(data[offset : offset+4])
-		result[i] = math.Float32frombits(bits)
-	}
-	return result, nil
-}
-
 type HubDataset struct {
-	repo      *hub.Repo
-	datasetID string
-	subset    string
-	logger    logrus.FieldLogger
+	repo    *hub.Repo
+	hubPath string // Path to dataset on the huggingface Hub, e.g. <user>/<dataset>
+	logger  logrus.FieldLogger
 }
 
-func NewHubDataset(datasetID string, subset string, logger logrus.FieldLogger) *HubDataset {
+func NewHubDataset(hubPath string, logger logrus.FieldLogger) *HubDataset {
 	hfAuthToken := os.Getenv("HF_TOKEN")
 	if hfAuthToken == "" {
 		logger.Warn("HF_TOKEN environment variable not set. Some datasets may require authentication.")
 	}
-	repo := hub.New(datasetID).
+	repo := hub.New(hubPath).
 		WithType(hub.RepoTypeDataset).
 		WithAuth(hfAuthToken)
 	return &HubDataset{
-		repo:      repo,
-		datasetID: datasetID,
-		subset:    subset,
-		logger:    logger,
+		repo:    repo,
+		hubPath: hubPath,
+		logger:  logger,
 	}
 }
 
 func (h *HubDataset) downloadParquetFile(name string) (string, error) {
-	filePath := fmt.Sprintf("%s/%s/%s.parquet", h.subset, name, name)
+	var downloadPath string
+	for fileName, err := range h.repo.IterFileNames() {
+		if err != nil {
+			h.logger.Errorf("Failed to list files in repo: %v", err)
+			return "", err
+		}
+		if strings.HasSuffix(fileName, name+".parquet") {
+			downloadPath = fileName
+		}
+	}
 
-	h.logger.Infof("Starting download of %s", filePath)
+	if downloadPath == "" {
+		return "", fmt.Errorf("failed to find file %s.parquet in repo", name)
+	}
+
+	h.logger.Infof("Starting download of %s", downloadPath)
 	startTime := time.Now()
 
-	localPath, err := h.repo.DownloadFile(filePath)
+	localPath, err := h.repo.DownloadFile(downloadPath)
 
 	duration := time.Since(startTime)
 	if err != nil {
-		h.logger.Errorf("Failed to download %s after %v: %v", filePath, duration, err)
+		h.logger.Errorf("Failed to download %s after %v: %v", downloadPath, duration, err)
 		return "", err
 	}
 
-	h.logger.Infof("Successfully downloaded %s in %v", filePath, duration)
+	h.logger.Infof("Successfully downloaded %s in %v", downloadPath, duration)
 	return localPath, nil
+}
+
+// TODO: Clean up this abstraction..
+type ParquetFile struct {
+	localPath     string
+	file          *os.File
+	parquetFile   *parquet.File
+	columnIndices map[string]int
+	numRows       int
+}
+
+func (p *ParquetFile) Close() {
+	p.file.Close()
+}
+
+func (h *HubDataset) downloadAndOpenParquetFile(name string) (*ParquetFile, error) {
+	localFile, err := h.downloadParquetFile(name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to download file %s: %w", localFile, err)
+	}
+	// Open the parquet file
+	file, err := os.Open(localFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open file %s: %w", localFile, err)
+	}
+	shouldClose := true
+	defer func() {
+		if shouldClose {
+			file.Close()
+		}
+	}()
+
+	// Get file size
+	fileInfo, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get file info for %s: %w", localFile, err)
+	}
+	fileSize := fileInfo.Size()
+
+	// Open as parquet file with optimizations
+	pqFile, err := parquet.OpenFile(file, fileSize,
+		parquet.SkipPageIndex(true),
+		parquet.SkipBloomFilters(true),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open parquet file %s: %w", localFile, err)
+	}
+	shouldClose = false
+	columnIndices, numRows := h.parquetMetadata(pqFile)
+	return &ParquetFile{
+		localPath:     localFile,
+		file:          file,
+		parquetFile:   pqFile,
+		columnIndices: columnIndices,
+		numRows:       numRows,
+	}, nil
 }
 
 func (h *HubDataset) parquetMetadata(pqFile *parquet.File) (map[string]int, int) {
@@ -107,237 +159,123 @@ func (h *HubDataset) validateColumns(columnIndices map[string]int, requiredColum
 	return nil
 }
 
-func (h *HubDataset) LoadTrainingData() (ids []uint64, vectors [][]float32, err error) {
-	localFile, err := h.downloadParquetFile("train")
+func (h *HubDataset) LoadTrainData() (ids []uint64, vectors [][]float32, err error) {
+	file, err := h.downloadAndOpenParquetFile("train")
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to download file %s: %w", localFile, err)
-	}
-	// Open the parquet file
-	file, err := os.Open(localFile)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open file %s: %w", localFile, err)
+		return nil, nil, err
 	}
 	defer file.Close()
 
-	// Get file size
-	fileInfo, err := file.Stat()
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get file info for %s: %w", localFile, err)
-	}
-	fileSize := fileInfo.Size()
-
-	// Open as parquet file with optimizations
-	pqFile, err := parquet.OpenFile(file, fileSize,
-		parquet.SkipPageIndex(true),
-		parquet.SkipBloomFilters(true),
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open parquet file %s: %w", localFile, err)
-	}
-
-	columnIndices, numRows := h.parquetMetadata(pqFile)
-
 	// Validate required columns exist
-	if err := h.validateColumns(columnIndices, "embedding", "id"); err != nil {
+	if err := h.validateColumns(file.columnIndices, "id", "embedding"); err != nil {
 		return nil, nil, err
 	}
 
-	// Create reader for the parquet file
-	reader := parquet.NewReader(pqFile)
-	defer reader.Close()
+	embeddingColIdx := file.columnIndices["embedding"]
+	idColIdx := file.columnIndices["id"]
 
-	vectors = make([][]float32, 0, numRows)
-	ids = make([]uint64, 0, numRows)
+	ids = make([]uint64, 0, file.numRows)
+	vectorBuilder := NewVectorBuilderFloat32(file.numRows)
 
-	embeddingColIndex := columnIndices["embedding"]
-	idColIndex := columnIndices["id"]
-
-	batchSize := defaultBatchSize
-	totalRead := 0
-
-	// Allocate rows slice once outside the loop
-	rows := make([]parquet.Row, batchSize)
-
-	for totalRead < numRows {
-		remaining := numRows - totalRead
-		currentBatchSize := batchSize
-		if remaining < batchSize {
-			currentBatchSize = remaining
-		}
-		n, err := reader.ReadRows(rows[:currentBatchSize])
-		if err != nil && !errors.Is(err, io.EOF) {
-			return nil, nil, fmt.Errorf("failed to read rows: %w", err)
-		}
-
-		if n == 0 {
-			break
-		}
-
-		// Process batch using Row.Range for proper column handling
-		for i := 0; i < n; i++ {
-			row := rows[i]
-
-			// Use Row.Range to properly handle columns
-			row.Range(func(columnIndex int, columnValues []parquet.Value) bool {
-				switch columnIndex {
-				case idColIndex:
-					// Extract ID
-					if len(columnValues) > 0 && columnValues[0].Kind() == parquet.Int64 {
-						ids = append(ids, uint64(columnValues[0].Int64()))
-					}
-				case embeddingColIndex:
-					// Extract embedding
-					if len(columnValues) > 0 {
-						binaryData := columnValues[0].ByteArray()
-						if len(binaryData) > 0 {
-							convertedVector, err := convertBinaryToFloat32(binaryData)
-							if err != nil {
-								return false // Stop processing on error
-							}
-							vectors = append(vectors, convertedVector)
+	const defaultValueBufferSize = 1024
+	buffer := make([]parquet.Value, defaultValueBufferSize)
+	for _, rowGroup := range file.parquetFile.RowGroups() {
+		for _, columnChunk := range rowGroup.ColumnChunks() {
+			colIdx := columnChunk.Column()
+			if colIdx != idColIdx && colIdx != embeddingColIdx {
+				continue
+			}
+			valueReader := parquet.NewColumnChunkValueReader(columnChunk)
+			defer valueReader.Close()
+			for {
+				n, err := valueReader.ReadValues(buffer)
+				if err != nil && !errors.Is(err, io.EOF) {
+					return nil, nil, fmt.Errorf("failed to read rows: %w", err)
+				}
+				if n > 0 {
+					switch colIdx {
+					case idColIdx:
+						for i := range n {
+							ids = append(ids, uint64(buffer[i].Int64()))
+						}
+					case embeddingColIdx:
+						for i := range n {
+							vectorBuilder.Add(buffer[i])
 						}
 					}
 				}
-				return true // Continue processing
-			})
-		}
-
-		totalRead += n
-
-		if totalRead%10000 == 0 {
-			h.logger.Debugf("Processed %d rows", totalRead)
-		}
-
-		// Break if we got EOF or read fewer rows than expected
-		if err != nil && errors.Is(err, io.EOF) {
-			break
+				if errors.Is(err, io.EOF) {
+					break
+				}
+			}
 		}
 	}
 
-	h.logger.Infof("Loaded %d vectors", len(vectors))
-
-	if len(vectors) == 0 {
-		return nil, nil, fmt.Errorf("no vectors loaded - check parquet schema and data")
+	// Returns an error if we did not produce numRows vectors of the same length
+	vectors, err = vectorBuilder.AllVectors()
+	if err != nil {
+		return nil, nil, err
 	}
-
+	if len(ids) != file.numRows {
+		return nil, nil, fmt.Errorf("read %d ids from parquet file, expected %d", len(ids), file.numRows)
+	}
 	return ids, vectors, nil
 }
 
 func (h *HubDataset) LoadTestData() (neighbors [][]uint64, vectors [][]float32, err error) {
-	localFile, err := h.downloadParquetFile("test")
+	file, err := h.downloadAndOpenParquetFile("test")
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to download file %s: %w", localFile, err)
-	}
-	// Open the parquet file
-	file, err := os.Open(localFile)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open file %s: %w", localFile, err)
+		return nil, nil, err
 	}
 	defer file.Close()
 
-	// Get file size
-	fileInfo, err := file.Stat()
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get file info for %s: %w", localFile, err)
-	}
-	fileSize := fileInfo.Size()
-
-	// Open as parquet file with optimizations
-	pqFile, err := parquet.OpenFile(file, fileSize,
-		parquet.SkipPageIndex(true),
-		parquet.SkipBloomFilters(true),
-	)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to open parquet file %s: %w", localFile, err)
-	}
-
-	columnIndices, numRows := h.parquetMetadata(pqFile)
-
 	// Validate required columns exist
-	if err := h.validateColumns(columnIndices, "embedding", "neighbors"); err != nil {
+	if err := h.validateColumns(file.columnIndices, "embedding", "neighbors"); err != nil {
 		return nil, nil, err
 	}
 
 	// Create reader for the parquet file
-	reader := parquet.NewReader(pqFile)
+	reader := parquet.NewReader(file.parquetFile)
 	defer reader.Close()
 
-	vectors = make([][]float32, 0, numRows)
-	neighbors = make([][]uint64, 0, numRows)
+	vectors = make([][]float32, 0, file.numRows)
+	neighbors = make([][]uint64, 0, file.numRows)
 
-	embeddingColIndex := columnIndices["embedding"]
-	neighborsColIndex := columnIndices["neighbors"]
+	embeddingColIndex := file.columnIndices["embedding"]
+	neighborsColIndex := file.columnIndices["neighbors"]
 
-	batchSize := defaultBatchSize
-	totalRead := 0
-
-	// Allocate rows slice once outside the loop
-	rows := make([]parquet.Row, batchSize)
-
-	for totalRead < numRows {
-		remaining := numRows - totalRead
-		currentBatchSize := batchSize
-		if remaining < batchSize {
-			currentBatchSize = remaining
-		}
-
-		n, err := reader.ReadRows(rows[:currentBatchSize])
+	rows := make([]parquet.Row, defaultBatchSize)
+	for {
+		n, err := reader.ReadRows(rows)
 		if err != nil && !errors.Is(err, io.EOF) {
 			return nil, nil, fmt.Errorf("failed to read rows: %w", err)
 		}
-
-		if n == 0 {
-			break
-		}
-
-		// Process batch using Row.Range for proper column handling
 		for i := 0; i < n; i++ {
 			row := rows[i]
-			var currentNeighbors []uint64
-
-			// Use Row.Range to properly handle columns
 			row.Range(func(columnIndex int, columnValues []parquet.Value) bool {
 				switch columnIndex {
 				case embeddingColIndex:
 					// Extract embedding
-					if len(columnValues) > 0 {
-						binaryData := columnValues[0].ByteArray()
-						if len(binaryData) > 0 {
-							convertedVector, err := convertBinaryToFloat32(binaryData)
-							if err != nil {
-								return false // Stop processing on error
-							}
-							vectors = append(vectors, convertedVector)
-						}
+					vector := make([]float32, len(columnValues))
+					for j, value := range columnValues {
+						vector[j] = value.Float()
 					}
+					vectors = append(vectors, vector)
 				case neighborsColIndex:
 					// Extract all neighbor values for this row
+					var currentNeighbors []uint64
 					for _, value := range columnValues {
-						if value.Kind() == parquet.Int64 {
-							currentNeighbors = append(currentNeighbors, uint64(value.Int64()))
-						}
+						currentNeighbors = append(currentNeighbors, uint64(value.Int64()))
 					}
+					neighbors = append(neighbors, currentNeighbors)
 				}
 				return true // Continue processing
 			})
-
-			// Add the neighbors for this row
-			neighbors = append(neighbors, currentNeighbors)
 		}
-
-		totalRead += n
-
-		if totalRead%10000 == 0 {
-			h.logger.Debugf("Processed %d rows", totalRead)
-		}
-
-		// Break if we got EOF or read fewer rows than expected
-		if err != nil && errors.Is(err, io.EOF) {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 	}
-
-	h.logger.Infof("Loaded %d vectors", len(vectors))
 
 	if len(vectors) == 0 {
 		return nil, nil, fmt.Errorf("no vectors loaded - check parquet schema and data")

--- a/adapters/repos/db/vector/datasets/dataset_test.go
+++ b/adapters/repos/db/vector/datasets/dataset_test.go
@@ -10,116 +10,92 @@
 //
 
 //go:build benchmark
-// +build benchmark
 
 package datasets
 
 import (
-	"math"
 	"testing"
 
 	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
 )
 
-func TestLoadDataset(t *testing.T) {
+func TestLoadTrainData(t *testing.T) {
 	logger := logrus.New()
-	hf := NewHubDataset("trengrj/ann-datasets", "dbpedia-openai-100k", logger)
-
-	// Load training data
-	t.Log("Loading training data...")
-	ids, vectors, err := hf.LoadTrainingData()
+	logger.SetLevel(logrus.DebugLevel)
+	hf := NewHubDataset("tobias-weaviate/fiqa_gemma300m_d768_cosine", logger)
+	ids, vectors, err := hf.LoadTrainData()
 	if err != nil {
 		t.Fatalf("Failed to load training data: %v", err)
 	}
 
-	// Assert training data structure
-	if len(vectors) == 0 {
-		t.Fatal("Expected non-zero number of training vectors")
-	}
-	if len(ids) != len(vectors) {
-		t.Fatalf("Expected equal number of IDs (%d) and vectors (%d)", len(ids), len(vectors))
-	}
-	if len(vectors) < 100000 {
-		t.Errorf("Expected at least 100,000 training vectors, got %d", len(vectors))
+	n := 54351
+	d := 768
+	assert.Equal(t, len(ids), n)
+	assert.Equal(t, len(vectors), n)
+	assert.Equal(t, len(vectors[0]), d)
+	for i := range n {
+		assert.Equal(t, ids[i], uint64(i))
 	}
 
-	t.Logf("Loaded %d training vectors", len(vectors))
-
-	// Assert first training vector structure and values
-	if len(vectors) >= 1 {
-		vector1 := vectors[0]
-		if len(vector1) == 0 {
-			t.Fatal("Expected non-zero vector dimensions")
-		}
-
-		// Check first 5 dimensions match expected values (with tolerance for floating point)
-		expectedDims1 := []float32{-0.013902083, 0.016943572, 0.013771547, -0.0066899695, -0.026394377}
-		if len(vector1) >= 5 {
-			for i, expected := range expectedDims1 {
-				if math.Abs(float64(vector1[i]-expected)) > 1e-6 {
-					t.Errorf("Training vector 1 dimension %d: expected %f, got %f", i, expected, vector1[i])
-				}
-			}
-			t.Logf("Training vector 1 (ID: %d) first 5 dimensions: %v", ids[0], vector1[:5])
-		}
+	expectedValues := []float32{-0.0458683, -0.022633573, -0.023361705, 0.08714058}
+	actualValues := vectors[8763][634:638]
+	for i := range expectedValues {
+		assert.Equal(t, expectedValues[i], actualValues[i])
 	}
+}
 
-	// Load test data
-	t.Log("Loading test data...")
-	neighbors, testVectors, err := hf.LoadTestData()
+func TestLoadTestData(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+	hf := NewHubDataset("tobias-weaviate/fiqa_gemma300m_d768_cosine", logger)
+	neighbors, vectors, err := hf.LoadTestData()
 	if err != nil {
 		t.Fatalf("Failed to load test data: %v", err)
 	}
 
-	// Assert test data structure
-	if len(testVectors) == 0 {
-		t.Fatal("Expected non-zero number of test vectors")
-	}
-	if len(neighbors) != len(testVectors) {
-		t.Fatalf("Expected equal number of neighbors (%d) and test vectors (%d)", len(neighbors), len(testVectors))
-	}
-	if len(testVectors) < 900 {
-		t.Errorf("Expected at least 900 test vectors, got %d", len(testVectors))
+	n := 6640
+	assert.Equal(t, len(neighbors), n)
+	assert.Equal(t, len(vectors), n)
+
+	d := 768
+	for _, v := range vectors {
+		assert.Equal(t, d, len(v))
 	}
 
-	t.Logf("Loaded %d test vectors and %d neighbor lists", len(testVectors), len(neighbors))
+	// Verify that the neighbors are right in a sample location.
+	expectedValues := []uint64{11196, 24739, 44342}
+	actualValues := neighbors[3116][34:37]
+	for i := range expectedValues {
+		assert.Equal(t, expectedValues[i], actualValues[i])
+	}
 
-	// Assert first test vector structure and values
-	if len(testVectors) >= 1 {
-		testVector1 := testVectors[0]
-		if len(testVector1) == 0 {
-			t.Fatal("Expected non-zero test vector dimensions")
+	// Verify that vectors are correct in a sample location
+	assert.Equal(t, float32(-0.1131085529923439), vectors[5001][0])
+	assert.Equal(t, float32(-0.02702171355485916), vectors[5001][767])
+}
+
+func BenchmarkLoadData(b *testing.B) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.FatalLevel)
+	hf := NewHubDataset("tobias-weaviate/fiqa_gemma300m_d768_cosine", logger)
+	// Warmup runs to ensure that the data is downloaded.
+	ids, vectors, _ := hf.LoadTrainData()
+	n, d := len(ids), len(vectors[0])
+	numFloats := n * d
+
+	b.Run("Train", func(b *testing.B) {
+		for b.Loop() {
+			hf.LoadTrainData()
 		}
+		b.ReportMetric(float64(b.Elapsed().Milliseconds())/float64(b.N), "ms/op")
+		b.ReportMetric(float64(b.Elapsed().Nanoseconds())/float64(b.N*numFloats), "ns/float")
+	})
 
-		// Check first 5 dimensions match expected values
-		expectedTestDims1 := []float32{-0.027109032, -0.019073945, 0.016458161, -0.023066457, -0.0012101129}
-		if len(testVector1) >= 5 {
-			for i, expected := range expectedTestDims1 {
-				if math.Abs(float64(testVector1[i]-expected)) > 1e-6 {
-					t.Errorf("Test vector 1 dimension %d: expected %f, got %f", i, expected, testVector1[i])
-				}
-			}
-			t.Logf("Test vector 1 first 5 dimensions: %v", testVector1[:5])
+	b.Run("Test", func(b *testing.B) {
+		for b.Loop() {
+			hf.LoadTestData()
 		}
-
-		// Assert neighbors structure
-		if len(neighbors) > 0 {
-			neighbors1 := neighbors[0]
-			if len(neighbors1) == 0 {
-				t.Fatal("Expected non-zero number of neighbors")
-			}
-			if len(neighbors1) < 100 {
-				t.Errorf("Expected at least 100 neighbors, got %d", len(neighbors1))
-			}
-
-			// Check that neighbors are valid IDs (within training set range)
-			for _, neighborID := range neighbors1 {
-				if neighborID >= uint64(len(vectors)) {
-					t.Errorf("Invalid neighbor ID: %d (should be 0-%d)", neighborID, len(vectors)-1)
-				}
-			}
-
-			t.Logf("Test vector 1 neighbors count: %d", len(neighbors1))
-		}
-	}
+		b.ReportMetric(float64(b.Elapsed().Milliseconds())/float64(b.N), "ms/op")
+	})
 }

--- a/adapters/repos/db/vector/datasets/vectorbuilder.go
+++ b/adapters/repos/db/vector/datasets/vectorbuilder.go
@@ -1,0 +1,56 @@
+package datasets
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/parquet-go/parquet-go"
+)
+
+type VectorBuilderFloat32 struct {
+	vectors [][]float32
+	n       int // Number of vectors
+	d       int // Dimensionality of vectors to insert, updated after first insertion
+	i       int // Index into the vector collection of the current vector under construction
+	j       int // Index where to add the next value into the vector being constructed
+}
+
+func NewVectorBuilderFloat32(n int) *VectorBuilderFloat32 {
+	const maxDimension = (1 << 16) - 1 // Weaviates max dimensionality is 65535
+	return &VectorBuilderFloat32{
+		vectors: make([][]float32, 0, n),
+		n:       n,
+		d:       maxDimension,
+	}
+}
+
+func (vb *VectorBuilderFloat32) Add(value parquet.Value) {
+	// Values arrive in sequence. A value with a repetition level of zero
+	// indicates that the value is the first entry in a new list.
+	if value.RepetitionLevel() == 0 {
+		// Learn the dimensionality from the first vector
+		if len(vb.vectors) == 1 {
+			vb.d = vb.j
+			vb.vectors[0] = slices.Clip(vb.vectors[0][:vb.d])
+		}
+		vb.vectors = append(vb.vectors, make([]float32, vb.d))
+		vb.i = len(vb.vectors) - 1
+		vb.j = 0
+	}
+	vb.vectors[vb.i][vb.j] = value.Float()
+	vb.j++
+}
+
+func (vb *VectorBuilderFloat32) AllVectors() ([][]float32, error) {
+	if len(vb.vectors) != vb.n {
+		return nil, fmt.Errorf("expected %d vectors, but only %d were constructed", vb.n, len(vb.vectors))
+	}
+	// This check has already been carried out when we added values, except for
+	// the last vector. We do the full check here to keep the code explicit.
+	for i, v := range vb.vectors {
+		if len(v) != vb.d {
+			return nil, fmt.Errorf("the length of the vector at index %d was %d, expected %d", i, len(v), vb.d)
+		}
+	}
+	return vb.vectors, nil
+}


### PR DESCRIPTION
This patch modifies how the training data vectors are read. Instead of casting byte arrays we read the parquet values stored in the list representation from the parquet column and use the repetition level to build our collection of vectors. Currently we only support float32 vectors but this approach can be extended to other Parquet by reading their value from the parquet.

It seems that this is slightly less performant than casting byte arrays. This patch includes a benchmark that shows that reading ~54K 768-dim vectors takes approximately 275ms. The benefits of this format is that it makes the datasets integrate well with the huggingface ecosystem. I.e. datasets can be downloaded, processed, uploaded, and viewed online without any special knowledge about the encoding.

In the (relatively small) benchmark we use ~6.6 nanoseconds per float32 value when reading training data. If we interpolate to 1536-dimensional vectors we can read approximately 100K vectors per second. This is at least an order of magnitude faster than our indexing time, so this overhead should be tolerable.

In this iteration we load the train dataset by searching for a file named train.parquet in the huggingface repo and downloading it, and similarly for the test datast. This currently means we have one dataset per repo, and one file per configuration/split. We may need to update this to e.g. support sharding or multiple splits, but it is easier to see the best structure once we have produced more datasets.

### What's being changed:


### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: Not necessary.
- [x] Chaos pipeline run or not necessary. Link to pipeline: Not necessary, isolated feature.
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
