### PR TITLE
request's ctx passed to commit/abort calls of replicated ops

### DIFF
--- a/adapters/handlers/rest/clusterapi/fake_replicator_test.go
+++ b/adapters/handlers/rest/clusterapi/fake_replicator_test.go
@@ -64,7 +64,7 @@ func (f *fakeReplicator) ReplicateReferences(ctx context.Context, indexName, sha
 }
 
 // CommitReplication waits to return until a message is received on the commitBlock channel
-func (f *fakeReplicator) CommitReplication(indexName, shardName, requestID string) any {
+func (f *fakeReplicator) CommitReplication(_ context.Context, indexName, shardName, requestID string) any {
 	// Signal that the operation has started
 	select {
 	case f.startedChan <- struct{}{}:
@@ -77,7 +77,7 @@ func (f *fakeReplicator) CommitReplication(indexName, shardName, requestID strin
 	return map[string]string{"status": "committed"}
 }
 
-func (f *fakeReplicator) AbortReplication(indexName, shardName, requestID string) any {
+func (f *fakeReplicator) AbortReplication(_ context.Context, indexName, shardName, requestID string) any {
 	return map[string]string{"status": "aborted"}
 }
 

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -51,8 +51,8 @@ type replicator interface {
 		requestID string, uuids []strfmt.UUID, deletionTime time.Time, dryRun bool, schemaVersion uint64) replica.SimpleResponse
 	ReplicateReferences(ctx context.Context, indexName, shardName,
 		requestID string, refs []objects.BatchReference, schemaVersion uint64) replica.SimpleResponse
-	CommitReplication(indexName, shardName, requestID string) interface{}
-	AbortReplication(indexName, shardName, requestID string) interface{}
+	CommitReplication(ctx context.Context, indexName, shardName, requestID string) interface{}
+	AbortReplication(ctx context.Context, indexName, shardName, requestID string) interface{}
 	OverwriteObjects(ctx context.Context, index, shard string,
 		vobjects []*objects.VObject) ([]types.RepairResponse, error)
 	// Read endpoints
@@ -374,9 +374,9 @@ func (i *replicatedIndices) executeCommitPhase() http.Handler {
 
 		switch cmd {
 		case "commit":
-			resp = i.shards.CommitReplication(index, shard, requestID)
+			resp = i.shards.CommitReplication(r.Context(), index, shard, requestID)
 		case "abort":
-			resp = i.shards.AbortReplication(index, shard, requestID)
+			resp = i.shards.AbortReplication(r.Context(), index, shard, requestID)
 		default:
 			http.Error(w, fmt.Sprintf("unrecognized command: %s", cmd), http.StatusNotImplemented)
 			return

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -136,7 +136,7 @@ func (db *DB) CommitReplication(class,
 		return *pr
 	}
 
-	return index.CommitReplication(shard, requestID)
+	return index.CommitReplication(context.Background(), shard, requestID)
 }
 
 func (db *DB) AbortReplication(class,
@@ -147,7 +147,7 @@ func (db *DB) AbortReplication(class,
 		return *pr
 	}
 
-	return index.AbortReplication(shard, requestID)
+	return index.AbortReplication(context.Background(), shard, requestID)
 }
 
 func (db *DB) replicatedIndex(name string) (idx *Index, resp *replica.SimpleResponse) {
@@ -250,8 +250,8 @@ func (i *Index) ReplicateReferences(ctx context.Context, shard, requestID string
 	return localShard.prepareAddReferences(ctx, requestID, refs)
 }
 
-func (i *Index) CommitReplication(shard, requestID string) interface{} {
-	localShard, release, err := i.getOrInitShard(context.Background(), shard)
+func (i *Index) CommitReplication(ctx context.Context, shard, requestID string) interface{} {
+	localShard, release, err := i.getOrInitShard(ctx, shard)
 	if err != nil {
 		return replica.SimpleResponse{Errors: []replica.Error{
 			{Code: replica.StatusShardNotFound, Msg: shard, Err: err},
@@ -262,11 +262,11 @@ func (i *Index) CommitReplication(shard, requestID string) interface{} {
 	i.backupLock.RLock(shard)
 	defer i.backupLock.RUnlock(shard)
 
-	return localShard.commitReplication(context.Background(), requestID)
+	return localShard.commitReplication(ctx, requestID)
 }
 
-func (i *Index) AbortReplication(shard, requestID string) interface{} {
-	localShard, release, err := i.getOrInitShard(context.Background(), shard)
+func (i *Index) AbortReplication(ctx context.Context, shard, requestID string) interface{} {
+	localShard, release, err := i.getOrInitShard(ctx, shard)
 	if err != nil {
 		return replica.SimpleResponse{Errors: []replica.Error{
 			{Code: replica.StatusShardNotFound, Msg: shard, Err: err},
@@ -275,7 +275,7 @@ func (i *Index) AbortReplication(shard, requestID string) interface{} {
 
 	defer release()
 
-	return localShard.abortReplication(context.Background(), requestID)
+	return localShard.abortReplication(ctx, requestID)
 }
 
 func (i *Index) IncomingFilePutter(ctx context.Context, shardName,

--- a/usecases/replica/remote_incoming.go
+++ b/usecases/replica/remote_incoming.go
@@ -41,8 +41,8 @@ type RemoteIndexIncomingRepo interface {
 	ReplicateDeletion(ctx context.Context, shardName, requestID string, uuid strfmt.UUID, deletionTime time.Time) SimpleResponse
 	ReplicateDeletions(ctx context.Context, shardName, requestID string, uuids []strfmt.UUID, deletionTime time.Time, dryRun bool, schemaVersion uint64) SimpleResponse
 	ReplicateReferences(ctx context.Context, shardName, requestID string, refs []objects.BatchReference) SimpleResponse
-	CommitReplication(shardName, requestID string) interface{}
-	AbortReplication(shardName, requestID string) interface{}
+	CommitReplication(ctx context.Context, shardName, requestID string) interface{}
+	AbortReplication(ctx context.Context, shardName, requestID string) interface{}
 	OverwriteObjects(ctx context.Context, shard string, vobjects []*objects.VObject) ([]types.RepairResponse, error)
 	// Read endpoints
 	FetchObject(ctx context.Context, shardName string, id strfmt.UUID) (Replica, error)
@@ -126,24 +126,24 @@ func (rri *RemoteReplicaIncoming) ReplicateReferences(ctx context.Context, index
 	return index.ReplicateReferences(ctx, shardName, requestID, refs)
 }
 
-func (rri *RemoteReplicaIncoming) CommitReplication(indexName,
-	shardName, requestID string,
+func (rri *RemoteReplicaIncoming) CommitReplication(ctx context.Context,
+	indexName, shardName, requestID string,
 ) interface{} {
-	index, simpleResp := rri.indexForIncomingRead(context.Background(), indexName)
+	index, simpleResp := rri.indexForIncomingRead(ctx, indexName)
 	if simpleResp != nil {
 		return *simpleResp
 	}
-	return index.CommitReplication(shardName, requestID)
+	return index.CommitReplication(ctx, shardName, requestID)
 }
 
-func (rri *RemoteReplicaIncoming) AbortReplication(indexName,
-	shardName, requestID string,
+func (rri *RemoteReplicaIncoming) AbortReplication(ctx context.Context,
+	indexName, shardName, requestID string,
 ) interface{} {
-	index, simpleResp := rri.indexForIncomingRead(context.Background(), indexName)
+	index, simpleResp := rri.indexForIncomingRead(ctx, indexName)
 	if simpleResp != nil {
 		return *simpleResp
 	}
-	return index.AbortReplication(shardName, requestID)
+	return index.AbortReplication(ctx, shardName, requestID)
 }
 
 func (rri *RemoteReplicaIncoming) OverwriteObjects(ctx context.Context,


### PR DESCRIPTION
### What's being changed:
e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/20992959388
chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/20992964242

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
