### PR TITLE
Add a lifetime to RBAC cache

### DIFF
--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -97,8 +97,10 @@ func Init(conf rbacconf.Config, policyPath string, authNconf config.Authenticati
 		return nil, fmt.Errorf("failed to create enforcer: %w", err)
 	}
 	enforcer.EnableCache(true)
-	// Set a TTL to prevent unbounded cache growth. Policy changes already
-	// call InvalidateCache(), so this is purely a memory safety net.
+	// Set a TTL to prevent unbounded cache growth. Runtime policy updates via
+	// the Manager call InvalidateCache(); this TTL is an additional safeguard,
+	// including for init/upgrade paths that may modify policy without
+	// explicitly invalidating the cache.
 	enforcer.SetExpireTime(1 * time.Hour)
 
 	rbacStoragePath := fmt.Sprintf("%s/rbac", policyPath)


### PR DESCRIPTION
### What's being changed:

The rbac library caches each request and its decision. That has currently no lifetime and is growing unbounded. This PR adds a lifetime of one hours to stop the unbounded grow.

Note that we already evict the cache on every policy change, so this is safe to do.

e2e: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/22752258641
chaos: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/22752261182


customer profile:
<img width="321" height="487" alt="image" src="https://github.com/user-attachments/assets/463dc400-ba95-4d24-ae1c-ace98c4f9c08" />


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
