### PR TITLE
Reduce number of objects imported in replica movement tests

### DIFF
--- a/test/acceptance/replication/replica_replication/slow/large_shard_test.go
+++ b/test/acceptance/replication/replica_replication/slow/large_shard_test.go
@@ -62,7 +62,7 @@ func (suite *ReplicationTestSuite) TestReplicationReplicateOfLargeShard() {
 	tenantName := "tenant"
 	batch := make([]*models.Object, 0, 1000)
 	start := time.Now()
-	for j := 0; j < 1000000; j++ {
+	for j := 0; j < 100000; j++ {
 		batch = append(batch, (*models.Object)(articles.NewParagraph().
 			WithContents(fmt.Sprintf("paragraph#%d", j)).
 			WithTenant(tenantName).

--- a/test/acceptance/replication/replica_replication/slow/scale_out_test.go
+++ b/test/acceptance/replication/replica_replication/slow/scale_out_test.go
@@ -68,9 +68,9 @@ func (suite *ReplicationTestSuite) TestReplicationReplicateScaleOut() {
 
 	// Load data
 	batch := make([]*models.Object, 0, 1000)
-	tenantNames := make([]string, 0, 100)
+	tenantNames := make([]string, 0, 10)
 	t.Log("Loading data into tenants...")
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 10; i++ {
 		tenantName := fmt.Sprintf("tenant-%d", i)
 		tenantNames = append(tenantNames, tenantName)
 		for j := 0; j < 1000; j++ {
@@ -102,7 +102,7 @@ func (suite *ReplicationTestSuite) TestReplicationReplicateScaleOut() {
 		replication.NewGetCollectionShardingStateParams().WithCollection(&cls.Class), nil,
 	)
 	require.Nil(t, err)
-	require.Len(t, shardingState.Payload.ShardingState.Shards, 100)
+	require.Len(t, shardingState.Payload.ShardingState.Shards, 10)
 
 	movements := []movement{}
 	for _, state := range shardingState.Payload.ShardingState.Shards {


### PR DESCRIPTION
### What's being changed:

This PR reduces the scale of the slow replica movement tests to not take so much time in the CI when importing the initial objects. Ideally, we'd have a way to have this data ready on demand perhaps as a backup so that the import isn't necessary but for now reducing the scale will suffice

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
