### PR TITLE
moves memtable's parts out of locked block

### DIFF
--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -228,10 +228,6 @@ func (m *Memtable) put(key, value []byte, opts ...SecondaryKeyOption) error {
 		return errors.Errorf("put only possible with strategy 'replace'")
 	}
 
-	m.Lock()
-	defer m.Unlock()
-	m.writesSinceLastSync = true
-
 	var secondaryKeys [][]byte
 	if m.secondaryIndices > 0 {
 		secondaryKeys = make([][]byte, m.secondaryIndices)
@@ -241,23 +237,25 @@ func (m *Memtable) put(key, value []byte, opts ...SecondaryKeyOption) error {
 			}
 		}
 	}
-
-	if err := m.commitlog.put(segmentReplaceNode{
+	node := segmentReplaceNode{
 		primaryKey:          key,
 		value:               value,
 		secondaryIndexCount: m.secondaryIndices,
 		secondaryKeys:       secondaryKeys,
 		tombstone:           false,
-	}); err != nil {
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	if err := m.commitlog.put(node); err != nil {
 		return errors.Wrap(err, "write into commit log")
 	}
 
 	netAdditions, previousKeys := m.key.insert(key, value, secondaryKeys)
-
 	for i, sec := range previousKeys {
 		m.secondaryToPrimary[i][string(sec)] = nil
 	}
-
 	for i, sec := range secondaryKeys {
 		m.secondaryToPrimary[i][string(sec)] = key
 	}
@@ -265,6 +263,7 @@ func (m *Memtable) put(key, value []byte, opts ...SecondaryKeyOption) error {
 	m.size += uint64(netAdditions)
 	m.metrics.observeSize(m.size)
 	m.updateDirtyAt()
+	m.writesSinceLastSync = true
 
 	return nil
 }
@@ -277,10 +276,6 @@ func (m *Memtable) setTombstone(key []byte, opts ...SecondaryKeyOption) error {
 		return errors.Errorf("setTombstone only possible with strategy 'replace'")
 	}
 
-	m.Lock()
-	defer m.Unlock()
-	m.writesSinceLastSync = true
-
 	var secondaryKeys [][]byte
 	if m.secondaryIndices > 0 {
 		secondaryKeys = make([][]byte, m.secondaryIndices)
@@ -290,14 +285,18 @@ func (m *Memtable) setTombstone(key []byte, opts ...SecondaryKeyOption) error {
 			}
 		}
 	}
-
-	if err := m.commitlog.put(segmentReplaceNode{
+	node := segmentReplaceNode{
 		primaryKey:          key,
 		value:               nil,
 		secondaryIndexCount: m.secondaryIndices,
 		secondaryKeys:       secondaryKeys,
 		tombstone:           true,
-	}); err != nil {
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	if err := m.commitlog.put(node); err != nil {
 		return errors.Wrap(err, "write into commit log")
 	}
 
@@ -305,6 +304,7 @@ func (m *Memtable) setTombstone(key []byte, opts ...SecondaryKeyOption) error {
 	m.size += uint64(len(key)) + 1 // 1 byte for tombstone
 	m.metrics.observeSize(m.size)
 	m.updateDirtyAt()
+	m.writesSinceLastSync = true
 
 	return nil
 }
@@ -317,10 +317,6 @@ func (m *Memtable) setTombstoneWith(key []byte, deletionTime time.Time, opts ...
 		return errors.Errorf("setTombstone only possible with strategy 'replace'")
 	}
 
-	m.Lock()
-	defer m.Unlock()
-	m.writesSinceLastSync = true
-
 	var secondaryKeys [][]byte
 	if m.secondaryIndices > 0 {
 		secondaryKeys = make([][]byte, m.secondaryIndices)
@@ -330,16 +326,19 @@ func (m *Memtable) setTombstoneWith(key []byte, deletionTime time.Time, opts ...
 			}
 		}
 	}
-
 	tombstonedVal := tombstonedValue(deletionTime)
-
-	if err := m.commitlog.put(segmentReplaceNode{
+	node := segmentReplaceNode{
 		primaryKey:          key,
 		value:               tombstonedVal[:],
 		secondaryIndexCount: m.secondaryIndices,
 		secondaryKeys:       secondaryKeys,
 		tombstone:           true,
-	}); err != nil {
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	if err := m.commitlog.put(node); err != nil {
 		return errors.Wrap(err, "write into commit log")
 	}
 
@@ -347,6 +346,7 @@ func (m *Memtable) setTombstoneWith(key []byte, deletionTime time.Time, opts ...
 	m.size += uint64(len(key)) + 1 // 1 byte for tombstone
 	m.metrics.observeSize(m.size)
 	m.updateDirtyAt()
+	m.writesSinceLastSync = true
 
 	return nil
 }


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
