### PR TITLE
perf: use a single byte for posting version

### DIFF
--- a/adapters/repos/db/vector/hfresh/store.go
+++ b/adapters/repos/db/vector/hfresh/store.go
@@ -48,7 +48,7 @@ func NewPostingStore(store *lsmkv.Store, sharedBucket *lsmkv.Bucket, metrics *Me
 						return false, fmt.Errorf("invalid key length: %d", len(key))
 					}
 					postingID := binary.LittleEndian.Uint64(key[:8])
-					segmentPostingVersion := binary.LittleEndian.Uint32(key[8:])
+					segmentPostingVersion := key[8]
 					currentPostingVersion, err := versions.Get(ctx, postingID)
 					if err != nil {
 						return false, errors.Wrap(err, "get posting version during compaction")
@@ -73,13 +73,13 @@ func NewPostingStore(store *lsmkv.Store, sharedBucket *lsmkv.Bucket, metrics *Me
 }
 
 func (p *PostingStore) getKeyBytes(ctx context.Context, postingID uint64) ([]byte, error) {
-	var buf [12]byte
+	var buf [9]byte
 	binary.LittleEndian.PutUint64(buf[:], postingID)
 	version, err := p.versions.Get(ctx, postingID)
 	if err != nil {
 		return nil, errors.Wrapf(err, "get posting version for id %d", postingID)
 	}
-	binary.LittleEndian.PutUint32(buf[8:], version)
+	buf[8] = version
 	return buf[:], nil
 }
 
@@ -144,9 +144,9 @@ func (p *PostingStore) Put(ctx context.Context, postingID uint64, posting Postin
 	}
 	newVersion := currentVersion + 1
 
-	var buf [12]byte
+	var buf [9]byte
 	binary.LittleEndian.PutUint64(buf[:], postingID)
-	binary.LittleEndian.PutUint32(buf[8:], newVersion)
+	buf[8] = newVersion
 	err = p.bucket.SetAdd(buf[:], set)
 	if err != nil {
 		return errors.Wrapf(err, "failed to put posting %d", postingID)
@@ -187,12 +187,11 @@ func postingsBucketName(id string) string {
 type PostingVersionsStore struct {
 	bucket    *lsmkv.Bucket
 	keyPrefix byte
-	cache     *otter.Cache[uint64, uint32]
+	cache     *otter.Cache[uint64, uint8]
 }
 
 func NewPostingVersionsStore(bucket *lsmkv.Bucket) *PostingVersionsStore {
-	cache, _ := otter.New[uint64, uint32](nil)
-
+	cache, _ := otter.New[uint64, uint8](nil)
 	return &PostingVersionsStore{
 		bucket:    bucket,
 		keyPrefix: postingVersionBucketPrefix,
@@ -207,8 +206,8 @@ func (p *PostingVersionsStore) key(postingID uint64) [9]byte {
 	return buf
 }
 
-func (p *PostingVersionsStore) Get(ctx context.Context, postingID uint64) (uint32, error) {
-	version, err := p.cache.Get(ctx, postingID, otter.LoaderFunc[uint64, uint32](func(ctx context.Context, key uint64) (uint32, error) {
+func (p *PostingVersionsStore) Get(ctx context.Context, postingID uint64) (uint8, error) {
+	version, err := p.cache.Get(ctx, postingID, otter.LoaderFunc[uint64, uint8](func(ctx context.Context, key uint64) (uint8, error) {
 		k := p.key(postingID)
 		v, err := p.bucket.Get(k[:])
 		if err != nil {
@@ -218,7 +217,7 @@ func (p *PostingVersionsStore) Get(ctx context.Context, postingID uint64) (uint3
 			return 0, otter.ErrNotFound
 		}
 
-		return binary.LittleEndian.Uint32(v), nil
+		return v[0], nil
 	}))
 	if errors.Is(err, otter.ErrNotFound) {
 		return 0, nil
@@ -227,9 +226,9 @@ func (p *PostingVersionsStore) Get(ctx context.Context, postingID uint64) (uint3
 	return version, err
 }
 
-func (p *PostingVersionsStore) Set(ctx context.Context, postingID uint64, version uint32) error {
+func (p *PostingVersionsStore) Set(ctx context.Context, postingID uint64, version uint8) error {
 	key := p.key(postingID)
-	err := p.bucket.Put(key[:], binary.LittleEndian.AppendUint32(nil, version))
+	err := p.bucket.Put(key[:], []byte{version})
 	if err != nil {
 		return err
 	}

--- a/adapters/repos/db/vector/hfresh/store_test.go
+++ b/adapters/repos/db/vector/hfresh/store_test.go
@@ -114,14 +114,14 @@ func TestStore(t *testing.T) {
 
 		version, err := s.versions.Get(ctx, 1)
 		require.NoError(t, err)
-		require.Equal(t, uint32(1), version)
+		require.Equal(t, uint8(1), version)
 
 		err = s.Put(ctx, 1, Posting{})
 		require.NoError(t, err)
 
 		version, err = s.versions.Get(ctx, 1)
 		require.NoError(t, err)
-		require.Equal(t, uint32(2), version)
+		require.Equal(t, uint8(2), version)
 	})
 
 	t.Run("append", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Posting versions are never going over 2^8 bits, so 1 byte is enough

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
