### PR TITLE
fix(replication): reject replication requests if not ready

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -95,6 +95,8 @@ type replicatedIndices struct {
 	// workerWg waits for all workers to finish
 	workerWg sync.WaitGroup
 	logger   logrus.FieldLogger
+	// nodeReady reports whether the node is ready to accept requests
+	nodeReady func() bool
 }
 
 var (
@@ -135,6 +137,7 @@ func NewReplicatedIndices(
 	maintenanceModeEnabled func() bool,
 	requestQueueConfig cluster.RequestQueueConfig,
 	logger logrus.FieldLogger,
+	nodeReady func() bool,
 ) *replicatedIndices {
 	// validate the requestQueueConfig
 	if requestQueueConfig.QueueFullHttpStatus == 0 {
@@ -153,6 +156,7 @@ func NewReplicatedIndices(
 		requestQueue:           make(chan queuedRequest, requestQueueConfig.QueueSize),
 		requestQueueConfig:     requestQueueConfig,
 		logger:                 logger,
+		nodeReady:              nodeReady,
 	}
 	if requestQueueConfig.IsEnabled != nil && requestQueueConfig.IsEnabled.Get() {
 		i.startWorkersOnce.Do(i.startWorkers)
@@ -226,6 +230,11 @@ func (i *replicatedIndices) indicesHandler() http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		if i.maintenanceModeEnabled() {
 			http.Error(w, "418 Maintenance mode", http.StatusTeapot)
+			return
+		}
+
+		if i.nodeReady != nil && !i.nodeReady() {
+			http.Error(w, "503 Node not ready", http.StatusServiceUnavailable)
 			return
 		}
 

--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -51,7 +51,9 @@ func NewServer(appState *state.State) *Server {
 		auth,
 		appState.Cluster.MaintenanceModeEnabledForLocalhost,
 		appState.ServerConfig.Config.Cluster.RequestQueueConfig,
-		appState.Logger)
+		appState.Logger,
+		appState.ClusterService.Ready)
+
 	classifications := NewClassifications(appState.ClassificationRepo.TxManager(), auth)
 	nodes := NewNodes(appState.RemoteNodeIncoming, auth)
 	backups := NewBackups(appState.BackupManager, auth)


### PR DESCRIPTION
### What's being changed:
this PR makes sure node reject replication request if node is not ready yet to avoid overwhelming the node 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/19928827894
- [x] e2e pipeline : https://github.com/weaviate/weaviate-e2e-tests/actions/runs/19928843171
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
