### PR TITLE
Use acks to avoid overloading server and filling up grpc frame needlessly

### DIFF
--- a/test/acceptance/grpc/batching_test.go
+++ b/test/acceptance/grpc/batching_test.go
@@ -531,7 +531,9 @@ func TestGRPC_ClusterBatching(t *testing.T) {
 			batch := make([]*pb.BatchObject, 0, batchSize)
 			for i := 0; i < numObjs; i++ {
 				for shuttingDown.Load() {
+					streamRestartLock.RLock()
 					stream.CloseSend()
+					streamRestartLock.RUnlock()
 					t.Logf("%s Can't send, server is shutting down\n", time.Now().Format("15:04:05"))
 					time.Sleep(5 * time.Second)
 					continue
@@ -553,7 +555,6 @@ func TestGRPC_ClusterBatching(t *testing.T) {
 					}
 					batch = make([]*pb.BatchObject, 0, batchSize)
 				}
-				<-acked
 			}
 			fmt.Printf("%s Done sending objects\n", time.Now().Format("15:04:05"))
 			stop(stream)


### PR DESCRIPTION
### What's being changed:

This PR attempts to fix flakey tests in the CI potentially being caused by overloading of the gRPC frame size due to the tests not observing the required client behaviour of waiting for `Acks` messages before sending the next message over the wire

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
