### PR TITLE
atomic dimensions to avoid races

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -73,7 +73,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 			}
 		}
 		if cfg.PQ.Enabled {
-			dims := int(h.dims)
+			dims := int(h.dims.Load())
 
 			if cfg.PQ.Segments <= 0 {
 				cfg.PQ.Segments = common.CalculateOptimalSegments(dims)

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -111,7 +111,7 @@ type hnsw struct {
 	trackDimensionsOnce               sync.Once
 	trackMuveraOnce                   sync.Once
 	trackRQOnce                       sync.Once
-	dims                              int32
+	dims                              atomic.Int32
 
 	cache               cache.Cache[float32]
 	waitForCachePrefill bool
@@ -1043,7 +1043,7 @@ func (h *hnsw) Stats() (*HnswStats, error) {
 	}
 
 	stats := HnswStats{
-		Dimensions:         h.dims,
+		Dimensions:         h.dims.Load(),
 		EntryPointID:       h.entryPointID,
 		DistributionLayers: distributionLayers,
 		UnreachablePoints:  h.calculateUnreachablePoints(),

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -662,7 +662,7 @@ func (h *hnsw) currentWorstResultDistanceToByte(results *priorityqueue.Queue[any
 }
 
 func (h *hnsw) distanceFromBytesToFloatNodeWithView(ctx context.Context, concreteDistancer compressionhelpers.CompressorDistancer, nodeID uint64, view common.BucketView) (float32, error) {
-	slice := h.pools.tempVectors.Get(int(h.dims))
+	slice := h.pools.tempVectors.Get(int(h.dims.Load()))
 	defer h.pools.tempVectors.Put(slice)
 	var vec []float32
 	var err error
@@ -960,7 +960,7 @@ func (h *hnsw) computeScore(searchVecs [][]float32, docID uint64) (float32, erro
 	h.RUnlock()
 	var docVecs [][]float32
 	if h.compressed.Load() {
-		slice := h.pools.tempVectors.Get(int(h.dims))
+		slice := h.pools.tempVectors.Get(int(h.dims.Load()))
 		var err error
 		docVecs, err = h.TempMultiVectorForIDThunk(context.Background(), docID, slice)
 		if err != nil {

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -141,7 +141,7 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 		h.cache.Drop()
 		if state.CompressionPQData != nil {
 			data := state.CompressionPQData
-			h.dims = int32(data.Dimensions)
+			h.dims.Store(int32(data.Dimensions))
 
 			if len(data.Encoders) > 0 {
 				// 0 means it was created using the default value. The user did not set the value, we calculated for him/her
@@ -184,7 +184,7 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 			}
 		} else if state.CompressionSQData != nil {
 			data := state.CompressionSQData
-			h.dims = int32(data.Dimensions)
+			h.dims.Store(int32(data.Dimensions))
 			if !h.multivector.Load() || h.muvera.Load() {
 				h.compressor, err = compressionhelpers.RestoreHNSWSQCompressor(
 					h.distancerProvider,
@@ -241,7 +241,7 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 		h.compressor.GrowCache(uint64(len(h.nodes)))
 	}
 
-	if h.dims == 0 {
+	if h.dims.Load() == 0 {
 		h.setDimensionsFromEntrypoint()
 	}
 
@@ -263,13 +263,13 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 func (h *hnsw) setDimensionsFromEntrypoint() {
 	if len(h.nodes) > 0 {
 		if vec, err := h.VectorForIDThunk(context.Background(), h.entryPointID); err == nil {
-			h.dims = int32(len(vec))
+			h.dims.Store(int32(len(vec)))
 		}
 	}
 }
 
 func (h *hnsw) restoreRotationalQuantization(data *compressionhelpers.RQData) error {
-	h.dims = int32(data.InputDim)
+	h.dims.Store(int32(data.InputDim))
 	var err error
 	if !h.multivector.Load() || h.muvera.Load() {
 		h.trackRQOnce.Do(func() {


### PR DESCRIPTION
### What's being changed:

back porting the atomicity of the dimensions property to avoid data races on hnsw

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
