### PR TITLE
chore: change parallel iterator warning logs to debug

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
@@ -109,7 +109,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 					"action": "hnsw_compressed_vector_cache_prefill",
 					"len":    len(v),
 					"lenk":   len(k),
-				}).Warn("skipping compressed vector with unexpected length")
+				}).Debug("skipping compressed vector with unexpected length")
 				continue
 			}
 			if cpi.loadId(k) > (1 << 15) {
@@ -117,7 +117,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 					"action": "hnsw_compressed_vector_cache_prefill",
 					"len":    len(v),
 					"lenk":   len(k),
-				}).Warn("skipping compressed vector with unexpected key endianness")
+				}).Debug("skipping compressed vector with unexpected key endianness")
 				continue
 			}
 
@@ -151,7 +151,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 						"action": "hnsw_compressed_vector_cache_prefill",
 						"len":    len(v),
 						"lenk":   len(k),
-					}).Warn("skipping compressed vector with unexpected length")
+					}).Debug("skipping compressed vector with unexpected length")
 					continue
 				}
 				if cpi.loadId(k) > (1 << 15) {
@@ -159,7 +159,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 						"action": "hnsw_compressed_vector_cache_prefill",
 						"len":    len(v),
 						"lenk":   len(k),
-					}).Warn("skipping compressed vector with unexpected key endianness")
+					}).Debug("skipping compressed vector with unexpected key endianness")
 					continue
 				}
 
@@ -190,7 +190,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 					"action": "hnsw_compressed_vector_cache_prefill",
 					"len":    len(v),
 					"lenk":   len(k),
-				}).Warn("skipping compressed vector with unexpected length")
+				}).Debug("skipping compressed vector with unexpected length")
 				continue
 			}
 			if cpi.loadId(k) > (1 << 15) {
@@ -198,7 +198,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 					"action": "hnsw_compressed_vector_cache_prefill",
 					"len":    len(v),
 					"lenk":   len(k),
-				}).Warn("skipping compressed vector with unexpected key endianness")
+				}).Debug("skipping compressed vector with unexpected key endianness")
 				continue
 			}
 
@@ -239,7 +239,7 @@ func (cpi *parallelIterator[T]) iterateAllNoConcurrency() chan []VecAndID[T] {
 					"action": "hnsw_compressed_vector_cache_prefill",
 					"len":    len(v),
 					"lenk":   len(k),
-				}).Warn("skipping compressed vector with unexpected length")
+				}).Debug("skipping compressed vector with unexpected length")
 				continue
 			}
 			id := cpi.loadId(k)


### PR DESCRIPTION
### What's being changed:

Change parallel iterator warning logs to debug.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
