### PR TITLE
fix: update downloadWorker to use temporary file handling for safer file downloads

### DIFF
--- a/cluster/replication/copier/copier.go
+++ b/cluster/replication/copier/copier.go
@@ -317,7 +317,7 @@ func (c *Copier) downloadWorker(ctx context.Context, client FileReplicationServi
 			}
 		} else if checksum == meta.Crc32 {
 			// local file matches remote one, no need to download it
-			return nil
+			continue
 		}
 
 		err = stream.Send(&protocol.GetFileRequest{
@@ -334,12 +334,18 @@ func (c *Copier) downloadWorker(ctx context.Context, client FileReplicationServi
 			return fmt.Errorf("create parent folder for %s: %w", localFilePath, err)
 		}
 
+		tmpPath := localFilePath + ".tmp"
+
 		if err := func() error {
-			f, err := os.Create(localFilePath + ".tmp")
+			f, err := os.Create(tmpPath)
 			if err != nil {
-				return fmt.Errorf("open file %q for writing: %w", localFilePath, err)
+				return fmt.Errorf("open file %q for writing: %w", tmpPath, err)
 			}
-			defer f.Close()
+			defer func() {
+				if f != nil {
+					f.Close()
+				}
+			}()
 
 			wbuf := bufio.NewWriter(f)
 
@@ -352,7 +358,7 @@ func (c *Copier) downloadWorker(ctx context.Context, client FileReplicationServi
 				if len(chunk.Data) > 0 {
 					_, err = wbuf.Write(chunk.Data)
 					if err != nil {
-						return fmt.Errorf("writing chunk to file %q: %w", localFilePath+".tmp", err)
+						return fmt.Errorf("writing chunk to file %q: %w", tmpPath, err)
 					}
 				}
 
@@ -363,31 +369,40 @@ func (c *Copier) downloadWorker(ctx context.Context, client FileReplicationServi
 
 			err = wbuf.Flush()
 			if err != nil {
-				return fmt.Errorf("flushing buffer to file %q: %w", localFilePath+".tmp", err)
+				return fmt.Errorf("flushing buffer to file %q: %w", tmpPath, err)
 			}
 
 			err = f.Sync()
 			if err != nil {
-				return fmt.Errorf("fsyncing file %q for writing: %w", localFilePath+".tmp", err)
+				return fmt.Errorf("fsyncing file %q for writing: %w", tmpPath, err)
 			}
 
-			_, checksum, err = integrity.CRC32(localFilePath + ".tmp")
+			err = f.Close()
+			f = nil // prevent deferred close
 			if err != nil {
-				return fmt.Errorf("calculating checksum for file %q: %w", localFilePath+".tmp", err)
+				return fmt.Errorf("closing file: %w", err)
+			}
+
+			_, checksum, err = integrity.CRC32(tmpPath)
+			if err != nil {
+				return fmt.Errorf("calculating checksum for file %q: %w", tmpPath, err)
 			}
 
 			if checksum != meta.Crc32 {
-				defer os.Remove(localFilePath + ".tmp")
-				return fmt.Errorf("checksum validation of file %q failed, expected %d, got %d", localFilePath+".tmp", meta.Crc32, checksum)
+				return fmt.Errorf("checksum validation of file %q failed, expected %d, got %d", tmpPath, meta.Crc32, checksum)
 			}
 
-			err = os.Rename(localFilePath+".tmp", localFilePath)
+			err = os.Rename(tmpPath, localFilePath)
 			if err != nil {
-				return fmt.Errorf("renaming temporary file %q to final path %q: %w", localFilePath+".tmp", localFilePath, err)
+				return fmt.Errorf("renaming temporary file %q to final path %q: %w", tmpPath, localFilePath, err)
 			}
 
 			return nil
 		}(); err != nil {
+			rerr := os.Remove(tmpPath)
+			if rerr != nil {
+				c.logger.Warnf("failed to remove temporary file %q after error", tmpPath)
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
### What's being changed:

This pull request refactors the file download logic in the `Copier`'s `downloadWorker` function to improve clarity and reliability when handling temporary files. The main changes include consistent use of a `tmpPath` variable for temporary file operations, improved error handling and resource cleanup, and a fix to the control flow when skipping downloads for files with matching checksums.

**File handling and error management improvements:**

* Introduced a `tmpPath` variable to consistently reference the temporary file throughout the download process, replacing repeated string concatenations. All file operations and error messages now use `tmpPath` for clarity. [[1]](diffhunk://#diff-a4aca2e85e420f460ce97a54772ceaca80bdce2b96b6143cdf455003f1b47ed1R337-R348) [[2]](diffhunk://#diff-a4aca2e85e420f460ce97a54772ceaca80bdce2b96b6143cdf455003f1b47ed1L355-R361) [[3]](diffhunk://#diff-a4aca2e85e420f460ce97a54772ceaca80bdce2b96b6143cdf455003f1b47ed1L366-R401)
* Enhanced resource cleanup by using a deferred function for closing the file, and explicitly setting `f = nil` after a successful close to prevent double closing. [[1]](diffhunk://#diff-a4aca2e85e420f460ce97a54772ceaca80bdce2b96b6143cdf455003f1b47ed1R337-R348) [[2]](diffhunk://#diff-a4aca2e85e420f460ce97a54772ceaca80bdce2b96b6143cdf455003f1b47ed1L366-R401)
* Improved error handling by removing the temporary file (`tmpPath`) if an error occurs during the download or validation steps, ensuring no leftover files remain.

**Control flow and logic fixes:**

* Changed the logic for skipping downloads of files that already match the remote checksum: replaced `return nil` with `continue` to correctly proceed to the next file in the loop.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
