### PR TITLE
claude: add CI / Pipeline Monitoring section for Claude to automatically monitor CI for a given PR

### DIFF
--- a/.claude/scripts/monitor_docker.sh
+++ b/.claude/scripts/monitor_docker.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -euo pipefail
+
+RUN_ID=${1:-}
+if [ -z "$RUN_ID" ]; then
+  echo "Usage: $0 <run_id>"
+  exit 1
+fi
+
+echo "Monitoring generate-docker-report for run $RUN_ID..."
+
+while true; do
+  RESULT=$(gh run view "$RUN_ID" --repo weaviate/weaviate --json jobs \
+    --jq '.jobs[] | select(.name | test("generate-docker-report|docker report")) | {status: .status, conclusion: .conclusion}' 2>&1)
+
+  STATUS=$(echo "$RESULT" | jq -r '.status' 2>/dev/null || echo "unknown")
+  CONCLUSION=$(echo "$RESULT" | jq -r '.conclusion' 2>/dev/null || echo "unknown")
+
+  echo "[$(date '+%H:%M:%S')] status=$STATUS conclusion=$CONCLUSION"
+
+  if [ "$STATUS" = "completed" ]; then
+    if [ "$CONCLUSION" = "success" ]; then
+      echo "Docker image is ready!"
+      JOB_ID=$(gh run view "$RUN_ID" --repo weaviate/weaviate --json jobs \
+        --jq '.jobs[] | select(.name | test("generate-docker-report|docker report")) | .databaseId')
+      echo "Docker image tags:"
+      gh api repos/weaviate/weaviate/actions/jobs/"$JOB_ID"/logs 2>&1 \
+        | sed 's/\x1b\[[0-9;]*m//g' \
+        | grep -oE 'semitechnologies/weaviate:[a-zA-Z0-9.:_-]+' \
+        | sort -u \
+        | while read -r tag; do echo "  $tag"; done
+      exit 0
+    else
+      echo "generate-docker-report ended with: $CONCLUSION"
+      exit 1
+    fi
+  fi
+
+  sleep 30
+done

--- a/.claude/scripts/monitor_pr.sh
+++ b/.claude/scripts/monitor_pr.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Monitor CI checks for a PR until all checks complete.
+# Usage: PR=<number> .claude/scripts/monitor_pr.sh
+# Exits with code 0 if all pass, 1 if any fail.
+PR=${PR:-}
+if [ -z "$PR" ]; then
+  echo "Usage: PR=<number> $0"
+  exit 1
+fi
+
+while true; do
+  OUTPUT=$(gh pr checks $PR --repo weaviate/weaviate 2>&1)
+  PASS=$(echo "$OUTPUT" | grep -c $'\tpass\t')
+  FAIL=$(echo "$OUTPUT" | grep -c $'\tfail\t')
+  PENDING=$(echo "$OUTPUT" | grep -c $'\tpending\t')
+  FAILED_CHECKS=$(echo "$OUTPUT" | grep $'\tfail\t' | awk -F'\t' '{print $1}')
+
+  echo "[$(date '+%H:%M:%S')] PASS: $PASS | FAIL: $FAIL | PENDING: $PENDING"
+
+  if [ "$PENDING" -eq 0 ]; then
+    echo ""
+    echo "=== ALL CHECKS COMPLETE ==="
+    echo "PASSED: $PASS | FAILED: $FAIL"
+    if [ -n "$FAILED_CHECKS" ]; then
+      echo ""
+      echo "Failed checks:"
+      echo "$FAILED_CHECKS" | while read line; do echo "  - $line"; done
+      exit 1
+    fi
+    exit 0
+  fi
+
+  sleep 60
+done

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ test/modules/backup-filesystem/bucketPath
 # Claude
 .claude/*
 !.claude/settings.json
+!.claude/scripts/


### PR DESCRIPTION
### What's being changed:

Adds a **CI / Pipeline Monitoring** section to `CLAUDE.md` with a reusable shell script and `gh` CLI commands that allow Claude (or any developer) to:
- Poll PR check statuses until all checks complete, reporting pass/fail counts at each interval
- Get notified automatically when checks finish or new failures appear
- Inspect failed job logs directly via the GitHub API
- Re-run only failed jobs without triggering a full pipeline re-run

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->