### PR TITLE
Fix EC and blocking of `SyncShard`

### DIFF
--- a/cluster/schema/manager.go
+++ b/cluster/schema/manager.go
@@ -509,17 +509,15 @@ func (s *SchemaManager) SyncShard(cmd *command.ApplyRequest, schemaOnly bool) er
 
 	var physical *sharding.Physical
 	var partitioningEnabled bool
-	err := s.NewSchemaReader().retry(func(*schema) error {
-		return s.schema.Read(req.Collection, true, func(class *models.Class, state *sharding.State) error {
-			p, ok := state.Physical[req.Shard]
-			if !ok {
-				// no physical, leave var as nil
-				return nil
-			}
-			physical = &p
-			partitioningEnabled = state.PartitioningEnabled
+	err := s.NewSchemaReader().Read(req.Collection, true, func(class *models.Class, state *sharding.State) error {
+		partitioningEnabled = state.PartitioningEnabled
+		p, ok := state.Physical[req.Shard]
+		if !ok {
+			// no physical, leave var as nil
 			return nil
-		})
+		}
+		physical = &p
+		return nil
 	})
 	if err != nil {
 		return fmt.Errorf("read schema for sync shard: %w", err)


### PR DESCRIPTION
### What's being changed:

- Retry schema read incase of class not found EC issue
- Pull physical outside of `updateStore` to avoid blocking `meta.RLockGuard` by `db` ops

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
