### PR TITLE
Fix flaky test by waiting for terminal states

### DIFF
--- a/usecases/backup/backupper_test.go
+++ b/usecases/backup/backupper_test.go
@@ -41,7 +41,7 @@ func (r *backupper) waitForCompletion(n, ms int) backup.Status {
 		if i < 1 {
 			continue
 		}
-		if x := r.lastOp.get(); x.Status != "" {
+		if x := r.lastOp.get(); x.Status == backup.Success || x.Status == backup.Failed || x.Status == backup.Cancelled {
 			return x.Status
 		}
 	}


### PR DESCRIPTION
### What's being changed:

`waitForCompletion` returns for every non-"" state. However, a backup will transition through some intermediate states (Started, Transferring) before finishing. On a fast local machine the backup is completed before the first check. But on slow CI machines it can take a bit longer and sometimes it hits an intermediate state and fails

Fixed by waiting explicitly for Terminal states

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
