### PR TITLE
request's ctx passed to commit/abort calls of replicated ops

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -341,9 +341,9 @@ func (i *replicatedIndices) executeCommitPhase() http.Handler {
 
 		switch cmd {
 		case "commit":
-			resp = i.replicator.CommitReplication(index, shard, requestID)
+			resp = i.replicator.CommitReplication(r.Context(), index, shard, requestID)
 		case "abort":
-			resp = i.replicator.AbortReplication(index, shard, requestID)
+			resp = i.replicator.AbortReplication(r.Context(), index, shard, requestID)
 		default:
 			http.Error(w, fmt.Sprintf("unrecognized command: %s", cmd), http.StatusNotImplemented)
 			return

--- a/adapters/handlers/rest/clusterapi/indices_replicas_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas_test.go
@@ -191,9 +191,11 @@ func TestReplicatedIndicesWorkQueue(t *testing.T) {
 			commitBlock := make(chan struct{})
 
 			//  Configure CommitReplication to block until signaled
-			fakeReplicator.EXPECT().CommitReplication(mock.Anything, mock.Anything, mock.Anything).Run(func(_ string, _ string, _ string) {
-				<-commitBlock
-			}).Return(replica.SimpleResponse{})
+			fakeReplicator.EXPECT().
+				CommitReplication(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+				Run(func(_ context.Context, _ string, _ string, _ string) {
+					<-commitBlock
+				}).Return(replica.SimpleResponse{})
 
 			logger, _ := test.NewNullLogger()
 			indices := clusterapi.NewReplicatedIndices(fakeReplicator, noopAuth, func() bool { return false }, tc.requestQueueConfig, logger, func() bool { return true })
@@ -370,13 +372,15 @@ func TestReplicatedIndicesRejectsRequestsDuringShutdown(t *testing.T) {
 	doneSignal := make(chan struct{})
 
 	// Configure CommitReplication to signal start and block until done
-	fakeReplicator.EXPECT().CommitReplication(mock.Anything, mock.Anything, mock.Anything).Run(func(_ string, _ string, _ string) {
-		select {
-		case startSignal <- struct{}{}:
-		default:
-		}
-		<-doneSignal
-	}).Return(replica.SimpleResponse{})
+	fakeReplicator.EXPECT().
+		CommitReplication(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, _ string, _ string, _ string) {
+			select {
+			case startSignal <- struct{}{}:
+			default:
+			}
+			<-doneSignal
+		}).Return(replica.SimpleResponse{})
 
 	logger, _ := test.NewNullLogger()
 
@@ -510,13 +514,15 @@ func TestReplicatedIndicesShutdownWithStuckRequests(t *testing.T) {
 	doneSignal := make(chan struct{})
 
 	// Configure CommitReplication to signal start and block until done
-	fakeReplicator.EXPECT().CommitReplication(mock.Anything, mock.Anything, mock.Anything).Run(func(_ string, _ string, _ string) {
-		select {
-		case startSignal <- struct{}{}:
-		default:
-		}
-		<-doneSignal
-	}).Return(replica.SimpleResponse{})
+	fakeReplicator.EXPECT().
+		CommitReplication(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+		Run(func(_ context.Context, _ string, _ string, _ string) {
+			select {
+			case startSignal <- struct{}{}:
+			default:
+			}
+			<-doneSignal
+		}).Return(replica.SimpleResponse{})
 
 	logger, _ := test.NewNullLogger()
 

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -185,26 +185,26 @@ func (db *DB) HashTreeLevel(ctx context.Context, className, shardName string, le
 	return index.HashTreeLevel(ctx, shardName, level, discriminant)
 }
 
-func (db *DB) CommitReplication(class,
-	shard, requestID string,
+func (db *DB) CommitReplication(ctx context.Context,
+	class, shard, requestID string,
 ) interface{} {
 	index, pr := db.replicatedIndex(class)
 	if pr != nil {
 		return *pr
 	}
 
-	return index.CommitReplication(shard, requestID)
+	return index.CommitReplication(ctx, shard, requestID)
 }
 
-func (db *DB) AbortReplication(class,
-	shard, requestID string,
+func (db *DB) AbortReplication(ctx context.Context,
+	class, shard, requestID string,
 ) interface{} {
 	index, pr := db.replicatedIndex(class)
 	if pr != nil {
 		return *pr
 	}
 
-	return index.AbortReplication(shard, requestID)
+	return index.AbortReplication(ctx, shard, requestID)
 }
 
 func (db *DB) replicatedIndex(name string) (idx *Index, resp *replica.SimpleResponse) {
@@ -314,8 +314,8 @@ func (i *Index) ReplicateReferences(ctx context.Context, shard, requestID string
 	return localShard.prepareAddReferences(ctx, requestID, refs)
 }
 
-func (i *Index) CommitReplication(shard, requestID string) interface{} {
-	localShard, release, err := i.getOrInitShard(context.Background(), shard)
+func (i *Index) CommitReplication(ctx context.Context, shard, requestID string) interface{} {
+	localShard, release, err := i.getOrInitShard(ctx, shard)
 	if err != nil {
 		return replica.SimpleResponse{Errors: []replica.Error{
 			{Code: replica.StatusShardNotFound, Msg: shard, Err: err},
@@ -326,11 +326,11 @@ func (i *Index) CommitReplication(shard, requestID string) interface{} {
 	i.backupLock.RLock(shard)
 	defer i.backupLock.RUnlock(shard)
 
-	return localShard.commitReplication(context.Background(), requestID)
+	return localShard.commitReplication(ctx, requestID)
 }
 
-func (i *Index) AbortReplication(shard, requestID string) interface{} {
-	localShard, release, err := i.getOrInitShard(context.Background(), shard)
+func (i *Index) AbortReplication(ctx context.Context, shard, requestID string) interface{} {
+	localShard, release, err := i.getOrInitShard(ctx, shard)
 	if err != nil {
 		return replica.SimpleResponse{Errors: []replica.Error{
 			{Code: replica.StatusShardNotFound, Msg: shard, Err: err},
@@ -339,7 +339,7 @@ func (i *Index) AbortReplication(shard, requestID string) interface{} {
 
 	defer release()
 
-	return localShard.abortReplication(context.Background(), requestID)
+	return localShard.abortReplication(ctx, requestID)
 }
 
 func (i *Index) IncomingFilePutter(ctx context.Context, shardName,

--- a/usecases/replica/types/mock_replicator.go
+++ b/usecases/replica/types/mock_replicator.go
@@ -45,17 +45,17 @@ func (_m *MockReplicator) EXPECT() *MockReplicator_Expecter {
 	return &MockReplicator_Expecter{mock: &_m.Mock}
 }
 
-// AbortReplication provides a mock function with given fields: className, shardName, requestID
-func (_m *MockReplicator) AbortReplication(className string, shardName string, requestID string) interface{} {
-	ret := _m.Called(className, shardName, requestID)
+// AbortReplication provides a mock function with given fields: ctx, className, shardName, requestID
+func (_m *MockReplicator) AbortReplication(ctx context.Context, className string, shardName string, requestID string) interface{} {
+	ret := _m.Called(ctx, className, shardName, requestID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for AbortReplication")
 	}
 
 	var r0 interface{}
-	if rf, ok := ret.Get(0).(func(string, string, string) interface{}); ok {
-		r0 = rf(className, shardName, requestID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) interface{}); ok {
+		r0 = rf(ctx, className, shardName, requestID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(interface{})
@@ -71,16 +71,17 @@ type MockReplicator_AbortReplication_Call struct {
 }
 
 // AbortReplication is a helper method to define mock.On call
+//   - ctx context.Context
 //   - className string
 //   - shardName string
 //   - requestID string
-func (_e *MockReplicator_Expecter) AbortReplication(className interface{}, shardName interface{}, requestID interface{}) *MockReplicator_AbortReplication_Call {
-	return &MockReplicator_AbortReplication_Call{Call: _e.mock.On("AbortReplication", className, shardName, requestID)}
+func (_e *MockReplicator_Expecter) AbortReplication(ctx interface{}, className interface{}, shardName interface{}, requestID interface{}) *MockReplicator_AbortReplication_Call {
+	return &MockReplicator_AbortReplication_Call{Call: _e.mock.On("AbortReplication", ctx, className, shardName, requestID)}
 }
 
-func (_c *MockReplicator_AbortReplication_Call) Run(run func(className string, shardName string, requestID string)) *MockReplicator_AbortReplication_Call {
+func (_c *MockReplicator_AbortReplication_Call) Run(run func(ctx context.Context, className string, shardName string, requestID string)) *MockReplicator_AbortReplication_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
 	})
 	return _c
 }
@@ -90,22 +91,22 @@ func (_c *MockReplicator_AbortReplication_Call) Return(_a0 interface{}) *MockRep
 	return _c
 }
 
-func (_c *MockReplicator_AbortReplication_Call) RunAndReturn(run func(string, string, string) interface{}) *MockReplicator_AbortReplication_Call {
+func (_c *MockReplicator_AbortReplication_Call) RunAndReturn(run func(context.Context, string, string, string) interface{}) *MockReplicator_AbortReplication_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// CommitReplication provides a mock function with given fields: className, shardName, requestID
-func (_m *MockReplicator) CommitReplication(className string, shardName string, requestID string) interface{} {
-	ret := _m.Called(className, shardName, requestID)
+// CommitReplication provides a mock function with given fields: ctx, className, shardName, requestID
+func (_m *MockReplicator) CommitReplication(ctx context.Context, className string, shardName string, requestID string) interface{} {
+	ret := _m.Called(ctx, className, shardName, requestID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CommitReplication")
 	}
 
 	var r0 interface{}
-	if rf, ok := ret.Get(0).(func(string, string, string) interface{}); ok {
-		r0 = rf(className, shardName, requestID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string) interface{}); ok {
+		r0 = rf(ctx, className, shardName, requestID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(interface{})
@@ -121,16 +122,17 @@ type MockReplicator_CommitReplication_Call struct {
 }
 
 // CommitReplication is a helper method to define mock.On call
+//   - ctx context.Context
 //   - className string
 //   - shardName string
 //   - requestID string
-func (_e *MockReplicator_Expecter) CommitReplication(className interface{}, shardName interface{}, requestID interface{}) *MockReplicator_CommitReplication_Call {
-	return &MockReplicator_CommitReplication_Call{Call: _e.mock.On("CommitReplication", className, shardName, requestID)}
+func (_e *MockReplicator_Expecter) CommitReplication(ctx interface{}, className interface{}, shardName interface{}, requestID interface{}) *MockReplicator_CommitReplication_Call {
+	return &MockReplicator_CommitReplication_Call{Call: _e.mock.On("CommitReplication", ctx, className, shardName, requestID)}
 }
 
-func (_c *MockReplicator_CommitReplication_Call) Run(run func(className string, shardName string, requestID string)) *MockReplicator_CommitReplication_Call {
+func (_c *MockReplicator_CommitReplication_Call) Run(run func(ctx context.Context, className string, shardName string, requestID string)) *MockReplicator_CommitReplication_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string))
 	})
 	return _c
 }
@@ -140,7 +142,7 @@ func (_c *MockReplicator_CommitReplication_Call) Return(_a0 interface{}) *MockRe
 	return _c
 }
 
-func (_c *MockReplicator_CommitReplication_Call) RunAndReturn(run func(string, string, string) interface{}) *MockReplicator_CommitReplication_Call {
+func (_c *MockReplicator_CommitReplication_Call) RunAndReturn(run func(context.Context, string, string, string) interface{}) *MockReplicator_CommitReplication_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/usecases/replica/types/replicator.go
+++ b/usecases/replica/types/replicator.go
@@ -32,8 +32,8 @@ type Replicator interface {
 	ReplicateDeletion(ctx context.Context, className, shardName, requestID string, uuid strfmt.UUID, deletionTime time.Time, schemaVersion uint64) replica.SimpleResponse
 	ReplicateDeletions(ctx context.Context, className, shardName, requestID string, uuids []strfmt.UUID, deletionTime time.Time, dryRun bool, schemaVersion uint64) replica.SimpleResponse
 	ReplicateReferences(ctx context.Context, className, shardName, requestID string, refs []objects.BatchReference, schemaVersion uint64) replica.SimpleResponse
-	CommitReplication(className, shardName, requestID string) interface{}
-	AbortReplication(className, shardName, requestID string) interface{}
+	CommitReplication(ctx context.Context, className, shardName, requestID string) interface{}
+	AbortReplication(ctx context.Context, className, shardName, requestID string) interface{}
 	OverwriteObjects(ctx context.Context, className, shard string, vobjects []*objects.VObject) ([]types.RepairResponse, error)
 	// Read endpoints
 	FetchObject(ctx context.Context, className, shardName string, id strfmt.UUID) (replica.Replica, error)


### PR DESCRIPTION
### What's being changed:
e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/20993224641
chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/20993227057

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
