### PR TITLE
chore(test): rename used func in TestExtractHost

### DIFF
--- a/usecases/cluster/state_test.go
+++ b/usecases/cluster/state_test.go
@@ -590,7 +590,7 @@ func TestExtractHostPreservesValidIPForLookup(t *testing.T) {
 	// net.ParseIP does not accept zone IDs, but the extracted host is still
 	// usable for net.Dial and net.LookupIP which handle zones.
 	t.Run("IPv6 with zone ID", func(t *testing.T) {
-		host := extractJoinHost("[fe80::1%25eth0]:7946")
+		host := extractHost("[fe80::1%25eth0]:7946")
 		assert.Equal(t, "fe80::1%25eth0", host)
 		// Zone IDs are not parseable by net.ParseIP, but that's expected.
 		assert.Nil(t, net.ParseIP(host))


### PR DESCRIPTION
### What's being changed:
typo in used func
related to [this ](https://github.com/weaviate/weaviate/pull/10722)
### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
