### PR TITLE
HFresh increase max posting size floor

### DIFF
--- a/adapters/repos/db/vector/hfresh/config.go
+++ b/adapters/repos/db/vector/hfresh/config.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	maxPostingSizeFloor uint32 = 8 // Minimum vectors per posting
-	minPostingSizeFloor uint32 = 3 // Minimum vectors for split threshold
+	maxPostingSizeFloor uint32 = 192 // Minimum vectors per posting
+	minPostingSizeFloor uint32 = 3   // Minimum vectors for split threshold
 )
 
 type Config struct {

--- a/adapters/repos/db/vector/hfresh/insert_test.go
+++ b/adapters/repos/db/vector/hfresh/insert_test.go
@@ -70,7 +70,7 @@ func TestHFreshOptimizedPostingSize(t *testing.T) {
 			name:                   "max posting size kb large vector",
 			maxPostingSizeKB:       8,
 			vectorDim:              4096,
-			expectedMaxPostingSize: 16,
+			expectedMaxPostingSize: 192,
 		},
 	}
 


### PR DESCRIPTION
### What's being changed:
- For large dimension vectors the kb based sizing can product too small postings
- This adds a flow for max posting size of 192
- It will only affect vectors with dimensions > 1536 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
