### PR TITLE
fix: remove all possible weaviate_lsm_bucket_cursor_duration_seconds related metrics

### DIFF
--- a/test/acceptance/graphql_resolvers/metrics_stability_test.go
+++ b/test/acceptance/graphql_resolvers/metrics_stability_test.go
@@ -197,7 +197,7 @@ func countMetricsLines(t *testing.T) (int, []string) {
 		if strings.Contains(line, "shards_loaded") || strings.Contains(line, "shards_loading") || strings.Contains(line, "shards_unloading") || strings.Contains(line, "shards_unloaded") {
 			continue
 		}
-		if strings.Contains(line, "weaviate_lsm_bucket_cursor_duration_seconds_bucket") {
+		if strings.Contains(line, "weaviate_lsm_bucket_cursor_duration_seconds") {
 			continue
 		}
 		require.NotContains(


### PR DESCRIPTION
### What's being changed:

Remove all possible weaviate_lsm_bucket_cursor_duration_seconds related metrics

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
