### PR TITLE
DTM follow-up: move dbShardLister to db.DB, rename su→u

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -74,7 +74,6 @@ import (
 	"github.com/weaviate/weaviate/entities/modulecapabilities"
 	"github.com/weaviate/weaviate/entities/moduletools"
 	"github.com/weaviate/weaviate/entities/replication"
-	entschema "github.com/weaviate/weaviate/entities/schema"
 	vectorIndex "github.com/weaviate/weaviate/entities/vectorindex"
 	grpcconn "github.com/weaviate/weaviate/grpc/conn"
 	modstgazure "github.com/weaviate/weaviate/modules/backup-azure"
@@ -801,7 +800,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 
 		if entconfig.Enabled(os.Getenv("SHARD_NOOP_PROVIDER_ENABLED")) {
 			shardNoopProvider := distributedtask.NewShardNoopProvider(
-				appState.Cluster.LocalName(), appState.Logger, &dbShardLister{db: repo},
+				appState.Cluster.LocalName(), appState.Logger, repo,
 				appState.ServerConfig.Config.Persistence.DataPath,
 			)
 			providers[distributedtask.ShardNoopProviderNamespace] = shardNoopProvider
@@ -836,31 +835,6 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	}
 
 	return appState
-}
-
-// dbShardLister adapts [db.DB] to the [distributedtask.ShardLister] interface,
-// allowing the [distributedtask.ShardNoopProvider] to discover which shards are
-// local to this node for a given collection.
-type dbShardLister struct {
-	db *db.DB
-}
-
-func (v *dbShardLister) GetLocalShardNames(collection string) ([]string, error) {
-	index := v.db.GetIndex(entschema.ClassName(collection))
-	if index == nil {
-		return nil, fmt.Errorf("collection %q not found", collection)
-	}
-	var names []string
-	if err := index.ForEachShard(func(name string, _ db.ShardLike) error {
-		names = append(names, name)
-		return nil
-	}); err != nil {
-		return nil, err
-	}
-	if len(names) == 0 {
-		return nil, fmt.Errorf("collection %q has no local shards", collection)
-	}
-	return names, nil
 }
 
 func configureBitmapBufPool(appState *state.State) (pool roaringset.BitmapBufPool, close func()) {

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -353,6 +353,27 @@ func (db *DB) GetIndex(className schema.ClassName) *Index {
 	return index
 }
 
+// GetLocalShardNames returns the names of all shards local to this node for
+// the given collection. Returns an error if the collection is not found or has
+// no local shards.
+func (db *DB) GetLocalShardNames(collection string) ([]string, error) {
+	index := db.GetIndex(schema.ClassName(collection))
+	if index == nil {
+		return nil, fmt.Errorf("collection %q not found", collection)
+	}
+	var names []string
+	if err := index.ForEachShard(func(name string, _ ShardLike) error {
+		names = append(names, name)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("collection %q has no local shards", collection)
+	}
+	return names, nil
+}
+
 // IndexExists returns if an index exists
 func (db *DB) IndexExists(className schema.ClassName) bool {
 	return db.GetIndex(className) != nil

--- a/cluster/distributedtask/manager.go
+++ b/cluster/distributedtask/manager.go
@@ -125,17 +125,17 @@ func (m *Manager) findStartedUnitWithLock(namespace, taskID string, version uint
 		return nil, nil, errTaskNotRunning(namespace, taskID, task.Version)
 	}
 
-	su, ok := task.Units[unitID]
+	u, ok := task.Units[unitID]
 	if !ok {
 		return nil, nil, fmt.Errorf("unit %s does not exist in task %s/%s/%d", unitID, namespace, taskID, task.Version)
 	}
 
-	if su.NodeID != "" && su.NodeID != nodeID {
+	if u.NodeID != "" && u.NodeID != nodeID {
 		return nil, nil, fmt.Errorf("unit %s in task %s/%s/%d belongs to node %s, not %s",
-			unitID, namespace, taskID, task.Version, su.NodeID, nodeID)
+			unitID, namespace, taskID, task.Version, u.NodeID, nodeID)
 	}
 
-	return task, su, nil
+	return task, u, nil
 }
 
 // RecordUnitCompletion handles both success and failure (distinguished by a non-empty error
@@ -152,30 +152,30 @@ func (m *Manager) RecordUnitCompletion(c *api.ApplyRequest) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	task, su, err := m.findStartedUnitWithLock(r.Namespace, r.Id, r.Version, r.UnitId, r.NodeId)
+	task, u, err := m.findStartedUnitWithLock(r.Namespace, r.Id, r.Version, r.UnitId, r.NodeId)
 	if err != nil {
 		return err
 	}
 
-	if su.Status == UnitStatusCompleted || su.Status == UnitStatusFailed {
+	if u.Status == UnitStatusCompleted || u.Status == UnitStatusFailed {
 		return fmt.Errorf("unit %s in task %s/%s/%d is already terminal", r.UnitId, r.Namespace, r.Id, task.Version)
 	}
 
 	finishedAt := time.UnixMilli(r.FinishedAtUnixMillis)
 
 	if r.Error != "" {
-		su.Status = UnitStatusFailed
-		su.Error = r.Error
-		su.FinishedAt = finishedAt
+		u.Status = UnitStatusFailed
+		u.Error = r.Error
+		u.FinishedAt = finishedAt
 		task.Status = TaskStatusFailed
 		task.Error = fmt.Sprintf("unit %s failed: %s", r.UnitId, r.Error)
 		task.FinishedAt = finishedAt
 		return nil
 	}
 
-	su.Status = UnitStatusCompleted
-	su.Progress = 1.0
-	su.FinishedAt = finishedAt
+	u.Status = UnitStatusCompleted
+	u.Progress = 1.0
+	u.FinishedAt = finishedAt
 
 	if task.AllUnitsTerminal() {
 		if task.AnyUnitFailed() {
@@ -202,12 +202,12 @@ func (m *Manager) UpdateUnitProgress(c *api.ApplyRequest) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
-	_, su, err := m.findStartedUnitWithLock(r.Namespace, r.Id, r.Version, r.UnitId, r.NodeId)
+	_, u, err := m.findStartedUnitWithLock(r.Namespace, r.Id, r.Version, r.UnitId, r.NodeId)
 	if err != nil {
 		return err
 	}
 
-	if su.Status == UnitStatusCompleted || su.Status == UnitStatusFailed {
+	if u.Status == UnitStatusCompleted || u.Status == UnitStatusFailed {
 		return nil // silently ignore progress updates for terminal units
 	}
 
@@ -216,12 +216,12 @@ func (m *Manager) UpdateUnitProgress(c *api.ApplyRequest) error {
 			r.UnitId, r.Namespace, r.Id, r.Version, r.Progress)
 	}
 
-	su.NodeID = r.NodeId
-	su.Progress = r.Progress
-	su.UpdatedAt = time.UnixMilli(r.UpdatedAtUnixMillis)
+	u.NodeID = r.NodeId
+	u.Progress = r.Progress
+	u.UpdatedAt = time.UnixMilli(r.UpdatedAtUnixMillis)
 
-	if su.Status == UnitStatusPending {
-		su.Status = UnitStatusInProgress
+	if u.Status == UnitStatusPending {
+		u.Status = UnitStatusInProgress
 	}
 
 	return nil

--- a/cluster/distributedtask/manager_test.go
+++ b/cluster/distributedtask/manager_test.go
@@ -481,28 +481,28 @@ func addTaskWithUnits(t *testing.T, h *testHarness, ns, id string, version uint6
 }
 
 // completeUnit records a successful unit completion.
-func completeUnit(t *testing.T, h *testHarness, ns, id string, version uint64, node, su string) {
+func completeUnit(t *testing.T, h *testHarness, ns, id string, version uint64, node, unitID string) {
 	t.Helper()
 	err := h.manager.RecordUnitCompletion(toCmd(t, &cmd.RecordDistributedTaskUnitCompletionRequest{
 		Namespace:            ns,
 		Id:                   id,
 		Version:              version,
 		NodeId:               node,
-		UnitId:               su,
+		UnitId:               unitID,
 		FinishedAtUnixMillis: h.clock.Now().UnixMilli(),
 	}))
 	require.NoError(t, err)
 }
 
 // failUnit records a failed unit completion.
-func failUnit(t *testing.T, h *testHarness, ns, id string, version uint64, node, su, errMsg string) {
+func failUnit(t *testing.T, h *testHarness, ns, id string, version uint64, node, unitID, errMsg string) {
 	t.Helper()
 	err := h.manager.RecordUnitCompletion(toCmd(t, &cmd.RecordDistributedTaskUnitCompletionRequest{
 		Namespace:            ns,
 		Id:                   id,
 		Version:              version,
 		NodeId:               node,
-		UnitId:               su,
+		UnitId:               unitID,
 		Error:                errMsg,
 		FinishedAtUnixMillis: h.clock.Now().UnixMilli(),
 	}))
@@ -510,14 +510,14 @@ func failUnit(t *testing.T, h *testHarness, ns, id string, version uint64, node,
 }
 
 // updateProgress updates a unit's progress value.
-func updateProgress(t *testing.T, h *testHarness, ns, id string, version uint64, node, su string, progress float32) {
+func updateProgress(t *testing.T, h *testHarness, ns, id string, version uint64, node, unitID string, progress float32) {
 	t.Helper()
 	err := h.manager.UpdateUnitProgress(toCmd(t, &cmd.UpdateDistributedTaskUnitProgressRequest{
 		Namespace:           ns,
 		Id:                  id,
 		Version:             version,
 		NodeId:              node,
-		UnitId:              su,
+		UnitId:              unitID,
 		Progress:            progress,
 		UpdatedAtUnixMillis: h.clock.Now().UnixMilli(),
 	}))
@@ -544,10 +544,10 @@ func TestManager_AddTask_WithUnits(t *testing.T) {
 	require.NotNil(t, task.Units)
 	require.Len(t, task.Units, 3)
 	for _, id := range []string{"su-1", "su-2", "su-3"} {
-		su, ok := task.Units[id]
+		u, ok := task.Units[id]
 		require.True(t, ok, "unit %s should exist", id)
-		assert.Equal(t, UnitStatusPending, su.Status)
-		assert.Equal(t, id, su.ID)
+		assert.Equal(t, UnitStatusPending, u.Status)
+		assert.Equal(t, id, u.ID)
 	}
 }
 
@@ -634,10 +634,10 @@ func TestManager_UpdateUnitProgress(t *testing.T) {
 	updateProgress(t, h, "ns", "task1", version, "node-1", "su-1", 0.5)
 
 	tasks, _ := h.manager.ListDistributedTasks(context.Background())
-	su := tasks["ns"][0].Units["su-1"]
-	assert.Equal(t, UnitStatusInProgress, su.Status)
-	assert.Equal(t, float32(0.5), su.Progress)
-	assert.Equal(t, "node-1", su.NodeID)
+	u := tasks["ns"][0].Units["su-1"]
+	assert.Equal(t, UnitStatusInProgress, u.Status)
+	assert.Equal(t, float32(0.5), u.Progress)
+	assert.Equal(t, "node-1", u.NodeID)
 }
 
 func TestManager_UpdateUnitProgress_Failures(t *testing.T) {

--- a/cluster/distributedtask/shard_noop_provider.go
+++ b/cluster/distributedtask/shard_noop_provider.go
@@ -171,12 +171,12 @@ func (p *ShardNoopProvider) OnGroupCompleted(task *Task, groupID string, localGr
 	if len(task.Payload) > 0 {
 		_ = json.Unmarshal(task.Payload, &payload)
 	}
-	for _, suID := range localGroupUnitIDs {
+	for _, uID := range localGroupUnitIDs {
 		var dir string
 		if payload.Collection != "" {
-			shardName := suID
+			shardName := uID
 			if payload.UnitToShard != nil {
-				if sn, ok := payload.UnitToShard[suID]; ok {
+				if sn, ok := payload.UnitToShard[uID]; ok {
 					shardName = sn
 				}
 			}
@@ -194,13 +194,13 @@ func (p *ShardNoopProvider) OnGroupCompleted(task *Task, groupID string, localGr
 		var markerName string
 		if payload.Collection != "" {
 			if groupID != "" {
-				markerName = fmt.Sprintf(".dtm-finalize--%s--%s--%s", task.ID, groupID, suID)
+				markerName = fmt.Sprintf(".dtm-finalize--%s--%s--%s", task.ID, groupID, uID)
 			} else {
-				markerName = fmt.Sprintf(".dtm-finalize--%s--%s", task.ID, suID)
+				markerName = fmt.Sprintf(".dtm-finalize--%s--%s", task.ID, uID)
 			}
 		} else {
 			// Synthetic mode: use unit ID as the file name (old layout under dataRoot/.dtm/).
-			markerName = suID
+			markerName = uID
 		}
 		path := filepath.Join(dir, markerName)
 		if err := os.WriteFile(path, []byte(fmt.Sprintf("finalized by %s", p.nodeID)), 0o644); err != nil {
@@ -348,22 +348,22 @@ func (p *ShardNoopProvider) processUnits(task *Task, handle *shardNoopTaskHandle
 	}
 
 	ctx := context.Background()
-	for suID, su := range task.Units {
+	for uID, u := range task.Units {
 		select {
 		case <-handle.stopCh:
 			return
 		default:
 		}
 
-		if su.Status == UnitStatusCompleted || su.Status == UnitStatusFailed {
+		if u.Status == UnitStatusCompleted || u.Status == UnitStatusFailed {
 			continue
 		}
 
-		if !p.shouldProcessUnit(suID, su, payload, localShardSet) {
+		if !p.shouldProcessUnit(uID, u, payload, localShardSet) {
 			continue
 		}
 
-		p.processOneUnit(ctx, task, handle, suID, payload, processingDelay)
+		p.processOneUnit(ctx, task, handle, uID, payload, processingDelay)
 	}
 }
 
@@ -383,12 +383,12 @@ func (p *ShardNoopProvider) processUnitsConcurrent(task *Task, handle *shardNoop
 	}, p.logger)
 
 	var wg sync.WaitGroup
-	for suID, su := range task.Units {
-		if su.Status == UnitStatusCompleted || su.Status == UnitStatusFailed {
+	for uID, u := range task.Units {
+		if u.Status == UnitStatusCompleted || u.Status == UnitStatusFailed {
 			continue
 		}
 
-		if !p.shouldProcessUnit(suID, su, payload, localShardSet) {
+		if !p.shouldProcessUnit(uID, u, payload, localShardSet) {
 			continue
 		}
 
@@ -397,12 +397,12 @@ func (p *ShardNoopProvider) processUnitsConcurrent(task *Task, handle *shardNoop
 		}
 
 		wg.Add(1)
-		suID := suID // capture loop variable
+		uID := uID // capture loop variable
 		enterrors.GoWrapper(func() {
 			defer wg.Done()
 			defer limiter.Release()
 
-			p.processOneUnit(ctx, task, handle, suID, payload, processingDelay)
+			p.processOneUnit(ctx, task, handle, uID, payload, processingDelay)
 		}, p.logger)
 	}
 
@@ -410,20 +410,20 @@ func (p *ShardNoopProvider) processUnitsConcurrent(task *Task, handle *shardNoop
 }
 
 // shouldProcessUnit checks whether this node should process the given unit.
-func (p *ShardNoopProvider) shouldProcessUnit(suID string, su *Unit, payload ShardNoopProviderPayload, localShardSet map[string]bool) bool {
+func (p *ShardNoopProvider) shouldProcessUnit(uID string, u *Unit, payload ShardNoopProviderPayload, localShardSet map[string]bool) bool {
 	if localShardSet != nil && payload.UnitToShard != nil {
-		shardName, ok := payload.UnitToShard[suID]
+		shardName, ok := payload.UnitToShard[uID]
 		if !ok || !localShardSet[shardName] {
 			return false
 		}
-		if ownerNode, ok := payload.UnitToNode[suID]; ok && ownerNode != p.nodeID {
+		if ownerNode, ok := payload.UnitToNode[uID]; ok && ownerNode != p.nodeID {
 			return false
 		}
 		return true
 	} else if localShardSet != nil {
-		return localShardSet[suID]
+		return localShardSet[uID]
 	}
-	nodeID := su.NodeID
+	nodeID := u.NodeID
 	if nodeID == "" {
 		nodeID = p.nodeID
 	}
@@ -431,17 +431,17 @@ func (p *ShardNoopProvider) shouldProcessUnit(suID string, su *Unit, payload Sha
 }
 
 // processOneUnit handles a single unit's lifecycle (progress, delay, complete/fail).
-func (p *ShardNoopProvider) processOneUnit(ctx context.Context, task *Task, handle *shardNoopTaskHandle, suID string, payload ShardNoopProviderPayload, processingDelay time.Duration) {
-	p.logger.WithField("suID", suID).WithField("nodeID", p.nodeID).
+func (p *ShardNoopProvider) processOneUnit(ctx context.Context, task *Task, handle *shardNoopTaskHandle, uID string, payload ShardNoopProviderPayload, processingDelay time.Duration) {
+	p.logger.WithField("uID", uID).WithField("nodeID", p.nodeID).
 		Info("shard-noop provider: processing unit")
 
 	p.retryRecorderCall(handle, func() error {
 		return p.recorder.UpdateDistributedTaskUnitProgress(
-			ctx, task.Namespace, task.ID, task.Version, p.nodeID, suID, 0.5,
+			ctx, task.Namespace, task.ID, task.Version, p.nodeID, uID, 0.5,
 		)
 	})
 
-	if payload.SlowUnitID == suID && payload.SlowUnitDelayMs > 0 {
+	if payload.SlowUnitID == uID && payload.SlowUnitDelayMs > 0 {
 		select {
 		case <-handle.stopCh:
 			return
@@ -459,10 +459,10 @@ func (p *ShardNoopProvider) processOneUnit(ctx context.Context, task *Task, hand
 	case <-time.After(processingDelay):
 	}
 
-	if payload.FailUnitID == suID {
+	if payload.FailUnitID == uID {
 		p.retryRecorderCall(handle, func() error {
 			return p.recorder.RecordDistributedTaskUnitFailure(
-				ctx, task.Namespace, task.ID, task.Version, p.nodeID, suID, "dummy failure",
+				ctx, task.Namespace, task.ID, task.Version, p.nodeID, uID, "dummy failure",
 			)
 		})
 		return
@@ -470,7 +470,7 @@ func (p *ShardNoopProvider) processOneUnit(ctx context.Context, task *Task, hand
 
 	p.retryRecorderCall(handle, func() error {
 		return p.recorder.RecordDistributedTaskUnitCompletion(
-			ctx, task.Namespace, task.ID, task.Version, p.nodeID, suID,
+			ctx, task.Namespace, task.ID, task.Version, p.nodeID, uID,
 		)
 	})
 
@@ -478,9 +478,9 @@ func (p *ShardNoopProvider) processOneUnit(ctx context.Context, task *Task, hand
 	// {dataRoot}/.dtm/dtm-process/{taskID}/ (synthetic).
 	var dir string
 	if payload.Collection != "" {
-		shardName := suID
+		shardName := uID
 		if payload.UnitToShard != nil {
-			if sn, ok := payload.UnitToShard[suID]; ok {
+			if sn, ok := payload.UnitToShard[uID]; ok {
 				shardName = sn
 			}
 		}
@@ -493,9 +493,9 @@ func (p *ShardNoopProvider) processOneUnit(ctx context.Context, task *Task, hand
 	} else {
 		var markerName string
 		if payload.Collection != "" {
-			markerName = fmt.Sprintf(".dtm-process--%s--%s", task.ID, suID)
+			markerName = fmt.Sprintf(".dtm-process--%s--%s", task.ID, uID)
 		} else {
-			markerName = suID
+			markerName = uID
 		}
 		path := filepath.Join(dir, markerName)
 		if err := os.WriteFile(path, []byte(fmt.Sprintf("processed by %s", p.nodeID)), 0o644); err != nil {

--- a/cluster/distributedtask/shard_noop_provider_test.go
+++ b/cluster/distributedtask/shard_noop_provider_test.go
@@ -171,28 +171,28 @@ func (f *providerFixture) startAndAwaitCompleted(t *testing.T, task *Task, expec
 func TestShardNoopProvider_SyntheticUnits_NilShardLister(t *testing.T) {
 	f := newProviderFixture(t, "node1", nil)
 	task := f.newTask(map[string]*Unit{
-		"su-1": {Status: UnitStatusPending},
-		"su-2": {Status: UnitStatusPending},
+		"u-1": {Status: UnitStatusPending},
+		"u-2": {Status: UnitStatusPending},
 	})
 
 	handle, completed := f.startAndAwaitCompleted(t, task, 2)
 	defer handle.Terminate()
 
-	assert.ElementsMatch(t, []string{"su-1", "su-2"}, completed)
+	assert.ElementsMatch(t, []string{"u-1", "u-2"}, completed)
 }
 
 func TestShardNoopProvider_SyntheticUnits_SkipsOtherNodes(t *testing.T) {
 	f := newProviderFixture(t, "node1", nil)
 	task := f.newTask(map[string]*Unit{
-		"su-1": {Status: UnitStatusPending, NodeID: "node1"},
-		"su-2": {Status: UnitStatusPending, NodeID: "node2"}, // belongs to another node
-		"su-3": {Status: UnitStatusPending},                  // unassigned → claimed by this node
+		"u-1": {Status: UnitStatusPending, NodeID: "node1"},
+		"u-2": {Status: UnitStatusPending, NodeID: "node2"}, // belongs to another node
+		"u-3": {Status: UnitStatusPending},                  // unassigned → claimed by this node
 	})
 
 	handle, completed := f.startAndAwaitCompleted(t, task, 2)
 	defer handle.Terminate()
 
-	assert.ElementsMatch(t, []string{"su-1", "su-3"}, completed)
+	assert.ElementsMatch(t, []string{"u-1", "u-3"}, completed)
 }
 
 func TestShardNoopProvider_CollectionAware_OnlyProcessesLocalShards(t *testing.T) {
@@ -246,7 +246,7 @@ func TestShardNoopProvider_CollectionAware_ShardListerError(t *testing.T) {
 	task := f.newTaskWithPayload(
 		ShardNoopProviderPayload{Collection: "NonExistent"},
 		map[string]*Unit{
-			"su-1": {Status: UnitStatusPending},
+			"u-1": {Status: UnitStatusPending},
 		},
 	)
 
@@ -297,41 +297,41 @@ func TestShardNoopProvider_CollectionAware_EmptyPayloadFallsBackToSynthetic(t *t
 	f := newProviderFixture(t, "node1", lister)
 
 	task := f.newTask(map[string]*Unit{
-		"su-1": {Status: UnitStatusPending},
-		"su-2": {Status: UnitStatusPending, NodeID: "node2"},
+		"u-1": {Status: UnitStatusPending},
+		"u-2": {Status: UnitStatusPending, NodeID: "node2"},
 	})
 
 	handle, completed := f.startAndAwaitCompleted(t, task, 1)
 	defer handle.Terminate()
 
-	assert.ElementsMatch(t, []string{"su-1"}, completed,
-		"only su-1 should be processed in synthetic mode (su-2 belongs to node2)")
+	assert.ElementsMatch(t, []string{"u-1"}, completed,
+		"only u-1 should be processed in synthetic mode (u-2 belongs to node2)")
 }
 
 func TestShardNoopProvider_OnGroupCompleted(t *testing.T) {
 	f := newProviderFixture(t, "node1", nil)
 	task := f.newTask(nil)
 
-	f.provider.OnGroupCompleted(task, "", []string{"su-1", "su-2"})
+	f.provider.OnGroupCompleted(task, "", []string{"u-1", "u-2"})
 
 	finalized := f.provider.GetFinalizedUnits(task.TaskDescriptor)
-	assert.ElementsMatch(t, []string{"su-1", "su-2"}, finalized)
+	assert.ElementsMatch(t, []string{"u-1", "u-2"}, finalized)
 }
 
 func TestShardNoopProvider_OnGroupCompleted_MultipleGroups(t *testing.T) {
 	f := newProviderFixture(t, "node1", nil)
 	task := f.newTask(nil)
 
-	f.provider.OnGroupCompleted(task, "groupA", []string{"su-1"})
-	f.provider.OnGroupCompleted(task, "groupB", []string{"su-2", "su-3"})
+	f.provider.OnGroupCompleted(task, "groupA", []string{"u-1"})
+	f.provider.OnGroupCompleted(task, "groupB", []string{"u-2", "u-3"})
 
 	groups := f.provider.GetFinalizedGroups(task.TaskDescriptor)
-	assert.ElementsMatch(t, []string{"su-1"}, groups["groupA"])
-	assert.ElementsMatch(t, []string{"su-2", "su-3"}, groups["groupB"])
+	assert.ElementsMatch(t, []string{"u-1"}, groups["groupA"])
+	assert.ElementsMatch(t, []string{"u-2", "u-3"}, groups["groupB"])
 
 	// GetFinalizedUnits should return all across groups
 	all := f.provider.GetFinalizedUnits(task.TaskDescriptor)
-	assert.ElementsMatch(t, []string{"su-1", "su-2", "su-3"}, all)
+	assert.ElementsMatch(t, []string{"u-1", "u-2", "u-3"}, all)
 }
 
 func TestShardNoopProvider_OnTaskCompleted(t *testing.T) {
@@ -424,13 +424,13 @@ func TestShardNoopProvider_SlowUnit(t *testing.T) {
 
 	task := f.newTaskWithPayload(
 		ShardNoopProviderPayload{
-			SlowUnitID:        "su-slow",
+			SlowUnitID:        "u-slow",
 			SlowUnitDelayMs:   500,
 			ProcessingDelayMs: 10,
 		},
 		map[string]*Unit{
-			"su-fast": {Status: UnitStatusPending},
-			"su-slow": {Status: UnitStatusPending},
+			"u-fast": {Status: UnitStatusPending},
+			"u-slow": {Status: UnitStatusPending},
 		},
 	)
 
@@ -441,7 +441,7 @@ func TestShardNoopProvider_SlowUnit(t *testing.T) {
 	elapsed := time.Since(start)
 	assert.Greater(t, elapsed, 400*time.Millisecond, "slow unit delay should be applied")
 
-	assert.ElementsMatch(t, []string{"su-fast", "su-slow"}, completed)
+	assert.ElementsMatch(t, []string{"u-fast", "u-slow"}, completed)
 }
 
 func TestShardNoopProvider_ProcessingDelayOverride(t *testing.T) {
@@ -452,9 +452,9 @@ func TestShardNoopProvider_ProcessingDelayOverride(t *testing.T) {
 			ProcessingDelayMs: 10, // fast override
 		},
 		map[string]*Unit{
-			"su-1": {Status: UnitStatusPending},
-			"su-2": {Status: UnitStatusPending},
-			"su-3": {Status: UnitStatusPending},
+			"u-1": {Status: UnitStatusPending},
+			"u-2": {Status: UnitStatusPending},
+			"u-3": {Status: UnitStatusPending},
 		},
 	)
 
@@ -466,7 +466,7 @@ func TestShardNoopProvider_ProcessingDelayOverride(t *testing.T) {
 	// With 10ms delay per unit, should be much faster than default 100ms * 3 = 300ms
 	assert.Less(t, elapsed, 200*time.Millisecond, "processing should use fast delay override")
 
-	assert.ElementsMatch(t, []string{"su-1", "su-2", "su-3"}, completed)
+	assert.ElementsMatch(t, []string{"u-1", "u-2", "u-3"}, completed)
 }
 
 func TestShardNoopProvider_TaskLifecycle(t *testing.T) {

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -184,8 +184,8 @@ func (t *Task) Clone() *Task {
 	if t.Units != nil {
 		clone.Units = make(map[string]*Unit, len(t.Units))
 		for k, v := range t.Units {
-			subCopy := *v
-			clone.Units[k] = &subCopy
+			uCopy := *v
+			clone.Units[k] = &uCopy
 		}
 	}
 	return &clone
@@ -193,8 +193,8 @@ func (t *Task) Clone() *Task {
 
 // AllUnitsTerminal returns true if all units are in a terminal state (COMPLETED or FAILED).
 func (t *Task) AllUnitsTerminal() bool {
-	for _, su := range t.Units {
-		if su.Status != UnitStatusCompleted && su.Status != UnitStatusFailed {
+	for _, u := range t.Units {
+		if u.Status != UnitStatusCompleted && u.Status != UnitStatusFailed {
 			return false
 		}
 	}
@@ -203,8 +203,8 @@ func (t *Task) AllUnitsTerminal() bool {
 
 // AnyUnitFailed returns true if any unit has FAILED status.
 func (t *Task) AnyUnitFailed() bool {
-	for _, su := range t.Units {
-		if su.Status == UnitStatusFailed {
+	for _, u := range t.Units {
+		if u.Status == UnitStatusFailed {
 			return true
 		}
 	}
@@ -214,8 +214,8 @@ func (t *Task) AnyUnitFailed() bool {
 // LocalUnitIDs returns the IDs of units assigned to the given node.
 func (t *Task) LocalUnitIDs(nodeID string) []string {
 	var ids []string
-	for id, su := range t.Units {
-		if su.NodeID == nodeID {
+	for id, u := range t.Units {
+		if u.NodeID == nodeID {
 			ids = append(ids, id)
 		}
 	}
@@ -225,8 +225,8 @@ func (t *Task) LocalUnitIDs(nodeID string) []string {
 // Groups returns the distinct GroupIDs across all units (includes "" for ungrouped).
 func (t *Task) Groups() []string {
 	seen := map[string]bool{}
-	for _, su := range t.Units {
-		seen[su.GroupID] = true
+	for _, u := range t.Units {
+		seen[u.GroupID] = true
 	}
 	groups := make([]string, 0, len(seen))
 	for g := range seen {
@@ -237,11 +237,11 @@ func (t *Task) Groups() []string {
 
 // AllGroupUnitsTerminal returns true if all units in the given group are terminal.
 func (t *Task) AllGroupUnitsTerminal(groupID string) bool {
-	for _, su := range t.Units {
-		if su.GroupID != groupID {
+	for _, u := range t.Units {
+		if u.GroupID != groupID {
 			continue
 		}
-		if su.Status != UnitStatusCompleted && su.Status != UnitStatusFailed {
+		if u.Status != UnitStatusCompleted && u.Status != UnitStatusFailed {
 			return false
 		}
 	}
@@ -251,8 +251,8 @@ func (t *Task) AllGroupUnitsTerminal(groupID string) bool {
 // LocalGroupUnitIDs returns the IDs of units in the given group assigned to the given node.
 func (t *Task) LocalGroupUnitIDs(groupID, nodeID string) []string {
 	var ids []string
-	for id, su := range t.Units {
-		if su.GroupID == groupID && su.NodeID == nodeID {
+	for id, u := range t.Units {
+		if u.GroupID == groupID && u.NodeID == nodeID {
 			ids = append(ids, id)
 		}
 	}
@@ -262,11 +262,11 @@ func (t *Task) LocalGroupUnitIDs(groupID, nodeID string) []string {
 // NodeHasNonTerminalUnits returns true if the given node has units that are not yet terminal.
 // Unassigned units (empty NodeID) are considered as belonging to any node.
 func (t *Task) NodeHasNonTerminalUnits(nodeID string) bool {
-	for _, su := range t.Units {
-		if su.Status == UnitStatusCompleted || su.Status == UnitStatusFailed {
+	for _, u := range t.Units {
+		if u.Status == UnitStatusCompleted || u.Status == UnitStatusFailed {
 			continue
 		}
-		if su.NodeID == "" || su.NodeID == nodeID {
+		if u.NodeID == "" || u.NodeID == nodeID {
 			return true
 		}
 	}

--- a/test/acceptance/distributed_tasks/crash_recovery_test.go
+++ b/test/acceptance/distributed_tasks/crash_recovery_test.go
@@ -200,8 +200,8 @@ func awaitAnyUnitInProgress(t *testing.T, restURI, taskID string) {
 		if task == nil {
 			return false
 		}
-		for _, su := range task.Units {
-			if su.Status == "IN_PROGRESS" {
+		for _, u := range task.Units {
+			if u.Status == "IN_PROGRESS" {
 				return true
 			}
 		}

--- a/test/acceptance/distributed_tasks/group_test.go
+++ b/test/acceptance/distributed_tasks/group_test.go
@@ -64,8 +64,8 @@ func TestGroupFinalizationSuite(t *testing.T) {
 		require.NotNil(t, task.Units)
 		assert.Len(t, task.Units, 6)
 
-		for _, su := range task.Units {
-			assert.Equal(t, "COMPLETED", su.Status, "unit %s should be completed", su.ID)
+		for _, u := range task.Units {
+			assert.Equal(t, "COMPLETED", u.Status, "unit %s should be completed", u.ID)
 		}
 
 		awaitGroupFinalizedUnits(t, ctx, compose, taskID, "group-A", []string{"g1-su1", "g1-su2", "g1-su3"})
@@ -127,8 +127,8 @@ func TestGroupFinalizationSuite(t *testing.T) {
 		require.NotNil(t, task.Units)
 		assert.Len(t, task.Units, numGroups*unitsPerGroup)
 
-		for _, su := range task.Units {
-			assert.Equal(t, "COMPLETED", su.Status, "unit %s should be completed", su.ID)
+		for _, u := range task.Units {
+			assert.Equal(t, "COMPLETED", u.Status, "unit %s should be completed", u.ID)
 		}
 
 		spotCheckGroupFinalization(t, ctx, compose, taskID, unitsPerGroup, 0, 9, 19)
@@ -171,9 +171,9 @@ func buildGroupUnits(numGroups, unitsPerGroup int) ([]string, map[string]string)
 	for g := 0; g < numGroups; g++ {
 		groupID := fmt.Sprintf("grp-%03d", g)
 		for s := 0; s < unitsPerGroup; s++ {
-			suID := fmt.Sprintf("%s-su%d", groupID, s)
-			units = append(units, suID)
-			unitGroups[suID] = groupID
+			uID := fmt.Sprintf("%s-u%d", groupID, s)
+			units = append(units, uID)
+			unitGroups[uID] = groupID
 		}
 	}
 	return units, unitGroups
@@ -186,7 +186,7 @@ func spotCheckGroupFinalization(t *testing.T, ctx context.Context, compose *dock
 		groupID := fmt.Sprintf("grp-%03d", g)
 		var expected []string
 		for s := 0; s < unitsPerGroup; s++ {
-			expected = append(expected, fmt.Sprintf("%s-su%d", groupID, s))
+			expected = append(expected, fmt.Sprintf("%s-u%d", groupID, s))
 		}
 		awaitGroupFinalizedUnits(t, ctx, compose, taskID, groupID, expected)
 	}

--- a/test/acceptance/distributed_tasks/unit_tracking_test.go
+++ b/test/acceptance/distributed_tasks/unit_tracking_test.go
@@ -56,9 +56,9 @@ func TestUnitTaskLifecycle_Success(t *testing.T) {
 	require.NotNil(t, task.Units)
 	assert.Len(t, task.Units, 3)
 
-	for _, su := range task.Units {
-		assert.Equal(t, "COMPLETED", su.Status, "unit %s should be completed", su.ID)
-		assert.Equal(t, float32(1.0), su.Progress, "unit %s should have progress 1.0", su.ID)
+	for _, u := range task.Units {
+		assert.Equal(t, "COMPLETED", u.Status, "unit %s should be completed", u.ID)
+		assert.Equal(t, float32(1.0), u.Progress, "unit %s should have progress 1.0", u.ID)
 	}
 }
 
@@ -83,9 +83,9 @@ func TestUnitTaskLifecycle_Failure(t *testing.T) {
 	require.NotNil(t, task.Units)
 
 	var failedUnit *models.DistributedTaskUnit
-	for _, su := range task.Units {
-		if su.ID == "su-2" {
-			failedUnit = su
+	for _, u := range task.Units {
+		if u.ID == "su-2" {
+			failedUnit = u
 			break
 		}
 	}
@@ -338,9 +338,9 @@ func TestRealCollectionSuite(t *testing.T) {
 			if task == nil {
 				return false
 			}
-			for _, su := range task.Units {
+			for _, u := range task.Units {
 				for _, fsu := range fastUnits {
-					if su.ID == fsu && su.Status == "COMPLETED" {
+					if u.ID == fsu && u.Status == "COMPLETED" {
 						return true
 					}
 				}

--- a/usecases/distributedtask/handler.go
+++ b/usecases/distributedtask/handler.go
@@ -82,15 +82,15 @@ func (h *Handler) ListTasks(ctx context.Context, principal *models.Principal) (m
 
 func mapUnits(task *distributedtask.Task) []*models.DistributedTaskUnit {
 	units := make([]*models.DistributedTaskUnit, 0, len(task.Units))
-	for _, su := range task.Units {
+	for _, u := range task.Units {
 		units = append(units, &models.DistributedTaskUnit{
-			ID:         su.ID,
-			NodeID:     su.NodeID,
-			Status:     string(su.Status),
-			Progress:   su.Progress,
-			Error:      su.Error,
-			UpdatedAt:  strfmt.DateTime(su.UpdatedAt),
-			FinishedAt: strfmt.DateTime(su.FinishedAt),
+			ID:         u.ID,
+			NodeID:     u.NodeID,
+			Status:     string(u.Status),
+			Progress:   u.Progress,
+			Error:      u.Error,
+			UpdatedAt:  strfmt.DateTime(u.UpdatedAt),
+			FinishedAt: strfmt.DateTime(u.FinishedAt),
 		})
 	}
 	sort.Slice(units, func(i, j int) bool {


### PR DESCRIPTION
## Summary

Follow-up to #10697 addressing non-blocking review feedback:

- **Move `dbShardLister` out of `rest`**: Added `DB.GetLocalShardNames()` method to `adapters/repos/db` so `db.DB` directly satisfies `distributedtask.ShardLister`. Removed the adapter struct from `configure_api.go` — now passes `repo` directly.
- **Rename `su`/`suID`/`subCopy` variables**: Consistent `u`/`uID`/`uCopy` naming throughout `types.go`, `manager.go`, `shard_noop_provider.go`, `handler.go`, and all test files. Also renamed `su-` prefixed test data IDs to `u-`.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./cluster/distributedtask/...` passes
- [x] `go test ./usecases/distributedtask/...` passes
- [x] `golangci-lint run` — 0 issues
- [x] `./tools/gen-code-from-swagger.sh` — no diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)