### PR TITLE
Fix race in backup test

### DIFF
--- a/usecases/backup/backupper_test.go
+++ b/usecases/backup/backupper_test.go
@@ -237,9 +237,9 @@ func TestManagerCoordinatedBackup(t *testing.T) {
 		err := m.OnCommit(ctx, &StatusRequest{OpCreate, req.ID, backendName, "", "", ""})
 		assert.Nil(t, err)
 		m.backupper.waitForCompletion(20, 50)
-		meta := backend.getMeta()
-		assert.Equal(t, backup.Success, meta.Status)
-		assert.Equal(t, "", meta.Error)
+		status, errMsg := backend.getMetaStatus()
+		assert.Equal(t, backup.Success, status)
+		assert.Equal(t, "", errMsg)
 	})
 
 	t.Run("AbortBeforeCommit", func(t *testing.T) {
@@ -308,11 +308,11 @@ func TestManagerCoordinatedBackup(t *testing.T) {
 		err := m.OnCommit(ctx, &StatusRequest{OpCreate, req.ID, backendName, "", "", ""})
 		assert.Nil(t, err)
 		m.backupper.waitForCompletion(20, 50)
-		meta := backend.getMeta()
-		assert.Equal(t, backup.Cancelled, meta.Status)
-		errMsg := context.Canceled.Error()
-		assert.Equal(t, errMsg, meta.Error)
-		assert.Contains(t, m.backupper.lastAsyncError.Error(), errMsg)
+		status, metaErr := backend.getMetaStatus()
+		assert.Equal(t, backup.Cancelled, status)
+		wantErr := context.Canceled.Error()
+		assert.Equal(t, wantErr, metaErr)
+		assert.Contains(t, m.backupper.lastAsyncError.Error(), wantErr)
 	})
 
 	t.Run("ExpirationTimeout", func(t *testing.T) {

--- a/usecases/backup/fakes_test.go
+++ b/usecases/backup/fakes_test.go
@@ -82,10 +82,10 @@ type fakeBackend struct {
 	doneChan chan bool
 }
 
-func (fb *fakeBackend) getMeta() backup.BackupDescriptor {
+func (fb *fakeBackend) getMetaStatus() (backup.Status, string) {
 	fb.RLock()
 	defer fb.RUnlock()
-	return fb.meta
+	return fb.meta.Status, fb.meta.Error
 }
 
 func newFakeBackend() *fakeBackend {


### PR DESCRIPTION
### What's being changed:

The test reads backend.meta.Status and backend.meta.Error directly (without a lock) after waitForCompletion returns. The backup goroutine may still be writing to fb.meta via json.Unmarshal in PutObject (which does hold the lock). The read side was unprotected which is fixed now.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
