### PR TITLE
[shard-raft] Implement multiplexed yamux transport

### DIFF
--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -180,6 +180,8 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 			InvertedSorterDisabled:                       m.db.config.InvertedSorterDisabled,
 			MaintenanceModeEnabled:                       m.db.config.MaintenanceModeEnabled,
 			HFreshEnabled:                                m.db.config.HFreshEnabled,
+			RaftReplicationEnabled:                       class.ReplicationConfig.RaftEnabled,
+			ShardRegistry:                                m.db.config.ShardRegistry,
 		},
 		// no backward-compatibility check required, since newly added classes will
 		// always have the field set

--- a/cluster/shard/registry.go
+++ b/cluster/shard/registry.go
@@ -120,9 +120,9 @@ func (reg *Registry) Start() error {
 
 	bindAddr := fmt.Sprintf("0.0.0.0:%d", reg.config.RaftPort)
 	provider := &ShardAddressProvider{
-		resolver:         reg.config.AddressResolver,
-		raftPort:         reg.config.RaftPort,
-		isLocalCluster:   reg.config.IsLocalCluster,
+		resolver:          reg.config.AddressResolver,
+		raftPort:          reg.config.RaftPort,
+		isLocalCluster:    reg.config.IsLocalCluster,
 		nodeNameToPortMap: reg.config.NodeNameToPortMap,
 	}
 

--- a/cluster/shard/replicator.go
+++ b/cluster/shard/replicator.go
@@ -176,8 +176,8 @@ func (r *replicator) forwardToLeader(
 	var lastErr error
 	operation := func() error {
 		// Get the current leader (may change between retries)
-		leader := store.Leader()
-		if leader == "" {
+		leaderID := store.LeaderID()
+		if leaderID == "" {
 			r.log.WithFields(logrus.Fields{
 				"class": req.Class,
 				"shard": req.Shard,
@@ -186,14 +186,14 @@ func (r *replicator) forwardToLeader(
 		}
 
 		r.log.WithFields(logrus.Fields{
-			"class":  req.Class,
-			"shard":  req.Shard,
-			"leader": leader,
+			"class":    req.Class,
+			"shard":    req.Shard,
+			"leaderID": leaderID,
 		}).Debug("forwarding PutObject to leader")
 
-		client, err := r.rpcClientMaker(ctx, leader)
+		client, err := r.rpcClientMaker(ctx, leaderID)
 		if err != nil {
-			return fmt.Errorf("create RPC client for leader %s: %w", leader, err)
+			return fmt.Errorf("create RPC client for leader %s: %w", leaderID, err)
 		}
 
 		// Forward to the leader
@@ -209,7 +209,7 @@ func (r *replicator) forwardToLeader(
 			r.log.WithFields(logrus.Fields{
 				"class":  req.Class,
 				"shard":  req.Shard,
-				"leader": leader,
+				"leaderID": leaderID,
 			}).Debug("leader changed, will retry")
 			return err // Retry
 		}

--- a/cluster/shard/replicator.go
+++ b/cluster/shard/replicator.go
@@ -105,39 +105,6 @@ func Newreplicator(config RouterConfig) *replicator {
 	}
 }
 
-// PutObject routes a PutObject operation to the appropriate shard leader.
-// If this node is the leader, the operation is applied locally via RAFT.
-// If this node is not the leader and a forwarding client is configured,
-// the operation is forwarded to the leader.
-func (r *replicator) PutObject(ctx context.Context, shard string, obj *storobj.Object, l routerTypes.ConsistencyLevel, schemaVersion uint64) error {
-	// Build the PutObject sub-command
-	objBytes, err := obj.MarshalBinary()
-	if err != nil {
-		return fmt.Errorf("marshal object: %w", err)
-	}
-
-	putReq := &shardproto.PutObjectRequest{
-		Object:        objBytes,
-		SchemaVersion: schemaVersion,
-	}
-	subCmd, err := proto.Marshal(putReq)
-	if err != nil {
-		return fmt.Errorf("marshal put request: %w", err)
-	}
-
-	compressed := s2.Encode(nil, subCmd)
-
-	req := &shardproto.ApplyRequest{
-		Type:       shardproto.ApplyRequest_TYPE_PUT_OBJECT,
-		Class:      r.class,
-		Shard:      shard,
-		SubCommand: compressed,
-		Compressed: true,
-	}
-	_, err = r.apply(ctx, req)
-	return err
-}
-
 func (r *replicator) apply(ctx context.Context, req *shardproto.ApplyRequest) (*shardproto.ApplyResponse, error) {
 	store := r.raft.GetStore(req.Shard)
 	if store == nil {
@@ -226,6 +193,39 @@ func (r *replicator) forwardToLeader(
 	}
 
 	return resp, nil
+}
+
+// PutObject routes a PutObject operation to the appropriate shard leader.
+// If this node is the leader, the operation is applied locally via RAFT.
+// If this node is not the leader and a forwarding client is configured,
+// the operation is forwarded to the leader.
+func (r *replicator) PutObject(ctx context.Context, shard string, obj *storobj.Object, l routerTypes.ConsistencyLevel, schemaVersion uint64) error {
+	// Build the PutObject sub-command
+	objBytes, err := obj.MarshalBinary()
+	if err != nil {
+		return fmt.Errorf("marshal object: %w", err)
+	}
+
+	putReq := &shardproto.PutObjectRequest{
+		Object:        objBytes,
+		SchemaVersion: schemaVersion,
+	}
+	subCmd, err := proto.Marshal(putReq)
+	if err != nil {
+		return fmt.Errorf("marshal put request: %w", err)
+	}
+
+	compressed := s2.Encode(nil, subCmd)
+
+	req := &shardproto.ApplyRequest{
+		Type:       shardproto.ApplyRequest_TYPE_PUT_OBJECT,
+		Class:      r.class,
+		Shard:      shard,
+		SubCommand: compressed,
+		Compressed: true,
+	}
+	_, err = r.apply(ctx, req)
+	return err
 }
 
 // DeleteObject routes a DeleteObject operation to the appropriate shard leader.

--- a/cluster/shard/replicator.go
+++ b/cluster/shard/replicator.go
@@ -207,8 +207,8 @@ func (r *replicator) forwardToLeader(
 		// Check if error indicates leader change - should retry
 		if errors.Is(err, ErrNotLeader) || strings.Contains(err.Error(), "not leader") {
 			r.log.WithFields(logrus.Fields{
-				"class":  req.Class,
-				"shard":  req.Shard,
+				"class":    req.Class,
+				"shard":    req.Shard,
 				"leaderID": leaderID,
 			}).Debug("leader changed, will retry")
 			return err // Retry

--- a/cluster/shard/state_transfer_test.go
+++ b/cluster/shard/state_transfer_test.go
@@ -165,10 +165,9 @@ func TestStateTransfer_HappyPath(t *testing.T) {
 
 	reinitCalled := false
 	st := &shard.StateTransfer{
-		RpcClientMaker: func(ctx context.Context, addr string) (shardproto.ShardReplicationServiceClient, error) {
+		RpcClientMaker: func(ctx context.Context, nodeID string) (shardproto.ShardReplicationServiceClient, error) {
 			return mockClient, nil
 		},
-		AddressResolver: &fakeAddrResolver{addr: "10.0.0.1:8080"},
 		Reinitializer: &fakeReinitializer{fn: func(ctx context.Context, className, shardName string) error {
 			reinitCalled = true
 			assert.Equal(t, testClassName, className)
@@ -205,14 +204,13 @@ func TestStateTransfer_CreateSnapshotFails(t *testing.T) {
 	}
 
 	st := &shard.StateTransfer{
-		RpcClientMaker: func(ctx context.Context, addr string) (shardproto.ShardReplicationServiceClient, error) {
+		RpcClientMaker: func(ctx context.Context, nodeID string) (shardproto.ShardReplicationServiceClient, error) {
 			return mockClient, nil
 		},
-		AddressResolver: &fakeAddrResolver{addr: "10.0.0.1:8080"},
-		Reinitializer:   &fakeReinitializer{},
-		LeaderFunc:      func(className, shardName string) string { return "leader-node" },
-		RootDataPath:    t.TempDir(),
-		Log:             logger,
+		Reinitializer: &fakeReinitializer{},
+		LeaderFunc:    func(className, shardName string) string { return "leader-node" },
+		RootDataPath:  t.TempDir(),
+		Log:           logger,
 	}
 
 	err := st.TransferState(context.Background(), testClassName, testShardName)
@@ -226,11 +224,10 @@ func TestStateTransfer_NoLeader_RetriesAndFails(t *testing.T) {
 
 	callCount := 0
 	st := &shard.StateTransfer{
-		RpcClientMaker: func(ctx context.Context, addr string) (shardproto.ShardReplicationServiceClient, error) {
+		RpcClientMaker: func(ctx context.Context, nodeID string) (shardproto.ShardReplicationServiceClient, error) {
 			return nil, nil
 		},
-		AddressResolver: &fakeAddrResolver{addr: "10.0.0.1:8080"},
-		Reinitializer:   &fakeReinitializer{},
+		Reinitializer: &fakeReinitializer{},
 		LeaderFunc: func(className, shardName string) string {
 			callCount++
 			return "" // no leader
@@ -261,10 +258,9 @@ func TestStateTransfer_ReinitFails(t *testing.T) {
 	}
 
 	st := &shard.StateTransfer{
-		RpcClientMaker: func(ctx context.Context, addr string) (shardproto.ShardReplicationServiceClient, error) {
+		RpcClientMaker: func(ctx context.Context, nodeID string) (shardproto.ShardReplicationServiceClient, error) {
 			return mockClient, nil
 		},
-		AddressResolver: &fakeAddrResolver{addr: "10.0.0.1:8080"},
 		Reinitializer: &fakeReinitializer{fn: func(ctx context.Context, className, shardName string) error {
 			return errors.New("reinit failed")
 		}},
@@ -297,14 +293,13 @@ func TestStateTransfer_ReleaseCalledOnDownloadError(t *testing.T) {
 	}
 
 	st := &shard.StateTransfer{
-		RpcClientMaker: func(ctx context.Context, addr string) (shardproto.ShardReplicationServiceClient, error) {
+		RpcClientMaker: func(ctx context.Context, nodeID string) (shardproto.ShardReplicationServiceClient, error) {
 			return mockClient, nil
 		},
-		AddressResolver: &fakeAddrResolver{addr: "10.0.0.1:8080"},
-		Reinitializer:   &fakeReinitializer{},
-		LeaderFunc:      func(className, shardName string) string { return "leader-node" },
-		RootDataPath:    t.TempDir(),
-		Log:             logger,
+		Reinitializer: &fakeReinitializer{},
+		LeaderFunc:    func(className, shardName string) string { return "leader-node" },
+		RootDataPath:  t.TempDir(),
+		Log:           logger,
 	}
 
 	err := st.TransferState(context.Background(), testClassName, testShardName)
@@ -349,10 +344,9 @@ func TestStateTransfer_IncrementalSkipsMatchingFiles(t *testing.T) {
 
 	reinitCalled := false
 	st := &shard.StateTransfer{
-		RpcClientMaker: func(ctx context.Context, addr string) (shardproto.ShardReplicationServiceClient, error) {
+		RpcClientMaker: func(ctx context.Context, nodeID string) (shardproto.ShardReplicationServiceClient, error) {
 			return mockClient, nil
 		},
-		AddressResolver: &fakeAddrResolver{addr: "10.0.0.1:8080"},
 		Reinitializer: &fakeReinitializer{fn: func(ctx context.Context, cn, sn string) error {
 			reinitCalled = true
 			return nil
@@ -413,14 +407,13 @@ func TestStateTransfer_CleanupRemovesStaleFiles(t *testing.T) {
 	}
 
 	st := &shard.StateTransfer{
-		RpcClientMaker: func(ctx context.Context, addr string) (shardproto.ShardReplicationServiceClient, error) {
+		RpcClientMaker: func(ctx context.Context, nodeID string) (shardproto.ShardReplicationServiceClient, error) {
 			return mockClient, nil
 		},
-		AddressResolver: &fakeAddrResolver{addr: "10.0.0.1:8080"},
-		Reinitializer:   &fakeReinitializer{},
-		LeaderFunc:      func(cn, sn string) string { return "leader-node" },
-		RootDataPath:    rootDir,
-		Log:             logger,
+		Reinitializer: &fakeReinitializer{},
+		LeaderFunc:    func(cn, sn string) string { return "leader-node" },
+		RootDataPath:  rootDir,
+		Log:           logger,
 	}
 
 	err = st.TransferState(context.Background(), testClassName, testShardName)
@@ -451,14 +444,6 @@ type mockStateTransferer struct {
 
 func (m *mockStateTransferer) TransferState(ctx context.Context, className, shardName string) error {
 	return m.fn(ctx, className, shardName)
-}
-
-type fakeAddrResolver struct {
-	addr string
-}
-
-func (f *fakeAddrResolver) NodeAddress(nodeName string) string {
-	return f.addr
 }
 
 type fakeReinitializer struct {

--- a/cluster/shard/store.go
+++ b/cluster/shard/store.go
@@ -234,7 +234,6 @@ func (s *Store) initRaft() error {
 	cfg := s.raftConfig()
 
 	var err error
-	// TODO: init transport properly
 	s.raft, err = raft.NewRaft(cfg, s.fsm, s.logCache, s.logStore, s.snapshotStore, s.transport)
 	if err != nil {
 		return fmt.Errorf("new raft: %w", err)

--- a/cluster/shard/store.go
+++ b/cluster/shard/store.go
@@ -234,6 +234,7 @@ func (s *Store) initRaft() error {
 	cfg := s.raftConfig()
 
 	var err error
+	// TODO: init transport properly
 	s.raft, err = raft.NewRaft(cfg, s.fsm, s.logCache, s.logStore, s.snapshotStore, s.transport)
 	if err != nil {
 		return fmt.Errorf("new raft: %w", err)

--- a/cluster/shard/transport.go
+++ b/cluster/shard/transport.go
@@ -1,0 +1,399 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package shard
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/hashicorp/yamux"
+	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/cluster/log"
+)
+
+// ShardAddressProvider implements raft.ServerAddressProvider.
+// It resolves a RAFT server ID (node name) to a host:port address
+// for the shard RAFT transport layer.
+type ShardAddressProvider struct {
+	resolver         addressResolver
+	raftPort         int
+	isLocalCluster   bool
+	nodeNameToPortMap map[string]int
+}
+
+// ServerAddr resolves a server ID to a RAFT transport address.
+func (p *ShardAddressProvider) ServerAddr(id raft.ServerID) (raft.ServerAddress, error) {
+	addr := p.resolver.NodeAddress(string(id))
+	if addr == "" {
+		return "", fmt.Errorf("could not resolve node %s", id)
+	}
+	if !p.isLocalCluster {
+		return raft.ServerAddress(fmt.Sprintf("%s:%d", addr, p.raftPort)), nil
+	}
+	port, exists := p.nodeNameToPortMap[string(id)]
+	if !exists {
+		port = p.raftPort
+	}
+	return raft.ServerAddress(fmt.Sprintf("%s:%d", addr, port)), nil
+}
+
+// MuxTransport is a per-node singleton that manages a shared TCP listener
+// and yamux session pool for multiplexing per-shard RAFT traffic.
+// All shard RAFT clusters on a node share a bounded number of TCP connections
+// (at most 2 per peer pair) via yamux stream multiplexing.
+type MuxTransport struct {
+	listener     net.Listener
+	advertise    net.Addr
+	addrProvider *ShardAddressProvider
+	logger       logrus.FieldLogger
+	yamuxCfg     *yamux.Config
+
+	sessions   map[string]*yamux.Session // peerAddr -> outbound session
+	sessionsMu sync.RWMutex
+
+	shardLayers   map[string]*ShardStreamLayer // shardKey -> layer
+	shardLayersMu sync.RWMutex
+
+	shutdownCh chan struct{}
+}
+
+// NewMuxTransport creates a new multiplexed transport. It binds a TCP listener
+// on bindAddr and starts an accept loop for incoming connections.
+func NewMuxTransport(
+	bindAddr string,
+	advertise net.Addr,
+	provider *ShardAddressProvider,
+	logger logrus.FieldLogger,
+) (*MuxTransport, error) {
+	ln, err := net.Listen("tcp", bindAddr)
+	if err != nil {
+		return nil, fmt.Errorf("bind shard raft transport on %s: %w", bindAddr, err)
+	}
+
+	yamuxCfg := yamux.DefaultConfig()
+	yamuxCfg.AcceptBacklog = 1024
+	yamuxCfg.ConnectionWriteTimeout = 10 * time.Second
+	yamuxCfg.KeepAliveInterval = 15 * time.Second
+	yamuxCfg.LogOutput = io.Discard
+
+	m := &MuxTransport{
+		listener:     ln,
+		advertise:    advertise,
+		addrProvider: provider,
+		logger:       logger,
+		yamuxCfg:     yamuxCfg,
+		sessions:     make(map[string]*yamux.Session),
+		shardLayers:  make(map[string]*ShardStreamLayer),
+		shutdownCh:   make(chan struct{}),
+	}
+
+	go m.acceptLoop()
+
+	logger.WithFields(logrus.Fields{
+		"bind":      bindAddr,
+		"advertise": advertise.String(),
+	}).Info("shard RAFT mux transport started")
+
+	return m, nil
+}
+
+// acceptLoop accepts incoming TCP connections and wraps each in a yamux
+// server session, then dispatches streams to the appropriate shard layers.
+func (m *MuxTransport) acceptLoop() {
+	for {
+		conn, err := m.listener.Accept()
+		if err != nil {
+			select {
+			case <-m.shutdownCh:
+				return
+			default:
+			}
+			m.logger.WithError(err).Warn("shard mux transport: accept error")
+			continue
+		}
+
+		session, err := yamux.Server(conn, m.yamuxCfg)
+		if err != nil {
+			m.logger.WithError(err).Warn("shard mux transport: yamux server error")
+			conn.Close()
+			continue
+		}
+
+		go m.handleSession(session)
+	}
+}
+
+// handleSession accepts yamux streams from a session and dispatches each
+// to the appropriate ShardStreamLayer based on the shard key header.
+func (m *MuxTransport) handleSession(session *yamux.Session) {
+	for {
+		stream, err := session.Accept()
+		if err != nil {
+			select {
+			case <-m.shutdownCh:
+				return
+			default:
+			}
+			if !session.IsClosed() {
+				m.logger.WithError(err).Debug("shard mux transport: stream accept error")
+			}
+			return
+		}
+
+		key, err := readShardKeyHeader(stream)
+		if err != nil {
+			m.logger.WithError(err).Warn("shard mux transport: read shard key header")
+			stream.Close()
+			continue
+		}
+
+		m.shardLayersMu.RLock()
+		layer, ok := m.shardLayers[key]
+		m.shardLayersMu.RUnlock()
+
+		if !ok {
+			m.logger.WithField("shard_key", key).Warn("shard mux transport: unknown shard key, closing stream")
+			stream.Close()
+			continue
+		}
+
+		// Non-blocking send to the shard layer's incoming channel.
+		// If the buffer is full, close the stream — remote RAFT will retry.
+		select {
+		case layer.incomingCh <- stream:
+		default:
+			m.logger.WithField("shard_key", key).Warn("shard mux transport: incoming buffer full, dropping stream")
+			stream.Close()
+		}
+	}
+}
+
+// getOrDialSession returns an existing outbound yamux session for the peer,
+// or dials a new TCP connection and creates a yamux client session.
+func (m *MuxTransport) getOrDialSession(address raft.ServerAddress) (*yamux.Session, error) {
+	addr := string(address)
+
+	m.sessionsMu.RLock()
+	session, ok := m.sessions[addr]
+	m.sessionsMu.RUnlock()
+
+	if ok && !session.IsClosed() {
+		return session, nil
+	}
+
+	m.sessionsMu.Lock()
+	defer m.sessionsMu.Unlock()
+
+	// Double-check after acquiring write lock
+	if session, ok = m.sessions[addr]; ok && !session.IsClosed() {
+		return session, nil
+	}
+
+	// Dial new TCP connection
+	conn, err := net.DialTimeout("tcp", addr, 10*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("dial peer %s: %w", addr, err)
+	}
+
+	session, err = yamux.Client(conn, m.yamuxCfg)
+	if err != nil {
+		conn.Close()
+		return nil, fmt.Errorf("yamux client for %s: %w", addr, err)
+	}
+
+	m.sessions[addr] = session
+	return session, nil
+}
+
+// CreateShardTransport creates a per-shard RAFT transport. It registers a
+// ShardStreamLayer and wraps it in a raft.NetworkTransport.
+func (m *MuxTransport) CreateShardTransport(
+	className, shardName string,
+	logger *logrus.Logger,
+) (raft.Transport, error) {
+	key := shardKey(className, shardName)
+
+	layer := &ShardStreamLayer{
+		shardKey:   key,
+		mux:        m,
+		advertise:  m.advertise,
+		incomingCh: make(chan net.Conn, 64),
+		closeCh:    make(chan struct{}),
+	}
+
+	m.shardLayersMu.Lock()
+	m.shardLayers[key] = layer
+	m.shardLayersMu.Unlock()
+
+	transport := raft.NewNetworkTransportWithConfig(&raft.NetworkTransportConfig{
+		Stream:                layer,
+		MaxPool:               3,
+		Timeout:               10 * time.Second,
+		ServerAddressProvider: m.addrProvider,
+		Logger:                log.NewHCLogrusLogger("shard-raft-net", logger),
+	})
+
+	return transport, nil
+}
+
+// DestroyShardTransport unregisters a shard's stream layer and closes it.
+func (m *MuxTransport) DestroyShardTransport(className, shardName string) {
+	key := shardKey(className, shardName)
+
+	m.shardLayersMu.Lock()
+	layer, ok := m.shardLayers[key]
+	if ok {
+		delete(m.shardLayers, key)
+	}
+	m.shardLayersMu.Unlock()
+
+	if ok {
+		layer.Close()
+	}
+}
+
+// Close shuts down the mux transport: closes the listener, all yamux sessions,
+// and signals all goroutines to stop.
+func (m *MuxTransport) Close() error {
+	close(m.shutdownCh)
+
+	if err := m.listener.Close(); err != nil {
+		m.logger.WithError(err).Warn("shard mux transport: error closing listener")
+	}
+
+	m.sessionsMu.Lock()
+	for addr, session := range m.sessions {
+		if err := session.Close(); err != nil {
+			m.logger.WithError(err).WithField("peer", addr).Debug("shard mux transport: error closing session")
+		}
+		delete(m.sessions, addr)
+	}
+	m.sessionsMu.Unlock()
+
+	m.shardLayersMu.Lock()
+	for key, layer := range m.shardLayers {
+		layer.Close()
+		delete(m.shardLayers, key)
+	}
+	m.shardLayersMu.Unlock()
+
+	m.logger.Info("shard RAFT mux transport closed")
+	return nil
+}
+
+// ShardStreamLayer implements raft.StreamLayer for a single shard.
+// It provides virtual per-shard Accept/Dial over shared yamux sessions.
+type ShardStreamLayer struct {
+	shardKey   string
+	mux        *MuxTransport
+	advertise  net.Addr
+	incomingCh chan net.Conn // buffered, populated by MuxTransport.handleSession
+	closeCh    chan struct{}
+}
+
+// Accept waits for and returns the next incoming connection for this shard.
+func (s *ShardStreamLayer) Accept() (net.Conn, error) {
+	select {
+	case conn := <-s.incomingCh:
+		return conn, nil
+	case <-s.closeCh:
+		return nil, fmt.Errorf("shard stream layer closed")
+	}
+}
+
+// Close closes the stream layer, causing Accept to return an error.
+func (s *ShardStreamLayer) Close() error {
+	select {
+	case <-s.closeCh:
+		// Already closed
+	default:
+		close(s.closeCh)
+		// Drain and close any pending connections
+		for {
+			select {
+			case conn := <-s.incomingCh:
+				conn.Close()
+			default:
+				return nil
+			}
+		}
+	}
+	return nil
+}
+
+// Addr returns the advertise address for this stream layer.
+func (s *ShardStreamLayer) Addr() net.Addr {
+	return s.advertise
+}
+
+// Dial opens a new yamux stream to the target address and writes the shard
+// key header so the remote MuxTransport can dispatch it correctly.
+func (s *ShardStreamLayer) Dial(address raft.ServerAddress, timeout time.Duration) (net.Conn, error) {
+	session, err := s.mux.getOrDialSession(address)
+	if err != nil {
+		return nil, err
+	}
+
+	stream, err := session.Open()
+	if err != nil {
+		return nil, fmt.Errorf("open yamux stream to %s: %w", address, err)
+	}
+
+	if err := writeShardKeyHeader(stream, s.shardKey); err != nil {
+		stream.Close()
+		return nil, fmt.Errorf("write shard key header to %s: %w", address, err)
+	}
+
+	return stream, nil
+}
+
+// writeShardKeyHeader writes a shard key header: [uint16 BE length][key bytes].
+func writeShardKeyHeader(w io.Writer, key string) error {
+	keyBytes := []byte(key)
+	if len(keyBytes) > 65535 {
+		return fmt.Errorf("shard key too long: %d bytes", len(keyBytes))
+	}
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], uint16(len(keyBytes)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(keyBytes)
+	return err
+}
+
+// readShardKeyHeader reads a shard key header: [uint16 BE length][key bytes].
+func readShardKeyHeader(r io.Reader) (string, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return "", err
+	}
+	length := binary.BigEndian.Uint16(hdr[:])
+	if length == 0 {
+		return "", fmt.Errorf("empty shard key")
+	}
+	buf := make([]byte, length)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+// shardKey creates a composite key for identifying a shard's RAFT cluster.
+func shardKey(className, shardName string) string {
+	return className + "/" + shardName
+}

--- a/cluster/shard/transport_test.go
+++ b/cluster/shard/transport_test.go
@@ -1,0 +1,379 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package shard
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/hashicorp/raft"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShardKeyHeader_RoundTrip(t *testing.T) {
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{"simple", "MyClass/shard1"},
+		{"long_class", "VeryLongClassName/shard-abc-123"},
+		{"unicode", "TestClass/shard-\u00e9\u00e8\u00ea"},
+		{"single_char", "A/B"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := writeShardKeyHeader(&buf, tc.key)
+			require.NoError(t, err)
+
+			got, err := readShardKeyHeader(&buf)
+			require.NoError(t, err)
+			assert.Equal(t, tc.key, got)
+		})
+	}
+}
+
+func TestShardKeyHeader_EmptyKey(t *testing.T) {
+	var buf bytes.Buffer
+	// Write a zero-length header manually
+	buf.Write([]byte{0, 0})
+	_, err := readShardKeyHeader(&buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty shard key")
+}
+
+func TestShardAddressProvider_Resolution(t *testing.T) {
+	resolver := &mockResolver{
+		addresses: map[string]string{
+			"node-1": "10.0.0.1",
+			"node-2": "10.0.0.2",
+			"node-3": "10.0.0.3",
+		},
+	}
+
+	provider := &ShardAddressProvider{
+		resolver: resolver,
+		raftPort: 8301,
+	}
+
+	addr, err := provider.ServerAddr("node-1")
+	require.NoError(t, err)
+	assert.Equal(t, raft.ServerAddress("10.0.0.1:8301"), addr)
+
+	addr, err = provider.ServerAddr("node-2")
+	require.NoError(t, err)
+	assert.Equal(t, raft.ServerAddress("10.0.0.2:8301"), addr)
+
+	// Unknown node
+	_, err = provider.ServerAddr("node-unknown")
+	require.Error(t, err)
+}
+
+func TestShardAddressProvider_LocalCluster(t *testing.T) {
+	resolver := &mockResolver{
+		addresses: map[string]string{
+			"node-1": "127.0.0.1",
+			"node-2": "127.0.0.1",
+			"node-3": "127.0.0.1",
+		},
+	}
+
+	provider := &ShardAddressProvider{
+		resolver:       resolver,
+		raftPort:       8301,
+		isLocalCluster: true,
+		nodeNameToPortMap: map[string]int{
+			"node-1": 8301,
+			"node-2": 8311,
+			"node-3": 8321,
+		},
+	}
+
+	addr, err := provider.ServerAddr("node-1")
+	require.NoError(t, err)
+	assert.Equal(t, raft.ServerAddress("127.0.0.1:8301"), addr)
+
+	addr, err = provider.ServerAddr("node-2")
+	require.NoError(t, err)
+	assert.Equal(t, raft.ServerAddress("127.0.0.1:8311"), addr)
+
+	addr, err = provider.ServerAddr("node-3")
+	require.NoError(t, err)
+	assert.Equal(t, raft.ServerAddress("127.0.0.1:8321"), addr)
+}
+
+func TestShardAddressProvider_LocalCluster_FallbackPort(t *testing.T) {
+	resolver := &mockResolver{
+		addresses: map[string]string{
+			"node-1": "127.0.0.1",
+			"node-4": "127.0.0.1",
+		},
+	}
+
+	provider := &ShardAddressProvider{
+		resolver:       resolver,
+		raftPort:       8301,
+		isLocalCluster: true,
+		nodeNameToPortMap: map[string]int{
+			"node-1": 8301,
+		},
+	}
+
+	// node-4 is not in the port map, should fall back to raftPort
+	addr, err := provider.ServerAddr("node-4")
+	require.NoError(t, err)
+	assert.Equal(t, raft.ServerAddress("127.0.0.1:8301"), addr)
+}
+
+// TestMuxTransport_SingleShard_ThreeNodes creates 3 MuxTransport instances,
+// registers one shard on each, forms a RAFT cluster, and verifies leader election.
+func TestMuxTransport_SingleShard_ThreeNodes(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	nodes := setupMuxNodes(t, 3, logger)
+
+	className := "TestClass"
+	shardName := "shard1"
+
+	// Create shard transport on each node
+	transports := make([]raft.Transport, 3)
+	for i, n := range nodes {
+		tr, err := n.mux.CreateShardTransport(className, shardName, logger)
+		require.NoError(t, err)
+		transports[i] = tr
+	}
+
+	// Build RAFT cluster
+	stores := startRaftCluster(t, nodes, transports, className, shardName, logger)
+	defer stopStores(stores)
+
+	// Wait for leader election
+	leader := waitForLeader(t, stores, 10*time.Second)
+	require.NotNil(t, leader, "expected a leader to be elected")
+}
+
+// TestMuxTransport_MultipleShards_SharedConnections creates 2 MuxTransport
+// instances, registers 10 shards on each, and verifies all 10 RAFT clusters
+// elect leaders (validates multiplexing).
+func TestMuxTransport_MultipleShards_SharedConnections(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	nodes := setupMuxNodes(t, 2, logger)
+
+	className := "TestClass"
+	numShards := 10
+
+	allStores := make([][]*Store, numShards)
+
+	for s := 0; s < numShards; s++ {
+		shardName := fmt.Sprintf("shard-%d", s)
+
+		transports := make([]raft.Transport, 2)
+		for i, n := range nodes {
+			tr, err := n.mux.CreateShardTransport(className, shardName, logger)
+			require.NoError(t, err)
+			transports[i] = tr
+		}
+
+		stores := startRaftCluster(t, nodes, transports, className, shardName, logger)
+		allStores[s] = stores
+	}
+
+	defer func() {
+		for _, stores := range allStores {
+			stopStores(stores)
+		}
+	}()
+
+	// Verify each shard cluster elects a leader
+	for s := 0; s < numShards; s++ {
+		leader := waitForLeader(t, allStores[s], 10*time.Second)
+		require.NotNil(t, leader, "shard-%d: expected a leader to be elected", s)
+	}
+}
+
+// TestMuxTransport_SessionReconnect verifies that closing a yamux session
+// causes the next Dial to create a new one.
+func TestMuxTransport_SessionReconnect(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	nodes := setupMuxNodes(t, 2, logger)
+
+	// Dial from node 0 to node 1
+	addr1 := raft.ServerAddress(nodes[1].mux.listener.Addr().String())
+	session1, err := nodes[0].mux.getOrDialSession(addr1)
+	require.NoError(t, err)
+	require.False(t, session1.IsClosed())
+
+	// Close the session
+	session1.Close()
+	require.True(t, session1.IsClosed())
+
+	// Next dial should create a new session
+	session2, err := nodes[0].mux.getOrDialSession(addr1)
+	require.NoError(t, err)
+	require.False(t, session2.IsClosed())
+
+	// Should be a different session
+	assert.NotSame(t, session1, session2)
+}
+
+// --- Test helpers ---
+
+type testMuxNode struct {
+	id   string
+	mux  *MuxTransport
+	addr string
+}
+
+type mockResolver struct {
+	addresses map[string]string
+}
+
+func (r *mockResolver) NodeAddress(nodeName string) string {
+	return r.addresses[nodeName]
+}
+
+func setupMuxNodes(t *testing.T, n int, logger *logrus.Logger) []testMuxNode {
+	t.Helper()
+
+	// Create listeners on random ports
+	nodes := make([]testMuxNode, n)
+	addresses := make(map[string]string, n)
+	portMap := make(map[string]int, n)
+
+	// First pass: create listeners to get ports
+	listeners := make([]net.Listener, n)
+	for i := 0; i < n; i++ {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		require.NoError(t, err)
+		listeners[i] = ln
+
+		nodeID := fmt.Sprintf("node-%d", i)
+		addr := ln.Addr().(*net.TCPAddr)
+		addresses[nodeID] = addr.IP.String()
+		portMap[nodeID] = addr.Port
+		nodes[i].id = nodeID
+		nodes[i].addr = ln.Addr().String()
+	}
+
+	// Close temp listeners so MuxTransport can bind
+	for _, ln := range listeners {
+		ln.Close()
+	}
+
+	resolver := &mockResolver{addresses: addresses}
+
+	// Second pass: create MuxTransports on the same ports
+	for i := 0; i < n; i++ {
+		provider := &ShardAddressProvider{
+			resolver:          resolver,
+			raftPort:          portMap[nodes[i].id],
+			isLocalCluster:    true,
+			nodeNameToPortMap: portMap,
+		}
+
+		advertise, err := net.ResolveTCPAddr("tcp", nodes[i].addr)
+		require.NoError(t, err)
+
+		mux, err := NewMuxTransport(nodes[i].addr, advertise, provider, logger)
+		require.NoError(t, err)
+		nodes[i].mux = mux
+
+		t.Cleanup(func() { mux.Close() })
+	}
+
+	return nodes
+}
+
+func startRaftCluster(
+	t *testing.T,
+	nodes []testMuxNode,
+	transports []raft.Transport,
+	className, shardName string,
+	logger *logrus.Logger,
+) []*Store {
+	t.Helper()
+
+	members := make([]string, len(nodes))
+	for i, n := range nodes {
+		members[i] = n.id
+	}
+
+	stores := make([]*Store, len(nodes))
+	for i, n := range nodes {
+		cfg := StoreConfig{
+			ClassName:          className,
+			ShardName:          shardName,
+			NodeID:             n.id,
+			DataPath:           t.TempDir(),
+			Members:            members,
+			Logger:             logger,
+			Transport:          transports[i],
+			HeartbeatTimeout:   150 * time.Millisecond,
+			ElectionTimeout:    150 * time.Millisecond,
+			LeaderLeaseTimeout: 100 * time.Millisecond,
+			SnapshotInterval:   10 * time.Second,
+			SnapshotThreshold:  1024,
+		}
+
+		store, err := NewStore(cfg)
+		require.NoError(t, err)
+
+		// FSM is created with nil shard, which is fine for leader election
+		// tests that don't apply commands.
+		ctx := context.Background()
+		err = store.Start(ctx)
+		require.NoError(t, err)
+
+		stores[i] = store
+	}
+
+	return stores
+}
+
+func stopStores(stores []*Store) {
+	for _, s := range stores {
+		if s != nil {
+			s.Stop()
+		}
+	}
+}
+
+func waitForLeader(t *testing.T, stores []*Store, timeout time.Duration) *Store {
+	t.Helper()
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for leader election")
+			return nil
+		case <-ticker.C:
+			for _, s := range stores {
+				if s.IsLeader() {
+					return s
+				}
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -194,6 +194,7 @@ require (
 	github.com/hashicorp/go-sockaddr v1.0.7 // indirect
 	github.com/hashicorp/go-uuid v1.0.1 // indirect
 	github.com/hashicorp/golang-lru v1.0.2 // indirect
+	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/karrick/godirwalk v1.15.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -381,6 +381,8 @@ github.com/hashicorp/raft-boltdb v0.0.0-20230125174641-2a8082862702 h1:RLKEcCuKc
 github.com/hashicorp/raft-boltdb v0.0.0-20230125174641-2a8082862702/go.mod h1:nTakvJ4XYq45UXtn0DbwR4aU9ZdjlnIenpbs6Cd+FM0=
 github.com/hashicorp/raft-boltdb/v2 v2.3.1 h1:ackhdCNPKblmOhjEU9+4lHSJYFkJd6Jqyvj6eW9pwkc=
 github.com/hashicorp/raft-boltdb/v2 v2.3.1/go.mod h1:n4S+g43dXF1tqDT+yzcXHhXM6y7MrlUd3TTwGRcUvQE=
+github.com/hashicorp/yamux v0.1.2 h1:XtB8kyFOyHXYVFnwT5C3+Bdo8gArse7j2AQ0DA0Uey8=
+github.com/hashicorp/yamux v0.1.2/go.mod h1:C+zze2n6e/7wshOZep2A70/aQU6QBRWJO/G6FT1wIns=
 github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
 github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=

--- a/plans/phase-six.md
+++ b/plans/phase-six.md
@@ -1,0 +1,207 @@
+# Plan: Multiplexed Transport for Per-Shard RAFT
+
+## Context
+
+`cluster/shard/store.go:238` calls `raft.NewRaft()` with a nil `s.transport`, causing a panic. Transport was intentionally deferred (TODO at line 237). The core challenge: each shard needs its own `raft.Transport` with its own consumer channel, but we can't have a separate TCP connection per shard since there could be millions. We need multiplexed transport where node pairs share a bounded number of connections supporting N parallel shard RAFT clusters.
+
+**Solution**: Use **hashicorp/yamux** for stream multiplexing. One TCP listener per node, yamux sessions to peers (2 TCP connections per peer pair — one per direction), per-shard virtual `StreamLayer` that routes via shard key headers. Each shard gets its own `raft.NetworkTransport` wrapping its virtual stream layer, reusing all of hashicorp/raft's proven wire protocol, pipelining, and heartbeat handling.
+
+---
+
+## Architecture
+
+```
+MuxTransport (per-node, owned by Registry)
+  ├── TCP Listener (single port: raftCfg.Port + 1)
+  ├── Session Pool: map[peerAddr]*yamux.Session (outbound, one per peer)
+  ├── Accept Loop: incoming TCP → yamux.Server → dispatch streams by shard key
+  └── ShardStreamLayer registry: map[shardKey]*ShardStreamLayer
+
+Per Shard:
+  ShardStreamLayer (implements raft.StreamLayer)
+    ├── Accept(): reads from dispatch channel (populated by MuxTransport)
+    ├── Dial(): opens yamux stream → writes shard key header → returns stream
+    └── Wraps in: raft.NetworkTransport (standard hashicorp/raft transport)
+         └── Used by Store as raft.Transport
+```
+
+**Wire protocol per yamux stream:**
+```
+[2 bytes: shard key length, uint16 big-endian]
+[N bytes: shard key string ("className/shardName")]
+[... standard hashicorp/raft NetworkTransport msgpack protocol ...]
+```
+
+**Connection model**: At most 2 TCP connections per peer pair (one per direction). All shard RAFT clusters multiplex over these via yamux streams.
+
+---
+
+## Implementation Steps
+
+### Step 1: Add yamux dependency
+
+```bash
+go get github.com/hashicorp/yamux
+```
+
+### Step 2: Create `cluster/shard/transport.go`
+
+This is the core new file containing three types:
+
+#### `ShardAddressProvider`
+
+Implements `raft.ServerAddressProvider`. Resolves node ID → `host:shardRaftPort` using the existing `addressResolver` interface. Pattern mirrors `cluster/resolver/raft.go:60-84`.
+
+```go
+type ShardAddressProvider struct {
+    resolver addressResolver
+    raftPort int
+}
+
+func (p *ShardAddressProvider) ServerAddr(id raft.ServerID) (raft.ServerAddress, error) {
+    addr := p.resolver.NodeAddress(string(id))
+    if addr == "" {
+        return "", fmt.Errorf("could not resolve node %s", id)
+    }
+    return raft.ServerAddress(fmt.Sprintf("%s:%d", addr, p.raftPort)), nil
+}
+```
+
+#### `MuxTransport`
+
+Per-node singleton managing the shared TCP listener and yamux session pool.
+
+```go
+type MuxTransport struct {
+    listener    net.Listener
+    advertise   net.Addr
+    addrProvider *ShardAddressProvider
+    logger      logrus.FieldLogger
+
+    sessions   map[string]*yamux.Session  // peerAddr → outbound session
+    sessionsMu sync.RWMutex
+
+    shardLayers   map[string]*ShardStreamLayer  // shardKey → layer
+    shardLayersMu sync.RWMutex
+
+    shutdownCh chan struct{}
+}
+```
+
+Key methods:
+- `NewMuxTransport(bindAddr string, advertise net.Addr, provider *ShardAddressProvider, logger) (*MuxTransport, error)` — binds TCP listener, starts `acceptLoop` goroutine
+- `acceptLoop()` — accepts TCP connections, wraps each in `yamux.Server(conn, cfg)`, starts `handleSession` goroutine per session
+- `handleSession(session)` — accepts yamux streams from session, reads shard key header via `readShardKeyHeader()`, dispatches stream to matching `ShardStreamLayer.incomingCh`. If shard key not found (race during startup), logs warning and closes stream.
+- `getOrDialSession(address raft.ServerAddress) (*yamux.Session, error)` — returns existing outbound yamux session or dials new TCP connection + `yamux.Client(conn, cfg)`. Checks `session.IsClosed()` to handle stale sessions from peer restarts.
+- `CreateShardTransport(className, shardName string, logger) (raft.Transport, error)` — creates `ShardStreamLayer`, registers it, wraps in `raft.NewNetworkTransportWithConfig()` with `ShardAddressProvider` and `maxPool=3`
+- `DestroyShardTransport(className, shardName string)` — unregisters `ShardStreamLayer`, closes it
+- `Close() error` — closes listener, all sessions, signals shutdown
+
+#### `ShardStreamLayer`
+
+Per-shard virtual stream layer implementing `raft.StreamLayer` (`net.Listener` + `Dial`).
+
+```go
+type ShardStreamLayer struct {
+    shardKey   string
+    mux        *MuxTransport
+    advertise  net.Addr
+    incomingCh chan net.Conn  // buffered (64), populated by MuxTransport.handleSession
+    closeCh    chan struct{}
+}
+```
+
+Methods:
+- `Accept() (net.Conn, error)` — blocks on `incomingCh`, returns `ErrTransportShutdown` when `closeCh` closed
+- `Dial(address raft.ServerAddress, timeout time.Duration) (net.Conn, error)` — calls `mux.getOrDialSession(address)`, opens yamux stream via `session.Open()`, writes shard key header via `writeShardKeyHeader()`, returns stream as `net.Conn`
+- `Close() error` — closes `closeCh`, drains `incomingCh`
+- `Addr() net.Addr` — returns advertise address (used by `NetworkTransport.LocalAddr()`)
+
+#### Helper functions
+
+```go
+func writeShardKeyHeader(w io.Writer, shardKey string) error  // uint16 BE length + bytes
+func readShardKeyHeader(r io.Reader) (string, error)          // inverse
+func shardKey(className, shardName string) string             // "className/shardName"
+```
+
+### Step 3: Modify `cluster/shard/registry.go`
+
+- Add `muxTransport *MuxTransport` field to `Registry` struct (line 66-75)
+- In `Start()` (lines 89-109): after resolving advertise address, create `MuxTransport`:
+  ```go
+  advertiseAddr := fmt.Sprintf("%s:%d", advertiseAddr, reg.config.RaftPort)
+  tcpAddr, _ := net.ResolveTCPAddr("tcp", advertiseAddr)
+  bindAddr := fmt.Sprintf("0.0.0.0:%d", reg.config.RaftPort)
+  provider := &ShardAddressProvider{resolver: reg.config.AddressResolver, raftPort: reg.config.RaftPort}
+  reg.muxTransport, err = NewMuxTransport(bindAddr, tcpAddr, provider, reg.log)
+  ```
+- In `Shutdown()` (lines 112-132): after stopping all Raft instances, call `reg.muxTransport.Close()`
+- In `GetOrCreateRaft()` (lines 148-160): add `MuxTransport: reg.muxTransport` to `RaftConfig`
+
+### Step 4: Modify `cluster/shard/raft.go`
+
+- Add `MuxTransport *MuxTransport` field to `RaftConfig` (lines 24-44)
+- In `GetOrCreateStore()` (lines 127-141): after building `StoreConfig`, create shard transport:
+  ```go
+  transport, err := r.config.MuxTransport.CreateShardTransport(r.config.ClassName, shardName, r.config.Logger)
+  storeConfig.Transport = transport
+  ```
+- In `Shutdown()` (lines 85-105): after stopping each store, call `r.config.MuxTransport.DestroyShardTransport(r.config.ClassName, shardName)`
+
+### Step 5: Modify `cluster/shard/store.go`
+
+- Remove the `// TODO: init transport properly` comment at line 237
+- No other changes — `Store` already receives and uses `Transport` from `StoreConfig`
+
+### Step 6: Create `cluster/shard/transport_test.go`
+
+Unit and integration tests:
+
+1. **TestShardKeyHeader_RoundTrip** — write + read shard key header, verify correctness
+2. **TestMuxTransport_SingleShard_ThreeNodes** — 3 MuxTransport instances on different ports, one shard each, form RAFT cluster, verify leader election
+3. **TestMuxTransport_MultipleShards_SharedConnections** — 2 MuxTransport instances, 10 shards each, verify all 10 RAFT clusters elect leaders (validates multiplexing)
+4. **TestMuxTransport_SessionReconnect** — close a yamux session, verify next Dial creates new session
+5. **TestShardAddressProvider_Resolution** — verify node ID → host:port resolution
+
+### Step 7: Verify no regressions
+
+- `go test ./cluster/shard/...` — existing tests use `InmemTransport` directly via `StoreConfig`, bypassing `MuxTransport` entirely
+- `go test -race ./cluster/shard/...` — race detection
+
+---
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `cluster/shard/transport.go` | **NEW** — MuxTransport, ShardStreamLayer, ShardAddressProvider, helpers |
+| `cluster/shard/transport_test.go` | **NEW** — transport unit + integration tests |
+| `cluster/shard/registry.go` | Add `muxTransport` field, create in `Start()`, close in `Shutdown()`, pass to `RaftConfig` |
+| `cluster/shard/raft.go` | Add `MuxTransport` to `RaftConfig`, call `CreateShardTransport` in `GetOrCreateStore()`, destroy in `Shutdown()` |
+| `cluster/shard/store.go` | Remove TODO comment (line 237) |
+| `go.mod` / `go.sum` | Add `github.com/hashicorp/yamux` |
+
+## Existing Code Reused
+
+- `raft.NewNetworkTransportWithConfig()` — wraps our `ShardStreamLayer`, provides all RAFT wire protocol, pooling, pipelining
+- `raft.NetworkTransportConfig.ServerAddressProvider` — pluggable address resolution (same pattern as `cluster/resolver/raft.go`)
+- `addressResolver` interface (registry.go:30-32) — already available, resolves node names to addresses
+- `cluster/log.NewHCLogrusLogger()` — existing logrus → hclog adapter
+- `raft.NewInmemTransport()` — tests continue using this unchanged
+
+## Verification
+
+1. **Unit tests**: `go test -v -race ./cluster/shard/... -run TestMuxTransport`
+2. **Existing tests**: `go test -v -race ./cluster/shard/...` (no regressions)
+3. **Acceptance test**: Start 3-node cluster via `docker-compose-raft.yml`, run `go test ./test/acceptance/replication/shard/...`
+   - Ensure `docker-compose-raft.yml` exposes shard RAFT port (schema RAFT port + 1)
+4. **Build**: `go build ./cmd/weaviate-server/` (compile check)
+
+## Edge Cases Handled
+
+- **Stale yamux sessions** (peer restart): `getOrDialSession` checks `session.IsClosed()`, re-dials if stale
+- **Unknown shard key on accept** (startup race): log warning, close stream — remote RAFT retries automatically
+- **Full incomingCh buffer**: use select with default to avoid blocking `handleSession`, close stream if buffer full
+- **Graceful shutdown ordering**: Stop all Raft/Store instances first (closes NetworkTransports → ShardStreamLayers), then close MuxTransport (listener + sessions)
+- **Concurrent store creation**: `GetOrCreateStore` already uses `LoadOrStore` for thread safety; `RegisterShardLayer` uses mutex

--- a/test/acceptance/replication/shard/raft_test.go
+++ b/test/acceptance/replication/shard/raft_test.go
@@ -1,3 +1,14 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
 package shard
 
 import (

--- a/test/acceptance/replication/shard/raft_test.go
+++ b/test/acceptance/replication/shard/raft_test.go
@@ -19,7 +19,7 @@ func Test_RaftShardReplication(t *testing.T) {
 
 	cls := articles.ParagraphsClass()
 	cls.ReplicationConfig = &models.ReplicationConfig{
-		Factor:      1,
+		Factor:      3,
 		RaftEnabled: true,
 	}
 

--- a/test/acceptance/replication/shard/raft_test.go
+++ b/test/acceptance/replication/shard/raft_test.go
@@ -12,7 +12,10 @@ import (
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
 
-const UUID = strfmt.UUID("73f2eb5f-5abf-447a-81ca-74b1dd168241")
+const (
+	UUID1 = strfmt.UUID("73f2eb5f-5abf-447a-81ca-74b1dd168241")
+	UUID2 = strfmt.UUID("d1c9e5b8-9a3e-4c8b-9f1e-2a5f6b7c8d9e")
+)
 
 func Test_RaftShardReplication(t *testing.T) {
 	helper.SetupClient("localhost:8080")
@@ -25,20 +28,60 @@ func Test_RaftShardReplication(t *testing.T) {
 
 	helper.DeleteClass(t, cls.Class)
 	helper.CreateClass(t, cls)
-	helper.CreateObject(t, articles.NewParagraph().WithContents("RAFT").WithID(UUID).Object())
 
-	// Verify the object eventually exists on all nodes
-	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		for _, port := range []string{"8080", "8081", "8082"} {
-			obj := getObj(t, cls.Class, port)
-			assert.NotNil(ct, obj, "Object should exist on node at port %s", port)
-		}
-	}, 60*time.Second, 1*time.Second)
+	t.Run("add object", func(t *testing.T) {
+		helper.CreateObject(t, articles.NewParagraph().WithContents("RAFT").WithID(UUID1).Object())
+		// Verify the object eventually exists on all nodes
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			for _, port := range []string{"8080", "8081", "8082"} {
+				obj, err := getObj(t, port, cls.Class, UUID1)
+				assert.Nil(ct, err, "Object should exist on node at port %s", port)
+				assert.NotNil(ct, obj, "Object should exist on node at port %s", port)
+			}
+		}, 10*time.Second, 1*time.Second)
+	})
+
+	t.Run("update object", func(t *testing.T) {
+		helper.UpdateObject(t, articles.NewParagraph().WithContents("RAFT Updated").WithID(UUID1).Object())
+		// Verify the update eventually exists on all nodes
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			for _, port := range []string{"8080", "8081", "8082"} {
+				obj, err := getObj(t, port, cls.Class, UUID1)
+				assert.Nil(ct, err, "Object should exist on node at port %s", port)
+				assert.NotNil(ct, obj, "Object should exist on node at port %s", port)
+				assert.Equal(ct, "RAFT Updated", obj.Properties.(map[string]any)["contents"], "Object should be updated on node at port %s", port)
+			}
+		}, 10*time.Second, 1*time.Second)
+	})
+
+	t.Run("create and update object", func(t *testing.T) {
+		helper.CreateObject(t, articles.NewParagraph().WithContents("RAFT New").WithID(UUID2).Object())
+		helper.UpdateObject(t, articles.NewParagraph().WithContents("RAFT New Updated").WithID(UUID2).Object())
+
+		// Verify the new object and update eventually exist on all nodes
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			for _, port := range []string{"8080", "8081", "8082"} {
+				obj, err := getObj(t, port, cls.Class, UUID2)
+				assert.Nil(ct, err, "Object should exist on node at port %s", port)
+				assert.NotNil(ct, obj, "Object should exist on node at port %s", port)
+				assert.Equal(ct, "RAFT New Updated", obj.Properties.(map[string]any)["contents"], "Object should be updated on node at port %s", port)
+			}
+		}, 10*time.Second, 1*time.Second)
+	})
+
+	t.Run("delete object", func(t *testing.T) {
+		helper.DeleteObject(t, &models.Object{Class: cls.Class, ID: UUID2})
+		// Verify the object is eventually deleted on all nodes
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			for _, port := range []string{"8080", "8081", "8082"} {
+				_, err := getObj(t, port, cls.Class, UUID2)
+				assert.NotNil(ct, err, "Object should be deleted on node at port %s", port)
+			}
+		}, 10*time.Second, 1*time.Second)
+	})
 }
 
-func getObj(t *testing.T, cls, port string) *models.Object {
+func getObj(t *testing.T, port, cls string, uuid strfmt.UUID) (*models.Object, error) {
 	helper.SetupClient("localhost:" + port)
-	obj, err := helper.GetObject(t, cls, UUID)
-	require.NoError(t, err)
-	return obj
+	return helper.GetObject(t, cls, uuid)
 }

--- a/test/acceptance/replication/shard/raft_test.go
+++ b/test/acceptance/replication/shard/raft_test.go
@@ -1,0 +1,44 @@
+package shard
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+const UUID = strfmt.UUID("73f2eb5f-5abf-447a-81ca-74b1dd168241")
+
+func Test_RaftShardReplication(t *testing.T) {
+	helper.SetupClient("localhost:8080")
+
+	cls := articles.ParagraphsClass()
+	cls.ReplicationConfig = &models.ReplicationConfig{
+		Factor:      1,
+		RaftEnabled: true,
+	}
+
+	helper.DeleteClass(t, cls.Class)
+	helper.CreateClass(t, cls)
+	helper.CreateObject(t, articles.NewParagraph().WithContents("RAFT").WithID(UUID).Object())
+
+	// Verify the object eventually exists on all nodes
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		for _, port := range []string{"8080", "8081", "8082"} {
+			obj := getObj(t, cls.Class, port)
+			assert.NotNil(ct, obj, "Object should exist on node at port %s", port)
+		}
+	}, 60*time.Second, 1*time.Second)
+}
+
+func getObj(t *testing.T, cls, port string) *models.Object {
+	helper.SetupClient("localhost:" + port)
+	obj, err := helper.GetObject(t, cls, UUID)
+	require.NoError(t, err)
+	return obj
+}

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -576,6 +576,7 @@ type Raft struct {
 
 	// Shard-level RAFT parameters with tuned defaults for per-shard RAFT clusters.
 	// When zero, the schema-level values above are used as fallback.
+	ShardRaftPort          int
 	ShardSnapshotThreshold uint64
 	ShardSnapshotInterval  time.Duration
 	ShardTrailingLogs      uint64

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -35,6 +35,7 @@ import (
 const (
 	DefaultRaftPort         = 8300
 	DefaultRaftInternalPort = 8301
+	DefaultShardRaftPort    = 8302
 	DefaultRaftGRPCMaxSize  = 1024 * 1024 * 1024
 	// DefaultRaftBootstrapTimeout is the time raft will wait to bootstrap or rejoin the cluster on a restart. We set it
 	// to 600 because if we're loading a large DB we need to wait for it to load before being able to join the cluster
@@ -1177,6 +1178,14 @@ func parseRAFTConfig(hostname string) (Raft, error) {
 	}
 
 	// Shard-level RAFT parameters with tuned defaults for per-shard RAFT clusters.
+	if err := parsePositiveInt(
+		"SHARD_RAFT_PORT",
+		func(val int) { cfg.ShardRaftPort = val },
+		DefaultShardRaftPort,
+	); err != nil {
+		return cfg, err
+	}
+
 	if err := parsePositiveInt(
 		"SHARD_RAFT_SNAPSHOT_THRESHOLD",
 		func(val int) { cfg.ShardSnapshotThreshold = uint64(val) },

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -75,6 +75,7 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 		return &Error{err.Error(), StatusInternalServerError, err}
 	}
 
+	// TODO: wait for leader here when raft-based object replication is enabled in case of races between adding and updating an object
 	obj, err := m.vectorRepo.Object(ctx, cls, id, nil, additional.Properties{}, repl, updates.Tenant)
 	if err != nil {
 		switch {


### PR DESCRIPTION
### What's being changed:

- Add cluster/shard/transport.go with MuxTransport (per-node singleton managing TCP listener + yamux session pool), ShardStreamLayer (per-shard virtual raft.StreamLayer), and ShardAddressProvider (node ID to host:port resolution supporting both distributed and local cluster modes)
- Wire protocol: uint16 BE shard key length + key bytes prefix per yamux stream, followed by standard hashicorp/raft NetworkTransport msgpack
- Registry.Start() creates MuxTransport, Shutdown() closes it
- Raft.GetOrCreateStore() creates per-shard transport with race cleanup via LoadOrStore; Shutdown()/StopStore() destroy shard transports
- Remove transport TODO in store.go (transport now provided by caller)
- Wire IsLocalCluster and shard port map (schema RAFT port + 1) into RegistryConfig from configure_api.go
- Add transport_test.go: header round-trip, address provider, 3-node leader election, 10-shard multiplexing, session reconnect

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
