### PR TITLE
Implements ASYNC_REPLICATION_ENFORCED and ASYNC_REPLICATION_DEFAULT

### DIFF
--- a/entities/replication/config.go
+++ b/entities/replication/config.go
@@ -25,4 +25,13 @@ type GlobalConfig struct {
 	MinimumFactor int `json:"minimum_factor" yaml:"minimum_factor"`
 
 	DeletionStrategy string `json:"deletion_strategy" yaml:"deletion_strategy"`
+
+	// AsyncEnforced enforces async replication on all collections.
+	// When set, creating or updating a collection with async_enabled=false will
+	// have it silently upgraded to true.
+	AsyncEnforced bool `json:"async_enforced" yaml:"async_enforced"`
+
+	// AsyncDefault, when true, sets async_enabled=true by default on new
+	// collections that don't specify any ReplicationConfig.
+	AsyncDefault bool `json:"async_default" yaml:"async_default"`
 }

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -901,8 +901,8 @@ func FromEnv(config *Config) error {
 		config.Replication.DeletionStrategy = v
 	}
 
-	config.Replication.AsyncEnforced = entcfg.Enabled(os.Getenv("REPLICATION_ASYNC_ENFORCED"))
-	config.Replication.AsyncDefault = entcfg.Enabled(os.Getenv("REPLICATION_ASYNC_DEFAULT"))
+	config.Replication.AsyncEnforced = entcfg.Enabled(os.Getenv("ASYNC_REPLICATION_ENFORCED"))
+	config.Replication.AsyncDefault = entcfg.Enabled(os.Getenv("ASYNC_REPLICATION_DEFAULT"))
 
 	config.DisableTelemetry = false
 	if entcfg.Enabled(os.Getenv("DISABLE_TELEMETRY")) {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -901,6 +901,9 @@ func FromEnv(config *Config) error {
 		config.Replication.DeletionStrategy = v
 	}
 
+	config.Replication.AsyncEnforced = entcfg.Enabled(os.Getenv("REPLICATION_ASYNC_ENFORCED"))
+	config.Replication.AsyncDefault = entcfg.Enabled(os.Getenv("REPLICATION_ASYNC_DEFAULT"))
+
 	config.DisableTelemetry = false
 	if entcfg.Enabled(os.Getenv("DISABLE_TELEMETRY")) {
 		config.DisableTelemetry = true

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -1440,7 +1440,7 @@ func TestEnvironmentAsyncIndexing(t *testing.T) {
 	}
 }
 
-func TestEnvironmentReplicationAsyncEnforced(t *testing.T) {
+func TestEnvironmentAsyncReplicationEnforced(t *testing.T) {
 	factors := []struct {
 		name     string
 		value    []string
@@ -1457,7 +1457,7 @@ func TestEnvironmentReplicationAsyncEnforced(t *testing.T) {
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
 			if len(tt.value) == 1 {
-				t.Setenv("REPLICATION_ASYNC_ENFORCED", tt.value[0])
+				t.Setenv("ASYNC_REPLICATION_ENFORCED", tt.value[0])
 			}
 			conf := Config{}
 			err := FromEnv(&conf)
@@ -1468,7 +1468,7 @@ func TestEnvironmentReplicationAsyncEnforced(t *testing.T) {
 	}
 }
 
-func TestEnvironmentReplicationAsyncDefault(t *testing.T) {
+func TestEnvironmentAsyncReplicationDefault(t *testing.T) {
 	factors := []struct {
 		name     string
 		value    []string
@@ -1485,7 +1485,7 @@ func TestEnvironmentReplicationAsyncDefault(t *testing.T) {
 	for _, tt := range factors {
 		t.Run(tt.name, func(t *testing.T) {
 			if len(tt.value) == 1 {
-				t.Setenv("REPLICATION_ASYNC_DEFAULT", tt.value[0])
+				t.Setenv("ASYNC_REPLICATION_DEFAULT", tt.value[0])
 			}
 			conf := Config{}
 			err := FromEnv(&conf)

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -1440,8 +1440,8 @@ func TestEnvironmentAsyncIndexing(t *testing.T) {
 	}
 }
 
-func TestEnvironmentAsyncReplicationEnforced(t *testing.T) {
-	factors := []struct {
+func TestEnvironmentAsyncReplicationBoolVars(t *testing.T) {
+	boolValues := []struct {
 		name     string
 		value    []string
 		expected bool
@@ -1454,44 +1454,29 @@ func TestEnvironmentAsyncReplicationEnforced(t *testing.T) {
 		{"Valid: off", []string{"off"}, false},
 		{"not given", []string{}, false},
 	}
-	for _, tt := range factors {
-		t.Run(tt.name, func(t *testing.T) {
-			if len(tt.value) == 1 {
-				t.Setenv("ASYNC_REPLICATION_ENFORCED", tt.value[0])
-			}
-			conf := Config{}
-			err := FromEnv(&conf)
 
-			require.Nil(t, err)
-			require.Equal(t, tt.expected, conf.Replication.AsyncEnforced)
-		})
-	}
-}
-
-func TestEnvironmentAsyncReplicationDefault(t *testing.T) {
-	factors := []struct {
-		name     string
-		value    []string
-		expected bool
+	vars := []struct {
+		envKey string
+		getVal func(Config) bool
 	}{
-		{"Valid: true", []string{"true"}, true},
-		{"Valid: false", []string{"false"}, false},
-		{"Valid: 1", []string{"1"}, true},
-		{"Valid: 0", []string{"0"}, false},
-		{"Valid: on", []string{"on"}, true},
-		{"Valid: off", []string{"off"}, false},
-		{"not given", []string{}, false},
+		{"ASYNC_REPLICATION_ENFORCED", func(c Config) bool { return c.Replication.AsyncEnforced }},
+		{"ASYNC_REPLICATION_DEFAULT", func(c Config) bool { return c.Replication.AsyncDefault }},
 	}
-	for _, tt := range factors {
-		t.Run(tt.name, func(t *testing.T) {
-			if len(tt.value) == 1 {
-				t.Setenv("ASYNC_REPLICATION_DEFAULT", tt.value[0])
-			}
-			conf := Config{}
-			err := FromEnv(&conf)
 
-			require.Nil(t, err)
-			require.Equal(t, tt.expected, conf.Replication.AsyncDefault)
+	for _, v := range vars {
+		t.Run(v.envKey, func(t *testing.T) {
+			for _, tt := range boolValues {
+				t.Run(tt.name, func(t *testing.T) {
+					if len(tt.value) == 1 {
+						t.Setenv(v.envKey, tt.value[0])
+					}
+					conf := Config{}
+					err := FromEnv(&conf)
+
+					require.Nil(t, err)
+					require.Equal(t, tt.expected, v.getVal(conf))
+				})
+			}
 		})
 	}
 }

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -1439,3 +1439,59 @@ func TestEnvironmentAsyncIndexing(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvironmentReplicationAsyncEnforced(t *testing.T) {
+	factors := []struct {
+		name     string
+		value    []string
+		expected bool
+	}{
+		{"Valid: true", []string{"true"}, true},
+		{"Valid: false", []string{"false"}, false},
+		{"Valid: 1", []string{"1"}, true},
+		{"Valid: 0", []string{"0"}, false},
+		{"Valid: on", []string{"on"}, true},
+		{"Valid: off", []string{"off"}, false},
+		{"not given", []string{}, false},
+	}
+	for _, tt := range factors {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.value) == 1 {
+				t.Setenv("REPLICATION_ASYNC_ENFORCED", tt.value[0])
+			}
+			conf := Config{}
+			err := FromEnv(&conf)
+
+			require.Nil(t, err)
+			require.Equal(t, tt.expected, conf.Replication.AsyncEnforced)
+		})
+	}
+}
+
+func TestEnvironmentReplicationAsyncDefault(t *testing.T) {
+	factors := []struct {
+		name     string
+		value    []string
+		expected bool
+	}{
+		{"Valid: true", []string{"true"}, true},
+		{"Valid: false", []string{"false"}, false},
+		{"Valid: 1", []string{"1"}, true},
+		{"Valid: 0", []string{"0"}, false},
+		{"Valid: on", []string{"on"}, true},
+		{"Valid: off", []string{"off"}, false},
+		{"not given", []string{}, false},
+	}
+	for _, tt := range factors {
+		t.Run(tt.name, func(t *testing.T) {
+			if len(tt.value) == 1 {
+				t.Setenv("REPLICATION_ASYNC_DEFAULT", tt.value[0])
+			}
+			conf := Config{}
+			err := FromEnv(&conf)
+
+			require.Nil(t, err)
+			require.Equal(t, tt.expected, conf.Replication.AsyncDefault)
+		})
+	}
+}

--- a/usecases/replica/config.go
+++ b/usecases/replica/config.go
@@ -27,6 +27,7 @@ func ValidateConfig(class *models.Class, globalCfg replication.GlobalConfig) err
 		class.ReplicationConfig = &models.ReplicationConfig{
 			Factor:           int64(globalCfg.MinimumFactor),
 			DeletionStrategy: globalCfg.DeletionStrategy,
+			AsyncEnabled:     globalCfg.AsyncEnforced,
 		}
 		return nil
 	}
@@ -42,6 +43,10 @@ func ValidateConfig(class *models.Class, globalCfg replication.GlobalConfig) err
 
 	if globalCfg.DeletionStrategy != "" {
 		class.ReplicationConfig.DeletionStrategy = globalCfg.DeletionStrategy
+	}
+
+	if globalCfg.AsyncEnforced {
+		class.ReplicationConfig.AsyncEnabled = true
 	}
 
 	return nil

--- a/usecases/replica/config_test.go
+++ b/usecases/replica/config_test.go
@@ -67,6 +67,38 @@ func Test_ValidateConfig(t *testing.T) {
 			globalConfig:  replication.GlobalConfig{MinimumFactor: 2},
 			expectedErr:   fmt.Errorf("invalid replication factor: setup requires a minimum replication factor of 2: got 1"),
 		},
+		{
+			name:          "ENFORCED: config nil, async upgraded to true",
+			initialconfig: nil,
+			resultConfig:  &models.ReplicationConfig{Factor: 1, AsyncEnabled: true},
+			globalConfig:  replication.GlobalConfig{MinimumFactor: 1, AsyncEnforced: true},
+		},
+		{
+			name:          "ENFORCED: async_enabled=false is upgraded to true",
+			initialconfig: &models.ReplicationConfig{Factor: 1, AsyncEnabled: false},
+			resultConfig:  &models.ReplicationConfig{Factor: 1, AsyncEnabled: true},
+			globalConfig:  replication.GlobalConfig{MinimumFactor: 1, AsyncEnforced: true},
+		},
+		{
+			name:          "ENFORCED: async_enabled=true remains true",
+			initialconfig: &models.ReplicationConfig{Factor: 1, AsyncEnabled: true},
+			resultConfig:  &models.ReplicationConfig{Factor: 1, AsyncEnabled: true},
+			globalConfig:  replication.GlobalConfig{MinimumFactor: 1, AsyncEnforced: true},
+		},
+		{
+			name:          "ENFORCED=false: async_enabled=false remains false",
+			initialconfig: &models.ReplicationConfig{Factor: 1, AsyncEnabled: false},
+			resultConfig:  &models.ReplicationConfig{Factor: 1, AsyncEnabled: false},
+			globalConfig:  replication.GlobalConfig{MinimumFactor: 1},
+		},
+		{
+			// AsyncDefault must NOT be applied in ValidateConfig — it is a schema-layer
+			// concern handled in setClassDefaults. ValidateConfig only applies AsyncEnforced.
+			name:          "DEFAULT=true, config nil: async remains false (DEFAULT does not apply here)",
+			initialconfig: nil,
+			resultConfig:  &models.ReplicationConfig{Factor: 1, AsyncEnabled: false},
+			globalConfig:  replication.GlobalConfig{MinimumFactor: 1, AsyncDefault: true},
+		},
 	}
 
 	for _, test := range tests {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -431,15 +431,6 @@ func (m *Handler) setNewClassDefaults(class *models.Class, globalCfg replication
 		return err
 	}
 
-	if class.ReplicationConfig == nil {
-		class.ReplicationConfig = &models.ReplicationConfig{
-			Factor:           int64(m.config.Replication.MinimumFactor),
-			DeletionStrategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
-			AsyncEnabled:     false,
-		}
-		return nil
-	}
-
 	if class.ReplicationConfig.DeletionStrategy == "" {
 		class.ReplicationConfig.DeletionStrategy = models.ReplicationConfigDeletionStrategyTimeBasedResolution
 	}
@@ -475,7 +466,10 @@ func (h *Handler) setClassDefaults(class *models.Class, globalCfg replication.Gl
 	}
 
 	if class.ReplicationConfig == nil {
-		class.ReplicationConfig = &models.ReplicationConfig{Factor: int64(globalCfg.MinimumFactor)}
+		class.ReplicationConfig = &models.ReplicationConfig{
+			Factor:       int64(globalCfg.MinimumFactor),
+			AsyncEnabled: globalCfg.AsyncEnforced || globalCfg.AsyncDefault,
+		}
 	}
 
 	if class.ReplicationConfig.Factor > 0 && class.ReplicationConfig.Factor < int64(globalCfg.MinimumFactor) {
@@ -485,6 +479,10 @@ func (h *Handler) setClassDefaults(class *models.Class, globalCfg replication.Gl
 
 	if class.ReplicationConfig.Factor < 1 {
 		class.ReplicationConfig.Factor = int64(globalCfg.MinimumFactor)
+	}
+
+	if globalCfg.AsyncEnforced && !class.ReplicationConfig.AsyncEnabled {
+		class.ReplicationConfig.AsyncEnabled = true
 	}
 
 	h.moduleConfig.SetClassDefaults(class)

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -2781,6 +2781,100 @@ func Test_SetClassDefaults(t *testing.T) {
 	}
 }
 
+func Test_SetClassDefaults_AsyncReplication(t *testing.T) {
+	tests := []struct {
+		name          string
+		globalCfg     replication.GlobalConfig
+		class         *models.Class
+		expectedAsync bool
+	}{
+		{
+			name:          "DEFAULT=false, config nil: async remains false",
+			globalCfg:     replication.GlobalConfig{MinimumFactor: 1},
+			class:         &models.Class{},
+			expectedAsync: false,
+		},
+		{
+			name:          "DEFAULT=true, config nil: async defaults to true",
+			globalCfg:     replication.GlobalConfig{MinimumFactor: 1, AsyncDefault: true},
+			class:         &models.Class{},
+			expectedAsync: true,
+		},
+		{
+			name:      "DEFAULT=true, explicit async_enabled=false: false is respected",
+			globalCfg: replication.GlobalConfig{MinimumFactor: 1, AsyncDefault: true},
+			class: &models.Class{
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1, AsyncEnabled: false},
+			},
+			expectedAsync: false,
+		},
+		{
+			name:      "DEFAULT=true, explicit async_enabled=true: true remains true",
+			globalCfg: replication.GlobalConfig{MinimumFactor: 1, AsyncDefault: true},
+			class: &models.Class{
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1, AsyncEnabled: true},
+			},
+			expectedAsync: true,
+		},
+		{
+			name:          "ENFORCED=true, config nil: async upgraded to true",
+			globalCfg:     replication.GlobalConfig{MinimumFactor: 1, AsyncEnforced: true},
+			class:         &models.Class{},
+			expectedAsync: true,
+		},
+		{
+			name:      "ENFORCED=true, explicit async_enabled=false: upgraded to true",
+			globalCfg: replication.GlobalConfig{MinimumFactor: 1, AsyncEnforced: true},
+			class: &models.Class{
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1, AsyncEnabled: false},
+			},
+			expectedAsync: true,
+		},
+		{
+			name:      "ENFORCED=true, explicit async_enabled=true: remains true",
+			globalCfg: replication.GlobalConfig{MinimumFactor: 1, AsyncEnforced: true},
+			class: &models.Class{
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1, AsyncEnabled: true},
+			},
+			expectedAsync: true,
+		},
+		{
+			// When both flags are set, async=true (OR logic in nil-init, ENFORCED in non-nil)
+			name:          "ENFORCED=true + DEFAULT=true, config nil: async=true",
+			globalCfg:     replication.GlobalConfig{MinimumFactor: 1, AsyncEnforced: true, AsyncDefault: true},
+			class:         &models.Class{},
+			expectedAsync: true,
+		},
+		{
+			// ENFORCED wins over explicit false even when DEFAULT is also set
+			name:      "ENFORCED=true + DEFAULT=true, explicit async_enabled=false: upgraded to true",
+			globalCfg: replication.GlobalConfig{MinimumFactor: 1, AsyncEnforced: true, AsyncDefault: true},
+			class: &models.Class{
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1, AsyncEnabled: false},
+			},
+			expectedAsync: true,
+		},
+		{
+			// DEFAULT does not override explicit false — only ENFORCED does
+			name:      "ENFORCED=false + DEFAULT=true, explicit async_enabled=false: false is respected",
+			globalCfg: replication.GlobalConfig{MinimumFactor: 1, AsyncDefault: true},
+			class: &models.Class{
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1, AsyncEnabled: false},
+			},
+			expectedAsync: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, _ := newTestHandler(t, &fakeDB{})
+			err := handler.setClassDefaults(tt.class, tt.globalCfg)
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedAsync, tt.class.ReplicationConfig.AsyncEnabled)
+		})
+	}
+}
+
 func Test_GetConsistentClass_WithAlias(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -2781,7 +2781,7 @@ func Test_SetClassDefaults(t *testing.T) {
 	}
 }
 
-func Test_SetClassDefaults_AsyncReplication(t *testing.T) {
+func TestSetClassDefaultsAsyncReplication(t *testing.T) {
 	tests := []struct {
 		name          string
 		globalCfg     replication.GlobalConfig


### PR DESCRIPTION
### What's being changed:
Fixes #10672

This should be [added on docs](https://docs.weaviate.io/deploy/configuration/env-vars):

`ASYNC_REPLICATION_ENFORCED `
**Description**: Enforce async replication on all collections. When enabled, any collection created or updated with asyncEnabled: false will have it silently upgraded to true.
**Type**	boolean
**Default**	false
**Example**	true

`ASYNC_REPLICATION_DEFAULT `
**Description**: Set async replication as the default for newly created collections. When enabled, collections created without an explicit ReplicationConfig will have asyncEnabled: true set automatically. Collections created with an explicit asyncEnabled: false are not affected.
**Type**: boolean
**Default**:	false
**Example**:	true

**Note**: this will work even in Clusters with replication factor = 1, considering that replication factor can be changed later on.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
