### PR TITLE
[fix] HFresh Version Map

### DIFF
--- a/adapters/repos/db/vector/hfresh/version_map.go
+++ b/adapters/repos/db/vector/hfresh/version_map.go
@@ -73,7 +73,7 @@ func (v *VersionMap) Get(ctx context.Context, vectorID uint64) (VectorVersion, e
 				return 0, otter.ErrNotFound
 			}
 
-			return 0, otter.ErrNotFound
+			return 0, err
 		}
 
 		return version, nil


### PR DESCRIPTION
### What's being changed:
When incrementing the version map `Increment()` if an entry is not in otter cache then we want to read its value from disk.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
