### PR TITLE
hfresh: fix count all vectors

### DIFF
--- a/adapters/repos/db/vector/hfresh/posting_map.go
+++ b/adapters/repos/db/vector/hfresh/posting_map.go
@@ -47,7 +47,7 @@ func NewPostingMap(bucket *lsmkv.Bucket, metrics *Metrics) *PostingMap {
 		data:       xsync.NewMap[uint64, *PostingMetadata](),
 		metrics:    metrics,
 		bucket:     b,
-		sizeMetric: OncePer(5 * time.Second),
+		sizeMetric: OncePer(30 * time.Second),
 	}
 }
 


### PR DESCRIPTION
### What's being changed:

Reduced the frequency of the vector count metric calculation and reduced the time spent holding the lock by copying the value before iterating.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
