### PR TITLE
feat: add queryVector to _additional fields

### DIFF
--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -181,6 +181,7 @@ func (b *classBuilder) additionalFields(classProperties graphql.Fields, class *m
 	additionalProperties["certainty"] = b.additionalCertaintyField(class)
 	additionalProperties["distance"] = b.additionalDistanceField(class)
 	additionalProperties["vector"] = b.additionalVectorField(class)
+	additionalProperties["queryVector"] = b.additionalQueryVectorField(class)
 	additionalProperties["vectors"] = b.additionalVectorsField(class)
 	additionalProperties["id"] = b.additionalIDField()
 	additionalProperties["creationTimeUnix"] = b.additionalCreationTimeUnix()
@@ -240,6 +241,12 @@ func (b *classBuilder) additionalDistanceField(class *models.Class) *graphql.Fie
 }
 
 func (b *classBuilder) additionalVectorField(class *models.Class) *graphql.Field {
+	return &graphql.Field{
+		Type: graphql.NewList(graphql.Float),
+	}
+}
+
+func (b *classBuilder) additionalQueryVectorField(class *models.Class) *graphql.Field {
 	return &graphql.Field{
 		Type: graphql.NewList(graphql.Float),
 	}

--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -587,7 +587,7 @@ type additionalCheck struct {
 func (ac *additionalCheck) isAdditional(parentName, name string) bool {
 	if parentName == "_additional" {
 		if name == "classification" || name == "certainty" ||
-			name == "distance" || name == "id" || name == "vector" || name == "vectors" ||
+			name == "distance" || name == "id" || name == "vector" || name == "queryVector" || name == "vectors" ||
 			name == "creationTimeUnix" || name == "lastUpdateTimeUnix" ||
 			name == "score" || name == "explainScore" || name == "isConsistent" ||
 			name == "group" {
@@ -671,6 +671,10 @@ func extractProperties(className string, selections *ast.SelectionSet,
 						}
 						if additionalProperty == "vector" {
 							additionalProps.Vector = true
+							continue
+						}
+						if additionalProperty == "queryVector" {
+							additionalProps.QueryVector = true
 							continue
 						}
 						if additionalProperty == "vectors" {

--- a/adapters/handlers/graphql/local/get/get_test.go
+++ b/adapters/handlers/graphql/local/get/get_test.go
@@ -434,6 +434,28 @@ func TestExtractAdditionalFields(t *testing.T) {
 			},
 		},
 		{
+			name:  "with _additional queryVector",
+			query: "{ Get { SomeAction { _additional { queryVector } } } }",
+			expectedParams: dto.GetParams{
+				ClassName: "SomeAction",
+				AdditionalProperties: additional.Properties{
+					QueryVector: true,
+				},
+			},
+			resolverReturn: []interface{}{
+				map[string]interface{}{
+					"_additional": map[string]interface{}{
+						"queryVector": []float32{0.2, 0.4, -0.1},
+					},
+				},
+			},
+			expectedResult: map[string]interface{}{
+				"_additional": map[string]interface{}{
+					"queryVector": []interface{}{float32(0.2), float32(0.4), float32(-0.1)},
+				},
+			},
+		},
+		{
 			name:  "with _additional creationTimeUnix",
 			query: "{ Get { SomeAction { _additional { creationTimeUnix } } } }",
 			expectedParams: dto.GetParams{

--- a/entities/additional/classification.go
+++ b/entities/additional/classification.go
@@ -41,6 +41,7 @@ type Properties struct {
 	ExplainScore            bool                   `json:"explainScore"`
 	IsConsistent            bool                   `json:"isConsistent"`
 	Group                   bool                   `json:"group"`
+	QueryVector             bool                   `json:"queryVector"`
 
 	// The User is not interested in returning props, we can skip any costly
 	// operation that isn't required.

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -508,6 +508,10 @@ func (e *Explorer) searchResultsToGetResponseWithType(ctx context.Context, input
 			additionalProperties["vector"] = res.Vector
 		}
 
+		if params.AdditionalProperties.QueryVector && searchVector != nil {
+			additionalProperties["queryVector"] = searchVector
+		}
+
 		if len(params.AdditionalProperties.Vectors) > 0 {
 			vectors := make(map[string]models.Vector)
 			for _, targetVector := range params.AdditionalProperties.Vectors {


### PR DESCRIPTION
adds the queryVector field to GraphQL _additional properties to return the vectorized query used in the search. this allows users to see what vector was actually searched for, enabling better analysis and debugging of vector searches.

this implements the feature requested in #2496

changes:
- add QueryVector field to additional.Properties struct
- add queryVector GraphQL field to _additional object
- add logic to return the search vector when queryVector is requested
- add test case for queryVector field