### PR TITLE
Fix swagger field format for compression property

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -7189,7 +7189,7 @@ func init() {
         },
         "compressed": {
           "description": "The status of vector compression/quantization.",
-          "format": "boolean",
+          "type": "boolean",
           "x-omitempty": false
         },
         "loaded": {
@@ -7228,7 +7228,7 @@ func init() {
         },
         "vectorIndexingStatus": {
           "description": "The status of the vector indexing process.",
-          "format": "string",
+          "type": "string",
           "x-omitempty": false
         },
         "vectorQueueLength": {
@@ -16437,7 +16437,7 @@ func init() {
         },
         "compressed": {
           "description": "The status of vector compression/quantization.",
-          "format": "boolean",
+          "type": "boolean",
           "x-omitempty": false
         },
         "loaded": {
@@ -16476,7 +16476,7 @@ func init() {
         },
         "vectorIndexingStatus": {
           "description": "The status of the vector indexing process.",
-          "format": "string",
+          "type": "string",
           "x-omitempty": false
         },
         "vectorQueueLength": {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1956,7 +1956,7 @@
         },
         "vectorIndexingStatus": {
           "description": "The status of the vector indexing process.",
-          "format": "string",
+          "type": "string",
           "x-omitempty": false
         },
         "compressed": {


### PR DESCRIPTION
Correct the swagger field format from 'format' to 'type' for the compression property in NodeShardStatus. This change ensures proper schema validation and client generation.

