### PR TITLE
fix(usage): report per node backup size

### DIFF
--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -106,10 +106,19 @@ func (s *service) Usage(ctx context.Context, exactObjectCount bool) (*types.Repo
 			if backup.Status != backupent.Success {
 				continue
 			}
+
+			var sizeInGib float64
+			for name, n := range backup.Nodes {
+				if name == usage.Node {
+					sizeInGib = float64(n.PreCompressionSizeBytes) / (1024 * 1024 * 1024) // Convert bytes to GiB
+					break
+				}
+			}
+
 			usage.Backups = append(usage.Backups, &types.BackupUsage{
 				ID:             backup.ID,
 				CompletionTime: backup.CompletedAt.Format(time.RFC3339),
-				SizeInGib:      float64(backup.PreCompressionSizeBytes) / (1024 * 1024 * 1024), // Convert bytes to GiB
+				SizeInGib:      sizeInGib,
 				Type:           string(backup.Status),
 				Collections:    backup.Classes(),
 			})


### PR DESCRIPTION
### What's being changed:

This PR changes usage metric to report per node backup size.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
