### PR TITLE
fix: improve correctness of lsmkv ReplaceBuckets and RenameBucket

### DIFF
--- a/adapters/repos/db/lsmkv/store.go
+++ b/adapters/repos/db/lsmkv/store.go
@@ -464,44 +464,18 @@ func (s *Store) CreateBucket(ctx context.Context, bucketName string,
 	return nil
 }
 
-func (s *Store) replaceBucket(ctx context.Context, replacementBucket *Bucket, replacementBucketName string, bucket *Bucket, bucketName string) (string, string, string, string, error) {
-	replacementBucket.disk.maintenanceLock.Lock()
-	defer replacementBucket.disk.maintenanceLock.Unlock()
-
-	currBucketDir := bucket.dir
-	newBucketDir := bucket.dir + "___del"
-	currReplacementBucketDir := replacementBucket.dir
-	newReplacementBucketDir := currBucketDir
-
-	if err := bucket.Shutdown(ctx); err != nil {
-		return "", "", "", "", errors.Wrapf(err, "failed shutting down bucket old '%s'", bucketName)
-	}
-
-	s.logger.WithField("action", "lsm_replace_bucket").
-		WithField("bucket", bucketName).
-		WithField("replacement_bucket", replacementBucketName).
-		WithField("dir", s.dir).
-		Info("replacing bucket")
-
-	replacementBucket.flushLock.Lock()
-	defer replacementBucket.flushLock.Unlock()
-	if err := os.Rename(currBucketDir, newBucketDir); err != nil {
-		return "", "", "", "", errors.Wrapf(err, "failed moving orig bucket dir '%s'", currBucketDir)
-	}
-	if err := os.Rename(currReplacementBucketDir, newReplacementBucketDir); err != nil {
-		return "", "", "", "", errors.Wrapf(err, "failed moving replacement bucket dir '%s'", currReplacementBucketDir)
-	}
-
-	return currBucketDir, newBucketDir, currReplacementBucketDir, newReplacementBucketDir, nil
-}
-
-// Replaces 1st bucket with 2nd one. Both buckets have to registered in bucketsByName.
-// 2nd bucket swaps the 1st one in bucketsByName using 1st one's name, 2nd one's name is deleted.
-// Dir path of 2nd bucket is changed to dir of 1st bucket as well as all other related paths of
-// bucket resources (segment group, memtables, commit log).
-// Dir path of 1st bucket is temporarily suffixed with "___del", later on bucket is shutdown and
-// its files deleted.
-// 2nd bucket becomes 1st bucket
+// ReplaceBuckets atomically replaces bucketName with replacementBucketName.
+// After the call, replacementBucketName's data is served under bucketName, and
+// replacementBucketName is removed from the store. The old bucket is shut down
+// and its directory deleted.
+//
+// IMPORTANT: Both buckets must be fully flushed to disk segments before calling
+// this method. Any data that exists only in the active memtable will be lost,
+// because the method creates a fresh memtable (with a commit log path matching
+// the new directory) and discards the old one. Callers must call
+// Bucket.FlushAndSwitch (or equivalent) on the replacement bucket before
+// invoking ReplaceBuckets. The method checks that no flush is in progress, but
+// does not verify that a flush has already completed.
 func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucketName string) error {
 	s.closeLock.RLock()
 	defer s.closeLock.RUnlock()
@@ -522,34 +496,72 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 	if replacementBucket == nil {
 		return fmt.Errorf("replacement bucket '%s' not found", replacementBucketName)
 	}
-	s.bucketsByName[bucketName] = replacementBucket
-	delete(s.bucketsByName, replacementBucketName)
 
-	var currBucketDir, newBucketDir, currReplacementBucketDir, newReplacementBucketDir string
-	var err error
-	currBucketDir, newBucketDir, currReplacementBucketDir, newReplacementBucketDir, err = s.replaceBucket(ctx, replacementBucket, replacementBucketName, bucket, bucketName)
-	if err != nil {
-		return errors.Wrapf(err, "failed renaming bucket '%s' to '%s'", bucketName, replacementBucketName)
+	currBucketDir := bucket.dir
+	newBucketDir := bucket.dir + "___del"
+	currReplacementBucketDir := replacementBucket.dir
+	newReplacementBucketDir := currBucketDir
+
+	// Shut down the old bucket before any filesystem changes.
+	if err := bucket.Shutdown(ctx); err != nil {
+		return errors.Wrapf(err, "failed shutting down old bucket '%s'", bucketName)
 	}
 
+	s.logger.WithField("action", "lsm_replace_bucket").
+		WithField("bucket", bucketName).
+		WithField("replacement_bucket", replacementBucketName).
+		WithField("dir", s.dir).
+		Info("replacing bucket")
+
+	// Hold flushLock for the entire sequence: flushing check, directory renames,
+	// in-memory state updates, and map swap. This eliminates the gap where a
+	// flush could start between replaceBucket and the caller re-acquiring the lock.
 	replacementBucket.flushLock.Lock()
 	defer replacementBucket.flushLock.Unlock()
 
 	if replacementBucket.flushing != nil {
-		return fmt.Errorf("bucket '%s' can not be renamed before flushing", replacementBucketName)
+		return fmt.Errorf("bucket '%s' can not be replaced before flushing completes", replacementBucketName)
 	}
 
+	// Hold maintenanceLock during filesystem renames to prevent compaction from
+	// modifying segments while directories are being moved. Released before
+	// updateBucketDir which needs to acquire maintenanceLock.RLock().
+	replacementBucket.disk.maintenanceLock.Lock()
+
+	// Rename directories: old → old___del, replacement → old's original path.
+	if err := os.Rename(currBucketDir, newBucketDir); err != nil {
+		replacementBucket.disk.maintenanceLock.Unlock()
+		return errors.Wrapf(err, "failed moving orig bucket dir '%s'", currBucketDir)
+	}
+	if err := os.Rename(currReplacementBucketDir, newReplacementBucketDir); err != nil {
+		// Best-effort rollback: move old bucket dir back.
+		_ = os.Rename(newBucketDir, currBucketDir)
+		replacementBucket.disk.maintenanceLock.Unlock()
+		return errors.Wrapf(err, "failed moving replacement bucket dir '%s'", currReplacementBucketDir)
+	}
+
+	replacementBucket.disk.maintenanceLock.Unlock()
+
+	// Update replacement bucket's in-memory state to reflect its new directory.
 	replacementBucket.dir = newReplacementBucketDir
 
 	mt, err := replacementBucket.createNewActiveMemtable()
 	if err != nil {
+		// Rollback filesystem changes.
+		_ = os.Rename(newReplacementBucketDir, currReplacementBucketDir)
+		_ = os.Rename(newBucketDir, currBucketDir)
 		return fmt.Errorf("switch active memtable: %w", err)
 	}
 	replacementBucket.active = mt
 
-	s.updateBucketDir(bucket, currBucketDir, newBucketDir)
 	s.updateBucketDir(replacementBucket, currReplacementBucketDir, newReplacementBucketDir)
 
+	// Map swap is last — if anything above failed, the map still has the
+	// original buckets and all state is consistent.
+	s.bucketsByName[bucketName] = replacementBucket
+	delete(s.bucketsByName, replacementBucketName)
+
+	// Clean up old bucket's directory (now at newBucketDir = old___del).
 	if err := os.RemoveAll(newBucketDir); err != nil {
 		return errors.Wrapf(err, "failed removing dir '%s'", newBucketDir)
 	}
@@ -557,6 +569,16 @@ func (s *Store) ReplaceBuckets(ctx context.Context, bucketName, replacementBucke
 	return nil
 }
 
+// RenameBucket renames bucketName to newBucketName. The bucket must be in
+// ReadOnly mode and newBucketName must not already exist.
+//
+// IMPORTANT: The bucket must be fully flushed to disk segments before calling
+// this method. Any data that exists only in the active memtable will be lost,
+// because the method creates a fresh memtable (with a commit log path matching
+// the new directory) and discards the old one. Callers must call
+// Bucket.FlushAndSwitch (or equivalent) before invoking RenameBucket. The
+// method checks that no flush is in progress, but does not verify that a flush
+// has already completed.
 func (s *Store) RenameBucket(ctx context.Context, bucketName, newBucketName string) error {
 	s.closeLock.RLock()
 	defer s.closeLock.RUnlock()
@@ -591,22 +613,28 @@ func (s *Store) RenameBucket(ctx context.Context, bucketName, newBucketName stri
 		return fmt.Errorf("bucket '%s' can not be renamed before flushing", bucketName)
 	}
 
-	currBucket.dir = newBucketDir
-
-	mt, err := currBucket.createNewActiveMemtable()
-	if err != nil {
-		return fmt.Errorf("switch active memtable: %w", err)
-	}
-	currBucket.active = mt
-
-	s.bucketsByName[newBucketName] = currBucket
-	delete(s.bucketsByName, bucketName)
-
+	// Filesystem rename first — if this fails, nothing has changed in memory.
 	if err := os.Rename(currBucketDir, newBucketDir); err != nil {
 		return errors.Wrapf(err, "failed renaming bucket dir '%s' to '%s'", currBucketDir, newBucketDir)
 	}
 
+	// Update in-memory state after successful filesystem rename.
+	currBucket.dir = newBucketDir
+
+	mt, err := currBucket.createNewActiveMemtable()
+	if err != nil {
+		// Rollback: move directory back since in-memory state is partially updated.
+		currBucket.dir = currBucketDir
+		_ = os.Rename(newBucketDir, currBucketDir)
+		return fmt.Errorf("switch active memtable: %w", err)
+	}
+	currBucket.active = mt
+
 	s.updateBucketDir(currBucket, currBucketDir, newBucketDir)
+
+	// Map swap is last — only after all filesystem and state updates succeed.
+	s.bucketsByName[newBucketName] = currBucket
+	delete(s.bucketsByName, bucketName)
 
 	return nil
 }

--- a/adapters/repos/db/lsmkv/store_replace_test.go
+++ b/adapters/repos/db/lsmkv/store_replace_test.go
@@ -1,0 +1,314 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/storagestate"
+)
+
+func newTestStore(t *testing.T, dir string) *Store {
+	t.Helper()
+	if dir == "" {
+		dir = t.TempDir()
+	}
+	logger, _ := test.NewNullLogger()
+
+	store, err := New(dir, dir, logger, nil, nil,
+		cyclemanager.NewCallbackGroup("compaction", logger, 1),
+		cyclemanager.NewCallbackGroup("compactionNonObjects", logger, 1),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+
+	return store
+}
+
+func TestStore_ReplaceBuckets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		store := newTestStore(t, "")
+		defer store.Shutdown(ctx)
+
+		require.NoError(t, store.CreateOrLoadBucket(ctx, "original",
+			WithStrategy(StrategyReplace)))
+		origBucket := store.Bucket("original")
+		require.NotNil(t, origBucket)
+		require.NoError(t, origBucket.Put([]byte("key1"), []byte("old_value")))
+		require.NoError(t, origBucket.FlushAndSwitch())
+
+		require.NoError(t, store.CreateOrLoadBucket(ctx, "replacement",
+			WithStrategy(StrategyReplace)))
+		replBucket := store.Bucket("replacement")
+		require.NotNil(t, replBucket)
+		require.NoError(t, replBucket.Put([]byte("key1"), []byte("new_value")))
+		require.NoError(t, replBucket.Put([]byte("key2"), []byte("extra")))
+		require.NoError(t, replBucket.FlushAndSwitch())
+
+		require.NoError(t, store.ReplaceBuckets(ctx, "original", "replacement"))
+
+		// Bucket "original" should now serve replacement data.
+		b := store.Bucket("original")
+		require.NotNil(t, b)
+
+		val, err := b.Get([]byte("key1"))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("new_value"), val)
+
+		val, err = b.Get([]byte("key2"))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("extra"), val)
+
+		// Replacement name should no longer exist.
+		assert.Nil(t, store.Bucket("replacement"))
+	})
+
+	t.Run("non-existent original bucket", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		store := newTestStore(t, "")
+		defer store.Shutdown(ctx)
+
+		require.NoError(t, store.CreateOrLoadBucket(ctx, "replacement",
+			WithStrategy(StrategyReplace)))
+
+		err := store.ReplaceBuckets(ctx, "nonexistent", "replacement")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		// Replacement bucket should still be accessible.
+		assert.NotNil(t, store.Bucket("replacement"))
+	})
+
+	t.Run("non-existent replacement bucket", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		store := newTestStore(t, "")
+		defer store.Shutdown(ctx)
+
+		require.NoError(t, store.CreateOrLoadBucket(ctx, "original",
+			WithStrategy(StrategyReplace)))
+
+		err := store.ReplaceBuckets(ctx, "original", "nonexistent")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+
+		// Original bucket should still be accessible.
+		assert.NotNil(t, store.Bucket("original"))
+	})
+
+	t.Run("old bucket directory is cleaned up", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		store := newTestStore(t, "")
+		defer store.Shutdown(ctx)
+
+		require.NoError(t, store.CreateOrLoadBucket(ctx, "original",
+			WithStrategy(StrategyReplace)))
+		origBucket := store.Bucket("original")
+		require.NoError(t, origBucket.Put([]byte("key"), []byte("val")))
+		require.NoError(t, origBucket.FlushAndSwitch())
+
+		require.NoError(t, store.CreateOrLoadBucket(ctx, "replacement",
+			WithStrategy(StrategyReplace)))
+		replBucket := store.Bucket("replacement")
+		require.NoError(t, replBucket.Put([]byte("key"), []byte("val2")))
+		require.NoError(t, replBucket.FlushAndSwitch())
+
+		origDir := origBucket.dir
+
+		require.NoError(t, store.ReplaceBuckets(ctx, "original", "replacement"))
+
+		// The ___del directory should have been removed.
+		_, err := os.Stat(origDir + "___del")
+		assert.True(t, os.IsNotExist(err), "old bucket dir should be cleaned up")
+
+		// The replacement bucket should now live at the original's path.
+		b := store.Bucket("original")
+		require.NotNil(t, b)
+		assert.Equal(t, origDir, b.dir)
+	})
+
+	t.Run("concurrent reads during replace", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		store := newTestStore(t, "")
+		defer store.Shutdown(ctx)
+
+		require.NoError(t, store.CreateOrLoadBucket(ctx, "bucket",
+			WithStrategy(StrategyReplace)))
+		require.NoError(t, store.Bucket("bucket").Put([]byte("key"), []byte("original")))
+		require.NoError(t, store.Bucket("bucket").FlushAndSwitch())
+
+		require.NoError(t, store.CreateOrLoadBucket(ctx, "bucket_new",
+			WithStrategy(StrategyReplace)))
+		require.NoError(t, store.Bucket("bucket_new").Put([]byte("key"), []byte("replaced")))
+		require.NoError(t, store.Bucket("bucket_new").FlushAndSwitch())
+
+		const numReaders = 10
+		const readsPerReader = 100
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		errs := make([]error, numReaders+1)
+
+		// Start readers that continuously read from the bucket.
+		for i := 0; i < numReaders; i++ {
+			wg.Add(1)
+			i := i
+			go func() {
+				defer wg.Done()
+				<-start
+				for j := 0; j < readsPerReader; j++ {
+					b := store.Bucket("bucket")
+					if b == nil {
+						errs[i] = fmt.Errorf("bucket was nil on read %d", j)
+						return
+					}
+					_, err := b.Get([]byte("key"))
+					if err != nil {
+						errs[i] = err
+						return
+					}
+				}
+			}()
+		}
+
+		// Start the replace concurrently with reads.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if err := store.ReplaceBuckets(ctx, "bucket", "bucket_new"); err != nil {
+				errs[numReaders] = err
+			}
+		}()
+
+		close(start)
+		wg.Wait()
+
+		for i, err := range errs {
+			assert.NoError(t, err, "goroutine %d had error", i)
+		}
+
+		// After replace, reads should return replacement data.
+		b := store.Bucket("bucket")
+		require.NotNil(t, b)
+		val, err := b.Get([]byte("key"))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("replaced"), val)
+	})
+}
+
+func TestStore_RenameBucket(t *testing.T) {
+	t.Parallel()
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		store := newTestStore(t, "")
+		defer store.Shutdown(ctx)
+
+		require.NoError(t, store.CreateOrLoadBucket(ctx, "old_name",
+			WithStrategy(StrategyReplace)))
+		bucket := store.Bucket("old_name")
+		require.NotNil(t, bucket)
+		require.NoError(t, bucket.Put([]byte("key"), []byte("value")))
+		require.NoError(t, bucket.FlushAndSwitch())
+
+		bucket.UpdateStatus(storagestate.StatusReadOnly)
+
+		require.NoError(t, store.RenameBucket(ctx, "old_name", "new_name"))
+
+		// Old name should be gone.
+		assert.Nil(t, store.Bucket("old_name"))
+
+		// New name should have the data.
+		b := store.Bucket("new_name")
+		require.NotNil(t, b)
+		val, err := b.Get([]byte("key"))
+		require.NoError(t, err)
+		assert.Equal(t, []byte("value"), val)
+
+		// Directory should be at the new location.
+		expectedDir := filepath.Join(store.dir, "new_name")
+		assert.Equal(t, expectedDir, b.dir)
+
+		// Old directory should not exist.
+		oldDir := filepath.Join(store.dir, "old_name")
+		_, err = os.Stat(oldDir)
+		assert.True(t, os.IsNotExist(err))
+	})
+
+	t.Run("target already exists", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		store := newTestStore(t, "")
+		defer store.Shutdown(ctx)
+
+		require.NoError(t, store.CreateOrLoadBucket(ctx, "bucket_a",
+			WithStrategy(StrategyReplace)))
+		require.NoError(t, store.CreateOrLoadBucket(ctx, "bucket_b",
+			WithStrategy(StrategyReplace)))
+
+		store.Bucket("bucket_a").UpdateStatus(storagestate.StatusReadOnly)
+
+		err := store.RenameBucket(ctx, "bucket_a", "bucket_b")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "already exists")
+
+		// Both buckets should still be accessible under original names.
+		assert.NotNil(t, store.Bucket("bucket_a"))
+		assert.NotNil(t, store.Bucket("bucket_b"))
+	})
+
+	t.Run("source not found", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		store := newTestStore(t, "")
+		defer store.Shutdown(ctx)
+
+		err := store.RenameBucket(ctx, "nonexistent", "new_name")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not found")
+	})
+
+	t.Run("not ReadOnly", func(t *testing.T) {
+		t.Parallel()
+		ctx := context.Background()
+		store := newTestStore(t, "")
+		defer store.Shutdown(ctx)
+
+		require.NoError(t, store.CreateOrLoadBucket(ctx, "bucket",
+			WithStrategy(StrategyReplace)))
+
+		err := store.RenameBucket(ctx, "bucket", "new_name")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "READONLY")
+
+		// Bucket should still be accessible under original name.
+		assert.NotNil(t, store.Bucket("bucket"))
+		assert.Nil(t, store.Bucket("new_name"))
+	})
+}


### PR DESCRIPTION
## Summary

- Fix ordering and locking issues in `ReplaceBuckets` and `RenameBucket` (`adapters/repos/db/lsmkv/store.go`) that made them unsafe for general-purpose use outside the `ShardInvertedReindexer`'s carefully orchestrated flow.
- Defer `bucketsByName` map swaps until after all filesystem and in-memory state changes succeed, so failures leave the store in a consistent state.
- Add rollback logic for partial failures (directory renames, memtable creation).
- Document the critical precondition: buckets must be fully flushed to disk segments before calling these methods.

### ReplaceBuckets
- Inline `replaceBucket` helper and consolidate all operations under a single `flushLock` acquisition, eliminating a gap where a flush could start between the helper and the caller re-acquiring the lock.
- Remove dead `updateBucketDir` call on the already-shutdown old bucket.

### RenameBucket
- Perform filesystem rename before in-memory state updates, so a failed `os.Rename` leaves memory untouched.
- Add rollback if `createNewActiveMemtable` fails after a successful directory rename.

## Test plan

- [x] New unit tests in `store_replace_test.go`: happy paths, error conditions (non-existent buckets, target exists, not ReadOnly), directory cleanup, concurrent reads during replace
- [x] All new tests pass with `-race` flag
- [x] Existing `test/acceptance_lsmkv` acceptance tests pass
- [x] `go vet` clean, goroutine linter clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)