### PR TITLE
chore: set internal props indexing to immutable

### DIFF
--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -992,6 +992,25 @@ func validateImmutableFields(initial, updated *models.Class) error {
 		}
 	}
 
+	// changing indexing not allowed
+	compareIndexSetting := func(name string, extractVal func(config *models.InvertedIndexConfig) bool) error {
+		initialVal := initial.InvertedIndexConfig != nil && extractVal(initial.InvertedIndexConfig)
+		updatedVal := updated.InvertedIndexConfig != nil && extractVal(updated.InvertedIndexConfig)
+		if initialVal != updatedVal {
+			return fmt.Errorf("%q setting is immutable. Value changed from \"%v\" to \"%v\"", name, initialVal, updatedVal)
+		}
+		return nil
+	}
+	if err := compareIndexSetting("indexTimestamp", func(config *models.InvertedIndexConfig) bool { return config.IndexTimestamps }); err != nil {
+		return err
+	}
+	if err := compareIndexSetting("indexNullState", func(config *models.InvertedIndexConfig) bool { return config.IndexNullState }); err != nil {
+		return err
+	}
+	if err := compareIndexSetting("indexPropertyLength", func(config *models.InvertedIndexConfig) bool { return config.IndexPropertyLength }); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -1486,6 +1486,128 @@ func Test_UpdateClass(t *testing.T) {
 					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 				},
 			},
+
+			{
+				name: "attempting to update the inverted IndexTimestamps true->false",
+				initial: &models.Class{
+					Class:      "InitialName",
+					Vectorizer: "none",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexTimestamps: true,
+					},
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				},
+				update: &models.Class{
+					Class:      "InitialName",
+					Vectorizer: "none",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexTimestamps: false,
+					},
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				},
+				expectedError: fmt.Errorf("\"indexTimestamp\" setting is immutable. Value changed from \"true\" to \"false\""),
+			},
+			{
+				name: "attempting to update the inverted IndexTimestamps false->true",
+				initial: &models.Class{
+					Class:      "InitialName",
+					Vectorizer: "none",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexTimestamps: false,
+					},
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				},
+				update: &models.Class{
+					Class:      "InitialName",
+					Vectorizer: "none",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexTimestamps: true,
+					},
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				},
+				expectedError: fmt.Errorf("\"indexTimestamp\" setting is immutable. Value changed from \"false\" to \"true\""),
+			},
+			{
+				name: "attempting to update the inverted IndexNullState true->false",
+				initial: &models.Class{
+					Class:      "InitialName",
+					Vectorizer: "none",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexNullState: true,
+					},
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				},
+				update: &models.Class{
+					Class:      "InitialName",
+					Vectorizer: "none",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexNullState: false,
+					},
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				},
+				expectedError: fmt.Errorf("\"indexNullState\" setting is immutable. Value changed from \"true\" to \"false\""),
+			},
+			{
+				name: "attempting to update the inverted IndexNullState false->true",
+				initial: &models.Class{
+					Class:      "InitialName",
+					Vectorizer: "none",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexNullState: false,
+					},
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				},
+				update: &models.Class{
+					Class:      "InitialName",
+					Vectorizer: "none",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexNullState: true,
+					},
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				},
+				expectedError: fmt.Errorf("\"indexNullState\" setting is immutable. Value changed from \"false\" to \"true\""),
+			},
+			{
+				name: "attempting to update the inverted IndexPropertyLength true->false",
+				initial: &models.Class{
+					Class:      "InitialName",
+					Vectorizer: "none",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexPropertyLength: true,
+					},
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				},
+				update: &models.Class{
+					Class:      "InitialName",
+					Vectorizer: "none",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexPropertyLength: false,
+					},
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				},
+				expectedError: fmt.Errorf("\"indexPropertyLength\" setting is immutable. Value changed from \"true\" to \"false\""),
+			},
+			{
+				name: "attempting to update the inverted IndexPropertyLength false->true",
+				initial: &models.Class{
+					Class:      "InitialName",
+					Vectorizer: "none",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexPropertyLength: false,
+					},
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				},
+				update: &models.Class{
+					Class:      "InitialName",
+					Vectorizer: "none",
+					InvertedIndexConfig: &models.InvertedIndexConfig{
+						IndexPropertyLength: true,
+					},
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				},
+				expectedError: fmt.Errorf("\"indexPropertyLength\" setting is immutable. Value changed from \"false\" to \"true\""),
+			},
+
 			{
 				name: "attempting to update module config",
 				initial: &models.Class{


### PR DESCRIPTION
### What's being changed:
`InvertedIndexConfig.IndexTimestamps`, `InvertedIndexConfig.IndexNullState` and `InvertedIndexConfig.IndexPropertyLength` settings of collection schema should not be mutable once collection is created as this may lead to issues in multi tenant configurations (like errors on adding objects to tenants created before indexing was enabled).

This PR ensured settings can not be changed on collection schema is update.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
