### PR TITLE
fix: correct typo 'dont' to 'don't'

### DIFF
--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -349,7 +349,7 @@ func (s *Service) classGetterWithAuthzFunc(ctx context.Context, principal *model
 			if tenant != "" {
 				resources = authorization.ShardsData(name, tenant)
 			}
-			// having data access is enough for querying as we dont leak any info from the collection config that you cannot get via data access anyways
+			// having data access is enough for querying as we don't leak any info from the collection config that you cannot get via data access anyways
 			if err := s.authorizer.Authorize(ctx, principal, authorization.READ, resources...); err != nil {
 				return nil, err
 			}

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -291,7 +291,7 @@ func (h *dynUserHandler) getLastUsed(users []*apikey.User) map[string]time.Time 
 
 	// update all other nodes with maximum time so usage does not "jump back" when the node that has the latest time
 	// recorded is down.
-	// This is opportunistic (we dont care about errors) and there is no need to keep the request waiting for this
+	// This is opportunistic (we don't care about errors) and there is no need to keep the request waiting for this
 	enterrors.GoWrapper(func() {
 		ctx2, cancelFunc2 := context.WithTimeout(context.Background(), time.Second)
 		defer cancelFunc2()
@@ -301,7 +301,7 @@ func (h *dynUserHandler) getLastUsed(users []*apikey.User) map[string]time.Time 
 			nodeName := nodeName
 			enterrors.GoWrapper(func() {
 				defer wg.Done()
-				// dont care about returns or errors
+				// don't care about returns or errors
 				_, _ = h.remoteUser.GetAndUpdateLastUsedTime(ctx2, nodeName, usersWithTime, false)
 			}, h.logger)
 		}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -394,7 +394,7 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 				break
 			}
 		} else {
-			// dont lazy load segments on config update
+			// don't lazy load segments on config update
 			if err = s.initTargetVector(ctx, targetVector, targetCfg, false); err != nil {
 				return fmt.Errorf("creating new vector index: %w", err)
 			}

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -1091,7 +1091,7 @@ func UnmarshalProperties(data []byte, properties map[string]interface{}, propert
 			properties[propertyName] = val
 		case jsonparser.Array: // can be a beacon or an actual array
 			arrayEntries := value[1 : len(value)-1] // without leading and trailing []
-			// this checks if refs are present - the return points to the underlying memory, dont use without copying
+			// this checks if refs are present - the return points to the underlying memory, don't use without copying
 			_, errBeacon := jsonparser.GetUnsafeString(arrayEntries, "beacon")
 			if errBeacon == nil {
 				// there can be more than one

--- a/modules/text2vec-contextionary/module.go
+++ b/modules/text2vec-contextionary/module.go
@@ -222,7 +222,7 @@ func (m *ContextionaryModule) VectorizeObject(ctx context.Context,
 func (m *ContextionaryModule) VectorizeBatch(ctx context.Context, objs []*models.Object, skipObject []bool, cfg moduletools.ClassConfig) ([][]float32, []models.AdditionalProperties, map[int]error) {
 	vecs := make([][]float32, len(objs))
 	addProps := make([]models.AdditionalProperties, len(objs))
-	// error should be the exception so dont preallocate
+	// error should be the exception so don't preallocate
 	errs := make(map[int]error, 0)
 	for i, obj := range objs {
 		if skipObject[i] {

--- a/modules/text2vec-model2vec/module.go
+++ b/modules/text2vec-model2vec/module.go
@@ -125,7 +125,7 @@ func (m *Model2VecModule) VectorizeObject(ctx context.Context,
 func (m *Model2VecModule) VectorizeBatch(ctx context.Context, objs []*models.Object, skipObject []bool, cfg moduletools.ClassConfig) ([][]float32, []models.AdditionalProperties, map[int]error) {
 	vecs := make([][]float32, len(objs))
 	addProps := make([]models.AdditionalProperties, len(objs))
-	// error should be the exception so dont preallocate
+	// error should be the exception so don't preallocate
 	errs := make(map[int]error, 0)
 	for i, obj := range objs {
 		if skipObject[i] {

--- a/modules/text2vec-transformers/module.go
+++ b/modules/text2vec-transformers/module.go
@@ -146,7 +146,7 @@ func (m *TransformersModule) VectorizeObject(ctx context.Context,
 func (m *TransformersModule) VectorizeBatch(ctx context.Context, objs []*models.Object, skipObject []bool, cfg moduletools.ClassConfig) ([][]float32, []models.AdditionalProperties, map[int]error) {
 	vecs := make([][]float32, len(objs))
 	addProps := make([]models.AdditionalProperties, len(objs))
-	// error should be the exception so dont preallocate
+	// error should be the exception so don't preallocate
 	errs := make(map[int]error, 0)
 	for i, obj := range objs {
 		if skipObject[i] {

--- a/usecases/modulecomponents/batch/batch_simple.go
+++ b/usecases/modulecomponents/batch/batch_simple.go
@@ -33,7 +33,7 @@ func VectorizeBatch[T dto.Embedding](
 	objectVectorizer objectVectorizer[T],
 ) ([]T, []models.AdditionalProperties, map[int]error) {
 	vecs := make([]T, len(objs))
-	// error should be the exception so dont preallocate
+	// error should be the exception so don't preallocate
 	errs := make(map[int]error, 0)
 	errorLock := sync.Mutex{}
 
@@ -87,7 +87,7 @@ func VectorizeBatchObjects[T dto.Embedding](
 	batchSize int,
 ) ([]T, []models.AdditionalProperties, map[int]error) {
 	vecs := make([]T, len(objs))
-	// error should be the exception so dont preallocate
+	// error should be the exception so don't preallocate
 	errs := make(map[int]error, 0)
 	errorLock := sync.Mutex{}
 	// create batches


### PR DESCRIPTION
Fixes spelling in comments across 8 files.