### PR TITLE
fix(schema): prevent panic when creating/updating tenants with null parameters

### DIFF
--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -40,6 +40,12 @@ func (h *Handler) AddTenants(ctx context.Context,
 	class string,
 	tenants []*models.Tenant,
 ) (uint64, error) {
+	for i, tenant := range tenants {
+		if tenant == nil {
+			return 0, uco.NewErrInvalidUserInput("tenant at index %d is null", i)
+		}
+	}
+
 	tenantNames := make([]string, len(tenants))
 	for i, tenant := range tenants {
 		tenantNames[i] = tenant.Name
@@ -78,6 +84,10 @@ func validateTenants(tenants []*models.Tenant, allowOverHundred bool) (validated
 	}
 	uniq := make(map[string]*models.Tenant)
 	for i, requested := range tenants {
+		if requested == nil {
+			err = uco.NewErrInvalidUserInput("tenant at index %d is null", i)
+			return validated, err
+		}
 		if errMsg := schema.ValidateTenantName(requested.Name); errMsg != nil {
 			err = uco.NewErrInvalidUserInput("tenant name at index %d: %s", i, errMsg.Error())
 			return validated, err
@@ -145,6 +155,12 @@ func (h *Handler) validateActivityStatuses(ctx context.Context, tenants []*model
 func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal,
 	class string, tenants []*models.Tenant,
 ) ([]*models.Tenant, error) {
+	for i, tenant := range tenants {
+		if tenant == nil {
+			return nil, uco.NewErrInvalidUserInput("tenant at index %d is null", i)
+		}
+	}
+
 	shardNames := make([]string, len(tenants))
 	for idx := range tenants {
 		shardNames[idx] = tenants[idx].Name

--- a/usecases/schema/tenant_test.go
+++ b/usecases/schema/tenant_test.go
@@ -107,6 +107,17 @@ func TestAddTenants(t *testing.T) {
 			mockCalls: func(fakeSchemaManager *fakeSchemaManager) {},
 		},
 		{
+			name:  "NilTenantInArray",
+			class: mtEnabledClass.Class,
+			tenants: []*models.Tenant{
+				{Name: "Aaaa"},
+				nil,
+				{Name: "Bbbb"},
+			},
+			errMsgs:   []string{"null"},
+			mockCalls: func(fakeSchemaManager *fakeSchemaManager) {},
+		},
+		{
 			name:  "InvalidActivityStatus",
 			class: mtEnabledClass.Class,
 			tenants: []*models.Tenant{
@@ -251,6 +262,17 @@ func TestUpdateTenants(t *testing.T) {
 				{Name: "", ActivityStatus: models.TenantActivityStatusCOLD},
 			},
 			errMsgs:         []string{"tenant"},
+			expectedTenants: tenants,
+			mockCalls:       func(fakeSchemaManager *fakeSchemaManager) {},
+		},
+		{
+			name:  "NilTenantInArray",
+			class: mtEnabledClass.Class,
+			updateTenants: []*models.Tenant{
+				{Name: tenants[0].Name, ActivityStatus: models.TenantActivityStatusCOLD},
+				nil,
+			},
+			errMsgs:         []string{"null"},
 			expectedTenants: tenants,
 			mockCalls:       func(fakeSchemaManager *fakeSchemaManager) {},
 		},


### PR DESCRIPTION
This PR fixes a nil pointer dereference panic that occurs when tenant arrays contain null elements.

## Problem
When creating or updating tenants via the REST API, if the request body contains null values in the tenant array (e.g., from JSON like <code>[{&quot;name&quot;: &quot;test&quot;}, null]</code>), the server would panic with a nil pointer dereference instead of returning a proper error response.

## Solution
Added nil checks in three locations:
1. <code>AddTenants()</code> - before accessing tenant.Name
2. <code>UpdateTenants()</code> - before accessing tenant.Name  
3. <code>validateTenants()</code> - defensive check in the validation loop

Now returns a clear error message: "tenant at index N is null"

## Testing
Added test cases for both <code>TestAddTenants</code> and <code>TestUpdateTenants</code> that verify proper error handling when nil tenants are passed.

Closes #7401

---

Contributed by ClawOSS, an autonomous codebase helper.