### PR TITLE
refact(lazyloadshard): convert lazyload shard locks to RW and use atomic for loaded

### DIFF
--- a/adapters/repos/db/crud.go
+++ b/adapters/repos/db/crud.go
@@ -168,7 +168,7 @@ func (db *DB) Object(ctx context.Context, class string, id strfmt.UUID,
 ) (*search.Result, error) {
 	idx := db.GetIndex(schema.ClassName(class))
 	if idx == nil {
-		return nil, nil
+		return nil, fmt.Errorf("no index for class %q", class)
 	}
 
 	obj, err := idx.objectByID(ctx, id, props, addl, repl, tenant)

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
+
 	shardusage "github.com/weaviate/weaviate/adapters/repos/db/shard_usage"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/dynamic"
@@ -140,7 +141,7 @@ func (i *Index) usageForCollection(ctx context.Context, jitterInterval time.Dura
 						release := lazyShard.blockLoading()
 						defer release()
 
-						if lazyShard.loaded {
+						if lazyShard.loaded.Load() {
 							shardUsage, err2 = i.calculateLoadedShardUsage(ctx, lazyShard.shard, exactObjectCount)
 							if err2 != nil {
 								err2 = fmt.Errorf("loaded lazy shard %s: %w", shardName, err2)

--- a/adapters/repos/db/shard_lazyloader_test.go
+++ b/adapters/repos/db/shard_lazyloader_test.go
@@ -1,0 +1,88 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+func TestLazyLoadShard_ObjectCountAsync_Race(t *testing.T) {
+	ctx := context.Background()
+	className := "TestClass"
+
+	// Create shard and add objects to create .cna files
+	shd, idx := testShard(t, ctx, className)
+	defer os.RemoveAll(shd.Index().Config.RootPath)
+
+	// Add objects and flush to create .cna files
+	for i := 0; i < 100; i++ {
+		errs := shd.PutObjectBatch(ctx, []*storobj.Object{testObject(className)})
+		require.NoError(t, errs[0])
+		if i%5 == 0 {
+			shd.Store().Bucket(helpers.ObjectsBucketLSM).FlushMemtable()
+		}
+	}
+
+	require.NoError(t, idx.Shutdown(ctx))
+
+	// Create LazyLoadShard that reads from disk
+	class := idx.getSchema.ReadOnlyClass(className)
+	lazyShard := NewLazyLoadShard(ctx, monitoring.GetMetrics(), shd.Name(), idx, class,
+		idx.centralJobQueue, idx.indexCheckpoints, idx.allocChecker, idx.shardLoadLimiter,
+		idx.shardReindexer, false, idx.bitmapBufPool)
+	require.False(t, lazyShard.loaded.Load())
+
+	// Start multiple concurrent ObjectCountAsync calls, then load shard to trigger race condition
+	const numConcurrentCalls = 10
+	var wg sync.WaitGroup
+	results := make([]struct {
+		count int64
+		err   error
+	}, numConcurrentCalls)
+
+	wg.Add(numConcurrentCalls)
+	for i := 0; i < numConcurrentCalls; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			// Small random delay to increase race condition probability
+			time.Sleep(time.Duration(idx) * time.Millisecond)
+			results[idx].count, results[idx].err = lazyShard.ObjectCountAsync(ctx)
+		}(i)
+	}
+
+	// Load shard while ObjectCountAsync is running (triggers compaction)
+	time.Sleep(5 * time.Millisecond)
+	require.NoError(t, lazyShard.Load(ctx))
+	wg.Wait()
+
+	// Verify all calls complete gracefully (success or error, but no panic)
+	for i, result := range results {
+		if result.err != nil {
+			assert.Contains(t, result.err.Error(), "error while getting object count", "goroutine %d failed", i)
+		} else {
+			// This is not made equal because it's fine to report eventually consistent
+			// data here as this used for usage and billing purposes
+			assert.Greater(t, result.count, int64(0), "goroutine %d should return positive count", i)
+		}
+	}
+}

--- a/test/modules/offload-s3/offlad_delete_test.go
+++ b/test/modules/offload-s3/offlad_delete_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/weaviate/weaviate/cluster/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -31,8 +32,7 @@ import (
 
 func Test_DeleteClassS3Journey(t *testing.T) {
 	t.Run("delete class, deleting frozen tenants", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
@@ -401,7 +401,7 @@ func Test_DeleteAndRecreateS3Journey(t *testing.T) {
 		t.Run("verify created object", func(t *testing.T) {
 			resp, err := helper.TenantListObjects(t, className, tenantNames[0])
 			require.Nil(t, err)
-			assert.Equal(t, 1, len(resp.Objects))
+			require.Equal(t, 1, len(resp.Objects))
 			assert.Equal(t, tenantObjects[0].Class, resp.Objects[0].Class)
 			assert.Equal(t, tenantObjects[0].Properties, resp.Objects[0].Properties)
 		})


### PR DESCRIPTION
### What's being changed:
- use RWLocks for shards to avoid lock contentions 
- remove unnecessary ctx timeouts in offload tests
-  fix offload acceptance test flakiness 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/19499261433
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
