### PR TITLE
feat: use time-based deletion strategy as default for new collections

### DIFF
--- a/test/acceptance/replication/read_repair/read_repair_test.go
+++ b/test/acceptance/replication/read_repair/read_repair_test.go
@@ -51,12 +51,14 @@ func (suite *ReplicationTestSuite) TestReadRepair() {
 
 	t.Run("CreateSchema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor: 3,
+			Factor:           3,
+			DeletionStrategy: models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
 		articleClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor: 3,
+			Factor:           3,
+			DeletionStrategy: models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
 		}
 		helper.CreateClass(t, articleClass)
 	})

--- a/test/acceptance/schema/get_schema_without_client_test.go
+++ b/test/acceptance/schema/get_schema_without_client_test.go
@@ -102,7 +102,7 @@ func testGetSchemaWithoutClient(t *testing.T) {
 				"replicationConfig": map[string]interface{}{
 					"asyncEnabled":     false,
 					"factor":           float64(1),
-					"deletionStrategy": "NoAutomatedResolution",
+					"deletionStrategy": "TimeBasedResolution",
 				},
 				"vectorizer": "text2vec-contextionary", // global default from env var, see docker-compose-test.yml
 				"invertedIndexConfig": map[string]interface{}{

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -431,14 +431,14 @@ func (m *Handler) setNewClassDefaults(class *models.Class, globalCfg replication
 	if class.ReplicationConfig == nil {
 		class.ReplicationConfig = &models.ReplicationConfig{
 			Factor:           int64(m.config.Replication.MinimumFactor),
-			DeletionStrategy: models.ReplicationConfigDeletionStrategyNoAutomatedResolution,
+			DeletionStrategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
 			AsyncEnabled:     false,
 		}
 		return nil
 	}
 
 	if class.ReplicationConfig.DeletionStrategy == "" {
-		class.ReplicationConfig.DeletionStrategy = models.ReplicationConfigDeletionStrategyNoAutomatedResolution
+		class.ReplicationConfig.DeletionStrategy = models.ReplicationConfigDeletionStrategyTimeBasedResolution
 	}
 
 	return nil


### PR DESCRIPTION
### What's being changed:

This pull request updates the default replication deletion strategy for new classes in the schema handler. Instead of using "NoAutomatedResolution" as the default, the system will now default to "TimeBasedResolution" for the `DeletionStrategy` field in `ReplicationConfig`.

- Changed the default value of `ReplicationConfig.DeletionStrategy` from `NoAutomatedResolution` to `TimeBasedResolution` when creating a new class or when the field is unset in `usecases/schema/class.go`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
