### PR TITLE
No back connecting while tombstone cleaning up

### DIFF
--- a/adapters/repos/db/vector/hnsw/neighbor_connections.go
+++ b/adapters/repos/db/vector/hnsw/neighbor_connections.go
@@ -305,9 +305,11 @@ func (n *neighborFinderConnector) doAtLevel(ctx context.Context, level int) erro
 		return errors.Wrapf(err, "ReplaceLinksAtLevel node %d at level %d", n.node.id, level)
 	}
 
-	for _, neighborID := range neighborsCpy {
-		if err := n.connectNeighborAtLevel(neighborID, level); err != nil {
-			return errors.Wrapf(err, "connect neighbor %d", neighborID)
+	if !n.tombstoneCleanupNodes {
+		for _, neighborID := range neighborsCpy {
+			if err := n.connectNeighborAtLevel(neighborID, level); err != nil {
+				return errors.Wrapf(err, "connect neighbor %d", neighborID)
+			}
 		}
 	}
 


### PR DESCRIPTION
### What's being changed:

When we cleanup tombstone connections, we do not need to add back connections since, unlike at insertion time, we are not adding new nodes but correcting well established connections. If the node we are connecting to needs a back connection, it will be handled by the time we analyse such a node.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
