### PR TITLE
fix: update method calls to use ForEachLoadedShard for vector index config updates

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -676,7 +676,7 @@ func (i *Index) updateVectorIndexConfig(ctx context.Context,
 	updated schemaConfig.VectorIndexConfig,
 ) error {
 	// an updated is not specific to one shard, but rather all
-	err := i.ForEachShard(func(name string, shard ShardLike) error {
+	err := i.ForEachLoadedShard(func(name string, shard ShardLike) error {
 		// At the moment, we don't do anything in an update that could fail, but
 		// technically this should be part of some sort of a two-phase commit  or
 		// have another way to rollback if we have updates that could potentially
@@ -700,7 +700,7 @@ func (i *Index) updateVectorIndexConfig(ctx context.Context,
 func (i *Index) updateVectorIndexConfigs(ctx context.Context,
 	updated map[string]schemaConfig.VectorIndexConfig,
 ) error {
-	err := i.ForEachShard(func(name string, shard ShardLike) error {
+	err := i.ForEachLoadedShard(func(name string, shard ShardLike) error {
 		if err := shard.UpdateVectorIndexConfigs(ctx, updated); err != nil {
 			return fmt.Errorf("shard %q: %w", name, err)
 		}


### PR DESCRIPTION
### What's being changed:

This pull request makes a targeted update to how configuration changes are applied to shards in the vector index. Instead of applying updates to all shards, the logic is changed to only apply updates to loaded shards, which can help avoid errors or unnecessary operations on unloaded or inactive shards.

**Improvement to configuration update logic:**

* Changed calls from `ForEachShard` to `ForEachLoadedShard` in both `updateVectorIndexConfig` and `updateVectorIndexConfigs` methods in `index.go`, ensuring that vector index configuration updates are only applied to currently loaded shards. [[1]](diffhunk://#diff-d080e5efa621477a1d974bced14c39a8912fcb7a649eb4a0fb219647728dbc3dL679-R679) [[2]](diffhunk://#diff-d080e5efa621477a1d974bced14c39a8912fcb7a649eb4a0fb219647728dbc3dL703-R703)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
