### PR TITLE
feat(modules): add naive batch logic to text2vec-google module

### DIFF
--- a/modules/text2vec-google/module.go
+++ b/modules/text2vec-google/module.go
@@ -14,6 +14,7 @@ package modgoogle
 import (
 	"context"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/pkg/errors"
@@ -28,11 +29,13 @@ import (
 	"github.com/weaviate/weaviate/usecases/modulecomponents/additional"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/batch"
 	"github.com/weaviate/weaviate/usecases/modulecomponents/text2vecbase"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/vectorizer/batchtext"
 )
 
 const (
-	Name       = "text2vec-google"
-	LegacyName = "text2vec-palm"
+	Name             = "text2vec-google"
+	LegacyName       = "text2vec-palm"
+	defaultBatchSize = 50
 )
 
 var batchSettings = batch.Settings{
@@ -50,6 +53,9 @@ func New() *GoogleModule {
 
 type GoogleModule struct {
 	vectorizer                   text2vecbase.TextVectorizerBatch[[]float32]
+	vectorizerBatchSimple        batchtext.Vectorizer[[]float32]
+	useBatchSimpleVectorizer     bool
+	batchSize                    int
 	vectorizerWithTitleProperty  text2vecbase.TextVectorizer[[]float32]
 	metaProvider                 text2vecbase.MetaProvider
 	graphqlProvider              modulecapabilities.GraphQLArguments
@@ -116,6 +122,17 @@ func (m *GoogleModule) initVectorizer(ctx context.Context, timeout time.Duration
 	useGoogleAuth := entcfg.Enabled(os.Getenv("USE_GOOGLE_AUTH"))
 	client := clients.New(apiKey, useGoogleAuth, timeout, logger)
 
+	m.useBatchSimpleVectorizer = entcfg.Enabled(os.Getenv("USE_T2V_GOOGLE_BATCH_SIMPLE_LOGIC"))
+	m.vectorizerBatchSimple = batchtext.NewWithAltNames(Name, m.AltNames(), vectorizer.LowerCaseInput, client)
+	m.batchSize = defaultBatchSize
+	if batchSizeStr := os.Getenv("T2V_GOOGLE_BATCH_SIMPLE_BATCH_SIZE"); batchSizeStr != "" {
+		if batchSize, err := strconv.Atoi(batchSizeStr); err == nil && batchSize > 0 {
+			m.batchSize = batchSize
+		} else {
+			logger.Warnf("invalid (must be a positive number > 0) T2V_GOOGLE_BATCH_SIMPLE_BATCH_SIZE value: %s, using default: %v", batchSizeStr, m.batchSize)
+		}
+	}
+
 	m.vectorizerWithTitleProperty = vectorizer.New(client)
 
 	m.vectorizer = text2vecbase.New(client,
@@ -136,12 +153,22 @@ func (m *GoogleModule) initAdditionalPropertiesProvider() error {
 func (m *GoogleModule) VectorizeObject(ctx context.Context,
 	obj *models.Object, cfg moduletools.ClassConfig,
 ) ([]float32, models.AdditionalProperties, error) {
+	if m.useBatchSimpleVectorizer {
+		// use batch simple logic
+		return m.vectorizerBatchSimple.Object(ctx, obj, cfg)
+	}
+	// use default batch logic
 	icheck := vectorizer.NewClassSettings(cfg)
 	return m.vectorizer.Object(ctx, obj, cfg, icheck)
 }
 
 func (m *GoogleModule) VectorizeBatch(ctx context.Context, objs []*models.Object, skipObject []bool, cfg moduletools.ClassConfig) ([][]float32, []models.AdditionalProperties, map[int]error) {
 	icheck := vectorizer.NewClassSettings(cfg)
+	if m.useBatchSimpleVectorizer {
+		// use batch simple logic
+		return batch.VectorizeBatchObjects(ctx, objs, skipObject, cfg, m.logger, m.vectorizerBatchSimple.Objects, m.batchSize)
+	}
+	// use default batch logic
 	if icheck.TitleProperty() == "" {
 		vecs, errs := m.vectorizer.ObjectBatch(ctx, objs, skipObject, cfg)
 		return vecs, nil, errs
@@ -160,6 +187,11 @@ func (m *GoogleModule) AdditionalProperties() map[string]modulecapabilities.Addi
 func (m *GoogleModule) VectorizeInput(ctx context.Context,
 	input string, cfg moduletools.ClassConfig,
 ) ([]float32, error) {
+	if m.useBatchSimpleVectorizer {
+		// use batch simple logic
+		return m.vectorizerBatchSimple.Texts(ctx, []string{input}, cfg)
+	}
+	// use default batch logic
 	return m.vectorizer.Texts(ctx, []string{input}, cfg)
 }
 


### PR DESCRIPTION
### What's being changed:

This PR adds naive batch logic to `text2vec-google` module.

Simple batch logic can be turned on using `USE_T2V_GOOGLE_BATCH_SIMPLE_LOGIC=true` setting, by default simple batch is turned off.

The batch size can be configured using `T2V_GOOGLE_BATCH_SIMPLE_BATCH_SIZE` environment variable (default: `50`). The value must be a positive integer; if an invalid value is provided, the default is used and a warning is logged.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->