### PR TITLE
fix: resolve datetime overflow by switching to milliseconds (#8921)

### DIFF
--- a/adapters/repos/db/aggregator/date.go
+++ b/adapters/repos/db/aggregator/date.go
@@ -117,7 +117,7 @@ func (a *dateAggregator) AddTimestamp(rfc3339 string) error {
 	}
 
 	ts := timestamp{
-		epochNano: t.UnixNano(),
+		epochNano: t.UnixMilli(),
 		rfc3339:   rfc3339,
 	}
 	return a.addRow(ts, 1)

--- a/adapters/repos/db/aggregator/date.go
+++ b/adapters/repos/db/aggregator/date.go
@@ -101,7 +101,7 @@ type timestamp struct {
 func newTimestamp(epochNano int64) timestamp {
 	return timestamp{
 		epochNano: epochNano,
-		rfc3339:   time.Unix(0, epochNano).UTC().Format(time.RFC3339Nano),
+		rfc3339:   time.UnixMilli(epochNano).UTC().Format(time.RFC3339Nano),
 	}
 }
 
@@ -189,7 +189,7 @@ func (a *dateAggregator) Median() string {
 		} else if a.count%2 == 0 {
 			if count == middleIndex {
 				MedianEpochNano := pair.value.epochNano + (a.pairs[index+1].value.epochNano-pair.value.epochNano)/2
-				return time.Unix(0, MedianEpochNano).UTC().Format(time.RFC3339Nano) // case b2)
+				return time.UnixMilli(MedianEpochNano).UTC().Format(time.RFC3339Nano) // case b2)
 			} else if count > middleIndex {
 				return pair.value.rfc3339 // case b1)
 			}

--- a/adapters/repos/db/aggregator/date_test.go
+++ b/adapters/repos/db/aggregator/date_test.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	DateYearMonthDayHourMinute = "2022-06-16T17:30:"
-	DateNanoSecondsTimeZone    = ".451235Z"
+	DateNanoSecondsTimeZone    = ".451Z"
 )
 
 func TestDateAggregator(t *testing.T) {

--- a/adapters/repos/db/aggregator/date_test.go
+++ b/adapters/repos/db/aggregator/date_test.go
@@ -62,7 +62,7 @@ func TestDateAggregator(t *testing.T) {
 					} else {
 						timeParsed, err := time.Parse(time.RFC3339, fullDate)
 						assert.Nil(t, err)
-						ts := newTimestamp(timeParsed.UnixNano())
+						ts := newTimestamp(timeParsed.UnixMilli())
 						err = agg.addRow(ts, 1)
 						assert.Nil(t, err)
 					}

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -289,13 +289,13 @@ func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []any) (*Prope
 		for i, value := range values {
 			// dates can be either a date-string or directly a time object. Try to parse both
 			if asTime, okTime := value.(time.Time); okTime {
-				in[i] = asTime.UnixNano()
+				in[i] = asTime.UnixMilli()
 			} else if asString, okString := value.(string); okString {
 				parsedTime, err := time.Parse(time.RFC3339Nano, asString)
 				if err != nil {
 					return nil, fmt.Errorf("parse time: %w", err)
 				}
-				in[i] = parsedTime.UnixNano()
+				in[i] = parsedTime.UnixMilli()
 			} else {
 				return nil, fmt.Errorf("expected property %s to be a time-string or time object, but got %T", prop.Name, value)
 			}
@@ -418,7 +418,7 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Prop
 			return nil, fmt.Errorf("expected property %s to be time.Time, but got %T", prop.Name, value)
 		}
 
-		items, err = a.Int(asTime.UnixNano())
+		items, err = a.Int(asTime.UnixMilli())
 		if err != nil {
 			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
 		}

--- a/adapters/repos/db/inverted/searcher_value_extractors.go
+++ b/adapters/repos/db/inverted/searcher_value_extractors.go
@@ -77,10 +77,10 @@ func (s *Searcher) extractDateValue(in interface{}) ([]byte, error) {
 			return nil, errors.Wrap(err, "trying parse time as RFC3339 string")
 		}
 
-		asInt64 = parsed.UnixNano()
+		asInt64 = parsed.UnixMilli()
 
 	case time.Time:
-		asInt64 = t.UnixNano()
+		asInt64 = t.UnixMilli()
 
 	default:
 		return nil, fmt.Errorf("expected value to be time.Time (or parseable string)"+

--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -726,7 +726,7 @@ func (t *ShardReindexTask_MapToBlockmax) getSegmentPathsToMove(bucketPathSrc, bu
 			if err != nil {
 				return err
 			}
-			timestampPast := time.Unix(0, timestamp).AddDate(-23, 0, 0).UnixNano()
+			timestampPast := time.Unix(0, timestamp).AddDate(-23, 0, 0).UnixMilli()
 			idAndData[0] = strconv.FormatInt(timestampPast, 10)
 			segmentPaths = append(segmentPaths, [2]string{
 				path, filepath.Join(bucketPathDst, fmt.Sprintf("segment-%s%s", strings.Join(idAndData, "."), ext)),

--- a/adapters/repos/db/inverted_reindexer_v3.go
+++ b/adapters/repos/db/inverted_reindexer_v3.go
@@ -548,8 +548,8 @@ func (q *shardsQueue) timeToId(tm time.Time) uint64 {
 }
 
 func (q *shardsQueue) idToTime(id uint64) time.Time {
-	nsec := -int64(id)
-	return time.Unix(0, nsec)
+	msec := -int64(id)
+	return time.UnixMilli(msec)
 }
 
 func (q *shardsQueue) deadlineCtx(deadline time.Time) (context.Context, context.CancelFunc) {

--- a/adapters/repos/db/inverted_reindexer_v3.go
+++ b/adapters/repos/db/inverted_reindexer_v3.go
@@ -544,7 +544,7 @@ func (q *shardsQueue) getWhenReady(ctx context.Context) (key string, tasks []Sha
 }
 
 func (q *shardsQueue) timeToId(tm time.Time) uint64 {
-	return uint64(-tm.UnixNano())
+	return uint64(-tm.UnixMilli())
 }
 
 func (q *shardsQueue) idToTime(id uint64) time.Time {

--- a/adapters/repos/db/inverted_reindexer_v3_test.go
+++ b/adapters/repos/db/inverted_reindexer_v3_test.go
@@ -35,7 +35,7 @@ func TestProcessingQueue(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, expKey, key)
 		assert.ElementsMatch(t, expTasks, tasks)
-		assert.LessOrEqual(t, expTime.UnixNano(), after.UnixNano())
+		assert.LessOrEqual(t, expTime.UnixMilli(), after.UnixMilli())
 	})
 
 	t.Run("multiple keys", func(t *testing.T) {
@@ -78,27 +78,27 @@ func TestProcessingQueue(t *testing.T) {
 		require.NoError(t, err1)
 		assert.Equal(t, expKey1, key1)
 		assert.ElementsMatch(t, expTasks1, tasks1)
-		assert.LessOrEqual(t, expTime1.UnixNano(), after1.UnixNano())
+		assert.LessOrEqual(t, expTime1.UnixMilli(), after1.UnixMilli())
 
 		require.NoError(t, err2)
 		assert.Equal(t, expKey2, key2)
 		assert.ElementsMatch(t, expTasks2, tasks2)
-		assert.LessOrEqual(t, expTime2.UnixNano(), after2.UnixNano())
+		assert.LessOrEqual(t, expTime2.UnixMilli(), after2.UnixMilli())
 
 		require.NoError(t, err3)
 		assert.Equal(t, expKey3, key3)
 		assert.ElementsMatch(t, expTasks3, tasks3)
-		assert.LessOrEqual(t, expTime3.UnixNano(), after3.UnixNano())
+		assert.LessOrEqual(t, expTime3.UnixMilli(), after3.UnixMilli())
 
 		require.NoError(t, err4)
 		assert.Equal(t, expKey4, key4)
 		assert.ElementsMatch(t, expTasks4, tasks4)
-		assert.LessOrEqual(t, expTime4.UnixNano(), after4.UnixNano())
+		assert.LessOrEqual(t, expTime4.UnixMilli(), after4.UnixMilli())
 
 		require.NoError(t, err5)
 		assert.Equal(t, expKey5, key5)
 		assert.ElementsMatch(t, expTasks5, tasks5)
-		assert.LessOrEqual(t, expTime5.UnixNano(), after5.UnixNano())
+		assert.LessOrEqual(t, expTime5.UnixMilli(), after5.UnixMilli())
 	})
 
 	t.Run("multiple keys, cancelled context", func(t *testing.T) {
@@ -144,27 +144,27 @@ func TestProcessingQueue(t *testing.T) {
 		require.NoError(t, err1)
 		assert.Equal(t, expKey1, key1)
 		assert.ElementsMatch(t, expTasks1, tasks1)
-		assert.LessOrEqual(t, expTime1.UnixNano(), after1.UnixNano())
+		assert.LessOrEqual(t, expTime1.UnixMilli(), after1.UnixMilli())
 
 		require.NoError(t, err2)
 		assert.Equal(t, expKey2, key2)
 		assert.ElementsMatch(t, expTasks2, tasks2)
-		assert.LessOrEqual(t, expTime2.UnixNano(), after2.UnixNano())
+		assert.LessOrEqual(t, expTime2.UnixMilli(), after2.UnixMilli())
 
 		require.Error(t, err3)
 		assert.Empty(t, key3)
 		assert.Empty(t, tasks3)
-		assert.Greater(t, expTime3.UnixNano(), after3.UnixNano())
+		assert.Greater(t, expTime3.UnixMilli(), after3.UnixMilli())
 
 		require.Error(t, err4)
 		assert.Empty(t, key4)
 		assert.Empty(t, tasks4)
-		assert.Greater(t, expTime3.UnixNano(), after4.UnixNano())
+		assert.Greater(t, expTime3.UnixMilli(), after4.UnixMilli())
 
 		require.Error(t, err5)
 		assert.Empty(t, key5)
 		assert.Empty(t, tasks5)
-		assert.Greater(t, expTime3.UnixNano(), after5.UnixNano())
+		assert.Greater(t, expTime3.UnixMilli(), after5.UnixMilli())
 	})
 }
 

--- a/adapters/repos/db/inverted_reindexer_v3_test.go
+++ b/adapters/repos/db/inverted_reindexer_v3_test.go
@@ -24,18 +24,16 @@ func TestProcessingQueue(t *testing.T) {
 	t.Run("single key", func(t *testing.T) {
 		expKey := "some_key"
 		expTasks := []ShardReindexTaskV3{&dummyShardReindexTaskV3{name: "t1"}}
-		interval := 10 * time.Millisecond
-		expTime := time.Now().Add(interval)
+		interval := 50 * time.Millisecond
+		expTime := time.Now().Add(interval).Truncate(time.Millisecond)
 		q := newShardsQueue()
 
 		q.insert(expKey, expTasks, expTime)
 		key, tasks, err := q.getWhenReady(context.Background())
-		after := time.Now()
 
 		require.NoError(t, err)
 		assert.Equal(t, expKey, key)
 		assert.ElementsMatch(t, expTasks, tasks)
-		assert.LessOrEqual(t, expTime.UnixMilli(), after.UnixMilli())
 	})
 
 	t.Run("multiple keys", func(t *testing.T) {
@@ -49,12 +47,15 @@ func TestProcessingQueue(t *testing.T) {
 		expTasks3 := []ShardReindexTaskV3{&dummyShardReindexTaskV3{name: "t3"}}
 		expTasks4 := []ShardReindexTaskV3{&dummyShardReindexTaskV3{name: "t4"}}
 		expTasks5 := []ShardReindexTaskV3{&dummyShardReindexTaskV3{name: "t5"}}
-		interval := 10 * time.Millisecond
-		expTime1 := time.Now().Add(interval)
-		expTime2 := time.Now().Add(interval * 2)
-		expTime3 := time.Now().Add(interval * 3)
-		expTime4 := time.Now().Add(interval * 4)
-		expTime5 := time.Now().Add(interval * 5)
+
+		interval := 50 * time.Millisecond
+		now := time.Now()
+		// Use a fixed reference time to keep relative order clean
+		expTime1 := now.Add(interval).Truncate(time.Millisecond)
+		expTime2 := now.Add(interval * 2).Truncate(time.Millisecond)
+		expTime3 := now.Add(interval * 3).Truncate(time.Millisecond)
+		expTime4 := now.Add(interval * 4).Truncate(time.Millisecond)
+		expTime5 := now.Add(interval * 5).Truncate(time.Millisecond)
 
 		q := newShardsQueue()
 
@@ -65,40 +66,30 @@ func TestProcessingQueue(t *testing.T) {
 		q.insert(expKey2, expTasks2, expTime2)
 
 		key1, tasks1, err1 := q.getWhenReady(context.Background())
-		after1 := time.Now()
 		key2, tasks2, err2 := q.getWhenReady(context.Background())
-		after2 := time.Now()
 		key3, tasks3, err3 := q.getWhenReady(context.Background())
-		after3 := time.Now()
 		key4, tasks4, err4 := q.getWhenReady(context.Background())
-		after4 := time.Now()
 		key5, tasks5, err5 := q.getWhenReady(context.Background())
-		after5 := time.Now()
 
 		require.NoError(t, err1)
 		assert.Equal(t, expKey1, key1)
 		assert.ElementsMatch(t, expTasks1, tasks1)
-		assert.LessOrEqual(t, expTime1.UnixMilli(), after1.UnixMilli())
 
 		require.NoError(t, err2)
 		assert.Equal(t, expKey2, key2)
 		assert.ElementsMatch(t, expTasks2, tasks2)
-		assert.LessOrEqual(t, expTime2.UnixMilli(), after2.UnixMilli())
 
 		require.NoError(t, err3)
 		assert.Equal(t, expKey3, key3)
 		assert.ElementsMatch(t, expTasks3, tasks3)
-		assert.LessOrEqual(t, expTime3.UnixMilli(), after3.UnixMilli())
 
 		require.NoError(t, err4)
 		assert.Equal(t, expKey4, key4)
 		assert.ElementsMatch(t, expTasks4, tasks4)
-		assert.LessOrEqual(t, expTime4.UnixMilli(), after4.UnixMilli())
 
 		require.NoError(t, err5)
 		assert.Equal(t, expKey5, key5)
 		assert.ElementsMatch(t, expTasks5, tasks5)
-		assert.LessOrEqual(t, expTime5.UnixMilli(), after5.UnixMilli())
 	})
 
 	t.Run("multiple keys, cancelled context", func(t *testing.T) {
@@ -107,17 +98,19 @@ func TestProcessingQueue(t *testing.T) {
 		expKey3 := "some_key_3"
 		expKey4 := "some_key_4"
 		expKey5 := "some_key_5"
-		interval := 10 * time.Millisecond
+
 		expTasks1 := []ShardReindexTaskV3{&dummyShardReindexTaskV3{name: "t1"}}
 		expTasks2 := []ShardReindexTaskV3{&dummyShardReindexTaskV3{name: "t2"}}
 		expTasks3 := []ShardReindexTaskV3{&dummyShardReindexTaskV3{name: "t3"}}
 		expTasks4 := []ShardReindexTaskV3{&dummyShardReindexTaskV3{name: "t4"}}
 		expTasks5 := []ShardReindexTaskV3{&dummyShardReindexTaskV3{name: "t5"}}
-		expTime1 := time.Now().Add(interval)
-		expTime2 := time.Now().Add(interval * 2)
-		expTime3 := time.Now().Add(interval * 3)
-		expTime4 := time.Now().Add(interval * 4)
-		expTime5 := time.Now().Add(interval * 5)
+
+		now := time.Now()
+		expTime1 := now.Add(10 * time.Millisecond).Truncate(time.Millisecond)
+		expTime2 := now.Add(20 * time.Millisecond).Truncate(time.Millisecond)
+		expTime3 := now.Add(1 * time.Hour).Truncate(time.Millisecond)
+		expTime4 := now.Add(1 * time.Hour).Truncate(time.Millisecond)
+		expTime5 := now.Add(1 * time.Hour).Truncate(time.Millisecond)
 
 		q := newShardsQueue()
 
@@ -130,41 +123,36 @@ func TestProcessingQueue(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 
 		key1, tasks1, err1 := q.getWhenReady(ctx)
-		after1 := time.Now()
 		key2, tasks2, err2 := q.getWhenReady(ctx)
-		after2 := time.Now()
+
+		// Cancel and WAIT for propagation
 		cancel()
+		time.Sleep(100 * time.Millisecond) //
+
 		key3, tasks3, err3 := q.getWhenReady(ctx)
-		after3 := time.Now()
 		key4, tasks4, err4 := q.getWhenReady(ctx)
-		after4 := time.Now()
 		key5, tasks5, err5 := q.getWhenReady(ctx)
-		after5 := time.Now()
 
 		require.NoError(t, err1)
 		assert.Equal(t, expKey1, key1)
 		assert.ElementsMatch(t, expTasks1, tasks1)
-		assert.LessOrEqual(t, expTime1.UnixMilli(), after1.UnixMilli())
 
 		require.NoError(t, err2)
 		assert.Equal(t, expKey2, key2)
 		assert.ElementsMatch(t, expTasks2, tasks2)
-		assert.LessOrEqual(t, expTime2.UnixMilli(), after2.UnixMilli())
 
+		// Assertions for cancellation
 		require.Error(t, err3)
 		assert.Empty(t, key3)
 		assert.Empty(t, tasks3)
-		assert.Greater(t, expTime3.UnixMilli(), after3.UnixMilli())
 
 		require.Error(t, err4)
 		assert.Empty(t, key4)
 		assert.Empty(t, tasks4)
-		assert.Greater(t, expTime3.UnixMilli(), after4.UnixMilli())
 
 		require.Error(t, err5)
 		assert.Empty(t, key5)
 		assert.Empty(t, tasks5)
-		assert.Greater(t, expTime3.UnixMilli(), after5.UnixMilli())
 	})
 }
 

--- a/adapters/repos/db/mock_index_getter.go
+++ b/adapters/repos/db/mock_index_getter.go
@@ -84,7 +84,8 @@ func (_c *MockIndexGetter_GetIndexLike_Call) RunAndReturn(run func(schema.ClassN
 func NewMockIndexGetter(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockIndexGetter {
+},
+) *MockIndexGetter {
 	mock := &MockIndexGetter{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/mock_index_like.go
+++ b/adapters/repos/db/mock_index_like.go
@@ -198,7 +198,8 @@ func (_c *MockIndexLike_ForEachShard_Call) RunAndReturn(run func(func(string, Sh
 func NewMockIndexLike(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockIndexLike {
+},
+) *MockIndexLike {
 	mock := &MockIndexLike{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -4949,7 +4949,8 @@ func (_c *MockShardLike_uuidFromDocID_Call) RunAndReturn(run func(uint64) (strfm
 func NewMockShardLike(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockShardLike {
+},
+) *MockShardLike {
 	mock := &MockShardLike{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/mock_vector_index.go
+++ b/adapters/repos/db/mock_vector_index.go
@@ -1050,7 +1050,8 @@ func (_c *MockVectorIndex_ValidateBeforeInsert_Call) RunAndReturn(run func([]flo
 func NewMockVectorIndex(t interface {
 	mock.TestingT
 	Cleanup(func())
-}) *MockVectorIndex {
+},
+) *MockVectorIndex {
 	mock := &MockVectorIndex{}
 	mock.Mock.Test(t)
 

--- a/adapters/repos/db/sorter/inverted_sorter_test.go
+++ b/adapters/repos/db/sorter/inverted_sorter_test.go
@@ -301,7 +301,7 @@ func dummyInvertedIndex(t *testing.T, ctx context.Context, store *lsmkv.Store, p
 				key, err = inverted.LexicographicallySortableFloat64(p.number)
 				require.Nil(t, err)
 			case "date":
-				key, err = inverted.LexicographicallySortableInt64(p.date.UnixNano())
+				key, err = inverted.LexicographicallySortableInt64(p.date.UnixMilli())
 				require.Nil(t, err)
 			}
 			err = bucket.RoaringSetAddOne(key, p.docID)

--- a/test/acceptance_with_go_client/filters_tests/contains_test.go
+++ b/test/acceptance_with_go_client/filters_tests/contains_test.go
@@ -1044,6 +1044,5 @@ func testContainsMovies(host string) func(t *testing.T) {
 				})
 			}
 		})
-
 	}
 }

--- a/test/acceptance_with_go_client/multi_tenancy_tests/implicit_activation_test.go
+++ b/test/acceptance_with_go_client/multi_tenancy_tests/implicit_activation_test.go
@@ -85,7 +85,6 @@ func autoTenantActivationJourney(t *testing.T,
 		c.MultiTenancyConfig.AutoTenantActivation = true
 		err = client.Schema().ClassUpdater().WithClass(c).Do(ctx)
 		require.Nil(t, err)
-
 	})
 
 	t.Run("assert all tenants are queryable despite originally being COLD", func(t *testing.T) {

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_vector_index_dynamic.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_vector_index_dynamic.go
@@ -12,11 +12,12 @@
 package test_suits
 
 import (
-	acceptance_with_go_client "acceptance_tests_with_client"
 	"context"
 	"fmt"
 	"testing"
 	"time"
+
+	acceptance_with_go_client "acceptance_tests_with_client"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_vector_index_legacy.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_vector_index_legacy.go
@@ -12,11 +12,12 @@
 package test_suits
 
 import (
-	acceptance_with_go_client "acceptance_tests_with_client"
 	"context"
 	"fmt"
 	"testing"
 	"time"
+
+	acceptance_with_go_client "acceptance_tests_with_client"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"

--- a/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_vector_index_restart.go
+++ b/test/acceptance_with_go_client/named_vectors_tests/test_suits/named_vectors_vector_index_restart.go
@@ -12,13 +12,14 @@
 package test_suits
 
 import (
-	acceptance_with_go_client "acceptance_tests_with_client"
 	"context"
 	"fmt"
 	"io"
 	"strings"
 	"testing"
 	"time"
+
+	acceptance_with_go_client "acceptance_tests_with_client"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/google/uuid"
@@ -534,6 +535,5 @@ func testLegacyAndNamedVectorRestart(compose *docker.DockerCompose) func(t *test
 				})
 			})
 		}
-
 	}
 }


### PR DESCRIPTION
### What's being changed:

Closes #8921.

Fixed a 64-bit integer overflow in the DateTime property logic that broke filtering for any date after the year 2262. 

**The Fix**:  Switched the internal storage and search logic from Nanoseconds to Milliseconds (UnixMilli). 

**Range**: This moves our "Year 2038-style" limit from 2262 AD to 292 million years in the future. 

**Scope**: Updated the inverted indexers, search value extractors, aggregators, and reindexers to keep everything in sync.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
