### PR TITLE
Fix: eliminate race condition in ClientTracker test

### DIFF
--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -639,10 +639,6 @@ func TestClientTracker(t *testing.T) {
 	})
 
 	t.Run("identify client from User-Agent", func(t *testing.T) {
-		logger, _ := test.NewNullLogger()
-		tracker := NewClientTracker(logger)
-		defer tracker.Stop()
-
 		testCases := []struct {
 			name     string
 			header   string
@@ -686,23 +682,9 @@ func TestClientTracker(t *testing.T) {
 					req.Header.Set("X-Weaviate-Client", tc.header)
 				}
 
-				// Track the request
-				tracker.Track(req)
-
-				// Get counts and verify
-				counts := tracker.GetAndReset()
-				if tc.expected != ClientTypeUnknown {
-					versions, exists := counts[tc.expected]
-					assert.True(t, exists, "Expected %s to be tracked", tc.expected)
-					var totalCount int64
-					for _, count := range versions {
-						totalCount += count
-					}
-					assert.Greater(t, totalCount, int64(0), "Expected %s to have count > 0", tc.expected)
-				} else {
-					// Unknown clients should not be tracked
-					assert.Empty(t, counts)
-				}
+				// Test client identification directly
+				clientInfo := identifyClient(req)
+				assert.Equal(t, tc.expected, clientInfo.Type)
 			})
 		}
 	})


### PR DESCRIPTION
### What's being changed:

`TestClientTracker` is flaky in our CI pipeline. This modifies the test to use `identifyClient()` directly instead of using the async tracker machinery to avoid timing issues between `Track()` and `GetAndReset()`. The test is specifically for header parsing logic, not async behavior.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
