### PR TITLE
Reduce context check frequency in compression iterator

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator.go
@@ -40,6 +40,8 @@ type parallelIterator[T byte | uint64] struct {
 	trackInterval int64
 	// how often to report progress to the user (via logs)
 	reportProgressInterval time.Duration
+	// how often to check for context cancellation
+	checkContextEveryN int
 }
 
 func NewParallelIterator[T byte | uint64](bucket *lsmkv.Bucket, parallel int, loadId func([]byte) uint64, fromCompressedBytes func(compressed []byte, buf *[]T) []T,
@@ -53,6 +55,7 @@ func NewParallelIterator[T byte | uint64](bucket *lsmkv.Bucket, parallel int, lo
 		fromCompressedBytes:    fromCompressedBytes,
 		trackInterval:          1000,
 		reportProgressInterval: 5 * time.Second,
+		checkContextEveryN:     1000,
 	}
 }
 
@@ -91,7 +94,6 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 	}
 
 	wg := sync.WaitGroup{}
-	checkEveryN := 1000
 	abort := &atomic.Bool{}
 
 	// There are three scenarios:
@@ -121,7 +123,7 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 
 		n := 1
 		for k, v := c.First(); k != nil && bytes.Compare(k, seeds[0]) < 0; k, v = c.Next() {
-			if n%checkEveryN == 0 && ctx.Err() != nil {
+			if n%cpi.checkContextEveryN == 0 && ctx.Err() != nil {
 				abort.Store(true)
 				break
 			}
@@ -172,7 +174,7 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 
 			n := 1
 			for k, v := c.Seek(start); k != nil && bytes.Compare(k, end) < 0; k, v = c.Next() {
-				if n%checkEveryN == 0 && ctx.Err() != nil {
+				if n%cpi.checkContextEveryN == 0 && ctx.Err() != nil {
 					abort.Store(true)
 					break
 				}
@@ -220,7 +222,7 @@ func (cpi *parallelIterator[T]) IterateAll(ctx context.Context) (out chan []VecA
 
 		n := 1
 		for k, v := c.Seek(seeds[len(seeds)-1]); k != nil; k, v = c.Next() {
-			if n%checkEveryN == 0 && ctx.Err() != nil {
+			if n%cpi.checkContextEveryN == 0 && ctx.Err() != nil {
 				abort.Store(true)
 				break
 			}

--- a/adapters/repos/db/vector/compressionhelpers/parallel_iterator_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/parallel_iterator_test.go
@@ -161,6 +161,7 @@ func TestCompressedParallelIterator(t *testing.T) {
 					defer bucket.Shutdown(context.Background())
 
 					cpi := NewParallelIterator(bucket, test.parallel, loadId, fromCompressed, logger)
+					cpi.checkContextEveryN = 10 // make sure we check context often enough for this test
 					ctxCancellable, cancel := context.WithCancel(context.Background())
 
 					vecsCh, abortedCh := cpi.IterateAll(ctxCancellable)


### PR DESCRIPTION
### What's being changed:

every 10 objects is a bit much :) 

<img width="666" height="1364" alt="image" src="https://github.com/user-attachments/assets/92dcbb85-ff88-4e4d-b7c0-91388ba1bad2" />


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
