### PR TITLE
Revert "Merge pull request #10010 from weaviate/hfresh_rq1"

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/binary_rotational_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/binary_rotational_quantization.go
@@ -36,15 +36,6 @@ type BinaryRotationalQuantizer struct {
 	cos       float32
 }
 
-func (rq *BinaryRotationalQuantizer) Data() RQData {
-	return RQData{
-		InputDim: rq.inputDim,
-		Bits:     1,
-		Rotation: *rq.rotation,
-		Rounding: rq.rounding,
-	}
-}
-
 func NewBinaryRotationalQuantizer(inputDim int, seed uint64, distancer distancer.Provider) *BinaryRotationalQuantizer {
 	// Pad the input if it is low-dimensional.
 	if inputDim < minCodeBits {
@@ -196,8 +187,7 @@ func (rq *BinaryRotationalQuantizer) Encode(x []float32) []uint64 {
 }
 
 func (rq *BinaryRotationalQuantizer) Decode(compressed []uint64) []float32 {
-	restored := rq.Restore(compressed)
-	return rq.rotation.UnRotate(restored)
+	panic("unimplemented")
 }
 
 // Restore -> NewCompressedQuantizerDistancer -> NewDistancerFromID -> reassignNeighbor in when deleting

--- a/adapters/repos/db/vector/compressionhelpers/rotational_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/rotational_quantization.go
@@ -364,7 +364,6 @@ type RQData struct {
 	InputDim uint32
 	Bits     uint32
 	Rotation FastRotation
-	Rounding []float32
 }
 
 func (rq *RotationalQuantizer) PersistCompression(logger CommitLogger) {

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -60,7 +60,6 @@ type HFresh struct {
 	replicas       uint32
 	rngFactor      float32
 	searchProbe    uint32
-	rescoreLimit   uint32
 	store          *lsmkv.Store
 
 	// some components require knowing the vector size beforehand
@@ -69,7 +68,7 @@ type HFresh struct {
 	initDimensionsOnce sync.Once
 	dims               uint32 // Number of dimensions of expected vectors
 	distancer          *Distancer
-	quantizer          *compressionhelpers.BinaryRotationalQuantizer
+	quantizer          *compressionhelpers.RotationalQuantizer
 
 	// Internal components
 	Centroids    *HNSWIndex       // Provides access to the centroids.
@@ -144,7 +143,6 @@ func New(cfg *Config, uc ent.UserConfig, store *lsmkv.Store) (*HFresh, error) {
 		replicas:       uc.Replicas,
 		rngFactor:      uc.RNGFactor,
 		searchProbe:    uc.SearchProbe,
-		rescoreLimit:   uc.RescoreLimit,
 	}
 
 	h.Centroids, err = NewHNSWIndex(metrics, store, cfg, 1024*1024, 1024)
@@ -200,7 +198,6 @@ func (h *HFresh) UpdateUserConfig(updated schemaConfig.VectorIndexConfig, callba
 	}
 
 	atomic.StoreUint32(&h.searchProbe, parsed.SearchProbe)
-	atomic.StoreUint32(&h.rescoreLimit, parsed.RescoreLimit)
 
 	callback()
 	return nil

--- a/adapters/repos/db/vector/hfresh/hnsw.go
+++ b/adapters/repos/db/vector/hfresh/hnsw.go
@@ -37,7 +37,7 @@ type HNSWIndex struct {
 	metrics   *Metrics
 	hnsw      *hnsw.HNSW
 	counter   atomic.Int32
-	quantizer *compressionhelpers.BinaryRotationalQuantizer
+	quantizer *compressionhelpers.RotationalQuantizer
 }
 
 func NewHNSWIndex(metrics *Metrics, store *lsmkv.Store, cfg *Config, pages, pageSize uint64) (*HNSWIndex, error) {
@@ -69,7 +69,7 @@ func NewHNSWIndex(metrics *Metrics, store *lsmkv.Store, cfg *Config, pages, page
 	return &index, nil
 }
 
-func (i *HNSWIndex) SetQuantizer(quantizer *compressionhelpers.BinaryRotationalQuantizer) {
+func (i *HNSWIndex) SetQuantizer(quantizer *compressionhelpers.RotationalQuantizer) {
 	i.quantizer = quantizer
 }
 
@@ -80,7 +80,7 @@ func (i *HNSWIndex) Get(id uint64) *Centroid {
 	}
 	return &Centroid{
 		Uncompressed: vec,
-		Compressed:   i.quantizer.CompressedBytes(i.quantizer.Encode(vec)),
+		Compressed:   i.quantizer.Encode(vec),
 		Deleted:      false,
 	}
 }

--- a/adapters/repos/db/vector/hfresh/insert.go
+++ b/adapters/repos/db/vector/hfresh/insert.go
@@ -66,9 +66,9 @@ func (h *HFresh) Add(ctx context.Context, id uint64, vector []float32) (err erro
 			err = errors.Wrap(err, "could not persist dimensions")
 			return // Fail the entire initialization
 		}
-		h.quantizer = compressionhelpers.NewBinaryRotationalQuantizer(int(h.dims), 42, h.config.DistanceProvider)
-		h.Centroids.SetQuantizer(h.quantizer)
 
+		h.quantizer = compressionhelpers.NewRotationalQuantizer(int(h.dims), 42, 8, h.config.DistanceProvider)
+		h.Centroids.SetQuantizer(h.quantizer)
 		if err = h.persistQuantizationData(); err != nil {
 			err = errors.Wrap(err, "could not persist RQ data")
 			return // Fail the entire initialization
@@ -93,7 +93,7 @@ func (h *HFresh) Add(ctx context.Context, id uint64, vector []float32) (err erro
 
 	var v Vector
 
-	compressed := h.quantizer.CompressedBytes(h.quantizer.Encode(vector))
+	compressed := h.quantizer.Encode(vector)
 	v = NewVector(id, version, compressed)
 
 	targets, _, err := h.RNGSelect(vector, 0)

--- a/adapters/repos/db/vector/hfresh/metadata.go
+++ b/adapters/repos/db/vector/hfresh/metadata.go
@@ -134,13 +134,13 @@ func (h *HFresh) persistQuantizationData() error {
 // restoreQuantizationData restores RQ quantizer from msgpack data
 func (h *HFresh) restoreQuantizationData(rqData *compressionhelpers.RQData) error {
 	// Restore the RQ quantizer
-	rq, err := compressionhelpers.RestoreBinaryRotationalQuantizer(
+	rq, err := compressionhelpers.RestoreRotationalQuantizer(
 		int(rqData.InputDim),
+		int(rqData.Bits),
 		int(rqData.Rotation.OutputDim),
 		int(rqData.Rotation.Rounds),
 		rqData.Rotation.Swaps,
 		rqData.Rotation.Signs,
-		rqData.Rounding,
 		h.config.DistanceProvider,
 	)
 	if err != nil {

--- a/adapters/repos/db/vector/hfresh/posting.go
+++ b/adapters/repos/db/vector/hfresh/posting.go
@@ -98,23 +98,23 @@ func (p Posting) GarbageCollect(versionMap *VersionMap) (Posting, error) {
 	return p, nil
 }
 
-func (p Posting) Uncompress(quantizer *compressionhelpers.BinaryRotationalQuantizer) [][]float32 {
+func (p Posting) Uncompress(quantizer *compressionhelpers.RotationalQuantizer) [][]float32 {
 	data := make([][]float32, 0, len(p))
 
 	for _, v := range p {
-		data = append(data, quantizer.Decode(quantizer.FromCompressedBytes(v.Data())))
+		data = append(data, quantizer.Decode(v.Data()))
 	}
 
 	return data
 }
 
 type Distancer struct {
-	quantizer *compressionhelpers.BinaryRotationalQuantizer
+	quantizer *compressionhelpers.RotationalQuantizer
 	distancer distancer.Provider
 }
 
 func (d *Distancer) DistanceBetweenCompressedVectors(a, b []byte) (float32, error) {
-	return d.quantizer.DistanceBetweenCompressedVectors(d.quantizer.FromCompressedBytes(a), d.quantizer.FromCompressedBytes(b))
+	return d.quantizer.DistanceBetweenCompressedVectors(a, b)
 }
 
 func (d *Distancer) DistanceBetweenVectors(a, b []float32) (float32, error) {

--- a/adapters/repos/db/vector/hfresh/reassign.go
+++ b/adapters/repos/db/vector/hfresh/reassign.go
@@ -72,7 +72,7 @@ func (h *HFresh) doReassign(ctx context.Context, op reassignOperation) error {
 	}
 
 	// create a new vector with the updated version
-	newVector := NewVector(op.VectorID, version, h.quantizer.CompressedBytes(h.quantizer.Encode(q)))
+	newVector := NewVector(op.VectorID, version, h.quantizer.Encode(q))
 
 	// append the vector to each replica
 	for id := range replicas.Iter() {

--- a/adapters/repos/db/vector/hfresh/search.go
+++ b/adapters/repos/db/vector/hfresh/search.go
@@ -27,18 +27,18 @@ const (
 )
 
 func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, allowList helpers.AllowList) ([]uint64, []float32, error) {
-	rescoreLimit := int(min(h.rescoreLimit, h.searchProbe)) // Todo: Remove this line when we add support on the benchmarker for lowering the rescore limit too
+	rescoreLimit := k + 5
 	vector = h.normalizeVec(vector)
-	queryVector := NewAnonymousVector(h.quantizer.CompressedBytes(h.quantizer.Encode(vector)))
+	queryVector := NewAnonymousVector(h.quantizer.Encode(vector))
 
-	var selectedCentroids []uint64
+	var selected []uint64
 	var postings []Posting
 
 	// If k is larger than the configured number of candidates, use k as the candidate number
 	// to enlarge the search space.
-	candidateCentroidNum := max(k, int(h.searchProbe))
+	candidateNum := max(rescoreLimit, int(h.searchProbe))
 
-	centroids, err := h.Centroids.Search(vector, candidateCentroidNum)
+	centroids, err := h.Centroids.Search(vector, candidateNum)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -52,8 +52,8 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 	maxDist := centroids.data[0].Distance * h.config.MaxDistanceRatio
 
 	// filter out candidates that are too far away or have no vectors
-	selectedCentroids = make([]uint64, 0, candidateCentroidNum)
-	for i := 0; i < len(centroids.data) && len(selectedCentroids) < candidateCentroidNum; i++ {
+	selected = make([]uint64, 0, candidateNum)
+	for i := 0; i < len(centroids.data) && len(selected) < candidateNum; i++ {
 		if maxDist > pruningMinMaxDistance && centroids.data[i].Distance > maxDist {
 			continue
 		}
@@ -65,11 +65,11 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 			continue
 		}
 
-		selectedCentroids = append(selectedCentroids, centroids.data[i].ID)
+		selected = append(selected, centroids.data[i].ID)
 	}
 
 	// read all the selected postings
-	postings, err = h.PostingStore.MultiGet(ctx, selectedCentroids)
+	postings, err = h.PostingStore.MultiGet(ctx, selected)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -121,9 +121,9 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 		// if the posting size is lower than the configured minimum,
 		// enqueue a merge operation
 		if postingSize < int(h.minPostingSize) {
-			err = h.taskQueue.EnqueueMerge(selectedCentroids[i])
+			err = h.taskQueue.EnqueueMerge(selected[i])
 			if err != nil {
-				return nil, nil, errors.Wrapf(err, "failed to enqueue merge for posting %d", selectedCentroids[i])
+				return nil, nil, errors.Wrapf(err, "failed to enqueue merge for posting %d", selected[i])
 			}
 		}
 	}

--- a/adapters/repos/db/vector/hfresh/split.go
+++ b/adapters/repos/db/vector/hfresh/split.go
@@ -171,7 +171,7 @@ func (h *HFresh) splitPosting(posting Posting) ([]SplitResult, error) {
 			Uncompressed: enc.Centroid(byte(i)),
 		}
 
-		results[i].Centroid = h.quantizer.CompressedBytes(h.quantizer.Encode(enc.Centroid(byte(i))))
+		results[i].Centroid = h.quantizer.Encode(enc.Centroid(byte(i)))
 	}
 
 	for i, v := range data {

--- a/entities/vectorindex/hfresh/config.go
+++ b/entities/vectorindex/hfresh/config.go
@@ -24,7 +24,6 @@ const (
 	DefaultReplicas       = 8
 	DefaultRNGFactor      = 10.0
 	DefaultSearchProbe    = 64
-	DefaultRescoreLimit   = 350
 )
 
 // UserConfig defines the configuration options for the HFresh index.
@@ -36,7 +35,7 @@ type UserConfig struct {
 	RNGFactor      float32 `json:"rngFactor"`
 	SearchProbe    uint32  `json:"searchProbe"`
 	Distance       string  `json:"distance"`
-	RescoreLimit   uint32  `json:"rescoreLimit"`
+	// TODO: add quantization config
 }
 
 // IndexType returns the type of the underlying vector index, thus making sure
@@ -61,7 +60,7 @@ func (u *UserConfig) SetDefaults() {
 	u.RNGFactor = DefaultRNGFactor
 	u.SearchProbe = DefaultSearchProbe
 	u.Distance = vectorIndexCommon.DefaultDistanceMetric
-	u.RescoreLimit = DefaultRescoreLimit
+
 	// TODO: add quantization config
 }
 
@@ -112,12 +111,6 @@ func ParseAndValidateConfig(input interface{}, isMultiVector bool) (schemaConfig
 
 	if err := vectorIndexCommon.OptionalIntFromMap(asMap, "searchProbe", func(v int) {
 		uc.SearchProbe = uint32(v)
-	}); err != nil {
-		return uc, err
-	}
-
-	if err := vectorIndexCommon.OptionalIntFromMap(asMap, "rescoreLimit", func(v int) {
-		uc.RescoreLimit = uint32(v)
 	}); err != nil {
 		return uc, err
 	}


### PR DESCRIPTION
This reverts commit b7b50067734ff53efabde17c1c9c3031af7bccc4, reversing changes made to d03bee374b6b190f87835c8b9941f3ab263195da.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
