### PR TITLE
Add metric to track total number of streams opened in ssb

### DIFF
--- a/adapters/handlers/grpc/v1/batch/metrics.go
+++ b/adapters/handlers/grpc/v1/batch/metrics.go
@@ -32,6 +32,12 @@ func NewBatchStreamingMetrics(reg prometheus.Registerer) *BatchStreamingMetrics 
 		return nil
 	}
 
+	totalStreams := promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+		Namespace: "weaviate",
+		Name:      "batch_streaming_total_streams",
+		Help:      "Total number of batch streaming connections started",
+	}, []string{})
+
 	openStreams := promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: "weaviate",
 		Name:      "batch_streaming_open_streams",
@@ -58,6 +64,7 @@ func NewBatchStreamingMetrics(reg prometheus.Registerer) *BatchStreamingMetrics 
 
 	return &BatchStreamingMetrics{
 		OnStreamStart: func() {
+			totalStreams.WithLabelValues().Inc()
 			openStreams.WithLabelValues().Inc()
 		},
 		OnStreamStop: func() {


### PR DESCRIPTION
### What's being changed:

Adds a new metric, `batch_streaming_total_streams`, as a counter to track how many total streams have been opened on the server

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
