### PR TITLE
[shard-raft] Introduce waiting for leader index before obj PUT and PATCH to ensure no dirty reads caused by EC

### DIFF
--- a/adapters/repos/db/crud.go
+++ b/adapters/repos/db/crud.go
@@ -32,6 +32,17 @@ import (
 	"github.com/weaviate/weaviate/usecases/objects"
 )
 
+// EnsureReplicaCaughtUp waits for the local RAFT replica to catch up to the
+// leader's applied index for the shard that owns the given object. This is
+// called before local reads in update/merge paths to avoid stale reads.
+func (db *DB) EnsureReplicaCaughtUp(ctx context.Context, class string, id strfmt.UUID, tenant string) error {
+	idx := db.GetIndex(schema.ClassName(class))
+	if idx == nil {
+		return nil
+	}
+	return idx.ensureReplicaCaughtUp(ctx, id, tenant)
+}
+
 func (db *DB) PutObject(ctx context.Context, obj *models.Object,
 	vector []float32, vectors map[string][]float32, multivectors map[string][][]float32,
 	repl *additional.ReplicationProperties,

--- a/cluster/shard/fsm_test.go
+++ b/cluster/shard/fsm_test.go
@@ -1,0 +1,104 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package shard
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitForIndex_FastPath(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	fsm := NewFSM("TestClass", "shard0", "node1", logger)
+
+	// Simulate that index 5 was already applied.
+	fsm.lastAppliedIndex.Store(5)
+
+	ctx := context.Background()
+	err := fsm.WaitForIndex(ctx, 3)
+	require.NoError(t, err)
+
+	err = fsm.WaitForIndex(ctx, 5)
+	require.NoError(t, err)
+}
+
+func TestWaitForIndex_WaitsForApply(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	fsm := NewFSM("TestClass", "shard0", "node1", logger)
+	fsm.lastAppliedIndex.Store(0)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- fsm.WaitForIndex(context.Background(), 3)
+	}()
+
+	// Give the goroutine time to enter Wait().
+	time.Sleep(10 * time.Millisecond)
+
+	// Simulate applying entries 1, 2, 3.
+	for i := uint64(1); i <= 3; i++ {
+		fsm.lastAppliedIndex.Store(i)
+		fsm.indexCond.Broadcast()
+	}
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForIndex did not return in time")
+	}
+
+	assert.GreaterOrEqual(t, fsm.lastAppliedIndex.Load(), uint64(3))
+}
+
+func TestWaitForIndex_ContextCancelled(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	fsm := NewFSM("TestClass", "shard0", "node1", logger)
+	fsm.lastAppliedIndex.Store(0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() {
+		done <- fsm.WaitForIndex(ctx, 100)
+	}()
+
+	// Give the goroutine time to enter Wait().
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(5 * time.Second):
+		t.Fatal("WaitForIndex did not return after context cancellation")
+	}
+}
+
+func TestWaitForIndex_Timeout(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	fsm := NewFSM("TestClass", "shard0", "node1", logger)
+	fsm.lastAppliedIndex.Store(0)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := fsm.WaitForIndex(ctx, 100)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+}

--- a/cluster/shard/proto/messages.pb.go
+++ b/cluster/shard/proto/messages.pb.go
@@ -1103,6 +1103,105 @@ func (*ReleaseTransferSnapshotResponse) Descriptor() ([]byte, []int) {
 	return file_messages_proto_rawDescGZIP(), []int{16}
 }
 
+// GetLastAppliedIndexRequest asks a node for its last applied RAFT log index
+// for a specific shard.
+type GetLastAppliedIndexRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Class         string                 `protobuf:"bytes,1,opt,name=class,proto3" json:"class,omitempty"`
+	Shard         string                 `protobuf:"bytes,2,opt,name=shard,proto3" json:"shard,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *GetLastAppliedIndexRequest) Reset() {
+	*x = GetLastAppliedIndexRequest{}
+	mi := &file_messages_proto_msgTypes[17]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetLastAppliedIndexRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetLastAppliedIndexRequest) ProtoMessage() {}
+
+func (x *GetLastAppliedIndexRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_messages_proto_msgTypes[17]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetLastAppliedIndexRequest.ProtoReflect.Descriptor instead.
+func (*GetLastAppliedIndexRequest) Descriptor() ([]byte, []int) {
+	return file_messages_proto_rawDescGZIP(), []int{17}
+}
+
+func (x *GetLastAppliedIndexRequest) GetClass() string {
+	if x != nil {
+		return x.Class
+	}
+	return ""
+}
+
+func (x *GetLastAppliedIndexRequest) GetShard() string {
+	if x != nil {
+		return x.Shard
+	}
+	return ""
+}
+
+// GetLastAppliedIndexResponse returns the node's last applied RAFT log index.
+type GetLastAppliedIndexResponse struct {
+	state            protoimpl.MessageState `protogen:"open.v1"`
+	LastAppliedIndex uint64                 `protobuf:"varint,1,opt,name=last_applied_index,json=lastAppliedIndex,proto3" json:"last_applied_index,omitempty"`
+	unknownFields    protoimpl.UnknownFields
+	sizeCache        protoimpl.SizeCache
+}
+
+func (x *GetLastAppliedIndexResponse) Reset() {
+	*x = GetLastAppliedIndexResponse{}
+	mi := &file_messages_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *GetLastAppliedIndexResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*GetLastAppliedIndexResponse) ProtoMessage() {}
+
+func (x *GetLastAppliedIndexResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_messages_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use GetLastAppliedIndexResponse.ProtoReflect.Descriptor instead.
+func (*GetLastAppliedIndexResponse) Descriptor() ([]byte, []int) {
+	return file_messages_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *GetLastAppliedIndexResponse) GetLastAppliedIndex() uint64 {
+	if x != nil {
+		return x.LastAppliedIndex
+	}
+	return 0
+}
+
 var File_messages_proto protoreflect.FileDescriptor
 
 const file_messages_proto_rawDesc = "" +
@@ -1187,12 +1286,18 @@ const file_messages_proto_rawDesc = "" +
 	"\x1eReleaseTransferSnapshotRequest\x12\x1f\n" +
 	"\vsnapshot_id\x18\x01 \x01(\tR\n" +
 	"snapshotId\"!\n" +
-	"\x1fReleaseTransferSnapshotResponse2\xfe\x03\n" +
+	"\x1fReleaseTransferSnapshotResponse\"H\n" +
+	"\x1aGetLastAppliedIndexRequest\x12\x14\n" +
+	"\x05class\x18\x01 \x01(\tR\x05class\x12\x14\n" +
+	"\x05shard\x18\x02 \x01(\tR\x05shard\"K\n" +
+	"\x1bGetLastAppliedIndexResponse\x12,\n" +
+	"\x12last_applied_index\x18\x01 \x01(\x04R\x10lastAppliedIndex2\x81\x05\n" +
 	"\x17ShardReplicationService\x12V\n" +
 	"\x05Apply\x12$.weaviate.internal.data.ApplyRequest\x1a%.weaviate.internal.data.ApplyResponse\"\x00\x12\x89\x01\n" +
 	"\x16CreateTransferSnapshot\x125.weaviate.internal.data.CreateTransferSnapshotRequest\x1a6.weaviate.internal.data.CreateTransferSnapshotResponse\"\x00\x12p\n" +
 	"\x0fGetSnapshotFile\x12..weaviate.internal.data.GetSnapshotFileRequest\x1a).weaviate.internal.data.SnapshotFileChunk\"\x000\x01\x12\x8c\x01\n" +
-	"\x17ReleaseTransferSnapshot\x126.weaviate.internal.data.ReleaseTransferSnapshotRequest\x1a7.weaviate.internal.data.ReleaseTransferSnapshotResponse\"\x00B\xd6\x01\n" +
+	"\x17ReleaseTransferSnapshot\x126.weaviate.internal.data.ReleaseTransferSnapshotRequest\x1a7.weaviate.internal.data.ReleaseTransferSnapshotResponse\"\x00\x12\x80\x01\n" +
+	"\x13GetLastAppliedIndex\x122.weaviate.internal.data.GetLastAppliedIndexRequest\x1a3.weaviate.internal.data.GetLastAppliedIndexResponse\"\x00B\xd6\x01\n" +
 	"\x1acom.weaviate.internal.dataB\rMessagesProtoP\x01Z/github.com/weaviate/weaviate/cluster/data/proto\xa2\x02\x03WID\xaa\x02\x16Weaviate.Internal.Data\xca\x02\x16Weaviate\\Internal\\Data\xe2\x02\"Weaviate\\Internal\\Data\\GPBMetadata\xea\x02\x18Weaviate::Internal::Datab\x06proto3"
 
 var (
@@ -1208,7 +1313,7 @@ func file_messages_proto_rawDescGZIP() []byte {
 }
 
 var file_messages_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_messages_proto_msgTypes = make([]protoimpl.MessageInfo, 17)
+var file_messages_proto_msgTypes = make([]protoimpl.MessageInfo, 19)
 var file_messages_proto_goTypes = []any{
 	(ApplyRequest_Type)(0),                  // 0: weaviate.internal.data.ApplyRequest.Type
 	(*ApplyRequest)(nil),                    // 1: weaviate.internal.data.ApplyRequest
@@ -1228,6 +1333,8 @@ var file_messages_proto_goTypes = []any{
 	(*SnapshotFileChunk)(nil),               // 15: weaviate.internal.data.SnapshotFileChunk
 	(*ReleaseTransferSnapshotRequest)(nil),  // 16: weaviate.internal.data.ReleaseTransferSnapshotRequest
 	(*ReleaseTransferSnapshotResponse)(nil), // 17: weaviate.internal.data.ReleaseTransferSnapshotResponse
+	(*GetLastAppliedIndexRequest)(nil),      // 18: weaviate.internal.data.GetLastAppliedIndexRequest
+	(*GetLastAppliedIndexResponse)(nil),     // 19: weaviate.internal.data.GetLastAppliedIndexResponse
 }
 var file_messages_proto_depIdxs = []int32{
 	0,  // 0: weaviate.internal.data.ApplyRequest.type:type_name -> weaviate.internal.data.ApplyRequest.Type
@@ -1236,12 +1343,14 @@ var file_messages_proto_depIdxs = []int32{
 	11, // 3: weaviate.internal.data.ShardReplicationService.CreateTransferSnapshot:input_type -> weaviate.internal.data.CreateTransferSnapshotRequest
 	14, // 4: weaviate.internal.data.ShardReplicationService.GetSnapshotFile:input_type -> weaviate.internal.data.GetSnapshotFileRequest
 	16, // 5: weaviate.internal.data.ShardReplicationService.ReleaseTransferSnapshot:input_type -> weaviate.internal.data.ReleaseTransferSnapshotRequest
-	2,  // 6: weaviate.internal.data.ShardReplicationService.Apply:output_type -> weaviate.internal.data.ApplyResponse
-	13, // 7: weaviate.internal.data.ShardReplicationService.CreateTransferSnapshot:output_type -> weaviate.internal.data.CreateTransferSnapshotResponse
-	15, // 8: weaviate.internal.data.ShardReplicationService.GetSnapshotFile:output_type -> weaviate.internal.data.SnapshotFileChunk
-	17, // 9: weaviate.internal.data.ShardReplicationService.ReleaseTransferSnapshot:output_type -> weaviate.internal.data.ReleaseTransferSnapshotResponse
-	6,  // [6:10] is the sub-list for method output_type
-	2,  // [2:6] is the sub-list for method input_type
+	18, // 6: weaviate.internal.data.ShardReplicationService.GetLastAppliedIndex:input_type -> weaviate.internal.data.GetLastAppliedIndexRequest
+	2,  // 7: weaviate.internal.data.ShardReplicationService.Apply:output_type -> weaviate.internal.data.ApplyResponse
+	13, // 8: weaviate.internal.data.ShardReplicationService.CreateTransferSnapshot:output_type -> weaviate.internal.data.CreateTransferSnapshotResponse
+	15, // 9: weaviate.internal.data.ShardReplicationService.GetSnapshotFile:output_type -> weaviate.internal.data.SnapshotFileChunk
+	17, // 10: weaviate.internal.data.ShardReplicationService.ReleaseTransferSnapshot:output_type -> weaviate.internal.data.ReleaseTransferSnapshotResponse
+	19, // 11: weaviate.internal.data.ShardReplicationService.GetLastAppliedIndex:output_type -> weaviate.internal.data.GetLastAppliedIndexResponse
+	7,  // [7:12] is the sub-list for method output_type
+	2,  // [2:7] is the sub-list for method input_type
 	2,  // [2:2] is the sub-list for extension type_name
 	2,  // [2:2] is the sub-list for extension extendee
 	0,  // [0:2] is the sub-list for field type_name
@@ -1259,7 +1368,7 @@ func file_messages_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_messages_proto_rawDesc), len(file_messages_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   17,
+			NumMessages:   19,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/cluster/shard/proto/messages.proto
+++ b/cluster/shard/proto/messages.proto
@@ -70,6 +70,11 @@ service ShardReplicationService {
   rpc CreateTransferSnapshot(CreateTransferSnapshotRequest) returns (CreateTransferSnapshotResponse) {}
   rpc GetSnapshotFile(GetSnapshotFileRequest) returns (stream SnapshotFileChunk) {}
   rpc ReleaseTransferSnapshot(ReleaseTransferSnapshotRequest) returns (ReleaseTransferSnapshotResponse) {}
+
+  // GetLastAppliedIndex returns the leader's last applied RAFT log index.
+  // Used by followers to determine how far they need to catch up before
+  // performing a local read.
+  rpc GetLastAppliedIndex(GetLastAppliedIndexRequest) returns (GetLastAppliedIndexResponse) {}
 }
 
 // PutObjectRequest is sent from a follower to the leader to apply a PutObject operation.
@@ -175,4 +180,16 @@ message ReleaseTransferSnapshotRequest {
 
 // ReleaseTransferSnapshotResponse is empty — success is indicated by a nil error.
 message ReleaseTransferSnapshotResponse {
+}
+
+// GetLastAppliedIndexRequest asks a node for its last applied RAFT log index
+// for a specific shard.
+message GetLastAppliedIndexRequest {
+  string class = 1;
+  string shard = 2;
+}
+
+// GetLastAppliedIndexResponse returns the node's last applied RAFT log index.
+message GetLastAppliedIndexResponse {
+  uint64 last_applied_index = 1;
 }

--- a/cluster/shard/server.go
+++ b/cluster/shard/server.go
@@ -191,6 +191,18 @@ func (s *Server) ReleaseTransferSnapshot(ctx context.Context, req *shardproto.Re
 	return &shardproto.ReleaseTransferSnapshotResponse{}, nil
 }
 
+// GetLastAppliedIndex returns the last applied RAFT log index for a shard.
+// Used by followers to determine how far they need to catch up before a local read.
+func (s *Server) GetLastAppliedIndex(ctx context.Context, req *shardproto.GetLastAppliedIndexRequest) (*shardproto.GetLastAppliedIndexResponse, error) {
+	store := s.registry.GetStore(req.Class, req.Shard)
+	if store == nil {
+		return nil, status.Errorf(codes.NotFound, "store not found for %s/%s", req.Class, req.Shard)
+	}
+	return &shardproto.GetLastAppliedIndexResponse{
+		LastAppliedIndex: store.LastAppliedIndex(),
+	}, nil
+}
+
 // toRPCError returns a gRPC error with the right error code based on the error.
 func toRPCError(err error) error {
 	if err == nil {

--- a/cluster/shard/state_transfer_test.go
+++ b/cluster/shard/state_transfer_test.go
@@ -490,6 +490,10 @@ func (f *fakeReplicationClient) ReleaseTransferSnapshot(ctx context.Context, in 
 	return f.releaseResp, f.releaseErr
 }
 
+func (f *fakeReplicationClient) GetLastAppliedIndex(ctx context.Context, in *shardproto.GetLastAppliedIndexRequest, opts ...grpc.CallOption) (*shardproto.GetLastAppliedIndexResponse, error) {
+	return &shardproto.GetLastAppliedIndexResponse{}, nil
+}
+
 // fakeSnapshotFileStream implements grpc.ServerStreamingClient[SnapshotFileChunk].
 type fakeSnapshotFileStream struct {
 	grpc.ClientStream

--- a/cluster/shard/store.go
+++ b/cluster/shard/store.go
@@ -460,6 +460,13 @@ func (s *Store) LastAppliedIndex() uint64 {
 	return s.fsm.LastAppliedIndex()
 }
 
+// WaitForAppliedIndex blocks until the local FSM has applied at least
+// targetIndex, or the context is cancelled. Used by followers to ensure
+// their local state has caught up before performing a local read.
+func (s *Store) WaitForAppliedIndex(ctx context.Context, targetIndex uint64) error {
+	return s.fsm.WaitForIndex(ctx, targetIndex)
+}
+
 type Response struct {
 	Error   error
 	Version uint64

--- a/plans/analysis.md
+++ b/plans/analysis.md
@@ -1,0 +1,413 @@
+# Deep Analysis: UpdateObject vs MergeObject - Object Fetch Dependencies
+
+## EXECUTIVE SUMMARY
+
+Both UpdateObject and MergeObject fetch the existing object from the local shard BEFORE the write. This fetch is used for:
+1. **Validation** (tenant mismatch check, cross-reference validation)
+2. **Vectorization comparison** (reVectorize check - compares old vs new properties)
+3. **Metadata preservation** (creation time for updates, default vector preservation for merges)
+4. **Dirty-read detection** (for deleted objects during replication)
+
+The vectorization step is the primary bottleneck and legitimate reason for the fetch, but only for **comparison purposes** - not because new vectors cannot be generated without the old object.
+
+---
+
+## UpdateObject Flow (update.go, lines 63-130)
+
+### Pre-Write Operations That Depend on Existing Object:
+
+```
+Line 75:  obj, err := m.getObjectFromRepo(ctx, className, id, additional.Properties{}, repl, updates.Tenant)
+          ↓ Fetches full object from vectorRepo
+
+Line 98:  prevObj := obj.Object()
+          ↓ Extracts object
+
+Line 99:  m.validateObjectAndNormalizeNames(ctx, repl, updates, prevObj, fetchedClasses)
+          ├─ Uses prevObj ONLY for tenant mismatch check (properties_validation.go:50-51)
+          └─ Uses prevObj in cRef validation to validate reference existence (but does NOT examine prevObj content)
+
+Line 108: updates.CreationTimeUnix = obj.Created
+          └─ MUST preserve original creation time
+
+Line 111: m.modulesProvider.UpdateVector(ctx, updates, class, m.findObject, m.logger)
+          └─ **CRITICAL**: Uses m.findObject callback which calls vectorRepo.Object() internally
+             when reVectorize check is needed (details below)
+
+Line 124: m.vectorRepo.PutObject(...)
+          └─ Writes through RAFT
+```
+
+### Detailed Analysis of UpdateVector Flow:
+
+**vectorizer.go, vectorizeOne() (lines 341-356):**
+- Calls `shouldVectorize()` to determine if re-vectorization is needed
+- If yes: calls `vectorize()` which calls the actual vectorizer module
+- If no: skips vectorization (uses existing vectors)
+
+**vectorizer.go, vectorize() (lines 358-441):**
+- Calls `reVectorize()` (compare.go:27-55) with the **provided object**
+- `reVectorize()` is a COMPARISON function, not a generation function
+
+**compare.go, reVectorize() (lines 27-55):**
+```go
+func reVectorize(ctx context.Context,
+    cfg moduletools.ClassConfig,
+    mod modulecapabilities.Vectorizer[[]float32],
+    object *models.Object,  // <-- THE PROVIDED UPDATED OBJECT
+    class *models.Class,
+    sourceProperties []string,
+    targetVector string,
+    findObjectFn modulecapabilities.FindObjectFn,  // <-- CB to fetch old object IF needed
+    reVectorizeDisabled bool,
+) (bool, models.AdditionalProperties, []float32, error) {
+    if reVectorizeDisabled {
+        return true, nil, nil, nil
+    }
+
+    // Call reVectorizeEmbeddings which MAY call findObjectFn
+    shouldReVectorize, oldObject := reVectorizeEmbeddings(ctx, cfg, mod, object, class, sourceProperties, findObjectFn)
+    
+    if shouldReVectorize {  // <-- If re-vectorization needed, return true
+        return shouldReVectorize, nil, nil, nil
+    }
+
+    // If NOT re-vectorizing, return OLD object's vectors
+    if targetVector == "" {
+        return false, oldObject.AdditionalProperties, oldObject.Vector, nil
+    } else {
+        return false, oldObject.AdditionalProperties, vector, nil
+    }
+}
+```
+
+**compare.go, reVectorizeEmbeddings() (lines 109-237):**
+```go
+func reVectorizeEmbeddings[T dto.Embedding](ctx context.Context,
+    cfg moduletools.ClassConfig,
+    mod modulecapabilities.Vectorizer[T],
+    object *models.Object,  // <-- PROVIDED UPDATED OBJECT
+    class *models.Class,
+    sourceProperties []string,
+    findObjectFn modulecapabilities.FindObjectFn,
+) (bool, *search.Result) {
+    // ... determine which properties are vectorizable ...
+    
+    // Line 178-182: If no properties to compare, fetch old object
+    if len(propsToCompare) == 0 {
+        oldObject, err := findObjectFn(ctx, class.Class, object.ID, nil, additional.Properties{}, object.Tenant)
+        if err != nil || oldObject == nil {
+            return true, nil  // Force re-vectorization
+        }
+        return false, oldObject  // Return old vectors (no properties changed)
+    }
+    
+    // Line 189: Fetch OLD object with ONLY the vectorizable properties
+    oldObject, err := findObjectFn(ctx, class.Class, object.ID, returnProps, additional.Properties{}, object.Tenant)
+    if err != nil || oldObject == nil {
+        return true, nil  // Force re-vectorization
+    }
+    
+    // Line 193-235: COMPARE old vs new property values
+    oldProps := oldObject.Schema.(map[string]interface{})
+    newProps := object.Properties.(map[string]interface{})
+    for _, propStruct := range propsToCompare {
+        valNew, isPresentNew := newProps[propStruct.Name]
+        valOld, isPresentOld := oldProps[propStruct.Name]
+        
+        // Property presence changed?
+        if isPresentNew != isPresentOld {
+            return true, nil  // Force re-vectorization
+        }
+        
+        // Property value changed?
+        if valOld != valNew {
+            return true, nil  // Force re-vectorization
+        }
+    }
+    
+    return false, oldObject  // No vectorizable properties changed
+}
+```
+
+**KEY INSIGHT**: The `findObjectFn` is called CONDITIONALLY within `reVectorizeEmbeddings()` ONLY IF:
+1. There are vectorizable properties in the schema, AND
+2. The system needs to compare old vs new property values
+
+The comparison is done to optimize: "Do the vectorizable properties actually change?"
+
+---
+
+## MergeObject Flow (merge.go, lines 45-127)
+
+### Pre-Write Operations That Depend on Existing Object:
+
+```
+Line 79:  obj, err := m.vectorRepo.Object(ctx, cls, id, nil, additional.Properties{}, repl, updates.Tenant)
+          ↓ Fetches full object
+
+Line 113: prevObj := obj.Object()
+          ↓ Extracts object
+
+Line 114: m.validateObjectAndNormalizeNames(ctx, repl, updates, prevObj, fetchedClass)
+          └─ Same as Update: tenant check + cRef validation
+
+Line 122: m.patchObject(ctx, prevObj, updates, repl, ...)
+          └─ Calls mergeObjectSchemaAndVectorize which:
+             ├─ Merges prevObj.Properties with updates.Properties (line 136-141)
+             └─ Calls UpdateVector(ctx, mergedObject, class, m.findObject, logger) (line 234)
+             └─ Like Update: vectorization with conditional old-object fetch
+             └─ Preserves previous vectors if vectorizer is "none" (lines 239-264)
+```
+
+### patchObject -> mergeObjectSchemaAndVectorize (lines 206-267):
+
+```go
+func (m *Manager) mergeObjectSchemaAndVectorize(ctx context.Context, 
+    prevPropsSch models.PropertySchema,
+    nextProps map[string]interface{}, 
+    prevVec, nextVec []float32, 
+    prevVecs models.Vectors, nextVecs models.Vectors,
+    id strfmt.UUID, 
+    class *models.Class,
+) (*models.Object, error) {
+    // ... merge properties ...
+    
+    obj := &models.Object{Class: class.Class, Properties: mergedProps, Vector: vector, Vectors: vectors, ID: id}
+    
+    // Line 234: UpdateVector with findObject callback
+    if err := m.modulesProvider.UpdateVector(ctx, obj, class, m.findObject, m.logger); err != nil {
+        return nil, err
+    }
+    
+    // Line 239-264: If vectorizer is "none", preserve old vectors
+    if obj.Vector == nil && class.Vectorizer == config.VectorizerModuleNone {
+        obj.Vector = prevVec
+    }
+    
+    for name, vectorConfig := range class.VectorConfig {
+        if _, ok := vectorConfig.Vectorizer.(map[string]interface{})[config.VectorizerModuleNone]; !ok {
+            continue  // Not "none" vectorizer, skip
+        }
+        
+        prevTargetVector, ok := prevVecs[name]
+        if !ok {
+            continue
+        }
+        
+        if _, ok := obj.Vectors[name]; !ok {
+            obj.Vectors[name] = prevTargetVector  // Preserve old vector
+        }
+    }
+    
+    return obj, nil
+}
+```
+
+**KEY INSIGHT**: MergeObject also fetches to:
+1. Merge previous properties with new properties (line 223-228)
+2. Preserve previous vectors when vectorizer is "none" (lines 239-264)
+
+The second point is interesting: if properties are updated but vectorizer is "none", the code needs to preserve the old vector. However, this logic could be deferred to the RAFT FSM if we pass both old and new vectors through the merge document.
+
+---
+
+## AddObject Flow (add.go, lines 71-127)
+
+For comparison - AddObject does NOT fetch the existing object:
+
+```
+Line 96:  m.validateObjectAndNormalizeNames(ctx, repl, object, nil, fetchedClasses)
+          └─ existing param is nil!
+
+Line 108: m.modulesProvider.UpdateVector(ctx, object, class, m.findObject, m.logger)
+          └─ Same UpdateVector call, but:
+             └─ m.findObject will be called IF reVectorizeEmbeddings needs to compare
+             └─ But this is a NEW object, so the comparison will find nothing and force re-vectorization
+             └─ Result: the vectorizer ALWAYS runs for new objects (no comparison optimization)
+```
+
+**CRITICAL**: AddObject SUCCESSFULLY generates vectors without fetching any existing object. The `findObject` callback is only used IF the vectorization system needs to compare old vs new properties - but for Add, that comparison always results in "force vectorization" because the object doesn't exist yet.
+
+---
+
+## What Actually Needs the Existing Object
+
+### For UpdateObject:
+
+1. **Creation time preservation** (line 108) - MUST have
+   - Solution: Store in metadata or pass through RAFT FSM
+
+2. **Vectorization comparison** (inside UpdateVector)
+   - Currently: Compares old vs new properties to decide if re-vectorization is needed
+   - Problem: Requires fetching old object with specific properties
+   - Solution: Could defer comparison to FSM, but requires passing old object state through RAFT
+
+3. **Validation - cRef checks** (validateObjectAndNormalizeNames)
+   - Current behavior: Validates that cross-reference targets exist
+   - Existing object param use: ONLY for tenant mismatch check (line 50 of properties_validation.go)
+   - Impact: Actually very minimal - just ensures tenant consistency
+
+### For MergeObject:
+
+1. **Property merging** (lines 223-228)
+   - MUST merge old properties with new properties
+   - Solution: Could defer to FSM if we pass old properties through
+
+2. **Vector preservation for "none" vectorizer** (lines 239-264)
+   - Preserves old vectors if vectorizer is "none"
+   - Solution: Could defer to FSM if we pass old vectors through
+
+3. **Same as Update**: Creation time (implicitly - merge doesn't set it, so old one is used)
+
+4. **Same as Update**: Vectorization comparison (for "normal" vectorizers, not "none")
+
+---
+
+## Critical Blocking Issues for Deferral to FSM
+
+### Issue 1: The findObject Callback is Nested Deep
+
+The `findObject` callback passed to `UpdateVector()` is invoked **conditionally** deep inside `reVectorizeEmbeddings()`, which:
+- Is a comparison function
+- Makes a decision based on whether old and new properties match
+- Returns a flag: `shouldReVectorize: bool`
+
+To move this to the FSM, you would need to:
+1. Pre-compute `shouldReVectorize` in the handler before RAFT
+2. Pass the flag + old object state through RAFT
+3. Reconstruct the logic in the FSM
+
+**Problem**: The handler currently makes this decision AFTER vectorization. Moving it before would require refactoring the vectorization flow.
+
+### Issue 2: AddObject Shows It's Possible, But Different
+
+AddObject shows that vectorization CAN work without fetching the existing object because:
+- For a NEW object, `findObjectFn` will error or return nil
+- This causes `reVectorizeEmbeddings()` to return `shouldReVectorize=true`
+- The vectorizer then runs unconditionally
+
+For UPDATE/MERGE, you'd want the optimization (skip vectorization if properties unchanged), which requires the comparison. But the comparison needs the old object state.
+
+### Issue 3: Multi-Vector and Named Vector Support
+
+The system supports:
+- Single vector (object.Vector)
+- Multiple named vectors (object.Vectors[name])
+- ReferenceVectorizer (needs findObjectFn for ref2Vec lookups)
+
+Each has slightly different handling in `UpdateVector()`. Moving this to FSM would require significant refactoring.
+
+---
+
+## Operations That ARE Deferrable
+
+Based on this analysis, here's what COULD theoretically be deferred:
+
+1. **Creation time preservation** (Update only)
+   - MINIMAL COST: Just a single int64 field
+   - Could be handled by: Pass `was_update: true` flag in RAFT, FSM reads old object time
+   - Or: Pass `original_creation_time` in the command
+
+2. **Property merging** (Merge only)
+   - MODERATE COST: Merge old + new properties
+   - Could be handled by: Pass old object's properties in merge document
+   - Risk: Replication consistency if old object state is stale
+
+3. **Vector preservation for "none" vectorizer** (Merge only)
+   - MINIMAL COST: Just a vector copy
+   - Could be handled by: FSM reads old vectors if vectorizer is "none"
+   - Or: Pass old vectors in merge document
+
+---
+
+## Vectorization Comparison: The Core Blocker
+
+The **biggest blocker** for deferring the fetch is the vectorization comparison:
+
+**Current approach:**
+```
+Handler:
+  fetch existing object
+  merge properties with updates
+  call UpdateVector()
+    which calls findObjectFn() (via reVectorizeEmbeddings)
+      which fetches old object AGAIN
+  vectorizer runs if properties changed
+  
+FSM:
+  writes merged object with new vectors
+```
+
+**To defer to FSM, you'd need:**
+```
+Handler:
+  (cannot fetch old object during update/merge)
+  merge properties with... what? unknown old properties
+  call UpdateVector()
+    which can't do comparison without old properties
+  vectorizer runs unconditionally
+  
+FSM:
+  gets merged object with vectors
+  writes it
+  (no comparison optimization)
+```
+
+The cost of unconditional vectorization for every update/merge is potentially significant if:
+- Vectorizer is expensive (e.g., remote API calls)
+- Most updates don't change vectorizable properties
+- The comparison optimization saves those calls
+
+---
+
+## Answer to Original Questions
+
+### Q: What fields from existing object are used downstream?
+A:
+- **Update**: `Created` timestamp (1 field)
+- **Update**: Property values (for vectorization comparison via callback)
+- **Merge**: ALL properties (for merging) + all vectors (for preservation if vectorizer="none")
+- Both: None from validation (existing param only used for tenant check)
+
+### Q: Could these be deferred to FSM?
+A:
+- **Partially yes** for metadata (creation time, vector preservation)
+- **No** for vectorization comparison optimization - would require passing old object state through RAFT
+- **No** for property merging in Merge - would require passing old properties through
+
+### Q: Is vectorization the main blocker?
+A:
+- **YES**: The optimization to skip vectorization when properties don't change requires comparing old vs new properties
+- This comparison is deeply nested in the reVectorizeEmbeddings() logic
+- Moving it would require significant refactoring of the vectorization pipeline
+
+### Q: Does AddObject vectorize without existing object?
+A:
+- **YES**: AddObject does NOT fetch existing object before vectorization
+- The `findObjectFn` callback is called but immediately returns an error (object doesn't exist)
+- This triggers unconditional vectorization (no comparison optimization)
+- This shows the pattern works but without the comparison optimization
+
+---
+
+## Architecture Impact Summary
+
+### Current State:
+- Handler fetches existing object (1 network call)
+- Passes object to vectorization layer
+- Vectorization layer may fetch object AGAIN via findObjectFn (for comparison)
+- All pre-RAFT validation and processing uses existing object
+- RAFT FSM receives: merged object + vectors (no reference to original state)
+
+### Why It's This Way:
+1. Comparison optimization requires knowing old property values
+2. Creation time must be preserved (immutable field)
+3. Property merging needs source properties
+4. Vector preservation for "none" vectorizer needs old vectors
+
+### If You Deferred Everything:
+- Pros: Handler doesn't know about storage layer
+- Cons: Lose vectorization comparison optimization (every update/merge revectorizes)
+- Cons: FSM becomes stateful (needs to know about object schema, vectorizers, etc.)
+- Cons: Complex to maintain consistency across replicas

--- a/plans/ec-plan.md
+++ b/plans/ec-plan.md
@@ -1,0 +1,191 @@
+# Plan: Wait for Leader Applied Index Before Local Reads
+
+## Context
+
+When a Create (PutObject) is immediately followed by an Update (UpdateObject/MergeObject), the update request may land on a RAFT follower that hasn't replicated the create yet. Both `UpdateObject` (update.go:75) and `MergeObject` (merge.go:79) read the object **locally** before writing through RAFT, so they fail with "not found" when the follower is behind. This causes flakiness in the "create and update object" acceptance test.
+
+**Root cause:** The usecases layer reads from local shard storage before replicating the write through RAFT, with no guarantee the local replica has caught up to the leader.
+
+**Why not refactor to defer reads into the RAFT FSM instead?**
+
+We explored whether the local read could be eliminated entirely by deferring all logic into the RAFT FSM Apply. This is not feasible for three fundamental reasons:
+
+1. **Vectorization is non-deterministic.** Vectorizer modules (text2vec-openai, etc.) make HTTP calls to external APIs. RAFT FSM Apply must be deterministic — all nodes must produce identical results from the same
+log entry. Running vectorization inside FSM would violate this guarantee.
+2. **Vectorization depends on the previous object**. The reVectorizeEmbeddings() comparison (modules/compare.go) fetches the old object to check if properties changed, avoiding expensive re-vectorization when
+unnecessary. This optimization requires the previous object state before the RAFT write.
+3. **Property merging for MergeObject is tightly coupled to vectorization**. The usecases layer merges prev+new properties, vectorizes the merged result, then only includes changed vectors in the MergeDocument sent
+through RAFT. Moving this into FSM would either lose the optimization or require passing the entire previous object through the RAFT log.
+
+The same pattern applies to reference operations (DeleteReference, UpdateReference) which are read-modify-write at the property level. A broader refactor would require architectural changes at both usecases and
+shard layers — not justified for this fix.
+
+**Solution:** Before performing a local read in UpdateObject/MergeObject, query the RAFT leader for its current applied index, then wait until the local FSM catches up to that index before reading.
+
+---
+
+## Implementation Steps
+
+### Step 1: Add channel-based index notification to FSM
+**File:** `cluster/shard/fsm.go`
+
+- Add `indexMu sync.Mutex` and `indexCond *sync.Cond` fields to `FSM` struct
+- Initialize `indexCond = sync.NewCond(&f.indexMu)` in `NewFSM()`
+- In `Apply()`, after `f.lastAppliedIndex.Store(l.Index)`, call `f.indexCond.Broadcast()`
+- Add `WaitForIndex(ctx context.Context, targetIndex uint64) error`:
+  - Fast path: if `lastAppliedIndex >= targetIndex`, return nil
+  - Spawn a context-cancellation goroutine that calls `Broadcast()` on ctx.Done
+  - Lock indexMu, loop `Wait()` until `lastAppliedIndex >= targetIndex` or ctx cancelled
+  - Clean up the waker goroutine on success via a `stopWaker` channel
+
+### Step 2: Expose WaitForAppliedIndex on Store
+**File:** `cluster/shard/store.go`
+
+- Add `WaitForAppliedIndex(ctx context.Context, targetIndex uint64) error`
+- Delegates to `s.fsm.WaitForIndex(ctx, targetIndex)`
+
+### Step 3: Add GetLastAppliedIndex gRPC RPC
+**File:** `cluster/shard/proto/messages.proto`
+
+Add to `ShardReplicationService`:
+```protobuf
+rpc GetLastAppliedIndex(GetLastAppliedIndexRequest) returns (GetLastAppliedIndexResponse) {}
+```
+
+Add messages:
+```protobuf
+message GetLastAppliedIndexRequest {
+  string class = 1;
+  string shard = 2;
+}
+
+message GetLastAppliedIndexResponse {
+  uint64 last_applied_index = 1;
+}
+```
+
+Then regenerate proto code: `cd cluster/shard/proto && PATH=$PATH:~/go/bin buf generate`
+
+### Step 4: Implement GetLastAppliedIndex in gRPC Server
+**File:** `cluster/shard/server.go`
+
+```go
+func (s *Server) GetLastAppliedIndex(ctx context.Context, req *shardproto.GetLastAppliedIndexRequest) (*shardproto.GetLastAppliedIndexResponse, error) {
+    store := s.registry.GetStore(req.Class, req.Shard)
+    if store == nil {
+        return nil, status.Errorf(codes.NotFound, "store not found for %s/%s", req.Class, req.Shard)
+    }
+    return &shardproto.GetLastAppliedIndexResponse{
+        LastAppliedIndex: store.LastAppliedIndex(),
+    }, nil
+}
+```
+
+### Step 5: Add WaitForShardReady on Registry
+**File:** `cluster/shard/registry.go`
+
+Add method to `Registry`:
+```go
+func (reg *Registry) WaitForShardReady(ctx context.Context, className, shardName string) error
+```
+
+Flow:
+1. `GetStore(className, shardName)` → if nil, return nil
+2. If `store.IsLeader()`, return nil (leader is always caught up)
+3. `store.LeaderID()` → if empty, return nil (no leader yet)
+4. `reg.RpcClientMaker(ctx, leaderID)` → create gRPC client to leader
+5. `client.GetLastAppliedIndex(ctx, &req{Class, Shard})` → get leader's applied index
+6. `store.WaitForAppliedIndex(ctx, resp.LastAppliedIndex)` → wait locally
+
+### Step 6: Add EnsureReplicaCaughtUp to DB/Index layer
+**File:** `adapters/repos/db/index.go`
+
+Add to Index:
+```go
+func (i *Index) ensureReplicaCaughtUp(ctx context.Context, id strfmt.UUID, tenant string) error {
+    if i.Config.ShardRegistry == nil {
+        return nil  // RAFT not enabled
+    }
+    shardName, err := i.shardResolver.ResolveShardByObjectID(ctx, id, tenant)
+    if err != nil {
+        return nil  // let the actual read handle shard resolution errors
+    }
+    return i.Config.ShardRegistry.WaitForShardReady(ctx, i.Config.ClassName.String(), shardName)
+}
+```
+
+**File:** `adapters/repos/db/crud.go`
+
+Add to DB:
+```go
+func (db *DB) EnsureReplicaCaughtUp(ctx context.Context, class string, id strfmt.UUID, tenant string) error {
+    idx := db.GetIndex(schema.ClassName(class))
+    if idx == nil {
+        return nil
+    }
+    return idx.ensureReplicaCaughtUp(ctx, id, tenant)
+}
+```
+
+### Step 7: Add EnsureReplicaCaughtUp to VectorRepo interface
+**File:** `usecases/objects/manager.go`
+
+Add to `VectorRepo` interface:
+```go
+EnsureReplicaCaughtUp(ctx context.Context, class string, id strfmt.UUID, tenant string) error
+```
+
+### Step 8: Call EnsureReplicaCaughtUp in UpdateObject and MergeObject
+
+**File:** `usecases/objects/update.go` (line ~75, before `getObjectFromRepo`)
+```go
+if err := m.vectorRepo.EnsureReplicaCaughtUp(ctx, className, id, updates.Tenant); err != nil {
+    return nil, fmt.Errorf("ensure replica caught up: %w", err)
+}
+```
+
+**File:** `usecases/objects/merge.go` (line ~78, replacing the TODO comment before `m.vectorRepo.Object`)
+```go
+if err := m.vectorRepo.EnsureReplicaCaughtUp(ctx, cls, id, updates.Tenant); err != nil {
+    return &Error{"ensure replica caught up", StatusInternalServerError, err}
+}
+```
+
+### Step 9: Update test mocks/fakes
+Add no-op `EnsureReplicaCaughtUp` to any mocks/fakes implementing VectorRepo (grep for existing fakes).
+
+### Step 10: Add unit tests
+
+**File:** `cluster/shard/fsm_test.go` — Test WaitForIndex:
+- Test fast path (already caught up)
+- Test wait path (apply arrives after wait starts)
+- Test context cancellation
+
+**File:** `cluster/shard/store_test.go` — Test WaitForAppliedIndex end-to-end
+
+---
+
+## Files Modified (summary)
+
+| File | Change |
+|------|--------|
+| `cluster/shard/fsm.go` | Add sync.Cond, WaitForIndex() |
+| `cluster/shard/store.go` | Add WaitForAppliedIndex() |
+| `cluster/shard/proto/messages.proto` | Add GetLastAppliedIndex RPC + messages |
+| `cluster/shard/proto/` (generated) | Regenerate proto code |
+| `cluster/shard/server.go` | Implement GetLastAppliedIndex |
+| `cluster/shard/registry.go` | Add WaitForShardReady() |
+| `adapters/repos/db/index.go` | Add ensureReplicaCaughtUp() |
+| `adapters/repos/db/crud.go` | Add EnsureReplicaCaughtUp() |
+| `usecases/objects/manager.go` | Add to VectorRepo interface |
+| `usecases/objects/update.go` | Call EnsureReplicaCaughtUp before read |
+| `usecases/objects/merge.go` | Call EnsureReplicaCaughtUp before read (replace TODO) |
+| Various test fakes | Add no-op EnsureReplicaCaughtUp |
+
+---
+
+## Verification
+
+1. **Unit tests:** `go test ./cluster/shard/... -run TestWaitForIndex`
+2. **Acceptance test:** `go test -v -count=1 -tags integrationTest ./test/acceptance/replication/shard/ -run Test_RaftShardReplication/create_and_update_object`
+3. Run the full shard RAFT test suite to ensure no regressions

--- a/test/acceptance/replication/shard/raft_test.go
+++ b/test/acceptance/replication/shard/raft_test.go
@@ -12,7 +12,6 @@
 package shard
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -20,7 +19,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
@@ -31,19 +29,21 @@ const (
 )
 
 func Test_RaftShardReplication(t *testing.T) {
-	ctx := context.Background()
+	// ctx := context.Background()
 
-	compose, err := docker.New().
-		WithWeaviateCluster(3).
-		Start(ctx)
-	require.NoError(t, err)
-	defer func() {
-		require.NoError(t, compose.Terminate(ctx))
-	}()
+	// compose, err := docker.New().
+	// 	WithWeaviateCluster(3).
+	// 	Start(ctx)
+	// require.NoError(t, err)
+	// defer func() {
+	// 	require.NoError(t, compose.Terminate(ctx))
+	// }()
 
-	// Point client at node-0
-	helper.SetupClient(compose.GetWeaviate().URI())
-	hosts := []string{compose.GetWeaviate().URI(), compose.GetWeaviate().URI(), compose.GetWeaviate().URI()}
+	// // Point client at node-0
+	// helper.SetupClient(compose.GetWeaviate().URI())
+	// hosts := []string{compose.GetWeaviate().URI(), compose.GetWeaviate().URI(), compose.GetWeaviate().URI()}
+	helper.SetupClient("localhost:8080")
+	hosts := []string{"localhost:8080", "localhost:8081", "localhost:8082"}
 
 	cls := articles.ParagraphsClass()
 	cls.ReplicationConfig = &models.ReplicationConfig{
@@ -54,7 +54,7 @@ func Test_RaftShardReplication(t *testing.T) {
 	helper.DeleteClass(t, cls.Class)
 	helper.CreateClass(t, cls)
 
-	t.Run("add object", func(t *testing.T) {
+	t.Run("create object", func(t *testing.T) {
 		helper.CreateObject(t, articles.NewParagraph().WithContents("RAFT").WithID(UUID1).Object())
 		// Verify the object eventually exists on all nodes
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -220,6 +220,10 @@ type fakeVectorRepo struct {
 	CapturedSchemaVersion uint64
 }
 
+func (f *fakeVectorRepo) EnsureReplicaCaughtUp(ctx context.Context, class string, id strfmt.UUID, tenant string) error {
+	return nil
+}
+
 func (f *fakeVectorRepo) Exists(ctx context.Context, class string, id strfmt.UUID, repl *additional.ReplicationProperties, tenant string) (bool, error) {
 	args := f.Called(class, id)
 	return args.Bool(0), args.Error(1)

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -121,6 +121,9 @@ type timeSource interface {
 }
 
 type VectorRepo interface {
+	// EnsureReplicaCaughtUp waits for the local RAFT replica to catch up to
+	// the leader before a local read. No-op when RAFT replication is disabled.
+	EnsureReplicaCaughtUp(ctx context.Context, class string, id strfmt.UUID, tenant string) error
 	PutObject(ctx context.Context, concept *models.Object, vector []float32,
 		vectors map[string][]float32, multiVectors map[string][][]float32,
 		repl *additional.ReplicationProperties, schemaVersion uint64) error

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -75,7 +75,10 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 		return &Error{err.Error(), StatusInternalServerError, err}
 	}
 
-	// TODO: wait for leader here when raft-based object replication is enabled in case of races between adding and updating an object
+	if err := m.vectorRepo.EnsureReplicaCaughtUp(ctx, cls, id, updates.Tenant); err != nil {
+		return &Error{"ensure replica caught up", StatusInternalServerError, err}
+	}
+
 	obj, err := m.vectorRepo.Object(ctx, cls, id, nil, additional.Properties{}, repl, updates.Tenant)
 	if err != nil {
 		switch {

--- a/usecases/objects/references_add.go
+++ b/usecases/objects/references_add.go
@@ -47,6 +47,10 @@ func (m *Manager) AddObjectReference(ctx context.Context, principal *models.Prin
 		return &Error{err.Error(), StatusForbidden, err}
 	}
 
+	if err := m.vectorRepo.EnsureReplicaCaughtUp(ctx, input.Class, input.ID, tenant); err != nil {
+		return &Error{"ensure replica caught up", StatusInternalServerError, err}
+	}
+
 	deprecatedEndpoint := input.Class == ""
 	if deprecatedEndpoint { // for backward compatibility only
 		if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Collections()...); err != nil {

--- a/usecases/objects/references_delete.go
+++ b/usecases/objects/references_delete.go
@@ -58,6 +58,10 @@ func (m *Manager) DeleteObjectReference(ctx context.Context, principal *models.P
 		return &Error{err.Error(), StatusForbidden, err}
 	}
 
+	if err := m.vectorRepo.EnsureReplicaCaughtUp(ctx, input.Class, input.ID, tenant); err != nil {
+		return &Error{"ensure replica caught up", StatusInternalServerError, err}
+	}
+
 	deprecatedEndpoint := input.Class == ""
 	// we need to know which collection an object belongs to, so for the deprecated case we first need to fetch the
 	// object from any collection, to then know its collection to check for the correct permissions after wards

--- a/usecases/objects/references_update.go
+++ b/usecases/objects/references_update.go
@@ -63,6 +63,10 @@ func (m *Manager) UpdateObjectReferences(ctx context.Context, principal *models.
 		}
 	}
 
+	if err := m.vectorRepo.EnsureReplicaCaughtUp(ctx, input.Class, input.ID, tenant); err != nil {
+		return &Error{"ensure replica caught up", StatusInternalServerError, err}
+	}
+
 	res, err := m.getObjectFromRepo(ctx, input.Class, input.ID, additional.Properties{}, nil, tenant)
 	if err != nil {
 		errnf := ErrNotFound{}

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -72,6 +72,10 @@ func (m *Manager) updateObjectToConnectorAndSchema(ctx context.Context,
 		return nil, NewErrInvalidUserInput("invalid update: field 'id' is immutable")
 	}
 
+	if err := m.vectorRepo.EnsureReplicaCaughtUp(ctx, className, id, updates.Tenant); err != nil {
+		return nil, fmt.Errorf("ensure replica caught up: %w", err)
+	}
+
 	obj, err := m.getObjectFromRepo(ctx, className, id, additional.Properties{}, repl, updates.Tenant)
 	if err != nil {
 		return nil, err

--- a/usecases/objects/vector.go
+++ b/usecases/objects/vector.go
@@ -26,6 +26,10 @@ func (m *Manager) updateRefVector(ctx context.Context, principal *models.Princip
 	className string, id strfmt.UUID, tenant string, class *models.Class, schemaVersion uint64,
 ) error {
 	if m.modulesProvider.UsingRef2Vec(className) {
+		if err := m.vectorRepo.EnsureReplicaCaughtUp(ctx, className, id, tenant); err != nil {
+			return fmt.Errorf("ensure replica caught up: %w", err)
+		}
+
 		parent, err := m.vectorRepo.Object(ctx, className, id,
 			search.SelectProperties{}, additional.Properties{}, nil, tenant)
 		if err != nil {


### PR DESCRIPTION


### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
