### PR TITLE
revert(replication): type of returned error if shard is nil to retry on non existence 

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -1517,7 +1517,7 @@ func (i *Index) IncomingGetObject(ctx context.Context, shardName string,
 	defer release()
 
 	if shard == nil {
-		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard does not exist", shardName))
+		return nil, fmt.Errorf("local %s shard not found", shardName)
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
@@ -1537,7 +1537,7 @@ func (i *Index) IncomingMultiGetObjects(ctx context.Context, shardName string,
 	defer release()
 
 	if shard == nil {
-		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard does not exist", shardName))
+		return nil, fmt.Errorf("local %s shard not found", shardName)
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
@@ -1683,7 +1683,7 @@ func (i *Index) IncomingExists(ctx context.Context, shardName string,
 	defer release()
 
 	if shard == nil {
-		return false, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard does not exist", shardName))
+		return false, fmt.Errorf("local %s shard not found", shardName)
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
@@ -2227,7 +2227,7 @@ func (i *Index) IncomingSearch(ctx context.Context, shardName string,
 	defer release()
 
 	if shard == nil {
-		return nil, nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard not found", shardName))
+		return nil, nil, fmt.Errorf("local %s shard not found", shardName)
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
@@ -2599,7 +2599,7 @@ func (i *Index) IncomingAggregate(ctx context.Context, shardName string,
 	defer release()
 
 	if shard == nil {
-		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard does not exist", shardName))
+		return nil, fmt.Errorf("local %s shard not found", shardName)
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
@@ -2861,7 +2861,7 @@ func (i *Index) IncomingGetShardQueueSize(ctx context.Context, shardName string)
 	defer release()
 
 	if shard == nil {
-		return 0, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard does not exist", shardName))
+		return 0, fmt.Errorf("local %s shard not found", shardName)
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
@@ -2924,7 +2924,7 @@ func (i *Index) IncomingGetShardStatus(ctx context.Context, shardName string) (s
 	defer release()
 
 	if shard == nil {
-		return "", enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard does not exist", shardName))
+		return "", fmt.Errorf("local %s shard not found", shardName)
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
@@ -3027,7 +3027,7 @@ func (i *Index) IncomingFindUUIDs(ctx context.Context, shardName string,
 	defer release()
 
 	if shard == nil {
-		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard does not exist", shardName))
+		return nil, fmt.Errorf("local %s shard not found", shardName)
 	}
 
 	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -736,7 +736,7 @@ func (i *Index) DigestObjects(ctx context.Context,
 		return nil, fmt.Errorf("shard %q not found locally", shardName)
 	}
 
-	if s.GetStatus() == storagestate.StatusLoading {
+	if s.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
 		return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 
@@ -844,7 +844,7 @@ func (i *Index) FetchObject(ctx context.Context,
 		return replica.Replica{}, fmt.Errorf("shard %q does not exist locally", shardName)
 	}
 
-	if shard.GetStatus() == storagestate.StatusLoading {
+	if shard.GetStatus() == storagestate.StatusLoading && i.replicationEnabled() {
 		return replica.Replica{}, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", shardName))
 	}
 


### PR DESCRIPTION
### What's being changed:
another follow up reverting the bits d type of returned error if shard is nil to retry on non existence was added in https://github.com/weaviate/weaviate/pull/10199 

follow up to https://github.com/weaviate/weaviate/pull/10585 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/22360250085
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
