### PR TITLE
fix: remove os.Chdir as it applies to all threads

### DIFF
--- a/adapters/repos/db/shard_compressed_vectors_migrator.go
+++ b/adapters/repos/db/shard_compressed_vectors_migrator.go
@@ -286,9 +286,8 @@ func (m compressedVectorsMigrator) isVectorsCompressedFolderSymlink(lsmDir strin
 }
 
 func (m compressedVectorsMigrator) createVectorsCompressedFolderSymlink(lsmDir, targetVectorBucket string) error {
-	sourcePath := filepath.Join(lsmDir, targetVectorBucket)
 	linkPath := filepath.Join(lsmDir, helpers.VectorsCompressedBucketLSM)
-	if err := os.Symlink(sourcePath, linkPath); err != nil {
+	if err := os.Symlink(targetVectorBucket, linkPath); err != nil {
 		return fmt.Errorf("failed to create a symlink: %w", err)
 	}
 	return nil


### PR DESCRIPTION
### What's being changed:

-  os.Chdir was changing global working dir and breaking shard creation operations

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
