### PR TITLE
fix(replication-retry): this reverts an introduced behaviour to retry node on loading shard 

### DIFF
--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -23,18 +23,17 @@ import (
 	"strings"
 	"time"
 
-	"github.com/weaviate/weaviate/cluster/router/types"
-	"github.com/weaviate/weaviate/entities/models"
-
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 
+	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/aggregation"
 	"github.com/weaviate/weaviate/entities/dto"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
 	entschema "github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/searchparams"
@@ -812,9 +811,8 @@ func (i *indices) postSearchObjects() http.Handler {
 
 		results, dists, err := i.shards.Search(r.Context(), index, shard,
 			vector, targetVector, certainty, limit, filters, keywordRanking, sort, cursor, groupBy, additional, targetCombination, props)
-		if err != nil && errors.As(err, &enterrors.ErrShardNotReady{}) {
-			// shard is not ready means it's transient, use 503 so replication client retries
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		if err != nil && errors.As(err, &enterrors.ErrUnprocessable{}) {
+			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 			return
 		}
 		if err != nil {
@@ -922,9 +920,8 @@ func (i *indices) postAggregateObjects() http.Handler {
 
 		aggRes, err := i.shards.Aggregate(r.Context(), index, shard, params)
 
-		if err != nil && errors.As(err, &enterrors.ErrShardNotReady{}) {
-			// shard is not ready means it's transient, use 503 so replication client retries
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		if err != nil && errors.As(err, &enterrors.ErrUnprocessable{}) {
+			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 			return
 		}
 		if err != nil {
@@ -982,9 +979,8 @@ func (i *indices) postFindUUIDs() http.Handler {
 
 		results, err := i.shards.FindUUIDs(r.Context(), index, shard, filters)
 
-		if err != nil && errors.As(err, &enterrors.ErrShardNotReady{}) {
-			// shard is not ready means it's transient, use 503 so replication client retries
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		if err != nil && errors.As(err, &enterrors.ErrUnprocessable{}) {
+			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 			return
 		}
 		if err != nil {
@@ -1081,9 +1077,8 @@ func (i *indices) getObjectsDigest() http.Handler {
 		}).Debug("digest objects ...")
 
 		results, err := i.shards.DigestObjects(r.Context(), index, shard, ids)
-		if err != nil && errors.As(err, &enterrors.ErrShardNotReady{}) {
-			// shard is not ready means it's transient, use 503 so replication client retries
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+		if err != nil && errors.As(err, &enterrors.ErrUnprocessable{}) {
+			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 			return
 		}
 		if err != nil {
@@ -1263,8 +1258,7 @@ func (i *indices) getGetShardQueueSize() http.Handler {
 
 		size, err := i.shards.GetShardQueueSize(r.Context(), index, shard)
 		if err != nil && errors.As(err, &enterrors.ErrUnprocessable{}) {
-			// shard is not ready means it's transient, use 503 so replication client retries
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 			return
 		}
 
@@ -1303,8 +1297,7 @@ func (i *indices) getGetShardStatus() http.Handler {
 
 		status, err := i.shards.GetShardStatus(r.Context(), index, shard)
 		if err != nil && errors.As(err, &enterrors.ErrUnprocessable{}) {
-			// shard is not ready means it's transient, use 503 so replication client retries
-			http.Error(w, err.Error(), http.StatusServiceUnavailable)
+			http.Error(w, err.Error(), http.StatusUnprocessableEntity)
 			return
 		}
 		if err != nil {

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -512,9 +512,8 @@ func (i *replicatedIndices) getObjectsDigest() http.Handler {
 		}
 
 		results, err := i.shards.DigestObjects(r.Context(), index, shard, ids)
-		if err != nil && errors.As(err, &enterrors.ErrShardNotReady{}) {
-			// shard is not ready means it's transient, use 503 so replication client retries
-			http.Error(w, "digest objects: "+err.Error(), http.StatusServiceUnavailable)
+		if err != nil && errors.As(err, &enterrors.ErrUnprocessable{}) {
+			http.Error(w, "digest objects: "+err.Error(), http.StatusUnprocessableEntity)
 			return
 		}
 
@@ -870,15 +869,9 @@ func (i *replicatedIndices) getObject() http.Handler {
 
 		defer r.Body.Close()
 
-		var (
-			resp replica.Replica
-			err  error
-		)
-
-		resp, err = i.shards.FetchObject(r.Context(), index, shard, strfmt.UUID(id))
-		if err != nil && errors.As(err, &enterrors.ErrShardNotReady{}) {
-			// shard is not ready means it's transient, use 503 so replication client retries
-			http.Error(w, "fetch objects: "+err.Error(), http.StatusServiceUnavailable)
+		resp, err := i.shards.FetchObject(r.Context(), index, shard, strfmt.UUID(id))
+		if err != nil && errors.As(err, &enterrors.ErrUnprocessable{}) {
+			http.Error(w, "fetch objects: "+err.Error(), http.StatusUnprocessableEntity)
 			return
 		}
 
@@ -933,9 +926,8 @@ func (i *replicatedIndices) getObjectsMulti() http.Handler {
 		}
 
 		resp, err := i.shards.FetchObjects(r.Context(), index, shard, ids)
-		if err != nil && errors.As(err, &enterrors.ErrShardNotReady{}) {
-			// shard is not ready means it's transient, use 503 so replication client retries
-			http.Error(w, "fetch objects: "+err.Error(), http.StatusServiceUnavailable)
+		if err != nil && errors.As(err, &enterrors.ErrUnprocessable{}) {
+			http.Error(w, "fetch objects: "+err.Error(), http.StatusUnprocessableEntity)
 			return
 		}
 		if err != nil {

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1521,7 +1521,7 @@ func (i *Index) IncomingGetObject(ctx context.Context, shardName string,
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, enterrors.NewErrShardNotReady(fmt.Errorf("local %s shard is not ready", shardName))
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	return shard.ObjectByID(ctx, id, props, additional)
@@ -1541,7 +1541,7 @@ func (i *Index) IncomingMultiGetObjects(ctx context.Context, shardName string,
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, enterrors.NewErrShardNotReady(fmt.Errorf("local %s shard is not ready", shardName))
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	return shard.MultiObjectByID(ctx, wrapIDsInMulti(ids))
@@ -1687,7 +1687,7 @@ func (i *Index) IncomingExists(ctx context.Context, shardName string,
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return false, enterrors.NewErrShardNotReady(fmt.Errorf("local %s shard is not ready", shardName))
+		return false, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	return shard.Exists(ctx, id)
@@ -1970,7 +1970,7 @@ func (i *Index) singleLocalShardObjectVectorSearch(ctx context.Context, searchVe
 	ctx = helpers.InitSlowQueryDetails(ctx)
 	helpers.AnnotateSlowQueryLog(ctx, "is_coordinator", true)
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, nil, enterrors.NewErrShardNotReady(fmt.Errorf("local %s shard is not ready", shard.Name()))
+		return nil, nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shard.Name()))
 	}
 	res, resDists, err := shard.ObjectVectorSearch(
 		ctx, searchVectors, targetVectors, dist, limit, filters, sort, groupBy, additional, targetCombination, properties)
@@ -2231,7 +2231,7 @@ func (i *Index) IncomingSearch(ctx context.Context, shardName string,
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, nil, enterrors.NewErrShardNotReady(fmt.Errorf("local %s shard is not ready", shardName))
+		return nil, nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	ctx = helpers.InitSlowQueryDetails(ctx)
@@ -2603,7 +2603,7 @@ func (i *Index) IncomingAggregate(ctx context.Context, shardName string,
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, enterrors.NewErrShardNotReady(fmt.Errorf("local %s shard is not ready", shardName))
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	return shard.Aggregate(ctx, params, mods.(*modules.Provider))
@@ -2865,7 +2865,7 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return 0, enterrors.NewErrShardNotReady(fmt.Errorf("local %s shard is not ready", shardName))
+		return 0, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 	var size int64
 	_ = shard.ForEachVectorQueue(func(_ string, queue *VectorIndexQueue) error {
@@ -2928,7 +2928,7 @@ func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (s
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return "", enterrors.NewErrShardNotReady(fmt.Errorf("local %s shard is not ready", shardName))
+		return "", enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 	return shard.GetStatus().String(), nil
 }

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -586,7 +586,7 @@ func (idx *Index) OverwriteObjects(ctx context.Context,
 	}
 
 	if s.GetStatus() == storagestate.StatusLoading && idx.replicationEnabled() {
-		return nil, enterrors.NewErrShardNotReady(fmt.Errorf("local %s shard is not ready", shard))
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shard))
 	}
 
 	var result []types.RepairResponse
@@ -737,7 +737,7 @@ func (i *Index) DigestObjects(ctx context.Context,
 	}
 
 	if s.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, enterrors.NewErrShardNotReady(fmt.Errorf("local %s shard is not ready", shardName))
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	multiIDs := make([]multi.Identifier, len(ids))
@@ -845,7 +845,7 @@ func (i *Index) FetchObject(ctx context.Context,
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return replica.Replica{}, enterrors.NewErrShardNotReady(fmt.Errorf("local %s shard is not ready", shardName))
+		return replica.Replica{}, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	obj, err := shard.ObjectByID(ctx, id, nil, additional.Properties{})
@@ -891,7 +891,7 @@ func (i *Index) FetchObjects(ctx context.Context,
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
-		return nil, enterrors.NewErrShardNotReady(fmt.Errorf("local %s shard is not ready", shardName))
+		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
 	objs, err := shard.MultiObjectByID(ctx, wrapIDsInMulti(ids))

--- a/entities/errors/errors_http.go
+++ b/entities/errors/errors_http.go
@@ -15,24 +15,12 @@ type ErrUnprocessable struct {
 	err error
 }
 
-type ErrShardNotReady struct {
-	err error
-}
-
 func (e ErrUnprocessable) Error() string {
 	return e.err.Error()
 }
 
 func NewErrUnprocessable(err error) ErrUnprocessable {
 	return ErrUnprocessable{err}
-}
-
-func (e ErrShardNotReady) Error() string {
-	return e.err.Error()
-}
-
-func NewErrShardNotReady(err error) ErrShardNotReady {
-	return ErrShardNotReady{err}
 }
 
 type ErrNotFound struct {


### PR DESCRIPTION
### What's being changed:
this PR reverts behaviour got introduced in [PR](https://github.com/weaviate/weaviate/pull/10199) , where there was retry on loading shards which caused query latency due to node stuck keep retrying, instead of moving to the next avaliable node. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
