### PR TITLE
Fix overflow bug in backoff logic

### DIFF
--- a/adapters/repos/db/queue/worker.go
+++ b/adapters/repos/db/queue/worker.go
@@ -132,8 +132,14 @@ func (w *Worker) do(batch *Batch) (err error) {
 }
 
 func (w *Worker) calculateBackoff(attempts int) time.Duration {
-	backoff := time.Duration(1<<uint(attempts-1)) * time.Second
-	return min(backoff, maxBackoffDuration)
+	// Cap attempts to prevent bit-shift overflow
+	const maxAttemptsBeforeCap = 5
+
+	if attempts > maxAttemptsBeforeCap {
+		return maxBackoffDuration
+	}
+
+	return time.Second << (attempts - 1)
 }
 
 func hasTransientErrors(errs []error) bool {

--- a/adapters/repos/db/queue/worker_test.go
+++ b/adapters/repos/db/queue/worker_test.go
@@ -244,8 +244,11 @@ func TestWorker_ExponentialBackoff(t *testing.T) {
 		{3, 4 * time.Second},
 		{4, 8 * time.Second},
 		{5, 16 * time.Second},
-		{6, 30 * time.Second},  // Capped at 30s
-		{10, 30 * time.Second}, // Still capped
+		{6, 30 * time.Second},     // Capped at 30s
+		{10, 30 * time.Second},    // Still capped
+		{100, 30 * time.Second},   // Still capped
+		{1000, 30 * time.Second},  // Still capped
+		{10000, 30 * time.Second}, // Still capped
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
### What's being changed:

In the previous implementation, as few as 100 attempts could make the logic overflow and return a `0` backoff, thus retrying forever in a hot loop.

- Extends the unit tests to test for more cases
- Fixes the underlying issue by capping the number of attempts to prevent an overflow in the bit-shift part

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
