### PR TITLE
hfresh: fix ContainsDoc

### DIFF
--- a/adapters/repos/db/vector/hfresh/analyze.go
+++ b/adapters/repos/db/vector/hfresh/analyze.go
@@ -59,6 +59,12 @@ func (h *HFresh) doAnalyze(ctx context.Context, postingID uint64) error {
 		return errors.Wrapf(err, "failed to set vector IDs for posting %d", postingID)
 	}
 
+	// ensure the vector versions are up to date on-disk
+	err = h.VersionMap.FlushPosting(ctx, postingID, p)
+	if err != nil {
+		return errors.Wrapf(err, "failed to flush versions for posting %d", postingID)
+	}
+
 	markedAsDone = true
 	h.postingLocks.Unlock(postingID)
 	h.taskQueue.AnalyzeDone(postingID)

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -347,7 +347,7 @@ func (h *HFresh) Multivector() bool {
 }
 
 func (h *HFresh) ContainsDoc(id uint64) bool {
-	v, err := h.VersionMap.Get(context.Background(), id)
+	v, err := h.VersionMap.VectorExists(context.Background(), id)
 	if err != nil {
 		h.logger.WithField("vectorID", id).
 			Debug("vector version get failed, returning false")

--- a/adapters/repos/db/vector/hfresh/version_map.go
+++ b/adapters/repos/db/vector/hfresh/version_map.go
@@ -162,6 +162,41 @@ func (v *VersionMap) IsDeleted(ctx context.Context, vectorID uint64) (bool, erro
 	return version.Deleted(), nil
 }
 
+// FlushPosting ensures that all vectors are persisted with at least version v1.
+// This is used during analyze to ensure that all vectors have a version on-disk, even if they haven't been updated since they were added to the posting.
+// This is necessary because the in-memory version map only tracks versions for vectors
+// that have been reassigned or deleted, for performance reasons.
+func (v *VersionMap) FlushPosting(ctx context.Context, postingID uint64, p Posting) error {
+	for _, vector := range p {
+		curVer, err := v.Get(ctx, vector.ID())
+		if err != nil {
+			return errors.Wrap(err, "failed to get current version for vector during flush")
+		}
+		if curVer > v1 || curVer.Deleted() {
+			// only flush versions for vectors that are still at the initial version,
+			// the other versions are already persisted by Increment or MarkDeleted operations
+			continue
+		}
+
+		// check if the version already exists on-disk to avoid unnecessary writes
+		_, err = v.store.Get(ctx, vector.ID())
+		if err != nil && !errors.Is(err, ErrVectorNotFound) {
+			return errors.Wrap(err, "failed to get version for vector during flush")
+		}
+		if err == nil {
+			// version already exists on-disk, no need to flush
+			continue
+		}
+		// version does not exist on-disk, flush the initial version
+		err = v.store.Set(ctx, vector.ID(), v1)
+		if err != nil {
+			return errors.Wrap(err, "failed to set version for vector during flush")
+		}
+	}
+
+	return nil
+}
+
 // VersionStore is a persistent store for vector versions.
 // It stores the versions in an LSMKV bucket.
 type VersionStore struct {

--- a/adapters/repos/db/vector/hfresh/version_map.go
+++ b/adapters/repos/db/vector/hfresh/version_map.go
@@ -197,6 +197,20 @@ func (v *VersionMap) FlushPosting(ctx context.Context, postingID uint64, p Posti
 	return nil
 }
 
+// VectorExists checks if a version exists for the given vector ID.
+// It reads from the disk to ensure that we don't return false positives for vectors that are not in the cache but do exist on-disk.
+func (v *VersionMap) VectorExists(ctx context.Context, vectorID uint64) (bool, error) {
+	_, err := v.store.Get(ctx, vectorID)
+	if err != nil {
+		if errors.Is(err, ErrVectorNotFound) {
+			return false, nil
+		}
+		return false, errors.Wrap(err, "failed to check if vector exists")
+	}
+
+	return true, nil
+}
+
 // VersionStore is a persistent store for vector versions.
 // It stores the versions in an LSMKV bucket.
 type VersionStore struct {

--- a/adapters/repos/db/vector/hfresh/version_map.go
+++ b/adapters/repos/db/vector/hfresh/version_map.go
@@ -199,16 +199,16 @@ func (v *VersionMap) FlushPosting(ctx context.Context, postingID uint64, p Posti
 
 // VectorExists checks if a version exists for the given vector ID.
 // It reads from the disk to ensure that we don't return false positives for vectors that are not in the cache but do exist on-disk.
-func (v *VersionMap) VectorExists(ctx context.Context, vectorID uint64) (bool, error) {
-	_, err := v.store.Get(ctx, vectorID)
+func (v *VersionMap) VectorExists(ctx context.Context, vectorID uint64) (VectorVersion, error) {
+	ver, err := v.store.Get(ctx, vectorID)
 	if err != nil {
 		if errors.Is(err, ErrVectorNotFound) {
-			return false, nil
+			return 0, nil
 		}
-		return false, errors.Wrap(err, "failed to check if vector exists")
+		return 0, errors.Wrap(err, "failed to check if vector exists")
 	}
 
-	return true, nil
+	return ver, nil
 }
 
 // VersionStore is a persistent store for vector versions.


### PR DESCRIPTION
### What's being changed:

This PR makes the `Analyze` operation ensure all vector versions are stored in the metadata bucket.
It also fixes `ContainsDoc` by checking for the existence of the vector on disk.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
