### PR TITLE
Feat: allow disabling of reference duplication in collection configuration

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -8055,6 +8055,12 @@ func init() {
           "description": "Description of the property.",
           "type": "string"
         },
+        "disableDuplicatedReferences": {
+          "description": "If set to false, allows multiple references to the same target object within this property. Setting it to true will enforce uniqueness of references within this property. By default, this is set to true.",
+          "type": "boolean",
+          "default": true,
+          "x-nullable": true
+        },
         "indexFilterable": {
           "description": "Whether to include this property in the filterable, Roaring Bitmap index. If ` + "`" + `false` + "`" + `, this property cannot be used in ` + "`" + `where` + "`" + ` filters. \u003cbr/\u003e\u003cbr/\u003eNote: Unrelated to vectorization behavior.",
           "type": "boolean",
@@ -17955,6 +17961,12 @@ func init() {
         "description": {
           "description": "Description of the property.",
           "type": "string"
+        },
+        "disableDuplicatedReferences": {
+          "description": "If set to false, allows multiple references to the same target object within this property. Setting it to true will enforce uniqueness of references within this property. By default, this is set to true.",
+          "type": "boolean",
+          "default": true,
+          "x-nullable": true
         },
         "indexFilterable": {
           "description": "Whether to include this property in the filterable, Roaring Bitmap index. If ` + "`" + `false` + "`" + `, this property cannot be used in ` + "`" + `where` + "`" + ` filters. \u003cbr/\u003e\u003cbr/\u003eNote: Unrelated to vectorization behavior.",

--- a/entities/models/property.go
+++ b/entities/models/property.go
@@ -38,6 +38,9 @@ type Property struct {
 	// Description of the property.
 	Description string `json:"description,omitempty"`
 
+	// If set to false, allows multiple references to the same target object within this property. Setting it to true will enforce uniqueness of references within this property. By default, this is set to true.
+	DisableDuplicatedReferences *bool `json:"disableDuplicatedReferences,omitempty"`
+
 	// Whether to include this property in the filterable, Roaring Bitmap index. If `false`, this property cannot be used in `where` filters. <br/><br/>Note: Unrelated to vectorization behavior.
 	IndexFilterable *bool `json:"indexFilterable,omitempty"`
 

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1589,6 +1589,12 @@
           },
           "type": "array",
           "x-omitempty": true
+        },
+        "disableDuplicatedReferences": {
+          "description": "If set to false, allows multiple references to the same target object within this property. Setting it to true will enforce uniqueness of references within this property. By default, this is set to true.",
+          "type": "boolean",
+          "x-nullable": true,
+          "default": true
         }
       },
       "type": "object"

--- a/test/acceptance/grpc/batch_references_test.go
+++ b/test/acceptance/grpc/batch_references_test.go
@@ -35,6 +35,8 @@ func TestGrpcBatchReferences(t *testing.T) {
 	grpcClient, _ := newClient(t)
 
 	clsA := articles.ArticlesClass()
+	trueVal := true
+	clsA.Properties[1].DisableDuplicatedReferences = &trueVal
 	clsP := articles.ParagraphsClass()
 
 	helper.DeleteClass(t, clsP.Class)


### PR DESCRIPTION
### What's being changed:

This PR introduces a new collection configuration option for reference properties that allows disabling of reference duplication

Currently, it is possible to define the same reference multiple times, e.g. a `Person` collection having a property `bought` that references an `Item` collection with that `Person` having multiple references to the same `Item` signifying how many times the `Person` has bought the `Item`. However, in other cases, users may want to enforce uniqueness of references so that batch insertion of references behaves as upserts, e.g. an `Article` collection having a property `hasParagraphs` that references a `Paragraph` collection where multiple references to the same paragraph would be nonsensical

As such, this PR allows both use-cases simultaneously by introducing the `disableDuplicatedReferences` flag inside the property config definition when creating collections. To achieve BC, this flag defaults to `false` so that duplicated references remain the default behaviour

Closes https://github.com/weaviate/weaviate/issues/5330

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
