### PR TITLE
fix(test): add WaitersLen method to DynamicWeighted and improve FIFO ordering test

### DIFF
--- a/usecases/dynsemaphore/dynsemaphore.go
+++ b/usecases/dynsemaphore/dynsemaphore.go
@@ -156,6 +156,12 @@ func (s *DynamicWeighted) Release(n int64) {
 	}
 }
 
+func (s *DynamicWeighted) WaitersLen() int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return len(s.waiters)
+}
+
 func (s *DynamicWeighted) releaseLocal(n int64) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/usecases/dynsemaphore/dynsemaphore_test.go
+++ b/usecases/dynsemaphore/dynsemaphore_test.go
@@ -150,13 +150,11 @@ func TestFIFOOrdering(t *testing.T) {
 	var order []int
 	var mu sync.Mutex
 
-	enqueued := make(chan struct{}, 3)
 	release := make(chan struct{})
 
 	for i := 0; i < 3; i++ {
 		i := i
 		go func() {
-			enqueued <- struct{}{} // signal intent
 			if err := sem.Acquire(ctx, 1); err != nil {
 				return
 			}
@@ -166,7 +164,12 @@ func TestFIFOOrdering(t *testing.T) {
 			<-release
 			sem.Release(1)
 		}()
-		<-enqueued // enforce enqueue order
+		// Wait until this goroutine is actually in the waiters queue
+		// before starting the next one, so FIFO order is deterministic.
+		expectedWaiters := i + 1
+		eventually(t, time.Second, func() bool {
+			return sem.WaitersLen() == expectedWaiters
+		})
 	}
 
 	// Allow first waiter to proceed


### PR DESCRIPTION
### What's being changed:

This pull request introduces a minor API addition and improves the determinism of the FIFO ordering test for the dynamic semaphore implementation. The most notable changes are the addition of a method to retrieve the number of waiters and a more robust approach to ensuring FIFO ordering in tests.

**API Enhancements:**

* Added a `WaitersLen()` method to the `DynamicWeighted` struct in `dynsemaphore.go` to allow querying the current number of waiters.

**Testing Improvements:**

* Updated the `TestFIFOOrdering` test in `dynsemaphore_test.go` to use the new `WaitersLen()` method, replacing the previous channel-based approach. This ensures that each goroutine is actually enqueued before proceeding, making the FIFO order deterministic. [[1]](diffhunk://#diff-0c234abe10f5b770c05eaa48a0b9a2e218d5b82f19772eddfc49f4801cc7ab86L153-L159) [[2]](diffhunk://#diff-0c234abe10f5b770c05eaa48a0b9a2e218d5b82f19772eddfc49f4801cc7ab86L169-R172)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
