### PR TITLE
Reserve several deprecated proto fields

### DIFF
--- a/adapters/handlers/grpc/v1/parse_aggregate_request.go
+++ b/adapters/handlers/grpc/v1/parse_aggregate_request.go
@@ -252,8 +252,6 @@ func (p *AggregateParser) Aggregate(req *pb.AggregateRequest) (*aggregation.Para
 				}
 			} else if len(hs.VectorBytes) > 0 {
 				vector = byteops.Fp32SliceFromBytes(hs.VectorBytes)
-			} else if len(hs.Vector) > 0 {
-				vector = hs.Vector
 			}
 
 			var distance float32
@@ -468,42 +466,52 @@ func extractTargetVectorsForAggregate(req *pb.AggregateRequest, class *models.Cl
 	var targets *pb.Targets
 	vectorSearch := false
 
-	extract := func(targets *pb.Targets, targetVectors *[]string) ([]string, *pb.Targets, bool) {
-		if targets != nil {
-			return targets.TargetVectors, targets, true
-		} else {
-			return *targetVectors, nil, true
+	extract := func(targets *pb.Targets) ([]string, *pb.Targets) {
+		if targets == nil {
+			return nil, nil
 		}
+		return targets.TargetVectors, targets
 	}
+
 	if hs := req.GetHybrid(); hs != nil {
-		targetVectors, targets, vectorSearch = extract(hs.Targets, &hs.TargetVectors)
+		targetVectors, targets = extract(hs.Targets)
+		vectorSearch = true
 	}
 	if na := req.GetNearAudio(); na != nil {
-		targetVectors, targets, vectorSearch = extract(na.Targets, &na.TargetVectors)
+		targetVectors, targets = extract(na.Targets)
+		vectorSearch = true
 	}
 	if nd := req.GetNearDepth(); nd != nil {
-		targetVectors, targets, vectorSearch = extract(nd.Targets, &nd.TargetVectors)
+		targetVectors, targets = extract(nd.Targets)
+		vectorSearch = true
 	}
 	if ni := req.GetNearImage(); ni != nil {
-		targetVectors, targets, vectorSearch = extract(ni.Targets, &ni.TargetVectors)
+		targetVectors, targets = extract(ni.Targets)
+		vectorSearch = true
 	}
 	if ni := req.GetNearImu(); ni != nil {
-		targetVectors, targets, vectorSearch = extract(ni.Targets, &ni.TargetVectors)
+		targetVectors, targets = extract(ni.Targets)
+		vectorSearch = true
 	}
 	if no := req.GetNearObject(); no != nil {
-		targetVectors, targets, vectorSearch = extract(no.Targets, &no.TargetVectors)
+		targetVectors, targets = extract(no.Targets)
+		vectorSearch = true
 	}
 	if nt := req.GetNearText(); nt != nil {
-		targetVectors, targets, vectorSearch = extract(nt.Targets, &nt.TargetVectors)
+		targetVectors, targets = extract(nt.Targets)
+		vectorSearch = true
 	}
 	if nt := req.GetNearThermal(); nt != nil {
-		targetVectors, targets, vectorSearch = extract(nt.Targets, &nt.TargetVectors)
+		targetVectors, targets = extract(nt.Targets)
+		vectorSearch = true
 	}
 	if nv := req.GetNearVector(); nv != nil {
-		targetVectors, targets, vectorSearch = extract(nv.Targets, &nv.TargetVectors)
+		targetVectors, targets = extract(nv.Targets)
+		vectorSearch = true
 	}
 	if nv := req.GetNearVideo(); nv != nil {
-		targetVectors, targets, vectorSearch = extract(nv.Targets, &nv.TargetVectors)
+		targetVectors, targets = extract(nv.Targets)
+		vectorSearch = true
 	}
 
 	var combination *dto.TargetCombination

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -329,7 +329,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 						Certainty:   &one,
 						Distance:    &one,
 					},
-					TargetVectors: []string{"custom"},
+					Targets: &pb.Targets{TargetVectors: []string{"custom"}},
 				},
 			},
 			out: dto.GetParams{
@@ -350,6 +350,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 					},
 					TargetVectors: []string{"custom"},
 				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0}},
 			},
 			error: false,
 		},
@@ -373,7 +374,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 							},
 						},
 					},
-					TargetVectors: []string{"custom"},
+					Targets: &pb.Targets{TargetVectors: []string{"custom"}},
 				},
 			},
 			out: dto.GetParams{
@@ -394,6 +395,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 					},
 					TargetVectors: []string{"custom"},
 				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0}},
 			},
 			error: false,
 		},
@@ -421,7 +423,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 							},
 						},
 					},
-					TargetVectors: []string{"custom_colbert"},
+					Targets: &pb.Targets{TargetVectors: []string{"custom_colbert"}},
 				},
 			},
 			out: dto.GetParams{
@@ -442,6 +444,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 					},
 					TargetVectors: []string{"custom_colbert"},
 				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0}},
 			},
 			error: false,
 		},
@@ -459,7 +462,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 							Type:        pb.Vectors_VECTOR_TYPE_SINGLE_FP32,
 						},
 					},
-					TargetVectors: []string{"custom"},
+					Targets: &pb.Targets{TargetVectors: []string{"custom"}},
 				},
 			},
 			out: dto.GetParams{
@@ -473,6 +476,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 					WithDistance:  true,
 					TargetVectors: []string{"custom"},
 				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0}},
 			},
 			error: false,
 		},
@@ -490,7 +494,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 							Type:        pb.Vectors_VECTOR_TYPE_MULTI_FP32,
 						},
 					},
-					TargetVectors: []string{"custom_colbert"},
+					Targets: &pb.Targets{TargetVectors: []string{"custom_colbert"}},
 				},
 			},
 			out: dto.GetParams{
@@ -503,6 +507,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 					Certainty:     1.0,
 					TargetVectors: []string{"custom_colbert"},
 				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0}},
 			},
 			error: false,
 		},
@@ -544,7 +549,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 		},
 		{
 			name: "Empty return properties given with new default logic",
-			req:  &pb.SearchRequest{Uses_123Api: true, Collection: classname, Properties: &pb.PropertiesRequest{}},
+			req:  &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{}},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{}, AdditionalProperties: additional.Properties{
 					NoProps: true,
@@ -589,7 +594,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 		},
 		{
 			name: "Metadata ID only query using new default logic",
-			req:  &pb.SearchRequest{Uses_123Api: true, Collection: classname, Properties: &pb.PropertiesRequest{}, Metadata: &pb.MetadataRequest{Uuid: true}},
+			req:  &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{}, Metadata: &pb.MetadataRequest{Uuid: true}},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination,
 				Properties: search.SelectProperties{},
@@ -615,8 +620,8 @@ func TestGRPCSearchRequest(t *testing.T) {
 				Metadata:   &pb.MetadataRequest{Vector: true},
 				Properties: &pb.PropertiesRequest{},
 				NearVector: &pb.NearVector{
-					Vector:        []float32{1, 2, 3},
-					TargetVectors: []string{"custom"},
+					Vector:  []float32{1, 2, 3},
+					Targets: &pb.Targets{TargetVectors: []string{"custom"}},
 				},
 			},
 			out: dto.GetParams{
@@ -628,6 +633,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 					TargetVectors: []string{"custom"},
 					Vectors:       []models.Vector{[]float32{1, 2, 3}},
 				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0}},
 			},
 			error: false,
 		},
@@ -641,7 +647,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 					Vectors: []*pb.Vectors{
 						{VectorBytes: byteops.Fp32SliceToBytes([]float32{1, 2, 3})},
 					},
-					TargetVectors: []string{"custom"},
+					Targets: &pb.Targets{TargetVectors: []string{"custom"}},
 				},
 			},
 			out: dto.GetParams{
@@ -653,6 +659,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 					TargetVectors: []string{"custom"},
 					Vectors:       []models.Vector{[]float32{1, 2, 3}},
 				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0}},
 			},
 			error: false,
 		},
@@ -666,7 +673,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 					Vectors: []*pb.Vectors{
 						{VectorBytes: byteops.Fp32SliceOfSlicesToBytes([][]float32{{1, 2, 3}, {1, 2, 3}}), Type: pb.Vectors_VECTOR_TYPE_MULTI_FP32},
 					},
-					TargetVectors: []string{"custom_colbert"},
+					Targets: &pb.Targets{TargetVectors: []string{"custom_colbert"}},
 				},
 			},
 			out: dto.GetParams{
@@ -678,6 +685,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 					TargetVectors: []string{"custom_colbert"},
 					Vectors:       []models.Vector{[][]float32{{1, 2, 3}, {1, 2, 3}}},
 				},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0}},
 			},
 			error: false,
 		},
@@ -691,7 +699,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 					Vectors: []*pb.Vectors{
 						{VectorBytes: byteops.Fp32SliceOfSlicesToBytes([][]float32{{1, 2, 3}, {1, 2, 3}}), Type: pb.Vectors_VECTOR_TYPE_MULTI_FP32},
 					},
-					TargetVectors: []string{"custom"},
+					Targets: &pb.Targets{TargetVectors: []string{"custom"}},
 				},
 			},
 			error: true,
@@ -716,8 +724,8 @@ func TestGRPCSearchRequest(t *testing.T) {
 				Metadata:   &pb.MetadataRequest{Vector: true},
 				Properties: &pb.PropertiesRequest{},
 				NearVector: &pb.NearVector{
-					Vector:        []float32{1, 2, 3},
-					TargetVectors: []string{"custom", "first"},
+					Vector:  []float32{1, 2, 3},
+					Targets: &pb.Targets{TargetVectors: []string{"custom", "first"}},
 				},
 			},
 			out: dto.GetParams{
@@ -729,12 +737,12 @@ func TestGRPCSearchRequest(t *testing.T) {
 					Vectors:       []models.Vector{[]float32{1, 2, 3}, []float32{1, 2, 3}},
 					TargetVectors: []string{"custom", "first"},
 				},
-				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0, 0}},
 			}, error: false,
 		},
 		{
 			name: "Properties return all nonref values with new default logic",
-			req:  &pb.SearchRequest{Uses_123Api: true, Collection: classname, Properties: &pb.PropertiesRequest{ReturnAllNonrefProperties: true}},
+			req:  &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{ReturnAllNonrefProperties: true}},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, Properties: defaultTestClassProps,
 			},
@@ -742,7 +750,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 		},
 		{
 			name: "Properties return all nonref values with ref and specific props using new default logic",
-			req: &pb.SearchRequest{Uses_123Api: true, Collection: classname, Properties: &pb.PropertiesRequest{
+			req: &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{
 				ReturnAllNonrefProperties: true,
 				RefProperties: []*pb.RefPropertiesRequest{{
 					ReferenceProperty: "ref",
@@ -770,7 +778,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 		},
 		{
 			name: "Properties return all nonref values with ref and all nonref props using new default logic",
-			req: &pb.SearchRequest{Uses_123Api: true, Collection: classname, Properties: &pb.PropertiesRequest{
+			req: &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{
 				ReturnAllNonrefProperties: true,
 				RefProperties: []*pb.RefPropertiesRequest{{
 					ReferenceProperty: "ref",
@@ -820,7 +828,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 		},
 		{
 			name: "Properties return values only ref using new default logic",
-			req: &pb.SearchRequest{Uses_123Api: true, Collection: classname, Properties: &pb.PropertiesRequest{
+			req: &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{
 				RefProperties: []*pb.RefPropertiesRequest{
 					{
 						ReferenceProperty: "ref",
@@ -847,7 +855,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 		},
 		{
 			name: "Properties return values non-ref with new default logic",
-			req:  &pb.SearchRequest{Uses_123Api: true, Collection: classname, Properties: &pb.PropertiesRequest{NonRefProperties: []string{"name", "CapitalizedName"}}},
+			req:  &pb.SearchRequest{Collection: classname, Properties: &pb.PropertiesRequest{NonRefProperties: []string{"name", "CapitalizedName"}}},
 			out: dto.GetParams{
 				ClassName: classname, Pagination: defaultPagination, Properties: search.SelectProperties{{Name: "name", IsPrimitive: true}, {Name: "capitalizedName", IsPrimitive: true}},
 			},
@@ -913,12 +921,13 @@ func TestGRPCSearchRequest(t *testing.T) {
 			name: "hybrid targetvectors",
 			req: &pb.SearchRequest{
 				Collection: multiVecClass, Metadata: &pb.MetadataRequest{Vector: true, Certainty: false},
-				HybridSearch: &pb.Hybrid{TargetVectors: []string{"first"}, Query: "query", FusionType: pb.Hybrid_FUSION_TYPE_RANKED, Alpha: 0.75, Properties: []string{"first"}},
+				HybridSearch: &pb.Hybrid{Targets: &pb.Targets{TargetVectors: []string{"first"}}, Query: "query", FusionType: pb.Hybrid_FUSION_TYPE_RANKED, Alpha: 0.75, Properties: []string{"first"}},
 			},
 			out: dto.GetParams{
 				ClassName: multiVecClass, Pagination: defaultPagination, HybridSearch: &searchparams.HybridSearch{TargetVectors: []string{"first"}, Query: "query", FusionAlgorithm: common_filters.HybridRankedFusion, Alpha: 0.75, Properties: []string{"first"}},
-				Properties:           defaultNamedVecProps,
-				AdditionalProperties: additional.Properties{Vectors: []string{"custom", "first", "second"}, NoProps: false, Vector: true},
+				Properties:              defaultNamedVecProps,
+				AdditionalProperties:    additional.Properties{Vectors: []string{"custom", "first", "second"}, NoProps: false, Vector: true},
+				TargetVectorCombination: &dto.TargetCombination{Type: dto.Minimum, Weights: []float32{0}},
 			},
 			error: false,
 		},
@@ -1969,7 +1978,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 		},
 		{
 			name: "No return values given nested with new default logic",
-			req:  &pb.SearchRequest{Uses_123Api: true, Collection: objClass, Properties: &pb.PropertiesRequest{ReturnAllNonrefProperties: true}},
+			req:  &pb.SearchRequest{Collection: objClass, Properties: &pb.PropertiesRequest{ReturnAllNonrefProperties: true}},
 			out: dto.GetParams{
 				ClassName: objClass, Pagination: defaultPagination,
 				Properties: search.SelectProperties{
@@ -2129,8 +2138,9 @@ func TestGRPCSearchRequest(t *testing.T) {
 			req: &pb.SearchRequest{
 				Collection: multiVecClass,
 				NearVector: &pb.NearVector{
-					Targets:         &pb.Targets{TargetVectors: []string{"first", "second"}, Combination: pb.CombinationMethod_COMBINATION_METHOD_TYPE_SUM},
-					VectorPerTarget: map[string][]byte{"first": byteVector([]float32{1, 2, 3}), "second": byteVector([]float32{1, 2, 3, 4})},
+					Targets: &pb.Targets{TargetVectors: []string{"first", "second"}, Combination: pb.CombinationMethod_COMBINATION_METHOD_TYPE_SUM},
+					// VectorPerTarget: map[string][]byte{"first": byteVector([]float32{1, 2, 3}), "second": byteVector([]float32{1, 2, 3, 4})},
+					VectorForTargets: []*pb.VectorForTarget{{Name: "first", VectorBytes: byteVector([]float32{1, 2, 3})}, {Name: "second", VectorBytes: byteVector([]float32{1, 2, 3, 4})}},
 				},
 			},
 			out: dto.GetParams{
@@ -2149,9 +2159,9 @@ func TestGRPCSearchRequest(t *testing.T) {
 			req: &pb.SearchRequest{
 				Collection: multiVecClass,
 				NearVector: &pb.NearVector{
-					VectorBytes:     byteVector([]float32{1, 2, 3}),
-					Targets:         &pb.Targets{TargetVectors: []string{"first", "second"}, Combination: pb.CombinationMethod_COMBINATION_METHOD_TYPE_SUM},
-					VectorPerTarget: map[string][]byte{"first": byteVector([]float32{1, 2, 3}), "second": byteVector([]float32{1, 2, 3, 4})},
+					VectorBytes:      byteVector([]float32{1, 2, 3}),
+					Targets:          &pb.Targets{TargetVectors: []string{"first", "second"}, Combination: pb.CombinationMethod_COMBINATION_METHOD_TYPE_SUM},
+					VectorForTargets: []*pb.VectorForTarget{{Name: "first", VectorBytes: byteVector([]float32{1, 2, 3})}, {Name: "second", VectorBytes: byteVector([]float32{1, 2, 3, 4})}},
 				},
 			},
 			out:   dto.GetParams{},
@@ -2162,9 +2172,8 @@ func TestGRPCSearchRequest(t *testing.T) {
 			req: &pb.SearchRequest{
 				Collection: multiVecClass,
 				NearVector: &pb.NearVector{
-					VectorBytes:     byteVector([]float32{1, 2, 3}),
-					Targets:         &pb.Targets{TargetVectors: []string{"first"}, Combination: pb.CombinationMethod_COMBINATION_METHOD_TYPE_SUM},
-					VectorPerTarget: map[string][]byte{"first": byteVector([]float32{1, 2, 3}), "second": byteVector([]float32{1, 2, 3, 4})},
+					Targets:          &pb.Targets{TargetVectors: []string{"first"}, Combination: pb.CombinationMethod_COMBINATION_METHOD_TYPE_SUM},
+					VectorForTargets: []*pb.VectorForTarget{{Name: "first", VectorBytes: byteVector([]float32{1, 2, 3})}, {Name: "second", VectorBytes: byteVector([]float32{1, 2, 3, 4})}},
 				},
 			},
 			out:   dto.GetParams{},
@@ -2212,8 +2221,8 @@ func TestGRPCSearchRequest(t *testing.T) {
 			req: &pb.SearchRequest{
 				Collection: multiVecClass,
 				NearVector: &pb.NearVector{
-					Targets:         &pb.Targets{TargetVectors: []string{"first", "second"}},
-					VectorPerTarget: map[string][]byte{"first": byteVector([]float32{1, 2, 3}), "second": byteVector([]float32{1, 2, 3, 4})},
+					Targets:          &pb.Targets{TargetVectors: []string{"first", "second"}},
+					VectorForTargets: []*pb.VectorForTarget{{Name: "first", VectorBytes: byteVector([]float32{1, 2, 3})}, {Name: "second", VectorBytes: byteVector([]float32{1, 2, 3, 4})}},
 				},
 				Metadata: &pb.MetadataRequest{Certainty: true},
 			},

--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -243,7 +243,6 @@ func (r *Replier) extractAdditionalProps(asMap map[string]any, additionalPropsPa
 		if ok {
 			vectorfmt, ok2 := vector.([]float32)
 			if ok2 {
-				addProps.Metadata.Vector = vectorfmt // deprecated, remove in a bit
 				addProps.Metadata.VectorBytes = byteops.Fp32SliceToBytes(vectorfmt)
 			}
 		}

--- a/adapters/handlers/grpc/v1/prepare_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_reply_test.go
@@ -205,8 +205,8 @@ func TestGRPCReply(t *testing.T) {
 			},
 			searchParams: dto.GetParams{AdditionalProperties: additional.Properties{Vector: true}},
 			outSearch: []*pb.SearchResult{
-				{Metadata: &pb.MetadataResult{Vector: []float32{1}, VectorBytes: byteVector([]float32{1})}, Properties: &pb.PropertiesResult{}},
-				{Metadata: &pb.MetadataResult{Vector: []float32{2}, VectorBytes: byteVector([]float32{2})}, Properties: &pb.PropertiesResult{}},
+				{Metadata: &pb.MetadataResult{VectorBytes: byteVector([]float32{1})}, Properties: &pb.PropertiesResult{}},
+				{Metadata: &pb.MetadataResult{VectorBytes: byteVector([]float32{2})}, Properties: &pb.PropertiesResult{}},
 			},
 		},
 		{
@@ -258,7 +258,6 @@ func TestGRPCReply(t *testing.T) {
 			outSearch: []*pb.SearchResult{
 				{
 					Metadata: &pb.MetadataResult{
-						Vector:                    []float32{1},
 						Id:                        string(UUID1),
 						Certainty:                 0.4,
 						CertaintyPresent:          true,
@@ -281,7 +280,6 @@ func TestGRPCReply(t *testing.T) {
 				},
 				{
 					Metadata: &pb.MetadataResult{
-						Vector:                    []float32{2},
 						Id:                        string(UUID2),
 						Certainty:                 0.5,
 						CertaintyPresent:          true,
@@ -713,7 +711,7 @@ func TestGRPCReply(t *testing.T) {
 							Properties: []*pb.PropertiesResult{
 								{
 									TargetCollection: refClass1,
-									Metadata:         &pb.MetadataResult{Vector: []float32{3}, VectorBytes: byteVector([]float32{3})},
+									Metadata:         &pb.MetadataResult{VectorBytes: byteVector([]float32{3})},
 									NonRefProps: &pb.Properties{
 										Fields: map[string]*pb.Value{
 											"something": {Kind: &pb.Value_TextValue{TextValue: "other"}},
@@ -739,7 +737,7 @@ func TestGRPCReply(t *testing.T) {
 							Properties: []*pb.PropertiesResult{
 								{
 									TargetCollection: refClass1,
-									Metadata:         &pb.MetadataResult{Vector: []float32{4}, VectorBytes: byteVector([]float32{4})},
+									Metadata:         &pb.MetadataResult{VectorBytes: byteVector([]float32{4})},
 									NonRefProps: &pb.Properties{
 										Fields: map[string]*pb.Value{
 											"something": {Kind: &pb.Value_TextValue{TextValue: "thing"}},
@@ -954,7 +952,7 @@ func TestGRPCReply(t *testing.T) {
 							Properties: []*pb.PropertiesResult{
 								{
 									TargetCollection: refClass1,
-									Metadata:         &pb.MetadataResult{Vector: []float32{3}, VectorBytes: byteVector([]float32{3})},
+									Metadata:         &pb.MetadataResult{VectorBytes: byteVector([]float32{3})},
 									NonRefProps: &pb.Properties{
 										Fields: map[string]*pb.Value{
 											"nums": {Kind: &pb.Value_ListValue{ListValue: &pb.ListValue{
@@ -1179,7 +1177,7 @@ func TestGRPCReply(t *testing.T) {
 									Properties: []*pb.PropertiesResult{
 										{
 											NonRefProps: &pb.Properties{Fields: map[string]*pb.Value{"something": {Kind: &pb.Value_TextValue{TextValue: "other"}}}},
-											Metadata:    &pb.MetadataResult{Vector: []float32{2}, Id: UUID1.String()},
+											Metadata:    &pb.MetadataResult{VectorBytes: byteVector([]float32{2}), Id: UUID1.String()},
 										},
 									},
 								},
@@ -1187,8 +1185,8 @@ func TestGRPCReply(t *testing.T) {
 							RefPropsRequested: true,
 						},
 						Metadata: &pb.MetadataResult{
-							Id:     string(UUID2),
-							Vector: []float32{3},
+							Id:          string(UUID2),
+							VectorBytes: byteVector([]float32{3}),
 						},
 					},
 					{
@@ -1196,8 +1194,8 @@ func TestGRPCReply(t *testing.T) {
 							NonRefProps: &pb.Properties{Fields: map[string]*pb.Value{"word": {Kind: &pb.Value_TextValue{TextValue: "other"}}}},
 						},
 						Metadata: &pb.MetadataResult{
-							Id:     string(UUID1),
-							Vector: []float32{4},
+							Id:          string(UUID1),
+							VectorBytes: byteVector([]float32{4}),
 						},
 					},
 				},
@@ -1300,7 +1298,7 @@ func TestGRPCReply(t *testing.T) {
 									Properties: []*pb.PropertiesResult{
 										{
 											NonRefProps: &pb.Properties{Fields: map[string]*pb.Value{"something": {Kind: &pb.Value_TextValue{TextValue: "other"}}}},
-											Metadata:    &pb.MetadataResult{Vector: []float32{2}, Id: UUID1.String()},
+											Metadata:    &pb.MetadataResult{VectorBytes: byteVector([]float32{2}), Id: UUID1.String()},
 										},
 									},
 								},
@@ -1308,8 +1306,8 @@ func TestGRPCReply(t *testing.T) {
 							RefPropsRequested: true,
 						},
 						Metadata: &pb.MetadataResult{
-							Id:     string(UUID2),
-							Vector: []float32{3},
+							Id:          string(UUID2),
+							VectorBytes: byteVector([]float32{3}),
 						},
 					},
 					{
@@ -1317,8 +1315,8 @@ func TestGRPCReply(t *testing.T) {
 							NonRefProps: &pb.Properties{Fields: map[string]*pb.Value{"word": {Kind: &pb.Value_TextValue{TextValue: "other"}}}},
 						},
 						Metadata: &pb.MetadataResult{
-							Id:     string(UUID1),
-							Vector: []float32{4},
+							Id:          string(UUID1),
+							VectorBytes: byteVector([]float32{4}),
 						},
 					},
 				},

--- a/grpc/generated/protocol/v1/base_search.pb.go
+++ b/grpc/generated/protocol/v1/base_search.pb.go
@@ -404,18 +404,12 @@ type Hybrid struct {
 	state      protoimpl.MessageState `protogen:"open.v1"`
 	Query      string                 `protobuf:"bytes,1,opt,name=query,proto3" json:"query,omitempty"`
 	Properties []string               `protobuf:"bytes,2,rep,name=properties,proto3" json:"properties,omitempty"`
-	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
-	//
+	Alpha      float32                `protobuf:"fixed32,4,opt,name=alpha,proto3" json:"alpha,omitempty"`
+	FusionType Hybrid_FusionType      `protobuf:"varint,5,opt,name=fusion_type,json=fusionType,proto3,enum=weaviate.v1.Hybrid_FusionType" json:"fusion_type,omitempty"`
 	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	Vector     []float32         `protobuf:"fixed32,3,rep,packed,name=vector,proto3" json:"vector,omitempty"` // will be removed in the future, use vectors
-	Alpha      float32           `protobuf:"fixed32,4,opt,name=alpha,proto3" json:"alpha,omitempty"`
-	FusionType Hybrid_FusionType `protobuf:"varint,5,opt,name=fusion_type,json=fusionType,proto3,enum=weaviate.v1.Hybrid_FusionType" json:"fusion_type,omitempty"`
-	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	VectorBytes []byte `protobuf:"bytes,6,opt,name=vector_bytes,json=vectorBytes,proto3" json:"vector_bytes,omitempty"` // deprecated in 1.29.0 - use vectors
-	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	TargetVectors      []string               `protobuf:"bytes,7,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
-	NearText           *NearTextSearch        `protobuf:"bytes,8,opt,name=near_text,json=nearText,proto3" json:"near_text,omitempty"`                // targets in msg is ignored and should not be set for hybrid
-	NearVector         *NearVector            `protobuf:"bytes,9,opt,name=near_vector,json=nearVector,proto3" json:"near_vector,omitempty"`          // same as above. Use the target vector in the hybrid message
+	VectorBytes        []byte                 `protobuf:"bytes,6,opt,name=vector_bytes,json=vectorBytes,proto3" json:"vector_bytes,omitempty"` // deprecated in 1.29.0 - use vectors
+	NearText           *NearTextSearch        `protobuf:"bytes,8,opt,name=near_text,json=nearText,proto3" json:"near_text,omitempty"`          // targets in msg is ignored and should not be set for hybrid
+	NearVector         *NearVector            `protobuf:"bytes,9,opt,name=near_vector,json=nearVector,proto3" json:"near_vector,omitempty"`    // same as above. Use the target vector in the hybrid message
 	Targets            *Targets               `protobuf:"bytes,10,opt,name=targets,proto3" json:"targets,omitempty"`
 	Bm25SearchOperator *SearchOperatorOptions `protobuf:"bytes,11,opt,name=bm25_search_operator,json=bm25SearchOperator,proto3,oneof" json:"bm25_search_operator,omitempty"`
 	// only vector distance, but keep it extendable
@@ -473,14 +467,6 @@ func (x *Hybrid) GetProperties() []string {
 	return nil
 }
 
-// Deprecated: Marked as deprecated in v1/base_search.proto.
-func (x *Hybrid) GetVector() []float32 {
-	if x != nil {
-		return x.Vector
-	}
-	return nil
-}
-
 func (x *Hybrid) GetAlpha() float32 {
 	if x != nil {
 		return x.Alpha
@@ -499,14 +485,6 @@ func (x *Hybrid) GetFusionType() Hybrid_FusionType {
 func (x *Hybrid) GetVectorBytes() []byte {
 	if x != nil {
 		return x.VectorBytes
-	}
-	return nil
-}
-
-// Deprecated: Marked as deprecated in v1/base_search.proto.
-func (x *Hybrid) GetTargetVectors() []string {
-	if x != nil {
-		return x.TargetVectors
 	}
 	return nil
 }
@@ -581,12 +559,8 @@ type NearVector struct {
 	Certainty *float64  `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
 	Distance  *float64  `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
 	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	VectorBytes []byte `protobuf:"bytes,4,opt,name=vector_bytes,json=vectorBytes,proto3" json:"vector_bytes,omitempty"` // deprecated in 1.29.0 - use vectors
-	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	TargetVectors []string `protobuf:"bytes,5,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
-	Targets       *Targets `protobuf:"bytes,6,opt,name=targets,proto3" json:"targets,omitempty"`
-	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	VectorPerTarget  map[string][]byte  `protobuf:"bytes,7,rep,name=vector_per_target,json=vectorPerTarget,proto3" json:"vector_per_target,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // deprecated in 1.26.2 - use vector_for_targets
+	VectorBytes      []byte             `protobuf:"bytes,4,opt,name=vector_bytes,json=vectorBytes,proto3" json:"vector_bytes,omitempty"` // deprecated in 1.29.0 - use vectors
+	Targets          *Targets           `protobuf:"bytes,6,opt,name=targets,proto3" json:"targets,omitempty"`
 	VectorForTargets []*VectorForTarget `protobuf:"bytes,8,rep,name=vector_for_targets,json=vectorForTargets,proto3" json:"vector_for_targets,omitempty"`
 	Vectors          []*Vectors         `protobuf:"bytes,9,rep,name=vectors,proto3" json:"vectors,omitempty"`
 	unknownFields    protoimpl.UnknownFields
@@ -653,25 +627,9 @@ func (x *NearVector) GetVectorBytes() []byte {
 	return nil
 }
 
-// Deprecated: Marked as deprecated in v1/base_search.proto.
-func (x *NearVector) GetTargetVectors() []string {
-	if x != nil {
-		return x.TargetVectors
-	}
-	return nil
-}
-
 func (x *NearVector) GetTargets() *Targets {
 	if x != nil {
 		return x.Targets
-	}
-	return nil
-}
-
-// Deprecated: Marked as deprecated in v1/base_search.proto.
-func (x *NearVector) GetVectorPerTarget() map[string][]byte {
-	if x != nil {
-		return x.VectorPerTarget
 	}
 	return nil
 }
@@ -691,13 +649,11 @@ func (x *NearVector) GetVectors() []*Vectors {
 }
 
 type NearObject struct {
-	state     protoimpl.MessageState `protogen:"open.v1"`
-	Id        string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	Certainty *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
-	Distance  *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
-	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	Certainty     *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
+	Distance      *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
+	Targets       *Targets               `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -753,14 +709,6 @@ func (x *NearObject) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Marked as deprecated in v1/base_search.proto.
-func (x *NearObject) GetTargetVectors() []string {
-	if x != nil {
-		return x.TargetVectors
-	}
-	return nil
-}
-
 func (x *NearObject) GetTargets() *Targets {
 	if x != nil {
 		return x.Targets
@@ -771,14 +719,12 @@ func (x *NearObject) GetTargets() *Targets {
 type NearTextSearch struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
-	Query     []string             `protobuf:"bytes,1,rep,name=query,proto3" json:"query,omitempty"`
-	Certainty *float64             `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
-	Distance  *float64             `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	MoveTo    *NearTextSearch_Move `protobuf:"bytes,4,opt,name=move_to,json=moveTo,proto3,oneof" json:"move_to,omitempty"`
-	MoveAway  *NearTextSearch_Move `protobuf:"bytes,5,opt,name=move_away,json=moveAway,proto3,oneof" json:"move_away,omitempty"`
-	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	TargetVectors []string `protobuf:"bytes,6,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
-	Targets       *Targets `protobuf:"bytes,7,opt,name=targets,proto3" json:"targets,omitempty"`
+	Query         []string             `protobuf:"bytes,1,rep,name=query,proto3" json:"query,omitempty"`
+	Certainty     *float64             `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
+	Distance      *float64             `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
+	MoveTo        *NearTextSearch_Move `protobuf:"bytes,4,opt,name=move_to,json=moveTo,proto3,oneof" json:"move_to,omitempty"`
+	MoveAway      *NearTextSearch_Move `protobuf:"bytes,5,opt,name=move_away,json=moveAway,proto3,oneof" json:"move_away,omitempty"`
+	Targets       *Targets             `protobuf:"bytes,7,opt,name=targets,proto3" json:"targets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -848,14 +794,6 @@ func (x *NearTextSearch) GetMoveAway() *NearTextSearch_Move {
 	return nil
 }
 
-// Deprecated: Marked as deprecated in v1/base_search.proto.
-func (x *NearTextSearch) GetTargetVectors() []string {
-	if x != nil {
-		return x.TargetVectors
-	}
-	return nil
-}
-
 func (x *NearTextSearch) GetTargets() *Targets {
 	if x != nil {
 		return x.Targets
@@ -864,13 +802,11 @@ func (x *NearTextSearch) GetTargets() *Targets {
 }
 
 type NearImageSearch struct {
-	state     protoimpl.MessageState `protogen:"open.v1"`
-	Image     string                 `protobuf:"bytes,1,opt,name=image,proto3" json:"image,omitempty"`
-	Certainty *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
-	Distance  *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
-	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Image         string                 `protobuf:"bytes,1,opt,name=image,proto3" json:"image,omitempty"`
+	Certainty     *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
+	Distance      *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
+	Targets       *Targets               `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -926,14 +862,6 @@ func (x *NearImageSearch) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Marked as deprecated in v1/base_search.proto.
-func (x *NearImageSearch) GetTargetVectors() []string {
-	if x != nil {
-		return x.TargetVectors
-	}
-	return nil
-}
-
 func (x *NearImageSearch) GetTargets() *Targets {
 	if x != nil {
 		return x.Targets
@@ -942,13 +870,11 @@ func (x *NearImageSearch) GetTargets() *Targets {
 }
 
 type NearAudioSearch struct {
-	state     protoimpl.MessageState `protogen:"open.v1"`
-	Audio     string                 `protobuf:"bytes,1,opt,name=audio,proto3" json:"audio,omitempty"`
-	Certainty *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
-	Distance  *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
-	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Audio         string                 `protobuf:"bytes,1,opt,name=audio,proto3" json:"audio,omitempty"`
+	Certainty     *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
+	Distance      *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
+	Targets       *Targets               `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1004,14 +930,6 @@ func (x *NearAudioSearch) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Marked as deprecated in v1/base_search.proto.
-func (x *NearAudioSearch) GetTargetVectors() []string {
-	if x != nil {
-		return x.TargetVectors
-	}
-	return nil
-}
-
 func (x *NearAudioSearch) GetTargets() *Targets {
 	if x != nil {
 		return x.Targets
@@ -1020,13 +938,11 @@ func (x *NearAudioSearch) GetTargets() *Targets {
 }
 
 type NearVideoSearch struct {
-	state     protoimpl.MessageState `protogen:"open.v1"`
-	Video     string                 `protobuf:"bytes,1,opt,name=video,proto3" json:"video,omitempty"`
-	Certainty *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
-	Distance  *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
-	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Video         string                 `protobuf:"bytes,1,opt,name=video,proto3" json:"video,omitempty"`
+	Certainty     *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
+	Distance      *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
+	Targets       *Targets               `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1082,14 +998,6 @@ func (x *NearVideoSearch) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Marked as deprecated in v1/base_search.proto.
-func (x *NearVideoSearch) GetTargetVectors() []string {
-	if x != nil {
-		return x.TargetVectors
-	}
-	return nil
-}
-
 func (x *NearVideoSearch) GetTargets() *Targets {
 	if x != nil {
 		return x.Targets
@@ -1098,13 +1006,11 @@ func (x *NearVideoSearch) GetTargets() *Targets {
 }
 
 type NearDepthSearch struct {
-	state     protoimpl.MessageState `protogen:"open.v1"`
-	Depth     string                 `protobuf:"bytes,1,opt,name=depth,proto3" json:"depth,omitempty"`
-	Certainty *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
-	Distance  *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
-	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Depth         string                 `protobuf:"bytes,1,opt,name=depth,proto3" json:"depth,omitempty"`
+	Certainty     *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
+	Distance      *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
+	Targets       *Targets               `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1160,14 +1066,6 @@ func (x *NearDepthSearch) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Marked as deprecated in v1/base_search.proto.
-func (x *NearDepthSearch) GetTargetVectors() []string {
-	if x != nil {
-		return x.TargetVectors
-	}
-	return nil
-}
-
 func (x *NearDepthSearch) GetTargets() *Targets {
 	if x != nil {
 		return x.Targets
@@ -1176,13 +1074,11 @@ func (x *NearDepthSearch) GetTargets() *Targets {
 }
 
 type NearThermalSearch struct {
-	state     protoimpl.MessageState `protogen:"open.v1"`
-	Thermal   string                 `protobuf:"bytes,1,opt,name=thermal,proto3" json:"thermal,omitempty"`
-	Certainty *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
-	Distance  *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
-	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Thermal       string                 `protobuf:"bytes,1,opt,name=thermal,proto3" json:"thermal,omitempty"`
+	Certainty     *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
+	Distance      *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
+	Targets       *Targets               `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1238,14 +1134,6 @@ func (x *NearThermalSearch) GetDistance() float64 {
 	return 0
 }
 
-// Deprecated: Marked as deprecated in v1/base_search.proto.
-func (x *NearThermalSearch) GetTargetVectors() []string {
-	if x != nil {
-		return x.TargetVectors
-	}
-	return nil
-}
-
 func (x *NearThermalSearch) GetTargets() *Targets {
 	if x != nil {
 		return x.Targets
@@ -1254,13 +1142,11 @@ func (x *NearThermalSearch) GetTargets() *Targets {
 }
 
 type NearIMUSearch struct {
-	state     protoimpl.MessageState `protogen:"open.v1"`
-	Imu       string                 `protobuf:"bytes,1,opt,name=imu,proto3" json:"imu,omitempty"`
-	Certainty *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
-	Distance  *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
-	// Deprecated: Marked as deprecated in v1/base_search.proto.
-	TargetVectors []string `protobuf:"bytes,4,rep,name=target_vectors,json=targetVectors,proto3" json:"target_vectors,omitempty"` // deprecated in 1.26 - use targets
-	Targets       *Targets `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Imu           string                 `protobuf:"bytes,1,opt,name=imu,proto3" json:"imu,omitempty"`
+	Certainty     *float64               `protobuf:"fixed64,2,opt,name=certainty,proto3,oneof" json:"certainty,omitempty"`
+	Distance      *float64               `protobuf:"fixed64,3,opt,name=distance,proto3,oneof" json:"distance,omitempty"`
+	Targets       *Targets               `protobuf:"bytes,5,opt,name=targets,proto3" json:"targets,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -1314,14 +1200,6 @@ func (x *NearIMUSearch) GetDistance() float64 {
 		return *x.Distance
 	}
 	return 0
-}
-
-// Deprecated: Marked as deprecated in v1/base_search.proto.
-func (x *NearIMUSearch) GetTargetVectors() []string {
-	if x != nil {
-		return x.TargetVectors
-	}
-	return nil
 }
 
 func (x *NearIMUSearch) GetTargets() *Targets {
@@ -1402,7 +1280,7 @@ type NearTextSearch_Move struct {
 
 func (x *NearTextSearch_Move) Reset() {
 	*x = NearTextSearch_Move{}
-	mi := &file_v1_base_search_proto_msgTypes[16]
+	mi := &file_v1_base_search_proto_msgTypes[15]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1414,7 +1292,7 @@ func (x *NearTextSearch_Move) String() string {
 func (*NearTextSearch_Move) ProtoMessage() {}
 
 func (x *NearTextSearch_Move) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_base_search_proto_msgTypes[16]
+	mi := &file_v1_base_search_proto_msgTypes[15]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1474,18 +1352,16 @@ const file_v1_base_search_proto_rawDesc = "" +
 	"\x14OPERATOR_UNSPECIFIED\x10\x00\x12\x0f\n" +
 	"\vOPERATOR_OR\x10\x01\x12\x10\n" +
 	"\fOPERATOR_AND\x10\x02B\x1a\n" +
-	"\x18_minimum_or_tokens_match\"\xe6\x05\n" +
+	"\x18_minimum_or_tokens_match\"\xab\x05\n" +
 	"\x06Hybrid\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\x12\x1e\n" +
 	"\n" +
 	"properties\x18\x02 \x03(\tR\n" +
-	"properties\x12\x1a\n" +
-	"\x06vector\x18\x03 \x03(\x02B\x02\x18\x01R\x06vector\x12\x14\n" +
+	"properties\x12\x14\n" +
 	"\x05alpha\x18\x04 \x01(\x02R\x05alpha\x12?\n" +
 	"\vfusion_type\x18\x05 \x01(\x0e2\x1e.weaviate.v1.Hybrid.FusionTypeR\n" +
 	"fusionType\x12%\n" +
-	"\fvector_bytes\x18\x06 \x01(\fB\x02\x18\x01R\vvectorBytes\x12)\n" +
-	"\x0etarget_vectors\x18\a \x03(\tB\x02\x18\x01R\rtargetVectors\x128\n" +
+	"\fvector_bytes\x18\x06 \x01(\fB\x02\x18\x01R\vvectorBytes\x128\n" +
 	"\tnear_text\x18\b \x01(\v2\x1b.weaviate.v1.NearTextSearchR\bnearText\x128\n" +
 	"\vnear_vector\x18\t \x01(\v2\x17.weaviate.v1.NearVectorR\n" +
 	"nearVector\x12.\n" +
@@ -1500,41 +1376,34 @@ const file_v1_base_search_proto_rawDesc = "" +
 	"\x12FUSION_TYPE_RANKED\x10\x01\x12\x1e\n" +
 	"\x1aFUSION_TYPE_RELATIVE_SCORE\x10\x02B\v\n" +
 	"\tthresholdB\x17\n" +
-	"\x15_bm25_search_operator\"\xa7\x04\n" +
+	"\x15_bm25_search_operatorJ\x04\b\x03\x10\x04J\x04\b\a\x10\b\"\xe6\x02\n" +
 	"\n" +
 	"NearVector\x12\x1a\n" +
 	"\x06vector\x18\x01 \x03(\x02B\x02\x18\x01R\x06vector\x12!\n" +
 	"\tcertainty\x18\x02 \x01(\x01H\x00R\tcertainty\x88\x01\x01\x12\x1f\n" +
 	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12%\n" +
-	"\fvector_bytes\x18\x04 \x01(\fB\x02\x18\x01R\vvectorBytes\x12)\n" +
-	"\x0etarget_vectors\x18\x05 \x03(\tB\x02\x18\x01R\rtargetVectors\x12.\n" +
-	"\atargets\x18\x06 \x01(\v2\x14.weaviate.v1.TargetsR\atargets\x12\\\n" +
-	"\x11vector_per_target\x18\a \x03(\v2,.weaviate.v1.NearVector.VectorPerTargetEntryB\x02\x18\x01R\x0fvectorPerTarget\x12J\n" +
+	"\fvector_bytes\x18\x04 \x01(\fB\x02\x18\x01R\vvectorBytes\x12.\n" +
+	"\atargets\x18\x06 \x01(\v2\x14.weaviate.v1.TargetsR\atargets\x12J\n" +
 	"\x12vector_for_targets\x18\b \x03(\v2\x1c.weaviate.v1.VectorForTargetR\x10vectorForTargets\x12.\n" +
-	"\avectors\x18\t \x03(\v2\x14.weaviate.v1.VectorsR\avectors\x1aB\n" +
-	"\x14VectorPerTargetEntry\x12\x10\n" +
-	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
-	"\x05value\x18\x02 \x01(\fR\x05value:\x028\x01B\f\n" +
+	"\avectors\x18\t \x03(\v2\x14.weaviate.v1.VectorsR\avectorsB\f\n" +
 	"\n" +
 	"_certaintyB\v\n" +
-	"\t_distance\"\xd6\x01\n" +
+	"\t_distanceJ\x04\b\x05\x10\x06J\x04\b\a\x10\b\"\xb1\x01\n" +
 	"\n" +
 	"NearObject\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12!\n" +
 	"\tcertainty\x18\x02 \x01(\x01H\x00R\tcertainty\x88\x01\x01\x12\x1f\n" +
-	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12)\n" +
-	"\x0etarget_vectors\x18\x04 \x03(\tB\x02\x18\x01R\rtargetVectors\x12.\n" +
+	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12.\n" +
 	"\atargets\x18\x05 \x01(\v2\x14.weaviate.v1.TargetsR\atargetsB\f\n" +
 	"\n" +
 	"_certaintyB\v\n" +
-	"\t_distance\"\xce\x03\n" +
+	"\t_distanceJ\x04\b\x04\x10\x05\"\xa9\x03\n" +
 	"\x0eNearTextSearch\x12\x14\n" +
 	"\x05query\x18\x01 \x03(\tR\x05query\x12!\n" +
 	"\tcertainty\x18\x02 \x01(\x01H\x00R\tcertainty\x88\x01\x01\x12\x1f\n" +
 	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12>\n" +
 	"\amove_to\x18\x04 \x01(\v2 .weaviate.v1.NearTextSearch.MoveH\x02R\x06moveTo\x88\x01\x01\x12B\n" +
-	"\tmove_away\x18\x05 \x01(\v2 .weaviate.v1.NearTextSearch.MoveH\x03R\bmoveAway\x88\x01\x01\x12)\n" +
-	"\x0etarget_vectors\x18\x06 \x03(\tB\x02\x18\x01R\rtargetVectors\x12.\n" +
+	"\tmove_away\x18\x05 \x01(\v2 .weaviate.v1.NearTextSearch.MoveH\x03R\bmoveAway\x88\x01\x01\x12.\n" +
 	"\atargets\x18\a \x01(\v2\x14.weaviate.v1.TargetsR\atargets\x1aN\n" +
 	"\x04Move\x12\x14\n" +
 	"\x05force\x18\x01 \x01(\x02R\x05force\x12\x1a\n" +
@@ -1546,61 +1415,55 @@ const file_v1_base_search_proto_rawDesc = "" +
 	"\n" +
 	"\b_move_toB\f\n" +
 	"\n" +
-	"_move_away\"\xe1\x01\n" +
+	"_move_awayJ\x04\b\x06\x10\a\"\xbc\x01\n" +
 	"\x0fNearImageSearch\x12\x14\n" +
 	"\x05image\x18\x01 \x01(\tR\x05image\x12!\n" +
 	"\tcertainty\x18\x02 \x01(\x01H\x00R\tcertainty\x88\x01\x01\x12\x1f\n" +
-	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12)\n" +
-	"\x0etarget_vectors\x18\x04 \x03(\tB\x02\x18\x01R\rtargetVectors\x12.\n" +
+	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12.\n" +
 	"\atargets\x18\x05 \x01(\v2\x14.weaviate.v1.TargetsR\atargetsB\f\n" +
 	"\n" +
 	"_certaintyB\v\n" +
-	"\t_distance\"\xe1\x01\n" +
+	"\t_distanceJ\x04\b\x04\x10\x05\"\xbc\x01\n" +
 	"\x0fNearAudioSearch\x12\x14\n" +
 	"\x05audio\x18\x01 \x01(\tR\x05audio\x12!\n" +
 	"\tcertainty\x18\x02 \x01(\x01H\x00R\tcertainty\x88\x01\x01\x12\x1f\n" +
-	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12)\n" +
-	"\x0etarget_vectors\x18\x04 \x03(\tB\x02\x18\x01R\rtargetVectors\x12.\n" +
+	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12.\n" +
 	"\atargets\x18\x05 \x01(\v2\x14.weaviate.v1.TargetsR\atargetsB\f\n" +
 	"\n" +
 	"_certaintyB\v\n" +
-	"\t_distance\"\xe1\x01\n" +
+	"\t_distanceJ\x04\b\x04\x10\x05\"\xbc\x01\n" +
 	"\x0fNearVideoSearch\x12\x14\n" +
 	"\x05video\x18\x01 \x01(\tR\x05video\x12!\n" +
 	"\tcertainty\x18\x02 \x01(\x01H\x00R\tcertainty\x88\x01\x01\x12\x1f\n" +
-	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12)\n" +
-	"\x0etarget_vectors\x18\x04 \x03(\tB\x02\x18\x01R\rtargetVectors\x12.\n" +
+	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12.\n" +
 	"\atargets\x18\x05 \x01(\v2\x14.weaviate.v1.TargetsR\atargetsB\f\n" +
 	"\n" +
 	"_certaintyB\v\n" +
-	"\t_distance\"\xe1\x01\n" +
+	"\t_distanceJ\x04\b\x04\x10\x05\"\xbc\x01\n" +
 	"\x0fNearDepthSearch\x12\x14\n" +
 	"\x05depth\x18\x01 \x01(\tR\x05depth\x12!\n" +
 	"\tcertainty\x18\x02 \x01(\x01H\x00R\tcertainty\x88\x01\x01\x12\x1f\n" +
-	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12)\n" +
-	"\x0etarget_vectors\x18\x04 \x03(\tB\x02\x18\x01R\rtargetVectors\x12.\n" +
+	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12.\n" +
 	"\atargets\x18\x05 \x01(\v2\x14.weaviate.v1.TargetsR\atargetsB\f\n" +
 	"\n" +
 	"_certaintyB\v\n" +
-	"\t_distance\"\xe7\x01\n" +
+	"\t_distanceJ\x04\b\x04\x10\x05\"\xc2\x01\n" +
 	"\x11NearThermalSearch\x12\x18\n" +
 	"\athermal\x18\x01 \x01(\tR\athermal\x12!\n" +
 	"\tcertainty\x18\x02 \x01(\x01H\x00R\tcertainty\x88\x01\x01\x12\x1f\n" +
-	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12)\n" +
-	"\x0etarget_vectors\x18\x04 \x03(\tB\x02\x18\x01R\rtargetVectors\x12.\n" +
+	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12.\n" +
 	"\atargets\x18\x05 \x01(\v2\x14.weaviate.v1.TargetsR\atargetsB\f\n" +
 	"\n" +
 	"_certaintyB\v\n" +
-	"\t_distance\"\xdb\x01\n" +
+	"\t_distanceJ\x04\b\x04\x10\x05\"\xb6\x01\n" +
 	"\rNearIMUSearch\x12\x10\n" +
 	"\x03imu\x18\x01 \x01(\tR\x03imu\x12!\n" +
 	"\tcertainty\x18\x02 \x01(\x01H\x00R\tcertainty\x88\x01\x01\x12\x1f\n" +
-	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12)\n" +
-	"\x0etarget_vectors\x18\x04 \x03(\tB\x02\x18\x01R\rtargetVectors\x12.\n" +
+	"\bdistance\x18\x03 \x01(\x01H\x01R\bdistance\x88\x01\x01\x12.\n" +
 	"\atargets\x18\x05 \x01(\v2\x14.weaviate.v1.TargetsR\atargetsB\f\n" +
 	"\n" +
 	"_certaintyB\v\n" +
-	"\t_distance\"\xa2\x01\n" +
+	"\t_distanceJ\x04\b\x04\x10\x05\"\xa2\x01\n" +
 	"\x04BM25\x12\x14\n" +
 	"\x05query\x18\x01 \x01(\tR\x05query\x12\x1e\n" +
 	"\n" +
@@ -1630,7 +1493,7 @@ func file_v1_base_search_proto_rawDescGZIP() []byte {
 }
 
 var file_v1_base_search_proto_enumTypes = make([]protoimpl.EnumInfo, 3)
-var file_v1_base_search_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_v1_base_search_proto_msgTypes = make([]protoimpl.MessageInfo, 16)
 var file_v1_base_search_proto_goTypes = []any{
 	(CombinationMethod)(0),              // 0: weaviate.v1.CombinationMethod
 	(SearchOperatorOptions_Operator)(0), // 1: weaviate.v1.SearchOperatorOptions.Operator
@@ -1650,41 +1513,39 @@ var file_v1_base_search_proto_goTypes = []any{
 	(*NearThermalSearch)(nil),           // 15: weaviate.v1.NearThermalSearch
 	(*NearIMUSearch)(nil),               // 16: weaviate.v1.NearIMUSearch
 	(*BM25)(nil),                        // 17: weaviate.v1.BM25
-	nil,                                 // 18: weaviate.v1.NearVector.VectorPerTargetEntry
-	(*NearTextSearch_Move)(nil),         // 19: weaviate.v1.NearTextSearch.Move
-	(*Vectors)(nil),                     // 20: weaviate.v1.Vectors
+	(*NearTextSearch_Move)(nil),         // 18: weaviate.v1.NearTextSearch.Move
+	(*Vectors)(nil),                     // 19: weaviate.v1.Vectors
 }
 var file_v1_base_search_proto_depIdxs = []int32{
 	0,  // 0: weaviate.v1.Targets.combination:type_name -> weaviate.v1.CombinationMethod
 	3,  // 1: weaviate.v1.Targets.weights_for_targets:type_name -> weaviate.v1.WeightsForTarget
-	20, // 2: weaviate.v1.VectorForTarget.vectors:type_name -> weaviate.v1.Vectors
+	19, // 2: weaviate.v1.VectorForTarget.vectors:type_name -> weaviate.v1.Vectors
 	1,  // 3: weaviate.v1.SearchOperatorOptions.operator:type_name -> weaviate.v1.SearchOperatorOptions.Operator
 	2,  // 4: weaviate.v1.Hybrid.fusion_type:type_name -> weaviate.v1.Hybrid.FusionType
 	10, // 5: weaviate.v1.Hybrid.near_text:type_name -> weaviate.v1.NearTextSearch
 	8,  // 6: weaviate.v1.Hybrid.near_vector:type_name -> weaviate.v1.NearVector
 	4,  // 7: weaviate.v1.Hybrid.targets:type_name -> weaviate.v1.Targets
 	6,  // 8: weaviate.v1.Hybrid.bm25_search_operator:type_name -> weaviate.v1.SearchOperatorOptions
-	20, // 9: weaviate.v1.Hybrid.vectors:type_name -> weaviate.v1.Vectors
+	19, // 9: weaviate.v1.Hybrid.vectors:type_name -> weaviate.v1.Vectors
 	4,  // 10: weaviate.v1.NearVector.targets:type_name -> weaviate.v1.Targets
-	18, // 11: weaviate.v1.NearVector.vector_per_target:type_name -> weaviate.v1.NearVector.VectorPerTargetEntry
-	5,  // 12: weaviate.v1.NearVector.vector_for_targets:type_name -> weaviate.v1.VectorForTarget
-	20, // 13: weaviate.v1.NearVector.vectors:type_name -> weaviate.v1.Vectors
-	4,  // 14: weaviate.v1.NearObject.targets:type_name -> weaviate.v1.Targets
-	19, // 15: weaviate.v1.NearTextSearch.move_to:type_name -> weaviate.v1.NearTextSearch.Move
-	19, // 16: weaviate.v1.NearTextSearch.move_away:type_name -> weaviate.v1.NearTextSearch.Move
-	4,  // 17: weaviate.v1.NearTextSearch.targets:type_name -> weaviate.v1.Targets
-	4,  // 18: weaviate.v1.NearImageSearch.targets:type_name -> weaviate.v1.Targets
-	4,  // 19: weaviate.v1.NearAudioSearch.targets:type_name -> weaviate.v1.Targets
-	4,  // 20: weaviate.v1.NearVideoSearch.targets:type_name -> weaviate.v1.Targets
-	4,  // 21: weaviate.v1.NearDepthSearch.targets:type_name -> weaviate.v1.Targets
-	4,  // 22: weaviate.v1.NearThermalSearch.targets:type_name -> weaviate.v1.Targets
-	4,  // 23: weaviate.v1.NearIMUSearch.targets:type_name -> weaviate.v1.Targets
-	6,  // 24: weaviate.v1.BM25.search_operator:type_name -> weaviate.v1.SearchOperatorOptions
-	25, // [25:25] is the sub-list for method output_type
-	25, // [25:25] is the sub-list for method input_type
-	25, // [25:25] is the sub-list for extension type_name
-	25, // [25:25] is the sub-list for extension extendee
-	0,  // [0:25] is the sub-list for field type_name
+	5,  // 11: weaviate.v1.NearVector.vector_for_targets:type_name -> weaviate.v1.VectorForTarget
+	19, // 12: weaviate.v1.NearVector.vectors:type_name -> weaviate.v1.Vectors
+	4,  // 13: weaviate.v1.NearObject.targets:type_name -> weaviate.v1.Targets
+	18, // 14: weaviate.v1.NearTextSearch.move_to:type_name -> weaviate.v1.NearTextSearch.Move
+	18, // 15: weaviate.v1.NearTextSearch.move_away:type_name -> weaviate.v1.NearTextSearch.Move
+	4,  // 16: weaviate.v1.NearTextSearch.targets:type_name -> weaviate.v1.Targets
+	4,  // 17: weaviate.v1.NearImageSearch.targets:type_name -> weaviate.v1.Targets
+	4,  // 18: weaviate.v1.NearAudioSearch.targets:type_name -> weaviate.v1.Targets
+	4,  // 19: weaviate.v1.NearVideoSearch.targets:type_name -> weaviate.v1.Targets
+	4,  // 20: weaviate.v1.NearDepthSearch.targets:type_name -> weaviate.v1.Targets
+	4,  // 21: weaviate.v1.NearThermalSearch.targets:type_name -> weaviate.v1.Targets
+	4,  // 22: weaviate.v1.NearIMUSearch.targets:type_name -> weaviate.v1.Targets
+	6,  // 23: weaviate.v1.BM25.search_operator:type_name -> weaviate.v1.SearchOperatorOptions
+	24, // [24:24] is the sub-list for method output_type
+	24, // [24:24] is the sub-list for method input_type
+	24, // [24:24] is the sub-list for extension type_name
+	24, // [24:24] is the sub-list for extension extendee
+	0,  // [0:24] is the sub-list for field type_name
 }
 
 func init() { file_v1_base_search_proto_init() }
@@ -1713,7 +1574,7 @@ func file_v1_base_search_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1_base_search_proto_rawDesc), len(file_v1_base_search_proto_rawDesc)),
 			NumEnums:      3,
-			NumMessages:   17,
+			NumMessages:   16,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/grpc/generated/protocol/v1/file_replication.pb.go
+++ b/grpc/generated/protocol/v1/file_replication.pb.go
@@ -735,8 +735,8 @@ const file_v1_file_replication_proto_rawDesc = "" +
 	"\x12ResumeFileActivity\x12&.weaviate.v1.ResumeFileActivityRequest\x1a'.weaviate.v1.ResumeFileActivityResponse\x12J\n" +
 	"\tListFiles\x12\x1d.weaviate.v1.ListFilesRequest\x1a\x1e.weaviate.v1.ListFilesResponse\x12U\n" +
 	"\x0fGetFileMetadata\x12#.weaviate.v1.GetFileMetadataRequest\x1a\x19.weaviate.v1.FileMetadata(\x010\x01\x12B\n" +
-	"\aGetFile\x12\x1b.weaviate.v1.GetFileRequest\x1a\x16.weaviate.v1.FileChunk(\x010\x01Bj\n" +
-	"#io.weaviate.client.grpc.protocol.v1B\rWeaviateProtoZ4github.com/weaviate/weaviate/grpc/generated;protocolb\x06proto3"
+	"\aGetFile\x12\x1b.weaviate.v1.GetFileRequest\x1a\x16.weaviate.v1.FileChunk(\x010\x01By\n" +
+	"#io.weaviate.client.grpc.protocol.v1B\x1cWeaviateProtoFileReplicationZ4github.com/weaviate/weaviate/grpc/generated;protocolb\x06proto3"
 
 var (
 	file_v1_file_replication_proto_rawDescOnce sync.Once

--- a/grpc/generated/protocol/v1/search_get.pb.go
+++ b/grpc/generated/protocol/v1/search_get.pb.go
@@ -37,25 +37,21 @@ type SearchRequest struct {
 	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
 	SortBy []*SortBy `protobuf:"bytes,34,rep,name=sort_by,json=sortBy,proto3" json:"sort_by,omitempty"`
 	// matches/searches for objects
-	Filters      *Filters           `protobuf:"bytes,40,opt,name=filters,proto3,oneof" json:"filters,omitempty"`
-	HybridSearch *Hybrid            `protobuf:"bytes,41,opt,name=hybrid_search,json=hybridSearch,proto3,oneof" json:"hybrid_search,omitempty"`
-	Bm25Search   *BM25              `protobuf:"bytes,42,opt,name=bm25_search,json=bm25Search,proto3,oneof" json:"bm25_search,omitempty"`
-	NearVector   *NearVector        `protobuf:"bytes,43,opt,name=near_vector,json=nearVector,proto3,oneof" json:"near_vector,omitempty"`
-	NearObject   *NearObject        `protobuf:"bytes,44,opt,name=near_object,json=nearObject,proto3,oneof" json:"near_object,omitempty"`
-	NearText     *NearTextSearch    `protobuf:"bytes,45,opt,name=near_text,json=nearText,proto3,oneof" json:"near_text,omitempty"`
-	NearImage    *NearImageSearch   `protobuf:"bytes,46,opt,name=near_image,json=nearImage,proto3,oneof" json:"near_image,omitempty"`
-	NearAudio    *NearAudioSearch   `protobuf:"bytes,47,opt,name=near_audio,json=nearAudio,proto3,oneof" json:"near_audio,omitempty"`
-	NearVideo    *NearVideoSearch   `protobuf:"bytes,48,opt,name=near_video,json=nearVideo,proto3,oneof" json:"near_video,omitempty"`
-	NearDepth    *NearDepthSearch   `protobuf:"bytes,49,opt,name=near_depth,json=nearDepth,proto3,oneof" json:"near_depth,omitempty"`
-	NearThermal  *NearThermalSearch `protobuf:"bytes,50,opt,name=near_thermal,json=nearThermal,proto3,oneof" json:"near_thermal,omitempty"`
-	NearImu      *NearIMUSearch     `protobuf:"bytes,51,opt,name=near_imu,json=nearImu,proto3,oneof" json:"near_imu,omitempty"`
-	Generative   *GenerativeSearch  `protobuf:"bytes,60,opt,name=generative,proto3,oneof" json:"generative,omitempty"`
-	Rerank       *Rerank            `protobuf:"bytes,61,opt,name=rerank,proto3,oneof" json:"rerank,omitempty"`
-	// Deprecated: Marked as deprecated in v1/search_get.proto.
-	Uses_123Api bool `protobuf:"varint,100,opt,name=uses_123_api,json=uses123Api,proto3" json:"uses_123_api,omitempty"`
-	// Deprecated: Marked as deprecated in v1/search_get.proto.
-	Uses_125Api   bool `protobuf:"varint,101,opt,name=uses_125_api,json=uses125Api,proto3" json:"uses_125_api,omitempty"`
-	Uses_127Api   bool `protobuf:"varint,102,opt,name=uses_127_api,json=uses127Api,proto3" json:"uses_127_api,omitempty"`
+	Filters       *Filters           `protobuf:"bytes,40,opt,name=filters,proto3,oneof" json:"filters,omitempty"`
+	HybridSearch  *Hybrid            `protobuf:"bytes,41,opt,name=hybrid_search,json=hybridSearch,proto3,oneof" json:"hybrid_search,omitempty"`
+	Bm25Search    *BM25              `protobuf:"bytes,42,opt,name=bm25_search,json=bm25Search,proto3,oneof" json:"bm25_search,omitempty"`
+	NearVector    *NearVector        `protobuf:"bytes,43,opt,name=near_vector,json=nearVector,proto3,oneof" json:"near_vector,omitempty"`
+	NearObject    *NearObject        `protobuf:"bytes,44,opt,name=near_object,json=nearObject,proto3,oneof" json:"near_object,omitempty"`
+	NearText      *NearTextSearch    `protobuf:"bytes,45,opt,name=near_text,json=nearText,proto3,oneof" json:"near_text,omitempty"`
+	NearImage     *NearImageSearch   `protobuf:"bytes,46,opt,name=near_image,json=nearImage,proto3,oneof" json:"near_image,omitempty"`
+	NearAudio     *NearAudioSearch   `protobuf:"bytes,47,opt,name=near_audio,json=nearAudio,proto3,oneof" json:"near_audio,omitempty"`
+	NearVideo     *NearVideoSearch   `protobuf:"bytes,48,opt,name=near_video,json=nearVideo,proto3,oneof" json:"near_video,omitempty"`
+	NearDepth     *NearDepthSearch   `protobuf:"bytes,49,opt,name=near_depth,json=nearDepth,proto3,oneof" json:"near_depth,omitempty"`
+	NearThermal   *NearThermalSearch `protobuf:"bytes,50,opt,name=near_thermal,json=nearThermal,proto3,oneof" json:"near_thermal,omitempty"`
+	NearImu       *NearIMUSearch     `protobuf:"bytes,51,opt,name=near_imu,json=nearImu,proto3,oneof" json:"near_imu,omitempty"`
+	Generative    *GenerativeSearch  `protobuf:"bytes,60,opt,name=generative,proto3,oneof" json:"generative,omitempty"`
+	Rerank        *Rerank            `protobuf:"bytes,61,opt,name=rerank,proto3,oneof" json:"rerank,omitempty"`
+	Uses_127Api   bool               `protobuf:"varint,102,opt,name=uses_127_api,json=uses127Api,proto3" json:"uses_127_api,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -263,22 +259,6 @@ func (x *SearchRequest) GetRerank() *Rerank {
 		return x.Rerank
 	}
 	return nil
-}
-
-// Deprecated: Marked as deprecated in v1/search_get.proto.
-func (x *SearchRequest) GetUses_123Api() bool {
-	if x != nil {
-		return x.Uses_123Api
-	}
-	return false
-}
-
-// Deprecated: Marked as deprecated in v1/search_get.proto.
-func (x *SearchRequest) GetUses_125Api() bool {
-	if x != nil {
-		return x.Uses_125Api
-	}
-	return false
 }
 
 func (x *SearchRequest) GetUses_127Api() bool {
@@ -1056,25 +1036,21 @@ func (x *SearchResult) GetGenerative() *GenerativeResult {
 }
 
 type MetadataResult struct {
-	state protoimpl.MessageState `protogen:"open.v1"`
-	Id    string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
-	// protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
-	//
-	// Deprecated: Marked as deprecated in v1/search_get.proto.
-	Vector                    []float32 `protobuf:"fixed32,2,rep,packed,name=vector,proto3" json:"vector,omitempty"`
-	CreationTimeUnix          int64     `protobuf:"varint,3,opt,name=creation_time_unix,json=creationTimeUnix,proto3" json:"creation_time_unix,omitempty"`
-	CreationTimeUnixPresent   bool      `protobuf:"varint,4,opt,name=creation_time_unix_present,json=creationTimeUnixPresent,proto3" json:"creation_time_unix_present,omitempty"`
-	LastUpdateTimeUnix        int64     `protobuf:"varint,5,opt,name=last_update_time_unix,json=lastUpdateTimeUnix,proto3" json:"last_update_time_unix,omitempty"`
-	LastUpdateTimeUnixPresent bool      `protobuf:"varint,6,opt,name=last_update_time_unix_present,json=lastUpdateTimeUnixPresent,proto3" json:"last_update_time_unix_present,omitempty"`
-	Distance                  float32   `protobuf:"fixed32,7,opt,name=distance,proto3" json:"distance,omitempty"`
-	DistancePresent           bool      `protobuf:"varint,8,opt,name=distance_present,json=distancePresent,proto3" json:"distance_present,omitempty"`
-	Certainty                 float32   `protobuf:"fixed32,9,opt,name=certainty,proto3" json:"certainty,omitempty"`
-	CertaintyPresent          bool      `protobuf:"varint,10,opt,name=certainty_present,json=certaintyPresent,proto3" json:"certainty_present,omitempty"`
-	Score                     float32   `protobuf:"fixed32,11,opt,name=score,proto3" json:"score,omitempty"`
-	ScorePresent              bool      `protobuf:"varint,12,opt,name=score_present,json=scorePresent,proto3" json:"score_present,omitempty"`
-	ExplainScore              string    `protobuf:"bytes,13,opt,name=explain_score,json=explainScore,proto3" json:"explain_score,omitempty"`
-	ExplainScorePresent       bool      `protobuf:"varint,14,opt,name=explain_score_present,json=explainScorePresent,proto3" json:"explain_score_present,omitempty"`
-	IsConsistent              *bool     `protobuf:"varint,15,opt,name=is_consistent,json=isConsistent,proto3,oneof" json:"is_consistent,omitempty"`
+	state                     protoimpl.MessageState `protogen:"open.v1"`
+	Id                        string                 `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`
+	CreationTimeUnix          int64                  `protobuf:"varint,3,opt,name=creation_time_unix,json=creationTimeUnix,proto3" json:"creation_time_unix,omitempty"`
+	CreationTimeUnixPresent   bool                   `protobuf:"varint,4,opt,name=creation_time_unix_present,json=creationTimeUnixPresent,proto3" json:"creation_time_unix_present,omitempty"`
+	LastUpdateTimeUnix        int64                  `protobuf:"varint,5,opt,name=last_update_time_unix,json=lastUpdateTimeUnix,proto3" json:"last_update_time_unix,omitempty"`
+	LastUpdateTimeUnixPresent bool                   `protobuf:"varint,6,opt,name=last_update_time_unix_present,json=lastUpdateTimeUnixPresent,proto3" json:"last_update_time_unix_present,omitempty"`
+	Distance                  float32                `protobuf:"fixed32,7,opt,name=distance,proto3" json:"distance,omitempty"`
+	DistancePresent           bool                   `protobuf:"varint,8,opt,name=distance_present,json=distancePresent,proto3" json:"distance_present,omitempty"`
+	Certainty                 float32                `protobuf:"fixed32,9,opt,name=certainty,proto3" json:"certainty,omitempty"`
+	CertaintyPresent          bool                   `protobuf:"varint,10,opt,name=certainty_present,json=certaintyPresent,proto3" json:"certainty_present,omitempty"`
+	Score                     float32                `protobuf:"fixed32,11,opt,name=score,proto3" json:"score,omitempty"`
+	ScorePresent              bool                   `protobuf:"varint,12,opt,name=score_present,json=scorePresent,proto3" json:"score_present,omitempty"`
+	ExplainScore              string                 `protobuf:"bytes,13,opt,name=explain_score,json=explainScore,proto3" json:"explain_score,omitempty"`
+	ExplainScorePresent       bool                   `protobuf:"varint,14,opt,name=explain_score_present,json=explainScorePresent,proto3" json:"explain_score_present,omitempty"`
+	IsConsistent              *bool                  `protobuf:"varint,15,opt,name=is_consistent,json=isConsistent,proto3,oneof" json:"is_consistent,omitempty"`
 	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	Generative string `protobuf:"bytes,16,opt,name=generative,proto3" json:"generative,omitempty"`
 	// Deprecated: Marked as deprecated in v1/search_get.proto.
@@ -1124,14 +1100,6 @@ func (x *MetadataResult) GetId() string {
 		return x.Id
 	}
 	return ""
-}
-
-// Deprecated: Marked as deprecated in v1/search_get.proto.
-func (x *MetadataResult) GetVector() []float32 {
-	if x != nil {
-		return x.Vector
-	}
-	return nil
 }
 
 func (x *MetadataResult) GetCreationTimeUnix() int64 {
@@ -1415,7 +1383,7 @@ var File_v1_search_get_proto protoreflect.FileDescriptor
 
 const file_v1_search_get_proto_rawDesc = "" +
 	"\n" +
-	"\x13v1/search_get.proto\x12\vweaviate.v1\x1a\rv1/base.proto\x1a\x14v1/base_search.proto\x1a\x13v1/generative.proto\x1a\x13v1/properties.proto\"\xc7\r\n" +
+	"\x13v1/search_get.proto\x12\vweaviate.v1\x1a\rv1/base.proto\x1a\x14v1/base_search.proto\x1a\x13v1/generative.proto\x1a\x13v1/properties.proto\"\x87\r\n" +
 	"\rSearchRequest\x12\x1e\n" +
 	"\n" +
 	"collection\x18\x01 \x01(\tR\n" +
@@ -1456,11 +1424,7 @@ const file_v1_search_get_proto_rawDesc = "" +
 	"\n" +
 	"generative\x18< \x01(\v2\x1d.weaviate.v1.GenerativeSearchH\x10R\n" +
 	"generative\x88\x01\x01\x120\n" +
-	"\x06rerank\x18= \x01(\v2\x13.weaviate.v1.RerankH\x11R\x06rerank\x88\x01\x01\x12$\n" +
-	"\fuses_123_api\x18d \x01(\bB\x02\x18\x01R\n" +
-	"uses123Api\x12$\n" +
-	"\fuses_125_api\x18e \x01(\bB\x02\x18\x01R\n" +
-	"uses125Api\x12 \n" +
+	"\x06rerank\x18= \x01(\v2\x13.weaviate.v1.RerankH\x11R\x06rerank\x88\x01\x01\x12 \n" +
 	"\fuses_127_api\x18f \x01(\bR\n" +
 	"uses127ApiB\x14\n" +
 	"\x12_consistency_levelB\r\n" +
@@ -1482,7 +1446,7 @@ const file_v1_search_get_proto_rawDesc = "" +
 	"\r_near_thermalB\v\n" +
 	"\t_near_imuB\r\n" +
 	"\v_generativeB\t\n" +
-	"\a_rerank\"s\n" +
+	"\a_rerankJ\x04\bd\x10eJ\x04\be\x10f\"s\n" +
 	"\aGroupBy\x12\x12\n" +
 	"\x04path\x18\x01 \x03(\tR\x04path\x12(\n" +
 	"\x10number_of_groups\x18\x02 \x01(\x05R\x0enumberOfGroups\x12*\n" +
@@ -1554,10 +1518,9 @@ const file_v1_search_get_proto_rawDesc = "" +
 	"\n" +
 	"generative\x18\x03 \x01(\v2\x1d.weaviate.v1.GenerativeResultH\x00R\n" +
 	"generative\x88\x01\x01B\r\n" +
-	"\v_generative\"\xd1\a\n" +
+	"\v_generative\"\xbb\a\n" +
 	"\x0eMetadataResult\x12\x0e\n" +
-	"\x02id\x18\x01 \x01(\tR\x02id\x12\x1a\n" +
-	"\x06vector\x18\x02 \x03(\x02B\x02\x18\x01R\x06vector\x12,\n" +
+	"\x02id\x18\x01 \x01(\tR\x02id\x12,\n" +
 	"\x12creation_time_unix\x18\x03 \x01(\x03R\x10creationTimeUnix\x12;\n" +
 	"\x1acreation_time_unix_present\x18\x04 \x01(\bR\x17creationTimeUnixPresent\x121\n" +
 	"\x15last_update_time_unix\x18\x05 \x01(\x03R\x12lastUpdateTimeUnix\x12@\n" +
@@ -1582,7 +1545,7 @@ const file_v1_search_get_proto_rawDesc = "" +
 	"\frerank_score\x18\x15 \x01(\x01R\vrerankScore\x120\n" +
 	"\x14rerank_score_present\x18\x16 \x01(\bR\x12rerankScorePresent\x12.\n" +
 	"\avectors\x18\x17 \x03(\v2\x14.weaviate.v1.VectorsR\avectorsB\x10\n" +
-	"\x0e_is_consistent\"\xce\x02\n" +
+	"\x0e_is_consistentJ\x04\b\x02\x10\x03\"\xce\x02\n" +
 	"\x10PropertiesResult\x12=\n" +
 	"\tref_props\x18\x02 \x03(\v2 .weaviate.v1.RefPropertiesResultR\brefProps\x12+\n" +
 	"\x11target_collection\x18\x03 \x01(\tR\x10targetCollection\x127\n" +

--- a/grpc/proto/v1/base_search.proto
+++ b/grpc/proto/v1/base_search.proto
@@ -49,7 +49,7 @@ message Hybrid {
   string query = 1;
   repeated string properties = 2;
   // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
-  repeated float vector = 3 [deprecated = true];  // will be removed in the future, use vectors
+  reserved 3;  // was vector
   float alpha = 4;
   enum FusionType {
     FUSION_TYPE_UNSPECIFIED = 0;
@@ -58,7 +58,7 @@ message Hybrid {
   }
   FusionType fusion_type = 5;
   bytes vector_bytes = 6 [deprecated = true];  // deprecated in 1.29.0 - use vectors
-  repeated string target_vectors = 7 [deprecated = true];  // deprecated in 1.26 - use targets
+  reserved 7;  // was target_vectors
   NearTextSearch near_text = 8;  // targets in msg is ignored and should not be set for hybrid
   NearVector near_vector = 9;  // same as above. Use the target vector in the hybrid message
   Targets targets = 10;
@@ -78,9 +78,9 @@ message NearVector {
   optional double certainty = 2;
   optional double distance = 3;
   bytes vector_bytes = 4 [deprecated = true];  // deprecated in 1.29.0 - use vectors
-  repeated string target_vectors = 5 [deprecated = true];  // deprecated in 1.26 - use targets
+  reserved 5;  // was target_vectors
   Targets targets = 6;
-  map <string, bytes> vector_per_target = 7 [deprecated = true]; // deprecated in 1.26.2 - use vector_for_targets
+  reserved 7;  // was vector_per_target
   repeated VectorForTarget vector_for_targets = 8;
   repeated Vectors vectors = 9;
 }
@@ -89,7 +89,7 @@ message NearObject {
   string id = 1;
   optional double certainty = 2;
   optional double distance = 3;
-  repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
+  reserved 4;  // was target_vectors
   Targets targets = 5;
 }
 
@@ -106,7 +106,7 @@ message NearTextSearch {
   optional double distance = 3;
   optional Move move_to = 4;
   optional Move move_away = 5;
-  repeated string target_vectors = 6 [deprecated = true];  // deprecated in 1.26 - use targets
+  reserved 6;  // was target_vectors
   Targets targets = 7;
 };
 
@@ -114,7 +114,7 @@ message NearImageSearch {
   string image = 1;
   optional double certainty = 2;
   optional double distance = 3;
-  repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
+  reserved 4;  // was target_vectors
   Targets targets = 5;
 };
 
@@ -122,7 +122,7 @@ message NearAudioSearch {
   string audio = 1;
   optional double certainty = 2;
   optional double distance = 3;
-  repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
+  reserved 4;  // was target_vectors
   Targets targets = 5;
 };
 
@@ -130,7 +130,7 @@ message NearVideoSearch {
   string video = 1;
   optional double certainty = 2;
   optional double distance = 3;
-  repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
+  reserved 4;  // was target_vectors
   Targets targets = 5;
 };
 
@@ -138,7 +138,7 @@ message NearDepthSearch {
   string depth = 1;
   optional double certainty = 2;
   optional double distance = 3;
-  repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
+  reserved 4;  // was target_vectors
   Targets targets = 5;
 }
 
@@ -146,7 +146,7 @@ message NearThermalSearch {
   string thermal = 1;
   optional double certainty = 2;
   optional double distance = 3;
-  repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
+  reserved 4;  // was target_vectors
   Targets targets = 5;
 }
 
@@ -154,7 +154,7 @@ message NearIMUSearch {
   string imu = 1;
   optional double certainty = 2;
   optional double distance = 3;
-  repeated string target_vectors = 4 [deprecated = true];  // deprecated in 1.26 - use targets
+  reserved 4;  // was target_vectors
   Targets targets = 5;
 }
 

--- a/grpc/proto/v1/search_get.proto
+++ b/grpc/proto/v1/search_get.proto
@@ -49,8 +49,8 @@ message SearchRequest {
   optional GenerativeSearch generative = 60;
   optional Rerank rerank = 61;
 
-  bool uses_123_api = 100 [deprecated = true];
-  bool uses_125_api = 101 [deprecated = true];
+  reserved 100; // was uses_123_api
+  reserved 101; // was uses_125_api
   bool uses_127_api = 102; 
 }
 
@@ -143,7 +143,7 @@ message SearchResult {
 message MetadataResult {
   string id = 1;
   // protolint:disable:next REPEATED_FIELD_NAMES_PLURALIZED
-  repeated float vector = 2 [deprecated = true];
+  reserved 2; // was vector
   int64 creation_time_unix = 3;
   bool creation_time_unix_present = 4;
   int64 last_update_time_unix = 5;

--- a/test/acceptance/aliases/aliases_api_grpc_test.go
+++ b/test/acceptance/aliases/aliases_api_grpc_test.go
@@ -102,9 +102,8 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 			t.Run("search", func(t *testing.T) {
 				t.Run("get", func(t *testing.T) {
 					resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
-						Collection:  tt.accessUsing,
-						Uses_123Api: true,
-						Uses_125Api: true,
+						Collection: tt.accessUsing,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -121,8 +120,7 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 							On:        []string{"title"},
 							TestValue: &pb.Filters_ValueText{ValueText: "Dune"},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -139,8 +137,7 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 						NearText: &pb.NearTextSearch{
 							Query: []string{"Dune"},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -157,8 +154,7 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 							Query:      "Dune",
 							Properties: []string{"title"},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -178,8 +174,7 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 						Properties: &pb.PropertiesRequest{
 							NonRefProperties: []string{"title"},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -355,8 +350,7 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 							On:        []string{filters.InternalPropID},
 							TestValue: &pb.Filters_ValueText{ValueText: theMartian},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)

--- a/test/acceptance/grpc/filtered_search_test.go
+++ b/test/acceptance/grpc/filtered_search_test.go
@@ -102,8 +102,6 @@ func TestGRPC_FilteredSearch(t *testing.T) {
 							Target: &pb.FilterTarget_Property{Property: propName},
 						},
 					},
-					Uses_123Api: true,
-					Uses_125Api: true,
 				}
 				t.Run(fmt.Sprintf("with singular token %q", tok1), func(t *testing.T) {
 					t.Parallel()
@@ -172,8 +170,6 @@ func TestGRPC_FilteredSearch(t *testing.T) {
 							Target: &pb.FilterTarget_Property{Property: propName},
 						},
 					},
-					Uses_123Api: true,
-					Uses_125Api: true,
 				}
 
 				searchResp, err := grpcClient.Search(context.Background(), &in)
@@ -213,8 +209,6 @@ func TestGRPC_FilteredSearch(t *testing.T) {
 							Target: &pb.FilterTarget_Property{Property: propName},
 						},
 					},
-					Uses_123Api: true,
-					Uses_125Api: true,
 				}
 
 				searchResp, err := grpcClient.Search(context.Background(), &in)

--- a/test/acceptance/grpc/grpc_named_vectors_test.go
+++ b/test/acceptance/grpc/grpc_named_vectors_test.go
@@ -74,8 +74,6 @@ func TestGRPC_NamedVectors(t *testing.T) {
 					Query:         "Dune",
 					TargetVectors: []string{"all"},
 				},
-				Uses_123Api: true,
-				Uses_125Api: true,
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)
@@ -100,7 +98,6 @@ func TestGRPC_NamedVectors(t *testing.T) {
 					Query:         "Dune",
 					TargetVectors: []string{"all"},
 				},
-				Uses_123Api: true,
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)
@@ -128,8 +125,6 @@ func TestGRPC_NamedVectors(t *testing.T) {
 					},
 					TargetVectors: []string{"all"},
 				},
-				Uses_123Api: true,
-				Uses_125Api: true,
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)
@@ -149,8 +144,6 @@ func TestGRPC_NamedVectors(t *testing.T) {
 					Query:         []string{"Dune"},
 					TargetVectors: []string{"all"},
 				},
-				Uses_123Api: true,
-				Uses_125Api: true,
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)
@@ -175,7 +168,6 @@ func TestGRPC_NamedVectors(t *testing.T) {
 					Query:         []string{"Dune"},
 					TargetVectors: []string{"all"},
 				},
-				Uses_123Api: true,
 			})
 			require.NoError(t, err)
 			require.NotNil(t, resp)

--- a/test/acceptance/grpc/grpc_search_test.go
+++ b/test/acceptance/grpc/grpc_search_test.go
@@ -180,10 +180,9 @@ func TestGRPCSearch(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				resp, err := grpcClient.Search(ctx, &protocol.SearchRequest{
-					Collection:  class.Class,
-					NearVector:  tt.nearVector,
-					Uses_123Api: true,
-					Uses_125Api: true,
+					Collection: class.Class,
+					NearVector: tt.nearVector,
+
 					Uses_127Api: true,
 				})
 				require.NoError(t, err)
@@ -232,8 +231,7 @@ func TestGRPCSearch(t *testing.T) {
 								TargetVectors: []string{"regular"},
 							},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -262,8 +260,7 @@ func TestGRPCSearch(t *testing.T) {
 							TargetVectors: []string{"regular"},
 						},
 					},
-					Uses_123Api: true,
-					Uses_125Api: true,
+
 					Uses_127Api: true,
 				})
 				require.NoError(t, err)
@@ -289,8 +286,7 @@ func TestGRPCSearch(t *testing.T) {
 							TargetVectors: []string{"colbert"},
 						},
 					},
-					Uses_123Api: true,
-					Uses_125Api: true,
+
 					Uses_127Api: true,
 				})
 				require.NoError(t, err)
@@ -317,8 +313,7 @@ func TestGRPCSearch(t *testing.T) {
 						TargetVectors: []string{"regular"},
 					},
 				},
-				Uses_123Api: true,
-				Uses_125Api: true,
+
 				Uses_127Api: true,
 			})
 			require.NoError(t, err)
@@ -348,8 +343,7 @@ func TestGRPCSearch(t *testing.T) {
 						TargetVectors: []string{"colbert"},
 					},
 				},
-				Uses_123Api: true,
-				Uses_125Api: true,
+
 				Uses_127Api: true,
 			})
 			require.NoError(t, err)
@@ -388,8 +382,7 @@ func TestGRPCSearch(t *testing.T) {
 						TargetVectors: []string{"regular", "colbert"},
 					},
 				},
-				Uses_123Api: true,
-				Uses_125Api: true,
+
 				Uses_127Api: true,
 			})
 			require.NoError(t, err)
@@ -438,8 +431,7 @@ func TestGRPCSearch(t *testing.T) {
 						TargetVectors: []string{"regular", "colbert", "description"},
 					},
 				},
-				Uses_123Api: true,
-				Uses_125Api: true,
+
 				Uses_127Api: true,
 			})
 			require.NoError(t, err)
@@ -499,8 +491,7 @@ func TestGRPCSearch(t *testing.T) {
 								TargetVectors:     []string{"regular", "regular"},
 							},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -566,8 +557,7 @@ func TestGRPCSearch(t *testing.T) {
 								TargetVectors:     tt.targetVectors,
 							},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -615,8 +605,7 @@ func TestGRPCSearch(t *testing.T) {
 						TargetVectors: []string{"regular", "regular", "colbert", "colbert"},
 					},
 				},
-				Uses_123Api: true,
-				Uses_125Api: true,
+
 				Uses_127Api: true,
 			})
 			require.NoError(t, err)
@@ -705,8 +694,7 @@ func TestGRPCSearch(t *testing.T) {
 								TargetVectors:     tt.targetVectors,
 							},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -777,8 +765,7 @@ func TestGRPCSearch(t *testing.T) {
 								TargetVectors:     []string{"regular", "description"},
 							},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -842,8 +829,7 @@ func TestGRPCSearch(t *testing.T) {
 								TargetVectors:     []string{"regular", "regular"},
 							},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -912,8 +898,7 @@ func TestGRPCSearch(t *testing.T) {
 								TargetVectors:     tt.targetVectors,
 							},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -1007,8 +992,7 @@ func TestGRPCSearch(t *testing.T) {
 								TargetVectors:     tt.targetVectors,
 							},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)
@@ -1067,8 +1051,7 @@ func TestGRPCSearch(t *testing.T) {
 								TargetVectors:     []string{"regular", "regular"},
 							},
 						},
-						Uses_123Api: true,
-						Uses_125Api: true,
+
 						Uses_127Api: true,
 					})
 					require.NoError(t, err)

--- a/test/acceptance/grpc/grpc_test.go
+++ b/test/acceptance/grpc/grpc_test.go
@@ -97,8 +97,6 @@ func TestGRPC(t *testing.T) {
 				Metadata: &pb.MetadataRequest{
 					Uuid: true,
 				},
-				Uses_123Api: true,
-				Uses_125Api: true,
 			},
 		},
 		{
@@ -108,8 +106,6 @@ func TestGRPC(t *testing.T) {
 				Metadata: &pb.MetadataRequest{
 					Uuid: true,
 				},
-				Uses_123Api: true,
-				Uses_125Api: true,
 			},
 		},
 	}
@@ -205,8 +201,6 @@ func TestGRPC(t *testing.T) {
 			HybridSearch: &pb.Hybrid{
 				Query: "Dune",
 			},
-			Uses_123Api: true,
-			Uses_125Api: true,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -225,7 +219,6 @@ func TestGRPC(t *testing.T) {
 			HybridSearch: &pb.Hybrid{
 				Query: "Dune",
 			},
-			Uses_123Api: true,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -239,8 +232,6 @@ func TestGRPC(t *testing.T) {
 			NearText: &pb.NearTextSearch{
 				Query: []string{"Dune"},
 			},
-			Uses_123Api: true,
-			Uses_125Api: true,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
@@ -259,7 +250,6 @@ func TestGRPC(t *testing.T) {
 			NearText: &pb.NearTextSearch{
 				Query: []string{"Dune"},
 			},
-			Uses_123Api: true,
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp)

--- a/test/acceptance/grpc/list_value_return_test.go
+++ b/test/acceptance/grpc/list_value_return_test.go
@@ -140,8 +140,6 @@ func TestGRPC_ListValueReturn(t *testing.T) {
 					PrimitiveProperties: []string{"texts"},
 				}},
 			},
-			Uses_123Api: true,
-			Uses_125Api: true,
 		}
 		searchResp, err := grpcClient.Search(context.Background(), &in)
 		require.Nil(t, err)


### PR DESCRIPTION
### What's being changed:

Removes and reserves:
- `uses_123_api`
- `uses_125_api`
- `vector_bytes` in certain instances
- `vector_per_target`
- `target_vectors`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
