### PR TITLE
use correct boundary for mix endianness detection

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -298,7 +298,7 @@ func (compressor *quantizedVectorsCompressor[T]) PrefillCache() {
 			// maxID which would cause us to allocate a huge cache.
 			// In that case, we consider that anything larger than a quadrillion is an error
 			// and should be skipped.
-			if v.Id > 1<<15 {
+			if v.Id > 1e15 {
 				continue
 			}
 
@@ -349,7 +349,7 @@ func (compressor *quantizedVectorsCompressor[T]) PrefillMultiCache(docIDVectors 
 			// maxID which would cause us to allocate a huge cache.
 			// In that case, we consider that anything larger than a quadrillion is an error
 			// and should be skipped.
-			if v.Id > 1<<15 {
+			if v.Id > 1e15 {
 				continue
 			}
 

--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
@@ -112,7 +112,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 				}).Warn("skipping compressed vector with unexpected length")
 				continue
 			}
-			if cpi.loadId(k) > (1 << 15) {
+			if cpi.loadId(k) > (1e15) {
 				cpi.logger.WithFields(logrus.Fields{
 					"action": "hnsw_compressed_vector_cache_prefill",
 					"len":    len(v),
@@ -154,7 +154,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 					}).Warn("skipping compressed vector with unexpected length")
 					continue
 				}
-				if cpi.loadId(k) > (1 << 15) {
+				if cpi.loadId(k) > (1e15) {
 					cpi.logger.WithFields(logrus.Fields{
 						"action": "hnsw_compressed_vector_cache_prefill",
 						"len":    len(v),
@@ -193,7 +193,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 				}).Warn("skipping compressed vector with unexpected length")
 				continue
 			}
-			if cpi.loadId(k) > (1 << 15) {
+			if cpi.loadId(k) > (1e15) {
 				cpi.logger.WithFields(logrus.Fields{
 					"action": "hnsw_compressed_vector_cache_prefill",
 					"len":    len(v),

--- a/adapters/repos/db/vector/flat/index.go
+++ b/adapters/repos/db/vector/flat/index.go
@@ -840,7 +840,7 @@ func (index *flat) PostStartup() {
 			// maxID which would cause us to allocate a huge cache.
 			// In that case, we consider that anything larger than a quadrillion is an error
 			// and should be skipped.
-			if v.Id > 1<<15 {
+			if v.Id > 1e15 {
 				continue
 			}
 


### PR DESCRIPTION
### What's being changed:

This uses the correct boundary when detection a mix of big-endian / little-endian in the same bucket.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
