### PR TITLE
test: add property index bucket folder check to alter schema drop property index mt tests

### DIFF
--- a/test/acceptance/properties/properties_helpers_test.go
+++ b/test/acceptance/properties/properties_helpers_test.go
@@ -1,0 +1,45 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package properties
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/test/docker"
+)
+
+func checkFolderExistence(t *testing.T,
+	compose *docker.DockerCompose, className, shardName, directory string,
+) bool {
+	weaviateContainer := compose.GetWeaviate().Container()
+	path := fmt.Sprintf("/data/%s/%s/lsm", strings.ToLower(className), shardName)
+	code, reader, err := weaviateContainer.Exec(context.TODO(), []string{"ls", "-1", path})
+	require.NoError(t, err)
+	require.Equal(t, 0, code)
+
+	buf := new(strings.Builder)
+	_, err = io.Copy(buf, reader)
+	require.NoError(t, err)
+	output := buf.String()
+
+	for dir := range strings.SplitSeq(output, "\n") {
+		if directory == dir {
+			return true
+		}
+	}
+	return false
+}

--- a/test/acceptance/properties/properties_test.go
+++ b/test/acceptance/properties/properties_test.go
@@ -39,7 +39,7 @@ func TestProperties_SingleNode(t *testing.T) {
 		defer helper.ResetClient()
 	}
 
-	t.Run("delete property's index multi-tenant", testDeletePropertyIndexMultiTenant())
+	t.Run("delete property's index multi-tenant", testDeletePropertyIndexMultiTenant(compose))
 	t.Run("delete property's index", testDeletePropertyIndex(compose))
 }
 
@@ -57,6 +57,6 @@ func TestProperties_Cluster(t *testing.T) {
 	helper.SetupClient(compose.GetWeaviate().URI())
 	defer helper.ResetClient()
 
-	t.Run("delete property's index multi-tenant", testDeletePropertyIndexMultiTenant())
+	t.Run("delete property's index multi-tenant", testDeletePropertyIndexMultiTenant(nil))
 	t.Run("delete property's index", testDeletePropertyIndex(nil))
 }


### PR DESCRIPTION
### What's being changed:

This PR adds property index bucket folder check to alter schema drop property index multi-tenancy tests

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
