### PR TITLE
Delay tombstone cleanup until cache prefilled

### DIFF
--- a/adapters/repos/db/vector/hnsw/periodic_tombstone_removal_test.go
+++ b/adapters/repos/db/vector/hnsw/periodic_tombstone_removal_test.go
@@ -96,3 +96,77 @@ func TestPeriodicTombstoneRemoval(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTombstoneCleanupBlockedUntilCachePrefilled(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	cleanupIntervalSeconds := 1
+	tombstoneCallbacks := cyclemanager.NewCallbackGroup("tombstone", logger, 1)
+	tombstoneCleanupCycle := cyclemanager.NewManager(
+		cyclemanager.NewFixedTicker(time.Duration(cleanupIntervalSeconds)*time.Second),
+		tombstoneCallbacks.CycleCallback, logger)
+	tombstoneCleanupCycle.Start()
+
+	config := ent.UserConfig{}
+	config.SetDefaults()
+	config.CleanupIntervalSeconds = cleanupIntervalSeconds
+
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "tombstone-blocked-by-cache",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:      testVectorForID,
+		GetViewThunk:          func() common.BucketView { return &periodicNoopBucketView{} },
+	}, config, tombstoneCallbacks, testinghelpers.NewDummyStore(t))
+	require.Nil(t, err)
+
+	// Simulate a non-empty index that hasn't finished cache prefill yet.
+	index.cachePrefilled.Store(false)
+
+	for i, vec := range testVectors {
+		err := index.Add(ctx, uint64(i), vec)
+		require.Nil(t, err)
+	}
+
+	// Delete some entries to create tombstones.
+	for i := range testVectors {
+		if i%2 != 0 {
+			continue
+		}
+		err := index.Delete(uint64(i))
+		require.Nil(t, err)
+	}
+
+	index.tombstoneLock.RLock()
+	initialTombstones := len(index.tombstones)
+	index.tombstoneLock.RUnlock()
+	require.True(t, initialTombstones > 0, "expected tombstones after delete")
+
+	// Wait for several cleanup cycles
+	time.Sleep(2 * time.Second)
+
+	index.tombstoneLock.RLock()
+	tombstonesAfterWait := len(index.tombstones)
+	index.tombstoneLock.RUnlock()
+	assert.Equal(t, initialTombstones, tombstonesAfterWait,
+		"tombstones should not be cleaned up before cache is prefilled")
+
+	// Now prefill the cache, which sets cachePrefilled to true.
+	index.PostStartup(ctx)
+
+	// Tombstones should now get cleaned up by the cycle manager.
+	testhelper.AssertEventuallyEqual(t, true, func() interface{} {
+		index.tombstoneLock.RLock()
+		ts := len(index.tombstones)
+		index.tombstoneLock.RUnlock()
+		return ts == 0
+	}, "tombstones should be cleaned up after cache is prefilled")
+
+	if err := index.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := tombstoneCleanupCycle.StopAndWait(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -436,6 +436,10 @@ func (h *hnsw) populateKeys() {
 }
 
 func (h *hnsw) tombstoneCleanup(shouldAbort cyclemanager.ShouldAbortCallback) bool {
+	if !h.cachePrefilled.Load() {
+		return false
+	}
+
 	if h.allocChecker != nil {
 		// allocChecker is optional, we can only check if it was actually set
 


### PR DESCRIPTION
### What's being changed:
- Tombstone cleanup running while the cache is not prefilled is very slow and a source of errors
- This change delays running tombstone cleanup until after the cache is prefilled

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
