### PR TITLE
Skip reading classname from object store

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices_payloads.go
+++ b/adapters/handlers/rest/clusterapi/indices_payloads.go
@@ -187,7 +187,7 @@ func (p singleObjectPayload) Marshal(in *storobj.Object) ([]byte, error) {
 }
 
 func (p singleObjectPayload) Unmarshal(in []byte) (*storobj.Object, error) {
-	return storobj.FromBinary(in)
+	return storobj.FromNetworkBinary(in)
 }
 
 type objectListPayload struct{}
@@ -254,7 +254,7 @@ func (p objectListPayload) Unmarshal(in []byte) ([]*storobj.Object, error) {
 			return nil, err
 		}
 
-		obj, err := storobj.FromBinary(payloadBytes)
+		obj, err := storobj.FromNetworkBinary(payloadBytes)
 		if err != nil {
 			return nil, err
 		}

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -292,7 +292,7 @@ func ScanAllLSM(ctx context.Context, store *lsmkv.Store, scan docid.ObjectScanFn
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			elem, err := storobj.FromDiskBinaryOptional(v, additional.Properties{}, properties)
+			elem, err := storobj.FromDiskBinaryOptional(v, additional.Properties{}, properties, store.GetClassName())
 			if err != nil {
 				return errors.Wrapf(err, "unmarshal data object")
 			}

--- a/adapters/repos/db/aggregator/grouper.go
+++ b/adapters/repos/db/aggregator/grouper.go
@@ -292,7 +292,7 @@ func ScanAllLSM(ctx context.Context, store *lsmkv.Store, scan docid.ObjectScanFn
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			elem, err := storobj.FromBinaryOptional(v, additional.Properties{}, properties)
+			elem, err := storobj.FromDiskBinaryOptional(v, additional.Properties{}, properties)
 			if err != nil {
 				return errors.Wrapf(err, "unmarshal data object")
 			}

--- a/adapters/repos/db/aggregator/vector_search.go
+++ b/adapters/repos/db/aggregator/vector_search.go
@@ -76,7 +76,7 @@ func (a *Aggregator) objectVectorSearch(ctx context.Context, searchVector models
 	}
 
 	bucket := a.store.Bucket(helpers.ObjectsBucketLSM)
-	objs, err := storobj.ObjectsByDocID(bucket, ids, additional.Properties{}, nil, a.logger)
+	objs, err := storobj.ObjectsByDocID(bucket, ids, additional.Properties{}, nil, a.logger, string(a.params.ClassName))
 	if err != nil {
 		return nil, nil, fmt.Errorf("get objects by doc id: %w", err)
 	}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -602,7 +602,7 @@ func (i *Index) IterateObjects(ctx context.Context, cb func(index *Index, shard 
 			return cb(i, shard, object)
 		}
 		bucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
-		return bucket.IterateObjects(ctx, wrapper)
+		return bucket.IterateObjects(ctx, wrapper, string(i.Config.ClassName))
 	})
 }
 

--- a/adapters/repos/db/index_usage.go
+++ b/adapters/repos/db/index_usage.go
@@ -372,7 +372,7 @@ func (i *Index) calculateUnloadedShardUsage(ctx context.Context, shardName strin
 			vectorUsage.VectorIndexType = vectorIndexConfig.IndexType()
 		}
 
-		dimensionalities, err := shardusage.CalculateUnloadedDimensionsUsage(ctx, i.logger, i.path(), shardName, targetVector)
+		dimensionalities, err := shardusage.CalculateUnloadedDimensionsUsage(ctx, i.logger, i.path(), string(i.Config.ClassName), shardName, targetVector)
 		if err != nil {
 			return nil, err
 		}

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -111,7 +111,7 @@ func (b *BM25Searcher) BM25F(ctx context.Context, filterDocIds helpers.AllowList
 	if useWand {
 		objs, scores, err = b.wand(ctx, filterDocIds, class, keywordRanking, limit, additional)
 	} else {
-		objs, scores, useWand, err = b.wandBlock(ctx, filterDocIds, class, keywordRanking, limit, additional)
+		objs, scores, useWand, err = b.wandBlock(ctx, className, filterDocIds, class, keywordRanking, limit, additional)
 	}
 
 	if useWand {
@@ -355,7 +355,7 @@ func (b *BM25Searcher) wand(
 	}
 
 	start = time.Now()
-	objects, scores, err := b.getTopKObjects(topKHeap, params.AdditionalExplanations, allQueryTerms, additional)
+	objects, scores, err := b.getTopKObjects(class.Class, topKHeap, params.AdditionalExplanations, allQueryTerms, additional)
 
 	fetchTime := time.Since(start)
 	helpers.AnnotateSlowQueryLog(ctx, "kwd_5_objects_time", fetchTime)
@@ -388,7 +388,7 @@ WordLoop:
 	}
 }
 
-func (b *BM25Searcher) getTopKObjects(topKHeap *priorityqueue.Queue[[]*terms.DocPointerWithScore], additionalExplanations bool,
+func (b *BM25Searcher) getTopKObjects(className string, topKHeap *priorityqueue.Queue[[]*terms.DocPointerWithScore], additionalExplanations bool,
 	allRequests []string, additional additional.Properties,
 ) ([]*storobj.Object, []float32, error) {
 	objectsBucket := b.store.Bucket(helpers.ObjectsBucketLSM)
@@ -402,7 +402,7 @@ func (b *BM25Searcher) getTopKObjects(topKHeap *priorityqueue.Queue[[]*terms.Doc
 		explanations = append(explanations, res.Value)
 	}
 
-	objs, err := storobj.ObjectsByDocID(objectsBucket, ids, additional, nil, b.logger)
+	objs, err := storobj.ObjectsByDocID(objectsBucket, ids, additional, nil, b.logger, className)
 	if err != nil {
 		return objs, nil, errors.Errorf("objects loading")
 	}

--- a/adapters/repos/db/inverted/filters_integration_test.go
+++ b/adapters/repos/db/inverted/filters_integration_test.go
@@ -47,7 +47,7 @@ func Test_Filters_String(t *testing.T) {
 	store, err := lsmkv.New(dirName, dirName, logger, nil,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
+		cyclemanager.NewCallbackGroupNoop(), "class")
 	require.Nil(t, err)
 
 	propName := "inverted-with-frequency"
@@ -337,7 +337,7 @@ func Test_Filters_Int(t *testing.T) {
 	store, err := lsmkv.New(dirName, dirName, logger, nil,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
+		cyclemanager.NewCallbackGroupNoop(), "class")
 	require.NoError(t, err)
 	defer store.Shutdown(context.Background())
 
@@ -1107,7 +1107,7 @@ func Test_Filters_String_DuplicateEntriesInAnd(t *testing.T) {
 	store, err := lsmkv.New(dirName, dirName, logger, nil,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
+		cyclemanager.NewCallbackGroupNoop(), "class")
 	require.Nil(t, err)
 
 	propName := "inverted-with-frequency"

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -197,7 +197,7 @@ func (s *Searcher) objectsByDocID(ctx context.Context, it docIDsIterator, classN
 		if additional.ReferenceQuery {
 			unmarshalled, err = storobj.FromDiskBinaryUUIDOnly(res, string(className))
 		} else {
-			unmarshalled, err = storobj.FromDiskBinaryOptional(res, additional, props)
+			unmarshalled, err = storobj.FromDiskBinaryOptional(res, additional, props, string(className))
 		}
 		if err != nil {
 			return nil, fmt.Errorf("unmarshal data object at position %d: %w", i, err)

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -114,7 +114,7 @@ func (s *Searcher) Objects(ctx context.Context, limit int,
 	defer func() {
 		helpers.AnnotateSlowQueryLog(ctx, "objects_by_doc_ids_took", time.Since(beforeObjects))
 	}()
-	return s.objectsByDocID(ctx, it, additional, limit, properties)
+	return s.objectsByDocID(ctx, it, className, additional, limit, properties)
 }
 
 func (s *Searcher) sort(ctx context.Context, limit int, sort []filters.Sort,
@@ -128,7 +128,7 @@ func (s *Searcher) sort(ctx context.Context, limit int, sort []filters.Sort,
 	return lsmSorter.SortDocIDs(ctx, limit, sort, docIDs)
 }
 
-func (s *Searcher) objectsByDocID(ctx context.Context, it docIDsIterator,
+func (s *Searcher) objectsByDocID(ctx context.Context, it docIDsIterator, className schema.ClassName,
 	additional additional.Properties, limit int, properties []string,
 ) ([]*storobj.Object, error) {
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
@@ -195,9 +195,9 @@ func (s *Searcher) objectsByDocID(ctx context.Context, it docIDsIterator,
 
 		var unmarshalled *storobj.Object
 		if additional.ReferenceQuery {
-			unmarshalled, err = storobj.FromBinaryUUIDOnly(res)
+			unmarshalled, err = storobj.FromDiskBinaryUUIDOnly(res, string(className))
 		} else {
-			unmarshalled, err = storobj.FromBinaryOptional(res, additional, props)
+			unmarshalled, err = storobj.FromDiskBinaryOptional(res, additional, props)
 		}
 		if err != nil {
 			return nil, fmt.Errorf("unmarshal data object at position %d: %w", i, err)

--- a/adapters/repos/db/inverted/searcher_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_integration_test.go
@@ -53,7 +53,7 @@ func TestObjects(t *testing.T) {
 	store, err := lsmkv.New(dirName, dirName, logger, nil,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
+		cyclemanager.NewCallbackGroupNoop(), "class")
 	require.Nil(t, err)
 	defer func() { assert.Nil(t, err) }()
 
@@ -273,7 +273,7 @@ func TestDocIDs(t *testing.T) {
 	store, err := lsmkv.New(dirName, dirName, logger, nil,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
+		cyclemanager.NewCallbackGroupNoop(), "class")
 	require.Nil(t, err)
 	defer func() { assert.Nil(t, err) }()
 
@@ -427,7 +427,7 @@ func TestSearcher_ResolveDocIds(t *testing.T) {
 		store, err := lsmkv.New(dirName, dirName, logger, nil,
 			cyclemanager.NewCallbackGroupNoop(),
 			cyclemanager.NewCallbackGroupNoop(),
-			cyclemanager.NewCallbackGroupNoop())
+			cyclemanager.NewCallbackGroupNoop(), "class")
 		require.NoError(t, err)
 		t.Cleanup(func() { store.Shutdown(context.Background()) }) // cleanup in outer test
 

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -36,7 +36,7 @@ type ShardInvertedReindexTask interface {
 	ObjectsIterator(shard ShardLike) objectsIterator
 }
 
-type objectsIterator func(ctx context.Context, fn func(object *storobj.Object) error) error
+type objectsIterator func(ctx context.Context, fn func(object *storobj.Object) error, className string) error
 
 type ReindexableProperty struct {
 	PropertyName    string
@@ -287,7 +287,7 @@ func (r *ShardInvertedReindexer) reindexProperties(ctx context.Context, reindexa
 
 		i++
 		return nil
-	}); err != nil {
+	}, r.class.Class); err != nil {
 		return err
 	}
 

--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -1245,7 +1245,7 @@ func uuidObjectsIteratorAsync(logger logrus.FieldLogger, shard ShardLike, lastKe
 
 		for ; k != nil; k, v = cursor.Next() {
 			ik := keyParse(k)
-			obj, err := storobj.FromBinaryOptional(v, addProps, propExtraction)
+			obj, err := storobj.FromDiskBinaryOptional(v, addProps, propExtraction)
 			if err != nil {
 				mdCh <- &migrationData{err: fmt.Errorf("unmarshalling object '%s': %w", ik.String(), err)}
 				break

--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -1245,7 +1245,7 @@ func uuidObjectsIteratorAsync(logger logrus.FieldLogger, shard ShardLike, lastKe
 
 		for ; k != nil; k, v = cursor.Next() {
 			ik := keyParse(k)
-			obj, err := storobj.FromDiskBinaryOptional(v, addProps, propExtraction)
+			obj, err := storobj.FromDiskBinaryOptional(v, addProps, propExtraction, shard.Index().Config.ClassName.String())
 			if err != nil {
 				mdCh <- &migrationData{err: fmt.Errorf("unmarshalling object '%s': %w", ik.String(), err)}
 				break

--- a/adapters/repos/db/inverted_reindexer_specified_index.go
+++ b/adapters/repos/db/inverted_reindexer_specified_index.go
@@ -141,7 +141,7 @@ func (t *ShardInvertedReindexTask_SpecifiedIndex) ObjectsIterator(shard ShardLik
 
 		i := 0
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
-			obj, err := storobj.FromDiskBinaryOptional(v, additional.Properties{}, propsExtraction)
+			obj, err := storobj.FromDiskBinaryOptional(v, additional.Properties{}, propsExtraction, shard.Index().Config.ClassName.String())
 			if err != nil {
 				return fmt.Errorf("cannot unmarshal object %d, %w", i, err)
 			}

--- a/adapters/repos/db/inverted_reindexer_specified_index.go
+++ b/adapters/repos/db/inverted_reindexer_specified_index.go
@@ -135,13 +135,13 @@ func (t *ShardInvertedReindexTask_SpecifiedIndex) ObjectsIterator(shard ShardLik
 	}
 
 	objectsBucket := shard.Store().Bucket(helpers.ObjectsBucketLSM)
-	return func(ctx context.Context, fn func(object *storobj.Object) error) error {
+	return func(ctx context.Context, fn func(object *storobj.Object) error, class string) error {
 		cursor := objectsBucket.Cursor()
 		defer cursor.Close()
 
 		i := 0
 		for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
-			obj, err := storobj.FromBinaryOptional(v, additional.Properties{}, propsExtraction)
+			obj, err := storobj.FromDiskBinaryOptional(v, additional.Properties{}, propsExtraction)
 			if err != nil {
 				return fmt.Errorf("cannot unmarshal object %d, %w", i, err)
 			}

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -66,18 +66,19 @@ const (
 
 type BucketCreator interface {
 	NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogger,
-		metrics *Metrics, compactionCallbacks, flushCallbacks cyclemanager.CycleCallbackGroup,
+		metrics *Metrics, compactionCallbacks, flushCallbacks cyclemanager.CycleCallbackGroup, className string,
 		opts ...BucketOption,
 	) (*Bucket, error)
 }
 
 type Bucket struct {
-	dir      string
-	rootDir  string
-	active   memtable
-	flushing memtable
-	disk     *SegmentGroup
-	logger   logrus.FieldLogger
+	dir       string
+	rootDir   string
+	className string
+	active    memtable
+	flushing  memtable
+	disk      *SegmentGroup
+	logger    logrus.FieldLogger
 
 	// Lock() means a move from active to flushing is happening, RLock() is
 	// normal operation
@@ -196,7 +197,7 @@ func NewBucketCreator() *Bucket { return &Bucket{} }
 // [Store]. In this case the [Store] can manage buckets for you, using methods
 // such as CreateOrLoadBucket().
 func (*Bucket) NewBucket(ctx context.Context, dir, rootDir string, logger logrus.FieldLogger,
-	metrics *Metrics, compactionCallbacks, flushCallbacks cyclemanager.CycleCallbackGroup,
+	metrics *Metrics, compactionCallbacks, flushCallbacks cyclemanager.CycleCallbackGroup, className string,
 	opts ...BucketOption,
 ) (b *Bucket, err error) {
 	beforeAll := time.Now()
@@ -223,6 +224,7 @@ func (*Bucket) NewBucket(ctx context.Context, dir, rootDir string, logger logrus
 		haltedFlushTimer:             interval.NewBackoffTimer(),
 		writeSegmentInfoIntoFileName: false,
 		minWalThreshold:              config.DefaultPersistenceMaxReuseWalSize,
+		className:                    className,
 	}
 
 	for _, opt := range opts {
@@ -356,14 +358,14 @@ func (b *Bucket) GetFlushCallbackCtrl() cyclemanager.CycleCallbackCtrl {
 	return b.flushCallbackCtrl
 }
 
-func (b *Bucket) IterateObjects(ctx context.Context, f func(object *storobj.Object) error) error {
+func (b *Bucket) IterateObjects(ctx context.Context, f func(object *storobj.Object) error, className string) error {
 	cursor := b.Cursor()
 	defer cursor.Close()
 
 	i := 0
 
 	for k, v := cursor.First(); k != nil; k, v = cursor.Next() {
-		obj, err := storobj.FromBinary(v)
+		obj, err := storobj.FromDiskBinary(v, className)
 		if err != nil {
 			return fmt.Errorf("cannot unmarshal object %d, %w", i, err)
 		}
@@ -434,7 +436,7 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
-				obj, err := storobj.FromBinaryUUIDOnly(v)
+				obj, err := storobj.FromDiskBinaryUUIDOnly(v, b.className)
 				if err != nil {
 					return fmt.Errorf("cannot unmarshal object: %w", err)
 				}
@@ -457,7 +459,7 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			obj, err := storobj.FromBinaryUUIDOnly(v)
+			obj, err := storobj.FromDiskBinaryUUIDOnly(v, b.className)
 			if err != nil {
 				return fmt.Errorf("cannot unmarshal object: %w", err)
 			}

--- a/adapters/repos/db/lsmkv/bucket_backup_test.go
+++ b/adapters/repos/db/lsmkv/bucket_backup_test.go
@@ -49,7 +49,7 @@ func bucketBackup_FlushMemtable(ctx context.Context, t *testing.T, opts []Bucket
 		dirName := t.TempDir()
 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, logrus.New(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 		b.UpdateStatus(storagestate.StatusReadOnly)
 
@@ -67,7 +67,7 @@ func bucketBackup_ListFiles(ctx context.Context, t *testing.T, opts []BucketOpti
 	dirName := t.TempDir()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, logrus.New(), nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.NoError(t, err)
 
 	for i := 0; i < 10; i++ {

--- a/adapters/repos/db/lsmkv/bucket_recover_test.go
+++ b/adapters/repos/db/lsmkv/bucket_recover_test.go
@@ -40,7 +40,7 @@ func TestBucketWalReload(t *testing.T) {
 
 			// initial bucket, always create segment, even if it is just a single entry
 			b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount),
 				WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 			require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestBucketWalReload(t *testing.T) {
 
 			// start fresh with a new memtable, new entries will stay in wal until size is reached
 			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount),
 				WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 			require.NoError(t, err)
@@ -101,7 +101,7 @@ func TestBucketWalReload(t *testing.T) {
 
 			// will load wal and reuse memtable
 			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(strategy), WithSecondaryIndices(1),
 				WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 			require.NoError(t, err)
@@ -134,7 +134,7 @@ func TestBucketWalReload(t *testing.T) {
 
 			// now add a lot of entries to hit .wal file limit
 			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount),
 				WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 			require.NoError(t, err)
@@ -169,7 +169,7 @@ func TestBucketWalReload(t *testing.T) {
 			require.Equal(t, 0, fileTypes[".wal"], "single wal file")
 
 			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(strategy), WithSecondaryIndices(secondaryIndicesCount),
 				WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 			require.NoError(t, err)
@@ -186,7 +186,7 @@ func TestBucketRecovery(t *testing.T) {
 	dirName := t.TempDir()
 	tmpDir := t.TempDir()
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(true), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithWriteSegmentInfoIntoFileName(true), WithStrategy(StrategyReplace),
 	)
 	require.NoError(t, err)
 	require.NoError(t, b.Put([]byte("hello1"), []byte("world1"), WithSecondaryKey(0, []byte("bonjour1"))))
@@ -210,7 +210,7 @@ func TestBucketRecovery(t *testing.T) {
 	require.Equal(t, walFiles, 0)
 
 	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(true), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithWriteSegmentInfoIntoFileName(true), WithStrategy(StrategyReplace),
 	)
 	require.NoError(t, err)
 	require.NoError(t, b.Put([]byte("hello2"), []byte("world2"), WithSecondaryKey(0, []byte("bonjour2"))))
@@ -223,7 +223,7 @@ func TestBucketRecovery(t *testing.T) {
 	require.NoError(t, os.Rename(tmpPath, oldPath))
 
 	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(true), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithWriteSegmentInfoIntoFileName(true), WithStrategy(StrategyReplace),
 	)
 	require.NoError(t, err)
 	get, err := b.Get([]byte("hello1"))
@@ -274,7 +274,7 @@ func TestBucketReloadAfterWalDamange(t *testing.T) {
 	ctx := context.Background()
 	dirName := t.TempDir()
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithCalcCountNetAdditions(true), WithSecondaryIndices(2), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithCalcCountNetAdditions(true), WithSecondaryIndices(2), WithStrategy(StrategyReplace),
 	)
 	require.NoError(t, err)
 
@@ -302,7 +302,7 @@ func TestBucketReloadAfterWalDamange(t *testing.T) {
 
 	// now reload bucket
 	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithCalcCountNetAdditions(true), WithSecondaryIndices(2), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithCalcCountNetAdditions(true), WithSecondaryIndices(2), WithStrategy(StrategyReplace),
 	)
 	require.NoError(t, err)
 
@@ -325,7 +325,7 @@ func TestBucketReloadAfterWalDamange(t *testing.T) {
 	require.Equal(t, walFiles, 1)
 
 	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithCalcCountNetAdditions(true), WithSecondaryIndices(2), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithCalcCountNetAdditions(true), WithSecondaryIndices(2), WithStrategy(StrategyReplace),
 	)
 	require.NoError(t, err)
 
@@ -338,7 +338,7 @@ func TestBucketReloadAfterWalDamange(t *testing.T) {
 	require.NoError(t, b.Shutdown(ctx))
 
 	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithCalcCountNetAdditions(true), WithSecondaryIndices(2), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithCalcCountNetAdditions(true), WithSecondaryIndices(2), WithStrategy(StrategyReplace),
 	)
 	require.NoError(t, err)
 	count, err = b.Count(ctx)

--- a/adapters/repos/db/lsmkv/bucket_test.go
+++ b/adapters/repos/db/lsmkv/bucket_test.go
@@ -93,7 +93,7 @@ func bucket_WasDeleted_KeepTombstones(ctx context.Context, t *testing.T, opts []
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 	t.Cleanup(func() {
 		require.Nil(t, b.Shutdown(context.Background()))
@@ -145,7 +145,7 @@ func bucket_WasDeleted_CleanupTombstones(ctx context.Context, t *testing.T, opts
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		require.NoError(t, b.Shutdown(context.Background()))
@@ -190,7 +190,7 @@ func bucketReadsIntoMemory(ctx context.Context, t *testing.T, opts []BucketOptio
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 
 	require.Nil(t, b.Put([]byte("hello"), []byte("world"),
@@ -208,7 +208,7 @@ func bucketReadsIntoMemory(ctx context.Context, t *testing.T, opts []BucketOptio
 	b.Shutdown(ctx)
 
 	b2, err := NewBucketCreator().NewBucket(ctx, b.GetDir(), "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
 
@@ -292,7 +292,7 @@ func TestBucketGetBySecondary(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 
@@ -333,7 +333,7 @@ func TestBucketInfoInFileName(t *testing.T) {
 		t.Run(fmt.Sprintf("%t", segmentInfo), func(t *testing.T) {
 			dirName := t.TempDir()
 			b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(segmentInfo), WithStrategy(StrategyReplace),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithWriteSegmentInfoIntoFileName(segmentInfo), WithStrategy(StrategyReplace),
 			)
 			require.NoError(t, err)
 			require.NoError(t, b.Put([]byte("hello1"), []byte("world1"), WithSecondaryKey(0, []byte("bonjour1"))))
@@ -364,7 +364,7 @@ func TestBucketCompactionFileName(t *testing.T) {
 		t.Run(fmt.Sprintf("firstSegment: %t", tt.firstSegment), func(t *testing.T) {
 			dirName := t.TempDir()
 			b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(tt.firstSegment), WithStrategy(StrategyReplace),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithWriteSegmentInfoIntoFileName(tt.firstSegment), WithStrategy(StrategyReplace),
 			)
 			require.NoError(t, err)
 			require.NoError(t, b.Put([]byte("hello1"), []byte("world1"), WithSecondaryKey(0, []byte("bonjour1"))))
@@ -375,7 +375,7 @@ func TestBucketCompactionFileName(t *testing.T) {
 			oldNames := verifyFileInfo(t, dirName, nil, tt.firstSegment, 0)
 
 			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(tt.secondSegment), WithStrategy(StrategyReplace),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithWriteSegmentInfoIntoFileName(tt.secondSegment), WithStrategy(StrategyReplace),
 			)
 			require.NoError(t, err)
 			require.NoError(t, b.Put([]byte("hello2"), []byte("world2"), WithSecondaryKey(0, []byte("bonjour2"))))
@@ -387,7 +387,7 @@ func TestBucketCompactionFileName(t *testing.T) {
 			oldNames = verifyFileInfo(t, dirName, oldNames, tt.secondSegment, 0)
 
 			b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithWriteSegmentInfoIntoFileName(tt.compaction), WithStrategy(StrategyReplace),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithWriteSegmentInfoIntoFileName(tt.compaction), WithStrategy(StrategyReplace),
 			)
 			require.NoError(t, err)
 			compact, err := b.disk.compactOnce()
@@ -440,7 +440,7 @@ func TestNetCountComputationAtInit(t *testing.T) {
 	ctx := context.Background()
 	dirName := t.TempDir()
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace), WithMinWalThreshold(0),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace), WithMinWalThreshold(0),
 	)
 	require.NoError(t, err)
 
@@ -476,7 +476,7 @@ func TestNetCountComputationAtInit(t *testing.T) {
 	require.Equal(t, 4, fileTypes[".cna"]) // cna file for new segment not yet computed
 
 	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace), WithMinWalThreshold(0),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace), WithMinWalThreshold(0),
 	)
 	require.NoError(t, err)
 

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -48,7 +48,7 @@ func TestWriteAheadLogThreshold_Replace(t *testing.T) {
 	flushCycle.Start()
 
 	bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), flushCallbacks,
+		cyclemanager.NewCallbackGroupNoop(), flushCallbacks, "class",
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(1024*1024*1024),
 		WithWalThreshold(walThreshold),
@@ -152,7 +152,7 @@ func TestMemtableThreshold_Replace(t *testing.T) {
 	flushCycle.Start()
 
 	bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), flushCallbacks,
+		cyclemanager.NewCallbackGroupNoop(), flushCallbacks, "class",
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(memtableThreshold),
 		WithMinWalThreshold(0),
@@ -247,7 +247,7 @@ func TestMemtableFlushesIfDirty(t *testing.T) {
 		flushCycle.Start()
 
 		bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), flushCallbacks,
+			cyclemanager.NewCallbackGroupNoop(), flushCallbacks, "class",
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test
@@ -292,7 +292,7 @@ func TestMemtableFlushesIfDirty(t *testing.T) {
 		flushCycle.Start()
 
 		bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), flushCallbacks,
+			cyclemanager.NewCallbackGroupNoop(), flushCallbacks, "class",
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test
@@ -341,7 +341,7 @@ func TestMemtableFlushesIfDirty(t *testing.T) {
 		flushCycle.Start()
 
 		bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), flushCallbacks,
+			cyclemanager.NewCallbackGroupNoop(), flushCallbacks, "class",
 			WithStrategy(StrategyReplace),
 			WithMemtableThreshold(1e12), // large enough to not affect this test
 			WithWalThreshold(1e12),      // large enough to not affect this test

--- a/adapters/repos/db/lsmkv/cleanup_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/cleanup_replace_integration_test.go
@@ -28,7 +28,7 @@ func cleanupReplaceStrategy(ctx context.Context, t *testing.T, opts []BucketOpti
 	dir := t.TempDir()
 
 	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 	defer bucket.Shutdown(context.Background())
 
@@ -400,7 +400,7 @@ func cleanupReplaceStrategy_WithSecondaryKeys(ctx context.Context, t *testing.T,
 	dir := t.TempDir()
 
 	bucket, err := NewBucketCreator().NewBucket(ctx, dir, dir, nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 	defer bucket.Shutdown(context.Background())
 

--- a/adapters/repos/db/lsmkv/compaction_bench_test.go
+++ b/adapters/repos/db/lsmkv/compaction_bench_test.go
@@ -46,7 +46,7 @@ func BenchmarkCompaction(b *testing.B) {
 					tmpDir := b.TempDir()
 
 					bu, err := NewBucketCreator().NewBucket(ctx, tmpDir, "", logger, nil,
-						cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+						cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 					require.NoError(b, err)
 
 					for j := 0; j < valuesPerSegment; j++ {

--- a/adapters/repos/db/lsmkv/compaction_integration2_test.go
+++ b/adapters/repos/db/lsmkv/compaction_integration2_test.go
@@ -134,7 +134,7 @@ func TestCompactionReplaceStrategyStraggler(t *testing.T) {
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(context.TODO(), dirName, "", nullLogger2(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/compaction_map_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_map_integration_test.go
@@ -298,7 +298,7 @@ func compactionMapStrategy(ctx context.Context, t *testing.T, opts []BucketOptio
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -431,7 +431,7 @@ func compactionMapStrategy(ctx context.Context, t *testing.T, opts []BucketOptio
 func compactionMapStrategy_HugeEntries(ctx context.Context, t *testing.T, opts []BucketOption) {
 	dirName := t.TempDir()
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 
 	// so big it effectively never triggers as part of this test
@@ -487,7 +487,7 @@ func compactionMapStrategy_RemoveUnnecessary(ctx context.Context, t *testing.T, 
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -618,7 +618,7 @@ func compactionMapStrategy_FrequentPutDeleteOperations(ctx context.Context, t *t
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 				require.Nil(t, err)
 
 				// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/compaction_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_replace_integration_test.go
@@ -128,7 +128,7 @@ func compactionReplaceStrategy(ctx context.Context, t *testing.T, opts []BucketO
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -354,7 +354,7 @@ func compactionReplaceStrategy_WithSecondaryKeys(ctx context.Context, t *testing
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -467,7 +467,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryDeletes(ctx context.Context, t *
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -558,7 +558,7 @@ func compactionReplaceStrategy_RemoveUnnecessaryUpdates(ctx context.Context, t *
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -639,7 +639,7 @@ func compactionReplaceStrategy_FrequentPutDeleteOperations(ctx context.Context, 
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -705,7 +705,7 @@ func compactionReplaceStrategy_FrequentPutDeleteOperations_WithSecondaryKeys(ctx
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 				require.Nil(t, err)
 
 				// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_integration_test.go
@@ -40,7 +40,7 @@ func compactionRoaringSetStrategy_Random(ctx context.Context, t *testing.T, opts
 	control := controlFromInstructions(instr, maxID)
 
 	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 
 	defer b.Shutdown(testCtx())
@@ -338,7 +338,7 @@ func compactionRoaringSetStrategy(ctx context.Context, t *testing.T, opts []Buck
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -466,7 +466,7 @@ func compactionRoaringSetStrategy_RemoveUnnecessary(ctx context.Context, t *test
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -560,7 +560,7 @@ func compactionRoaringSetStrategy_FrequentPutDeleteOperations(ctx context.Contex
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 				require.Nil(t, err)
 
 				// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/compaction_roaring_set_range_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_roaring_set_range_integration_test.go
@@ -40,7 +40,7 @@ func compactionRoaringSetRangeStrategy_Random(ctx context.Context, t *testing.T,
 	control := controlFromRangeInstructions(instr, maxKey)
 
 	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 
 	defer b.Shutdown(testCtx())
@@ -324,7 +324,7 @@ func compactionRoaringSetRangeStrategy(ctx context.Context, t *testing.T, opts [
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -460,7 +460,7 @@ func compactionRoaringSetRangeStrategy_RemoveUnnecessary(ctx context.Context, t 
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -530,7 +530,7 @@ func compactionRoaringSetRangeStrategy_FrequentPutDeleteOperations(ctx context.C
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 				require.Nil(t, err)
 
 				// so big it effectively never triggers as part of this test
@@ -622,7 +622,7 @@ func compactionRoaringSetRangeStrategy_FrequentPutDeleteOperations(ctx context.C
 // Data in this test come from compactionRoaringSetRangeStrategy_Random test for which test failed.
 func compactionRoaringSetRangeStrategy_BugfixOverwrittenBuffer(ctx context.Context, t *testing.T, opts []BucketOption) {
 	b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 	defer b.Shutdown(testCtx())
 	// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/compaction_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/compaction_set_integration_test.go
@@ -232,7 +232,7 @@ func compactionSetStrategy(ctx context.Context, t *testing.T, opts []BucketOptio
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -358,7 +358,7 @@ func compactionSetStrategy_RemoveUnnecessary(ctx context.Context, t *testing.T, 
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -453,7 +453,7 @@ func compactionSetStrategy_FrequentPutDeleteOperations(ctx context.Context, t *t
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 				require.Nil(t, err)
 
 				// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/compactor_inverted_integration_test.go
+++ b/adapters/repos/db/lsmkv/compactor_inverted_integration_test.go
@@ -535,7 +535,7 @@ func compactionInvertedStrategy(ctx context.Context, t *testing.T, opts []Bucket
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -894,7 +894,7 @@ func compactionInvertedStrategy_RemoveUnnecessary(ctx context.Context, t *testin
 
 	t.Run("init bucket", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyInverted))
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithStrategy(StrategyInverted))
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test
@@ -1061,7 +1061,7 @@ func compactionInvertedStrategy_FrequentPutDeleteOperations(ctx context.Context,
 
 			t.Run("init bucket", func(t *testing.T) {
 				b, err := NewBucketCreator().NewBucket(ctx, dirName, dirName, nullLogger(), nil,
-					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 				require.Nil(t, err)
 
 				// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/concurrent_reading_benchmark_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_reading_benchmark_test.go
@@ -63,7 +63,7 @@ func prepareBucket(b *testing.B) (bucket *Bucket, cleanup func()) {
 	}()
 
 	bucket, err := NewBucketCreator().NewBucket(testCtxB(), dirName, "", nullLoggerB(), nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyMapCollection),
 		WithMemtableThreshold(5000))
 	require.Nil(b, err)

--- a/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
@@ -44,7 +44,7 @@ func TestConcurrentWriting_Replace(t *testing.T) {
 	values := make([][]byte, amount)
 
 	bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace),
 		WithMemtableThreshold(10000))
 	require.Nil(t, err)
@@ -141,7 +141,7 @@ func TestConcurrentWriting_Set(t *testing.T) {
 		flushGroup.CycleCallback,
 		nullLogger()).Start()
 	bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), flushGroup,
+		cyclemanager.NewCallbackGroupNoop(), flushGroup, "class",
 		WithStrategy(StrategySetCollection),
 		WithMemtableThreshold(10000))
 	require.Nil(t, err)
@@ -235,7 +235,7 @@ func TestConcurrentWriting_RoaringSet(t *testing.T) {
 		flushGroup.CycleCallback,
 		logger).Start()
 	bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), flushGroup,
+		cyclemanager.NewCallbackGroupNoop(), flushGroup, "class",
 		WithStrategy(StrategyRoaringSet),
 		WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()),
 		WithMemtableThreshold(1000))
@@ -324,7 +324,7 @@ func TestConcurrentWriting_RoaringSetRange(t *testing.T) {
 		flushGroup.CycleCallback,
 		nullLogger()).Start()
 	bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), flushGroup,
+		cyclemanager.NewCallbackGroupNoop(), flushGroup, "class",
 		WithStrategy(StrategyRoaringSetRange),
 		WithMemtableThreshold(1000),
 		WithUseBloomFilter(false))
@@ -406,7 +406,7 @@ func TestConcurrentWriting_Map(t *testing.T) {
 	values := make([][]MapPair, amount)
 
 	bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyMapCollection),
 		WithMemtableThreshold(5000))
 	require.Nil(t, err)

--- a/adapters/repos/db/lsmkv/mock_bucket_creator.go
+++ b/adapters/repos/db/lsmkv/mock_bucket_creator.go
@@ -36,7 +36,7 @@ func (_m *MockBucketCreator) EXPECT() *MockBucketCreator_Expecter {
 }
 
 // NewBucket provides a mock function with given fields: ctx, dir, rootDir, logger, metrics, compactionCallbacks, flushCallbacks, opts
-func (_m *MockBucketCreator) NewBucket(ctx context.Context, dir string, rootDir string, logger logrus.FieldLogger, metrics *Metrics, compactionCallbacks cyclemanager.CycleCallbackGroup, flushCallbacks cyclemanager.CycleCallbackGroup, opts ...BucketOption) (*Bucket, error) {
+func (_m *MockBucketCreator) NewBucket(ctx context.Context, dir string, rootDir string, logger logrus.FieldLogger, metrics *Metrics, compactionCallbacks cyclemanager.CycleCallbackGroup, flushCallbacks cyclemanager.CycleCallbackGroup, classname string, opts ...BucketOption) (*Bucket, error) {
 	_va := make([]interface{}, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
@@ -119,7 +119,8 @@ func (_c *MockBucketCreator_NewBucket_Call) RunAndReturn(run func(context.Contex
 func NewMockBucketCreator(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockBucketCreator {
+},
+) *MockBucketCreator {
 	mock := &MockBucketCreator{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/lsmkv/quantile_keys_test.go
+++ b/adapters/repos/db/lsmkv/quantile_keys_test.go
@@ -30,7 +30,7 @@ func TestQuantileKeysSingleSegment(t *testing.T) {
 
 	b, err := NewBucketCreator().NewBucket(
 		ctx, dir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyReplace))
+		cyclemanager.NewCallbackGroupNoop(), "class", WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 
 	importConsecutiveKeys(t, b, 0, 1000)
@@ -72,7 +72,7 @@ func TestQuantileKeysMultipleSegmentsUniqueEntries(t *testing.T) {
 
 	b, err := NewBucketCreator().NewBucket(
 		ctx, dir, "", logger, nil, cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop(), WithStrategy(StrategyReplace))
+		cyclemanager.NewCallbackGroupNoop(), "class", WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 
 	importConsecutiveKeys(t, b, 0, 1000)

--- a/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
+++ b/adapters/repos/db/lsmkv/recover_from_wal_integration_test.go
@@ -36,7 +36,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("with some previous state", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 			WithStrategy(StrategyReplace), WithMinWalThreshold(0))
 		require.Nil(t, err)
 
@@ -71,7 +71,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 			// then recreate bucket
 			var err error
 			b, err = NewBucketCreator().NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(StrategyReplace), WithMinWalThreshold(0))
 			require.Nil(t, err)
 		})
@@ -157,7 +157,7 @@ func TestReplaceStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucketCreator().NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(StrategyReplace), WithMinWalThreshold(0))
 			require.Nil(t, err)
 
@@ -192,7 +192,7 @@ func TestReplaceStrategy_RecoverFromWALWithCorruptLastElement(t *testing.T) {
 
 	t.Run("without previous state", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 			WithStrategy(StrategyReplace))
 		require.Nil(t, err)
 
@@ -300,7 +300,7 @@ func TestReplaceStrategy_RecoverFromWALWithCorruptLastElement(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucketCreator().NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(StrategyReplace))
 			require.Nil(t, err)
 
@@ -340,7 +340,7 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 			WithStrategy(StrategySetCollection))
 		require.Nil(t, err)
 
@@ -440,7 +440,7 @@ func TestSetStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucketCreator().NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(StrategySetCollection))
 			require.Nil(t, err)
 
@@ -482,7 +482,7 @@ func TestRoaringSetStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 			WithStrategy(StrategyRoaringSet), WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 		require.Nil(t, err)
 
@@ -588,7 +588,7 @@ func TestRoaringSetStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucketCreator().NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(StrategyRoaringSet), WithBitmapBufPool(roaringset.NewBitmapBufPoolNoop()))
 			require.Nil(t, err)
 
@@ -631,7 +631,7 @@ func TestRoaringSetRangeStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 			WithStrategy(StrategyRoaringSetRange))
 		require.Nil(t, err)
 
@@ -743,7 +743,7 @@ func TestRoaringSetRangeStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucketCreator().NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(StrategyRoaringSetRange))
 			require.Nil(t, err)
 
@@ -789,7 +789,7 @@ func TestMapStrategy_RecoverFromWAL(t *testing.T) {
 
 	t.Run("without prior state", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(testCtx(), dirNameOriginal, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 			WithStrategy(StrategyMapCollection))
 		require.Nil(t, err)
 
@@ -927,7 +927,7 @@ func TestMapStrategy_RecoverFromWAL(t *testing.T) {
 
 		t.Run("create new bucket from existing state", func(t *testing.T) {
 			b, err := NewBucketCreator().NewBucket(testCtx(), dirNameRecovered, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(StrategyMapCollection))
 			require.Nil(t, err)
 

--- a/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters_test.go
@@ -35,7 +35,7 @@ func TestCreateBloomOnFlush(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 
@@ -55,7 +55,7 @@ func TestCreateBloomOnFlush(t *testing.T) {
 	require.Nil(t, b.Shutdown(ctx))
 
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -78,7 +78,7 @@ func TestCreateBloomInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
@@ -106,7 +106,7 @@ func TestCreateBloomInit(t *testing.T) {
 
 	// now create a new bucket and assert that the file is re-created on init
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -130,7 +130,7 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 
@@ -150,7 +150,7 @@ func TestRepairCorruptedBloomOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -167,7 +167,7 @@ func TestRepairTooShortBloomOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 
@@ -186,7 +186,7 @@ func TestRepairTooShortBloomOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -203,7 +203,7 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 
@@ -224,7 +224,7 @@ func TestRepairCorruptedBloomSecondaryOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -253,7 +253,7 @@ func TestRepairCorruptedBloomSecondaryOnInitIntoMemory(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 
@@ -274,7 +274,7 @@ func TestRepairCorruptedBloomSecondaryOnInitIntoMemory(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -291,7 +291,7 @@ func TestRepairTooShortBloomSecondaryOnInit(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 
@@ -311,7 +311,7 @@ func TestRepairTooShortBloomSecondaryOnInit(t *testing.T) {
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithStrategy(StrategyReplace), WithSecondaryIndices(1))
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
@@ -411,7 +411,7 @@ func dontCreateBloom(ctx context.Context, t *testing.T, opts []BucketOption) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		opts...)
 	require.NoError(t, err)
 	defer b.Shutdown(ctx)
@@ -449,7 +449,7 @@ func dontRecreateBloom(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 	t.Run("create, populate, shutdown", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 			opts...)
 		require.NoError(t, err)
 		defer b.Shutdown(ctx)
@@ -460,7 +460,7 @@ func dontRecreateBloom(ctx context.Context, t *testing.T, opts []BucketOption) {
 	})
 
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		opts...)
 	require.NoError(t, err)
 	defer b2.Shutdown(ctx)
@@ -491,7 +491,7 @@ func dontPrecomputeBloom(ctx context.Context, t *testing.T, opts []BucketOption)
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		opts...)
 	require.NoError(t, err)
 	defer b.Shutdown(ctx)
@@ -609,7 +609,7 @@ func BenchmarkName(b *testing.B) {
 			dirName := b.TempDir()
 			ctx := context.Background()
 			bu, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithStrategy(StrategyReplace))
 			require.Nil(b, err)
 

--- a/adapters/repos/db/lsmkv/segment_group_loading_test.go
+++ b/adapters/repos/db/lsmkv/segment_group_loading_test.go
@@ -67,7 +67,7 @@ func TestCompactionCleanupBothSegmentsPresent(t *testing.T) {
 				copyFile(t, tmpDir+"/"+entriesTmp[1].Name(), testDir+"/"+entriesTmp[1].Name())
 
 				b2, err := NewBucketCreator().NewBucket(ctx, testDir, "", logger, nil,
-					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo), WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace),
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo), WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace),
 				)
 				if tt.expectErr {
 					require.Error(t, err)
@@ -149,7 +149,7 @@ func TestCompactionCleanupBothSegmentsPresentUpgrade(t *testing.T) {
 				copyFile(t, tmpDir+"/"+entriesTmp[1].Name(), testDir+"/"+entriesTmp[1].Name())
 
 				b2, err := NewBucketCreator().NewBucket(ctx, testDir, "", logger, nil,
-					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(fileInfo.loadingBucket), WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace),
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(fileInfo.loadingBucket), WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace),
 				)
 				if tt.expectErr {
 					require.Error(t, err)
@@ -200,7 +200,7 @@ func TestWalFilePresent(t *testing.T) {
 	ctx := context.Background()
 	dirName := t.TempDir()
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(true), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(true), WithStrategy(StrategyReplace),
 	)
 
 	// create "incomplete" segment
@@ -237,7 +237,7 @@ func TestWalFilePresent(t *testing.T) {
 
 	// incomplete segment will be deleted and memtable is reconstructed from .wal
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(true), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(true), WithStrategy(StrategyReplace),
 	)
 	require.NoError(t, err)
 
@@ -257,7 +257,7 @@ func TestComputeNetCountAfterCompaction(t *testing.T) {
 
 	finalTestDir := t.TempDir()
 	b, err := NewBucketCreator().NewBucket(ctx, finalTestDir, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace),
 	)
 	require.NoError(t, err)
 
@@ -297,7 +297,7 @@ func TestComputeNetCountAfterCompaction(t *testing.T) {
 
 	// recover after "crash"
 	b, err = NewBucketCreator().NewBucket(ctx, finalTestDir, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace),
 	)
 	require.NoError(t, err)
 	count, err = b.Count(ctx)
@@ -312,7 +312,7 @@ func createSegmentFiles(t *testing.T, ctx context.Context, logger logrus.FieldLo
 	}
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo[0]), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo[0]), WithStrategy(StrategyReplace),
 	)
 	require.NoError(t, err)
 	for i := 0; i < 10; i++ {
@@ -325,7 +325,7 @@ func createSegmentFiles(t *testing.T, ctx context.Context, logger logrus.FieldLo
 	require.NoError(t, b.Shutdown(ctx))
 
 	b, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo[1]), WithStrategy(StrategyReplace),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", WithUseBloomFilter(false), WithWriteSegmentInfoIntoFileName(addFileInfo[1]), WithStrategy(StrategyReplace),
 	)
 	require.NoError(t, err)
 

--- a/adapters/repos/db/lsmkv/segment_metadata_test.go
+++ b/adapters/repos/db/lsmkv/segment_metadata_test.go
@@ -52,7 +52,7 @@ func TestMetadataNoWrites(t *testing.T) {
 
 			secondaryIndexCount := 2
 			b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithWriteMetadata(tt.writeMetadata), WithUseBloomFilter(tt.bloomFilter), WithCalcCountNetAdditions(tt.cna), WithSecondaryIndices(uint16(secondaryIndexCount)), WithStrategy(StrategyReplace))
 			require.NoError(t, err)
 			require.NoError(t, b.Shutdown(ctx))
@@ -71,7 +71,7 @@ func TestMetadataNoWrites(t *testing.T) {
 
 			// read again
 			_, err = NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 				WithWriteMetadata(tt.writeMetadata), WithUseBloomFilter(tt.bloomFilter), WithCalcCountNetAdditions(tt.cna), WithSecondaryIndices(uint16(secondaryIndexCount)), WithStrategy(StrategyReplace))
 			require.NoError(t, err)
 		})
@@ -84,7 +84,7 @@ func TestNoWriteIfBloomPresent(t *testing.T) {
 	dirName := t.TempDir()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithUseBloomFilter(true), WithStrategy(StrategyReplace))
 	require.NoError(t, err)
 	require.NoError(t, b.Put([]byte("key"), []byte("value")))
@@ -97,7 +97,7 @@ func TestNoWriteIfBloomPresent(t *testing.T) {
 
 	// load with writeMetadata enabled, no metadata files should be written
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithUseBloomFilter(true), WithWriteMetadata(true), WithStrategy(StrategyReplace))
 	require.NoError(t, err)
 	require.NoError(t, b2.Shutdown(ctx))
@@ -114,7 +114,7 @@ func TestCnaNoBloomPresent(t *testing.T) {
 	dirName := t.TempDir()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithUseBloomFilter(false), WithWriteMetadata(true), WithCalcCountNetAdditions(true), WithStrategy(StrategyReplace))
 	require.NoError(t, err)
 	require.NoError(t, b.Put([]byte("key"), []byte("value")))
@@ -134,7 +134,7 @@ func TestSecondaryBloomNoCna(t *testing.T) {
 	dirName := t.TempDir()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithUseBloomFilter(true),
 		WithWriteMetadata(true),
 		WithCalcCountNetAdditions(false),
@@ -165,7 +165,7 @@ func TestMarkMetadataAsDeleted(t *testing.T) {
 	dirName := t.TempDir()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithUseBloomFilter(true), WithWriteMetadata(true), WithCalcCountNetAdditions(true), WithSecondaryIndices(2), WithStrategy(StrategyReplace))
 	require.NoError(t, err)
 	require.NoError(t, b.Put([]byte("key"), []byte("value"), WithSecondaryKey(0, []byte("key0")), WithSecondaryKey(1, []byte("key1"))))
@@ -188,7 +188,7 @@ func TestDropImmediately(t *testing.T) {
 	dirName := t.TempDir()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithUseBloomFilter(true), WithWriteMetadata(true), WithCalcCountNetAdditions(true), WithSecondaryIndices(2), WithStrategy(StrategyReplace))
 	require.NoError(t, err)
 	require.NoError(t, b.Put([]byte("key"), []byte("value"), WithSecondaryKey(0, []byte("key0")), WithSecondaryKey(1, []byte("key1"))))
@@ -213,7 +213,7 @@ func TestCorruptFile(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithWriteMetadata(true), WithUseBloomFilter(true), WithCalcCountNetAdditions(true), WithSecondaryIndices(uint16(2)), WithStrategy(StrategyReplace))
 	require.NoError(t, err)
 
@@ -229,7 +229,7 @@ func TestCorruptFile(t *testing.T) {
 
 	// broken file is ignored and correct one is recreated
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		WithWriteMetadata(true), WithUseBloomFilter(true), WithCalcCountNetAdditions(true), WithSecondaryIndices(uint16(2)), WithStrategy(StrategyReplace))
 	require.NoError(t, err)
 	value, err := b2.Get([]byte("key"))

--- a/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions_test.go
@@ -63,7 +63,7 @@ func createCNAOnFlush(ctx context.Context, t *testing.T, opts []BucketOption) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
@@ -85,7 +85,7 @@ func createCNAInit(ctx context.Context, t *testing.T, opts []BucketOption) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
@@ -114,7 +114,7 @@ func createCNAInit(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 	// now create a new bucket and assert that the file is re-created on init
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
 
@@ -136,7 +136,7 @@ func repairCorruptedCNAOnInit(ctx context.Context, t *testing.T, opts []BucketOp
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 	defer b.Shutdown(ctx)
 
@@ -156,7 +156,7 @@ func repairCorruptedCNAOnInit(ctx context.Context, t *testing.T, opts []BucketOp
 	// now create a new bucket and assert that the file is ignored, re-created on
 	// init, and the count matches
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 	require.Nil(t, err)
 	defer b2.Shutdown(ctx)
 	count, err := b2.Count(ctx)
@@ -198,7 +198,7 @@ func dontCreateCNA(ctx context.Context, t *testing.T, opts []BucketOption) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		opts...)
 	require.NoError(t, err)
 	defer b.Shutdown(ctx)
@@ -230,7 +230,7 @@ func dontRecreateCNA(ctx context.Context, t *testing.T, opts []BucketOption) {
 
 	t.Run("create, populate, shutdown", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 			opts...)
 		require.NoError(t, err)
 		defer b.Shutdown(ctx)
@@ -240,7 +240,7 @@ func dontRecreateCNA(ctx context.Context, t *testing.T, opts []BucketOption) {
 	})
 
 	b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		opts...)
 	require.NoError(t, err)
 	defer b2.Shutdown(ctx)
@@ -266,7 +266,7 @@ func dontPrecomputeCNA(ctx context.Context, t *testing.T, opts []BucketOption) {
 	logger, _ := test.NewNullLogger()
 
 	b, err := NewBucketCreator().NewBucket(ctx, dirName, "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		opts...)
 	require.NoError(t, err)
 	defer b.Shutdown(ctx)

--- a/adapters/repos/db/lsmkv/segment_test.go
+++ b/adapters/repos/db/lsmkv/segment_test.go
@@ -196,7 +196,7 @@ func createSegmentFilesUsingBucket(t *testing.T, ctx context.Context, logger log
 
 	func() {
 		b, err := NewBucketCreator().NewBucket(ctx, path, "", logger, nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), bucketOptions...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", bucketOptions...)
 		require.NoError(t, err)
 		defer b.Shutdown(ctx)
 

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -83,6 +83,10 @@ func New(dir, rootDir string, logger logrus.FieldLogger, metrics *Metrics,
 	return s, s.init()
 }
 
+func (s *Store) GetClassName() string {
+	return s.className
+}
+
 func (s *Store) Bucket(name string) *Bucket {
 	s.bucketAccessLock.RLock()
 	defer s.bucketAccessLock.RUnlock()

--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -39,8 +39,9 @@ var ErrAlreadyClosed = errors.New("store already closed")
 // Store groups multiple buckets together, it "owns" one folder on the file
 // system
 type Store struct {
-	dir     string
-	rootDir string
+	dir       string
+	rootDir   string
+	className string
 
 	// Prevent concurrent manipulations to the bucketsByNameMap, most notably
 	// when initializing buckets in parallel
@@ -65,7 +66,7 @@ type Store struct {
 // there.
 func New(dir, rootDir string, logger logrus.FieldLogger, metrics *Metrics,
 	shardCompactionCallbacks, shardCompactionAuxCallbacks,
-	shardFlushCallbacks cyclemanager.CycleCallbackGroup,
+	shardFlushCallbacks cyclemanager.CycleCallbackGroup, className string,
 ) (*Store, error) {
 	s := &Store{
 		dir:           dir,
@@ -75,6 +76,7 @@ func New(dir, rootDir string, logger logrus.FieldLogger, metrics *Metrics,
 		bcreator:      NewBucketCreator(),
 		logger:        logger,
 		metrics:       metrics,
+		className:     className,
 	}
 	s.initCycleCallbacks(shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
 
@@ -187,7 +189,7 @@ func (s *Store) CreateOrLoadBucket(ctx context.Context, bucketName string,
 	// bucket can be concurrently loaded with another buckets but
 	// the same bucket will be loaded only once
 	b, err := s.bcreator.NewBucket(ctx, s.bucketDir(bucketName), s.rootDir, s.logger, s.metrics,
-		compactionCallbacks, s.cycleCallbacks.flushCallbacks, opts...)
+		compactionCallbacks, s.cycleCallbacks.flushCallbacks, s.className, opts...)
 	if err != nil {
 		return err
 	}
@@ -444,7 +446,7 @@ func (s *Store) CreateBucket(ctx context.Context, bucketName string,
 	}
 
 	b, err := s.bcreator.NewBucket(ctx, bucketDir, s.rootDir, s.logger, s.metrics,
-		compactionCallbacks, s.cycleCallbacks.flushCallbacks, opts...)
+		compactionCallbacks, s.cycleCallbacks.flushCallbacks, s.className, opts...)
 	if err != nil {
 		return err
 	}

--- a/adapters/repos/db/lsmkv/store_backup_test.go
+++ b/adapters/repos/db/lsmkv/store_backup_test.go
@@ -65,7 +65,7 @@ func pauseCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 				shardFlushCallbacks := cyclemanager.NewCallbackGroupNoop()
 
 				store, err := New(dirName, dirName, logger, nil,
-					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
+					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks, "class")
 				require.Nil(t, err)
 
 				for _, bucket := range buckets {
@@ -102,7 +102,7 @@ func pauseCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 				shardFlushCallbacks := cyclemanager.NewCallbackGroupNoop()
 
 				store, err := New(dirName, dirName, logger, nil,
-					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
+					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks, "class")
 				require.Nil(t, err)
 
 				for _, bucket := range buckets {
@@ -148,7 +148,7 @@ func resumeCompaction(ctx context.Context, t *testing.T, opts []BucketOption) {
 				shardFlushCallbacks := cyclemanager.NewCallbackGroupNoop()
 
 				store, err := New(dirName, dirName, logger, nil,
-					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
+					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks, "class")
 				require.Nil(t, err)
 
 				for _, bucket := range buckets {
@@ -200,7 +200,7 @@ func flushMemtable(ctx context.Context, t *testing.T, opts []BucketOption) {
 				shardFlushCallbacks := cyclemanager.NewCallbackGroup("classFlush", logger, 1)
 
 				store, err := New(dirName, dirName, logger, nil,
-					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
+					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks, "class")
 				require.Nil(t, err)
 
 				for _, bucket := range buckets {
@@ -237,7 +237,7 @@ func flushMemtable(ctx context.Context, t *testing.T, opts []BucketOption) {
 				shardFlushCallbacks := cyclemanager.NewCallbackGroup("classFlush", logger, 1)
 
 				store, err := New(dirName, dirName, logger, nil,
-					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
+					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks, "class")
 				require.Nil(t, err)
 
 				err = store.CreateOrLoadBucket(ctx, "test_bucket", opts...)
@@ -291,7 +291,7 @@ func flushMemtable(ctx context.Context, t *testing.T, opts []BucketOption) {
 				shardFlushCallbacks := cyclemanager.NewCallbackGroup("classFlush", logger, 1)
 
 				store, err := New(dirName, dirName, logger, nil,
-					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks)
+					shardCompactionCallbacks, shardCompactionAuxCallbacks, shardFlushCallbacks, "class")
 				require.Nil(t, err)
 
 				for _, bucket := range buckets {

--- a/adapters/repos/db/lsmkv/store_integration_test.go
+++ b/adapters/repos/db/lsmkv/store_integration_test.go
@@ -44,7 +44,7 @@ func testStoreLifecycle(ctx context.Context, t *testing.T, opts []BucketOption) 
 		store, err := New(dirName, dirName, logger, nil,
 			cyclemanager.NewCallbackGroupNoop(),
 			cyclemanager.NewCallbackGroupNoop(),
-			cyclemanager.NewCallbackGroupNoop())
+			cyclemanager.NewCallbackGroupNoop(), "class")
 		require.Nil(t, err)
 
 		err = store.CreateOrLoadBucket(testCtx(), "bucket1", opts...)
@@ -73,7 +73,7 @@ func testStoreLifecycle(ctx context.Context, t *testing.T, opts []BucketOption) 
 		store, err := New(dirName, dirName, logger, nil,
 			cyclemanager.NewCallbackGroupNoop(),
 			cyclemanager.NewCallbackGroupNoop(),
-			cyclemanager.NewCallbackGroupNoop())
+			cyclemanager.NewCallbackGroupNoop(), "class")
 		require.Nil(t, err)
 
 		err = store.CreateOrLoadBucket(testCtx(), "bucket1", opts...)

--- a/adapters/repos/db/lsmkv/store_test.go
+++ b/adapters/repos/db/lsmkv/store_test.go
@@ -33,7 +33,7 @@ func TestCreateOrLoadBucketConcurrency(t *testing.T) {
 	store, err := New(dirName, dirName, logger, nil,
 		cyclemanager.NewCallbackGroup("classCompactionObjects", logger, 1),
 		cyclemanager.NewCallbackGroup("classCompactionNonObjects", logger, 1),
-		cyclemanager.NewCallbackGroupNoop())
+		cyclemanager.NewCallbackGroupNoop(), "class")
 	require.Nil(t, err)
 
 	mockBucketCreator := NewMockBucketCreator(t)
@@ -79,7 +79,7 @@ func TestCreateBucketConcurrency(t *testing.T) {
 	store, err := New(dirName, dirName, logger, nil,
 		cyclemanager.NewCallbackGroup("classCompactionObjects", logger, 1),
 		cyclemanager.NewCallbackGroup("classCompactionNonObjects", logger, 1),
-		cyclemanager.NewCallbackGroupNoop())
+		cyclemanager.NewCallbackGroupNoop(), "class")
 	require.Nil(t, err)
 
 	mockBucketCreator := NewMockBucketCreator(t)

--- a/adapters/repos/db/lsmkv/strategies_map_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_map_integration_test.go
@@ -56,7 +56,7 @@ func mapInsertAndAppend(ctx context.Context, t *testing.T, opts []BucketOption) 
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -148,7 +148,7 @@ func mapInsertAndAppend(ctx context.Context, t *testing.T, opts []BucketOption) 
 
 	t.Run("with a single flush between updates", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -244,7 +244,7 @@ func mapInsertAndAppend(ctx context.Context, t *testing.T, opts []BucketOption) 
 
 	t.Run("with flushes after initial and update", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -343,7 +343,7 @@ func mapInsertAndAppend(ctx context.Context, t *testing.T, opts []BucketOption) 
 
 	t.Run("update in memtable, then do an orderly shutdown, and re-init", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -407,7 +407,7 @@ func mapInsertAndAppend(ctx context.Context, t *testing.T, opts []BucketOption) 
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 			require.Nil(t, err)
 
 			row1Updated := []MapPair{
@@ -449,7 +449,7 @@ func mapInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOption) 
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -545,7 +545,7 @@ func mapInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOption) 
 
 	t.Run("with flushes between updates", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -649,7 +649,7 @@ func mapInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOption) 
 
 	t.Run("with memtable only, then an orderly shutdown and restart", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -717,7 +717,7 @@ func mapInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOption) 
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 			require.Nil(t, err)
 
 			row1Updated := []MapPair{
@@ -758,7 +758,7 @@ func mapCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		dirName := t.TempDir()
 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -949,7 +949,7 @@ func mapCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		dirName := t.TempDir()
 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		// so big it effectively never triggers as part of this test

--- a/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_replace_integration_test.go
@@ -67,7 +67,7 @@ func TestReplaceStrategy(t *testing.T) {
 func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOption) {
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -140,7 +140,7 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 
 	t.Run("with single flush in between updates", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -222,7 +222,7 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 
 	t.Run("with a flush after the initial write and after the update", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -299,7 +299,7 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 	t.Run("update in memtable, then do an orderly shutdown, and re-init", func(t *testing.T) {
 		dirName := t.TempDir()
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -353,7 +353,7 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 			require.Nil(t, err)
 
 			key1 := []byte("key-1")
@@ -385,7 +385,7 @@ func replaceInsertAndUpdate(ctx context.Context, t *testing.T, opts []BucketOpti
 func replaceInsertAndUpdate_WithSecondaryKeys(ctx context.Context, t *testing.T, opts []BucketOption) {
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -478,7 +478,7 @@ func replaceInsertAndUpdate_WithSecondaryKeys(ctx context.Context, t *testing.T,
 
 	t.Run("with single flush in between updates", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -539,7 +539,7 @@ func replaceInsertAndUpdate_WithSecondaryKeys(ctx context.Context, t *testing.T,
 
 	t.Run("with a flush after initial write and update", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -612,7 +612,7 @@ func replaceInsertAndUpdate_WithSecondaryKeys(ctx context.Context, t *testing.T,
 	t.Run("update in memtable then do an orderly shutdown and reinit", func(t *testing.T) {
 		dirName := t.TempDir()
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -659,7 +659,7 @@ func replaceInsertAndUpdate_WithSecondaryKeys(ctx context.Context, t *testing.T,
 
 		t.Run("init a new one and verify", func(t *testing.T) {
 			b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 			require.Nil(t, err)
 
 			secondaryKey1 := []byte("secondary-key-1")
@@ -686,7 +686,7 @@ func replaceInsertAndUpdate_WithSecondaryKeys(ctx context.Context, t *testing.T,
 func replaceInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOption) {
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -745,7 +745,7 @@ func replaceInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOpti
 
 	t.Run("with single flush in between updates", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -808,7 +808,7 @@ func replaceInsertAndDelete(ctx context.Context, t *testing.T, opts []BucketOpti
 
 	t.Run("with flushes after initial write and delete", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, t.TempDir(), "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -877,7 +877,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		dirName := t.TempDir()
 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -1112,7 +1112,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		dirName := t.TempDir()
 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -1206,7 +1206,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		dirName := t.TempDir()
 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -1497,7 +1497,7 @@ func replaceCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		dirName := t.TempDir()
 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)

--- a/adapters/repos/db/lsmkv/strategies_roaringset_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_roaringset_integration_test.go
@@ -43,7 +43,7 @@ func roaringsetInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -126,7 +126,7 @@ func roaringsetInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 
 	t.Run("with a single flush in between updates", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)

--- a/adapters/repos/db/lsmkv/strategies_roaringsetrange_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_roaringsetrange_integration_test.go
@@ -41,7 +41,7 @@ func roaringsetrangeInsertAndSetAdd(ctx context.Context, t *testing.T, opts []Bu
 	t.Run("memtable-only", func(t *testing.T) {
 		dirName := t.TempDir()
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -113,7 +113,7 @@ func roaringsetrangeInsertAndSetAdd(ctx context.Context, t *testing.T, opts []Bu
 	t.Run("with a single flush in between updates", func(t *testing.T) {
 		dirName := t.TempDir()
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)

--- a/adapters/repos/db/lsmkv/strategies_set_integration_test.go
+++ b/adapters/repos/db/lsmkv/strategies_set_integration_test.go
@@ -56,7 +56,7 @@ func collectionInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -117,7 +117,7 @@ func collectionInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 
 	t.Run("with a single flush between updates", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -182,7 +182,7 @@ func collectionInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 
 	t.Run("with flushes after initial and update", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -249,7 +249,7 @@ func collectionInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 
 	t.Run("update in memtable, then do an orderly shutdown, and re-init", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -313,7 +313,7 @@ func collectionInsertAndSetAdd(ctx context.Context, t *testing.T, opts []BucketO
 
 		t.Run("init another bucket on the same files", func(t *testing.T) {
 			b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 			require.Nil(t, err)
 
 			orig1 := [][]byte{[]byte("value 1.1"), []byte("value 1.2")}
@@ -340,7 +340,7 @@ func collectionInsertAndSetAddInsertAndDelete(ctx context.Context, t *testing.T,
 
 	t.Run("memtable-only", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -438,7 +438,7 @@ func collectionInsertAndSetAddInsertAndDelete(ctx context.Context, t *testing.T,
 
 	t.Run("with a single flush between updates", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -540,7 +540,7 @@ func collectionInsertAndSetAddInsertAndDelete(ctx context.Context, t *testing.T,
 
 	t.Run("with flushes in between and after the update", func(t *testing.T) {
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -651,7 +651,7 @@ func collectionInsertAndSetAddInsertAndDelete(ctx context.Context, t *testing.T,
 	t.Run("update in memtable, make orderly shutdown, then create a new bucket from disk",
 		func(t *testing.T) {
 			b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 			require.Nil(t, err)
 
 			defer b.Shutdown(ctx)
@@ -702,7 +702,7 @@ func collectionInsertAndSetAddInsertAndDelete(ctx context.Context, t *testing.T,
 
 			t.Run("init another bucket on the same files", func(t *testing.T) {
 				b2, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 				require.Nil(t, err)
 
 				expected1 := [][]byte{[]byte("value 1.1"), []byte("value 1.2")} // unchanged
@@ -728,7 +728,7 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		dirName := t.TempDir()
 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)
@@ -857,7 +857,7 @@ func collectionCursors(ctx context.Context, t *testing.T, opts []BucketOption) {
 		dirName := t.TempDir()
 
 		b, err := NewBucketCreator().NewBucket(ctx, dirName, "", nullLogger(), nil,
-			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), opts...)
+			cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", opts...)
 		require.Nil(t, err)
 
 		defer b.Shutdown(ctx)

--- a/adapters/repos/db/search.go
+++ b/adapters/repos/db/search.go
@@ -334,7 +334,7 @@ func (db *DB) objectSearch(ctx context.Context, offset, limit int,
 	filters *filters.LocalFilter, sort []filters.Sort,
 	additional additional.Properties, tenant string,
 ) (search.Results, error) {
-	var found []*storobj.Object
+	var found search.Results
 
 	if err := db.validateSort(sort); err != nil {
 		return nil, errors.Wrap(err, "search")
@@ -382,10 +382,9 @@ func (db *DB) objectSearch(ctx context.Context, offset, limit int,
 				if obj == nil {
 					continue
 				}
-				obj.Object.Class = string(index.Config.ClassName)
 			}
 
-			found = append(found, res...)
+			found = append(found, storobj.SearchResults(res, additional, string(index.Config.ClassName), tenant)...)
 			if len(found) >= totalLimit {
 				// we are done
 				break
@@ -396,7 +395,7 @@ func (db *DB) objectSearch(ctx context.Context, offset, limit int,
 		return nil, err
 	}
 
-	return db.getSearchResults(storobj.SearchResults(found, additional, "", tenant), offset, limit), nil
+	return db.getSearchResults(found, offset, limit), nil
 }
 
 // ResolveReferences takes a list of search results and enriches them

--- a/adapters/repos/db/shard_async.go
+++ b/adapters/repos/db/shard_async.go
@@ -237,7 +237,7 @@ func (s *Shard) iterateOnLSMObjects(
 		if v == nil {
 			continue
 		}
-		obj, err := storobj.FromBinaryOptional(v, addProps, properties)
+		obj, err := storobj.FromDiskBinaryOptional(v, addProps, properties)
 		if err != nil {
 			return errors.Wrap(err, "unmarshal last indexed object")
 		}

--- a/adapters/repos/db/shard_async.go
+++ b/adapters/repos/db/shard_async.go
@@ -237,7 +237,7 @@ func (s *Shard) iterateOnLSMObjects(
 		if v == nil {
 			continue
 		}
-		obj, err := storobj.FromDiskBinaryOptional(v, addProps, properties)
+		obj, err := storobj.FromDiskBinaryOptional(v, addProps, properties, s.class.Class)
 		if err != nil {
 			return errors.Wrap(err, "unmarshal last indexed object")
 		}

--- a/adapters/repos/db/shard_group_by.go
+++ b/adapters/repos/db/shard_group_by.go
@@ -136,7 +136,7 @@ DOCS_LOOP:
 
 			if _, ok := docIDObject[docID]; !ok {
 				// whole object, might be that we only need value and ID to be extracted
-				unmarshalled, err := storobj.FromBinaryOptional(objData, g.additional, props)
+				unmarshalled, err := storobj.FromDiskBinaryOptional(objData, g.additional, props)
 				if err != nil {
 					return nil, nil, fmt.Errorf("%w: unmarshal data object at position %d", err, i)
 				}
@@ -217,7 +217,7 @@ func (g *grouper) getUnmarshalled(docID uint64,
 		if err != nil {
 			return nil, fmt.Errorf("%w: could not get obj by doc id %d", err, docID)
 		}
-		unmarshalled, err := storobj.FromBinaryOptional(objData, g.additional, nil)
+		unmarshalled, err := storobj.FromDiskBinaryOptional(objData, g.additional, nil)
 		if err != nil {
 			return nil, fmt.Errorf("%w: unmarshal data object doc id %d", err, docID)
 		}

--- a/adapters/repos/db/shard_init_lsm.go
+++ b/adapters/repos/db/shard_init_lsm.go
@@ -135,7 +135,7 @@ func (s *Shard) initLSMStore() error {
 	store, err := lsmkv.New(s.pathLSM(), s.path(), annotatedLogger, metrics,
 		s.cycleCallbacks.compactionCallbacks,
 		s.cycleCallbacks.compactionAuxCallbacks,
-		s.cycleCallbacks.flushCallbacks)
+		s.cycleCallbacks.flushCallbacks, s.class.Class)
 	if err != nil {
 		return fmt.Errorf("init lsmkv store at %s: %w", s.pathLSM(), err)
 	}

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -474,7 +474,7 @@ func (l *LazyLoadShard) Dimensions(ctx context.Context, targetVector string) (in
 
 	// For unloaded shards, get dimensions from unloaded shard/tenant calculation
 	idx := l.shardOpts.index
-	dimensionality, err := shardusage.CalculateUnloadedDimensionsUsage(ctx, idx.logger, idx.path(), l.shardOpts.name, targetVector)
+	dimensionality, err := shardusage.CalculateUnloadedDimensionsUsage(ctx, idx.logger, idx.path(), string(idx.Config.ClassName), l.shardOpts.name, targetVector)
 	if err != nil {
 		return 0, err
 	}

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -57,7 +57,7 @@ func (s *Shard) ObjectByIDErrDeleted(ctx context.Context, id strfmt.UUID, props 
 		return nil, nil
 	}
 
-	obj, err := storobj.FromBinary(bytes)
+	obj, err := storobj.FromDiskBinary(bytes, s.class.Class)
 	if err != nil {
 		return nil, errors.Wrap(err, "unmarshal object")
 	}
@@ -81,7 +81,7 @@ func (s *Shard) ObjectByID(ctx context.Context, id strfmt.UUID, props search.Sel
 		return nil, nil
 	}
 
-	obj, err := storobj.FromBinary(bytes)
+	obj, err := storobj.FromDiskBinary(bytes, s.class.Class)
 	if err != nil {
 		return nil, errors.Wrap(err, "unmarshal object")
 	}
@@ -114,7 +114,7 @@ func (s *Shard) MultiObjectByID(ctx context.Context, query []multi.Identifier) (
 			continue
 		}
 
-		obj, err := storobj.FromBinary(bytes)
+		obj, err := storobj.FromDiskBinary(bytes, s.class.Class)
 		if err != nil {
 			return nil, errors.Wrap(err, "unmarshal kind object")
 		}
@@ -150,7 +150,7 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 			return objs, ctx.Err()
 		}
 
-		obj, err := storobj.FromBinaryUUIDOnly(v)
+		obj, err := storobj.FromDiskBinaryUUIDOnly(v, s.class.Class)
 		if err != nil {
 			return objs, fmt.Errorf("cannot unmarshal object: %w", err)
 		}
@@ -209,7 +209,7 @@ func (s *Shard) objectByIndexID(ctx context.Context, indexID uint64, acceptDelet
 			"uuid found for docID, but object is nil")
 	}
 
-	obj, err := storobj.FromBinary(bytes)
+	obj, err := storobj.FromDiskBinary(bytes, s.class.Class)
 	if err != nil {
 		return nil, errors.Wrap(err, "unmarshal kind object")
 	}
@@ -608,7 +608,7 @@ func (s *Shard) cursorObjectList(ctx context.Context, c *filters.Cursor,
 	out := make([]*storobj.Object, c.Limit)
 
 	for ; key != nil && i < c.Limit; key, val = cursor.Next() {
-		obj, err := storobj.FromBinary(val)
+		obj, err := storobj.FromDiskBinary(val, s.class.Class)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unmarhsal item %d", i)
 		}

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -543,7 +543,7 @@ func (s *Shard) ObjectVectorSearch(ctx context.Context, searchVectors []models.V
 	beforeObjects := time.Now()
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
-	objs, err := storobj.ObjectsByDocID(bucket, idsCombined, additional, properties, s.index.logger)
+	objs, err := storobj.ObjectsByDocID(bucket, idsCombined, additional, properties, s.index.logger, s.class.Class)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -573,7 +573,7 @@ func (s *Shard) ObjectList(ctx context.Context, limit int, sort []filters.Sort, 
 			took := time.Since(beforeObjects)
 			helpers.AnnotateSlowQueryLog(ctx, "objects_took", took)
 		}()
-		return storobj.ObjectsByDocID(bucket, docIDs, additional, nil, s.index.logger)
+		return storobj.ObjectsByDocID(bucket, docIDs, additional, nil, s.index.logger, string(className))
 	}
 
 	if cursor == nil {

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -544,7 +544,7 @@ func TestShard_RepairIndex(t *testing.T) {
 				binary.LittleEndian.PutUint64(buf, uint64(i))
 				v, err := bucket.GetBySecondary(ctx, 0, buf)
 				require.NoError(t, err)
-				obj, err := storobj.FromBinary(v)
+				obj, err := storobj.FromDiskBinary(v, className)
 				require.NoError(t, err)
 				idBytes, err := uuid.MustParse(obj.ID().String()).MarshalBinary()
 				require.NoError(t, err)

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -99,7 +99,7 @@ func usageDisk(shardUsage *types.ShardUsage) *types.UsageDisk {
 }
 
 // CalculateUnloadedDimensionsUsage calculates dimensions and object count for an unloaded shard without loading it into memory
-func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLogger, path, tenantName, targetVector string) (types.Dimensionality, error) {
+func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLogger, path, className, tenantName, targetVector string) (types.Dimensionality, error) {
 	bucketPath := shardPathDimensionsLSM(path, tenantName)
 	strategy, err := lsmkv.DetermineUnloadedBucketStrategyAmong(bucketPath, lsmkv.DimensionsBucketPrioritizedStrategies)
 	if err != nil {
@@ -113,6 +113,7 @@ func CalculateUnloadedDimensionsUsage(ctx context.Context, logger logrus.FieldLo
 		nil,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
+		className,
 		lsmkv.WithStrategy(strategy),
 	)
 	if err != nil {

--- a/adapters/repos/db/shard_usage/usage_test.go
+++ b/adapters/repos/db/shard_usage/usage_test.go
@@ -156,7 +156,7 @@ func TestCalculateUnloadedObjectsMetrics(t *testing.T) {
 			bucketFolder := shardPathObjectsLSM(dirName, tenantName)
 
 			b, err := lsmkv.NewBucketCreator().NewBucket(ctx, bucketFolder, "", logger, nil,
-				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), lsmkv.WithStrategy(lsmkv.StrategyReplace), lsmkv.WithCalcCountNetAdditions(true), lsmkv.WithWriteMetadata(metadata))
+				cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class", lsmkv.WithStrategy(lsmkv.StrategyReplace), lsmkv.WithCalcCountNetAdditions(true), lsmkv.WithWriteMetadata(metadata))
 			require.NoError(t, err)
 			defer b.Shutdown(ctx)
 

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -112,7 +112,7 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 }
 
 func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) error {
-	previousObject, err := storobj.FromBinary(previous)
+	previousObject, err := storobj.FromDiskBinary(previous, s.class.Class)
 	if err != nil {
 		return fmt.Errorf("unmarshal previous object: %w", err)
 	}

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -138,7 +138,7 @@ func (s *Shard) mergeObjectInStorage(merge objects.MergeDocument,
 		lock.Lock()
 		defer lock.Unlock()
 
-		prevObj, err = fetchObject(bucket, idBytes)
+		prevObj, err = fetchObject(bucket, idBytes, s.class.Class)
 		if err != nil {
 			return errors.Wrap(err, "get bucket")
 		}
@@ -227,7 +227,7 @@ func (s *Shard) mutableMergeObjectLSM(merge objects.MergeDocument,
 	lock.Lock()
 	defer lock.Unlock()
 
-	prevObj, err := fetchObject(bucket, idBytes)
+	prevObj, err := fetchObject(bucket, idBytes, s.class.Class)
 	if err != nil {
 		return out, err
 	}

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -185,7 +185,7 @@ func (s *Shard) updateMultiVectorIndex(ctx context.Context, vector [][]float32,
 	return updateVectorInVectorIndex(ctx, s, targetVector, vector, status)
 }
 
-func fetchObject(bucket *lsmkv.Bucket, idBytes []byte) (*storobj.Object, error) {
+func fetchObject(bucket *lsmkv.Bucket, idBytes []byte, className string) (*storobj.Object, error) {
 	objBytes, err := bucket.Get(idBytes)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ func fetchObject(bucket *lsmkv.Bucket, idBytes []byte) (*storobj.Object, error) 
 		return nil, nil
 	}
 
-	obj, err := storobj.FromBinary(objBytes)
+	obj, err := storobj.FromDiskBinary(objBytes, className)
 	if err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func (s *Shard) putObjectLSM(obj *storobj.Object, idBytes []byte,
 		defer lock.Unlock()
 
 		before = time.Now()
-		prevObj, err = fetchObject(bucket, idBytes)
+		prevObj, err = fetchObject(bucket, idBytes, s.class.Class)
 		if err != nil {
 			return err
 		}

--- a/adapters/repos/db/sorter/inverted_sorter_test.go
+++ b/adapters/repos/db/sorter/inverted_sorter_test.go
@@ -203,7 +203,7 @@ func createStoreAndInitWithObjects(t *testing.T, ctx context.Context, objectCoun
 	store, err := lsmkv.New(dirName, dirName, logger, nil,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
+		cyclemanager.NewCallbackGroupNoop(), "class")
 	require.Nil(t, err)
 
 	err = store.CreateOrLoadBucket(ctx, helpers.ObjectsBucketLSM, lsmkv.WithStrategy(lsmkv.StrategyReplace))

--- a/adapters/repos/db/sorter/query_planner_test.go
+++ b/adapters/repos/db/sorter/query_planner_test.go
@@ -189,7 +189,7 @@ func TestQueryPlanner(t *testing.T) {
 			store, err := lsmkv.New(dirName, dirName, logger, nil,
 				cyclemanager.NewCallbackGroupNoop(),
 				cyclemanager.NewCallbackGroupNoop(),
-				cyclemanager.NewCallbackGroupNoop())
+				cyclemanager.NewCallbackGroupNoop(), "class")
 			require.Nil(t, err)
 			defer store.Shutdown(ctx)
 

--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator_test.go
@@ -225,7 +225,7 @@ func buildCompressedBucketForTest(t *testing.T, totalVecs int) *lsmkv.Bucket {
 	ctx := context.Background()
 	logger, _ := logrustest.NewNullLogger()
 	bucket, err := lsmkv.NewBucketCreator().NewBucket(ctx, t.TempDir(), "", logger, nil,
-		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), "class",
 		lsmkv.WithPread(true), lsmkv.WithSegmentsChecksumValidationEnabled(false), lsmkv.WithStrategy(lsmkv.StrategyReplace))
 	require.Nil(t, err)
 

--- a/adapters/repos/db/vector/flat/index_test.go
+++ b/adapters/repos/db/vector/flat/index_test.go
@@ -62,7 +62,7 @@ func testStore(t *testing.T, dirName string, logger *logrus.Logger) *lsmkv.Store
 	store, err := lsmkv.New(dirName, dirName, logger, nil,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
+		cyclemanager.NewCallbackGroupNoop(), "class")
 	require.Nil(t, err)
 	return store
 }

--- a/adapters/repos/db/vector/flat/iterate_test.go
+++ b/adapters/repos/db/vector/flat/iterate_test.go
@@ -33,7 +33,7 @@ func createTestIndex(t *testing.T) *flat {
 	store, err := lsmkv.New(dirName, dirName, logger, nil,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
+		cyclemanager.NewCallbackGroupNoop(), "class")
 	require.NoError(t, err)
 
 	index, err := New(Config{

--- a/adapters/repos/db/vector/testinghelpers/helpers.go
+++ b/adapters/repos/db/vector/testinghelpers/helpers.go
@@ -299,7 +299,7 @@ func NewDummyStore(t testing.TB) *lsmkv.Store {
 	store, err := lsmkv.New(storeDir, storeDir, logger, nil,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
+		cyclemanager.NewCallbackGroupNoop(), "class")
 	require.Nil(t, err)
 	return store
 }
@@ -309,7 +309,7 @@ func NewDummyStoreFromFolder(storeDir string, t testing.TB) *lsmkv.Store {
 	store, err := lsmkv.New(storeDir, storeDir, logger, nil,
 		cyclemanager.NewCallbackGroupNoop(),
 		cyclemanager.NewCallbackGroupNoop(),
-		cyclemanager.NewCallbackGroupNoop())
+		cyclemanager.NewCallbackGroupNoop(), "class")
 	require.Nil(t, err)
 	return store
 }

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -549,10 +549,6 @@ func (ko *Object) SearchResult(additional additional.Properties, className, tena
 		additionalProperties["explainScore"] = ko.ExplainScore()
 	}
 
-	if className == "" {
-		className = ko.Class().String()
-	}
-
 	return &search.Result{
 		ID:        ko.ID(),
 		DocID:     &ko.DocID,

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -243,7 +243,7 @@ func TestStorageObjectUnMarshallingMultiVector(t *testing.T) {
 
 		t.Run("check multi vectors optional", func(t *testing.T) {
 			t.Run("FromDiskBinaryOptional: empty additional", func(t *testing.T) {
-				afterMultiVectorsOptional, err := FromDiskBinaryOptional(asBinary, additional.Properties{}, nil)
+				afterMultiVectorsOptional, err := FromDiskBinaryOptional(asBinary, additional.Properties{}, nil, before.Object.Class)
 				require.Nil(t, err)
 				require.Nil(t, afterMultiVectorsOptional.MultiVectors)
 			})
@@ -251,7 +251,7 @@ func TestStorageObjectUnMarshallingMultiVector(t *testing.T) {
 			t.Run("FromDiskBinaryOptional: multi vector in additional", func(t *testing.T) {
 				afterMultiVectorsOptional, err := FromDiskBinaryOptional(asBinary, additional.Properties{
 					Vectors: []string{"vector4"},
-				}, nil)
+				}, nil, before.Object.Class)
 				require.Nil(t, err)
 				require.NotEmpty(t, afterMultiVectorsOptional.MultiVectors)
 				require.Len(t, afterMultiVectorsOptional.MultiVectors, 1)
@@ -261,7 +261,7 @@ func TestStorageObjectUnMarshallingMultiVector(t *testing.T) {
 			t.Run("FromDiskBinaryOptional: named vector and multi vector in additional", func(t *testing.T) {
 				afterMultiVectorsOptional, err := FromDiskBinaryOptional(asBinary, additional.Properties{
 					Vectors: []string{"vector2", "vector4"},
-				}, nil)
+				}, nil, before.Object.Class)
 				require.Nil(t, err)
 				require.NotEmpty(t, afterMultiVectorsOptional.Vectors)
 				require.NotEmpty(t, afterMultiVectorsOptional.MultiVectors)
@@ -462,7 +462,7 @@ func TestStorageObjectUnmarshallingSpecificProps(t *testing.T) {
 	require.Nil(t, err)
 
 	t.Run("without any optional", func(t *testing.T) {
-		after, err := FromDiskBinaryOptional(asBinary, additional.Properties{}, nil)
+		after, err := FromDiskBinaryOptional(asBinary, additional.Properties{}, nil, before.Object.Class)
 		require.Nil(t, err)
 
 		t.Run("compare", func(t *testing.T) {
@@ -914,7 +914,7 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 				require.Nil(t, err)
 
 				t.Run("get without additional properties", func(t *testing.T) {
-					after, err := FromDiskBinaryOptional(asBinary, additional.Properties{}, nil)
+					after, err := FromDiskBinaryOptional(asBinary, additional.Properties{}, nil, before.Object.Class)
 					require.Nil(t, err)
 					// modify before to match expectations of after
 					before.Object.Additional = nil
@@ -930,7 +930,7 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 				})
 
 				t.Run("get with additional property vector", func(t *testing.T) {
-					after, err := FromDiskBinaryOptional(asBinary, additional.Properties{Vector: true}, nil)
+					after, err := FromDiskBinaryOptional(asBinary, additional.Properties{Vector: true}, nil, before.Object.Class)
 					require.Nil(t, err)
 					// modify before to match expectations of after
 					before.Object.Additional = nil
@@ -949,7 +949,7 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 
 				t.Run("with explicit properties", func(t *testing.T) {
 					after, err := FromDiskBinaryOptional(asBinary, additional.Properties{},
-						&PropertyExtraction{PropertyPaths: [][]string{{"name"}}},
+						&PropertyExtraction{PropertyPaths: [][]string{{"name"}}}, before.Object.Class,
 					)
 					require.Nil(t, err)
 
@@ -963,7 +963,7 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 						NoProps:      true,
 						ModuleParams: map[string]interface{}{"foo": "bar"}, // this causes the property extraction code to run
 					},
-						&PropertyExtraction{PropertyPaths: nil},
+						&PropertyExtraction{PropertyPaths: nil}, before.Object.Class,
 					)
 					require.Nil(t, err)
 
@@ -1323,7 +1323,7 @@ func benchmarkExtraction(b *testing.B, propStrings []string) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		after, err := FromDiskBinaryOptional(asBinary, additional.Properties{}, props)
+		after, err := FromDiskBinaryOptional(asBinary, additional.Properties{}, props, before.Object.Class)
 		require.Nil(b, err)
 		require.NotNil(b, after)
 	}
@@ -1382,7 +1382,7 @@ func TestObjectsByDocID(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			res, err := ObjectsByDocID(bucket, test.inputIDs, additional.Properties{}, nil, logger)
+			res, err := ObjectsByDocID(bucket, test.inputIDs, additional.Properties{}, nil, logger, "")
 			require.Nil(t, err)
 			require.Len(t, res, len(test.inputIDs))
 
@@ -1401,7 +1401,7 @@ func TestSkipMissingObjects(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	ids := pickRandomIDsBetween(0, 1000, 100)
 	ids = append(ids, 1001, 1002, 1003)
-	objs, err := objectsByDocIDParallel(bucket, ids, additional.Properties{}, nil, logger)
+	objs, err := objectsByDocIDParallel(bucket, ids, additional.Properties{}, nil, logger, "")
 	require.Nil(t, err)
 	require.Len(t, objs, 100)
 	for _, obj := range objs {
@@ -1525,11 +1525,11 @@ func BenchmarkObjectsByDocID(b *testing.B) {
 		b.Run(fmt.Sprintf("Concurrent: %v with amount: %v", tt.concurrent, tt.amount), func(t *testing.B) {
 			for i := 0; i < b.N; i++ {
 				if tt.concurrent {
-					_, err := objectsByDocIDParallel(bucket, ids[:tt.amount], additional.Properties{}, nil, logger)
+					_, err := objectsByDocIDParallel(bucket, ids[:tt.amount], additional.Properties{}, nil, logger, "")
 					require.Nil(t, err)
 
 				} else {
-					_, err := objectsByDocIDSequential(bucket, ids[:tt.amount], additional.Properties{}, nil)
+					_, err := objectsByDocIDSequential(bucket, ids[:tt.amount], additional.Properties{}, nil, "")
 					require.Nil(t, err)
 				}
 			}
@@ -1572,7 +1572,7 @@ func FuzzObjectGet(f *testing.F) {
 			}
 		}
 
-		res, err := ObjectsByDocID(bucket, ids, additional.Properties{}, nil, logger)
+		res, err := ObjectsByDocID(bucket, ids, additional.Properties{}, nil, logger, "")
 		require.Nil(t, err)
 		require.Len(t, res, len(ids))
 		for i, obj := range res {

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -70,7 +70,7 @@ func TestStorageObjectMarshalling(t *testing.T) {
 	asBinary, err := before.MarshalBinary()
 	require.Nil(t, err)
 
-	after, err := FromBinary(asBinary)
+	after, err := FromDiskBinary(asBinary, before.Object.Class)
 	require.Nil(t, err)
 
 	t.Run("compare", func(t *testing.T) {
@@ -142,7 +142,7 @@ func TestStorageObjectMarshallingMultiVector(t *testing.T) {
 	asBinary, err := before.MarshalBinary()
 	require.Nil(t, err)
 
-	after, err := FromBinary(asBinary)
+	after, err := FromDiskBinary(asBinary, before.Object.Class)
 	require.Nil(t, err)
 
 	t.Run("compare", func(t *testing.T) {
@@ -216,7 +216,7 @@ func TestStorageObjectUnMarshallingMultiVector(t *testing.T) {
 		require.Nil(t, err)
 
 		after := &Object{}
-		after.UnmarshalBinary(asBinary)
+		after.UnmarshalBinaryNetwork(asBinary)
 		require.Nil(t, err)
 
 		t.Run("compare", func(t *testing.T) {
@@ -242,14 +242,14 @@ func TestStorageObjectUnMarshallingMultiVector(t *testing.T) {
 		})
 
 		t.Run("check multi vectors optional", func(t *testing.T) {
-			t.Run("FromBinaryOptional: empty additional", func(t *testing.T) {
-				afterMultiVectorsOptional, err := FromBinaryOptional(asBinary, additional.Properties{}, nil)
+			t.Run("FromDiskBinaryOptional: empty additional", func(t *testing.T) {
+				afterMultiVectorsOptional, err := FromDiskBinaryOptional(asBinary, additional.Properties{}, nil)
 				require.Nil(t, err)
 				require.Nil(t, afterMultiVectorsOptional.MultiVectors)
 			})
 
-			t.Run("FromBinaryOptional: multi vector in additional", func(t *testing.T) {
-				afterMultiVectorsOptional, err := FromBinaryOptional(asBinary, additional.Properties{
+			t.Run("FromDiskBinaryOptional: multi vector in additional", func(t *testing.T) {
+				afterMultiVectorsOptional, err := FromDiskBinaryOptional(asBinary, additional.Properties{
 					Vectors: []string{"vector4"},
 				}, nil)
 				require.Nil(t, err)
@@ -258,8 +258,8 @@ func TestStorageObjectUnMarshallingMultiVector(t *testing.T) {
 				require.Equal(t, before.MultiVectors["vector4"], afterMultiVectorsOptional.MultiVectors["vector4"])
 			})
 
-			t.Run("FromBinaryOptional: named vector and multi vector in additional", func(t *testing.T) {
-				afterMultiVectorsOptional, err := FromBinaryOptional(asBinary, additional.Properties{
+			t.Run("FromDiskBinaryOptional: named vector and multi vector in additional", func(t *testing.T) {
+				afterMultiVectorsOptional, err := FromDiskBinaryOptional(asBinary, additional.Properties{
 					Vectors: []string{"vector2", "vector4"},
 				}, nil)
 				require.Nil(t, err)
@@ -317,7 +317,7 @@ func TestStorageObjectUnMarshallingMultiVector(t *testing.T) {
 		require.Nil(t, err)
 
 		after := &Object{}
-		after.UnmarshalBinary(asBinary)
+		after.UnmarshalBinaryNetwork(asBinary)
 		require.Nil(t, err)
 
 		t.Run("check vector", func(t *testing.T) {
@@ -378,7 +378,7 @@ func TestStorageObjectUnMarshallingMultiVector(t *testing.T) {
 		require.Nil(t, err)
 
 		after := &Object{}
-		after.UnmarshalBinary(asBinary)
+		after.UnmarshalBinaryNetwork(asBinary)
 		require.Nil(t, err)
 
 		t.Run("check vector", func(t *testing.T) {
@@ -462,7 +462,7 @@ func TestStorageObjectUnmarshallingSpecificProps(t *testing.T) {
 	require.Nil(t, err)
 
 	t.Run("without any optional", func(t *testing.T) {
-		after, err := FromBinaryOptional(asBinary, additional.Properties{}, nil)
+		after, err := FromDiskBinaryOptional(asBinary, additional.Properties{}, nil)
 		require.Nil(t, err)
 
 		t.Run("compare", func(t *testing.T) {
@@ -632,7 +632,7 @@ func TestStorageArrayObjectMarshalling(t *testing.T) {
 	asBinary, err := before.MarshalBinary()
 	require.Nil(t, err)
 
-	after, err := FromBinary(asBinary)
+	after, err := FromDiskBinary(asBinary, before.Object.Class)
 	require.Nil(t, err)
 
 	t.Run("compare", func(t *testing.T) {
@@ -792,7 +792,7 @@ func TestStorageObjectMarshallingWithGroup(t *testing.T) {
 	asBinary, err := before.MarshalBinary()
 	require.Nil(t, err)
 
-	after, err := FromBinary(asBinary)
+	after, err := FromDiskBinary(asBinary, before.Object.Class)
 	require.Nil(t, err)
 
 	t.Run("compare", func(t *testing.T) {
@@ -877,7 +877,7 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 				asBinary, err := before.MarshalBinary()
 				require.Nil(t, err)
 
-				after, err := FromBinary(asBinary)
+				after, err := FromDiskBinary(asBinary, before.Object.Class)
 				require.Nil(t, err)
 
 				t.Run("compare", func(t *testing.T) {
@@ -914,7 +914,7 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 				require.Nil(t, err)
 
 				t.Run("get without additional properties", func(t *testing.T) {
-					after, err := FromBinaryOptional(asBinary, additional.Properties{}, nil)
+					after, err := FromDiskBinaryOptional(asBinary, additional.Properties{}, nil)
 					require.Nil(t, err)
 					// modify before to match expectations of after
 					before.Object.Additional = nil
@@ -930,7 +930,7 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 				})
 
 				t.Run("get with additional property vector", func(t *testing.T) {
-					after, err := FromBinaryOptional(asBinary, additional.Properties{Vector: true}, nil)
+					after, err := FromDiskBinaryOptional(asBinary, additional.Properties{Vector: true}, nil)
 					require.Nil(t, err)
 					// modify before to match expectations of after
 					before.Object.Additional = nil
@@ -948,7 +948,7 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 				})
 
 				t.Run("with explicit properties", func(t *testing.T) {
-					after, err := FromBinaryOptional(asBinary, additional.Properties{},
+					after, err := FromDiskBinaryOptional(asBinary, additional.Properties{},
 						&PropertyExtraction{PropertyPaths: [][]string{{"name"}}},
 					)
 					require.Nil(t, err)
@@ -959,7 +959,7 @@ func TestStorageMaxVectorDimensionsObjectMarshalling(t *testing.T) {
 				})
 
 				t.Run("test no props and moduleparams", func(t *testing.T) {
-					after, err := FromBinaryOptional(asBinary, additional.Properties{
+					after, err := FromDiskBinaryOptional(asBinary, additional.Properties{
 						NoProps:      true,
 						ModuleParams: map[string]interface{}{"foo": "bar"}, // this causes the property extraction code to run
 					},
@@ -1323,7 +1323,7 @@ func benchmarkExtraction(b *testing.B, propStrings []string) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		after, err := FromBinaryOptional(asBinary, additional.Properties{}, props)
+		after, err := FromDiskBinaryOptional(asBinary, additional.Properties{}, props)
 		require.Nil(b, err)
 		require.NotNil(b, after)
 	}

--- a/test/acceptance_lsmkv/data_integrity_test.go
+++ b/test/acceptance_lsmkv/data_integrity_test.go
@@ -98,7 +98,7 @@ func newTestBucket(dataPath string, checkSumEnabled bool) (*lsmkv.Bucket, error)
 	return lsmkv.NewBucketCreator().
 		NewBucket(context.Background(), dataPath, "", log, nil,
 			cyclemanager.NewCallbackGroupNoop(),
-			cyclemanager.NewCallbackGroupNoop(),
+			cyclemanager.NewCallbackGroupNoop(), "class",
 			lsmkv.WithSegmentsChecksumValidationEnabled(checkSumEnabled),
 			lsmkv.WithCalcCountNetAdditions(true),
 			lsmkv.WithStrategy(lsmkv.StrategyReplace),

--- a/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
@@ -53,7 +53,7 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 	compactionCycle.Start()
 
 	bucket, err := c.NewBucket(ctx, filepath.Join(dir, "my-bucket"), "", logger, nil,
-		compactionCallbacks, flushCallbacks,
+		compactionCallbacks, flushCallbacks, "class",
 		lsmkv.WithPread(true),
 		lsmkv.WithDynamicMemtableSizing(1, 2, 1, 4),
 		lsmkv.WithStrategy(lsmkv.StrategyReplace),

--- a/test/acceptance_lsmkv_long_running/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv_long_running/replace_bucket_acceptance_test.go
@@ -65,7 +65,7 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 
 	logger.Info("loading bucket")
 	bucket, err := c.NewBucket(ctx, filepath.Join(dir, "my-bucket"), "", logger, nil,
-		compactionCallbacks, flushCallbacks,
+		compactionCallbacks, flushCallbacks, "class",
 		lsmkv.WithPread(true),
 	)
 	if err != nil {

--- a/usecases/replica/replica.go
+++ b/usecases/replica/replica.go
@@ -69,7 +69,7 @@ func (r *Replica) UnmarshalBinary(data []byte) error {
 
 	if b.Object != nil {
 		var obj storobj.Object
-		err = obj.UnmarshalBinary(b.Object)
+		err = obj.UnmarshalBinaryNetwork(b.Object)
 		if err != nil {
 			return fmt.Errorf("unmarshal object: %w", err)
 		}
@@ -120,7 +120,7 @@ func (ro *Replicas) UnmarshalBinary(data []byte) error {
 		}
 		if m.Object != nil {
 			var obj storobj.Object
-			err = obj.UnmarshalBinary(m.Object)
+			err = obj.UnmarshalBinaryNetwork(m.Object)
 			if err != nil {
 				return fmt.Errorf("unmarshal object %q: %w", m.ID, err)
 			}

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -353,7 +353,7 @@ func (e *Explorer) getClassList(ctx context.Context,
 	userSetAdditionalVector := params.AdditionalProperties.Vector
 
 	// if both grouping and whereFilter/sort are present, the below
-	// class search will eventually call storobj.FromBinaryOptional
+	// class search will eventually call storobj.FromDiskBinaryOptional
 	// to unmarshal the record. in this case, we must manually set
 	// the vector addl prop to unmarshal the result vector into each
 	// result payload. if we skip this step, the grouper will attempt

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -72,7 +72,7 @@ func sparseSearch(ctx context.Context, e *Explorer, params dto.GetParams) ([]*se
 
 	out := make([]*search.Result, len(results))
 	for i, obj := range results {
-		sr := obj.SearchResultWithScore(additional.Properties{}, scores[i])
+		sr := obj.SearchResultWithScore(additional.Properties{}, scores[i], params.ClassName)
 		sr.SecondarySortValue = sr.Score
 		out[i] = &sr
 	}


### PR DESCRIPTION
### What's being changed:

Preparation for storage improvement. Instead of reading the objects class name from the stored object, take it from the index (same as tenant)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
