### PR TITLE
test: remove lsm bucket cursor metric from being counted in metrics count test

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -31,7 +31,6 @@ services:
       ASYNC_INDEXING: ${ASYNC_INDEXING:-false}
       DISABLE_TELEMETRY: "true"
       DISABLE_RECOVERY_ON_PANIC: "true"
-      TRACK_VECTOR_DIMENSIONS_INTERVAL: "3m"
       QUERY_MAXIMUM_RESULTS: 10005
 
       # necessary for the metrics tests, some metrics only exist once segments

--- a/test/acceptance/graphql_resolvers/metrics_stability_test.go
+++ b/test/acceptance/graphql_resolvers/metrics_stability_test.go
@@ -39,11 +39,15 @@ func metricsCount(t *testing.T) {
 	createImportQueryMetricsClasses(t, 0, 10)
 	backupID := startBackup(t, 0, 10)
 	waitForBackupToFinish(t, backupID)
-	metricsLinesBefore := countMetricsLines(t)
+	metricsLinesBefore, linesBefore := countMetricsLines(t)
 	createImportQueryMetricsClasses(t, 10, 20)
 	backupID = startBackup(t, 0, 20)
 	waitForBackupToFinish(t, backupID)
-	metricsLinesAfter := countMetricsLines(t)
+	metricsLinesAfter, linesAfter := countMetricsLines(t)
+	if metricsLinesAfter != metricsLinesBefore {
+		t.Logf("metric lines before:\n%s\n", strings.Join(linesBefore, "\n"))
+		t.Logf("metric lines after:\n%s\n", strings.Join(linesAfter, "\n"))
+	}
 	assert.Equal(t, metricsLinesBefore, metricsLinesAfter, "number of metrics should not have changed")
 }
 
@@ -170,7 +174,7 @@ func randomVector(dims int) []float32 {
 	return out
 }
 
-func countMetricsLines(t *testing.T) int {
+func countMetricsLines(t *testing.T) (int, []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
@@ -187,9 +191,13 @@ func countMetricsLines(t *testing.T) int {
 
 	scanner := bufio.NewScanner(res.Body)
 	lineCount := 0
+	var lines []string
 	for scanner.Scan() {
 		line := scanner.Text()
 		if strings.Contains(line, "shards_loaded") || strings.Contains(line, "shards_loading") || strings.Contains(line, "shards_unloading") || strings.Contains(line, "shards_unloaded") {
+			continue
+		}
+		if strings.Contains(line, "weaviate_lsm_bucket_cursor_duration_seconds_bucket") {
 			continue
 		}
 		require.NotContains(
@@ -198,11 +206,12 @@ func countMetricsLines(t *testing.T) int {
 			strings.ToLower(metricClassPrefix),
 		)
 		lineCount++
+		lines = append(lines, line)
 	}
 
 	require.Nil(t, scanner.Err())
 
-	return lineCount
+	return lineCount, lines
 }
 
 func metricsClassName(classIndex int) string {


### PR DESCRIPTION
### What's being changed:

Remove lsm bucket cursor metric from being counted in metrics count test.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
