### PR TITLE
refact(nodes-endpoint): avoid db contention when loading all indices

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -717,6 +717,27 @@ func (i *Index) ForEachShard(f func(name string, shard ShardLike) error) error {
 	return i.shards.Range(f)
 }
 
+// withDropRLock runs f while holding this index's drop read lock. Take it
+// just-in-time per index, never up front for a whole snapshot: DeleteIndex
+// holds db.indexLock for as long as it waits on dropIndex.Lock, so an
+// acquire-all blocks every GetIndex in the process for the caller's lifetime.
+//
+// f is skipped if the index was dropped or shut down since being snapshotted,
+// which is not an error for the status and metrics callers this serves.
+func (i *Index) withDropRLock(f func() error) error {
+	i.dropIndex.RLock()
+	defer i.dropIndex.RUnlock()
+
+	i.closeLock.RLock()
+	closed := i.closed
+	i.closeLock.RUnlock()
+	if closed {
+		return nil
+	}
+
+	return f()
+}
+
 func (i *Index) ForEachLoadedShard(f func(name string, shard ShardLike) error) error {
 	return i.shards.Range(func(name string, shard ShardLike) error {
 		// Skip lazy loaded shard which are not loaded

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -99,7 +99,7 @@ func (db *DB) LocalNodeStatus(ctx context.Context, className, shardName, output 
 		nodeStats *models.NodeStats
 	)
 	if output == verbosity.OutputVerbose {
-		nodeStats = db.localNodeShardStats(ctx, &shards, className, shardName)
+		nodeStats, shards = db.localNodeShardStats(ctx, className, shardName)
 	}
 
 	clusterHealthStatus := models.NodeStatusStatusHEALTHY
@@ -122,37 +122,72 @@ func (db *DB) LocalNodeStatus(ctx context.Context, className, shardName, output 
 }
 
 func (db *DB) localNodeShardStats(ctx context.Context,
-	status *[]*models.NodeShardStatus, className, shardName string,
-) *models.NodeStats {
+	className, shardName string,
+) (*models.NodeStats, []*models.NodeShardStatus) {
 	var objectCount, shardCount int64
 	if className == "" {
+		// Snapshot the indices rather than holding the index lock while collecting:
+		// collection does I/O per shard and would otherwise block every index
+		// creation and deletion for its entire duration. dropIndex.RLock is taken
+		// under indexLock so an index cannot be dropped once it is in the snapshot.
 		db.indexLock.RLock()
-		defer db.indexLock.RUnlock()
+		indices := make([]*Index, 0, len(db.indices))
 		for name, idx := range db.indices {
 			if idx == nil {
 				db.logger.WithField("action", "local_node_status_for_all").
 					Warningf("no resource found for index %q", name)
 				continue
 			}
-			objects, shards := idx.getShardsNodeStatus(ctx, status, shardName)
-			objectCount, shardCount = objectCount+objects, shardCount+shards
+			idx.dropIndex.RLock()
+			indices = append(indices, idx)
+		}
+		db.indexLock.RUnlock()
+		defer func() {
+			for _, idx := range indices {
+				idx.dropIndex.RUnlock()
+			}
+		}()
+
+		type indexStats struct {
+			objects, shards int64
+			status          []*models.NodeShardStatus
+		}
+		results := make([]indexStats, len(indices))
+
+		eg := enterrors.NewErrorGroupWrapper(db.logger)
+		eg.SetLimit(_NUMCPU)
+		for i, idx := range indices {
+			eg.Go(func() error {
+				objects, shards, status := idx.getShardsNodeStatus(ctx, shardName)
+				results[i] = indexStats{objects: objects, shards: shards, status: status}
+				return nil
+			})
+		}
+		if err := eg.Wait(); err != nil {
+			db.logger.WithField("action", "local_node_status_for_all").Error(err)
+		}
+
+		var status []*models.NodeShardStatus
+		for _, res := range results {
+			objectCount, shardCount = objectCount+res.objects, shardCount+res.shards
+			status = append(status, res.status...)
 		}
 		return &models.NodeStats{
 			ObjectCount: objectCount,
 			ShardCount:  shardCount,
-		}
+		}, status
 	}
 	idx := db.GetIndex(schema.ClassName(className))
 	if idx == nil {
 		db.logger.WithField("action", "local_node_status_for_class").
 			Warningf("no index found for class %q", className)
-		return nil
+		return nil, nil
 	}
-	objectCount, shardCount = idx.getShardsNodeStatus(ctx, status, shardName)
+	objectCount, shardCount, status := idx.getShardsNodeStatus(ctx, shardName)
 	return &models.NodeStats{
 		ObjectCount: objectCount,
 		ShardCount:  shardCount,
-	}
+	}, status
 }
 
 func (db *DB) localNodeBatchStats() *models.BatchStats {
@@ -166,15 +201,15 @@ func (db *DB) localNodeBatchStats() *models.BatchStats {
 	return stats
 }
 
-// getShardsNodeStatus modifies the status slice to include the shard statuses.
+// getShardsNodeStatus returns the status of the index's shards, along with the
+// total object count and the number of shards.
 // If shardName is provided, it will only get the status of the specific shard.
 // Otherwise, it will get the status of all shards.
-// Returns the total object count and the number of shards.
-// If an error occurs, the status slice may have been modified and this method
-// may return a partial result.
-func (i *Index) getShardsNodeStatus(ctx context.Context,
-	status *[]*models.NodeShardStatus, shardName string,
-) (totalCount, shardCount int64) {
+// If an error occurs, this method may return a partial result.
+func (i *Index) getShardsNodeStatus(ctx context.Context, shardName string,
+) (totalCount, shardCount int64, status []*models.NodeShardStatus) {
+	replicationFactor, replicasPerShard := i.getShardsReplicationDetails(shardName)
+
 	i.ForEachShard(func(name string, shard ShardLike) error {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -188,17 +223,16 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 		className := i.Config.ClassName.String()
 		if lazy, ok := shard.(*LazyLoadShard); ok {
 			if !lazy.isLoaded() {
-				numberOfReplicas, replicationFactor := getShardReplicationDetails(i, shard.Name())
 				shardStatus := &models.NodeShardStatus{
 					Name:                 name,
 					Class:                className,
 					VectorIndexingStatus: shard.GetStatus().String(),
 					Loaded:               false,
 					ReplicationFactor:    replicationFactor,
-					NumberOfReplicas:     numberOfReplicas,
+					NumberOfReplicas:     replicasPerShard[name],
 					// don't add compression status as this would trigger loading the shard
 				}
-				*status = append(*status, shardStatus)
+				status = append(status, shardStatus)
 				shardCount++
 				return nil
 			}
@@ -228,11 +262,6 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 			return nil
 		})
 
-		numberOfReplicas, replicationFactor := getShardReplicationDetails(i, shard.Name())
-		if err != nil {
-			i.logger.Errorf("error while getting number of replicas for shard %s: %w", shard.Name(), err)
-		}
-
 		shardStatus := &models.NodeShardStatus{
 			Name:                   name,
 			Class:                  className,
@@ -243,32 +272,42 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 			Loaded:                 true,
 			AsyncReplicationStatus: shard.getAsyncReplicationStats(ctx),
 			ReplicationFactor:      replicationFactor,
-			NumberOfReplicas:       numberOfReplicas,
+			NumberOfReplicas:       replicasPerShard[name],
 		}
-		*status = append(*status, shardStatus)
+		status = append(status, shardStatus)
 		shardCount++
 		return nil
 	})
-	return totalCount, shardCount
+	return totalCount, shardCount, status
 }
 
-func getShardReplicationDetails(i *Index, shardName string) (int64, int64) {
-	var numberOfReplicas int64
+// getShardsReplicationDetails resolves the replication factor and the number of
+// replicas per shard in a single schema read. All shards of an index share the
+// same sharding state, so reading it per shard only adds contention on the
+// schema lock. If shardName is set, only that shard is resolved.
+func (i *Index) getShardsReplicationDetails(shardName string) (int64, map[string]int64) {
 	var replicationFactor int64
+	replicasPerShard := map[string]int64{}
 	class := i.Config.ClassName.String()
 	err := i.schemaReader.Read(class, true, func(class *models.Class, state *sharding.State) error {
-		var err error
 		replicationFactor = state.ReplicationFactor
-		numberOfReplicas, err = state.NumberOfReplicas(shardName)
-		if err != nil {
-			return fmt.Errorf("unable to retrieve number of replicas for class %s: %w", class.Class, err)
+		if shardName != "" {
+			numberOfReplicas, err := state.NumberOfReplicas(shardName)
+			if err != nil {
+				return fmt.Errorf("unable to retrieve number of replicas for class %s: %w", class.Class, err)
+			}
+			replicasPerShard[shardName] = numberOfReplicas
+			return nil
+		}
+		for name, physical := range state.Physical {
+			replicasPerShard[name] = int64(len(physical.BelongsToNodes))
 		}
 		return nil
 	})
 	if err != nil {
-		i.logger.Errorf("error while getting number of replicas for shard %s: %v", shardName, err)
+		i.logger.Errorf("error while getting replication details for class %s: %v", class, err)
 	}
-	return numberOfReplicas, replicationFactor
+	return replicationFactor, replicasPerShard
 }
 
 func isAnyVectorIndexCompressed(shard ShardLike) bool {

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -126,8 +126,7 @@ func (db *DB) localNodeShardStats(ctx context.Context,
 ) *models.NodeStats {
 	var objectCount, shardCount int64
 	if className == "" {
-		indices, release := db.snapshotIndices()
-		defer release()
+		indices := db.snapshotIndices()
 
 		type indexStats struct {
 			objects, shards int64
@@ -136,15 +135,19 @@ func (db *DB) localNodeShardStats(ctx context.Context,
 		results := make([]indexStats, len(indices))
 
 		eg := enterrors.NewErrorGroupWrapper(db.logger)
-		eg.SetLimit(_NUMCPU)
+		eg.SetLimit(min(_NUMCPU, len(indices)))
 		for i, idx := range indices {
 			eg.Go(func() error {
-				var shardsStatus []*models.NodeShardStatus
-				objects, shards := idx.getShardsNodeStatus(ctx, &shardsStatus, shardName)
-				results[i] = indexStats{objects: objects, shards: shards, status: shardsStatus}
-				return nil
-			})
+				return idx.withDropRLock(func() error {
+					var shardsStatus []*models.NodeShardStatus
+					objects, shards := idx.getShardsNodeStatus(ctx, &shardsStatus, shardName)
+					results[i] = indexStats{objects: objects, shards: shards, status: shardsStatus}
+					return nil
+				})
+			}, idx.Config.ClassName)
 		}
+		// only non-nil for a recovered panic; that index's slot stays zeroed and
+		// the counts below are short by its contribution
 		if err := eg.Wait(); err != nil {
 			db.logger.WithField("action", "local_node_status_for_all").Error(err)
 		}
@@ -191,22 +194,34 @@ func (db *DB) localNodeBatchStats() *models.BatchStats {
 func (i *Index) getShardsNodeStatus(ctx context.Context,
 	status *[]*models.NodeShardStatus, shardName string,
 ) (totalCount, shardCount int64) {
-	replicationFactor, replicasPerShard := i.getShardsReplicationDetails(shardName)
-
+	names := make([]string, 0, 16)
+	shards := make([]ShardLike, 0, 16)
 	i.ForEachShard(func(name string, shard ShardLike) error {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
 		// if shardName is provided, only return the status for the specified shard
 		if shardName != "" && shardName != name {
 			return nil
 		}
+		names = append(names, name)
+		shards = append(shards, shard)
+		return nil
+	})
+	if len(names) == 0 {
+		return 0, 0
+	}
+
+	replicationFactor, replicasPerShard := i.getShardsReplicationDetails(names)
+	className := i.Config.ClassName.String()
+
+	for idx, shard := range shards {
+		if ctx.Err() != nil {
+			break
+		}
+		name := names[idx]
 
 		// Don't force load a lazy shard to get nodes status
-		className := i.Config.ClassName.String()
 		if lazy, ok := shard.(*LazyLoadShard); ok {
 			if !lazy.isLoaded() {
-				shardStatus := &models.NodeShardStatus{
+				*status = append(*status, &models.NodeShardStatus{
 					Name:                 name,
 					Class:                className,
 					VectorIndexingStatus: shard.GetStatus().String(),
@@ -214,16 +229,15 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 					ReplicationFactor:    replicationFactor,
 					NumberOfReplicas:     replicasPerShard[name],
 					// don't add compression status as this would trigger loading the shard
-				}
-				*status = append(*status, shardStatus)
+				})
 				shardCount++
-				return nil
+				continue
 			}
 		}
 
 		objectCount, err := shard.ObjectCountAsync(ctx)
 		if err != nil {
-			i.logger.Warnf("error while getting object count for shard %s: %w", shard.Name(), err)
+			i.logger.Warnf("error while getting object count for shard %s: %v", name, err)
 		}
 
 		totalCount += int64(objectCount)
@@ -239,13 +253,7 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 			return nil
 		})
 
-		var compressed bool
-		_ = shard.ForEachVectorIndex(func(_ string, index VectorIndex) error {
-			compressed = compressed || index.Compressed()
-			return nil
-		})
-
-		shardStatus := &models.NodeShardStatus{
+		*status = append(*status, &models.NodeShardStatus{
 			Name:                   name,
 			Class:                  className,
 			ObjectCount:            objectCount,
@@ -256,38 +264,35 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 			AsyncReplicationStatus: shard.getAsyncReplicationStats(ctx),
 			ReplicationFactor:      replicationFactor,
 			NumberOfReplicas:       replicasPerShard[name],
-		}
-		*status = append(*status, shardStatus)
+		})
 		shardCount++
-		return nil
-	})
+	}
 	return totalCount, shardCount
 }
 
-// getShardsReplicationDetails resolves the replication factor and the number of
-// replicas per shard in a single schema read: all shards of an index share the
-// same sharding state, so reading it per shard only contends on the schema lock.
-func (i *Index) getShardsReplicationDetails(shardName string) (int64, map[string]int64) {
+// getShardsReplicationDetails resolves the replication factor and replica count
+// for the given shards in a single schema read. Only the named shards are
+// looked up: for a multi-tenant class state.Physical holds an entry per tenant
+// cluster-wide, so walking it would cost O(all tenants) under the class lock to
+// report on the handful of shards this node hosts.
+func (i *Index) getShardsReplicationDetails(shardNames []string) (int64, map[string]int64) {
 	var replicationFactor int64
-	replicasPerShard := map[string]int64{}
-	class := i.Config.ClassName.String()
-	err := i.schemaReader.Read(class, true, func(class *models.Class, state *sharding.State) error {
+	replicasPerShard := make(map[string]int64, len(shardNames))
+	className := i.Config.ClassName.String()
+	err := i.schemaReader.Read(className, true, func(_ *models.Class, state *sharding.State) error {
 		replicationFactor = state.ReplicationFactor
-		if shardName != "" {
-			numberOfReplicas, err := state.NumberOfReplicas(shardName)
-			if err != nil {
-				return fmt.Errorf("unable to retrieve number of replicas for class %s: %w", class.Class, err)
+		for _, name := range shardNames {
+			physical, ok := state.Physical[name]
+			if !ok {
+				// concurrently deleted tenant; skip rather than fail the index
+				continue
 			}
-			replicasPerShard[shardName] = numberOfReplicas
-			return nil
-		}
-		for name, physical := range state.Physical {
 			replicasPerShard[name] = int64(len(physical.BelongsToNodes))
 		}
 		return nil
 	})
 	if err != nil {
-		i.logger.Errorf("error while getting replication details for class %s: %v", class, err)
+		i.logger.Errorf("error while getting replication details for class %s: %v", className, err)
 	}
 	return replicationFactor, replicasPerShard
 }

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -99,7 +99,7 @@ func (db *DB) LocalNodeStatus(ctx context.Context, className, shardName, output 
 		nodeStats *models.NodeStats
 	)
 	if output == verbosity.OutputVerbose {
-		nodeStats, shards = db.localNodeShardStats(ctx, className, shardName)
+		nodeStats = db.localNodeShardStats(ctx, &shards, className, shardName)
 	}
 
 	clusterHealthStatus := models.NodeStatusStatusHEALTHY
@@ -122,31 +122,12 @@ func (db *DB) LocalNodeStatus(ctx context.Context, className, shardName, output 
 }
 
 func (db *DB) localNodeShardStats(ctx context.Context,
-	className, shardName string,
-) (*models.NodeStats, []*models.NodeShardStatus) {
+	status *[]*models.NodeShardStatus, className, shardName string,
+) *models.NodeStats {
 	var objectCount, shardCount int64
 	if className == "" {
-		// Snapshot the indices rather than holding the index lock while collecting:
-		// collection does I/O per shard and would otherwise block every index
-		// creation and deletion for its entire duration. dropIndex.RLock is taken
-		// under indexLock so an index cannot be dropped once it is in the snapshot.
-		db.indexLock.RLock()
-		indices := make([]*Index, 0, len(db.indices))
-		for name, idx := range db.indices {
-			if idx == nil {
-				db.logger.WithField("action", "local_node_status_for_all").
-					Warningf("no resource found for index %q", name)
-				continue
-			}
-			idx.dropIndex.RLock()
-			indices = append(indices, idx)
-		}
-		db.indexLock.RUnlock()
-		defer func() {
-			for _, idx := range indices {
-				idx.dropIndex.RUnlock()
-			}
-		}()
+		indices, release := db.snapshotIndices()
+		defer release()
 
 		type indexStats struct {
 			objects, shards int64
@@ -158,8 +139,9 @@ func (db *DB) localNodeShardStats(ctx context.Context,
 		eg.SetLimit(_NUMCPU)
 		for i, idx := range indices {
 			eg.Go(func() error {
-				objects, shards, status := idx.getShardsNodeStatus(ctx, shardName)
-				results[i] = indexStats{objects: objects, shards: shards, status: status}
+				var shardsStatus []*models.NodeShardStatus
+				objects, shards := idx.getShardsNodeStatus(ctx, &shardsStatus, shardName)
+				results[i] = indexStats{objects: objects, shards: shards, status: shardsStatus}
 				return nil
 			})
 		}
@@ -167,27 +149,26 @@ func (db *DB) localNodeShardStats(ctx context.Context,
 			db.logger.WithField("action", "local_node_status_for_all").Error(err)
 		}
 
-		var status []*models.NodeShardStatus
 		for _, res := range results {
 			objectCount, shardCount = objectCount+res.objects, shardCount+res.shards
-			status = append(status, res.status...)
+			*status = append(*status, res.status...)
 		}
 		return &models.NodeStats{
 			ObjectCount: objectCount,
 			ShardCount:  shardCount,
-		}, status
+		}
 	}
 	idx := db.GetIndex(schema.ClassName(className))
 	if idx == nil {
 		db.logger.WithField("action", "local_node_status_for_class").
 			Warningf("no index found for class %q", className)
-		return nil, nil
+		return nil
 	}
-	objectCount, shardCount, status := idx.getShardsNodeStatus(ctx, shardName)
+	objectCount, shardCount = idx.getShardsNodeStatus(ctx, status, shardName)
 	return &models.NodeStats{
 		ObjectCount: objectCount,
 		ShardCount:  shardCount,
-	}, status
+	}
 }
 
 func (db *DB) localNodeBatchStats() *models.BatchStats {
@@ -201,13 +182,15 @@ func (db *DB) localNodeBatchStats() *models.BatchStats {
 	return stats
 }
 
-// getShardsNodeStatus returns the status of the index's shards, along with the
-// total object count and the number of shards.
+// getShardsNodeStatus modifies the status slice to include the shard statuses.
 // If shardName is provided, it will only get the status of the specific shard.
 // Otherwise, it will get the status of all shards.
-// If an error occurs, this method may return a partial result.
-func (i *Index) getShardsNodeStatus(ctx context.Context, shardName string,
-) (totalCount, shardCount int64, status []*models.NodeShardStatus) {
+// Returns the total object count and the number of shards.
+// If an error occurs, the status slice may have been modified and this method
+// may return a partial result.
+func (i *Index) getShardsNodeStatus(ctx context.Context,
+	status *[]*models.NodeShardStatus, shardName string,
+) (totalCount, shardCount int64) {
 	replicationFactor, replicasPerShard := i.getShardsReplicationDetails(shardName)
 
 	i.ForEachShard(func(name string, shard ShardLike) error {
@@ -232,7 +215,7 @@ func (i *Index) getShardsNodeStatus(ctx context.Context, shardName string,
 					NumberOfReplicas:     replicasPerShard[name],
 					// don't add compression status as this would trigger loading the shard
 				}
-				status = append(status, shardStatus)
+				*status = append(*status, shardStatus)
 				shardCount++
 				return nil
 			}
@@ -274,17 +257,16 @@ func (i *Index) getShardsNodeStatus(ctx context.Context, shardName string,
 			ReplicationFactor:      replicationFactor,
 			NumberOfReplicas:       replicasPerShard[name],
 		}
-		status = append(status, shardStatus)
+		*status = append(*status, shardStatus)
 		shardCount++
 		return nil
 	})
-	return totalCount, shardCount, status
+	return totalCount, shardCount
 }
 
 // getShardsReplicationDetails resolves the replication factor and the number of
-// replicas per shard in a single schema read. All shards of an index share the
-// same sharding state, so reading it per shard only adds contention on the
-// schema lock. If shardName is set, only that shard is resolved.
+// replicas per shard in a single schema read: all shards of an index share the
+// same sharding state, so reading it per shard only contends on the schema lock.
 func (i *Index) getShardsReplicationDetails(shardName string) (int64, map[string]int64) {
 	var replicationFactor int64
 	replicasPerShard := map[string]int64{}

--- a/adapters/repos/db/nodes_contention_test.go
+++ b/adapters/repos/db/nodes_contention_test.go
@@ -1,0 +1,294 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	replicationTypes "github.com/weaviate/weaviate/cluster/replication/types"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// TestSnapshotIndicesLeavesIndicesDroppable pins that snapshotIndices hands back
+// pointers only. Taking every index's drop lock up front would let a concurrent
+// DeleteIndex block on dropIndex.Lock while holding db.indexLock, stalling every
+// GetIndex in the process for as long as the caller held the snapshot.
+func TestSnapshotIndicesLeavesIndicesDroppable(t *testing.T) {
+	logger, _ := logrustest.NewNullLogger()
+
+	db := &DB{
+		logger: logger,
+		indices: map[string]*Index{
+			"a": {Config: IndexConfig{ClassName: "A"}, logger: logger},
+			"b": {Config: IndexConfig{ClassName: "B"}, logger: logger},
+			"c": nil, // must be skipped, not panic
+		},
+	}
+
+	indices := db.snapshotIndices()
+	require.Len(t, indices, 2)
+
+	for _, idx := range indices {
+		assert.True(t, idx.dropIndex.TryLock(),
+			"snapshotIndices must not hold %s's drop lock", idx.Config.ClassName)
+		idx.dropIndex.Unlock()
+	}
+}
+
+// TestWithDropRLockSkipsClosedIndex covers the window the just-in-time drop lock
+// opens: an index can be dropped between being snapshotted and being used.
+func TestWithDropRLockSkipsClosedIndex(t *testing.T) {
+	logger, _ := logrustest.NewNullLogger()
+
+	tests := []struct {
+		name    string
+		closed  bool
+		wantRun bool
+	}{
+		{name: "live index runs f", closed: false, wantRun: true},
+		{name: "closed index skips f", closed: true, wantRun: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			idx := &Index{Config: IndexConfig{ClassName: "A"}, logger: logger, closed: test.closed}
+
+			var ran bool
+			require.NoError(t, idx.withDropRLock(func() error {
+				ran = true
+				return nil
+			}))
+			assert.Equal(t, test.wantRun, ran)
+
+			assert.True(t, idx.dropIndex.TryLock(), "drop lock must be released either way")
+			idx.dropIndex.Unlock()
+		})
+	}
+}
+
+// TestGetShardsReplicationDetailsScopedToLocalShards pins that the bulk schema
+// read resolves only the shards this node hosts. Walking state.Physical instead
+// would, for a multi-tenant class, copy an entry per tenant cluster-wide.
+func TestGetShardsReplicationDetailsScopedToLocalShards(t *testing.T) {
+	const className = "Multi"
+
+	physical := map[string]sharding.Physical{
+		"local-1": {Name: "local-1", BelongsToNodes: []string{"n1"}},
+		"local-2": {Name: "local-2", BelongsToNodes: []string{"n1", "n2"}},
+		"local-3": {Name: "local-3", BelongsToNodes: []string{"n1", "n2", "n3"}},
+	}
+	for n := range 1000 {
+		name := fmt.Sprintf("remote-%d", n)
+		physical[name] = sharding.Physical{Name: name, BelongsToNodes: []string{"n2"}}
+	}
+	state := &sharding.State{Physical: physical, ReplicationFactor: 3}
+
+	tests := []struct {
+		name       string
+		localNames []string
+		want       map[string]int64
+	}{
+		{
+			name:       "replica counts are per shard, not per class",
+			localNames: []string{"local-1", "local-2", "local-3"},
+			want:       map[string]int64{"local-1": 1, "local-2": 2, "local-3": 3},
+		},
+		{
+			name:       "single shard request resolves only that shard",
+			localNames: []string{"local-2"},
+			want:       map[string]int64{"local-2": 2},
+		},
+		{
+			name:       "shard missing from the sharding state is omitted, not fatal",
+			localNames: []string{"local-1", "vanished"},
+			want:       map[string]int64{"local-1": 1},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			logger, hook := logrustest.NewNullLogger()
+
+			reader := schemaUC.NewMockSchemaReader(t)
+			reader.EXPECT().Read(className, true, mock.Anything).RunAndReturn(
+				func(_ string, _ bool, fn func(*models.Class, *sharding.State) error) error {
+					return fn(&models.Class{Class: className}, state)
+				}).Once()
+
+			idx := &Index{
+				Config:       IndexConfig{ClassName: schema.ClassName(className)},
+				schemaReader: reader,
+				logger:       logger,
+			}
+
+			replicationFactor, replicasPerShard := idx.getShardsReplicationDetails(test.localNames)
+
+			assert.Equal(t, int64(3), replicationFactor)
+			assert.Equal(t, test.want, replicasPerShard,
+				"only the requested local shards may be resolved")
+			assert.Empty(t, hook.AllEntries(), "resolving local shards must not log")
+		})
+	}
+}
+
+// TestNodeStatusDoesNotBlockConcurrentDrop verifies that a slow /nodes gather on
+// one collection does not block a DeleteIndex of a different collection.
+//
+// DeleteIndex takes db.indexLock and then waits on dropIndex.Lock, so a gather
+// holding every index's drop lock for its whole duration stalls the drop, and
+// through db.indexLock every GetIndex in the process.
+func TestNodeStatusDoesNotBlockConcurrentDrop(t *testing.T) {
+	ctx := context.Background()
+	nodeName := "test-node"
+	slowClass := "SlowCollection"
+	droppedClass := "DroppedCollection"
+	shardName := "shard1"
+
+	newClass := func(name string) *models.Class {
+		return &models.Class{
+			Class:               name,
+			ReplicationConfig:   &models.ReplicationConfig{Factor: 1},
+			VectorConfig:        map[string]models.VectorConfig{"vec": {VectorIndexConfig: enthnsw.UserConfig{}}},
+			InvertedIndexConfig: &models.InvertedIndexConfig{CleanupIntervalSeconds: 60},
+		}
+	}
+	classes := map[string]*models.Class{
+		slowClass:    newClass(slowClass),
+		droppedClass: newClass(droppedClass),
+	}
+
+	shardingState := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			shardName: {Name: shardName, BelongsToNodes: []string{nodeName}, Status: models.TenantActivityStatusHOT},
+		},
+		ReplicationFactor: 1,
+	}
+	shardingState.SetLocalName(nodeName)
+
+	// armed only once both indices exist, so class setup is not blocked
+	var armed atomic.Bool
+	gatherReachedSlowClass := make(chan struct{}, 1)
+	releaseSlowClassCh := make(chan struct{})
+	var releaseOnce sync.Once
+	releaseSlowClass := func() { releaseOnce.Do(func() { close(releaseSlowClassCh) }) }
+
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().Read(mock.Anything, mock.Anything, mock.Anything).RunAndReturn(
+		func(class string, _ bool, fn func(*models.Class, *sharding.State) error) error {
+			if armed.Load() && class == slowClass {
+				select {
+				case gatherReachedSlowClass <- struct{}{}:
+				default:
+				}
+				<-releaseSlowClassCh
+			}
+			return fn(classes[class], shardingState)
+		}).Maybe()
+	mockSchemaReader.EXPECT().Shards(mock.Anything).Return(shardingState.AllPhysicalShards(), nil).Maybe()
+	mockSchemaReader.EXPECT().ReadOnlySchema().Return(models.Schema{Classes: nil}).Maybe()
+	mockSchemaReader.EXPECT().LocalShards(mock.Anything).Return([]string{shardName}, nil).Maybe()
+	mockSchemaReader.EXPECT().LocalActiveShardsCount(mock.Anything).Return(1, nil).Maybe()
+	mockSchemaReader.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{nodeName}, nil).Maybe()
+
+	fakeSchema := schema.Schema{Objects: &models.Schema{
+		Classes: []*models.Class{classes[slowClass], classes[droppedClass]},
+	}}
+
+	mockSchemaGetter := schemaUC.NewMockSchemaGetter(t)
+	mockSchemaGetter.EXPECT().GetSchemaSkipAuth().Return(fakeSchema).Maybe()
+	mockSchemaGetter.EXPECT().ReadOnlyClass(mock.Anything).RunAndReturn(
+		func(name string) *models.Class { return classes[name] }).Maybe()
+	mockSchemaGetter.EXPECT().NodeName().Return(nodeName).Maybe()
+	mockSchemaGetter.EXPECT().ClusterHealthScore().Return(0).Maybe()
+	mockSchemaGetter.EXPECT().Nodes().Return([]string{nodeName}).Maybe()
+	mockSchemaGetter.EXPECT().ShardOwner(mock.Anything, mock.Anything).Return(nodeName, nil).Maybe()
+	mockSchemaGetter.EXPECT().ShardReplicas(mock.Anything, mock.Anything).Return([]string{nodeName}, nil).Maybe()
+	mockSchemaGetter.EXPECT().ResolveAlias(mock.Anything).Return("").Maybe()
+	mockSchemaGetter.EXPECT().GetAliasesForClass(mock.Anything).Return(nil).Maybe()
+
+	mockNodeSelector := cluster.NewMockNodeSelector(t)
+	mockNodeSelector.EXPECT().LocalName().Return(nodeName).Maybe()
+	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return(nodeName, true).Maybe()
+	mockReplicationFSMReader := replicationTypes.NewMockReplicationFSMReader(t)
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasRead(mock.Anything, mock.Anything, mock.Anything).Return([]string{nodeName}).Maybe()
+	mockReplicationFSMReader.EXPECT().FilterOneShardReplicasWrite(mock.Anything, mock.Anything, mock.Anything).Return([]string{nodeName}, nil).Maybe()
+
+	logger, _ := logrustest.NewNullLogger()
+	repo, err := New(logger, nodeName, Config{
+		RootPath:                  t.TempDir(),
+		MaxImportGoroutinesFactor: 1,
+	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, &FakeReplicationClient{}, nil,
+		memwatch.NewDummyMonitor(), mockNodeSelector, mockSchemaReader, mockReplicationFSMReader)
+	require.NoError(t, err)
+	repo.SetSchemaGetter(mockSchemaGetter)
+	require.NoError(t, repo.WaitForStartup(ctx))
+	defer func() {
+		releaseSlowClass()
+		repo.Shutdown(ctx)
+	}()
+
+	// both indices are created from the schema during startup
+	require.NotNil(t, repo.GetIndex(schema.ClassName(slowClass)))
+	require.NotNil(t, repo.GetIndex(schema.ClassName(droppedClass)))
+
+	armed.Store(true)
+
+	gatherDone := make(chan struct{})
+	enterrors.GoWrapper(func() {
+		defer close(gatherDone)
+		var shards []*models.NodeShardStatus
+		repo.localNodeShardStats(ctx, &shards, "", "")
+	}, logger)
+
+	select {
+	case <-gatherReachedSlowClass:
+	case <-time.After(10 * time.Second):
+		t.Fatal("gather never reached the slow collection")
+	}
+
+	deleteDone := make(chan error, 1)
+	enterrors.GoWrapper(func() {
+		deleteDone <- repo.DeleteIndex(schema.ClassName(droppedClass))
+	}, logger)
+
+	select {
+	case err := <-deleteDone:
+		require.NoError(t, err)
+	case <-time.After(10 * time.Second):
+		t.Fatal("DeleteIndex is blocked behind an in-flight node status gather on an unrelated collection")
+	}
+
+	releaseSlowClass()
+
+	select {
+	case <-gatherDone:
+	case <-time.After(10 * time.Second):
+		t.Fatal("node status gather did not finish")
+	}
+}

--- a/adapters/repos/db/nodes_integration_test.go
+++ b/adapters/repos/db/nodes_integration_test.go
@@ -262,9 +262,11 @@ func TestLazyLoadedShards(t *testing.T) {
 	require.NoError(t, err)
 
 	// make sure that getting the node status does not trigger loading of lazy shards
-	_, _, status := index.getShardsNodeStatus(ctx, "")
-	_, _, status2 := index.getShardsNodeStatus(ctx, "")
+	status := &[]*models.NodeShardStatus{}
+	index.getShardsNodeStatus(ctx, status, "")
+	status2 := &[]*models.NodeShardStatus{}
+	index.getShardsNodeStatus(ctx, status2, "")
 	require.Equal(t, status, status2)
-	require.Len(t, status, 1)
-	require.False(t, status[0].Loaded)
+	require.Len(t, *status, 1)
+	require.False(t, (*status)[0].Loaded)
 }

--- a/adapters/repos/db/nodes_integration_test.go
+++ b/adapters/repos/db/nodes_integration_test.go
@@ -262,11 +262,9 @@ func TestLazyLoadedShards(t *testing.T) {
 	require.NoError(t, err)
 
 	// make sure that getting the node status does not trigger loading of lazy shards
-	status := &[]*models.NodeShardStatus{}
-	index.getShardsNodeStatus(ctx, status, "")
-	status2 := &[]*models.NodeShardStatus{}
-	index.getShardsNodeStatus(ctx, status2, "")
+	_, _, status := index.getShardsNodeStatus(ctx, "")
+	_, _, status2 := index.getShardsNodeStatus(ctx, "")
 	require.Equal(t, status, status2)
-	require.Len(t, *status, 1)
-	require.False(t, (*status)[0].Loaded)
+	require.Len(t, status, 1)
+	require.False(t, status[0].Loaded)
 }

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -550,11 +550,10 @@ func (db *DB) IndexExists(className schema.ClassName) bool {
 	return db.GetIndex(className) != nil
 }
 
-// snapshotIndices returns every index with its drop lock held, so callers can
-// work on them without holding db.indexLock for the duration. Taking the drop
-// lock under db.indexLock is what keeps a snapshotted index from being dropped
-// while still in use. The returned func releases them.
-func (db *DB) snapshotIndices() ([]*Index, func()) {
+// snapshotIndices copies the index pointers under db.indexLock so callers can
+// iterate them without holding it. The snapshot alone grants no right to use an
+// index: callers MUST wrap every use in (*Index).withDropRLock.
+func (db *DB) snapshotIndices() []*Index {
 	db.indexLock.RLock()
 	defer db.indexLock.RUnlock()
 
@@ -565,15 +564,10 @@ func (db *DB) snapshotIndices() ([]*Index, func()) {
 				Warningf("no resource found for index %q", name)
 			continue
 		}
-		idx.dropIndex.RLock()
 		indices = append(indices, idx)
 	}
 
-	return indices, func() {
-		for _, idx := range indices {
-			idx.dropIndex.RUnlock()
-		}
-	}
+	return indices
 }
 
 // TODO-RAFT: Because of interfaces and import order we can't have this function just return the same index interface

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -550,6 +550,32 @@ func (db *DB) IndexExists(className schema.ClassName) bool {
 	return db.GetIndex(className) != nil
 }
 
+// snapshotIndices returns every index with its drop lock held, so callers can
+// work on them without holding db.indexLock for the duration. Taking the drop
+// lock under db.indexLock is what keeps a snapshotted index from being dropped
+// while still in use. The returned func releases them.
+func (db *DB) snapshotIndices() ([]*Index, func()) {
+	db.indexLock.RLock()
+	defer db.indexLock.RUnlock()
+
+	indices := make([]*Index, 0, len(db.indices))
+	for name, idx := range db.indices {
+		if idx == nil {
+			db.logger.WithField("action", "snapshot_indices").
+				Warningf("no resource found for index %q", name)
+			continue
+		}
+		idx.dropIndex.RLock()
+		indices = append(indices, idx)
+	}
+
+	return indices, func() {
+		for _, idx := range indices {
+			idx.dropIndex.RUnlock()
+		}
+	}
+}
+
 // TODO-RAFT: Because of interfaces and import order we can't have this function just return the same index interface
 // for both sharding and replica usage. With a refactor of the interfaces this can be done and we can remove the
 // deduplication


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline:https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/30539578259
- [x] E2E : https://github.com/weaviate/weaviate-e2e-tests/actions/runs/30539593484
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
