### PR TITLE
Fix big endian check iterator

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
@@ -112,7 +112,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 				}).Warn("skipping compressed vector with unexpected length")
 				continue
 			}
-			if cpi.loadId(k) > (1 << 15) {
+			if cpi.loadId(k) > (1e15) {
 				cpi.logger.WithFields(logrus.Fields{
 					"action": "hnsw_compressed_vector_cache_prefill",
 					"len":    len(v),
@@ -154,7 +154,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 					}).Warn("skipping compressed vector with unexpected length")
 					continue
 				}
-				if cpi.loadId(k) > (1 << 15) {
+				if cpi.loadId(k) > (1e15) {
 					cpi.logger.WithFields(logrus.Fields{
 						"action": "hnsw_compressed_vector_cache_prefill",
 						"len":    len(v),
@@ -193,7 +193,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 				}).Warn("skipping compressed vector with unexpected length")
 				continue
 			}
-			if cpi.loadId(k) > (1 << 15) {
+			if cpi.loadId(k) > (1e15) {
 				cpi.logger.WithFields(logrus.Fields{
 					"action": "hnsw_compressed_vector_cache_prefill",
 					"len":    len(v),


### PR DESCRIPTION
### What's being changed:

Fix the validation to check 1 trillion objects instead of 32k.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
