### PR TITLE
chore: change log level from Info to debug for async replication stats updates

### DIFF
--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -743,7 +743,7 @@ func (s *Shard) initHashBeater(ctx context.Context, config asyncReplicationConfi
 									"remote_object_digests_count":     stat.remoteObjectDigestsCount,
 									"local_objects_propagation_count": stat.localObjectsPropagationCount,
 									"local_objects_propagation_took":  stat.localObjectsPropagationTook,
-								}).Info("updating async replication stats")
+								}).Debug("updating async replication stats")
 								s.asyncReplicationStatsByTargetNode[stat.targetNodeName] = stat
 							}
 						}
@@ -809,7 +809,7 @@ func (s *Shard) initHashBeater(ctx context.Context, config asyncReplicationConfi
 							WithField("remote_object_digests_count", stat.remoteObjectDigestsCount).
 							WithField("local_objects_propagation_count", stat.localObjectsPropagationCount).
 							WithField("local_objects_propagation_took", stat.localObjectsPropagationTook).
-							Info("hashbeat iteration successfully completed")
+							Debug("hashbeat iteration successfully completed")
 						if stat.localObjectDigestsCount > 0 {
 							statsHaveObjectsPropagated = true
 						}


### PR DESCRIPTION
### What's being changed:

This pull request makes a minor logging change to the async replication logic in `shard_async_replication.go`. The logging level for two key messages has been lowered from `Info` to `Debug`, which will reduce noise in production logs and make these messages visible only when debug logging is enabled.

Logging changes:

* Changed the log level from `Info` to `Debug` for the message about updating async replication stats in the `initHashBeater` function.
* Changed the log level from `Info` to `Debug` for the message indicating successful completion of a hashbeat iteration in the `initHashBeater` function.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
