### PR TITLE
fix: take into account empty objects when using batch text vectorizer

### DIFF
--- a/usecases/modulecomponents/vectorizer/batchtext/batch_text_vectorizer.go
+++ b/usecases/modulecomponents/vectorizer/batchtext/batch_text_vectorizer.go
@@ -45,8 +45,7 @@ type Client[T dto.Embedding] interface {
 }
 
 type batchObject struct {
-	index   int
-	isEmpty bool
+	index int
 }
 
 type BatchTextVectorizer[T dto.Embedding] struct {
@@ -106,9 +105,7 @@ func (v *BatchTextVectorizer[T]) objects(ctx context.Context, objects []*models.
 	inputIndex := 0
 	for i := range objects {
 		corpi, _ := v.objectVectorizer.TextsWithTitleProperty(ctx, objects[i], icheck, titleProperty)
-		if corpi == "" {
-			batchObjects[i] = &batchObject{isEmpty: true}
-		} else {
+		if corpi != "" {
 			inputs = append(inputs, corpi)
 			batchObjects[i] = &batchObject{index: inputIndex}
 			inputIndex++
@@ -129,9 +126,7 @@ func (v *BatchTextVectorizer[T]) objects(ctx context.Context, objects []*models.
 
 	results := make([]T, len(batchObjects))
 	for i := range batchObjects {
-		if batchObjects[i].isEmpty {
-			results[i] = nil
-		} else {
+		if batchObjects[i] != nil {
 			results[i] = res.Vector[batchObjects[i].index]
 		}
 	}


### PR DESCRIPTION
### What's being changed:

This PR takes into account empty objects when using batch text vectorizer.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
