### PR TITLE
Add debug endpoint for setting max CPUs dynamically

### DIFF
--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -17,8 +17,10 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"runtime"
 	"runtime/debug"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -858,6 +860,47 @@ func setupDebugHandlers(appState *state.State) {
 		}
 		w.WriteHeader(http.StatusOK)
 		jsonBytes, err := json.Marshal(prevLimit)
+		if err != nil {
+			logger.WithError(err).Error("marshal failed on stats")
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+
+		if jsonBytes != nil {
+			w.Write(jsonBytes)
+		}
+	}))
+
+	// Call via something like:
+	// - current limit: curl -X GET localhost:6060/debug/config/gomemlimit
+	// - set limit: curl -X POST localhost:6060/debug/config/gomemlimit?limit=XXXMiB - can also be bytes or GiB
+	// The port is Weaviate's configured Go profiling port (defaults to 6060)
+	http.HandleFunc("/debug/config/gomaxprocs", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var prevMaxProcs int
+		switch r.Method {
+		case http.MethodGet:
+			prevMaxProcs = runtime.GOMAXPROCS(-1)
+		case http.MethodPost:
+			procsStr := r.URL.Query().Get("procs")
+			if procsStr == "" {
+				http.Error(w, "procs is required", http.StatusBadRequest)
+				return
+			}
+			procsInt, err := strconv.Atoi(procsStr)
+			if err != nil {
+				http.Error(w, "invalid procs value: "+err.Error(), http.StatusBadRequest)
+				return
+			}
+			prevMaxProcs = runtime.GOMAXPROCS(procsInt)
+			appState.Logger.
+				WithField("new_cpu_limit", procsInt).
+				WithField("previous_cpu_limit", prevMaxProcs).
+				Info("updating go-runtime CPU limit")
+		default:
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		}
+		w.WriteHeader(http.StatusOK)
+		jsonBytes, err := json.Marshal(prevMaxProcs)
 		if err != nil {
 			logger.WithError(err).Error("marshal failed on stats")
 			http.Error(w, err.Error(), http.StatusBadRequest)


### PR DESCRIPTION
### What's being changed:

```
curl -X GET localhost:6060/debug/config/gomaxprocs
curl -X POST localhost:6060/debug/config/gomaxprocs\?procs=15
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
