### PR TITLE
metrics: count background operations - HFresh

### DIFF
--- a/adapters/repos/db/vector/hfresh/metrics.go
+++ b/adapters/repos/db/vector/hfresh/metrics.go
@@ -29,10 +29,13 @@ type Metrics struct {
 	postingSize      prometheus.Observer
 	splitsPending    prometheus.Gauge
 	split            prometheus.Observer
+	splitCount       prometheus.Gauge
 	mergesPending    prometheus.Gauge
 	merge            prometheus.Observer
+	mergeCount       prometheus.Gauge
 	reassignsPending prometheus.Gauge
 	reassign         prometheus.Observer
+	reassignCount    prometheus.Gauge
 	centroids        prometheus.Observer
 	storeGet         prometheus.Observer
 	storeAppend      prometheus.Observer
@@ -104,6 +107,12 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 		"operation":  "split",
 	})
 
+	splitCount := prom.VectorIndexBackgroundOperationsCount.With(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+		"operation":  "split",
+	})
+
 	mergesPending := prom.VectorIndexPendingBackgroundOperations.With(prometheus.Labels{
 		"class_name": className,
 		"shard_name": shardName,
@@ -116,6 +125,12 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 		"operation":  "merge",
 	})
 
+	mergeCount := prom.VectorIndexBackgroundOperationsCount.With(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+		"operation":  "merge",
+	})
+
 	reassignsPending := prom.VectorIndexPendingBackgroundOperations.With(prometheus.Labels{
 		"class_name": className,
 		"shard_name": shardName,
@@ -123,6 +138,12 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 	})
 
 	reassign := prom.VectorIndexBackgroundOperationsDurations.With(prometheus.Labels{
+		"class_name": className,
+		"shard_name": shardName,
+		"operation":  "reassign",
+	})
+
+	reassignCount := prom.VectorIndexBackgroundOperationsCount.With(prometheus.Labels{
 		"class_name": className,
 		"shard_name": shardName,
 		"operation":  "reassign",
@@ -163,10 +184,13 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 		postingSize:      postingSize,
 		splitsPending:    splitsPending,
 		split:            split,
+		splitCount:       splitCount,
 		mergesPending:    mergesPending,
 		merge:            merge,
+		mergeCount:       mergeCount,
 		reassignsPending: reassignsPending,
 		reassign:         reassign,
+		reassignCount:    reassignCount,
 		centroids:        centroids,
 		storeGet:         storeGet,
 		storeAppend:      storeAppend,
@@ -240,6 +264,14 @@ func (m *Metrics) SplitDuration(start time.Time) {
 	m.split.Observe(float64(time.Since(start).Milliseconds()))
 }
 
+func (m *Metrics) IncSplitCount() {
+	if !m.enabled {
+		return
+	}
+
+	m.splitCount.Inc()
+}
+
 func (m *Metrics) EnqueueMergeTask() {
 	if !m.enabled {
 		return
@@ -264,6 +296,14 @@ func (m *Metrics) MergeDuration(start time.Time) {
 	m.merge.Observe(float64(time.Since(start).Milliseconds()))
 }
 
+func (m *Metrics) IncMergeCount() {
+	if !m.enabled {
+		return
+	}
+
+	m.mergeCount.Inc()
+}
+
 func (m *Metrics) EnqueueReassignTask() {
 	if !m.enabled {
 		return
@@ -286,6 +326,14 @@ func (m *Metrics) ReassignDuration(start time.Time) {
 	}
 
 	m.reassign.Observe(float64(time.Since(start).Milliseconds()))
+}
+
+func (m *Metrics) IncReassignCount() {
+	if !m.enabled {
+		return
+	}
+
+	m.reassignCount.Inc()
 }
 
 func (m *Metrics) CentroidSearchDuration(start time.Time) {

--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -253,6 +253,7 @@ func (t *SplitTask) Execute(ctx context.Context) error {
 	}
 
 	t.idx.metrics.DequeueSplitTask()
+	t.idx.metrics.IncSplitCount()
 	return nil
 }
 
@@ -282,6 +283,7 @@ func (t *MergeTask) Execute(ctx context.Context) error {
 	}
 
 	t.idx.metrics.DequeueMergeTask()
+	t.idx.metrics.IncMergeCount()
 	return nil
 }
 
@@ -312,6 +314,7 @@ func (t *ReassignTask) Execute(ctx context.Context) error {
 	}
 
 	t.idx.metrics.DequeueReassignTask()
+	t.idx.metrics.IncReassignCount()
 	return nil
 }
 

--- a/tools/dev/grafana/dashboards/spfresh.json
+++ b/tools/dev/grafana/dashboards/spfresh.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 16,
+  "id": 19,
   "links": [],
   "panels": [
     {
@@ -720,6 +720,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -735,7 +736,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -766,7 +767,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "disableTextWrap": false,
@@ -817,6 +818,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -832,7 +834,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -863,7 +865,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "disableTextWrap": false,
@@ -914,6 +916,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -929,7 +932,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -960,7 +963,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "disableTextWrap": false,
@@ -1011,6 +1014,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1026,7 +1030,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1057,7 +1061,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "disableTextWrap": false,
@@ -1108,6 +1112,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1123,7 +1128,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1154,11 +1159,11 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "disableTextWrap": false,
-          "editorMode": "builder",
+          "editorMode": "code",
           "expr": "vector_index_pending_background_operations{operation=\"merge\"}",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1205,6 +1210,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1220,7 +1226,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1251,7 +1257,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "11.5.1",
+      "pluginVersion": "12.3.0",
       "targets": [
         {
           "editorMode": "code",
@@ -1265,12 +1271,204 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 22,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "vector_index_background_operations_count{operation=\"split\"}",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Split Count",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 23,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "vector_index_background_operations_count{operation=\"merge\"}",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Merge Count",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "Prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 35
+      },
+      "id": 24,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "percentChangeColorMode": "standard",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showPercentChange": false,
+        "textMode": "auto",
+        "wideLayout": true
+      },
+      "pluginVersion": "12.3.0",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "vector_index_background_operations_count{operation=\"reassign\"}",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Reassign Count",
+      "type": "stat"
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 43
       },
       "id": 10,
       "panels": [
@@ -1665,7 +1863,7 @@
   ],
   "preload": false,
   "refresh": "auto",
-  "schemaVersion": 40,
+  "schemaVersion": 42,
   "tags": [],
   "templating": {
     "list": []
@@ -1678,6 +1876,5 @@
   "timezone": "browser",
   "title": "HFresh",
   "uid": "b6dc6d4a-c957-421f-a250-293da2d0ae1e",
-  "version": 1,
-  "weekStart": ""
+  "version": 1
 }

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -106,6 +106,7 @@ type PrometheusMetrics struct {
 	VectorIndexPostingSize                   *prometheus.HistogramVec
 	VectorIndexPendingBackgroundOperations   *prometheus.GaugeVec
 	VectorIndexBackgroundOperationsDurations *prometheus.SummaryVec
+	VectorIndexBackgroundOperationsCount     *prometheus.GaugeVec
 	VectorIndexStoreOperationsDurations      *prometheus.SummaryVec
 
 	VectorDimensionsSum                 *prometheus.GaugeVec
@@ -657,6 +658,10 @@ func newPrometheusMetrics() *PrometheusMetrics {
 		VectorIndexBackgroundOperationsDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
 			Name: "vector_index_background_operations_durations_ms",
 			Help: "Duration of typical vector index background operations (split, merge, reassign)",
+		}, []string{"operation", "class_name", "shard_name"}),
+		VectorIndexBackgroundOperationsCount: promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "vector_index_background_operations_count",
+			Help: "Total number of background operations (split, merge, reassign)",
 		}, []string{"operation", "class_name", "shard_name"}),
 		VectorIndexStoreOperationsDurations: promauto.NewSummaryVec(prometheus.SummaryOpts{
 			Name: "vector_index_store_operations_durations_ms",


### PR DESCRIPTION
### What's being changed:
It adds to HFresh metrics the count of executed background operations (split, merge and reassign)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
