### PR TITLE
chore(migration): create vectors_compressed folder for new named vectors

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -356,6 +356,11 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 		return err
 	}
 
+	if err := newCompressedVectorsMigrator(s.index.logger).doUpdate(s, updated); err != nil {
+		s.index.logger.WithField("action", "update_vector_index_configs").
+			Errorf("failed to migrate vectors compressed folder: %v", err)
+	}
+
 	i := 0
 	targetVecs := make([]string, len(updated))
 	for targetVec := range updated {

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -228,7 +228,7 @@ func (s *Shard) initTargetVectors(ctx context.Context) error {
 
 	if err := newCompressedVectorsMigrator(s.index.logger).do(s); err != nil {
 		s.index.logger.WithField("action", "init_target_vectors").
-			WithError(err).Error("failed to migrate vectors compressed folder")
+			Errorf("failed to migrate vectors compressed folder: %v", err)
 	}
 
 	s.vectorIndexes = make(map[string]VectorIndex, len(s.index.vectorIndexUserConfigs))


### PR DESCRIPTION
### What's being changed:

This PR ensures to always create a vectors_compressed folder symlink, to enable us downgrades.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
