### PR TITLE
fix(tenant-offload): frozen tenants activation after onloading

### DIFF
--- a/cluster/schema/meta_class.go
+++ b/cluster/schema/meta_class.go
@@ -386,6 +386,7 @@ func (m *metaClass) UpdateTenants(nodeID string, req *command.UpdateTenantsReque
 			}
 		case types.TenantActivityStatusUNFREEZING:
 			// ignore multiple unfreezing
+			req.ImplicitUpdateRequest = true
 			var statusInProgress string
 			processes, exists := m.ShardProcesses[shardProcessID(req.Tenants[i].Name, command.TenantProcessRequest_ACTION_UNFREEZING)]
 			if exists {

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -19,13 +19,13 @@ import (
 	"sync"
 
 	"github.com/sirupsen/logrus"
-	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"golang.org/x/exp/slices"
 
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 )
 
 var _NUMCPU = runtime.GOMAXPROCS(0)
@@ -287,7 +287,7 @@ func (e *executor) UpdateTenantsProcess(class string, req *api.TenantProcessRequ
 		})
 	}
 
-	if err := e.migrator.UpdateTenants(ctx, cls, updates, false); err != nil {
+	if err := e.migrator.UpdateTenants(ctx, cls, updates, true); err != nil {
 		e.logger.WithFields(logrus.Fields{
 			"action":     "update_tenants_process",
 			"sub-action": "update_tenants",


### PR DESCRIPTION
### What's being changed:
[there was a change back in June added shards implicit activation flag ](https://github.com/weaviate/weaviate/commit/df90b890952b087049b1f3294fa91fa5d6f989db)and this is the root cause because shards were getting downloaded from s3 but not activated as results and that what lead to tenant offload flakiness 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
