### PR TITLE
feat(sharding): add hedged replica query support

### DIFF
--- a/adapters/clients/remote_index_hang_test.go
+++ b/adapters/clients/remote_index_hang_test.go
@@ -75,7 +75,7 @@ func newHangAndHealthyRemoteIndex(t *testing.T) (*sharding.RemoteIndex, *atomic.
 			"N0": strings.TrimPrefix(hangSrv.URL, "http://"),
 			"N1": strings.TrimPrefix(healthySrv.URL, "http://"),
 		}},
-		cl, nil)
+		cl, nil, nil)
 	return ri, &hangCalls, &healthyCalls
 }
 

--- a/adapters/clients/remote_index_hang_test.go
+++ b/adapters/clients/remote_index_hang_test.go
@@ -1,0 +1,151 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package clients
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	clusterapi "github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/shared"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+type hangTestSchema struct{ replicas []string }
+
+func (s hangTestSchema) ShardOwner(class, shard string) (string, error) { return s.replicas[0], nil }
+func (s hangTestSchema) ShardReplicas(class, shard string) ([]string, error) {
+	return s.replicas, nil
+}
+
+type hangTestResolver struct{ hosts map[string]string }
+
+func (r hangTestResolver) NodeHostname(nodeName string) (string, bool) {
+	h, ok := r.hosts[nodeName]
+	return h, ok
+}
+
+func newHangAndHealthyRemoteIndex(t *testing.T) (*sharding.RemoteIndex, *atomic.Int32, *atomic.Int32) {
+	t.Helper()
+
+	var hangCalls, healthyCalls atomic.Int32
+
+	hangRelease := make(chan struct{})
+	hangSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hangCalls.Add(1)
+		select {
+		case <-hangRelease:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(hangSrv.Close)
+	t.Cleanup(func() { close(hangRelease) })
+
+	healthySrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		healthyCalls.Add(1)
+		body, err := clusterapi.IndicesPayloads.SearchResults.MarshalWithAdditional(nil, nil, additional.Properties{}, nil)
+		if err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		clusterapi.IndicesPayloads.SearchResults.SetContentTypeHeader(w)
+		w.Write(body)
+	}))
+	t.Cleanup(healthySrv.Close)
+
+	cl := newRemoteIndex(&http.Client{})
+	ri := sharding.NewRemoteIndex("C",
+		hangTestSchema{replicas: []string{"N0", "N1"}},
+		hangTestResolver{hosts: map[string]string{
+			"N0": strings.TrimPrefix(hangSrv.URL, "http://"),
+			"N1": strings.TrimPrefix(healthySrv.URL, "http://"),
+		}},
+		cl, nil)
+	return ri, &hangCalls, &healthyCalls
+}
+
+// TestRemoteIndexSearchShardHangingReplicaFailover pins the tail-latency symptom: a hung replica burns the full inner client timeout before sequential failover succeeds.
+func TestRemoteIndexSearchShardHangingReplicaFailover(t *testing.T) {
+	ri, hangCalls, healthyCalls := newHangAndHealthyRemoteIndex(t)
+	innerTimeout := 20 * time.Millisecond * QUERY_TIMEOUT_VALUE
+
+	sawHungFirst := false
+	for i := 0; i < 50 && !sawHungFirst; i++ {
+		hangBefore, healthyBefore := hangCalls.Load(), healthyCalls.Load()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		start := time.Now()
+		_, _, _, node, err := ri.SearchShard(ctx, "S", nil, nil, 0, 10, nil, nil, nil, nil, nil, additional.Properties{}, nil, nil)
+		elapsed := time.Since(start)
+		cancel()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if node != "N1" {
+			continue
+		}
+		if hangCalls.Load() == hangBefore {
+			if healthyCalls.Load() != healthyBefore+1 {
+				t.Fatalf("healthy-first iteration: want exactly one healthy call, got %d", healthyCalls.Load()-healthyBefore)
+			}
+			continue
+		}
+		sawHungFirst = true
+		if elapsed < innerTimeout {
+			t.Fatalf("failover happened before the inner client timeout: %v < %v", elapsed, innerTimeout)
+		}
+		if elapsed > 5*time.Second {
+			t.Fatalf("failover took unexpectedly long: %v", elapsed)
+		}
+	}
+	if !sawHungFirst {
+		t.Fatal("random start never selected the hung replica first in 50 iterations")
+	}
+}
+
+// TestRemoteIndexSearchShardHangingReplicaShortDeadline pins the DEADLINE_EXCEEDED symptom: with an outer deadline below the inner client timeout, the healthy replica is never tried.
+func TestRemoteIndexSearchShardHangingReplicaShortDeadline(t *testing.T) {
+	ri, hangCalls, healthyCalls := newHangAndHealthyRemoteIndex(t)
+
+	sawHungFirst := false
+	for i := 0; i < 50 && !sawHungFirst; i++ {
+		hangBefore, healthyBefore := hangCalls.Load(), healthyCalls.Load()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+		_, _, _, _, err := ri.SearchShard(ctx, "S", nil, nil, 0, 10, nil, nil, nil, nil, nil, additional.Properties{}, nil, nil)
+		cancel()
+
+		if hangCalls.Load() == hangBefore {
+			if err != nil {
+				t.Fatalf("healthy-first iteration: unexpected error: %v", err)
+			}
+			continue
+		}
+		sawHungFirst = true
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("hung-first iteration: want context.DeadlineExceeded, got %v", err)
+		}
+		if got := healthyCalls.Load() - healthyBefore; got != 0 {
+			t.Fatalf("hung-first iteration: healthy replica was tried %d times despite expired deadline", got)
+		}
+	}
+	if !sawHungFirst {
+		t.Fatal("random start never selected the hung replica first in 50 iterations")
+	}
+}

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -526,6 +526,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 		QuerySlowLogEnabled:                          appState.ServerConfig.Config.QuerySlowLogEnabled,
 		QuerySlowLogThreshold:                        appState.ServerConfig.Config.QuerySlowLogThreshold,
 		InvertedSorterDisabled:                       appState.ServerConfig.Config.InvertedSorterDisabled,
+		QueryHedgedTimeout:                           appState.ServerConfig.Config.QueryHedgedTimeout,
 		QueryBatchedContainsEnabled:                  appState.ServerConfig.Config.QueryBatchedContainsEnabled,
 		LazyPropertyLengthsEnabled:                   appState.ServerConfig.Config.LazyPropertyLengthsEnabled,
 		MaintenanceModeEnabled:                       appState.Cluster.MaintenanceModeEnabledForLocalhost,
@@ -2694,6 +2695,7 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		registered.QuerySlowLogEnabled = appState.ServerConfig.Config.QuerySlowLogEnabled
 		registered.QuerySlowLogThreshold = appState.ServerConfig.Config.QuerySlowLogThreshold
 		registered.InvertedSorterDisabled = appState.ServerConfig.Config.InvertedSorterDisabled
+		registered.QueryHedgedTimeout = appState.ServerConfig.Config.QueryHedgedTimeout
 		registered.QueryBatchedContainsEnabled = appState.ServerConfig.Config.QueryBatchedContainsEnabled
 		registered.LazyPropertyLengthsEnabled = appState.ServerConfig.Config.LazyPropertyLengthsEnabled
 		registered.BM25FilterTombMergeGateRatio = appState.ServerConfig.Config.BM25FilterTombMergeGateRatio

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -452,7 +452,7 @@ func NewIndex(
 		stopwords:               sd,
 		partitioningEnabled:     multitenancy.IsMultiTenant(class.MultiTenancyConfig),
 		AsyncIndexingEnabled:    asyncIndexingEnabled,
-		remote:                  sharding.NewRemoteIndex(cfg.ClassName.String(), sg, nodeResolver, remoteClient, cfg.QueryHedgedTimeout),
+		remote:                  sharding.NewRemoteIndex(cfg.ClassName.String(), sg, nodeResolver, remoteClient, cfg.QueryHedgedTimeout, logger),
 		metrics:                 metrics,
 		centralJobQueue:         jobQueueCh,
 		backupLock:              esync.NewKeyRWLocker(),

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -452,7 +452,7 @@ func NewIndex(
 		stopwords:               sd,
 		partitioningEnabled:     multitenancy.IsMultiTenant(class.MultiTenancyConfig),
 		AsyncIndexingEnabled:    asyncIndexingEnabled,
-		remote:                  sharding.NewRemoteIndex(cfg.ClassName.String(), sg, nodeResolver, remoteClient),
+		remote:                  sharding.NewRemoteIndex(cfg.ClassName.String(), sg, nodeResolver, remoteClient, cfg.QueryHedgedTimeout),
 		metrics:                 metrics,
 		centralJobQueue:         jobQueueCh,
 		backupLock:              esync.NewKeyRWLocker(),
@@ -1184,6 +1184,7 @@ type IndexConfig struct {
 	QuerySlowLogEnabled         *configRuntime.DynamicValue[bool]
 	QuerySlowLogThreshold       *configRuntime.DynamicValue[time.Duration]
 	InvertedSorterDisabled      *configRuntime.DynamicValue[bool]
+	QueryHedgedTimeout          *configRuntime.DynamicValue[time.Duration]
 	QueryBatchedContainsEnabled *configRuntime.DynamicValue[bool]
 	LazyPropertyLengthsEnabled  *configRuntime.DynamicValue[bool]
 	MaintenanceModeEnabled      func() bool

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -205,6 +205,7 @@ func (db *DB) init(ctx context.Context) error {
 				QuerySlowLogEnabled:          db.config.QuerySlowLogEnabled,
 				QuerySlowLogThreshold:        db.config.QuerySlowLogThreshold,
 				InvertedSorterDisabled:       db.config.InvertedSorterDisabled,
+				QueryHedgedTimeout:           db.config.QueryHedgedTimeout,
 				QueryBatchedContainsEnabled:  db.config.QueryBatchedContainsEnabled,
 				LazyPropertyLengthsEnabled:   db.config.LazyPropertyLengthsEnabled,
 				MaintenanceModeEnabled:       db.config.MaintenanceModeEnabled,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -228,6 +228,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 			QuerySlowLogEnabled:          m.db.config.QuerySlowLogEnabled,
 			QuerySlowLogThreshold:        m.db.config.QuerySlowLogThreshold,
 			InvertedSorterDisabled:       m.db.config.InvertedSorterDisabled,
+			QueryHedgedTimeout:           m.db.config.QueryHedgedTimeout,
 			QueryBatchedContainsEnabled:  m.db.config.QueryBatchedContainsEnabled,
 			LazyPropertyLengthsEnabled:   m.db.config.LazyPropertyLengthsEnabled,
 			MaintenanceModeEnabled:       m.db.config.MaintenanceModeEnabled,

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -483,6 +483,7 @@ type Config struct {
 	QuerySlowLogEnabled         *configRuntime.DynamicValue[bool]
 	QuerySlowLogThreshold       *configRuntime.DynamicValue[time.Duration]
 	InvertedSorterDisabled      *configRuntime.DynamicValue[bool]
+	QueryHedgedTimeout          *configRuntime.DynamicValue[time.Duration]
 	QueryBatchedContainsEnabled *configRuntime.DynamicValue[bool]
 	LazyPropertyLengthsEnabled  *configRuntime.DynamicValue[bool]
 	MaintenanceModeEnabled      func() bool

--- a/adapters/repos/db/shard_refcount_test.go
+++ b/adapters/repos/db/shard_refcount_test.go
@@ -55,7 +55,7 @@ func refCountTestIndex(t *testing.T, className string) (*Index, *Shard) {
 		enthnsw.NewDefaultUserConfig(), false, false, false, func(i *Index) {
 			i.shardResolver = resolver.NewShardResolver(className, false, i.getSchema)
 			i.remote = sharding.NewRemoteIndex(className, i.getSchema,
-				nodeResolver, &FakeRemoteClient{}, nil)
+				nodeResolver, &FakeRemoteClient{}, nil, nil)
 		})
 
 	localShard := underlyingShard(t, shard)

--- a/adapters/repos/db/shard_refcount_test.go
+++ b/adapters/repos/db/shard_refcount_test.go
@@ -55,7 +55,7 @@ func refCountTestIndex(t *testing.T, className string) (*Index, *Shard) {
 		enthnsw.NewDefaultUserConfig(), false, false, false, func(i *Index) {
 			i.shardResolver = resolver.NewShardResolver(className, false, i.getSchema)
 			i.remote = sharding.NewRemoteIndex(className, i.getSchema,
-				nodeResolver, &FakeRemoteClient{})
+				nodeResolver, &FakeRemoteClient{}, nil)
 		})
 
 	localShard := underlyingShard(t, shard)

--- a/test/acceptance/replication/hung_replica/hung_replica_test.go
+++ b/test/acceptance/replication/hung_replica/hung_replica_test.go
@@ -1,0 +1,270 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hung_replica
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/test/acceptance/replication/common"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+const (
+	className = "HungReplicaRepro"
+	burstSize = 40
+)
+
+// TestHungReplica reproduces the coordinator-side symptoms of one replica that
+// hangs (accepts TCP, never responds) instead of failing fast: sequential
+// replica fallback burns the whole client deadline (DEADLINE_EXCEEDED) or the
+// full 20s inner RPC timeout (tail latency). HUNG_REPLICA_HEDGED=true runs the
+// same scenarios on a cluster with QUERY_HEDGED_TIMEOUT=100ms and flips the
+// assertions to the hedged expectations.
+func TestHungReplica(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping multi-node fault-injection test in short mode")
+	}
+	hedged := os.Getenv("HUNG_REPLICA_HEDGED") == "true"
+	ctx := context.Background()
+
+	builder := docker.New().WithWeaviateClusterWithGRPC()
+	if hedged {
+		builder = builder.WithWeaviateEnv("QUERY_HEDGED_TIMEOUT", "100ms")
+	}
+	compose, err := builder.Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer helper.ResetClient()
+
+	grpcConn, err := helper.CreateGrpcConnectionClient(compose.GetWeaviate().GrpcURI())
+	require.NoError(t, err)
+	defer grpcConn.Close()
+	grpcClient := helper.CreateGrpcWeaviateClient(grpcConn)
+
+	class := &models.Class{
+		Class:      className,
+		Vectorizer: "none",
+		Properties: []*models.Property{
+			{Name: "contents", DataType: schema.DataTypeText.PropString()},
+		},
+		ShardingConfig:    map[string]interface{}{"desiredCount": float64(3)},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 2},
+	}
+	helper.CreateClass(t, class)
+
+	objects := make([]*models.Object, 500)
+	for i := range objects {
+		objects[i] = &models.Object{
+			Class: className,
+			Properties: map[string]interface{}{
+				"contents": fmt.Sprintf("document %d about weaviate replication behavior", i),
+			},
+		}
+	}
+	helper.CreateObjectsBatch(t, objects)
+
+	victimNode := findFullyRemoteShardReplica(t, compose.GetWeaviate().URI())
+	victimN, err := strconv.Atoi(strings.TrimPrefix(victimNode, "weaviate-"))
+	require.NoError(t, err)
+	t.Logf("coordinator=weaviate-0 victim=%s hedged=%v", victimNode, hedged)
+
+	searchReq := &pb.SearchRequest{
+		Collection:  className,
+		Limit:       10,
+		Bm25Search:  &pb.BM25{Query: "weaviate", Properties: []string{"contents"}},
+		Uses_127Api: true,
+	}
+
+	burst := func(deadline time.Duration) (latencies []time.Duration, errs []error) {
+		var mu sync.Mutex
+		var wg sync.WaitGroup
+		for i := 0; i < burstSize; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				qctx, cancel := context.WithTimeout(ctx, deadline)
+				defer cancel()
+				start := time.Now()
+				_, err := grpcClient.Search(qctx, searchReq)
+				elapsed := time.Since(start)
+				mu.Lock()
+				defer mu.Unlock()
+				if err != nil {
+					errs = append(errs, err)
+					return
+				}
+				latencies = append(latencies, elapsed)
+			}()
+		}
+		wg.Wait()
+		return latencies, errs
+	}
+
+	t.Run("healthy cluster baseline", func(t *testing.T) {
+		latencies, errs := burst(10 * time.Second)
+		require.Empty(t, errs)
+		require.Len(t, latencies, burstSize)
+		assert.Less(t, percentile(latencies, 0.99), 2*time.Second)
+	})
+
+	t.Run("hang with short deadline", func(t *testing.T) {
+		require.NoError(t, compose.PauseNode(ctx, victimN))
+		time.Sleep(500 * time.Millisecond)
+		latencies, errs := burst(5 * time.Second)
+		require.NoError(t, compose.UnpauseNode(ctx, victimN))
+		waitAllHealthy(t, compose.GetWeaviate().URI())
+
+		logLatencies(t, "hang-5s-deadline", latencies, errs)
+		if hedged {
+			require.Empty(t, errs)
+			assert.Less(t, percentile(latencies, 0.99), 2*time.Second)
+			return
+		}
+		for _, err := range errs {
+			require.Equalf(t, codes.DeadlineExceeded, status.Code(err), "unexpected failure kind: %v", err)
+		}
+		assert.GreaterOrEqual(t, len(errs), 8, "expected ~half the burst to start on the hung replica")
+		assert.LessOrEqual(t, len(errs), 32, "expected ~half the burst to survive")
+		for _, l := range latencies {
+			assert.Less(t, l, 2*time.Second)
+		}
+	})
+
+	t.Run("hang with generous deadline", func(t *testing.T) {
+		require.NoError(t, compose.PauseNode(ctx, victimN))
+		time.Sleep(500 * time.Millisecond)
+		latencies, errs := burst(35 * time.Second)
+		require.NoError(t, compose.UnpauseNode(ctx, victimN))
+		waitAllHealthy(t, compose.GetWeaviate().URI())
+
+		logLatencies(t, "hang-35s-deadline", latencies, errs)
+		require.Empty(t, errs)
+		require.Len(t, latencies, burstSize)
+		if hedged {
+			assert.Less(t, maxLatency(latencies), 3*time.Second)
+			return
+		}
+		fast, slow := 0, 0
+		for _, l := range latencies {
+			if l <= 2*time.Second {
+				fast++
+			}
+			if l >= 15*time.Second {
+				slow++
+			}
+		}
+		assert.GreaterOrEqual(t, fast, burstSize/4, "expected a fast mode from healthy-first queries")
+		assert.GreaterOrEqual(t, slow, burstSize/4, "expected a ~20s mode from hung-first queries")
+		assert.LessOrEqual(t, maxLatency(latencies), 30*time.Second)
+	})
+
+	t.Run("stopped node is benign", func(t *testing.T) {
+		require.NoError(t, compose.StopNode(ctx, victimN, nil))
+		latencies, errs := burst(5 * time.Second)
+		require.NoError(t, compose.StartNode(ctx, victimN))
+		waitAllHealthy(t, compose.GetWeaviate().URI())
+
+		logLatencies(t, "stopped-node", latencies, errs)
+		require.Empty(t, errs, "connection-refused failover must not eat the deadline")
+		assert.Less(t, percentile(latencies, 0.99), 3*time.Second)
+	})
+}
+
+func findFullyRemoteShardReplica(t *testing.T, coordinatorURI string) string {
+	t.Helper()
+	shardNodes := map[string][]string{}
+	for _, node := range common.GetNodes(t, coordinatorURI).Nodes {
+		for _, shard := range node.Shards {
+			if shard.Class == className {
+				shardNodes[shard.Name] = append(shardNodes[shard.Name], node.Name)
+			}
+		}
+	}
+	require.Len(t, shardNodes, 3)
+	for shard, nodes := range shardNodes {
+		require.Lenf(t, nodes, 2, "shard %s must have RF=2", shard)
+		if nodes[0] != "weaviate-0" && nodes[1] != "weaviate-0" {
+			sort.Strings(nodes)
+			return nodes[1]
+		}
+	}
+	t.Fatal("no shard is fully remote to the coordinator weaviate-0")
+	return ""
+}
+
+func waitAllHealthy(t *testing.T, coordinatorURI string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		healthy := 0
+		for _, node := range common.GetNodes(t, coordinatorURI).Nodes {
+			if node.Status != nil && *node.Status == models.NodeStatusStatusHEALTHY {
+				healthy++
+			}
+		}
+		assert.Equal(collect, 3, healthy)
+	}, 90*time.Second, time.Second)
+}
+
+func percentile(latencies []time.Duration, p float64) time.Duration {
+	if len(latencies) == 0 {
+		return 0
+	}
+	sorted := append([]time.Duration(nil), latencies...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	idx := int(float64(len(sorted))*p) - 1
+	if idx < 0 {
+		idx = 0
+	}
+	if idx >= len(sorted) {
+		idx = len(sorted) - 1
+	}
+	return sorted[idx]
+}
+
+func maxLatency(latencies []time.Duration) time.Duration {
+	var max time.Duration
+	for _, l := range latencies {
+		if l > max {
+			max = l
+		}
+	}
+	return max
+}
+
+func logLatencies(t *testing.T, label string, latencies []time.Duration, errs []error) {
+	t.Helper()
+	t.Logf("%s: ok=%d err=%d p50=%v p90=%v p99=%v max=%v",
+		label, len(latencies), len(errs),
+		percentile(latencies, 0.50), percentile(latencies, 0.90),
+		percentile(latencies, 0.99), maxLatency(latencies))
+}

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -313,9 +313,13 @@ func (d *DockerCompose) PauseAt(ctx context.Context, nodeIndex int) error {
 		return errors.Errorf("node index is greater than available nodes")
 	}
 	c := d.containers[nodeIndex]
-	cmd := exec.CommandContext(ctx, "docker", "pause", c.container.GetContainerID())
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("PauseAt[%s]: docker pause failed: %w (output: %s)", c.name, err, string(out))
+	cli, err := testcontainers.NewDockerClientWithOpts(ctx)
+	if err != nil {
+		return fmt.Errorf("PauseAt[%s]: create docker client: %w", c.name, err)
+	}
+	defer cli.Close()
+	if err := cli.ContainerPause(ctx, c.container.GetContainerID()); err != nil {
+		return fmt.Errorf("PauseAt[%s]: %w", c.name, err)
 	}
 	return nil
 }
@@ -327,9 +331,13 @@ func (d *DockerCompose) UnpauseAt(ctx context.Context, nodeIndex int) error {
 		return errors.Errorf("node index is greater than available nodes")
 	}
 	c := d.containers[nodeIndex]
-	cmd := exec.CommandContext(ctx, "docker", "unpause", c.container.GetContainerID())
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("UnpauseAt[%s]: docker unpause failed: %w (output: %s)", c.name, err, string(out))
+	cli, err := testcontainers.NewDockerClientWithOpts(ctx)
+	if err != nil {
+		return fmt.Errorf("UnpauseAt[%s]: create docker client: %w", c.name, err)
+	}
+	defer cli.Close()
+	if err := cli.ContainerUnpause(ctx, c.container.GetContainerID()); err != nil {
+		return fmt.Errorf("UnpauseAt[%s]: %w", c.name, err)
 	}
 	return nil
 }

--- a/test/docker/docker.go
+++ b/test/docker/docker.go
@@ -303,6 +303,55 @@ func (d *DockerCompose) RestartAt(ctx context.Context, nodeIndex int, timeout *t
 	return nil
 }
 
+// PauseAt freezes a container via `docker pause` (cgroup freezer): the kernel
+// still accepts TCP connections but userspace never responds, so requests to
+// the node hang instead of failing fast. Deliberately does NOT poll /v1/nodes
+// health — a paused node stays reported HEALTHY until memberlist evicts it,
+// which is exactly the state hang-injection tests need to hold.
+func (d *DockerCompose) PauseAt(ctx context.Context, nodeIndex int) error {
+	if nodeIndex >= len(d.containers) {
+		return errors.Errorf("node index is greater than available nodes")
+	}
+	c := d.containers[nodeIndex]
+	cmd := exec.CommandContext(ctx, "docker", "pause", c.container.GetContainerID())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("PauseAt[%s]: docker pause failed: %w (output: %s)", c.name, err, string(out))
+	}
+	return nil
+}
+
+// UnpauseAt resumes a container previously frozen with PauseAt. Ports stay
+// mapped across pause/unpause, so no endpoint re-resolution is needed.
+func (d *DockerCompose) UnpauseAt(ctx context.Context, nodeIndex int) error {
+	if nodeIndex >= len(d.containers) {
+		return errors.Errorf("node index is greater than available nodes")
+	}
+	c := d.containers[nodeIndex]
+	cmd := exec.CommandContext(ctx, "docker", "unpause", c.container.GetContainerID())
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("UnpauseAt[%s]: docker unpause failed: %w (output: %s)", c.name, err, string(out))
+	}
+	return nil
+}
+
+// PauseNode pauses the node with cluster hostname weaviate-<n>.
+func (d *DockerCompose) PauseNode(ctx context.Context, n int) error {
+	idx, err := d.weaviateNodeIndex(n)
+	if err != nil {
+		return err
+	}
+	return d.PauseAt(ctx, idx)
+}
+
+// UnpauseNode unpauses the node with cluster hostname weaviate-<n>.
+func (d *DockerCompose) UnpauseNode(ctx context.Context, n int) error {
+	idx, err := d.weaviateNodeIndex(n)
+	if err != nil {
+		return err
+	}
+	return d.UnpauseAt(ctx, idx)
+}
+
 // weaviateNodeIndex resolves the containers-slice position of weaviate node n
 // (1-based) by name, so callers are unaffected by sidecar containers (e.g.
 // MinIO) that may precede the cluster nodes in the slice.

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -281,6 +281,7 @@ type Config struct {
 	QuerySlowLogEnabled   *runtime.DynamicValue[bool]          `json:"query_slow_log_enabled" yaml:"query_slow_log_enabled"`
 	QuerySlowLogThreshold *runtime.DynamicValue[time.Duration] `json:"query_slow_log_threshold" yaml:"query_slow_log_threshold"`
 
+	// QueryHedgedTimeout is the delay before a remote replica search is hedged to the next replica; 0 disables hedging.
 	QueryHedgedTimeout *runtime.DynamicValue[time.Duration] `json:"query_hedged_timeout" yaml:"query_hedged_timeout"`
 
 	// New classes will be created with the default quantization

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -281,6 +281,8 @@ type Config struct {
 	QuerySlowLogEnabled   *runtime.DynamicValue[bool]          `json:"query_slow_log_enabled" yaml:"query_slow_log_enabled"`
 	QuerySlowLogThreshold *runtime.DynamicValue[time.Duration] `json:"query_slow_log_threshold" yaml:"query_slow_log_threshold"`
 
+	QueryHedgedTimeout *runtime.DynamicValue[time.Duration] `json:"query_hedged_timeout" yaml:"query_hedged_timeout"`
+
 	// New classes will be created with the default quantization
 	DefaultQuantization *runtime.DynamicValue[string] `json:"default_quantization" yaml:"default_quantization"`
 

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1430,6 +1430,16 @@ func FromEnv(config *Config) error {
 	}
 	config.QuerySlowLogThreshold = configRuntime.NewDynamicValue(querySlowLogThreshold)
 
+	queryHedgedTimeout := time.Duration(0)
+	if v := os.Getenv("QUERY_HEDGED_TIMEOUT"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return fmt.Errorf("parse QUERY_HEDGED_TIMEOUT as time.Duration: %w", err)
+		}
+		queryHedgedTimeout = d
+	}
+	config.QueryHedgedTimeout = configRuntime.NewDynamicValue(queryHedgedTimeout)
+
 	envName := "QUERY_BITMAP_BUFS_MAX_MEMORY"
 	config.QueryBitmapBufsMaxMemory = DefaultQueryBitmapBufsMaxMemory
 	if v := os.Getenv(envName); v != "" {

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -57,6 +57,7 @@ type WeaviateRuntimeConfig struct {
 	QuerySlowLogEnabled                       *runtime.DynamicValue[bool]          `json:"query_slow_log_enabled" yaml:"query_slow_log_enabled"`
 	QuerySlowLogThreshold                     *runtime.DynamicValue[time.Duration] `json:"query_slow_log_threshold" yaml:"query_slow_log_threshold"`
 	InvertedSorterDisabled                    *runtime.DynamicValue[bool]          `json:"inverted_sorter_disabled" yaml:"inverted_sorter_disabled"`
+	QueryHedgedTimeout                        *runtime.DynamicValue[time.Duration] `json:"query_hedged_timeout" yaml:"query_hedged_timeout"`
 	QueryBatchedContainsEnabled               *runtime.DynamicValue[bool]          `json:"query_batched_contains_enabled" yaml:"query_batched_contains_enabled"`
 	LazyPropertyLengthsEnabled                *runtime.DynamicValue[bool]          `json:"lazy_property_lengths_enabled" yaml:"lazy_property_lengths_enabled"`
 	BM25FilterTombMergeGateRatio              *runtime.DynamicValue[float64]       `json:"bm25_filter_tombstone_merge_gate_ratio" yaml:"bm25_filter_tombstone_merge_gate_ratio"`

--- a/usecases/sharding/remote_index.go
+++ b/usecases/sharding/remote_index.go
@@ -35,13 +35,16 @@ import (
 	"github.com/weaviate/weaviate/entities/searchparams"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/objects"
+
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
 type RemoteIndex struct {
-	class        string
-	stateGetter  shardingStateGetter
-	client       RemoteIndexClient
-	nodeResolver nodeResolver
+	class         string
+	stateGetter   shardingStateGetter
+	client        RemoteIndexClient
+	nodeResolver  nodeResolver
+	hedgedTimeout *configRuntime.DynamicValue[time.Duration]
 }
 
 type shardingStateGetter interface {
@@ -53,12 +56,14 @@ type shardingStateGetter interface {
 func NewRemoteIndex(className string,
 	stateGetter shardingStateGetter, nodeResolver nodeResolver,
 	client RemoteIndexClient,
+	hedgedTimeout *configRuntime.DynamicValue[time.Duration],
 ) *RemoteIndex {
 	return &RemoteIndex{
-		class:        className,
-		stateGetter:  stateGetter,
-		client:       client,
-		nodeResolver: nodeResolver,
+		class:         className,
+		stateGetter:   stateGetter,
+		client:        client,
+		nodeResolver:  nodeResolver,
+		hedgedTimeout: hedgedTimeout,
 	}
 }
 
@@ -309,7 +314,7 @@ func (ri *RemoteIndex) SearchShard(ctx context.Context, shard string,
 		scores        []float32
 		queryProfiles []helpers.ShardQueryProfile
 	}
-	f := func(node, host string) (interface{}, error) {
+	f := func(ctx context.Context, node, host string) (interface{}, error) {
 		objs, scores, queryProfiles, err := ri.client.SearchShard(ctx, host, ri.class, shard,
 			queryVec, targetVector, distance, limit, filters, keywordRanking, sort, cursor, groupBy, adds, targetCombination, properties)
 		if err != nil {
@@ -317,7 +322,11 @@ func (ri *RemoteIndex) SearchShard(ctx context.Context, shard string,
 		}
 		return result{objs, scores, queryProfiles}, err
 	}
-	rr, node, err := ri.queryReplicas(ctx, shard, f)
+	var hedgedTimeout time.Duration
+	if ri.hedgedTimeout != nil {
+		hedgedTimeout = ri.hedgedTimeout.Get()
+	}
+	rr, node, err := ri.queryReplicas(ctx, shard, hedgedTimeout, f)
 	if err != nil {
 		return nil, nil, nil, node, err
 	}
@@ -330,14 +339,18 @@ func (ri *RemoteIndex) Aggregate(
 	shard string,
 	params aggregation.Params,
 ) (*aggregation.Result, error) {
-	f := func(_, host string) (interface{}, error) {
+	f := func(ctx context.Context, _, host string) (interface{}, error) {
 		r, err := ri.client.Aggregate(ctx, host, ri.class, shard, params)
 		if err != nil {
 			return nil, err
 		}
 		return r, nil
 	}
-	rr, _, err := ri.queryReplicas(ctx, shard, f)
+	var hedgedTimeout time.Duration
+	if ri.hedgedTimeout != nil {
+		hedgedTimeout = ri.hedgedTimeout.Get()
+	}
+	rr, _, err := ri.queryReplicas(ctx, shard, hedgedTimeout, f)
 	if err != nil {
 		return nil, err
 	}
@@ -500,7 +513,8 @@ func (ri *RemoteIndex) queryAllReplicas(
 func (ri *RemoteIndex) queryReplicas(
 	ctx context.Context,
 	shard string,
-	do func(nodeName, host string) (interface{}, error),
+	hedgedTimeout time.Duration,
+	do func(ctx context.Context, nodeName, host string) (interface{}, error),
 ) (resp interface{}, node string, err error) {
 	replicas, err := ri.stateGetter.ShardReplicas(ri.class, shard)
 	if err != nil || len(replicas) == 0 {
@@ -509,28 +523,128 @@ func (ri *RemoteIndex) queryReplicas(
 			fmt.Errorf("class %q has no physical shard %q: %w", ri.class, shard, err)
 	}
 
-	queryOne := func(replica string) (interface{}, error) {
+	queryOne := func(ctx context.Context, replica string) (interface{}, error) {
 		host, ok := ri.nodeResolver.NodeHostname(replica)
 		if !ok || host == "" {
 			return nil, fmt.Errorf("resolve node name %q to host", replica)
 		}
-		return do(replica, host)
+		return do(ctx, replica, host)
 	}
 
-	queryUntil := func(replicas []string) (resp interface{}, node string, err error) {
-		for _, node = range replicas {
+	// Build an ordered replica list starting from a random offset so that load
+	// is spread across replicas across requests.
+	first := rand.Intn(len(replicas))
+	ordered := make([]string, 0, len(replicas))
+	ordered = append(ordered, replicas[first:]...)
+	ordered = append(ordered, replicas[:first]...)
+
+	if hedgedTimeout <= 0 {
+		// Sequential fallback: try replicas one at a time in order.
+		for _, node = range ordered {
 			if errC := ctx.Err(); errC != nil {
 				return nil, node, errC
 			}
-			if resp, err = queryOne(node); err == nil {
+			if resp, err = queryOne(ctx, node); err == nil {
 				return resp, node, nil
 			}
 		}
 		return resp, node, err
 	}
-	first := rand.Intn(len(replicas))
-	if resp, node, err = queryUntil(replicas[first:]); err != nil && first != 0 {
-		return queryUntil(replicas[:first])
+
+	// Short-circuit if the context is already cancelled before starting any work.
+	if err := ctx.Err(); err != nil {
+		return nil, "", err
 	}
-	return resp, node, err
+
+	// Hedged requests: launch a request to the first replica immediately, then
+	// after each hedgedTimeout interval without a successful response, launch a
+	// concurrent request to the next replica. The first successful response wins
+	// and all remaining in-flight requests are cancelled via hedgeCtx. If the
+	// outer context expires before any replica responds, its error is returned.
+	type result struct {
+		resp interface{}
+		node string
+		err  error
+	}
+	resultCh := make(chan result, len(ordered))
+
+	hedgeCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	launchQuery := func(n string) {
+		// The outer GoWrapper goroutine always sends to resultCh.
+		// GoWrapperWithBlock runs queryOne in an inner goroutine: if queryOne
+		// panics, the panic is logged and reported to Sentry by the inner wrapper
+		// and returned as an error here, so the outer goroutine can still send a
+		// result to resultCh instead of leaving the main loop blocked forever.
+		enterrors.GoWrapper(func() {
+			var r interface{}
+			var e error
+			if panicErr := enterrors.GoWrapperWithBlock(func() {
+				r, e = queryOne(hedgeCtx, n)
+			}, logrus.StandardLogger()); panicErr != nil {
+				e = panicErr
+			}
+			resultCh <- result{r, n, e}
+		}, logrus.StandardLogger())
+	}
+
+	launchQuery(ordered[0])
+	launched := 1
+
+	timer := time.NewTimer(hedgedTimeout)
+	defer timer.Stop()
+
+	var lastErr error
+	var lastNode string
+	received := 0
+	for {
+		select {
+		case <-hedgeCtx.Done():
+			// Return the last launched node for observability when no result has
+			// arrived yet (lastNode is empty before the first result is received).
+			node := lastNode
+			if node == "" {
+				node = ordered[launched-1]
+			}
+			return nil, node, hedgeCtx.Err()
+		case r := <-resultCh:
+			received++
+			lastNode = r.node
+			if r.err == nil {
+				cancel()
+				return r.resp, r.node, nil
+			}
+			lastErr = r.err
+			if received == len(ordered) {
+				return nil, lastNode, lastErr
+			}
+			// Fast failure: launch the next replica immediately rather than
+			// waiting for the hedge timer to fire.
+			if launched < len(ordered) {
+				launchQuery(ordered[launched])
+				launched++
+				if launched < len(ordered) {
+					if !timer.Stop() {
+						select {
+						case <-timer.C:
+						default:
+						}
+					}
+					timer.Reset(hedgedTimeout)
+				}
+			}
+		case <-timer.C:
+			// Guard against the race where both timer.C and hedgeCtx.Done() are
+			// ready simultaneously and Go's select chose timer.C — don't launch
+			// new queries after the hedge context has already been cancelled.
+			if launched < len(ordered) && hedgeCtx.Err() == nil {
+				launchQuery(ordered[launched])
+				launched++
+				if launched < len(ordered) {
+					timer.Reset(hedgedTimeout)
+				}
+			}
+		}
+	}
 }

--- a/usecases/sharding/remote_index.go
+++ b/usecases/sharding/remote_index.go
@@ -45,6 +45,7 @@ type RemoteIndex struct {
 	client        RemoteIndexClient
 	nodeResolver  nodeResolver
 	hedgedTimeout *configRuntime.DynamicValue[time.Duration]
+	logger        logrus.FieldLogger
 }
 
 type shardingStateGetter interface {
@@ -57,13 +58,18 @@ func NewRemoteIndex(className string,
 	stateGetter shardingStateGetter, nodeResolver nodeResolver,
 	client RemoteIndexClient,
 	hedgedTimeout *configRuntime.DynamicValue[time.Duration],
+	logger logrus.FieldLogger,
 ) *RemoteIndex {
+	if logger == nil {
+		logger = logrus.StandardLogger()
+	}
 	return &RemoteIndex{
 		class:         className,
 		stateGetter:   stateGetter,
 		client:        client,
 		nodeResolver:  nodeResolver,
 		hedgedTimeout: hedgedTimeout,
+		logger:        logger,
 	}
 }
 
@@ -571,6 +577,12 @@ func (ri *RemoteIndex) queryReplicas(
 	hedgeCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	logger := ri.logger
+	if logger == nil {
+		logger = logrus.StandardLogger()
+	}
+	logger = logger.WithFields(logrus.Fields{"class": ri.class, "shard": shard})
+
 	launchQuery := func(n string) {
 		// The outer GoWrapper goroutine always sends to resultCh.
 		// GoWrapperWithBlock runs queryOne in an inner goroutine: if queryOne
@@ -582,11 +594,11 @@ func (ri *RemoteIndex) queryReplicas(
 			var e error
 			if panicErr := enterrors.GoWrapperWithBlock(func() {
 				r, e = queryOne(hedgeCtx, n)
-			}, logrus.StandardLogger()); panicErr != nil {
+			}, logger); panicErr != nil {
 				e = panicErr
 			}
 			resultCh <- result{r, n, e}
-		}, logrus.StandardLogger())
+		}, logger)
 	}
 
 	launchQuery(ordered[0])

--- a/usecases/sharding/remote_index_hang_test.go
+++ b/usecases/sharding/remote_index_hang_test.go
@@ -1,0 +1,149 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package sharding
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestQueryReplicasSequentialHangShortDeadline pins the sequential-path flaw hedging addresses: a hung first replica eats the outer deadline and the healthy fallback is never tried.
+func TestQueryReplicasSequentialHangShortDeadline(t *testing.T) {
+	resolver := newFakeResolver(0, 2)
+	schema := newFakeSchema(0, 2)
+	rindex := RemoteIndex{class: "C", stateGetter: &schema, nodeResolver: &resolver}
+
+	var mu sync.Mutex
+	var callLog []string
+	do := func(ctx context.Context, node, host string) (interface{}, error) {
+		mu.Lock()
+		callLog = append(callLog, node)
+		mu.Unlock()
+		if node == "N0" {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+		return node, nil
+	}
+
+	sawHungFirst := false
+	for i := 0; i < 50 && !sawHungFirst; i++ {
+		mu.Lock()
+		callLog = nil
+		mu.Unlock()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		start := time.Now()
+		got, _, err := rindex.queryReplicas(ctx, "S", 0, do)
+		elapsed := time.Since(start)
+		cancel()
+
+		mu.Lock()
+		log := append([]string(nil), callLog...)
+		mu.Unlock()
+
+		if len(log) > 0 && log[0] == "N0" {
+			sawHungFirst = true
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("hung-first iteration: want context.DeadlineExceeded, got %v", err)
+			}
+			if got != nil {
+				t.Fatalf("hung-first iteration: want nil result, got %v", got)
+			}
+			if elapsed < 200*time.Millisecond {
+				t.Fatalf("hung-first iteration: returned before the outer deadline (%v)", elapsed)
+			}
+			if len(log) != 1 {
+				t.Fatalf("hung-first iteration: healthy replica was tried, call log %v", log)
+			}
+		} else {
+			if err != nil {
+				t.Fatalf("healthy-first iteration: unexpected error: %v", err)
+			}
+		}
+	}
+	if !sawHungFirst {
+		t.Fatal("random start never selected the hung replica first in 50 iterations")
+	}
+}
+
+// TestQueryReplicasSequentialHangFailoverLatency pins the tail-latency symptom: with a generous deadline the hung attempt burns its full budget before failover succeeds.
+func TestQueryReplicasSequentialHangFailoverLatency(t *testing.T) {
+	innerTimeout := 300 * time.Millisecond
+	resolver := newFakeResolver(0, 2)
+	schema := newFakeSchema(0, 2)
+	rindex := RemoteIndex{class: "C", stateGetter: &schema, nodeResolver: &resolver}
+
+	var mu sync.Mutex
+	var firstNode string
+	do := func(ctx context.Context, node, host string) (interface{}, error) {
+		mu.Lock()
+		if firstNode == "" {
+			firstNode = node
+		}
+		mu.Unlock()
+		if node == "N0" {
+			select {
+			case <-time.After(innerTimeout):
+				return nil, errAny
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}
+		return node, nil
+	}
+
+	sawHungFirst, sawHealthyFirst := false, false
+	for i := 0; i < 50 && (!sawHungFirst || !sawHealthyFirst); i++ {
+		mu.Lock()
+		firstNode = ""
+		mu.Unlock()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		start := time.Now()
+		got, node, err := rindex.queryReplicas(ctx, "S", 0, do)
+		elapsed := time.Since(start)
+		cancel()
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected a result")
+		}
+
+		mu.Lock()
+		first := firstNode
+		mu.Unlock()
+
+		if first == "N0" {
+			sawHungFirst = true
+			if node != "N1" {
+				t.Fatalf("hung-first iteration: want winner N1, got %s", node)
+			}
+			if elapsed < innerTimeout {
+				t.Fatalf("hung-first iteration: failover happened before the inner timeout (%v)", elapsed)
+			}
+		} else {
+			sawHealthyFirst = true
+			if elapsed > 150*time.Millisecond {
+				t.Fatalf("healthy-first iteration: unexpectedly slow (%v)", elapsed)
+			}
+		}
+	}
+	if !sawHungFirst || !sawHealthyFirst {
+		t.Fatalf("did not observe both orderings in 50 iterations (hungFirst=%v healthyFirst=%v)", sawHungFirst, sawHealthyFirst)
+	}
+}

--- a/usecases/sharding/remote_index_lazy_test.go
+++ b/usecases/sharding/remote_index_lazy_test.go
@@ -1,0 +1,94 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package sharding
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+)
+
+// TestQueryReplicasHedgedLazyLoadingReplica pins that hedging bounds a lazily
+// unloaded replica in both of its observable behaviors: blocking on an inline
+// load, and rejecting the read as not ready.
+func TestQueryReplicasHedgedLazyLoadingReplica(t *testing.T) {
+	t.Run("replica blocking on an inline load is out-raced by the hedge", func(t *testing.T) {
+		loadDone := make(chan struct{})
+		defer close(loadDone)
+
+		var calls atomic.Int32
+		var loadingNode atomic.Value
+		do := func(ctx context.Context, node, host string) (interface{}, error) {
+			if calls.Add(1) == 1 {
+				loadingNode.Store(node)
+				select {
+				case <-loadDone:
+					return node, nil
+				case <-ctx.Done():
+					return nil, ctx.Err()
+				}
+			}
+			return node, nil
+		}
+
+		resolver := newFakeResolver(0, 2)
+		schema := newFakeSchema(0, 2)
+		rindex := RemoteIndex{class: "C", stateGetter: &schema, nodeResolver: &resolver}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		got, node, err := rindex.queryReplicas(ctx, "S", 20*time.Millisecond, do)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected a result")
+		}
+		if node == loadingNode.Load().(string) {
+			t.Fatalf("the loading replica %s won; the hedge never fired", node)
+		}
+		if n := calls.Load(); n != 2 {
+			t.Fatalf("expected 2 replica calls (1 loading + 1 hedged), got %d", n)
+		}
+	})
+
+	t.Run("replica rejecting the read as not ready fails over without waiting for the hedge timer", func(t *testing.T) {
+		var calls atomic.Int32
+		do := func(ctx context.Context, node, host string) (interface{}, error) {
+			if calls.Add(1) == 1 {
+				return nil, enterrors.NewErrUnprocessable(fmt.Errorf("local %s shard is not ready", "S"))
+			}
+			return node, nil
+		}
+
+		resolver := newFakeResolver(0, 2)
+		schema := newFakeSchema(0, 2)
+		rindex := RemoteIndex{class: "C", stateGetter: &schema, nodeResolver: &resolver}
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		got, _, err := rindex.queryReplicas(ctx, "S", 10*time.Second, do)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected a result")
+		}
+		if n := calls.Load(); n != 2 {
+			t.Fatalf("expected 2 replica calls (1 rejected + 1 fast-failure launch), got %d", n)
+		}
+	})
+}

--- a/usecases/sharding/remote_index_test.go
+++ b/usecases/sharding/remote_index_test.go
@@ -15,7 +15,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 var errAny = errors.New("anyErr")
@@ -26,8 +28,8 @@ func TestQueryReplica(t *testing.T) {
 		canceledCtx, cancledFunc = context.WithCancel(ctx)
 	)
 	cancledFunc()
-	doIf := func(targetNode string) func(node, host string) (interface{}, error) {
-		return func(node, host string) (interface{}, error) {
+	doIf := func(targetNode string) func(ctx context.Context, node, host string) (interface{}, error) {
+		return func(ctx context.Context, node, host string) (interface{}, error) {
 			if node != targetNode {
 				return nil, errAny
 			}
@@ -60,8 +62,8 @@ func TestQueryReplica(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		rindex := RemoteIndex{"C", &test.schema, nil, &test.resolver}
-		got, lastNode, err := rindex.queryReplicas(test.ctx, "S", doIf(test.targetNode))
+		rindex := RemoteIndex{class: "C", stateGetter: &test.schema, nodeResolver: &test.resolver}
+		got, lastNode, err := rindex.queryReplicas(test.ctx, "S", 0, doIf(test.targetNode))
 		if !test.success {
 			if got != nil {
 				t.Errorf("%s: want: nil, got: %v", test.name, got)
@@ -74,6 +76,183 @@ func TestQueryReplica(t *testing.T) {
 			t.Errorf("%s: last responding node want:%s got:%s", test.name, test.targetNode, lastNode)
 		}
 	}
+}
+
+func TestQueryReplicasHedged(t *testing.T) {
+	// Returns the first replica immediately — hedge timer should never fire.
+	// Verified by checking that exactly one call was made after queryReplicas
+	// returns (no wall-clock timing assertions).
+	t.Run("first replica responds before hedge fires", func(t *testing.T) {
+		var calls atomic.Int32
+		do := func(ctx context.Context, node, host string) (interface{}, error) {
+			calls.Add(1)
+			return node, nil
+		}
+		resolver := newFakeResolver(0, 4)
+		schema := newFakeSchema(0, 4)
+		rindex := RemoteIndex{class: "C", stateGetter: &schema, nodeResolver: &resolver}
+
+		// Use a very large hedge delay so the timer never fires before the first
+		// (immediately responding) replica completes, avoiding flakiness on loaded CI.
+		got, _, err := rindex.queryReplicas(context.Background(), "S", 10*time.Second, do)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected a result, got nil")
+		}
+		// Once queryReplicas returns the hedge timer is stopped; no additional
+		// goroutines will be launched, so the call count is stable.
+		if n := calls.Load(); n != 1 {
+			t.Errorf("expected 1 replica call, got %d (hedge fired too early)", n)
+		}
+	})
+
+	// First called replica is unresponsive; after hedgeDelay the second is launched
+	// and responds immediately. The blocked goroutine unblocks via hedgeCtx
+	// cancellation when the winner is found, so no goroutine leak occurs.
+	t.Run("hedge fires and second replica wins when first is unresponsive", func(t *testing.T) {
+		hedgeDelay := 20 * time.Millisecond
+
+		var callOrder atomic.Int32
+		do := func(ctx context.Context, node, host string) (interface{}, error) {
+			if callOrder.Add(1) == 1 {
+				<-ctx.Done() // ctx is hedgeCtx; cancelled when a winner is found
+				return nil, ctx.Err()
+			}
+			return node, nil
+		}
+
+		resolver := newFakeResolver(0, 3)
+		schema := newFakeSchema(0, 3)
+		rindex := RemoteIndex{class: "C", stateGetter: &schema, nodeResolver: &resolver}
+
+		// Use a timeout context so the test fails fast if hedging/cancellation breaks.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		got, _, err := rindex.queryReplicas(ctx, "S", hedgeDelay, do)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected a result, got nil")
+		}
+		// The first call blocks until its context is cancelled; a second call
+		// must have been started (hedge fired) to obtain the successful result.
+		if n := callOrder.Load(); n != 2 {
+			t.Errorf("expected 2 replica calls (hedge fired once), got %d", n)
+		}
+	})
+
+	// The first N-1 called replicas are all unresponsive; each hedge fires and
+	// launches the next, until the last replica responds immediately. Blocked
+	// goroutines are unblocked by hedgeCtx cancellation on success.
+	t.Run("multiple unresponsive replicas, last healthy one wins", func(t *testing.T) {
+		hedgeDelay := 20 * time.Millisecond
+		numNodes := 4
+
+		var callOrder atomic.Int32
+		do := func(ctx context.Context, node, host string) (interface{}, error) {
+			if callOrder.Add(1) < int32(numNodes) {
+				<-ctx.Done() // ctx is hedgeCtx; cancelled when a winner is found
+				return nil, ctx.Err()
+			}
+			return node, nil
+		}
+
+		resolver := newFakeResolver(0, numNodes)
+		schema := newFakeSchema(0, numNodes)
+		rindex := RemoteIndex{class: "C", stateGetter: &schema, nodeResolver: &resolver}
+
+		// Use a timeout context so the test fails fast if hedging/cancellation breaks.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		got, _, err := rindex.queryReplicas(ctx, "S", hedgeDelay, do)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected a result, got nil")
+		}
+		// All N replicas must have been called: N-1 hedges fired before the last one won.
+		if n := callOrder.Load(); n != int32(numNodes) {
+			t.Errorf("expected %d replica calls, got %d", numNodes, n)
+		}
+	})
+
+	// First replica panics; the panic is recovered and forwarded as an error so
+	// the fast-failure path launches the second replica immediately, which
+	// succeeds. queryReplicas must not hang.
+	t.Run("panic in queryOne is recovered and does not block", func(t *testing.T) {
+		var calls atomic.Int32
+		do := func(ctx context.Context, node, host string) (interface{}, error) {
+			if calls.Add(1) == 1 {
+				panic("simulated panic in queryOne")
+			}
+			return node, nil
+		}
+
+		resolver := newFakeResolver(0, 3)
+		schema := newFakeSchema(0, 3)
+		rindex := RemoteIndex{class: "C", stateGetter: &schema, nodeResolver: &resolver}
+
+		// Large hedge delay: fast-failure path (not the timer) launches the next replica.
+		got, _, err := rindex.queryReplicas(context.Background(), "S", 10*time.Second, do)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got == nil {
+			t.Fatal("expected a result, got nil")
+		}
+		// Panic triggers fast-failure: second replica is launched immediately.
+		if n := calls.Load(); n != 2 {
+			t.Errorf("expected 2 calls (1 panicking + 1 successful), got %d", n)
+		}
+	})
+
+	// Every replica returns an error; queryReplicas should surface the last error.
+	t.Run("all replicas fail returns error", func(t *testing.T) {
+		do := func(ctx context.Context, node, host string) (interface{}, error) {
+			return nil, errAny
+		}
+		resolver := newFakeResolver(0, 3)
+		schema := newFakeSchema(0, 3)
+		rindex := RemoteIndex{class: "C", stateGetter: &schema, nodeResolver: &resolver}
+
+		got, _, err := rindex.queryReplicas(context.Background(), "S", 5*time.Millisecond, do)
+
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if got != nil {
+			t.Errorf("expected nil result on all-fail, got %v", got)
+		}
+	})
+
+	// The outer context expires before any replica responds; the context error
+	// must be returned and no result produced.
+	t.Run("context expires before any replica responds", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+		defer cancel()
+
+		do := func(ctx context.Context, node, host string) (interface{}, error) {
+			<-ctx.Done()
+			return nil, ctx.Err()
+		}
+
+		resolver := newFakeResolver(0, 3)
+		schema := newFakeSchema(0, 3)
+		rindex := RemoteIndex{class: "C", stateGetter: &schema, nodeResolver: &resolver}
+
+		got, _, err := rindex.queryReplicas(ctx, "S", 5*time.Millisecond, do)
+
+		if err == nil {
+			t.Fatal("expected a context error, got nil")
+		}
+		if got != nil {
+			t.Errorf("expected nil result on timeout, got %v", got)
+		}
+	})
 }
 
 func newFakeResolver(fromNode, toNode int) fakeNodeResolver {


### PR DESCRIPTION
### What's being changed:

This PR adds support for **hedged replica queries** in `RemoteIndex.queryReplicas`, the path used by searches and aggregations to read a shard that has no local replica. It is gated by a new `QueryHedgedTimeout` setting (env var `QUERY_HEDGED_TIMEOUT`, also live-tunable via runtime config overrides), **default 0 = disabled**, which preserves the existing sequential behavior exactly.

**The problem.** `queryReplicas` tries replicas strictly sequentially from a random start and checks the caller's context only *between* attempts. An in-flight attempt is bounded only by min(client deadline, the 20s per-attempt RPC timeout in `adapters/clients`). When a replica **hangs** (accepts TCP but never responds — overloaded node, GC stall, NotReady kubelet, asymmetric partition) instead of failing fast:

- With a client deadline **below 20s** (the common case), the deadline expires mid-hang and the loop aborts **without ever trying the healthy fallback replica** — every query that randomly starts on the hung replica (~1/RF of remote-shard reads) fails with a guaranteed `DEADLINE_EXCEEDED`.
- With a client deadline **above 20s**, the query survives but eats the full 20s per hung replica: a hard ~20s tail latency mode.

A cleanly *stopped* node (connection refused) is unaffected — sequential fallback already handles fast failures well. The pathology is specific to hangs.

**The fix.** When `QueryHedgedTimeout > 0`, the first replica is queried immediately; each time the hedge interval elapses without a response, a concurrent request is launched to the next replica. The first successful response wins and all losers are cancelled through a shared hedge context (which also aborts the hung request instead of letting it burn its 20s). A fast failure launches the next replica immediately rather than waiting for the timer. Panics inside a hedged attempt are recovered and surfaced as errors so the dispatch loop can never block. Legitimately slow queries are not harmed: the first attempt keeps running while hedges race it, so a slow-but-alive replica can still win.

### Measured results

3-node cluster (testcontainers), collection with `desiredCount: 3` / replication factor 2, 500 objects, bursts of 40 concurrent gRPC BM25 searches against a coordinator that reads one shard remotely. Fault: `docker pause` on one replica of that shard (kernel accepts TCP, process frozen — the hang scenario above).

| Scenario | Without this PR | This PR, `QUERY_HEDGED_TIMEOUT=100ms` | This PR, hedging disabled (default) |
|---|---|---|---|
| Hung replica, 5s client deadline | **18/40 `DEADLINE_EXCEEDED`**; survivors p99 = 23ms | **40/40 OK**, max = 118ms | 23/40 `DEADLINE_EXCEEDED` |
| Hung replica, 35s client deadline | 40/40 OK, slow mode = **20.02s** | 40/40 OK, max = **121ms** | 40/40 OK, slow mode = 20.02s |
| Stopped replica, 5s client deadline | 40/40 OK, p99 = 10ms | 40/40 OK, p99 = 11ms | 40/40 OK, p99 = 10ms |

The last column confirms the default is behavior-neutral: with the timeout unset this PR reproduces the pre-PR numbers exactly.

### Tests

- `usecases/sharding/remote_index_test.go`: hedged-path unit tests (first-responder wins, hedge fires on unresponsive replica, cascading hedges, panic containment, all-fail, context expiry).
- `usecases/sharding/remote_index_hang_test.go`: pins the sequential-path symptoms at the `queryReplicas` level (healthy fallback never tried under a short deadline; full inner-timeout burn before failover under a generous one).
- `usecases/sharding/remote_index_lazy_test.go`: pins that hedging bounds a lazily unloaded replica whichever way it manifests — the hedge out-races a replica that blocks on an inline shard load, and a replica that instead rejects the read as not ready fails over through the fast-failure launch without waiting for the hedge timer.
- `adapters/clients/remote_index_hang_test.go`: same two symptoms through the real HTTP client against a hanging `httptest` server.
- `test/acceptance/replication/hung_replica/`: E2E repro of the table above (`HUNG_REPLICA_HEDGED=true` flips assertions to the hedged expectations), plus new `PauseAt`/`UnpauseAt` docker-compose fault-injection helpers.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->

