### PR TITLE
fix: add 2-minute timeout to vector dimension metrics observation

### DIFF
--- a/adapters/repos/db/lsmkv/strategies_map_sorted_merger.go
+++ b/adapters/repos/db/lsmkv/strategies_map_sorted_merger.go
@@ -35,7 +35,7 @@ func (s *sortedMapMerger) do(ctx context.Context, segments [][]MapPair) ([]MapPa
 
 	i := 0
 	for {
-		if i%100 == 0 && ctx.Err() != nil {
+		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}
 

--- a/adapters/repos/db/shard_usage/usage.go
+++ b/adapters/repos/db/shard_usage/usage.go
@@ -295,6 +295,9 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 			k, v = c.Seek(ctx, []byte(targetVector))
 		}
 		for ; k != nil; k, v = c.Next(ctx) {
+			if ctx.Err() != nil {
+				break
+			}
 			// for named vectors we have to additionally check if the key is prefixed with the vector name
 			if len(k) != expectedKeyLen || !strings.HasPrefix(string(k), targetVector) {
 				break
@@ -317,6 +320,9 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 			k, v = c.Seek([]byte(targetVector))
 		}
 		for ; k != nil; k, v = c.Next() {
+			if ctx.Err() != nil {
+				break
+			}
 			// for named vectors we have to additionally check if the key is prefixed with the vector name
 			if len(k) != expectedKeyLen || !strings.HasPrefix(string(k), targetVector) {
 				break
@@ -328,6 +334,10 @@ func CalculateTargetVectorDimensionsFromBucket(ctx context.Context, b *lsmkv.Buc
 				dimensionality.Count = v.GetCardinality()
 			}
 		}
+	}
+
+	if err := ctx.Err(); err != nil {
+		return dimensionality, err
 	}
 
 	return dimensionality, nil


### PR DESCRIPTION
## Summary

- Add a 2-minute timeout context to `publishVectorMetrics` to prevent dimension tracking from blocking segment compaction indefinitely
- Propagate context cancellation through `CursorMap.seekAll`/`firstAll`/`serveCurrentStateAndAdvance` so individual cursor calls are interruptible
- Check context every iteration in `sortedMapMerger.do()` instead of every 100th (cheap atomic read)
- Replace panic on merger error with graceful nil return in `serveCurrentStateAndAdvance`
- Add context checks in `CalculateTargetVectorDimensionsFromBucket` cursor loops as safety net
- Reset ticker after timeout to ensure full interval before retrying

## Context

With 1000s of LSM segments, `publishVectorMetrics` cursor operations become extremely slow because `seekAll`/`firstAll` call into every segment and the sorted map merger iterates millions of times. The merger's context check (`i%100 == 0 && ctx.Err() != nil`) was ineffective because the context had no timeout. Meanwhile, slow cursors hold segment refs via `getConsistentViewOfSegments()`, preventing compaction's `waitForReferenceCountToReachZero()` from completing — a catch-22 where segment count grows indefinitely.

## Test plan

- [x] `go test ./adapters/repos/db/... -run Dimension -count=1`
- [x] `go test ./adapters/repos/db/shard_usage/... -count=1`
- [x] `go test ./adapters/repos/db/lsmkv/... -run Cursor -count=1`
- [x] `go test ./adapters/repos/db/lsmkv/... -run Merger -count=1`
- [x] New unit tests: `TestPublishVectorMetrics_ExpiredContext`, `TestPublishVectorMetrics_Success`

🤖 Generated with [Claude Code](https://claude.com/claude-code)