### PR TITLE
fix: return error instead of panic on truncated segment file

### DIFF
--- a/adapters/repos/db/lsmkv/segment.go
+++ b/adapters/repos/db/lsmkv/segment.go
@@ -263,6 +263,10 @@ func newSegment(path string, logger logrus.FieldLogger, metrics *Metrics,
 		readFromMemory = true
 		useBloomFilter = false
 	}
+	if len(contents) < segmentindex.HeaderSize {
+		return nil, fmt.Errorf("segment file too small: %d bytes, need at least %d for header",
+			len(contents), segmentindex.HeaderSize)
+	}
 	header, err := segmentindex.ParseHeader(contents[:segmentindex.HeaderSize])
 	if err != nil {
 		return nil, fmt.Errorf("parse header: %w", err)

--- a/adapters/repos/db/lsmkv/segment_test.go
+++ b/adapters/repos/db/lsmkv/segment_test.go
@@ -243,3 +243,18 @@ func createSegmentFilesUsingBucket(t *testing.T, ctx context.Context, logger log
 	err = diskio.Fsync(path)
 	require.NoError(t, err)
 }
+
+func TestSegment_TruncatedFileReturnsError(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	existsOnLower := func(key []byte) (bool, error) { return false, nil }
+
+	dir := t.TempDir()
+	segPath := filepath.Join(dir, "truncated.db")
+
+	// Write a file smaller than the 16-byte header
+	require.NoError(t, os.WriteFile(segPath, []byte("short"), 0o644))
+
+	_, err := newSegment(segPath, logger, nil, existsOnLower, segmentConfig{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "segment file too small")
+}


### PR DESCRIPTION
## Summary
- Add bounds check in `newSegment()` before slicing `contents[:segmentindex.HeaderSize]` to prevent `runtime error: slice bounds out of range` panic when loading a truncated/corrupted segment file
- Returns a descriptive error: `"segment file too small: N bytes, need at least 16 for header"`
- Adds test `TestSegment_TruncatedFileReturnsError` verifying the fix

Fixes #10251

## Test plan
- [x] New unit test creates a 5-byte file, calls `newSegment()`, asserts error (not panic)
- [x] `go test ./adapters/repos/db/lsmkv/... -run TestSegment_TruncatedFileReturnsError` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)