### PR TITLE
refactor: replace bucketsByName map with sync.Map for improved concurrency

### DIFF
--- a/adapters/repos/db/lsmkv/store_backup.go
+++ b/adapters/repos/db/lsmkv/store_backup.go
@@ -38,9 +38,11 @@ func (s *Store) PauseCompaction(ctx context.Context) error {
 	defer s.bucketAccessLock.RUnlock()
 
 	// TODO common_cycle_manager maybe not necessary, or to be replaced with store pause stats
-	for _, b := range s.bucketsByName {
+	s.bucketsByName.Range(func(key, value interface{}) bool {
+		b := value.(*Bucket)
 		b.doStartPauseTimer()
-	}
+		return true
+	})
 
 	return nil
 }
@@ -55,9 +57,11 @@ func (s *Store) ResumeCompaction(ctx context.Context) error {
 	defer s.bucketAccessLock.RUnlock()
 
 	// TODO common_cycle_manager maybe not necessary, or to be replaced with store pause stats
-	for _, b := range s.bucketsByName {
+	s.bucketsByName.Range(func(key, value interface{}) bool {
+		b := value.(*Bucket)
 		b.doStopPauseTimer()
-	}
+		return true
+	})
 
 	return nil
 }


### PR DESCRIPTION
### What's being changed:

bucketsByName map is mostly read, but lock can result in problems during concurrent operations.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
