### PR TITLE
feat: add output dimensions support for VoyageAI

### DIFF
--- a/modules/multi2vec-voyageai/clients/voyageai.go
+++ b/modules/multi2vec-voyageai/clients/voyageai.go
@@ -57,10 +57,11 @@ func (v *vectorizer) Vectorize(ctx context.Context,
 ) (*modulecomponents.VectorizationCLIPResult[[]float32], error) {
 	settings := ent.NewClassSettings(cfg)
 	return v.client.VectorizeMultiModal(ctx, texts, images, voyageai.Settings{
-		BaseURL:   settings.BaseURL(),
-		Model:     settings.Model(),
-		Truncate:  settings.Truncate(),
-		InputType: voyageai.Document,
+		BaseURL:         settings.BaseURL(),
+		Model:           settings.Model(),
+		Truncate:        settings.Truncate(),
+		InputType:       voyageai.Document,
+		OutputDimension: settings.Dimensions(),
 	})
 }
 
@@ -69,10 +70,11 @@ func (v *vectorizer) VectorizeQuery(ctx context.Context,
 ) (*modulecomponents.VectorizationCLIPResult[[]float32], error) {
 	settings := ent.NewClassSettings(cfg)
 	return v.client.VectorizeMultiModal(ctx, input, nil, voyageai.Settings{
-		BaseURL:   settings.BaseURL(),
-		Model:     settings.Model(),
-		Truncate:  settings.Truncate(),
-		InputType: voyageai.Query,
+		BaseURL:         settings.BaseURL(),
+		Model:           settings.Model(),
+		Truncate:        settings.Truncate(),
+		InputType:       voyageai.Query,
+		OutputDimension: settings.Dimensions(),
 	})
 }
 
@@ -81,9 +83,10 @@ func (v *vectorizer) VectorizeImageQuery(ctx context.Context,
 ) (*modulecomponents.VectorizationCLIPResult[[]float32], error) {
 	settings := ent.NewClassSettings(cfg)
 	return v.client.VectorizeMultiModal(ctx, nil, images, voyageai.Settings{
-		BaseURL:   settings.BaseURL(),
-		Model:     settings.Model(),
-		Truncate:  settings.Truncate(),
-		InputType: voyageai.Query,
+		BaseURL:         settings.BaseURL(),
+		Model:           settings.Model(),
+		Truncate:        settings.Truncate(),
+		InputType:       voyageai.Query,
+		OutputDimension: settings.Dimensions(),
 	})
 }

--- a/modules/multi2vec-voyageai/ent/class_settings.go
+++ b/modules/multi2vec-voyageai/ent/class_settings.go
@@ -27,6 +27,10 @@ const (
 	truncateProperty = "truncate"
 )
 
+var availableVoyageModelsWithDimensions = []string{
+	"voyage-multimodal-3",
+}
+
 const (
 	DefaultBaseURL               = "https://api.voyageai.com/v1"
 	DefaultVoyageAIModel         = "voyage-multimodal-3"
@@ -173,6 +177,11 @@ func (ic *classSettings) Validate() error {
 		if err != nil {
 			errorMessages = append(errorMessages, err.Error())
 		}
+	}
+
+	// Validate dimensions if set
+	if err := basesettings.ValidateDimensions(ic.base.Dimensions(), ic.Model(), basesettings.AvailableVoyageDimensions, availableVoyageModelsWithDimensions); err != nil {
+		errorMessages = append(errorMessages, err.Error())
 	}
 
 	if len(errorMessages) > 0 {

--- a/modules/multi2vec-voyageai/ent/class_settings.go
+++ b/modules/multi2vec-voyageai/ent/class_settings.go
@@ -65,6 +65,10 @@ func (cs *classSettings) BaseURL() string {
 	return cs.base.GetPropertyAsString(baseURLProperty, DefaultBaseURL)
 }
 
+func (cs *classSettings) Dimensions() *int64 {
+	return cs.base.Dimensions()
+}
+
 // CLIP module specific settings
 func (ic *classSettings) ImageField(property string) bool {
 	return ic.field("imageFields", property)

--- a/modules/text2vec-voyageai/clients/voyageai.go
+++ b/modules/text2vec-voyageai/clients/voyageai.go
@@ -73,9 +73,10 @@ func (v *vectorizer) Vectorize(ctx context.Context, input []string, cfg moduleto
 ) (*modulecomponents.VectorizationResult[[]float32], *modulecomponents.RateLimits, int, error) {
 	settings := ent.NewClassSettings(cfg)
 	return v.client.Vectorize(ctx, input, voyageai.Settings{
-		BaseURL:  settings.BaseURL(),
-		Model:    settings.Model(),
-		Truncate: settings.Truncate(),
+		BaseURL:         settings.BaseURL(),
+		Model:           settings.Model(),
+		Truncate:        settings.Truncate(),
+		OutputDimension: settings.Dimensions(),
 	})
 }
 
@@ -84,9 +85,10 @@ func (v *vectorizer) VectorizeQuery(ctx context.Context, input []string,
 ) (*modulecomponents.VectorizationResult[[]float32], error) {
 	settings := ent.NewClassSettings(cfg)
 	return v.client.VectorizeQuery(ctx, input, voyageai.Settings{
-		BaseURL:  settings.BaseURL(),
-		Model:    settings.Model(),
-		Truncate: settings.Truncate(),
+		BaseURL:         settings.BaseURL(),
+		Model:           settings.Model(),
+		Truncate:        settings.Truncate(),
+		OutputDimension: settings.Dimensions(),
 	})
 }
 

--- a/modules/text2vec-voyageai/ent/class_settings.go
+++ b/modules/text2vec-voyageai/ent/class_settings.go
@@ -29,6 +29,10 @@ const (
 	LowerCaseInput               = false
 )
 
+var availableVoyageModelsWithDimensions = []string{
+	"voyage-3", "voyage-3-large", "voyage-3.5", "voyage-3.5-lite", "voyage-code-3",
+}
+
 type classSettings struct {
 	basesettings.BaseClassSettings
 	cfg moduletools.ClassConfig
@@ -54,5 +58,11 @@ func (cs classSettings) Validate(class *models.Class) error {
 	if err := cs.BaseClassSettings.Validate(class); err != nil {
 		return err
 	}
+
+	// Validate dimensions if set
+	if err := basesettings.ValidateDimensions(cs.BaseClassSettings.Dimensions(), cs.Model(), basesettings.AvailableVoyageDimensions, availableVoyageModelsWithDimensions); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/usecases/modulecomponents/clients/voyageai/voyageai.go
+++ b/usecases/modulecomponents/clients/voyageai/voyageai.go
@@ -48,11 +48,12 @@ type multimodalContent struct {
 }
 
 type embeddingsRequest struct {
-	Input      []string          `json:"input,omitempty"`
-	Inputs     []multimodalInput `json:"inputs,omitempty"`
-	Model      string            `json:"model"`
-	Truncation bool              `json:"truncation,omitempty"`
-	InputType  InputType         `json:"input_type,omitempty"`
+	Input           []string          `json:"input,omitempty"`
+	Inputs          []multimodalInput `json:"inputs,omitempty"`
+	Model           string            `json:"model"`
+	Truncation      bool              `json:"truncation,omitempty"`
+	InputType       InputType         `json:"input_type,omitempty"`
+	OutputDimension *int64            `json:"output_dimension,omitempty"`
 }
 
 type embeddingsDataResponse struct {
@@ -85,10 +86,11 @@ const (
 )
 
 type Settings struct {
-	BaseURL   string
-	Model     string
-	Truncate  bool
-	InputType InputType
+	BaseURL         string
+	Model           string
+	Truncate        bool
+	InputType       InputType
+	OutputDimension *int64
 }
 
 type VoyageRLModel struct {
@@ -110,10 +112,11 @@ func New(apiKey string, timeout time.Duration, urlBuilder UrlBuilder, logger log
 func (c *Client) Vectorize(ctx context.Context, input []string, settings Settings,
 ) (*modulecomponents.VectorizationResult[[]float32], *modulecomponents.RateLimits, int, error) {
 	resBody, err := c.vectorize(ctx, settings.BaseURL, embeddingsRequest{
-		Input:      input,
-		Model:      settings.Model,
-		Truncation: settings.Truncate,
-		InputType:  Document,
+		Input:           input,
+		Model:           settings.Model,
+		Truncation:      settings.Truncate,
+		InputType:       Document,
+		OutputDimension: settings.OutputDimension,
 	})
 	if err != nil {
 		return nil, nil, 0, err
@@ -125,10 +128,11 @@ func (c *Client) Vectorize(ctx context.Context, input []string, settings Setting
 func (c *Client) VectorizeQuery(ctx context.Context, input []string, settings Settings,
 ) (*modulecomponents.VectorizationResult[[]float32], error) {
 	resBody, err := c.vectorize(ctx, settings.BaseURL, embeddingsRequest{
-		Input:      input,
-		Model:      settings.Model,
-		Truncation: settings.Truncate,
-		InputType:  Query,
+		Input:           input,
+		Model:           settings.Model,
+		Truncation:      settings.Truncate,
+		InputType:       Query,
+		OutputDimension: settings.OutputDimension,
 	})
 	if err != nil {
 		return nil, err
@@ -177,10 +181,11 @@ func (c *Client) getMultiModalEmbeddingsRequest(texts, images []string, settings
 		}
 	}
 	return embeddingsRequest{
-		Inputs:     inputs,
-		Model:      settings.Model,
-		Truncation: settings.Truncate,
-		InputType:  settings.InputType,
+		Inputs:          inputs,
+		Model:           settings.Model,
+		Truncation:      settings.Truncate,
+		InputType:       settings.InputType,
+		OutputDimension: settings.OutputDimension,
 	}
 }
 

--- a/usecases/modulecomponents/settings/base_class_settings.go
+++ b/usecases/modulecomponents/settings/base_class_settings.go
@@ -28,6 +28,9 @@ const (
 	DefaultVectorizePropertyName = false
 )
 
+// AvailableVoyageDimensions defines the supported output dimensions for VoyageAI models
+var AvailableVoyageDimensions = []int64{256, 512, 1024, 2048}
+
 var errInvalidProperties = fmt.Errorf("invalid properties: didn't find a single property which is " +
 	"vectorizable and is not excluded from indexing. " +
 	"To fix this add a vectorizable property which is not excluded from indexing")
@@ -220,6 +223,10 @@ func (s BaseClassSettings) GetPropertyAsBool(name string, defaultValue bool) boo
 	return s.propertyHelper.GetPropertyAsBool(s.cfg, name, defaultValue)
 }
 
+func (s BaseClassSettings) Dimensions() *int64 {
+	return s.GetPropertyAsInt64("dimensions", nil)
+}
+
 func (s BaseClassSettings) GetNumber(in interface{}) (float32, error) {
 	return s.propertyHelper.GetNumber(in)
 }
@@ -317,4 +324,21 @@ func (s BaseClassSettings) isPropertyDataTypeSupported(dt string) bool {
 
 func ValidateSetting[T string | int64](value T, availableValues []T) bool {
 	return slices.Contains(availableValues, value)
+}
+
+// ValidateDimensions validates if the given dimension value is supported and if the model supports dimensions configuration
+func ValidateDimensions(dimensions *int64, model string, availableDimensions []int64, supportedModels []string) error {
+	if dimensions == nil {
+		return nil
+	}
+
+	if !ValidateSetting(*dimensions, availableDimensions) {
+		return fmt.Errorf("invalid dimensions value %d: supported values are %v", *dimensions, availableDimensions)
+	}
+
+	if !ValidateSetting(model, supportedModels) {
+		return fmt.Errorf("model %s does not support output dimensions configuration", model)
+	}
+
+	return nil
 }

--- a/usecases/modulecomponents/settings/base_class_settings_test.go
+++ b/usecases/modulecomponents/settings/base_class_settings_test.go
@@ -401,3 +401,56 @@ func Test_BaseClassSettings_Validate(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateDimensions(t *testing.T) {
+	const testModel = "model-v3"
+	availableDims := []int64{256, 512, 1024, 2048}
+	supportedModels := []string{testModel, "model-v3-large"}
+
+	tests := []struct {
+		name       string
+		dimensions *int64
+		model      string
+		wantErr    bool
+	}{
+		{
+			name:       "nil dimensions should pass",
+			dimensions: nil,
+			model:      testModel,
+			wantErr:    false,
+		},
+		{
+			name:       "valid dimension should pass",
+			dimensions: ptr(int64(512)),
+			model:      testModel,
+			wantErr:    false,
+		},
+		{
+			name:       "invalid dimension should fail",
+			dimensions: ptr(int64(123)),
+			model:      testModel,
+			wantErr:    true,
+		},
+		{
+			name:       "unsupported model should fail",
+			dimensions: ptr(int64(512)),
+			model:      "old-model",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateDimensions(tt.dimensions, tt.model, availableDims, supportedModels)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func ptr(v int64) *int64 {
+	return &v
+}


### PR DESCRIPTION
### What's being changed:

This PR adds support for the `output_dimension` parameter in VoyageAI text2vec and multi2vec modules, enabling users to configure embedding dimensions (256, 512, 1024, 2048) for Voyage V3+ models.

**Implements**: #8311

#### Changes:
- Added `OutputDimension *int64` field to VoyageAI client Settings and embeddingsRequest
- Implemented `Dimensions()` method in both text2vec and multi2vec modules
- Added validation for supported dimensions and models
- Used `*int64` with `omitempty` JSON tag for multimodal compatibility (nil values not serialized)

#### Supported models:
- **text2vec**: voyage-3, voyage-3-large, voyage-3.5, voyage-3.5-lite, voyage-code-3
- **multi2vec**: voyage-multimodal-3

#### Files modified:
- `usecases/modulecomponents/clients/voyageai/voyageai.go`
- `modules/text2vec-voyageai/ent/class_settings.go`
- `modules/text2vec-voyageai/clients/voyageai.go`
- `modules/multi2vec-voyageai/ent/class_settings.go`
- `modules/multi2vec-voyageai/clients/voyageai.go`

#### Example usage:
```json
{
  "class": "Article",
  "vectorizer": "text2vec-voyageai",
  "moduleConfig": {
    "text2vec-voyageai": {
      "model": "voyage-3",
      "dimensions": 1024
    }
  }
}
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

### Cross-functional impact

- [x] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

**Note**: Client libraries may need updates to expose the new `dimensions` configuration option in their respective module configs.