### PR TITLE
perf(hnsw): parallelize Muvera late-interaction rescoring

### DIFF
--- a/adapters/repos/db/vector/hnsw/multivector_entrypoint_repair_test.go
+++ b/adapters/repos/db/vector/hnsw/multivector_entrypoint_repair_test.go
@@ -83,9 +83,12 @@ func TestMultivectorEntrypointRepair(t *testing.T) {
 				return nil, errors.New("multivector index must not use VectorForIDThunk")
 			},
 			MultiVectorForIDThunk: store.multiVectorForID,
-			MakeBucketOptions:     lsmkv.MakeNoopBucketOptions,
-			GetViewThunk:          func() common.BucketView { return &noopBucketView{} },
-			AllocChecker:          memwatch.NewDummyMonitor(),
+			TempMultiVectorForIDWithViewThunk: func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([][]float32, error) {
+				return store.multiVectorForID(ctx, id)
+			},
+			MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+			GetViewThunk:      func() common.BucketView { return &noopBucketView{} },
+			AllocChecker:      memwatch.NewDummyMonitor(),
 		}, ent.UserConfig{
 			VectorCacheMaxObjects: 100000,
 			MaxConnections:        8,

--- a/adapters/repos/db/vector/hnsw/multivector_hnsw_test.go
+++ b/adapters/repos/db/vector/hnsw/multivector_hnsw_test.go
@@ -96,6 +96,9 @@ func TestMultiVectorHnsw(t *testing.T) {
 			},
 			MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
 			GetViewThunk:      func() common.BucketView { return &multivectorNoopBucketView{} },
+			TempMultiVectorForIDWithViewThunk: func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([][]float32, error) {
+				return multiVectors[id], nil
+			},
 		}, ent.UserConfig{
 			VectorCacheMaxObjects: 1e12,
 			MaxConnections:        maxConnections,
@@ -278,6 +281,9 @@ func TestMultiVectorBQHnsw(t *testing.T) {
 				return multiVectors[id], nil
 			},
 			MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
+			TempMultiVectorForIDWithViewThunk: func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([][]float32, error) {
+				return multiVectors[id], nil
+			},
 		}, ent.UserConfig{
 			VectorCacheMaxObjects: 1e12,
 			MaxConnections:        maxConnections,
@@ -370,6 +376,9 @@ func TestMultivectorPersistence(t *testing.T) {
 		},
 		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
 		GetViewThunk:      func() common.BucketView { return &multivectorNoopBucketView{} },
+		TempMultiVectorForIDWithViewThunk: func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([][]float32, error) {
+			return multiVectors[id], nil
+		},
 	}, ent.UserConfig{
 		VectorCacheMaxObjects: 1e12,
 		MaxConnections:        maxConnections,
@@ -414,6 +423,9 @@ func TestMultivectorPersistence(t *testing.T) {
 		},
 		MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
 		GetViewThunk:      func() common.BucketView { return &multivectorNoopBucketView{} },
+		TempMultiVectorForIDWithViewThunk: func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([][]float32, error) {
+			return multiVectors[id], nil
+		},
 	}, ent.UserConfig{
 		VectorCacheMaxObjects: 1e12,
 		MaxConnections:        maxConnections,
@@ -455,6 +467,9 @@ func TestMuveraHnsw(t *testing.T) {
 			MakeBucketOptions: lsmkv.MakeNoopBucketOptions,
 			AllocChecker:      memwatch.NewDummyMonitor(),
 			GetViewThunk:      func() common.BucketView { return &multivectorNoopBucketView{} },
+			TempMultiVectorForIDWithViewThunk: func(ctx context.Context, id uint64, container *common.VectorSlice, view common.BucketView) ([][]float32, error) {
+				return multiVectors[id], nil
+			},
 		}, ent.UserConfig{
 			VectorCacheMaxObjects: 1e12,
 			MaxConnections:        maxConnections,

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -113,7 +113,7 @@ func (h *hnsw) SearchByMultiVector(ctx context.Context, vectors [][]float32, k i
 		for _, docID := range docIDs {
 			candidateSet[docID] = struct{}{}
 		}
-		return h.computeLateInteraction(vectors, k, candidateSet)
+		return h.computeLateInteraction(ctx, vectors, k, candidateSet)
 	}
 
 	h.compressActionLock.RLock()
@@ -1004,34 +1004,71 @@ func (h *hnsw) knnSearchByMultiVector(ctx context.Context, queryVectors [][]floa
 			candidateSet[docId] = struct{}{}
 		}
 	}
-	return h.computeLateInteraction(queryVectors, k, candidateSet)
+	return h.computeLateInteraction(ctx, queryVectors, k, candidateSet)
 }
 
-func (h *hnsw) computeLateInteraction(queryVectors [][]float32, k int, candidateSet map[uint64]struct{}) ([]uint64, []float32, error) {
-	resultsQueue := priorityqueue.NewMax[any](1)
+func (h *hnsw) computeLateInteraction(ctx context.Context, queryVectors [][]float32, k int, candidateSet map[uint64]struct{}) ([]uint64, []float32, error) {
+	// Convert map to slice for stride-based index access across workers.
+	ids := make([]uint64, 0, len(candidateSet))
 	for docID := range candidateSet {
-		sim, err := h.computeScore(queryVectors, docID)
-		if err != nil {
-			return nil, nil, err
-		}
-		resultsQueue.Insert(docID, sim)
+		ids = append(ids, docID)
+	}
+
+	// Acquire a single consistent view for all disk reads to avoid per-candidate flushLock acquisitions.
+	view := h.GetViewThunk()
+	defer view.ReleaseView()
+
+	resultsQueue := priorityqueue.NewMax[any](k)
+	mu := sync.Mutex{}
+	addResult := func(id uint64, sim float32) {
+		mu.Lock()
+		defer mu.Unlock()
+		resultsQueue.Insert(id, sim)
 		if resultsQueue.Len() > k {
 			resultsQueue.Pop()
 		}
 	}
 
-	distances := make([]float32, resultsQueue.Len())
-	ids := make([]uint64, resultsQueue.Len())
+	eg := enterrors.NewErrorGroupWrapper(h.logger)
+	for workerID := 0; workerID < h.rescoreConcurrency; workerID++ {
+		workerID := workerID
+		eg.Go(func() error {
+			slice := h.pools.tempVectors.Get(int(h.dims.Load()))
+			defer h.pools.tempVectors.Put(slice)
 
-	i := len(ids) - 1
-	for resultsQueue.Len() > 0 {
-		element := resultsQueue.Pop()
-		ids[i] = element.ID
-		distances[i] = element.Dist
-		i--
+			for idPos := workerID; idPos < len(ids); idPos += h.rescoreConcurrency {
+				if err := ctx.Err(); err != nil {
+					return fmt.Errorf("computeLateInteraction: %w", err)
+				}
+				docID := ids[idPos]
+				sim, err := h.computeScoreWithView(ctx, queryVectors, docID, slice, view)
+				if err != nil {
+					h.logger.
+						WithField("action", "computeLateInteraction").
+						WithError(err).
+						Warnf("could not compute score for docID %d", docID)
+					continue
+				}
+				addResult(docID, sim)
+			}
+			return nil
+		}, h.logger)
 	}
 
-	return ids, distances, nil
+	if err := eg.Wait(); err != nil {
+		return nil, nil, err
+	}
+
+	distances := make([]float32, resultsQueue.Len())
+	resultIDs := make([]uint64, resultsQueue.Len())
+	i := len(resultIDs) - 1
+	for resultsQueue.Len() > 0 {
+		el := resultsQueue.Pop()
+		resultIDs[i] = el.ID
+		distances[i] = el.Dist
+		i--
+	}
+	return resultIDs, distances, nil
 }
 
 func (h *hnsw) computeScore(searchVecs [][]float32, docID uint64) (float32, error) {
@@ -1085,6 +1122,30 @@ func (h *hnsw) computeScore(searchVecs [][]float32, docID uint64) (float32, erro
 		similarity += maxSim
 	}
 
+	return similarity, nil
+}
+
+func (h *hnsw) computeScoreWithView(ctx context.Context, searchVecs [][]float32, docID uint64, slice *common.VectorSlice, view common.BucketView) (float32, error) {
+	docVecs, err := h.TempMultiVectorForIDWithViewThunk(ctx, docID, slice, view)
+	if err != nil {
+		return 0, errors.Wrap(err, "get vectors for docID")
+	}
+
+	similarity := float32(0.0)
+	for _, searchVec := range searchVecs {
+		maxSim := float32(math.MaxFloat32)
+		dist := h.multiDistancerProvider.New(searchVec)
+		for _, docVec := range docVecs {
+			d, err := dist.Distance(docVec)
+			if err != nil {
+				return 0, errors.Wrap(err, "calculate distance")
+			}
+			if d < maxSim {
+				maxSim = d
+			}
+		}
+		similarity += maxSim
+	}
 	return similarity, nil
 }
 

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -113,7 +113,10 @@ func (h *hnsw) SearchByMultiVector(ctx context.Context, vectors [][]float32, k i
 		for _, docID := range docIDs {
 			candidateSet[docID] = struct{}{}
 		}
-		return h.computeLateInteraction(ctx, vectors, k, candidateSet)
+		beforeRescore := time.Now()
+		ids, dists, err := h.computeLateInteraction(ctx, vectors, k, candidateSet)
+		helpers.AnnotateSlowQueryLog(ctx, "muvera_rescore_took", time.Since(beforeRescore))
+		return ids, dists, err
 	}
 
 	h.compressActionLock.RLock()
@@ -1004,7 +1007,10 @@ func (h *hnsw) knnSearchByMultiVector(ctx context.Context, queryVectors [][]floa
 			candidateSet[docId] = struct{}{}
 		}
 	}
-	return h.computeLateInteraction(ctx, queryVectors, k, candidateSet)
+	beforeRescore := time.Now()
+	ids, dists, err := h.computeLateInteraction(ctx, queryVectors, k, candidateSet)
+	helpers.AnnotateSlowQueryLog(ctx, "multivector_rescore_took", time.Since(beforeRescore))
+	return ids, dists, err
 }
 
 func (h *hnsw) computeLateInteraction(ctx context.Context, queryVectors [][]float32, k int, candidateSet map[uint64]struct{}) ([]uint64, []float32, error) {

--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -28,6 +28,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/visited"
+	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/dto"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -1035,14 +1036,20 @@ func (h *hnsw) computeLateInteraction(ctx context.Context, queryVectors [][]floa
 		}
 	}
 
+	// Respect the per-query concurrency budget if the context carries one
+	// (see entities/concurrency): under concurrent load the budget shrinks
+	// the fan-out, without one we fall back to the full rescore concurrency.
+	// The floor of 1 keeps a zero budget from silently skipping rescoring.
+	workers := max(1, min(concurrency.BudgetFromCtx(ctx, h.rescoreConcurrency), h.rescoreConcurrency, len(ids)))
+
 	eg := enterrors.NewErrorGroupWrapper(h.logger)
-	for workerID := 0; workerID < h.rescoreConcurrency; workerID++ {
+	for workerID := 0; workerID < workers; workerID++ {
 		workerID := workerID
 		eg.Go(func() error {
 			slice := h.pools.tempVectors.Get(int(h.dims.Load()))
 			defer h.pools.tempVectors.Put(slice)
 
-			for idPos := workerID; idPos < len(ids); idPos += h.rescoreConcurrency {
+			for idPos := workerID; idPos < len(ids); idPos += workers {
 				if err := ctx.Err(); err != nil {
 					return fmt.Errorf("computeLateInteraction: %w", err)
 				}


### PR DESCRIPTION
### What's being changed:

Replace the single-threaded `computeLateInteraction` (Muvera/multivector late-interaction rescoring) with a parallel implementation that mirrors the existing `rescore()` approach:

- Acquire **one** consistent LSM view shared across all candidates via `h.GetViewThunk()`, instead of one `flushLock` acquisition per candidate.
- Spread candidates across `rescoreConcurrency` workers (2×GOMAXPROCS) using stride-based partitioning, reusing per-goroutine scratch buffers from `h.pools.tempVectors`.
- Add `computeScoreWithView` helper that reads vectors via `TempMultiVectorForIDWithViewThunk` using the shared view.
- Per-doc errors now log a warning and continue (consistent with `rescore()`) rather than aborting the entire candidate set.
- Update integration test configs to provide `TempMultiVectorForIDWithViewThunk` in all setups that exercise `SearchByMultiVector`.

### Benchmarks

As expected, the biggest impact is for low parallelism and many individual vectors per object, where the rescoring overhead is the most significant:

<img width="977" height="751" alt="benchmark_muvera,_lotte-lifestyle_(full),_cosine,_m=128,_parallel=1" src="https://github.com/user-attachments/assets/bbfbec98-e972-490e-8913-5c0e4c444b1e" />
<img width="985" height="751" alt="benchmark_muvera,_lotte-lifestyle_(full),_cosine,_m=128,_parallel=10" src="https://github.com/user-attachments/assets/1a38000f-29be-4faa-b224-6a2834f73985" />
<img width="1071" height="751" alt="benchmark_muvera,_lotte-recreation_(reduced),_cosine,_m=128,_parallel=1" src="https://github.com/user-attachments/assets/1635980f-9c61-44ec-ad1a-997b97e8131f" />
<img width="1079" height="751" alt="benchmark_muvera,_lotte-recreation_(reduced),_cosine,_m=128,_parallel=10" src="https://github.com/user-attachments/assets/284a98c2-b37e-42f6-a2d2-fb19ba8f0c6c" />



### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.