### PR TITLE
fix(tx): possible panic in txManager

### DIFF
--- a/usecases/cluster/transactions_write.go
+++ b/usecases/cluster/transactions_write.go
@@ -362,7 +362,7 @@ func (c *TxManager) beginTransaction(ctx context.Context, trType TransactionType
 		"ownership": "coordinator",
 	}).Inc()
 
-	c.resetTxExpiry(ttl, c.currentTransaction.ID)
+	c.resetTxExpiry(ttl, tx.ID)
 
 	if err := c.remote.BroadcastTransaction(ctx, tx); err != nil {
 		// we could not open the transaction on every node, therefore we need to
@@ -405,7 +405,7 @@ func (c *TxManager) beginTransaction(ctx context.Context, trType TransactionType
 	c.Lock()
 	defer c.Unlock()
 	c.slowLog.Update("begin_tx_completed")
-	return c.currentTransaction, nil
+	return tx, nil
 }
 
 func (c *TxManager) CommitWriteTransaction(ctx context.Context,


### PR DESCRIPTION
### What's being changed:
sometime we get panic like the following and this because the goroutine can fire and call `c.clearTransaction()` before that final `c.Lock()`, this changes makes sure even if this happens won't panic and still keep returning the tx ID

```go
--- FAIL: TestTryingToCommitTransactionPastTTL (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xf5b978]

goroutine 214 [running]:
testing.tRunner.func1.2({0x10cc8c0, 0x18f7310})
	/opt/hostedtoolcache/go/1.24.13/x64/src/testing/testing.go:1734 +0x3eb
testing.tRunner.func1()
	/opt/hostedtoolcache/go/1.24.13/x64/src/testing/testing.go:1737 +0x696
panic({0x10cc8c0?, 0x18f7310?})
	/opt/hostedtoolcache/go/1.24.13/x64/src/runtime/panic.go:792 +0x132
github.com/weaviate/weaviate/usecases/cluster.TestTryingToCommitTransactionPastTTL(0xc0001a4540)
	/home/runner/work/weaviate/weaviate/usecases/cluster/transactions_test.go:89 +0x198
testing.tRunner(0xc0001a4540, 0x12133b0)
	/opt/hostedtoolcache/go/1.24.13/x64/src/testing/testing.go:1792 +0x226
created by testing.(*T).Run in goroutine 1
	/opt/hostedtoolcache/go/1.24.13/x64/src/testing/testing.go:1851 +0x8f3
```
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
