### PR TITLE
fix: avoid writing empty deleted keys

### DIFF
--- a/adapters/repos/db/lsmkv/memtable_flush_inverted.go
+++ b/adapters/repos/db/lsmkv/memtable_flush_inverted.go
@@ -173,6 +173,7 @@ func (m *Memtable) flushDataInverted(f *segmentindex.SegmentFile, ogF *diskio.Me
 			actuallyWritten++
 		}
 	}
+	keys = keys[:actuallyWritten]
 
 	tombstoneOffset := totalWritten
 
@@ -265,5 +266,5 @@ func (m *Memtable) flushDataInverted(f *segmentindex.SegmentFile, ogF *diskio.Me
 		return nil, nil, fmt.Errorf("write headers: %w", err)
 	}
 
-	return keys[:actuallyWritten], tombstones, nil
+	return keys, tombstones, nil
 }


### PR DESCRIPTION
### What's being changed:

- Remove deleted elements from flush before adding to the tree

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
