### PR TITLE
chore: update default propagation settings for async replication

### DIFF
--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -49,16 +49,16 @@ const (
 	defaultHashtreeHeightSingleTenant  = 16
 	defaultHashtreeHeightMultiTenant   = 10
 	defaultFrequency                   = 30 * time.Second
-	defaultFrequencyWhilePropagating   = 3 * time.Second
+	defaultFrequencyWhilePropagating   = 5 * time.Second
 	defaultAliveNodesCheckingFrequency = 5 * time.Second
 	defaultLoggingFrequency            = 60 * time.Second
 	defaultDiffBatchSize               = 1_000
 	defaultDiffPerNodeTimeout          = 10 * time.Second
 	defaultPrePropagationTimeout       = 300 * time.Second
 	defaultPropagationTimeout          = 60 * time.Second
-	defaultPropagationLimit            = 10_000
+	defaultPropagationLimit            = 1_000
 	defaultPropagationDelay            = 30 * time.Second
-	defaultPropagationConcurrency      = 5
+	defaultPropagationConcurrency      = 1
 	defaultPropagationBatchSize        = 100
 
 	minHashtreeHeight = 0


### PR DESCRIPTION
### What's being changed:

This pull request makes adjustments to the default configuration constants for the shard async replication process in `shard_async_replication.go`. The main goal is to slow down propagation and reduce resource usage during replication.

Configuration changes to async replication:

* Increased `defaultFrequencyWhilePropagating` from 3 seconds to 5 seconds, slowing down the polling interval during propagation.
* Reduced `defaultPropagationLimit` from 10,000 to 1,000, limiting the maximum number of items propagated the same iteration
* Decreased `defaultPropagationConcurrency` from 5 to 1, allowing only a single concurrent propagation operation.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
