### PR TITLE
fix(memberlist): return configured node name instead of dependency on memberlist

### DIFF
--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -271,6 +271,9 @@ func (s *State) AllHostnames() []string {
 
 // All node names (not their hostnames!) for live members, including self.
 func (s *State) AllNames() []string {
+	if s.list == nil {
+		return []string{}
+	}
 	mem := s.list.Members()
 	out := make([]string, len(mem))
 


### PR DESCRIPTION
### What's being changed:
we have already the local node name to avoid dependency on memberlist because of possible shutdown and dependeancy from usage module could cause panic 

e.g. 
```go
weaviate-1 weaviate panic: runtime error: invalid memory address or nil pointer dereference
weaviate-1 weaviate [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe0981b]
weaviate-1 weaviate 
weaviate-1 weaviate goroutine 14620 [running]:
weaviate-1 weaviate github.com/hashicorp/memberlist.(*Memberlist).LocalNode(0x0?)
weaviate-1 weaviate 	github.com/hashicorp/memberlist@v0.5.2/memberlist.go:504 +0x9b
weaviate-1 weaviate github.com/weaviate/weaviate/usecases/cluster.(*State).LocalName(0xc006c2a840?)
weaviate-1 weaviate 	github.com/weaviate/weaviate/usecases/cluster/state.go:369 +0x1a
weaviate-1 weaviate github.com/weaviate/weaviate/usecases/schema.(*Handler).NodeName(...)
weaviate-1 weaviate 	github.com/weaviate/weaviate/usecases/schema/handler.go:243
weaviate-1 weaviate github.com/weaviate/weaviate/cluster/usage.(*service).Usage(0xc000545300, {0x497b4f0, 0x7ea19a0}, 0x0)
weaviate-1 weaviate 	github.com/weaviate/weaviate/cluster/usage/service.go:72 +0x7e
weaviate-1 weaviate github.com/weaviate/weaviate/usecases/modulecomponents/usage.(*BaseModule).collectUsageData(0xc001466480, {0x497b4f0?, 0x7ea19a0?})
weaviate-1 weaviate 	github.com/weaviate/weaviate/usecases/modulecomponents/usage/base_module.go:263 +0x42
weaviate-1 weaviate github.com/weaviate/weaviate/usecases/modulecomponents/usage.(*BaseModule).collectAndUploadUsage(0xc001466480, {0x497b4f0, 0x7ea19a0})
weaviate-1 weaviate 	github.com/weaviate/weaviate/usecases/modulecomponents/usage/base_module.go:234 +0x245
weaviate-1 weaviate github.com/weaviate/weaviate/usecases/modulecomponents/usage.(*BaseModule).collectAndUploadPeriodically.func1()
weaviate-1 weaviate 	github.com/weaviate/weaviate/usecases/modulecomponents/usage/base_module.go:197 +0x28
weaviate-1 weaviate github.com/weaviate/weaviate/entities/errors.GoWrapper.func1()
weaviate-1 weaviate 	github.com/weaviate/weaviate/entities/errors/go_wrapper.go:36 +0x53
weaviate-1 weaviate created by github.com/weaviate/weaviate/entities/errors.GoWrapper in goroutine 139
weaviate-1 weaviate 	github.com/weaviate/weaviate/entities/errors/go_wrapper.go:26 +0x74
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
