### PR TITLE
hfresh: fix iteration during garbage collection

### DIFF
--- a/adapters/repos/db/vector/spfresh/posting.go
+++ b/adapters/repos/db/vector/spfresh/posting.go
@@ -84,7 +84,8 @@ func (p *Posting) AddVector(v Vector) {
 // and return the filtered posting.
 // This method doesn't allocate a new slice, the filtering is done in-place.
 func (p *Posting) GarbageCollect(versionMap *VersionMap) (*Posting, error) {
-	for i, v := range p.vectors {
+	for i := len(p.vectors) - 1; i >= 0; i-- {
+		v := p.vectors[i]
 		id := v.ID()
 		version, err := versionMap.Get(context.Background(), id)
 		if err != nil {


### PR DESCRIPTION
### What's being changed:

This fixes the posting garbage collection logic which performs an in-place update. By iterating backwards we avoid out-of-range errors now.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
