### PR TITLE
chore: enable gzip compression for gRPC calls in file copy service

### DIFF
--- a/adapters/handlers/rest/clusterapi/grpc/server.go
+++ b/adapters/handlers/rest/clusterapi/grpc/server.go
@@ -34,8 +34,10 @@ type Server struct {
 }
 
 const (
-	PB_OVERHEAD      = 16 * 1024       // 16kB for any extra overhead
-	DEFAULT_MSG_SIZE = 4 * 1024 * 1024 // 4MB default from grpc
+	PB_OVERHEAD       = 16 * 1024       // 16kB for any extra overhead
+	DEFAULT_MSG_SIZE  = 4 * 1024 * 1024 // 4MB default from grpc
+	READ_BUFFER_SIZE  = 4 << 20         // 4 MB
+	WRITE_BUFFER_SIZE = 4 << 20         // 4 MB
 )
 
 // NewServer creates *grpc.Server with optional grpc.Serveroption passed.
@@ -50,8 +52,8 @@ func NewServer(state *state.State, options ...grpc.ServerOption) *Server {
 		grpc.MaxSendMsgSize(maxSize),
 		grpc.InitialWindowSize(int32(maxSize)),
 		grpc.InitialConnWindowSize(int32(initialConnWindowSize)),
-		grpc.ReadBufferSize(4 << 20),  // 4 MB
-		grpc.WriteBufferSize(4 << 20), // 4 MB
+		grpc.ReadBufferSize(READ_BUFFER_SIZE),
+		grpc.WriteBufferSize(WRITE_BUFFER_SIZE),
 	}
 
 	basicAuth := state.ServerConfig.Config.Cluster.AuthConfig.BasicAuth

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -535,8 +535,8 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 			),
 			grpc.WithInitialWindowSize(int32(maxSize)),
 			grpc.WithInitialConnWindowSize(int32(initialConnWindowSize)),
-			grpc.WithReadBufferSize(4<<20),  // 4 MB
-			grpc.WithWriteBufferSize(4<<20), // 4 MB
+			grpc.WithReadBufferSize(clusterapigrpc.READ_BUFFER_SIZE),
+			grpc.WithWriteBufferSize(clusterapigrpc.WRITE_BUFFER_SIZE),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create gRPC client connection: %w", err)


### PR DESCRIPTION
### What's being changed:

This pull request introduces gzip compression for gRPC calls. The main changes ensure that gRPC communication between services uses gzip compression by default, which can help reduce bandwidth usage and improve performance for large messages.

gRPC Compression Improvements:

* Added the `gzip` encoding package to the imports in `configure_api.go` to enable gzip support for gRPC.
* Updated the gRPC dial options in `MakeAppState` to use gzip compression for all outgoing calls by default.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
