### PR TITLE
chore(modules): switch module e2e tests to use model2vec vectorizer

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -150,7 +150,6 @@ jobs:
           "--only-module-backup-gcs",
           "--only-module-backup-s3",
           "--only-module-offload-s3",
-          "--only-module-text2vec-ollama",
           "--only-module-text2vec-model2vec"
         ]
     steps:
@@ -214,6 +213,7 @@ jobs:
           "--only-module-img2vec-neural",
           "--only-module-text2vec-transformers",
           "--only-module-many-modules",
+          "--only-module-text2vec-ollama",
         ]
     steps:
       - uses: actions/checkout@v4

--- a/test/docker/ollama.go
+++ b/test/docker/ollama.go
@@ -38,7 +38,7 @@ func startOllama(ctx context.Context, networkName, hostname, model string) (*Doc
 	port := nat.Port("11434/tcp")
 	container, err := testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
 		ContainerRequest: testcontainers.ContainerRequest{
-			Image:    "ollama/ollama:0.11.4",
+			Image:    "ollama/ollama:0.12.11",
 			Hostname: hostname,
 			Networks: []string{networkName},
 			NetworkAliases: map[string][]string{

--- a/test/helper/sample-schema/multishard/multishard.go
+++ b/test/helper/sample-schema/multishard/multishard.go
@@ -31,6 +31,10 @@ func ClassTransformersVectorizer() *models.Class {
 	return class("text2vec-transformers")
 }
 
+func ClassModel2VecVectorizer() *models.Class {
+	return class("text2vec-model2vec")
+}
+
 func class(vectorizer string) *models.Class {
 	return &models.Class{
 		Class: "MultiShard",

--- a/test/modules/generative-anthropic/generative_anthropic_test.go
+++ b/test/modules/generative-anthropic/generative_anthropic_test.go
@@ -36,9 +36,9 @@ func testGenerativeAnthropic(rest, grpc string) func(t *testing.T) {
 		class := planets.BaseClass("PlanetsGenerativeTest")
 		class.VectorConfig = map[string]models.VectorConfig{
 			"description": {
-				Vectorizer: map[string]interface{}{
-					"text2vec-transformers": map[string]interface{}{
-						"properties":         []interface{}{"description"},
+				Vectorizer: map[string]any{
+					"text2vec-model2vec": map[string]any{
+						"properties":         []any{"description"},
 						"vectorizeClassName": false,
 					},
 				},
@@ -79,8 +79,8 @@ func testGenerativeAnthropic(rest, grpc string) func(t *testing.T) {
 				if tt.absentModuleConfig {
 					t.Log("skipping adding module config configuration to class")
 				} else {
-					class.ModuleConfig = map[string]interface{}{
-						"generative-anthropic": map[string]interface{}{
+					class.ModuleConfig = map[string]any{
+						"generative-anthropic": map[string]any{
 							"model": tt.generativeModel,
 						},
 					}

--- a/test/modules/generative-anthropic/setup_test.go
+++ b/test/modules/generative-anthropic/setup_test.go
@@ -48,7 +48,7 @@ func createSingleNodeEnvironment(ctx context.Context, apiKey string,
 
 func composeModules(apiKey string) (composeModules *docker.Compose) {
 	composeModules = docker.New().
-		WithText2VecTransformers().
+		WithText2VecModel2Vec().
 		WithGenerativeAnthropic(apiKey)
 	return composeModules
 }

--- a/test/modules/generative-friendliai/generative_friendliai_test.go
+++ b/test/modules/generative-friendliai/generative_friendliai_test.go
@@ -30,9 +30,9 @@ func testGenerativeFriendliAI(host string) func(t *testing.T) {
 		class := planets.BaseClass("PlanetsGenerativeTest")
 		class.VectorConfig = map[string]models.VectorConfig{
 			"description": {
-				Vectorizer: map[string]interface{}{
-					"text2vec-transformers": map[string]interface{}{
-						"properties":         []interface{}{"description"},
+				Vectorizer: map[string]any{
+					"text2vec-model2vec": map[string]any{
+						"properties":         []any{"description"},
 						"vectorizeClassName": false,
 					},
 				},
@@ -59,8 +59,8 @@ func testGenerativeFriendliAI(host string) func(t *testing.T) {
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				class.ModuleConfig = map[string]interface{}{
-					"generative-friendliai": map[string]interface{}{
+				class.ModuleConfig = map[string]any{
+					"generative-friendliai": map[string]any{
 						"model":              tt.generativeModel,
 						"X-Friendli-Baseurl": tt.headerURL,
 					},

--- a/test/modules/generative-friendliai/setup_test.go
+++ b/test/modules/generative-friendliai/setup_test.go
@@ -46,7 +46,7 @@ func createSingleNodeEnvironment(ctx context.Context, apiKey string,
 
 func composeModules(apiKey string) (composeModules *docker.Compose) {
 	composeModules = docker.New().
-		WithText2VecTransformers().
+		WithText2VecModel2Vec().
 		WithGenerativeFriendliAI(apiKey)
 	return composeModules
 }

--- a/test/modules/generative-nvidia/generative_nvidia_test.go
+++ b/test/modules/generative-nvidia/generative_nvidia_test.go
@@ -33,9 +33,9 @@ func testGenerativeNvidia(rest, grpc string) func(t *testing.T) {
 		class := planets.BaseClass("PlanetsGenerativeTest")
 		class.VectorConfig = map[string]models.VectorConfig{
 			"description": {
-				Vectorizer: map[string]interface{}{
-					"text2vec-transformers": map[string]interface{}{
-						"properties":         []interface{}{"description"},
+				Vectorizer: map[string]any{
+					"text2vec-model2vec": map[string]any{
+						"properties":         []any{"description"},
 						"vectorizeClassName": false,
 					},
 				},
@@ -63,8 +63,8 @@ func testGenerativeNvidia(rest, grpc string) func(t *testing.T) {
 				if tt.absentModuleConfig {
 					t.Log("skipping adding module config configuration to class")
 				} else {
-					class.ModuleConfig = map[string]interface{}{
-						"generative-nvidia": map[string]interface{}{
+					class.ModuleConfig = map[string]any{
+						"generative-nvidia": map[string]any{
 							"model": tt.generativeModel,
 						},
 					}

--- a/test/modules/generative-nvidia/setup_test.go
+++ b/test/modules/generative-nvidia/setup_test.go
@@ -47,7 +47,7 @@ func createSingleNodeEnvironment(ctx context.Context, apiKey string,
 
 func composeModules(apiKey string) (composeModules *docker.Compose) {
 	composeModules = docker.New().
-		WithText2VecTransformers().
+		WithText2VecModel2Vec().
 		WithGenerativeNvidia(apiKey)
 	return composeModules
 }

--- a/test/modules/generative-ollama/generative_ollama_test.go
+++ b/test/modules/generative-ollama/generative_ollama_test.go
@@ -33,9 +33,9 @@ func testGenerativeOllama(rest, grpc, ollamaApiEndpoint string) func(t *testing.
 		class := planets.BaseClass("PlanetsGenerativeTest")
 		class.VectorConfig = map[string]models.VectorConfig{
 			"description": {
-				Vectorizer: map[string]interface{}{
-					"text2vec-transformers": map[string]interface{}{
-						"properties":         []interface{}{"description"},
+				Vectorizer: map[string]any{
+					"text2vec-model2vec": map[string]any{
+						"properties":         []any{"description"},
 						"vectorizeClassName": false,
 					},
 				},
@@ -53,8 +53,8 @@ func testGenerativeOllama(rest, grpc, ollamaApiEndpoint string) func(t *testing.
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				class.ModuleConfig = map[string]interface{}{
-					"generative-ollama": map[string]interface{}{
+				class.ModuleConfig = map[string]any{
+					"generative-ollama": map[string]any{
 						"apiEndpoint": ollamaApiEndpoint,
 						"model":       tt.generativeModel,
 					},

--- a/test/modules/generative-ollama/setup_test.go
+++ b/test/modules/generative-ollama/setup_test.go
@@ -44,7 +44,7 @@ func createSingleNodeEnvironment(ctx context.Context,
 
 func composeModules() (composeModules *docker.Compose) {
 	composeModules = docker.New().
-		WithText2VecTransformers().
+		WithText2VecModel2Vec().
 		WithGenerativeOllama()
 	return composeModules
 }

--- a/test/modules/generative-xai/generative_xai_test.go
+++ b/test/modules/generative-xai/generative_xai_test.go
@@ -37,7 +37,7 @@ func testGenerativeXAI(rest, grpc string) func(t *testing.T) {
 		class.VectorConfig = map[string]models.VectorConfig{
 			"description": {
 				Vectorizer: map[string]any{
-					"text2vec-transformers": map[string]any{
+					"text2vec-model2vec": map[string]any{
 						"properties":         []any{"description"},
 						"vectorizeClassName": false,
 					},

--- a/test/modules/generative-xai/setup_test.go
+++ b/test/modules/generative-xai/setup_test.go
@@ -48,7 +48,7 @@ func createSingleNodeEnvironment(ctx context.Context, apiKey string,
 
 func composeModules(apiKey string) (composeModules *docker.Compose) {
 	composeModules = docker.New().
-		WithText2VecTransformers().
+		WithText2VecModel2Vec().
 		WithGenerativeXAI(apiKey)
 	return composeModules
 }

--- a/test/modules/many-generative/many_generative_test.go
+++ b/test/modules/many-generative/many_generative_test.go
@@ -30,26 +30,26 @@ func testGenerativeManyModules(host, ollamaApiEndpoint, region, gcpProject strin
 		class := planets.BaseClass("PlanetsGenerativeTest")
 		class.VectorConfig = map[string]models.VectorConfig{
 			"description": {
-				Vectorizer: map[string]interface{}{
-					"text2vec-transformers": map[string]interface{}{
-						"properties":         []interface{}{"description"},
+				Vectorizer: map[string]any{
+					"text2vec-model2vec": map[string]any{
+						"properties":         []any{"description"},
 						"vectorizeClassName": false,
 					},
 				},
 				VectorIndexType: "flat",
 			},
 		}
-		class.ModuleConfig = map[string]interface{}{
-			"generative-aws": map[string]interface{}{
+		class.ModuleConfig = map[string]any{
+			"generative-aws": map[string]any{
 				"service": "bedrock",
 				"region":  region,
 				"model":   "amazon.titan-text-lite-v1",
 			},
-			"generative-google": map[string]interface{}{
+			"generative-google": map[string]any{
 				"projectId": gcpProject,
 				"modelId":   "gemini-1.0-pro",
 			},
-			"generative-ollama": map[string]interface{}{
+			"generative-ollama": map[string]any{
 				"apiEndpoint": ollamaApiEndpoint,
 			},
 		}

--- a/test/modules/many-generative/setup_test.go
+++ b/test/modules/many-generative/setup_test.go
@@ -90,7 +90,7 @@ func composeModules(accessKey, secretKey, sessionToken string,
 	googleApiKey, cohereApiKey string,
 ) (composeModules *docker.Compose) {
 	composeModules = docker.New().
-		WithText2VecTransformers().
+		WithText2VecModel2Vec().
 		WithGenerativeOllama().
 		WithGenerativeAWS(accessKey, secretKey, sessionToken).
 		WithGenerativeGoogle(googleApiKey).

--- a/test/modules/many-modules/api_based_modules_sanity_test.go
+++ b/test/modules/many-modules/api_based_modules_sanity_test.go
@@ -29,12 +29,12 @@ func apiBasedModulesTests(endpoint string) func(t *testing.T) {
 
 			expectedModuleNames := []string{
 				"generative-cohere", "generative-google", "generative-openai", "generative-aws", "generative-anyscale", "generative-friendliai",
-				"text2vec-cohere", "text2vec-contextionary", "text2vec-openai", "text2vec-huggingface",
-				"text2vec-google", "text2vec-aws", "text2vec-transformers", "qna-openai", "reranker-cohere",
+				"text2vec-cohere", "text2vec-openai", "text2vec-huggingface",
+				"text2vec-google", "text2vec-aws", "text2vec-model2vec", "qna-openai", "reranker-cohere",
 				"text2vec-voyageai", "reranker-voyageai",
 			}
 
-			modules, ok := meta.Modules.(map[string]interface{})
+			modules, ok := meta.Modules.(map[string]any)
 			require.True(t, ok)
 			assert.True(t, len(modules) >= len(expectedModuleNames))
 

--- a/test/modules/many-modules/many_modules_openai_test.go
+++ b/test/modules/many-modules/many_modules_openai_test.go
@@ -39,12 +39,12 @@ func createSchemaOpenAISanityChecks(endpoint string) func(t *testing.T) {
 		}
 		tests := []struct {
 			name                  string
-			text2vecOpenAI        map[string]interface{}
+			text2vecOpenAI        map[string]any
 			expectDefaultSettings bool
 		}{
 			{
 				name: "model: text-embedding-3-large, dimensions: 256, vectorizeClassName: false",
-				text2vecOpenAI: map[string]interface{}{
+				text2vecOpenAI: map[string]any{
 					"vectorizeClassName": false,
 					"model":              "text-embedding-3-large",
 					"dimensions":         256,
@@ -52,7 +52,7 @@ func createSchemaOpenAISanityChecks(endpoint string) func(t *testing.T) {
 			},
 			{
 				name: "model: text-embedding-3-large, dimensions: 1024, vectorizeClassName: false",
-				text2vecOpenAI: map[string]interface{}{
+				text2vecOpenAI: map[string]any{
 					"vectorizeClassName": false,
 					"model":              "text-embedding-3-large",
 					"dimensions":         1024,
@@ -60,7 +60,7 @@ func createSchemaOpenAISanityChecks(endpoint string) func(t *testing.T) {
 			},
 			{
 				name: "model: text-embedding-3-large, dimensions: 3072, vectorizeClassName: false",
-				text2vecOpenAI: map[string]interface{}{
+				text2vecOpenAI: map[string]any{
 					"vectorizeClassName": false,
 					"model":              "text-embedding-3-large",
 					"dimensions":         3072,
@@ -68,7 +68,7 @@ func createSchemaOpenAISanityChecks(endpoint string) func(t *testing.T) {
 			},
 			{
 				name: "model: text-embedding-3-small, dimensions: 512, vectorizeClassName: true",
-				text2vecOpenAI: map[string]interface{}{
+				text2vecOpenAI: map[string]any{
 					"vectorizeClassName": true,
 					"model":              "text-embedding-3-small",
 					"dimensions":         512,
@@ -76,7 +76,7 @@ func createSchemaOpenAISanityChecks(endpoint string) func(t *testing.T) {
 			},
 			{
 				name: "model: text-embedding-3-small, dimensions: 1536, vectorizeClassName: false",
-				text2vecOpenAI: map[string]interface{}{
+				text2vecOpenAI: map[string]any{
 					"vectorizeClassName": false,
 					"model":              "text-embedding-3-small",
 					"dimensions":         1536,
@@ -84,7 +84,7 @@ func createSchemaOpenAISanityChecks(endpoint string) func(t *testing.T) {
 			},
 			{
 				name: "model: text-embedding-3-small, dimensions: 1536, vectorizeClassName: true",
-				text2vecOpenAI: map[string]interface{}{
+				text2vecOpenAI: map[string]any{
 					"vectorizeClassName": true,
 					"model":              "text-embedding-3-small",
 					"dimensions":         1536,
@@ -92,7 +92,7 @@ func createSchemaOpenAISanityChecks(endpoint string) func(t *testing.T) {
 			},
 			{
 				name: "model: ada, vectorizeClassName: false",
-				text2vecOpenAI: map[string]interface{}{
+				text2vecOpenAI: map[string]any{
 					"vectorizeClassName": false,
 					"model":              "ada",
 				},
@@ -104,22 +104,22 @@ func createSchemaOpenAISanityChecks(endpoint string) func(t *testing.T) {
 			},
 			{
 				name:                  "empty settings",
-				text2vecOpenAI:        map[string]interface{}{},
+				text2vecOpenAI:        map[string]any{},
 				expectDefaultSettings: true,
 			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				class.ModuleConfig = map[string]interface{}{
+				class.ModuleConfig = map[string]any{
 					vectorizer: tt.text2vecOpenAI,
 				}
 				helper.CreateClass(t, class)
 				defer helper.DeleteClass(t, class.Class)
 				verifyClass := helper.GetClass(t, class.Class)
-				moduleConfig, ok := verifyClass.ModuleConfig.(map[string]interface{})
+				moduleConfig, ok := verifyClass.ModuleConfig.(map[string]any)
 				require.True(t, ok)
 				require.NotEmpty(t, moduleConfig)
-				text2vecOpenAI, ok := moduleConfig[vectorizer].(map[string]interface{})
+				text2vecOpenAI, ok := moduleConfig[vectorizer].(map[string]any)
 				require.True(t, ok)
 				require.NotEmpty(t, text2vecOpenAI)
 				if tt.expectDefaultSettings {

--- a/test/modules/many-modules/many_modules_sanity_test.go
+++ b/test/modules/many-modules/many_modules_sanity_test.go
@@ -35,12 +35,12 @@ func manyModulesTests(endpoint string) func(t *testing.T) {
 
 			expectedModuleNames := []string{
 				"generative-cohere", "generative-google", "generative-openai", "generative-aws", "generative-anyscale", "generative-friendliai",
-				"generative-anthropic", "text2vec-cohere", "text2vec-contextionary", "text2vec-openai", "text2vec-huggingface",
-				"text2vec-google", "text2vec-aws", "text2vec-transformers", "qna-openai", "reranker-cohere",
+				"generative-anthropic", "text2vec-cohere", "text2vec-openai", "text2vec-huggingface",
+				"text2vec-google", "text2vec-aws", "text2vec-model2vec", "qna-openai", "reranker-cohere",
 				"text2vec-voyageai", "reranker-voyageai",
 			}
 
-			modules, ok := meta.Modules.(map[string]interface{})
+			modules, ok := meta.Modules.(map[string]any)
 			require.True(t, ok)
 			assert.Len(t, modules, len(expectedModuleNames))
 
@@ -51,8 +51,8 @@ func manyModulesTests(endpoint string) func(t *testing.T) {
 			assert.ElementsMatch(t, expectedModuleNames, moduleNames)
 		})
 
-		booksClass := books.ClassContextionaryVectorizer()
-		multiShardClass := multishard.ClassContextionaryVectorizer()
+		booksClass := books.ClassModel2VecVectorizer()
+		multiShardClass := multishard.ClassModel2VecVectorizer()
 		helper.CreateClass(t, booksClass)
 		helper.CreateClass(t, multiShardClass)
 		defer helper.DeleteClass(t, booksClass.Class)
@@ -79,7 +79,7 @@ func manyModulesTests(endpoint string) func(t *testing.T) {
 				result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, query)
 				books := result.Get("Get", "Books").AsSlice()
 				require.True(t, len(books) > 0)
-				results, ok := books[0].(map[string]interface{})
+				results, ok := books[0].(map[string]any)
 				require.True(t, ok)
 				assert.True(t, results["title"] != nil)
 			}
@@ -132,9 +132,9 @@ func manyModulesTests(endpoint string) func(t *testing.T) {
 					require.True(t, len(books) == 3)
 					vectors := make([]string, 3)
 					for i := 0; i < 3; i++ {
-						results, ok := books[i].(map[string]interface{})
+						results, ok := books[i].(map[string]any)
 						require.True(t, ok)
-						vector, ok := results["_additional"].(map[string]interface{})["vector"].([]interface{})
+						vector, ok := results["_additional"].(map[string]any)["vector"].([]any)
 						require.True(t, ok)
 						vec, err := json.Marshal(vector)
 						require.Nil(t, err)

--- a/test/modules/many-modules/setup_test.go
+++ b/test/modules/many-modules/setup_test.go
@@ -79,8 +79,7 @@ func createClusterEnvironment(ctx context.Context) (compose *docker.DockerCompos
 
 func composeModules() (composeModules *docker.Compose) {
 	composeModules = docker.New().
-		WithText2VecContextionary().
-		WithText2VecTransformers().
+		WithText2VecModel2Vec().
 		WithText2VecOpenAI(os.Getenv("OPENAI_APIKEY"), os.Getenv("OPENAI_ORGANIZATION"), os.Getenv("AZURE_APIKEY")).
 		WithText2VecCohere(os.Getenv("COHERE_APIKEY")).
 		WithText2VecVoyageAI(os.Getenv("VOYAGEAI_APIKEY")).

--- a/test/modules/reranker-nvidia/reranker_nvidia_test.go
+++ b/test/modules/reranker-nvidia/reranker_nvidia_test.go
@@ -24,7 +24,7 @@ import (
 func testRerankerNvidia(host string) func(t *testing.T) {
 	return func(t *testing.T) {
 		helper.SetupClient(host)
-		booksClass := books.ClassContextionaryVectorizer()
+		booksClass := books.ClassModel2VecVectorizer()
 		booksClass.ModuleConfig.(map[string]interface{})["reranker-nvidia"] = map[string]interface{}{}
 		helper.CreateClass(t, booksClass)
 		defer helper.DeleteClass(t, booksClass.Class)

--- a/test/modules/reranker-nvidia/setup_test.go
+++ b/test/modules/reranker-nvidia/setup_test.go
@@ -46,7 +46,7 @@ func createSingleNodeEnvironment(ctx context.Context, apiApiKey string,
 
 func composeModules(apiApiKey string) (composeModules *docker.Compose) {
 	composeModules = docker.New().
-		WithText2VecContextionary().
+		WithText2VecModel2Vec().
 		WithRerankerNvidia(apiApiKey)
 	return composeModules
 }


### PR DESCRIPTION
### What's being changed:

This PR switches module e2e tests to use a more lightweight and modern `model2vec` static vectorizer.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
