### PR TITLE
ci(test): lower the tracking dimensions interval to 3 minutes

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -31,6 +31,7 @@ services:
       ASYNC_INDEXING: ${ASYNC_INDEXING:-false}
       DISABLE_TELEMETRY: "true"
       DISABLE_RECOVERY_ON_PANIC: "true"
+      TRACK_VECTOR_DIMENSIONS_INTERVAL: "3m"
       QUERY_MAXIMUM_RESULTS: 10005
 
       # necessary for the metrics tests, some metrics only exist once segments


### PR DESCRIPTION
### What's being changed:

It's a fix for `metricsCount` test, that is counting the number of the exposed metrics. Flakiness came from the fact the the tracking dimensions interval was triggered during this test resulting in extra metrics connected with `MapCollection` bucket which is the default bucket for tracking dimensions.

```
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="0.01"} 34
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="0.02"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="0.04"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="0.08"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="0.16"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="0.32"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="0.64"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="1.28"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="2.56"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="5.12"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="10.24"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="20.48"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="40.96"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="81.92"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="163.84"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="327.68"} 35
weaviate_lsm_bucket_cursor_duration_seconds_bucket{strategy="mapcollection",le="+Inf"} 35
weaviate_lsm_bucket_cursor_duration_seconds_sum{strategy="mapcollection"} 0.15500750400000005
weaviate_lsm_bucket_cursor_duration_seconds_count{strategy="mapcollection"} 35
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
