### PR TITLE
fix: use randomly generated docker container names for Weaviate container

### DIFF
--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -234,11 +234,13 @@ func (d *DockerCompose) DisconnectFromNetwork(ctx context.Context, nodeIndex int
 
 	// Get the network name
 	networkName := d.network.Name
+	// Get the container ID
+	containerID := container.container.GetContainerID()
 
 	// Execute docker network disconnect command
-	cmd := exec.CommandContext(ctx, "docker", "network", "disconnect", networkName, container.name)
+	cmd := exec.CommandContext(ctx, "docker", "network", "disconnect", networkName, containerID)
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to disconnect container %s from network: %w", container.name, err)
+		return fmt.Errorf("failed to disconnect container %s (id: %s) from network: %w", container.name, containerID, err)
 	}
 	// sleep to make sure that the off node is detected by memberlist and marked failed
 	time.Sleep(3 * time.Second)
@@ -258,11 +260,13 @@ func (d *DockerCompose) ConnectToNetwork(ctx context.Context, nodeIndex int) err
 
 	// Get the network name
 	networkName := d.network.Name
+	// Get the container ID
+	containerID := container.container.GetContainerID()
 
 	// Execute docker network connect command
-	cmd := exec.CommandContext(ctx, "docker", "network", "connect", networkName, container.name)
+	cmd := exec.CommandContext(ctx, "docker", "network", "connect", networkName, containerID)
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to connect container %s to network: %w", container.name, err)
+		return fmt.Errorf("failed to connect container %s (id: %s) to network: %w", container.name, containerID, err)
 	}
 
 	// sleep to make sure that the off node is detected by memberlist and connected to the network

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -118,7 +118,6 @@ func startWeaviate(ctx context.Context,
 		FromDockerfile: fromDockerFile,
 		Image:          weaviateImage,
 		Hostname:       containerName,
-		Name:           containerName,
 		Networks:       []string{networkName},
 		NetworkAliases: map[string][]string{
 			networkName: {containerName},


### PR DESCRIPTION
### What's being changed:

This PR makes the Weaviate docker containers to be created with random names. Previously they were always assigned a name, which lead to conflict when we try to run multiple docker Weaviate containers.

This PR should fix this error:
```
--- FAIL: TestMaximumAllowedCollectionsCount (258.58s)
    --- FAIL: TestMaximumAllowedCollectionsCount/with_limit_of_1 (135.31s)
        add_class_test.go:476: 
            	Error Trace:	/home/runner/work/weaviate/weaviate/test/acceptance/schema/add_class_test.go:476
            	Error:      	Expected nil, but got: start weaviate: create container: container create: Error response from daemon: Conflict. The container name "/weaviate" is already in use by container "a2aa63cdfea183fe9420009a159457917c99a2f6e9c02dbf24072c1324022525". You have to remove (or rename) that container to be able to reuse that name.
            	Test:       	TestMaximumAllowedCollectionsCount/with_limit_of_1
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
