### PR TITLE
optimization: object digest with partial unmarshalling

### DIFF
--- a/adapters/repos/db/index_async_replication.go
+++ b/adapters/repos/db/index_async_replication.go
@@ -13,7 +13,6 @@ package db
 
 import (
 	"fmt"
-	"math"
 	"os"
 	"strconv"
 	"time"
@@ -41,8 +40,8 @@ func asyncReplicationConfigFromModel(multiTenancyEnabled bool, cfg *models.Repli
 	config.maxWorkers, err = optParseInt(
 		os.Getenv("ASYNC_REPLICATION_MAX_WORKERS"),
 		maxWorkers,
-		1,
-		math.MaxInt,
+		minMaxWorkers,
+		maxMaxWorkers,
 	)
 	if err != nil {
 		return AsyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_MAX_WORKERS", err)

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -397,7 +397,7 @@ func (b *Bucket) resumeCompaction(ctx context.Context) error {
 // processing is stopped and the error is returned.
 // Note: this function pauses compaction while it is running, to ensure a consistent view of the data.
 func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
-	afterInMemCallback func(), f func(object *storobj.Object) error,
+	afterInMemCallback func(), f func(uuidBytes []byte, updateTime int64) error,
 ) error {
 	err := b.pauseCompaction(ctx)
 	if err != nil {
@@ -437,15 +437,15 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 			case <-ctx.Done():
 				return ctx.Err()
 			default:
-				obj, err := storobj.FromBinaryUUIDOnly(v)
+				docID, updateTime, err := storobj.DocIDAndTimeFromBinary(v)
 				if err != nil {
 					return fmt.Errorf("cannot unmarshal object: %w", err)
 				}
-				if err := f(obj); err != nil {
-					return fmt.Errorf("callback on object '%d' failed: %w", obj.DocID, err)
+				if err := f(k, updateTime); err != nil {
+					return fmt.Errorf("callback on object '%d' failed: %w", docID, err)
 				}
 
-				inmemProcessedDocIDs[obj.DocID] = struct{}{}
+				inmemProcessedDocIDs[docID] = struct{}{}
 			}
 		}
 
@@ -460,17 +460,17 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 		case <-ctx.Done():
 			return ctx.Err()
 		default:
-			obj, err := storobj.FromBinaryUUIDOnly(v)
+			docID, updateTime, err := storobj.DocIDAndTimeFromBinary(v)
 			if err != nil {
 				return fmt.Errorf("cannot unmarshal object: %w", err)
 			}
 
-			if _, ok := inmemProcessedDocIDs[obj.DocID]; ok {
+			if _, ok := inmemProcessedDocIDs[docID]; ok {
 				continue
 			}
 
-			if err := f(obj); err != nil {
-				return fmt.Errorf("callback on object '%d' failed: %w", obj.DocID, err)
+			if err := f(k, updateTime); err != nil {
+				return fmt.Errorf("callback on object '%d' failed: %w", docID, err)
 			}
 		}
 	}

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -1445,21 +1445,33 @@ func (_c *MockShardLike_Index_Call) RunAndReturn(run func() *Index) *MockShardLi
 }
 
 // ListBackupFiles provides a mock function with given fields: ctx, ret
-func (_m *MockShardLike) ListBackupFiles(ctx context.Context, ret *backup.ShardDescriptor) error {
+func (_m *MockShardLike) ListBackupFiles(ctx context.Context, ret *backup.ShardDescriptor) ([]string, error) {
 	ret_2 := _m.Called(ctx, ret)
 
 	if len(ret_2) == 0 {
 		panic("no return value specified for ListBackupFiles")
 	}
 
-	var r0 error
-	if rf, ok := ret_2.Get(0).(func(context.Context, *backup.ShardDescriptor) error); ok {
+	var r0 []string
+	var r1 error
+	if rf, ok := ret_2.Get(0).(func(context.Context, *backup.ShardDescriptor) ([]string, error)); ok {
+		return rf(ctx, ret)
+	}
+	if rf, ok := ret_2.Get(0).(func(context.Context, *backup.ShardDescriptor) []string); ok {
 		r0 = rf(ctx, ret)
 	} else {
-		r0 = ret_2.Error(0)
+		if ret_2.Get(0) != nil {
+			r0 = ret_2.Get(0).([]string)
+		}
 	}
 
-	return r0
+	if rf, ok := ret_2.Get(1).(func(context.Context, *backup.ShardDescriptor) error); ok {
+		r1 = rf(ctx, ret)
+	} else {
+		r1 = ret_2.Error(1)
+	}
+
+	return r0, r1
 }
 
 // MockShardLike_ListBackupFiles_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListBackupFiles'
@@ -1481,12 +1493,12 @@ func (_c *MockShardLike_ListBackupFiles_Call) Run(run func(ctx context.Context, 
 	return _c
 }
 
-func (_c *MockShardLike_ListBackupFiles_Call) Return(_a0 error) *MockShardLike_ListBackupFiles_Call {
-	_c.Call.Return(_a0)
+func (_c *MockShardLike_ListBackupFiles_Call) Return(_a0 []string, _a1 error) *MockShardLike_ListBackupFiles_Call {
+	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockShardLike_ListBackupFiles_Call) RunAndReturn(run func(context.Context, *backup.ShardDescriptor) error) *MockShardLike_ListBackupFiles_Call {
+func (_c *MockShardLike_ListBackupFiles_Call) RunAndReturn(run func(context.Context, *backup.ShardDescriptor) ([]string, error)) *MockShardLike_ListBackupFiles_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -1782,67 +1794,6 @@ func (_c *MockShardLike_ObjectByID_Call) RunAndReturn(run func(context.Context, 
 	return _c
 }
 
-// ObjectByIDErrDeleted provides a mock function with given fields: ctx, id, props, _a3
-func (_m *MockShardLike) ObjectByIDErrDeleted(ctx context.Context, id strfmt.UUID, props search.SelectProperties, _a3 additional.Properties) (*storobj.Object, error) {
-	ret := _m.Called(ctx, id, props, _a3)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ObjectByIDErrDeleted")
-	}
-
-	var r0 *storobj.Object
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, strfmt.UUID, search.SelectProperties, additional.Properties) (*storobj.Object, error)); ok {
-		return rf(ctx, id, props, _a3)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, strfmt.UUID, search.SelectProperties, additional.Properties) *storobj.Object); ok {
-		r0 = rf(ctx, id, props, _a3)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*storobj.Object)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, strfmt.UUID, search.SelectProperties, additional.Properties) error); ok {
-		r1 = rf(ctx, id, props, _a3)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockShardLike_ObjectByIDErrDeleted_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ObjectByIDErrDeleted'
-type MockShardLike_ObjectByIDErrDeleted_Call struct {
-	*mock.Call
-}
-
-// ObjectByIDErrDeleted is a helper method to define mock.On call
-//   - ctx context.Context
-//   - id strfmt.UUID
-//   - props search.SelectProperties
-//   - _a3 additional.Properties
-func (_e *MockShardLike_Expecter) ObjectByIDErrDeleted(ctx interface{}, id interface{}, props interface{}, _a3 interface{}) *MockShardLike_ObjectByIDErrDeleted_Call {
-	return &MockShardLike_ObjectByIDErrDeleted_Call{Call: _e.mock.On("ObjectByIDErrDeleted", ctx, id, props, _a3)}
-}
-
-func (_c *MockShardLike_ObjectByIDErrDeleted_Call) Run(run func(ctx context.Context, id strfmt.UUID, props search.SelectProperties, _a3 additional.Properties)) *MockShardLike_ObjectByIDErrDeleted_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(strfmt.UUID), args[2].(search.SelectProperties), args[3].(additional.Properties))
-	})
-	return _c
-}
-
-func (_c *MockShardLike_ObjectByIDErrDeleted_Call) Return(_a0 *storobj.Object, _a1 error) *MockShardLike_ObjectByIDErrDeleted_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockShardLike_ObjectByIDErrDeleted_Call) RunAndReturn(run func(context.Context, strfmt.UUID, search.SelectProperties, additional.Properties) (*storobj.Object, error)) *MockShardLike_ObjectByIDErrDeleted_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // ObjectCount provides a mock function with given fields: ctx
 func (_m *MockShardLike) ObjectCount(ctx context.Context) (int, error) {
 	ret := _m.Called(ctx)
@@ -1951,6 +1902,122 @@ func (_c *MockShardLike_ObjectCountAsync_Call) Return(_a0 int64, _a1 error) *Moc
 }
 
 func (_c *MockShardLike_ObjectCountAsync_Call) RunAndReturn(run func(context.Context) (int64, error)) *MockShardLike_ObjectCountAsync_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ObjectDigestErrDeleted provides a mock function with given fields: ctx, id
+func (_m *MockShardLike) ObjectDigestErrDeleted(ctx context.Context, id strfmt.UUID) (types.RepairResponse, error) {
+	ret := _m.Called(ctx, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ObjectDigestErrDeleted")
+	}
+
+	var r0 types.RepairResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, strfmt.UUID) (types.RepairResponse, error)); ok {
+		return rf(ctx, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, strfmt.UUID) types.RepairResponse); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Get(0).(types.RepairResponse)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, strfmt.UUID) error); ok {
+		r1 = rf(ctx, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockShardLike_ObjectDigestErrDeleted_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ObjectDigestErrDeleted'
+type MockShardLike_ObjectDigestErrDeleted_Call struct {
+	*mock.Call
+}
+
+// ObjectDigestErrDeleted is a helper method to define mock.On call
+//   - ctx context.Context
+//   - id strfmt.UUID
+func (_e *MockShardLike_Expecter) ObjectDigestErrDeleted(ctx interface{}, id interface{}) *MockShardLike_ObjectDigestErrDeleted_Call {
+	return &MockShardLike_ObjectDigestErrDeleted_Call{Call: _e.mock.On("ObjectDigestErrDeleted", ctx, id)}
+}
+
+func (_c *MockShardLike_ObjectDigestErrDeleted_Call) Run(run func(ctx context.Context, id strfmt.UUID)) *MockShardLike_ObjectDigestErrDeleted_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(strfmt.UUID))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_ObjectDigestErrDeleted_Call) Return(_a0 types.RepairResponse, _a1 error) *MockShardLike_ObjectDigestErrDeleted_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockShardLike_ObjectDigestErrDeleted_Call) RunAndReturn(run func(context.Context, strfmt.UUID) (types.RepairResponse, error)) *MockShardLike_ObjectDigestErrDeleted_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ObjectDigests provides a mock function with given fields: ctx, query
+func (_m *MockShardLike) ObjectDigests(ctx context.Context, query []multi.Identifier) ([]types.RepairResponse, error) {
+	ret := _m.Called(ctx, query)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ObjectDigests")
+	}
+
+	var r0 []types.RepairResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []multi.Identifier) ([]types.RepairResponse, error)); ok {
+		return rf(ctx, query)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []multi.Identifier) []types.RepairResponse); ok {
+		r0 = rf(ctx, query)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]types.RepairResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []multi.Identifier) error); ok {
+		r1 = rf(ctx, query)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockShardLike_ObjectDigests_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ObjectDigests'
+type MockShardLike_ObjectDigests_Call struct {
+	*mock.Call
+}
+
+// ObjectDigests is a helper method to define mock.On call
+//   - ctx context.Context
+//   - query []multi.Identifier
+func (_e *MockShardLike_Expecter) ObjectDigests(ctx interface{}, query interface{}) *MockShardLike_ObjectDigests_Call {
+	return &MockShardLike_ObjectDigests_Call{Call: _e.mock.On("ObjectDigests", ctx, query)}
+}
+
+func (_c *MockShardLike_ObjectDigests_Call) Run(run func(ctx context.Context, query []multi.Identifier)) *MockShardLike_ObjectDigests_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]multi.Identifier))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_ObjectDigests_Call) Return(_a0 []types.RepairResponse, _a1 error) *MockShardLike_ObjectDigests_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockShardLike_ObjectDigests_Call) RunAndReturn(run func(context.Context, []multi.Identifier) ([]types.RepairResponse, error)) *MockShardLike_ObjectDigests_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -613,9 +613,9 @@ func (idx *Index) OverwriteObjects(ctx context.Context,
 		var currUpdateTime int64 // 0 means object doesn't exist on this node
 		var locallyDeleted bool
 
-		localObj, err := s.ObjectByIDErrDeleted(ctx, id, nil, additional.Properties{})
+		localObj, err := s.ObjectDigestErrDeleted(ctx, id)
 		if err == nil {
-			currUpdateTime = localObj.LastUpdateTimeUnix()
+			currUpdateTime = localObj.UpdateTime
 		} else if errors.Is(err, lsmkv.Deleted) {
 			locallyDeleted = true
 			var errDeleted lsmkv.ErrDeleted
@@ -725,8 +725,6 @@ func (i *Index) IncomingOverwriteObjects(ctx context.Context,
 func (i *Index) DigestObjects(ctx context.Context,
 	shardName string, ids []strfmt.UUID,
 ) (result []types.RepairResponse, err error) {
-	result = make([]types.RepairResponse, len(ids))
-
 	s, release, err := i.GetShard(ctx, shardName)
 	if err != nil {
 		return nil, fmt.Errorf("shard %q not found locally", shardName)
@@ -746,41 +744,36 @@ func (i *Index) DigestObjects(ctx context.Context,
 		multiIDs[j] = multi.Identifier{ID: ids[j].String()}
 	}
 
-	objs, err := s.MultiObjectByID(ctx, multiIDs)
+	objs, err := s.ObjectDigests(ctx, multiIDs)
 	if err != nil {
 		return nil, fmt.Errorf("shard objects digest: %w", err)
 	}
 
 	for j := range objs {
-		if objs[j] == nil {
-			deleted, deletionTime, err := s.WasDeleted(ctx, ids[j])
-			if err != nil {
-				return nil, err
-			}
+		if objs[j].ID != "" {
+			continue
+		}
 
-			var updateTime int64
-			if deleted && !deletionTime.IsZero() {
-				updateTime = deletionTime.UnixMilli()
-			}
+		deleted, deletionTime, err := s.WasDeleted(ctx, ids[j])
+		if err != nil {
+			return nil, err
+		}
 
-			result[j] = types.RepairResponse{
-				ID:         ids[j].String(),
-				Deleted:    deleted,
-				UpdateTime: updateTime,
-				// TODO: use version when supported
-				Version: 0,
-			}
-		} else {
-			result[j] = types.RepairResponse{
-				ID:         objs[j].ID().String(),
-				UpdateTime: objs[j].LastUpdateTimeUnix(),
-				// TODO: use version when supported
-				Version: 0,
-			}
+		var updateTime int64
+		if deleted && !deletionTime.IsZero() {
+			updateTime = deletionTime.UnixMilli()
+		}
+
+		objs[j] = types.RepairResponse{
+			ID:         ids[j].String(),
+			Deleted:    deleted,
+			UpdateTime: updateTime,
+			// TODO: use version when supported
+			Version: 0,
 		}
 	}
 
-	return result, err
+	return objs, nil
 }
 
 func (i *Index) IncomingDigestObjects(ctx context.Context,

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -84,7 +84,7 @@ type ShardLike interface {
 	PutObject(context.Context, *storobj.Object) error
 	PutObjectBatch(context.Context, []*storobj.Object) []error
 	ObjectByID(ctx context.Context, id strfmt.UUID, props search.SelectProperties, additional additional.Properties) (*storobj.Object, error)
-	ObjectByIDErrDeleted(ctx context.Context, id strfmt.UUID, props search.SelectProperties, additional additional.Properties) (*storobj.Object, error)
+	ObjectDigestErrDeleted(ctx context.Context, id strfmt.UUID) (types.RepairResponse, error)
 	Exists(ctx context.Context, id strfmt.UUID) (bool, error)
 	ObjectSearch(ctx context.Context, limit int, filters *filters.LocalFilter, keywordRanking *searchparams.KeywordRanking, sort []filters.Sort, cursor *filters.Cursor, additional additional.Properties, properties []string) ([]*storobj.Object, []float32, error)
 	ObjectVectorSearch(ctx context.Context, searchVectors []models.Vector, targetVectors []string, targetDist float32, limit int, filters *filters.LocalFilter, sort []filters.Sort, groupBy *searchparams.GroupBy, additional additional.Properties, targetCombination *dto.TargetCombination, properties []string) ([]*storobj.Object, []float32, error)
@@ -94,6 +94,7 @@ type ShardLike interface {
 	DeleteObjectBatch(ctx context.Context, ids []strfmt.UUID, deletionTime time.Time, dryRun bool) objects.BatchSimpleObjects // Delete many objects by id
 	DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error                                           // Delete object by id
 	MultiObjectByID(ctx context.Context, query []multi.Identifier) ([]*storobj.Object, error)
+	ObjectDigests(ctx context.Context, query []multi.Identifier) ([]types.RepairResponse, error)
 	ObjectDigestsInRange(ctx context.Context, initialUUID, finalUUID strfmt.UUID, limit int) (objs []types.RepairResponse, err error)
 	ID() string // Get the shard id
 	drop(keepFiles bool) error

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -44,13 +44,13 @@ import (
 
 const (
 	defaultAsyncReplicationMaxWorkersSingleTenant = 3
-	defaultAsyncReplicationMaxWorkersMultiTenant  = 30
+	defaultAsyncReplicationMaxWorkersMultiTenant  = 5
 
-	defaultHashtreeHeightSingleTenant  = 16
+	defaultHashtreeHeightSingleTenant  = 20
 	defaultHashtreeHeightMultiTenant   = 10
 	defaultFrequency                   = 30 * time.Second
 	defaultFrequencyWhilePropagating   = 5 * time.Second
-	defaultAliveNodesCheckingFrequency = 5 * time.Second
+	defaultAliveNodesCheckingFrequency = 30 * time.Second
 	defaultLoggingFrequency            = 60 * time.Second
 	defaultDiffBatchSize               = 1_000
 	defaultDiffPerNodeTimeout          = 10 * time.Second
@@ -61,14 +61,17 @@ const (
 	defaultPropagationConcurrency      = 1
 	defaultPropagationBatchSize        = 100
 
+	minMaxWorkers = 1
+	maxMaxWorkers = 10
+
 	minHashtreeHeight = 0
-	maxHashtreeHeight = 20
+	maxHashtreeHeight = 22
 
 	minDiffBatchSize = 1
 	maxDiffBatchSize = 10_000
 
 	minPropagationLimit = 1
-	maxPropagationLimit = 1_000_000
+	maxPropagationLimit = 100_000
 
 	minPropagationConcurrency = 1
 	maxPropagationConcurrency = 20
@@ -257,7 +260,7 @@ func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig,
 	objCount := 0
 	prevProgressLogging := time.Now()
 
-	err = bucket.ApplyToObjectDigests(ctx, releaseInitialization, func(object *storobj.Object) error {
+	err = bucket.ApplyToObjectDigests(ctx, releaseInitialization, func(uuidBytes []byte, updateTime int64) error {
 		if time.Since(prevProgressLogging) >= config.loggingFrequency {
 			s.index.logger.
 				WithField("action", "async_replication").
@@ -269,15 +272,12 @@ func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig,
 			prevProgressLogging = time.Now()
 		}
 
-		uuidBytes, err := parseBytesUUID(object.ID())
-		if err != nil {
-			return err
-		}
-
 		s.asyncReplicationRWMux.RLock()
 		defer s.asyncReplicationRWMux.RUnlock()
 
-		err = s.mayUpsertObjectHashTree(object, uuidBytes, objectInsertStatus{})
+		obj := &storobj.Object{}
+		obj.Object.LastUpdateTimeUnix = updateTime
+		err := s.mayUpsertObjectHashTree(obj, uuidBytes, objectInsertStatus{})
 		if err != nil {
 			return err
 		}

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -244,11 +244,11 @@ func (l *LazyLoadShard) ObjectByID(ctx context.Context, id strfmt.UUID, props se
 	return l.shard.ObjectByID(ctx, id, props, additional)
 }
 
-func (l *LazyLoadShard) ObjectByIDErrDeleted(ctx context.Context, id strfmt.UUID, props search.SelectProperties, additional additional.Properties) (*storobj.Object, error) {
+func (l *LazyLoadShard) ObjectDigestErrDeleted(ctx context.Context, id strfmt.UUID) (types.RepairResponse, error) {
 	if err := l.Load(ctx); err != nil {
-		return nil, err
+		return types.RepairResponse{}, err
 	}
-	return l.shard.ObjectByIDErrDeleted(ctx, id, props, additional)
+	return l.shard.ObjectDigestErrDeleted(ctx, id)
 }
 
 func (l *LazyLoadShard) Exists(ctx context.Context, id strfmt.UUID) (bool, error) {
@@ -349,13 +349,19 @@ func (l *LazyLoadShard) MultiObjectByID(ctx context.Context, query []multi.Ident
 	return l.shard.MultiObjectByID(ctx, query)
 }
 
+func (l *LazyLoadShard) ObjectDigests(ctx context.Context, query []multi.Identifier) ([]types.RepairResponse, error) {
+	if err := l.Load(ctx); err != nil {
+		return nil, err
+	}
+	return l.shard.ObjectDigests(ctx, query)
+}
+
 func (l *LazyLoadShard) ObjectDigestsInRange(ctx context.Context,
 	initialUUID, finalUUID strfmt.UUID, limit int,
 ) (objs []types.RepairResponse, err error) {
-	if !l.isLoaded() {
+	if err := l.Load(ctx); err != nil {
 		return nil, err
 	}
-
 	return l.shard.ObjectDigestsInRange(ctx, initialUUID, finalUUID, limit)
 }
 

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -42,27 +42,32 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 )
 
-func (s *Shard) ObjectByIDErrDeleted(ctx context.Context, id strfmt.UUID, props search.SelectProperties, additional additional.Properties) (*storobj.Object, error) {
+func (s *Shard) ObjectDigestErrDeleted(ctx context.Context, id strfmt.UUID) (types.RepairResponse, error) {
+	s.activityTrackerRead.Add(1)
+
 	idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
 	if err != nil {
-		return nil, err
+		return types.RepairResponse{}, err
 	}
 
 	bytes, err := s.store.Bucket(helpers.ObjectsBucketLSM).GetErrDeleted(idBytes)
 	if err != nil {
-		return nil, err
+		return types.RepairResponse{}, err
 	}
 
-	if bytes == nil {
-		return nil, nil
-	}
-
-	obj, err := storobj.FromBinary(bytes)
+	_, updateTime, err := storobj.DocIDAndTimeFromBinary(bytes)
 	if err != nil {
-		return nil, errors.Wrap(err, "unmarshal object")
+		return types.RepairResponse{}, fmt.Errorf("cannot extract updateTime from binary header for id %s: %w", id.String(), err)
 	}
 
-	return obj, nil
+	replicaObj := types.RepairResponse{
+		ID:         id.String(),
+		UpdateTime: updateTime,
+		// TODO: use version when supported
+		Version: 0,
+	}
+
+	return replicaObj, nil
 }
 
 func (s *Shard) ObjectByID(ctx context.Context, id strfmt.UUID, props search.SelectProperties, additional additional.Properties) (*storobj.Object, error) {
@@ -124,6 +129,41 @@ func (s *Shard) MultiObjectByID(ctx context.Context, query []multi.Identifier) (
 	return objects, nil
 }
 
+func (s *Shard) ObjectDigests(ctx context.Context, query []multi.Identifier) ([]types.RepairResponse, error) {
+	s.activityTrackerRead.Add(1)
+
+	objects := make([]types.RepairResponse, len(query))
+
+	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	for i, q := range query {
+		idBytes, err := uuid.MustParse(q.ID).MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+
+		data, err := bucket.Get(idBytes)
+		if err != nil {
+			return nil, err
+		}
+
+		if data == nil {
+			continue
+		}
+
+		_, updateTime, err := storobj.DocIDAndTimeFromBinary(data)
+		if err != nil {
+			return nil, errors.Wrap(err, "cannot extract docID/updateTime from binary header")
+		}
+
+		objects[i] = types.RepairResponse{
+			ID:         q.ID,
+			UpdateTime: updateTime,
+		}
+	}
+
+	return objects, nil
+}
+
 func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 	initialUUID, finalUUID strfmt.UUID, limit int) (
 	objs []types.RepairResponse, err error,
@@ -150,14 +190,19 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 			return objs, ctx.Err()
 		}
 
-		obj, err := storobj.FromBinaryUUIDOnly(v)
+		_, updateTime, err := storobj.DocIDAndTimeFromBinary(v)
 		if err != nil {
-			return objs, fmt.Errorf("cannot unmarshal object: %w", err)
+			return objs, fmt.Errorf("cannot extract docID/updateTime from binary header: %w", err)
+		}
+
+		uuidParsed, err := uuid.FromBytes(k)
+		if err != nil {
+			return objs, fmt.Errorf("cannot parse object uuid: %w", err)
 		}
 
 		replicaObj := types.RepairResponse{
-			ID:         obj.ID().String(),
-			UpdateTime: obj.LastUpdateTimeUnix(),
+			ID:         uuidParsed.String(),
+			UpdateTime: updateTime,
 			// TODO: use version when supported
 			Version: 0,
 		}

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -12,12 +12,10 @@
 package storobj
 
 import (
-	"bytes"
 	"context"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"io"
 	"math"
 	"runtime"
 
@@ -713,39 +711,20 @@ func DocIDFromBinary(in []byte) (uint64, error) {
 	if len(in) < 9 {
 		return 0, errors.Errorf("binary data too short")
 	}
-	// first by is kind, then 8 bytes for the docID
+	// byte 0 is the marshaller version; bytes 1-8 are the docID (little-endian uint64)
 	return binary.LittleEndian.Uint64(in[1:9]), nil
 }
 
-func DocIDAndTimeFromBinary(in []byte) (docID uint64, updateTime int64, err error) {
-	r := bytes.NewReader(in)
-
-	var version uint8
-
-	le := binary.LittleEndian
-
-	if err := binary.Read(r, le, &version); err != nil {
-		return 0, 0, err
+func DocIDAndTimeFromBinary(in []byte) (uint64, int64, error) {
+	// Additional fields may follow after the header and are ignored.
+	if len(in) < marshallerV1HeaderLen {
+		return 0, 0, errors.Errorf("binary data too short")
 	}
-
-	if version != 1 {
-		return 0, 0, errors.Errorf("unsupported binary marshaller version %d", version)
+	if in[0] != 1 {
+		return 0, 0, errors.Errorf("unsupported binary marshaller version %d", in[0])
 	}
-
-	err = binary.Read(r, le, &docID)
-	if err != nil {
-		return 0, 0, err
-	}
-
-	var buf [1 + 16 + 8 + 8]byte // kind uuid createtime updatetime
-
-	_, err = io.ReadFull(r, buf[:])
-	if err != nil {
-		return 0, 0, err
-	}
-
-	updateTime = int64(binary.LittleEndian.Uint64(buf[1+16+8:]))
-
+	docID := binary.LittleEndian.Uint64(in[1:9])
+	updateTime := int64(binary.LittleEndian.Uint64(in[marshallerV1UpdateTimeOffset:marshallerV1HeaderLen]))
 	return docID, updateTime, nil
 }
 
@@ -781,6 +760,13 @@ func DocIDAndTimeFromBinary(in []byte) (docID uint64, updateTime int64, err erro
 // 4             | uint32                   | length of multivectors segment (in bytes)
 // 4 + (2 + n*4) | uint32 + (uint16+[]byte) | multivectors segment: num vecs + (vec length + vec floats), ...
 // TODO vec lengths immediately following num vecs so you can jump straight to specific vec?
+
+// Binary header layout (version 1):
+// version(1) + docID(8) + kind(1) + uuid(16) + createTime(8) + updateTime(8) = 42 bytes
+const (
+	marshallerV1HeaderLen        = 1 + 8 + 1 + 16 + 8 + 8 // 42
+	marshallerV1UpdateTimeOffset = 1 + 8 + 1 + 16 + 8     // 34
+)
 
 const (
 	maxVectorLength               int = math.MaxUint16
@@ -1455,7 +1441,7 @@ func VectorFromBinary(in []byte, buffer []float32, targetVector string) ([]float
 	// assume that we can directly access the vector length field. The only
 	// situation where this is not accessible would be on corrupted data - where
 	// it would be acceptable to panic
-	vecLen := binary.LittleEndian.Uint16(in[42:44])
+	vecLen := binary.LittleEndian.Uint16(in[marshallerV1HeaderLen : marshallerV1HeaderLen+2])
 
 	var out []float32
 	if cap(buffer) >= int(vecLen) {
@@ -1506,7 +1492,7 @@ func MultiVectorFromBinary(in []byte, buffer []float32, targetVector string) ([]
 	// assume that we can directly access the vector length field. The only
 	// situation where this is not accessible would be on corrupted data - where
 	// it would be acceptable to panic
-	vecLen := binary.LittleEndian.Uint16(in[42:44])
+	vecLen := binary.LittleEndian.Uint16(in[marshallerV1HeaderLen : marshallerV1HeaderLen+2])
 
 	var out []float32
 	if cap(buffer) >= int(vecLen) {

--- a/entities/storobj/storage_object_test.go
+++ b/entities/storobj/storage_object_test.go
@@ -1813,6 +1813,33 @@ func genFakeBucket(t testing.TB, maxSize uint64) *fakeBucket {
 	return bucket
 }
 
+func TestDocIDAndTimeFromBinary_Errors(t *testing.T) {
+	t.Run("input too short returns error", func(t *testing.T) {
+		for _, length := range []int{0, 1, 10, 41} {
+			input := make([]byte, length)
+			_, _, err := DocIDAndTimeFromBinary(input)
+			require.Error(t, err, "expected error for input length %d", length)
+			assert.Contains(t, err.Error(), "binary data too short")
+		}
+	})
+
+	t.Run("unsupported marshaller version returns error", func(t *testing.T) {
+		input := make([]byte, 42)
+		input[0] = 2 // version 2 is unsupported
+		_, _, err := DocIDAndTimeFromBinary(input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported binary marshaller version 2")
+	})
+
+	t.Run("version 0 returns error", func(t *testing.T) {
+		input := make([]byte, 42)
+		input[0] = 0
+		_, _, err := DocIDAndTimeFromBinary(input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported binary marshaller version 0")
+	})
+}
+
 func pickRandomIDsBetween(start, end uint64, count int) []uint64 {
 	ids := make([]uint64, count)
 	for i := 0; i < count; i++ {

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1385,7 +1385,7 @@ const (
 	DefaultGRPCPort                            = 50051
 	DefaultGRPCMaxMsgSize                      = 104858000 // 100 * 1024 * 1024 + 400
 	DefaultMinimumReplicationFactor            = 1
-	DefaultAsyncReplicationClusterMaxWorkers   = 30
+	DefaultAsyncReplicationClusterMaxWorkers   = 15
 	DefaultMaximumAllowedCollectionsCount      = -1 // unlimited
 )
 


### PR DESCRIPTION
### What's being changed:

This pull request introduces several changes to the asynchronous replication and object digest APIs in the database adapter layer. The main focus is on improving and refactoring the way object digests are handled for replication and repair, including interface changes, mock updates, and adjustments to default configuration parameters.

**API and Interface Refactoring:**

* Replaced the `ObjectByIDErrDeleted` method in the `ShardLike` interface with `ObjectDigestErrDeleted`, which now returns a `types.RepairResponse` instead of a full object. Added a new `ObjectDigests` method for batch retrieval of object digests. These changes are reflected in both the interface and its mock implementations. [[1]](diffhunk://#diff-f5ceda6e94dc8658eea9558fa308aa70db8835f5a0d07762a7cc8ea445777034L87-R87) [[2]](diffhunk://#diff-f5ceda6e94dc8658eea9558fa308aa70db8835f5a0d07762a7cc8ea445777034R97) [[3]](diffhunk://#diff-496907f60760c7795d469b0e468fb5f4d5447889dc7494403a113a147c516597R1909-R2024) [[4]](diffhunk://#diff-da3785a57e3e2760e83c3f147c52db256b03105e52549b18f84f1a98c9a31e28L247-R251) [[5]](diffhunk://#diff-da3785a57e3e2760e83c3f147c52db256b03105e52549b18f84f1a98c9a31e28R352-L358)

* Updated all relevant code paths to use the new digest API, including replacing usages of `ObjectByIDErrDeleted` with `ObjectDigestErrDeleted` and `MultiObjectByID` with `ObjectDigests` where appropriate. [[1]](diffhunk://#diff-43faf3509d2b0cde090504767f99a960363ab7a7d4075b7ab8c3f56b0da1331aL616-R618) [[2]](diffhunk://#diff-43faf3509d2b0cde090504767f99a960363ab7a7d4075b7ab8c3f56b0da1331aL749-R756) [[3]](diffhunk://#diff-43faf3509d2b0cde090504767f99a960363ab7a7d4075b7ab8c3f56b0da1331aL766-R776)

**Mock and Test Code Updates:**

* Refactored the `MockShardLike` mock implementation to support the new digest methods, including removal of the old `ObjectByIDErrDeleted` mock and addition of mocks for `ObjectDigestErrDeleted` and `ObjectDigests`. Adjusted related test helpers and return signatures. [[1]](diffhunk://#diff-496907f60760c7795d469b0e468fb5f4d5447889dc7494403a113a147c516597L1785-L1845) [[2]](diffhunk://#diff-496907f60760c7795d469b0e468fb5f4d5447889dc7494403a113a147c516597R1909-R2024)

* Updated the mock for `ListBackupFiles` to return a slice of strings and an error, matching its real signature. [[1]](diffhunk://#diff-496907f60760c7795d469b0e468fb5f4d5447889dc7494403a113a147c516597L1448-R1474) [[2]](diffhunk://#diff-496907f60760c7795d469b0e468fb5f4d5447889dc7494403a113a147c516597L1484-R1501)

**Replication and Compaction Logic:**

* Modified the compaction and hashtree initialization logic to use the new digest callback signature, passing UUID bytes and update time instead of full objects, and updated related logic to match. [[1]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28L400-R400) [[2]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28L440-R448) [[3]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28L463-R473) [[4]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L260-R263) [[5]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L272-R280)

**Configuration and Defaults:**

* Adjusted default and maximum values for async replication workers and hashtree height, and introduced new constants for min/max validation. [[1]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L47-R49) [[2]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210R64-R68) [[3]](diffhunk://#diff-4f91fe61f6a7baa52e723c4fdce2ef55b193172cd9c4f3171c80f8cdd87183beL44-R44)

**Cleanup:**

* Removed an unnecessary import of the `math` package from `index_async_replication.go`.

These changes collectively improve the efficiency, clarity, and maintainability of the replication and repair logic, especially in how object digests are queried and processed.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
