### PR TITLE
fix(shutdown): coordinate request rejection across all server types

### DIFF
--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -66,6 +66,7 @@ func CreateGRPCServer(state *state.State, options ...grpc.ServerOption) (*grpc.S
 
 	var interceptors []grpc.UnaryServerInterceptor
 
+	interceptors = append(interceptors, makeShutdownCheckInterceptor(state))
 	interceptors = append(interceptors, makeAuthInterceptor())
 
 	// If sentry is enabled add automatic spans on gRPC requests
@@ -138,6 +139,34 @@ func makeMetricsInterceptor(logger logrus.FieldLogger, metrics *monitoring.Prome
 
 		return resp, err
 	}
+}
+
+func makeShutdownCheckInterceptor(state *state.State) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+	) (any, error) {
+		// Skip health check service - it has its own shutdown handling via SetServingStatus
+		// Health checks use grpc.health.v1.Health service which is handled separately
+		if isHealthCheckService(info.FullMethod) {
+			return handler(ctx, req)
+		}
+
+		if state.IsShuttingDown() {
+			state.Logger.WithField("action", "grpc_shutdown_reject").
+				WithField("method", info.FullMethod).
+				Debug("rejecting gRPC request during shutdown")
+			return nil, status.Error(codes.Unavailable, "server is shutting down")
+		}
+
+		return handler(ctx, req)
+	}
+}
+
+// isHealthCheckService checks if the method belongs to the gRPC health check service.
+// The health service has its own shutdown handling via SetServingStatus and should not
+// be intercepted by the general shutdown check.
+func isHealthCheckService(fullMethod string) bool {
+	return strings.HasPrefix(fullMethod, "/"+grpc_health_v1.Health_ServiceDesc.ServiceName+"/")
 }
 
 func makeAuthInterceptor() grpc.UnaryServerInterceptor {

--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -89,6 +89,9 @@ func NewServer(appState *state.State) *Server {
 		)
 	}
 
+	// Add shutdown check middleware as the outermost layer to reject requests during shutdown
+	handler = shutdownCheckMiddleware(handler, appState)
+
 	return &Server{
 		server: &http.Server{
 			Addr:    fmt.Sprintf(":%d", port),
@@ -160,4 +163,21 @@ func staticRoute(mux *http.ServeMux) monitoring.StaticRouteLabel {
 		}
 		return r, route
 	}
+}
+
+// shutdownCheckMiddleware wraps the handler to reject new requests during shutdown.
+// This middleware checks if the server is shutting down and returns 503 Service Unavailable
+// for any new requests, preventing the cluster API from accepting new work while shutdown
+// is in progress.
+func shutdownCheckMiddleware(next http.Handler, appState *state.State) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if appState.IsShuttingDown() {
+			appState.Logger.WithField("action", "cluster_api_shutdown_reject").
+				WithField("path", r.URL.Path).
+				Debug("rejecting request during shutdown")
+			http.Error(w, "Service shutting down", http.StatusServiceUnavailable)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
 }


### PR DESCRIPTION
### What's being changed:

This PR synchronizes shutdown behavior across all server types (HTTP, gRPC, and cluster API) to ensure no server accepts new requests after shutdown is initiated.

In PR #9354 and #9360, we improved the HTTP server shutdown introducing a `SHutdownCoordinator` component and using `PreServerShutdown()` to set the shutdown flag. This ensured that the HTTP server stops accepting new connections while the readiness probe returns 503, giving load balancers time to stop routing traffic before connection draining begins.

However, this left a gap: while external HTTP traffic was properly rejected during shutdown, the cluster API server (InternalServer) and gRPC server continued accepting new requests. This created an inconsistent state where internal cluster communication and gRPC calls could still be initiated even after the pod had signaled it was shutting down.

This inconsistency could lead to incomplete request handling during shutdown, longer pod termination times in Kubernetes, and potential issues with distributed operations that span multiple nodes.

This PR extends the shutdown coordination mechanism to cover all server types by checking the global shutdown state before processing requests.

For the **cluster API server**, we added a shutdown check middleware that wraps all handlers. When shutdown is detected, the middleware immediately returns a 503 Service Unavailable response and logs the rejected request. This middleware sits at the outermost layer, ensuring that shutdown checks happen before any other processing, including monitoring instrumentation and Sentry error tracking.

For the **gRPC server**, we added a shutdown check interceptor that runs before all other interceptors in the chain. When shutdown is detected, it returns a gRPC Unavailable error to reject new RPC calls. The interceptor makes an important exception for the health check service, which needs to continue functioning during shutdown to properly communicate the `NOT_SERVING` status (see `PreServerShutdown()` through the standard gRPC health protocol. We detect health check requests by comparing against the official service descriptor from the generated protobuf code, avoiding hardcoded string comparisons.

  ## How Shutdown Works Now

When `PreServerShutdown()` is called during pod termination, it sets a global shutdown flag through the `shutdownCoordinator`. From that moment, all three server types coordinate their response. The HTTP server disables keep-alives and the readiness probe starts returning 503. The cluster API middleware begins rejecting internal cluster requests with 503 responses. The gRPC interceptor rejects new RPC calls with `Unavailable` errors while allowing health checks to continue reporting `NOT_SERVING` status.

After setting these flags, there's a 2-second sleep (`ReadinessProbeLeadTime`) to give Kubernetes and load balancers time to detect the shutdown state and stop routing new traffic. During this window and after, all three servers consistently reject new work while allowing existing requests to complete gracefully. Finally, the `ServerShutdown()` hook runs to close all resources and perform cleanup.

## Implementation Details

The cluster API changes are in `adapters/handlers/rest/clusterapi/serve.go`. The new `shutdownCheckMiddleware()` function checks `appState.IsShuttingDown()` and short-circuits request processing when shutdown is active. This leverages the existing shutdown tracking infrastructure that was already in place for the readiness probe.

The gRPC changes are in `adapters/handlers/grpc/server.go`. The new `makeShutdownCheckInterceptor()` function checks `state.IsShuttingDown()` similarly, but with special handling for the health service. The helper function `isHealthCheckService()` uses `grpc_health_v1.Health_ServiceDesc.ServiceName` from the generated protobuf code to identify health check requests in a type-safe way, rather than hardcoding method names.

Both implementations log rejected requests at debug level with appropriate context (request path for HTTP, method name for gRPC) to help with troubleshooting and observability during shutdown scenarios.

## Related Work

This PR builds on the HTTP shutdown improvements from PR #9354 and #9360 completing the shutdown coordination system across all server types (cluster, HTTP and gRPC).

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.