### PR TITLE
Add compression sentinel

### DIFF
--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -110,6 +110,9 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 				TempVectorForIDWithViewThunk:      hnsw.NewTempVectorForIDWithViewThunk(targetVector, s.readVectorByIndexIDIntoSliceWithView),
 				TempMultiVectorForIDWithViewThunk: hnsw.NewTempVectorForIDWithViewThunk(targetVector, s.readMultiVectorByIndexIDIntoSliceWithView),
 				DistanceProvider:                  distProv,
+				IterateVectorsThunk: func(ctx context.Context, fn func(id uint64, vector []float32) error) error {
+					return s.iterateOnLSMVectors(ctx, 0, targetVector, fn)
+				},
 				MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
 					return hnsw.NewCommitLogger(s.path(), vecIdxID,
 						s.index.logger, s.cycleCallbacks.vectorCommitLoggerCallbacks,
@@ -205,6 +208,9 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 			VectorForIDThunk:             hnsw.NewVectorForIDThunk(targetVector, s.vectorByIndexID),
 			GetViewThunk:                 func() vcommon.BucketView { return s.GetObjectsBucketView() },
 			TempVectorForIDWithViewThunk: hnsw.NewTempVectorForIDWithViewThunk(targetVector, s.readVectorByIndexIDIntoSliceWithView),
+			IterateVectorsThunk: func(ctx context.Context, fn func(id uint64, vector []float32) error) error {
+				return s.iterateOnLSMVectors(ctx, 0, targetVector, fn)
+			},
 			MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
 				return hnsw.NewCommitLogger(s.path(), vecIdxID,
 					s.index.logger, s.cycleCallbacks.vectorCommitLoggerCallbacks,
@@ -276,6 +282,9 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 					TempVectorForIDWithViewThunk:      hnsw.NewTempVectorForIDWithViewThunk(targetVector, s.readVectorByIndexIDIntoSliceWithView),
 					TempMultiVectorForIDWithViewThunk: hnsw.NewTempVectorForIDWithViewThunk(targetVector, s.readMultiVectorByIndexIDIntoSliceWithView),
 					DistanceProvider:                  distProv,
+					IterateVectorsThunk: func(ctx context.Context, fn func(id uint64, vector []float32) error) error {
+						return s.iterateOnLSMVectors(ctx, 0, targetVector, fn)
+					},
 					MakeCommitLoggerThunk: func() (hnsw.CommitLogger, error) {
 						return hnsw.NewCommitLogger(s.path(), spfreshConfigID+"_centroids",
 							s.index.logger, s.cycleCallbacks.vectorCommitLoggerCallbacks,

--- a/adapters/repos/db/vector/dynamic/config.go
+++ b/adapters/repos/db/vector/dynamic/config.go
@@ -12,6 +12,8 @@
 package dynamic
 
 import (
+	"context"
+
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
@@ -45,6 +47,7 @@ type Config struct {
 	HNSWDisableSnapshots         bool
 	HNSWSnapshotOnStartup        bool
 	HNSWWaitForCachePrefill      bool
+	IterateVectorsThunk          func(ctx context.Context, fn func(id uint64, vector []float32) error) error
 	MinMMapSize                  int64
 	MaxWalReuseSize              int64
 	LazyLoadSegments             bool

--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -102,6 +102,7 @@ type dynamic struct {
 	vectorForIDThunk             common.VectorForID[float32]
 	getViewThunk                 common.GetViewThunk
 	tempVectorForIDWithViewThunk common.TempVectorForIDWithView[float32]
+	iterateVectorsThunk          func(ctx context.Context, fn func(id uint64, vector []float32) error) error
 	distanceProvider             distancer.Provider
 	makeCommitLoggerThunk        hnsw.MakeCommitLogger
 	threshold                    uint64
@@ -163,6 +164,7 @@ func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
 		vectorForIDThunk:             cfg.VectorForIDThunk,
 		getViewThunk:                 cfg.GetViewThunk,
 		tempVectorForIDWithViewThunk: cfg.TempVectorForIDWithViewThunk,
+		iterateVectorsThunk:          cfg.IterateVectorsThunk,
 		distanceProvider:             cfg.DistanceProvider,
 		makeCommitLoggerThunk:        cfg.MakeCommitLoggerThunk,
 		store:                        store,
@@ -200,6 +202,7 @@ func New(cfg Config, uc ent.UserConfig, store *lsmkv.Store) (*dynamic, error) {
 				TempVectorForIDWithViewThunk: index.tempVectorForIDWithViewThunk,
 				DistanceProvider:             index.distanceProvider,
 				MakeCommitLoggerThunk:        index.makeCommitLoggerThunk,
+				IterateVectorsThunk:          index.iterateVectorsThunk,
 				DisableSnapshots:             index.hnswDisableSnapshots,
 				SnapshotOnStartup:            index.hnswSnapshotOnStartup,
 				LazyLoadSegments:             index.LazyLoadSegments,
@@ -538,6 +541,7 @@ func (dynamic *dynamic) doUpgrade() error {
 			TempVectorForIDWithViewThunk: dynamic.tempVectorForIDWithViewThunk,
 			DistanceProvider:             dynamic.distanceProvider,
 			MakeCommitLoggerThunk:        dynamic.makeCommitLoggerThunk,
+			IterateVectorsThunk:          dynamic.iterateVectorsThunk,
 			DisableSnapshots:             dynamic.hnswDisableSnapshots,
 			SnapshotOnStartup:            dynamic.hnswSnapshotOnStartup,
 			WaitForCachePrefill:          dynamic.hnswWaitForCachePrefill,

--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -16,6 +16,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/entities/storobj"
@@ -132,6 +133,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 		h.checkAndCompress()
 		return nil
 	}
+	h.markCompressionInProgress()
 	if singleVector {
 		compressionhelpers.Concurrently(h.logger, uint64(len(data)),
 			func(index uint64) {
@@ -150,8 +152,42 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 				h.compressor.PreloadPassage(index, docID, relativeID, data[index])
 			})
 	}
+	h.clearCompressionSentinel()
 
 	h.compressed.Store(true)
 	h.cache.Drop()
 	return nil
+}
+
+// compressionSentinelKey is used to track whether a compression preload completed.
+// It uses MaxUint64 as the key, which is beyond any valid node ID and is
+// skipped by PrefillCache (which filters IDs > MaxValidID).
+var compressionSentinelKey = []byte{0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF}
+
+func (h *hnsw) markCompressionInProgress() {
+	bucket := h.store.Bucket(helpers.GetCompressedBucketName(h.getTargetVector()))
+	if bucket == nil {
+		return
+	}
+	bucket.Put(compressionSentinelKey, []byte{1})
+}
+
+func (h *hnsw) clearCompressionSentinel() {
+	bucket := h.store.Bucket(helpers.GetCompressedBucketName(h.getTargetVector()))
+	if bucket == nil {
+		return
+	}
+	bucket.Delete(compressionSentinelKey)
+}
+
+func (h *hnsw) compressionIncomplete() bool {
+	bucket := h.store.Bucket(helpers.GetCompressedBucketName(h.getTargetVector()))
+	if bucket == nil {
+		return false
+	}
+	v, err := bucket.Get(compressionSentinelKey)
+	if err != nil {
+		return false
+	}
+	return len(v) > 0
 }

--- a/adapters/repos/db/vector/hnsw/compress_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_test.go
@@ -98,6 +98,134 @@ func Test_NoRaceCompressReturnsErrorWhenNotEnoughData(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func Test_CompressionSentinelClearedAfterSuccessfulCompress(t *testing.T) {
+	dimensions := 20
+	vectorsSize := 50
+	vectors, _ := testinghelpers.RandomVecs(vectorsSize, 0, dimensions)
+	dist := distancer.NewL2SquaredProvider()
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	dummyStore := testinghelpers.NewDummyStoreFromFolder(tempDir, t)
+
+	uc := userConfig(dimensions/10, 5, 32, 64, 32, vectorsSize)
+	cfg := indexConfig("sentinel_test", tempDir, logger, vectors, dist)
+
+	index, err := New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), dummyStore)
+	require.NoError(t, err)
+	defer index.Shutdown(ctx)
+
+	require.NoError(t, compressionhelpers.ConcurrentlyWithError(logger, uint64(vectorsSize), func(id uint64) error {
+		return index.Add(ctx, uint64(id), vectors[id])
+	}))
+
+	// Before compression, sentinel should not be set.
+	require.False(t, index.compressionIncomplete(), "sentinel should not exist before compression")
+
+	// Compress with PQ.
+	require.NoError(t, index.compress(uc))
+
+	// After successful compression, sentinel should be cleared.
+	require.False(t, index.compressionIncomplete(), "sentinel should be cleared after successful compression")
+	require.True(t, index.compressed.Load(), "index should be compressed")
+}
+
+func Test_CompressionSentinelDetectedWhenNotCleared(t *testing.T) {
+	dimensions := 20
+	vectorsSize := 50
+	vectors, _ := testinghelpers.RandomVecs(vectorsSize, 0, dimensions)
+	dist := distancer.NewL2SquaredProvider()
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	dummyStore := testinghelpers.NewDummyStoreFromFolder(tempDir, t)
+
+	uc := userConfig(dimensions/10, 5, 32, 64, 32, vectorsSize)
+	cfg := indexConfig("sentinel_incomplete", tempDir, logger, vectors, dist)
+
+	index, err := New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), dummyStore)
+	require.NoError(t, err)
+	defer index.Shutdown(ctx)
+
+	require.NoError(t, compressionhelpers.ConcurrentlyWithError(logger, uint64(vectorsSize), func(id uint64) error {
+		return index.Add(ctx, uint64(id), vectors[id])
+	}))
+
+	// Compress to create the compressor and the compressed bucket.
+	require.NoError(t, index.compress(uc))
+	require.True(t, index.compressed.Load())
+
+	// Simulate an interrupted re-compression by marking in progress without clearing.
+	index.markCompressionInProgress()
+	require.True(t, index.compressionIncomplete(), "sentinel should be detected as incomplete")
+
+	// Clearing should remove it.
+	index.clearCompressionSentinel()
+	require.False(t, index.compressionIncomplete(), "sentinel should be cleared after explicit clear")
+}
+
+func Test_CompressionSentinelRecoveryOnRestart(t *testing.T) {
+	dimensions := 20
+	vectorsSize := 50
+	vectors, queries := testinghelpers.RandomVecs(vectorsSize, 1, dimensions)
+	dist := distancer.NewL2SquaredProvider()
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	dummyStore := testinghelpers.NewDummyStoreFromFolder(tempDir, t)
+
+	uc := userConfig(dimensions/10, 5, 32, 64, 32, vectorsSize)
+	cfg := indexConfig("sentinel_recovery", tempDir, logger, vectors, dist)
+
+	// Phase 1: build index, compress, then simulate interrupted re-compression.
+	index, err := New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), dummyStore)
+	require.NoError(t, err)
+
+	require.NoError(t, compressionhelpers.ConcurrentlyWithError(logger, uint64(vectorsSize), func(id uint64) error {
+		return index.Add(ctx, uint64(id), vectors[id])
+	}))
+
+	require.NoError(t, index.compress(uc))
+
+	// Record search results before the simulated crash.
+	control, _, err := index.SearchByVector(ctx, queries[0], 10, nil)
+	require.NoError(t, err)
+
+	// Simulate interrupted re-compression: set sentinel, then shutdown.
+	index.markCompressionInProgress()
+	require.NoError(t, index.Flush())
+	require.NoError(t, index.Shutdown(ctx))
+	dummyStore.FlushMemtables(ctx)
+
+	// Phase 2: restart with IterateVectorsThunk to enable recovery.
+	restartCfg := indexConfig("sentinel_recovery", tempDir, logger, vectors, dist)
+	restartCfg.WaitForCachePrefill = true
+	restartCfg.IterateVectorsThunk = func(ctx context.Context, fn func(id uint64, vector []float32) error) error {
+		for i, v := range vectors {
+			if err := fn(uint64(i), v); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	index, err = New(restartCfg, uc, cyclemanager.NewCallbackGroupNoop(), dummyStore)
+	require.NoError(t, err)
+	defer index.Shutdown(ctx)
+
+	// PostStartup should detect the sentinel and trigger recovery.
+	index.PostStartup(ctx)
+
+	// After recovery, sentinel should be cleared.
+	require.False(t, index.compressionIncomplete(), "sentinel should be cleared after recovery")
+	require.True(t, index.compressed.Load(), "index should still be compressed")
+
+	// Search should return correct results.
+	results, _, err := index.SearchByVector(ctx, queries[0], 10, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, control, results, "search results should match after recovery")
+}
+
 func Test_CompressAndInsertDoNotRace(t *testing.T) {
 	efConstruction := 64
 	ef := 32

--- a/adapters/repos/db/vector/hnsw/config.go
+++ b/adapters/repos/db/vector/hnsw/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	WriteSegmentInfoIntoFileName      bool
 	WriteMetadataFilesEnabled         bool
 
+	IterateVectorsThunk func(ctx context.Context, fn func(id uint64, vector []float32) error) error
+
 	MinMMapSize     int64
 	MaxWalReuseSize int64
 

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -192,6 +192,8 @@ type hnsw struct {
 	shardedNodeLocks      *common.ShardedRWLocks
 	store                 *lsmkv.Store
 
+	iterateVectors func(ctx context.Context, fn func(id uint64, vector []float32) error) error
+
 	allocChecker            memwatch.AllocChecker
 	tombstoneCleanupRunning atomic.Bool
 
@@ -362,6 +364,7 @@ func New(cfg Config, uc ent.UserConfig,
 		shardedNodeLocks:                  common.NewDefaultShardedRWLocks(),
 
 		store:                  store,
+		iterateVectors:         cfg.IterateVectorsThunk,
 		allocChecker:           cfg.AllocChecker,
 		visitedListPoolMaxSize: cfg.VisitedListPoolMaxSize,
 

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -500,6 +500,14 @@ func (h *hnsw) prefillCache(ctx context.Context) {
 		return
 	}
 
+	// If compressed and preload was interrupted, recover synchronously
+	// before serving any queries, regardless of waitForCachePrefill.
+	if h.compressed.Load() && h.compressionIncomplete() {
+		h.recoverCompression(ctx)
+		h.cachePrefilled.Store(true)
+		return
+	}
+
 	limit := 0
 	if h.compressed.Load() {
 		limit = int(h.compressor.GetCacheMaxSize())
@@ -544,4 +552,35 @@ func (h *hnsw) prefillCache(ctx context.Context) {
 		}).Info("not waiting for vector cache prefill, running in background")
 		enterrors.GoWrapper(prefillCacheFunc, h.logger)
 	}
+}
+
+func (h *hnsw) recoverCompression(ctx context.Context) {
+	h.logger.Warn("detected incomplete compression preload, recovering")
+
+	if h.iterateVectors == nil {
+		h.logger.Error("cannot recover compression: no vector iterator available")
+		return
+	}
+
+	total := 0
+	err := h.iterateVectors(ctx, func(id uint64, vector []float32) error {
+		if len(vector) == 0 {
+			return nil
+		}
+		vector = h.normalizeVec(vector)
+		h.compressor.Preload(id, vector)
+		total++
+		return nil
+	})
+	if err != nil {
+		h.logger.WithField("action", "compression_recovery").
+			WithError(err).Error("compression recovery failed")
+		return
+	}
+
+	h.clearCompressionSentinel()
+	h.logger.WithFields(logrus.Fields{
+		"action": "compression_recovery",
+		"total":  total,
+	}).Info("compression recovery complete")
 }


### PR DESCRIPTION
### What's being changed:
- If compression fails to encode all vectors, this change makes them be force encoded on startup via use of a sentinel key.
- Wait for cache prefill will be ignored in this case.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
