### PR TITLE
fix multi2vec-cohere name

### DIFF
--- a/modules/multi2vec-cohere/clients/meta.go
+++ b/modules/multi2vec-cohere/clients/meta.go
@@ -13,7 +13,7 @@ package clients
 
 func (v *vectorizer) MetaInfo() (map[string]interface{}, error) {
 	return map[string]interface{}{
-		"name":              "Cohere Module",
+		"name":              "Cohere Multimodal Module",
 		"documentationHref": "https://docs.cohere.ai/embedding-wiki/",
 	}, nil
 }


### PR DESCRIPTION
### What's being changed:

Fix the name of Cohere Multimodal Module as it's currently the same as text2vec-cohere and can create confusion on integrations

<img width="607" height="354" alt="image" src="https://github.com/user-attachments/assets/e0c83aad-90aa-479f-85bb-b30bc3ab6b2b" />


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
