### PR TITLE
hfresh: reduce disk writes with analyze

### DIFF
--- a/adapters/repos/db/vector/hfresh/posting_map.go
+++ b/adapters/repos/db/vector/hfresh/posting_map.go
@@ -151,7 +151,23 @@ func (v *PostingMap) SetVectorIDs(ctx context.Context, postingID uint64, posting
 
 	count := pm.Count()
 
-	v.data.Store(postingID, &PostingMetadata{PackedPostingMetadata: pm})
+	// update the in-memory cache, if the posting metadata already exists,
+	// update it in-place to avoid unnecessary allocations
+	v.data.Compute(postingID, func(oldValue *PostingMetadata, loaded bool) (newValue *PostingMetadata, op xsync.ComputeOp) {
+		if !loaded {
+			return &PostingMetadata{PackedPostingMetadata: pm}, xsync.UpdateOp
+		}
+
+		oldValue.Lock()
+		if !bytes.Equal(oldValue.PackedPostingMetadata, pm) {
+			oldValue.PackedPostingMetadata = pm
+		}
+		oldValue.Unlock()
+
+		// we modified the internal pointer of the existing value, so we don't need to update the map
+		return oldValue, xsync.CancelOp
+	})
+
 	v.metrics.ObservePostingSize(float64(count))
 
 	return nil


### PR DESCRIPTION
### What's being changed:

This modifies the analyze logic to skip a disk write if the current disk value is the same as the one computed in-memory.
This should reduce pressure on the LSM store and on the cache.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
