### PR TITLE
fix(runtime-config): load overridden runtime configuration immediately upon start

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -224,14 +224,6 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 
 	appState := startupRoutine(ctx, options)
 
-	// this is before initRuntimeOverrides to be able to init module configs
-	// as runtime overrides are applied after initModules
-	if err := registerModules(appState); err != nil {
-		appState.Logger.
-			WithField("action", "startup").WithError(err).
-			Fatal("modules didn't load")
-	}
-
 	// while we accept an overall longer startup, e.g. due to a recovery, we
 	// still want to limit the module startup context, as that's mostly service
 	// discovery / dependency checking
@@ -250,9 +242,6 @@ func MakeAppState(ctx context.Context, options *swag.CommandLineOptionsGroup) *s
 			WithField("action", "startup").WithError(err).
 			Fatal("invalid config")
 	}
-
-	// initializing at the top to reflect the config changes before we pass on to different components.
-	initRuntimeOverrides(appState)
 
 	if appState.ServerConfig.Config.Monitoring.Enabled {
 		appState.HTTPServerMetrics = monitoring.NewHTTPServerMetrics(monitoring.DefaultMetricsNamespace, prometheus.DefaultRegisterer)
@@ -1052,6 +1041,14 @@ func startupRoutine(ctx context.Context, options *swag.CommandLineOptionsGroup) 
 		logger.WithField("action", "startup").WithError(err).Error("could not load config")
 		logger.Exit(1)
 	}
+	// Register enabled modules
+	if err := registerModules(appState); err != nil {
+		appState.Logger.
+			WithField("action", "startup").WithError(err).
+			Fatal("modules didn't load")
+	}
+	// Initialize runtime config and load overridden config
+	runtimeConfigManager := initRuntimeOverrides(appState)
 	dataPath := serverConfig.Config.Persistence.DataPath
 	if err := os.MkdirAll(dataPath, 0o777); err != nil {
 		logger.WithField("action", "startup").
@@ -1116,6 +1113,9 @@ func startupRoutine(ctx context.Context, options *swag.CommandLineOptionsGroup) 
 	appState.Logger.
 		WithField("action", "startup").
 		Debug("startup routine complete")
+
+	// Initialize runtime config hooks and start runtime config background process
+	postInitRuntimeOverrides(appState, runtimeConfigManager)
 
 	return appState
 }
@@ -1921,10 +1921,9 @@ func (m membership) LeaderID() string {
 
 // initRuntimeOverrides assumes, Configs from envs are loaded before
 // initializing runtime overrides.
-func initRuntimeOverrides(appState *state.State) {
+func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[config.WeaviateRuntimeConfig] {
 	// Enable runtime config manager
 	if appState.ServerConfig.Config.RuntimeOverrides.Enabled {
-
 		// Runtimeconfig manager takes of keeping the `registered` config values upto date
 		registered := &config.WeaviateRuntimeConfig{}
 		registered.MaximumAllowedCollectionsCount = appState.ServerConfig.Config.SchemaHandlerConfig.MaximumAllowedCollectionsCount
@@ -1956,19 +1955,15 @@ func initRuntimeOverrides(appState *state.State) {
 			registered.UsageVerifyPermissions = appState.ServerConfig.Config.Usage.VerifyPermissions
 		}
 
-		hooks := make(map[string]func() error)
-		if appState.OIDC.Config.Enabled {
-			registered.OIDCIssuer = appState.OIDC.Config.Issuer
-			registered.OIDCClientID = appState.OIDC.Config.ClientID
-			registered.OIDCSkipClientIDCheck = appState.OIDC.Config.SkipClientIDCheck
-			registered.OIDCUsernameClaim = appState.OIDC.Config.UsernameClaim
-			registered.OIDCGroupsClaim = appState.OIDC.Config.GroupsClaim
-			registered.OIDCScopes = appState.OIDC.Config.Scopes
-			registered.OIDCCertificate = appState.OIDC.Config.Certificate
-			registered.OIDCJWKSUrl = appState.OIDC.Config.JWKSUrl
-
-			hooks["OIDC"] = appState.OIDC.Init
-			appState.Logger.Log(logrus.InfoLevel, "registereing OIDC runtime overrides hooks")
+		if appState.ServerConfig.Config.Authentication.OIDC.Enabled {
+			registered.OIDCIssuer = appState.ServerConfig.Config.Authentication.OIDC.Issuer
+			registered.OIDCClientID = appState.ServerConfig.Config.Authentication.OIDC.ClientID
+			registered.OIDCSkipClientIDCheck = appState.ServerConfig.Config.Authentication.OIDC.SkipClientIDCheck
+			registered.OIDCUsernameClaim = appState.ServerConfig.Config.Authentication.OIDC.UsernameClaim
+			registered.OIDCGroupsClaim = appState.ServerConfig.Config.Authentication.OIDC.GroupsClaim
+			registered.OIDCScopes = appState.ServerConfig.Config.Authentication.OIDC.Scopes
+			registered.OIDCCertificate = appState.ServerConfig.Config.Authentication.OIDC.Certificate
+			registered.OIDCJWKSUrl = appState.ServerConfig.Config.Authentication.OIDC.JWKSUrl
 		}
 
 		cm, err := configRuntime.NewConfigManager(
@@ -1978,11 +1973,24 @@ func initRuntimeOverrides(appState *state.State) {
 			registered,
 			appState.ServerConfig.Config.RuntimeOverrides.LoadInterval,
 			appState.Logger,
-			hooks,
 			prometheus.DefaultRegisterer)
 		if err != nil {
-			appState.Logger.WithField("action", "startup").WithError(err).Error("could not create runtime config manager")
+			appState.Logger.WithField("action", "startup").Errorf("could not create runtime config manager: %v", err)
 		}
+		return cm
+	}
+	return nil
+}
+
+// postInitRuntimeOverrides registers hooks and starts runtime config background process
+func postInitRuntimeOverrides(appState *state.State, cm *configRuntime.ConfigManager[config.WeaviateRuntimeConfig]) {
+	if appState.ServerConfig.Config.RuntimeOverrides.Enabled && cm != nil {
+		hooks := make(map[string]func() error)
+		if appState.ServerConfig.Config.Authentication.OIDC.Enabled {
+			hooks["OIDC"] = appState.OIDC.Init
+		}
+		appState.Logger.Log(logrus.InfoLevel, "registereing OIDC runtime overrides hooks")
+		cm.RegisterHooks(hooks)
 
 		enterrors.GoWrapper(func() {
 			// NOTE: Not using parent `ctx` because that is getting cancelled in the caller even during startup.
@@ -1990,8 +1998,7 @@ func initRuntimeOverrides(appState *state.State) {
 			defer cancel()
 
 			if err := cm.Run(ctx); err != nil {
-				appState.Logger.WithField("action", "runtime config manager startup").WithError(err).
-					Fatal("runtime config manager stopped")
+				appState.Logger.WithField("action", "runtime config manager startup").Fatalf("runtime config manager stopped: %v", err)
 			}
 		}, appState.Logger)
 	}

--- a/usecases/config/runtime/manager.go
+++ b/usecases/config/runtime/manager.go
@@ -75,7 +75,6 @@ func NewConfigManager[T any](
 	registered *T,
 	interval time.Duration,
 	log logrus.FieldLogger,
-	hooks map[string]func() error,
 	r prometheus.Registerer,
 ) (*ConfigManager[T], error) {
 	// catch empty filepath early
@@ -98,7 +97,7 @@ func NewConfigManager[T any](
 			Help: "Hash value of the currently active runtime configuration",
 		}, []string{"sha256"}), // sha256 is type of checksum and hard-coded for now
 		currentConfig: registered,
-		hooks:         hooks,
+		hooks:         nil,
 	}
 
 	// try to load it once to fail early if configs are invalid
@@ -114,6 +113,11 @@ func NewConfigManager[T any](
 // Meaning, cancelling the passed `ctx` stops the actor.
 func (cm *ConfigManager[T]) Run(ctx context.Context) error {
 	return cm.loop(ctx)
+}
+
+// RegisterHooks registers any hooks that should be enabled prior runtime config start
+func (cm *ConfigManager[T]) RegisterHooks(hooks map[string]func() error) {
+	cm.hooks = hooks
 }
 
 // loadConfig reads and unmarshal the config from the file location.

--- a/usecases/config/runtime/manager_test.go
+++ b/usecases/config/runtime/manager_test.go
@@ -60,7 +60,7 @@ func TestConfigManager_loadConfig(t *testing.T) {
 
 	t.Run("non-exist config should fail config manager at the startup", func(t *testing.T) {
 		reg := prometheus.NewPedanticRegistry()
-		_, err := NewConfigManager("non-exist.yaml", parseYaml, updater, registered, 10*time.Millisecond, log, nil, reg)
+		_, err := NewConfigManager("non-exist.yaml", parseYaml, updater, registered, 10*time.Millisecond, log, reg)
 		require.ErrorIs(t, err, ErrFailedToOpenConfig)
 
 		// assert: config_last_load_success=0 and no metric for config_hash
@@ -84,7 +84,7 @@ func TestConfigManager_loadConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, tmp.Close())
 
-		_, err = NewConfigManager(tmp.Name(), parseYaml, updater, registered, 10*time.Millisecond, log, nil, reg)
+		_, err = NewConfigManager(tmp.Name(), parseYaml, updater, registered, 10*time.Millisecond, log, reg)
 		require.ErrorIs(t, err, ErrFailedToParseConfig)
 
 		// assert: config_last_load_success=0 and no metric for config_hash
@@ -110,7 +110,7 @@ func TestConfigManager_loadConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, tmp.Close())
 
-		_, err = NewConfigManager(tmp.Name(), parseYaml, updater, registered, 10*time.Millisecond, log, nil, reg)
+		_, err = NewConfigManager(tmp.Name(), parseYaml, updater, registered, 10*time.Millisecond, log, reg)
 		require.NoError(t, err)
 
 		// assert: config_last_load_success=1 and config_hash should be set.
@@ -146,7 +146,7 @@ func TestConfigManager_loadConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, tmp.Close())
 
-		cm, err := NewConfigManager(tmp.Name(), trackedParser, updater, registered, 10*time.Millisecond, log, nil, reg)
+		cm, err := NewConfigManager(tmp.Name(), trackedParser, updater, registered, 10*time.Millisecond, log, reg)
 		require.NoError(t, err)
 
 		// assert: should have called `parser` only once during initial loading.
@@ -218,7 +218,7 @@ func TestConfigManager_loadConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, tmp.Close())
 
-		cm, err := NewConfigManager(tmp.Name(), trackedParser, updater, registered, 10*time.Millisecond, log, nil, reg)
+		cm, err := NewConfigManager(tmp.Name(), trackedParser, updater, registered, 10*time.Millisecond, log, reg)
 		require.NoError(t, err)
 
 		// assert: should have called `parser` only once during initial loading.
@@ -285,7 +285,7 @@ func TestConfigManager_loadConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, tmp.Close())
 
-		cm, err := NewConfigManager(tmp.Name(), trackedParser, updater, registered, 10*time.Millisecond, log, nil, reg)
+		cm, err := NewConfigManager(tmp.Name(), trackedParser, updater, registered, 10*time.Millisecond, log, reg)
 		require.NoError(t, err)
 
 		// assert: should have called `parser` only once during initial loading.
@@ -347,7 +347,7 @@ func TestConfigManager_GetConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, tmp.Close())
 
-		_, err = NewConfigManager(tmp.Name(), parseYaml, updater, registered, 100*time.Millisecond, log, nil, reg)
+		_, err = NewConfigManager(tmp.Name(), parseYaml, updater, registered, 100*time.Millisecond, log, reg)
 		require.NoError(t, err)
 
 		getConfigWait := make(chan struct{})
@@ -388,7 +388,7 @@ func TestConfigManager_GetConfig(t *testing.T) {
 		require.NoError(t, err)
 		require.NoError(t, tmp.Close())
 
-		cm, err := NewConfigManager(tmp.Name(), parseYaml, updater, registered, 100*time.Millisecond, log, nil, reg)
+		cm, err := NewConfigManager(tmp.Name(), parseYaml, updater, registered, 100*time.Millisecond, log, reg)
 		require.NoError(t, err)
 		assertConfig(t, cm, registered, 10*time.Second)
 


### PR DESCRIPTION
### What's being changed:

This PR changes the way we load runtime configuration, now once we initialize our static config we right after try to override it so that next Weaviate init actions will take immediately into account overridden values.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
