### PR TITLE
make PQ distance LUT branchless by precomputing all possible options

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/product_quantization.go
+++ b/adapters/repos/db/vector/compressionhelpers/product_quantization.go
@@ -31,7 +31,6 @@ const (
 )
 
 type DistanceLookUpTable struct {
-	calculated []bool
 	distances  []float32
 	center     [][]float32
 	segments   int
@@ -41,7 +40,6 @@ type DistanceLookUpTable struct {
 
 func NewDistanceLookUpTable(segments int, centroids int, center []float32) *DistanceLookUpTable {
 	distances := make([]float32, segments*centroids)
-	calculated := make([]bool, segments*centroids)
 	parsedCenter := make([][]float32, segments)
 	ds := len(center) / segments
 	for c := 0; c < segments; c++ {
@@ -50,7 +48,6 @@ func NewDistanceLookUpTable(segments int, centroids int, center []float32) *Dist
 
 	dlt := &DistanceLookUpTable{
 		distances:  distances,
-		calculated: calculated,
 		center:     parsedCenter,
 		segments:   segments,
 		centroids:  centroids,
@@ -64,17 +61,10 @@ func (lut *DistanceLookUpTable) Reset(segments int, centroids int, center []floa
 	lut.segments = segments
 	lut.centroids = centroids
 	if len(lut.distances) != elems ||
-		len(lut.calculated) != elems ||
 		len(lut.center) != segments {
 		lut.distances = make([]float32, segments*centroids)
-		lut.calculated = make([]bool, segments*centroids)
 		lut.center = make([][]float32, segments)
-	} else {
-		for i := range lut.calculated {
-			lut.calculated[i] = false
-		}
 	}
-
 	ds := len(center) / segments
 	for c := 0; c < segments; c++ {
 		lut.center[c] = center[c*ds : (c+1)*ds]


### PR DESCRIPTION
### What's being changed:

- Precalculate PQ Distance Look-up Table with all possible options
- Remove "isCalculated" check from `LookUp()` to make it branchless

### Benchmarks Query

Dpbedia OpenAI, 1M, locally on M1 Pro:

<img width="986" height="703" alt="image" src="https://github.com/user-attachments/assets/9c0b1082-7018-4900-867e-4a42cd282836" />

### Benchmarks Ingest:

PR:
```INFO[0951] Total load time                               duration=15m51.062829125s```

Control:
```INFO[1337] Total load time                               duration=22m16.696568625s```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
