### PR TITLE
fix: closure issue in downloadWorker by capturing loop variable for chunk data

### DIFF
--- a/cluster/replication/copier/copier.go
+++ b/cluster/replication/copier/copier.go
@@ -321,8 +321,10 @@ func (c *Copier) downloadWorker(ctx context.Context, client FileReplicationServi
 					return fmt.Errorf("failed to receive file chunk for %s: %w", meta.FileName, err)
 				}
 				if len(chunk.Data) > 0 {
+					ch := chunk // capture loop variable
+
 					eg.Go(func() error {
-						if _, err := f.WriteAt(chunk.Data, chunk.Offset); err != nil {
+						if _, err := f.WriteAt(ch.Data, ch.Offset); err != nil {
 							return fmt.Errorf("writing chunk to file %q: %w", tmpPath, err)
 						}
 						return nil


### PR DESCRIPTION
### What's being changed:

This pull request addresses a concurrency bug in the `downloadWorker` method of the `Copier` class. The main change ensures that each goroutine correctly captures the current chunk data when writing file chunks concurrently.

Concurrency bug fix:

* In `cluster/replication/copier/copier.go`, the loop variable `chunk` is now captured in a new variable `ch` before being used inside the goroutine, preventing data races and ensuring each goroutine writes the correct chunk to the file.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
