### PR TITLE
fix(migration): use relative path for vectors_compressed folder when creating a symlink

### DIFF
--- a/adapters/repos/db/shard_compressed_vectors_migrator.go
+++ b/adapters/repos/db/shard_compressed_vectors_migrator.go
@@ -134,12 +134,19 @@ func (m compressedVectorsMigrator) migrate(targetVector string,
 			return err
 		}
 		m.logger.Infof("renamed old vectors compressed bucket for target vector: %s", targetVector)
-		if err := os.Chdir(lsmDir); err != nil {
-			return err
-		}
-		err := os.Symlink(targetVectorBucket, vectorsCompressedPath)
+		cwd, err := os.Getwd()
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to get current working directory: %w", err)
+		}
+		if err := os.Chdir(lsmDir); err != nil {
+			return fmt.Errorf("failed to set the current working directory to %s: %w", lsmDir, err)
+		}
+		err = os.Symlink(targetVectorBucket, helpers.VectorsCompressedBucketLSM)
+		if err != nil {
+			return fmt.Errorf("failed to create a symlink: %w", err)
+		}
+		if err := os.Chdir(cwd); err != nil {
+			return fmt.Errorf("failed to set the current working back to %s: %w", cwd, err)
 		}
 		m.logger.Infof("created symbolic link to old vectors compressed folder for target vector: %s", targetVector)
 		return nil


### PR DESCRIPTION
### What's being changed:

Always use absolute path when creating a symlink to vectors_compressed folder, this fix prevents this error from happening, when we have set a relative path to `PERSISTENCE_DATA_PATH="./data":
```
ERRO[0008] failed to migrate vectors compressed folder   action=init_target_vectors build_git_commit=4a359814b1 build_go_version=go1.25.0 build_image_tag=stable/v1.33 build_wv_version=1.33.0 error="failed to rename old compressed vector bucket for target vector left: symlink vectors_compressed_left data/dualvector/m2yoWn0JdsaP/lsm/vectors_compressed: no such file or directory"
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
