### PR TITLE
fix: ensure GOPATH is set for gse tokenizer to find dicts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,7 @@ ENTRYPOINT ["./tools/dev/telemetry_mock_api.sh"]
 ###############################################################################
 # Weaviate (no differentiation between dev/test/prod - 12 factor!)
 FROM alpine:3.22 AS weaviate
+ENV GOPATH=/go
 RUN apk add --no-cache bc ca-certificates openssl && mkdir ./modules
 COPY --from=server_builder /weaviate-server /bin/weaviate
 COPY --from=server_builder /runtime/go-ego/ /go/pkg/mod/github.com/go-ego/

--- a/entities/tokenizer/gse_repro_test.go
+++ b/entities/tokenizer/gse_repro_test.go
@@ -1,0 +1,31 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package tokenizer
+
+import (
+	"testing"
+
+	"github.com/go-ego/gse"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGseDictLoading(t *testing.T) {
+	t.Run("Japanese Dict", func(t *testing.T) {
+		_, err := gse.New("ja")
+		require.NoError(t, err, "Failed to load Japanese dictionary")
+	})
+
+	t.Run("Chinese Dict", func(t *testing.T) {
+		_, err := gse.New("zh")
+		require.NoError(t, err, "Failed to load Chinese dictionary")
+	})
+}

--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -103,20 +103,11 @@ func InitOptionalTokenizers() {
 	}
 }
 
-// ensureGoPath sets GOPATH to /go if it is not set.
-// This is required for gse to find dictionaries in Docker environments where GOPATH might be stripped.
-func ensureGoPath() {
-	if os.Getenv("GOPATH") == "" {
-		os.Setenv("GOPATH", "/go")
-	}
-}
-
 func init_gse() {
 	gseLock.Lock()
 	defer gseLock.Unlock()
 	if gseTokenizer == nil {
 		startTime := time.Now()
-		ensureGoPath()
 		seg, err := gse.New("ja")
 		if err != nil {
 			return
@@ -131,7 +122,6 @@ func init_gse_ch() {
 	defer gseLock.Unlock()
 	if gseTokenizerCh == nil {
 		startTime := time.Now()
-		ensureGoPath()
 		seg, err := gse.New("zh")
 		if err != nil {
 			return

--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -116,7 +116,7 @@ func init_gse() {
 	defer gseLock.Unlock()
 	if gseTokenizer == nil {
 		startTime := time.Now()
-		ensureGoPath() 
+		ensureGoPath()
 		seg, err := gse.New("ja")
 		if err != nil {
 			return
@@ -131,7 +131,7 @@ func init_gse_ch() {
 	defer gseLock.Unlock()
 	if gseTokenizerCh == nil {
 		startTime := time.Now()
-		ensureGoPath() 
+		ensureGoPath()
 		seg, err := gse.New("zh")
 		if err != nil {
 			return

--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -103,11 +103,20 @@ func InitOptionalTokenizers() {
 	}
 }
 
+// ensureGoPath sets GOPATH to /go if it is not set.
+// This is required for gse to find dictionaries in Docker environments where GOPATH might be stripped.
+func ensureGoPath() {
+	if os.Getenv("GOPATH") == "" {
+		os.Setenv("GOPATH", "/go")
+	}
+}
+
 func init_gse() {
 	gseLock.Lock()
 	defer gseLock.Unlock()
 	if gseTokenizer == nil {
 		startTime := time.Now()
+		ensureGoPath() 
 		seg, err := gse.New("ja")
 		if err != nil {
 			return
@@ -122,6 +131,7 @@ func init_gse_ch() {
 	defer gseLock.Unlock()
 	if gseTokenizerCh == nil {
 		startTime := time.Now()
+		ensureGoPath() 
 		seg, err := gse.New("zh")
 		if err != nil {
 			return


### PR DESCRIPTION
### What's being changed:
Closes #10097

This PR fixes a problem where the `gse` tokenizer cannot load dictionary files in Docker environments without a set `GOPATH` (Weaviate v1.34+).

**The Issue:**
The `gse` library needs the `GOPATH` environment variable to find its default dictionary files, which are stored in the module cache. In newer Docker images, `GOPATH` may not be set. This situation causes `gse` to search for files in relative paths (for example, `github.com/...`) rather than absolute paths (for instance, `/go/pkg/mod/github.com/...`). As a result, it triggers "no such file or directory" errors.

**The Fix:**
I added an `ensureGoPath()` helper in `entities/tokenizer/tokenizer.go`. This helper sets `GOPATH` to `/go`, the default in Docker, if it is missing, before the tokenizer is initialized. This change makes sure that `gse` can properly find the absolute path to the dictionary files.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.


