### PR TITLE
replica scaling based on shard copy operations

### DIFF
--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -99,7 +99,7 @@ func TestRaftEndpoints(t *testing.T) {
 		Class:              "C",
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 	}
-	ss := &sharding.State{PartitioningEnabled: true, Physical: map[string]sharding.Physical{"T0": {Name: "T0"}}}
+	ss := &sharding.State{PartitioningEnabled: true, Physical: map[string]sharding.Physical{"T0": {Name: "T0", BelongsToNodes: []string{"N0"}}}}
 	version0, err := srv.AddClass(ctx, cls, ss)
 	assert.Nil(t, err)
 	assert.Equal(t, schemaReader.ClassEqual("C"), "C")
@@ -162,19 +162,16 @@ func TestRaftEndpoints(t *testing.T) {
 		assert.Equal(t, models.TenantActivityStatusHOT, status)
 	}
 
-	// QueryShardOwner - Err
-	_, _, err = srv.QueryShardOwner(cls.Class, "T0")
-	assert.NotNil(t, err)
-
 	// QueryShardOwner
-	srv.UpdateClass(ctx, cls, &sharding.State{Physical: map[string]sharding.Physical{"T0": {BelongsToNodes: []string{"N0"}}}})
+	srv.UpdateClass(ctx, cls, &sharding.State{PartitioningEnabled: true, Physical: map[string]sharding.Physical{"T0": {Name: "T0", BelongsToNodes: []string{"N0"}}}})
 	getShardOwner, _, err := srv.QueryShardOwner(cls.Class, "T0")
 	assert.Nil(t, err)
 	assert.Equal(t, "N0", getShardOwner)
 
 	// QueryShardingState
-	shardingState := &sharding.State{Physical: map[string]sharding.Physical{"T0": {BelongsToNodes: []string{"N0"}}}, ReplicationFactor: 2}
+	shardingState := &sharding.State{PartitioningEnabled: true, Physical: map[string]sharding.Physical{"T0": {Name: "T0", BelongsToNodes: []string{"N0"}}}, ReplicationFactor: 1}
 	srv.UpdateClass(ctx, cls, shardingState)
+
 	getShardingState, _, err := srv.QueryShardingState(cls.Class)
 	assert.Nil(t, err)
 	assert.Equal(t, shardingState, getShardingState)

--- a/cluster/replication/shard_replication_apply.go
+++ b/cluster/replication/shard_replication_apply.go
@@ -14,7 +14,6 @@ package replication
 import (
 	"errors"
 	"fmt"
-	"slices"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/hashicorp/go-multierror"
@@ -538,7 +537,7 @@ func findAndDeleteOp(id uint64, ops []ShardReplicationOp) ([]ShardReplicationOp,
 		}
 	}
 	if ok {
-		ops = slices.Delete(ops, indexToDelete, indexToDelete+1)
+		ops = append(ops[:indexToDelete], ops[indexToDelete+1:]...)
 	}
 	return ops, ok
 }

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -1923,7 +1923,7 @@ func Test_UpdateClass(t *testing.T) {
 				fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
 				fakeSchemaManager.On("UpdateClass", mock.Anything, mock.Anything).Return(nil)
 				fakeSchemaManager.On("ReadOnlyClass", test.initial.Class, mock.Anything).Return(test.initial)
-				fakeSchemaManager.On("QueryShardingState", mock.Anything).Return(nil, nil)
+				fakeSchemaManager.On("CopyShardingState", mock.Anything).Return(&sharding.State{}, nil)
 				if len(test.initial.Properties) > 0 {
 					fakeSchemaManager.On("ReadOnlyClass", test.initial.Class, mock.Anything).Return(test.initial)
 				}

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -136,9 +136,12 @@ type Handler struct {
 	clusterState            clusterState
 	configParser            VectorConfigParser
 	invertedConfigValidator InvertedConfigValidator
-	scaleOut                scaleOut
-	parser                  Parser
-	classGetter             *ClassGetter
+
+	scaleOut               scaleOut
+	replicaMovementEnabled bool
+
+	parser      Parser
+	classGetter *ClassGetter
 
 	asyncIndexingEnabled bool
 }
@@ -172,6 +175,7 @@ func NewHandler(
 		moduleConfig:            moduleConfig,
 		clusterState:            clusterState,
 		scaleOut:                scaleoutManager,
+		replicaMovementEnabled:  config.ReplicaMovementEnabled,
 		cloud:                   cloud,
 		classGetter:             classGetter,
 


### PR DESCRIPTION
### What's being changed:

This pull request introduces several improvements and optimizations to the replication and schema update logic, focusing on batch processing, replication management, and configuration scaling. The most notable changes are the introduction of batch updates for object overwrites, enhancements to replication handling during class updates, and increased configuration limits for better scalability.

### Replication and Batch Processing Improvements

* Changed `OverwriteObjects` in `adapters/repos/db/replication.go` to batch object updates using `PutObjectBatch`, improving write efficiency and error handling for multiple objects. [[1]](diffhunk://#diff-43faf3509d2b0cde090504767f99a960363ab7a7d4075b7ab8c3f56b0da1331aR576-R577) [[2]](diffhunk://#diff-43faf3509d2b0cde090504767f99a960363ab7a7d4075b7ab8c3f56b0da1331aL675-R693)
* Updated the replication client in `adapters/clients/replication.go` to use a new `tryOnce` method for HTTP requests in `OverwriteObjects`, simplifying and streamlining the request logic. [[1]](diffhunk://#diff-9c6b07b40ed868288b28472fd7e8e41e994cfdaad151ca02a8442e772453a922L138-R140) [[2]](diffhunk://#diff-9c6b07b40ed868288b28472fd7e8e41e994cfdaad151ca02a8442e772453a922R370-R392)

### Replication Management During Schema Updates

* Enhanced `UpdateClass` in `cluster/raft_apply_endpoints.go` to force-delete replications for a collection before updating, and to handle node changes per shard by removing and adding replicas as needed, including logic for selecting source nodes and generating replica UUIDs.
* Added the helper function `diffNodesPerShard` to efficiently compute node membership changes for shards, supporting more robust replication adjustments.

### Scalability and Configuration Adjustments

* Increased limits for maximum hash tree height, diff batch size, and propagation concurrency in `adapters/repos/db/shard_async_replication.go`, allowing for improved scalability in replication and propagation operations.

### Schema Update Refactoring

* Refactored `UpdateClassInternal` in `usecases/schema/class.go` to always deep copy the sharding state and adjust replicas directly, simplifying the scaling logic and ensuring correct handling of replication factor changes. [[1]](diffhunk://#diff-1a5c5c0798757a773c7cfd4b69f5265b9d9d6364ae6425e5725c46aea0e679b2L276-L278) [[2]](diffhunk://#diff-1a5c5c0798757a773c7cfd4b69f5265b9d9d6364ae6425e5725c46aea0e679b2L287-R305)

These changes collectively improve reliability, performance, and scalability for schema and replication operations.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
