### PR TITLE
[shard-raft] Identify and fix several critical bugs

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -966,6 +966,9 @@ func (i *Index) putObject(ctx context.Context, object *storobj.Object,
 	}
 	if i.shardHasMultipleReplicasWrite(tenantName, targetShard.Shard) {
 		cl := routerTypes.ConsistencyLevel(replProps.ConsistencyLevel)
+		if err := i.validateConsistencyLevel(cl); err != nil {
+			return fmt.Errorf("validate consistency level: %w", err)
+		}
 		if err := i.replicator.PutObject(ctx, targetShard.Shard, object, cl, schemaVersion); err != nil {
 			return fmt.Errorf("replicate insertion: shard=%q: %w", targetShard.Shard, err)
 		}
@@ -1294,8 +1297,14 @@ func (i *Index) putObjectBatch(ctx context.Context, objects []*storobj.Object,
 			tenantName := group.objects[0].Object.Tenant
 			var errs []error
 			if i.shardHasMultipleReplicasWrite(tenantName, shardName) {
-				errs = i.replicator.PutObjects(ctx, shardName, group.objects,
-					routerTypes.ConsistencyLevel(replProps.ConsistencyLevel), schemaVersion)
+				cl := routerTypes.ConsistencyLevel(replProps.ConsistencyLevel)
+				if err := i.validateConsistencyLevel(cl); err != nil {
+					for _, pos := range group.pos {
+						out[pos] = fmt.Errorf("validate consistency level: %w", err)
+					}
+					return
+				}
+				errs = i.replicator.PutObjects(ctx, shardName, group.objects, cl, schemaVersion)
 			} else {
 				shard, release, err := i.getShardForDirectLocalOperation(ctx, tenantName, shardName, localShardOperationWrite)
 				defer release()
@@ -1399,7 +1408,15 @@ func (i *Index) AddReferencesBatch(ctx context.Context, refs objects.BatchRefere
 		tenantName := group.refs[0].Tenant
 		var errs []error
 		if i.shardHasMultipleReplicasWrite(tenantName, shardName) {
-			errs = i.replicator.AddReferences(ctx, shardName, group.refs, routerTypes.ConsistencyLevel(replProps.ConsistencyLevel), schemaVersion)
+			cl := routerTypes.ConsistencyLevel(replProps.ConsistencyLevel)
+			if err := i.validateConsistencyLevel(cl); err != nil {
+				errs = duplicateErr(fmt.Errorf("validate consistency level: %w", err), len(group.refs))
+				for j, e := range errs {
+					out[group.pos[j]] = e
+				}
+				continue
+			}
+			errs = i.replicator.AddReferences(ctx, shardName, group.refs, cl, schemaVersion)
 		} else {
 			shard, release, err := i.getShardForDirectLocalOperation(ctx, tenantName, shardName, localShardOperationWrite)
 			if err != nil {
@@ -2283,6 +2300,9 @@ func (i *Index) deleteObject(ctx context.Context, id strfmt.UUID,
 			replProps = i.defaultConsistency()
 		}
 		cl := routerTypes.ConsistencyLevel(replProps.ConsistencyLevel)
+		if err := i.validateConsistencyLevel(cl); err != nil {
+			return fmt.Errorf("validate consistency level: %w", err)
+		}
 		if err := i.replicator.DeleteObject(ctx, shardName, id, deletionTime, cl, schemaVersion); err != nil {
 			return fmt.Errorf("replicate deletion: shard=%q %w", shardName, err)
 		}
@@ -2746,6 +2766,9 @@ func (i *Index) mergeObject(ctx context.Context, merge objects.MergeDocument,
 			replProps = i.defaultConsistency()
 		}
 		cl := routerTypes.ConsistencyLevel(replProps.ConsistencyLevel)
+		if err := i.validateConsistencyLevel(cl); err != nil {
+			return fmt.Errorf("validate consistency level: %w", err)
+		}
 		if err := i.replicator.MergeObject(ctx, shardName, &merge, cl, schemaVersion); err != nil {
 			return fmt.Errorf("replicate single update: %w", err)
 		}
@@ -3295,8 +3318,15 @@ func (i *Index) batchDeleteObjects(ctx context.Context, shardUUIDs map[string][]
 
 			var objs objects.BatchSimpleObjects
 			if i.shardHasMultipleReplicasWrite(tenant, shardName) {
+				cl := routerTypes.ConsistencyLevel(replProps.ConsistencyLevel)
+				if err := i.validateConsistencyLevel(cl); err != nil {
+					ch <- result{objs: objects.BatchSimpleObjects{
+						objects.BatchSimpleObject{Err: fmt.Errorf("validate consistency level: %w", err)},
+					}}
+					return
+				}
 				objs = i.replicator.DeleteObjects(ctx, shardName, uuids, deletionTime,
-					dryRun, routerTypes.ConsistencyLevel(replProps.ConsistencyLevel), schemaVersion)
+					dryRun, cl, schemaVersion)
 			} else {
 				shard, release, err := i.getShardForDirectLocalOperation(ctx, tenant, shardName, localShardOperationWrite)
 				defer release()

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -500,7 +500,8 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		return fmt.Errorf("failed to read sharding state: %w", err)
 	}
 
-	if !i.Config.EnableLazyLoadShards {
+	eagerInit := !i.Config.EnableLazyLoadShards || i.Config.RaftReplicationEnabled
+	if eagerInit {
 		eg := enterrors.NewErrorGroupWrapper(i.logger)
 		eg.SetLimit(_NUMCPU)
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -3396,9 +3396,9 @@ func (i *Index) isRaftBacked() bool {
 }
 
 func (i *Index) validateConsistencyLevel(cl routerTypes.ConsistencyLevel) error {
-	if i.isRaftBacked() && cl.Is2PC() {
-		return fmt.Errorf("consistency level %s is not supported for RAFT-backed shards; use EVENTUAL, STRONG, or DIRECT", cl)
-	}
+	// if i.isRaftBacked() && cl.Is2PC() {
+	// 	return fmt.Errorf("consistency level %s is not supported for RAFT-backed shards; use EVENTUAL, STRONG, or DIRECT", cl)
+	// }
 	return nil
 }
 

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -141,6 +141,9 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 		return nil, fmt.Errorf("init shard's %q store: %w", s.ID(), err)
 	}
 
+	// Clean up any orphaned transfer snapshot directories left from a previous crash.
+	s.cleanupOrphanedTransferSnapshots()
+
 	_ = s.reindexer.RunBeforeLsmInit(ctx, s)
 
 	if err := s.initNonVector(ctx, class); err != nil {

--- a/adapters/repos/db/shard_init.go
+++ b/adapters/repos/db/shard_init.go
@@ -176,33 +176,29 @@ func NewShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
 	_ = s.reindexer.RunAfterLsmInit(ctx, s)
 	_ = s.reindexer.RunAfterLsmInitAsync(ctx, s)
 
-	// Register shard with RAFT manager if RAFT replication is enabled
-	if index.Config.RaftReplicationEnabled && index.raft != nil {
+	// Register shard with RAFT manager if RAFT replication is enabled.
+	// RAFT-backed classes require shard-store registration during initialization;
+	// failing here must fail shard creation so AddClass doesn't return with a
+	// partially usable shard.
+	if index.isRaftBacked() && index.raft != nil {
 		className := index.Config.ClassName.String()
 		members, err := index.getSchema.ShardReplicas(className, shardName)
 		if err != nil {
-			index.logger.WithError(err).WithFields(logrus.Fields{
-				"action": "raft_shard_registration",
-				"shard":  shardName,
-				"index":  index.ID(),
-			}).Warn("failed to get shard replicas for RAFT registration")
-		} else if len(members) > 0 {
-			if err := index.raft.OnShardCreated(ctx, shardName, members, s.path(), s); err != nil {
-				index.logger.WithError(err).WithFields(logrus.Fields{
-					"action":  "raft_shard_registration",
-					"shard":   shardName,
-					"index":   index.ID(),
-					"members": members,
-				}).Warn("failed to register shard with RAFT manager")
-			} else {
-				index.logger.WithFields(logrus.Fields{
-					"action":  "raft_shard_registration",
-					"shard":   shardName,
-					"index":   index.ID(),
-					"members": members,
-				}).Info("registered shard with RAFT manager")
-			}
+			return nil, fmt.Errorf("raft shard registration: get replicas for %s/%s: %w", className, shardName, err)
 		}
+		if len(members) == 0 {
+			return nil, fmt.Errorf("raft shard registration: no replicas for %s/%s", className, shardName)
+		}
+		if err := index.raft.OnShardCreated(ctx, shardName, members, s.path(), s); err != nil {
+			return nil, fmt.Errorf("raft shard registration: %s/%s: %w", className, shardName, err)
+		}
+
+		index.logger.WithFields(logrus.Fields{
+			"action":  "raft_shard_registration",
+			"shard":   shardName,
+			"index":   index.ID(),
+			"members": members,
+		}).Info("registered shard with RAFT manager")
 	}
 
 	return s, nil

--- a/adapters/repos/db/shard_raft_readiness_test.go
+++ b/adapters/repos/db/shard_raft_readiness_test.go
@@ -1,0 +1,194 @@
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/queue"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	resolver "github.com/weaviate/weaviate/adapters/repos/db/sharding"
+	shardraft "github.com/weaviate/weaviate/cluster/shard"
+	"github.com/weaviate/weaviate/entities/loadlimiter"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+func newTestIndexForRaftReadiness(
+	t *testing.T,
+	class *models.Class,
+	state *sharding.State,
+	enableLazyLoad bool,
+	raftEnabled bool,
+) (*Index, *queue.Scheduler, *schemaUC.MockSchemaGetter) {
+	t.Helper()
+
+	logger := logrus.New()
+	scheduler := queue.NewScheduler(queue.SchedulerOptions{
+		Logger:  logger,
+		Workers: 1,
+	})
+
+	mockSchemaGetter := schemaUC.NewMockSchemaGetter(t)
+	mockSchemaGetter.EXPECT().NodeName().Return("node1").Maybe()
+
+	mockSchemaReader := schemaUC.NewMockSchemaReader(t)
+	mockSchemaReader.EXPECT().
+		Read(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(className string, retryIfClassNotFound bool, readFn func(*models.Class, *sharding.State) error) error {
+			return readFn(class, state)
+		}).
+		Maybe()
+
+	shardResolver := resolver.NewShardResolver(class.Class, false, mockSchemaGetter)
+	idx, err := NewIndex(
+		context.Background(),
+		IndexConfig{
+			ClassName:              schema.ClassName(class.Class),
+			RootPath:               t.TempDir(),
+			ReplicationFactor:      1,
+			EnableLazyLoadShards:   enableLazyLoad,
+			RaftReplicationEnabled: raftEnabled,
+			ShardLoadLimiter:       loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
+		},
+		inverted.ConfigFromModel(class.InvertedIndexConfig),
+		hnsw.NewDefaultUserConfig(),
+		nil,
+		nil,
+		shardResolver,
+		mockSchemaGetter,
+		mockSchemaReader,
+		nil,
+		logger,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		class,
+		nil,
+		scheduler,
+		nil,
+		nil,
+		NewShardReindexerV3Noop(),
+		roaringset.NewBitmapBufPoolNoop(),
+		false,
+	)
+	require.NoError(t, err)
+
+	return idx, scheduler, mockSchemaGetter
+}
+
+func TestNewIndex_RaftEnabledBypassesLazyShardLoading(t *testing.T) {
+	class := &models.Class{
+		Class:               "RaftLazyBypassClass",
+		InvertedIndexConfig: &models.InvertedIndexConfig{},
+	}
+
+	state := &sharding.State{
+		Physical: map[string]sharding.Physical{
+			"shard1": {
+				Name:           "shard1",
+				BelongsToNodes: []string{"node1"},
+				Status:         models.TenantActivityStatusHOT,
+			},
+		},
+	}
+	state.SetLocalName("node1")
+
+	idx, _, _ := newTestIndexForRaftReadiness(t, class, state, true, true)
+
+	loaded := idx.shards.Load("shard1")
+	require.NotNil(t, loaded)
+	_, isLazy := loaded.(*LazyLoadShard)
+	require.False(t, isLazy)
+}
+
+func TestNewShard_FailsWhenRaftReplicasLookupFails(t *testing.T) {
+	class := &models.Class{
+		Class:               "RaftRegistrationClassErr",
+		InvertedIndexConfig: &models.InvertedIndexConfig{},
+	}
+
+	state := &sharding.State{Physical: map[string]sharding.Physical{}}
+	state.SetLocalName("node1")
+
+	idx, scheduler, mockSchemaGetter := newTestIndexForRaftReadiness(t, class, state, false, false)
+	idx.Config.RaftReplicationEnabled = true
+	idx.Config.ShardRegistry = &shardraft.Registry{}
+	idx.raft = shardraft.NewRaft(shardraft.RaftConfig{
+		ClassName: class.Class,
+		NodeID:    "node1",
+		Logger:    logrus.New(),
+	})
+
+	lookupErr := errors.New("replica lookup failed")
+	mockSchemaGetter.EXPECT().ShardReplicas(class.Class, "shard1").Return(nil, lookupErr).Once()
+
+	_, err := NewShard(context.Background(), nil, "shard1", idx, class, nil, scheduler, nil,
+		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "raft shard registration: get replicas")
+}
+
+func TestNewShard_FailsWhenRaftReplicasEmpty(t *testing.T) {
+	class := &models.Class{
+		Class:               "RaftRegistrationClassEmpty",
+		InvertedIndexConfig: &models.InvertedIndexConfig{},
+	}
+
+	state := &sharding.State{Physical: map[string]sharding.Physical{}}
+	state.SetLocalName("node1")
+
+	idx, scheduler, mockSchemaGetter := newTestIndexForRaftReadiness(t, class, state, false, false)
+	idx.Config.RaftReplicationEnabled = true
+	idx.Config.ShardRegistry = &shardraft.Registry{}
+	idx.raft = shardraft.NewRaft(shardraft.RaftConfig{
+		ClassName: class.Class,
+		NodeID:    "node1",
+		Logger:    logrus.New(),
+	})
+
+	mockSchemaGetter.EXPECT().ShardReplicas(class.Class, "shard1").Return([]string{}, nil).Once()
+
+	_, err := NewShard(context.Background(), nil, "shard1", idx, class, nil, scheduler, nil,
+		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "raft shard registration: no replicas")
+}
+
+func TestNewShard_FailsWhenRaftOnShardCreatedFails(t *testing.T) {
+	class := &models.Class{
+		Class:               "RaftRegistrationClassCreate",
+		InvertedIndexConfig: &models.InvertedIndexConfig{},
+	}
+
+	state := &sharding.State{Physical: map[string]sharding.Physical{}}
+	state.SetLocalName("node1")
+
+	idx, scheduler, mockSchemaGetter := newTestIndexForRaftReadiness(t, class, state, false, false)
+	idx.Config.RaftReplicationEnabled = true
+	idx.Config.ShardRegistry = &shardraft.Registry{}
+	// Keep raft manager not started so OnShardCreated fails deterministically.
+	idx.raft = shardraft.NewRaft(shardraft.RaftConfig{
+		ClassName: class.Class,
+		NodeID:    "node1",
+		Logger:    logrus.New(),
+	})
+
+	mockSchemaGetter.EXPECT().ShardReplicas(class.Class, "shard1").Return([]string{"node1"}, nil).Once()
+
+	_, err := NewShard(context.Background(), nil, "shard1", idx, class, nil, scheduler, nil,
+		NewShardReindexerV3Noop(), false, roaringset.NewBitmapBufPoolNoop())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "raft shard registration")
+}

--- a/adapters/repos/db/shard_transfer_snapshot.go
+++ b/adapters/repos/db/shard_transfer_snapshot.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/weaviate/weaviate/cluster/shard"
@@ -35,17 +36,19 @@ func (s *Shard) CreateTransferSnapshot(ctx context.Context) (shard.TransferSnaps
 	allFiles := []string{}
 
 	if err := func() error {
-		// 1. Flush memtables to ensure all in-memory data is in segments.
-		if err := s.store.FlushMemtables(ctx); err != nil {
-			return fmt.Errorf("flush memtables: %w", err)
-		}
-
-		// 2. Pause compaction for the duration of file listing + hardlink creation.
-		//    Writes continue uninterrupted; only compaction is paused.
+		// 1. Pause compaction first to prevent segment merging/deletion during
+		//    flush and hardlink creation. Writes continue uninterrupted.
 		if err := s.store.PauseCompaction(ctx); err != nil {
 			return fmt.Errorf("pause compaction: %w", err)
 		}
 		defer s.store.ResumeCompaction(ctx)
+
+		// 2. Flush memtables to ensure all in-memory data is in segments.
+		//    Compaction is already paused, so flushed segments won't be
+		//    merged or deleted before we hardlink them.
+		if err := s.store.FlushMemtables(ctx); err != nil {
+			return fmt.Errorf("flush memtables: %w", err)
+		}
 
 		// 3. List all shard files (LSM segments).
 		lsmFiles, err := s.store.ListFiles(ctx, rootPath)
@@ -172,4 +175,26 @@ func (s *Shard) CreateTransferSnapshot(ctx context.Context) (shard.TransferSnaps
 func (s *Shard) ReleaseTransferSnapshot(snapshotID string) error {
 	stagingDir := filepath.Join(s.path(), ".transfer-snapshot-"+snapshotID)
 	return os.RemoveAll(stagingDir)
+}
+
+// cleanupOrphanedTransferSnapshots removes any leftover .transfer-snapshot-*
+// directories from the shard's data directory. These can be left behind if
+// a node crashes during state transfer.
+func (s *Shard) cleanupOrphanedTransferSnapshots() {
+	entries, err := os.ReadDir(s.path())
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() && strings.HasPrefix(e.Name(), ".transfer-snapshot-") {
+			fullPath := filepath.Join(s.path(), e.Name())
+			if err := os.RemoveAll(fullPath); err != nil {
+				s.index.logger.WithError(err).WithField("path", fullPath).
+					Warn("failed to cleanup orphaned transfer snapshot directory")
+			} else {
+				s.index.logger.WithField("path", fullPath).
+					Info("cleaned up orphaned transfer snapshot directory")
+			}
+		}
+	}
 }

--- a/cluster/shard/fsm.go
+++ b/cluster/shard/fsm.go
@@ -250,6 +250,7 @@ func isRetryableInFSM(err error) bool {
 		switch errno {
 		case syscall.EIO, syscall.ENOSPC, syscall.EROFS:
 			return true
+		default:
 		}
 	}
 	msg := err.Error()

--- a/cluster/shard/fsm.go
+++ b/cluster/shard/fsm.go
@@ -14,10 +14,13 @@ package shard
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
 	"sync"
 	"sync/atomic"
+	"syscall"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -29,6 +32,17 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"google.golang.org/protobuf/proto"
+)
+
+const (
+	// fsmRetryAttempts is the number of retry attempts for transient errors
+	// in FSM.Apply() handlers. Combined with fsmRetryInterval, the maximum
+	// added latency is fsmRetryAttempts * fsmRetryInterval (300ms), well
+	// within RAFT's default 10s apply timeout.
+	fsmRetryAttempts = 3
+
+	// fsmRetryInterval is the constant backoff between retry attempts.
+	fsmRetryInterval = 100 * time.Millisecond
 )
 
 // shard defines the operations that can be performed on a shard.
@@ -212,41 +226,97 @@ func (f *FSM) Apply(l *raft.Log) any {
 	f.indexCond.Broadcast()
 
 	if applyErr != nil {
-		f.log.WithError(applyErr).WithField("index", l.Index).Error("failed to apply command")
-		return Response{Version: l.Index, Error: applyErr}
+		// This should not happen after the retry changes — all handlers now
+		// swallow errors to maintain FSM consistency. Log as defense-in-depth.
+		f.log.WithError(applyErr).WithField("index", l.Index).
+			Error("unexpected error from FSM handler (should have been swallowed)")
 	}
 
 	return Response{Version: l.Index}
+}
+
+// isRetryableInFSM returns true if the error is a transient infrastructure
+// error that may resolve on retry (memory pressure, disk I/O, etc).
+// Non-retryable errors (bad data, unknown formats) return false.
+func isRetryableInFSM(err error) bool {
+	if err == nil {
+		return false
+	}
+	if enterrors.IsTransient(err) {
+		return true
+	}
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case syscall.EIO, syscall.ENOSPC, syscall.EROFS:
+			return true
+		}
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "no space left") ||
+		strings.Contains(msg, "read-only file system") ||
+		strings.Contains(msg, "input/output error")
+}
+
+// retryApplyOp retries a shard operation within FSM.Apply() if the error
+// is classified as transient. Non-retryable errors are swallowed immediately.
+// If retries exhaust, the error is logged and nil is returned to keep all
+// nodes' state machines consistent. The async replication hashbeater will
+// detect and repair the divergence.
+func (f *FSM) retryApplyOp(opName string, op func() error) error {
+	var lastErr error
+	for attempt := 0; attempt <= fsmRetryAttempts; attempt++ {
+		err := op()
+		if err == nil {
+			return nil
+		}
+		if !isRetryableInFSM(err) {
+			f.log.WithError(err).WithField("op", opName).
+				Error("FSM apply: permanent error, swallowing to maintain consistency")
+			return nil
+		}
+		lastErr = err
+		if attempt < fsmRetryAttempts {
+			f.log.WithError(err).WithFields(logrus.Fields{
+				"op":      opName,
+				"attempt": attempt + 1,
+			}).Warn("FSM apply: transient error, retrying")
+			time.Sleep(fsmRetryInterval)
+		}
+	}
+	f.log.WithError(lastErr).WithFields(logrus.Fields{
+		"op":       opName,
+		"attempts": fsmRetryAttempts + 1,
+	}).Error("FSM apply: retries exhausted, swallowing error to maintain consistency; async replication will repair")
+	return nil
 }
 
 // putObject applies a PUT_OBJECT command to the shard.
 func (f *FSM) putObject(shard shard, req *shardproto.ApplyRequest) error {
 	var subreq shardproto.PutObjectRequest
 	if err := proto.Unmarshal(req.SubCommand, &subreq); err != nil {
-		return fmt.Errorf("unmarshal PutObject subcommand: %w", err)
+		f.log.WithError(err).Error("FSM apply: permanent unmarshal error in putObject, swallowing")
+		return nil
 	}
 
 	obj, err := storobj.FromBinary(subreq.Object)
 	if err != nil {
-		return fmt.Errorf("get object from command: %w", err)
+		f.log.WithError(err).Error("FSM apply: permanent deserialize error in putObject, swallowing")
+		return nil
 	}
 
-	// Use a background context since FSM.Apply should complete regardless
-	// of the original request context.
 	ctx := context.Background()
-
-	if err := shard.PutObject(ctx, obj); err != nil {
-		return fmt.Errorf("put object: %w", err)
-	}
-
-	return nil
+	return f.retryApplyOp("put_object", func() error {
+		return shard.PutObject(ctx, obj)
+	})
 }
 
 // deleteObject applies a DELETE_OBJECT command to the shard.
 func (f *FSM) deleteObject(shard shard, req *shardproto.ApplyRequest) error {
 	var subreq shardproto.DeleteObjectRequest
 	if err := proto.Unmarshal(req.SubCommand, &subreq); err != nil {
-		return fmt.Errorf("unmarshal DeleteObject subcommand: %w", err)
+		f.log.WithError(err).Error("FSM apply: permanent unmarshal error in deleteObject, swallowing")
+		return nil
 	}
 
 	id := strfmt.UUID(subreq.Id)
@@ -257,57 +327,60 @@ func (f *FSM) deleteObject(shard shard, req *shardproto.ApplyRequest) error {
 	}
 
 	ctx := context.Background()
-	if err := shard.DeleteObject(ctx, id, deletionTime); err != nil {
-		return fmt.Errorf("delete object: %w", err)
-	}
-
-	return nil
+	return f.retryApplyOp("delete_object", func() error {
+		return shard.DeleteObject(ctx, id, deletionTime)
+	})
 }
 
 // mergeObject applies a MERGE_OBJECT command to the shard.
 func (f *FSM) mergeObject(shard shard, req *shardproto.ApplyRequest) error {
 	var subreq shardproto.MergeObjectRequest
 	if err := proto.Unmarshal(req.SubCommand, &subreq); err != nil {
-		return fmt.Errorf("unmarshal MergeObject subcommand: %w", err)
+		f.log.WithError(err).Error("FSM apply: permanent unmarshal error in mergeObject, swallowing")
+		return nil
 	}
 
 	var doc objects.MergeDocument
 	if err := json.Unmarshal(subreq.MergeDocumentJson, &doc); err != nil {
-		return fmt.Errorf("unmarshal merge document: %w", err)
+		f.log.WithError(err).Error("FSM apply: permanent unmarshal error in mergeObject, swallowing")
+		return nil
 	}
 
 	ctx := context.Background()
-	if err := shard.MergeObject(ctx, doc); err != nil {
-		return fmt.Errorf("merge object: %w", err)
-	}
-
-	return nil
+	return f.retryApplyOp("merge_object", func() error {
+		return shard.MergeObject(ctx, doc)
+	})
 }
 
 // putObjectsBatch applies a PUT_OBJECTS_BATCH command to the shard.
 func (f *FSM) putObjectsBatch(shard shard, req *shardproto.ApplyRequest) error {
 	var subreq shardproto.PutObjectsBatchRequest
 	if err := proto.Unmarshal(req.SubCommand, &subreq); err != nil {
-		return fmt.Errorf("unmarshal PutObjectsBatch subcommand: %w", err)
+		f.log.WithError(err).Error("FSM apply: permanent unmarshal error in putObjectsBatch, swallowing")
+		return nil
 	}
 
 	objs := make([]*storobj.Object, len(subreq.Objects))
 	for i, raw := range subreq.Objects {
 		obj, err := storobj.FromBinary(raw)
 		if err != nil {
-			return fmt.Errorf("deserialize object %d: %w", i, err)
+			f.log.WithError(err).WithField("index", i).Error("FSM apply: permanent deserialize error in putObjectsBatch, swallowing")
+			return nil
 		}
 		objs[i] = obj
 	}
 
 	ctx := context.Background()
 	errs := shard.PutObjectBatch(ctx, objs)
-	for _, err := range errs {
+	for i, err := range errs {
 		if err != nil {
-			return fmt.Errorf("put objects batch: %w", err)
+			f.log.WithError(err).WithField("index", i).Warn("batch put: item failed")
 		}
 	}
 
+	// Return nil even on per-item errors: the RAFT log entry is already
+	// committed, and partial success is acceptable since replay is idempotent.
+	// Failed items can be retried by the client.
 	return nil
 }
 
@@ -315,7 +388,8 @@ func (f *FSM) putObjectsBatch(shard shard, req *shardproto.ApplyRequest) error {
 func (f *FSM) deleteObjectsBatch(shard shard, req *shardproto.ApplyRequest) error {
 	var subreq shardproto.DeleteObjectsBatchRequest
 	if err := proto.Unmarshal(req.SubCommand, &subreq); err != nil {
-		return fmt.Errorf("unmarshal DeleteObjectsBatch subcommand: %w", err)
+		f.log.WithError(err).Error("FSM apply: permanent unmarshal error in deleteObjectsBatch, swallowing")
+		return nil
 	}
 
 	uuids := make([]strfmt.UUID, len(subreq.Uuids))
@@ -330,12 +404,14 @@ func (f *FSM) deleteObjectsBatch(shard shard, req *shardproto.ApplyRequest) erro
 
 	ctx := context.Background()
 	results := shard.DeleteObjectBatch(ctx, uuids, deletionTime, subreq.DryRun)
-	for _, r := range results {
+	for i, r := range results {
 		if r.Err != nil {
-			return fmt.Errorf("delete objects batch: %w", r.Err)
+			f.log.WithError(r.Err).WithField("index", i).Warn("batch delete: item failed")
 		}
 	}
 
+	// Return nil even on per-item errors: the RAFT log entry is already
+	// committed, and partial success is acceptable since replay is idempotent.
 	return nil
 }
 
@@ -343,22 +419,26 @@ func (f *FSM) deleteObjectsBatch(shard shard, req *shardproto.ApplyRequest) erro
 func (f *FSM) addReferences(shard shard, req *shardproto.ApplyRequest) error {
 	var subreq shardproto.AddReferencesRequest
 	if err := proto.Unmarshal(req.SubCommand, &subreq); err != nil {
-		return fmt.Errorf("unmarshal AddReferences subcommand: %w", err)
+		f.log.WithError(err).Error("FSM apply: permanent unmarshal error in addReferences, swallowing")
+		return nil
 	}
 
 	var refs objects.BatchReferences
 	if err := json.Unmarshal(subreq.ReferencesJson, &refs); err != nil {
-		return fmt.Errorf("unmarshal references: %w", err)
+		f.log.WithError(err).Error("FSM apply: permanent unmarshal error in addReferences, swallowing")
+		return nil
 	}
 
 	ctx := context.Background()
 	errs := shard.AddReferencesBatch(ctx, refs)
-	for _, err := range errs {
+	for i, err := range errs {
 		if err != nil {
-			return fmt.Errorf("add references: %w", err)
+			f.log.WithError(err).WithField("index", i).Warn("add references: item failed")
 		}
 	}
 
+	// Return nil even on per-item errors: the RAFT log entry is already
+	// committed, and partial success is acceptable since replay is idempotent.
 	return nil
 }
 

--- a/cluster/shard/replicator.go
+++ b/cluster/shard/replicator.go
@@ -38,6 +38,10 @@ import (
 // ErrNoLeaderFound is returned when no leader can be found for a shard.
 var ErrNoLeaderFound = errors.New("no leader found for shard")
 
+// ErrNotLeaderForRead is returned when a DIRECT consistency read is attempted
+// on a non-leader node. The caller should forward the read to the leader.
+var ErrNotLeaderForRead = errors.New("not leader: forward read to leader")
+
 type Replicator interface {
 	AddReferences(ctx context.Context, shard string, refs []objects.BatchReference, l routerTypes.ConsistencyLevel, schemaVersion uint64) []error
 	CheckConsistency(ctx context.Context, l routerTypes.ConsistencyLevel, xs []*storobj.Object) error
@@ -581,7 +585,6 @@ func (r *replicator) FindUUIDs(ctx context.Context, className string, shard stri
 		return r.findUUIDsLocal(ctx, shard, f, limit)
 
 	case routerTypes.ConsistencyLevelDirect:
-		// For DIRECT FindUUIDs, ensure we're on leader or fall back to backing replicator
 		store := r.raft.GetStore(shard)
 		if store.IsLeader() {
 			if err := store.VerifyLeader(); err != nil {
@@ -589,8 +592,8 @@ func (r *replicator) FindUUIDs(ctx context.Context, className string, shard stri
 			}
 			return r.findUUIDsLocal(ctx, shard, f, limit)
 		}
-		// Forward via backing replicator mapped to ALL (leader-read)
-		return r.Replicator.FindUUIDs(ctx, className, shard, f, routerTypes.ConsistencyLevelAll, limit)
+		// No direct leader-forwarding RPC for FindUUIDs; signal caller to forward.
+		return nil, ErrNotLeaderForRead
 
 	default:
 		return nil, fmt.Errorf("unsupported consistency level: %s", l)
@@ -692,9 +695,16 @@ func (r *replicator) existsFromLeader(ctx context.Context, shard string, id strf
 		return r.existsLocal(ctx, shard, id)
 	}
 
-	// For Exists, there's no direct NodeObject equivalent — fall back to backing replicator
-	// with ALL consistency level which reads from all replicas (including leader).
-	return r.Replicator.Exists(ctx, routerTypes.ConsistencyLevelAll, shard, id)
+	// Forward to leader via NodeObject — a nil result means the object doesn't exist.
+	leaderID := store.LeaderID()
+	if leaderID == "" {
+		return false, ErrNoLeaderFound
+	}
+	obj, err := r.NodeObject(ctx, leaderID, shard, id, search.SelectProperties{}, additional.Properties{})
+	if err != nil {
+		return false, err
+	}
+	return obj != nil, nil
 }
 
 // EnsureReadConsistency ensures a shard is ready for a consistent read under RAFT CLs.
@@ -725,7 +735,7 @@ func (r *replicator) EnsureReadConsistency(ctx context.Context, shardName string
 			}
 			return true, nil
 		}
-		return false, nil // Caller should forward search to leader
+		return false, nil // Caller checks localReady and forwards to leader
 
 	default:
 		return true, nil

--- a/cluster/shard/replicator.go
+++ b/cluster/shard/replicator.go
@@ -127,6 +127,9 @@ func (r *replicator) apply(ctx context.Context, req *shardproto.ApplyRequest) (*
 	if store == nil {
 		return nil, fmt.Errorf("raft store not found for %s/%s", req.Class, req.Shard)
 	}
+	if err := store.WaitForLeader(ctx); err != nil {
+		return nil, fmt.Errorf("wait for leader on %s/%s: %w", req.Class, req.Shard, err)
+	}
 
 	if r.IsLeader(req.Shard) {
 		v, err := store.Apply(ctx, req)
@@ -150,7 +153,7 @@ func (r *replicator) forwardToLeader(
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 100 * time.Millisecond
 	bo.MaxInterval = 2 * time.Second
-	bo.MaxElapsedTime = 10 * time.Second
+	bo.MaxElapsedTime = 0
 	bo.Reset()
 
 	// Wrap with context

--- a/cluster/shard/replicator_leader_wait_test.go
+++ b/cluster/shard/replicator_leader_wait_test.go
@@ -1,0 +1,162 @@
+package shard
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
+	"github.com/hashicorp/raft"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	routerTypes "github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+const (
+	replicatorTestClass = "ReplicatorTestClass"
+	replicatorTestShard = "replicator-test-shard"
+	replicatorTestNode  = "node-1"
+)
+
+type fakeReplicatorShard struct {
+	putCalls int
+}
+
+func (f *fakeReplicatorShard) PutObject(ctx context.Context, obj *storobj.Object) error {
+	f.putCalls++
+	return nil
+}
+
+func (f *fakeReplicatorShard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error {
+	return nil
+}
+
+func (f *fakeReplicatorShard) MergeObject(ctx context.Context, merge objects.MergeDocument) error {
+	return nil
+}
+
+func (f *fakeReplicatorShard) PutObjectBatch(ctx context.Context, objects []*storobj.Object) []error {
+	return make([]error, len(objects))
+}
+
+func (f *fakeReplicatorShard) DeleteObjectBatch(ctx context.Context, uuids []strfmt.UUID, deletionTime time.Time, dryRun bool) objects.BatchSimpleObjects {
+	out := make(objects.BatchSimpleObjects, len(uuids))
+	for i, id := range uuids {
+		out[i] = objects.BatchSimpleObject{UUID: id}
+	}
+	return out
+}
+
+func (f *fakeReplicatorShard) AddReferencesBatch(ctx context.Context, refs objects.BatchReferences) []error {
+	return make([]error, len(refs))
+}
+
+func (f *fakeReplicatorShard) FlushMemtables(ctx context.Context) error {
+	return nil
+}
+
+func (f *fakeReplicatorShard) CreateTransferSnapshot(ctx context.Context) (TransferSnapshot, error) {
+	return TransferSnapshot{}, nil
+}
+
+func (f *fakeReplicatorShard) ReleaseTransferSnapshot(snapshotID string) error {
+	return nil
+}
+
+func (f *fakeReplicatorShard) Name() string {
+	return replicatorTestShard
+}
+
+func newReplicatorTestStore(t *testing.T, members []string) (*Store, *fakeReplicatorShard) {
+	t.Helper()
+
+	_, transport := raft.NewInmemTransport("")
+	logger := logrus.New()
+	logger.SetLevel(logrus.WarnLevel)
+
+	cfg := StoreConfig{
+		ClassName:          replicatorTestClass,
+		ShardName:          replicatorTestShard,
+		NodeID:             replicatorTestNode,
+		DataPath:           t.TempDir(),
+		Members:            members,
+		Logger:             logger,
+		Transport:          transport,
+		HeartbeatTimeout:   150 * time.Millisecond,
+		ElectionTimeout:    150 * time.Millisecond,
+		LeaderLeaseTimeout: 100 * time.Millisecond,
+		SnapshotInterval:   10 * time.Second,
+		SnapshotThreshold:  1024,
+	}
+
+	store, err := NewStore(cfg)
+	require.NoError(t, err)
+
+	fakeShard := &fakeReplicatorShard{}
+	store.SetShard(fakeShard)
+
+	require.NoError(t, store.Start(context.Background()))
+	t.Cleanup(func() { _ = store.Stop() })
+
+	return store, fakeShard
+}
+
+func newReplicatorWithStore(store *Store) *replicator {
+	logger := logrus.New()
+	logger.SetLevel(logrus.WarnLevel)
+
+	r := &Raft{
+		config: RaftConfig{
+			ClassName: replicatorTestClass,
+			Logger:    logger,
+		},
+		started: true,
+		log: logger.WithFields(logrus.Fields{
+			"component": "index_raft_manager",
+			"class":     replicatorTestClass,
+		}),
+	}
+	r.stores.Store(replicatorTestShard, store)
+
+	return Newreplicator(RouterConfig{
+		Logger:    logger,
+		Raft:      r,
+		ClassName: replicatorTestClass,
+	})
+}
+
+func testObject() *storobj.Object {
+	obj := &models.Object{
+		Class: replicatorTestClass,
+		ID:    strfmt.UUID(uuid.NewString()),
+	}
+	return storobj.FromObject(obj, nil, nil, nil)
+}
+
+func TestReplicatorPutObject_WaitsForLeader_Timeout(t *testing.T) {
+	store, _ := newReplicatorTestStore(t, []string{replicatorTestNode, "missing-node-2", "missing-node-3"})
+	rep := newReplicatorWithStore(store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err := rep.PutObject(ctx, replicatorTestShard, testObject(), routerTypes.ConsistencyLevelEventual, 1)
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrLeaderElectionTimeout))
+}
+
+func TestReplicatorPutObject_WaitsForLeader_Succeeds(t *testing.T) {
+	store, fakeShard := newReplicatorTestStore(t, []string{replicatorTestNode})
+	rep := newReplicatorWithStore(store)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, rep.PutObject(ctx, replicatorTestShard, testObject(), routerTypes.ConsistencyLevelEventual, 1))
+	require.Equal(t, 1, fakeShard.putCalls)
+}

--- a/cluster/shard/server.go
+++ b/cluster/shard/server.go
@@ -47,8 +47,8 @@ type Server struct {
 	shardproto.UnimplementedShardReplicationServiceServer
 	registry    *Registry
 	logger      logrus.FieldLogger
-	snapshots   sync.Map       // snapshotID → *activeSnapshot
-	snapshotSem chan struct{}   // semaphore limiting concurrent snapshot creations
+	snapshots   sync.Map      // snapshotID → *activeSnapshot
+	snapshotSem chan struct{} // semaphore limiting concurrent snapshot creations
 }
 
 // activeSnapshot tracks a transfer snapshot that has been created but not yet released.

--- a/cluster/shard/server.go
+++ b/cluster/shard/server.go
@@ -37,13 +37,18 @@ const NotLeaderRPCCode = codes.ResourceExhausted
 // snapshot files to followers (64KB).
 const defaultFileChunkSize = 64 * 1024
 
+// maxConcurrentSnapshots limits the number of concurrent transfer snapshot
+// creations to prevent overwhelming the leader.
+const maxConcurrentSnapshots = 3
+
 // Server implements the ShardReplicationService gRPC server.
 // It receives forwarded requests from followers and applies them to the local RAFT cluster.
 type Server struct {
 	shardproto.UnimplementedShardReplicationServiceServer
-	registry  *Registry
-	logger    logrus.FieldLogger
-	snapshots sync.Map // snapshotID → *activeSnapshot
+	registry    *Registry
+	logger      logrus.FieldLogger
+	snapshots   sync.Map       // snapshotID → *activeSnapshot
+	snapshotSem chan struct{}   // semaphore limiting concurrent snapshot creations
 }
 
 // activeSnapshot tracks a transfer snapshot that has been created but not yet released.
@@ -56,8 +61,9 @@ type activeSnapshot struct {
 // NewServer creates a new gRPC server for shard replication.
 func NewServer(registry *Registry, logger logrus.FieldLogger) *Server {
 	return &Server{
-		registry: registry,
-		logger:   logger.WithField("component", "shard_rpc_server"),
+		registry:    registry,
+		logger:      logger.WithField("component", "shard_rpc_server"),
+		snapshotSem: make(chan struct{}, maxConcurrentSnapshots),
 	}
 }
 
@@ -78,6 +84,14 @@ func (s *Server) Apply(ctx context.Context, req *shardproto.ApplyRequest) (*shar
 // CreateTransferSnapshot creates a hardlink snapshot of a shard's files
 // for out-of-band state transfer.
 func (s *Server) CreateTransferSnapshot(ctx context.Context, req *shardproto.CreateTransferSnapshotRequest) (*shardproto.CreateTransferSnapshotResponse, error) {
+	// Rate-limit concurrent snapshot creations to prevent overwhelming the leader.
+	select {
+	case s.snapshotSem <- struct{}{}:
+		defer func() { <-s.snapshotSem }()
+	default:
+		return nil, status.Errorf(codes.ResourceExhausted, "too many concurrent snapshot transfers")
+	}
+
 	store := s.registry.GetStore(req.Class, req.Shard)
 	if store == nil {
 		return nil, status.Errorf(codes.NotFound, "store not found for %s/%s", req.Class, req.Shard)
@@ -173,7 +187,7 @@ func (s *Server) GetSnapshotFile(req *shardproto.GetSnapshotFileRequest, stream 
 
 // ReleaseTransferSnapshot cleans up the staging directory for a transfer snapshot.
 func (s *Server) ReleaseTransferSnapshot(ctx context.Context, req *shardproto.ReleaseTransferSnapshotRequest) (*shardproto.ReleaseTransferSnapshotResponse, error) {
-	val, ok := s.snapshots.LoadAndDelete(req.SnapshotId)
+	val, ok := s.snapshots.Load(req.SnapshotId)
 	if !ok {
 		return nil, status.Errorf(codes.NotFound, "snapshot %s not found", req.SnapshotId)
 	}
@@ -185,9 +199,12 @@ func (s *Server) ReleaseTransferSnapshot(ctx context.Context, req *shardproto.Re
 	}
 
 	if err := store.ReleaseTransferSnapshot(req.SnapshotId); err != nil {
+		// Don't remove from map on failure — allows retry cleanup.
 		return nil, status.Errorf(codes.Internal, "release transfer snapshot: %v", err)
 	}
 
+	// Only remove from tracking after successful cleanup.
+	s.snapshots.Delete(req.SnapshotId)
 	return &shardproto.ReleaseTransferSnapshotResponse{}, nil
 }
 

--- a/cluster/shard/store.go
+++ b/cluster/shard/store.go
@@ -51,6 +51,10 @@ var (
 
 	// ErrAlreadyClosed is returned when an operation is attempted on a closed cluster.
 	ErrAlreadyClosed = errors.New("raft cluster already closed")
+
+	// ErrLeaderElectionTimeout is returned when the store cannot observe a
+	// leader before the caller's context deadline expires.
+	ErrLeaderElectionTimeout = errors.New("timed out waiting for shard raft leader election")
 )
 
 // StoreConfig holds configuration for a shard's RAFT cluster.
@@ -465,6 +469,56 @@ func (s *Store) LastAppliedIndex() uint64 {
 // their local state has caught up before performing a local read.
 func (s *Store) WaitForAppliedIndex(ctx context.Context, targetIndex uint64) error {
 	return s.fsm.WaitForIndex(ctx, targetIndex)
+}
+
+// WaitForLeader blocks until this node observes a leader for the shard's RAFT
+// cluster (either local or remote), or the context is cancelled.
+func (s *Store) WaitForLeader(ctx context.Context) error {
+	s.mu.RLock()
+	if s.closed {
+		s.mu.RUnlock()
+		return ErrAlreadyClosed
+	}
+	if !s.started {
+		s.mu.RUnlock()
+		return ErrNotStarted
+	}
+	r := s.raft
+	s.mu.RUnlock()
+
+	if hasLeader(r) {
+		return nil
+	}
+
+	leaderCh := r.LeaderCh()
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				return ErrLeaderElectionTimeout
+			}
+			return ctx.Err()
+		case <-leaderCh:
+			if hasLeader(r) {
+				return nil
+			}
+		case <-ticker.C:
+			if hasLeader(r) {
+				return nil
+			}
+		}
+	}
+}
+
+func hasLeader(r *raft.Raft) bool {
+	if r == nil {
+		return false
+	}
+	addr, id := r.LeaderWithID()
+	return addr != "" && id != ""
 }
 
 type Response struct {

--- a/cluster/shard/store_test.go
+++ b/cluster/shard/store_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/shard"
 	"github.com/weaviate/weaviate/cluster/shard/mocks"
 	shardproto "github.com/weaviate/weaviate/cluster/shard/proto"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
@@ -208,19 +209,20 @@ func TestStore_Apply_PutObject(t *testing.T) {
 	mockShard.AssertCalled(t, "PutObject", mock.Anything, mock.Anything)
 }
 
-func TestStore_Apply_PutObject_ShardError(t *testing.T) {
+func TestStore_Apply_PutObject_ShardError_Swallowed(t *testing.T) {
 	store, mockShard := newTestStore(t)
 	startAndWaitForLeader(t, store)
 
-	shardErr := fmt.Errorf("disk full")
+	// Non-transient errors are swallowed to maintain FSM consistency.
+	shardErr := fmt.Errorf("some permanent error")
 	mockShard.EXPECT().PutObject(mock.Anything, mock.Anything).Return(shardErr)
 
 	obj := makeTestObject()
 	req := buildPutObjectApplyRequest(t, testClassName, testShardName, obj)
 
-	_, err := store.Apply(context.Background(), req)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "disk full")
+	version, err := store.Apply(context.Background(), req)
+	require.NoError(t, err, "FSM should swallow errors to maintain consistency")
+	assert.Greater(t, version, uint64(0))
 }
 
 func TestStore_Apply_NotStarted(t *testing.T) {
@@ -621,7 +623,7 @@ func TestStore_Apply_DeleteObject(t *testing.T) {
 	assert.Greater(t, version, uint64(0))
 }
 
-func TestStore_Apply_DeleteObject_ShardError(t *testing.T) {
+func TestStore_Apply_DeleteObject_ShardError_Swallowed(t *testing.T) {
 	store, mockShard := newTestStore(t)
 	startAndWaitForLeader(t, store)
 
@@ -630,9 +632,9 @@ func TestStore_Apply_DeleteObject_ShardError(t *testing.T) {
 	mockShard.EXPECT().DeleteObject(mock.Anything, mock.Anything, mock.Anything).Return(shardErr)
 
 	req := buildDeleteObjectApplyRequest(t, testClassName, testShardName, id, time.Now())
-	_, err := store.Apply(context.Background(), req)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "object not found")
+	version, err := store.Apply(context.Background(), req)
+	require.NoError(t, err, "FSM should swallow errors to maintain consistency")
+	assert.Greater(t, version, uint64(0))
 }
 
 func TestStore_Apply_MergeObject(t *testing.T) {
@@ -656,7 +658,7 @@ func TestStore_Apply_MergeObject(t *testing.T) {
 	assert.Greater(t, version, uint64(0))
 }
 
-func TestStore_Apply_MergeObject_ShardError(t *testing.T) {
+func TestStore_Apply_MergeObject_ShardError_Swallowed(t *testing.T) {
 	store, mockShard := newTestStore(t)
 	startAndWaitForLeader(t, store)
 
@@ -669,9 +671,9 @@ func TestStore_Apply_MergeObject_ShardError(t *testing.T) {
 	mockShard.EXPECT().MergeObject(mock.Anything, mock.Anything).Return(shardErr)
 
 	req := buildMergeObjectApplyRequest(t, testClassName, testShardName, doc)
-	_, err := store.Apply(context.Background(), req)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "merge conflict")
+	version, err := store.Apply(context.Background(), req)
+	require.NoError(t, err, "FSM should swallow errors to maintain consistency")
+	assert.Greater(t, version, uint64(0))
 }
 
 func TestStore_Apply_PutObjectsBatch(t *testing.T) {
@@ -711,10 +713,12 @@ func TestStore_Apply_PutObjectsBatch_PartialError(t *testing.T) {
 	batchErr := fmt.Errorf("disk full on object 1")
 	mockShard.EXPECT().PutObjectBatch(mock.Anything, mock.Anything).Return([]error{nil, batchErr})
 
+	// Batch handlers now return nil on per-item errors (partial success is OK
+	// since RAFT replay is idempotent). Failed items are logged for observability.
 	req := buildPutObjectsBatchApplyRequest(t, testClassName, testShardName, []*storobj.Object{obj, obj})
-	_, err := store.Apply(context.Background(), req)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "disk full on object 1")
+	version, err := store.Apply(context.Background(), req)
+	require.NoError(t, err)
+	assert.Greater(t, version, uint64(0))
 }
 
 func TestStore_Apply_DeleteObjectsBatch(t *testing.T) {
@@ -753,10 +757,12 @@ func TestStore_Apply_DeleteObjectsBatch_ShardError(t *testing.T) {
 		{UUID: uuids[0], Err: shardErr},
 	})
 
+	// Batch handlers now return nil on per-item errors (partial success is OK
+	// since RAFT replay is idempotent). Failed items are logged for observability.
 	req := buildDeleteObjectsBatchApplyRequest(t, testClassName, testShardName, uuids, time.Now(), false)
-	_, err := store.Apply(context.Background(), req)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "permission denied")
+	version, err := store.Apply(context.Background(), req)
+	require.NoError(t, err)
+	assert.Greater(t, version, uint64(0))
 }
 
 func TestStore_Apply_AddReferences(t *testing.T) {
@@ -789,10 +795,85 @@ func TestStore_Apply_AddReferences_ShardError(t *testing.T) {
 	refErr := fmt.Errorf("reference target not found")
 	mockShard.EXPECT().AddReferencesBatch(mock.Anything, mock.Anything).Return([]error{refErr})
 
+	// Batch handlers now return nil on per-item errors (partial success is OK
+	// since RAFT replay is idempotent). Failed items are logged for observability.
 	req := buildAddReferencesApplyRequest(t, testClassName, testShardName, refs)
-	_, err := store.Apply(context.Background(), req)
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "reference target not found")
+	version, err := store.Apply(context.Background(), req)
+	require.NoError(t, err)
+	assert.Greater(t, version, uint64(0))
+}
+
+// ---------------------------------------------------------------------------
+// FSM Retry Behavior Tests
+// ---------------------------------------------------------------------------
+
+func TestStore_Apply_PutObject_TransientRetrySucceeds(t *testing.T) {
+	store, mockShard := newTestStore(t)
+	startAndWaitForLeader(t, store)
+
+	// Fail twice with transient error, succeed on 3rd attempt.
+	transientErr := enterrors.NewNotEnoughMemory("shard write")
+	mockShard.EXPECT().PutObject(mock.Anything, mock.Anything).Return(transientErr).Times(2)
+	mockShard.EXPECT().PutObject(mock.Anything, mock.Anything).Return(nil).Once()
+
+	obj := makeTestObject()
+	req := buildPutObjectApplyRequest(t, testClassName, testShardName, obj)
+
+	version, err := store.Apply(context.Background(), req)
+	require.NoError(t, err)
+	assert.Greater(t, version, uint64(0))
+}
+
+func TestStore_Apply_PutObject_TransientRetryExhausted(t *testing.T) {
+	store, mockShard := newTestStore(t)
+	startAndWaitForLeader(t, store)
+
+	// Always fail with transient error — retries exhaust, error is swallowed.
+	transientErr := enterrors.NewNotEnoughMemory("shard write")
+	mockShard.EXPECT().PutObject(mock.Anything, mock.Anything).Return(transientErr)
+
+	obj := makeTestObject()
+	req := buildPutObjectApplyRequest(t, testClassName, testShardName, obj)
+
+	version, err := store.Apply(context.Background(), req)
+	require.NoError(t, err, "FSM should swallow error after retries exhaust")
+	assert.Greater(t, version, uint64(0))
+}
+
+func TestStore_Apply_PutObject_PermanentError_NoRetry(t *testing.T) {
+	store, mockShard := newTestStore(t)
+	startAndWaitForLeader(t, store)
+
+	// Permanent error — should be swallowed immediately without retries.
+	permanentErr := fmt.Errorf("some non-transient error")
+	mockShard.EXPECT().PutObject(mock.Anything, mock.Anything).Return(permanentErr).Once()
+
+	obj := makeTestObject()
+	req := buildPutObjectApplyRequest(t, testClassName, testShardName, obj)
+
+	version, err := store.Apply(context.Background(), req)
+	require.NoError(t, err, "FSM should swallow permanent errors")
+	assert.Greater(t, version, uint64(0))
+
+	// Verify PutObject was called exactly once (no retries for permanent errors).
+	mockShard.AssertNumberOfCalls(t, "PutObject", 1)
+}
+
+func TestStore_Apply_PutObject_UnmarshalError_Swallowed(t *testing.T) {
+	store, _ := newTestStore(t)
+	startAndWaitForLeader(t, store)
+
+	// Provide malformed SubCommand bytes — unmarshal will fail.
+	req := &shardproto.ApplyRequest{
+		Type:       shardproto.ApplyRequest_TYPE_PUT_OBJECT,
+		Class:      testClassName,
+		Shard:      testShardName,
+		SubCommand: []byte("invalid protobuf data"),
+	}
+
+	version, err := store.Apply(context.Background(), req)
+	require.NoError(t, err, "FSM should swallow unmarshal errors")
+	assert.Greater(t, version, uint64(0))
 }
 
 // ---------------------------------------------------------------------------

--- a/cluster/shard/store_test.go
+++ b/cluster/shard/store_test.go
@@ -326,6 +326,75 @@ func TestStore_State_Leader(t *testing.T) {
 	assert.Equal(t, raft.Leader, store.State())
 }
 
+func TestStore_WaitForLeader_HappyPath(t *testing.T) {
+	store, _ := newTestStore(t)
+
+	err := store.Start(context.Background())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.Stop() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	require.NoError(t, store.WaitForLeader(ctx))
+	assert.True(t, store.IsLeader())
+}
+
+func TestStore_WaitForLeader_NotStarted(t *testing.T) {
+	store, _ := newTestStore(t)
+
+	err := store.WaitForLeader(context.Background())
+	assert.ErrorIs(t, err, shard.ErrNotStarted)
+}
+
+func TestStore_WaitForLeader_AlreadyClosed(t *testing.T) {
+	store, _ := newTestStore(t)
+
+	err := store.Start(context.Background())
+	require.NoError(t, err)
+
+	err = store.Stop()
+	require.NoError(t, err)
+
+	err = store.WaitForLeader(context.Background())
+	assert.ErrorIs(t, err, shard.ErrAlreadyClosed)
+}
+
+func TestStore_WaitForLeader_TimeoutNoQuorum(t *testing.T) {
+	_, transport := raft.NewInmemTransport("")
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.WarnLevel)
+
+	cfg := shard.StoreConfig{
+		ClassName:          testClassName,
+		ShardName:          testShardName,
+		NodeID:             testNodeID,
+		DataPath:           t.TempDir(),
+		Members:            []string{testNodeID, "missing-node-2", "missing-node-3"},
+		Logger:             logger,
+		Transport:          transport,
+		HeartbeatTimeout:   150 * time.Millisecond,
+		ElectionTimeout:    150 * time.Millisecond,
+		LeaderLeaseTimeout: 100 * time.Millisecond,
+		SnapshotInterval:   10 * time.Second,
+		SnapshotThreshold:  1024,
+	}
+
+	store, err := shard.NewStore(cfg)
+	require.NoError(t, err)
+	store.SetShard(mocks.NewMockshard(t))
+
+	require.NoError(t, store.Start(context.Background()))
+	t.Cleanup(func() { _ = store.Stop() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	err = store.WaitForLeader(ctx)
+	assert.ErrorIs(t, err, shard.ErrLeaderElectionTimeout)
+}
+
 func TestStore_Stop_Idempotent(t *testing.T) {
 	store, _ := newTestStore(t)
 


### PR DESCRIPTION
### What's being changed:

- FSM error handling: retry transient errors, log multiply failing errors, rely on async repl to fix ec eventually
- Pause compaction before flushing memtables when creating snapshots
- Limit concurrency of snapshot creation in case of multiple nodes joining at once
- Fix cleanup after snapshots created
- Fix FixUUIDs when reading with DIRECT consistency
- Eventual consistency of created shards during `AddClass` in relation to the presence of the shard and the necessary election of the raft ring for that shard

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
