### PR TITLE
Make sure that grpc server is always closed even if rest server fails to close

### DIFF
--- a/adapters/handlers/rest/clusterapi/serve.go
+++ b/adapters/handlers/rest/clusterapi/serve.go
@@ -23,6 +23,7 @@ import (
 	sentryhttp "github.com/getsentry/sentry-go/http"
 
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 
 	"github.com/weaviate/weaviate/adapters/handlers/rest/raft"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
@@ -159,16 +160,28 @@ func (s *Server) Close(ctx context.Context) error {
 		}
 	}
 
-	// Now shutdown the HTTP server after the replicated indices have been closed
-	if err := s.server.Shutdown(ctx); err != nil {
-		s.appState.Logger.WithField("action", "cluster_api_shutdown").
-			WithError(err).
-			Error("could not stop server gracefully")
-		return s.server.Close()
-	}
-	// Finally, stop the gRPC server
-	s.grpc.GracefulStop()
-	return nil
+	// Now shutdown the servers after the replicated indices have been closed
+	eg := enterrors.NewErrorGroupWrapper(s.appState.Logger)
+	eg.Go(func() error {
+		if err := s.server.Shutdown(ctx); err != nil {
+			s.appState.Logger.WithField("action", "cluster_api_shutdown").
+				WithError(err).
+				Error("could not stop server gracefully")
+			return s.server.Close()
+		}
+		return nil
+	})
+	eg.Go(func() error {
+		if err := s.grpc.Close(ctx); err != nil {
+			s.appState.Logger.WithField("action", "cluster_api_shutdown").
+				WithError(err).
+				Error("could not stop grpc server gracefully")
+			return err
+		}
+		return nil
+	})
+
+	return eg.Wait()
 }
 
 // Serve is kept for backward compatibility


### PR DESCRIPTION
### What's being changed:

Previously, if the internal rest server fails to close properly then the grpc server wouldn't be closed leading to resource usage leakage, i.e. ports held open by zombie processes

Now, the grpc clusterapi server will always be closed regardless of whether the rest clusterapi server closed successfully

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
