### PR TITLE
hfresh: limit the size of HFresh's queue chunks

### DIFF
--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -29,6 +29,13 @@ const (
 	taskQueueReassignOp
 )
 
+// limit the size of each task chunk to
+// to avoid sending too many tasks at once.
+const (
+	mainTaskQueueChunkSize  = 128 * 1024 // 128KB
+	mergeTaskQueueChunkSize = 64 * 1024  // 64KB
+)
+
 type TaskQueue struct {
 	// queue for split and reassign operations
 	q *queue.DiskQueue
@@ -61,6 +68,7 @@ func NewTaskQueue(index *HFresh) (*TaskQueue, error) {
 			Dir:              filepath.Join(index.config.RootPath, fmt.Sprintf("%s.queue.d", index.config.ID)),
 			TaskDecoder:      &tq,
 			OnBatchProcessed: tq.OnBatchProcessed,
+			ChunkSize:        mainTaskQueueChunkSize,
 		},
 	)
 	if err != nil {
@@ -80,6 +88,7 @@ func NewTaskQueue(index *HFresh) (*TaskQueue, error) {
 			Dir:              filepath.Join(index.config.RootPath, fmt.Sprintf("%s.merge.queue.d", index.config.ID)),
 			TaskDecoder:      &tq,
 			OnBatchProcessed: tq.OnBatchProcessed,
+			ChunkSize:        mergeTaskQueueChunkSize,
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
### What's being changed:

This reduces the size of the chunks of HFresh queues to reduce the number of tasks we send at a time to the workers.
The smaller the chunk, the less CPU time the queues will hoard, this will allow other queues (e.g. vector queue) to execute more often.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
