### PR TITLE
Let tombstones bypass async indexing queue

### DIFF
--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -217,6 +217,10 @@ func (h *hnsw) AddBatch(ctx context.Context, ids []uint64, vectors [][]float32) 
 			return err
 		}
 
+		if h.hasTombstone(ids[i]) {
+			continue
+		}
+
 		vector := vectors[i]
 		node := &vertex{
 			id:    ids[i],
@@ -306,6 +310,10 @@ func (h *hnsw) AddMultiBatch(ctx context.Context, docIDs []uint64, vectors [][][
 	}
 
 	for i, docID := range docIDs {
+		if h.hasTombstone(docID) {
+			continue
+		}
+
 		numVectors := len(vectors[i])
 		levels := make([]int, numVectors)
 		for j := range numVectors {

--- a/adapters/repos/db/vector_index_queue.go
+++ b/adapters/repos/db/vector_index_queue.go
@@ -197,36 +197,12 @@ func (iq *VectorIndexQueue) DequeueBatch() (*queue.Batch, error) {
 }
 
 func (iq *VectorIndexQueue) Delete(ids ...uint64) error {
-	if !iq.asyncEnabled {
-		return iq.vectorIndex.Delete(ids...)
-	}
-
-	if iq.vectorIndex.Multivector() {
-		return iq.delete(vectorIndexQueueMultiDeleteOp, ids...)
-	}
-	return iq.delete(vectorIndexQueueDeleteOp, ids...)
-}
-
-func (iq *VectorIndexQueue) delete(deleteOperation uint8, ids ...uint64) error {
-	start := time.Now()
-	defer iq.metrics.Delete(start, len(ids))
-
-	var buf []byte
-
-	for _, id := range ids {
-		buf = buf[:0]
-		// write the operation
-		buf = append(buf, deleteOperation)
-		// write the id
-		buf = binary.BigEndian.AppendUint64(buf, id)
-
-		err := iq.DiskQueue.Push(buf)
-		if err != nil {
-			return errors.Wrap(err, "failed to push record to queue")
-		}
-	}
-
-	return nil
+	// Always apply tombstones directly to the vector index, bypassing the queue.
+	// This is safe because HNSW's Delete() handles nodes that don't exist yet
+	// (the tombstone is stored in a map, no bounds check needed).
+	// The insert path (AddBatch/AddMultiBatch) checks for tombstones before
+	// inserting, so queued inserts for the same ID will be skipped.
+	return iq.vectorIndex.Delete(ids...)
 }
 
 func (iq *VectorIndexQueue) Flush() error {


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
