### PR TITLE
objects ttl: throttle deletion - pause every X batches

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -412,6 +412,8 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		ForceFullReplicasSearch:             appState.ServerConfig.Config.ForceFullReplicasSearch,
 		TransferInactivityTimeout:           appState.ServerConfig.Config.TransferInactivityTimeout,
 		ObjectsTTLBatchSize:                 appState.ServerConfig.Config.ObjectsTTLBatchSize,
+		ObjectsTTLPauseEveryNoBatches:       appState.ServerConfig.Config.ObjectsTTLPauseEveryNoBatches,
+		ObjectsTTLPauseDuration:             appState.ServerConfig.Config.ObjectsTTLPauseDuration,
 		ObjectsTTLConcurrencyFactor:         appState.ServerConfig.Config.ObjectsTTLConcurrencyFactor,
 		LSMEnableSegmentsChecksumValidation: appState.ServerConfig.Config.Persistence.LSMEnableSegmentsChecksumValidation,
 		// Pass dummy replication config with minimum factor 1. Otherwise the
@@ -2084,6 +2086,8 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		registered.OperationalMode = appState.ServerConfig.Config.OperationalMode
 		registered.ObjectsTTLDeleteSchedule = appState.ServerConfig.Config.ObjectsTTLDeleteSchedule
 		registered.ObjectsTTLBatchSize = appState.ServerConfig.Config.ObjectsTTLBatchSize
+		registered.ObjectsTTLPauseEveryNoBatches = appState.ServerConfig.Config.ObjectsTTLPauseEveryNoBatches
+		registered.ObjectsTTLPauseDuration = appState.ServerConfig.Config.ObjectsTTLPauseDuration
 		registered.ObjectsTTLConcurrencyFactor = appState.ServerConfig.Config.ObjectsTTLConcurrencyFactor
 
 		if appState.ServerConfig.Config.Authentication.OIDC.Enabled {

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -114,6 +114,8 @@ func (db *DB) init(ctx context.Context) error {
 				CycleManagerRoutinesFactor:                   db.config.CycleManagerRoutinesFactor,
 				IndexRangeableInMemory:                       db.config.IndexRangeableInMemory,
 				ObjectsTTLBatchSize:                          db.config.ObjectsTTLBatchSize,
+				ObjectsTTLPauseEveryNoBatches:                db.config.ObjectsTTLPauseEveryNoBatches,
+				ObjectsTTLPauseDuration:                      db.config.ObjectsTTLPauseDuration,
 				MaxSegmentSize:                               db.config.MaxSegmentSize,
 				TrackVectorDimensions:                        db.config.TrackVectorDimensions,
 				TrackVectorDimensionsInterval:                db.config.TrackVectorDimensionsInterval,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -142,6 +142,8 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 			CycleManagerRoutinesFactor:                   m.db.config.CycleManagerRoutinesFactor,
 			IndexRangeableInMemory:                       m.db.config.IndexRangeableInMemory,
 			ObjectsTTLBatchSize:                          m.db.config.ObjectsTTLBatchSize,
+			ObjectsTTLPauseEveryNoBatches:                m.db.config.ObjectsTTLPauseEveryNoBatches,
+			ObjectsTTLPauseDuration:                      m.db.config.ObjectsTTLPauseDuration,
 			MaxSegmentSize:                               m.db.config.MaxSegmentSize,
 			TrackVectorDimensions:                        m.db.config.TrackVectorDimensions,
 			TrackVectorDimensionsInterval:                m.db.config.TrackVectorDimensionsInterval,

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -291,6 +291,8 @@ type Config struct {
 	CycleManagerRoutinesFactor          int
 	IndexRangeableInMemory              bool
 	ObjectsTTLBatchSize                 *configRuntime.DynamicValue[int]
+	ObjectsTTLPauseEveryNoBatches       *configRuntime.DynamicValue[int]
+	ObjectsTTLPauseDuration             *configRuntime.DynamicValue[time.Duration]
 	ObjectsTTLConcurrencyFactor         *configRuntime.DynamicValue[float64]
 
 	HNSWMaxLogSize                               int64

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -72,9 +72,11 @@ const (
 )
 
 const (
-	DefaultObjectsTTLDeleteSchedule    = "" // disabled
-	DefaultObjectsTTLBatchSize         = 10_000
-	DefaultObjectsTTLConcurrencyFactor = 1
+	DefaultObjectsTTLDeleteSchedule      = "" // disabled
+	DefaultObjectsTTLBatchSize           = 10_000
+	DefaultObjectsTTLConcurrencyFactor   = 1
+	DefaultObjectsTTLPauseEveryNoBatches = 10
+	DefaultObjectsTTLPauseDuration       = time.Minute
 )
 
 // Flags are input options
@@ -242,9 +244,11 @@ type Config struct {
 
 	// Time expired objects should be deleted at by background routine
 	// accepts format: https://github.com/netresearch/go-cron?tab=readme-ov-file#cron-expression-format
-	ObjectsTTLDeleteSchedule    *runtime.DynamicValue[string]  `json:"objects_ttl_delete_schedule" yaml:"objects_ttl_delete_schedule"`
-	ObjectsTTLBatchSize         *runtime.DynamicValue[int]     `json:"objects_ttl_batch_size" yaml:"objects_ttl_batch_size"`
-	ObjectsTTLConcurrencyFactor *runtime.DynamicValue[float64] `json:"objects_ttl_concurrency_factor" yaml:"objects_ttl_concurrency_factor"`
+	ObjectsTTLDeleteSchedule      *runtime.DynamicValue[string]        `json:"objects_ttl_delete_schedule" yaml:"objects_ttl_delete_schedule"`
+	ObjectsTTLBatchSize           *runtime.DynamicValue[int]           `json:"objects_ttl_batch_size" yaml:"objects_ttl_batch_size"`
+	ObjectsTTLPauseEveryNoBatches *runtime.DynamicValue[int]           `json:"objects_ttl_pause_every_no_batches" yaml:"objects_ttl_pause_every_no_batches"`
+	ObjectsTTLPauseDuration       *runtime.DynamicValue[time.Duration] `json:"objects_ttl_pause_duration" yaml:"objects_ttl_pause_duration"`
+	ObjectsTTLConcurrencyFactor   *runtime.DynamicValue[float64]       `json:"objects_ttl_concurrency_factor" yaml:"objects_ttl_concurrency_factor"`
 
 	// The specific mode of operation for the instance itself. Is an enum of Full, WriteOnly, ReadOnly, ScaleOut
 	OperationalMode *runtime.DynamicValue[string] `json:"operational_mode" yaml:"operational_mode"`

--- a/usecases/config/parser/envparser.go
+++ b/usecases/config/parser/envparser.go
@@ -1,0 +1,131 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package parser
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
+)
+
+func parseDynamicValue[T configRuntime.DynamicType](envName string, defaultValue T,
+	parse func(string) (T, error), onSuccess func(*configRuntime.DynamicValue[T]),
+) error {
+	val := defaultValue
+	if env := os.Getenv(envName); env != "" {
+		var err error
+		val, err = parse(env)
+		if err != nil {
+			return fmt.Errorf("%s: %w", envName, err)
+		}
+	}
+
+	onSuccess(configRuntime.NewDynamicValue(val))
+	return nil
+}
+
+func parseDynamicValueWithValidation[T configRuntime.DynamicType](envName string, defaultValue T,
+	parse func(string) (T, error), validate func(T) error, onSuccess func(*configRuntime.DynamicValue[T]),
+) error {
+	val := defaultValue
+	if v := os.Getenv(envName); v != "" {
+		var err error
+		val, err = parse(v)
+		if err != nil {
+			return fmt.Errorf("%s: %w", envName, err)
+		}
+	}
+
+	dynVal, err := configRuntime.NewDynamicValueWithValidation(val, func(val T) error {
+		if err := validate(val); err != nil {
+			return fmt.Errorf("%s: %w", envName, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	onSuccess(dynVal)
+	return nil
+}
+
+// ----------------------------------------------------------------------------
+
+func parseFloat(v string) (float64, error) {
+	return strconv.ParseFloat(v, 64)
+}
+
+func ParseDynamicFloat(envName string, defaultValue float64,
+	onSuccess func(val *configRuntime.DynamicValue[float64]),
+) error {
+	return parseDynamicValue(envName, defaultValue, parseFloat, onSuccess)
+}
+
+func ParseDynamicFloatWithValidation(envName string, defaultValue float64,
+	validate func(val float64) error,
+	onSuccess func(val *configRuntime.DynamicValue[float64]),
+) error {
+	return parseDynamicValueWithValidation(envName, defaultValue, parseFloat, validate, onSuccess)
+}
+
+// ----------------------------------------------------------------------------
+
+func ParseDynamicInt(envName string, defaultValue int,
+	onSuccess func(val *configRuntime.DynamicValue[int]),
+) error {
+	return parseDynamicValue(envName, defaultValue, strconv.Atoi, onSuccess)
+}
+
+func ParseDynamicIntWithValidation(envName string, defaultValue int,
+	validate func(val int) error,
+	onSuccess func(val *configRuntime.DynamicValue[int]),
+) error {
+	return parseDynamicValueWithValidation(envName, defaultValue, strconv.Atoi, validate, onSuccess)
+}
+
+// ----------------------------------------------------------------------------
+
+func parseString(v string) (string, error) {
+	return v, nil
+}
+
+func ParseDynamicString(envName string, defaultValue string,
+	onSuccess func(val *configRuntime.DynamicValue[string]),
+) error {
+	return parseDynamicValue(envName, defaultValue, parseString, onSuccess)
+}
+
+func ParseDynamicStringWithValidation(envName string, defaultValue string,
+	validate func(val string) error,
+	onSuccess func(val *configRuntime.DynamicValue[string]),
+) error {
+	return parseDynamicValueWithValidation(envName, defaultValue, parseString, validate, onSuccess)
+}
+
+// ----------------------------------------------------------------------------
+
+func ParseDynamicDuration(envName string, defaultValue time.Duration,
+	onSuccess func(val *configRuntime.DynamicValue[time.Duration]),
+) error {
+	return parseDynamicValue(envName, defaultValue, time.ParseDuration, onSuccess)
+}
+
+func ParseDynamicDurationWithValidation(envName string, defaultValue time.Duration,
+	validate func(val time.Duration) error,
+	onSuccess func(val *configRuntime.DynamicValue[time.Duration]),
+) error {
+	return parseDynamicValueWithValidation(envName, defaultValue, time.ParseDuration, validate, onSuccess)
+}

--- a/usecases/config/parser/validation.go
+++ b/usecases/config/parser/validation.go
@@ -1,0 +1,70 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package parser
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/netresearch/go-cron"
+)
+
+func ValidateFloatGreaterThan0(val float64) error {
+	if val > 0 {
+		return nil
+	}
+	return fmt.Errorf("float greater than 0 expected, got %v", val)
+}
+
+func ValidateFloatGreaterThanEqual0(val float64) error {
+	if val >= 0 {
+		return nil
+	}
+	return fmt.Errorf("float greater than equal 0 expected, got %v", val)
+}
+
+func ValidateIntGreaterThan0(val int) error {
+	if val > 0 {
+		return nil
+	}
+	return fmt.Errorf("int greater than 0 expected, got %v", val)
+}
+
+func ValidateIntGreaterThanEqual0(val int) error {
+	if val >= 0 {
+		return nil
+	}
+	return fmt.Errorf("int greater than equal 0 expected, got %v", val)
+}
+
+func ValidateDurationGreaterThan0(val time.Duration) error {
+	if val > 0 {
+		return nil
+	}
+	return fmt.Errorf("duration greater than 0 expected, got %v", val)
+}
+
+func ValidateDurationGreaterThanEqual0(val time.Duration) error {
+	if val >= 0 {
+		return nil
+	}
+	return fmt.Errorf("duration greater than equal 0 expected, got %v", val)
+}
+
+func ValidateGocronSchedule(val string) error {
+	if val != "" {
+		if _, err := cron.FullParser().Parse(val); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -51,9 +51,11 @@ type WeaviateRuntimeConfig struct {
 	OperationalMode                      *runtime.DynamicValue[string]        `json:"operational_mode" yaml:"operational_mode"`
 	DefaultQuantization                  *runtime.DynamicValue[string]        `yaml:"default_quantization" json:"default_quantization"`
 
-	ObjectsTTLDeleteSchedule    *runtime.DynamicValue[string]  `json:"objects_ttl_delete_schedule" yaml:"objects_ttl_delete_schedule"`
-	ObjectsTTLBatchSize         *runtime.DynamicValue[int]     `json:"objects_ttl_batch_size" yaml:"objects_ttl_batch_size"`
-	ObjectsTTLConcurrencyFactor *runtime.DynamicValue[float64] `json:"objects_ttl_concurrency_factor" yaml:"objects_ttl_concurrency_factor"`
+	ObjectsTTLDeleteSchedule      *runtime.DynamicValue[string]        `json:"objects_ttl_delete_schedule" yaml:"objects_ttl_delete_schedule"`
+	ObjectsTTLBatchSize           *runtime.DynamicValue[int]           `json:"objects_ttl_batch_size" yaml:"objects_ttl_batch_size"`
+	ObjectsTTLPauseEveryNoBatches *runtime.DynamicValue[int]           `json:"objects_ttl_pause_every_no_batches" yaml:"objects_ttl_pause_every_no_batches"`
+	ObjectsTTLPauseDuration       *runtime.DynamicValue[time.Duration] `json:"objects_ttl_pause_duration" yaml:"objects_ttl_pause_duration"`
+	ObjectsTTLConcurrencyFactor   *runtime.DynamicValue[float64]       `json:"objects_ttl_concurrency_factor" yaml:"objects_ttl_concurrency_factor"`
 
 	// RAFT specific configs
 	RaftDrainSleep        *runtime.DynamicValue[time.Duration] `json:"raft_drain_sleep" yaml:"raft_drain_sleep"`


### PR DESCRIPTION
### What's being changed:
Adds pauses in between N batch delete calls.
Pause duration can be set with dynamic env var `OBJECTS_TTL_PAUSE_DURATION` (default `1 minute`) and number of batches to be processed before each pause with dynamic env var `OBJECTS_TTL_PAUSE_EVERY_NO_BATCHES` (default `10`)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
