### PR TITLE
Restore Duration Observability

### DIFF
--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -567,7 +567,6 @@ func (fw *fileWriter) setMigrator(m func(classPath string) error) { fw.migrator 
 
 // Write downloads files and put them in the destination directory
 func (fw *fileWriter) Write(ctx context.Context, desc *backup.ClassDescriptor, overrideBucket, overridePath string, compressionType backup.CompressionType) (err error) {
-	writeStart := time.Now()
 	if len(desc.Shards) == 0 { // nothing to copy
 		return nil
 	}
@@ -578,24 +577,10 @@ func (fw *fileWriter) Write(ctx context.Context, desc *backup.ClassDescriptor, o
 	}
 
 	if fw.migrator != nil {
-		migrateStart := time.Now()
 		if err := fw.migrator(classTempDir); err != nil {
 			return fmt.Errorf("migrate from pre 1.23: %w", err)
 		}
-		fw.logger.WithFields(logrus.Fields{
-			"action":      "restore_file_migrate",
-			"class_name":  desc.Name,
-			"duration_ms": time.Since(migrateStart).Milliseconds(),
-		}).Debug("restore file migration timing")
 	}
-
-	fw.logger.WithFields(logrus.Fields{
-		"action":      "restore_file_write",
-		"class_name":  desc.Name,
-		"num_shards":  len(desc.Shards),
-		"compressed":  fw.compressed,
-		"duration_ms": time.Since(writeStart).Milliseconds(),
-	}).Debug("restore file write timing")
 
 	return nil
 }
@@ -604,7 +589,6 @@ func (fw *fileWriter) Write(ctx context.Context, desc *backup.ClassDescriptor, o
 // temporary directory path = d.tempDir/className
 // Function makes sure that created files will be removed in case of an error
 func (fw *fileWriter) writeTempFiles(ctx context.Context, classTempDir, overrideBucket, overridePath string, desc *backup.ClassDescriptor, compressionType backup.CompressionType) (err error) {
-	tempFilesStart := time.Now()
 	if err := os.RemoveAll(classTempDir); err != nil {
 		return fmt.Errorf("remove %s: %w", classTempDir, err)
 	}
@@ -622,15 +606,7 @@ func (fw *fileWriter) writeTempFiles(ctx context.Context, classTempDir, override
 			shard := shard
 			eg.Go(func() error { return fw.writeTempShard(ctx, shard, classTempDir, overrideBucket, overridePath) }, shard.Name)
 		}
-		err := eg.Wait()
-		fw.logger.WithFields(logrus.Fields{
-			"action":      "restore_write_temp_files",
-			"class_name":  desc.Name,
-			"num_shards":  len(desc.Shards),
-			"compressed":  false,
-			"duration_ms": time.Since(tempFilesStart).Milliseconds(),
-		}).Debug("restore write temp files timing (uncompressed)")
-		return err
+		return eg.Wait()
 	}
 
 	// source files are compressed
@@ -647,15 +623,7 @@ func (fw *fileWriter) writeTempFiles(ctx context.Context, classTempDir, override
 			return err
 		})
 	}
-	err = eg.Wait()
-	fw.logger.WithFields(logrus.Fields{
-		"action":      "restore_write_temp_files",
-		"class_name":  desc.Name,
-		"num_chunks":  len(desc.Chunks),
-		"compressed":  true,
-		"duration_ms": time.Since(tempFilesStart).Milliseconds(),
-	}).Debug("restore write temp files timing (compressed)")
-	return err
+	return eg.Wait()
 }
 
 func (fw *fileWriter) writeTempShard(ctx context.Context, sd *backup.ShardDescriptor, classTempDir, overrideBucket, overridePath string) error {

--- a/usecases/backup/restorer.go
+++ b/usecases/backup/restorer.go
@@ -135,60 +135,30 @@ func (r *restorer) restoreAll(ctx context.Context,
 	desc *backup.BackupDescriptor, cpuPercentage int,
 	store nodeStore, overrideBucket, overridePath, rbacRestoreOption, usersRestoreOption string,
 ) error {
-	stagingStart := time.Now()
 	compressionType := desc.GetCompressionType()
 	compressed := desc.Version > version1
 	r.lastOp.set(backup.Transferring)
 
 	if r.dynUserSourcer != nil && len(desc.UserBackups) > 0 && usersRestoreOption != models.RestoreConfigUsersOptionsNoRestore {
-		userRestoreStart := time.Now()
 		if err := r.dynUserSourcer.Restore(desc.UserBackups); err != nil {
 			return fmt.Errorf("restore rbac: %w", err)
 		}
-		r.logger.WithFields(logrus.Fields{
-			"action":      "restore_user_data",
-			"backup_id":   desc.ID,
-			"duration_ms": time.Since(userRestoreStart).Milliseconds(),
-		}).Debug("restore user data timing")
 	}
 
 	if r.rbacSourcer != nil && len(desc.RbacBackups) > 0 && rbacRestoreOption != models.RestoreConfigRolesOptionsNoRestore {
-		rbacRestoreStart := time.Now()
 		if err := r.rbacSourcer.Restore(desc.RbacBackups); err != nil {
 			return fmt.Errorf("restore rbac: %w", err)
 		}
-		r.logger.WithFields(logrus.Fields{
-			"action":      "restore_rbac_data",
-			"backup_id":   desc.ID,
-			"duration_ms": time.Since(rbacRestoreStart).Milliseconds(),
-		}).Debug("restore RBAC data timing")
 	}
 
 	for _, cdesc := range desc.Classes {
-		classStart := time.Now()
 		if err := r.restoreOne(ctx, &cdesc, desc.ServerVersion, compressionType, compressed, cpuPercentage, store, overrideBucket, overridePath); err != nil {
 			return fmt.Errorf("restore class %s: %w", cdesc.Name, err)
 		}
-		classDuration := time.Since(classStart)
-		r.logger.WithFields(logrus.Fields{
-			"action":      "restore_class_staging",
-			"backup_id":   desc.ID,
-			"class_name":  cdesc.Name,
-			"duration_ms": classDuration.Milliseconds(),
-		}).Debug("restore class staging timing")
-
 		r.logger.WithField("action", "restore").
 			WithField("backup_id", desc.ID).
 			WithField("class", cdesc.Name).Info("successfully restored")
 	}
-
-	// Log total staging duration for this node
-	r.logger.WithFields(logrus.Fields{
-		"action":      "restore_node_staging_complete",
-		"backup_id":   desc.ID,
-		"duration_ms": time.Since(stagingStart).Milliseconds(),
-		"num_classes": len(desc.Classes),
-	}).Debug("restore node staging total timing")
 
 	return nil
 }


### PR DESCRIPTION
### What's being changed:

Adds instrumentation to measure how long each phase of the backup restore process takes.

**Metrics Added**
- `weaviate_restore_phase_duration_seconds`: Duration of each coordinator phase (`prepare`, `object_storage_download`, `schema_apply`)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
