### PR TITLE
Optimize reading compressed vectors in iterator

### DIFF
--- a/adapters/repos/db/vector/compressionhelpers/quantizer.go
+++ b/adapters/repos/db/vector/compressionhelpers/quantizer.go
@@ -86,7 +86,12 @@ func (bq *BinaryQuantizer) FromCompressedBytesWithSubsliceBuffer(compressed []by
 	}
 
 	if len(*buffer) < l {
-		*buffer = make([]uint64, 1000*l)
+		// reuse existing buffer if it's big enough
+		if cap(*buffer) > l {
+			*buffer = (*buffer)[:cap(*buffer)]
+		} else {
+			*buffer = make([]uint64, 1000*l)
+		}
 	}
 
 	// take from end so we can address the start of the buffer
@@ -113,7 +118,12 @@ func (pq *ProductQuantizer) FromCompressedBytes(compressed []byte) []byte {
 
 func (pq *ProductQuantizer) FromCompressedBytesWithSubsliceBuffer(compressed []byte, buffer *[]byte) []byte {
 	if len(*buffer) < len(compressed) {
-		*buffer = make([]byte, len(compressed)*1000)
+		// reuse existing buffer if it's big enough
+		if cap(*buffer) > len(compressed) {
+			*buffer = (*buffer)[:cap(*buffer)]
+		} else {
+			*buffer = make([]byte, len(compressed)*1000)
+		}
 	}
 
 	// take from end so we can address the start of the buffer

--- a/adapters/repos/db/vector/compressionhelpers/quantizer_benchmark_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/quantizer_benchmark_test.go
@@ -46,7 +46,7 @@ func BenchmarkBQFromCompressedBytes(b *testing.B) {
 
 func BenchmarkBQFromCompressedBytesWithSubsliceBuffer(b *testing.B) {
 	bq := NewBinaryQuantizer(nil)
-	iterations := 1000
+	iterations := 100000
 	encoded := make([][]uint64, iterations)
 	for i := range encoded {
 		encoded[i] = make([]uint64, 6)


### PR DESCRIPTION
### What's being changed:

I had an alloc profile open (cant remember why) and these functions created a lot of allocs. Now they create less allocs.

Before/after (adapters/repos/db/vector/compressionhelpers/quantizer_benchmark_test.go::BenchmarkBQFromCompressedBytesWithSubsliceBuffer)
```
BenchmarkBQFromCompressedBytesWithSubsliceBuffer-16    	    2004	    576768 ns/op	 4915207 B/op	     100 allocs/op
BenchmarkBQFromCompressedBytesWithSubsliceBuffer-16    	    2487	    422023 ns/op	   49154 B/op	       1 allocs/op
```



### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
