### PR TITLE
fix: migrate conflicting module settings and compare vectorizer settings

### DIFF
--- a/entities/modulecapabilities/config.go
+++ b/entities/modulecapabilities/config.go
@@ -26,7 +26,7 @@ type ClassConfigurator interface {
 	// ClassDefaults provides the defaults for a per-class module config. The
 	// module provider will merge the props into the user-specified config with
 	// the user-provided values taking precedence
-	ClassConfigDefaults() map[string]interface{}
+	ClassConfigDefaults() map[string]any
 
 	// PropertyConfigDefaults provides the defaults for a per-property module
 	// config. The module provider will merge the props into the user-specified
@@ -35,7 +35,7 @@ type ClassConfigurator interface {
 	// dataType is not guaranteed to be non-nil, it might be nil in the case a
 	// user specified an invalid dataType, as some validation only occurs after
 	// defaults are set.
-	PropertyConfigDefaults(dataType *schema.DataType) map[string]interface{}
+	PropertyConfigDefaults(dataType *schema.DataType) map[string]any
 
 	// ValidateClass MAY validate anything about the class, except the config of
 	// another module. The specified ClassConfig can be used to easily retrieve
@@ -45,4 +45,29 @@ type ClassConfigurator interface {
 	// from class.ModuleConfig["other-modules-name"].
 	ValidateClass(ctx context.Context, class *models.Class,
 		classConfig moduletools.ClassConfig) error
+}
+
+// MigrateProperty defines module settings property name migration.
+// Example #1:
+// { Name: "baseUrl", NewName: "baseURL" }
+// This definition means that if a class config contains a property
+// with an old name, then it's value will be assigned to new name
+// and the old name will be removed for class's config.
+// Example #2:
+// { Name: "baseURL" }
+// This definition means that a new property with name baseURL
+// was added to configuration and we need to add it to config
+// Example #3:
+// { Name: "baseURL", IsDeleted: true }
+// This definition means that a property with name baseURL
+// was deleted from default configuration and we need to remove it
+type MigrateProperty struct {
+	Name, NewName string
+	IsDeleted     bool
+}
+
+// MigrateProperties interface enables module settings property names to be migrated
+// from old names to new names.
+type MigrateProperties interface {
+	MigrateProperties() []MigrateProperty
 }

--- a/modules/text2vec-cohere/module.go
+++ b/modules/text2vec-cohere/module.go
@@ -146,6 +146,14 @@ func (m *CohereModule) AdditionalProperties() map[string]modulecapabilities.Addi
 	return m.additionalPropertiesProvider.AdditionalProperties()
 }
 
+func (m *CohereModule) MigrateProperties() []modulecapabilities.MigrateProperty {
+	return []modulecapabilities.MigrateProperty{
+		{Name: "model"},
+		{Name: "truncate"},
+		{Name: "baseUrl"},
+	}
+}
+
 // verify we implement the modules.Module interface
 var (
 	_ = modulecapabilities.Module(New())
@@ -154,4 +162,5 @@ var (
 	_ = modulecapabilities.Searcher[[]float32](New())
 	_ = modulecapabilities.GraphQLArguments(New())
 	_ = modulecapabilities.InputVectorizer[[]float32](New())
+	_ = modulecapabilities.MigrateProperties(New())
 )

--- a/modules/text2vec-huggingface/module.go
+++ b/modules/text2vec-huggingface/module.go
@@ -145,6 +145,15 @@ func (m *HuggingFaceModule) VectorizeInput(ctx context.Context,
 	return m.vectorizer.Texts(ctx, []string{input}, cfg)
 }
 
+func (m *HuggingFaceModule) MigrateProperties() []modulecapabilities.MigrateProperty {
+	return []modulecapabilities.MigrateProperty{
+		{Name: "model"},
+		{Name: "waitForModel"},
+		{Name: "useGPU"},
+		{Name: "useCache"},
+	}
+}
+
 // verify we implement the modules.Module interface
 var (
 	_ = modulecapabilities.Module(New())
@@ -153,4 +162,5 @@ var (
 	_ = modulecapabilities.Searcher[[]float32](New())
 	_ = modulecapabilities.GraphQLArguments(New())
 	_ = modulecapabilities.InputVectorizer[[]float32](New())
+	_ = modulecapabilities.MigrateProperties(New())
 )

--- a/modules/text2vec-jinaai/module.go
+++ b/modules/text2vec-jinaai/module.go
@@ -149,6 +149,12 @@ func (m *JinaAIModule) VectorizeInput(ctx context.Context,
 	return m.vectorizer.Texts(ctx, []string{input}, cfg)
 }
 
+func (m *JinaAIModule) MigrateProperties() []modulecapabilities.MigrateProperty {
+	return []modulecapabilities.MigrateProperty{
+		{Name: "baseURL"},
+	}
+}
+
 // verify we implement the modules.Module interface
 var (
 	_ = modulecapabilities.Module(New())
@@ -156,4 +162,5 @@ var (
 	_ = modulecapabilities.MetaProvider(New())
 	_ = modulecapabilities.Searcher[[]float32](New())
 	_ = modulecapabilities.GraphQLArguments(New())
+	_ = modulecapabilities.MigrateProperties(New())
 )

--- a/modules/text2vec-openai/module.go
+++ b/modules/text2vec-openai/module.go
@@ -160,6 +160,14 @@ func (m *OpenAIModule) VectorizableProperties(cfg moduletools.ClassConfig) (bool
 	return true, nil, nil
 }
 
+func (m *OpenAIModule) MigrateProperties() []modulecapabilities.MigrateProperty {
+	return []modulecapabilities.MigrateProperty{
+		{Name: "modelVersion"},
+		{Name: "type"},
+		{Name: "baseURL"},
+	}
+}
+
 // verify we implement the modules.Module interface
 var (
 	_ = modulecapabilities.Module(New())
@@ -167,4 +175,5 @@ var (
 	_ = modulecapabilities.MetaProvider(New())
 	_ = modulecapabilities.Searcher[[]float32](New())
 	_ = modulecapabilities.GraphQLArguments(New())
+	_ = modulecapabilities.MigrateProperties(New())
 )

--- a/modules/text2vec-voyageai/module.go
+++ b/modules/text2vec-voyageai/module.go
@@ -163,6 +163,14 @@ func (m *VoyageAIModule) AdditionalProperties() map[string]modulecapabilities.Ad
 	return m.additionalPropertiesProvider.AdditionalProperties()
 }
 
+func (m *VoyageAIModule) MigrateProperties() []modulecapabilities.MigrateProperty {
+	return []modulecapabilities.MigrateProperty{
+		{Name: "baseURL"},
+		{Name: "model"},
+		{Name: "truncate"},
+	}
+}
+
 // verify we implement the modules.Module interface
 var (
 	_ = modulecapabilities.Module(New())
@@ -171,4 +179,5 @@ var (
 	_ = modulecapabilities.Searcher[[]float32](New())
 	_ = modulecapabilities.GraphQLArguments(New())
 	_ = modulecapabilities.InputVectorizer[[]float32](New())
+	_ = modulecapabilities.MigrateProperties(New())
 )

--- a/modules/text2vec-weaviate/module.go
+++ b/modules/text2vec-weaviate/module.go
@@ -146,6 +146,15 @@ func (m *WeaviateEmbedModule) AdditionalProperties() map[string]modulecapabiliti
 	return m.additionalPropertiesProvider.AdditionalProperties()
 }
 
+func (m *WeaviateEmbedModule) MigrateProperties() []modulecapabilities.MigrateProperty {
+	return []modulecapabilities.MigrateProperty{
+		{Name: "baseUrl", NewName: "baseURL"},
+		{Name: "baseURL"},
+		{Name: "model"},
+		{Name: "truncate"},
+	}
+}
+
 var (
 	_ = modulecapabilities.Module(New())
 	_ = modulecapabilities.Vectorizer[[]float32](New())
@@ -153,4 +162,5 @@ var (
 	_ = modulecapabilities.Searcher[[]float32](New())
 	_ = modulecapabilities.GraphQLArguments(New())
 	_ = modulecapabilities.InputVectorizer[[]float32](New())
+	_ = modulecapabilities.MigrateProperties(New())
 )

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -405,7 +405,7 @@ func UpdateClassInternal(h *Handler, ctx context.Context, className string, upda
 			}
 		}
 
-		if err := validateImmutableFields(initial, updated); err != nil {
+		if err := validateImmutableFields(initial, updated, h.parser.modules); err != nil {
 			return err
 		}
 	}
@@ -984,7 +984,7 @@ func validateUpdatingMT(current, update *models.Class) (enabled bool, err error)
 	return enabled, err
 }
 
-func validateImmutableFields(initial, updated *models.Class) error {
+func validateImmutableFields(initial, updated *models.Class, modulesProvider modulesProvider) error {
 	immutableFields := []immutableText{
 		{
 			name:     "class name",
@@ -1001,8 +1001,18 @@ func validateImmutableFields(initial, updated *models.Class) error {
 			continue
 		}
 
-		if !reflect.DeepEqual(initial.VectorConfig[k].Vectorizer, v.Vectorizer) {
-			return fmt.Errorf("vectorizer config of vector %q is immutable", k)
+		if !deepEqualVectorizerSettings(initial.VectorConfig[k].Vectorizer, v.Vectorizer) {
+			// There might be module settings that need to be migrated to new names, for example
+			// if baseUrl property setting was renamed to baseURL then we need to adjust module settings
+			// and migrate baseUrl to baseURL
+			if modulesProvider.MigrateVectorizerSettings(initial.VectorConfig[k].Vectorizer, v.Vectorizer) {
+				// Module settings have been migrated, let's recheck vectorizer settings
+				if deepEqualVectorizerSettings(initial.VectorConfig[k].Vectorizer, v.Vectorizer) {
+					continue
+				}
+			}
+
+			return fmt.Errorf("vectorizer config of vector %q is immutable for class %s", k, updated.Class)
 		}
 	}
 
@@ -1026,6 +1036,19 @@ func validateImmutableFields(initial, updated *models.Class) error {
 	}
 
 	return nil
+}
+
+func deepEqualVectorizerSettings(initial, updated any) bool {
+	return reflect.DeepEqual(structToMap(initial), structToMap(updated))
+}
+
+func structToMap(obj any) (objMap map[string]any) {
+	if obj == nil {
+		return nil
+	}
+	data, _ := json.Marshal(obj)  // Convert to a json string
+	json.Unmarshal(data, &objMap) // Convert to a map
+	return objMap
 }
 
 type immutableText struct {

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -2537,3 +2537,78 @@ func Test_GetConsistentClass_WithAlias(t *testing.T) {
 		fakeSchemaManager.AssertExpectations(t)
 	})
 }
+
+func Test_deepEqualVectorizerSettings(t *testing.T) {
+	tests := []struct {
+		name    string
+		initial any
+		updated any
+		want    bool
+	}{
+		{
+			name: "all empty",
+			want: true,
+		},
+		{
+			name: "initial is empty, updated is not empty",
+			updated: map[string]any{
+				"model": "name",
+			},
+			want: false,
+		},
+		{
+			name: "initial is not empty, updated is empty",
+			initial: map[string]any{
+				"model": "name",
+			},
+			want: false,
+		},
+		{
+			name: "both are equal",
+			initial: map[string]any{
+				"model":      "name",
+				"dimensions": 1024,
+			},
+			updated: map[string]any{
+				"model":      "name",
+				"dimensions": 1024,
+			},
+			want: true,
+		},
+		{
+			name: "both are equal, but dimensions is json.Number type",
+			initial: map[string]any{
+				"model":      "name",
+				"dimensions": 1024,
+			},
+			updated: map[string]any{
+				"model":      "name",
+				"dimensions": json.Number("1024"),
+			},
+			want: true,
+		},
+		{
+			name: "both are equal, but weights ares of json.Number type",
+			initial: map[string]any{
+				"model":      "name",
+				"dimensions": 1024,
+				"weights": map[string]any{
+					"image": 0.9,
+				},
+			},
+			updated: map[string]any{
+				"model":      "name",
+				"dimensions": 1024,
+				"weights": map[string]any{
+					"image": json.Number("0.9"),
+				},
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, deepEqualVectorizerSettings(tt.initial, tt.updated))
+		})
+	}
+}

--- a/usecases/schema/parser.go
+++ b/usecases/schema/parser.go
@@ -38,6 +38,7 @@ type modulesProvider interface {
 	IsGenerative(string) bool
 	IsReranker(string) bool
 	IsMultiVector(string) bool
+	MigrateVectorizerSettings(any, any) bool
 }
 
 type Parser struct {
@@ -241,7 +242,7 @@ func (p *Parser) ParseClassUpdate(class, update *models.Class) (*models.Class, e
 		return nil, err
 	}
 
-	if err := validateImmutableFields(class, update); err != nil {
+	if err := validateImmutableFields(class, update, p.modules); err != nil {
 		return nil, err
 	}
 
@@ -455,11 +456,21 @@ func (p *Parser) validateModuleConfigsParityAndImmutables(initial, updated *mode
 			continue
 		}
 
-		if reflect.DeepEqual(initialModConf[module], updatedModConf[module]) {
+		if deepEqualVectorizerSettings(initialModConf[module], updatedModConf[module]) {
 			continue
 		}
 
-		return fmt.Errorf("can only update generative and reranker module configs. Got: %v", module)
+		// There might be module settings that need to be migrated to new names, for example
+		// if baseUrl property setting was renamed to baseURL then we need to adjust module settings
+		// and migrate baseUrl to baseURL
+		if p.modules.MigrateVectorizerSettings(initialModConf, updatedModConf) {
+			// Module settings have been migrated, let's recheck vectorizer settings
+			if deepEqualVectorizerSettings(initialModConf[module], updatedModConf[module]) {
+				continue
+			}
+		}
+
+		return fmt.Errorf("can only update generative and reranker module configs. Got: %v for class: %s", module, updated.Class)
 	}
 
 	if initial.ModuleConfig == nil {

--- a/usecases/schema/parser_test.go
+++ b/usecases/schema/parser_test.go
@@ -180,3 +180,7 @@ func (m fakeModulesProvider) IsGenerative(name string) bool {
 func (m fakeModulesProvider) IsMultiVector(name string) bool {
 	return strings.Contains(name, "colbert")
 }
+
+func (m fakeModulesProvider) MigrateVectorizerSettings(any, any) bool {
+	return false
+}


### PR DESCRIPTION
### What's being changed:

This PR adds a possibility of migrating conflicting module settings.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
