### PR TITLE
Reduce threshold prior to sending errors/successes to client

### DIFF
--- a/adapters/handlers/grpc/v1/batch/stream.go
+++ b/adapters/handlers/grpc/v1/batch/stream.go
@@ -281,7 +281,7 @@ func (h *StreamHandler) sender(ctx context.Context, streamId string, stream pb.W
 		log.Errorf("failed to send started message: %s", err)
 		return err
 	}
-	batchResults := newBatchResults()
+	batchResults := newBatchResults(h.workerStats(streamId).getBatchSize())
 	timer := time.NewTicker(5 * time.Second)
 	defer timer.Stop()
 	for {
@@ -334,6 +334,7 @@ func (h *StreamHandler) sender(ctx context.Context, streamId string, stream pb.W
 		case <-timer.C:
 			// Periodically send the current batchSizeEma to the client to adjust its sending rate
 			batchSize := h.workerStats(streamId).getBatchSize()
+			batchResults.updateBatchSize(batchSize)
 			log.WithField("batchSize", batchSize).Debug("sending backoff message to client")
 			if err := stream.Send(newBatchBackoffMessage(batchSize)); err != nil {
 				log.Errorf("failed to send backoff message: %s", err)
@@ -574,15 +575,21 @@ func estimateBatchMemory(objs []*pb.BatchObject) int64 {
 }
 
 type batchResults struct {
+	batchSize int
 	successes []*pb.BatchStreamReply_Results_Success
 	errors    []*pb.BatchStreamReply_Results_Error
 }
 
-func newBatchResults() *batchResults {
+func newBatchResults(batchSize int) *batchResults {
 	return &batchResults{
-		successes: make([]*pb.BatchStreamReply_Results_Success, 0, 10000),
-		errors:    make([]*pb.BatchStreamReply_Results_Error, 0),
+		batchSize: batchSize,
+		successes: make([]*pb.BatchStreamReply_Results_Success, 0, batchSize),
+		errors:    make([]*pb.BatchStreamReply_Results_Error, 0, batchSize),
 	}
+}
+
+func (r *batchResults) updateBatchSize(newSize int) {
+	r.batchSize = newSize
 }
 
 func (r *batchResults) add(successes []*pb.BatchStreamReply_Results_Success, errors []*pb.BatchStreamReply_Results_Error) {
@@ -596,7 +603,7 @@ func (r *batchResults) reset() {
 }
 
 func (r *batchResults) shouldSend() bool {
-	return len(r.successes)+len(r.errors) > 10000
+	return len(r.successes)+len(r.errors) > r.batchSize
 }
 
 func (r *batchResults) send(stream pb.Weaviate_BatchStreamServer) error {


### PR DESCRIPTION
### What's being changed:

Previously, the hard-coded value of 10k would lead to ingestions seeming to hang for 10k objects before global errors, e.g. collection misconfiguration, are surfaced by the SSB logic

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
