### PR TITLE
fix: don't strip nils for bm25 search

### DIFF
--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -376,6 +376,11 @@ func objectsByDocIDParallelInner(bucket bucket, ids []uint64,
 		return nil, err
 	}
 
+	if includeEmpty {
+		// Positions are meaningful: nils indicate missing objects; do not compact.
+		return out, nil
+	}
+
 	// fix gaps in the output array
 	j := 0
 	for i := range out {


### PR DESCRIPTION
### What's being changed:

- don't strip nils for bm25 search

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
