### PR TITLE
fix: Change training limit in test

### DIFF
--- a/test/acceptance_with_python/test_usage.py
+++ b/test/acceptance_with_python/test_usage.py
@@ -205,7 +205,7 @@ def test_usage_mt(
         wvc.config.Reconfigure.VectorIndex.Quantizer.bq(enabled=True),
         wvc.config.Reconfigure.VectorIndex.Quantizer.rq(enabled=True),
         wvc.config.Reconfigure.VectorIndex.Quantizer.sq(enabled=True, training_limit=50),
-        wvc.config.Reconfigure.VectorIndex.Quantizer.pq(enabled=True, training_limit=150),
+        wvc.config.Reconfigure.VectorIndex.Quantizer.pq(enabled=True, training_limit=300),
     ],
 )
 def test_usage_enabling_compression(


### PR DESCRIPTION
### What's being changed:
When running `pq` tests the training limit was set to `150`, but k-means **requires** to have at least `256` vectors since the number of centroids will be 256.

It increases in test training limit to `300`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
