### PR TITLE
Use a lock to coordinate close on request channel and avoid race detector error

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -82,10 +82,12 @@ type replicatedIndices struct {
 	maintenanceModeEnabled func() bool
 
 	requestQueueConfig cluster.RequestQueueConfig
+	// requestQueueLock is used to synchronize sending to the requestQueue and closing it, without
+	// this we would have a race condition in case the channel closed right before we try to send.
+	requestQueueLock sync.RWMutex
 	// requestQueue buffers requests until they're picked up by a worker, goal is to avoid
 	// overwhelming the system with requests during spikes (also allows for backpressure)
-	requestQueueLock sync.RWMutex
-	requestQueue     chan queuedRequest
+	requestQueue chan queuedRequest
 	// startWorkersOnce ensures that the workers are started only once
 	startWorkersOnce sync.Once
 	// set to true when shutting down


### PR DESCRIPTION
### What's being changed:

Without this change, there is a race condition between closing the replicated indices `requestQueue` and sending to that queue. For example, the queue could be closed right before we try to send to it. I had assumed previously that golang's select block would handle that case by taking the default branch but this was incorrect. This PR adds a lock to synchronize the closing of the channel vs sending of requests to fix the race condition.

I'm curious if there's a simpler and more idiomatic go approach to solving this (e.g.: by restructuring how I'm using channels/contexts) which may also improve performance by avoiding the need for the read lock on the indices handler, but my past experience in non-go languages tends to cause me to reach for mutexes when fixing things like this. Let me know if you have any ideas.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
