### PR TITLE
feat: use go-cron v0.15.0 DrainAndUpsertJob for atomic TTL reschedule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/mark3labs/mcp-go v0.37.1-0.20250812151906-9f16336f83e1
 	github.com/maypok86/otter/v2 v2.2.1
 	github.com/minio/minio-go/v7 v7.0.97
-	github.com/netresearch/go-cron v0.9.1
+	github.com/netresearch/go-cron v0.15.0
 	github.com/nyaruka/phonenumbers v1.2.2
 	github.com/parquet-go/parquet-go v0.29.0
 	github.com/pbnjay/memory v0.0.0-20210728143218-7b4eea64cf58

--- a/go.sum
+++ b/go.sum
@@ -533,8 +533,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/netresearch/go-cron v0.9.1 h1:lEjuHz4oJmbR622XTAHcHH0Ekec0tjwMLQyQWQm7UDQ=
-github.com/netresearch/go-cron v0.9.1/go.mod h1:oRPUA7fHC/ul86n+d3SdUD54cEuHIuCLiFJCua5a5/E=
+github.com/netresearch/go-cron v0.15.0 h1:pu+dhMZjBao9m5IpYe0o+zcNFlP94Z7TDHrORQk+/t0=
+github.com/netresearch/go-cron v0.15.0/go.mod h1:79iktHfV90py3jcaFUtWcGSKbZXRev+WwoLMyV5eMvo=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/nyaruka/phonenumbers v1.2.2 h1:OwVjf7Y4uHoK9VJUrA8ebR0ha2yc6sEYbfrwkq0asCY=

--- a/usecases/config/parser/validation.go
+++ b/usecases/config/parser/validation.go
@@ -62,9 +62,7 @@ func ValidateDurationGreaterThanEqual0(val time.Duration) error {
 
 func ValidateGocronSchedule(val string) error {
 	if val != "" {
-		if _, err := cron.FullParser().Parse(val); err != nil {
-			return err
-		}
+		return cron.ValidateSpecWith(val, cron.FullParser())
 	}
 	return nil
 }

--- a/usecases/cron/gocron.go
+++ b/usecases/cron/gocron.go
@@ -122,26 +122,20 @@ func (c *cronsObjectsTTL) Init(cr *gocron.Cron, clusterService *cluster.Service,
 	errors.GoWrapper(func() {
 		jobName := "trigger_objects_ttl_deletion"
 		jobLogger := c.logger.WithField("job", jobName)
-		var jobCtx context.Context
-		var cancel context.CancelFunc = func() {} // noop
-		wgRunning := new(sync.WaitGroup)
+		job := c.createJob(jobLogger, c.gocronLogger, clusterService, coordinator)
 
 		for {
 			select {
 			case schedule := <-c.scheduleCh:
-				cancel()
-				if cr.RemoveByName(jobName) {
-					jobLogger.Info("cron job removed")
-				}
-
 				if schedule == "" {
+					if cr.RemoveByName(jobName) {
+						jobLogger.Info("cron job removed")
+					}
 					jobLogger.Info("cron job skipped, no schedule")
 					continue
 				}
 
-				// ensure removed job is no longer running before adding one with new schedule
-				wgRunning.Wait()
-				// ensure context still valid after waiting
+				// Skip rescheduling if shutdown was requested.
 				select {
 				case <-c.serverShutdownCtx.Done():
 					jobLogger.Debug("server shutdown context cancelled")
@@ -149,21 +143,19 @@ func (c *cronsObjectsTTL) Init(cr *gocron.Cron, clusterService *cluster.Service,
 				default:
 				}
 
-				jobCtx, cancel = context.WithCancel(c.serverShutdownCtx)
-				job := c.createJob(jobCtx, jobLogger, c.gocronLogger, clusterService, coordinator, wgRunning)
-
-				entryId, err := cr.AddJob(schedule, job, gocron.WithName(jobName))
+				// Drain the running invocation, then atomically replace the
+				// entry, leaving no window where the old schedule can fire again.
+				entryId, err := cr.DrainAndUpsertJob(schedule, job, gocron.WithName(jobName))
 				if err != nil {
-					jobLogger.WithError(err).Error("cron job not added")
+					jobLogger.WithError(err).Error("cron job upsert failed")
 					continue
 				}
 				jobLogger.WithFields(logrus.Fields{
 					"entry_id": entryId,
 					"schedule": schedule,
-				}).Info("cron job added")
+				}).Info("cron job upserted")
 
 			case <-c.serverShutdownCtx.Done():
-				cancel()
 				jobLogger.Debug("server shutdown context cancelled")
 				return
 			}
@@ -173,15 +165,14 @@ func (c *cronsObjectsTTL) Init(cr *gocron.Cron, clusterService *cluster.Service,
 	return nil
 }
 
-func (c *cronsObjectsTTL) createJob(ctx context.Context, jobLogger logrus.FieldLogger, gocronLogger gocron.Logger,
-	clusterService *cluster.Service, coordinator *objectttl.Coordinator, wgRunning *sync.WaitGroup,
+func (c *cronsObjectsTTL) createJob(jobLogger logrus.FieldLogger, gocronLogger gocron.Logger,
+	clusterService *cluster.Service, coordinator *objectttl.Coordinator,
 ) gocron.Job {
+	// FuncJobWithContext receives a per-entry context, canceled when the entry
+	// is replaced or the scheduler stops, so a long-running deletion can abort.
 	return gocron.NewChain(
 		gocron.SkipIfStillRunning(gocronLogger),
-	).Then(gocron.FuncJob(func() {
-		wgRunning.Add(1)
-		defer wgRunning.Done()
-
+	).Then(gocron.FuncJobWithContext(func(ctx context.Context) {
 		if !clusterService.IsLeader() {
 			jobLogger.Debug("not a ttl scheduler - skipping")
 			return


### PR DESCRIPTION
Upgrade `netresearch/go-cron` to [v0.15.0](https://github.com/netresearch/go-cron/releases/tag/v0.15.0) and replace the manual TTL reschedule plumbing — `context.WithCancel` + `sync.WaitGroup` + `RemoveByName`/`AddJob` — with a single `DrainAndUpsertJob` call.

`DrainAndUpsertJob` pauses the entry, drains the running invocation, atomically swaps schedule+job, then restores the prior paused state — a windowless reschedule, so no tick can fire the old schedule between the drain and the swap. The job uses `FuncJobWithContext`, whose per-entry context is canceled on replacement and on shutdown. Schedule validation switches to `ValidateSpecWith`.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.