### PR TITLE
fix(modules): add missing generative-aws module setting to proto definition

### DIFF
--- a/adapters/handlers/grpc/v1/generative/parser.go
+++ b/adapters/handlers/grpc/v1/generative/parser.go
@@ -209,13 +209,17 @@ func (p *Parser) anthropic(in *pb.GenerativeAnthropic) map[string]any {
 	if in == nil {
 		return nil
 	}
+	var stopSequences []string
+	if in.StopSequences != nil {
+		stopSequences = in.StopSequences.GetValues()
+	}
 	return map[string]any{
 		anthropicParams.Name: anthropicParams.Params{
 			BaseURL:         in.GetBaseUrl(),
 			Model:           in.GetModel(),
 			Temperature:     in.Temperature,
 			MaxTokens:       p.int64ToInt(in.MaxTokens),
-			StopSequences:   in.StopSequences.GetValues(),
+			StopSequences:   stopSequences,
 			TopP:            in.TopP,
 			TopK:            p.int64ToInt(in.TopK),
 			Images:          p.getStringPtrs(in.Images),
@@ -241,6 +245,10 @@ func (p *Parser) aws(in *pb.GenerativeAWS) map[string]any {
 	if in == nil {
 		return nil
 	}
+	var stopSequences []string
+	if in.StopSequences != nil {
+		stopSequences = in.StopSequences.GetValues()
+	}
 	return map[string]any{
 		awsParams.Name: awsParams.Params{
 			Service:         in.GetService(),
@@ -251,6 +259,7 @@ func (p *Parser) aws(in *pb.GenerativeAWS) map[string]any {
 			Model:           in.GetModel(),
 			Temperature:     in.Temperature,
 			MaxTokens:       p.int64ToInt(in.MaxTokens),
+			StopSequences:   stopSequences,
 			Images:          p.getStringPtrs(in.Images),
 			ImageProperties: p.getStrings(in.ImageProperties),
 		},
@@ -261,6 +270,10 @@ func (p *Parser) cohere(in *pb.GenerativeCohere) map[string]any {
 	if in == nil {
 		return nil
 	}
+	var stopSequences []string
+	if in.StopSequences != nil {
+		stopSequences = in.StopSequences.GetValues()
+	}
 	return map[string]any{
 		cohereParams.Name: cohereParams.Params{
 			BaseURL:          in.GetBaseUrl(),
@@ -269,7 +282,7 @@ func (p *Parser) cohere(in *pb.GenerativeCohere) map[string]any {
 			MaxTokens:        p.int64ToInt(in.MaxTokens),
 			K:                p.int64ToInt(in.K),
 			P:                in.P,
-			StopSequences:    in.StopSequences.GetValues(),
+			StopSequences:    stopSequences,
 			FrequencyPenalty: in.FrequencyPenalty,
 			PresencePenalty:  in.PresencePenalty,
 			Images:           p.getStringPtrs(in.Images),
@@ -355,6 +368,10 @@ func (p *Parser) google(in *pb.GenerativeGoogle) map[string]any {
 	if in == nil {
 		return nil
 	}
+	var stopSequences []string
+	if in.StopSequences != nil {
+		stopSequences = in.StopSequences.GetValues()
+	}
 	return map[string]any{
 		googleParams.Name: googleParams.Params{
 			ApiEndpoint:      in.GetApiEndpoint(),
@@ -366,7 +383,7 @@ func (p *Parser) google(in *pb.GenerativeGoogle) map[string]any {
 			MaxTokens:        p.int64ToInt(in.MaxTokens),
 			TopP:             in.TopP,
 			TopK:             p.int64ToInt(in.TopK),
-			StopSequences:    in.StopSequences.GetValues(),
+			StopSequences:    stopSequences,
 			PresencePenalty:  in.PresencePenalty,
 			FrequencyPenalty: in.FrequencyPenalty,
 			Images:           p.getStringPtrs(in.Images),

--- a/adapters/handlers/grpc/v1/generative/parser_test.go
+++ b/adapters/handlers/grpc/v1/generative/parser_test.go
@@ -385,6 +385,9 @@ func Test_RequestParser(t *testing.T) {
 									Model:         makeStrPtr("model"),
 									Temperature:   makeFloat64Ptr(0.5),
 									MaxTokens:     makeInt64Ptr(500),
+									StopSequences: &pb.TextArray{
+										Values: []string{"stop"},
+									},
 								},
 							},
 						},
@@ -403,6 +406,7 @@ func Test_RequestParser(t *testing.T) {
 						Model:         "model",
 						Temperature:   makeFloat64Ptr(0.5),
 						MaxTokens:     makeIntPtr(500),
+						StopSequences: []string{"stop"},
 					},
 				},
 			},

--- a/grpc/generated/protocol/v1/generative.pb.go
+++ b/grpc/generated/protocol/v1/generative.pb.go
@@ -653,6 +653,7 @@ type GenerativeAWS struct {
 	Images          *TextArray             `protobuf:"bytes,14,opt,name=images,proto3,oneof" json:"images,omitempty"`
 	ImageProperties *TextArray             `protobuf:"bytes,15,opt,name=image_properties,json=imageProperties,proto3,oneof" json:"image_properties,omitempty"`
 	MaxTokens       *int64                 `protobuf:"varint,16,opt,name=max_tokens,json=maxTokens,proto3,oneof" json:"max_tokens,omitempty"`
+	StopSequences   *TextArray             `protobuf:"bytes,17,opt,name=stop_sequences,json=stopSequences,proto3,oneof" json:"stop_sequences,omitempty"`
 	unknownFields   protoimpl.UnknownFields
 	sizeCache       protoimpl.SizeCache
 }
@@ -755,6 +756,13 @@ func (x *GenerativeAWS) GetMaxTokens() int64 {
 		return *x.MaxTokens
 	}
 	return 0
+}
+
+func (x *GenerativeAWS) GetStopSequences() *TextArray {
+	if x != nil {
+		return x.StopSequences
+	}
+	return nil
 }
 
 type GenerativeCohere struct {
@@ -3743,7 +3751,7 @@ const file_v1_generative_proto_rawDesc = "" +
 	"\vtemperature\x18\x03 \x01(\x01H\x02R\vtemperature\x88\x01\x01B\v\n" +
 	"\t_base_urlB\b\n" +
 	"\x06_modelB\x0e\n" +
-	"\f_temperature\"\xb4\x04\n" +
+	"\f_temperature\"\x8b\x05\n" +
 	"\rGenerativeAWS\x12\x19\n" +
 	"\x05model\x18\x03 \x01(\tH\x00R\x05model\x88\x01\x01\x12%\n" +
 	"\vtemperature\x18\b \x01(\x01H\x01R\vtemperature\x88\x01\x01\x12\x1d\n" +
@@ -3756,7 +3764,9 @@ const file_v1_generative_proto_rawDesc = "" +
 	"\x06images\x18\x0e \x01(\v2\x16.weaviate.v1.TextArrayH\aR\x06images\x88\x01\x01\x12F\n" +
 	"\x10image_properties\x18\x0f \x01(\v2\x16.weaviate.v1.TextArrayH\bR\x0fimageProperties\x88\x01\x01\x12\"\n" +
 	"\n" +
-	"max_tokens\x18\x10 \x01(\x03H\tR\tmaxTokens\x88\x01\x01B\b\n" +
+	"max_tokens\x18\x10 \x01(\x03H\tR\tmaxTokens\x88\x01\x01\x12B\n" +
+	"\x0estop_sequences\x18\x11 \x01(\v2\x16.weaviate.v1.TextArrayH\n" +
+	"R\rstopSequences\x88\x01\x01B\b\n" +
 	"\x06_modelB\x0e\n" +
 	"\f_temperatureB\n" +
 	"\n" +
@@ -3767,7 +3777,8 @@ const file_v1_generative_proto_rawDesc = "" +
 	"\x0f_target_variantB\t\n" +
 	"\a_imagesB\x13\n" +
 	"\x11_image_propertiesB\r\n" +
-	"\v_max_tokens\"\x81\x05\n" +
+	"\v_max_tokensB\x11\n" +
+	"\x0f_stop_sequences\"\x81\x05\n" +
 	"\x10GenerativeCohere\x12\x1e\n" +
 	"\bbase_url\x18\x01 \x01(\tH\x00R\abaseUrl\x88\x01\x01\x120\n" +
 	"\x11frequency_penalty\x18\x02 \x01(\x01H\x01R\x10frequencyPenalty\x88\x01\x01\x12\"\n" +
@@ -4223,62 +4234,63 @@ var file_v1_generative_proto_depIdxs = []int32{
 	50, // 17: weaviate.v1.GenerativeAnthropic.image_properties:type_name -> weaviate.v1.TextArray
 	50, // 18: weaviate.v1.GenerativeAWS.images:type_name -> weaviate.v1.TextArray
 	50, // 19: weaviate.v1.GenerativeAWS.image_properties:type_name -> weaviate.v1.TextArray
-	50, // 20: weaviate.v1.GenerativeCohere.stop_sequences:type_name -> weaviate.v1.TextArray
-	50, // 21: weaviate.v1.GenerativeCohere.images:type_name -> weaviate.v1.TextArray
-	50, // 22: weaviate.v1.GenerativeCohere.image_properties:type_name -> weaviate.v1.TextArray
-	50, // 23: weaviate.v1.GenerativeOllama.images:type_name -> weaviate.v1.TextArray
-	50, // 24: weaviate.v1.GenerativeOllama.image_properties:type_name -> weaviate.v1.TextArray
-	50, // 25: weaviate.v1.GenerativeOpenAI.stop:type_name -> weaviate.v1.TextArray
-	50, // 26: weaviate.v1.GenerativeOpenAI.images:type_name -> weaviate.v1.TextArray
-	50, // 27: weaviate.v1.GenerativeOpenAI.image_properties:type_name -> weaviate.v1.TextArray
-	0,  // 28: weaviate.v1.GenerativeOpenAI.reasoning_effort:type_name -> weaviate.v1.GenerativeOpenAI.ReasoningEffort
-	1,  // 29: weaviate.v1.GenerativeOpenAI.verbosity:type_name -> weaviate.v1.GenerativeOpenAI.Verbosity
-	50, // 30: weaviate.v1.GenerativeGoogle.stop_sequences:type_name -> weaviate.v1.TextArray
-	50, // 31: weaviate.v1.GenerativeGoogle.images:type_name -> weaviate.v1.TextArray
-	50, // 32: weaviate.v1.GenerativeGoogle.image_properties:type_name -> weaviate.v1.TextArray
-	50, // 33: weaviate.v1.GenerativeDatabricks.stop:type_name -> weaviate.v1.TextArray
-	50, // 34: weaviate.v1.GenerativeXAI.images:type_name -> weaviate.v1.TextArray
-	50, // 35: weaviate.v1.GenerativeXAI.image_properties:type_name -> weaviate.v1.TextArray
-	36, // 36: weaviate.v1.GenerativeAnthropicMetadata.usage:type_name -> weaviate.v1.GenerativeAnthropicMetadata.Usage
-	37, // 37: weaviate.v1.GenerativeCohereMetadata.api_version:type_name -> weaviate.v1.GenerativeCohereMetadata.ApiVersion
-	38, // 38: weaviate.v1.GenerativeCohereMetadata.billed_units:type_name -> weaviate.v1.GenerativeCohereMetadata.BilledUnits
-	39, // 39: weaviate.v1.GenerativeCohereMetadata.tokens:type_name -> weaviate.v1.GenerativeCohereMetadata.Tokens
-	50, // 40: weaviate.v1.GenerativeCohereMetadata.warnings:type_name -> weaviate.v1.TextArray
-	40, // 41: weaviate.v1.GenerativeMistralMetadata.usage:type_name -> weaviate.v1.GenerativeMistralMetadata.Usage
-	41, // 42: weaviate.v1.GenerativeOpenAIMetadata.usage:type_name -> weaviate.v1.GenerativeOpenAIMetadata.Usage
-	44, // 43: weaviate.v1.GenerativeGoogleMetadata.metadata:type_name -> weaviate.v1.GenerativeGoogleMetadata.Metadata
-	45, // 44: weaviate.v1.GenerativeGoogleMetadata.usage_metadata:type_name -> weaviate.v1.GenerativeGoogleMetadata.UsageMetadata
-	46, // 45: weaviate.v1.GenerativeDatabricksMetadata.usage:type_name -> weaviate.v1.GenerativeDatabricksMetadata.Usage
-	47, // 46: weaviate.v1.GenerativeFriendliAIMetadata.usage:type_name -> weaviate.v1.GenerativeFriendliAIMetadata.Usage
-	48, // 47: weaviate.v1.GenerativeNvidiaMetadata.usage:type_name -> weaviate.v1.GenerativeNvidiaMetadata.Usage
-	49, // 48: weaviate.v1.GenerativeXAIMetadata.usage:type_name -> weaviate.v1.GenerativeXAIMetadata.Usage
-	17, // 49: weaviate.v1.GenerativeMetadata.anthropic:type_name -> weaviate.v1.GenerativeAnthropicMetadata
-	18, // 50: weaviate.v1.GenerativeMetadata.anyscale:type_name -> weaviate.v1.GenerativeAnyscaleMetadata
-	19, // 51: weaviate.v1.GenerativeMetadata.aws:type_name -> weaviate.v1.GenerativeAWSMetadata
-	20, // 52: weaviate.v1.GenerativeMetadata.cohere:type_name -> weaviate.v1.GenerativeCohereMetadata
-	21, // 53: weaviate.v1.GenerativeMetadata.dummy:type_name -> weaviate.v1.GenerativeDummyMetadata
-	22, // 54: weaviate.v1.GenerativeMetadata.mistral:type_name -> weaviate.v1.GenerativeMistralMetadata
-	23, // 55: weaviate.v1.GenerativeMetadata.ollama:type_name -> weaviate.v1.GenerativeOllamaMetadata
-	24, // 56: weaviate.v1.GenerativeMetadata.openai:type_name -> weaviate.v1.GenerativeOpenAIMetadata
-	25, // 57: weaviate.v1.GenerativeMetadata.google:type_name -> weaviate.v1.GenerativeGoogleMetadata
-	26, // 58: weaviate.v1.GenerativeMetadata.databricks:type_name -> weaviate.v1.GenerativeDatabricksMetadata
-	27, // 59: weaviate.v1.GenerativeMetadata.friendliai:type_name -> weaviate.v1.GenerativeFriendliAIMetadata
-	28, // 60: weaviate.v1.GenerativeMetadata.nvidia:type_name -> weaviate.v1.GenerativeNvidiaMetadata
-	29, // 61: weaviate.v1.GenerativeMetadata.xai:type_name -> weaviate.v1.GenerativeXAIMetadata
-	33, // 62: weaviate.v1.GenerativeReply.debug:type_name -> weaviate.v1.GenerativeDebug
-	30, // 63: weaviate.v1.GenerativeReply.metadata:type_name -> weaviate.v1.GenerativeMetadata
-	31, // 64: weaviate.v1.GenerativeResult.values:type_name -> weaviate.v1.GenerativeReply
-	3,  // 65: weaviate.v1.GenerativeSearch.Single.queries:type_name -> weaviate.v1.GenerativeProvider
-	50, // 66: weaviate.v1.GenerativeSearch.Grouped.properties:type_name -> weaviate.v1.TextArray
-	3,  // 67: weaviate.v1.GenerativeSearch.Grouped.queries:type_name -> weaviate.v1.GenerativeProvider
-	42, // 68: weaviate.v1.GenerativeGoogleMetadata.TokenMetadata.input_token_count:type_name -> weaviate.v1.GenerativeGoogleMetadata.TokenCount
-	42, // 69: weaviate.v1.GenerativeGoogleMetadata.TokenMetadata.output_token_count:type_name -> weaviate.v1.GenerativeGoogleMetadata.TokenCount
-	43, // 70: weaviate.v1.GenerativeGoogleMetadata.Metadata.token_metadata:type_name -> weaviate.v1.GenerativeGoogleMetadata.TokenMetadata
-	71, // [71:71] is the sub-list for method output_type
-	71, // [71:71] is the sub-list for method input_type
-	71, // [71:71] is the sub-list for extension type_name
-	71, // [71:71] is the sub-list for extension extendee
-	0,  // [0:71] is the sub-list for field type_name
+	50, // 20: weaviate.v1.GenerativeAWS.stop_sequences:type_name -> weaviate.v1.TextArray
+	50, // 21: weaviate.v1.GenerativeCohere.stop_sequences:type_name -> weaviate.v1.TextArray
+	50, // 22: weaviate.v1.GenerativeCohere.images:type_name -> weaviate.v1.TextArray
+	50, // 23: weaviate.v1.GenerativeCohere.image_properties:type_name -> weaviate.v1.TextArray
+	50, // 24: weaviate.v1.GenerativeOllama.images:type_name -> weaviate.v1.TextArray
+	50, // 25: weaviate.v1.GenerativeOllama.image_properties:type_name -> weaviate.v1.TextArray
+	50, // 26: weaviate.v1.GenerativeOpenAI.stop:type_name -> weaviate.v1.TextArray
+	50, // 27: weaviate.v1.GenerativeOpenAI.images:type_name -> weaviate.v1.TextArray
+	50, // 28: weaviate.v1.GenerativeOpenAI.image_properties:type_name -> weaviate.v1.TextArray
+	0,  // 29: weaviate.v1.GenerativeOpenAI.reasoning_effort:type_name -> weaviate.v1.GenerativeOpenAI.ReasoningEffort
+	1,  // 30: weaviate.v1.GenerativeOpenAI.verbosity:type_name -> weaviate.v1.GenerativeOpenAI.Verbosity
+	50, // 31: weaviate.v1.GenerativeGoogle.stop_sequences:type_name -> weaviate.v1.TextArray
+	50, // 32: weaviate.v1.GenerativeGoogle.images:type_name -> weaviate.v1.TextArray
+	50, // 33: weaviate.v1.GenerativeGoogle.image_properties:type_name -> weaviate.v1.TextArray
+	50, // 34: weaviate.v1.GenerativeDatabricks.stop:type_name -> weaviate.v1.TextArray
+	50, // 35: weaviate.v1.GenerativeXAI.images:type_name -> weaviate.v1.TextArray
+	50, // 36: weaviate.v1.GenerativeXAI.image_properties:type_name -> weaviate.v1.TextArray
+	36, // 37: weaviate.v1.GenerativeAnthropicMetadata.usage:type_name -> weaviate.v1.GenerativeAnthropicMetadata.Usage
+	37, // 38: weaviate.v1.GenerativeCohereMetadata.api_version:type_name -> weaviate.v1.GenerativeCohereMetadata.ApiVersion
+	38, // 39: weaviate.v1.GenerativeCohereMetadata.billed_units:type_name -> weaviate.v1.GenerativeCohereMetadata.BilledUnits
+	39, // 40: weaviate.v1.GenerativeCohereMetadata.tokens:type_name -> weaviate.v1.GenerativeCohereMetadata.Tokens
+	50, // 41: weaviate.v1.GenerativeCohereMetadata.warnings:type_name -> weaviate.v1.TextArray
+	40, // 42: weaviate.v1.GenerativeMistralMetadata.usage:type_name -> weaviate.v1.GenerativeMistralMetadata.Usage
+	41, // 43: weaviate.v1.GenerativeOpenAIMetadata.usage:type_name -> weaviate.v1.GenerativeOpenAIMetadata.Usage
+	44, // 44: weaviate.v1.GenerativeGoogleMetadata.metadata:type_name -> weaviate.v1.GenerativeGoogleMetadata.Metadata
+	45, // 45: weaviate.v1.GenerativeGoogleMetadata.usage_metadata:type_name -> weaviate.v1.GenerativeGoogleMetadata.UsageMetadata
+	46, // 46: weaviate.v1.GenerativeDatabricksMetadata.usage:type_name -> weaviate.v1.GenerativeDatabricksMetadata.Usage
+	47, // 47: weaviate.v1.GenerativeFriendliAIMetadata.usage:type_name -> weaviate.v1.GenerativeFriendliAIMetadata.Usage
+	48, // 48: weaviate.v1.GenerativeNvidiaMetadata.usage:type_name -> weaviate.v1.GenerativeNvidiaMetadata.Usage
+	49, // 49: weaviate.v1.GenerativeXAIMetadata.usage:type_name -> weaviate.v1.GenerativeXAIMetadata.Usage
+	17, // 50: weaviate.v1.GenerativeMetadata.anthropic:type_name -> weaviate.v1.GenerativeAnthropicMetadata
+	18, // 51: weaviate.v1.GenerativeMetadata.anyscale:type_name -> weaviate.v1.GenerativeAnyscaleMetadata
+	19, // 52: weaviate.v1.GenerativeMetadata.aws:type_name -> weaviate.v1.GenerativeAWSMetadata
+	20, // 53: weaviate.v1.GenerativeMetadata.cohere:type_name -> weaviate.v1.GenerativeCohereMetadata
+	21, // 54: weaviate.v1.GenerativeMetadata.dummy:type_name -> weaviate.v1.GenerativeDummyMetadata
+	22, // 55: weaviate.v1.GenerativeMetadata.mistral:type_name -> weaviate.v1.GenerativeMistralMetadata
+	23, // 56: weaviate.v1.GenerativeMetadata.ollama:type_name -> weaviate.v1.GenerativeOllamaMetadata
+	24, // 57: weaviate.v1.GenerativeMetadata.openai:type_name -> weaviate.v1.GenerativeOpenAIMetadata
+	25, // 58: weaviate.v1.GenerativeMetadata.google:type_name -> weaviate.v1.GenerativeGoogleMetadata
+	26, // 59: weaviate.v1.GenerativeMetadata.databricks:type_name -> weaviate.v1.GenerativeDatabricksMetadata
+	27, // 60: weaviate.v1.GenerativeMetadata.friendliai:type_name -> weaviate.v1.GenerativeFriendliAIMetadata
+	28, // 61: weaviate.v1.GenerativeMetadata.nvidia:type_name -> weaviate.v1.GenerativeNvidiaMetadata
+	29, // 62: weaviate.v1.GenerativeMetadata.xai:type_name -> weaviate.v1.GenerativeXAIMetadata
+	33, // 63: weaviate.v1.GenerativeReply.debug:type_name -> weaviate.v1.GenerativeDebug
+	30, // 64: weaviate.v1.GenerativeReply.metadata:type_name -> weaviate.v1.GenerativeMetadata
+	31, // 65: weaviate.v1.GenerativeResult.values:type_name -> weaviate.v1.GenerativeReply
+	3,  // 66: weaviate.v1.GenerativeSearch.Single.queries:type_name -> weaviate.v1.GenerativeProvider
+	50, // 67: weaviate.v1.GenerativeSearch.Grouped.properties:type_name -> weaviate.v1.TextArray
+	3,  // 68: weaviate.v1.GenerativeSearch.Grouped.queries:type_name -> weaviate.v1.GenerativeProvider
+	42, // 69: weaviate.v1.GenerativeGoogleMetadata.TokenMetadata.input_token_count:type_name -> weaviate.v1.GenerativeGoogleMetadata.TokenCount
+	42, // 70: weaviate.v1.GenerativeGoogleMetadata.TokenMetadata.output_token_count:type_name -> weaviate.v1.GenerativeGoogleMetadata.TokenCount
+	43, // 71: weaviate.v1.GenerativeGoogleMetadata.Metadata.token_metadata:type_name -> weaviate.v1.GenerativeGoogleMetadata.TokenMetadata
+	72, // [72:72] is the sub-list for method output_type
+	72, // [72:72] is the sub-list for method input_type
+	72, // [72:72] is the sub-list for extension type_name
+	72, // [72:72] is the sub-list for extension extendee
+	0,  // [0:72] is the sub-list for field type_name
 }
 
 func init() { file_v1_generative_proto_init() }

--- a/grpc/proto/v1/generative.proto
+++ b/grpc/proto/v1/generative.proto
@@ -79,6 +79,7 @@ message GenerativeAWS{
   optional TextArray images = 14;
   optional TextArray image_properties = 15;
   optional int64 max_tokens = 16;
+  optional TextArray stop_sequences = 17;
 }
 
 message GenerativeCohere{

--- a/modules/generative-aws/clients/aws.go
+++ b/modules/generative-aws/clients/aws.go
@@ -219,8 +219,11 @@ func (v *awsClient) getParameters(cfg moduletools.ClassConfig, options interface
 		params.Temperature = temperature
 	}
 	if params.MaxTokens == nil {
-		maxTokens := settings.MaxTokenCount(params.Service, params.Model)
+		maxTokens := settings.MaxTokens(params.Service, params.Model)
 		params.MaxTokens = maxTokens
+	}
+	if len(params.StopSequences) == 0 {
+		params.StopSequences = settings.StopSequences(params.Service, params.Model)
 	}
 
 	params.Images = generativecomponents.ParseImageProperties(params.Images, params.ImageProperties, imagePropertiesArray)
@@ -359,7 +362,7 @@ func (v *awsClient) createRequestBody(prompt string, params awsparams.Params, cf
 			Prompt:            builder.String(),
 			Temperature:       params.Temperature,
 			MaxTokensToSample: params.MaxTokens,
-			StopSequences:     settings.StopSequences(service, model),
+			StopSequences:     params.StopSequences,
 			TopK:              settings.TopK(service, model),
 			TopP:              settings.TopP(service, model),
 			AnthropicVersion:  "bedrock-2023-05-31",
@@ -370,7 +373,7 @@ func (v *awsClient) createRequestBody(prompt string, params awsparams.Params, cf
 			Temperature:   params.Temperature,
 			MaxTokens:     params.MaxTokens,
 			TopP:          settings.TopP(service, model),
-			StopSequences: settings.StopSequences(service, model),
+			StopSequences: params.StopSequences,
 		}, nil
 	} else if v.isCohereCommandRModel(model) {
 		return bedrockCohereCommandRRequest{

--- a/modules/generative-aws/config/class_settings.go
+++ b/modules/generative-aws/config/class_settings.go
@@ -28,8 +28,9 @@ const (
 	endpointProperty          = "endpoint"
 	targetModelProperty       = "targetModel"
 	targetVariantProperty     = "targetVariant"
-	maxTokenCountProperty     = "maxTokenCount"
-	maxTokensToSampleProperty = "maxTokensToSample"
+	maxTokenCountProperty     = "maxTokenCount"     // deprecated, use: maxTokens
+	maxTokensToSampleProperty = "maxTokensToSample" // deprecated, use: maxTokens
+	maxTokensProperty         = "maxTokens"
 	stopSequencesProperty     = "stopSequences"
 	temperatureProperty       = "temperature"
 	topPProperty              = "topP"
@@ -108,9 +109,9 @@ func (ic *classSettings) Validate(class *models.Class) error {
 		if model == "" {
 			errorMessages = append(errorMessages, fmt.Sprintf("%s has to be defined", modelProperty))
 		}
-		maxTokenCount := ic.MaxTokenCount(Bedrock, model)
-		if maxTokenCount != nil && (*maxTokenCount < 1 || *maxTokenCount > 8192) {
-			errorMessages = append(errorMessages, fmt.Sprintf("%s has to be an integer value between 1 and 8096", maxTokenCountProperty))
+		maxTokens := ic.MaxTokens(Bedrock, model)
+		if maxTokens != nil && (*maxTokens < 1 || *maxTokens > 8192) {
+			errorMessages = append(errorMessages, fmt.Sprintf("%s has to be an integer value between 1 and 8096", maxTokensProperty))
 		}
 		temperature := ic.Temperature(Bedrock, model)
 		if temperature != nil && (*temperature < 0 || *temperature > 1) {
@@ -198,26 +199,47 @@ func (ic *classSettings) Model() string {
 	return ic.getStringProperty(modelProperty, "")
 }
 
-func (ic *classSettings) MaxTokenCount(service, model string) *int {
+func (ic *classSettings) MaxTokens(service, model string) *int {
 	if isBedrock(service) {
 		if isAmazonModel(model) {
+			if maxTokens := ic.getIntProperty(maxTokensProperty, nil); maxTokens != nil {
+				return maxTokens
+			}
 			return ic.getIntProperty(maxTokenCountProperty, &DefaultTitanMaxTokens)
 		}
 		if isAnthropicModel(model) {
+			if maxTokens := ic.getIntProperty(maxTokensProperty, nil); maxTokens != nil {
+				return maxTokens
+			}
 			return ic.getIntProperty(maxTokensToSampleProperty, &DefaultAnthropicMaxTokensToSample)
 		}
 		if isAI21Model(model) {
+			if maxTokens := ic.getIntProperty(maxTokensProperty, nil); maxTokens != nil {
+				return maxTokens
+			}
 			return ic.getIntProperty(maxTokenCountProperty, &DefaultAI21MaxTokens)
 		}
 		if isCohereModel(model) {
+			if maxTokens := ic.getIntProperty(maxTokensProperty, nil); maxTokens != nil {
+				return maxTokens
+			}
 			return ic.getIntProperty(maxTokenCountProperty, &DefaultCohereMaxTokens)
 		}
 		if isMistralAIModel(model) {
+			if maxTokens := ic.getIntProperty(maxTokensProperty, nil); maxTokens != nil {
+				return maxTokens
+			}
 			return ic.getIntProperty(maxTokenCountProperty, &DefaultMistralAIMaxTokens)
 		}
 		if isMetaModel(model) {
+			if maxTokens := ic.getIntProperty(maxTokensProperty, nil); maxTokens != nil {
+				return maxTokens
+			}
 			return ic.getIntProperty(maxTokenCountProperty, &DefaultMetaMaxTokens)
 		}
+	}
+	if maxTokens := ic.getIntProperty(maxTokensProperty, nil); maxTokens != nil {
+		return maxTokens
 	}
 	return ic.getIntProperty(maxTokenCountProperty, nil)
 }

--- a/modules/generative-aws/config/class_settings_test.go
+++ b/modules/generative-aws/config/class_settings_test.go
@@ -40,14 +40,14 @@ func Test_classSettings_Validate(t *testing.T) {
 		{
 			name: "empty model",
 			cfg: fakeClassConfig{
-				classConfig: map[string]interface{}{},
+				classConfig: map[string]any{},
 			},
 			wantErr: fmt.Errorf("model has to be defined"),
 		},
 		{
 			name: "happy flow - Bedrock",
 			cfg: fakeClassConfig{
-				classConfig: map[string]interface{}{
+				classConfig: map[string]any{
 					"service": "bedrock",
 					"region":  "us-east-1",
 					"model":   "ai21.j2-ultra-v1",
@@ -64,7 +64,7 @@ func Test_classSettings_Validate(t *testing.T) {
 		{
 			name: "happy flow - Sagemaker",
 			cfg: fakeClassConfig{
-				classConfig: map[string]interface{}{
+				classConfig: map[string]any{
 					"service":       "sagemaker",
 					"region":        "us-east-1",
 					"endpoint":      "my-endpoint-deployment",
@@ -81,7 +81,7 @@ func Test_classSettings_Validate(t *testing.T) {
 		{
 			name: "custom values - Bedrock",
 			cfg: fakeClassConfig{
-				classConfig: map[string]interface{}{
+				classConfig: map[string]any{
 					"service":       "bedrock",
 					"region":        "us-east-1",
 					"model":         "amazon.titan-text-lite-v1",
@@ -100,9 +100,30 @@ func Test_classSettings_Validate(t *testing.T) {
 			wantTopP:          0,
 		},
 		{
+			name: "custom values using maxTokens - Bedrock",
+			cfg: fakeClassConfig{
+				classConfig: map[string]any{
+					"service":       "bedrock",
+					"region":        "us-east-1",
+					"model":         "amazon.titan-text-lite-v1",
+					"maxTokens":     1,
+					"stopSequences": []string{"test", "test2"},
+					"temperature":   0.2,
+					"topP":          0,
+				},
+			},
+			wantService:       "bedrock",
+			wantRegion:        "us-east-1",
+			wantModel:         "amazon.titan-text-lite-v1",
+			wantMaxTokenCount: 1,
+			wantStopSequences: []string{"test", "test2"},
+			wantTemperature:   0.2,
+			wantTopP:          0,
+		},
+		{
 			name: "custom values - Sagemaker",
 			cfg: fakeClassConfig{
-				classConfig: map[string]interface{}{
+				classConfig: map[string]any{
 					"service":       "sagemaker",
 					"region":        "us-east-1",
 					"endpoint":      "this-is-my-endpoint",
@@ -119,7 +140,7 @@ func Test_classSettings_Validate(t *testing.T) {
 		{
 			name: "wrong temperature",
 			cfg: fakeClassConfig{
-				classConfig: map[string]interface{}{
+				classConfig: map[string]any{
 					"service":     "bedrock",
 					"region":      "us-east-1",
 					"model":       "amazon.titan-text-lite-v1",
@@ -131,19 +152,19 @@ func Test_classSettings_Validate(t *testing.T) {
 		{
 			name: "wrong maxTokenCount",
 			cfg: fakeClassConfig{
-				classConfig: map[string]interface{}{
+				classConfig: map[string]any{
 					"service":       "bedrock",
 					"region":        "us-east-1",
 					"model":         "amazon.titan-text-lite-v1",
 					"maxTokenCount": 9000,
 				},
 			},
-			wantErr: fmt.Errorf("maxTokenCount has to be an integer value between 1 and 8096"),
+			wantErr: fmt.Errorf("maxTokens has to be an integer value between 1 and 8096"),
 		},
 		{
 			name: "wrong topP",
 			cfg: fakeClassConfig{
-				classConfig: map[string]interface{}{
+				classConfig: map[string]any{
 					"service": "bedrock",
 					"region":  "us-east-1",
 					"model":   "amazon.titan-text-lite-v1",
@@ -179,10 +200,10 @@ func Test_classSettings_Validate(t *testing.T) {
 }
 
 type fakeClassConfig struct {
-	classConfig map[string]interface{}
+	classConfig map[string]any
 }
 
-func (f fakeClassConfig) Class() map[string]interface{} {
+func (f fakeClassConfig) Class() map[string]any {
 	return f.classConfig
 }
 
@@ -190,11 +211,11 @@ func (f fakeClassConfig) Tenant() string {
 	return ""
 }
 
-func (f fakeClassConfig) ClassByModuleName(moduleName string) map[string]interface{} {
+func (f fakeClassConfig) ClassByModuleName(moduleName string) map[string]any {
 	return f.classConfig
 }
 
-func (f fakeClassConfig) Property(propName string) map[string]interface{} {
+func (f fakeClassConfig) Property(propName string) map[string]any {
 	return nil
 }
 

--- a/modules/generative-aws/parameters/graphql.go
+++ b/modules/generative-aws/parameters/graphql.go
@@ -55,6 +55,10 @@ func input(prefix string) *graphql.InputObjectFieldConfig {
 					Description: "maxTokens",
 					Type:        graphql.Int,
 				},
+				"stopSequences": &graphql.InputObjectFieldConfig{
+					Description: "stopSequences",
+					Type:        graphql.NewList(graphql.String),
+				},
 				"images": &graphql.InputObjectFieldConfig{
 					Description: "images",
 					Type:        graphql.NewList(graphql.String),

--- a/modules/generative-aws/parameters/params.go
+++ b/modules/generative-aws/parameters/params.go
@@ -25,6 +25,7 @@ type Params struct {
 	Model           string
 	Temperature     *float64
 	MaxTokens       *int
+	StopSequences   []string
 	Images          []*string
 	ImageProperties []string
 }
@@ -51,6 +52,8 @@ func extract(field *ast.ObjectField) interface{} {
 				out.Temperature = gqlparser.GetValueAsFloat64(f)
 			case "maxTokens":
 				out.MaxTokens = gqlparser.GetValueAsInt(f)
+			case "stopSequences":
+				out.StopSequences = gqlparser.GetValueAsStringArray(f)
 			case "images":
 				out.Images = gqlparser.GetValueAsStringPtrArray(f)
 			case "imageProperties":


### PR DESCRIPTION
### What's being changed:

This PR adds `stopSequences` parameter to AWS set of dynamic RAG parameters.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
