### PR TITLE
fix(replicamovement): ensure schema version is properly synchronized during replication

### DIFF
--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -567,7 +567,9 @@ func (c *CopyOpConsumer) processHydratingOp(ctx context.Context, op ShardReplica
 		}
 		// Update the local operation status with the stored schema version so it's available
 		// when processFinalizingOp is called in the next state transition
-		op.Status.SchemaVersion = schemaVersion
+		if schemaVersion > op.Status.SchemaVersion {
+			op.Status.SchemaVersion = schemaVersion
+		}
 	}
 
 	if ctx.Err() != nil {


### PR DESCRIPTION
### What's being changed:
this PR handles eventual consistency in replica movement operation, this was causing flakey acceptance tests like this 


```go
--- FAIL: TestReplicationTestSuite (681.10s)
    mutating_data_test.go:211: Mutation context done, stopping data mutation
    --- FAIL: TestReplicationTestSuite/TestReplicationReplicateWhileMutatingDataWithNoAutomatedResolution (85.87s)
        mutating_data_test.go:65: Creating class Paragraph
        mutating_data_test.go:80: Loading data into tenant
        mutating_data_test.go:92: Finding nodes and tenant replicas
        mutating_data_test.go:111: Starting data mutation in background
        mutating_data_test.go:126: Starting replication for tenant tenant from node node2 to target node node3
        mutating_data_test.go:141: Waiting for replication operation to complete
        mutating_data_test.go:151: Replication operation completed successfully, cancelling data mutation
        mutating_data_test.go:154: Waiting for a while to ensure all data is replicated
        mutating_data_test.go:157: Verifying data consistency of tenant
        mutating_data_test.go:159: Replication operation completed successfully, cancelling data mutation
        mutating_data_test.go:211: Mutation context done, stopping data mutation
        mutating_data_test.go:187: Verifying object counts across replicas
        mutating_data_test.go:198: Node node1 has 959 objects for tenant tenant
        mutating_data_test.go:202: 
            	Error Trace:	/home/runner/work/weaviate/weaviate/test/acceptance/replication/replica_replication/fast/mutating_data_test.go:202
            	            				/home/runner/work/weaviate/weaviate/test/acceptance/replication/replica_replication/fast/mutating_data_test.go:37
            	Error:      	"956" is not greater than or equal to "959"
            	Test:       	TestReplicationTestSuite/TestReplicationReplicateWhileMutatingDataWithNoAutomatedResolution
            	Messages:   	object count mismatch for tenant tenant on node node1
    mutating_data_test.go:239: Error listing objects for tenant tenant: [GET /objects][422] objectsListUnprocessableEntity  &{Error:[0xc001159c50]}
    mutating_data_test.go:211: Mutation context done, stopping data mutation
FAIL
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
