### PR TITLE
fix: delete property index in empty collection

### DIFF
--- a/adapters/repos/db/shard_init_properties.go
+++ b/adapters/repos/db/shard_init_properties.go
@@ -135,14 +135,14 @@ func (s *Shard) removeBucket(ctx context.Context, bucketName string) error {
 	// Remove the bucket's directory from disk
 	// If this fails after successful shutdown, we're in an inconsistent state:
 	// the bucket is removed from the store but its data remains on disk
-	if err := s.removeBucketDir(bucketName); err != nil {
+	if err := s.removeBucketDir(s.pathLSM(), bucketName); err != nil {
 		return fmt.Errorf("bucket %s shut down successfully but directory removal failed: %w", bucketName, err)
 	}
 	return nil
 }
 
-func (s *Shard) removeBucketDir(bucketName string) error {
-	bucketDir := filepath.Join(s.pathLSM(), bucketName)
+func (s *Shard) removeBucketDir(pathLSM, bucketName string) error {
+	bucketDir := filepath.Join(pathLSM, bucketName)
 	if _, err := os.Stat(bucketDir); !os.IsNotExist(err) {
 		if err := os.RemoveAll(bucketDir); err != nil {
 			return fmt.Errorf("failed to remove data for %s bucket: "+

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -438,19 +438,19 @@ func (l *LazyLoadShard) updateUnloadedPropertyBuckets(ctx context.Context,
 ) {
 	eg.Go(func() error {
 		if !inverted.HasFilterableIndex(prop) {
-			err := l.shard.removeBucketDir(helpers.BucketFromPropNameLSM(prop.Name))
+			err := l.shard.removeBucketDir(l.pathLSM(), helpers.BucketFromPropNameLSM(prop.Name))
 			if err != nil {
 				return fmt.Errorf("cannot remove unloaded filterable index for %s property: %w", prop.Name, err)
 			}
 		}
 		if !inverted.HasSearchableIndex(prop) {
-			err := l.shard.removeBucketDir(helpers.BucketSearchableFromPropNameLSM(prop.Name))
+			err := l.shard.removeBucketDir(l.pathLSM(), helpers.BucketSearchableFromPropNameLSM(prop.Name))
 			if err != nil {
 				return fmt.Errorf("cannot remove unloaded searchable index for %s property: %w", prop.Name, err)
 			}
 		}
 		if !inverted.HasRangeableIndex(prop) {
-			err := l.shard.removeBucketDir(helpers.BucketRangeableFromPropNameLSM(prop.Name))
+			err := l.shard.removeBucketDir(l.pathLSM(), helpers.BucketRangeableFromPropNameLSM(prop.Name))
 			if err != nil {
 				return fmt.Errorf("cannot remove unloaded rangeable index for %s property: %w", prop.Name, err)
 			}

--- a/test/acceptance/properties/delete_property_index_empty_test.go
+++ b/test/acceptance/properties/delete_property_index_empty_test.go
@@ -1,0 +1,126 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package properties
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	clschema "github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func testDeletePropertyIndexEmpty() func(t *testing.T) {
+	return func(t *testing.T) {
+		bookClass := "BookEmpty"
+		title := "title"
+		size := "size"
+
+		ptrBool := func(in bool) *bool {
+			return &in
+		}
+
+		deleteIndex := func(t *testing.T, propertyName, indexName string) {
+			updateParams := clschema.NewSchemaObjectsPropertiesDeleteParams().
+				WithClassName(bookClass).WithPropertyName(propertyName).WithIndexName(indexName)
+			updateOk, err := helper.Client(t).Schema.SchemaObjectsPropertiesDelete(updateParams, nil)
+			helper.AssertRequestOk(t, updateOk, err, nil)
+			require.Equal(t, 200, updateOk.Code())
+		}
+
+		getProperty := func(t *testing.T, propertyName string) *models.Property {
+			cls := helper.GetClass(t, bookClass)
+			for _, prop := range cls.Properties {
+				if prop.Name == propertyName {
+					return prop
+				}
+			}
+			t.Fatalf("property %s not found", propertyName)
+			return nil
+		}
+
+		// cleanup before and after
+		deleteClassParams := clschema.NewSchemaObjectsDeleteParams().WithClassName(bookClass)
+		deleteClassResp, err := helper.Client(t).Schema.SchemaObjectsDelete(deleteClassParams, nil)
+		helper.AssertRequestOk(t, deleteClassResp, err, nil)
+		t.Cleanup(func() {
+			deleteClassParams := clschema.NewSchemaObjectsDeleteParams().WithClassName(bookClass)
+			helper.Client(t).Schema.SchemaObjectsDelete(deleteClassParams, nil)
+		})
+
+		book := &models.Class{
+			Class: bookClass,
+			Properties: []*models.Property{
+				{
+					Name:            title,
+					DataType:        []string{schema.DataTypeText.String()},
+					IndexFilterable: ptrBool(true),
+					IndexSearchable: ptrBool(true),
+				},
+				{
+					Name:              size,
+					DataType:          []string{schema.DataTypeNumber.String()},
+					IndexFilterable:   ptrBool(true),
+					IndexRangeFilters: ptrBool(true),
+				},
+			},
+		}
+		params := clschema.NewSchemaObjectsCreateParams().WithObjectClass(book)
+		resp, err := helper.Client(t).Schema.SchemaObjectsCreate(params, nil)
+		helper.AssertRequestOk(t, resp, err, nil)
+
+		t.Run("verify initial schema", func(t *testing.T) {
+			titleProp := getProperty(t, title)
+			assert.True(t, *titleProp.IndexFilterable)
+			assert.True(t, *titleProp.IndexSearchable)
+
+			sizeProp := getProperty(t, size)
+			assert.True(t, *sizeProp.IndexFilterable)
+			assert.True(t, *sizeProp.IndexRangeFilters)
+		})
+
+		t.Run("delete title filterable index", func(t *testing.T) {
+			deleteIndex(t, title, "filterable")
+
+			titleProp := getProperty(t, title)
+			assert.False(t, *titleProp.IndexFilterable)
+			assert.True(t, *titleProp.IndexSearchable)
+		})
+
+		t.Run("delete title searchable index", func(t *testing.T) {
+			deleteIndex(t, title, "searchable")
+
+			titleProp := getProperty(t, title)
+			assert.False(t, *titleProp.IndexFilterable)
+			assert.False(t, *titleProp.IndexSearchable)
+		})
+
+		t.Run("delete size filterable index", func(t *testing.T) {
+			deleteIndex(t, size, "filterable")
+
+			sizeProp := getProperty(t, size)
+			assert.False(t, *sizeProp.IndexFilterable)
+			assert.True(t, *sizeProp.IndexRangeFilters)
+		})
+
+		t.Run("delete size rangeFilters index", func(t *testing.T) {
+			deleteIndex(t, size, "rangeFilters")
+
+			sizeProp := getProperty(t, size)
+			assert.False(t, *sizeProp.IndexFilterable)
+			assert.False(t, *sizeProp.IndexRangeFilters)
+		})
+	}
+}

--- a/test/acceptance/properties/properties_test.go
+++ b/test/acceptance/properties/properties_test.go
@@ -39,6 +39,7 @@ func TestProperties_SingleNode(t *testing.T) {
 		defer helper.ResetClient()
 	}
 
+	t.Run("delete property's index empty collection", testDeletePropertyIndexEmpty())
 	t.Run("delete property's index multi-tenant", testDeletePropertyIndexMultiTenant(compose))
 	t.Run("delete property's index", testDeletePropertyIndex(compose))
 }
@@ -57,6 +58,7 @@ func TestProperties_Cluster(t *testing.T) {
 	helper.SetupClient(compose.GetWeaviate().URI())
 	defer helper.ResetClient()
 
+	t.Run("delete property's index empty collection", testDeletePropertyIndexEmpty())
 	t.Run("delete property's index multi-tenant", testDeletePropertyIndexMultiTenant(nil))
 	t.Run("delete property's index", testDeletePropertyIndex(nil))
 }


### PR DESCRIPTION
### What's being changed:

This PR fixes `alter schema - drop property` feature with lazy loaded shards.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
