### PR TITLE
HFAllowList: skip ids not in centroid index

### DIFF
--- a/adapters/repos/db/vector/hfresh/hf_allow_list.go
+++ b/adapters/repos/db/vector/hfresh/hf_allow_list.go
@@ -74,6 +74,10 @@ func (a *hfAllowList) Contains(id uint64) bool {
 		return true
 	}
 
+	if a.h.Centroids != nil && !a.h.Centroids.Exists(id) {
+		return false
+	}
+
 	p, err := a.h.PostingMap.Get(a.ctx, id)
 	if err != nil {
 		return false


### PR DESCRIPTION
### What's being changed:
- Skip ids not in centroid index in HFAllowList
- Improves performance significantly (2x+) as otherwise `NewHFALIterator` will encounter nil entries in the posting map leading to disk access

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
