### PR TITLE
Retry GCS transport errors for backups

### DIFF
--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -76,6 +76,10 @@ func newClient(ctx context.Context, config *clientConfig, dataPath string) (*gcs
 	}),
 		storage.WithPolicy(storage.RetryAlways),
 		storage.WithErrorFunc(func(err error) bool {
+			if err == nil {
+				return false
+			}
+
 			if storage.ShouldRetry(err) {
 				return true
 			}


### PR DESCRIPTION
### What's being changed:

Retry network errors in GCP module to fix 

```
failed to write chunk to backend: write: find bucket: find bucket: Get "XXXX": http2: client connection lost
```

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
