### PR TITLE
More allocation/heap optimization

### DIFF
--- a/adapters/repos/db/vector/hnsw/search.go
+++ b/adapters/repos/db/vector/hnsw/search.go
@@ -743,8 +743,9 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 	}
 
 	// stop at layer 1, not 0!
+	eps := priorityqueue.NewMin[any](10)
 	for level := maxLayer; level >= 1; level-- {
-		eps := priorityqueue.NewMin[any](10)
+		eps.Reset()
 		eps.Insert(entryPointID, entryPointDistance)
 
 		res, err := h.searchLayerByVectorWithDistancer(ctx, searchVec, eps, 1, level, nil, compressorDistancer)
@@ -788,7 +789,7 @@ func (h *hnsw) knnSearchByVector(ctx context.Context, searchVec []float32, k int
 		h.pools.pqResults.Put(res)
 	}
 
-	eps := priorityqueue.NewMin[any](10)
+	eps.Reset()
 	eps.Insert(entryPointID, entryPointDistance)
 	var strategy FilterStrategy
 	h.shardedNodeLocks.RLock(entryPointID)

--- a/cluster/replication/changelog/entry.go
+++ b/cluster/replication/changelog/entry.go
@@ -68,7 +68,7 @@ func Encode(dst []byte, e *Entry) ([]byte, error) {
 	// LSN is big-endian per the spec; byteops is little-endian only.
 	binary.BigEndian.PutUint64(dst[1:9], e.LSN)
 
-	rw := byteops.NewReadWriterWithOps(dst, byteops.WithPosition(9))
+	rw := byteops.NewReadWriterWithPosition(dst, 9)
 	var flags uint8
 	if e.IsDelete {
 		flags |= flagDelete

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -1182,7 +1182,7 @@ func UnmarshalPropertiesFromObject(data []byte, resultProperties map[string]inte
 	clear(resultProperties)
 
 	startPos := uint64(1 + 8 + 1 + 16 + 8 + 8) // elements at the start
-	rw := byteops.NewReadWriterWithOps(data, byteops.WithPosition(startPos))
+	rw := byteops.NewReadWriterWithPosition(data, startPos)
 	// get the length of the vector, each element is a float32 (4 bytes)
 	vectorLength := uint64(rw.ReadUint16())
 	rw.MoveBufferPositionForward(vectorLength * 4)
@@ -1327,7 +1327,7 @@ func (ko *Object) unmarshalInternal(data []byte, className string) error {
 	}
 	ko.MarshallerVersion = version
 
-	rw := byteops.NewReadWriterWithOps(data, byteops.WithPosition(1))
+	rw := byteops.NewReadWriterWithPosition(data, 1)
 	ko.DocID = rw.ReadUint64()
 	rw.MoveBufferPositionForward(1) // kind-byte
 
@@ -1508,12 +1508,12 @@ func unmarshalMultiVectors(
 				}
 				rw.MoveBufferToAbsolutePosition(pos + uint64(offset))
 				numVecs := rw.ReadUint32()
-				vecs := make([][]float32, 0)
+				vecs := make([][]float32, numVecs)
 				for i := 0; i < int(numVecs); i++ {
 					vecLen := rw.ReadUint16()
 					vec := make([]float32, vecLen)
 					byteops.CopyBytesToSlice(vec, rw.ReadBytesFromBuffer(uint64(vecLen)*byteops.Uint32Len))
-					vecs = append(vecs, vec)
+					vecs[i] = vec
 				}
 				multiVectors[name] = vecs
 			}
@@ -1537,7 +1537,7 @@ func VectorFromBinary(in []byte, buffer []float32, targetVector string) ([]float
 
 	if targetVector != "" {
 		startPos := uint64(1 + 8 + 1 + 16 + 8 + 8) // elements at the start
-		rw := byteops.NewReadWriterWithOps(in, byteops.WithPosition(startPos))
+		rw := byteops.NewReadWriterWithPosition(in, startPos)
 
 		vectorLength := uint64(rw.ReadUint16())
 		rw.MoveBufferPositionForward(vectorLength * 4)
@@ -1638,7 +1638,7 @@ func MultiVectorFromBinary(in []byte, buffer []float32, targetVector string) ([]
 	var multiVectors map[string][][]float32
 
 	if len(in) > pos {
-		rw := byteops.NewReadWriterWithOps(in, byteops.WithPosition(uint64(pos)))
+		rw := byteops.NewReadWriterWithPosition(in, uint64(pos))
 		mv, err := unmarshalMultiVectors(&rw, map[string]interface{}{targetVector: nil})
 		if err != nil {
 			return nil, errors.Errorf("unable to unmarshal multivector for target vector: %s", targetVector)

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -1361,22 +1361,13 @@ func (ko *Object) unmarshalInternal(data []byte, className string) error {
 	}
 
 	schemaLength := uint64(rw.ReadUint32())
-	schema, err := rw.CopyBytesFromBuffer(schemaLength, nil)
-	if err != nil {
-		return errors.Wrap(err, "Could not copy schema")
-	}
+	schema := rw.ReadBytesFromBuffer(schemaLength)
 
 	metaLength := uint64(rw.ReadUint32())
-	meta, err := rw.CopyBytesFromBuffer(metaLength, nil)
-	if err != nil {
-		return errors.Wrap(err, "Could not copy meta")
-	}
+	meta := rw.ReadBytesFromBuffer(metaLength)
 
 	vectorWeightsLength := uint64(rw.ReadUint32())
-	vectorWeights, err := rw.CopyBytesFromBuffer(vectorWeightsLength, nil)
-	if err != nil {
-		return errors.Wrap(err, "Could not copy vectorWeights")
-	}
+	vectorWeights := rw.ReadBytesFromBuffer(vectorWeightsLength)
 
 	vectors, err := unmarshalTargetVectors(&rw)
 	if err != nil {

--- a/usecases/byteops/byteops.go
+++ b/usecases/byteops/byteops.go
@@ -16,7 +16,6 @@ import (
 	"encoding/binary"
 	"errors"
 	"io"
-	"math"
 )
 
 const (
@@ -31,24 +30,13 @@ type ReadWriter struct {
 	Buffer   []byte
 }
 
-func WithPosition(pos uint64) func(*ReadWriter) {
-	return func(rw *ReadWriter) {
-		rw.Position = pos
-	}
-}
-
 func NewReadWriter(buf []byte) ReadWriter {
 	rw := ReadWriter{Buffer: buf}
 	return rw
 }
 
-// NewReadWriterWithOps escapes to heap even if no ops are given
-func NewReadWriterWithOps(buf []byte, opts ...func(writer *ReadWriter)) ReadWriter {
-	rw := ReadWriter{Buffer: buf}
-	for _, opt := range opts {
-		opt(&rw)
-	}
-	return rw
+func NewReadWriterWithPosition(buf []byte, pos uint64) ReadWriter {
+	return ReadWriter{Buffer: buf, Position: pos}
 }
 
 func (bo *ReadWriter) ResetBuffer(buf []byte) {
@@ -210,9 +198,7 @@ func Fp32SliceToBytes(slice []float32) []byte {
 		return []byte{}
 	}
 	vector := make([]byte, len(slice)*Uint32Len)
-	for i := 0; i < len(slice); i++ {
-		binary.LittleEndian.PutUint32(vector[i*Uint32Len:(i+1)*Uint32Len], math.Float32bits(slice[i]))
-	}
+	CopySliceToBytes(vector, slice)
 	return vector
 }
 
@@ -244,9 +230,7 @@ func Fp32SliceOfSlicesToBytes(slices [][]float32) []byte {
 
 func Fp64SliceToBytes(floats []float64) []byte {
 	vector := make([]byte, len(floats)*Uint64Len)
-	for i := 0; i < len(floats); i++ {
-		binary.LittleEndian.PutUint64(vector[i*Uint64Len:(i+1)*Uint64Len], math.Float64bits(floats[i]))
-	}
+	CopySliceToBytes(vector, floats)
 	return vector
 }
 
@@ -286,10 +270,7 @@ func Fp32SliceOfSlicesFromBytes(bytes []byte) ([][]float32, error) {
 
 func Fp64SliceFromBytes(vector []byte) []float64 {
 	floats := make([]float64, len(vector)/Uint64Len)
-	for i := 0; i < len(floats); i++ {
-		asUint := binary.LittleEndian.Uint64(vector[i*Uint64Len : (i+1)*Uint64Len])
-		floats[i] = math.Float64frombits(asUint)
-	}
+	CopyBytesToSlice(floats, vector)
 	return floats
 }
 
@@ -304,9 +285,6 @@ func IntsToByteVector(ints []float64) []byte {
 
 func IntsFromByteVector(vector []byte) []int64 {
 	ints := make([]int64, len(vector)/Uint64Len)
-	for i := 0; i < len(ints); i++ {
-		asUint := binary.LittleEndian.Uint64(vector[i*Uint64Len : (i+1)*Uint64Len])
-		ints[i] = int64(asUint)
-	}
+	CopyBytesToSlice(ints, vector)
 	return ints
 }

--- a/usecases/byteops/byteops_test.go
+++ b/usecases/byteops/byteops_test.go
@@ -402,6 +402,66 @@ func TestCopySliceToBytesUint64(t *testing.T) {
 	}
 }
 
+func TestCopyBytesToSliceFloat64(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		dst := make([]float64, 0)
+		CopyBytesToSlice(dst, nil)
+		assert.Empty(t, dst)
+	})
+
+	t.Run("non-empty", func(t *testing.T) {
+		srcVals := []float64{0, 1.5, -2.25, 3.75}
+		data := make([]byte, len(srcVals)*8)
+		for i, v := range srcVals {
+			binary.LittleEndian.PutUint64(data[i*8:], math.Float64bits(v))
+		}
+		dst := make([]float64, len(srcVals))
+		CopyBytesToSlice(dst, data)
+		assert.Equal(t, srcVals, dst)
+	})
+}
+
+func TestCopySliceToBytesFloat64(t *testing.T) {
+	srcVals := []float64{0, 1.5, -2.25, 3.75}
+	data := make([]byte, len(srcVals)*8)
+	CopySliceToBytes(data, srcVals)
+
+	for i, v := range srcVals {
+		got := math.Float64frombits(binary.LittleEndian.Uint64(data[i*8:]))
+		assert.Equal(t, v, got)
+	}
+}
+
+func TestCopyBytesToSliceInt64(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		dst := make([]int64, 0)
+		CopyBytesToSlice(dst, nil)
+		assert.Empty(t, dst)
+	})
+
+	t.Run("non-empty", func(t *testing.T) {
+		srcVals := []int64{0, -1, 42, math.MinInt64}
+		data := make([]byte, len(srcVals)*8)
+		for i, v := range srcVals {
+			binary.LittleEndian.PutUint64(data[i*8:], uint64(v))
+		}
+		dst := make([]int64, len(srcVals))
+		CopyBytesToSlice(dst, data)
+		assert.Equal(t, srcVals, dst)
+	})
+}
+
+func TestCopySliceToBytesInt64(t *testing.T) {
+	srcVals := []int64{0, -1, 42, math.MinInt64}
+	data := make([]byte, len(srcVals)*8)
+	CopySliceToBytes(data, srcVals)
+
+	for i, v := range srcVals {
+		got := int64(binary.LittleEndian.Uint64(data[i*8:]))
+		assert.Equal(t, v, got)
+	}
+}
+
 // makeFloat32Bytes creates a []byte containing n little-endian float32 values.
 func makeFloat32Bytes(n int) []byte {
 	data := make([]byte, n*4)

--- a/usecases/byteops/copy_be.go
+++ b/usecases/byteops/copy_be.go
@@ -21,16 +21,25 @@ import (
 // CopyBytesToSlice copies little-endian encoded bytes into a typed slice
 // using per-element decoding. This fallback is used on big-endian architectures
 // where the in-memory representation differs from the little-endian byte layout on disk.
-func CopyBytesToSlice[T float32 | uint64](dst []T, src []byte) {
+func CopyBytesToSlice[T float32 | float64 | uint64 | int64](dst []T, src []byte) {
 	switch any(dst).(type) {
 	case []float32:
 		for i := range dst {
 			bits := binary.LittleEndian.Uint32(src[i*Uint32Len : (i+1)*Uint32Len])
 			*(*float32)(any(&dst[i]).(*float32)) = math.Float32frombits(bits)
 		}
+	case []float64:
+		for i := range dst {
+			bits := binary.LittleEndian.Uint64(src[i*Uint64Len : (i+1)*Uint64Len])
+			*(*float64)(any(&dst[i]).(*float64)) = math.Float64frombits(bits)
+		}
 	case []uint64:
 		for i := range dst {
 			*(*uint64)(any(&dst[i]).(*uint64)) = binary.LittleEndian.Uint64(src[i*Uint64Len : (i+1)*Uint64Len])
+		}
+	case []int64:
+		for i := range dst {
+			*(*int64)(any(&dst[i]).(*int64)) = int64(binary.LittleEndian.Uint64(src[i*Uint64Len : (i+1)*Uint64Len]))
 		}
 	}
 }
@@ -38,15 +47,23 @@ func CopyBytesToSlice[T float32 | uint64](dst []T, src []byte) {
 // CopySliceToBytes copies a typed slice into little-endian encoded bytes
 // using per-element encoding. This fallback is used on big-endian architectures
 // where the in-memory representation differs from the little-endian byte layout on disk.
-func CopySliceToBytes[T float32 | uint64](dst []byte, src []T) {
+func CopySliceToBytes[T float32 | float64 | uint64 | int64](dst []byte, src []T) {
 	switch any(src).(type) {
 	case []float32:
 		for i := range src {
 			binary.LittleEndian.PutUint32(dst[i*Uint32Len:(i+1)*Uint32Len], math.Float32bits(*(*float32)(any(&src[i]).(*float32))))
 		}
+	case []float64:
+		for i := range src {
+			binary.LittleEndian.PutUint64(dst[i*Uint64Len:(i+1)*Uint64Len], math.Float64bits(*(*float64)(any(&src[i]).(*float64))))
+		}
 	case []uint64:
 		for i := range src {
 			binary.LittleEndian.PutUint64(dst[i*Uint64Len:(i+1)*Uint64Len], *(*uint64)(any(&src[i]).(*uint64)))
+		}
+	case []int64:
+		for i := range src {
+			binary.LittleEndian.PutUint64(dst[i*Uint64Len:(i+1)*Uint64Len], uint64(*(*int64)(any(&src[i]).(*int64))))
 		}
 	}
 }

--- a/usecases/byteops/copy_be.go
+++ b/usecases/byteops/copy_be.go
@@ -20,7 +20,8 @@ import (
 
 // CopyBytesToSlice copies little-endian encoded bytes into a typed slice
 // using per-element decoding. This fallback is used on big-endian architectures
-// where the in-memory representation differs from the little-endian byte layout on disk.
+// where the in-memory representation of the supported numeric types differs from
+// the little-endian byte layout on disk.
 func CopyBytesToSlice[T float32 | float64 | uint64 | int64](dst []T, src []byte) {
 	switch any(dst).(type) {
 	case []float32:

--- a/usecases/byteops/copy_le.go
+++ b/usecases/byteops/copy_le.go
@@ -18,7 +18,7 @@ import "unsafe"
 // CopyBytesToSlice bulk-copies src bytes into dst typed slice using a single memmove.
 // This is safe on little-endian architectures where the in-memory representation
 // of float32/uint64 matches the little-endian byte layout used on disk.
-func CopyBytesToSlice[T float32 | uint64](dst []T, src []byte) {
+func CopyBytesToSlice[T float32 | float64 | uint64 | int64](dst []T, src []byte) {
 	if len(dst) == 0 {
 		return
 	}
@@ -31,7 +31,7 @@ func CopyBytesToSlice[T float32 | uint64](dst []T, src []byte) {
 // CopySliceToBytes bulk-copies a typed slice into dst bytes using a single memmove.
 // This is safe on little-endian architectures where the in-memory representation
 // of float32/uint64 matches the little-endian byte layout used on disk.
-func CopySliceToBytes[T float32 | uint64](dst []byte, src []T) {
+func CopySliceToBytes[T float32 | float64 | uint64 | int64](dst []byte, src []T) {
 	if len(src) == 0 {
 		return
 	}

--- a/usecases/byteops/copy_le.go
+++ b/usecases/byteops/copy_le.go
@@ -17,7 +17,7 @@ import "unsafe"
 
 // CopyBytesToSlice bulk-copies src bytes into dst typed slice using a single memmove.
 // This is safe on little-endian architectures where the in-memory representation
-// of float32/uint64 matches the little-endian byte layout used on disk.
+// of the supported numeric types matches the little-endian byte layout used on disk.
 func CopyBytesToSlice[T float32 | float64 | uint64 | int64](dst []T, src []byte) {
 	if len(dst) == 0 {
 		return
@@ -30,7 +30,7 @@ func CopyBytesToSlice[T float32 | float64 | uint64 | int64](dst []T, src []byte)
 
 // CopySliceToBytes bulk-copies a typed slice into dst bytes using a single memmove.
 // This is safe on little-endian architectures where the in-memory representation
-// of float32/uint64 matches the little-endian byte layout used on disk.
+// of the supported numeric types matches the little-endian byte layout used on disk.
 func CopySliceToBytes[T float32 | float64 | uint64 | int64](dst []byte, src []T) {
 	if len(src) == 0 {
 		return


### PR DESCRIPTION
### What's being changed:

Couple more allocation optimizations:
- use a scratch buffer in the commitlogger. There are no races as access is guarded by a lock. Eliminates the per-write heap alloc entirely
- replace `NewReadWriterWithOps` with `NewReadWriterWithPosition`, due to the functional argument the former escapes to the heap
- replace `CopyBytesFromBuffer` with `ReadBytesFromBuffer`, The former creates a copy, the later just gives out a slice from the larger underlying slice
- few more copy instead of loop
- reuse priority queue instead of creating multiple ones

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
