### PR TITLE
Mitigation/logging for PQ out of bounds panic (issue #9470)

### DIFF
--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -130,6 +130,8 @@ func NewShardedUInt64LockCache(vecForID common.VectorForID[uint64], maxSize int,
 }
 
 func (s *shardedLockCache[T]) All() [][]T {
+	s.maintenanceLock.RLock()
+	defer s.maintenanceLock.RUnlock()
 	return s.cache
 }
 
@@ -548,6 +550,8 @@ func NewShardedMultiByteLockCache(multipleVecForID common.VectorForID[byte], max
 }
 
 func (s *shardedMultipleLockCache[T]) All() [][]T {
+	s.maintenanceLock.RLock()
+	defer s.maintenanceLock.RUnlock()
 	return s.cache
 }
 

--- a/adapters/repos/db/vector/compressionhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/product_quantization.go
@@ -393,6 +393,11 @@ func (pq *ProductQuantizer) Fit(data [][]float32) error {
 			return err
 		}
 	case UseKMeansEncoder:
+		for _, v := range data {
+			if len(v) != pq.dimensions {
+				return fmt.Errorf("unexpected vector length %d in PQ training data, expected %d", len(v), pq.dimensions)
+			}
+		}
 		mutex := sync.Mutex{}
 		var errorResult error = nil
 		pq.kms = make([]PQEncoder, pq.m)


### PR DESCRIPTION
Testing has revealed an issue (#9470) where the k-means algorithm used by product quantization is passed either nil vectors or empty vectors. This is a difficult issue to reproduce and it may stem from an underlying race condition.

This patch adds additional verification that all vectors passed to the PQ training algorithm have the same expected length. Prior to this patch we only checked if vectors returned by the sharded lock cache were nil.

This patch also adds locking around the return of the cache's internal slice of vectors in the implementation of All(). This method is only called in the context of compression. Prior to this patch there was no synchronization/protection when calling All() except for the HNSW compressActionLock. However it appears that AddBatch() can trigger a growth of the cache which will swap out the underlying cache slice without acquiring the compressActionLock. It is unlikely that this is the cause of the error we are seeing, but not impossible.

In the logs for the issue we see that the issue happens when the k-means algorithm is passed a slice with the following signature:

initializeRandom(0x40005c83c0, {0x4012f00000, 0x2710, 0x3ebe}

The slice has a length of 10000 (0x2710) and a capacity of 16062 (0x3ebe). Since the slice is initially instantiated to have the same capacity as the length of the vector cache it is unclear how it can have grown to exceed this and this might indicate a race condition or a bug in the sampling algorithm.

I cannot identify any other serious concurrency issues in the sharded lock cache itself by inspecting the code, so I suspect that the problem may be that the underlying VectorForId function that handles cache misses can sometimes return a vector that does not have the right length or that it is not thread-safe.

It is also possible that we have overlooked a bug in the k-means implementation, but then it should have been possible to reproduce the issue in a unit test and we would likely have seen the issue more often.

### Review checklist

- [x] Documentation has been updated, if necessary. _Not necessary_
- [] Chaos pipeline run or not necessary. _We should probably run the chaos pipeline to check if the additional locking causes in the cache could be causing an issue. I think it is very unlikely to be an issue as All() is only called when compressing vectors.._
- [x] All new code is covered by tests where it is reasonable. _Should be covered by existing tests._
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
