### PR TITLE
fix(dimension-tracking): set roaring set bucket strategy as default

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -51,10 +51,11 @@ import (
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
-// since v1.34 StrategyRoaringSet will be default strategy for dimensions bucket
+// since v1.34 StrategyRoaringSet is default strategy for dimensions bucket,
+// StrategyMapCollection is left as backward compatibility for buckets created earlier
 var DimensionsBucketPrioritizedStrategies = []string{
-	StrategyMapCollection,
 	StrategyRoaringSet,
+	StrategyMapCollection,
 }
 
 const (

--- a/adapters/repos/db/shard_dimension_tracking.go
+++ b/adapters/repos/db/shard_dimension_tracking.go
@@ -39,13 +39,6 @@ const (
 	DimensionCategoryRQ
 )
 
-// since v1.34 StrategyRoaringSet is default strategy for dimensions bucket,
-// StrategyMapCollection is left as backward compatibility for buckets created earlier
-var DimensionsBucketPrioritizedStrategies = []string{
-	lsmkv.StrategyRoaringSet,
-	lsmkv.StrategyMapCollection,
-}
-
 type DimensionInfo struct {
 	category DimensionCategory
 	segments int


### PR DESCRIPTION
### What's being changed:

Set roaring set bucket strategy as default in dimensions tracking

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
