### PR TITLE
shard: copy-on-write callback slices with deregistration

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -510,10 +510,26 @@ func (s *Shard) Activity() (int32, int32) {
 	return s.activityTrackerRead.Load(), s.activityTrackerWrite.Load()
 }
 
-func (s *Shard) registerAddToPropertyValueIndex(callback onAddToPropertyValueIndex) {
-	s.callbacksAddToPropertyValueIndex = append(s.callbacksAddToPropertyValueIndex, callback)
+func (s *Shard) registerAddToPropertyValueIndex(callback onAddToPropertyValueIndex) func() {
+	disabled := &atomic.Bool{}
+	s.callbacksAddToPropertyValueIndex = append(s.callbacksAddToPropertyValueIndex,
+		func(shard *Shard, docID uint64, property *inverted.Property) error {
+			if disabled.Load() {
+				return nil
+			}
+			return callback(shard, docID, property)
+		})
+	return func() { disabled.Store(true) }
 }
 
-func (s *Shard) registerDeleteFromPropertyValueIndex(callback onDeleteFromPropertyValueIndex) {
-	s.callbacksRemoveFromPropertyValueIndex = append(s.callbacksRemoveFromPropertyValueIndex, callback)
+func (s *Shard) registerDeleteFromPropertyValueIndex(callback onDeleteFromPropertyValueIndex) func() {
+	disabled := &atomic.Bool{}
+	s.callbacksRemoveFromPropertyValueIndex = append(s.callbacksRemoveFromPropertyValueIndex,
+		func(shard *Shard, docID uint64, property *inverted.Property) error {
+			if disabled.Load() {
+				return nil
+			}
+			return callback(shard, docID, property)
+		})
+	return func() { disabled.Store(true) }
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -286,9 +286,15 @@ type Shard struct {
 	shutCtx       context.Context
 	shutCtxCancel context.CancelCauseFunc
 
-	reindexer                             ShardReindexerV3
-	callbacksAddToPropertyValueIndex      []onAddToPropertyValueIndex
-	callbacksRemoveFromPropertyValueIndex []onDeleteFromPropertyValueIndex
+	reindexer ShardReindexerV3
+
+	// Copy-on-write callback slices stored in atomic.Value for lock-free reads
+	// on the hot write path. Registration (rare) copies the slice behind
+	// propertyValueIndexCallbacksMu; iteration (every object write) loads the
+	// current snapshot without locking.
+	callbacksAddToPropertyValueIndex      atomic.Value // []onAddToPropertyValueIndex
+	callbacksRemoveFromPropertyValueIndex atomic.Value // []onDeleteFromPropertyValueIndex
+	propertyValueIndexCallbacksMu         sync.Mutex
 	// stores names of properties that are searchable and use buckets of
 	// inverted strategy. for such properties delta analyzer should avoid
 	// computing delta between previous and current values of properties
@@ -512,24 +518,46 @@ func (s *Shard) Activity() (int32, int32) {
 
 func (s *Shard) registerAddToPropertyValueIndex(callback onAddToPropertyValueIndex) func() {
 	disabled := &atomic.Bool{}
-	s.callbacksAddToPropertyValueIndex = append(s.callbacksAddToPropertyValueIndex,
-		func(shard *Shard, docID uint64, property *inverted.Property) error {
-			if disabled.Load() {
-				return nil
-			}
-			return callback(shard, docID, property)
-		})
+	wrapped := func(shard *Shard, docID uint64, property *inverted.Property) error {
+		if disabled.Load() {
+			return nil
+		}
+		return callback(shard, docID, property)
+	}
+
+	s.propertyValueIndexCallbacksMu.Lock()
+	var current []onAddToPropertyValueIndex
+	if v := s.callbacksAddToPropertyValueIndex.Load(); v != nil {
+		current = v.([]onAddToPropertyValueIndex)
+	}
+	updated := make([]onAddToPropertyValueIndex, len(current)+1)
+	copy(updated, current)
+	updated[len(current)] = wrapped
+	s.callbacksAddToPropertyValueIndex.Store(updated)
+	s.propertyValueIndexCallbacksMu.Unlock()
+
 	return func() { disabled.Store(true) }
 }
 
 func (s *Shard) registerDeleteFromPropertyValueIndex(callback onDeleteFromPropertyValueIndex) func() {
 	disabled := &atomic.Bool{}
-	s.callbacksRemoveFromPropertyValueIndex = append(s.callbacksRemoveFromPropertyValueIndex,
-		func(shard *Shard, docID uint64, property *inverted.Property) error {
-			if disabled.Load() {
-				return nil
-			}
-			return callback(shard, docID, property)
-		})
+	wrapped := func(shard *Shard, docID uint64, property *inverted.Property) error {
+		if disabled.Load() {
+			return nil
+		}
+		return callback(shard, docID, property)
+	}
+
+	s.propertyValueIndexCallbacksMu.Lock()
+	var current []onDeleteFromPropertyValueIndex
+	if v := s.callbacksRemoveFromPropertyValueIndex.Load(); v != nil {
+		current = v.([]onDeleteFromPropertyValueIndex)
+	}
+	updated := make([]onDeleteFromPropertyValueIndex, len(current)+1)
+	copy(updated, current)
+	updated[len(current)] = wrapped
+	s.callbacksRemoveFromPropertyValueIndex.Store(updated)
+	s.propertyValueIndexCallbacksMu.Unlock()
+
 	return func() { disabled.Store(true) }
 }

--- a/adapters/repos/db/shard_callbacks_test.go
+++ b/adapters/repos/db/shard_callbacks_test.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"sync"
 	"sync/atomic"
 	"testing"
 
@@ -283,4 +284,55 @@ func TestShardCallbacks_DualWriteMigration(t *testing.T) {
 		"primary bucket must contain all docIDs (phases 1-3)")
 	assert.Equal(t, []uint64{4, 5, 6}, secondaryIDs,
 		"secondary bucket must contain only phase 2 docIDs (during dual-write)")
+}
+
+// TestShardCallbacks_ConcurrentRegistrationAndWrites verifies that
+// registering a callback while another goroutine is invoking callbacks
+// does not race. Run with -race to verify.
+func TestShardCallbacks_ConcurrentRegistrationAndWrites(t *testing.T) {
+	s := &Shard{}
+
+	// Pre-register a callback so the slice is non-empty from the start.
+	var baseCount atomic.Int64
+	s.registerAddToPropertyValueIndex(func(_ *Shard, _ uint64, _ *inverted.Property) error {
+		baseCount.Add(1)
+		return nil
+	})
+
+	const (
+		numWriters       = 4
+		writesPerWriter  = 500
+		numRegistrations = 20
+	)
+
+	var wg sync.WaitGroup
+
+	// Writers: continuously invoke callbacks.
+	for w := 0; w < numWriters; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < writesPerWriter; i++ {
+				_ = s.onAddToPropertyValueIndex(uint64(i), &inverted.Property{Name: "p"})
+			}
+		}()
+	}
+
+	// Registrations: add and deregister callbacks concurrently with writes.
+	for r := 0; r < numRegistrations; r++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			dereg := s.registerAddToPropertyValueIndex(
+				func(_ *Shard, _ uint64, _ *inverted.Property) error {
+					return nil
+				})
+			dereg()
+		}()
+	}
+
+	wg.Wait()
+
+	// The base callback must have been invoked at least once (sanity).
+	assert.Greater(t, baseCount.Load(), int64(0))
 }

--- a/adapters/repos/db/shard_callbacks_test.go
+++ b/adapters/repos/db/shard_callbacks_test.go
@@ -1,0 +1,286 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+func TestShardCallbacks_AddToPropertyValueIndex(t *testing.T) {
+	t.Run("callback fires", func(t *testing.T) {
+		s := &Shard{}
+		var called atomic.Bool
+		s.registerAddToPropertyValueIndex(func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			called.Store(true)
+			return nil
+		})
+
+		err := s.onAddToPropertyValueIndex(1, &inverted.Property{Name: "test"})
+		require.NoError(t, err)
+		assert.True(t, called.Load())
+	})
+
+	t.Run("deregister disables callback", func(t *testing.T) {
+		s := &Shard{}
+		var callCount atomic.Int32
+		deregister := s.registerAddToPropertyValueIndex(func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			callCount.Add(1)
+			return nil
+		})
+
+		// Fires before deregister.
+		err := s.onAddToPropertyValueIndex(1, &inverted.Property{Name: "test"})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), callCount.Load())
+
+		deregister()
+
+		// Does not fire after deregister.
+		err = s.onAddToPropertyValueIndex(1, &inverted.Property{Name: "test"})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), callCount.Load())
+	})
+
+	t.Run("deregister is idempotent", func(t *testing.T) {
+		s := &Shard{}
+		deregister := s.registerAddToPropertyValueIndex(func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			return nil
+		})
+
+		deregister()
+		deregister() // Must not panic.
+	})
+
+	t.Run("deregister one leaves others active", func(t *testing.T) {
+		s := &Shard{}
+		var calls [3]atomic.Int32
+
+		deregister0 := s.registerAddToPropertyValueIndex(func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			calls[0].Add(1)
+			return nil
+		})
+		s.registerAddToPropertyValueIndex(func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			calls[1].Add(1)
+			return nil
+		})
+		s.registerAddToPropertyValueIndex(func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			calls[2].Add(1)
+			return nil
+		})
+
+		// All fire initially.
+		err := s.onAddToPropertyValueIndex(1, &inverted.Property{Name: "test"})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), calls[0].Load())
+		assert.Equal(t, int32(1), calls[1].Load())
+		assert.Equal(t, int32(1), calls[2].Load())
+
+		// Deregister the first callback only.
+		deregister0()
+
+		err = s.onAddToPropertyValueIndex(1, &inverted.Property{Name: "test"})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), calls[0].Load(), "deregistered callback must not fire again")
+		assert.Equal(t, int32(2), calls[1].Load(), "other callback must still fire")
+		assert.Equal(t, int32(2), calls[2].Load(), "other callback must still fire")
+	})
+
+	t.Run("callback error propagates", func(t *testing.T) {
+		s := &Shard{}
+		s.registerAddToPropertyValueIndex(func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			return fmt.Errorf("boom")
+		})
+
+		err := s.onAddToPropertyValueIndex(1, &inverted.Property{Name: "test"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "boom")
+	})
+}
+
+func TestShardCallbacks_DeleteFromPropertyValueIndex(t *testing.T) {
+	t.Run("callback fires", func(t *testing.T) {
+		s := &Shard{}
+		var called atomic.Bool
+		s.registerDeleteFromPropertyValueIndex(func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			called.Store(true)
+			return nil
+		})
+
+		err := s.onDeleteFromPropertyValueIndex(1, &inverted.Property{Name: "test"})
+		require.NoError(t, err)
+		assert.True(t, called.Load())
+	})
+
+	t.Run("deregister disables callback", func(t *testing.T) {
+		s := &Shard{}
+		var callCount atomic.Int32
+		deregister := s.registerDeleteFromPropertyValueIndex(func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			callCount.Add(1)
+			return nil
+		})
+
+		err := s.onDeleteFromPropertyValueIndex(1, &inverted.Property{Name: "test"})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), callCount.Load())
+
+		deregister()
+
+		err = s.onDeleteFromPropertyValueIndex(1, &inverted.Property{Name: "test"})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), callCount.Load())
+	})
+
+	t.Run("deregister one leaves others active", func(t *testing.T) {
+		s := &Shard{}
+		var calls [2]atomic.Int32
+
+		deregister0 := s.registerDeleteFromPropertyValueIndex(func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			calls[0].Add(1)
+			return nil
+		})
+		s.registerDeleteFromPropertyValueIndex(func(_ *Shard, _ uint64, _ *inverted.Property) error {
+			calls[1].Add(1)
+			return nil
+		})
+
+		err := s.onDeleteFromPropertyValueIndex(1, &inverted.Property{Name: "test"})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), calls[0].Load())
+		assert.Equal(t, int32(1), calls[1].Load())
+
+		deregister0()
+
+		err = s.onDeleteFromPropertyValueIndex(1, &inverted.Property{Name: "test"})
+		require.NoError(t, err)
+		assert.Equal(t, int32(1), calls[0].Load())
+		assert.Equal(t, int32(2), calls[1].Load())
+	})
+}
+
+// TestShardCallbacks_DualWriteMigration simulates the lifecycle of a
+// dual-write migration: writes go to a primary bucket, then a callback is
+// registered so writes are duplicated to a secondary bucket, then the
+// callback is deregistered. Only writes during the dual-write window should
+// appear in the secondary bucket.
+func TestShardCallbacks_DualWriteMigration(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	dirName := t.TempDir()
+	store, err := lsmkv.New(dirName, dirName, logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	defer store.Shutdown(ctx)
+
+	const propName = "title"
+	primaryBucket := helpers.BucketFromPropNameLSM(propName)
+	secondaryBucket := primaryBucket + "_secondary"
+
+	// Create both buckets with RoaringSet strategy (same as filterable index).
+	err = store.CreateOrLoadBucket(ctx, primaryBucket,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet))
+	require.NoError(t, err)
+	err = store.CreateOrLoadBucket(ctx, secondaryBucket,
+		lsmkv.WithStrategy(lsmkv.StrategyRoaringSet))
+	require.NoError(t, err)
+
+	s := &Shard{store: store}
+
+	// Helper: write a property with HasFilterableIndex to the primary bucket
+	// (via addToPropertyValueIndex) which also triggers callbacks.
+	writeDoc := func(t *testing.T, docID uint64, term string) {
+		t.Helper()
+		err := s.addToPropertyValueIndex(docID, inverted.Property{
+			Name:               propName,
+			Items:              []inverted.Countable{{Data: []byte(term)}},
+			HasFilterableIndex: true,
+		})
+		require.NoError(t, err)
+	}
+
+	// Helper: check which docIDs are present in a bucket for a given term.
+	readDocIDs := func(t *testing.T, bucketName, term string) []uint64 {
+		t.Helper()
+		b := store.Bucket(bucketName)
+		require.NotNil(t, b, "bucket %q must exist", bucketName)
+		bm, release, err := b.RoaringSetGet([]byte(term))
+		require.NoError(t, err)
+		defer release()
+		if bm == nil {
+			return nil
+		}
+		return bm.ToArray()
+	}
+
+	// --- Phase 1: before dual-write ---
+	// docIDs 1-3 go only to the primary bucket.
+	for docID := uint64(1); docID <= 3; docID++ {
+		writeDoc(t, docID, "hello")
+	}
+
+	// --- Register dual-write callback ---
+	// The callback mirrors filterable writes to the secondary bucket,
+	// similar to what duplicateToBuckets does in the blockmax migrator.
+	deregister := s.registerAddToPropertyValueIndex(
+		func(shard *Shard, docID uint64, property *inverted.Property) error {
+			if !property.HasFilterableIndex {
+				return nil
+			}
+			secondary := shard.store.Bucket(helpers.BucketFromPropNameLSM(property.Name) + "_secondary")
+			if secondary == nil {
+				return nil
+			}
+			for _, item := range property.Items {
+				if err := secondary.RoaringSetAddOne(item.Data, docID); err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+
+	// --- Phase 2: during dual-write ---
+	// docIDs 4-6 should appear in both buckets.
+	for docID := uint64(4); docID <= 6; docID++ {
+		writeDoc(t, docID, "hello")
+	}
+
+	// --- Deregister the callback ---
+	deregister()
+
+	// --- Phase 3: after dual-write ---
+	// docIDs 7-9 go only to the primary bucket again.
+	for docID := uint64(7); docID <= 9; docID++ {
+		writeDoc(t, docID, "hello")
+	}
+
+	// --- Verify ---
+	primaryIDs := readDocIDs(t, primaryBucket, "hello")
+	secondaryIDs := readDocIDs(t, secondaryBucket, "hello")
+
+	assert.Equal(t, []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9}, primaryIDs,
+		"primary bucket must contain all docIDs (phases 1-3)")
+	assert.Equal(t, []uint64{4, 5, 6}, secondaryIDs,
+		"secondary bucket must contain only phase 2 docIDs (during dual-write)")
+}

--- a/adapters/repos/db/shard_write_inverted_lsm.go
+++ b/adapters/repos/db/shard_write_inverted_lsm.go
@@ -311,9 +311,10 @@ func (s *Shard) resetDimensionsLSM(ctx context.Context) error {
 }
 
 func (s *Shard) onAddToPropertyValueIndex(docID uint64, property *inverted.Property) error {
+	callbacks, _ := s.callbacksAddToPropertyValueIndex.Load().([]onAddToPropertyValueIndex)
 	ec := errorcompounder.New()
-	for i := range s.callbacksAddToPropertyValueIndex {
-		ec.Add(s.callbacksAddToPropertyValueIndex[i](s, docID, property))
+	for _, cb := range callbacks {
+		ec.Add(cb(s, docID, property))
 	}
 	return ec.ToError()
 }

--- a/adapters/repos/db/shard_write_inverted_lsm_delete.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_delete.go
@@ -182,9 +182,10 @@ func (s *Shard) deleteFromPropertyRangeBucket(bucket *lsmkv.Bucket, docID uint64
 }
 
 func (s *Shard) onDeleteFromPropertyValueIndex(docID uint64, property *inverted.Property) error {
+	callbacks, _ := s.callbacksRemoveFromPropertyValueIndex.Load().([]onDeleteFromPropertyValueIndex)
 	ec := errorcompounder.New()
-	for i := range s.callbacksRemoveFromPropertyValueIndex {
-		ec.Add(s.callbacksRemoveFromPropertyValueIndex[i](s, docID, property))
+	for _, cb := range callbacks {
+		ec.Add(cb(s, docID, property))
 	}
 	return ec.ToError()
 }


### PR DESCRIPTION
## Summary

- Modify `registerAddToPropertyValueIndex` and `registerDeleteFromPropertyValueIndex` to return a `func()` that disables the specific callback
- Each returned function sets an internal `atomic.Bool`; the wrapped callback checks this flag and returns nil when disabled
- Replace bare callback slices with **copy-on-write** via `atomic.Value`: reads on the hot write path are lock-free, registration copies the slice behind a mutex
- Backwards compatible: existing callers (e.g. `duplicateToBuckets` in the blockmax migrator) ignore the return value — no behavior change

## Motivation

The current V3 reindexer registers double-write callbacks during migration so that incoming writes are duplicated to the new bucket format. However, once the migration completes, the only way to stop the callbacks is to reload the entire shard — the callbacks are append-only with no removal mechanism.

For **runtime reindexing** (live bucket swap without shard reload), we need the ability to deregister callbacks after the swap completes. Without this, disabled callbacks would accumulate indefinitely, and there's no clean way to stop duplicating writes to buckets that have already been swapped in.

This PR adds migration-scoped deregistration: each `register*` call returns its own deregister handle (similar to Go's `context.CancelFunc` pattern). This is preferred over a blanket "clear all callbacks" approach because it ties the lifecycle to the specific migration task rather than to global shard state, which is safer if multiple migrations or concurrent tasks register callbacks in the future.

## Concurrency safety

Since runtime reindexing will register callbacks concurrently with the write path (unlike the current V3 migrator which only registers at shard startup), the callback slices need to be concurrency-safe:

- **Callback slices** use copy-on-write via `atomic.Value`. The write path loads the current snapshot lock-free (`atomic.Value.Load`), while registration (rare) copies the slice behind `propertyValueIndexCallbacksMu`
- **Deregistration** sets an `atomic.Bool` per callback — a single atomic write. The next invocation reads `disabled.Load()` — atomic read. No data race
- **No lock contention on the hot path**: the write path never acquires a mutex, only an atomic load

## Test plan

- [x] Unit tests: callback fires, deregister disables it, other callbacks still fire, deregister is idempotent, errors propagate
- [x] Dual-write migration test: real LSM store with two RoaringSet buckets exercising the full lifecycle (write → register callback → dual-write → deregister → write), verifying that only the dual-write window data appears in the secondary bucket
- [x] Concurrency test: 4 writer goroutines + 20 concurrent registrations/deregistrations, verified with `-race`

```
go test -run TestShardCallbacks -race -v ./adapters/repos/db/
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)