### PR TITLE
Fix shard metrics (shards_loaded, shards_unloaded) not being tracked correctly

### DIFF
--- a/usecases/monitoring/shards_test.go
+++ b/usecases/monitoring/shards_test.go
@@ -76,7 +76,7 @@ func TestShards(t *testing.T) {
 		loadingCount := testutil.ToFloat64(m.ShardsLoading)
 		unloadedCount := testutil.ToFloat64(m.ShardsUnloaded)
 
-		assert.Equal(t, float64(0), loadingCount) // dec
+		assert.Equal(t, float64(0), loadingCount)  // dec
 		assert.Equal(t, float64(2), unloadedCount) // inc
 	})
 


### PR DESCRIPTION
**Problem**
The Prometheus shard metrics (shards_loaded, shards_unloaded, shards_loading, shards_unloading) were reporting incorrect values, including negative counts for shards_loaded. This affected both lazy-loading enabled and disabled configurations.

**Root Causes:**
Lazy loading path: StartLoadingShard() and FinishLoadingShard() were never called when a LazyLoadShard was loaded via Load(). Only NewUnloadedshard() was called at creation time.
Non-lazy loading path (DISABLE_LAZY_LOAD_SHARDS=true): Shards created directly with NewShard() had no metrics recorded at all.
Shard deletion: When shards were dropped, Shard.drop() called StartUnloadingShard()/FinishUnloadingShard() which decremented ShardsLoaded (even if it was never incremented) and incremented ShardsUnloaded. This caused negative loaded counts and inflated unloaded counts for deleted shards.

**Solution**
Added metrics to lazy load path (shard_lazyloader.go):
Call StartLoadingShard() before loading
Call FinishLoadingShard() on success
Call FailLoadingShard() on failure (new method)
Added metrics to non-lazy path (index.go):
Call NewLoadedShard() after successfully creating a shard directly
Fixed shard deletion metrics (shard_drop.go, shard_lazyloader.go):
Use DeleteLoadedShard() for loaded shards being deleted (instead of unload transitions)
Use DeleteUnloadedShard() for unloaded shards being deleted
New metric methods (shards.go):
FailLoadingShard(): Reverts loading→unloaded when load fails
NewLoadedShard(): Registers directly-loaded shard
DeleteLoadedShard(): Removes loaded shard from count (deletion)
DeleteUnloadedShard(): Removes unloaded shard from count (deletion)

**Files Changed**
usecases/monitoring/shards.go - Added new metric methods
usecases/monitoring/shards_test.go - Added unit tests for new methods
adapters/repos/db/shard_lazyloader.go - Added metrics in Load() and drop()
adapters/repos/db/shard_drop.go - Fixed deletion to use DeleteLoadedShard()
adapters/repos/db/index.go - Added NewLoadedShard() for non-lazy path
adapters/repos/db/shard_lazyloader_metrics_test.go (new) - Integration test for full lifecycle


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
