### PR TITLE
fix: update visited list in spfresh

### DIFF
--- a/adapters/repos/db/vector/spfresh/search.go
+++ b/adapters/repos/db/vector/spfresh/search.go
@@ -83,7 +83,7 @@ func (s *SPFresh) SearchByVector(ctx context.Context, vector []float32, k int, a
 			}
 
 			// skip duplicates
-			if visited.Visited(id) || s.VersionMap.Get(id) != v.Version() {
+			if visited.Visited(id) {
 				continue
 			}
 


### PR DESCRIPTION
### What's being changed:
When computing the distances between our query and the vectors in the posting list we are not marking the visited vectors meaning that we may compute same distances multiple times and add them to the result set. This PR marks as visited the vectors that we compute the distance for.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
