### PR TITLE
feat: make file chunk size configurable for file replication service

### DIFF
--- a/adapters/handlers/rest/clusterapi/grpc/file_replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/file_replication_service.go
@@ -24,22 +24,20 @@ import (
 	"google.golang.org/grpc/status"
 )
 
-// fileChunkSize defines the size of each file chunk sent over gRPC.
-// Currently set to 64 KB, which is a reasonable size for network transmission.
-// It can be made configurable in the future if needed.
-const fileChunkSize = 64 * 1024 // 64 KB
-
 type FileReplicationService struct {
 	pb.UnimplementedFileReplicationServiceServer
 
 	repo   sharding.RemoteIncomingRepo
 	schema sharding.RemoteIncomingSchema
+
+	fileChunkSize int
 }
 
-func NewFileReplicationService(repo sharding.RemoteIncomingRepo, schema sharding.RemoteIncomingSchema) *FileReplicationService {
+func NewFileReplicationService(repo sharding.RemoteIncomingRepo, schema sharding.RemoteIncomingSchema, fileChunkSize int) *FileReplicationService {
 	return &FileReplicationService{
-		repo:   repo,
-		schema: schema,
+		repo:          repo,
+		schema:        schema,
+		fileChunkSize: fileChunkSize,
 	}
 }
 
@@ -171,7 +169,7 @@ func (fps *FileReplicationService) GetFile(stream pb.FileReplicationService_GetF
 			}
 			defer fileReader.Close()
 
-			buf := make([]byte, fileChunkSize)
+			buf := make([]byte, fps.fileChunkSize)
 
 			offset := 0
 

--- a/adapters/handlers/rest/clusterapi/grpc/server.go
+++ b/adapters/handlers/rest/clusterapi/grpc/server.go
@@ -53,7 +53,10 @@ func NewServer(state *state.State, options ...grpc.ServerOption) *Server {
 	}
 
 	s := grpc.NewServer(o...)
-	weaviateV1FileReplicationService := NewFileReplicationService(state.DB, state.ClusterService.SchemaReader())
+
+	fileCopyChunkSize := state.ServerConfig.Config.ReplicationEngineFileCopyChunkSize
+
+	weaviateV1FileReplicationService := NewFileReplicationService(state.DB, state.ClusterService.SchemaReader(), fileCopyChunkSize)
 	pb.RegisterFileReplicationServiceServer(s, weaviateV1FileReplicationService)
 
 	return &Server{Server: s, state: state}

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -159,6 +159,7 @@ type Config struct {
 	DistributedTasks                    DistributedTasksConfig   `json:"distributed_tasks" yaml:"distributed_tasks"`
 	ReplicationEngineMaxWorkers         int                      `json:"replication_engine_max_workers" yaml:"replication_engine_max_workers"`
 	ReplicationEngineFileCopyWorkers    int                      `json:"replication_engine_file_copy_workers" yaml:"replication_engine_file_copy_workers"`
+	ReplicationEngineFileCopyChunkSize  int                      `json:"replication_engine_file_copy_chunk_size" yaml:"replication_engine_file_copy_chunk_size"`
 	SPFreshEnabled                      bool                     `json:"spfresh_enabled" yaml:"spfresh_enabled"`
 	// Raft Specific configuration
 	// TODO-RAFT: Do we want to be able to specify these with config file as well ?

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -48,9 +48,10 @@ const (
 	DefaultDistributedTasksSchedulerTickInterval = time.Minute
 	DefaultDistributedTasksCompletedTaskTTL      = 5 * 24 * time.Hour
 
-	DefaultReplicationEngineMaxWorkers      = 10
-	DefaultReplicaMovementMinimumAsyncWait  = 60 * time.Second
-	DefaultReplicationEngineFileCopyWorkers = 10
+	DefaultReplicationEngineMaxWorkers        = 10
+	DefaultReplicaMovementMinimumAsyncWait    = 60 * time.Second
+	DefaultReplicationEngineFileCopyWorkers   = 10
+	DefaultReplicationEngineFileCopyChunkSize = 64 * 1024 // 64 KB
 
 	DefaultTransferInactivityTimeout = 5 * time.Minute
 
@@ -1175,6 +1176,14 @@ func (c *Config) parseMemtableConfig() error {
 		"REPLICATION_ENGINE_FILE_COPY_WORKERS",
 		func(val int) { c.ReplicationEngineFileCopyWorkers = val },
 		DefaultReplicationEngineFileCopyWorkers,
+	); err != nil {
+		return err
+	}
+
+	if err := parsePositiveInt(
+		"REPLICATION_ENGINE_FILE_COPY_CHUNK_SIZE",
+		func(val int) { c.ReplicationEngineFileCopyChunkSize = val },
+		DefaultReplicationEngineFileCopyChunkSize,
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
### What's being changed:

This pull request introduces configurability for the file chunk size used during file replication over gRPC. Previously, the chunk size was hardcoded; it can now be set via configuration, allowing for better tuning based on deployment needs. The changes span the configuration system and the file replication service implementation.

**Configuration enhancements:**

* Added a new field `ReplicationEngineFileCopyChunkSize` to the `Config` struct, enabling the file chunk size to be set via config files or environment variables.
* Defined a default value (`DefaultReplicationEngineFileCopyChunkSize = 64 * 1024`) and integrated parsing of the new environment variable `REPLICATION_ENGINE_FILE_COPY_CHUNK_SIZE` in the configuration loader. [[1]](diffhunk://#diff-dea1f7185dde03da48fccbab7c30a31d2c3d4cda46c293768446d5d91dcc5f09R54) [[2]](diffhunk://#diff-dea1f7185dde03da48fccbab7c30a31d2c3d4cda46c293768446d5d91dcc5f09R1183-R1190)

**File replication service updates:**

* Refactored `FileReplicationService` to accept `fileChunkSize` as a constructor argument and use it for chunking file reads, replacing the previous constant. [[1]](diffhunk://#diff-dbab8001cfe4d5d590357965628be947e0b4d0afd26802a47cd3d1f05e9b2b53L27-R40) [[2]](diffhunk://#diff-dbab8001cfe4d5d590357965628be947e0b4d0afd26802a47cd3d1f05e9b2b53L174-R172)
* Updated server initialization to pass the configured chunk size to the file replication service.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
