### PR TITLE
Fix deadlock when deleting index

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/weaviate/weaviate/entities/diskio"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
-	"github.com/weaviate/weaviate/usecases/config"
 
 	entcfg "github.com/weaviate/weaviate/entities/config"
 
@@ -225,7 +224,7 @@ func (*Bucket) NewBucket(ctx context.Context, dir, rootDir string, logger logrus
 		calcCountNetAdditions:        false,
 		haltedFlushTimer:             interval.NewBackoffTimer(),
 		writeSegmentInfoIntoFileName: false,
-		minWalThreshold:              config.DefaultPersistenceMaxReuseWalSize,
+		minWalThreshold:              entcfg.DefaultPersistenceMaxReuseWalSize,
 	}
 
 	for _, opt := range opts {

--- a/adapters/repos/db/lsmkv/memtable_flush_inverted.go
+++ b/adapters/repos/db/lsmkv/memtable_flush_inverted.go
@@ -24,8 +24,8 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/compactor"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/varenc"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/diskio"
-	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
@@ -135,8 +135,8 @@ func (m *Memtable) flushDataInverted(f *segmentindex.SegmentFile, ogF *diskio.Me
 				ValueStart: totalWritten,
 			}
 
-			b := config.DefaultBM25b
-			k1 := config.DefaultBM25k1
+			b := entcfg.DefaultBM25b
+			k1 := entcfg.DefaultBM25k1
 			if m.bm25config != nil {
 				b = m.bm25config.B
 				k1 = m.bm25config.K1

--- a/adapters/repos/db/lsmkv/segment_group_compaction.go
+++ b/adapters/repos/db/lsmkv/segment_group_compaction.go
@@ -26,7 +26,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv/segmentindex"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringsetrange"
-	"github.com/weaviate/weaviate/usecases/config"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 )
 
 // findCompactionCandidates looks for pair of segments eligible for compaction
@@ -397,8 +397,8 @@ func (sg *SegmentGroup) compactOnce() (compacted bool, err error) {
 		}
 	case segmentindex.StrategyInverted:
 		avgPropLen, _ := sg.GetAveragePropertyLength()
-		b := float64(config.DefaultBM25b)
-		k1 := float64(config.DefaultBM25k1)
+		b := float64(entcfg.DefaultBM25b)
+		k1 := float64(entcfg.DefaultBM25k1)
 		if sg.bm25config != nil {
 			b = sg.bm25config.B
 			k1 = sg.bm25config.K1

--- a/entities/config/constants.go
+++ b/entities/config/constants.go
@@ -1,0 +1,21 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package config
+
+const (
+	// BM25 default parameters
+	DefaultBM25k1 = float32(1.2)
+	DefaultBM25b  = float32(0.75)
+
+	// LSM persistence defaults
+	DefaultPersistenceMaxReuseWalSize = 4096 // 4kb by default
+)

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -51,10 +51,11 @@ const DefaultConfigFile string = "./weaviate.conf.json"
 // DefaultCleanupIntervalSeconds can be overwritten on a per-class basis
 const DefaultCleanupIntervalSeconds = int64(60)
 
+// BM25 tuning params are now defined in entities/config
+// These can be overwritten on a per-class basis
 const (
-	// These BM25 tuning params can be overwritten on a per-class basis
-	DefaultBM25k1 = float32(1.2)
-	DefaultBM25b  = float32(0.75)
+	DefaultBM25k1 = entcfg.DefaultBM25k1
+	DefaultBM25b  = entcfg.DefaultBM25b
 )
 
 var DefaultUsingBlockMaxWAND = os.Getenv("USE_INVERTED_SEARCHABLE") == "" || entcfg.Enabled(os.Getenv("USE_INVERTED_SEARCHABLE"))
@@ -468,8 +469,8 @@ const DefaultHNSWVisitedListPoolSize = -1 // unlimited for backward compatibilit
 const DefaultHNSWFlatSearchConcurrency = 1 // 1 for backward compatibility
 
 const (
-	DefaultPersistenceMinMMapSize     = 8192 // 8kb by default
-	DefaultPersistenceMaxReuseWalSize = 4096 // 4kb by default
+	DefaultPersistenceMinMMapSize     = 8192                                     // 8kb by default
+	DefaultPersistenceMaxReuseWalSize = entcfg.DefaultPersistenceMaxReuseWalSize // defined in entities/config
 )
 
 func (p Persistence) Validate() error {


### PR DESCRIPTION
### What's being changed:

in store::Shutdown we:
- get the bucketAccessLock
- try to get the view during the shutdown process

In the prefiller we
- get the view in (s *Shard) vectorByIndexID
- try to get the bucketAccessLock to access the vector


Fix by getting the bucket in the prefiller before getting the view


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
