### PR TITLE
modules(text2vec-openai): tolerate dimensions setting if it's set for legacy models

### DIFF
--- a/modules/text2vec-openai/ent/class_settings_test.go
+++ b/modules/text2vec-openai/ent/class_settings_test.go
@@ -102,14 +102,13 @@ func Test_classSettings_Validate(t *testing.T) {
 			},
 		},
 		{
-			name: "text-embedding-ada-002 - dimensions error",
+			name: "text-embedding-ada-002 - with dimensions set should pass",
 			cfg: &fakeClassConfig{
 				classConfig: map[string]interface{}{
 					"model":      "ada",
 					"dimensions": 512,
 				},
 			},
-			wantErr: errors.New("dimensions setting can only be used with V3 embedding models: [text-embedding-3-small text-embedding-3-large]"),
 		},
 		{
 			name: "custom endpoint - no dimension validation",

--- a/usecases/modulecomponents/clients/openai/openai.go
+++ b/usecases/modulecomponents/clients/openai/openai.go
@@ -162,7 +162,7 @@ func (v *Client) vectorize(ctx context.Context, input []string, model string, se
 	startTime := time.Now()
 	metrics.ModuleExternalRequests.WithLabelValues("text2vec", "openai").Inc()
 
-	body, err := json.Marshal(v.getEmbeddingsRequest(input, model, settings.IsAzure, settings.Dimensions))
+	body, err := json.Marshal(v.getEmbeddingsRequest(input, model, settings.ModelVersion, settings.IsAzure, settings.Dimensions))
 	if err != nil {
 		return nil, nil, 0, errors.Wrap(err, "marshal body")
 	}
@@ -287,9 +287,15 @@ func (v *Client) getError(statusCode int, requestID string, resBodyError *openAI
 	return errors.New(errorMsg)
 }
 
-func (v *Client) getEmbeddingsRequest(input []string, model string, isAzure bool, dimensions *int64) embeddingsRequest {
+func (v *Client) getEmbeddingsRequest(input []string, model, modelVersion string, isAzure bool, dimensions *int64) embeddingsRequest {
 	if isAzure {
 		return embeddingsRequest{Input: input, Dimensions: dimensions}
+	}
+	if modelVersion != "" {
+		// model version is present only for legacy models with possible values: 001, 002
+		// legacy models (text-embedding-ada-002) doesn't support dimensions setting
+		// we don't want to send this parameter even it's present in class's settings
+		return embeddingsRequest{Input: input, Model: model}
 	}
 	return embeddingsRequest{Input: input, Model: model, Dimensions: dimensions}
 }

--- a/usecases/modulecomponents/clients/openai/openai_test.go
+++ b/usecases/modulecomponents/clients/openai/openai_test.go
@@ -480,7 +480,7 @@ func TestGetOpenAIOrganization(t *testing.T) {
 func TestGetEmbeddingsRequest(t *testing.T) {
 	t.Run("Azure true omits model", func(t *testing.T) {
 		c := New("", "", "", 0, nullLogger())
-		req := c.getEmbeddingsRequest([]string{"foo"}, "model", true, nil)
+		req := c.getEmbeddingsRequest([]string{"foo"}, "model", "", true, nil)
 		assert.Equal(t, []string{"foo"}, req.Input)
 		assert.Equal(t, (*int64)(nil), req.Dimensions)
 		assert.Empty(t, req.Model)
@@ -488,10 +488,18 @@ func TestGetEmbeddingsRequest(t *testing.T) {
 	t.Run("Non-Azure includes model", func(t *testing.T) {
 		c := New("", "", "", 0, nullLogger())
 		dim := int64(42)
-		req := c.getEmbeddingsRequest([]string{"foo"}, "model", false, &dim)
+		req := c.getEmbeddingsRequest([]string{"foo"}, "model", "", false, &dim)
 		assert.Equal(t, []string{"foo"}, req.Input)
 		assert.Equal(t, "model", req.Model)
 		assert.Equal(t, &dim, req.Dimensions)
+	})
+	t.Run("legacy model with explicit dimensions settings", func(t *testing.T) {
+		c := New("", "", "", 0, nullLogger())
+		dim := int64(42)
+		req := c.getEmbeddingsRequest([]string{"foo"}, "text-embedding-ada-002", "002", false, &dim)
+		assert.Equal(t, []string{"foo"}, req.Input)
+		assert.Equal(t, "text-embedding-ada-002", req.Model)
+		assert.Nil(t, req.Dimensions)
 	})
 }
 


### PR DESCRIPTION
### What's being changed:

This PR adds a possibility of tolerating dimensions setting if it's present by mistake for other then `V3` models.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
