### PR TITLE
fix: SPFresh merge counter

### DIFF
--- a/adapters/repos/db/vector/spfresh/merge.go
+++ b/adapters/repos/db/vector/spfresh/merge.go
@@ -19,7 +19,6 @@ import (
 )
 
 func (s *SPFresh) doMerge(postingID uint64) error {
-	s.metrics.DequeueMergeTask()
 	start := time.Now()
 	defer s.metrics.MergeDuration(start)
 


### PR DESCRIPTION
### What's being changed:
This PR fixes the counter for SPFresh merge metric. 

Previously any completed merge operation was dequeued twice: in `task_queue.go` during `(t *MergeTask) Execute(...)` and in `doMerge(...)`. Now the logic is handled only in `task_queue.go`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
