### PR TITLE
fix(test): flaky test_usage.py::test_usage_with_caching e2e test

### DIFF
--- a/cluster/usage/service.go
+++ b/cluster/usage/service.go
@@ -85,11 +85,14 @@ func (s *service) Usage(ctx context.Context, exactObjectCount bool) (*types.Repo
 		// we lock the local index against being deleted while we collect usage, however we cannot lock the RAFT schema
 		// against being changed. If the class was deleted in the RAFT schema, we simply skip it here
 		// as it is no longer relevant for the current node usage
-		if errors.Is(err, clusterSchema.ErrClassNotFound) || collectionUsage == nil {
+		if errors.Is(err, clusterSchema.ErrClassNotFound) {
 			continue
 		}
 		if err != nil {
 			return nil, fmt.Errorf("collection %s: %w", collection.Class, err)
+		}
+		if collectionUsage == nil {
+			continue
 		}
 
 		usage.Collections = append(usage.Collections, collectionUsage)


### PR DESCRIPTION
### What's being changed:

This PR fixes flaky `test_usage.py::test_usage_with_caching` e2e test.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
