### PR TITLE
refact(replication): introduce replication error pkg and unify erroring

### DIFF
--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -30,6 +30,7 @@ import (
 	grpcconn "github.com/weaviate/weaviate/grpc/conn"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
@@ -513,10 +514,10 @@ func protoToSimpleResponse(r *protocol.SimpleReplicaResponse) replica.SimpleResp
 	if r == nil {
 		return replica.SimpleResponse{}
 	}
-	errs := make([]replica.Error, len(r.GetErrors()))
+	errs := make([]replicaerrors.Error, len(r.GetErrors()))
 	for i, e := range r.GetErrors() {
-		errs[i] = replica.Error{
-			Code: replica.StatusCode(e.GetCode()),
+		errs[i] = replicaerrors.Error{
+			Code: replicaerrors.StatusCode(e.GetCode()),
 			Msg:  e.GetMsg(),
 		}
 	}

--- a/adapters/clients/replication_grpc_test.go
+++ b/adapters/clients/replication_grpc_test.go
@@ -34,6 +34,7 @@ import (
 	grpcconn "github.com/weaviate/weaviate/grpc/conn"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/credentials/insecure"
@@ -161,7 +162,7 @@ func (f *fakeGRPCReplicationServer) Commit(_ context.Context, req *pb.CommitRequ
 		}
 		return &pb.CommitResponse{Payload: f.commitPayload}, nil
 	case RequestError:
-		payload, _ := json.Marshal(replica.SimpleResponse{Errors: []replica.Error{{Msg: "error"}}})
+		payload, _ := json.Marshal(replica.SimpleResponse{Errors: []replicaerrors.Error{{Msg: "error"}}})
 		return &pb.CommitResponse{Payload: payload}, nil
 	case RequestMalFormedResponse:
 		return &pb.CommitResponse{Payload: []byte(`not valid json`)}, nil
@@ -317,7 +318,7 @@ func TestGRPCReplicationPutObject(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		resp, err := client.PutObject(ctx, "passthrough:bufnet", "C1", "S1", RequestError, obj, 0)
 		assert.Nil(t, err)
-		assert.Equal(t, replica.SimpleResponse{Errors: []replica.Error{{Msg: "error"}}}, resp)
+		assert.Equal(t, replica.SimpleResponse{Errors: []replicaerrors.Error{{Msg: "error"}}}, resp)
 	})
 
 	t.Run("ServerInternalError", func(t *testing.T) {
@@ -364,7 +365,7 @@ func TestGRPCReplicationPutObjects(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		resp, err := client.PutObjects(ctx, "passthrough:bufnet", "C1", "S1", RequestError, objs, 123)
 		assert.Nil(t, err)
-		assert.Equal(t, replica.SimpleResponse{Errors: []replica.Error{{Msg: "error"}}}, resp)
+		assert.Equal(t, replica.SimpleResponse{Errors: []replicaerrors.Error{{Msg: "error"}}}, resp)
 	})
 
 	t.Run("ServerInternalError", func(t *testing.T) {
@@ -401,7 +402,7 @@ func TestGRPCReplicationMergeObject(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		resp, err := client.MergeObject(ctx, "passthrough:bufnet", "C1", "S1", RequestError, doc, 0)
 		assert.Nil(t, err)
-		assert.Equal(t, replica.SimpleResponse{Errors: []replica.Error{{Msg: "error"}}}, resp)
+		assert.Equal(t, replica.SimpleResponse{Errors: []replicaerrors.Error{{Msg: "error"}}}, resp)
 	})
 
 	t.Run("ServerInternalError", func(t *testing.T) {
@@ -439,7 +440,7 @@ func TestGRPCReplicationDeleteObject(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		resp, err := client.DeleteObject(ctx, "passthrough:bufnet", "C1", "S1", RequestError, uuid, deletionTime, 0)
 		assert.Nil(t, err)
-		assert.Equal(t, replica.SimpleResponse{Errors: []replica.Error{{Msg: "error"}}}, resp)
+		assert.Equal(t, replica.SimpleResponse{Errors: []replicaerrors.Error{{Msg: "error"}}}, resp)
 	})
 
 	t.Run("ServerInternalError", func(t *testing.T) {
@@ -477,7 +478,7 @@ func TestGRPCReplicationDeleteObjects(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		resp, err := client.DeleteObjects(ctx, "passthrough:bufnet", "C1", "S1", RequestError, uuids, deletionTime, false, 123)
 		assert.Nil(t, err)
-		assert.Equal(t, replica.SimpleResponse{Errors: []replica.Error{{Msg: "error"}}}, resp)
+		assert.Equal(t, replica.SimpleResponse{Errors: []replicaerrors.Error{{Msg: "error"}}}, resp)
 	})
 
 	t.Run("ServerInternalError", func(t *testing.T) {
@@ -514,7 +515,7 @@ func TestGRPCReplicationAddReferences(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		resp, err := client.AddReferences(ctx, "passthrough:bufnet", "C1", "S1", RequestError, refs, 0)
 		assert.Nil(t, err)
-		assert.Equal(t, replica.SimpleResponse{Errors: []replica.Error{{Msg: "error"}}}, resp)
+		assert.Equal(t, replica.SimpleResponse{Errors: []replicaerrors.Error{{Msg: "error"}}}, resp)
 	})
 
 	t.Run("ServerInternalError", func(t *testing.T) {
@@ -551,7 +552,7 @@ func TestGRPCReplicationCommit(t *testing.T) {
 		resp := replica.SimpleResponse{}
 		err := client.Commit(ctx, "passthrough:bufnet", "C1", "S1", RequestError, &resp)
 		assert.Nil(t, err)
-		assert.Equal(t, replica.SimpleResponse{Errors: []replica.Error{{Msg: "error"}}}, resp)
+		assert.Equal(t, replica.SimpleResponse{Errors: []replicaerrors.Error{{Msg: "error"}}}, resp)
 	})
 
 	t.Run("DecodeResponse", func(t *testing.T) {
@@ -587,7 +588,7 @@ func TestGRPCReplicationAbort(t *testing.T) {
 	t.Run("Error", func(t *testing.T) {
 		resp, err := client.Abort(ctx, "passthrough:bufnet", "C1", "S1", RequestError)
 		assert.Nil(t, err)
-		assert.Equal(t, replica.SimpleResponse{Errors: []replica.Error{{Msg: "error"}}}, resp)
+		assert.Equal(t, replica.SimpleResponse{Errors: []replicaerrors.Error{{Msg: "error"}}}, resp)
 	})
 
 	t.Run("ServerInternalError", func(t *testing.T) {

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -35,7 +35,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
@@ -65,7 +65,7 @@ func newFakeReplicationServer(t *testing.T, method, path string, schemaVersion u
 	return &fakeServer{
 		method:                method,
 		path:                  path,
-		RequestError:          replica.SimpleResponse{Errors: []rplicaerrors.Error{{Msg: "error"}}},
+		RequestError:          replica.SimpleResponse{Errors: []replicaerrors.Error{{Msg: "error"}}},
 		RequestSuccess:        replica.SimpleResponse{},
 		ExpectedSchemaVersion: fmt.Sprint(schemaVersion),
 	}
@@ -207,7 +207,7 @@ func TestReplicationPutObjects(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	fs := newFakeReplicationServer(t, http.MethodPost, "/replicas/indices/C1/shards/S1/objects", 123)
-	fs.RequestError.Errors = append(fs.RequestError.Errors, rplicaerrors.Error{Msg: "error2"})
+	fs.RequestError.Errors = append(fs.RequestError.Errors, replicaerrors.Error{Msg: "error2"})
 	ts := fs.server(t)
 	defer ts.Close()
 
@@ -289,7 +289,7 @@ func TestReplicationAddReferences(t *testing.T) {
 
 	ctx := context.Background()
 	fs := newFakeReplicationServer(t, http.MethodPost, "/replicas/indices/C1/shards/S1/objects/references", 0)
-	fs.RequestError.Errors = append(fs.RequestError.Errors, rplicaerrors.Error{Msg: "error2"})
+	fs.RequestError.Errors = append(fs.RequestError.Errors, replicaerrors.Error{Msg: "error2"})
 	ts := fs.server(t)
 	defer ts.Close()
 
@@ -325,7 +325,7 @@ func TestReplicationDeleteObjects(t *testing.T) {
 
 	ctx := context.Background()
 	fs := newFakeReplicationServer(t, http.MethodDelete, "/replicas/indices/C1/shards/S1/objects", 0)
-	fs.RequestError.Errors = append(fs.RequestError.Errors, rplicaerrors.Error{Msg: "error2"})
+	fs.RequestError.Errors = append(fs.RequestError.Errors, replicaerrors.Error{Msg: "error2"})
 	ts := fs.server(t)
 	defer ts.Close()
 	client := newReplicationClient(t, ts.Client())

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
@@ -64,7 +65,7 @@ func newFakeReplicationServer(t *testing.T, method, path string, schemaVersion u
 	return &fakeServer{
 		method:                method,
 		path:                  path,
-		RequestError:          replica.SimpleResponse{Errors: []replica.Error{{Msg: "error"}}},
+		RequestError:          replica.SimpleResponse{Errors: []rplicaerrors.Error{{Msg: "error"}}},
 		RequestSuccess:        replica.SimpleResponse{},
 		ExpectedSchemaVersion: fmt.Sprint(schemaVersion),
 	}
@@ -206,7 +207,7 @@ func TestReplicationPutObjects(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
 	fs := newFakeReplicationServer(t, http.MethodPost, "/replicas/indices/C1/shards/S1/objects", 123)
-	fs.RequestError.Errors = append(fs.RequestError.Errors, replica.Error{Msg: "error2"})
+	fs.RequestError.Errors = append(fs.RequestError.Errors, rplicaerrors.Error{Msg: "error2"})
 	ts := fs.server(t)
 	defer ts.Close()
 
@@ -288,7 +289,7 @@ func TestReplicationAddReferences(t *testing.T) {
 
 	ctx := context.Background()
 	fs := newFakeReplicationServer(t, http.MethodPost, "/replicas/indices/C1/shards/S1/objects/references", 0)
-	fs.RequestError.Errors = append(fs.RequestError.Errors, replica.Error{Msg: "error2"})
+	fs.RequestError.Errors = append(fs.RequestError.Errors, rplicaerrors.Error{Msg: "error2"})
 	ts := fs.server(t)
 	defer ts.Close()
 
@@ -324,7 +325,7 @@ func TestReplicationDeleteObjects(t *testing.T) {
 
 	ctx := context.Background()
 	fs := newFakeReplicationServer(t, http.MethodDelete, "/replicas/indices/C1/shards/S1/objects", 0)
-	fs.RequestError.Errors = append(fs.RequestError.Errors, replica.Error{Msg: "error2"})
+	fs.RequestError.Errors = append(fs.RequestError.Errors, rplicaerrors.Error{Msg: "error2"})
 	ts := fs.server(t)
 	defer ts.Close()
 	client := newReplicationClient(t, ts.Client())

--- a/adapters/handlers/grpc/v1/batch/worker.go
+++ b/adapters/handlers/grpc/v1/batch/worker.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 const (
@@ -99,7 +99,7 @@ func StartBatchWorkers(
 }
 
 func (w *worker) isTransientReplicationError(err string) bool {
-	return strings.Contains(err, rplicaerrors.ErrReplicas.Error()) || // coordinator: any error due to replicating to shutdown node
+	return strings.Contains(err, replicaerrors.ErrReplicas.Error()) || // coordinator: any error due to replicating to shutdown node
 		strings.Contains(err, "connect: Post") || // rest: failed to connect to shutdown node
 		strings.Contains(err, "status code: 404, error: request not found") || // rest: failed to find request on shutdown node
 		(strings.Contains(err, "resolve node name") && strings.Contains(err, "to host")) || // memberlist: failed to resolve to other shutdown node in cluster

--- a/adapters/handlers/grpc/v1/batch/worker.go
+++ b/adapters/handlers/grpc/v1/batch/worker.go
@@ -22,7 +22,7 @@ import (
 	"github.com/sirupsen/logrus"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
-	"github.com/weaviate/weaviate/usecases/replica"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 const (
@@ -99,7 +99,7 @@ func StartBatchWorkers(
 }
 
 func (w *worker) isTransientReplicationError(err string) bool {
-	return strings.Contains(err, replica.ErrReplicas.Error()) || // coordinator: any error due to replicating to shutdown node
+	return strings.Contains(err, rplicaerrors.ErrReplicas.Error()) || // coordinator: any error due to replicating to shutdown node
 		strings.Contains(err, "connect: Post") || // rest: failed to connect to shutdown node
 		strings.Contains(err, "status code: 404, error: request not found") || // rest: failed to find request on shutdown node
 		(strings.Contains(err, "resolve node name") && strings.Contains(err, "to host")) || // memberlist: failed to resolve to other shutdown node in cluster

--- a/adapters/handlers/grpc/v1/batch/worker_test.go
+++ b/adapters/handlers/grpc/v1/batch/worker_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/handlers/grpc/v1/batch/mocks"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
-	"github.com/weaviate/weaviate/usecases/replica"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 var StreamId string = "329c306b-c912-4ec7-9b1d-55e5e0ca8dea"
@@ -125,7 +125,7 @@ func TestWorkerLoop(t *testing.T) {
 
 		errorsObj := []*pb.BatchObjectsReply_BatchError{
 			{
-				Error: replica.ErrReplicas.Error(),
+				Error: rplicaerrors.ErrReplicas.Error(),
 				Index: 0,
 			},
 			{

--- a/adapters/handlers/grpc/v1/batch/worker_test.go
+++ b/adapters/handlers/grpc/v1/batch/worker_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/handlers/grpc/v1/batch/mocks"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 var StreamId string = "329c306b-c912-4ec7-9b1d-55e5e0ca8dea"
@@ -125,7 +125,7 @@ func TestWorkerLoop(t *testing.T) {
 
 		errorsObj := []*pb.BatchObjectsReply_BatchError{
 			{
-				Error: rplicaerrors.ErrReplicas.Error(),
+				Error: replicaerrors.ErrReplicas.Error(),
 				Index: 0,
 			},
 			{

--- a/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/replication_service_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/shared"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/replica"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -58,8 +59,8 @@ func TestLocalIndexNotReady(t *testing.T) {
 
 	t.Run("non-StatusNotReady error", func(t *testing.T) {
 		resp := replica.SimpleResponse{
-			Errors: []replica.Error{
-				{Code: replica.StatusConflict, Msg: "conflict"},
+			Errors: []replicaerrors.Error{
+				{Code: replicaerrors.StatusConflict, Msg: "conflict"},
 			},
 		}
 		assert.False(t, shared.LocalIndexNotReady(resp))
@@ -67,8 +68,8 @@ func TestLocalIndexNotReady(t *testing.T) {
 
 	t.Run("StatusNotReady returns true", func(t *testing.T) {
 		resp := replica.SimpleResponse{
-			Errors: []replica.Error{
-				{Code: replica.StatusNotReady, Msg: "index loading"},
+			Errors: []replicaerrors.Error{
+				{Code: replicaerrors.StatusNotReady, Msg: "index loading"},
 			},
 		}
 		assert.True(t, shared.LocalIndexNotReady(resp))

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -36,6 +36,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 	replicaTypes "github.com/weaviate/weaviate/usecases/replica/types"
 )
@@ -1042,6 +1043,16 @@ func (i *replicatedIndices) postRefs() http.Handler {
 
 		w.Write(b)
 	})
+}
+
+func localIndexNotReady(resp replica.SimpleResponse) bool {
+	if err := resp.FirstError(); err != nil {
+		var replicaErr *rplicaerrors.Error
+		if errors.As(err, &replicaErr) && replicaErr.IsStatusCode(rplicaerrors.StatusNotReady) {
+			return true
+		}
+	}
+	return false
 }
 
 // Close gracefully shuts down the replicatedIndices by draining the queue and waiting for workers to finish

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -36,7 +36,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
-	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 	replicaTypes "github.com/weaviate/weaviate/usecases/replica/types"
 )
@@ -1043,16 +1042,6 @@ func (i *replicatedIndices) postRefs() http.Handler {
 
 		w.Write(b)
 	})
-}
-
-func localIndexNotReady(resp replica.SimpleResponse) bool {
-	if err := resp.FirstError(); err != nil {
-		var replicaErr *replicaerrors.Error
-		if errors.As(err, &replicaErr) && replicaErr.IsStatusCode(replicaerrors.StatusNotReady) {
-			return true
-		}
-	}
-	return false
 }
 
 // Close gracefully shuts down the replicatedIndices by draining the queue and waiting for workers to finish

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -36,7 +36,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 	replicaTypes "github.com/weaviate/weaviate/usecases/replica/types"
 )
@@ -1047,8 +1047,8 @@ func (i *replicatedIndices) postRefs() http.Handler {
 
 func localIndexNotReady(resp replica.SimpleResponse) bool {
 	if err := resp.FirstError(); err != nil {
-		var replicaErr *rplicaerrors.Error
-		if errors.As(err, &replicaErr) && replicaErr.IsStatusCode(rplicaerrors.StatusNotReady) {
+		var replicaErr *replicaerrors.Error
+		if errors.As(err, &replicaErr) && replicaErr.IsStatusCode(replicaerrors.StatusNotReady) {
 			return true
 		}
 	}

--- a/adapters/handlers/rest/clusterapi/shared/util.go
+++ b/adapters/handlers/rest/clusterapi/shared/util.go
@@ -16,12 +16,13 @@ import (
 
 	"github.com/go-openapi/strfmt"
 	"github.com/weaviate/weaviate/usecases/replica"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 func LocalIndexNotReady(resp replica.SimpleResponse) bool {
 	if err := resp.FirstError(); err != nil {
-		var replicaErr *replica.Error
-		if errors.As(err, &replicaErr) && replicaErr.IsStatusCode(replica.StatusNotReady) {
+		var replicaErr *replicaerrors.Error
+		if errors.As(err, &replicaErr) && replicaErr.IsStatusCode(replicaerrors.StatusNotReady) {
 			return true
 		}
 	}

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/replication"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
-	"github.com/weaviate/weaviate/usecases/replica"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 // TestInitRetryBackoff verifies that initRetryBackoff never produces a negative
@@ -379,7 +379,7 @@ func TestAsyncSchedulerNextInterval(t *testing.T) {
 		{
 			name:         "ErrNoDiffFound returns frequency",
 			ctx:          context.Background(),
-			err:          replica.ErrNoDiffFound,
+			err:          replicaerrors.ErrNoDiffFound,
 			wantInterval: freq,
 		},
 		{
@@ -657,7 +657,7 @@ func TestNextIntervalErrNoDiffFoundWithPropagatedTrue(t *testing.T) {
 	entry := &asyncSchedulerEntry{shard: &Shard{asyncRepCtx: context.Background()}}
 	result := asyncSchedulerResult{
 		entry:      entry,
-		err:        replica.ErrNoDiffFound,
+		err:        replicaerrors.ErrNoDiffFound,
 		propagated: true, // propagated=true must NOT override the error path
 		ctx:        context.Background(),
 	}

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -39,6 +39,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/file"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
@@ -228,14 +229,14 @@ func (db *DB) AbortReplication(ctx context.Context,
 
 func (db *DB) replicatedIndex(name string) (idx *Index, resp *replica.SimpleResponse) {
 	if !db.StartupComplete() {
-		return nil, &replica.SimpleResponse{Errors: []replica.Error{
-			*replica.NewError(replica.StatusNotReady, name),
+		return nil, &replica.SimpleResponse{Errors: []rplicaerrors.Error{
+			*rplicaerrors.NewError(rplicaerrors.StatusNotReady, name),
 		}}
 	}
 
 	if idx = db.GetIndex(schema.ClassName(name)); idx == nil {
-		return nil, &replica.SimpleResponse{Errors: []replica.Error{
-			*replica.NewError(replica.StatusClassNotFound, name),
+		return nil, &replica.SimpleResponse{Errors: []rplicaerrors.Error{
+			*rplicaerrors.NewError(rplicaerrors.StatusClassNotFound, name),
 		}}
 	}
 	return idx, resp
@@ -243,7 +244,7 @@ func (db *DB) replicatedIndex(name string) (idx *Index, resp *replica.SimpleResp
 
 func (db *DB) waitForSchemaVersionForIndexWrite(ctx context.Context, schemaVersion uint64) *replica.SimpleResponse {
 	if err := db.schemaReader.WaitForUpdate(ctx, schemaVersion); err != nil {
-		return &replica.SimpleResponse{Errors: []replica.Error{{Err: fmt.Errorf("error waiting for schema version %d: %w", schemaVersion, err)}}}
+		return &replica.SimpleResponse{Errors: []rplicaerrors.Error{{Err: fmt.Errorf("error waiting for schema version %d: %w", schemaVersion, err)}}}
 	}
 	return nil
 }
@@ -251,15 +252,15 @@ func (db *DB) waitForSchemaVersionForIndexWrite(ctx context.Context, schemaVersi
 func (i *Index) writableShard(ctx context.Context, name string) (ShardLike, func(), *replica.SimpleResponse) {
 	localShard, release, err := i.getOrInitShard(ctx, name)
 	if err != nil {
-		return nil, func() {}, &replica.SimpleResponse{Errors: []replica.Error{
-			{Code: replica.StatusShardNotFound, Msg: name, Err: err},
+		return nil, func() {}, &replica.SimpleResponse{Errors: []rplicaerrors.Error{
+			{Code: rplicaerrors.StatusShardNotFound, Msg: name, Err: err},
 		}}
 	}
 	if localShard.isReadOnly() != nil {
 		release()
 
-		return nil, func() {}, &replica.SimpleResponse{Errors: []replica.Error{{
-			Code: replica.StatusReadOnly, Msg: name,
+		return nil, func() {}, &replica.SimpleResponse{Errors: []rplicaerrors.Error{{
+			Code: rplicaerrors.StatusReadOnly, Msg: name,
 		}}}
 	}
 	return localShard, release, nil
@@ -336,15 +337,15 @@ func (i *Index) ReplicateReferences(ctx context.Context, shard, requestID string
 func (i *Index) CommitReplication(ctx context.Context, shard, requestID string) any {
 	localShard, release, err := i.GetShard(ctx, shard)
 	if err != nil {
-		return replica.SimpleResponse{Errors: []replica.Error{
-			{Code: replica.StatusShardNotFound, Msg: shard, Err: err},
+		return replica.SimpleResponse{Errors: []rplicaerrors.Error{
+			{Code: rplicaerrors.StatusShardNotFound, Msg: shard, Err: err},
 		}}
 	}
 	defer release()
 
 	if localShard == nil {
-		return replica.SimpleResponse{Errors: []replica.Error{
-			{Code: replica.StatusShardNotFound, Msg: shard, Err: fmt.Errorf("shard %q does not exist locally", shard)},
+		return replica.SimpleResponse{Errors: []rplicaerrors.Error{
+			{Code: rplicaerrors.StatusShardNotFound, Msg: shard, Err: fmt.Errorf("shard %q does not exist locally", shard)},
 		}}
 	}
 
@@ -357,15 +358,15 @@ func (i *Index) CommitReplication(ctx context.Context, shard, requestID string) 
 func (i *Index) AbortReplication(ctx context.Context, shard, requestID string) any {
 	localShard, release, err := i.GetShard(ctx, shard)
 	if err != nil {
-		return replica.SimpleResponse{Errors: []replica.Error{
-			{Code: replica.StatusShardNotFound, Msg: shard, Err: err},
+		return replica.SimpleResponse{Errors: []rplicaerrors.Error{
+			{Code: rplicaerrors.StatusShardNotFound, Msg: shard, Err: err},
 		}}
 	}
 	defer release()
 
 	if localShard == nil {
-		return replica.SimpleResponse{Errors: []replica.Error{
-			{Code: replica.StatusShardNotFound, Msg: shard, Err: fmt.Errorf("shard %q does not exist locally", shard)},
+		return replica.SimpleResponse{Errors: []rplicaerrors.Error{
+			{Code: rplicaerrors.StatusShardNotFound, Msg: shard, Err: fmt.Errorf("shard %q does not exist locally", shard)},
 		}}
 	}
 

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -39,7 +39,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/file"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
@@ -229,14 +229,14 @@ func (db *DB) AbortReplication(ctx context.Context,
 
 func (db *DB) replicatedIndex(name string) (idx *Index, resp *replica.SimpleResponse) {
 	if !db.StartupComplete() {
-		return nil, &replica.SimpleResponse{Errors: []rplicaerrors.Error{
-			*rplicaerrors.NewError(rplicaerrors.StatusNotReady, name),
+		return nil, &replica.SimpleResponse{Errors: []replicaerrors.Error{
+			*replicaerrors.NewError(replicaerrors.StatusNotReady, name),
 		}}
 	}
 
 	if idx = db.GetIndex(schema.ClassName(name)); idx == nil {
-		return nil, &replica.SimpleResponse{Errors: []rplicaerrors.Error{
-			*rplicaerrors.NewError(rplicaerrors.StatusClassNotFound, name),
+		return nil, &replica.SimpleResponse{Errors: []replicaerrors.Error{
+			*replicaerrors.NewError(replicaerrors.StatusClassNotFound, name),
 		}}
 	}
 	return idx, resp
@@ -244,7 +244,7 @@ func (db *DB) replicatedIndex(name string) (idx *Index, resp *replica.SimpleResp
 
 func (db *DB) waitForSchemaVersionForIndexWrite(ctx context.Context, schemaVersion uint64) *replica.SimpleResponse {
 	if err := db.schemaReader.WaitForUpdate(ctx, schemaVersion); err != nil {
-		return &replica.SimpleResponse{Errors: []rplicaerrors.Error{{Err: fmt.Errorf("error waiting for schema version %d: %w", schemaVersion, err)}}}
+		return &replica.SimpleResponse{Errors: []replicaerrors.Error{{Err: fmt.Errorf("error waiting for schema version %d: %w", schemaVersion, err)}}}
 	}
 	return nil
 }
@@ -252,15 +252,15 @@ func (db *DB) waitForSchemaVersionForIndexWrite(ctx context.Context, schemaVersi
 func (i *Index) writableShard(ctx context.Context, name string) (ShardLike, func(), *replica.SimpleResponse) {
 	localShard, release, err := i.getOrInitShard(ctx, name)
 	if err != nil {
-		return nil, func() {}, &replica.SimpleResponse{Errors: []rplicaerrors.Error{
-			{Code: rplicaerrors.StatusShardNotFound, Msg: name, Err: err},
+		return nil, func() {}, &replica.SimpleResponse{Errors: []replicaerrors.Error{
+			{Code: replicaerrors.StatusShardNotFound, Msg: name, Err: err},
 		}}
 	}
 	if localShard.isReadOnly() != nil {
 		release()
 
-		return nil, func() {}, &replica.SimpleResponse{Errors: []rplicaerrors.Error{{
-			Code: rplicaerrors.StatusReadOnly, Msg: name,
+		return nil, func() {}, &replica.SimpleResponse{Errors: []replicaerrors.Error{{
+			Code: replicaerrors.StatusReadOnly, Msg: name,
 		}}}
 	}
 	return localShard, release, nil
@@ -337,15 +337,15 @@ func (i *Index) ReplicateReferences(ctx context.Context, shard, requestID string
 func (i *Index) CommitReplication(ctx context.Context, shard, requestID string) any {
 	localShard, release, err := i.GetShard(ctx, shard)
 	if err != nil {
-		return replica.SimpleResponse{Errors: []rplicaerrors.Error{
-			{Code: rplicaerrors.StatusShardNotFound, Msg: shard, Err: err},
+		return replica.SimpleResponse{Errors: []replicaerrors.Error{
+			{Code: replicaerrors.StatusShardNotFound, Msg: shard, Err: err},
 		}}
 	}
 	defer release()
 
 	if localShard == nil {
-		return replica.SimpleResponse{Errors: []rplicaerrors.Error{
-			{Code: rplicaerrors.StatusShardNotFound, Msg: shard, Err: fmt.Errorf("shard %q does not exist locally", shard)},
+		return replica.SimpleResponse{Errors: []replicaerrors.Error{
+			{Code: replicaerrors.StatusShardNotFound, Msg: shard, Err: fmt.Errorf("shard %q does not exist locally", shard)},
 		}}
 	}
 
@@ -358,15 +358,15 @@ func (i *Index) CommitReplication(ctx context.Context, shard, requestID string) 
 func (i *Index) AbortReplication(ctx context.Context, shard, requestID string) any {
 	localShard, release, err := i.GetShard(ctx, shard)
 	if err != nil {
-		return replica.SimpleResponse{Errors: []rplicaerrors.Error{
-			{Code: rplicaerrors.StatusShardNotFound, Msg: shard, Err: err},
+		return replica.SimpleResponse{Errors: []replicaerrors.Error{
+			{Code: replicaerrors.StatusShardNotFound, Msg: shard, Err: err},
 		}}
 	}
 	defer release()
 
 	if localShard == nil {
-		return replica.SimpleResponse{Errors: []rplicaerrors.Error{
-			{Code: rplicaerrors.StatusShardNotFound, Msg: shard, Err: fmt.Errorf("shard %q does not exist locally", shard)},
+		return replica.SimpleResponse{Errors: []replicaerrors.Error{
+			{Code: replicaerrors.StatusShardNotFound, Msg: shard, Err: fmt.Errorf("shard %q does not exist locally", shard)},
 		}}
 	}
 

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -244,7 +244,12 @@ func (db *DB) replicatedIndex(name string) (idx *Index, resp *replica.SimpleResp
 
 func (db *DB) waitForSchemaVersionForIndexWrite(ctx context.Context, schemaVersion uint64) *replica.SimpleResponse {
 	if err := db.schemaReader.WaitForUpdate(ctx, schemaVersion); err != nil {
-		return &replica.SimpleResponse{Errors: []replicaerrors.Error{{Err: fmt.Errorf("error waiting for schema version %d: %w", schemaVersion, err)}}}
+		wrapped := fmt.Errorf("error waiting for schema version %d: %w", schemaVersion, err)
+		return &replica.SimpleResponse{Errors: []replicaerrors.Error{{
+			Code: replicaerrors.StatusPreconditionFailed,
+			Msg:  wrapped.Error(),
+			Err:  wrapped,
+		}}}
 	}
 	return nil
 }

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -244,11 +244,13 @@ func (db *DB) replicatedIndex(name string) (idx *Index, resp *replica.SimpleResp
 
 func (db *DB) waitForSchemaVersionForIndexWrite(ctx context.Context, schemaVersion uint64) *replica.SimpleResponse {
 	if err := db.schemaReader.WaitForUpdate(ctx, schemaVersion); err != nil {
-		wrapped := fmt.Errorf("error waiting for schema version %d: %w", schemaVersion, err)
+		// Msg carries the human-readable detail because Err is not
+		// serialised over the wire (json:"-"); without Msg the remote
+		// coordinator would see an empty error and treat it as success.
 		return &replica.SimpleResponse{Errors: []replicaerrors.Error{{
 			Code: replicaerrors.StatusPreconditionFailed,
-			Msg:  wrapped.Error(),
-			Err:  wrapped,
+			Msg:  fmt.Sprintf("waiting for schema version %d: %v", schemaVersion, err),
+			Err:  err,
 		}}}
 	}
 	return nil

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -39,7 +39,7 @@ import (
 	entreplication "github.com/weaviate/weaviate/entities/replication"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/objects"
-	"github.com/weaviate/weaviate/usecases/replica"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
@@ -1246,7 +1246,7 @@ func (s *Shard) runHashbeatCycle(ctx context.Context, config AsyncReplicationCon
 		if s.asyncReplicationStatsByTargetNode == nil {
 			s.asyncReplicationStatsByTargetNode = make(map[string]*hashBeatHostStats)
 		}
-		if (err == nil || errors.Is(err, replica.ErrNoDiffFound)) && stats != nil {
+		if (err == nil || errors.Is(err, rplicaerrors.ErrNoDiffFound)) && stats != nil {
 			for _, stat := range stats {
 				if stat != nil {
 					s.asyncReplicationStatsByTargetNode[stat.targetNodeName] = stat
@@ -1274,9 +1274,9 @@ func (s *Shard) runHashbeatCycle(ctx context.Context, config AsyncReplicationCon
 			return false, ctx.Err()
 		}
 
-		if errors.Is(err, replica.ErrNoDiffFound) {
-			if time.Since(time.Unix(s.asyncRepLastLog.Load(), 0)) >= config.loggingFrequency {
-				s.asyncRepLastLog.Store(time.Now().Unix())
+		if errors.Is(err, rplicaerrors.ErrNoDiffFound) {
+			if time.Since(*lastLog) >= config.loggingFrequency {
+				*lastLog = time.Now()
 				s.index.logger.
 					WithField("action", "async_replication").
 					WithField("class_name", s.class.Class).
@@ -1378,7 +1378,7 @@ func (s *Shard) hashBeat(
 	defer func() {
 		s.metrics.DecAsyncReplicationIterationRunning()
 
-		if err != nil && !errors.Is(err, replica.ErrNoDiffFound) {
+		if err != nil && !errors.Is(err, rplicaerrors.ErrNoDiffFound) {
 			s.metrics.IncAsyncReplicationIterationFailureCount()
 			return
 		}
@@ -1406,7 +1406,7 @@ func (s *Shard) hashBeat(
 
 	shardDiffReader, err := s.index.replicator.CollectShardDifferences(ctx, s.name, ht, config.diffPerNodeTimeout, targetNodeOverridesSnapshot)
 	if err != nil {
-		if errors.Is(err, replica.ErrNoDiffFound) && len(targetNodeOverridesSnapshot) > 0 {
+		if errors.Is(err, rplicaerrors.ErrNoDiffFound) && len(targetNodeOverridesSnapshot) > 0 {
 			stats := make([]*hashBeatHostStats, 0, len(targetNodeOverridesSnapshot))
 			for _, o := range targetNodeOverridesSnapshot {
 				stats = append(stats, &hashBeatHostStats{

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1189,7 +1189,7 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 // worker goroutine. It uses shard-level state maps (asyncRepLast*) which are
 // only ever accessed from a single worker at a time (enforced by asyncRepWg).
 // Returns (propagated, err):
-//   - (false, replica.ErrNoDiffFound) – no diff; use long interval
+//   - (false, replicaerrors.ErrNoDiffFound) – no diff; use long interval
 //   - (false, ctx.Err())              – context cancelled
 //   - (false, <other error>)          – failure; scheduler applies backoff
 //   - (propagated, nil)               – success

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -39,7 +39,7 @@ import (
 	entreplication "github.com/weaviate/weaviate/entities/replication"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/objects"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
@@ -1246,7 +1246,7 @@ func (s *Shard) runHashbeatCycle(ctx context.Context, config AsyncReplicationCon
 		if s.asyncReplicationStatsByTargetNode == nil {
 			s.asyncReplicationStatsByTargetNode = make(map[string]*hashBeatHostStats)
 		}
-		if (err == nil || errors.Is(err, rplicaerrors.ErrNoDiffFound)) && stats != nil {
+		if (err == nil || errors.Is(err, replicaerrors.ErrNoDiffFound)) && stats != nil {
 			for _, stat := range stats {
 				if stat != nil {
 					s.asyncReplicationStatsByTargetNode[stat.targetNodeName] = stat
@@ -1274,7 +1274,7 @@ func (s *Shard) runHashbeatCycle(ctx context.Context, config AsyncReplicationCon
 			return false, ctx.Err()
 		}
 
-		if errors.Is(err, rplicaerrors.ErrNoDiffFound) {
+		if errors.Is(err, replicaerrors.ErrNoDiffFound) {
 			if time.Since(*lastLog) >= config.loggingFrequency {
 				*lastLog = time.Now()
 				s.index.logger.
@@ -1378,7 +1378,7 @@ func (s *Shard) hashBeat(
 	defer func() {
 		s.metrics.DecAsyncReplicationIterationRunning()
 
-		if err != nil && !errors.Is(err, rplicaerrors.ErrNoDiffFound) {
+		if err != nil && !errors.Is(err, replicaerrors.ErrNoDiffFound) {
 			s.metrics.IncAsyncReplicationIterationFailureCount()
 			return
 		}
@@ -1406,7 +1406,7 @@ func (s *Shard) hashBeat(
 
 	shardDiffReader, err := s.index.replicator.CollectShardDifferences(ctx, s.name, ht, config.diffPerNodeTimeout, targetNodeOverridesSnapshot)
 	if err != nil {
-		if errors.Is(err, rplicaerrors.ErrNoDiffFound) && len(targetNodeOverridesSnapshot) > 0 {
+		if errors.Is(err, replicaerrors.ErrNoDiffFound) && len(targetNodeOverridesSnapshot) > 0 {
 			stats := make([]*hashBeatHostStats, 0, len(targetNodeOverridesSnapshot))
 			for _, o := range targetNodeOverridesSnapshot {
 				stats = append(stats, &hashBeatHostStats{

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1275,8 +1275,8 @@ func (s *Shard) runHashbeatCycle(ctx context.Context, config AsyncReplicationCon
 		}
 
 		if errors.Is(err, replicaerrors.ErrNoDiffFound) {
-			if time.Since(*lastLog) >= config.loggingFrequency {
-				*lastLog = time.Now()
+			if time.Since(time.Unix(s.asyncRepLastLog.Load(), 0)) >= config.loggingFrequency {
+				s.asyncRepLastLog.Store(time.Now().Unix())
 				s.index.logger.
 					WithField("action", "async_replication").
 					WithField("class_name", s.class.Class).
@@ -1284,7 +1284,7 @@ func (s *Shard) runHashbeatCycle(ctx context.Context, config AsyncReplicationCon
 					WithField("hosts", s.getLastComparedHosts()).
 					Debug("hashbeat iteration successfully completed: no differences were found")
 			}
-			return false, replica.ErrNoDiffFound
+			return false, replicaerrors.ErrNoDiffFound
 		}
 
 		if time.Since(time.Unix(s.asyncRepLastLog.Load(), 0)) >= config.loggingFrequency {
@@ -1416,7 +1416,7 @@ func (s *Shard) hashBeat(
 			}
 			return stats, err
 		}
-		if errors.Is(err, replica.ErrNoDiffFound) {
+		if errors.Is(err, replicaerrors.ErrNoDiffFound) {
 			return []*hashBeatHostStats{{
 				hashtreeDiffStartTime: hashtreeDiffStart,
 				hashtreeDiffTook:      time.Since(hashtreeDiffStart),

--- a/adapters/repos/db/shard_replication.go
+++ b/adapters/repos/db/shard_replication.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 type replicaTask func(context.Context) interface{}
@@ -76,15 +77,15 @@ func (s *Shard) abortReplication(ctx context.Context, requestID string) replica.
 func (s *Shard) preparePutObject(ctx context.Context, requestID string, object *storobj.Object) replica.SimpleResponse {
 	uuid, err := parseBytesUUID(object.ID())
 	if err != nil {
-		return replica.SimpleResponse{Errors: []replica.Error{{
-			Code: replica.StatusPreconditionFailed, Msg: err.Error(),
+		return replica.SimpleResponse{Errors: []rplicaerrors.Error{{
+			Code: rplicaerrors.StatusPreconditionFailed, Msg: err.Error(),
 		}}}
 	}
 	task := func(ctx context.Context) interface{} {
 		resp := replica.SimpleResponse{}
 		if err := s.putOne(ctx, uuid, object); err != nil {
-			resp.Errors = []replica.Error{
-				{Code: replica.StatusConflict, Msg: err.Error()},
+			resp.Errors = []rplicaerrors.Error{
+				{Code: rplicaerrors.StatusConflict, Msg: err.Error()},
 			}
 		}
 		return resp
@@ -96,20 +97,20 @@ func (s *Shard) preparePutObject(ctx context.Context, requestID string, object *
 func (s *Shard) prepareMergeObject(ctx context.Context, requestID string, doc *objects.MergeDocument) replica.SimpleResponse {
 	uuid, err := parseBytesUUID(doc.ID)
 	if err != nil {
-		return replica.SimpleResponse{Errors: []replica.Error{
-			{Code: replica.StatusPreconditionFailed, Msg: err.Error()},
+		return replica.SimpleResponse{Errors: []rplicaerrors.Error{
+			{Code: rplicaerrors.StatusPreconditionFailed, Msg: err.Error()},
 		}}
 	}
 	task := func(ctx context.Context) interface{} {
 		resp := replica.SimpleResponse{}
 		if err := s.merge(ctx, uuid, *doc); err != nil {
-			var code replica.StatusCode
+			var code rplicaerrors.StatusCode
 			if errors.Is(err, errObjectNotFound) {
-				code = replica.StatusObjectNotFound
+				code = rplicaerrors.StatusObjectNotFound
 			} else {
-				code = replica.StatusConflict
+				code = rplicaerrors.StatusConflict
 			}
-			resp.Errors = []replica.Error{
+			resp.Errors = []rplicaerrors.Error{
 				{Code: code, Msg: err.Error()},
 			}
 		}
@@ -123,8 +124,8 @@ func (s *Shard) prepareDeleteObject(ctx context.Context, requestID string, uuid 
 	task := func(ctx context.Context) interface{} {
 		resp := replica.SimpleResponse{}
 		if err := s.DeleteObject(ctx, uuid, deletionTime); err != nil {
-			resp.Errors = []replica.Error{
-				{Code: replica.StatusConflict, Msg: err.Error()},
+			resp.Errors = []rplicaerrors.Error{
+				{Code: rplicaerrors.StatusConflict, Msg: err.Error()},
 			}
 		}
 		return resp
@@ -136,10 +137,10 @@ func (s *Shard) prepareDeleteObject(ctx context.Context, requestID string, uuid 
 func (s *Shard) preparePutObjects(ctx context.Context, requestID string, objects []*storobj.Object) replica.SimpleResponse {
 	task := func(ctx context.Context) interface{} {
 		rawErrs := s.putBatch(ctx, objects)
-		resp := replica.SimpleResponse{Errors: make([]replica.Error, len(rawErrs))}
+		resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, len(rawErrs))}
 		for i, err := range rawErrs {
 			if err != nil {
-				resp.Errors[i] = replica.Error{Code: replica.StatusConflict, Msg: err.Error()}
+				resp.Errors[i] = rplicaerrors.Error{Code: rplicaerrors.StatusConflict, Msg: err.Error()}
 			}
 		}
 		return resp
@@ -160,7 +161,7 @@ func (s *Shard) prepareDeleteObjects(ctx context.Context, requestID string,
 		for i, r := range result {
 			entry := replica.UUID2Error{UUID: string(r.UUID)}
 			if err := r.Err; err != nil {
-				entry.Error = replica.Error{Code: replica.StatusConflict, Msg: err.Error()}
+				entry.Error = rplicaerrors.Error{Code: rplicaerrors.StatusConflict, Msg: err.Error()}
 			}
 			resp.Batch[i] = entry
 		}
@@ -173,10 +174,10 @@ func (s *Shard) prepareDeleteObjects(ctx context.Context, requestID string,
 func (s *Shard) prepareAddReferences(ctx context.Context, requestID string, refs []objects.BatchReference) replica.SimpleResponse {
 	task := func(ctx context.Context) interface{} {
 		rawErrs := newReferencesBatcher(s).References(ctx, refs)
-		resp := replica.SimpleResponse{Errors: make([]replica.Error, len(rawErrs))}
+		resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, len(rawErrs))}
 		for i, err := range rawErrs {
 			if err != nil {
-				resp.Errors[i] = replica.Error{Code: replica.StatusConflict, Msg: err.Error()}
+				resp.Errors[i] = rplicaerrors.Error{Code: rplicaerrors.StatusConflict, Msg: err.Error()}
 			}
 		}
 		return resp

--- a/adapters/repos/db/shard_replication.go
+++ b/adapters/repos/db/shard_replication.go
@@ -23,7 +23,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 type replicaTask func(context.Context) interface{}
@@ -77,15 +77,15 @@ func (s *Shard) abortReplication(ctx context.Context, requestID string) replica.
 func (s *Shard) preparePutObject(ctx context.Context, requestID string, object *storobj.Object) replica.SimpleResponse {
 	uuid, err := parseBytesUUID(object.ID())
 	if err != nil {
-		return replica.SimpleResponse{Errors: []rplicaerrors.Error{{
-			Code: rplicaerrors.StatusPreconditionFailed, Msg: err.Error(),
+		return replica.SimpleResponse{Errors: []replicaerrors.Error{{
+			Code: replicaerrors.StatusPreconditionFailed, Msg: err.Error(),
 		}}}
 	}
 	task := func(ctx context.Context) interface{} {
 		resp := replica.SimpleResponse{}
 		if err := s.putOne(ctx, uuid, object); err != nil {
-			resp.Errors = []rplicaerrors.Error{
-				{Code: rplicaerrors.StatusConflict, Msg: err.Error()},
+			resp.Errors = []replicaerrors.Error{
+				{Code: replicaerrors.StatusConflict, Msg: err.Error()},
 			}
 		}
 		return resp
@@ -97,20 +97,20 @@ func (s *Shard) preparePutObject(ctx context.Context, requestID string, object *
 func (s *Shard) prepareMergeObject(ctx context.Context, requestID string, doc *objects.MergeDocument) replica.SimpleResponse {
 	uuid, err := parseBytesUUID(doc.ID)
 	if err != nil {
-		return replica.SimpleResponse{Errors: []rplicaerrors.Error{
-			{Code: rplicaerrors.StatusPreconditionFailed, Msg: err.Error()},
+		return replica.SimpleResponse{Errors: []replicaerrors.Error{
+			{Code: replicaerrors.StatusPreconditionFailed, Msg: err.Error()},
 		}}
 	}
 	task := func(ctx context.Context) interface{} {
 		resp := replica.SimpleResponse{}
 		if err := s.merge(ctx, uuid, *doc); err != nil {
-			var code rplicaerrors.StatusCode
+			var code replicaerrors.StatusCode
 			if errors.Is(err, errObjectNotFound) {
-				code = rplicaerrors.StatusObjectNotFound
+				code = replicaerrors.StatusObjectNotFound
 			} else {
-				code = rplicaerrors.StatusConflict
+				code = replicaerrors.StatusConflict
 			}
-			resp.Errors = []rplicaerrors.Error{
+			resp.Errors = []replicaerrors.Error{
 				{Code: code, Msg: err.Error()},
 			}
 		}
@@ -124,8 +124,8 @@ func (s *Shard) prepareDeleteObject(ctx context.Context, requestID string, uuid 
 	task := func(ctx context.Context) interface{} {
 		resp := replica.SimpleResponse{}
 		if err := s.DeleteObject(ctx, uuid, deletionTime); err != nil {
-			resp.Errors = []rplicaerrors.Error{
-				{Code: rplicaerrors.StatusConflict, Msg: err.Error()},
+			resp.Errors = []replicaerrors.Error{
+				{Code: replicaerrors.StatusConflict, Msg: err.Error()},
 			}
 		}
 		return resp
@@ -137,10 +137,10 @@ func (s *Shard) prepareDeleteObject(ctx context.Context, requestID string, uuid 
 func (s *Shard) preparePutObjects(ctx context.Context, requestID string, objects []*storobj.Object) replica.SimpleResponse {
 	task := func(ctx context.Context) interface{} {
 		rawErrs := s.putBatch(ctx, objects)
-		resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, len(rawErrs))}
+		resp := replica.SimpleResponse{Errors: make([]replicaerrors.Error, len(rawErrs))}
 		for i, err := range rawErrs {
 			if err != nil {
-				resp.Errors[i] = rplicaerrors.Error{Code: rplicaerrors.StatusConflict, Msg: err.Error()}
+				resp.Errors[i] = replicaerrors.Error{Code: replicaerrors.StatusConflict, Msg: err.Error()}
 			}
 		}
 		return resp
@@ -161,7 +161,7 @@ func (s *Shard) prepareDeleteObjects(ctx context.Context, requestID string,
 		for i, r := range result {
 			entry := replica.UUID2Error{UUID: string(r.UUID)}
 			if err := r.Err; err != nil {
-				entry.Error = rplicaerrors.Error{Code: rplicaerrors.StatusConflict, Msg: err.Error()}
+				entry.Error = replicaerrors.Error{Code: replicaerrors.StatusConflict, Msg: err.Error()}
 			}
 			resp.Batch[i] = entry
 		}
@@ -174,10 +174,10 @@ func (s *Shard) prepareDeleteObjects(ctx context.Context, requestID string,
 func (s *Shard) prepareAddReferences(ctx context.Context, requestID string, refs []objects.BatchReference) replica.SimpleResponse {
 	task := func(ctx context.Context) interface{} {
 		rawErrs := newReferencesBatcher(s).References(ctx, refs)
-		resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, len(rawErrs))}
+		resp := replica.SimpleResponse{Errors: make([]replicaerrors.Error, len(rawErrs))}
 		for i, err := range rawErrs {
 			if err != nil {
-				resp.Errors[i] = rplicaerrors.Error{Code: rplicaerrors.StatusConflict, Msg: err.Error()}
+				resp.Errors[i] = replicaerrors.Error{Code: replicaerrors.StatusConflict, Msg: err.Error()}
 			}
 		}
 		return resp

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -248,7 +248,15 @@ func (c *coordinator[T, R]) read(
 	}
 	var finalErr error
 	if level > 0 {
-		finalErr = replicaerrors.NewNotEnoughReplicasErrorWithCounts(required, required-level, errors.Join(replicaErrs...))
+		joined := errors.Join(replicaErrs...)
+		// If the upstream failure is already a "not enough replicas" error
+		// (e.g. broadcast aborted and sent its own NotEnoughReplicasError),
+		// surface it directly instead of nesting another wrapper.
+		if errors.Is(joined, replicaerrors.ErrReplicas) {
+			finalErr = joined
+		} else {
+			finalErr = replicaerrors.NewNotEnoughReplicasErrorWithCounts(required, required-level, joined)
+		}
 	}
 	failures = append(failures, successes...)
 	return onFlatten(batchSize, failures, finalErr)

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -13,6 +13,7 @@ package replica
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -137,22 +138,14 @@ func (c *coordinator[T, R]) broadcast(ctx context.Context,
 	f := func() {
 		defer close(resChan)
 		actives := make([]Result[string], 0, level) // cache for active replicas
-		// Track only the first error and a count of additional errors to
-		// keep memory usage O(1) regardless of the replica count.
-		var firstErr error
-		var additionalErrs int
+		var replicaErrs []error
 		for r := range prepare() {
 			if r.Err != nil { // connection error
 				c.log.WithField("op", "broadcast").Warn(r.Err)
-				if firstErr == nil {
-					// Attach the failing replica identifier so the
-					// resulting error remains actionable regardless of
-					// whether the per-replica op wrapped it with host
-					// context.
-					firstErr = annotateReplicaErr(r.Value, r.Err)
-				} else {
-					additionalErrs++
-				}
+				// Attach the failing replica identifier so the resulting
+				// error remains actionable regardless of whether the
+				// per-replica op wrapped it with host context.
+				replicaErrs = append(replicaErrs, annotateReplicaErr(r.Value, r.Err))
 				continue
 			}
 
@@ -174,7 +167,7 @@ func (c *coordinator[T, R]) broadcast(ctx context.Context,
 			for _, node := range replicas {
 				c.Abort(ctx, node, c.Class, c.Shard, c.TxID)
 			}
-			resChan <- Result[string]{Err: replicaerrors.NewNotEnoughReplicasErrorWithCounts(required, len(actives), firstErr, additionalErrs)}
+			resChan <- Result[string]{Err: replicaerrors.NewNotEnoughReplicasErrorWithCounts(required, len(actives), errors.Join(replicaErrs...))}
 		}
 	}
 	enterrors.GoWrapper(f, c.log)
@@ -238,20 +231,13 @@ func (c *coordinator[T, R]) read(
 	required := level
 	failures := make([]T, 0, level)
 	successes := make([]T, 0, level)
-	// Track only the first error and a count of additional errors to keep
-	// memory usage O(1) regardless of the number of replicas.
-	var firstError error
-	var additionalErrs int
+	var replicaErrs []error
 	for x := range ch {
 		var err error
 		var shouldDecreaseLevel bool
 		successes, failures, shouldDecreaseLevel, err = onResult(x, successes, failures)
 		if err != nil {
-			if firstError == nil {
-				firstError = err
-			} else {
-				additionalErrs++
-			}
+			replicaErrs = append(replicaErrs, err)
 		}
 		if shouldDecreaseLevel {
 			level--
@@ -260,11 +246,12 @@ func (c *coordinator[T, R]) read(
 			return onFlatten(batchSize, successes, nil)
 		}
 	}
+	var finalErr error
 	if level > 0 {
-		firstError = replicaerrors.NewNotEnoughReplicasErrorWithCounts(required, required-level, firstError, additionalErrs)
+		finalErr = replicaerrors.NewNotEnoughReplicasErrorWithCounts(required, required-level, errors.Join(replicaErrs...))
 	}
 	failures = append(failures, successes...)
-	return onFlatten(batchSize, failures, firstError)
+	return onFlatten(batchSize, failures, finalErr)
 }
 
 // Push pushes updates to all replicas of a specific shard

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -26,7 +26,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/cluster/utils"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 const (
@@ -164,7 +164,7 @@ func (c *coordinator[T, R]) broadcast(ctx context.Context,
 			for _, node := range replicas {
 				c.Abort(ctx, node, c.Class, c.Shard, c.TxID)
 			}
-			resChan <- Result[string]{Err: rplicaerrors.NewNotEnoughReplicasError(errors.Join(replicaErrs...))}
+			resChan <- Result[string]{Err: replicaerrors.NewNotEnoughReplicasError(errors.Join(replicaErrs...))}
 		}
 	}
 	enterrors.GoWrapper(f, c.log)
@@ -243,7 +243,7 @@ func (c *coordinator[T, R]) read(
 		}
 	}
 	if level > 0 && firstError == nil {
-		firstError = rplicaerrors.NewNotEnoughReplicasError(nil)
+		firstError = replicaerrors.NewNotEnoughReplicasError(nil)
 	}
 	failures = append(failures, successes...)
 	return onFlatten(batchSize, failures, firstError)

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -145,7 +145,11 @@ func (c *coordinator[T, R]) broadcast(ctx context.Context,
 			if r.Err != nil { // connection error
 				c.log.WithField("op", "broadcast").Warn(r.Err)
 				if firstErr == nil {
-					firstErr = r.Err
+					// Attach the failing replica identifier so the
+					// resulting error remains actionable regardless of
+					// whether the per-replica op wrapped it with host
+					// context.
+					firstErr = annotateReplicaErr(r.Value, r.Err)
 				} else {
 					additionalErrs++
 				}
@@ -454,4 +458,14 @@ func (c *coordinator[T, any]) Pull(ctx context.Context,
 type hostRetry struct {
 	host           string
 	currentBackOff backoff.BackOff
+}
+
+// annotateReplicaErr prefixes err with the replica identifier when
+// replica is non-empty.  It returns err unchanged when no identifier is
+// available so that an empty prefix is never emitted.
+func annotateReplicaErr(replica string, err error) error {
+	if replica == "" {
+		return err
+	}
+	return fmt.Errorf("replica %q: %w", replica, err)
 }

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -13,6 +13,7 @@ package replica
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -25,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/cluster/utils"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 const (
@@ -136,11 +138,11 @@ func (c *coordinator[T, R]) broadcast(ctx context.Context,
 	f := func() {
 		defer close(resChan)
 		actives := make([]Result[string], 0, level) // cache for active replicas
-		broadcastErrors := make([]string, 0, len(replicas)-level)
+		var replicaErrs []error
 		for r := range prepare() {
 			if r.Err != nil { // connection error
 				c.log.WithField("op", "broadcast").Warn(r.Err)
-				broadcastErrors = append(broadcastErrors, fmt.Errorf("replica %s; %w", r.Value, r.Err).Error())
+				replicaErrs = append(replicaErrs, r.Err)
 				continue
 			}
 
@@ -162,8 +164,7 @@ func (c *coordinator[T, R]) broadcast(ctx context.Context,
 			for _, node := range replicas {
 				c.Abort(ctx, node, c.Class, c.Shard, c.TxID)
 			}
-			errs := fmt.Sprintf("errors: %s", strings.Join(broadcastErrors, ", "))
-			resChan <- Result[string]{Err: fmt.Errorf("%s; broadcast: %w", errs, ErrReplicas)}
+			resChan <- Result[string]{Err: rplicaerrors.NewNotEnoughReplicasError(errors.Join(replicaErrs...))}
 		}
 	}
 	enterrors.GoWrapper(f, c.log)
@@ -242,7 +243,7 @@ func (c *coordinator[T, R]) read(
 		}
 	}
 	if level > 0 && firstError == nil {
-		firstError = fmt.Errorf("commit: %w", ErrReplicas)
+		firstError = rplicaerrors.NewNotEnoughReplicasError(nil)
 	}
 	failures = append(failures, successes...)
 	return onFlatten(batchSize, failures, firstError)

--- a/usecases/replica/coordinator.go
+++ b/usecases/replica/coordinator.go
@@ -13,9 +13,7 @@ package replica
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -135,14 +133,22 @@ func (c *coordinator[T, R]) broadcast(ctx context.Context,
 
 	// handle responses to prepare requests
 	resChan := make(chan Result[string], len(replicas))
+	required := level
 	f := func() {
 		defer close(resChan)
 		actives := make([]Result[string], 0, level) // cache for active replicas
-		var replicaErrs []error
+		// Track only the first error and a count of additional errors to
+		// keep memory usage O(1) regardless of the replica count.
+		var firstErr error
+		var additionalErrs int
 		for r := range prepare() {
 			if r.Err != nil { // connection error
 				c.log.WithField("op", "broadcast").Warn(r.Err)
-				replicaErrs = append(replicaErrs, r.Err)
+				if firstErr == nil {
+					firstErr = r.Err
+				} else {
+					additionalErrs++
+				}
 				continue
 			}
 
@@ -164,7 +170,7 @@ func (c *coordinator[T, R]) broadcast(ctx context.Context,
 			for _, node := range replicas {
 				c.Abort(ctx, node, c.Class, c.Shard, c.TxID)
 			}
-			resChan <- Result[string]{Err: replicaerrors.NewNotEnoughReplicasError(errors.Join(replicaErrs...))}
+			resChan <- Result[string]{Err: replicaerrors.NewNotEnoughReplicasErrorWithCounts(required, len(actives), firstErr, additionalErrs)}
 		}
 	}
 	enterrors.GoWrapper(f, c.log)
@@ -225,15 +231,23 @@ func (c *coordinator[T, R]) read(
 	onFlatten onFlatten[T, R],
 	batchSize int,
 ) []R {
+	required := level
 	failures := make([]T, 0, level)
 	successes := make([]T, 0, level)
+	// Track only the first error and a count of additional errors to keep
+	// memory usage O(1) regardless of the number of replicas.
 	var firstError error
+	var additionalErrs int
 	for x := range ch {
 		var err error
 		var shouldDecreaseLevel bool
 		successes, failures, shouldDecreaseLevel, err = onResult(x, successes, failures)
-		if err != nil && firstError == nil {
-			firstError = err
+		if err != nil {
+			if firstError == nil {
+				firstError = err
+			} else {
+				additionalErrs++
+			}
 		}
 		if shouldDecreaseLevel {
 			level--
@@ -242,8 +256,8 @@ func (c *coordinator[T, R]) read(
 			return onFlatten(batchSize, successes, nil)
 		}
 	}
-	if level > 0 && firstError == nil {
-		firstError = replicaerrors.NewNotEnoughReplicasError(nil)
+	if level > 0 {
+		firstError = replicaerrors.NewNotEnoughReplicasErrorWithCounts(required, required-level, firstError, additionalErrs)
 	}
 	failures = append(failures, successes...)
 	return onFlatten(batchSize, failures, firstError)

--- a/usecases/replica/coordinator_test.go
+++ b/usecases/replica/coordinator_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/replica"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 type errorType string
@@ -125,7 +126,7 @@ func Test_coordinatorPush(t *testing.T) {
 			}
 			w.WriteHeader(status)
 			b, err := json.Marshal(replica.SimpleResponse{
-				Errors: []replica.Error{{Msg: msg}},
+				Errors: []rplicaerrors.Error{{Msg: msg}},
 			})
 			require.NoError(t, err)
 			w.Write(b)

--- a/usecases/replica/coordinator_test.go
+++ b/usecases/replica/coordinator_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/replica"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 type errorType string
@@ -126,7 +126,7 @@ func Test_coordinatorPush(t *testing.T) {
 			}
 			w.WriteHeader(status)
 			b, err := json.Marshal(replica.SimpleResponse{
-				Errors: []rplicaerrors.Error{{Msg: msg}},
+				Errors: []replicaerrors.Error{{Msg: msg}},
 			})
 			require.NoError(t, err)
 			w.Write(b)

--- a/usecases/replica/errors/errors.go
+++ b/usecases/replica/errors/errors.go
@@ -1,0 +1,170 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package errors centralises error types and sentinel values for the
+// replication subsystem.  All packages that need to produce or inspect
+// replica errors should import this package rather than defining their own.
+package errors
+
+import (
+	"errors"
+	"fmt"
+)
+
+// MsgCLevel is the human-readable prefix used in consistency-level errors.
+const MsgCLevel = "cannot achieve consistency level"
+
+// Sentinel errors – use errors.Is / errors.As to inspect wrapped values.
+var (
+	// ErrReplicas is the canonical sentinel for "not enough replicas were
+	// reachable".  It is intentionally kept simple so that callers can rely
+	// on errors.Is for detection while the richer NotEnoughReplicasError
+	// type carries the underlying cause.
+	ErrReplicas = errors.New("cannot reach enough replicas")
+
+	ErrRepair      = errors.New("read repair error")
+	ErrRead        = errors.New("read error")
+	ErrNoDiffFound = errors.New("no diff found")
+
+	// ErrConflictExistOrDeleted is returned during read-repair when an object
+	// exists on one replica but has been deleted on another.
+	ErrConflictExistOrDeleted = errors.New("conflict: object has been deleted on another replica")
+
+	// ErrConflictObjectChanged is returned when the source object changed
+	// between the digest read and the repair write.
+	ErrConflictObjectChanged = errors.New("source object changed during repair")
+)
+
+// NotEnoughReplicasError is returned by the coordinator when it cannot reach
+// a sufficient number of replicas to satisfy the requested consistency level.
+// It wraps the underlying per-replica causes so that callers can inspect
+// what went wrong, while still being detectable via errors.Is(err, ErrReplicas).
+type NotEnoughReplicasError struct {
+	cause error
+}
+
+// NewNotEnoughReplicasError constructs a NotEnoughReplicasError that wraps
+// cause.  cause may be nil when no underlying diagnostic is available.
+func NewNotEnoughReplicasError(cause error) error {
+	return &NotEnoughReplicasError{cause: cause}
+}
+
+func (e *NotEnoughReplicasError) Error() string {
+	if e.cause != nil {
+		return ErrReplicas.Error() + ": " + e.cause.Error()
+	}
+	return ErrReplicas.Error()
+}
+
+// Unwrap returns the underlying cause so that errors.Is / errors.As can
+// traverse the chain.
+func (e *NotEnoughReplicasError) Unwrap() error { return e.cause }
+
+// Is makes errors.Is(err, ErrReplicas) match any NotEnoughReplicasError,
+// preserving backward-compatible error detection for callers that check for
+// the sentinel directly.
+func (e *NotEnoughReplicasError) Is(target error) bool {
+	return target == ErrReplicas
+}
+
+// ---------------------------------------------------------------------------
+// StatusCode and Error – transport-level error representation
+// ---------------------------------------------------------------------------
+
+// StatusCode communicates the cause of failure during replication.
+type StatusCode int
+
+const (
+	StatusOK            = 0
+	StatusClassNotFound = iota + 200
+	StatusShardNotFound
+	StatusNotFound
+	StatusAlreadyExisted
+	StatusNotReady
+	StatusConflict = iota + 300
+	StatusPreconditionFailed
+	StatusReadOnly
+	StatusObjectNotFound
+)
+
+// StatusText returns a text for the status code. It returns the empty string
+// if the code is unknown.
+func StatusText(code StatusCode) string {
+	switch code {
+	case StatusOK:
+		return "ok"
+	case StatusNotFound:
+		return "not found"
+	case StatusClassNotFound:
+		return "class not found"
+	case StatusShardNotFound:
+		return "shard not found"
+	case StatusConflict:
+		return "conflict"
+	case StatusPreconditionFailed:
+		return "precondition failed"
+	case StatusAlreadyExisted:
+		return "already existed"
+	case StatusNotReady:
+		return "local index not ready"
+	case StatusReadOnly:
+		return "read only"
+	case StatusObjectNotFound:
+		return "object not found"
+	default:
+		return ""
+	}
+}
+
+// Error reports an error that occurred during replication.  It is used as a
+// wire-level type and is intentionally JSON-serialisable.
+type Error struct {
+	Code StatusCode `json:"code"`
+	Msg  string     `json:"msg,omitempty"`
+	Err  error      `json:"-"`
+}
+
+// NewError creates a new replication error with the given code and message.
+func NewError(code StatusCode, msg string) *Error {
+	return &Error{code, msg, nil}
+}
+
+// Empty reports whether e is semantically nil (no code, no message, no
+// underlying error), which is equivalent to the absence of an error.
+func (e *Error) Empty() bool {
+	return e.Code == StatusOK && e.Msg == "" && e.Err == nil
+}
+
+// Clone returns a shallow copy of e.
+func (e *Error) Clone() *Error {
+	return &Error{Code: e.Code, Msg: e.Msg, Err: e.Err}
+}
+
+// Unwrap returns the underlying error so that errors.Is / errors.As can
+// traverse the chain.
+func (e *Error) Unwrap() error { return e.Err }
+
+func (e *Error) Error() string {
+	return fmt.Sprintf("%s %q: %v", StatusText(e.Code), e.Msg, e.Err)
+}
+
+// IsStatusCode reports whether e carries the given status code.
+func (e *Error) IsStatusCode(sc StatusCode) bool {
+	return e.Code == sc
+}
+
+// Timeout reports whether the underlying error is a timeout.
+func (e *Error) Timeout() bool {
+	t, ok := e.Err.(interface {
+		Timeout() bool
+	})
+	return ok && t.Timeout()
+}

--- a/usecases/replica/errors/errors.go
+++ b/usecases/replica/errors/errors.go
@@ -50,16 +50,13 @@ var (
 
 // notEnoughReplicasError is returned by the coordinator when it cannot reach
 // a sufficient number of replicas to satisfy the requested consistency level.
-// It preserves the first underlying cause and tracks how many additional
-// errors were observed (without retaining them) so memory remains O(1).
 //
 // Use errors.Is(err, ErrReplicas) for detection and errors.Unwrap / errors.As
 // to inspect the underlying cause.
 type notEnoughReplicasError struct {
-	required   int   // total replicas required to satisfy the consistency level
-	got        int   // number of replicas that succeeded
-	cause      error // first error observed from a failed replica (may be nil)
-	additional int   // count of further errors observed beyond cause
+	required int   // total replicas required to satisfy the consistency level
+	got      int   // number of replicas that succeeded
+	cause    error // joined per-replica errors observed (may be nil)
 }
 
 // NewNotEnoughReplicasError wraps cause in an error that satisfies
@@ -72,15 +69,12 @@ func NewNotEnoughReplicasError(cause error) error {
 
 // NewNotEnoughReplicasErrorWithCounts is the rich form of
 // NewNotEnoughReplicasError used by the coordinator when it knows how
-// many replicas were required vs. succeeded.  additional is the count of
-// further errors observed beyond the first one (cause); the count is kept
-// rather than the errors themselves so memory remains O(1).
-func NewNotEnoughReplicasErrorWithCounts(required, got int, cause error, additional int) error {
+// many replicas were required vs. succeeded.
+func NewNotEnoughReplicasErrorWithCounts(required, got int, cause error) error {
 	return &notEnoughReplicasError{
-		required:   required,
-		got:        got,
-		cause:      cause,
-		additional: additional,
+		required: required,
+		got:      got,
+		cause:    cause,
 	}
 }
 
@@ -92,9 +86,6 @@ func (e *notEnoughReplicasError) Error() string {
 	}
 	if e.cause != nil {
 		fmt.Fprintf(&sb, ": %v", e.cause)
-	}
-	if e.additional > 0 {
-		fmt.Fprintf(&sb, " (and %d more errors)", e.additional)
 	}
 	return sb.String()
 }
@@ -168,13 +159,13 @@ func (e *repairError) Is(target error) bool {
 type StatusCode int
 
 const (
-	StatusOK            = 0
-	StatusClassNotFound = iota + 200
+	StatusOK            StatusCode = 0
+	StatusClassNotFound StatusCode = iota + 200
 	StatusShardNotFound
 	StatusNotFound
 	StatusAlreadyExisted
 	StatusNotReady
-	StatusConflict = iota + 300
+	StatusConflict StatusCode = iota + 300
 	StatusPreconditionFailed
 	StatusReadOnly
 	StatusObjectNotFound
@@ -238,6 +229,9 @@ func (e *Error) Clone() *Error {
 func (e *Error) Unwrap() error { return e.Err }
 
 func (e *Error) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("%s %q", StatusText(e.Code), e.Msg)
+	}
 	return fmt.Sprintf("%s %q: %v", StatusText(e.Code), e.Msg, e.Err)
 }
 

--- a/usecases/replica/errors/errors.go
+++ b/usecases/replica/errors/errors.go
@@ -17,6 +17,7 @@ package errors
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 // MsgCLevel is the human-readable prefix used in consistency-level errors.
@@ -26,12 +27,16 @@ const MsgCLevel = "cannot achieve consistency level"
 var (
 	// ErrReplicas is the canonical sentinel for "not enough replicas were
 	// reachable".  It is intentionally kept simple so that callers can rely
-	// on errors.Is for detection while the richer NotEnoughReplicasError
-	// type carries the underlying cause.
+	// on errors.Is for detection while richer wrapper types carry the
+	// underlying cause.
 	ErrReplicas = errors.New("cannot reach enough replicas")
 
-	ErrRepair      = errors.New("read repair error")
-	ErrRead        = errors.New("read error")
+	// ErrRepair is the canonical sentinel for read-repair failures.
+	ErrRepair = errors.New("read repair error")
+
+	// ErrRead is the canonical sentinel for replica read failures.
+	ErrRead = errors.New("read error")
+
 	ErrNoDiffFound = errors.New("no diff found")
 
 	// ErrConflictExistOrDeleted is returned during read-repair when an object
@@ -43,36 +48,116 @@ var (
 	ErrConflictObjectChanged = errors.New("source object changed during repair")
 )
 
-// NotEnoughReplicasError is returned by the coordinator when it cannot reach
+// notEnoughReplicasError is returned by the coordinator when it cannot reach
 // a sufficient number of replicas to satisfy the requested consistency level.
-// It wraps the underlying per-replica causes so that callers can inspect
-// what went wrong, while still being detectable via errors.Is(err, ErrReplicas).
-type NotEnoughReplicasError struct {
-	cause error
+// It preserves the first underlying cause and tracks how many additional
+// errors were observed (without retaining them) so memory remains O(1).
+//
+// Use errors.Is(err, ErrReplicas) for detection and errors.Unwrap / errors.As
+// to inspect the underlying cause.
+type notEnoughReplicasError struct {
+	required   int   // total replicas required to satisfy the consistency level
+	got        int   // number of replicas that succeeded
+	cause      error // first error observed from a failed replica (may be nil)
+	additional int   // count of further errors observed beyond cause
 }
 
-// NewNotEnoughReplicasError constructs a NotEnoughReplicasError that wraps
-// cause.  cause may be nil when no underlying diagnostic is available.
+// NewNotEnoughReplicasError wraps cause in an error that satisfies
+// errors.Is(err, ErrReplicas).  Use this form when only the underlying
+// error is known (e.g. a routing-plan failure); for richer diagnostics
+// from the coordinator use NewNotEnoughReplicasErrorWithCounts.
 func NewNotEnoughReplicasError(cause error) error {
-	return &NotEnoughReplicasError{cause: cause}
+	return &notEnoughReplicasError{cause: cause}
 }
 
-func (e *NotEnoughReplicasError) Error() string {
-	if e.cause != nil {
-		return ErrReplicas.Error() + ": " + e.cause.Error()
+// NewNotEnoughReplicasErrorWithCounts is the rich form of
+// NewNotEnoughReplicasError used by the coordinator when it knows how
+// many replicas were required vs. succeeded.  additional is the count of
+// further errors observed beyond the first one (cause); the count is kept
+// rather than the errors themselves so memory remains O(1).
+func NewNotEnoughReplicasErrorWithCounts(required, got int, cause error, additional int) error {
+	return &notEnoughReplicasError{
+		required:   required,
+		got:        got,
+		cause:      cause,
+		additional: additional,
 	}
-	return ErrReplicas.Error()
+}
+
+func (e *notEnoughReplicasError) Error() string {
+	var sb strings.Builder
+	sb.WriteString(ErrReplicas.Error())
+	if e.required > 0 {
+		fmt.Fprintf(&sb, ": required %d replicas, got %d", e.required, e.got)
+	}
+	if e.cause != nil {
+		fmt.Fprintf(&sb, ": %v", e.cause)
+	}
+	if e.additional > 0 {
+		fmt.Fprintf(&sb, " (and %d more errors)", e.additional)
+	}
+	return sb.String()
 }
 
 // Unwrap returns the underlying cause so that errors.Is / errors.As can
 // traverse the chain.
-func (e *NotEnoughReplicasError) Unwrap() error { return e.cause }
+func (e *notEnoughReplicasError) Unwrap() error { return e.cause }
 
-// Is makes errors.Is(err, ErrReplicas) match any NotEnoughReplicasError,
+// Is makes errors.Is(err, ErrReplicas) match any notEnoughReplicasError,
 // preserving backward-compatible error detection for callers that check for
 // the sentinel directly.
-func (e *NotEnoughReplicasError) Is(target error) bool {
+func (e *notEnoughReplicasError) Is(target error) bool {
 	return target == ErrReplicas
+}
+
+// readError wraps the underlying cause of a replica read failure while
+// remaining detectable via errors.Is(err, ErrRead).
+type readError struct {
+	cause error
+}
+
+// NewReadError constructs an error that satisfies errors.Is(err, ErrRead)
+// and wraps cause.
+func NewReadError(cause error) error {
+	return &readError{cause: cause}
+}
+
+func (e *readError) Error() string {
+	if e.cause != nil {
+		return ErrRead.Error() + ": " + e.cause.Error()
+	}
+	return ErrRead.Error()
+}
+
+func (e *readError) Unwrap() error { return e.cause }
+
+func (e *readError) Is(target error) bool {
+	return target == ErrRead
+}
+
+// repairError wraps the underlying cause of a read-repair failure while
+// remaining detectable via errors.Is(err, ErrRepair).
+type repairError struct {
+	cause error
+}
+
+// NewRepairError constructs an error that satisfies errors.Is(err, ErrRepair)
+// and wraps cause.
+func NewRepairError(cause error) error {
+	return &repairError{cause: cause}
+}
+
+func (e *repairError) Error() string {
+	if e.cause != nil {
+		return ErrRepair.Error() + ": " + e.cause.Error()
+	}
+	return ErrRepair.Error()
+}
+
+func (e *repairError) Unwrap() error { return e.cause }
+
+func (e *repairError) Is(target error) bool {
+	return target == ErrRepair
 }
 
 // ---------------------------------------------------------------------------

--- a/usecases/replica/errors/errors.go
+++ b/usecases/replica/errors/errors.go
@@ -85,7 +85,10 @@ func (e *notEnoughReplicasError) Error() string {
 		fmt.Fprintf(&sb, ": required %d replicas, got %d", e.required, e.got)
 	}
 	if e.cause != nil {
-		fmt.Fprintf(&sb, ": %v", e.cause)
+		// errors.Join separates wrapped errors with newlines; normalise to
+		// "; " so the message stays on a single line in logs and HTTP
+		// responses while errors.Is / errors.As still traverse via Unwrap.
+		fmt.Fprintf(&sb, ": %s", strings.ReplaceAll(e.cause.Error(), "\n", "; "))
 	}
 	return sb.String()
 }

--- a/usecases/replica/errors/errors_test.go
+++ b/usecases/replica/errors/errors_test.go
@@ -75,7 +75,7 @@ func TestNotEnoughReplicasError(t *testing.T) {
 			}
 
 			// Unwrap returns the underlying cause.
-			if got := errors.Unwrap(err); got != tc.cause {
+			if got := errors.Unwrap(err); !errors.Is(got, tc.cause) {
 				t.Fatalf("Unwrap() = %v, want %v", got, tc.cause)
 			}
 		})
@@ -127,7 +127,7 @@ func TestReadError(t *testing.T) {
 	if !errors.Is(err, rootCause) {
 		t.Fatalf("errors.Is(err, rootCause) = false, want true")
 	}
-	if got := errors.Unwrap(err); got != rootCause {
+	if got := errors.Unwrap(err); !errors.Is(got, rootCause) {
 		t.Fatalf("Unwrap() = %v, want %v", got, rootCause)
 	}
 }
@@ -157,7 +157,7 @@ func TestRepairError(t *testing.T) {
 	if !errors.Is(err, rootCause) {
 		t.Fatalf("errors.Is(err, rootCause) = false, want true")
 	}
-	if got := errors.Unwrap(err); got != rootCause {
+	if got := errors.Unwrap(err); !errors.Is(got, rootCause) {
 		t.Fatalf("Unwrap() = %v, want %v", got, rootCause)
 	}
 }

--- a/usecases/replica/errors/errors_test.go
+++ b/usecases/replica/errors/errors_test.go
@@ -1,0 +1,229 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
+
+func TestNotEnoughReplicasError(t *testing.T) {
+	rootCause := errors.New("dial tcp 10.0.1.5:8080: i/o timeout")
+
+	tests := []struct {
+		name       string
+		required   int
+		got        int
+		cause      error
+		additional int
+		wantMsg    string
+	}{
+		{
+			name:    "no context",
+			wantMsg: ErrReplicas.Error(),
+		},
+		{
+			name:    "cause only",
+			cause:   rootCause,
+			wantMsg: ErrReplicas.Error() + ": " + rootCause.Error(),
+		},
+		{
+			name:     "counts only",
+			required: 3,
+			got:      1,
+			wantMsg:  ErrReplicas.Error() + ": required 3 replicas, got 1",
+		},
+		{
+			name:       "full message",
+			required:   3,
+			got:        1,
+			cause:      rootCause,
+			additional: 2,
+			wantMsg: ErrReplicas.Error() +
+				": required 3 replicas, got 1: " +
+				rootCause.Error() +
+				" (and 2 more errors)",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := NewNotEnoughReplicasErrorWithCounts(tc.required, tc.got, tc.cause, tc.additional)
+
+			if got := err.Error(); got != tc.wantMsg {
+				t.Fatalf("Error() = %q, want %q", got, tc.wantMsg)
+			}
+
+			// errors.Is must match the sentinel for backward compatibility.
+			if !errors.Is(err, ErrReplicas) {
+				t.Fatalf("errors.Is(err, ErrReplicas) = false, want true")
+			}
+
+			// errors.Is must traverse to the underlying cause.
+			if tc.cause != nil && !errors.Is(err, tc.cause) {
+				t.Fatalf("errors.Is(err, cause) = false, want true")
+			}
+
+			// Unwrap returns the underlying cause.
+			if got := errors.Unwrap(err); got != tc.cause {
+				t.Fatalf("Unwrap() = %v, want %v", got, tc.cause)
+			}
+		})
+	}
+}
+
+func TestNotEnoughReplicasError_Simple(t *testing.T) {
+	rootCause := errors.New("build routing plan: shard not found")
+	err := NewNotEnoughReplicasError(rootCause)
+
+	want := ErrReplicas.Error() + ": " + rootCause.Error()
+	if got := err.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+	if !errors.Is(err, ErrReplicas) {
+		t.Fatalf("errors.Is(err, ErrReplicas) = false, want true")
+	}
+	if !errors.Is(err, rootCause) {
+		t.Fatalf("errors.Is(err, rootCause) = false, want true")
+	}
+}
+
+func TestNotEnoughReplicasError_WrapsFmtErrorf(t *testing.T) {
+	rootCause := errors.New("connection refused")
+	wrapped := fmt.Errorf("commit: %w", NewNotEnoughReplicasErrorWithCounts(3, 1, rootCause, 0))
+
+	if !errors.Is(wrapped, ErrReplicas) {
+		t.Fatalf("errors.Is(wrapped, ErrReplicas) = false, want true")
+	}
+	if !errors.Is(wrapped, rootCause) {
+		t.Fatalf("errors.Is(wrapped, rootCause) = false, want true")
+	}
+	if want := "connection refused"; !contains(wrapped.Error(), want) {
+		t.Fatalf("Error() = %q, want it to contain %q", wrapped.Error(), want)
+	}
+}
+
+func TestReadError(t *testing.T) {
+	rootCause := errors.New("context deadline exceeded")
+	err := NewReadError(rootCause)
+
+	if got, want := err.Error(), ErrRead.Error()+": "+rootCause.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+
+	if !errors.Is(err, ErrRead) {
+		t.Fatalf("errors.Is(err, ErrRead) = false, want true")
+	}
+	if !errors.Is(err, rootCause) {
+		t.Fatalf("errors.Is(err, rootCause) = false, want true")
+	}
+	if got := errors.Unwrap(err); got != rootCause {
+		t.Fatalf("Unwrap() = %v, want %v", got, rootCause)
+	}
+}
+
+func TestReadError_NilCause(t *testing.T) {
+	err := NewReadError(nil)
+
+	if got := err.Error(); got != ErrRead.Error() {
+		t.Fatalf("Error() = %q, want %q", got, ErrRead.Error())
+	}
+	if !errors.Is(err, ErrRead) {
+		t.Fatalf("errors.Is(err, ErrRead) = false, want true")
+	}
+}
+
+func TestRepairError(t *testing.T) {
+	rootCause := errors.New("digest mismatch on shard-1")
+	err := NewRepairError(rootCause)
+
+	if got, want := err.Error(), ErrRepair.Error()+": "+rootCause.Error(); got != want {
+		t.Fatalf("Error() = %q, want %q", got, want)
+	}
+
+	if !errors.Is(err, ErrRepair) {
+		t.Fatalf("errors.Is(err, ErrRepair) = false, want true")
+	}
+	if !errors.Is(err, rootCause) {
+		t.Fatalf("errors.Is(err, rootCause) = false, want true")
+	}
+	if got := errors.Unwrap(err); got != rootCause {
+		t.Fatalf("Unwrap() = %v, want %v", got, rootCause)
+	}
+}
+
+func TestRepairError_NilCause(t *testing.T) {
+	err := NewRepairError(nil)
+
+	if got := err.Error(); got != ErrRepair.Error() {
+		t.Fatalf("Error() = %q, want %q", got, ErrRepair.Error())
+	}
+	if !errors.Is(err, ErrRepair) {
+		t.Fatalf("errors.Is(err, ErrRepair) = false, want true")
+	}
+}
+
+// TestErrors_DistinctSentinels ensures the three sentinels do not satisfy
+// each other's Is checks (e.g. a read error must not match ErrRepair).
+func TestErrors_DistinctSentinels(t *testing.T) {
+	cases := []struct {
+		name    string
+		err     error
+		matches error
+		other   []error
+	}{
+		{
+			name:    "not enough replicas",
+			err:     NewNotEnoughReplicasError(errors.New("x")),
+			matches: ErrReplicas,
+			other:   []error{ErrRead, ErrRepair},
+		},
+		{
+			name:    "read",
+			err:     NewReadError(errors.New("x")),
+			matches: ErrRead,
+			other:   []error{ErrReplicas, ErrRepair},
+		},
+		{
+			name:    "repair",
+			err:     NewRepairError(errors.New("x")),
+			matches: ErrRepair,
+			other:   []error{ErrReplicas, ErrRead},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !errors.Is(tc.err, tc.matches) {
+				t.Fatalf("errors.Is(%v, %v) = false, want true", tc.err, tc.matches)
+			}
+			for _, o := range tc.other {
+				if errors.Is(tc.err, o) {
+					t.Fatalf("errors.Is(%v, %v) = true, want false", tc.err, o)
+				}
+			}
+		})
+	}
+}
+
+func contains(haystack, needle string) bool {
+	if len(needle) == 0 {
+		return true
+	}
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/usecases/replica/errors/errors_test.go
+++ b/usecases/replica/errors/errors_test.go
@@ -21,12 +21,11 @@ func TestNotEnoughReplicasError(t *testing.T) {
 	rootCause := errors.New("dial tcp 10.0.1.5:8080: i/o timeout")
 
 	tests := []struct {
-		name       string
-		required   int
-		got        int
-		cause      error
-		additional int
-		wantMsg    string
+		name     string
+		required int
+		got      int
+		cause    error
+		wantMsg  string
 	}{
 		{
 			name:    "no context",
@@ -44,21 +43,19 @@ func TestNotEnoughReplicasError(t *testing.T) {
 			wantMsg:  ErrReplicas.Error() + ": required 3 replicas, got 1",
 		},
 		{
-			name:       "full message",
-			required:   3,
-			got:        1,
-			cause:      rootCause,
-			additional: 2,
+			name:     "full message",
+			required: 3,
+			got:      1,
+			cause:    rootCause,
 			wantMsg: ErrReplicas.Error() +
 				": required 3 replicas, got 1: " +
-				rootCause.Error() +
-				" (and 2 more errors)",
+				rootCause.Error(),
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := NewNotEnoughReplicasErrorWithCounts(tc.required, tc.got, tc.cause, tc.additional)
+			err := NewNotEnoughReplicasErrorWithCounts(tc.required, tc.got, tc.cause)
 
 			if got := err.Error(); got != tc.wantMsg {
 				t.Fatalf("Error() = %q, want %q", got, tc.wantMsg)
@@ -100,7 +97,7 @@ func TestNotEnoughReplicasError_Simple(t *testing.T) {
 
 func TestNotEnoughReplicasError_WrapsFmtErrorf(t *testing.T) {
 	rootCause := errors.New("connection refused")
-	wrapped := fmt.Errorf("commit: %w", NewNotEnoughReplicasErrorWithCounts(3, 1, rootCause, 0))
+	wrapped := fmt.Errorf("commit: %w", NewNotEnoughReplicasErrorWithCounts(3, 1, rootCause))
 
 	if !errors.Is(wrapped, ErrReplicas) {
 		t.Fatalf("errors.Is(wrapped, ErrReplicas) = false, want true")
@@ -213,6 +210,94 @@ func TestErrors_DistinctSentinels(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestError_Empty(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *Error
+		want bool
+	}{
+		{name: "zero value", err: &Error{}, want: true},
+		{name: "ok with empty msg and no inner", err: NewError(StatusOK, ""), want: true},
+		{name: "non-zero code", err: NewError(StatusConflict, ""), want: false},
+		{name: "non-empty msg", err: NewError(StatusOK, "boom"), want: false},
+		{name: "with inner err", err: &Error{Err: errors.New("x")}, want: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Empty(); got != tc.want {
+				t.Fatalf("Empty() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestError_IsStatusCode(t *testing.T) {
+	e := NewError(StatusConflict, "x")
+	if !e.IsStatusCode(StatusConflict) {
+		t.Fatalf("IsStatusCode(StatusConflict) = false, want true")
+	}
+	if e.IsStatusCode(StatusOK) {
+		t.Fatalf("IsStatusCode(StatusOK) = true, want false")
+	}
+}
+
+func TestError_ErrorFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		err  *Error
+		want string
+	}{
+		{
+			name: "with inner err",
+			err:  &Error{Code: StatusConflict, Msg: "Article", Err: errors.New("boom")},
+			want: `conflict "Article": boom`,
+		},
+		{
+			name: "no inner err omits trailing <nil>",
+			err:  &Error{Code: StatusConflict, Msg: "Article"},
+			want: `conflict "Article"`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.err.Error(); got != tc.want {
+				t.Fatalf("Error() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestStatusText_Unknown(t *testing.T) {
+	if got := StatusText(StatusCode(-1)); got != "" {
+		t.Fatalf("StatusText(-1) = %q, want empty", got)
+	}
+	if got := StatusText(StatusCode(99999)); got != "" {
+		t.Fatalf("StatusText(99999) = %q, want empty", got)
+	}
+}
+
+// TestStatusCode_Values pins the wire values so cross-version nodes keep
+// decoding each other's replication errors correctly.
+func TestStatusCode_Values(t *testing.T) {
+	cases := map[StatusCode]int{
+		StatusOK:                 0,
+		StatusClassNotFound:      201,
+		StatusShardNotFound:      202,
+		StatusNotFound:           203,
+		StatusAlreadyExisted:     204,
+		StatusNotReady:           205,
+		StatusConflict:           306,
+		StatusPreconditionFailed: 307,
+		StatusReadOnly:           308,
+		StatusObjectNotFound:     309,
+	}
+	for sc, want := range cases {
+		if int(sc) != want {
+			t.Fatalf("StatusCode %s = %d, want %d", StatusText(sc), int(sc), want)
+		}
 	}
 }
 

--- a/usecases/replica/errors/errors_test.go
+++ b/usecases/replica/errors/errors_test.go
@@ -79,6 +79,29 @@ func TestNotEnoughReplicasError(t *testing.T) {
 	}
 }
 
+func TestNotEnoughReplicasError_JoinedCauseIsSingleLine(t *testing.T) {
+	a := errors.New("replica \"a\": dial tcp: i/o timeout")
+	b := errors.New("replica \"b\": connection refused")
+	joined := errors.Join(a, b)
+
+	err := NewNotEnoughReplicasErrorWithCounts(3, 1, joined)
+
+	if contains(err.Error(), "\n") {
+		t.Fatalf("Error() must not contain newlines, got %q", err.Error())
+	}
+	for _, want := range []string{a.Error(), b.Error(), "; "} {
+		if !contains(err.Error(), want) {
+			t.Fatalf("Error() = %q, want it to contain %q", err.Error(), want)
+		}
+	}
+	if !errors.Is(err, ErrReplicas) {
+		t.Fatalf("errors.Is(err, ErrReplicas) = false, want true")
+	}
+	if !errors.Is(err, a) || !errors.Is(err, b) {
+		t.Fatalf("errors.Is must still traverse joined causes")
+	}
+}
+
 func TestNotEnoughReplicasError_Simple(t *testing.T) {
 	rootCause := errors.New("build routing plan: shard not found")
 	err := NewNotEnoughReplicasError(rootCause)

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -32,18 +32,8 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/objects"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
-)
-
-var (
-	// MsgCLevel consistency level cannot be achieved
-	MsgCLevel = "cannot achieve consistency level"
-
-	ErrReplicas = errors.New("cannot reach enough replicas")
-	ErrRepair   = errors.New("read repair error")
-	ErrRead     = errors.New("read error")
-
-	ErrNoDiffFound = errors.New("no diff found")
 )
 
 type (
@@ -132,12 +122,12 @@ func (f *Finder) GetOne(ctx context.Context,
 	replyCh, level, err := c.Pull(ctx, l, op, "", 20*time.Second)
 	if err != nil {
 		f.log.WithField("op", "pull.one").Error(err)
-		return nil, fmt.Errorf("%s %q: %w: %w", MsgCLevel, l, ErrReplicas, err)
+		return nil, fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
 	}
 	result := <-f.readOne(ctx, shard, id, replyCh, level)
 	if err = result.Err; err != nil {
-		err = fmt.Errorf("%s %q: %w", MsgCLevel, l, err)
-		if strings.Contains(err.Error(), ErrConflictExistOrDeleted.Error()) {
+		err = fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, err)
+		if strings.Contains(err.Error(), rplicaerrors.ErrConflictExistOrDeleted.Error()) {
 			err = objects.NewErrDirtyReadOfDeletedObject(err)
 		}
 	}
@@ -156,7 +146,7 @@ func (f *Finder) FindUUIDs(ctx context.Context, className, shard string,
 	replyCh, _, err := c.Pull(ctx, l, op, "", 30*time.Second)
 	if err != nil {
 		f.log.WithField("op", "pull.one").Error(err)
-		return nil, fmt.Errorf("%s %q: %w: %w", MsgCLevel, l, ErrReplicas, err)
+		return nil, fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
 	}
 
 	res := make(map[strfmt.UUID]struct{})
@@ -259,12 +249,12 @@ func (f *Finder) Exists(ctx context.Context,
 	replyCh, state, err := c.Pull(ctx, l, op, "", 20*time.Second)
 	if err != nil {
 		f.log.WithField("op", "pull.exist").Error(err)
-		return false, fmt.Errorf("%s %q: %w: %w", MsgCLevel, l, ErrReplicas, err)
+		return false, fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
 	}
 	result := <-f.readExistence(ctx, shard, id, replyCh, state)
 	if err = result.Err; err != nil {
-		err = fmt.Errorf("%s %q: %w", MsgCLevel, l, err)
-		if strings.Contains(err.Error(), ErrConflictExistOrDeleted.Error()) {
+		err = fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, err)
+		if strings.Contains(err.Error(), rplicaerrors.ErrConflictExistOrDeleted.Error()) {
 			err = objects.NewErrDirtyReadOfDeletedObject(err)
 		}
 	}
@@ -309,7 +299,7 @@ func (f *Finder) checkShardConsistency(ctx context.Context,
 
 	replyCh, state, err := c.Pull(ctx, l, op, batch.Node, 20*time.Second)
 	if err != nil {
-		return nil, fmt.Errorf("pull shard: %w: %w", ErrReplicas, err)
+		return nil, fmt.Errorf("pull shard: %w", rplicaerrors.NewNotEnoughReplicasError(err))
 	}
 	result := <-f.readBatchPart(ctx, batch, ids, replyCh, state)
 	return result.Value, result.Err
@@ -381,7 +371,7 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 			return &ShardDifferenceReader{
 				TargetNodeName:    targetNodeName,
 				TargetNodeAddress: targetNodeAddress,
-			}, ErrNoDiffFound
+			}, rplicaerrors.ErrNoDiffFound
 		}
 
 		rangeReader, err := ht.NewRangeReader(leaf)
@@ -443,7 +433,7 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 
 		diffReader, err := collectDiffForTargetNode(targetNodeAddress, targetNodeName)
 		if err != nil {
-			if !errors.Is(err, ErrNoDiffFound) {
+			if !errors.Is(err, rplicaerrors.ErrNoDiffFound) {
 				ec.Add(err)
 			}
 			continue
@@ -457,7 +447,7 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 		return nil, err
 	}
 
-	return &ShardDifferenceReader{}, ErrNoDiffFound
+	return &ShardDifferenceReader{}, rplicaerrors.ErrNoDiffFound
 }
 
 func (f *Finder) DigestObjectsInRange(ctx context.Context,

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"math/rand"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -127,7 +126,7 @@ func (f *Finder) GetOne(ctx context.Context,
 	result := <-f.readOne(ctx, shard, id, replyCh, level)
 	if err = result.Err; err != nil {
 		err = fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, err)
-		if strings.Contains(err.Error(), replicaerrors.ErrConflictExistOrDeleted.Error()) {
+		if errors.Is(err, replicaerrors.ErrConflictExistOrDeleted) {
 			err = objects.NewErrDirtyReadOfDeletedObject(err)
 		}
 	}
@@ -254,7 +253,7 @@ func (f *Finder) Exists(ctx context.Context,
 	result := <-f.readExistence(ctx, shard, id, replyCh, state)
 	if err = result.Err; err != nil {
 		err = fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, err)
-		if strings.Contains(err.Error(), replicaerrors.ErrConflictExistOrDeleted.Error()) {
+		if errors.Is(err, replicaerrors.ErrConflictExistOrDeleted) {
 			err = objects.NewErrDirtyReadOfDeletedObject(err)
 		}
 	}

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -32,7 +32,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/objects"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
@@ -122,12 +122,12 @@ func (f *Finder) GetOne(ctx context.Context,
 	replyCh, level, err := c.Pull(ctx, l, op, "", 20*time.Second)
 	if err != nil {
 		f.log.WithField("op", "pull.one").Error(err)
-		return nil, fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
+		return nil, fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, replicaerrors.NewNotEnoughReplicasError(err))
 	}
 	result := <-f.readOne(ctx, shard, id, replyCh, level)
 	if err = result.Err; err != nil {
-		err = fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, err)
-		if strings.Contains(err.Error(), rplicaerrors.ErrConflictExistOrDeleted.Error()) {
+		err = fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, err)
+		if strings.Contains(err.Error(), replicaerrors.ErrConflictExistOrDeleted.Error()) {
 			err = objects.NewErrDirtyReadOfDeletedObject(err)
 		}
 	}
@@ -146,7 +146,7 @@ func (f *Finder) FindUUIDs(ctx context.Context, className, shard string,
 	replyCh, _, err := c.Pull(ctx, l, op, "", 30*time.Second)
 	if err != nil {
 		f.log.WithField("op", "pull.one").Error(err)
-		return nil, fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
+		return nil, fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, replicaerrors.NewNotEnoughReplicasError(err))
 	}
 
 	res := make(map[strfmt.UUID]struct{})
@@ -249,12 +249,12 @@ func (f *Finder) Exists(ctx context.Context,
 	replyCh, state, err := c.Pull(ctx, l, op, "", 20*time.Second)
 	if err != nil {
 		f.log.WithField("op", "pull.exist").Error(err)
-		return false, fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
+		return false, fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, replicaerrors.NewNotEnoughReplicasError(err))
 	}
 	result := <-f.readExistence(ctx, shard, id, replyCh, state)
 	if err = result.Err; err != nil {
-		err = fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, err)
-		if strings.Contains(err.Error(), rplicaerrors.ErrConflictExistOrDeleted.Error()) {
+		err = fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, err)
+		if strings.Contains(err.Error(), replicaerrors.ErrConflictExistOrDeleted.Error()) {
 			err = objects.NewErrDirtyReadOfDeletedObject(err)
 		}
 	}
@@ -299,7 +299,7 @@ func (f *Finder) checkShardConsistency(ctx context.Context,
 
 	replyCh, state, err := c.Pull(ctx, l, op, batch.Node, 20*time.Second)
 	if err != nil {
-		return nil, fmt.Errorf("pull shard: %w", rplicaerrors.NewNotEnoughReplicasError(err))
+		return nil, fmt.Errorf("pull shard: %w", replicaerrors.NewNotEnoughReplicasError(err))
 	}
 	result := <-f.readBatchPart(ctx, batch, ids, replyCh, state)
 	return result.Value, result.Err
@@ -371,7 +371,7 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 			return &ShardDifferenceReader{
 				TargetNodeName:    targetNodeName,
 				TargetNodeAddress: targetNodeAddress,
-			}, rplicaerrors.ErrNoDiffFound
+			}, replicaerrors.ErrNoDiffFound
 		}
 
 		rangeReader, err := ht.NewRangeReader(leaf)
@@ -433,7 +433,7 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 
 		diffReader, err := collectDiffForTargetNode(targetNodeAddress, targetNodeName)
 		if err != nil {
-			if !errors.Is(err, rplicaerrors.ErrNoDiffFound) {
+			if !errors.Is(err, replicaerrors.ErrNoDiffFound) {
 				ec.Add(err)
 			}
 			continue
@@ -447,7 +447,7 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 		return nil, err
 	}
 
-	return &ShardDifferenceReader{}, rplicaerrors.ErrNoDiffFound
+	return &ShardDifferenceReader{}, replicaerrors.ErrNoDiffFound
 }
 
 func (f *Finder) DigestObjectsInRange(ctx context.Context,

--- a/usecases/replica/finder_stream.go
+++ b/usecases/replica/finder_stream.go
@@ -23,7 +23,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/router/types"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 // pullSteam is used by the finder to pull objects from replicas
@@ -68,7 +68,7 @@ func (f *finderStream) readOne(ctx context.Context,
 				f.log.WithField("op", "get").WithField("replica", resp.sender).
 					WithField("class", f.class).WithField("shard", shard).
 					WithField("uuid", id).Error(r.Err)
-				resultCh <- ObjResult{nil, rplicaerrors.ErrRead}
+				resultCh <- ObjResult{nil, replicaerrors.ErrRead}
 				return
 			}
 			if !resp.DigestRead {
@@ -107,7 +107,7 @@ func (f *finderStream) readOne(ctx context.Context,
 			return
 		}
 
-		resultCh <- ObjResult{nil, errors.Wrap(err, rplicaerrors.ErrRepair.Error())}
+		resultCh <- ObjResult{nil, errors.Wrap(err, replicaerrors.ErrRepair.Error())}
 		var sb strings.Builder
 		for i, c := range votes {
 			if i != 0 {
@@ -154,7 +154,7 @@ func (f *finderStream) readExistence(ctx context.Context,
 				f.log.WithField("op", "exists").WithField("replica", resp.Sender).
 					WithField("class", f.class).WithField("shard", shard).
 					WithField("uuid", id).Error(r.Err)
-				resultCh <- Result[bool]{false, rplicaerrors.ErrRead}
+				resultCh <- Result[bool]{false, replicaerrors.ErrRead}
 				return
 			}
 
@@ -184,7 +184,7 @@ func (f *finderStream) readExistence(ctx context.Context,
 			resultCh <- Result[bool]{obj, nil}
 			return
 		}
-		resultCh <- Result[bool]{false, errors.Wrap(err, rplicaerrors.ErrRepair.Error())}
+		resultCh <- Result[bool]{false, errors.Wrap(err, replicaerrors.ErrRepair.Error())}
 
 		var sb strings.Builder
 		for i, c := range votes {
@@ -225,7 +225,7 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 			if r.Err != nil { // at least one node is not responding
 				f.log.WithField("op", "read_batch.get").WithField("replica", r.Value.Sender).
 					WithField("class", f.class).WithField("shard", batch.Shard).Error(r.Err)
-				resultCh <- batchResult{nil, rplicaerrors.ErrRead}
+				resultCh <- batchResult{nil, replicaerrors.ErrRead}
 				return
 			}
 			if !resp.IsDigest {
@@ -263,7 +263,7 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 		}
 		res, err := f.repairBatchPart(ctx, batch.Shard, ids, votes, contentIdx)
 		if err != nil {
-			resultCh <- batchResult{nil, rplicaerrors.ErrRepair}
+			resultCh <- batchResult{nil, replicaerrors.ErrRepair}
 			f.log.WithField("op", "repair_batch").WithField("class", f.class).
 				WithField("shard", batch.Shard).WithField("uuids", ids).Error(err)
 			return

--- a/usecases/replica/finder_stream.go
+++ b/usecases/replica/finder_stream.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/router/types"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 // pullSteam is used by the finder to pull objects from replicas
@@ -67,7 +68,7 @@ func (f *finderStream) readOne(ctx context.Context,
 				f.log.WithField("op", "get").WithField("replica", resp.sender).
 					WithField("class", f.class).WithField("shard", shard).
 					WithField("uuid", id).Error(r.Err)
-				resultCh <- ObjResult{nil, ErrRead}
+				resultCh <- ObjResult{nil, rplicaerrors.ErrRead}
 				return
 			}
 			if !resp.DigestRead {
@@ -106,7 +107,7 @@ func (f *finderStream) readOne(ctx context.Context,
 			return
 		}
 
-		resultCh <- ObjResult{nil, errors.Wrap(err, ErrRepair.Error())}
+		resultCh <- ObjResult{nil, errors.Wrap(err, rplicaerrors.ErrRepair.Error())}
 		var sb strings.Builder
 		for i, c := range votes {
 			if i != 0 {
@@ -153,7 +154,7 @@ func (f *finderStream) readExistence(ctx context.Context,
 				f.log.WithField("op", "exists").WithField("replica", resp.Sender).
 					WithField("class", f.class).WithField("shard", shard).
 					WithField("uuid", id).Error(r.Err)
-				resultCh <- Result[bool]{false, ErrRead}
+				resultCh <- Result[bool]{false, rplicaerrors.ErrRead}
 				return
 			}
 
@@ -183,7 +184,7 @@ func (f *finderStream) readExistence(ctx context.Context,
 			resultCh <- Result[bool]{obj, nil}
 			return
 		}
-		resultCh <- Result[bool]{false, errors.Wrap(err, ErrRepair.Error())}
+		resultCh <- Result[bool]{false, errors.Wrap(err, rplicaerrors.ErrRepair.Error())}
 
 		var sb strings.Builder
 		for i, c := range votes {
@@ -224,7 +225,7 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 			if r.Err != nil { // at least one node is not responding
 				f.log.WithField("op", "read_batch.get").WithField("replica", r.Value.Sender).
 					WithField("class", f.class).WithField("shard", batch.Shard).Error(r.Err)
-				resultCh <- batchResult{nil, ErrRead}
+				resultCh <- batchResult{nil, rplicaerrors.ErrRead}
 				return
 			}
 			if !resp.IsDigest {
@@ -262,7 +263,7 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 		}
 		res, err := f.repairBatchPart(ctx, batch.Shard, ids, votes, contentIdx)
 		if err != nil {
-			resultCh <- batchResult{nil, ErrRepair}
+			resultCh <- batchResult{nil, rplicaerrors.ErrRepair}
 			f.log.WithField("op", "repair_batch").WithField("class", f.class).
 				WithField("shard", batch.Shard).WithField("uuids", ids).Error(err)
 			return

--- a/usecases/replica/finder_stream.go
+++ b/usecases/replica/finder_stream.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/cluster/router/types"
@@ -68,7 +67,7 @@ func (f *finderStream) readOne(ctx context.Context,
 				f.log.WithField("op", "get").WithField("replica", resp.sender).
 					WithField("class", f.class).WithField("shard", shard).
 					WithField("uuid", id).Error(r.Err)
-				resultCh <- ObjResult{nil, replicaerrors.ErrRead}
+				resultCh <- ObjResult{nil, replicaerrors.NewReadError(r.Err)}
 				return
 			}
 			if !resp.DigestRead {
@@ -107,7 +106,7 @@ func (f *finderStream) readOne(ctx context.Context,
 			return
 		}
 
-		resultCh <- ObjResult{nil, errors.Wrap(err, replicaerrors.ErrRepair.Error())}
+		resultCh <- ObjResult{nil, replicaerrors.NewRepairError(err)}
 		var sb strings.Builder
 		for i, c := range votes {
 			if i != 0 {
@@ -154,7 +153,7 @@ func (f *finderStream) readExistence(ctx context.Context,
 				f.log.WithField("op", "exists").WithField("replica", resp.Sender).
 					WithField("class", f.class).WithField("shard", shard).
 					WithField("uuid", id).Error(r.Err)
-				resultCh <- Result[bool]{false, replicaerrors.ErrRead}
+				resultCh <- Result[bool]{false, replicaerrors.NewReadError(r.Err)}
 				return
 			}
 
@@ -184,7 +183,7 @@ func (f *finderStream) readExistence(ctx context.Context,
 			resultCh <- Result[bool]{obj, nil}
 			return
 		}
-		resultCh <- Result[bool]{false, errors.Wrap(err, replicaerrors.ErrRepair.Error())}
+		resultCh <- Result[bool]{false, replicaerrors.NewRepairError(err)}
 
 		var sb strings.Builder
 		for i, c := range votes {
@@ -225,7 +224,7 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 			if r.Err != nil { // at least one node is not responding
 				f.log.WithField("op", "read_batch.get").WithField("replica", r.Value.Sender).
 					WithField("class", f.class).WithField("shard", batch.Shard).Error(r.Err)
-				resultCh <- batchResult{nil, replicaerrors.ErrRead}
+				resultCh <- batchResult{nil, replicaerrors.NewReadError(r.Err)}
 				return
 			}
 			if !resp.IsDigest {
@@ -263,7 +262,7 @@ func (f *finderStream) readBatchPart(ctx context.Context,
 		}
 		res, err := f.repairBatchPart(ctx, batch.Shard, ids, votes, contentIdx)
 		if err != nil {
-			resultCh <- batchResult{nil, replicaerrors.ErrRepair}
+			resultCh <- batchResult{nil, replicaerrors.NewRepairError(err)}
 			f.log.WithField("op", "repair_batch").WithField("class", f.class).
 				WithField("shard", batch.Shard).WithField("uuids", ids).Error(err)
 			return

--- a/usecases/replica/finder_test.go
+++ b/usecases/replica/finder_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/replica"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 func genInputs(node, shard string, updateTime int64, ids []strfmt.UUID) ([]*storobj.Object, []types.RepairResponse) {
@@ -125,7 +125,7 @@ func TestFinderCantReachEnoughReplicas(t *testing.T) {
 			)
 
 			finder.CheckConsistency(ctx, types.ConsistencyLevelAll, []*storobj.Object{objectEx("1", 1, "S", "N")})
-			f.assertLogErrorContains(t, rplicaerrors.ErrReplicas.Error())
+			f.assertLogErrorContains(t, replicaerrors.ErrReplicas.Error())
 		})
 	}
 }
@@ -217,7 +217,7 @@ func TestFinderGetOneWithConsistencyLevelALL(t *testing.T) {
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelAll, shard, id, proj, adds)
 
-			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
+			assert.ErrorIs(t, err, replicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 
 			assert.Equal(t, nilObject, got)
@@ -277,7 +277,7 @@ func TestFinderGetOneWithConsistencyLevelALL(t *testing.T) {
 			if s := time.Since(before); s > time.Second {
 				assert.Failf(t, "GetOne took too long to return after context was cancelled", "took: %v", s)
 			}
-			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
+			assert.ErrorIs(t, err, replicaerrors.ErrRead)
 			assert.Equal(t, nilObject, got)
 			f.assertLogErrorContains(t, errAny.Error())
 		})
@@ -345,7 +345,7 @@ func TestFinderGetOneWithConsistencyLevelQuorum(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 			defer cancel()
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelQuorum, shard, id, proj, adds)
-			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
+			assert.ErrorIs(t, err, replicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 			assert.Equal(t, nilObject, got)
 		})
@@ -432,7 +432,7 @@ func TestFinderGetOneWithConsistencyLevelQuorum(t *testing.T) {
 			defer cancel()
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelQuorum, shard, id, proj, adds)
 
-			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
+			assert.ErrorIs(t, err, replicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 			assert.Equal(t, nilObject, got)
 		})
@@ -460,7 +460,7 @@ func TestFinderGetOneWithConsistencyLevelQuorum(t *testing.T) {
 			defer cancel()
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelQuorum, shard, id, proj, adds)
 
-			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
+			assert.ErrorIs(t, err, replicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 			assert.Equal(t, nilObject, got)
 		})
@@ -543,7 +543,7 @@ func TestFinderGetOneWithConsistencyLevelOne(t *testing.T) {
 			}
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelOne, shard, id, proj, adds)
-			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
+			assert.ErrorIs(t, err, replicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 			assert.Equal(t, nilObject, got)
 		})
@@ -605,7 +605,7 @@ func TestFinderExistsWithConsistencyLevelALL(t *testing.T) {
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[2], cls, shard, digestIDs, 0).Return(digestR, nil)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelAll, shard, id)
-			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
+			assert.ErrorIs(t, err, replicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 			assert.Equal(t, false, got)
 		})
@@ -675,7 +675,7 @@ func TestFinderExistsWithConsistencyLevelQuorum(t *testing.T) {
 			f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs, 0).Return(digestR, errAny)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelQuorum, shard, id)
-			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
+			assert.ErrorIs(t, err, replicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 			assert.Equal(t, false, got)
 		})
@@ -797,9 +797,9 @@ func TestFinderCheckConsistencyALL(t *testing.T) {
 
 			err := finder.CheckConsistency(ctx, types.ConsistencyLevelAll, xs)
 			want := setObjectsConsistency(xs, false)
-			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
+			assert.ErrorIs(t, err, replicaerrors.ErrRead)
 			assert.ElementsMatch(t, want, xs)
-			f.assertLogErrorContains(t, rplicaerrors.ErrRead.Error())
+			f.assertLogErrorContains(t, replicaerrors.ErrRead.Error())
 		})
 
 		t.Run(fmt.Sprintf("OneShard_%v", tc.variant), func(t *testing.T) {
@@ -991,9 +991,9 @@ func TestFinderCheckConsistencyQuorum(t *testing.T) {
 
 			err := finder.CheckConsistency(ctx, types.ConsistencyLevelAll, xs)
 			want := setObjectsConsistency(xs, false)
-			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
+			assert.ErrorIs(t, err, replicaerrors.ErrRead)
 			assert.ElementsMatch(t, want, xs)
-			f.assertLogErrorContains(t, rplicaerrors.ErrRead.Error())
+			f.assertLogErrorContains(t, replicaerrors.ErrRead.Error())
 		})
 
 		t.Run(fmt.Sprintf("Success_%v", tc.variant), func(t *testing.T) {

--- a/usecases/replica/finder_test.go
+++ b/usecases/replica/finder_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/replica"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 func genInputs(node, shard string, updateTime int64, ids []strfmt.UUID) ([]*storobj.Object, []types.RepairResponse) {
@@ -124,7 +125,7 @@ func TestFinderCantReachEnoughReplicas(t *testing.T) {
 			)
 
 			finder.CheckConsistency(ctx, types.ConsistencyLevelAll, []*storobj.Object{objectEx("1", 1, "S", "N")})
-			f.assertLogErrorContains(t, replica.ErrReplicas.Error())
+			f.assertLogErrorContains(t, rplicaerrors.ErrReplicas.Error())
 		})
 	}
 }
@@ -216,7 +217,7 @@ func TestFinderGetOneWithConsistencyLevelALL(t *testing.T) {
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelAll, shard, id, proj, adds)
 
-			assert.ErrorIs(t, err, replica.ErrRead)
+			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 
 			assert.Equal(t, nilObject, got)
@@ -276,7 +277,7 @@ func TestFinderGetOneWithConsistencyLevelALL(t *testing.T) {
 			if s := time.Since(before); s > time.Second {
 				assert.Failf(t, "GetOne took too long to return after context was cancelled", "took: %v", s)
 			}
-			assert.ErrorIs(t, err, replica.ErrRead)
+			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
 			assert.Equal(t, nilObject, got)
 			f.assertLogErrorContains(t, errAny.Error())
 		})
@@ -344,7 +345,7 @@ func TestFinderGetOneWithConsistencyLevelQuorum(t *testing.T) {
 			ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 			defer cancel()
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelQuorum, shard, id, proj, adds)
-			assert.ErrorIs(t, err, replica.ErrRead)
+			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 			assert.Equal(t, nilObject, got)
 		})
@@ -431,7 +432,7 @@ func TestFinderGetOneWithConsistencyLevelQuorum(t *testing.T) {
 			defer cancel()
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelQuorum, shard, id, proj, adds)
 
-			assert.ErrorIs(t, err, replica.ErrRead)
+			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 			assert.Equal(t, nilObject, got)
 		})
@@ -459,7 +460,7 @@ func TestFinderGetOneWithConsistencyLevelQuorum(t *testing.T) {
 			defer cancel()
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelQuorum, shard, id, proj, adds)
 
-			assert.ErrorIs(t, err, replica.ErrRead)
+			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 			assert.Equal(t, nilObject, got)
 		})
@@ -542,7 +543,7 @@ func TestFinderGetOneWithConsistencyLevelOne(t *testing.T) {
 			}
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelOne, shard, id, proj, adds)
-			assert.ErrorIs(t, err, replica.ErrRead)
+			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 			assert.Equal(t, nilObject, got)
 		})
@@ -604,7 +605,7 @@ func TestFinderExistsWithConsistencyLevelALL(t *testing.T) {
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[2], cls, shard, digestIDs, 0).Return(digestR, nil)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelAll, shard, id)
-			assert.ErrorIs(t, err, replica.ErrRead)
+			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 			assert.Equal(t, false, got)
 		})
@@ -674,7 +675,7 @@ func TestFinderExistsWithConsistencyLevelQuorum(t *testing.T) {
 			f.RClient.On("DigestObjects", anyVal, nodes[2], cls, shard, digestIDs, 0).Return(digestR, errAny)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelQuorum, shard, id)
-			assert.ErrorIs(t, err, replica.ErrRead)
+			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
 			f.assertLogErrorContains(t, errAny.Error())
 			assert.Equal(t, false, got)
 		})
@@ -796,9 +797,9 @@ func TestFinderCheckConsistencyALL(t *testing.T) {
 
 			err := finder.CheckConsistency(ctx, types.ConsistencyLevelAll, xs)
 			want := setObjectsConsistency(xs, false)
-			assert.ErrorIs(t, err, replica.ErrRead)
+			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
 			assert.ElementsMatch(t, want, xs)
-			f.assertLogErrorContains(t, replica.ErrRead.Error())
+			f.assertLogErrorContains(t, rplicaerrors.ErrRead.Error())
 		})
 
 		t.Run(fmt.Sprintf("OneShard_%v", tc.variant), func(t *testing.T) {
@@ -990,9 +991,9 @@ func TestFinderCheckConsistencyQuorum(t *testing.T) {
 
 			err := finder.CheckConsistency(ctx, types.ConsistencyLevelAll, xs)
 			want := setObjectsConsistency(xs, false)
-			assert.ErrorIs(t, err, replica.ErrRead)
+			assert.ErrorIs(t, err, rplicaerrors.ErrRead)
 			assert.ElementsMatch(t, want, xs)
-			f.assertLogErrorContains(t, replica.ErrRead.Error())
+			f.assertLogErrorContains(t, rplicaerrors.ErrRead.Error())
 		})
 
 		t.Run(fmt.Sprintf("Success_%v", tc.variant), func(t *testing.T) {

--- a/usecases/replica/repairer.go
+++ b/usecases/replica/repairer.go
@@ -27,7 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 // repairer tries to detect inconsistencies and repair objects when reading them from replicas
@@ -99,7 +99,7 @@ func (r *repairer) repairOne(ctx context.Context,
 					return fmt.Errorf("node %q could not repair deleted object: %w", vote.Sender, err)
 				}
 				if len(resp) > 0 && resp[0].Err != "" {
-					return fmt.Errorf("overwrite deleted object %w %s: %s", rplicaerrors.ErrConflictObjectChanged, vote.Sender, resp[0].Err)
+					return fmt.Errorf("overwrite deleted object %w %s: %s", replicaerrors.ErrConflictObjectChanged, vote.Sender, resp[0].Err)
 				}
 				return nil
 			})
@@ -109,7 +109,7 @@ func (r *repairer) repairOne(ctx context.Context,
 	}
 
 	if deleted && deletionStrategy != models.ReplicationConfigDeletionStrategyTimeBasedResolution {
-		return nil, rplicaerrors.ErrConflictExistOrDeleted
+		return nil, replicaerrors.ErrConflictExistOrDeleted
 	}
 
 	// fetch most recent object
@@ -123,7 +123,7 @@ func (r *repairer) repairOne(ctx context.Context,
 			return nil, fmt.Errorf("get most recent object from %s: %w", winner.Sender, err)
 		}
 		if updates.UpdateTime() != lastUTime {
-			return nil, fmt.Errorf("fetch new state from %s: %w, %w", winner.Sender, rplicaerrors.ErrConflictObjectChanged, err)
+			return nil, fmt.Errorf("fetch new state from %s: %w, %w", winner.Sender, replicaerrors.ErrConflictObjectChanged, err)
 		}
 	}
 
@@ -173,7 +173,7 @@ func (r *repairer) repairOne(ctx context.Context,
 				return fmt.Errorf("node %q could not repair object: %w", vote.Sender, err)
 			}
 			if len(resp) > 0 && resp[0].Err != "" {
-				return fmt.Errorf("overwrite %w %s: %s", rplicaerrors.ErrConflictObjectChanged, vote.Sender, resp[0].Err)
+				return fmt.Errorf("overwrite %w %s: %s", replicaerrors.ErrConflictObjectChanged, vote.Sender, resp[0].Err)
 			}
 			return nil
 		})
@@ -250,7 +250,7 @@ func (r *repairer) repairExist(ctx context.Context,
 					return fmt.Errorf("node %q could not repair deleted object: %w", vote.Sender, err)
 				}
 				if len(resp) > 0 && resp[0].Err != "" {
-					return fmt.Errorf("overwrite deleted object %w %s: %s", rplicaerrors.ErrConflictObjectChanged, vote.Sender, resp[0].Err)
+					return fmt.Errorf("overwrite deleted object %w %s: %s", replicaerrors.ErrConflictObjectChanged, vote.Sender, resp[0].Err)
 				}
 				return nil
 			})
@@ -260,7 +260,7 @@ func (r *repairer) repairExist(ctx context.Context,
 	}
 
 	if deleted && deletionStrategy != models.ReplicationConfigDeletionStrategyTimeBasedResolution {
-		return false, rplicaerrors.ErrConflictExistOrDeleted
+		return false, replicaerrors.ErrConflictExistOrDeleted
 	}
 
 	// fetch most recent object
@@ -270,7 +270,7 @@ func (r *repairer) repairExist(ctx context.Context,
 		return false, fmt.Errorf("get most recent object from %s: %w", winner.Sender, err)
 	}
 	if resp.UpdateTime() != lastUTime {
-		return false, fmt.Errorf("fetch new state from %s: %w, %w", winner.Sender, rplicaerrors.ErrConflictObjectChanged, err)
+		return false, fmt.Errorf("fetch new state from %s: %w, %w", winner.Sender, replicaerrors.ErrConflictObjectChanged, err)
 	}
 
 	gr, ctx := enterrors.NewErrorGroupWithContextWrapper(r.logger, ctx)
@@ -321,7 +321,7 @@ func (r *repairer) repairExist(ctx context.Context,
 				return fmt.Errorf("node %q could not repair object: %w", vote.Sender, err)
 			}
 			if len(resp) > 0 && resp[0].Err != "" {
-				return fmt.Errorf("overwrite %w %s: %s", rplicaerrors.ErrConflictObjectChanged, vote.Sender, resp[0].Err)
+				return fmt.Errorf("overwrite %w %s: %s", replicaerrors.ErrConflictObjectChanged, vote.Sender, resp[0].Err)
 			}
 
 			return nil

--- a/usecases/replica/repairer.go
+++ b/usecases/replica/repairer.go
@@ -13,7 +13,6 @@ package replica
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -28,19 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
-)
-
-var (
-	// ErrConflictFindDeleted object exists on one replica but is deleted on the other.
-	//
-	// It depends on the order of operations
-	// Created -> Deleted    => It is safe in this case to propagate deletion to all replicas
-	// Created -> Deleted -> Created => propagating deletion will result in data lost
-
-	ErrConflictExistOrDeleted = errors.New("conflict: object has been deleted on another replica")
-
-	// ErrConflictObjectChanged object changed since last time and cannot be repaired
-	ErrConflictObjectChanged = errors.New("source object changed during repair")
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 // repairer tries to detect inconsistencies and repair objects when reading them from replicas
@@ -112,7 +99,7 @@ func (r *repairer) repairOne(ctx context.Context,
 					return fmt.Errorf("node %q could not repair deleted object: %w", vote.Sender, err)
 				}
 				if len(resp) > 0 && resp[0].Err != "" {
-					return fmt.Errorf("overwrite deleted object %w %s: %s", ErrConflictObjectChanged, vote.Sender, resp[0].Err)
+					return fmt.Errorf("overwrite deleted object %w %s: %s", rplicaerrors.ErrConflictObjectChanged, vote.Sender, resp[0].Err)
 				}
 				return nil
 			})
@@ -122,7 +109,7 @@ func (r *repairer) repairOne(ctx context.Context,
 	}
 
 	if deleted && deletionStrategy != models.ReplicationConfigDeletionStrategyTimeBasedResolution {
-		return nil, ErrConflictExistOrDeleted
+		return nil, rplicaerrors.ErrConflictExistOrDeleted
 	}
 
 	// fetch most recent object
@@ -136,7 +123,7 @@ func (r *repairer) repairOne(ctx context.Context,
 			return nil, fmt.Errorf("get most recent object from %s: %w", winner.Sender, err)
 		}
 		if updates.UpdateTime() != lastUTime {
-			return nil, fmt.Errorf("fetch new state from %s: %w, %w", winner.Sender, ErrConflictObjectChanged, err)
+			return nil, fmt.Errorf("fetch new state from %s: %w, %w", winner.Sender, rplicaerrors.ErrConflictObjectChanged, err)
 		}
 	}
 
@@ -186,7 +173,7 @@ func (r *repairer) repairOne(ctx context.Context,
 				return fmt.Errorf("node %q could not repair object: %w", vote.Sender, err)
 			}
 			if len(resp) > 0 && resp[0].Err != "" {
-				return fmt.Errorf("overwrite %w %s: %s", ErrConflictObjectChanged, vote.Sender, resp[0].Err)
+				return fmt.Errorf("overwrite %w %s: %s", rplicaerrors.ErrConflictObjectChanged, vote.Sender, resp[0].Err)
 			}
 			return nil
 		})
@@ -263,7 +250,7 @@ func (r *repairer) repairExist(ctx context.Context,
 					return fmt.Errorf("node %q could not repair deleted object: %w", vote.Sender, err)
 				}
 				if len(resp) > 0 && resp[0].Err != "" {
-					return fmt.Errorf("overwrite deleted object %w %s: %s", ErrConflictObjectChanged, vote.Sender, resp[0].Err)
+					return fmt.Errorf("overwrite deleted object %w %s: %s", rplicaerrors.ErrConflictObjectChanged, vote.Sender, resp[0].Err)
 				}
 				return nil
 			})
@@ -273,7 +260,7 @@ func (r *repairer) repairExist(ctx context.Context,
 	}
 
 	if deleted && deletionStrategy != models.ReplicationConfigDeletionStrategyTimeBasedResolution {
-		return false, ErrConflictExistOrDeleted
+		return false, rplicaerrors.ErrConflictExistOrDeleted
 	}
 
 	// fetch most recent object
@@ -283,7 +270,7 @@ func (r *repairer) repairExist(ctx context.Context,
 		return false, fmt.Errorf("get most recent object from %s: %w", winner.Sender, err)
 	}
 	if resp.UpdateTime() != lastUTime {
-		return false, fmt.Errorf("fetch new state from %s: %w, %w", winner.Sender, ErrConflictObjectChanged, err)
+		return false, fmt.Errorf("fetch new state from %s: %w, %w", winner.Sender, rplicaerrors.ErrConflictObjectChanged, err)
 	}
 
 	gr, ctx := enterrors.NewErrorGroupWithContextWrapper(r.logger, ctx)
@@ -334,7 +321,7 @@ func (r *repairer) repairExist(ctx context.Context,
 				return fmt.Errorf("node %q could not repair object: %w", vote.Sender, err)
 			}
 			if len(resp) > 0 && resp[0].Err != "" {
-				return fmt.Errorf("overwrite %w %s: %s", ErrConflictObjectChanged, vote.Sender, resp[0].Err)
+				return fmt.Errorf("overwrite %w %s: %s", rplicaerrors.ErrConflictObjectChanged, vote.Sender, resp[0].Err)
 			}
 
 			return nil

--- a/usecases/replica/repairer_test.go
+++ b/usecases/replica/repairer_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 func TestRepairerOneWithALL(t *testing.T) {
@@ -113,9 +113,9 @@ func TestRepairerOneWithALL(t *testing.T) {
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelAll, shard, id, proj, adds)
 			require.Error(t, err)
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
 			require.Nil(t, got)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
 			f.assertLogContains(t, "msg", "A:3", "B:2", "C:3")
 			f.assertLogErrorContains(t, "conflict")
 		})
@@ -174,8 +174,8 @@ func TestRepairerOneWithALL(t *testing.T) {
 			f.RClient.EXPECT().OverwriteObjects(anyVal, nodes[1], cls, shard, updates).Return(digestR2, errAny)
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelAll, shard, id, proj, adds)
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
 			require.Nil(t, got)
 			f.assertLogContains(t, "msg", "A:3", "B:2", "C:3")
 		})
@@ -196,8 +196,8 @@ func TestRepairerOneWithALL(t *testing.T) {
 			f.RClient.EXPECT().FetchObject(anyVal, nodes[2], cls, shard, id, proj, adds, anyVal).Return(emptyItem, errAny)
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelAll, shard, id, proj, adds)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
 			require.Nil(t, got)
 			f.assertLogContains(t, "msg", "A:1", "B:2", "C:3")
 		})
@@ -218,11 +218,11 @@ func TestRepairerOneWithALL(t *testing.T) {
 				Return(item1, nil).Once()
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelAll, shard, id, proj, adds)
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
 			require.Nil(t, got)
 			f.assertLogContains(t, "msg", "A:1", "B:2", "C:3")
-			f.assertLogErrorContains(t, rplicaerrors.ErrConflictObjectChanged.Error())
+			f.assertLogErrorContains(t, replicaerrors.ErrConflictObjectChanged.Error())
 		})
 
 		t.Run(fmt.Sprintf("CreateMissingObject_%v", tc.variant), func(t *testing.T) {
@@ -263,9 +263,9 @@ func TestRepairerOneWithALL(t *testing.T) {
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[2], cls, shard, digestIDs, anyVal).Return(digestR3, nil)
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelAll, shard, id, proj, adds)
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
 			require.Equal(t, nilObject, got)
-			f.assertLogErrorContains(t, rplicaerrors.ErrConflictExistOrDeleted.Error())
+			f.assertLogErrorContains(t, replicaerrors.ErrConflictExistOrDeleted.Error())
 		})
 		t.Run(fmt.Sprintf("NoConflictDeletedObject_%v", tc.variant), func(t *testing.T) {
 			var (
@@ -347,8 +347,8 @@ func TestRepairerExistsWithALL(t *testing.T) {
 			}
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelAll, shard, id)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 
 			f.assertLogContains(t, "msg", "A:3", "B:2", "C:3")
@@ -414,8 +414,8 @@ func TestRepairerExistsWithALL(t *testing.T) {
 			f.RClient.EXPECT().OverwriteObjects(anyVal, nodes[1], cls, shard, updates).Return(digestR2, errAny)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelAll, shard, id)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 
 			f.assertLogContains(t, "msg", "A:3", "B:2", "C:3")
@@ -439,8 +439,8 @@ func TestRepairerExistsWithALL(t *testing.T) {
 			f.RClient.EXPECT().FetchObject(anyVal, nodes[2], cls, shard, id, proj, adds, anyVal).Return(emptyItem, errAny)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelAll, shard, id)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 
 			f.assertLogContains(t, "msg", "A:1", "B:2", "C:3")
@@ -464,11 +464,11 @@ func TestRepairerExistsWithALL(t *testing.T) {
 			f.RClient.EXPECT().FetchObject(anyVal, nodes[2], cls, shard, id, proj, adds, anyVal).Return(item1, nil)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelAll, shard, id)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 			f.assertLogContains(t, "msg", "A:1", "B:2", "C:3")
-			f.assertLogErrorContains(t, rplicaerrors.ErrConflictObjectChanged.Error())
+			f.assertLogErrorContains(t, replicaerrors.ErrConflictObjectChanged.Error())
 		})
 
 		t.Run(fmt.Sprintf("CreateMissingObject_%v", tc.variant), func(t *testing.T) {
@@ -516,10 +516,10 @@ func TestRepairerExistsWithALL(t *testing.T) {
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[2], cls, shard, digestIDs, anyVal).Return(digestR3, nil)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelAll, shard, id)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
-			f.assertLogErrorContains(t, rplicaerrors.ErrConflictExistOrDeleted.Error())
+			f.assertLogErrorContains(t, replicaerrors.ErrConflictExistOrDeleted.Error())
 		})
 	}
 }
@@ -586,7 +586,7 @@ func TestRepairerExistsWithConsistencyLevelQuorum(t *testing.T) {
 			}
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelQuorum, shard, id)
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 			f.assertLogContains(t, "msg", "A:3", "B:2")
 			f.assertLogErrorContains(t, "conflict")
@@ -648,8 +648,8 @@ func TestRepairerExistsWithConsistencyLevelQuorum(t *testing.T) {
 			f.RClient.EXPECT().OverwriteObjects(anyVal, nodes[1], cls, shard, updates).Return(digestR2, errAny)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelQuorum, shard, id)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 			f.assertLogContains(t, "msg", "A:3", "B:2")
 			f.assertLogErrorContains(t, errAny.Error())
@@ -672,8 +672,8 @@ func TestRepairerExistsWithConsistencyLevelQuorum(t *testing.T) {
 			f.RClient.EXPECT().FetchObject(anyVal, nodes[2], cls, shard, id, proj, adds, anyVal).Return(emptyItem, errAny)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelQuorum, shard, id)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 			f.assertLogContains(t, "msg", "A:1", "C:3")
 			f.assertLogErrorContains(t, errAny.Error())
@@ -696,12 +696,12 @@ func TestRepairerExistsWithConsistencyLevelQuorum(t *testing.T) {
 			f.RClient.EXPECT().FetchObject(anyVal, nodes[1], cls, shard, id, proj, adds, anyVal).Return(item1, nil)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelQuorum, shard, id)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 
 			f.assertLogContains(t, "msg", "A:1", "B:3")
-			f.assertLogErrorContains(t, rplicaerrors.ErrConflictObjectChanged.Error())
+			f.assertLogErrorContains(t, replicaerrors.ErrConflictObjectChanged.Error())
 		})
 
 		t.Run(fmt.Sprintf("CreateMissingObject_%v", tc.variant), func(t *testing.T) {
@@ -744,9 +744,9 @@ func TestRepairerExistsWithConsistencyLevelQuorum(t *testing.T) {
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, digestIDs, anyVal).Return(digestR2, nil)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelQuorum, shard, id)
-			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
-			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
-			f.assertLogErrorContains(t, rplicaerrors.ErrConflictExistOrDeleted.Error())
+			require.ErrorContains(t, err, replicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, replicaerrors.MsgCLevel)
+			f.assertLogErrorContains(t, replicaerrors.ErrConflictExistOrDeleted.Error())
 			require.Equal(t, false, got)
 		})
 	}

--- a/usecases/replica/repairer_test.go
+++ b/usecases/replica/repairer_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 func TestRepairerOneWithALL(t *testing.T) {
@@ -112,9 +113,9 @@ func TestRepairerOneWithALL(t *testing.T) {
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelAll, shard, id, proj, adds)
 			require.Error(t, err)
-			require.ErrorContains(t, err, replica.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
 			require.Nil(t, got)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
 			f.assertLogContains(t, "msg", "A:3", "B:2", "C:3")
 			f.assertLogErrorContains(t, "conflict")
 		})
@@ -173,8 +174,8 @@ func TestRepairerOneWithALL(t *testing.T) {
 			f.RClient.EXPECT().OverwriteObjects(anyVal, nodes[1], cls, shard, updates).Return(digestR2, errAny)
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelAll, shard, id, proj, adds)
-			require.ErrorContains(t, err, replica.MsgCLevel)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
 			require.Nil(t, got)
 			f.assertLogContains(t, "msg", "A:3", "B:2", "C:3")
 		})
@@ -195,8 +196,8 @@ func TestRepairerOneWithALL(t *testing.T) {
 			f.RClient.EXPECT().FetchObject(anyVal, nodes[2], cls, shard, id, proj, adds, anyVal).Return(emptyItem, errAny)
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelAll, shard, id, proj, adds)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
-			require.ErrorContains(t, err, replica.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
 			require.Nil(t, got)
 			f.assertLogContains(t, "msg", "A:1", "B:2", "C:3")
 		})
@@ -217,11 +218,11 @@ func TestRepairerOneWithALL(t *testing.T) {
 				Return(item1, nil).Once()
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelAll, shard, id, proj, adds)
-			require.ErrorContains(t, err, replica.MsgCLevel)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
 			require.Nil(t, got)
 			f.assertLogContains(t, "msg", "A:1", "B:2", "C:3")
-			f.assertLogErrorContains(t, replica.ErrConflictObjectChanged.Error())
+			f.assertLogErrorContains(t, rplicaerrors.ErrConflictObjectChanged.Error())
 		})
 
 		t.Run(fmt.Sprintf("CreateMissingObject_%v", tc.variant), func(t *testing.T) {
@@ -262,9 +263,9 @@ func TestRepairerOneWithALL(t *testing.T) {
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[2], cls, shard, digestIDs, anyVal).Return(digestR3, nil)
 
 			got, err := finder.GetOne(ctx, types.ConsistencyLevelAll, shard, id, proj, adds)
-			require.ErrorContains(t, err, replica.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
 			require.Equal(t, nilObject, got)
-			f.assertLogErrorContains(t, replica.ErrConflictExistOrDeleted.Error())
+			f.assertLogErrorContains(t, rplicaerrors.ErrConflictExistOrDeleted.Error())
 		})
 		t.Run(fmt.Sprintf("NoConflictDeletedObject_%v", tc.variant), func(t *testing.T) {
 			var (
@@ -346,8 +347,8 @@ func TestRepairerExistsWithALL(t *testing.T) {
 			}
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelAll, shard, id)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
-			require.ErrorContains(t, err, replica.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 
 			f.assertLogContains(t, "msg", "A:3", "B:2", "C:3")
@@ -413,8 +414,8 @@ func TestRepairerExistsWithALL(t *testing.T) {
 			f.RClient.EXPECT().OverwriteObjects(anyVal, nodes[1], cls, shard, updates).Return(digestR2, errAny)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelAll, shard, id)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
-			require.ErrorContains(t, err, replica.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 
 			f.assertLogContains(t, "msg", "A:3", "B:2", "C:3")
@@ -438,8 +439,8 @@ func TestRepairerExistsWithALL(t *testing.T) {
 			f.RClient.EXPECT().FetchObject(anyVal, nodes[2], cls, shard, id, proj, adds, anyVal).Return(emptyItem, errAny)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelAll, shard, id)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
-			require.ErrorContains(t, err, replica.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 
 			f.assertLogContains(t, "msg", "A:1", "B:2", "C:3")
@@ -463,11 +464,11 @@ func TestRepairerExistsWithALL(t *testing.T) {
 			f.RClient.EXPECT().FetchObject(anyVal, nodes[2], cls, shard, id, proj, adds, anyVal).Return(item1, nil)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelAll, shard, id)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
-			require.ErrorContains(t, err, replica.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 			f.assertLogContains(t, "msg", "A:1", "B:2", "C:3")
-			f.assertLogErrorContains(t, replica.ErrConflictObjectChanged.Error())
+			f.assertLogErrorContains(t, rplicaerrors.ErrConflictObjectChanged.Error())
 		})
 
 		t.Run(fmt.Sprintf("CreateMissingObject_%v", tc.variant), func(t *testing.T) {
@@ -515,10 +516,10 @@ func TestRepairerExistsWithALL(t *testing.T) {
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[2], cls, shard, digestIDs, anyVal).Return(digestR3, nil)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelAll, shard, id)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
-			require.ErrorContains(t, err, replica.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
-			f.assertLogErrorContains(t, replica.ErrConflictExistOrDeleted.Error())
+			f.assertLogErrorContains(t, rplicaerrors.ErrConflictExistOrDeleted.Error())
 		})
 	}
 }
@@ -585,7 +586,7 @@ func TestRepairerExistsWithConsistencyLevelQuorum(t *testing.T) {
 			}
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelQuorum, shard, id)
-			require.ErrorContains(t, err, replica.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 			f.assertLogContains(t, "msg", "A:3", "B:2")
 			f.assertLogErrorContains(t, "conflict")
@@ -647,8 +648,8 @@ func TestRepairerExistsWithConsistencyLevelQuorum(t *testing.T) {
 			f.RClient.EXPECT().OverwriteObjects(anyVal, nodes[1], cls, shard, updates).Return(digestR2, errAny)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelQuorum, shard, id)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
-			require.ErrorContains(t, err, replica.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 			f.assertLogContains(t, "msg", "A:3", "B:2")
 			f.assertLogErrorContains(t, errAny.Error())
@@ -671,8 +672,8 @@ func TestRepairerExistsWithConsistencyLevelQuorum(t *testing.T) {
 			f.RClient.EXPECT().FetchObject(anyVal, nodes[2], cls, shard, id, proj, adds, anyVal).Return(emptyItem, errAny)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelQuorum, shard, id)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
-			require.ErrorContains(t, err, replica.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 			f.assertLogContains(t, "msg", "A:1", "C:3")
 			f.assertLogErrorContains(t, errAny.Error())
@@ -695,12 +696,12 @@ func TestRepairerExistsWithConsistencyLevelQuorum(t *testing.T) {
 			f.RClient.EXPECT().FetchObject(anyVal, nodes[1], cls, shard, id, proj, adds, anyVal).Return(item1, nil)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelQuorum, shard, id)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
-			require.ErrorContains(t, err, replica.MsgCLevel)
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
 			require.Equal(t, false, got)
 
 			f.assertLogContains(t, "msg", "A:1", "B:3")
-			f.assertLogErrorContains(t, replica.ErrConflictObjectChanged.Error())
+			f.assertLogErrorContains(t, rplicaerrors.ErrConflictObjectChanged.Error())
 		})
 
 		t.Run(fmt.Sprintf("CreateMissingObject_%v", tc.variant), func(t *testing.T) {
@@ -743,9 +744,9 @@ func TestRepairerExistsWithConsistencyLevelQuorum(t *testing.T) {
 			f.RClient.EXPECT().DigestObjects(anyVal, nodes[1], cls, shard, digestIDs, anyVal).Return(digestR2, nil)
 
 			got, err := finder.Exists(ctx, types.ConsistencyLevelQuorum, shard, id)
-			require.ErrorContains(t, err, replica.ErrRepair.Error())
-			require.ErrorContains(t, err, replica.MsgCLevel)
-			f.assertLogErrorContains(t, replica.ErrConflictExistOrDeleted.Error())
+			require.ErrorContains(t, err, rplicaerrors.ErrRepair.Error())
+			require.ErrorContains(t, err, rplicaerrors.MsgCLevel)
+			f.assertLogErrorContains(t, rplicaerrors.ErrConflictExistOrDeleted.Error())
 			require.Equal(t, false, got)
 		})
 	}

--- a/usecases/replica/replicator.go
+++ b/usecases/replica/replicator.go
@@ -26,7 +26,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 // opID operation encode as and int
@@ -114,7 +114,7 @@ func (r *Replicator) PutObject(ctx context.Context,
 	if err != nil {
 		r.log.WithField("op", "push.one").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		return fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
+		return fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, replicaerrors.NewNotEnoughReplicasError(err))
 	}
 	if err := firstError(rs); err != nil {
 		r.log.WithField("op", "put").WithField("class", r.class).
@@ -145,13 +145,13 @@ func (r *Replicator) MergeObject(ctx context.Context,
 	if err != nil {
 		r.log.WithField("op", "push.merge").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		return fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
+		return fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, replicaerrors.NewNotEnoughReplicasError(err))
 	}
 	if err := firstError(rs); err != nil {
 		r.log.WithField("op", "merge").WithField("class", r.class).
 			WithField("shard", shard).WithField("uuid", doc.ID).Error(err)
-		var replicaErr *rplicaerrors.Error
-		if errors.As(err, &replicaErr) && replicaErr != nil && replicaErr.Code == rplicaerrors.StatusObjectNotFound {
+		var replicaErr *replicaerrors.Error
+		if errors.As(err, &replicaErr) && replicaErr != nil && replicaErr.Code == replicaerrors.StatusObjectNotFound {
 			return objects.NewErrDirtyWriteOfDeletedObject(replicaErr)
 		}
 		return err
@@ -181,7 +181,7 @@ func (r *Replicator) DeleteObject(ctx context.Context,
 	if err != nil {
 		r.log.WithField("op", "push.delete").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		return fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
+		return fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, replicaerrors.NewNotEnoughReplicasError(err))
 	}
 	if err := firstError(rs); err != nil {
 		r.log.WithField("op", "put").WithField("class", r.class).
@@ -212,7 +212,7 @@ func (r *Replicator) PutObjects(ctx context.Context,
 	if err != nil {
 		r.log.WithField("op", "push.many").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		err = fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
+		err = fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, replicaerrors.NewNotEnoughReplicasError(err))
 		errs := make([]error, len(objs))
 		for i := 0; i < len(objs); i++ {
 			errs[i] = err
@@ -260,7 +260,7 @@ func (r *Replicator) DeleteObjects(ctx context.Context,
 	if err != nil {
 		r.log.WithField("op", "push.deletes").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		err = fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
+		err = fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, replicaerrors.NewNotEnoughReplicasError(err))
 		errs := make([]objects.BatchSimpleObject, len(uuids))
 		for i := 0; i < len(uuids); i++ {
 			errs[i].Err = err
@@ -295,7 +295,7 @@ func (r *Replicator) AddReferences(ctx context.Context,
 	if err != nil {
 		r.log.WithField("op", "push.refs").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		err = fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
+		err = fmt.Errorf("%s %q: %w", replicaerrors.MsgCLevel, l, replicaerrors.NewNotEnoughReplicasError(err))
 		errs := make([]error, len(refs))
 		for i := 0; i < len(refs); i++ {
 			errs[i] = err

--- a/usecases/replica/replicator.go
+++ b/usecases/replica/replicator.go
@@ -151,7 +151,7 @@ func (r *Replicator) MergeObject(ctx context.Context,
 		r.log.WithField("op", "merge").WithField("class", r.class).
 			WithField("shard", shard).WithField("uuid", doc.ID).Error(err)
 		var replicaErr *replicaerrors.Error
-		if errors.As(err, &replicaErr) && replicaErr != nil && replicaErr.Code == replicaerrors.StatusObjectNotFound {
+		if errors.As(err, &replicaErr) && replicaErr.Code == replicaerrors.StatusObjectNotFound {
 			return objects.NewErrDirtyWriteOfDeletedObject(replicaErr)
 		}
 		return err

--- a/usecases/replica/replicator.go
+++ b/usecases/replica/replicator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 // opID operation encode as and int
@@ -113,8 +114,7 @@ func (r *Replicator) PutObject(ctx context.Context,
 	if err != nil {
 		r.log.WithField("op", "push.one").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		return fmt.Errorf("%s %q: %w: %w", MsgCLevel, l, ErrReplicas, err)
-
+		return fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
 	}
 	if err := firstError(rs); err != nil {
 		r.log.WithField("op", "put").WithField("class", r.class).
@@ -145,13 +145,13 @@ func (r *Replicator) MergeObject(ctx context.Context,
 	if err != nil {
 		r.log.WithField("op", "push.merge").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		return fmt.Errorf("%s %q: %w: %w", MsgCLevel, l, ErrReplicas, err)
+		return fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
 	}
 	if err := firstError(rs); err != nil {
 		r.log.WithField("op", "merge").WithField("class", r.class).
 			WithField("shard", shard).WithField("uuid", doc.ID).Error(err)
-		var replicaErr *Error
-		if errors.As(err, &replicaErr) && replicaErr != nil && replicaErr.Code == StatusObjectNotFound {
+		var replicaErr *rplicaerrors.Error
+		if errors.As(err, &replicaErr) && replicaErr != nil && replicaErr.Code == rplicaerrors.StatusObjectNotFound {
 			return objects.NewErrDirtyWriteOfDeletedObject(replicaErr)
 		}
 		return err
@@ -181,7 +181,7 @@ func (r *Replicator) DeleteObject(ctx context.Context,
 	if err != nil {
 		r.log.WithField("op", "push.delete").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		return fmt.Errorf("%s %q: %w: %w", MsgCLevel, l, ErrReplicas, err)
+		return fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
 	}
 	if err := firstError(rs); err != nil {
 		r.log.WithField("op", "put").WithField("class", r.class).
@@ -212,7 +212,7 @@ func (r *Replicator) PutObjects(ctx context.Context,
 	if err != nil {
 		r.log.WithField("op", "push.many").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		err = fmt.Errorf("%s %q: %w: %w", MsgCLevel, l, ErrReplicas, err)
+		err = fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
 		errs := make([]error, len(objs))
 		for i := 0; i < len(objs); i++ {
 			errs[i] = err
@@ -260,7 +260,7 @@ func (r *Replicator) DeleteObjects(ctx context.Context,
 	if err != nil {
 		r.log.WithField("op", "push.deletes").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		err = fmt.Errorf("%s %q: %w: %w", MsgCLevel, l, ErrReplicas, err)
+		err = fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
 		errs := make([]objects.BatchSimpleObject, len(uuids))
 		for i := 0; i < len(uuids); i++ {
 			errs[i].Err = err
@@ -295,7 +295,7 @@ func (r *Replicator) AddReferences(ctx context.Context,
 	if err != nil {
 		r.log.WithField("op", "push.refs").WithField("class", r.class).
 			WithField("shard", shard).Error(err)
-		err = fmt.Errorf("%s %q: %w: %w", MsgCLevel, l, ErrReplicas, err)
+		err = fmt.Errorf("%s %q: %w", rplicaerrors.MsgCLevel, l, rplicaerrors.NewNotEnoughReplicasError(err))
 		errs := make([]error, len(refs))
 		for i := 0; i < len(refs); i++ {
 			errs[i] = err

--- a/usecases/replica/replicator_test.go
+++ b/usecases/replica/replicator_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
 	"github.com/weaviate/weaviate/usecases/sharding/config"
@@ -63,21 +63,21 @@ func TestReplicatorReplicaNotFound(t *testing.T) {
 			f := newFakeFactory(t, "C1", "S", []string{}, tc.isMultiTenant)
 			rep := f.newReplicator()
 			err := rep.PutObject(ctx, "S", nil, types.ConsistencyLevelAll, 0)
-			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
+			assert.ErrorIs(t, err, replicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("MergeObject_%v", tc.variant), func(t *testing.T) {
 			f := newFakeFactory(t, "C1", "S", []string{}, tc.isMultiTenant)
 			rep := f.newReplicator()
 			err := rep.MergeObject(ctx, "S", nil, types.ConsistencyLevelAll, 0)
-			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
+			assert.ErrorIs(t, err, replicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("DeleteObject_%v", tc.variant), func(t *testing.T) {
 			f := newFakeFactory(t, "C1", "S", []string{}, tc.isMultiTenant)
 			rep := f.newReplicator()
 			err := rep.DeleteObject(ctx, "S", "id", time.Now(), types.ConsistencyLevelAll, 0)
-			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
+			assert.ErrorIs(t, err, replicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("PutObjects_%v", tc.variant), func(t *testing.T) {
@@ -86,7 +86,7 @@ func TestReplicatorReplicaNotFound(t *testing.T) {
 			errs := rep.PutObjects(ctx, "S", []*storobj.Object{{}, {}}, types.ConsistencyLevelAll, 0)
 			assert.Equal(t, 2, len(errs))
 			for _, err := range errs {
-				assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
+				assert.ErrorIs(t, err, replicaerrors.ErrReplicas)
 			}
 		})
 
@@ -96,7 +96,7 @@ func TestReplicatorReplicaNotFound(t *testing.T) {
 			xs := rep.DeleteObjects(ctx, "S", []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2"), strfmt.UUID("3")}, time.Now(), false, types.ConsistencyLevelAll, 0)
 			assert.Equal(t, 3, len(xs))
 			for _, x := range xs {
-				assert.ErrorIs(t, x.Err, rplicaerrors.ErrReplicas)
+				assert.ErrorIs(t, x.Err, replicaerrors.ErrReplicas)
 			}
 		})
 
@@ -106,7 +106,7 @@ func TestReplicatorReplicaNotFound(t *testing.T) {
 			errs := rep.AddReferences(ctx, "S", []objects.BatchReference{{}, {}}, types.ConsistencyLevelAll, 0)
 			assert.Equal(t, 2, len(errs))
 			for _, err := range errs {
-				assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
+				assert.ErrorIs(t, err, replicaerrors.ErrReplicas)
 			}
 		})
 	}
@@ -184,7 +184,7 @@ func TestReplicatorPutObject(t *testing.T) {
 			f.WClient.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				defer wg.Done()
 				resp := a[5].(*replica.SimpleResponse)
-				*resp = replica.SimpleResponse{Errors: []rplicaerrors.Error{{Msg: "e3"}}}
+				*resp = replica.SimpleResponse{Errors: []replicaerrors.Error{{Msg: "e3"}}}
 			}
 			err := rep.PutObject(ctx, shard, obj, types.ConsistencyLevelQuorum, 123)
 			assert.Nil(t, err)
@@ -232,7 +232,7 @@ func TestReplicatorPutObject(t *testing.T) {
 			f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp, nil)
 
 			err := rep.PutObject(ctx, shard, obj, types.ConsistencyLevelAll, 123)
-			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
+			assert.ErrorIs(t, err, replicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("PhaseOneUnsuccessfulResponse_%v", tc.variant), func(t *testing.T) {
@@ -240,13 +240,13 @@ func TestReplicatorPutObject(t *testing.T) {
 			rep := f.newReplicator()
 			resp := replica.SimpleResponse{}
 			f.WClient.On("PutObject", mock.Anything, nodes[0], cls, shard, anyVal, obj, uint64(123)).Return(resp, nil)
-			resp2 := replica.SimpleResponse{[]rplicaerrors.Error{{Err: errAny}}}
+			resp2 := replica.SimpleResponse{[]replicaerrors.Error{{Err: errAny}}}
 			f.WClient.On("PutObject", mock.Anything, nodes[1], cls, shard, anyVal, obj, uint64(123)).Return(resp2, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[0], "C1", shard, anyVal).Return(resp, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp, nil)
 
 			err := rep.PutObject(ctx, shard, obj, types.ConsistencyLevelAll, 123)
-			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
+			assert.ErrorIs(t, err, replicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("Commit_%v", tc.variant), func(t *testing.T) {
@@ -305,7 +305,7 @@ func TestReplicatorMergeObject(t *testing.T) {
 			f.WClient.On("Abort", mock.Anything, nodes[1], cls, shard, anyVal).Return(resp, nil)
 
 			err := rep.MergeObject(ctx, shard, merge, types.ConsistencyLevelAll, 123)
-			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
+			assert.ErrorIs(t, err, replicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("PhaseOneUnsuccessfulResponse_%v", tc.variant), func(t *testing.T) {
@@ -313,13 +313,13 @@ func TestReplicatorMergeObject(t *testing.T) {
 			rep := f.newReplicator()
 			resp := replica.SimpleResponse{}
 			f.WClient.On("MergeObject", mock.Anything, nodes[0], cls, shard, anyVal, merge, uint64(123)).Return(resp, nil)
-			resp2 := replica.SimpleResponse{[]rplicaerrors.Error{{Err: errAny}}}
+			resp2 := replica.SimpleResponse{[]replicaerrors.Error{{Err: errAny}}}
 			f.WClient.On("MergeObject", mock.Anything, nodes[1], cls, shard, anyVal, merge, uint64(123)).Return(resp2, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[0], cls, shard, anyVal).Return(resp, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[1], cls, shard, anyVal).Return(resp, nil)
 
 			err := rep.MergeObject(ctx, shard, merge, types.ConsistencyLevelAll, 123)
-			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
+			assert.ErrorIs(t, err, replicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("Commit_%v", tc.variant), func(t *testing.T) {
@@ -360,7 +360,7 @@ func TestReplicatorDeleteObject(t *testing.T) {
 			factory := newFakeFactory(t, "C1", shard, nodes, tc.isMultiTenant)
 			client := factory.WClient
 			rep := factory.newReplicator()
-			resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 1)}
+			resp := replica.SimpleResponse{Errors: make([]replicaerrors.Error, 1)}
 			for _, n := range nodes[:2] {
 				client.On("DeleteObject", mock.Anything, n, cls, shard, anyVal, uuid, anyVal, uint64(123)).Return(resp, nil)
 			}
@@ -371,14 +371,14 @@ func TestReplicatorDeleteObject(t *testing.T) {
 
 			err := rep.DeleteObject(ctx, shard, uuid, time.Now(), types.ConsistencyLevelAll, 123)
 			assert.NotNil(t, err)
-			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
+			assert.ErrorIs(t, err, replicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("SuccessWithConsistencyLevelAll_%v", tc.variant), func(t *testing.T) {
 			factory := newFakeFactory(t, "C1", shard, nodes, tc.isMultiTenant)
 			client := factory.WClient
 			rep := factory.newReplicator()
-			resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 1)}
+			resp := replica.SimpleResponse{Errors: make([]replicaerrors.Error, 1)}
 			for _, n := range nodes {
 				client.On("DeleteObject", mock.Anything, n, cls, shard, anyVal, uuid, anyVal, uint64(123)).Return(resp, nil)
 				client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil)
@@ -392,13 +392,13 @@ func TestReplicatorDeleteObject(t *testing.T) {
 			factory := newFakeFactory(t, "C1", shard, nodes, tc.isMultiTenant)
 			client := factory.WClient
 			rep := factory.newReplicator()
-			resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 1)}
+			resp := replica.SimpleResponse{Errors: make([]replicaerrors.Error, 1)}
 			for _, n := range nodes[:2] {
 				client.On("DeleteObject", mock.Anything, n, cls, shard, anyVal, uuid, anyVal, uint64(123)).Return(resp, nil)
 				client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 					resp := a[5].(*replica.SimpleResponse)
 					*resp = replica.SimpleResponse{
-						Errors: []rplicaerrors.Error{{}},
+						Errors: []replicaerrors.Error{{}},
 					}
 				}
 			}
@@ -406,7 +406,7 @@ func TestReplicatorDeleteObject(t *testing.T) {
 			client.On("Commit", ctx, "C", "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				resp := a[5].(*replica.SimpleResponse)
 				*resp = replica.SimpleResponse{
-					Errors: []rplicaerrors.Error{{Msg: "e3"}},
+					Errors: []replicaerrors.Error{{Msg: "e3"}},
 				}
 			}
 
@@ -419,13 +419,13 @@ func TestReplicatorDeleteObject(t *testing.T) {
 			factory := newFakeFactory(t, "C1", shard, nodes, tc.isMultiTenant)
 			client := factory.WClient
 			rep := factory.newReplicator()
-			resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 1)}
+			resp := replica.SimpleResponse{Errors: make([]replicaerrors.Error, 1)}
 			for _, n := range nodes[:2] {
 				client.On("DeleteObject", mock.Anything, n, cls, shard, anyVal, uuid, anyVal, uint64(123)).Return(resp, nil)
 				client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 					resp := a[5].(*replica.SimpleResponse)
 					*resp = replica.SimpleResponse{
-						Errors: []rplicaerrors.Error{{}},
+						Errors: []replicaerrors.Error{{}},
 					}
 				}
 			}
@@ -433,7 +433,7 @@ func TestReplicatorDeleteObject(t *testing.T) {
 			client.On("Commit", ctx, "C", "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				resp := a[5].(*replica.SimpleResponse)
 				*resp = replica.SimpleResponse{
-					Errors: []rplicaerrors.Error{{Msg: "e3"}},
+					Errors: []replicaerrors.Error{{Msg: "e3"}},
 				}
 			}
 
@@ -473,7 +473,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 			result := factory.newReplicator().DeleteObjects(ctx, shard, docIDs, time.Now(), false, types.ConsistencyLevelAll, 123)
 			assert.Equal(t, len(result), 2)
 			for _, r := range result {
-				assert.ErrorIs(t, r.Err, rplicaerrors.ErrReplicas)
+				assert.ErrorIs(t, r.Err, replicaerrors.ErrReplicas)
 			}
 		})
 
@@ -503,14 +503,14 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 					defer wg.Done()
 					resp := args[5].(*replica.DeleteBatchResponse)
 					*resp = replica.DeleteBatchResponse{
-						Batch: []replica.UUID2Error{{"1", rplicaerrors.Error{}}, {"2", rplicaerrors.Error{Msg: "e1"}}},
+						Batch: []replica.UUID2Error{{"1", replicaerrors.Error{}}, {"2", replicaerrors.Error{Msg: "e1"}}},
 					}
 				}
 			}
 			result := rep.DeleteObjects(ctx, shard, docIDs, time.Now(), false, types.ConsistencyLevelAll, 123)
 			assert.Equal(t, len(result), 2)
 			assert.Equal(t, objects.BatchSimpleObject{UUID: "1", Err: nil}, result[0])
-			assert.Equal(t, objects.BatchSimpleObject{UUID: "2", Err: &rplicaerrors.Error{Msg: "e1"}}, result[1])
+			assert.Equal(t, objects.BatchSimpleObject{UUID: "2", Err: &replicaerrors.Error{Msg: "e1"}}, result[1])
 			// Wait for all Commit RunFn callbacks to complete before test cleanup runs
 			wg.Wait()
 		})
@@ -591,7 +591,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 				defer wg.Done()
 				resp := args[5].(*replica.DeleteBatchResponse)
 				*resp = replica.DeleteBatchResponse{
-					Batch: []replica.UUID2Error{{UUID: "1"}, {UUID: "2", Error: rplicaerrors.Error{Msg: "e2"}}},
+					Batch: []replica.UUID2Error{{UUID: "1"}, {UUID: "2", Error: replicaerrors.Error{Msg: "e2"}}},
 				}
 			}
 			result := rep.DeleteObjects(ctx, shard, docIDs, time.Now(), false, types.ConsistencyLevelQuorum, 123)
@@ -610,7 +610,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 		nodes = []string{"A", "B"}
 		ctx   = context.Background()
 		objs  = []*storobj.Object{{}, {}, {}}
-		resp1 = replica.SimpleResponse{[]rplicaerrors.Error{{}}}
+		resp1 = replica.SimpleResponse{[]replicaerrors.Error{{}}}
 	)
 
 	testCases := []struct {
@@ -625,7 +625,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 		t.Run(fmt.Sprintf("SuccessWithConsistencyLevelAll_%v", tc.variant), func(t *testing.T) {
 			f := newFakeFactory(t, "C1", shard, nodes, tc.isMultiTenant)
 			rep := f.newReplicator()
-			resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 3)}
+			resp := replica.SimpleResponse{Errors: make([]replicaerrors.Error, 3)}
 			for _, n := range nodes {
 				f.WClient.On("PutObjects", mock.Anything, n, cls, shard, anyVal, objs, uint64(123)).Return(resp, nil)
 				f.WClient.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil)
@@ -658,7 +658,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 			f.WClient.On("Commit", ctx, "A", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				defer wg.Done()
 				resp := a[5].(*replica.SimpleResponse)
-				*resp = replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 3)}
+				*resp = replica.SimpleResponse{Errors: make([]replicaerrors.Error, 3)}
 			}
 
 			errs := rep.PutObjects(ctx, shard, objs, types.ConsistencyLevelOne, 0)
@@ -678,7 +678,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 				f.WClient.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 					defer wg.Done()
 					resp := a[5].(*replica.SimpleResponse)
-					*resp = replica.SimpleResponse{Errors: []rplicaerrors.Error{{}}}
+					*resp = replica.SimpleResponse{Errors: []replicaerrors.Error{{}}}
 				}
 			}
 			f.WClient.On("PutObjects", mock.Anything, "C", cls, shard, anyVal, objs, uint64(0)).Return(resp1, nil)
@@ -686,7 +686,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 			f.WClient.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				defer wg.Done()
 				resp := a[5].(*replica.SimpleResponse)
-				*resp = replica.SimpleResponse{Errors: []rplicaerrors.Error{{Msg: "e3"}}}
+				*resp = replica.SimpleResponse{Errors: []replicaerrors.Error{{Msg: "e3"}}}
 			}
 			errs := rep.PutObjects(ctx, shard, objs, types.ConsistencyLevelQuorum, 0)
 			assert.Equal(t, []error{nil, nil, nil}, errs)
@@ -704,14 +704,14 @@ func TestReplicatorPutObjects(t *testing.T) {
 
 			errs := rep.PutObjects(ctx, shard, objs, types.ConsistencyLevelAll, 0)
 			assert.Equal(t, 3, len(errs))
-			assert.ErrorIs(t, errs[0], rplicaerrors.ErrReplicas)
+			assert.ErrorIs(t, errs[0], replicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("PhaseOneUnsuccessfulResponse_%v", tc.variant), func(t *testing.T) {
 			f := newFakeFactory(t, "C1", shard, nodes, tc.isMultiTenant)
 			rep := f.newReplicator()
 			f.WClient.On("PutObjects", mock.Anything, nodes[0], cls, shard, anyVal, objs, uint64(0)).Return(resp1, nil)
-			resp2 := replica.SimpleResponse{[]rplicaerrors.Error{{Msg: "E1"}, {Msg: "E2"}}}
+			resp2 := replica.SimpleResponse{[]replicaerrors.Error{{Msg: "E1"}, {Msg: "E2"}}}
 			f.WClient.On("PutObjects", mock.Anything, nodes[1], cls, shard, anyVal, objs, uint64(0)).Return(resp2, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[0], "C1", shard, anyVal).Return(resp1, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp1, nil)
@@ -719,7 +719,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 			errs := rep.PutObjects(ctx, shard, objs, types.ConsistencyLevelAll, 0)
 			assert.Equal(t, 3, len(errs))
 			for _, err := range errs {
-				assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
+				assert.ErrorIs(t, err, replicaerrors.ErrReplicas)
 			}
 		})
 
@@ -734,7 +734,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 			f.WClient.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				defer wg.Done()
 				resp := a[5].(*replica.SimpleResponse)
-				*resp = replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 3)}
+				*resp = replica.SimpleResponse{Errors: make([]replicaerrors.Error, 3)}
 			}
 			f.WClient.On("Commit", ctx, nodes[1], cls, shard, anyVal, anyVal).Return(errAny)
 
@@ -750,7 +750,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 		t.Run(fmt.Sprintf("PhaseTwoUnsuccessfulResponse_%v", tc.variant), func(t *testing.T) {
 			f := newFakeFactory(t, cls, shard, nodes, tc.isMultiTenant)
 			rep := f.newReplicator()
-			node2Errs := []rplicaerrors.Error{{Msg: "E1"}, {}, {Msg: "E3"}}
+			node2Errs := []replicaerrors.Error{{Msg: "E1"}, {}, {Msg: "E3"}}
 			var wg sync.WaitGroup
 			for _, n := range nodes {
 				f.WClient.On("PutObjects", mock.Anything, n, cls, shard, anyVal, objs, uint64(0)).Return(resp1, nil)
@@ -759,7 +759,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 			f.WClient.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				defer wg.Done()
 				resp := a[5].(*replica.SimpleResponse)
-				*resp = replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 3)}
+				*resp = replica.SimpleResponse{Errors: make([]replicaerrors.Error, 3)}
 			}
 			wg.Add(1)
 			f.WClient.On("Commit", ctx, nodes[1], cls, shard, anyVal, anyVal).Return(errAny).RunFn = func(a mock.Arguments) {
@@ -820,7 +820,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 
 			errs := rep.AddReferences(ctx, shard, refs, types.ConsistencyLevelAll, 123)
 			assert.Equal(t, 2, len(errs))
-			assert.ErrorIs(t, errs[0], rplicaerrors.ErrReplicas)
+			assert.ErrorIs(t, errs[0], replicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("PhaseOneUnsuccessfulResponse_%v", tc.variant), func(t *testing.T) {
@@ -828,7 +828,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 			rep := f.newReplicator()
 			resp := replica.SimpleResponse{}
 			f.WClient.On("AddReferences", mock.Anything, nodes[0], cls, shard, anyVal, refs, uint64(123)).Return(resp, nil)
-			resp2 := replica.SimpleResponse{[]rplicaerrors.Error{{Msg: "E1"}, {Msg: "E2"}}}
+			resp2 := replica.SimpleResponse{[]replicaerrors.Error{{Msg: "E1"}, {Msg: "E2"}}}
 			f.WClient.On("AddReferences", mock.Anything, nodes[1], cls, shard, anyVal, refs, uint64(123)).Return(resp2, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[0], "C1", shard, anyVal).Return(resp, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp, nil)
@@ -836,7 +836,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 			errs := rep.AddReferences(ctx, shard, refs, types.ConsistencyLevelAll, 123)
 			assert.Equal(t, 2, len(errs))
 			for _, err := range errs {
-				assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
+				assert.ErrorIs(t, err, replicaerrors.ErrReplicas)
 			}
 		})
 

--- a/usecases/replica/replicator_test.go
+++ b/usecases/replica/replicator_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
 	"github.com/weaviate/weaviate/usecases/sharding/config"
@@ -62,21 +63,21 @@ func TestReplicatorReplicaNotFound(t *testing.T) {
 			f := newFakeFactory(t, "C1", "S", []string{}, tc.isMultiTenant)
 			rep := f.newReplicator()
 			err := rep.PutObject(ctx, "S", nil, types.ConsistencyLevelAll, 0)
-			assert.ErrorIs(t, err, replica.ErrReplicas)
+			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("MergeObject_%v", tc.variant), func(t *testing.T) {
 			f := newFakeFactory(t, "C1", "S", []string{}, tc.isMultiTenant)
 			rep := f.newReplicator()
 			err := rep.MergeObject(ctx, "S", nil, types.ConsistencyLevelAll, 0)
-			assert.ErrorIs(t, err, replica.ErrReplicas)
+			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("DeleteObject_%v", tc.variant), func(t *testing.T) {
 			f := newFakeFactory(t, "C1", "S", []string{}, tc.isMultiTenant)
 			rep := f.newReplicator()
 			err := rep.DeleteObject(ctx, "S", "id", time.Now(), types.ConsistencyLevelAll, 0)
-			assert.ErrorIs(t, err, replica.ErrReplicas)
+			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("PutObjects_%v", tc.variant), func(t *testing.T) {
@@ -85,7 +86,7 @@ func TestReplicatorReplicaNotFound(t *testing.T) {
 			errs := rep.PutObjects(ctx, "S", []*storobj.Object{{}, {}}, types.ConsistencyLevelAll, 0)
 			assert.Equal(t, 2, len(errs))
 			for _, err := range errs {
-				assert.ErrorIs(t, err, replica.ErrReplicas)
+				assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
 			}
 		})
 
@@ -95,7 +96,7 @@ func TestReplicatorReplicaNotFound(t *testing.T) {
 			xs := rep.DeleteObjects(ctx, "S", []strfmt.UUID{strfmt.UUID("1"), strfmt.UUID("2"), strfmt.UUID("3")}, time.Now(), false, types.ConsistencyLevelAll, 0)
 			assert.Equal(t, 3, len(xs))
 			for _, x := range xs {
-				assert.ErrorIs(t, x.Err, replica.ErrReplicas)
+				assert.ErrorIs(t, x.Err, rplicaerrors.ErrReplicas)
 			}
 		})
 
@@ -105,7 +106,7 @@ func TestReplicatorReplicaNotFound(t *testing.T) {
 			errs := rep.AddReferences(ctx, "S", []objects.BatchReference{{}, {}}, types.ConsistencyLevelAll, 0)
 			assert.Equal(t, 2, len(errs))
 			for _, err := range errs {
-				assert.ErrorIs(t, err, replica.ErrReplicas)
+				assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
 			}
 		})
 	}
@@ -183,7 +184,7 @@ func TestReplicatorPutObject(t *testing.T) {
 			f.WClient.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				defer wg.Done()
 				resp := a[5].(*replica.SimpleResponse)
-				*resp = replica.SimpleResponse{Errors: []replica.Error{{Msg: "e3"}}}
+				*resp = replica.SimpleResponse{Errors: []rplicaerrors.Error{{Msg: "e3"}}}
 			}
 			err := rep.PutObject(ctx, shard, obj, types.ConsistencyLevelQuorum, 123)
 			assert.Nil(t, err)
@@ -231,7 +232,7 @@ func TestReplicatorPutObject(t *testing.T) {
 			f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp, nil)
 
 			err := rep.PutObject(ctx, shard, obj, types.ConsistencyLevelAll, 123)
-			assert.ErrorIs(t, err, replica.ErrReplicas)
+			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("PhaseOneUnsuccessfulResponse_%v", tc.variant), func(t *testing.T) {
@@ -239,13 +240,13 @@ func TestReplicatorPutObject(t *testing.T) {
 			rep := f.newReplicator()
 			resp := replica.SimpleResponse{}
 			f.WClient.On("PutObject", mock.Anything, nodes[0], cls, shard, anyVal, obj, uint64(123)).Return(resp, nil)
-			resp2 := replica.SimpleResponse{[]replica.Error{{Err: errAny}}}
+			resp2 := replica.SimpleResponse{[]rplicaerrors.Error{{Err: errAny}}}
 			f.WClient.On("PutObject", mock.Anything, nodes[1], cls, shard, anyVal, obj, uint64(123)).Return(resp2, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[0], "C1", shard, anyVal).Return(resp, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp, nil)
 
 			err := rep.PutObject(ctx, shard, obj, types.ConsistencyLevelAll, 123)
-			assert.ErrorIs(t, err, replica.ErrReplicas)
+			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("Commit_%v", tc.variant), func(t *testing.T) {
@@ -304,7 +305,7 @@ func TestReplicatorMergeObject(t *testing.T) {
 			f.WClient.On("Abort", mock.Anything, nodes[1], cls, shard, anyVal).Return(resp, nil)
 
 			err := rep.MergeObject(ctx, shard, merge, types.ConsistencyLevelAll, 123)
-			assert.ErrorIs(t, err, replica.ErrReplicas)
+			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("PhaseOneUnsuccessfulResponse_%v", tc.variant), func(t *testing.T) {
@@ -312,13 +313,13 @@ func TestReplicatorMergeObject(t *testing.T) {
 			rep := f.newReplicator()
 			resp := replica.SimpleResponse{}
 			f.WClient.On("MergeObject", mock.Anything, nodes[0], cls, shard, anyVal, merge, uint64(123)).Return(resp, nil)
-			resp2 := replica.SimpleResponse{[]replica.Error{{Err: errAny}}}
+			resp2 := replica.SimpleResponse{[]rplicaerrors.Error{{Err: errAny}}}
 			f.WClient.On("MergeObject", mock.Anything, nodes[1], cls, shard, anyVal, merge, uint64(123)).Return(resp2, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[0], cls, shard, anyVal).Return(resp, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[1], cls, shard, anyVal).Return(resp, nil)
 
 			err := rep.MergeObject(ctx, shard, merge, types.ConsistencyLevelAll, 123)
-			assert.ErrorIs(t, err, replica.ErrReplicas)
+			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("Commit_%v", tc.variant), func(t *testing.T) {
@@ -359,7 +360,7 @@ func TestReplicatorDeleteObject(t *testing.T) {
 			factory := newFakeFactory(t, "C1", shard, nodes, tc.isMultiTenant)
 			client := factory.WClient
 			rep := factory.newReplicator()
-			resp := replica.SimpleResponse{Errors: make([]replica.Error, 1)}
+			resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 1)}
 			for _, n := range nodes[:2] {
 				client.On("DeleteObject", mock.Anything, n, cls, shard, anyVal, uuid, anyVal, uint64(123)).Return(resp, nil)
 			}
@@ -370,14 +371,14 @@ func TestReplicatorDeleteObject(t *testing.T) {
 
 			err := rep.DeleteObject(ctx, shard, uuid, time.Now(), types.ConsistencyLevelAll, 123)
 			assert.NotNil(t, err)
-			assert.ErrorIs(t, err, replica.ErrReplicas)
+			assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("SuccessWithConsistencyLevelAll_%v", tc.variant), func(t *testing.T) {
 			factory := newFakeFactory(t, "C1", shard, nodes, tc.isMultiTenant)
 			client := factory.WClient
 			rep := factory.newReplicator()
-			resp := replica.SimpleResponse{Errors: make([]replica.Error, 1)}
+			resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 1)}
 			for _, n := range nodes {
 				client.On("DeleteObject", mock.Anything, n, cls, shard, anyVal, uuid, anyVal, uint64(123)).Return(resp, nil)
 				client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil)
@@ -391,13 +392,13 @@ func TestReplicatorDeleteObject(t *testing.T) {
 			factory := newFakeFactory(t, "C1", shard, nodes, tc.isMultiTenant)
 			client := factory.WClient
 			rep := factory.newReplicator()
-			resp := replica.SimpleResponse{Errors: make([]replica.Error, 1)}
+			resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 1)}
 			for _, n := range nodes[:2] {
 				client.On("DeleteObject", mock.Anything, n, cls, shard, anyVal, uuid, anyVal, uint64(123)).Return(resp, nil)
 				client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 					resp := a[5].(*replica.SimpleResponse)
 					*resp = replica.SimpleResponse{
-						Errors: []replica.Error{{}},
+						Errors: []rplicaerrors.Error{{}},
 					}
 				}
 			}
@@ -405,7 +406,7 @@ func TestReplicatorDeleteObject(t *testing.T) {
 			client.On("Commit", ctx, "C", "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				resp := a[5].(*replica.SimpleResponse)
 				*resp = replica.SimpleResponse{
-					Errors: []replica.Error{{Msg: "e3"}},
+					Errors: []rplicaerrors.Error{{Msg: "e3"}},
 				}
 			}
 
@@ -418,13 +419,13 @@ func TestReplicatorDeleteObject(t *testing.T) {
 			factory := newFakeFactory(t, "C1", shard, nodes, tc.isMultiTenant)
 			client := factory.WClient
 			rep := factory.newReplicator()
-			resp := replica.SimpleResponse{Errors: make([]replica.Error, 1)}
+			resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 1)}
 			for _, n := range nodes[:2] {
 				client.On("DeleteObject", mock.Anything, n, cls, shard, anyVal, uuid, anyVal, uint64(123)).Return(resp, nil)
 				client.On("Commit", ctx, n, "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 					resp := a[5].(*replica.SimpleResponse)
 					*resp = replica.SimpleResponse{
-						Errors: []replica.Error{{}},
+						Errors: []rplicaerrors.Error{{}},
 					}
 				}
 			}
@@ -432,7 +433,7 @@ func TestReplicatorDeleteObject(t *testing.T) {
 			client.On("Commit", ctx, "C", "C1", shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				resp := a[5].(*replica.SimpleResponse)
 				*resp = replica.SimpleResponse{
-					Errors: []replica.Error{{Msg: "e3"}},
+					Errors: []rplicaerrors.Error{{Msg: "e3"}},
 				}
 			}
 
@@ -472,7 +473,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 			result := factory.newReplicator().DeleteObjects(ctx, shard, docIDs, time.Now(), false, types.ConsistencyLevelAll, 123)
 			assert.Equal(t, len(result), 2)
 			for _, r := range result {
-				assert.ErrorIs(t, r.Err, replica.ErrReplicas)
+				assert.ErrorIs(t, r.Err, rplicaerrors.ErrReplicas)
 			}
 		})
 
@@ -502,14 +503,14 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 					defer wg.Done()
 					resp := args[5].(*replica.DeleteBatchResponse)
 					*resp = replica.DeleteBatchResponse{
-						Batch: []replica.UUID2Error{{"1", replica.Error{}}, {"2", replica.Error{Msg: "e1"}}},
+						Batch: []replica.UUID2Error{{"1", rplicaerrors.Error{}}, {"2", rplicaerrors.Error{Msg: "e1"}}},
 					}
 				}
 			}
 			result := rep.DeleteObjects(ctx, shard, docIDs, time.Now(), false, types.ConsistencyLevelAll, 123)
 			assert.Equal(t, len(result), 2)
 			assert.Equal(t, objects.BatchSimpleObject{UUID: "1", Err: nil}, result[0])
-			assert.Equal(t, objects.BatchSimpleObject{UUID: "2", Err: &replica.Error{Msg: "e1"}}, result[1])
+			assert.Equal(t, objects.BatchSimpleObject{UUID: "2", Err: &rplicaerrors.Error{Msg: "e1"}}, result[1])
 			// Wait for all Commit RunFn callbacks to complete before test cleanup runs
 			wg.Wait()
 		})
@@ -590,7 +591,7 @@ func TestReplicatorDeleteObjects(t *testing.T) {
 				defer wg.Done()
 				resp := args[5].(*replica.DeleteBatchResponse)
 				*resp = replica.DeleteBatchResponse{
-					Batch: []replica.UUID2Error{{UUID: "1"}, {UUID: "2", Error: replica.Error{Msg: "e2"}}},
+					Batch: []replica.UUID2Error{{UUID: "1"}, {UUID: "2", Error: rplicaerrors.Error{Msg: "e2"}}},
 				}
 			}
 			result := rep.DeleteObjects(ctx, shard, docIDs, time.Now(), false, types.ConsistencyLevelQuorum, 123)
@@ -609,7 +610,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 		nodes = []string{"A", "B"}
 		ctx   = context.Background()
 		objs  = []*storobj.Object{{}, {}, {}}
-		resp1 = replica.SimpleResponse{[]replica.Error{{}}}
+		resp1 = replica.SimpleResponse{[]rplicaerrors.Error{{}}}
 	)
 
 	testCases := []struct {
@@ -624,7 +625,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 		t.Run(fmt.Sprintf("SuccessWithConsistencyLevelAll_%v", tc.variant), func(t *testing.T) {
 			f := newFakeFactory(t, "C1", shard, nodes, tc.isMultiTenant)
 			rep := f.newReplicator()
-			resp := replica.SimpleResponse{Errors: make([]replica.Error, 3)}
+			resp := replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 3)}
 			for _, n := range nodes {
 				f.WClient.On("PutObjects", mock.Anything, n, cls, shard, anyVal, objs, uint64(123)).Return(resp, nil)
 				f.WClient.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil)
@@ -657,7 +658,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 			f.WClient.On("Commit", ctx, "A", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				defer wg.Done()
 				resp := a[5].(*replica.SimpleResponse)
-				*resp = replica.SimpleResponse{Errors: make([]replica.Error, 3)}
+				*resp = replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 3)}
 			}
 
 			errs := rep.PutObjects(ctx, shard, objs, types.ConsistencyLevelOne, 0)
@@ -677,7 +678,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 				f.WClient.On("Commit", ctx, n, cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 					defer wg.Done()
 					resp := a[5].(*replica.SimpleResponse)
-					*resp = replica.SimpleResponse{Errors: []replica.Error{{}}}
+					*resp = replica.SimpleResponse{Errors: []rplicaerrors.Error{{}}}
 				}
 			}
 			f.WClient.On("PutObjects", mock.Anything, "C", cls, shard, anyVal, objs, uint64(0)).Return(resp1, nil)
@@ -685,7 +686,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 			f.WClient.On("Commit", ctx, "C", cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				defer wg.Done()
 				resp := a[5].(*replica.SimpleResponse)
-				*resp = replica.SimpleResponse{Errors: []replica.Error{{Msg: "e3"}}}
+				*resp = replica.SimpleResponse{Errors: []rplicaerrors.Error{{Msg: "e3"}}}
 			}
 			errs := rep.PutObjects(ctx, shard, objs, types.ConsistencyLevelQuorum, 0)
 			assert.Equal(t, []error{nil, nil, nil}, errs)
@@ -703,14 +704,14 @@ func TestReplicatorPutObjects(t *testing.T) {
 
 			errs := rep.PutObjects(ctx, shard, objs, types.ConsistencyLevelAll, 0)
 			assert.Equal(t, 3, len(errs))
-			assert.ErrorIs(t, errs[0], replica.ErrReplicas)
+			assert.ErrorIs(t, errs[0], rplicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("PhaseOneUnsuccessfulResponse_%v", tc.variant), func(t *testing.T) {
 			f := newFakeFactory(t, "C1", shard, nodes, tc.isMultiTenant)
 			rep := f.newReplicator()
 			f.WClient.On("PutObjects", mock.Anything, nodes[0], cls, shard, anyVal, objs, uint64(0)).Return(resp1, nil)
-			resp2 := replica.SimpleResponse{[]replica.Error{{Msg: "E1"}, {Msg: "E2"}}}
+			resp2 := replica.SimpleResponse{[]rplicaerrors.Error{{Msg: "E1"}, {Msg: "E2"}}}
 			f.WClient.On("PutObjects", mock.Anything, nodes[1], cls, shard, anyVal, objs, uint64(0)).Return(resp2, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[0], "C1", shard, anyVal).Return(resp1, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp1, nil)
@@ -718,7 +719,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 			errs := rep.PutObjects(ctx, shard, objs, types.ConsistencyLevelAll, 0)
 			assert.Equal(t, 3, len(errs))
 			for _, err := range errs {
-				assert.ErrorIs(t, err, replica.ErrReplicas)
+				assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
 			}
 		})
 
@@ -733,7 +734,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 			f.WClient.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				defer wg.Done()
 				resp := a[5].(*replica.SimpleResponse)
-				*resp = replica.SimpleResponse{Errors: make([]replica.Error, 3)}
+				*resp = replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 3)}
 			}
 			f.WClient.On("Commit", ctx, nodes[1], cls, shard, anyVal, anyVal).Return(errAny)
 
@@ -749,7 +750,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 		t.Run(fmt.Sprintf("PhaseTwoUnsuccessfulResponse_%v", tc.variant), func(t *testing.T) {
 			f := newFakeFactory(t, cls, shard, nodes, tc.isMultiTenant)
 			rep := f.newReplicator()
-			node2Errs := []replica.Error{{Msg: "E1"}, {}, {Msg: "E3"}}
+			node2Errs := []rplicaerrors.Error{{Msg: "E1"}, {}, {Msg: "E3"}}
 			var wg sync.WaitGroup
 			for _, n := range nodes {
 				f.WClient.On("PutObjects", mock.Anything, n, cls, shard, anyVal, objs, uint64(0)).Return(resp1, nil)
@@ -758,7 +759,7 @@ func TestReplicatorPutObjects(t *testing.T) {
 			f.WClient.On("Commit", ctx, nodes[0], cls, shard, anyVal, anyVal).Return(nil).RunFn = func(a mock.Arguments) {
 				defer wg.Done()
 				resp := a[5].(*replica.SimpleResponse)
-				*resp = replica.SimpleResponse{Errors: make([]replica.Error, 3)}
+				*resp = replica.SimpleResponse{Errors: make([]rplicaerrors.Error, 3)}
 			}
 			wg.Add(1)
 			f.WClient.On("Commit", ctx, nodes[1], cls, shard, anyVal, anyVal).Return(errAny).RunFn = func(a mock.Arguments) {
@@ -819,7 +820,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 
 			errs := rep.AddReferences(ctx, shard, refs, types.ConsistencyLevelAll, 123)
 			assert.Equal(t, 2, len(errs))
-			assert.ErrorIs(t, errs[0], replica.ErrReplicas)
+			assert.ErrorIs(t, errs[0], rplicaerrors.ErrReplicas)
 		})
 
 		t.Run(fmt.Sprintf("PhaseOneUnsuccessfulResponse_%v", tc.variant), func(t *testing.T) {
@@ -827,7 +828,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 			rep := f.newReplicator()
 			resp := replica.SimpleResponse{}
 			f.WClient.On("AddReferences", mock.Anything, nodes[0], cls, shard, anyVal, refs, uint64(123)).Return(resp, nil)
-			resp2 := replica.SimpleResponse{[]replica.Error{{Msg: "E1"}, {Msg: "E2"}}}
+			resp2 := replica.SimpleResponse{[]rplicaerrors.Error{{Msg: "E1"}, {Msg: "E2"}}}
 			f.WClient.On("AddReferences", mock.Anything, nodes[1], cls, shard, anyVal, refs, uint64(123)).Return(resp2, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[0], "C1", shard, anyVal).Return(resp, nil)
 			f.WClient.On("Abort", mock.Anything, nodes[1], "C1", shard, anyVal).Return(resp, nil)
@@ -835,7 +836,7 @@ func TestReplicatorAddReferences(t *testing.T) {
 			errs := rep.AddReferences(ctx, shard, refs, types.ConsistencyLevelAll, 123)
 			assert.Equal(t, 2, len(errs))
 			for _, err := range errs {
-				assert.ErrorIs(t, err, replica.ErrReplicas)
+				assert.ErrorIs(t, err, rplicaerrors.ErrReplicas)
 			}
 		})
 

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -23,7 +23,7 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
@@ -47,7 +47,7 @@ type Client interface {
 }
 
 type SimpleResponse struct {
-	Errors []rplicaerrors.Error `json:"errors,omitempty"`
+	Errors []replicaerrors.Error `json:"errors,omitempty"`
 }
 
 func (r *SimpleResponse) FirstError() error {
@@ -65,8 +65,8 @@ type DeleteBatchResponse struct {
 }
 
 type UUID2Error struct {
-	UUID  string             `json:"uuid,omitempty"`
-	Error rplicaerrors.Error `json:"error,omitempty"`
+	UUID  string              `json:"uuid,omitempty"`
+	Error replicaerrors.Error `json:"error,omitempty"`
 }
 
 // FirstError returns the first found error

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
@@ -45,92 +46,8 @@ type Client interface {
 	WClient
 }
 
-// StatusCode is communicate the cause of failure during replication
-type StatusCode int
-
-const (
-	StatusOK            = 0
-	StatusClassNotFound = iota + 200
-	StatusShardNotFound
-	StatusNotFound
-	StatusAlreadyExisted
-	StatusNotReady
-	StatusConflict = iota + 300
-	StatusPreconditionFailed
-	StatusReadOnly
-	StatusObjectNotFound
-)
-
-// Error reports error happening during replication
-type Error struct {
-	Code StatusCode `json:"code"`
-	Msg  string     `json:"msg,omitempty"`
-	Err  error      `json:"-"`
-}
-
-// Empty checks whether e is an empty error which equivalent to e == nil
-func (e *Error) Empty() bool {
-	return e.Code == StatusOK && e.Msg == "" && e.Err == nil
-}
-
-// NewError create new replication error
-func NewError(code StatusCode, msg string) *Error {
-	return &Error{code, msg, nil}
-}
-
-func (e *Error) Clone() *Error {
-	return &Error{Code: e.Code, Msg: e.Msg, Err: e.Err}
-}
-
-// Unwrap underlying error
-func (e *Error) Unwrap() error { return e.Err }
-
-func (e *Error) Error() string {
-	return fmt.Sprintf("%s %q: %v", StatusText(e.Code), e.Msg, e.Err)
-}
-
-func (e *Error) IsStatusCode(sc StatusCode) bool {
-	return e.Code == sc
-}
-
-// StatusText returns a text for the status code. It returns the empty
-// string if the code is unknown.
-func StatusText(code StatusCode) string {
-	switch code {
-	case StatusOK:
-		return "ok"
-	case StatusNotFound:
-		return "not found"
-	case StatusClassNotFound:
-		return "class not found"
-	case StatusShardNotFound:
-		return "shard not found"
-	case StatusConflict:
-		return "conflict"
-	case StatusPreconditionFailed:
-		return "precondition failed"
-	case StatusAlreadyExisted:
-		return "already existed"
-	case StatusNotReady:
-		return "local index not ready"
-	case StatusReadOnly:
-		return "read only"
-	case StatusObjectNotFound:
-		return "object not found"
-	default:
-		return ""
-	}
-}
-
-func (e *Error) Timeout() bool {
-	t, ok := e.Err.(interface {
-		Timeout() bool
-	})
-	return ok && t.Timeout()
-}
-
 type SimpleResponse struct {
-	Errors []Error `json:"errors,omitempty"`
+	Errors []rplicaerrors.Error `json:"errors,omitempty"`
 }
 
 func (r *SimpleResponse) FirstError() error {
@@ -148,8 +65,8 @@ type DeleteBatchResponse struct {
 }
 
 type UUID2Error struct {
-	UUID  string `json:"uuid,omitempty"`
-	Error Error  `json:"error,omitempty"`
+	UUID  string             `json:"uuid,omitempty"`
+	Error rplicaerrors.Error `json:"error,omitempty"`
 }
 
 // FirstError returns the first found error

--- a/usecases/replica/transport_test.go
+++ b/usecases/replica/transport_test.go
@@ -17,49 +17,48 @@ import (
 	"testing"
 	"time"
 
-	"github.com/weaviate/weaviate/usecases/replica"
-
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 func TestReplicationErrorTimeout(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithDeadline(ctx, time.Now())
 	defer cancel()
-	err := &replica.Error{Err: ctx.Err()}
+	err := &rplicaerrors.Error{Err: ctx.Err()}
 	assert.True(t, err.Timeout())
 	err = err.Clone()
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestReplicationErrorMarshal(t *testing.T) {
-	rawErr := replica.Error{Code: replica.StatusClassNotFound, Msg: "Article", Err: errors.New("error cannot be marshalled")}
+	rawErr := rplicaerrors.Error{Code: rplicaerrors.StatusClassNotFound, Msg: "Article", Err: errors.New("error cannot be marshalled")}
 	bytes, err := json.Marshal(&rawErr)
 	assert.Nil(t, err)
-	got := replica.NewError(0, "")
+	got := rplicaerrors.NewError(0, "")
 	assert.Nil(t, json.Unmarshal(bytes, got))
-	want := &replica.Error{Code: replica.StatusClassNotFound, Msg: "Article"}
+	want := &rplicaerrors.Error{Code: rplicaerrors.StatusClassNotFound, Msg: "Article"}
 	assert.Equal(t, want, got)
 }
 
 func TestReplicationErrorStatus(t *testing.T) {
 	tests := []struct {
-		code replica.StatusCode
+		code rplicaerrors.StatusCode
 		desc string
 	}{
 		{-1, ""},
-		{replica.StatusOK, "ok"},
-		{replica.StatusClassNotFound, "class not found"},
-		{replica.StatusShardNotFound, "shard not found"},
-		{replica.StatusNotFound, "not found"},
-		{replica.StatusAlreadyExisted, "already existed"},
-		{replica.StatusConflict, "conflict"},
-		{replica.StatusPreconditionFailed, "precondition failed"},
-		{replica.StatusReadOnly, "read only"},
+		{rplicaerrors.StatusOK, "ok"},
+		{rplicaerrors.StatusClassNotFound, "class not found"},
+		{rplicaerrors.StatusShardNotFound, "shard not found"},
+		{rplicaerrors.StatusNotFound, "not found"},
+		{rplicaerrors.StatusAlreadyExisted, "already existed"},
+		{rplicaerrors.StatusConflict, "conflict"},
+		{rplicaerrors.StatusPreconditionFailed, "precondition failed"},
+		{rplicaerrors.StatusReadOnly, "read only"},
 	}
 	for _, test := range tests {
-		got := replica.StatusText(test.code)
+		got := rplicaerrors.StatusText(test.code)
 		if got != test.desc {
 			t.Errorf("StatusText(%d) want %v got %v", test.code, test.desc, got)
 		}

--- a/usecases/replica/transport_test.go
+++ b/usecases/replica/transport_test.go
@@ -19,46 +19,46 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
-	rplicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
+	replicaerrors "github.com/weaviate/weaviate/usecases/replica/errors"
 )
 
 func TestReplicationErrorTimeout(t *testing.T) {
 	ctx := context.Background()
 	ctx, cancel := context.WithDeadline(ctx, time.Now())
 	defer cancel()
-	err := &rplicaerrors.Error{Err: ctx.Err()}
+	err := &replicaerrors.Error{Err: ctx.Err()}
 	assert.True(t, err.Timeout())
 	err = err.Clone()
 	assert.ErrorIs(t, err, context.DeadlineExceeded)
 }
 
 func TestReplicationErrorMarshal(t *testing.T) {
-	rawErr := rplicaerrors.Error{Code: rplicaerrors.StatusClassNotFound, Msg: "Article", Err: errors.New("error cannot be marshalled")}
+	rawErr := replicaerrors.Error{Code: replicaerrors.StatusClassNotFound, Msg: "Article", Err: errors.New("error cannot be marshalled")}
 	bytes, err := json.Marshal(&rawErr)
 	assert.Nil(t, err)
-	got := rplicaerrors.NewError(0, "")
+	got := replicaerrors.NewError(0, "")
 	assert.Nil(t, json.Unmarshal(bytes, got))
-	want := &rplicaerrors.Error{Code: rplicaerrors.StatusClassNotFound, Msg: "Article"}
+	want := &replicaerrors.Error{Code: replicaerrors.StatusClassNotFound, Msg: "Article"}
 	assert.Equal(t, want, got)
 }
 
 func TestReplicationErrorStatus(t *testing.T) {
 	tests := []struct {
-		code rplicaerrors.StatusCode
+		code replicaerrors.StatusCode
 		desc string
 	}{
 		{-1, ""},
-		{rplicaerrors.StatusOK, "ok"},
-		{rplicaerrors.StatusClassNotFound, "class not found"},
-		{rplicaerrors.StatusShardNotFound, "shard not found"},
-		{rplicaerrors.StatusNotFound, "not found"},
-		{rplicaerrors.StatusAlreadyExisted, "already existed"},
-		{rplicaerrors.StatusConflict, "conflict"},
-		{rplicaerrors.StatusPreconditionFailed, "precondition failed"},
-		{rplicaerrors.StatusReadOnly, "read only"},
+		{replicaerrors.StatusOK, "ok"},
+		{replicaerrors.StatusClassNotFound, "class not found"},
+		{replicaerrors.StatusShardNotFound, "shard not found"},
+		{replicaerrors.StatusNotFound, "not found"},
+		{replicaerrors.StatusAlreadyExisted, "already existed"},
+		{replicaerrors.StatusConflict, "conflict"},
+		{replicaerrors.StatusPreconditionFailed, "precondition failed"},
+		{replicaerrors.StatusReadOnly, "read only"},
 	}
 	for _, test := range tests {
-		got := rplicaerrors.StatusText(test.code)
+		got := replicaerrors.StatusText(test.code)
 		if got != test.desc {
 			t.Errorf("StatusText(%d) want %v got %v", test.code, test.desc, got)
 		}


### PR DESCRIPTION
### What's being changed:
this PR refactors the replication error handling system by introducing a dedicated `usecases/replica/errors` package to centralize and unify error types and handling patterns across the replication subsystem.

Introduces new usecases/replica/errors package with sentinel errors and constructor functions
Migrates Error struct and StatusCode constants from transport.go to the new errors package
Updates all references across the codebase to use the new error package and helper functions


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
