### PR TITLE
fix drop cache does not block if no one is listening

### DIFF
--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -338,7 +338,11 @@ func (s *shardedLockCache[T]) CountVectors() int64 {
 func (s *shardedLockCache[T]) Drop() {
 	s.deleteAllVectors()
 	if s.deletionInterval != 0 {
-		s.cancel <- true
+		select {
+		case s.cancel <- true:
+		default:
+			// no one listening; no blocking
+		}
 	}
 }
 


### PR DESCRIPTION
### What's being changed:

Drop cache should not block if no one is listening

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
