### PR TITLE
change limits between big endian and little endian detection in stable/v1.33

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -303,9 +303,9 @@ func (compressor *quantizedVectorsCompressor[T]) PrefillCache() {
 		for _, v := range vectors {
 			// if we mix little and big endian IDs by mistake, we might get a very large
 			// maxID which would cause us to allocate a huge cache.
-			// In that case, we consider that anything larger than a quadrillion is an error
+			// In that case, we consider that anything larger than one hundred trillion is an error
 			// and should be skipped.
-			if v.Id > 1e15 {
+			if v.Id > 1e14 {
 				continue
 			}
 
@@ -354,9 +354,9 @@ func (compressor *quantizedVectorsCompressor[T]) PrefillMultiCache(docIDVectors 
 		for _, v := range vectors {
 			// if we mix little and big endian IDs by mistake, we might get a very large
 			// maxID which would cause us to allocate a huge cache.
-			// In that case, we consider that anything larger than a quadrillion is an error
+			// In that case, we consider that anything larger than one hundred trillion is an error
 			// and should be skipped.
-			if v.Id > 1e15 {
+			if v.Id > 1e14 {
 				continue
 			}
 

--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
@@ -112,7 +112,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 				}).Debug("skipping compressed vector with unexpected length")
 				continue
 			}
-			if cpi.loadId(k) > (1e15) {
+			if cpi.loadId(k) > (1e14) {
 				cpi.logger.WithFields(logrus.Fields{
 					"action": "hnsw_compressed_vector_cache_prefill",
 					"len":    len(v),
@@ -154,7 +154,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 					}).Debug("skipping compressed vector with unexpected length")
 					continue
 				}
-				if cpi.loadId(k) > (1e15) {
+				if cpi.loadId(k) > (1e14) {
 					cpi.logger.WithFields(logrus.Fields{
 						"action": "hnsw_compressed_vector_cache_prefill",
 						"len":    len(v),
@@ -193,7 +193,7 @@ func (cpi *parallelIterator[T]) IterateAll() chan []VecAndID[T] {
 				}).Debug("skipping compressed vector with unexpected length")
 				continue
 			}
-			if cpi.loadId(k) > (1e15) {
+			if cpi.loadId(k) > (1e14) {
 				cpi.logger.WithFields(logrus.Fields{
 					"action": "hnsw_compressed_vector_cache_prefill",
 					"len":    len(v),


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
