### PR TITLE
fix(cluster): preserve config-file BasicAuth credentials when env vars are absent

### DIFF
--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -691,6 +691,16 @@ func (f *WeaviateConfig) LoadConfig(flags *swag.CommandLineOptionsGroup, logger 
 	// Load config from flags
 	f.fromFlags(flags.Options.(*Flags))
 
+	_, usernameEnvSet := os.LookupEnv("CLUSTER_BASIC_AUTH_USERNAME")
+	_, passwordEnvSet := os.LookupEnv("CLUSTER_BASIC_AUTH_PASSWORD")
+	if f.Config.Cluster.AuthConfig.BasicAuth.Enabled() && !usernameEnvSet && !passwordEnvSet {
+		logger.WithField("action", "config_load").
+			Warn("inter-node cluster auth credentials sourced from config file because " +
+				"CLUSTER_BASIC_AUTH_USERNAME and CLUSTER_BASIC_AUTH_PASSWORD env vars are not set; " +
+				"if peer nodes loaded credentials from env vars at their startup, auth will be " +
+				"inconsistent and inter-node calls will return 401 — migrate to env vars to avoid this")
+	}
+
 	return f.Config.Validate()
 }
 


### PR DESCRIPTION
### What's being changed:

When one node in a cluster restarts and `CLUSTER_BASIC_AUTH_USERNAME` /`CLUSTER_BASIC_AUTH_PASSWORD` are not set as env vars, `FromEnv()` was silently overwriting any credentials loaded from `conf.yaml` with empty strings, disabling inter-node auth on the restarted node. 
  
 Peers still had auth enabled from their own startup, causing `401s` on all inter-node calls until the entire cluster was restarted.

Fix: use `os.LookupEnv()` to only override YAML-loaded credentials when the env vars are explicitly present in the environment.

Note: this was reported on rolling one node in a cluster in some cases due to conflict in config the restarted node gets `401s`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
