### PR TITLE
fix: add extra info to cleaned segments only if option enabled

### DIFF
--- a/adapters/repos/db/lsmkv/segment_group_cleanup.go
+++ b/adapters/repos/db/lsmkv/segment_group_cleanup.go
@@ -467,7 +467,13 @@ func (c *segmentCleanerCommon) cleanupOnce(shouldAbort cyclemanager.ShouldAbortC
 
 	oldSegment := c.sg.segmentAtPos(candidateIdx)
 	segmentId := segmentID(oldSegment.path)
-	tmpSegmentPath := filepath.Join(c.sg.dir, "segment-"+segmentId+segmentExtraInfo(oldSegment.level, oldSegment.strategy)+".db.tmp")
+	var filename string
+	if c.sg.writeSegmentInfoIntoFileName {
+		filename = "segment-" + segmentId + segmentExtraInfo(oldSegment.getLevel(), oldSegment.getStrategy()) + ".db.tmp"
+	} else {
+		filename = "segment-" + segmentId + ".db.tmp"
+	}
+	tmpSegmentPath := filepath.Join(c.sg.dir, filename)
 	scratchSpacePath := oldSegment.path + "cleanup.scratch.d"
 
 	start := time.Now()


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
