### PR TITLE
Revert change `delegate.NodeMetadata.RestPort` due to rolling restart issues

### DIFF
--- a/usecases/cluster/delegate.go
+++ b/usecases/cluster/delegate.go
@@ -125,7 +125,8 @@ type delegate struct {
 }
 
 type NodeMetadata struct {
-	DataPort int `json:"data_port"`
+	RestPort int `json:"rest_port"`
+	GrpcPort int `json:"grpc_port"`
 }
 
 func (d *delegate) setOwnSpace(x DiskUsage) {

--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -171,7 +171,8 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 			dataPath: dataPath,
 			log:      logger,
 			metadata: NodeMetadata{
-				DataPort: userConfig.DataBindPort,
+				RestPort: userConfig.DataBindPort,
+				GrpcPort: userConfig.DataBindPort,
 			},
 		},
 	}
@@ -284,7 +285,7 @@ func (s *State) dataPort(m *memberlist.Node) int {
 		return int(m.Port) + 1 // the convention that it's 1 higher than the gossip port
 	}
 
-	return meta.DataPort
+	return meta.RestPort
 }
 
 // AllHostnames for live members, including self.


### PR DESCRIPTION
### What's being changed:

This PR reverts a change to `delete.NodeMetadata.RestPort` that causes rolling updates to fail due to memberlist issues 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
