### PR TITLE
fix(EC): pass correct max class version on batch add

### DIFF
--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -90,6 +90,10 @@ func (b *BatchManager) addObjects(ctx context.Context, principal *models.Princip
 	}
 
 	var maxSchemaVersion uint64
+	for _, vc := range fetchedClasses {
+		maxSchemaVersion = max(maxSchemaVersion, vc.Version)
+	}
+
 	batchObjects, schemaVersion := b.validateAndGetVector(ctx, principal, objects, repl, fetchedClasses)
 	maxSchemaVersion = max(maxSchemaVersion, schemaVersion)
 

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -188,7 +188,7 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 	if err != nil {
 		return nil, err
 	}
-	uTenants := make([]*models.Tenant, len(tenantsStatus))
+	uTenants := make([]*models.Tenant, 0, len(tenantsStatus))
 	for name, status := range tenantsStatus {
 		uTenants = append(uTenants, &models.Tenant{
 			Name:           name,


### PR DESCRIPTION
### What's being changed:
this PR handle EC case on batch objects 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/22414203922
- [x] e2e pipeline : https://github.com/weaviate/weaviate-e2e-tests/actions/runs/22414214394
- 
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
