### PR TITLE
fix(geo): merge object with geo properties

### DIFF
--- a/adapters/repos/db/shard_geo_props.go
+++ b/adapters/repos/db/shard_geo_props.go
@@ -13,6 +13,7 @@ package db
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -166,9 +167,22 @@ func (s *Shard) addToGeoIndex(ctx context.Context, propName string,
 		return nil
 	}
 
-	// geo coordinates is the only supported one at the moment
-	asGeo, ok := propValue.(*models.GeoCoordinates)
-	if !ok {
+	var asGeo *models.GeoCoordinates
+	switch val := propValue.(type) {
+	case map[string]any:
+		asGeoBytes, err := json.Marshal(val)
+		if err != nil {
+			return fmt.Errorf("adjust geo property type: marshal geo property map: %w", err)
+		}
+		var asGeoAdjusted models.GeoCoordinates
+		err = json.Unmarshal(asGeoBytes, &asGeoAdjusted)
+		if err != nil {
+			return fmt.Errorf("adjust geo property type: unmarshal geo property map: %w", err)
+		}
+		asGeo = &asGeoAdjusted
+	case *models.GeoCoordinates:
+		asGeo = val
+	default:
 		return fmt.Errorf("expected prop to be of type %T, but got: %T",
 			&models.GeoCoordinates{}, propValue)
 	}

--- a/test/acceptance_with_go_client/cluster_test.go
+++ b/test/acceptance_with_go_client/cluster_test.go
@@ -1,0 +1,94 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2024 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package acceptance_with_go_client
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	wvt "github.com/weaviate/weaviate-go-client/v5/weaviate"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/docker"
+)
+
+func TestGeoPropertyUpdate(t *testing.T) {
+	ctx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviate().
+		With3NodeCluster().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	httpUri := compose.GetWeaviateNode(2).GetEndpoint(docker.HTTP)
+
+	config := wvt.Config{
+		Scheme: "http", Host: httpUri,
+		StartupTimeout: 30 * time.Second,
+	}
+	client, err := wvt.NewClient(config)
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	className := "GeoUpdateIssue"
+
+	// clean DB
+	client.Schema().ClassDeleter().WithClassName(className).Do(ctx)
+
+	class := &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{
+				Name:     "geo",
+				DataType: schema.DataTypeGeoCoordinates.PropString(),
+			},
+		},
+	}
+	err = client.Schema().ClassCreator().WithClass(class).Do(ctx)
+	require.NoError(t, err)
+
+	for i := range 10 {
+		_, err = client.Data().Creator().
+			WithID(fmt.Sprintf("00000000-0000-0000-0000-00000000000%v", i)).
+			WithClassName(className).
+			WithProperties(map[string]any{
+				"geo": map[string]any{
+					"latitude":  i,
+					"longitude": i,
+				},
+			}).
+			Do(ctx)
+		require.NoError(t, err)
+	}
+
+	for i := range 10 {
+		err = client.Data().Updater().
+			WithID(fmt.Sprintf("00000000-0000-0000-0000-00000000000%v", i)).
+			WithClassName(className).
+			WithProperties(map[string]any{
+				"geo": map[string]any{
+					"latitude":  1 + i,
+					"longitude": 2 + i,
+				},
+			}).
+			WithMerge().
+			Do(ctx)
+		require.NoError(t, err)
+	}
+}


### PR DESCRIPTION
### What's being changed:

When Weaviate is running in a multi-node cluster, objects can be created on any of the nodes.

When we send a merge request we use [Merge](https://github.com/weaviate/weaviate/blob/stable/v1.31/usecases/objects/merge.go#L38) struct to parse the incoming cluster merge request which deserializes properties into `map[string]any` type. 

This makes the `geo` properties to be deserialized into `map[string]any` and not to `models.GeoCoordinates`.

This PR takes into account a situation where `geo` property values can be of a `map[string]any` type and adjusts the type to `models.GeoCoordinates`.

Closes #8797

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
