### PR TITLE
Update disk usage for HFresh

### DIFF
--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -245,7 +245,7 @@ func CalculateNonLSMStorage(path, shardName string) (uint64, uint64, error) {
 		}
 
 		fullPath := filepath.Join(shardPath, dir)
-		filesSubFolder, _, err := diskio.GetFileWithSizes(fullPath)
+		filesSubFolder, subDirs, err := diskio.GetFileWithSizes(fullPath)
 		if err != nil {
 			return 0, 0, err
 		}
@@ -254,7 +254,30 @@ func CalculateNonLSMStorage(path, shardName string) (uint64, uint64, error) {
 		for _, size := range filesSubFolder {
 			totalSize += uint64(size)
 		}
-		if strings.HasSuffix(dir, "commitlog.d") || strings.HasSuffix(dir, "snapshot.d") {
+
+		if strings.HasSuffix(dir, ".hfresh.d") {
+			for _, subDir := range subDirs {
+				subDirPath := filepath.Join(fullPath, subDir)
+				subFiles, _, err := diskio.GetFileWithSizes(subDirPath)
+				if err != nil {
+					return 0, 0, err
+				}
+
+				subDirSize := uint64(0)
+				for _, size := range subFiles {
+					subDirSize += uint64(size)
+				}
+
+				if strings.HasSuffix(subDir, "commitlog.d") ||
+					strings.HasSuffix(subDir, "snapshot.d") ||
+					strings.HasSuffix(subDir, "queue.d") {
+					vectorCommitLogsStorageSize += subDirSize
+				} else {
+					otherNonLSMFoldersStorageSize += subDirSize
+				}
+			}
+			otherNonLSMFoldersStorageSize += totalSize
+		} else if strings.HasSuffix(dir, "commitlog.d") || strings.HasSuffix(dir, "snapshot.d") {
 			vectorCommitLogsStorageSize += totalSize
 		} else {
 			otherNonLSMFoldersStorageSize += totalSize


### PR DESCRIPTION
### What's being changed:
- Update usage modules to include `.hfresh.d/` queue files, commit logs, and snapshot dirs i.e.:

```
 tree ~/weaviate/data/vector/871zwNcMmGlV/main.hfresh.d/
~/weaviate/data/vector/871zwNcMmGlV/main.hfresh.d/
├── analyze.queue.d
├── main_centroids.hnsw.commitlog.d
│   └── 1770360989
├── main_centroids.hnsw.snapshot.d
├── merge.queue.d
├── reassign.queue.d
└── split.queue.d

7 directories, 1 file
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
