### PR TITLE
feat(text2vec-transformers): add native batch vectorization

### DIFF
--- a/modules/text2vec-transformers/clients/batch.go
+++ b/modules/text2vec-transformers/clients/batch.go
@@ -1,0 +1,216 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	txvectorizer "github.com/weaviate/weaviate/modules/text2vec-transformers/vectorizer"
+	"github.com/weaviate/weaviate/usecases/modulecomponents"
+	"github.com/weaviate/weaviate/usecases/modulecomponents/clients/transformers"
+)
+
+const (
+	readyEndpoint = "/.well-known/ready"
+	metaEndpoint  = "/meta"
+)
+
+// BatchVectorizer implements batchtext.Client interface for batch vectorization.
+// This is a separate struct to avoid method signature conflicts with the legacy vectorizer.
+type BatchVectorizer struct {
+	originPassage string
+	originQuery   string
+	client        *transformers.Client
+	urlBuilder    *transformers.URLBuilder
+	logger        logrus.FieldLogger
+}
+
+// NewBatchVectorizer creates a new batch-capable vectorizer client.
+func NewBatchVectorizer(originPassage, originQuery string, timeout time.Duration, logger logrus.FieldLogger) *BatchVectorizer {
+	urlBuilder := transformers.NewURLBuilder(originPassage, originQuery)
+	return &BatchVectorizer{
+		originPassage: originPassage,
+		originQuery:   originQuery,
+		urlBuilder:    urlBuilder,
+		client:        transformers.New(urlBuilder, timeout, logger),
+		logger:        logger,
+	}
+}
+
+// Vectorize implements batchtext.Client interface.
+// Sends all input texts in a single HTTP request for passage/document vectorization.
+func (b *BatchVectorizer) Vectorize(ctx context.Context, input []string,
+	cfg moduletools.ClassConfig,
+) (*modulecomponents.VectorizationResult[[]float32], *modulecomponents.RateLimits, int, error) {
+	config := b.getVectorizationConfig(cfg)
+	vectors, err := b.client.VectorizeObjects(ctx, input, config)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	return &modulecomponents.VectorizationResult[[]float32]{
+		Text:   input,
+		Vector: vectors,
+	}, nil, 0, nil
+}
+
+// VectorizeQuery implements batchtext.Client interface.
+// Sends all input texts in a single HTTP request for query vectorization.
+func (b *BatchVectorizer) VectorizeQuery(ctx context.Context, input []string,
+	cfg moduletools.ClassConfig,
+) (*modulecomponents.VectorizationResult[[]float32], error) {
+	config := b.getVectorizationConfig(cfg)
+	vectors, err := b.client.VectorizeQueries(ctx, input, config)
+	if err != nil {
+		return nil, err
+	}
+	return &modulecomponents.VectorizationResult[[]float32]{
+		Text:   input,
+		Vector: vectors,
+	}, nil
+}
+
+// getVectorizationConfig extracts the transformers config from ClassConfig.
+func (b *BatchVectorizer) getVectorizationConfig(cfg moduletools.ClassConfig) transformers.VectorizationConfig {
+	icheck := txvectorizer.NewClassSettings(cfg)
+	return transformers.VectorizationConfig{
+		PoolingStrategy:     icheck.PoolingStrategy(),
+		InferenceURL:        icheck.InferenceURL(),
+		PassageInferenceURL: icheck.PassageInferenceURL(),
+		QueryInferenceURL:   icheck.QueryInferenceURL(),
+		Dimensions:          icheck.Dimensions(),
+	}
+}
+
+// WaitForStartup waits for the inference server(s) to be ready.
+func (b *BatchVectorizer) WaitForStartup(initCtx context.Context, interval time.Duration) error {
+	endpoints := map[string]string{}
+	if b.originPassage != b.originQuery {
+		endpoints["passage"] = b.urlBuilder.GetPassageURL(readyEndpoint, transformers.VectorizationConfig{})
+		endpoints["query"] = b.urlBuilder.GetQueryURL(readyEndpoint, transformers.VectorizationConfig{})
+	} else {
+		endpoints[""] = b.urlBuilder.GetPassageURL(readyEndpoint, transformers.VectorizationConfig{})
+	}
+
+	ch := make(chan error, len(endpoints))
+	var wg sync.WaitGroup
+	for serviceName, endpoint := range endpoints {
+		serviceName, endpoint := serviceName, endpoint
+		wg.Add(1)
+		enterrors.GoWrapper(func() {
+			defer wg.Done()
+			if err := b.waitFor(initCtx, interval, endpoint, serviceName); err != nil {
+				ch <- err
+			}
+		}, b.logger)
+	}
+	wg.Wait()
+	close(ch)
+
+	if len(ch) > 0 {
+		var errs []string
+		for err := range ch {
+			errs = append(errs, err.Error())
+		}
+		return errors.New(strings.Join(errs, ", "))
+	}
+	return nil
+}
+
+func (b *BatchVectorizer) waitFor(initCtx context.Context, interval time.Duration, endpoint string, serviceName string) error {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	expired := initCtx.Done()
+	var lastErr error
+	prefix := ""
+	if serviceName != "" {
+		prefix = "[" + serviceName + "] "
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			lastErr = b.client.CheckReady(initCtx, endpoint)
+			if lastErr == nil {
+				return nil
+			}
+			b.logger.
+				WithField("action", "transformer_remote_wait_for_startup").
+				WithError(lastErr).Warnf("%stransformer remote inference service not ready", prefix)
+		case <-expired:
+			return errors.Wrapf(lastErr, "%sinit context expired before remote was ready", prefix)
+		}
+	}
+}
+
+// MetaInfo returns metadata about the inference server(s).
+func (b *BatchVectorizer) MetaInfo() (map[string]interface{}, error) {
+	type nameMetaErr struct {
+		name string
+		meta map[string]any
+		err  error
+	}
+
+	endpoints := map[string]string{}
+	if b.originPassage != b.originQuery {
+		endpoints["passage"] = b.urlBuilder.GetPassageURL(metaEndpoint, transformers.VectorizationConfig{})
+		endpoints["query"] = b.urlBuilder.GetQueryURL(metaEndpoint, transformers.VectorizationConfig{})
+	} else {
+		endpoints[""] = b.urlBuilder.GetPassageURL(metaEndpoint, transformers.VectorizationConfig{})
+	}
+
+	var wg sync.WaitGroup
+	ch := make(chan nameMetaErr, len(endpoints))
+	for serviceName, endpoint := range endpoints {
+		serviceName, endpoint := serviceName, endpoint
+		wg.Add(1)
+		enterrors.GoWrapper(func() {
+			defer wg.Done()
+			meta, err := b.client.MetaInfo(endpoint)
+			ch <- nameMetaErr{serviceName, meta, err}
+		}, b.logger)
+	}
+	wg.Wait()
+	close(ch)
+
+	metas := map[string]interface{}{}
+	var errs []string
+	for nme := range ch {
+		if nme.err != nil {
+			prefix := ""
+			if nme.name != "" {
+				prefix = "[" + nme.name + "] "
+			}
+			errs = append(errs, fmt.Sprintf("%s%v", prefix, nme.err.Error()))
+		}
+		if nme.meta != nil {
+			metas[nme.name] = nme.meta
+		}
+	}
+
+	if len(errs) > 0 {
+		return nil, errors.New(strings.Join(errs, ", "))
+	}
+	if len(metas) == 1 {
+		for _, meta := range metas {
+			return meta.(map[string]any), nil
+		}
+	}
+	return metas, nil
+}

--- a/modules/text2vec-transformers/clients/batch_test.go
+++ b/modules/text2vec-transformers/clients/batch_test.go
@@ -1,0 +1,176 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2025 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchVectorizer(t *testing.T) {
+	t.Run("when vectorizing batch of texts", func(t *testing.T) {
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			assert.Equal(t, "/vectors", r.URL.Path)
+			assert.Equal(t, http.MethodPost, r.Method)
+
+			var req struct {
+				Texts  []string `json:"texts"`
+				Config struct {
+					PoolingStrategy string `json:"pooling_strategy"`
+					TaskType        string `json:"task_type"`
+				} `json:"config"`
+			}
+			err := json.NewDecoder(r.Body).Decode(&req)
+			require.NoError(t, err)
+
+			assert.Len(t, req.Texts, 3)
+			assert.Equal(t, "passage", req.Config.TaskType)
+
+			vectors := make([][]float32, len(req.Texts))
+			for i := range vectors {
+				vectors[i] = []float32{float32(i) * 0.1, float32(i) * 0.2, float32(i) * 0.3}
+			}
+
+			json.NewEncoder(w).Encode(map[string]any{
+				"vectors": vectors,
+				"dims":    3,
+			})
+		}))
+		defer server.Close()
+
+		client := NewBatchVectorizer(server.URL, server.URL, 30*time.Second, nullLogger())
+
+		result, _, _, err := client.Vectorize(context.Background(),
+			[]string{"hello", "world", "test"}, nil)
+
+		require.NoError(t, err)
+		assert.Len(t, result.Vector, 3)
+		assert.Equal(t, 1, requestCount, "should make exactly 1 HTTP request for batch")
+	})
+
+	t.Run("when vectorizing queries", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			var req struct {
+				Texts  []string `json:"texts"`
+				Config struct {
+					TaskType string `json:"task_type"`
+				} `json:"config"`
+			}
+			json.NewDecoder(r.Body).Decode(&req)
+
+			assert.Equal(t, "query", req.Config.TaskType)
+
+			vectors := make([][]float32, len(req.Texts))
+			for i := range vectors {
+				vectors[i] = []float32{0.1, 0.2, 0.3}
+			}
+
+			json.NewEncoder(w).Encode(map[string]any{
+				"vectors": vectors,
+				"dims":    3,
+			})
+		}))
+		defer server.Close()
+
+		client := NewBatchVectorizer(server.URL, server.URL, 30*time.Second, nullLogger())
+
+		result, err := client.VectorizeQuery(context.Background(),
+			[]string{"search query"}, nil)
+
+		require.NoError(t, err)
+		assert.Len(t, result.Vector, 1)
+	})
+
+	t.Run("when input is empty", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			json.NewEncoder(w).Encode(map[string]any{
+				"vectors": [][]float32{},
+				"dims":    3,
+			})
+		}))
+		defer server.Close()
+
+		client := NewBatchVectorizer(server.URL, server.URL, 30*time.Second, nullLogger())
+
+		result, _, _, err := client.Vectorize(context.Background(), []string{}, nil)
+
+		require.NoError(t, err)
+		assert.Empty(t, result.Vector)
+	})
+
+	t.Run("when server returns error", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			json.NewEncoder(w).Encode(map[string]any{
+				"error": "model inference failed",
+			})
+		}))
+		defer server.Close()
+
+		client := NewBatchVectorizer(server.URL, server.URL, 30*time.Second, nullLogger())
+
+		_, _, _, err := client.Vectorize(context.Background(),
+			[]string{"test"}, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "500")
+	})
+
+	t.Run("when context is cancelled", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			time.Sleep(100 * time.Millisecond)
+			json.NewEncoder(w).Encode(map[string]any{
+				"vectors": [][]float32{{0.1, 0.2}},
+				"dims":    2,
+			})
+		}))
+		defer server.Close()
+
+		client := NewBatchVectorizer(server.URL, server.URL, 30*time.Second, nullLogger())
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+		defer cancel()
+
+		_, _, _, err := client.Vectorize(ctx, []string{"test"}, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "context")
+	})
+
+	t.Run("when vector count mismatch", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Return fewer vectors than requested
+			json.NewEncoder(w).Encode(map[string]any{
+				"vectors": [][]float32{{0.1, 0.2}},
+				"dims":    2,
+			})
+		}))
+		defer server.Close()
+
+		client := NewBatchVectorizer(server.URL, server.URL, 30*time.Second, nullLogger())
+
+		_, _, _, err := client.Vectorize(context.Background(),
+			[]string{"text1", "text2", "text3"}, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "expected 3 vectors")
+	})
+}


### PR DESCRIPTION
## Summary

- Replace sequential HTTP calls with native batch vectorization for `text2vec-transformers`
- Follow the `batchtext` pattern used by `text2vec-ollama` for consistency
- Use `batch.VectorizeBatchObjects` helper for proper batching, parallelization, and error isolation

## Problem

Previously, `VectorizeBatch` made **N HTTP requests** (one per object):

```go
// Old implementation
for i, obj := range objs {
    vec, _, err := m.vectorizer.Object(ctx, obj, cfg)  // 1 HTTP call per object
    vecs[i] = vec
}
```

## Solution

Now uses native batch HTTP requests with `{"texts": [...]}` format:
- 100 objects -> ~4 HTTP calls (batch size 32) instead of 100
- ~96% reduction in network round-trips

## Changes

| File | Change |
|------|--------|
| `usecases/.../transformers/transformers.go` | Add `VectorizeObjects()` and `VectorizeQueries()` batch methods |
| `modules/.../clients/batch.go` | **NEW** - `BatchVectorizer` implementing `batchtext.Client` |
| `modules/.../clients/batch_test.go` | **NEW** - Unit tests (6 test cases) |
| `modules/.../module.go` | Use `batchtext.New()` + `batch.VectorizeBatchObjects` |

## Requirements

Requires an inference server that supports batch format:

**Request:**
```json
POST /vectors
{"texts": ["text1", "text2", ...], "config": {"pooling_strategy": "masked_mean"}}
```

**Response:**
```json
{"vectors": [[...], [...], ...], "dims": 384}
```

## Test plan

- [x] `go build ./modules/text2vec-transformers/...`
- [x] `go test ./modules/text2vec-transformers/...` - All existing tests pass
- [x] `go test ./usecases/modulecomponents/clients/transformers/...` - All tests pass
- [x] New unit tests for `BatchVectorizer` (6 test cases)
- [x] `go vet` - No issues
- [x] Manual integration test with batch-capable inference server

## Backward Compatibility

- No changes to existing `vectorizer/` code
- No changes to `clients/transformers.go` (legacy client)

> **Note:** Requires an inference server that supports the batch format. Standard `t2v-transformers` images will need to be updated to support the `{"texts": [...]}` request format.
