### PR TITLE
DONOTMERGE: feat: enhance user error logging with detailed error information

### DIFF
--- a/adapters/handlers/rest/handlers_aliases.go
+++ b/adapters/handlers/rest/handlers_aliases.go
@@ -176,10 +176,10 @@ func newAliasesRequestsTotal(metrics *monitoring.PrometheusMetrics, logger logru
 func (e *aliasesRequestsTotal) logError(className string, err error) {
 	switch {
 	case errors.As(err, &authzerrors.Forbidden{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	case errors.As(err, &uco.ErrMultiTenancy{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	default:
-		e.logUserError(className)
+		e.logUserError(className, err)
 	}
 }

--- a/adapters/handlers/rest/handlers_backup.go
+++ b/adapters/handlers/rest/handlers_backup.go
@@ -358,9 +358,9 @@ func newBackupRequestsTotal(metrics *monitoring.PrometheusMetrics, logger logrus
 func (e *backupRequestsTotal) logError(className string, err error) {
 	switch {
 	case errors.As(err, &authzerrors.Forbidden{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	case errors.As(err, &backup.ErrUnprocessable{}) || errors.As(err, &backup.ErrNotFound{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	default:
 		e.logServerError(className, err)
 	}

--- a/adapters/handlers/rest/handlers_batch_objects.go
+++ b/adapters/handlers/rest/handlers_batch_objects.go
@@ -268,16 +268,16 @@ func newBatchRequestsTotal(metrics *monitoring.PrometheusMetrics, logger logrus.
 func (e *batchRequestsTotal) logError(className string, err error) {
 	switch {
 	case errors.As(err, &errReplication{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	case errors.As(err, &autherrs.Forbidden{}), errors.As(err, &objects.ErrInvalidUserInput{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	case errors.As(err, &objects.ErrMultiTenancy{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	default:
 		if errors.As(err, &objects.ErrMultiTenancy{}) ||
 			errors.As(err, &objects.ErrInvalidUserInput{}) ||
 			errors.As(err, &autherrs.Forbidden{}) {
-			e.logUserError(className)
+			e.logUserError(className, err)
 		} else {
 			e.logServerError(className, err)
 		}

--- a/adapters/handlers/rest/handlers_classification.go
+++ b/adapters/handlers/rest/handlers_classification.go
@@ -45,7 +45,7 @@ func setupClassificationHandlers(api *operations.WeaviateAPI,
 			}
 
 			if res == nil {
-				metricRequestsTotal.logUserError("")
+				metricRequestsTotal.logUserError("", errors.New("classification not found"))
 				return classifications.NewClassificationsGetNotFound()
 			}
 
@@ -58,7 +58,7 @@ func setupClassificationHandlers(api *operations.WeaviateAPI,
 		func(params classifications.ClassificationsPostParams, principal *models.Principal) middleware.Responder {
 			res, err := classifier.Schedule(params.HTTPRequest.Context(), principal, *params.Params)
 			if err != nil {
-				metricRequestsTotal.logUserError("")
+				metricRequestsTotal.logUserError("", err)
 
 				var forbidden autherrs.Forbidden
 				switch {

--- a/adapters/handlers/rest/handlers_misc.go
+++ b/adapters/handlers/rest/handlers_misc.go
@@ -57,7 +57,7 @@ func setupMiscHandlers(api *operations.WeaviateAPI, serverConfig *config.Weaviat
 	api.WellKnownGetWellKnownOpenidConfigurationHandler = well_known.GetWellKnownOpenidConfigurationHandlerFunc(
 		func(params well_known.GetWellKnownOpenidConfigurationParams, principal *models.Principal) middleware.Responder {
 			if !serverConfig.Config.Authentication.OIDC.Enabled {
-				metricRequestsTotal.logUserError("")
+				metricRequestsTotal.logUserError("", fmt.Errorf("OIDC not enabled"))
 				return well_known.NewGetWellKnownOpenidConfigurationNotFound()
 			}
 

--- a/adapters/handlers/rest/handlers_nodes.go
+++ b/adapters/handlers/rest/handlers_nodes.go
@@ -151,9 +151,9 @@ func newNodesRequestsTotal(metrics *monitoring.PrometheusMetrics, logger logrus.
 func (e *nodesRequestsTotal) logError(className string, err error) {
 	switch {
 	case errors.As(err, &enterrors.ErrNotFound{}), errors.As(err, &enterrors.ErrUnprocessable{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	case errors.As(err, &autherrs.Forbidden{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	default:
 		e.logServerError(className, err)
 	}

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -165,7 +165,7 @@ func (h *objectHandlers) getObject(params objects.ObjectsClassGetParams,
 			class, err = h.manager.GetObjectClassFromName(ctx, principal, params.ClassName)
 		}
 		if err != nil {
-			h.metricRequestsTotal.logUserError(params.ClassName)
+			h.metricRequestsTotal.logUserError(params.ClassName, err)
 			return objects.NewObjectsClassGetBadRequest().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
@@ -816,25 +816,25 @@ func (e *objectsRequestsTotal) logError(className string, err error) {
 	switch {
 
 	case errors.As(err, &uco.ErrMultiTenancy{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	case errors.As(err, &errReplication{}), errors.As(err, &errUnregonizedProperty{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	case errors.As(err, &authzerrors.Forbidden{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	case errors.As(err, &uco.ErrInvalidUserInput{}), errors.As(err, &uco.ErrNotFound{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	case errors.As(err, &customError):
 		switch customError.Code {
 		case uco.StatusInternalServerError:
 			e.logServerError(className, err)
 		default:
-			e.logUserError(className)
+			e.logUserError(className, err)
 		}
 	default:
 		if errors.As(err, &uco.ErrInvalidUserInput{}) ||
 			errors.As(err, &uco.ErrMultiTenancy{}) ||
 			errors.As(err, &authzerrors.Forbidden{}) {
-			e.logUserError(className)
+			e.logUserError(className, err)
 		} else {
 			e.logServerError(className, err)
 		}

--- a/adapters/handlers/rest/handlers_objects_test.go
+++ b/adapters/handlers/rest/handlers_objects_test.go
@@ -1162,5 +1162,5 @@ type fakeMetricRequestsTotal struct{}
 
 func (f *fakeMetricRequestsTotal) logError(className string, err error)       {}
 func (f *fakeMetricRequestsTotal) logOk(className string)                     {}
-func (f *fakeMetricRequestsTotal) logUserError(className string)              {}
+func (f *fakeMetricRequestsTotal) logUserError(className string, err error)   {}
 func (f *fakeMetricRequestsTotal) logServerError(className string, err error) {}

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -99,7 +99,7 @@ func (s *schemaHandlers) getClass(params schema.SchemaObjectsGetParams,
 	}
 
 	if class == nil {
-		s.metricRequestsTotal.logUserError(params.ClassName)
+		s.metricRequestsTotal.logUserError(params.ClassName, fmt.Errorf("class '%s' not found", params.ClassName))
 		return schema.NewSchemaObjectsGetNotFound()
 	}
 
@@ -330,7 +330,7 @@ func (s *schemaHandlers) getTenant(
 		}
 	}
 	if tenant == nil {
-		s.metricRequestsTotal.logUserError(params.ClassName)
+		s.metricRequestsTotal.logUserError(params.ClassName, fmt.Errorf("tenant '%s' not found when it should have been", params.TenantName))
 		return schema.NewTenantsGetOneUnprocessableEntity().
 			WithPayload(errPayloadFromSingleErr(fmt.Errorf("tenant '%s' not found when it should have been", params.TenantName)))
 	}
@@ -402,10 +402,10 @@ func newSchemaRequestsTotal(metrics *monitoring.PrometheusMetrics, logger logrus
 func (e *schemaRequestsTotal) logError(className string, err error) {
 	switch {
 	case errors.As(err, &authzerrors.Forbidden{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	case errors.As(err, &uco.ErrMultiTenancy{}):
-		e.logUserError(className)
+		e.logUserError(className, err)
 	default:
-		e.logUserError(className)
+		e.logUserError(className, err)
 	}
 }

--- a/adapters/handlers/rest/panics_middleware.go
+++ b/adapters/handlers/rest/panics_middleware.go
@@ -57,7 +57,7 @@ func handlePanics(logger logrus.FieldLogger, metricRequestsTotal restApiRequests
 	}
 
 	if errors.Is(err, syscall.EPIPE) {
-		metricRequestsTotal.logUserError("")
+		metricRequestsTotal.logUserError("", err)
 		handleBrokenPipe(err, logger, r)
 		return
 	}
@@ -65,7 +65,7 @@ func handlePanics(logger logrus.FieldLogger, metricRequestsTotal restApiRequests
 	var netErr net.Error
 	if errors.As(err, &netErr) {
 		if netErr.Timeout() {
-			metricRequestsTotal.logUserError("")
+			metricRequestsTotal.logUserError("", err)
 			handleTimeout(netErr, logger, r)
 			return
 		}

--- a/adapters/handlers/rest/requests_total_metrics.go
+++ b/adapters/handlers/rest/requests_total_metrics.go
@@ -74,7 +74,7 @@ func (m *requestsTotalMetric) RequestsTotalInc(status RequestStatus, className, 
 type restApiRequestsTotal interface {
 	logError(className string, err error)
 	logOk(className string)
-	logUserError(className string)
+	logUserError(className string, err error)
 	logServerError(className string, err error)
 }
 
@@ -90,7 +90,13 @@ func (e *restApiRequestsTotalImpl) logOk(className string) {
 	}
 }
 
-func (e *restApiRequestsTotalImpl) logUserError(className string) {
+func (e *restApiRequestsTotalImpl) logUserError(className string, err error) {
+	e.logger.WithFields(logrus.Fields{
+		"action":     "requests_total",
+		"api":        e.api,
+		"query_type": e.queryType,
+		"class_name": className,
+	}).WithError(err).Error("unexpected error")
 	if e.metrics != nil {
 		e.metrics.RequestsTotalInc(UserError, className, e.queryType)
 	}


### PR DESCRIPTION
### What's being changed:

This pull request refactors error logging across several REST API handler files to improve the granularity and traceability of user error logs. The main change is that the `logUserError` method now consistently accepts an `error` parameter, allowing the actual error to be logged with additional context. This change is applied throughout the codebase, including interface definitions, handler implementations, and test fakes.

**Error Logging Improvements:**

* The `logUserError` method in the `restApiRequestsTotal` interface and its implementations now takes an `error` argument, and logs the error details using `WithError(err)` for better traceability. (`requests_total_metrics.go`) [[1]](diffhunk://#diff-2b6202342fab710ae6a861629f3bef62d70372d871741fc95d5b0eb9390daec2L77-R77) [[2]](diffhunk://#diff-2b6202342fab710ae6a861629f3bef62d70372d871741fc95d5b0eb9390daec2L93-R99)
* All usages of `logUserError` in handler files such as `handlers_objects.go`, `handlers_schema.go`, `handlers_aliases.go`, `handlers_backup.go`, `handlers_batch_objects.go`, `handlers_nodes.go`, `handlers_classification.go`, and `handlers_misc.go` have been updated to pass the relevant `error` object. [[1]](diffhunk://#diff-1a3f33797730acbaa0362c3b9438f9b64e62b29ce18eb20ff2f08abe64cd111eL168-R168) [[2]](diffhunk://#diff-1a3f33797730acbaa0362c3b9438f9b64e62b29ce18eb20ff2f08abe64cd111eL819-R837) [[3]](diffhunk://#diff-73e4c57bc541d7a6da82489dd7726a70668bceece88af8f9d75a4017c2722142L102-R102) [[4]](diffhunk://#diff-73e4c57bc541d7a6da82489dd7726a70668bceece88af8f9d75a4017c2722142L333-R333) [[5]](diffhunk://#diff-73e4c57bc541d7a6da82489dd7726a70668bceece88af8f9d75a4017c2722142L405-R409) [[6]](diffhunk://#diff-4376d58d6476b54061b1d657c0213c9653cd418a2505af5818cf1a6fdab0c191L179-R183) [[7]](diffhunk://#diff-bac6f2cec95806019bf08173c9ae0abb37faeea97e886aeefee12bc38594654aL361-R363) [[8]](diffhunk://#diff-3cd467b0d31edf8b012ea58013113a22d8bbeda7d9ebed00829502ad34248862L271-R280) [[9]](diffhunk://#diff-e14f755a207b55babe101631c00408b3c1422edb3090ceda0064f1182aabfaffL154-R156) [[10]](diffhunk://#diff-cdfb3569bf28e5186da867a5721d10b44953a0e4160bf4d79c8081ed63fa9312L48-R48) [[11]](diffhunk://#diff-cdfb3569bf28e5186da867a5721d10b44953a0e4160bf4d79c8081ed63fa9312L61-R61) [[12]](diffhunk://#diff-bc66f9582f058f0ea35939160109e0d0c3694911225e1252991463dbdd5cd5efL60-R60) [[13]](diffhunk://#diff-9638235d2dde795de64877f0e4033843c33d6ec423ba58f67348bb0823f39d03L60-R68)

**Interface and Test Updates:**

* The `restApiRequestsTotal` interface and all implementations, including the `fakeMetricRequestsTotal` used in tests, have been updated to match the new signature of `logUserError(className string, err error)`. [[1]](diffhunk://#diff-2b6202342fab710ae6a861629f3bef62d70372d871741fc95d5b0eb9390daec2L77-R77) [[2]](diffhunk://#diff-0db2e160a92b02a0703e583fd015be5a223e2f160ab511e88d3a27f25d5d85c4L1165-R1165)

These changes ensure that user errors are logged with full error context, making debugging and monitoring more effective.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
