### PR TITLE
refactor(hnsw): optimize memory allocation for node levels during insert

### DIFF
--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -163,14 +163,13 @@ func (h *hnsw) AddBatch(ctx context.Context, ids []uint64, vectors [][]float32) 
 			return err
 		}
 	}
-
-	levels := make([]int, len(ids))
+	levels := make([]uint8, len(ids))
 	maxId := uint64(0)
 	for i, id := range ids {
 		if maxId < id {
 			maxId = id
 		}
-		levels[i] = int(h.generateLevel()) // TODO: represent level as uint8
+		levels[i] = h.generateLevel()
 	}
 	h.RLock()
 	if maxId >= uint64(len(h.nodes)) {
@@ -196,7 +195,7 @@ func (h *hnsw) AddBatch(ctx context.Context, ids []uint64, vectors [][]float32) 
 		vector := vectors[i]
 		node := &vertex{
 			id:    ids[i],
-			level: levels[i],
+			level: int(levels[i]),
 		}
 		globalBefore := time.Now()
 		if len(vector) == 0 {
@@ -309,9 +308,9 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 
 	for i, docID := range docIDs {
 		numVectors := len(vectors[i])
-		levels := make([]int, numVectors)
+		levels := make([]uint8, numVectors)
 		for j := range numVectors {
-			levels[j] = int(h.generateLevel()) // TODO: represent level as uint8
+			levels[j] = h.generateLevel()
 		}
 
 		h.Lock()
@@ -367,7 +366,7 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 
 			node := &vertex{
 				id:    uint64(nodeId),
-				level: levels[j],
+				level: int(levels[j]),
 			}
 
 			h.Lock()


### PR DESCRIPTION
### What's being changed:

Resolved a few `TODO` items in `adapters/repos/db/vector/hnsw/insert.go` regarding memory usage.

Specifically, the `AddBatch` and `AddMultiBatch` methods were allocating temporary slices of `int` (8 bytes) to store node levels. Since `HNSW` levels are small (usually < 20), I switched this to `uint8` (1 byte). This reduces the memory overhead for these temporary allocations by ~87%.

I handled the casting back to `int` when assigning to the `vertex` struct to ensure compatibility with the rest of the code.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

