### PR TITLE
Remove immutability checks for skipDefaultQuantization/trackDefaultQuantization

### DIFF
--- a/adapters/repos/db/vector/hnsw/config_update.go
+++ b/adapters/repos/db/vector/hnsw/config_update.go
@@ -62,14 +62,6 @@ func ValidateUserConfigUpdate(initial, updated config.VectorIndexConfig) error {
 			name:     "muvera enabled",
 			accessor: func(c ent.UserConfig) interface{} { return c.Multivector.MuveraConfig.Enabled },
 		},
-		{
-			name:     "skipDefaultQuantization",
-			accessor: func(c ent.UserConfig) interface{} { return c.SkipDefaultQuantization },
-		},
-		{
-			name:     "trackDefaultQuantization",
-			accessor: func(c ent.UserConfig) interface{} { return c.TrackDefaultQuantization },
-		},
 	}
 
 	for _, u := range immutableFields {

--- a/adapters/repos/db/vector/hnsw/config_update_test.go
+++ b/adapters/repos/db/vector/hnsw/config_update_test.go
@@ -64,20 +64,16 @@ func TestUserConfigUpdates(t *testing.T) {
 						"attempted change from \"cosine\" to \"l2-squared\""),
 			},
 			{
-				name:    "attempting to change skipDefaultQuantization",
-				initial: ent.UserConfig{SkipDefaultQuantization: true},
-				update:  ent.UserConfig{SkipDefaultQuantization: false},
-				expectedError: errors.Errorf(
-					"skipDefaultQuantization is immutable: " +
-						"attempted change from \"true\" to \"false\""),
+				name:          "attempting to change skipDefaultQuantization",
+				initial:       ent.UserConfig{SkipDefaultQuantization: true},
+				update:        ent.UserConfig{SkipDefaultQuantization: false},
+				expectedError: nil,
 			},
 			{
-				name:    "attempting to change trackDefaultQuantization",
-				initial: ent.UserConfig{TrackDefaultQuantization: true},
-				update:  ent.UserConfig{TrackDefaultQuantization: false},
-				expectedError: errors.Errorf(
-					"trackDefaultQuantization is immutable: " +
-						"attempted change from \"true\" to \"false\""),
+				name:          "attempting to change trackDefaultQuantization",
+				initial:       ent.UserConfig{TrackDefaultQuantization: true},
+				update:        ent.UserConfig{TrackDefaultQuantization: false},
+				expectedError: nil,
 			},
 			{
 				name: "attempting to change multivector",

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -1012,6 +1012,29 @@ func validateImmutableFields(initial, updated *models.Class, modulesProvider mod
 			continue
 		}
 
+		// SkipDefaultQuantization and TrackDefaultQuantization must be effectively immutable
+		// without enforcing that on the client. We just set these fields to their initial values.
+		switch cfg := v.VectorIndexConfig.(type) {
+		case hnsw.UserConfig:
+			cfgInitial := initial.VectorConfig[k].VectorIndexConfig.(hnsw.UserConfig)
+			cfg.SkipDefaultQuantization = cfgInitial.SkipDefaultQuantization
+			cfg.TrackDefaultQuantization = cfgInitial.TrackDefaultQuantization
+			v.VectorIndexConfig = cfg
+		case flat.UserConfig:
+			cfgInitial := initial.VectorConfig[k].VectorIndexConfig.(flat.UserConfig)
+			cfg.SkipDefaultQuantization = cfgInitial.SkipDefaultQuantization
+			cfg.TrackDefaultQuantization = cfgInitial.TrackDefaultQuantization
+			v.VectorIndexConfig = cfg
+		case dynamic.UserConfig:
+			cfgInitial := initial.VectorConfig[k].VectorIndexConfig.(dynamic.UserConfig)
+			cfg.HnswUC.SkipDefaultQuantization = cfgInitial.HnswUC.SkipDefaultQuantization
+			cfg.HnswUC.TrackDefaultQuantization = cfgInitial.HnswUC.TrackDefaultQuantization
+			cfg.FlatUC.SkipDefaultQuantization = cfgInitial.FlatUC.SkipDefaultQuantization
+			cfg.FlatUC.TrackDefaultQuantization = cfgInitial.FlatUC.TrackDefaultQuantization
+			v.VectorIndexConfig = cfg
+		}
+		updated.VectorConfig[k] = v
+
 		if !deepEqualVectorizerSettings(initial.VectorConfig[k].Vectorizer, v.Vectorizer) {
 			// There might be module settings that need to be migrated to new names, for example
 			// if baseUrl property setting was renamed to baseURL then we need to adjust module settings

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/vectorindex/dynamic"
+	"github.com/weaviate/weaviate/entities/vectorindex/flat"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/cluster/mocks"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -1384,6 +1386,129 @@ func Test_UpdateClass(t *testing.T) {
 		err := handler.UpdateClass(context.Background(), nil, "WrongClass", &models.Class{ReplicationConfig: &models.ReplicationConfig{Factor: 1}})
 		require.ErrorIs(t, err, ErrNotFound)
 		fakeSchemaManager.AssertExpectations(t)
+	})
+
+	t.Run("immutable vectorizer properties", func(t *testing.T) {
+		deepCopy := func(t *testing.T, vc *models.Class) *models.Class {
+			t.Helper()
+
+			b, err := json.Marshal(vc)
+			require.NoError(t, err, "deep copy %+v", vc)
+
+			var dest models.Class
+			err = json.Unmarshal(b, &dest)
+			require.NoError(t, err, "deep copy %s", string(b))
+
+			return &dest
+		}
+
+		for _, tt := range []struct {
+			indexType                string
+			initial, updated         any
+			skipDefaultQuantization  func(cfg any) bool
+			trackDefaultQuantization func(cfg any) bool
+		}{
+			{
+				indexType: "hnsw",
+				initial: hnsw.UserConfig{
+					SkipDefaultQuantization:  true,
+					TrackDefaultQuantization: true,
+				},
+				updated: *new(hnsw.UserConfig),
+				skipDefaultQuantization: func(cfg any) bool {
+					return cfg.(hnsw.UserConfig).SkipDefaultQuantization
+				},
+				trackDefaultQuantization: func(cfg any) bool {
+					return cfg.(hnsw.UserConfig).TrackDefaultQuantization
+				},
+			},
+			{
+				indexType: "flat",
+				initial: flat.UserConfig{
+					SkipDefaultQuantization:  true,
+					TrackDefaultQuantization: true,
+				},
+				updated: *new(flat.UserConfig),
+				skipDefaultQuantization: func(cfg any) bool {
+					return cfg.(flat.UserConfig).SkipDefaultQuantization
+				},
+				trackDefaultQuantization: func(cfg any) bool {
+					return cfg.(flat.UserConfig).TrackDefaultQuantization
+				},
+			},
+			{
+				indexType: "dynamic hnsw",
+				initial: dynamic.UserConfig{
+					HnswUC: hnsw.UserConfig{
+						SkipDefaultQuantization:  true,
+						TrackDefaultQuantization: true,
+					},
+				},
+				updated: *new(dynamic.UserConfig),
+				skipDefaultQuantization: func(cfg any) bool {
+					return cfg.(dynamic.UserConfig).HnswUC.SkipDefaultQuantization
+				},
+				trackDefaultQuantization: func(cfg any) bool {
+					return cfg.(dynamic.UserConfig).HnswUC.TrackDefaultQuantization
+				},
+			},
+			{
+				indexType: "dynamic flat",
+				initial: dynamic.UserConfig{
+					FlatUC: flat.UserConfig{
+						SkipDefaultQuantization:  true,
+						TrackDefaultQuantization: true,
+					},
+				},
+				updated: *new(dynamic.UserConfig),
+				skipDefaultQuantization: func(cfg any) bool {
+					return cfg.(dynamic.UserConfig).FlatUC.SkipDefaultQuantization
+				},
+				trackDefaultQuantization: func(cfg any) bool {
+					return cfg.(dynamic.UserConfig).FlatUC.TrackDefaultQuantization
+				},
+			},
+		} {
+			t.Run(tt.indexType, func(t *testing.T) {
+				initial := &models.Class{
+					Class: "Immutable",
+					ReplicationConfig: &models.ReplicationConfig{
+						Factor: 1,
+					},
+					VectorConfig: map[string]models.VectorConfig{
+						"example": {
+							VectorIndexType:   tt.indexType,
+							VectorIndexConfig: tt.initial,
+							Vectorizer: map[string]any{
+								"none": map[string]any{},
+							},
+						},
+					},
+				}
+
+				updated := deepCopy(t, initial)
+				updated.VectorConfig["example"] = models.VectorConfig{
+					VectorIndexType:   tt.indexType,
+					VectorIndexConfig: tt.updated,
+					Vectorizer: map[string]any{
+						"none": map[string]any{},
+					},
+				}
+
+				err := validateImmutableFields(initial, updated, nil)
+				require.NoError(t, err, "validate immutable fields")
+
+				assert.Equal(t,
+					tt.skipDefaultQuantization(updated.VectorConfig["example"].VectorIndexConfig),
+					tt.skipDefaultQuantization(initial.VectorConfig["example"].VectorIndexConfig),
+					"skipDefaultQuantization")
+
+				assert.Equal(t,
+					tt.trackDefaultQuantization(updated.VectorConfig["example"].VectorIndexConfig),
+					tt.trackDefaultQuantization(initial.VectorConfig["example"].VectorIndexConfig),
+					"trackDefaultQuantization")
+			})
+		}
 	})
 
 	t.Run("fields validation", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Both values are only read on the AddClass path,
not on the UpdateClass path. They can be (and actually are) ignored for the purposes of schema update.

Fields skipDefaultQuantization and trackDefaultQuantization must be effectively immutable in that the updated collection config always has the initial values.

### Review checklist
- [x] Chaos pipeline run or **not necessary**. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or **not necessary**.
