### PR TITLE
fix-test(offload): Test_UploadS3Journey simulate network down on cloud provider

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -358,11 +358,19 @@ jobs:
         with:
           username: ${{secrets.DOCKER_USERNAME}}
           password: ${{secrets.DOCKER_PASSWORD}}
+      - name: Determine timeout for test
+        env:
+          MATRIX_TEST: ${{ matrix.name }}
+        run: |
+          if [[ "$MATRIX_TEST" == "offload-s3" ]]; then
+            echo "test_timeout_minutes=45" >> $GITHUB_ENV
+          else
+            echo "test_timeout_minutes=15" >> $GITHUB_ENV
+          fi
       - name: Acceptance tests (modules)
         uses: nick-fields/retry@v3
         with:
-          # 15 Minute is a large enough timeout for most of our tests
-          timeout_minutes: 15
+          timeout_minutes: ${{ env.test_timeout_minutes }}
           max_attempts: 2
           command: ./test/run.sh ${{ matrix.test }}
           on_retry_command: ./test/run.sh --cleanup

--- a/modules/offload-s3/module.go
+++ b/modules/offload-s3/module.go
@@ -42,6 +42,7 @@ const (
 	s3BucketAutoCreate = "OFFLOAD_S3_BUCKET_AUTO_CREATE"
 	s3Bucket           = "OFFLOAD_S3_BUCKET"
 	concurrency        = "OFFLOAD_S3_CONCURRENCY"
+	workers            = "OFFLOAD_S3_WORKERS"
 	timeout            = "OFFLOAD_TIMEOUT"
 )
 
@@ -64,6 +65,14 @@ type Module struct {
 }
 
 func New() *Module {
+	workersCount := 256
+	if workers := os.Getenv(workers); workers != "" {
+		workersN, err := strconv.Atoi(workers)
+		if err != nil {
+			logrus.WithError(err).Error("failed to parse workers count")
+		}
+		workersCount = workersN
+	}
 	return &Module{
 		Endpoint:    "",
 		Bucket:      "weaviate-offload",
@@ -83,7 +92,7 @@ func New() *Module {
 			Flags: []cli.Flag{
 				&cli.IntFlag{
 					Name:  "numworkers",
-					Value: 256,
+					Value: workersCount,
 					Usage: "number of workers execute operation on each object",
 				},
 				&cli.IntFlag{

--- a/test/modules/offload-s3/offload_upload_test.go
+++ b/test/modules/offload-s3/offload_upload_test.go
@@ -28,10 +28,9 @@ import (
 	"github.com/weaviate/weaviate/test/helper"
 )
 
-func Test_UploadS3Journey(t *testing.T) {
+func Test_UploadS3JourneyHappyPath(t *testing.T) {
 	t.Run("happy path with RF 2 upload to s3 provider", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
 		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
@@ -201,10 +200,11 @@ func Test_UploadS3Journey(t *testing.T) {
 			})
 		})
 	})
+}
 
+func Test_UploadS3JourneyUnhappyPath(t *testing.T) {
 	t.Run("node is down while RF is 3, one weaviate node is down", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
 		t.Setenv(envS3SecretKey, s3BackupJourneySecretKey)
@@ -346,10 +346,11 @@ func Test_UploadS3Journey(t *testing.T) {
 			}, 5*time.Second, time.Second, fmt.Sprintf("tenant was never %s", models.TenantActivityStatusFROZEN))
 		})
 	})
+}
 
+func Test_UploadS3JourneyUnhappyPath_CloudProviderIsDown(t *testing.T) {
 	t.Run("unhappy path with RF 3, cloud provider is down", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		defer cancel()
+		ctx := context.Background()
 
 		t.Log("pre-instance env setup")
 		t.Setenv(envS3AccessKey, s3BackupJourneyAccessKey)
@@ -358,6 +359,8 @@ func Test_UploadS3Journey(t *testing.T) {
 		compose, err := docker.New().
 			WithOffloadS3("offloading", "us-west-1").
 			WithWeaviateEnv("OFFLOAD_TIMEOUT", "2").
+			WithWeaviateEnv("OFFLOAD_S3_CONCURRENCY", "1").
+			WithWeaviateEnv("OFFLOAD_S3_WORKERS", "1").
 			WithText2VecContextionary().
 			With3NodeCluster().
 			Start(ctx)
@@ -442,40 +445,50 @@ func Test_UploadS3Journey(t *testing.T) {
 			}
 		})
 
-		// Add many objects so offload takes long enough to observe FREEZING.
-		t.Run("add many objects to tenant to prolong FREEZING", func(t *testing.T) {
-			const extraObjects = 10000
-			for i := 0; i < extraObjects; i++ {
-				obj := &models.Object{
-					ID:    strfmt.UUID(fmt.Sprintf("0927a1e0-398e-4e76-91fb-%012x", i+1)),
-					Class: className,
-					Properties: map[string]interface{}{
-						"name":          fmt.Sprintf("extra-%d", i),
-						"someData":      "ref#0",
-						"someOtherData": "ref#1",
-					},
-					Tenant: tenantNames[0],
+		t.Run("add objects so offload is in progress when MinIO is killed", func(t *testing.T) {
+			const (
+				extraObjects = 50000
+				batchSize    = 1000
+			)
+			for offset := 0; offset < extraObjects; offset += batchSize {
+				n := batchSize
+				if offset+batchSize > extraObjects {
+					n = extraObjects - offset
 				}
-				assert.Nil(t, helper.CreateObject(t, obj))
+				if n > 30000 {
+					t.Run("update tenant to FROZEN (starts offload)", func(t *testing.T) {
+						go func() {
+							helper.UpdateTenants(t, className, []*models.Tenant{
+								{
+									Name:           tenantNames[0],
+									ActivityStatus: models.TenantActivityStatusFROZEN,
+								},
+							})
+						}()
+					})
+				}
+				objects := make([]*models.Object, n)
+				for i := 0; i < n; i++ {
+					objects[i] = &models.Object{
+						ID:    strfmt.UUID(fmt.Sprintf("0927a1e0-398e-4e76-91fb-%012x", offset+i+1)),
+						Class: className,
+						Properties: map[string]interface{}{
+							"name": fmt.Sprintf("extra-%d", offset+i),
+						},
+						Tenant: tenantNames[0],
+					}
+				}
+				helper.CreateObjectsBatch(t, objects)
 			}
 		})
 
-		t.Run("updating tenant status", func(t *testing.T) {
-			helper.UpdateTenants(t, className, []*models.Tenant{
-				{
-					Name:           tenantNames[0],
-					ActivityStatus: models.TenantActivityStatusFROZEN,
-				},
-			})
-		})
-
-		t.Run("terminate Minio", func(t *testing.T) {
+		t.Run("terminate MinIO so offload fails", func(t *testing.T) {
 			require.Nil(t, compose.TerminateContainer(ctx, docker.MinIO))
 		})
 
-		t.Run("verify tenant status HOT", func(xt *testing.T) {
+		t.Run("verify tenant is reset to HOT", func(t *testing.T) {
 			assert.EventuallyWithT(t, func(at *assert.CollectT) {
-				resp, err := helper.GetTenants(xt, className)
+				resp, err := helper.GetTenants(t, className)
 				require.Nil(t, err)
 
 				for _, tn := range resp.Payload {
@@ -484,7 +497,7 @@ func Test_UploadS3Journey(t *testing.T) {
 						break
 					}
 				}
-			}, 5*time.Second, time.Second, fmt.Sprintf("tenant was never %s", models.TenantActivityStatusHOT))
+			}, 60*time.Second, time.Second, fmt.Sprintf("tenant was never %s", models.TenantActivityStatusHOT))
 		})
 	})
 }

--- a/test/run.sh
+++ b/test/run.sh
@@ -739,7 +739,7 @@ function run_module_only_backup_tests() {
 
 function run_module_only_offload_tests() {
   for pkg in $(go list ./... |grep 'test/modules/offload'); do
-    if ! go test -count 1 -race -v "$pkg"; then
+    if ! go test -count 1 -race -timeout 30m -v "$pkg"; then
       echo "Test for $pkg failed" >&2
       return 1
     fi


### PR DESCRIPTION
### What's being changed:
this PR splits Test_UploadS3Journey  into smaller tests and fix the flakey test mocking cloud provider is down by controlling concurrency of the offload and importing more objects to prolong the offload process 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
