### PR TITLE
Backup: Return error to coordinator

### DIFF
--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -181,12 +181,12 @@ type uploader struct {
 	backupID       string
 	zipConfig
 	setStatus func(st backup.Status)
-	setErr    func(st backup.Status, err string)
+	setErr    func(st backup.Status, err error)
 	log       logrus.FieldLogger
 }
 
 func newUploader(cfg config.Backup, sourcer Sourcer, rbacSourcer fsm.Snapshotter, dynUserSourcer fsm.Snapshotter, backend nodeStore,
-	backupID string, setstatus func(st backup.Status), seterr func(st backup.Status, err string), l logrus.FieldLogger,
+	backupID string, setstatus func(st backup.Status), seterr func(st backup.Status, err error), l logrus.FieldLogger,
 ) *uploader {
 	return &uploader{
 		cfg:            cfg,
@@ -238,12 +238,12 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 
 		// Handle error cases
 		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-			u.setErr(backup.Cancelled, err.Error())
+			u.setErr(backup.Cancelled, err)
 			desc.Status = string(backup.Cancelled)
 		} else {
 			// For non-cancellation errors, set status to Failed with the error message.
 			// This ensures the error is available via OnStatus even before lastOp.reset().
-			u.setErr(backup.Failed, err.Error())
+			u.setErr(backup.Failed, err)
 			desc.Status = string(backup.Failed)
 		}
 

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -237,7 +237,7 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 		desc.Error = err.Error()
 
 		// Handle error cases
-		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		if errors.Is(err, context.Canceled) {
 			u.setErr(backup.Cancelled, err)
 			desc.Status = string(backup.Cancelled)
 		} else {

--- a/usecases/backup/backend.go
+++ b/usecases/backup/backend.go
@@ -181,21 +181,27 @@ type uploader struct {
 	backupID       string
 	zipConfig
 	setStatus func(st backup.Status)
+	setErr    func(st backup.Status, err string)
 	log       logrus.FieldLogger
 }
 
 func newUploader(cfg config.Backup, sourcer Sourcer, rbacSourcer fsm.Snapshotter, dynUserSourcer fsm.Snapshotter, backend nodeStore,
-	backupID string, setstatus func(st backup.Status), l logrus.FieldLogger,
+	backupID string, setstatus func(st backup.Status), seterr func(st backup.Status, err string), l logrus.FieldLogger,
 ) *uploader {
 	return &uploader{
-		cfg, sourcer, rbacSourcer, dynUserSourcer, backend,
-		backupID,
-		newZipConfig(Compression{
+		cfg:            cfg,
+		sourcer:        sourcer,
+		rbacSourcer:    rbacSourcer,
+		dynUserSourcer: dynUserSourcer,
+		backend:        backend,
+		backupID:       backupID,
+		zipConfig: newZipConfig(Compression{
 			Level:         GzipDefaultCompression,
 			CPUPercentage: DefaultCPUPercentage,
 		}),
-		setstatus,
-		l,
+		setStatus: setstatus,
+		setErr:    seterr,
+		log:       l,
 	}
 }
 
@@ -232,8 +238,13 @@ func (u *uploader) all(ctx context.Context, classes []string, desc *backup.Backu
 
 		// Handle error cases
 		if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-			u.setStatus(backup.Cancelled)
+			u.setErr(backup.Cancelled, err.Error())
 			desc.Status = string(backup.Cancelled)
+		} else {
+			// For non-cancellation errors, set status to Failed with the error message.
+			// This ensures the error is available via OnStatus even before lastOp.reset().
+			u.setErr(backup.Failed, err.Error())
+			desc.Status = string(backup.Failed)
 		}
 
 		u.log.Info("start uploading metadata for cancelled or failed backup")

--- a/usecases/backup/handler.go
+++ b/usecases/backup/handler.go
@@ -240,9 +240,12 @@ func (m *Handler) OnStatus(ctx context.Context, req *StatusRequest) *StatusRespo
 	case OpCreate:
 		st, err := m.backupper.OnStatus(ctx, req)
 		ret.Status = st.Status
-		// mm
 		if err != nil {
-			ret.Status = backup.Failed
+			// Preserve the status if it's already a terminal status (Cancelled/Failed),
+			// otherwise set to Failed
+			if st.Status != backup.Cancelled && st.Status != backup.Failed {
+				ret.Status = backup.Failed
+			}
 			ret.Err = err.Error()
 		}
 	case OpRestore:

--- a/usecases/backup/shard.go
+++ b/usecases/backup/shard.go
@@ -86,10 +86,12 @@ func (s *backupStat) set(st backup.Status) {
 // setErr sets both the status and error message atomically.
 // This is used when a backup fails to ensure the error is captured
 // before lastOp.reset() is called.
-func (s *backupStat) setErr(st backup.Status, err string) {
+func (s *backupStat) setErr(st backup.Status, err error) {
 	s.Lock()
 	s.reqState.Status = st
-	s.reqState.Err = err
+	if err != nil {
+		s.reqState.Err = err.Error()
+	}
 	s.Unlock()
 }
 

--- a/usecases/backup/shard.go
+++ b/usecases/backup/shard.go
@@ -32,6 +32,7 @@ type reqState struct {
 	Starttime      time.Time
 	ID             string
 	Status         backup.Status
+	Err            string
 	Path           string
 	OverrideBucket string
 	OverridePath   string
@@ -70,6 +71,7 @@ func (s *backupStat) reset() {
 	s.reqState.ID = ""
 	s.reqState.Path = ""
 	s.reqState.Status = ""
+	s.reqState.Err = ""
 	s.reqState.OverrideBucket = ""
 	s.reqState.OverridePath = ""
 	s.Unlock()
@@ -78,6 +80,16 @@ func (s *backupStat) reset() {
 func (s *backupStat) set(st backup.Status) {
 	s.Lock()
 	s.reqState.Status = st
+	s.Unlock()
+}
+
+// setErr sets both the status and error message atomically.
+// This is used when a backup fails to ensure the error is captured
+// before lastOp.reset() is called.
+func (s *backupStat) setErr(st backup.Status, err string) {
+	s.Lock()
+	s.reqState.Status = st
+	s.reqState.Err = err
 	s.Unlock()
 }
 


### PR DESCRIPTION
### What's being changed:

When a backup fails, OnStatus returns from the in-memory lastOp state while the backup is still "active" (before lastOp.reset() is called in backupper.backup's defer). Previously, lastOp only tracked status, not errors, and non-cancellation failures never updated the status from Transferring to Failed.

The fix adds an Err field to lastOp and calls setErr(Failed, errMsg) immediately when the failure occurs, so the coordinator gets the correct status and error.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
