### PR TITLE
test: fix passing Bucket args on hfresh test

### DIFF
--- a/adapters/repos/db/lsmkv/bucket_options.go
+++ b/adapters/repos/db/lsmkv/bucket_options.go
@@ -30,6 +30,12 @@ func MakeNoopBucketOptions(strategy string, _ ...BucketOption) []BucketOption {
 	return []BucketOption{WithStrategy(strategy)}
 }
 
+func MakeRegularBucketOptions(strategy string, customOptions ...BucketOption) []BucketOption {
+	return append([]BucketOption{
+		WithStrategy(strategy),
+	}, customOptions...)
+}
+
 func WithStrategy(strategy string) BucketOption {
 	return func(b *Bucket) error {
 		if err := CheckExpectedStrategy(strategy); err != nil {

--- a/adapters/repos/db/vector/hfresh/config.go
+++ b/adapters/repos/db/vector/hfresh/config.go
@@ -94,7 +94,7 @@ func DefaultConfig() *Config {
 		ReassignNeighbors:         DefaultReassignNeighbors,
 		MaxDistanceRatio:          DefaultMaxDistanceRatio,
 		DistanceProvider:          distancer.NewL2SquaredProvider(),
-		Store:                     StoreConfig{MakeBucketOptions: lsmkv.MakeNoopBucketOptions},
+		Store:                     StoreConfig{MakeBucketOptions: lsmkv.MakeRegularBucketOptions},
 	}
 }
 

--- a/adapters/repos/db/vector/hfresh/recall_test.go
+++ b/adapters/repos/db/vector/hfresh/recall_test.go
@@ -185,6 +185,10 @@ func runRecallTest(t *testing.T, testCfg testConfig) {
 
 	for index.taskQueue.Size() > 0 {
 		t.Logf("background tasks: %d", index.taskQueue.Size())
+		err := index.IndexMetadata.bucket.FlushAndSwitch()
+		require.NoError(t, err)
+		err = index.PostingStore.bucket.FlushAndSwitch()
+		require.NoError(t, err)
 		time.Sleep(500 * time.Millisecond)
 	}
 


### PR DESCRIPTION
### What's being changed:

- Make HFresh tests not ignore bucket args and add segment flushing

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
