### PR TITLE
feat(usage): add retry logic to usage GCS module during metrics upload

### DIFF
--- a/modules/usage-gcs/storage.go
+++ b/modules/usage-gcs/storage.go
@@ -14,10 +14,13 @@ package usagegcs
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	"github.com/googleapis/gax-go/v2"
 	"github.com/sirupsen/logrus"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 	storageapi "google.golang.org/api/storage/v1"
 
@@ -108,6 +111,18 @@ func (g *GCSStorage) UploadUsageData(ctx context.Context, usage *types.Report) e
 		Metadata: map[string]string{
 			"version": usage.Version,
 		},
+	}).WithRetry(&gax.Backoff{
+		Initial:    2 * time.Second, // Note: the client uses a jitter internally
+		Max:        60 * time.Second,
+		Multiplier: 3,
+	}, func(err error) bool {
+		var gerr *googleapi.Error
+		if errors.As(err, &gerr) {
+			g.Logger.WithField("gcs_upload", "retry").Debugf("retrying due to code: %v", gerr.Code)
+			// retry only on those given error codes
+			return gerr.Code == 401 || gerr.Code == 429 || (gerr.Code >= 500 && gerr.Code < 600)
+		}
+		return false
 	}).Media(bytes.NewReader(data)).Context(ctx).Do()
 	if err != nil {
 		return fmt.Errorf("failed to upload to GCS: %w", err)


### PR DESCRIPTION
### What's being changed:

This PR adds a retry logic to usage GCS module during metrics upload.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
