### PR TITLE
refactor: add context parameter to putObjectLSM and mutableMergeObjectLSM methods

### DIFF
--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -3924,9 +3924,9 @@ func (_c *MockShardLike_mayUpsertObjectHashTree_Call) RunAndReturn(run func(*sto
 	return _c
 }
 
-// mutableMergeObjectLSM provides a mock function with given fields: merge, idBytes
-func (_m *MockShardLike) mutableMergeObjectLSM(merge objects.MergeDocument, idBytes []byte) (mutableMergeResult, error) {
-	ret := _m.Called(merge, idBytes)
+// mutableMergeObjectLSM provides a mock function with given fields: ctx, merge, idBytes
+func (_m *MockShardLike) mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDocument, idBytes []byte) (mutableMergeResult, error) {
+	ret := _m.Called(ctx, merge, idBytes)
 
 	if len(ret) == 0 {
 		panic("no return value specified for mutableMergeObjectLSM")
@@ -3934,17 +3934,17 @@ func (_m *MockShardLike) mutableMergeObjectLSM(merge objects.MergeDocument, idBy
 
 	var r0 mutableMergeResult
 	var r1 error
-	if rf, ok := ret.Get(0).(func(objects.MergeDocument, []byte) (mutableMergeResult, error)); ok {
-		return rf(merge, idBytes)
+	if rf, ok := ret.Get(0).(func(context.Context, objects.MergeDocument, []byte) (mutableMergeResult, error)); ok {
+		return rf(ctx, merge, idBytes)
 	}
-	if rf, ok := ret.Get(0).(func(objects.MergeDocument, []byte) mutableMergeResult); ok {
-		r0 = rf(merge, idBytes)
+	if rf, ok := ret.Get(0).(func(context.Context, objects.MergeDocument, []byte) mutableMergeResult); ok {
+		r0 = rf(ctx, merge, idBytes)
 	} else {
 		r0 = ret.Get(0).(mutableMergeResult)
 	}
 
-	if rf, ok := ret.Get(1).(func(objects.MergeDocument, []byte) error); ok {
-		r1 = rf(merge, idBytes)
+	if rf, ok := ret.Get(1).(func(context.Context, objects.MergeDocument, []byte) error); ok {
+		r1 = rf(ctx, merge, idBytes)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -3958,15 +3958,16 @@ type MockShardLike_mutableMergeObjectLSM_Call struct {
 }
 
 // mutableMergeObjectLSM is a helper method to define mock.On call
+//   - ctx context.Context
 //   - merge objects.MergeDocument
 //   - idBytes []byte
-func (_e *MockShardLike_Expecter) mutableMergeObjectLSM(merge interface{}, idBytes interface{}) *MockShardLike_mutableMergeObjectLSM_Call {
-	return &MockShardLike_mutableMergeObjectLSM_Call{Call: _e.mock.On("mutableMergeObjectLSM", merge, idBytes)}
+func (_e *MockShardLike_Expecter) mutableMergeObjectLSM(ctx interface{}, merge interface{}, idBytes interface{}) *MockShardLike_mutableMergeObjectLSM_Call {
+	return &MockShardLike_mutableMergeObjectLSM_Call{Call: _e.mock.On("mutableMergeObjectLSM", ctx, merge, idBytes)}
 }
 
-func (_c *MockShardLike_mutableMergeObjectLSM_Call) Run(run func(merge objects.MergeDocument, idBytes []byte)) *MockShardLike_mutableMergeObjectLSM_Call {
+func (_c *MockShardLike_mutableMergeObjectLSM_Call) Run(run func(ctx context.Context, merge objects.MergeDocument, idBytes []byte)) *MockShardLike_mutableMergeObjectLSM_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(objects.MergeDocument), args[1].([]byte))
+		run(args[0].(context.Context), args[1].(objects.MergeDocument), args[2].([]byte))
 	})
 	return _c
 }
@@ -3976,7 +3977,7 @@ func (_c *MockShardLike_mutableMergeObjectLSM_Call) Return(_a0 mutableMergeResul
 	return _c
 }
 
-func (_c *MockShardLike_mutableMergeObjectLSM_Call) RunAndReturn(run func(objects.MergeDocument, []byte) (mutableMergeResult, error)) *MockShardLike_mutableMergeObjectLSM_Call {
+func (_c *MockShardLike_mutableMergeObjectLSM_Call) RunAndReturn(run func(context.Context, objects.MergeDocument, []byte) (mutableMergeResult, error)) *MockShardLike_mutableMergeObjectLSM_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -4422,9 +4423,9 @@ func (_c *MockShardLike_preventShutdown_Call) RunAndReturn(run func() (func(), e
 	return _c
 }
 
-// putObjectLSM provides a mock function with given fields: object, idBytes
-func (_m *MockShardLike) putObjectLSM(object *storobj.Object, idBytes []byte) (objectInsertStatus, error) {
-	ret := _m.Called(object, idBytes)
+// putObjectLSM provides a mock function with given fields: ctx, object, idBytes
+func (_m *MockShardLike) putObjectLSM(ctx context.Context, object *storobj.Object, idBytes []byte) (objectInsertStatus, error) {
+	ret := _m.Called(ctx, object, idBytes)
 
 	if len(ret) == 0 {
 		panic("no return value specified for putObjectLSM")
@@ -4432,17 +4433,17 @@ func (_m *MockShardLike) putObjectLSM(object *storobj.Object, idBytes []byte) (o
 
 	var r0 objectInsertStatus
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*storobj.Object, []byte) (objectInsertStatus, error)); ok {
-		return rf(object, idBytes)
+	if rf, ok := ret.Get(0).(func(context.Context, *storobj.Object, []byte) (objectInsertStatus, error)); ok {
+		return rf(ctx, object, idBytes)
 	}
-	if rf, ok := ret.Get(0).(func(*storobj.Object, []byte) objectInsertStatus); ok {
-		r0 = rf(object, idBytes)
+	if rf, ok := ret.Get(0).(func(context.Context, *storobj.Object, []byte) objectInsertStatus); ok {
+		r0 = rf(ctx, object, idBytes)
 	} else {
 		r0 = ret.Get(0).(objectInsertStatus)
 	}
 
-	if rf, ok := ret.Get(1).(func(*storobj.Object, []byte) error); ok {
-		r1 = rf(object, idBytes)
+	if rf, ok := ret.Get(1).(func(context.Context, *storobj.Object, []byte) error); ok {
+		r1 = rf(ctx, object, idBytes)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -4456,15 +4457,16 @@ type MockShardLike_putObjectLSM_Call struct {
 }
 
 // putObjectLSM is a helper method to define mock.On call
+//   - ctx context.Context
 //   - object *storobj.Object
 //   - idBytes []byte
-func (_e *MockShardLike_Expecter) putObjectLSM(object interface{}, idBytes interface{}) *MockShardLike_putObjectLSM_Call {
-	return &MockShardLike_putObjectLSM_Call{Call: _e.mock.On("putObjectLSM", object, idBytes)}
+func (_e *MockShardLike_Expecter) putObjectLSM(ctx interface{}, object interface{}, idBytes interface{}) *MockShardLike_putObjectLSM_Call {
+	return &MockShardLike_putObjectLSM_Call{Call: _e.mock.On("putObjectLSM", ctx, object, idBytes)}
 }
 
-func (_c *MockShardLike_putObjectLSM_Call) Run(run func(object *storobj.Object, idBytes []byte)) *MockShardLike_putObjectLSM_Call {
+func (_c *MockShardLike_putObjectLSM_Call) Run(run func(ctx context.Context, object *storobj.Object, idBytes []byte)) *MockShardLike_putObjectLSM_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(*storobj.Object), args[1].([]byte))
+		run(args[0].(context.Context), args[1].(*storobj.Object), args[2].([]byte))
 	})
 	return _c
 }
@@ -4474,7 +4476,7 @@ func (_c *MockShardLike_putObjectLSM_Call) Return(_a0 objectInsertStatus, _a1 er
 	return _c
 }
 
-func (_c *MockShardLike_putObjectLSM_Call) RunAndReturn(run func(*storobj.Object, []byte) (objectInsertStatus, error)) *MockShardLike_putObjectLSM_Call {
+func (_c *MockShardLike_putObjectLSM_Call) RunAndReturn(run func(context.Context, *storobj.Object, []byte) (objectInsertStatus, error)) *MockShardLike_putObjectLSM_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -158,9 +158,9 @@ type ShardLike interface {
 	addJobToQueue(job job)
 	uuidFromDocID(docID uint64) (strfmt.UUID, error)
 	batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error
-	putObjectLSM(object *storobj.Object, idBytes []byte) (objectInsertStatus, error)
+	putObjectLSM(ctx context.Context, object *storobj.Object, idBytes []byte) (objectInsertStatus, error)
 	mayUpsertObjectHashTree(object *storobj.Object, idBytes []byte, status objectInsertStatus) error
-	mutableMergeObjectLSM(merge objects.MergeDocument, idBytes []byte) (mutableMergeResult, error)
+	mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDocument, idBytes []byte) (mutableMergeResult, error)
 	batchExtendInvertedIndexItemsLSMNoFrequency(b *lsmkv.Bucket, item inverted.MergeItem) error
 	updatePropertySpecificIndices(ctx context.Context, object *storobj.Object, status objectInsertStatus) error
 	updateVectorIndexIgnoreDelete(ctx context.Context, vector []float32, status objectInsertStatus) error

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -695,9 +695,9 @@ func (l *LazyLoadShard) batchDeleteObject(ctx context.Context, id strfmt.UUID, d
 	return l.shard.batchDeleteObject(ctx, id, deletionTime)
 }
 
-func (l *LazyLoadShard) putObjectLSM(object *storobj.Object, idBytes []byte) (objectInsertStatus, error) {
+func (l *LazyLoadShard) putObjectLSM(ctx context.Context, object *storobj.Object, idBytes []byte) (objectInsertStatus, error) {
 	l.mustLoad()
-	return l.shard.putObjectLSM(object, idBytes)
+	return l.shard.putObjectLSM(ctx, object, idBytes)
 }
 
 func (l *LazyLoadShard) mayUpsertObjectHashTree(object *storobj.Object, idBytes []byte, status objectInsertStatus) error {
@@ -705,9 +705,9 @@ func (l *LazyLoadShard) mayUpsertObjectHashTree(object *storobj.Object, idBytes 
 	return l.shard.mayUpsertObjectHashTree(object, idBytes, status)
 }
 
-func (l *LazyLoadShard) mutableMergeObjectLSM(merge objects.MergeDocument, idBytes []byte) (mutableMergeResult, error) {
+func (l *LazyLoadShard) mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDocument, idBytes []byte) (mutableMergeResult, error) {
 	l.mustLoad()
-	return l.shard.mutableMergeObjectLSM(merge, idBytes)
+	return l.shard.mutableMergeObjectLSM(ctx, merge, idBytes)
 }
 
 func (l *LazyLoadShard) deleteFromPropertySetBucket(bucket *lsmkv.Bucket, docID uint64, key []byte) error {

--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -193,7 +193,7 @@ func (ob *objectsBatcher) storeObjectOfBatchInLSM(ctx context.Context,
 		return err
 	}
 
-	status, err := ob.shard.putObjectLSM(object, idBytes)
+	status, err := ob.shard.putObjectLSM(ctx, object, idBytes)
 	if err != nil {
 		return err
 	}

--- a/adapters/repos/db/shard_write_batch_references.go
+++ b/adapters/repos/db/shard_write_batch_references.go
@@ -126,7 +126,7 @@ func (b *referencesBatcher) storeSingleBatchInLSM(ctx context.Context, batch obj
 		}
 
 		mergeDoc := mergeDocFromBatchReference(ref)
-		res, err := b.shard.mutableMergeObjectLSM(mergeDoc, idBytes)
+		res, err := b.shard.mutableMergeObjectLSM(ctx, mergeDoc, idBytes)
 		if err != nil {
 			errLock.Lock()
 			errs[i] = err

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -75,7 +75,7 @@ func (s *Shard) MergeObject(ctx context.Context, merge objects.MergeDocument) er
 }
 
 func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocument) error {
-	obj, status, err := s.mergeObjectInStorage(doc, idBytes)
+	obj, status, err := s.mergeObjectInStorage(ctx, doc, idBytes)
 	if err != nil {
 		return err
 	}
@@ -114,7 +114,7 @@ func (s *Shard) merge(ctx context.Context, idBytes []byte, doc objects.MergeDocu
 	return nil
 }
 
-func (s *Shard) mergeObjectInStorage(merge objects.MergeDocument,
+func (s *Shard) mergeObjectInStorage(ctx context.Context, merge objects.MergeDocument,
 	idBytes []byte,
 ) (*storobj.Object, objectInsertStatus, error) {
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
@@ -130,7 +130,7 @@ func (s *Shard) mergeObjectInStorage(merge objects.MergeDocument,
 		s.asyncReplicationRWMux.RLock()
 		defer s.asyncReplicationRWMux.RUnlock()
 
-		err := s.waitForMinimalHashTreeInitialization(context.Background())
+		err := s.waitForMinimalHashTreeInitialization(ctx)
 		if err != nil {
 			return err
 		}
@@ -208,7 +208,7 @@ func (s *Shard) mergeObjectInStorage(merge objects.MergeDocument,
 // The above makes this a perfect candidate for a batch reference update as
 // this alters neither the vector position, nor does it remove anything from
 // the inverted index
-func (s *Shard) mutableMergeObjectLSM(merge objects.MergeDocument,
+func (s *Shard) mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDocument,
 	idBytes []byte,
 ) (mutableMergeResult, error) {
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
@@ -217,7 +217,7 @@ func (s *Shard) mutableMergeObjectLSM(merge objects.MergeDocument,
 	s.asyncReplicationRWMux.RLock()
 	defer s.asyncReplicationRWMux.RUnlock()
 
-	err := s.waitForMinimalHashTreeInitialization(context.Background())
+	err := s.waitForMinimalHashTreeInitialization(ctx)
 	if err != nil {
 		return out, err
 	}

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -43,7 +43,7 @@ func (s *Shard) PutObject(ctx context.Context, object *storobj.Object) error {
 }
 
 func (s *Shard) putOne(ctx context.Context, uuid []byte, object *storobj.Object) error {
-	status, err := s.putObjectLSM(object, uuid)
+	status, err := s.putObjectLSM(ctx, object, uuid)
 	if err != nil {
 		return errors.Wrap(err, "store object in LSM store")
 	}
@@ -202,7 +202,7 @@ func fetchObject(bucket *lsmkv.Bucket, idBytes []byte) (*storobj.Object, error) 
 	return obj, nil
 }
 
-func (s *Shard) putObjectLSM(obj *storobj.Object, idBytes []byte,
+func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes []byte,
 ) (status objectInsertStatus, err error) {
 	before := time.Now()
 	defer s.metrics.PutObject(before)
@@ -245,7 +245,7 @@ func (s *Shard) putObjectLSM(obj *storobj.Object, idBytes []byte,
 		s.asyncReplicationRWMux.RLock()
 		defer s.asyncReplicationRWMux.RUnlock()
 
-		err := s.waitForMinimalHashTreeInitialization(context.Background())
+		err := s.waitForMinimalHashTreeInitialization(ctx)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
### What's being changed:

This pull request updates the `putObjectLSM` and `mutableMergeObjectLSM` methods throughout the codebase to consistently accept a `context.Context` parameter. This change improves context propagation for cancellation, timeouts, and tracing, and ensures that all relevant operations are context-aware. The update touches interface definitions, implementations, and associated mocks.

The most important changes are:

### Interface and Implementation Updates

* Updated the `ShardLike` interface to require a `context.Context` parameter for `putObjectLSM` and `mutableMergeObjectLSM`, and modified all implementations in `Shard`, `LazyLoadShard`, and batchers to match the new signature. [[1]](diffhunk://#diff-f5ceda6e94dc8658eea9558fa308aa70db8835f5a0d07762a7cc8ea445777034L161-R163) [[2]](diffhunk://#diff-da3785a57e3e2760e83c3f147c52db256b03105e52549b18f84f1a98c9a31e28L698-R710) [[3]](diffhunk://#diff-6f454b28f1d7b2f00dc49220806d8b0ba25c155c06d3a145c6e339ed3dab926aL196-R196) [[4]](diffhunk://#diff-2dfe47f25fb5ae9a549a10ec40807deaa60d79a25653b9ecc09d2752d0908328L129-R129) [[5]](diffhunk://#diff-d2d4caafeb9dac97efc582f0f07bd30c8e256b5545d9c9cb468314152de15f5fL78-R78) [[6]](diffhunk://#diff-d2d4caafeb9dac97efc582f0f07bd30c8e256b5545d9c9cb468314152de15f5fL117-R117) [[7]](diffhunk://#diff-d2d4caafeb9dac97efc582f0f07bd30c8e256b5545d9c9cb468314152de15f5fL211-R211) [[8]](diffhunk://#diff-d2d4caafeb9dac97efc582f0f07bd30c8e256b5545d9c9cb468314152de15f5fL220-R220) [[9]](diffhunk://#diff-c609b960b987718c6a04d28771528a171826e60b892afe6afb2d48c5cafaca7aL46-R46) [[10]](diffhunk://#diff-c609b960b987718c6a04d28771528a171826e60b892afe6afb2d48c5cafaca7aL205-R205)

* Replaced all internal calls to `waitForMinimalHashTreeInitialization` that previously used `context.Background()` with the passed-in context, ensuring proper context propagation. [[1]](diffhunk://#diff-d2d4caafeb9dac97efc582f0f07bd30c8e256b5545d9c9cb468314152de15f5fL133-R133) [[2]](diffhunk://#diff-d2d4caafeb9dac97efc582f0f07bd30c8e256b5545d9c9cb468314152de15f5fL220-R220) [[3]](diffhunk://#diff-c609b960b987718c6a04d28771528a171826e60b892afe6afb2d48c5cafaca7aL248-R248)

### Mock and Testing Updates

* Updated the mock implementations in `mock_shard_like.go` to include the `context.Context` parameter for `putObjectLSM` and `mutableMergeObjectLSM`, including all helper and expectation methods. [[1]](diffhunk://#diff-496907f60760c7795d469b0e468fb5f4d5447889dc7494403a113a147c516597L3927-R3947) [[2]](diffhunk://#diff-496907f60760c7795d469b0e468fb5f4d5447889dc7494403a113a147c516597R3961-R3970) [[3]](diffhunk://#diff-496907f60760c7795d469b0e468fb5f4d5447889dc7494403a113a147c516597L3979-R3980) [[4]](diffhunk://#diff-496907f60760c7795d469b0e468fb5f4d5447889dc7494403a113a147c516597L4425-R4446) [[5]](diffhunk://#diff-496907f60760c7795d469b0e468fb5f4d5447889dc7494403a113a147c516597R4460-R4469) [[6]](diffhunk://#diff-496907f60760c7795d469b0e468fb5f4d5447889dc7494403a113a147c516597L4477-R4479)

These changes ensure that context is consistently handled throughout the storage and merging operations, improving reliability and observability.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
