### PR TITLE
fix(test): proper context management and timeout for backup tests

### DIFF
--- a/test/modules/backup-azure/multi_tenant_backup_test.go
+++ b/test/modules/backup-azure/multi_tenant_backup_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -29,7 +30,8 @@ const (
 )
 
 func Test_MultiTenantBackupJourney(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
 
 	multiTenantBackupJourneyStart(t, ctx, false, "backups", "", "")
 	t.Run("with override bucket and path", func(t *testing.T) {
@@ -51,7 +53,8 @@ func multiTenantBackupJourneyStart(t *testing.T, ctx context.Context, override b
 	}
 
 	t.Run("single node", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		defer cancel()
 		t.Log("pre-instance env setup")
 		containerToUse := containerName
 		if override {
@@ -85,7 +88,8 @@ func multiTenantBackupJourneyStart(t *testing.T, ctx context.Context, override b
 	})
 
 	t.Run("multiple node", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		defer cancel()
 		t.Log("pre-instance env setup")
 		containerToUse := containerName
 		if override {

--- a/test/modules/backup-gcs/multi_tenant_backup_test.go
+++ b/test/modules/backup-gcs/multi_tenant_backup_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -27,8 +28,8 @@ import (
 const numTenants = 50
 
 func Test_MultiTenantBackupJourney(t *testing.T) {
-	// Set up a context with a 30-minute timeout to manage test duration
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
 
 	// Define test cases using a table-driven approach
 	tests := []struct {
@@ -77,7 +78,8 @@ func multiTenantBackupJourneyStart(t *testing.T, ctx context.Context, override b
 	}
 
 	t.Run("single node", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		defer cancel()
 		t.Log("pre-instance env setup")
 		gcsBackupJourneyBucketName := "gcp-single-node"
 		t.Setenv(envGCSCredentials, "")
@@ -116,7 +118,8 @@ func multiTenantBackupJourneyStart(t *testing.T, ctx context.Context, override b
 	})
 
 	t.Run("multiple node", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		defer cancel()
 		t.Log("pre-instance env setup")
 		gcsBackupJourneyBucketName := "gcp-multiple-nodes"
 		t.Setenv(envGCSCredentials, "")

--- a/test/modules/backup-s3/multi_tenant_backup_test.go
+++ b/test/modules/backup-s3/multi_tenant_backup_test.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/test/docker"
@@ -25,7 +26,8 @@ import (
 const numTenants = 50
 
 func Test_MultiTenantBackupJourney(t *testing.T) {
-	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
 
 	multiTenantBackupJourneyStart(t, ctx, false, "backups", "", "")
 	t.Run("with override bucket and path", func(t *testing.T) {
@@ -42,7 +44,8 @@ func multiTenantBackupJourneyStart(t *testing.T, ctx context.Context, override b
 	}
 
 	t.Run("single node", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		defer cancel()
 
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
@@ -72,7 +75,8 @@ func multiTenantBackupJourneyStart(t *testing.T, ctx context.Context, override b
 	})
 
 	t.Run("multiple node", func(t *testing.T) {
-		ctx := context.Background()
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+		defer cancel()
 
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)

--- a/test/run.sh
+++ b/test/run.sh
@@ -449,7 +449,7 @@ function run_acceptance_only_tests() {
 
 function run_module_only_backup_tests() {
   for pkg in $(go list ./... | grep 'test/modules' | grep 'test/modules/backup'); do
-    if ! go test -count 1 -race "$pkg"; then
+    if ! go test -count 1 -race -timeout 30m "$pkg"; then
       echo "Test for $pkg failed" >&2
       return 1
     fi


### PR DESCRIPTION
## What's being changed:

Fixes context management bugs and adds missing timeout in backup module tests (GCS, Azure, S3) that caused test isolation failures and resource leaks leading to intermittent CI failures.

## Problem

All backup multi-tenant tests had identical context management issues:

1. **Context shadowing** - Subtests created new `context.Background()` instead of using the parent context parameter
2. **No timeout** - Parent context had no timeout despite code structure suggesting one was intended
3. **No cancellation** - No cancel functions created or deferred, making cleanup operations uncancellable
4. **Missing timeout in run.sh** - Backup tests had no timeout specified, allowing them to hang indefinitely

When tests failed or timed out, cleanup operations couldn't be interrupted. This left resources locked (LSM buckets, containers) causing failures like:

```
bucket "data/gcsbackup/Tenant5/lsm/property__id": bucket already registered
```

This resulted in:
- "bucket already registered" errors on subsequent test runs
- Testcontainers Reaper goroutines hanging indefinitely
- Cascading failures in parallel tests

## Solution

Applied fixes to all backup modules and test runner:

- Add 20-minute timeout with cancellation to parent test context
- Replace `context.Background()` in subtests with child contexts inheriting from parent
- Add 10-minute timeouts to single-node and multi-node subtests
- Ensure all contexts properly cancelled via `defer cancel()`
- Add 30-minute timeout to run.sh backup test execution (allows for context timeouts plus buffer)

This ensures cleanup operations respect timeouts and can be interrupted, preventing resource leaks between test iterations.

## Files Changed

- `test/modules/backup-gcs/multi_tenant_backup_test.go`
- `test/modules/backup-azure/multi_tenant_backup_test.go`
- `test/modules/backup-s3/multi_tenant_backup_test.go`
- `test/run.sh`

## Testing

Run each test multiple times to verify no resource leak errors:

```bash
go test -v -count 1 -race -timeout 30m github.com/weaviate/weaviate/test/modules/backup-gcs -run Test_MultiTenantBackupJourney
```

```bash
go test -v -count 1 -race -timeout 30m github.com/weaviate/weaviate/test/modules/backup-azure -run Test_MultiTenantBackupJourney
```

```bash
go test -v -count 1 -race -timeout 30m github.com/weaviate/weaviate/test/modules/backup-s3 -run Test_MultiTenantBackupJourney
```

## Related

Discovered during CI investigation for PR #9490. Should resolve intermittent failures in backup tests and related testcontainers cleanup issues affecting other parallel tests like replication.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
