### PR TITLE
feature: Update search probe for spfresh

### DIFF
--- a/adapters/repos/db/vector/spfresh/spfresh.go
+++ b/adapters/repos/db/vector/spfresh/spfresh.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -193,6 +194,14 @@ func (s *SPFresh) Type() common.IndexType {
 }
 
 func (s *SPFresh) UpdateUserConfig(updated schemaConfig.VectorIndexConfig, callback func()) error {
+	parsed, ok := updated.(ent.UserConfig)
+	if !ok {
+		callback()
+		return errors.Errorf("config is not UserConfig, but %T", updated)
+	}
+
+	atomic.StoreUint32(&s.searchProbe, parsed.SearchProbe)
+
 	callback()
 	return nil
 }


### PR DESCRIPTION
### What's being changed:
It allows users to update `searchProbe` parameter, it corresponds to the number of posting lists that we want to brute force.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
