### PR TITLE
fix: prevent nil Segmenter panic when GSE tokenizer init fails (#10268)

### DIFF
--- a/entities/tokenizer/tokenizer.go
+++ b/entities/tokenizer/tokenizer.go
@@ -269,7 +269,7 @@ func tokenizetrigram(in string) []string {
 
 // tokenizeGSE uses the gse tokenizer to tokenise Japanese
 func tokenizeGSE(in string) []string {
-	if !UseGse {
+	if !UseGse || gseTokenizer == nil {
 		return []string{}
 	}
 	startTime := time.Now()
@@ -287,7 +287,7 @@ func tokenizeGSE(in string) []string {
 
 // tokenizeGSE uses the gse tokenizer to tokenise Chinese
 func tokenizeGseCh(in string) []string {
-	if !UseGseCh {
+	if !UseGseCh || gseTokenizerCh == nil {
 		return []string{}
 	}
 	gseLock.Lock()


### PR DESCRIPTION
## Summary
Closes #10268

Add nil checks for `gseTokenizer` and `gseTokenizerCh` before use in `tokenizeGSE` and `tokenizeGseCh`.

## Root cause
When `init_gse`/`init_gse_ch` fails (e.g. dictionary load error), the segmenter stays nil but `UseGse`/`UseGseCh` remains true. During replication commit, `tokenizeGSE` is called and panics with `nil pointer dereference` when invoking `gseTokenizer.CutAll(in)`.

## Fix
Return empty token slice when segmenter is nil, matching the safe fallback behavior when the tokenizer is disabled. This prevents the panic and allows replication to complete (with empty tokens for the affected property).

## Testing
- Build passes
- Minimal change: 2 lines added (nil checks)

Made with [Cursor](https://cursor.com)