### PR TITLE
Always defer waitgroup in raft apply

### DIFF
--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -282,8 +282,8 @@ func (st *Store) Apply(l *raft.Log) any {
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 	g := func() {
+		defer wg.Done()
 		f()
-		wg.Done()
 	}
 	enterrors.GoWrapper(g, st.log)
 	wg.Wait()


### PR DESCRIPTION
### What's being changed:

in case "f()" panics, the wait group would never be finished and raft would wait forever

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
