### PR TITLE
chore(test): fix Test_UploadS3Journey

### DIFF
--- a/test/modules/offload-s3/offload_upload_test.go
+++ b/test/modules/offload-s3/offload_upload_test.go
@@ -450,7 +450,9 @@ func Test_UploadS3Journey(t *testing.T) {
 					ID:    strfmt.UUID(fmt.Sprintf("0927a1e0-398e-4e76-91fb-%012x", i+1)),
 					Class: className,
 					Properties: map[string]interface{}{
-						"name": fmt.Sprintf("extra-%d", i),
+						"name":          fmt.Sprintf("extra-%d", i),
+						"someData":      "ref#0",
+						"someOtherData": "ref#1",
 					},
 					Tenant: tenantNames[0],
 				}


### PR DESCRIPTION
### What's being changed:
increase number of inserted objects to  so offload takes long enough to observe cloud provider termination mock.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
