### PR TITLE
chore(test): TestScaleDownAfterRemoveNode extend time to avoid flakiness

### DIFF
--- a/test/acceptance/recovery/scale_down_after_remove_node_test.go
+++ b/test/acceptance/recovery/scale_down_after_remove_node_test.go
@@ -190,7 +190,7 @@ func TestScaleDownAfterRemoveNode(t *testing.T) {
 					"shard should have exactly %d replicas (RF=%d, remaining nodes=%d)",
 					expectedReplicas, desiredRF, remainingNodes)
 			}
-		}, 120*time.Second, 2*time.Second)
+		}, 360*time.Second, 2*time.Second)
 	})
 
 	// Extract node number from nodeToRemove (e.g., "node1" -> 1, "node2" -> 2)


### PR DESCRIPTION
### What's being changed:
extend time for `TestScaleDownAfterRemoveNode` to avoid flakiness 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
