### PR TITLE
Add GOMEMLIMIT to the usage module payload

### DIFF
--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -14,6 +14,7 @@ package usage
 import (
 	"context"
 	"fmt"
+	"runtime/debug"
 	"sort"
 	"time"
 
@@ -113,5 +114,9 @@ func (s *service) Usage(ctx context.Context, exactObjectCount bool) (*types.Repo
 			})
 		}
 	}
+
+	// -1 returns current limit without changing it
+	usage.GoMemLimit = debug.SetMemoryLimit(-1)
+
 	return usage, nil
 }

--- a/cluster/usage/service_test.go
+++ b/cluster/usage/service_test.go
@@ -13,6 +13,7 @@ package usage
 
 import (
 	"context"
+	"runtime/debug"
 	"sort"
 	"strings"
 	"testing"
@@ -54,6 +55,10 @@ func TestService_Usage_SingleTenant(t *testing.T) {
 	compressionRatio := 1.
 	dimensionality := 3
 	dimensionCount := 1
+	memLimit := int64(1_000_000)
+
+	debug.SetMemoryLimit(memLimit)
+
 	class := &models.Class{
 		Class: className,
 		ReplicationConfig: &models.ReplicationConfig{
@@ -136,6 +141,8 @@ func TestService_Usage_SingleTenant(t *testing.T) {
 	assert.Equal(t, dimensionality, dim.Dimensions)
 	assert.Equal(t, dimensionCount, dim.Count)
 
+	assert.Equal(t, memLimit, result.GoMemLimit)
+
 	mockSchemaGetter.AssertExpectations(t)
 	mockBackupProvider.AssertExpectations(t)
 }
@@ -154,6 +161,9 @@ func TestService_Usage_MultiTenant_HotAndCold(t *testing.T) {
 	compression := "standard"
 	compressionRatio := 1.0
 	dimensionCount := 2
+	memLimit := int64(100_000)
+
+	debug.SetMemoryLimit(memLimit)
 
 	class := &models.Class{
 		Class:              className,
@@ -256,6 +266,8 @@ func TestService_Usage_MultiTenant_HotAndCold(t *testing.T) {
 	dim := vector.Dimensionalities[0]
 	assert.Equal(t, 3, dim.Dimensions)
 	assert.Equal(t, dimensionCount, dim.Count)
+
+	assert.Equal(t, memLimit, result.GoMemLimit)
 
 	mockSchema.AssertExpectations(t)
 	mockBackupProvider.AssertExpectations(t)

--- a/cluster/usage/types/types.go
+++ b/cluster/usage/types/types.go
@@ -35,6 +35,8 @@ type Report struct {
 
 	// The local node's view of the schema
 	Schema *models.Schema `json:"schema,omitempty"`
+
+	GoMemLimit int64 `json:"go_mem_limit,omitempty"`
 }
 
 // CollectionUsage represents metrics for a single collection


### PR DESCRIPTION
### What's being changed:

As stated in the title, this patch adds the currently set value of `GOMEMLIMIT` to the usage module payload.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
