### PR TITLE
implements telemetry usage for X-Weaviate-Client-Integration

### DIFF
--- a/adapters/handlers/grpc/server.go
+++ b/adapters/handlers/grpc/server.go
@@ -54,7 +54,7 @@ import (
 
 // CreateGRPCServer creates *grpc.Server with optional grpc.Serveroption passed.
 // clientTracker is optional; when non-nil, a gRPC interceptor is added to track client SDK usage.
-func CreateGRPCServer(state *state.State, clientTracker *telemetry.ClientTracker, options ...grpc.ServerOption) (*grpc.Server, batch.Drain) {
+func CreateGRPCServer(state *state.State, clientTracker *telemetry.ClientTracker, integrationTracker *telemetry.IntegrationTracker, options ...grpc.ServerOption) (*grpc.Server, batch.Drain) {
 	o := []grpc.ServerOption{
 		grpc.MaxRecvMsgSize(state.ServerConfig.Config.GRPC.MaxMsgSize),
 		grpc.MaxSendMsgSize(state.ServerConfig.Config.GRPC.MaxMsgSize),
@@ -102,7 +102,7 @@ func CreateGRPCServer(state *state.State, clientTracker *telemetry.ClientTracker
 	if clientTracker != nil {
 		// ClientTrackingUnaryInterceptor both tracks usage and sets "clientIdentifier" in context,
 		// so no need for a separate makeClientIdentifierInterceptor.
-		interceptors = append(interceptors, telemetry.ClientTrackingUnaryInterceptor(clientTracker))
+		interceptors = append(interceptors, telemetry.ClientTrackingUnaryInterceptor(clientTracker, integrationTracker))
 	} else {
 		interceptors = append(interceptors, makeClientIdentifierInterceptor())
 	}

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1390,7 +1390,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		grpcInstrument = monitoring.InstrumentGrpc(appState.GRPCServerMetrics)
 	}
 
-	grpcServer, batchDrain := createGrpcServer(appState, telemeter.GetClientTracker(), grpcInstrument...)
+	grpcServer, batchDrain := createGrpcServer(appState, telemeter.GetClientTracker(), telemeter.GetIntegrationTracker(), grpcInstrument...)
 
 	setupMiddlewares := makeSetupMiddlewares(appState)
 	setupGlobalMiddleware := makeSetupGlobalMiddleware(appState, api.Context(), telemeter)

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1402,6 +1402,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 					Errorf("telemetry failed to start: %s", err.Error())
 			}
 		}, appState.Logger)
+		setupTelemetryDebugHandlers(telemeter)
 	}
 	if entconfig.Enabled(os.Getenv("ENABLE_CLEANUP_UNFINISHED_BACKUPS")) {
 		enterrors.GoWrapper(

--- a/adapters/handlers/rest/grpc.go
+++ b/adapters/handlers/rest/grpc.go
@@ -20,8 +20,8 @@ import (
 	"google.golang.org/grpc"
 )
 
-func createGrpcServer(state *state.State, clientTracker *telemetry.ClientTracker, options ...grpc.ServerOption) (*grpc.Server, batch.Drain) {
-	return grpcHandler.CreateGRPCServer(state, clientTracker, options...)
+func createGrpcServer(state *state.State, clientTracker *telemetry.ClientTracker, integrationTracker *telemetry.IntegrationTracker, options ...grpc.ServerOption) (*grpc.Server, batch.Drain) {
+	return grpcHandler.CreateGRPCServer(state, clientTracker, integrationTracker, options...)
 }
 
 func startGrpcServer(server *grpc.Server, state *state.State) {

--- a/adapters/handlers/rest/handlers_debug.go
+++ b/adapters/handlers/rest/handlers_debug.go
@@ -37,6 +37,7 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/telemetry"
 )
 
 func setupDebugHandlers(appState *state.State) {
@@ -1252,4 +1253,26 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	}
 	w.WriteHeader(status)
 	w.Write(jsonBytes)
+}
+
+// setupTelemetryDebugHandlers registers debug endpoints for inspecting live telemetry data.
+// It must be called after the telemeter has been created.
+func setupTelemetryDebugHandlers(telemeter *telemetry.Telemeter) {
+	http.HandleFunc("/debug/telemetry/clients", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		type clientsResponse struct {
+			ClientUsage            map[telemetry.ClientType]map[string]int64 `json:"clientUsage"`
+			ClientIntegrationUsage map[string]map[string]int64               `json:"clientIntegrationUsage"`
+		}
+
+		resp := clientsResponse{}
+		if ct := telemeter.GetClientTracker(); ct != nil {
+			resp.ClientUsage = ct.Get()
+		}
+		if it := telemeter.GetIntegrationTracker(); it != nil {
+			resp.ClientIntegrationUsage = it.Get()
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, http.StatusOK, resp)
+	}))
 }

--- a/adapters/handlers/rest/middlewares.go
+++ b/adapters/handlers/rest/middlewares.go
@@ -110,7 +110,7 @@ func makeSetupGlobalMiddleware(appState *state.State, context *middleware.Contex
 		handler = makeAddModuleHandlers(appState.Modules)(handler)
 		// Add client tracking middleware early in the chain to capture all requests
 		if telemeter != nil {
-			handler = telemetry.ClientTrackingMiddleware(telemeter.GetClientTracker())(handler)
+			handler = telemetry.ClientTrackingMiddleware(telemeter.GetClientTracker(), telemeter.GetIntegrationTracker())(handler)
 		}
 		handler = addInjectHeadersIntoContext(handler)
 		handler = makeCatchPanics(appState.Logger, newPanicsRequestsTotal(appState.Metrics, appState.Logger))(handler)

--- a/tools/telemetry-dashboard/main.go
+++ b/tools/telemetry-dashboard/main.go
@@ -765,7 +765,7 @@ func formatNumber(n int64) string {
 
 // fmtVersionCount formats a version string with its count for display, e.g. "1.0.0 (42)".
 func fmtVersionCount(version string, count int64) string {
-	return fmtVersionCount(version, count)
+	return fmt.Sprintf("%s (%d)", version, count)
 }
 
 func joinStrings(strs []string, sep string) string {

--- a/tools/telemetry-dashboard/main.go
+++ b/tools/telemetry-dashboard/main.go
@@ -608,7 +608,7 @@ func renderPayloadsHTML(payloads []*TelemetryPayload) string {
 			for clientType, versions := range p.ClientUsage {
 				versionItems := make([]string, 0)
 				for version, count := range versions {
-					versionItems = append(versionItems, fmt.Sprintf("%s (%d)", version, count))
+					versionItems = append(versionItems, fmtVersionCount(version, count))
 				}
 				html += fmt.Sprintf(`<span class="client-item"><strong>%s:</strong> %s</span>`, clientType, joinStrings(versionItems, ", "))
 			}
@@ -619,7 +619,7 @@ func renderPayloadsHTML(payloads []*TelemetryPayload) string {
 			for integration, versions := range p.ClientIntegrationUsage {
 				versionItems := make([]string, 0)
 				for version, count := range versions {
-					versionItems = append(versionItems, fmt.Sprintf("%s (%d)", version, count))
+					versionItems = append(versionItems, fmtVersionCount(version, count))
 				}
 				html += fmt.Sprintf(`<span class="client-item" style="background:#d1fae5;"><strong>%s:</strong> %s</span>`, integration, joinStrings(versionItems, ", "))
 			}
@@ -658,7 +658,7 @@ func renderMachinesHTML(machines map[string]*MachineStats) string {
 				versionItems := make([]string, 0)
 				for version, count := range versions {
 					totalCount += count
-					versionItems = append(versionItems, fmt.Sprintf("%s (%d)", version, count))
+					versionItems = append(versionItems, fmtVersionCount(version, count))
 				}
 				clientUsageHtml += fmt.Sprintf(`<span class="client-item"><strong>%s:</strong> %d total (%s)</span>`, clientType, totalCount, joinStrings(versionItems, ", "))
 			}
@@ -673,7 +673,7 @@ func renderMachinesHTML(machines map[string]*MachineStats) string {
 				versionItems := make([]string, 0)
 				for version, count := range versions {
 					totalCount += count
-					versionItems = append(versionItems, fmt.Sprintf("%s (%d)", version, count))
+					versionItems = append(versionItems, fmtVersionCount(version, count))
 				}
 				integrationUsageHtml += fmt.Sprintf(`<span class="client-item" style="background:#d1fae5;"><strong>%s:</strong> %d total (%s)</span>`, integration, totalCount, joinStrings(versionItems, ", "))
 			}
@@ -761,6 +761,11 @@ func formatNumber(n int64) string {
 		return fmt.Sprintf("%.1fK", float64(n)/1000)
 	}
 	return fmt.Sprintf("%d", n)
+}
+
+// fmtVersionCount formats a version string with its count for display, e.g. "1.0.0 (42)".
+func fmtVersionCount(version string, count int64) string {
+	return fmtVersionCount(version, count)
 }
 
 func joinStrings(strs []string, sep string) string {

--- a/tools/telemetry-dashboard/main.go
+++ b/tools/telemetry-dashboard/main.go
@@ -449,8 +449,11 @@ func generateDashboardHTML(payloads []*TelemetryPayload, machines map[string]*Ma
                 const clientUsage = p.clientUsage || {};
                 const clientHtml = Object.keys(clientUsage).map(function(type) {
                     const versions = clientUsage[type] || {};
+                    // The client SDK type is constrained to a fixed enum by the
+                    // server-side parser, but the version is taken verbatim
+                    // from the X-Weaviate-Client header and must be escaped.
                     const versionItems = Object.keys(versions).map(function(version) {
-                        return version + ' (' + versions[version] + ')';
+                        return escapeHtml(version) + ' (' + versions[version] + ')';
                     }).join(', ');
                     return '<span class="client-item"><strong>' + type + ':</strong> ' + versionItems + '</span>';
                 }).join('');
@@ -504,9 +507,11 @@ func generateDashboardHTML(payloads []*TelemetryPayload, machines map[string]*Ma
                 const clientHtml = Object.keys(clientUsage).map(function(type) {
                     const versions = clientUsage[type] || {};
                     var totalCount = 0;
+                    // See renderPayloads: type is enum-constrained, version is
+                    // user-controlled and must be escaped.
                     const versionDetails = Object.keys(versions).map(function(version) {
                         totalCount += versions[version];
-                        return version + ' (' + versions[version] + ')';
+                        return escapeHtml(version) + ' (' + versions[version] + ')';
                     }).join(', ');
                     return '<span class="client-item"><strong>' + type + ':</strong> ' + totalCount + ' total (' + versionDetails + ')</span>';
                 }).join('');

--- a/tools/telemetry-dashboard/main.go
+++ b/tools/telemetry-dashboard/main.go
@@ -14,7 +14,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	htmlpkg "html"
 	"io"
 	"log"
 	"net/http"
@@ -200,10 +199,11 @@ func main() {
 			return
 		}
 
-		payloads, machines := dashboard.GetData()
-		html := generateDashboardHTML(payloads, machines)
+		// The dashboard markup is static; refreshData() populates
+		// #payloads and #machines from /api/data on load and every
+		// 2 seconds thereafter.
 		w.Header().Set("Content-Type", "text/html")
-		w.Write([]byte(html))
+		w.Write([]byte(generateDashboardHTML()))
 	})
 
 	// API endpoint for JSON data (for auto-refresh)
@@ -223,7 +223,7 @@ func main() {
 	log.Fatal(http.ListenAndServe(port, nil))
 }
 
-func generateDashboardHTML(payloads []*TelemetryPayload, machines map[string]*MachineStats) string {
+func generateDashboardHTML() string {
 	return fmt.Sprintf(`<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -396,14 +396,14 @@ func generateDashboardHTML(payloads []*TelemetryPayload, machines map[string]*Ma
             <div class="card">
                 <h2>📊 Recent Payloads</h2>
                 <div class="payload-list" id="payloads">
-                    %s
+                    <div class="empty">Loading…</div>
                 </div>
             </div>
 
             <div class="card">
                 <h2>🖥️ Machines</h2>
                 <div id="machines">
-                    %s
+                    <div class="empty">Loading…</div>
                 </div>
             </div>
         </div>
@@ -593,213 +593,7 @@ func generateDashboardHTML(payloads []*TelemetryPayload, machines map[string]*Ma
         setInterval(refreshData, 2000);
     </script>
 </body>
-</html>`, port, telemetryURL, renderPayloadsHTML(payloads), renderMachinesHTML(machines))
-}
-
-func renderPayloadsHTML(payloads []*TelemetryPayload) string {
-	if len(payloads) == 0 {
-		return `<div class="empty">No telemetry data received yet</div>`
-	}
-
-	html := ""
-	for i := len(payloads) - 1; i >= 0; i-- {
-		p := payloads[i]
-		html += fmt.Sprintf(`
-			<div class="payload-item">
-				<div class="payload-header">
-					<span class="badge badge-%s">%s</span>
-					<span class="payload-time">%s</span>
-				</div>
-				<div><strong>Machine:</strong> <span class="machine-id">%s</span></div>
-				<div><strong>Version:</strong> %s</div>
-				<div><strong>OS/Arch:</strong> %s/%s</div>`,
-			toLower(p.Type), p.Type, formatRelativeTime(p.ReceivedAt),
-			p.MachineID, p.Version, p.OS, p.Arch)
-
-		if p.ObjectsCount > 0 {
-			html += fmt.Sprintf(`<div><strong>Objects:</strong> %s</div>`, formatNumber(p.ObjectsCount))
-		}
-		if p.CollectionsCount > 0 {
-			html += fmt.Sprintf(`<div><strong>Collections:</strong> %d</div>`, p.CollectionsCount)
-		}
-		if len(p.ClientUsage) > 0 {
-			html += `<div class="client-usage"><strong>Client Usage:</strong><br>`
-			for clientType, versions := range p.ClientUsage {
-				versionItems := make([]string, 0)
-				for version, count := range versions {
-					versionItems = append(versionItems, fmtVersionCount(version, count))
-				}
-				html += fmt.Sprintf(`<span class="client-item"><strong>%s:</strong> %s</span>`, clientType, joinStrings(versionItems, ", "))
-			}
-			html += `</div>`
-		}
-		if len(p.ClientIntegrationUsage) > 0 {
-			html += `<div class="client-usage"><strong>Integration Usage:</strong><br>`
-			for integration, versions := range p.ClientIntegrationUsage {
-				versionItems := make([]string, 0)
-				for version, count := range versions {
-					// Integration names and versions come from a user-controlled
-					// header, escape before concatenating into HTML.
-					versionItems = append(versionItems, fmtVersionCount(htmlpkg.EscapeString(version), count))
-				}
-				html += fmt.Sprintf(`<span class="client-item" style="background:#d1fae5;"><strong>%s:</strong> %s</span>`, htmlpkg.EscapeString(integration), joinStrings(versionItems, ", "))
-			}
-			html += `</div>`
-		}
-		if len(p.UsedModules) > 0 {
-			html += fmt.Sprintf(`<div><strong>Modules:</strong> %s</div>`, joinStrings(p.UsedModules, ", "))
-		}
-		html += `</div>`
-	}
-	return html
-}
-
-func renderMachinesHTML(machines map[string]*MachineStats) string {
-	if len(machines) == 0 {
-		return `<div class="empty">No machines registered yet</div>`
-	}
-
-	html := ""
-	for _, m := range machines {
-		modules := make([]string, 0, len(m.UsedModules))
-		for mod := range m.UsedModules {
-			modules = append(modules, mod)
-		}
-
-		payloadTypesHtml := ""
-		for ptype, count := range m.PayloadTypes {
-			payloadTypesHtml += fmt.Sprintf(`<span class="badge badge-%s">%s: %d</span> `, toLower(ptype), ptype, count)
-		}
-
-		clientUsageHtml := ""
-		if len(m.ClientUsage) > 0 {
-			clientUsageHtml = `<div class="client-usage" style="margin-top: 10px;"><strong>Total Client Usage:</strong><br>`
-			for clientType, versions := range m.ClientUsage {
-				var totalCount int64
-				versionItems := make([]string, 0)
-				for version, count := range versions {
-					totalCount += count
-					versionItems = append(versionItems, fmtVersionCount(version, count))
-				}
-				clientUsageHtml += fmt.Sprintf(`<span class="client-item"><strong>%s:</strong> %d total (%s)</span>`, clientType, totalCount, joinStrings(versionItems, ", "))
-			}
-			clientUsageHtml += `</div>`
-		}
-
-		integrationUsageHtml := ""
-		if len(m.ClientIntegrationUsage) > 0 {
-			integrationUsageHtml = `<div class="client-usage" style="margin-top: 10px;"><strong>Total Integration Usage:</strong><br>`
-			for integration, versions := range m.ClientIntegrationUsage {
-				var totalCount int64
-				versionItems := make([]string, 0)
-				for version, count := range versions {
-					totalCount += count
-					// Integration names and versions come from a user-controlled
-					// header, escape before concatenating into HTML.
-					versionItems = append(versionItems, fmtVersionCount(htmlpkg.EscapeString(version), count))
-				}
-				integrationUsageHtml += fmt.Sprintf(`<span class="client-item" style="background:#d1fae5;"><strong>%s:</strong> %d total (%s)</span>`, htmlpkg.EscapeString(integration), totalCount, joinStrings(versionItems, ", "))
-			}
-			integrationUsageHtml += `</div>`
-		}
-
-		modulesHtml := ""
-		if len(modules) > 0 {
-			modulesHtml = fmt.Sprintf(`<div style="margin-top: 10px;"><strong>Modules:</strong> %s</div>`, joinStrings(modules, ", "))
-		}
-
-		html += fmt.Sprintf(`
-			<div class="machine">
-				<div class="machine-header">
-					<div>
-						<div class="machine-id">%s</div>
-						<div style="margin-top: 5px;">%s</div>
-					</div>
-				</div>
-				<div class="stats">
-					<div class="stat-item">
-						<div class="stat-label">Version</div>
-						<div class="stat-value">%s</div>
-					</div>
-					<div class="stat-item">
-						<div class="stat-label">OS/Arch</div>
-						<div class="stat-value">%s/%s</div>
-					</div>
-					<div class="stat-item">
-						<div class="stat-label">Total Payloads</div>
-						<div class="stat-value">%d</div>
-					</div>
-					<div class="stat-item">
-						<div class="stat-label">Objects</div>
-						<div class="stat-value">%s</div>
-					</div>
-					<div class="stat-item">
-						<div class="stat-label">Collections</div>
-						<div class="stat-value">%d</div>
-					</div>
-					<div class="stat-item">
-						<div class="stat-label">Modules</div>
-						<div class="stat-value">%d</div>
-					</div>
-				</div>
-				%s
-				%s
-				%s
-				<div style="margin-top: 10px; font-size: 11px; color: #666;">
-					First seen: %s<br>
-					Last seen: %s (%s)
-				</div>
-			</div>`,
-			m.MachineID, payloadTypesHtml,
-			m.Version, m.OS, m.Arch,
-			m.TotalPayloads, formatNumber(m.TotalObjects), m.CollectionsCount, len(modules),
-			modulesHtml,
-			clientUsageHtml,
-			integrationUsageHtml,
-			formatTime(m.FirstSeen), formatTime(m.LastSeen), formatRelativeTime(m.LastSeen))
-	}
-	return html
-}
-
-func formatTime(t time.Time) string {
-	return t.Format("2006-01-02 15:04:05")
-}
-
-func formatRelativeTime(t time.Time) string {
-	diff := time.Since(t)
-	if diff < time.Minute {
-		return fmt.Sprintf("%ds ago", int(diff.Seconds()))
-	}
-	if diff < time.Hour {
-		return fmt.Sprintf("%dm ago", int(diff.Minutes()))
-	}
-	return fmt.Sprintf("%dh ago", int(diff.Hours()))
-}
-
-func formatNumber(n int64) string {
-	if n >= 1000000 {
-		return fmt.Sprintf("%.1fM", float64(n)/1000000)
-	}
-	if n >= 1000 {
-		return fmt.Sprintf("%.1fK", float64(n)/1000)
-	}
-	return fmt.Sprintf("%d", n)
-}
-
-// fmtVersionCount formats a version string with its count for display, e.g. "1.0.0 (42)".
-func fmtVersionCount(version string, count int64) string {
-	return fmt.Sprintf("%s (%d)", version, count)
-}
-
-func joinStrings(strs []string, sep string) string {
-	if len(strs) == 0 {
-		return ""
-	}
-	result := strs[0]
-	for i := 1; i < len(strs); i++ {
-		result += sep + strs[i]
-	}
-	return result
+</html>`, port, telemetryURL)
 }
 
 func toLower(s string) string {

--- a/tools/telemetry-dashboard/main.go
+++ b/tools/telemetry-dashboard/main.go
@@ -14,6 +14,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	htmlpkg "html"
 	"io"
 	"log"
 	"net/http"
@@ -411,6 +412,19 @@ func generateDashboardHTML(payloads []*TelemetryPayload, machines map[string]*Ma
     </div>
 
     <script>
+        // escapeHtml escapes user-controlled values (integration names, versions,
+        // client SDK identifiers) before they are concatenated into HTML, so a
+        // crafted telemetry payload cannot execute markup in the dashboard.
+        function escapeHtml(s) {
+            if (s === null || s === undefined) return '';
+            return String(s)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
         function formatTime(timeStr) {
             if (!timeStr) return 'N/A';
             const date = new Date(timeStr);
@@ -444,9 +458,9 @@ func generateDashboardHTML(payloads []*TelemetryPayload, machines map[string]*Ma
                 const integrationHtml = Object.keys(integrationUsage).map(function(name) {
                     const versions = integrationUsage[name] || {};
                     const versionItems = Object.keys(versions).map(function(version) {
-                        return version + ' (' + versions[version] + ')';
+                        return escapeHtml(version) + ' (' + versions[version] + ')';
                     }).join(', ');
-                    return '<span class="client-item" style="background:#d1fae5;"><strong>' + name + ':</strong> ' + versionItems + '</span>';
+                    return '<span class="client-item" style="background:#d1fae5;"><strong>' + escapeHtml(name) + ':</strong> ' + versionItems + '</span>';
                 }).join('');
                 var html = '<div class="payload-item">' +
                     '<div class="payload-header">' +
@@ -535,9 +549,9 @@ func generateDashboardHTML(payloads []*TelemetryPayload, machines map[string]*Ma
                     var totalCount = 0;
                     const versionDetails = Object.keys(versions).map(function(version) {
                         totalCount += versions[version];
-                        return version + ' (' + versions[version] + ')';
+                        return escapeHtml(version) + ' (' + versions[version] + ')';
                     }).join(', ');
-                    return '<span class="client-item" style="background:#d1fae5;"><strong>' + name + ':</strong> ' + totalCount + ' total (' + versionDetails + ')</span>';
+                    return '<span class="client-item" style="background:#d1fae5;"><strong>' + escapeHtml(name) + ':</strong> ' + totalCount + ' total (' + versionDetails + ')</span>';
                 }).join('');
                 if (modules.length > 0) {
                     html += '<div style="margin-top: 10px;"><strong>Modules:</strong> ' + modules.join(', ') + '</div>';
@@ -619,9 +633,11 @@ func renderPayloadsHTML(payloads []*TelemetryPayload) string {
 			for integration, versions := range p.ClientIntegrationUsage {
 				versionItems := make([]string, 0)
 				for version, count := range versions {
-					versionItems = append(versionItems, fmtVersionCount(version, count))
+					// Integration names and versions come from a user-controlled
+					// header, escape before concatenating into HTML.
+					versionItems = append(versionItems, fmtVersionCount(htmlpkg.EscapeString(version), count))
 				}
-				html += fmt.Sprintf(`<span class="client-item" style="background:#d1fae5;"><strong>%s:</strong> %s</span>`, integration, joinStrings(versionItems, ", "))
+				html += fmt.Sprintf(`<span class="client-item" style="background:#d1fae5;"><strong>%s:</strong> %s</span>`, htmlpkg.EscapeString(integration), joinStrings(versionItems, ", "))
 			}
 			html += `</div>`
 		}
@@ -673,9 +689,11 @@ func renderMachinesHTML(machines map[string]*MachineStats) string {
 				versionItems := make([]string, 0)
 				for version, count := range versions {
 					totalCount += count
-					versionItems = append(versionItems, fmtVersionCount(version, count))
+					// Integration names and versions come from a user-controlled
+					// header, escape before concatenating into HTML.
+					versionItems = append(versionItems, fmtVersionCount(htmlpkg.EscapeString(version), count))
 				}
-				integrationUsageHtml += fmt.Sprintf(`<span class="client-item" style="background:#d1fae5;"><strong>%s:</strong> %d total (%s)</span>`, integration, totalCount, joinStrings(versionItems, ", "))
+				integrationUsageHtml += fmt.Sprintf(`<span class="client-item" style="background:#d1fae5;"><strong>%s:</strong> %d total (%s)</span>`, htmlpkg.EscapeString(integration), totalCount, joinStrings(versionItems, ", "))
 			}
 			integrationUsageHtml += `</div>`
 		}

--- a/tools/telemetry-dashboard/main.go
+++ b/tools/telemetry-dashboard/main.go
@@ -149,17 +149,49 @@ func (d *Dashboard) GetData() ([]*TelemetryPayload, map[string]*MachineStats) {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 
-	// Return copies
+	// Return copies. A shallow copy of *MachineStats is not enough — its
+	// map fields are reference types, so a concurrent AddPayload that
+	// inserts into e.g. stats.ClientUsage[type] would race with the
+	// renderer (or JSON encoder) iterating the same map after GetData
+	// returns and releases the read lock.
 	payloads := make([]*TelemetryPayload, len(d.payloads))
 	copy(payloads, d.payloads)
 
-	machines := make(map[string]*MachineStats)
+	machines := make(map[string]*MachineStats, len(d.machines))
 	for k, v := range d.machines {
-		stats := *v
-		machines[k] = &stats
+		machines[k] = copyMachineStats(v)
 	}
 
 	return payloads, machines
+}
+
+// copyMachineStats returns a deep copy of m so callers can iterate its
+// map fields without holding d.mu against concurrent writers.
+func copyMachineStats(m *MachineStats) *MachineStats {
+	out := *m
+	out.UsedModules = make(map[string]bool, len(m.UsedModules))
+	for k, v := range m.UsedModules {
+		out.UsedModules[k] = v
+	}
+	out.PayloadTypes = make(map[string]int, len(m.PayloadTypes))
+	for k, v := range m.PayloadTypes {
+		out.PayloadTypes[k] = v
+	}
+	out.ClientUsage = copyCountMap(m.ClientUsage)
+	out.ClientIntegrationUsage = copyCountMap(m.ClientIntegrationUsage)
+	return &out
+}
+
+func copyCountMap(m map[string]map[string]int64) map[string]map[string]int64 {
+	out := make(map[string]map[string]int64, len(m))
+	for k, inner := range m {
+		dup := make(map[string]int64, len(inner))
+		for ik, iv := range inner {
+			dup[ik] = iv
+		}
+		out[k] = dup
+	}
+	return out
 }
 
 func main() {

--- a/tools/telemetry-dashboard/main.go
+++ b/tools/telemetry-dashboard/main.go
@@ -627,18 +627,3 @@ func generateDashboardHTML() string {
 </body>
 </html>`, port, telemetryURL)
 }
-
-func toLower(s string) string {
-	if len(s) == 0 {
-		return s
-	}
-	result := ""
-	for _, r := range s {
-		if r >= 'A' && r <= 'Z' {
-			result += string(r + 32)
-		} else {
-			result += string(r)
-		}
-	}
-	return result
-}

--- a/usecases/telemetry/client_middleware.go
+++ b/usecases/telemetry/client_middleware.go
@@ -19,20 +19,20 @@ import (
 	"google.golang.org/grpc/metadata"
 )
 
-// ClientTrackingMiddleware creates an HTTP middleware that tracks client SDK usage.
-// It should be placed early in the middleware chain to capture all requests.
-func ClientTrackingMiddleware(tracker *ClientTracker) func(http.Handler) http.Handler {
-	if tracker == nil {
-		// If no tracker is provided, return a no-op middleware
-		return func(next http.Handler) http.Handler {
-			return next
-		}
-	}
-
+// ClientTrackingMiddleware creates an HTTP middleware that tracks client SDK usage
+// and client integration usage. It should be placed early in the middleware chain
+// to capture all requests.
+func ClientTrackingMiddleware(tracker *ClientTracker, integrationTracker *IntegrationTracker) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// Track the client before processing the request
-			tracker.Track(r)
+			// Track the client SDK before processing the request
+			if tracker != nil {
+				tracker.Track(r)
+			}
+			// Track the client integration before processing the request
+			if integrationTracker != nil {
+				integrationTracker.Track(r)
+			}
 
 			// Continue with the request
 			next.ServeHTTP(w, r)

--- a/usecases/telemetry/client_middleware.go
+++ b/usecases/telemetry/client_middleware.go
@@ -14,6 +14,7 @@ package telemetry
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -51,18 +52,37 @@ func (ct *ClientTracker) TrackHeader(headerValue string) {
 	ct.inner.send(clientInfo.Type, clientInfo.Version)
 }
 
+// TrackHeader records an integration from a raw header value. This is useful for
+// gRPC requests where there is no *http.Request available. The header is parsed
+// using the same {name}/{version} format as the HTTP path and length-capped via
+// SanitizeClientHeader.
+func (it *IntegrationTracker) TrackHeader(headerValue string) {
+	name, version := parseIntegrationHeader(headerValue)
+	if name == "" {
+		return
+	}
+	it.inner.send(name, version)
+}
+
 // ClientTrackingUnaryInterceptor creates a gRPC unary interceptor that tracks
-// client SDK usage by reading the x-weaviate-client metadata header.
-// It also sets the sanitized header value in the context under "clientIdentifier",
-// combining both tracking and context-setting to avoid parsing metadata twice.
-func ClientTrackingUnaryInterceptor(tracker *ClientTracker) grpc.UnaryServerInterceptor {
+// client SDK usage (from x-weaviate-client) and integration usage (from
+// x-weaviate-client-integration) via the gRPC metadata. It also sets the
+// sanitized client header in the context under "clientIdentifier", combining
+// tracking and context-setting to avoid parsing metadata twice.
+// Either tracker may be nil; the respective metadata header is then ignored.
+func ClientTrackingUnaryInterceptor(tracker *ClientTracker, integrationTracker *IntegrationTracker) grpc.UnaryServerInterceptor {
 	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
-		if tracker != nil {
-			if md, ok := metadata.FromIncomingContext(ctx); ok {
+		if md, ok := metadata.FromIncomingContext(ctx); ok {
+			if tracker != nil {
 				if vals := md.Get("x-weaviate-client"); len(vals) > 0 {
 					sanitized := SanitizeClientHeader(vals[0])
 					ctx = context.WithValue(ctx, "clientIdentifier", sanitized)
 					tracker.TrackHeader(vals[0])
+				}
+			}
+			if integrationTracker != nil {
+				if vals := md.Get(strings.ToLower(integrationHeaderKey)); len(vals) > 0 {
+					integrationTracker.TrackHeader(vals[0])
 				}
 			}
 		}

--- a/usecases/telemetry/client_middleware.go
+++ b/usecases/telemetry/client_middleware.go
@@ -14,7 +14,6 @@ package telemetry
 import (
 	"context"
 	"net/http"
-	"strings"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
@@ -81,7 +80,7 @@ func ClientTrackingUnaryInterceptor(tracker *ClientTracker, integrationTracker *
 				}
 			}
 			if integrationTracker != nil {
-				if vals := md.Get(strings.ToLower(integrationHeaderKey)); len(vals) > 0 {
+				if vals := md.Get(integrationHeaderKeyLower); len(vals) > 0 {
 					integrationTracker.TrackHeader(vals[0])
 				}
 			}

--- a/usecases/telemetry/client_middleware.go
+++ b/usecases/telemetry/client_middleware.go
@@ -48,10 +48,7 @@ func (ct *ClientTracker) TrackHeader(headerValue string) {
 		return
 	}
 
-	select {
-	case ct.trackChan <- clientInfo:
-	default:
-	}
+	ct.inner.send(clientInfo.Type, clientInfo.Version)
 }
 
 // ClientTrackingUnaryInterceptor creates a gRPC unary interceptor that tracks

--- a/usecases/telemetry/client_tracker.go
+++ b/usecases/telemetry/client_tracker.go
@@ -136,20 +136,22 @@ func (t *mapTracker[K]) run() {
 }
 
 func (t *mapTracker[K]) processEvent(counts map[K]map[string]int64, ev trackEvent[K]) {
-	if t.maxKeys > 0 && counts[ev.key] == nil && len(counts) >= t.maxKeys {
-		return
-	}
-	if counts[ev.key] == nil {
-		counts[ev.key] = make(map[string]int64)
+	versions, ok := counts[ev.key]
+	if !ok {
+		if t.maxKeys > 0 && len(counts) >= t.maxKeys {
+			return
+		}
+		versions = make(map[string]int64)
+		counts[ev.key] = versions
 	}
 	version := ev.version
 	if version == "" {
 		version = "unknown"
 	}
-	if t.maxVersions > 0 && counts[ev.key][version] == 0 && len(counts[ev.key]) >= t.maxVersions {
+	if _, vok := versions[version]; !vok && t.maxVersions > 0 && len(versions) >= t.maxVersions {
 		return
 	}
-	counts[ev.key][version]++
+	versions[version]++
 }
 
 func (t *mapTracker[K]) deepCopy(counts map[K]map[string]int64) map[K]map[string]int64 {

--- a/usecases/telemetry/client_tracker.go
+++ b/usecases/telemetry/client_tracker.go
@@ -247,3 +247,157 @@ func IdentifyClientFromHeader(headerValue string) ClientInfo {
 
 	return ClientInfo{Type: clientType, Version: version}
 }
+
+// IntegrationTracker tracks client integration usage using channel-based concurrency.
+// Unlike ClientTracker, it accepts any arbitrary integration name without a predefined list,
+// since new integrations are created frequently.
+// A background goroutine aggregates tracking events, eliminating lock
+// contention on the hot path (Track method).
+type IntegrationTracker struct {
+	trackChan chan [2]string                             // Buffered, for non-blocking Track()
+	getChan   chan chan map[string]map[string]int64      // Request/response for Get()
+	resetChan chan chan map[string]map[string]int64      // Request/response for GetAndReset()
+	stopChan  chan struct{}                              // Signal to stop goroutine
+	stopOnce  sync.Once                                  // Ensures Stop() is safe to call multiple times
+}
+
+// NewIntegrationTracker creates a new integration tracker and starts its background goroutine.
+func NewIntegrationTracker(logger logrus.FieldLogger) *IntegrationTracker {
+	it := &IntegrationTracker{
+		trackChan: make(chan [2]string, 1024),
+		getChan:   make(chan chan map[string]map[string]int64),
+		resetChan: make(chan chan map[string]map[string]int64),
+		stopChan:  make(chan struct{}),
+	}
+	errors.GoWrapper(it.run, logger)
+	return it
+}
+
+// run is the background goroutine that aggregates all tracking events.
+// It owns the counts map exclusively, eliminating the need for locks.
+func (it *IntegrationTracker) run() {
+	counts := make(map[string]map[string]int64)
+	for {
+		// Priority: drain all pending tracking events first
+		select {
+		case info := <-it.trackChan:
+			it.processTrackEvent(counts, info)
+			continue
+		case <-it.stopChan:
+			return
+		default:
+			// No pending track events, proceed to handle other operations
+		}
+
+		// Handle Get, GetAndReset, or more Track events
+		select {
+		case info := <-it.trackChan:
+			it.processTrackEvent(counts, info)
+
+		case respChan := <-it.getChan:
+			respChan <- it.deepCopy(counts)
+
+		case respChan := <-it.resetChan:
+			respChan <- it.deepCopy(counts)
+			counts = make(map[string]map[string]int64)
+
+		case <-it.stopChan:
+			return
+		}
+	}
+}
+
+// processTrackEvent aggregates a single tracking event into the counts map.
+func (it *IntegrationTracker) processTrackEvent(counts map[string]map[string]int64, info [2]string) {
+	name, version := info[0], info[1]
+	if counts[name] == nil {
+		counts[name] = make(map[string]int64)
+	}
+	if version == "" {
+		version = "unknown"
+	}
+	counts[name][version]++
+}
+
+// deepCopy creates a deep copy of the counts map.
+func (it *IntegrationTracker) deepCopy(counts map[string]map[string]int64) map[string]map[string]int64 {
+	result := make(map[string]map[string]int64, len(counts))
+	for name, versions := range counts {
+		versionMap := make(map[string]int64, len(versions))
+		for version, count := range versions {
+			versionMap[version] = count
+		}
+		result[name] = versionMap
+	}
+	return result
+}
+
+// Track records a client integration request. This is non-blocking and safe to call
+// from any goroutine. If the internal buffer is full, the event is dropped
+// silently (telemetry is best-effort). Any non-empty integration name is accepted.
+func (it *IntegrationTracker) Track(r *http.Request) {
+	name, version := identifyIntegration(r)
+	if name == "" {
+		return // No integration header present
+	}
+
+	select {
+	case it.trackChan <- [2]string{name, version}:
+		// Successfully queued
+	default:
+		// Channel full - drop silently, telemetry is best-effort.
+	}
+}
+
+// GetAndReset returns the current integration counts and resets the tracker.
+// Returns nil if the tracker has been stopped.
+func (it *IntegrationTracker) GetAndReset() map[string]map[string]int64 {
+	respChan := make(chan map[string]map[string]int64, 1)
+	select {
+	case it.resetChan <- respChan:
+		return <-respChan
+	case <-it.stopChan:
+		return nil
+	}
+}
+
+// Get returns the current integration counts without resetting.
+// Returns nil if the tracker has been stopped.
+func (it *IntegrationTracker) Get() map[string]map[string]int64 {
+	respChan := make(chan map[string]map[string]int64, 1)
+	select {
+	case it.getChan <- respChan:
+		return <-respChan
+	case <-it.stopChan:
+		return nil
+	}
+}
+
+// Stop gracefully shuts down the background goroutine.
+// This is safe to call multiple times.
+func (it *IntegrationTracker) Stop() {
+	it.stopOnce.Do(func() {
+		close(it.stopChan)
+	})
+}
+
+// identifyIntegration reads the X-Weaviate-Client-Integration header and returns
+// the integration name and version. The header format is: {name}/{version}
+// Any non-empty name is accepted — there is no predefined list of known integrations.
+// Returns ("", "") if the header is absent or empty.
+func identifyIntegration(r *http.Request) (name, version string) {
+	header := strings.TrimSpace(r.Header.Get("X-Weaviate-Client-Integration"))
+	if header == "" {
+		return "", ""
+	}
+
+	parts := strings.SplitN(header, "/", 2)
+	name = strings.TrimSpace(parts[0])
+	if name == "" {
+		return "", ""
+	}
+	if len(parts) == 2 {
+		version = strings.TrimSpace(parts[1])
+	}
+	return name, version
+}

--- a/usecases/telemetry/client_tracker.go
+++ b/usecases/telemetry/client_tracker.go
@@ -47,7 +47,13 @@ const (
 )
 
 // integrationHeaderKey is the HTTP header used to identify the client integration.
-const integrationHeaderKey = "X-Weaviate-Client-Integration"
+// integrationHeaderKeyLower is the same value pre-lowercased so the gRPC
+// interceptor (which receives metadata with lowercased keys) does not have to
+// call strings.ToLower on every request.
+const (
+	integrationHeaderKey      = "X-Weaviate-Client-Integration"
+	integrationHeaderKeyLower = "x-weaviate-client-integration"
+)
 
 // ClientInfo represents a client SDK with its type and version
 type ClientInfo struct {

--- a/usecases/telemetry/client_tracker.go
+++ b/usecases/telemetry/client_tracker.go
@@ -358,13 +358,19 @@ func (it *IntegrationTracker) Stop() {
 }
 
 // identifyIntegration reads the X-Weaviate-Client-Integration header and returns
-// the integration name and version. The header format is: {name}/{version}
-// Any non-empty name is accepted — there is no predefined list of known integrations.
-// Returns ("", "") if the header is absent or empty.
-// The header is length-capped via SanitizeClientHeader before parsing to prevent
-// arbitrarily large strings from reaching the tracker map or the telemetry payload.
+// the integration name and version. See parseIntegrationHeader for the header
+// format and sanitization rules.
 func identifyIntegration(r *http.Request) (name, version string) {
-	header := SanitizeClientHeader(strings.TrimSpace(r.Header.Get(integrationHeaderKey)))
+	return parseIntegrationHeader(r.Header.Get(integrationHeaderKey))
+}
+
+// parseIntegrationHeader parses a raw X-Weaviate-Client-Integration header value.
+// Format: {name}/{version}. Any non-empty name is accepted — there is no predefined
+// list of known integrations. Returns ("", "") if the value is absent or empty.
+// The value is length-capped via SanitizeClientHeader before parsing to prevent
+// arbitrarily large strings from reaching the tracker map or the telemetry payload.
+func parseIntegrationHeader(headerValue string) (name, version string) {
+	header := SanitizeClientHeader(strings.TrimSpace(headerValue))
 	if header == "" {
 		return "", ""
 	}

--- a/usecases/telemetry/client_tracker.go
+++ b/usecases/telemetry/client_tracker.go
@@ -69,10 +69,10 @@ type mapTracker[K comparable] struct {
 	getChan     chan chan map[K]map[string]int64 // Request/response for Get()
 	resetChan   chan chan map[K]map[string]int64 // Request/response for GetAndReset()
 	stopChan    chan struct{}                    // Signal to stop goroutine
-	stopOnce    sync.Once                       // Ensures stop() is safe to call multiple times
-	initCap     int                             // Initial map capacity hint
-	maxKeys     int                             // Max distinct keys; 0 = unlimited
-	maxVersions int                             // Max distinct versions per key; 0 = unlimited
+	stopOnce    sync.Once                        // Ensures stop() is safe to call multiple times
+	initCap     int                              // Initial map capacity hint
+	maxKeys     int                              // Max distinct keys; 0 = unlimited
+	maxVersions int                              // Max distinct versions per key; 0 = unlimited
 }
 
 func newMapTracker[K comparable](logger logrus.FieldLogger, initCap, maxKeys, maxVersions int) *mapTracker[K] {

--- a/usecases/telemetry/client_tracker.go
+++ b/usecases/telemetry/client_tracker.go
@@ -41,6 +41,9 @@ const knownClientTypeCount = 7
 // integrationHeaderKey is the HTTP header used to identify the client integration.
 const integrationHeaderKey = "X-Weaviate-Client-Integration"
 
+// integrationHeaderKey is the HTTP header used to identify the client integration.
+const integrationHeaderKey = "X-Weaviate-Client-Integration"
+
 // ClientInfo represents a client SDK with its type and version
 type ClientInfo struct {
 	Type    ClientType `json:"type"`

--- a/usecases/telemetry/client_tracker.go
+++ b/usecases/telemetry/client_tracker.go
@@ -38,6 +38,14 @@ const (
 // Used for map preallocation.
 const knownClientTypeCount = 7
 
+// maxIntegrationKeys caps the number of distinct integration names tracked per period.
+// maxIntegrationVersions caps the number of distinct versions per integration name.
+// Both limits bound memory growth from user-controlled header values.
+const (
+	maxIntegrationKeys     = 256
+	maxIntegrationVersions = 64
+)
+
 // integrationHeaderKey is the HTTP header used to identify the client integration.
 const integrationHeaderKey = "X-Weaviate-Client-Integration"
 
@@ -57,24 +65,28 @@ type trackEvent[K comparable] struct {
 // A single background goroutine owns the counts map, eliminating lock contention on
 // the hot path. Both ClientTracker and IntegrationTracker delegate to this type.
 type mapTracker[K comparable] struct {
-	trackChan chan trackEvent[K]               // Buffered, for non-blocking sends
-	getChan   chan chan map[K]map[string]int64 // Request/response for Get()
-	resetChan chan chan map[K]map[string]int64 // Request/response for GetAndReset()
-	stopChan  chan struct{}                    // Signal to stop goroutine
-	stopOnce  sync.Once                        // Ensures stop() is safe to call multiple times
-	initCap   int                              // Initial map capacity hint
+	trackChan   chan trackEvent[K]               // Buffered, for non-blocking sends
+	getChan     chan chan map[K]map[string]int64 // Request/response for Get()
+	resetChan   chan chan map[K]map[string]int64 // Request/response for GetAndReset()
+	stopChan    chan struct{}                    // Signal to stop goroutine
+	stopOnce    sync.Once                       // Ensures stop() is safe to call multiple times
+	initCap     int                             // Initial map capacity hint
+	maxKeys     int                             // Max distinct keys; 0 = unlimited
+	maxVersions int                             // Max distinct versions per key; 0 = unlimited
 }
 
-func newMapTracker[K comparable](logger logrus.FieldLogger, initCap int) *mapTracker[K] {
+func newMapTracker[K comparable](logger logrus.FieldLogger, initCap, maxKeys, maxVersions int) *mapTracker[K] {
 	t := &mapTracker[K]{
 		// Buffered for 1024 pending events. This is a somewhat arbitrary number that
 		// should be enough to handle most cases without blocking, and only requires
 		// ~32KB of memory.
-		trackChan: make(chan trackEvent[K], 1024),
-		getChan:   make(chan chan map[K]map[string]int64),
-		resetChan: make(chan chan map[K]map[string]int64),
-		stopChan:  make(chan struct{}),
-		initCap:   initCap,
+		trackChan:   make(chan trackEvent[K], 1024),
+		getChan:     make(chan chan map[K]map[string]int64),
+		resetChan:   make(chan chan map[K]map[string]int64),
+		stopChan:    make(chan struct{}),
+		initCap:     initCap,
+		maxKeys:     maxKeys,
+		maxVersions: maxVersions,
 	}
 	errors.GoWrapper(t.run, logger)
 	return t
@@ -118,12 +130,18 @@ func (t *mapTracker[K]) run() {
 }
 
 func (t *mapTracker[K]) processEvent(counts map[K]map[string]int64, ev trackEvent[K]) {
+	if t.maxKeys > 0 && counts[ev.key] == nil && len(counts) >= t.maxKeys {
+		return
+	}
 	if counts[ev.key] == nil {
 		counts[ev.key] = make(map[string]int64)
 	}
 	version := ev.version
 	if version == "" {
 		version = "unknown"
+	}
+	if t.maxVersions > 0 && counts[ev.key][version] == 0 && len(counts[ev.key]) >= t.maxVersions {
+		return
 	}
 	counts[ev.key][version]++
 }
@@ -153,7 +171,12 @@ func (t *mapTracker[K]) get() map[K]map[string]int64 {
 	respChan := make(chan map[K]map[string]int64, 1)
 	select {
 	case t.getChan <- respChan:
-		return <-respChan
+	case <-t.stopChan:
+		return nil
+	}
+	select {
+	case result := <-respChan:
+		return result
 	case <-t.stopChan:
 		return nil
 	}
@@ -163,7 +186,12 @@ func (t *mapTracker[K]) getAndReset() map[K]map[string]int64 {
 	respChan := make(chan map[K]map[string]int64, 1)
 	select {
 	case t.resetChan <- respChan:
-		return <-respChan
+	case <-t.stopChan:
+		return nil
+	}
+	select {
+	case result := <-respChan:
+		return result
 	case <-t.stopChan:
 		return nil
 	}
@@ -183,7 +211,7 @@ type ClientTracker struct {
 
 // NewClientTracker creates a new client tracker and starts its background goroutine.
 func NewClientTracker(logger logrus.FieldLogger) *ClientTracker {
-	return &ClientTracker{inner: newMapTracker[ClientType](logger, knownClientTypeCount)}
+	return &ClientTracker{inner: newMapTracker[ClientType](logger, knownClientTypeCount, 0, 0)}
 }
 
 // Track records a client request. This is non-blocking and safe to call
@@ -297,7 +325,7 @@ type IntegrationTracker struct {
 
 // NewIntegrationTracker creates a new integration tracker and starts its background goroutine.
 func NewIntegrationTracker(logger logrus.FieldLogger) *IntegrationTracker {
-	return &IntegrationTracker{inner: newMapTracker[string](logger, 0)}
+	return &IntegrationTracker{inner: newMapTracker[string](logger, 0, maxIntegrationKeys, maxIntegrationVersions)}
 }
 
 // Track records a client integration request. This is non-blocking and safe to call
@@ -333,8 +361,10 @@ func (it *IntegrationTracker) Stop() {
 // the integration name and version. The header format is: {name}/{version}
 // Any non-empty name is accepted — there is no predefined list of known integrations.
 // Returns ("", "") if the header is absent or empty.
+// The header is length-capped via SanitizeClientHeader before parsing to prevent
+// arbitrarily large strings from reaching the tracker map or the telemetry payload.
 func identifyIntegration(r *http.Request) (name, version string) {
-	header := strings.TrimSpace(r.Header.Get(integrationHeaderKey))
+	header := SanitizeClientHeader(strings.TrimSpace(r.Header.Get(integrationHeaderKey)))
 	if header == "" {
 		return "", ""
 	}

--- a/usecases/telemetry/client_tracker.go
+++ b/usecases/telemetry/client_tracker.go
@@ -29,12 +29,17 @@ const (
 	ClientTypeCSharp     ClientType = "csharp"
 	ClientTypeTypeScript ClientType = "typescript"
 	ClientTypeGo         ClientType = "go"
+	ClientTypePHP        ClientType = "php"
+	ClientTypeRuby       ClientType = "ruby"
 	ClientTypeUnknown    ClientType = "unknown"
 )
 
 // knownClientTypeCount is the number of known client types we track (excludes ClientTypeUnknown).
 // Used for map preallocation.
-const knownClientTypeCount = 5
+const knownClientTypeCount = 7
+
+// integrationHeaderKey is the HTTP header used to identify the client integration.
+const integrationHeaderKey = "X-Weaviate-Client-Integration"
 
 // ClientInfo represents a client SDK with its type and version
 type ClientInfo struct {
@@ -42,92 +47,143 @@ type ClientInfo struct {
 	Version string     `json:"version"`
 }
 
-// ClientTracker tracks client SDK usage using channel-based concurrency.
-// A background goroutine aggregates tracking events, eliminating lock
-// contention on the hot path (Track method).
-type ClientTracker struct {
-	trackChan chan ClientInfo                           // Buffered, for non-blocking Track()
-	getChan   chan chan map[ClientType]map[string]int64 // Request/response for Get()
-	resetChan chan chan map[ClientType]map[string]int64 // Request/response for GetAndReset()
-	stopChan  chan struct{}                             // Signal to stop goroutine
-	stopOnce  sync.Once                                 // Ensures Stop() is safe to call multiple times
+// trackEvent holds a key/version pair sent to the background goroutine.
+type trackEvent[K comparable] struct {
+	key     K
+	version string
 }
 
-// NewClientTracker creates a new client tracker and starts its background goroutine
-func NewClientTracker(logger logrus.FieldLogger) *ClientTracker {
-	ct := &ClientTracker{
+// mapTracker is a generic, channel-based aggregator for map[K]map[string]int64 counts.
+// A single background goroutine owns the counts map, eliminating lock contention on
+// the hot path. Both ClientTracker and IntegrationTracker delegate to this type.
+type mapTracker[K comparable] struct {
+	trackChan chan trackEvent[K]               // Buffered, for non-blocking sends
+	getChan   chan chan map[K]map[string]int64 // Request/response for Get()
+	resetChan chan chan map[K]map[string]int64 // Request/response for GetAndReset()
+	stopChan  chan struct{}                    // Signal to stop goroutine
+	stopOnce  sync.Once                        // Ensures stop() is safe to call multiple times
+	initCap   int                              // Initial map capacity hint
+}
+
+func newMapTracker[K comparable](logger logrus.FieldLogger, initCap int) *mapTracker[K] {
+	t := &mapTracker[K]{
 		// Buffered for 1024 pending events. This is a somewhat arbitrary number that
 		// should be enough to handle most cases without blocking, and only requires
 		// ~32KB of memory.
-		trackChan: make(chan ClientInfo, 1024),
-		getChan:   make(chan chan map[ClientType]map[string]int64),
-		resetChan: make(chan chan map[ClientType]map[string]int64),
+		trackChan: make(chan trackEvent[K], 1024),
+		getChan:   make(chan chan map[K]map[string]int64),
+		resetChan: make(chan chan map[K]map[string]int64),
 		stopChan:  make(chan struct{}),
+		initCap:   initCap,
 	}
-	errors.GoWrapper(ct.run, logger)
-	return ct
+	errors.GoWrapper(t.run, logger)
+	return t
 }
 
 // run is the background goroutine that aggregates all tracking events.
 // It owns the counts map exclusively, eliminating the need for locks.
 // Uses a priority select pattern to drain all tracking events before
 // handling Get/GetAndReset requests, ensuring consistent results.
-func (ct *ClientTracker) run() {
-	counts := make(map[ClientType]map[string]int64, knownClientTypeCount)
+func (t *mapTracker[K]) run() {
+	counts := make(map[K]map[string]int64, t.initCap)
 	for {
-		// Priority: drain all pending tracking events first
-		// This ensures Get/GetAndReset return accurate counts
+		// Priority: drain all pending tracking events first.
+		// This ensures Get/GetAndReset return accurate counts.
 		select {
-		case info := <-ct.trackChan:
-			ct.processTrackEvent(counts, info)
+		case ev := <-t.trackChan:
+			t.processEvent(counts, ev)
 			continue
-		case <-ct.stopChan:
+		case <-t.stopChan:
 			return
 		default:
-			// No pending track events, proceed to handle other operations
+			// No pending track events, proceed to handle other operations.
 		}
 
-		// Handle Get, GetAndReset, or more Track events
+		// Handle Get, GetAndReset, or more Track events.
 		select {
-		case info := <-ct.trackChan:
-			ct.processTrackEvent(counts, info)
+		case ev := <-t.trackChan:
+			t.processEvent(counts, ev)
 
-		case respChan := <-ct.getChan:
-			respChan <- ct.deepCopy(counts)
+		case respChan := <-t.getChan:
+			respChan <- t.deepCopy(counts)
 
-		case respChan := <-ct.resetChan:
-			respChan <- ct.deepCopy(counts)
-			counts = make(map[ClientType]map[string]int64, knownClientTypeCount)
+		case respChan := <-t.resetChan:
+			respChan <- t.deepCopy(counts)
+			counts = make(map[K]map[string]int64, t.initCap)
 
-		case <-ct.stopChan:
+		case <-t.stopChan:
 			return
 		}
 	}
 }
 
-// processTrackEvent aggregates a single tracking event into the counts map
-func (ct *ClientTracker) processTrackEvent(counts map[ClientType]map[string]int64, info ClientInfo) {
-	if counts[info.Type] == nil {
-		counts[info.Type] = make(map[string]int64)
+func (t *mapTracker[K]) processEvent(counts map[K]map[string]int64, ev trackEvent[K]) {
+	if counts[ev.key] == nil {
+		counts[ev.key] = make(map[string]int64)
 	}
-	version := info.Version
+	version := ev.version
 	if version == "" {
 		version = "unknown"
 	}
-	counts[info.Type][version]++
+	counts[ev.key][version]++
 }
 
-// deepCopy creates a deep copy of the counts map
-func (ct *ClientTracker) deepCopy(counts map[ClientType]map[string]int64) map[ClientType]map[string]int64 {
-	result := make(map[ClientType]map[string]int64, len(counts))
-	for clientType, versions := range counts {
+func (t *mapTracker[K]) deepCopy(counts map[K]map[string]int64) map[K]map[string]int64 {
+	result := make(map[K]map[string]int64, len(counts))
+	for key, versions := range counts {
 		versionMap := make(map[string]int64, len(versions))
 		for version, count := range versions {
 			versionMap[version] = count
 		}
-		result[clientType] = versionMap
+		result[key] = versionMap
 	}
 	return result
+}
+
+func (t *mapTracker[K]) send(key K, version string) {
+	select {
+	case t.trackChan <- trackEvent[K]{key: key, version: version}:
+		// Successfully queued
+	default:
+		// Channel full - drop silently, telemetry is best-effort.
+	}
+}
+
+func (t *mapTracker[K]) get() map[K]map[string]int64 {
+	respChan := make(chan map[K]map[string]int64, 1)
+	select {
+	case t.getChan <- respChan:
+		return <-respChan
+	case <-t.stopChan:
+		return nil
+	}
+}
+
+func (t *mapTracker[K]) getAndReset() map[K]map[string]int64 {
+	respChan := make(chan map[K]map[string]int64, 1)
+	select {
+	case t.resetChan <- respChan:
+		return <-respChan
+	case <-t.stopChan:
+		return nil
+	}
+}
+
+func (t *mapTracker[K]) stop() {
+	t.stopOnce.Do(func() {
+		close(t.stopChan)
+	})
+}
+
+// ClientTracker tracks client SDK usage. Only known SDK types are recorded;
+// unknown or missing headers are ignored to avoid noise.
+type ClientTracker struct {
+	inner *mapTracker[ClientType]
+}
+
+// NewClientTracker creates a new client tracker and starts its background goroutine.
+func NewClientTracker(logger logrus.FieldLogger) *ClientTracker {
+	return &ClientTracker{inner: newMapTracker[ClientType](logger, knownClientTypeCount)}
 }
 
 // Track records a client request. This is non-blocking and safe to call
@@ -138,46 +194,26 @@ func (ct *ClientTracker) Track(r *http.Request) {
 	if clientInfo.Type == ClientTypeUnknown {
 		return // Don't track unknown clients to avoid noise
 	}
-
-	select {
-	case ct.trackChan <- clientInfo:
-		// Successfully queued
-	default:
-		// Channel full - drop silently, telemetry is best-effort for now. We can revisit this later.
-	}
+	ct.inner.send(clientInfo.Type, clientInfo.Version)
 }
 
 // GetAndReset returns the current client counts and resets the tracker.
 // This is called when building telemetry payloads to get usage data
 // for the reporting period. Returns nil if the tracker has been stopped.
 func (ct *ClientTracker) GetAndReset() map[ClientType]map[string]int64 {
-	respChan := make(chan map[ClientType]map[string]int64, 1)
-	select {
-	case ct.resetChan <- respChan:
-		return <-respChan
-	case <-ct.stopChan:
-		return nil
-	}
+	return ct.inner.getAndReset()
 }
 
 // Get returns the current client counts without resetting.
 // Useful for inspection without clearing data. Returns nil if the tracker has been stopped.
 func (ct *ClientTracker) Get() map[ClientType]map[string]int64 {
-	respChan := make(chan map[ClientType]map[string]int64, 1)
-	select {
-	case ct.getChan <- respChan:
-		return <-respChan
-	case <-ct.stopChan:
-		return nil
-	}
+	return ct.inner.get()
 }
 
 // Stop gracefully shuts down the background goroutine.
 // This is safe to call multiple times.
 func (ct *ClientTracker) Stop() {
-	ct.stopOnce.Do(func() {
-		close(ct.stopChan)
-	})
+	ct.inner.stop()
 }
 
 const maxClientHeaderLen = 128
@@ -202,7 +238,7 @@ func identifyClient(r *http.Request) ClientInfo {
 // IdentifyClientFromHeader parses a client header value (e.g. "weaviate-client-python/4.10.0")
 // and returns the identified client info. The header follows the pattern:
 // weaviate-client-{sdk}/{version}
-// where sdk is one of: python, java, typescript, go, csharp
+// where sdk is one of: python, java, typescript, go, csharp, php, ruby
 func IdentifyClientFromHeader(headerValue string) ClientInfo {
 	if headerValue == "" {
 		return ClientInfo{Type: ClientTypeUnknown, Version: ""}
@@ -241,6 +277,10 @@ func IdentifyClientFromHeader(headerValue string) ClientInfo {
 		clientType = ClientTypeTypeScript
 	case "go":
 		clientType = ClientTypeGo
+	case "php":
+		clientType = ClientTypePHP
+	case "ruby":
+		clientType = ClientTypeRuby
 	default:
 		return ClientInfo{Type: ClientTypeUnknown, Version: ""}
 	}
@@ -248,88 +288,16 @@ func IdentifyClientFromHeader(headerValue string) ClientInfo {
 	return ClientInfo{Type: clientType, Version: version}
 }
 
-// IntegrationTracker tracks client integration usage using channel-based concurrency.
-// Unlike ClientTracker, it accepts any arbitrary integration name without a predefined list,
+// IntegrationTracker tracks client integration usage. Unlike ClientTracker,
+// it accepts any arbitrary integration name without a predefined list,
 // since new integrations are created frequently.
-// A background goroutine aggregates tracking events, eliminating lock
-// contention on the hot path (Track method).
 type IntegrationTracker struct {
-	trackChan chan [2]string                             // Buffered, for non-blocking Track()
-	getChan   chan chan map[string]map[string]int64      // Request/response for Get()
-	resetChan chan chan map[string]map[string]int64      // Request/response for GetAndReset()
-	stopChan  chan struct{}                              // Signal to stop goroutine
-	stopOnce  sync.Once                                  // Ensures Stop() is safe to call multiple times
+	inner *mapTracker[string]
 }
 
 // NewIntegrationTracker creates a new integration tracker and starts its background goroutine.
 func NewIntegrationTracker(logger logrus.FieldLogger) *IntegrationTracker {
-	it := &IntegrationTracker{
-		trackChan: make(chan [2]string, 1024),
-		getChan:   make(chan chan map[string]map[string]int64),
-		resetChan: make(chan chan map[string]map[string]int64),
-		stopChan:  make(chan struct{}),
-	}
-	errors.GoWrapper(it.run, logger)
-	return it
-}
-
-// run is the background goroutine that aggregates all tracking events.
-// It owns the counts map exclusively, eliminating the need for locks.
-func (it *IntegrationTracker) run() {
-	counts := make(map[string]map[string]int64)
-	for {
-		// Priority: drain all pending tracking events first
-		select {
-		case info := <-it.trackChan:
-			it.processTrackEvent(counts, info)
-			continue
-		case <-it.stopChan:
-			return
-		default:
-			// No pending track events, proceed to handle other operations
-		}
-
-		// Handle Get, GetAndReset, or more Track events
-		select {
-		case info := <-it.trackChan:
-			it.processTrackEvent(counts, info)
-
-		case respChan := <-it.getChan:
-			respChan <- it.deepCopy(counts)
-
-		case respChan := <-it.resetChan:
-			respChan <- it.deepCopy(counts)
-			counts = make(map[string]map[string]int64)
-
-		case <-it.stopChan:
-			return
-		}
-	}
-}
-
-// processTrackEvent aggregates a single tracking event into the counts map.
-func (it *IntegrationTracker) processTrackEvent(counts map[string]map[string]int64, info [2]string) {
-	name, version := info[0], info[1]
-	if counts[name] == nil {
-		counts[name] = make(map[string]int64)
-	}
-	if version == "" {
-		version = "unknown"
-	}
-	counts[name][version]++
-}
-
-// deepCopy creates a deep copy of the counts map.
-func (it *IntegrationTracker) deepCopy(counts map[string]map[string]int64) map[string]map[string]int64 {
-	result := make(map[string]map[string]int64, len(counts))
-	for name, versions := range counts {
-		versionMap := make(map[string]int64, len(versions))
-		for version, count := range versions {
-			versionMap[version] = count
-		}
-		result[name] = versionMap
-	}
-	return result
+	return &IntegrationTracker{inner: newMapTracker[string](logger, 0)}
 }
 
 // Track records a client integration request. This is non-blocking and safe to call
@@ -340,45 +308,25 @@ func (it *IntegrationTracker) Track(r *http.Request) {
 	if name == "" {
 		return // No integration header present
 	}
-
-	select {
-	case it.trackChan <- [2]string{name, version}:
-		// Successfully queued
-	default:
-		// Channel full - drop silently, telemetry is best-effort.
-	}
+	it.inner.send(name, version)
 }
 
 // GetAndReset returns the current integration counts and resets the tracker.
 // Returns nil if the tracker has been stopped.
 func (it *IntegrationTracker) GetAndReset() map[string]map[string]int64 {
-	respChan := make(chan map[string]map[string]int64, 1)
-	select {
-	case it.resetChan <- respChan:
-		return <-respChan
-	case <-it.stopChan:
-		return nil
-	}
+	return it.inner.getAndReset()
 }
 
 // Get returns the current integration counts without resetting.
 // Returns nil if the tracker has been stopped.
 func (it *IntegrationTracker) Get() map[string]map[string]int64 {
-	respChan := make(chan map[string]map[string]int64, 1)
-	select {
-	case it.getChan <- respChan:
-		return <-respChan
-	case <-it.stopChan:
-		return nil
-	}
+	return it.inner.get()
 }
 
 // Stop gracefully shuts down the background goroutine.
 // This is safe to call multiple times.
 func (it *IntegrationTracker) Stop() {
-	it.stopOnce.Do(func() {
-		close(it.stopChan)
-	})
+	it.inner.stop()
 }
 
 // identifyIntegration reads the X-Weaviate-Client-Integration header and returns
@@ -386,7 +334,7 @@ func (it *IntegrationTracker) Stop() {
 // Any non-empty name is accepted — there is no predefined list of known integrations.
 // Returns ("", "") if the header is absent or empty.
 func identifyIntegration(r *http.Request) (name, version string) {
-	header := strings.TrimSpace(r.Header.Get("X-Weaviate-Client-Integration"))
+	header := strings.TrimSpace(r.Header.Get(integrationHeaderKey))
 	if header == "" {
 		return "", ""
 	}

--- a/usecases/telemetry/client_tracker.go
+++ b/usecases/telemetry/client_tracker.go
@@ -41,9 +41,6 @@ const knownClientTypeCount = 7
 // integrationHeaderKey is the HTTP header used to identify the client integration.
 const integrationHeaderKey = "X-Weaviate-Client-Integration"
 
-// integrationHeaderKey is the HTTP header used to identify the client integration.
-const integrationHeaderKey = "X-Weaviate-Client-Integration"
-
 // ClientInfo represents a client SDK with its type and version
 type ClientInfo struct {
 	Type    ClientType `json:"type"`

--- a/usecases/telemetry/client_tracker_test.go
+++ b/usecases/telemetry/client_tracker_test.go
@@ -62,6 +62,18 @@ func TestIdentifyClientFromHeader(t *testing.T) {
 			expectedVer:  "1.0.0",
 		},
 		{
+			name:         "php client",
+			headerValue:  "weaviate-client-php/0.5.0",
+			expectedType: ClientTypePHP,
+			expectedVer:  "0.5.0",
+		},
+		{
+			name:         "ruby client",
+			headerValue:  "weaviate-client-ruby/0.9.0",
+			expectedType: ClientTypeRuby,
+			expectedVer:  "0.9.0",
+		},
+		{
 			name:         "no version",
 			headerValue:  "weaviate-client-python",
 			expectedType: ClientTypePython,

--- a/usecases/telemetry/client_tracker_test.go
+++ b/usecases/telemetry/client_tracker_test.go
@@ -81,7 +81,7 @@ func TestIdentifyClientFromHeader(t *testing.T) {
 		},
 		{
 			name:         "unknown sdk",
-			headerValue:  "weaviate-client-ruby/1.0.0",
+			headerValue:  "weaviate-client-rust/1.0.0",
 			expectedType: ClientTypeUnknown,
 			expectedVer:  "",
 		},

--- a/usecases/telemetry/client_tracker_test.go
+++ b/usecases/telemetry/client_tracker_test.go
@@ -116,7 +116,7 @@ func TestClientTrackingUnaryInterceptor(t *testing.T) {
 	tracker := NewClientTracker(logger)
 	defer tracker.Stop()
 
-	interceptor := ClientTrackingUnaryInterceptor(tracker)
+	interceptor := ClientTrackingUnaryInterceptor(tracker, nil)
 
 	handler := func(ctx context.Context, req any) (any, error) {
 		return nil, nil
@@ -141,7 +141,7 @@ func TestClientTrackingUnaryInterceptor_NoHeader(t *testing.T) {
 	tracker := NewClientTracker(logger)
 	defer tracker.Stop()
 
-	interceptor := ClientTrackingUnaryInterceptor(tracker)
+	interceptor := ClientTrackingUnaryInterceptor(tracker, nil)
 
 	handler := func(ctx context.Context, req any) (any, error) {
 		return nil, nil
@@ -153,4 +153,31 @@ func TestClientTrackingUnaryInterceptor_NoHeader(t *testing.T) {
 
 	counts := tracker.Get()
 	assert.Empty(t, counts)
+}
+
+func TestClientTrackingUnaryInterceptor_Integration(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	clientTracker := NewClientTracker(logger)
+	defer clientTracker.Stop()
+	integrationTracker := NewIntegrationTracker(logger)
+	defer integrationTracker.Stop()
+
+	interceptor := ClientTrackingUnaryInterceptor(clientTracker, integrationTracker)
+
+	handler := func(ctx context.Context, req any) (any, error) {
+		return nil, nil
+	}
+
+	// gRPC metadata keys are lowercased; send the integration header through
+	// gRPC just as a client would.
+	md := metadata.Pairs("x-weaviate-client-integration", "llamaindex/0.10.5")
+	ctx := metadata.NewIncomingContext(context.Background(), md)
+
+	_, err := interceptor(ctx, nil, &grpc.UnaryServerInfo{}, handler)
+	require.NoError(t, err)
+
+	assert.Eventually(t, func() bool {
+		counts := integrationTracker.Get()
+		return counts["llamaindex"]["0.10.5"] == 1
+	}, time.Second, 10*time.Millisecond)
 }

--- a/usecases/telemetry/payload.go
+++ b/usecases/telemetry/payload.go
@@ -28,16 +28,16 @@ var PayloadType = struct {
 
 // Payload is the object transmitted for telemetry purposes
 type Payload struct {
-	MachineID        strfmt.UUID                     `json:"machineId"`
-	Type             string                          `json:"type"`
-	Version          string                          `json:"version"`
-	ObjectsCount     int64                           `json:"objs"`
-	OS               string                          `json:"os"`
-	Arch             string                          `json:"arch"`
-	UsedModules      []string                        `json:"usedModules,omitempty"`
-	CollectionsCount int                             `json:"collectionsCount"`
-	ClientUsage             map[ClientType]map[string]int64 `json:"clientUsage,omitempty"`
-	ClientIntegrationUsage  map[string]map[string]int64    `json:"clientIntegrationUsage,omitempty"`
-	CloudProvider           *string                        `json:"cloudProvider,omitempty"`
-	UniqueID                *string                        `json:"uniqueID,omitempty"`
+	MachineID              strfmt.UUID                     `json:"machineId"`
+	Type                   string                          `json:"type"`
+	Version                string                          `json:"version"`
+	ObjectsCount           int64                           `json:"objs"`
+	OS                     string                          `json:"os"`
+	Arch                   string                          `json:"arch"`
+	UsedModules            []string                        `json:"usedModules,omitempty"`
+	CollectionsCount       int                             `json:"collectionsCount"`
+	ClientUsage            map[ClientType]map[string]int64 `json:"clientUsage,omitempty"`
+	ClientIntegrationUsage map[string]map[string]int64     `json:"clientIntegrationUsage,omitempty"`
+	CloudProvider          *string                         `json:"cloudProvider,omitempty"`
+	UniqueID               *string                         `json:"uniqueID,omitempty"`
 }

--- a/usecases/telemetry/payload.go
+++ b/usecases/telemetry/payload.go
@@ -36,7 +36,8 @@ type Payload struct {
 	Arch             string                          `json:"arch"`
 	UsedModules      []string                        `json:"usedModules,omitempty"`
 	CollectionsCount int                             `json:"collectionsCount"`
-	ClientUsage      map[ClientType]map[string]int64 `json:"clientUsage,omitempty"`
-	CloudProvider    *string                         `json:"cloudProvider,omitempty"`
-	UniqueID         *string                         `json:"uniqueID,omitempty"`
+	ClientUsage             map[ClientType]map[string]int64 `json:"clientUsage,omitempty"`
+	ClientIntegrationUsage  map[string]map[string]int64    `json:"clientIntegrationUsage,omitempty"`
+	CloudProvider           *string                        `json:"cloudProvider,omitempty"`
+	UniqueID                *string                        `json:"uniqueID,omitempty"`
 }

--- a/usecases/telemetry/telemetry.go
+++ b/usecases/telemetry/telemetry.go
@@ -231,26 +231,9 @@ func (tel *Telemeter) buildPayload(ctx context.Context, payloadType string) (*Pa
 		return nil, fmt.Errorf("get collections count: %w", err)
 	}
 
-	// Get client usage data and reset for the next period
-	// For Init payloads, we don't have client data yet, so skip it
-	var clientUsage map[ClientType]map[string]int64
-	var clientIntegrationUsage map[string]map[string]int64
-	if payloadType != PayloadType.Init {
-		if tel.clientTracker != nil {
-			clientUsage = tel.clientTracker.GetAndReset()
-			// Only include if there's actual data
-			if len(clientUsage) == 0 {
-				clientUsage = nil
-			}
-		}
-		if tel.integrationTracker != nil {
-			clientIntegrationUsage = tel.integrationTracker.GetAndReset()
-			// Only include if there's actual data
-			if len(clientIntegrationUsage) == 0 {
-				clientIntegrationUsage = nil
-			}
-		}
-	}
+	// Get client usage data and reset for the next period.
+	// For Init payloads, we don't have client data yet, so skip it.
+	clientUsage, clientIntegrationUsage := tel.collectUsageForPayload(payloadType)
 
 	cloudProvider, uniqueID := tel.getCloudInfo()
 
@@ -268,6 +251,31 @@ func (tel *Telemeter) buildPayload(ctx context.Context, payloadType string) (*Pa
 		CloudProvider:          cloudProvider,
 		UniqueID:               uniqueID,
 	}, nil
+}
+
+// collectUsageForPayload returns client and integration usage maps for the given
+// payload type, resetting the trackers. Returns (nil, nil) for Init payloads,
+// and nil for any map that contains no data.
+func (tel *Telemeter) collectUsageForPayload(payloadType string) (
+	clientUsage map[ClientType]map[string]int64,
+	clientIntegrationUsage map[string]map[string]int64,
+) {
+	if payloadType == PayloadType.Init {
+		return nil, nil
+	}
+	if tel.clientTracker != nil {
+		clientUsage = tel.clientTracker.GetAndReset()
+		if len(clientUsage) == 0 {
+			clientUsage = nil
+		}
+	}
+	if tel.integrationTracker != nil {
+		clientIntegrationUsage = tel.integrationTracker.GetAndReset()
+		if len(clientIntegrationUsage) == 0 {
+			clientIntegrationUsage = nil
+		}
+	}
+	return clientUsage, clientIntegrationUsage
 }
 
 func (tel *Telemeter) getUsedModules() ([]string, error) {

--- a/usecases/telemetry/telemetry.go
+++ b/usecases/telemetry/telemetry.go
@@ -85,14 +85,14 @@ func New(nodesStatusGetter nodesStatusGetter, schemaManager schemaManager,
 		shutdown:          make(chan struct{}),
 		consumer:          consumerURL,
 		pushInterval:      pushInterval,
-		clientTracker:     NewClientTracker(logger),
 		cloudInfoHelper:   newCloudInfoHelper(logger, telemetryEnabled),
 	}
-	// Only spin up the IntegrationTracker goroutine when telemetry is enabled;
-	// otherwise it would leak for the lifetime of the process, since shutdown
-	// only calls Stop when telemetry is enabled. Callers must handle a nil
-	// IntegrationTracker (middleware and debug handlers already do).
+	// Only spin up tracker goroutines when telemetry is enabled; otherwise they
+	// would leak for the lifetime of the process, since shutdown only calls
+	// Stop when telemetry is enabled. Callers must handle a nil tracker
+	// (middleware and debug handlers already do).
 	if telemetryEnabled {
+		tel.clientTracker = NewClientTracker(logger)
 		tel.integrationTracker = NewIntegrationTracker(logger)
 	}
 	return tel

--- a/usecases/telemetry/telemetry.go
+++ b/usecases/telemetry/telemetry.go
@@ -50,14 +50,14 @@ type schemaManager interface {
 
 // Telemeter is responsible for managing the transmission of telemetry data
 type Telemeter struct {
-	machineID         strfmt.UUID
-	nodesStatusGetter nodesStatusGetter
-	schemaManager     schemaManager
-	logger            logrus.FieldLogger
-	shutdown          chan struct{}
-	failedToStart     bool
-	consumer          string
-	pushInterval      time.Duration
+	machineID          strfmt.UUID
+	nodesStatusGetter  nodesStatusGetter
+	schemaManager      schemaManager
+	logger             logrus.FieldLogger
+	shutdown           chan struct{}
+	failedToStart      bool
+	consumer           string
+	pushInterval       time.Duration
 	clientTracker      *ClientTracker
 	integrationTracker *IntegrationTracker
 	cloudInfoHelper    *cloudInfoHelper

--- a/usecases/telemetry/telemetry.go
+++ b/usecases/telemetry/telemetry.go
@@ -58,8 +58,9 @@ type Telemeter struct {
 	failedToStart     bool
 	consumer          string
 	pushInterval      time.Duration
-	clientTracker     *ClientTracker
-	cloudInfoHelper   *cloudInfoHelper
+	clientTracker      *ClientTracker
+	integrationTracker *IntegrationTracker
+	cloudInfoHelper    *cloudInfoHelper
 }
 
 // New creates a new Telemeter instance.
@@ -77,15 +78,16 @@ func New(nodesStatusGetter nodesStatusGetter, schemaManager schemaManager,
 	}
 
 	tel := &Telemeter{
-		machineID:         strfmt.UUID(uuid.NewString()),
-		nodesStatusGetter: nodesStatusGetter,
-		schemaManager:     schemaManager,
-		logger:            logger,
-		shutdown:          make(chan struct{}),
-		consumer:          consumerURL,
-		pushInterval:      pushInterval,
-		clientTracker:     NewClientTracker(logger),
-		cloudInfoHelper:   newCloudInfoHelper(logger, telemetryEnabled),
+		machineID:          strfmt.UUID(uuid.NewString()),
+		nodesStatusGetter:  nodesStatusGetter,
+		schemaManager:      schemaManager,
+		logger:             logger,
+		shutdown:           make(chan struct{}),
+		consumer:           consumerURL,
+		pushInterval:       pushInterval,
+		clientTracker:      NewClientTracker(logger),
+		integrationTracker: NewIntegrationTracker(logger),
+		cloudInfoHelper:    newCloudInfoHelper(logger, telemetryEnabled),
 	}
 	return tel
 }
@@ -93,6 +95,11 @@ func New(nodesStatusGetter nodesStatusGetter, schemaManager schemaManager,
 // GetClientTracker returns the client tracker instance for use in middleware
 func (tel *Telemeter) GetClientTracker() *ClientTracker {
 	return tel.clientTracker
+}
+
+// GetIntegrationTracker returns the integration tracker instance for use in middleware
+func (tel *Telemeter) GetIntegrationTracker() *IntegrationTracker {
+	return tel.integrationTracker
 }
 
 // Start begins telemetry for the node
@@ -137,11 +144,14 @@ func (tel *Telemeter) Start(ctx context.Context) error {
 
 // Stop shuts down the telemeter
 func (tel *Telemeter) Stop(ctx context.Context) error {
-	// Always stop the client tracker goroutine, even if telemetry failed to start.
+	// Always stop the tracker goroutines, even if telemetry failed to start.
 	// This prevents goroutine leaks.
 	defer func() {
 		if tel.clientTracker != nil {
 			tel.clientTracker.Stop()
+		}
+		if tel.integrationTracker != nil {
+			tel.integrationTracker.Stop()
 		}
 	}()
 
@@ -224,28 +234,39 @@ func (tel *Telemeter) buildPayload(ctx context.Context, payloadType string) (*Pa
 	// Get client usage data and reset for the next period
 	// For Init payloads, we don't have client data yet, so skip it
 	var clientUsage map[ClientType]map[string]int64
-	if payloadType != PayloadType.Init && tel.clientTracker != nil {
-		clientUsage = tel.clientTracker.GetAndReset()
-		// Only include if there's actual data
-		if len(clientUsage) == 0 {
-			clientUsage = nil
+	var clientIntegrationUsage map[string]map[string]int64
+	if payloadType != PayloadType.Init {
+		if tel.clientTracker != nil {
+			clientUsage = tel.clientTracker.GetAndReset()
+			// Only include if there's actual data
+			if len(clientUsage) == 0 {
+				clientUsage = nil
+			}
+		}
+		if tel.integrationTracker != nil {
+			clientIntegrationUsage = tel.integrationTracker.GetAndReset()
+			// Only include if there's actual data
+			if len(clientIntegrationUsage) == 0 {
+				clientIntegrationUsage = nil
+			}
 		}
 	}
 
 	cloudProvider, uniqueID := tel.getCloudInfo()
 
 	return &Payload{
-		MachineID:        tel.machineID,
-		Type:             payloadType,
-		Version:          config.ServerVersion,
-		ObjectsCount:     objs,
-		OS:               runtime.GOOS,
-		Arch:             runtime.GOARCH,
-		UsedModules:      usedMods,
-		CollectionsCount: cols,
-		ClientUsage:      clientUsage,
-		CloudProvider:    cloudProvider,
-		UniqueID:         uniqueID,
+		MachineID:              tel.machineID,
+		Type:                   payloadType,
+		Version:                config.ServerVersion,
+		ObjectsCount:           objs,
+		OS:                     runtime.GOOS,
+		Arch:                   runtime.GOARCH,
+		UsedModules:            usedMods,
+		CollectionsCount:       cols,
+		ClientUsage:            clientUsage,
+		ClientIntegrationUsage: clientIntegrationUsage,
+		CloudProvider:          cloudProvider,
+		UniqueID:               uniqueID,
 	}, nil
 }
 

--- a/usecases/telemetry/telemetry.go
+++ b/usecases/telemetry/telemetry.go
@@ -78,16 +78,22 @@ func New(nodesStatusGetter nodesStatusGetter, schemaManager schemaManager,
 	}
 
 	tel := &Telemeter{
-		machineID:          strfmt.UUID(uuid.NewString()),
-		nodesStatusGetter:  nodesStatusGetter,
-		schemaManager:      schemaManager,
-		logger:             logger,
-		shutdown:           make(chan struct{}),
-		consumer:           consumerURL,
-		pushInterval:       pushInterval,
-		clientTracker:      NewClientTracker(logger),
-		integrationTracker: NewIntegrationTracker(logger),
-		cloudInfoHelper:    newCloudInfoHelper(logger, telemetryEnabled),
+		machineID:         strfmt.UUID(uuid.NewString()),
+		nodesStatusGetter: nodesStatusGetter,
+		schemaManager:     schemaManager,
+		logger:            logger,
+		shutdown:          make(chan struct{}),
+		consumer:          consumerURL,
+		pushInterval:      pushInterval,
+		clientTracker:     NewClientTracker(logger),
+		cloudInfoHelper:   newCloudInfoHelper(logger, telemetryEnabled),
+	}
+	// Only spin up the IntegrationTracker goroutine when telemetry is enabled;
+	// otherwise it would leak for the lifetime of the process, since shutdown
+	// only calls Stop when telemetry is enabled. Callers must handle a nil
+	// IntegrationTracker (middleware and debug handlers already do).
+	if telemetryEnabled {
+		tel.integrationTracker = NewIntegrationTracker(logger)
 	}
 	return tel
 }

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -788,14 +788,6 @@ func trackClientRequest(t *testing.T, tel *Telemeter, clientType, userAgent stri
 	tel.clientTracker.Track(req)
 }
 
-// trackIntegrationRequest is a helper function to simulate an integration request
-func trackIntegrationRequest(t *testing.T, tel *Telemeter, integrationHeader string) {
-	t.Helper()
-	req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
-	req.Header.Set(integrationHeaderKey, integrationHeader)
-	tel.integrationTracker.Track(req)
-}
-
 func TestClientTracker(t *testing.T) {
 	t.Run("track and get client counts", func(t *testing.T) {
 		logger, _ := test.NewNullLogger()

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -156,7 +156,7 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 		})
 
 		t.Run("on update", func(t *testing.T) {
-			tel, sg, sm, ci := newTestTelemeterWithCloudInfo()
+			tel, sg, sm, ci := newTestTelemeterWithCloudInfo(withIntegrationTracker())
 			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 				&models.NodeStatus{
 					Stats: &models.NodeStats{
@@ -203,6 +203,18 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 			trackClientRequest(t, tel, "typescript", "weaviate-client-typescript/1.0.0")
 			trackClientRequest(t, tel, "go", "weaviate-client-go/1.0.0")
 			trackClientRequest(t, tel, "csharp", "weaviate-client-csharp/1.0.0")
+			// Track integrations to populate ClientIntegrationUsage
+			trackIntegrationRequest(t, tel, "llamaindex", "0.10.5")
+			trackIntegrationRequest(t, tel, "llamaindex", "0.10.5")
+			trackIntegrationRequest(t, tel, "langchain", "0.2.0")
+
+			// Trackers process events asynchronously; wait for the integration
+			// counter to settle before the synchronous GetAndReset inside
+			// buildPayload reads it.
+			require.Eventually(t, func() bool {
+				snapshot := tel.integrationTracker.Get()
+				return snapshot["llamaindex"]["0.10.5"] == 2 && snapshot["langchain"]["0.2.0"] == 1
+			}, time.Second, 10*time.Millisecond)
 
 			payload, err := tel.buildPayload(context.Background(), PayloadType.Update)
 			assert.Nil(t, err)
@@ -229,15 +241,20 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 			assert.Equal(t, int64(1), payload.ClientUsage[ClientTypeGo]["1.0.0"])
 			assert.NotNil(t, payload.ClientUsage[ClientTypeCSharp])
 			assert.Equal(t, int64(1), payload.ClientUsage[ClientTypeCSharp]["1.0.0"])
+			// UPDATE payloads should include integration usage data
+			assert.NotNil(t, payload.ClientIntegrationUsage)
+			assert.Equal(t, int64(2), payload.ClientIntegrationUsage["llamaindex"]["0.10.5"])
+			assert.Equal(t, int64(1), payload.ClientIntegrationUsage["langchain"]["0.2.0"])
 			// Verify tracker was reset after GetAndReset
 			currentCounts := tel.clientTracker.Get()
 			assert.Empty(t, currentCounts)
+			assert.Empty(t, tel.integrationTracker.Get())
 			assert.Nil(t, payload.CloudProvider)
 			assert.Nil(t, payload.UniqueID)
 		})
 
 		t.Run("on terminate", func(t *testing.T) {
-			tel, sg, _, ci := newTestTelemeterWithCloudInfo()
+			tel, sg, _, ci := newTestTelemeterWithCloudInfo(withIntegrationTracker())
 			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 				&models.NodeStatus{
 					Stats: &models.NodeStats{
@@ -250,6 +267,14 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 			trackClientRequest(t, tel, "python", "weaviate-client-python/1.0.0")
 			trackClientRequest(t, tel, "java", "weaviate-client-java/1.0.0")
 			trackClientRequest(t, tel, "typescript", "weaviate-client-typescript/1.0.0")
+			// Track integrations before terminate
+			trackIntegrationRequest(t, tel, "llamaindex", "0.10.5")
+			trackIntegrationRequest(t, tel, "dspy", "0.1.0")
+
+			require.Eventually(t, func() bool {
+				snapshot := tel.integrationTracker.Get()
+				return snapshot["llamaindex"]["0.10.5"] == 1 && snapshot["dspy"]["0.1.0"] == 1
+			}, time.Second, 10*time.Millisecond)
 
 			payload, err := tel.buildPayload(context.Background(), PayloadType.Terminate)
 			assert.Nil(t, err)
@@ -268,6 +293,12 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 			assert.Equal(t, int64(1), payload.ClientUsage[ClientTypeJava]["1.0.0"])
 			assert.NotNil(t, payload.ClientUsage[ClientTypeTypeScript])
 			assert.Equal(t, int64(1), payload.ClientUsage[ClientTypeTypeScript]["1.0.0"])
+			// TERMINATE payloads should include integration usage data
+			assert.NotNil(t, payload.ClientIntegrationUsage)
+			assert.Equal(t, int64(1), payload.ClientIntegrationUsage["llamaindex"]["0.10.5"])
+			assert.Equal(t, int64(1), payload.ClientIntegrationUsage["dspy"]["0.1.0"])
+			// Verify integration tracker was reset after GetAndReset
+			assert.Empty(t, tel.integrationTracker.Get())
 			assert.Nil(t, payload.CloudProvider)
 			assert.Nil(t, payload.UniqueID)
 		})
@@ -601,6 +632,17 @@ func withPushInterval(interval time.Duration) telemetryOpt {
 	}
 }
 
+// withIntegrationTracker attaches a freshly-spawned IntegrationTracker so tests
+// that drive buildPayload can exercise the ClientIntegrationUsage field. Needed
+// because the default test telemeter is constructed with telemetryEnabled=false,
+// which skips IntegrationTracker creation to avoid a goroutine leak in disabled
+// deployments.
+func withIntegrationTracker() telemetryOpt {
+	return func(tel *Telemeter) {
+		tel.integrationTracker = NewIntegrationTracker(tel.logger)
+	}
+}
+
 func newTestTelemeter(opts ...telemetryOpt,
 ) (*Telemeter, *fakeNodesStatusGetter, *fakeSchemaManager,
 ) {
@@ -786,6 +828,13 @@ func trackClientRequest(t *testing.T, tel *Telemeter, clientType, userAgent stri
 		req.Header.Set("X-Weaviate-Client", "weaviate-client-csharp/1.0.0")
 	}
 	tel.clientTracker.Track(req)
+}
+
+func trackIntegrationRequest(t *testing.T, tel *Telemeter, name, version string) {
+	require.NotNil(t, tel.integrationTracker, "telemeter must be built with withIntegrationTracker()")
+	req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
+	req.Header.Set("X-Weaviate-Client-Integration", name+"/"+version)
+	tel.integrationTracker.Track(req)
 }
 
 func TestClientTracker(t *testing.T) {

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -41,7 +41,7 @@ const (
 func TestTelemetry_BuildPayload(t *testing.T) {
 	t.Run("happy path", func(t *testing.T) {
 		t.Run("on init", func(t *testing.T) {
-			tel, sg, sm, ci := newTestTelemeterWithCloudInfo()
+			tel, sg, sm, ci := newTestTelemeterWithCloudInfo(withClientTracker())
 			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 				&models.NodeStatus{
 					Stats: &models.NodeStats{
@@ -156,7 +156,7 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 		})
 
 		t.Run("on update", func(t *testing.T) {
-			tel, sg, sm, ci := newTestTelemeterWithCloudInfo(withIntegrationTracker())
+			tel, sg, sm, ci := newTestTelemeterWithCloudInfo(withClientTracker(), withIntegrationTracker())
 			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 				&models.NodeStatus{
 					Stats: &models.NodeStats{
@@ -254,7 +254,7 @@ func TestTelemetry_BuildPayload(t *testing.T) {
 		})
 
 		t.Run("on terminate", func(t *testing.T) {
-			tel, sg, _, ci := newTestTelemeterWithCloudInfo(withIntegrationTracker())
+			tel, sg, _, ci := newTestTelemeterWithCloudInfo(withClientTracker(), withIntegrationTracker())
 			sg.On("LocalNodeStatus", context.Background(), "", "", verbosity.OutputVerbose).Return(
 				&models.NodeStatus{
 					Stats: &models.NodeStats{
@@ -364,6 +364,7 @@ func TestTelemetry_WithConsumer(t *testing.T) {
 	opts := []telemetryOpt{
 		withConsumerURL(consumerURL),
 		withPushInterval(100 * time.Millisecond),
+		withClientTracker(),
 	}
 	tel, sg, sm := newTestTelemeter(opts...)
 
@@ -643,6 +644,17 @@ func withIntegrationTracker() telemetryOpt {
 	}
 }
 
+// withClientTracker attaches a freshly-spawned ClientTracker so tests that
+// drive buildPayload or directly invoke clientTracker.Track can exercise the
+// ClientUsage field. Needed because the default test telemeter is constructed
+// with telemetryEnabled=false, which skips ClientTracker creation to avoid a
+// goroutine leak in disabled deployments.
+func withClientTracker() telemetryOpt {
+	return func(tel *Telemeter) {
+		tel.clientTracker = NewClientTracker(tel.logger)
+	}
+}
+
 func newTestTelemeter(opts ...telemetryOpt,
 ) (*Telemeter, *fakeNodesStatusGetter, *fakeSchemaManager,
 ) {
@@ -810,6 +822,7 @@ func (h *testConsumer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 // trackClientRequest is a helper function to simulate a client request
 func trackClientRequest(t *testing.T, tel *Telemeter, clientType, userAgent string) {
+	require.NotNil(t, tel.clientTracker, "telemeter must be built with withClientTracker()")
 	req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
 	if userAgent != "" {
 		req.Header.Set("User-Agent", userAgent)

--- a/usecases/telemetry/telemetry_test.go
+++ b/usecases/telemetry/telemetry_test.go
@@ -978,7 +978,7 @@ func TestIntegrationTracker(t *testing.T) {
 		assert.Empty(t, counts4)
 	})
 
-	t.Run("accepts arbitrary integration names without validation", func(t *testing.T) {
+	t.Run("accepts arbitrary integration names", func(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		tracker := NewIntegrationTracker(logger)
 		defer tracker.Stop()
@@ -989,6 +989,40 @@ func TestIntegrationTracker(t *testing.T) {
 
 		counts := tracker.Get()
 		assert.Equal(t, int64(1), counts["anydatahere"]["0.3.0"])
+	})
+
+	t.Run("drops events beyond maxIntegrationKeys distinct names", func(t *testing.T) {
+		logger, _ := test.NewNullLogger()
+		tracker := NewIntegrationTracker(logger)
+		defer tracker.Stop()
+
+		for i := 0; i < maxIntegrationKeys+10; i++ {
+			req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
+			req.Header.Set(integrationHeaderKey, fmt.Sprintf("integration-%d/1.0.0", i))
+			tracker.Track(req)
+		}
+
+		assert.Eventually(t, func() bool {
+			counts := tracker.Get()
+			return len(counts) == maxIntegrationKeys
+		}, time.Second, 10*time.Millisecond)
+	})
+
+	t.Run("drops events beyond maxIntegrationVersions per name", func(t *testing.T) {
+		logger, _ := test.NewNullLogger()
+		tracker := NewIntegrationTracker(logger)
+		defer tracker.Stop()
+
+		for i := 0; i < maxIntegrationVersions+10; i++ {
+			req := httptest.NewRequest(http.MethodGet, "/v1/objects", nil)
+			req.Header.Set(integrationHeaderKey, fmt.Sprintf("langchain/%d.0.0", i))
+			tracker.Track(req)
+		}
+
+		assert.Eventually(t, func() bool {
+			counts := tracker.Get()
+			return len(counts["langchain"]) == maxIntegrationVersions
+		}, time.Second, 10*time.Millisecond)
 	})
 
 	t.Run("skips empty header", func(t *testing.T) {
@@ -1065,6 +1099,12 @@ func TestIdentifyIntegration(t *testing.T) {
 		{
 			name:   "whitespace only",
 			header: "   ",
+		},
+		{
+			name:            "header exceeding max length is truncated",
+			header:          strings.Repeat("a", maxClientHeaderLen+10) + "/1.0.0",
+			expectedName:    strings.Repeat("a", maxClientHeaderLen),
+			expectedVersion: "",
 		},
 	}
 


### PR DESCRIPTION
### What's being changed:

Adds a ClientIntegrationUsage for telemetry:

```bash
curl -H "X-Weaviate-Client: weaviate-client-python/4.0.0" \
     -H "X-Weaviate-Client-Integration: langchain/0.3.0" \
     http://localhost:8080/v1/schema
```
<img width="207" height="125" alt="image" src="https://github.com/user-attachments/assets/3ef0b86d-2eb7-4ce8-85b9-082e6ff58748" />


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
