### PR TITLE
[fix] Restore analyze count HFresh

### DIFF
--- a/adapters/repos/db/vector/hfresh/index_metadata.go
+++ b/adapters/repos/db/vector/hfresh/index_metadata.go
@@ -174,10 +174,12 @@ func (h *HFresh) restoreBackgroundMetrics() error {
 	splitCount := h.taskQueue.splitQueue.Size()
 	mergeCount := h.taskQueue.mergeQueue.Size()
 	reassignCount := h.taskQueue.reassignQueue.Size()
+	analyzeCount := h.taskQueue.analyzeQueue.Size()
 
 	h.metrics.SetSplitCount(splitCount)
 	h.metrics.SetMergeCount(mergeCount)
 	h.metrics.SetReassignCount(reassignCount)
+	h.metrics.SetAnalyzeCount(analyzeCount)
 
 	return nil
 }


### PR DESCRIPTION
### What's being changed:
On startup it restore the number of pending analyze operation.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
