### PR TITLE
Async Replication Enabled Per Shard

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -232,6 +232,8 @@ type Index struct {
 	shardReindexer ShardReindexerV3
 
 	bitmapBufPool roaringset.BitmapBufPool
+
+	router *router.Router
 }
 
 func (i *Index) ID() string {
@@ -305,6 +307,7 @@ func NewIndex(ctx context.Context, cfg IndexConfig,
 		shardLoadLimiter:        cfg.ShardLoadLimiter,
 		shardReindexer:          shardReindexer,
 		bitmapBufPool:           bitmapBufPool,
+		router:                  router,
 	}
 
 	getDeletionStrategy := func() string {
@@ -644,10 +647,10 @@ func (i *Index) updateReplicationConfig(ctx context.Context, cfg *models.Replica
 
 	i.Config.ReplicationFactor = cfg.Factor
 	i.Config.DeletionStrategy = cfg.DeletionStrategy
-	i.Config.AsyncReplicationEnabled = cfg.AsyncEnabled && i.Config.ReplicationFactor > 1 && !i.asyncReplicationGloballyDisabled()
+	i.Config.AsyncReplicationEnabled = cfg.AsyncEnabled && !i.asyncReplicationGloballyDisabled()
 
 	err := i.ForEachLoadedShard(func(name string, shard ShardLike) error {
-		if err := shard.SetAsyncReplicationEnabled(ctx, i.Config.AsyncReplicationEnabled); err != nil {
+		if err := shard.SetAsyncReplicationEnabled(ctx, i.AsyncReplicationEnabledForShard(name)); err != nil {
 			return fmt.Errorf("updating async replication on shard %q: %w", name, err)
 		}
 		return nil
@@ -869,6 +872,22 @@ func (i *Index) asyncReplicationEnabled() bool {
 	defer i.replicationConfigLock.RUnlock()
 
 	return i.Config.ReplicationFactor > 1 && i.Config.AsyncReplicationEnabled && !i.asyncReplicationGloballyDisabled()
+}
+
+func (i *Index) replicationEnabledForShard(shardName string) bool {
+	plan, err := i.router.BuildWriteRoutingPlan(types.RoutingPlanBuildOptions{
+		Collection:       i.Config.ClassName.String(),
+		Shard:            shardName,
+		ConsistencyLevel: types.ConsistencyLevel(types.ConsistencyLevelAll),
+	})
+	if err != nil {
+		return false
+	}
+	return len(plan.Replicas) > 1
+}
+
+func (i *Index) AsyncReplicationEnabledForShard(shardName string) bool {
+	return i.Config.AsyncReplicationEnabled && !i.asyncReplicationGloballyDisabled() && i.replicationEnabledForShard(shardName)
 }
 
 // parseDateFieldsInProps checks the schema for the current class for which

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -700,7 +700,7 @@ func (s *Shard) initHashBeater(ctx context.Context, config asyncReplicationConfi
 					config.targetNodeOverrides = s.asyncReplicationConfig.targetNodeOverrides
 				}()
 
-				if (!s.index.asyncReplicationEnabled() && len(config.targetNodeOverrides) == 0) ||
+				if (!s.index.AsyncReplicationEnabledForShard(s.name) && len(config.targetNodeOverrides) == 0) ||
 					(config.maintenanceModeEnabled != nil && config.maintenanceModeEnabled()) {
 					// skip hashbeat iteration when async replication is disabled and no target node overrides are set
 					// or maintenance mode is enabled for localhost

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -565,7 +565,7 @@ func (s *Shard) removeTargetNodeOverride(ctx context.Context, targetNodeOverride
 	// if there are no overrides left, return the async replication config to what it
 	// was before overrides were added
 	if targetNodeOverrideLen == 0 {
-		return s.SetAsyncReplicationEnabled(ctx, s.index.Config.AsyncReplicationEnabled)
+		return s.SetAsyncReplicationEnabled(ctx, s.index.AsyncReplicationEnabledForShard(s.name))
 	}
 	return nil
 }
@@ -577,7 +577,7 @@ func (s *Shard) removeAllTargetNodeOverrides(ctx context.Context) error {
 		defer s.asyncReplicationRWMux.Unlock()
 		s.asyncReplicationConfig.targetNodeOverrides = make([]additional.AsyncReplicationTargetNodeOverride, 0)
 	}()
-	return s.SetAsyncReplicationEnabled(ctx, s.index.Config.AsyncReplicationEnabled)
+	return s.SetAsyncReplicationEnabled(ctx, s.index.AsyncReplicationEnabledForShard(s.name))
 }
 
 func (s *Shard) getAsyncReplicationStats(ctx context.Context) []*models.AsyncReplicationStatus {

--- a/adapters/repos/db/shard_init_lsm.go
+++ b/adapters/repos/db/shard_init_lsm.go
@@ -92,7 +92,7 @@ func (s *Shard) initNonVector(ctx context.Context, class *models.Class, lazyLoad
 	}
 
 	// Object bucket must be available, initAsyncReplication depends on it
-	if s.index.asyncReplicationEnabled() {
+	if s.index.AsyncReplicationEnabledForShard(s.name) {
 		s.asyncReplicationRWMux.Lock()
 		defer s.asyncReplicationRWMux.Unlock()
 

--- a/cluster/replication/copier/copier.go
+++ b/cluster/replication/copier/copier.go
@@ -385,7 +385,7 @@ func (c *Copier) RevertAsyncReplicationLocally(ctx context.Context, collectionNa
 	}
 	defer release()
 
-	return shard.SetAsyncReplicationEnabled(ctx, shard.Index().Config.AsyncReplicationEnabled)
+	return shard.SetAsyncReplicationEnabled(ctx, shard.Index().AsyncReplicationEnabledForShard(shardName))
 }
 
 // AsyncReplicationStatus returns the async replication status for a shard.


### PR DESCRIPTION
### What's being changed:

Makes async replication auomatically turn on/off for specific shards if it is enabled on the collection. For example, if a collection has replication factor = 1 but a replica movement COPY operation has been run on a shard, then we would want to start async replication on that shard since it has an effective replication factor of 2 after the COPY.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
