### PR TITLE
Introduce `http.Protocols` in `http.Server` instead of using `h2c`

### DIFF
--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 
 	sentryhttp "github.com/getsentry/sentry-go/http"
-	"golang.org/x/net/http2"
-	"golang.org/x/net/http2/h2c"
 
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
@@ -114,16 +112,15 @@ func NewServer(appState *state.State) *Server {
 		)
 	}
 
-	// Configure HTTP/2 server
-	h2s := &http2.Server{
-		MaxConcurrentStreams: MAX_CONCURRENT_STREAMS,
-		MaxReadFrameSize:     MAX_READ_FRAME_SIZE,
-	}
+	protocols := http.Protocols{}
+	protocols.SetHTTP1(true)
+	protocols.SetUnencryptedHTTP2(true)
 
 	return &Server{
 		server: &http.Server{
-			Addr:    fmt.Sprintf(":%d", port),
-			Handler: h2c.NewHandler(handler, h2s),
+			Addr:      fmt.Sprintf(":%d", port),
+			Handler:   handler,
+			Protocols: &protocols,
 		},
 		appState:          appState,
 		replicatedIndices: replicatedIndices,


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
