### PR TITLE
refact(memberlist): unconditional cluster join 

### DIFF
--- a/usecases/cluster/state.go
+++ b/usecases/cluster/state.go
@@ -198,7 +198,7 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 	// Set delegate and events
 	cfg.Delegate = &state.delegate
 	cfg.Events = events{&state.delegate}
-
+	joinAddresses := parseJoinAddresses(userConfig.Join)
 	// Log configuration details
 	logger.WithFields(logrus.Fields{
 		"action":          "memberlist_config",
@@ -210,6 +210,7 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 		"config_type":     getConfigType(userConfig),
 		"tcp_timeout":     cfg.TCPTimeout,
 		"raft_multiplier": raftTimeoutsMultiplier,
+		"join_addresses":  joinAddresses,
 	}).Info("memberlist configuration")
 
 	// Create memberlist
@@ -225,27 +226,23 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 		}).Errorf("memberlist not created: %v", err)
 		return nil, errors.Wrap(err, "create memberlist")
 	}
-	var joinAddr []string
-	if userConfig.Join != "" {
-		joinAddr = strings.Split(userConfig.Join, ",")
-	}
 
-	if len(joinAddr) > 0 {
-		joinHost := extractHost(joinAddr[0])
+	if len(joinAddresses) > 0 {
+		joinHost := extractHost(joinAddresses[0])
 		_, err := net.LookupIP(joinHost)
 		if err != nil {
 			logger.WithFields(logrus.Fields{
 				"action":          "cluster_attempt_join",
-				"remote_hostname": joinAddr[0],
+				"remote_hostname": joinAddresses[0],
 			}).WithError(err).Warn(
 				"specified hostname to join cluster cannot be resolved. This is fine" +
 					"if this is the first node of a new cluster, but problematic otherwise.")
 		} else {
-			_, err := state.list.Join(joinAddr)
+			_, err := state.list.Join(joinAddresses)
 			if err != nil {
 				logger.WithFields(logrus.Fields{
 					"action":          "memberlist_init",
-					"remote_hostname": joinAddr,
+					"remote_hostname": joinAddresses,
 				}).WithError(err).Error("memberlist join not successful")
 				return nil, errors.Wrap(err, "join cluster")
 			}
@@ -257,9 +254,9 @@ func Init(userConfig Config, raftTimeoutsMultiplier int, dataPath string, nonSto
 	// memberlist to purge all knowledge of it (and vice versa). Without periodic
 	// rejoin, such a node can never re-discover the cluster because memberlist only
 	// calls Join() once at startup.
-	if len(joinAddr) > 0 && userConfig.RaftBootstrapExpect > 1 {
+	if len(joinAddresses) > 0 && userConfig.RaftBootstrapExpect > 1 {
 		enterrors.GoWrapper(func() {
-			state.periodicRejoin(cfg.PushPullInterval, joinAddr, userConfig.RaftBootstrapExpect, logger)
+			state.periodicRejoin(cfg.PushPullInterval, joinAddresses, userConfig.RaftBootstrapExpect, logger)
 		}, logger)
 	}
 
@@ -597,6 +594,15 @@ func (s *State) periodicRejoin(pushPullInterval time.Duration, joinAddr []string
 			}).Debug("successfully rejoined cluster")
 		}
 	}
+}
+
+// parseJoinAddresses splits the Join config (comma-separated addresses) into a slice.
+// Empty string yields nil; no comma yields a single-element slice.
+func parseJoinAddresses(join string) []string {
+	if join == "" {
+		return nil
+	}
+	return strings.Split(join, ",")
 }
 
 // validateClusterConfig validates the cluster configuration

--- a/usecases/cluster/state_test.go
+++ b/usecases/cluster/state_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/memberlist"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -567,6 +568,25 @@ func TestExtractHost(t *testing.T) {
 	}
 }
 
+func TestParseJoinAddresses(t *testing.T) {
+	tests := []struct {
+		name     string
+		join     string
+		expected []string
+	}{
+		{"empty string yields nil", "", nil},
+		{"single address no comma", "192.168.1.1:7946", []string{"192.168.1.1:7946"}},
+		{"two addresses", "host1:7946,host2:7946", []string{"host1:7946", "host2:7946"}},
+		{"three addresses", "a:1,b:2,c:3", []string{"a:1", "b:2", "c:3"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseJoinAddresses(tt.join)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
 func TestExtractHostPreservesValidIPForLookup(t *testing.T) {
 	// Verify that extractHost returns a value that net.ParseIP accepts.
 	// This is the critical property: the old code using strings.Split(":")[0]
@@ -665,4 +685,51 @@ func TestIPv6AddressConstruction(t *testing.T) {
 			assert.Equal(t, fmt.Sprintf("%d", tt.port), port)
 		})
 	}
+}
+
+func TestInitJoinBehavior(t *testing.T) {
+	logger := logrus.New()
+	logger.SetLevel(logrus.ErrorLevel) // reduce noise in tests
+
+	validConfig := Config{
+		Hostname:       "test-node-join",
+		GossipBindPort: 17946,
+		DataBindPort:   17947,
+		AdvertisePort:  17946,
+		AdvertiseAddr:  "127.0.0.1",
+		BindAddr:       "127.0.0.1",
+		Localhost:      true,
+	}
+
+	t.Run("empty Join does not attempt join and succeeds", func(t *testing.T) {
+		cfg := validConfig
+		cfg.Hostname = "test-node-empty-join"
+		cfg.Join = ""
+		state, err := Init(cfg, 1, ".", nil, logger)
+		require.NoError(t, err)
+		require.NotNil(t, state)
+		defer func() { _ = state.Shutdown() }()
+	})
+
+	t.Run("non-empty Join attempts join and returns error when unreachable", func(t *testing.T) {
+		cfg := validConfig
+		cfg.Hostname = "test-node-unreachable"
+		cfg.GossipBindPort, cfg.DataBindPort, cfg.AdvertisePort = 17956, 17957, 17956
+		cfg.Join = "nonexistent-host.invalid:7946"
+		state, err := Init(cfg, 1, ".", nil, logger)
+		require.Error(t, err)
+		assert.Nil(t, state)
+		assert.Contains(t, err.Error(), "join cluster")
+	})
+
+	t.Run("multiple join addresses are all passed to Join", func(t *testing.T) {
+		cfg := validConfig
+		cfg.Hostname = "test-node-multi-join"
+		cfg.GossipBindPort, cfg.DataBindPort, cfg.AdvertisePort = 17966, 17967, 17966
+		cfg.Join = "host1.invalid:7946,host2.invalid:7946"
+		state, err := Init(cfg, 1, ".", nil, logger)
+		require.Error(t, err)
+		assert.Nil(t, state)
+		assert.Contains(t, err.Error(), "join cluster")
+	})
 }


### PR DESCRIPTION
### What's being changed:
Refactors cluster initialization to centralize parsing of the Join config and to always pass join value 

Changes:

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/22309267137
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
