### PR TITLE
chore(log): change broadcast log level to warn

### DIFF
--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -124,7 +124,7 @@ func (c *coordinator[T]) broadcast(ctx context.Context,
 		actives := make([]_Result[string], 0, level) // cache for active replicas
 		for r := range prepare() {
 			if r.Err != nil { // connection error
-				c.log.WithField("op", "broadcast").Error(r.Err)
+				c.log.WithField("op", "broadcast").Warn(r.Err)
 				continue
 			}
 


### PR DESCRIPTION
### What's being changed:
this error is not actionable and logged twice, instead of logging it as Error it will be decreased to Warn 
eventually will be logged here 
e.g. https://github.com/weaviate/weaviate/blob/stable/v1.31/usecases/replica/replicator.go#L125

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
