### PR TITLE
chore(tests): remove end of life amazon.titan-text-lite-v1 model from AWS e2e tests

### DIFF
--- a/test/modules/generative-aws/generative_aws_test.go
+++ b/test/modules/generative-aws/generative_aws_test.go
@@ -72,10 +72,6 @@ func testGenerativeAWS(rest, grpc, region string) func(t *testing.T) {
 			},
 			// Amazon Titan
 			{
-				name:            "amazon.titan-text-lite-v1",
-				generativeModel: "amazon.titan-text-lite-v1",
-			},
-			{
 				name:            "amazon.titan-text-express-v1",
 				generativeModel: "amazon.titan-text-express-v1",
 			},


### PR DESCRIPTION
### What's being changed:

This PR removes end of life amazon.titan-text-lite-v1 model from AWS e2e tests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
