### PR TITLE
Implement CompareDigests functionality for component replication

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -147,6 +147,59 @@ func (c *replicationClient) DigestObjectsInRange(ctx context.Context,
 	return resp.Digests, nil
 }
 
+// CompareDigests sends the source's local digests to the target node using a
+// binary-encoded request and decodes the binary response. The target returns
+// only those digests that the source must act on: objects missing from the
+// target (UpdateTime==0), stale on the target, or tombstoned on the target
+// (Deleted==true) requiring the source to delete its copy.
+//
+// Wire format: CompareDigestsRecordLength bytes per record —
+// 16-byte UUID + 8-byte UpdateTime + 1-byte flags. The flags byte is
+// meaningful only in the response direction: the request always sends
+// flags=0 because the source sends live objects exclusively.
+func (c *replicationClient) CompareDigests(ctx context.Context,
+	host, index, shard string, digests []types.RepairResponse,
+) ([]types.RepairResponse, error) {
+	// Binary-encode the request: N × CompareDigestsRecordLength bytes.
+	body := make([]byte, 0, len(digests)*replica.CompareDigestsRecordLength)
+	var buf [replica.CompareDigestsRecordLength]byte
+	for _, d := range digests {
+		uuidParsed, err := uuid.Parse(d.ID)
+		if err != nil {
+			return nil, fmt.Errorf("parse uuid %q: %w", d.ID, err)
+		}
+		copy(buf[:16], uuidParsed[:])
+		binary.BigEndian.PutUint64(buf[16:24], uint64(d.UpdateTime))
+		buf[24] = 0 // request flags are always zero: source sends only live objects
+		body = append(body, buf[:]...)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, c.timeoutUnit*20)
+	defer cancel()
+
+	req, err := newHttpReplicaRequest(
+		ctx, http.MethodPost, host, index, shard,
+		"", "compareDigests", bytes.NewReader(body), 0)
+	if err != nil {
+		return nil, fmt.Errorf("create http request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	res, err := c.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(res.Body)
+		return nil, fmt.Errorf("status code: %v, error: %s", res.StatusCode, b)
+	}
+
+	return readCompareDigestsBinaryStream(res.Body, res.ContentLength)
+}
+
 // readDigestsInRangeBinaryStream decodes a fixed-size binary stream produced
 // by writeDigestsInRangeResponse. Each record is
 // replica.DigestObjectsInRangeRecordLength bytes: 16-byte UUID (RFC-4122
@@ -179,11 +232,53 @@ func readDigestsInRangeBinaryStream(r io.Reader, contentLength int64) ([]types.R
 	}
 }
 
+// readCompareDigestsBinaryStream decodes a fixed-size binary stream produced
+// by postCompareDigests. Each record is replica.CompareDigestsRecordLength
+// bytes: 16-byte UUID + 8-byte UpdateTime (int64 big-endian) + 1-byte flags
+// (bit 0 = Deleted). The Deleted flag indicates the source must delete its
+// copy of the object rather than propagate it.
+func readCompareDigestsBinaryStream(r io.Reader, contentLength int64) ([]types.RepairResponse, error) {
+	var results []types.RepairResponse
+	if contentLength > 0 {
+		if recordCount := contentLength / int64(replica.CompareDigestsRecordLength); recordCount <= int64(math.MaxInt) {
+			results = make([]types.RepairResponse, 0, int(recordCount))
+		}
+	}
+	var buf [replica.CompareDigestsRecordLength]byte
+	for {
+		_, err := io.ReadFull(r, buf[:])
+		if stderrors.Is(err, io.EOF) {
+			return results, nil
+		}
+		if err != nil {
+			return nil, fmt.Errorf("read compare digests record: %w", err)
+		}
+		id, err := uuid.FromBytes(buf[:16])
+		if err != nil {
+			return nil, fmt.Errorf("parse uuid from compare digests record: %w", err)
+		}
+		updateTime := int64(binary.BigEndian.Uint64(buf[16:24]))
+		deleted := buf[24]&replica.CompareDigestsFlagDeleted != 0
+		results = append(results, types.RepairResponse{
+			ID:         id.String(),
+			UpdateTime: updateTime,
+			Deleted:    deleted,
+		})
+	}
+}
+
 // HashTreeLevel fetches hash tree level digests
 func (c *replicationClient) HashTreeLevel(ctx context.Context,
 	host, index, shard string, level int, discriminant *hashtree.Bitset,
 ) ([]hashtree.Digest, error) {
-	body, err := discriminant.Marshal()
+	// Extract only the bits relevant to this level (level-local encoding).
+	// bit i of the extracted slice maps to global node InnerNodesCount(level)+i.
+	// This reduces the per-call payload from NodesCount(height) bits to
+	// nodesAtLevel(level) = LeavesCount(level) bits, cutting total request
+	// bytes across a full traversal by a factor of (height+1).
+	levelLocalDisc := discriminant.ExtractSlice(hashtree.InnerNodesCount(level), hashtree.LeavesCount(level))
+
+	body, err := levelLocalDisc.Marshal()
 	if err != nil {
 		return nil, fmt.Errorf("marshal hashtree level input: %w", err)
 	}

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -601,9 +601,12 @@ func TestReplicationHashTreeLevel(t *testing.T) {
 		{0xdeadbeefcafebabe, 0x0123456789abcdef},
 	}
 
-	discriminant := hashtree.NewBitset(4)
-	discriminant.Set(0)
-	discriminant.Set(2)
+	// The global discriminant must be sized for the full tree (NodesCount(height)).
+	// Level-3 leaf nodes occupy positions InnerNodesCount(3)=7 through 14.
+	// Bits 0 and 2 at level 3 correspond to global positions 7 and 9.
+	discriminant := hashtree.NewBitset(hashtree.NodesCount(3))
+	discriminant.Set(hashtree.InnerNodesCount(3) + 0)
+	discriminant.Set(hashtree.InnerNodesCount(3) + 2)
 
 	t.Run("BinaryResponse", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -780,6 +783,166 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		_, err := c.DigestObjectsInRange(context.Background(), server.URL[7:], "C1", "S1", UUID1, UUID2, 10)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "read digest in range record")
+	})
+}
+
+func TestReplicationCompareDigests(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	// Two digests the source has locally; their UUIDs are valid RFC-4122 strings.
+	input := []types.RepairResponse{
+		{ID: UUID1.String(), UpdateTime: now.UnixMilli()},
+		{ID: UUID2.String(), UpdateTime: now.Add(time.Hour).UnixMilli()},
+	}
+	// The target reports that UUID1 is missing (UpdateTime==0) and UUID2 is stale.
+	stale := []types.RepairResponse{
+		{ID: UUID1.String(), UpdateTime: 0},
+		{ID: UUID2.String(), UpdateTime: now.UnixMilli()},
+	}
+
+	// buildBinaryPayload encodes a slice of RepairResponse records using the
+	// 25-byte CompareDigests wire format: UUID + UpdateTime + flags byte.
+	buildBinaryPayload := func(records []types.RepairResponse) []byte {
+		buf := make([]byte, len(records)*replica.CompareDigestsRecordLength)
+		for i, r := range records {
+			id, err := uuid.Parse(r.ID)
+			require.NoError(t, err)
+			idBytes, err := id.MarshalBinary()
+			require.NoError(t, err)
+			off := i * replica.CompareDigestsRecordLength
+			copy(buf[off:], idBytes)
+			binary.BigEndian.PutUint64(buf[off+16:], uint64(r.UpdateTime))
+			if r.Deleted {
+				buf[off+24] = replica.CompareDigestsFlagDeleted
+			}
+		}
+		return buf
+	}
+
+	t.Run("BinaryRequestEncoding", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			assert.Equal(t, http.MethodPost, r.Method)
+			assert.Equal(t, "/replicas/indices/C1/shards/S1/objects/compareDigests", r.URL.Path)
+			assert.Equal(t, "application/octet-stream", r.Header.Get("Content-Type"))
+			// compareDigests is binary-only; no content-negotiation header is sent.
+			assert.Empty(t, r.Header.Get("X-Accept-Response-Encoding"))
+
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.Equal(t, len(input)*replica.CompareDigestsRecordLength, len(body))
+
+			// Decode and verify each record.
+			for i, in := range input {
+				off := i * replica.CompareDigestsRecordLength
+				rec := body[off : off+replica.CompareDigestsRecordLength]
+				id, err := uuid.FromBytes(rec[:16])
+				require.NoError(t, err)
+				assert.Equal(t, in.ID, id.String())
+				assert.Equal(t, uint64(in.UpdateTime), binary.BigEndian.Uint64(rec[16:24]))
+				assert.Equal(t, in.Deleted, rec[24]&replica.CompareDigestsFlagDeleted != 0)
+			}
+
+			// Return an empty binary response (no X-Response-Encoding needed).
+			w.Header().Set("Content-Type", "application/octet-stream")
+		}))
+		defer server.Close()
+
+		c := newReplicationClient(t, server.Client())
+		_, err := c.CompareDigests(context.Background(), server.URL[7:], "C1", "S1", input)
+		require.NoError(t, err)
+	})
+
+	t.Run("BinaryResponse", func(t *testing.T) {
+		payload := buildBinaryPayload(stale)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+			w.Write(payload) //nolint:errcheck
+		}))
+		defer server.Close()
+
+		c := newReplicationClient(t, server.Client())
+		got, err := c.CompareDigests(context.Background(), server.URL[7:], "C1", "S1", input)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.Equal(t, stale[0].ID, got[0].ID)
+		assert.Equal(t, stale[0].UpdateTime, got[0].UpdateTime)
+		assert.Equal(t, stale[0].Deleted, got[0].Deleted)
+		assert.Equal(t, stale[1].ID, got[1].ID)
+		assert.Equal(t, stale[1].UpdateTime, got[1].UpdateTime)
+		assert.Equal(t, stale[1].Deleted, got[1].Deleted)
+	})
+
+	t.Run("DeletedFlagInResponse", func(t *testing.T) {
+		// Verify that a response record with Deleted=true is decoded correctly.
+		deletedStale := []types.RepairResponse{
+			{ID: UUID1.String(), UpdateTime: now.UnixMilli() - 1000, Deleted: true},
+			{ID: UUID2.String(), UpdateTime: now.UnixMilli(), Deleted: false},
+		}
+		payload := buildBinaryPayload(deletedStale)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(payload)))
+			w.Write(payload) //nolint:errcheck
+		}))
+		defer server.Close()
+
+		c := newReplicationClient(t, server.Client())
+		got, err := c.CompareDigests(context.Background(), server.URL[7:], "C1", "S1", input)
+		require.NoError(t, err)
+		require.Len(t, got, 2)
+		assert.Equal(t, deletedStale[0].ID, got[0].ID)
+		assert.Equal(t, deletedStale[0].UpdateTime, got[0].UpdateTime)
+		assert.True(t, got[0].Deleted, "first record must have Deleted=true")
+		assert.Equal(t, deletedStale[1].ID, got[1].ID)
+		assert.Equal(t, deletedStale[1].UpdateTime, got[1].UpdateTime)
+		assert.False(t, got[1].Deleted, "second record must have Deleted=false")
+	})
+
+	t.Run("EmptyBinaryResponse", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			// empty body — nothing stale
+		}))
+		defer server.Close()
+
+		c := newReplicationClient(t, server.Client())
+		got, err := c.CompareDigests(context.Background(), server.URL[7:], "C1", "S1", input)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("ConnectionError", func(t *testing.T) {
+		c := newReplicationClient(t, &http.Client{})
+		_, err := c.CompareDigests(context.Background(), "127.0.0.1:0", "C1", "S1", input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "connect")
+	})
+
+	t.Run("ServerError", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "internal error", http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		c := newReplicationClient(t, server.Client())
+		_, err := c.CompareDigests(context.Background(), server.URL[7:], "C1", "S1", input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "status code")
+	})
+
+	t.Run("TruncatedBinaryRecord", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// 10 bytes — not a multiple of CompareDigestsRecordLength (25)
+			w.Write([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a}) //nolint:errcheck
+		}))
+		defer server.Close()
+
+		c := newReplicationClient(t, server.Client())
+		_, err := c.CompareDigests(context.Background(), server.URL[7:], "C1", "S1", input)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "read compare digests record")
 	})
 }
 

--- a/adapters/handlers/rest/clusterapi/fake_replicator_test.go
+++ b/adapters/handlers/rest/clusterapi/fake_replicator_test.go
@@ -101,6 +101,10 @@ func (f *fakeReplicator) DigestObjectsInRange(ctx context.Context, class, shardN
 	return []types.RepairResponse{}, nil
 }
 
+func (f *fakeReplicator) CompareDigests(ctx context.Context, class, shardName string, digests []types.RepairResponse) ([]types.RepairResponse, error) {
+	return []types.RepairResponse{}, nil
+}
+
 func (f *fakeReplicator) HashTreeLevel(ctx context.Context, index, shard string, level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error) {
 	return []hashtree.Digest{}, nil
 }

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -57,6 +57,9 @@ type replicatedIndices struct {
 	startWorkersOnce sync.Once
 	// set to true when shutting down
 	isShutdown atomic.Bool
+	// shutdownStartedCh is closed once isShutdown transitions to true so that
+	// callers can synchronize with the moment shutdown begins without polling.
+	shutdownStartedCh chan struct{}
 	// workerWg waits for all workers to finish
 	workerWg sync.WaitGroup
 	logger   logrus.FieldLogger
@@ -72,6 +75,9 @@ var (
 const (
 	responseShuttingDown = "503 Service Unavailable - shutting down"
 	responseQueueFull    = "too many buffered requests"
+
+	// compareDigestsMaxBodyBytes is the maximum body size accepted by postCompareDigests (4 MiB).
+	compareDigestsMaxBodyBytes = 4 * 1024 * 1024
 )
 
 var (
@@ -83,6 +89,8 @@ var (
 		`\/shards\/(` + sh + `)\/objects/_digest`)
 	regexObjectsDigestsInRange = regexp.MustCompile(`\/indices\/(` + cl + `)` +
 		`\/shards\/(` + sh + `)\/objects/digestsInRange`)
+	regexCompareDigests = regexp.MustCompile(`\/indices\/(` + cl + `)` +
+		`\/shards\/(` + sh + `)\/objects/compareDigests`)
 	regxHashTreeLevel = regexp.MustCompile(`\/indices\/(` + cl + `)` +
 		`\/shards\/(` + sh + `)\/objects\/hashtree\/level\/(` + l + `)`)
 	regxObjects = regexp.MustCompile(`\/replicas\/indices\/(` + cl + `)` +
@@ -118,6 +126,7 @@ func NewReplicatedIndices(
 		requestQueueConfig:     requestQueueConfig,
 		logger:                 logger,
 		nodeReady:              nodeReady,
+		shutdownStartedCh:      make(chan struct{}),
 	}
 	if requestQueueConfig.IsEnabled != nil && requestQueueConfig.IsEnabled.Get() {
 		i.startWorkersOnce.Do(i.startWorkers)
@@ -237,6 +246,14 @@ func (i *replicatedIndices) handleRequest(qr queuedRequest) {
 	case regxObjectsDigest.MatchString(path):
 		if r.Method == http.MethodGet {
 			i.getObjectsDigest().ServeHTTP(w, r)
+			return
+		}
+
+		http.Error(w, "405 Method not Allowed", http.StatusMethodNotAllowed)
+		return
+	case regexCompareDigests.MatchString(path):
+		if r.Method == http.MethodPost {
+			i.postCompareDigests().ServeHTTP(w, r)
 			return
 		}
 
@@ -535,6 +552,94 @@ func (i *replicatedIndices) getObjectsDigestsInRange() http.Handler {
 		}
 
 		writeDigestsInRangeResponse(w, r, digests)
+	})
+}
+
+// postCompareDigests decodes a binary-encoded list of source digests, delegates
+// to the replicator to compare against local state, and returns the actionable
+// subset as a binary stream. The protocol is binary-only: there is no JSON
+// fallback and no content-negotiation header required.
+//
+// Both request and response use replica.CompareDigestsRecordLength (25-byte)
+// records: 16-byte UUID + 8-byte UpdateTime (int64 big-endian) + 1-byte flags.
+// Bit 0 of the flags byte (CompareDigestsFlagDeleted) is set in the response
+// when the target has a tombstone that should win, instructing the source to
+// delete its copy.
+func (i *replicatedIndices) postCompareDigests() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		args := regexCompareDigests.FindStringSubmatch(r.URL.Path)
+		if len(args) != 3 {
+			http.Error(w, "invalid URI", http.StatusBadRequest)
+			return
+		}
+
+		index, shard := args[1], args[2]
+
+		defer r.Body.Close()
+		body, err := io.ReadAll(http.MaxBytesReader(w, r.Body, compareDigestsMaxBodyBytes))
+		if err != nil {
+			var maxBytesErr *http.MaxBytesError
+			if errors.As(err, &maxBytesErr) {
+				http.Error(w, "request body too large", http.StatusRequestEntityTooLarge)
+				return
+			}
+			http.Error(w, "read request body: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// Decode binary request: N × CompareDigestsRecordLength bytes.
+		var sourceDigests []types.RepairResponse
+		if len(body) > 0 {
+			if len(body)%replica.CompareDigestsRecordLength != 0 {
+				http.Error(w, "invalid binary payload length", http.StatusBadRequest)
+				return
+			}
+			n := len(body) / replica.CompareDigestsRecordLength
+			sourceDigests = make([]types.RepairResponse, n)
+			for j := 0; j < n; j++ {
+				off := j * replica.CompareDigestsRecordLength
+				rec := body[off : off+replica.CompareDigestsRecordLength]
+				id, err := uuid.FromBytes(rec[:16])
+				if err != nil {
+					http.Error(w, "parse uuid from binary: "+err.Error(), http.StatusBadRequest)
+					return
+				}
+				sourceDigests[j] = types.RepairResponse{
+					ID:         id.String(),
+					UpdateTime: int64(binary.BigEndian.Uint64(rec[16:24])),
+					Deleted:    rec[24]&replica.CompareDigestsFlagDeleted != 0,
+				}
+			}
+		}
+
+		stale, err := i.replicator.CompareDigests(r.Context(), index, shard, sourceDigests)
+		if err != nil {
+			http.Error(w, "compare digests: "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		// Encode all records before writing headers so that a UUID parse error
+		// doesn't produce an http.Error after headers have been sent.
+		out := make([]byte, 0, len(stale)*replica.CompareDigestsRecordLength)
+		var obuf [replica.CompareDigestsRecordLength]byte
+		for _, d := range stale {
+			id, err := uuid.Parse(d.ID)
+			if err != nil {
+				http.Error(w, "parse uuid: "+err.Error(), http.StatusInternalServerError)
+				return
+			}
+			copy(obuf[:16], id[:])
+			binary.BigEndian.PutUint64(obuf[16:24], uint64(d.UpdateTime))
+			obuf[24] = 0
+			if d.Deleted {
+				obuf[24] = replica.CompareDigestsFlagDeleted
+			}
+			out = append(out, obuf[:]...)
+		}
+
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Header().Set("Content-Length", strconv.Itoa(len(out)))
+		w.Write(out) //nolint:errcheck
 	})
 }
 
@@ -1039,6 +1144,9 @@ func localIndexNotReady(resp replica.SimpleResponse) bool {
 func (i *replicatedIndices) Close(ctx context.Context) error {
 	i.logger.WithField("action", "close_replicated_indices").Debug("attempting to shut down replicated indices")
 	if i.isShutdown.CompareAndSwap(false, true) {
+		// Signal waiters immediately so they can observe the shutdown state
+		// before the (potentially long) worker-drain below completes.
+		close(i.shutdownStartedCh)
 		i.logger.WithField("action", "close_replicated_indices").Debug("shutting down replicated indices")
 		// Set a timeout for graceful shutdown
 		shutdownTimeoutSeconds := i.requestQueueConfig.QueueShutdownTimeoutSeconds
@@ -1088,4 +1196,11 @@ func (i *replicatedIndices) Close(ctx context.Context) error {
 		i.logger.WithField("action", "close_replicated_indices").Debug("replicated indices shutdown complete")
 	}
 	return nil
+}
+
+// ShuttingDown returns a channel that is closed as soon as Close begins
+// (i.e. the moment isShutdown transitions to true). Callers can select on
+// this channel to synchronize with shutdown without polling.
+func (i *replicatedIndices) ShuttingDown() <-chan struct{} {
+	return i.shutdownStartedCh
 }

--- a/adapters/handlers/rest/clusterapi/indices_replicas_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas_test.go
@@ -14,8 +14,10 @@ package clusterapi_test
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -24,6 +26,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
+	"github.com/google/uuid"
 	"github.com/klauspost/compress/zstd"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +34,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi"
+	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
@@ -64,6 +68,9 @@ func TestMaintenanceModeReplicatedIndices(t *testing.T) {
 		{"GET", "/objects"},
 		{"POST", "/objects"},
 		{"DELETE", "/objects"},
+		{"POST", "/objects/digestsInRange"},
+		{"POST", "/objects/compareDigests"},
+		{"POST", "/objects/hashtree/level/0"},
 		{"PUT", "/replication-factor:increase"},
 		{"POST", ":commit"},
 		{"POST", ":abort"},
@@ -211,21 +218,21 @@ func TestReplicatedIndicesWorkQueue(t *testing.T) {
 			requestKey := fmt.Sprintf("%s=%s", replica.RequestKey, "test_request_id")
 			req, err := http.NewRequest("POST", fmt.Sprintf("%s/replicas/indices/MyClass/shards/myshard:commit?%s", server.URL, requestKey), nil)
 			assert.Nil(t, err)
-			wgAccepted := sync.WaitGroup{}
-			wgRejected := sync.WaitGroup{}
-			wgAccepted.Add(tc.expectedAccepted)
-			wgRejected.Add(tc.expectedRejected)
+			var wgAll sync.WaitGroup
+			wgAll.Add(tc.numRequests)
+			rejectedCh := make(chan struct{}, tc.numRequests)
 			httpStatuses := make(chan int, tc.numRequests)
 			for i := 0; i < tc.numRequests; i++ {
 				go func() {
-					res, err := http.DefaultClient.Do(req)
+					defer wgAll.Done()
+					res, err := http.DefaultClient.Do(req.Clone(req.Context()))
 					assert.Nil(t, err)
 					defer res.Body.Close()
 					httpStatuses <- res.StatusCode
 					if res.StatusCode == http.StatusOK {
-						wgAccepted.Done()
+						// accepted — will be unblocked by close(commitBlock) below
 					} else if res.StatusCode == tc.requestQueueConfig.QueueFullHttpStatus {
-						wgRejected.Done()
+						rejectedCh <- struct{}{}
 					} else {
 						// unexpected status code received
 						fmt.Println("unexpected status code: ", res.StatusCode)
@@ -233,11 +240,12 @@ func TestReplicatedIndicesWorkQueue(t *testing.T) {
 					}
 				}()
 			}
-			wgRejected.Wait()
-			for i := 0; i < tc.expectedAccepted; i++ {
-				commitBlock <- struct{}{}
+			// Wait until we have seen enough rejections, then unblock all accepted requests
+			for i := 0; i < tc.expectedRejected; i++ {
+				<-rejectedCh
 			}
-			wgAccepted.Wait()
+			close(commitBlock)
+			wgAll.Wait()
 			close(httpStatuses)
 
 			actualAccepted := 0
@@ -438,6 +446,14 @@ func TestReplicatedIndicesRejectsRequestsDuringShutdown(t *testing.T) {
 		closeErr <- indices.Close(context.Background())
 	}()
 
+	// Wait until Close() has set isShutdown = true before sending requests,
+	// so we have a happens-before guarantee and the test is not racy.
+	select {
+	case <-indices.ShuttingDown():
+	case <-t.Context().Done():
+		t.Fatalf("timed out waiting for shutdown to start")
+	}
+
 	// Send a few concurrent requests while shutdown is in progress
 	const numConcurrentRequests = 10
 	var wg sync.WaitGroup
@@ -516,15 +532,13 @@ func TestReplicatedIndicesShutdownWithStuckRequests(t *testing.T) {
 	noopAuth := clusterapi.NewNoopAuthHandler()
 	// Create a fake replicator that blocks on commit operations
 	fakeReplicator := replicaTypes.NewMockReplicator(t)
-	startSignal := make(chan struct{})
+	// Buffered so the mock send never races against the test receive.
+	startSignal := make(chan struct{}, 1)
 	doneSignal := make(chan struct{})
 
 	// Configure CommitReplication to signal start and block until done
 	fakeReplicator.EXPECT().CommitReplication(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(_ context.Context, _ string, _ string, _ string) {
-		select {
-		case startSignal <- struct{}{}:
-		default:
-		}
+		startSignal <- struct{}{} // never blocks: buffered channel has capacity 1
 		<-doneSignal
 	}).Return(replica.SimpleResponse{})
 
@@ -548,6 +562,15 @@ func TestReplicatedIndicesShutdownWithStuckRequests(t *testing.T) {
 	mux.Handle("/replicas/indices/", indices.Indices())
 	server := httptest.NewServer(mux)
 	defer server.Close()
+	// Safeguard: unblock any stuck worker before server.Close() waits for
+	// active connections. This defer runs first (LIFO) so that server.Close()
+	// never hangs even if the test fails before the explicit send below.
+	defer func() {
+		select {
+		case doneSignal <- struct{}{}:
+		default:
+		}
+	}()
 
 	// Send a request that will get stuck
 	requestKey := fmt.Sprintf("%s=%s", replica.RequestKey, "stuck_request")
@@ -721,4 +744,240 @@ func TestPutOverwriteObjectsCompression(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newCompareDigestsServer builds a test HTTP server that serves the replicated
+// indices handler backed by the supplied replicator.
+func newCompareDigestsServer(t *testing.T, replicator replicaTypes.Replicator) (*httptest.Server, string) {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	indices := clusterapi.NewReplicatedIndices(
+		replicator,
+		clusterapi.NewNoopAuthHandler(),
+		func() bool { return false },
+		cluster.RequestQueueConfig{},
+		logger,
+		func() bool { return true },
+	)
+	mux := http.NewServeMux()
+	mux.Handle("/replicas/indices/", indices.Indices())
+	server := httptest.NewServer(mux)
+	t.Cleanup(server.Close)
+	url := server.URL + "/replicas/indices/C1/shards/S1/objects/compareDigests"
+	return server, url
+}
+
+// buildBinaryDigests encodes a slice of RepairResponse records into the 25-byte
+// binary wire format used by postCompareDigests (UUID + UpdateTime + flags byte).
+func buildBinaryDigests(t *testing.T, records []types.RepairResponse) []byte {
+	t.Helper()
+	buf := make([]byte, len(records)*replica.CompareDigestsRecordLength)
+	for i, r := range records {
+		id, err := uuid.Parse(r.ID)
+		require.NoError(t, err)
+		off := i * replica.CompareDigestsRecordLength
+		copy(buf[off:], id[:])
+		binary.BigEndian.PutUint64(buf[off+16:], uint64(r.UpdateTime))
+		if r.Deleted {
+			buf[off+24] = replica.CompareDigestsFlagDeleted
+		}
+	}
+	return buf
+}
+
+func TestPostCompareDigests(t *testing.T) {
+	t.Parallel()
+
+	const (
+		testUUID1 = "73f2eb5f-5abf-447a-81ca-74b1dd168241"
+		testUUID2 = "73f2eb5f-5abf-447a-81ca-74b1dd168242"
+	)
+
+	now := time.Now().UnixMilli()
+
+	sourceDigests := []types.RepairResponse{
+		{ID: testUUID1, UpdateTime: now},
+		{ID: testUUID2, UpdateTime: now + 1000},
+	}
+	// The target reports uuid1 as missing and uuid2 as stale.
+	staleDigests := []types.RepairResponse{
+		{ID: testUUID1, UpdateTime: 0},
+		{ID: testUUID2, UpdateTime: now},
+	}
+
+	t.Run("HappyPath", func(t *testing.T) {
+		t.Parallel()
+		rep := replicaTypes.NewMockReplicator(t)
+		rep.EXPECT().
+			CompareDigests(mock.Anything, "C1", "S1", mock.MatchedBy(func(d []types.RepairResponse) bool {
+				return len(d) == 2
+			})).
+			Return(staleDigests, nil)
+
+		_, url := newCompareDigestsServer(t, rep)
+
+		body := buildBinaryDigests(t, sourceDigests)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/octet-stream")
+		// compareDigests is binary-only; no X-Accept-Response-Encoding needed.
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "application/octet-stream", resp.Header.Get("Content-Type"))
+		// No X-Response-Encoding header — the protocol is unconditionally binary.
+		assert.Empty(t, resp.Header.Get("X-Response-Encoding"))
+
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, len(staleDigests)*replica.CompareDigestsRecordLength, len(respBody))
+
+		// Decode and verify each returned stale record.
+		for i, want := range staleDigests {
+			off := i * replica.CompareDigestsRecordLength
+			rec := respBody[off : off+replica.CompareDigestsRecordLength]
+			gotID, err := uuid.FromBytes(rec[:16])
+			require.NoError(t, err)
+			assert.Equal(t, want.ID, gotID.String())
+			assert.Equal(t, uint64(want.UpdateTime), binary.BigEndian.Uint64(rec[16:24]))
+			assert.Equal(t, want.Deleted, rec[24]&replica.CompareDigestsFlagDeleted != 0)
+		}
+	})
+
+	t.Run("EmptyBody", func(t *testing.T) {
+		t.Parallel()
+		rep := replicaTypes.NewMockReplicator(t)
+		rep.EXPECT().
+			CompareDigests(mock.Anything, "C1", "S1", []types.RepairResponse(nil)).
+			Return(nil, nil)
+
+		_, url := newCompareDigestsServer(t, rep)
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, http.NoBody)
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		assert.Empty(t, respBody)
+	})
+
+	t.Run("InvalidPayloadLength", func(t *testing.T) {
+		t.Parallel()
+		// A payload of 10 bytes is not a multiple of CompareDigestsRecordLength (25).
+		rep := newFakeReplicator(false)
+		_, url := newCompareDigestsServer(t, rep)
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url,
+			bytes.NewReader([]byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a}))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/octet-stream")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+	})
+
+	t.Run("ReplicatorError", func(t *testing.T) {
+		t.Parallel()
+		rep := replicaTypes.NewMockReplicator(t)
+		rep.EXPECT().
+			CompareDigests(mock.Anything, "C1", "S1", mock.Anything).
+			Return(nil, fmt.Errorf("storage unavailable"))
+
+		_, url := newCompareDigestsServer(t, rep)
+
+		body := buildBinaryDigests(t, sourceDigests)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/octet-stream")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+	})
+
+	t.Run("RequestPayloadRoundTrip", func(t *testing.T) {
+		t.Parallel()
+		// Verify that the handler decodes the binary request faithfully:
+		// each UUID and UpdateTime must match what the client encoded.
+		var gotDigests []types.RepairResponse
+		rep := replicaTypes.NewMockReplicator(t)
+		rep.EXPECT().
+			CompareDigests(mock.Anything, "C1", "S1", mock.MatchedBy(func(d []types.RepairResponse) bool {
+				gotDigests = d
+				return true
+			})).
+			Return(nil, nil)
+
+		_, url := newCompareDigestsServer(t, rep)
+
+		body := buildBinaryDigests(t, sourceDigests)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(body))
+		require.NoError(t, err)
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		require.Len(t, gotDigests, len(sourceDigests))
+		for i, want := range sourceDigests {
+			assert.Equal(t, want.ID, gotDigests[i].ID)
+			assert.Equal(t, want.UpdateTime, gotDigests[i].UpdateTime)
+		}
+	})
+
+	t.Run("DeletedFlagRoundTrip", func(t *testing.T) {
+		t.Parallel()
+		// When the replicator returns Deleted=true for an object, the response
+		// flags byte must have CompareDigestsFlagDeleted set, and the client
+		// must decode it back to Deleted=true.
+		deletedDigests := []types.RepairResponse{
+			{ID: testUUID1, UpdateTime: now - 1000, Deleted: true},
+			{ID: testUUID2, UpdateTime: now, Deleted: false},
+		}
+		rep := replicaTypes.NewMockReplicator(t)
+		rep.EXPECT().
+			CompareDigests(mock.Anything, "C1", "S1", mock.Anything).
+			Return(deletedDigests, nil)
+
+		_, url := newCompareDigestsServer(t, rep)
+
+		body := buildBinaryDigests(t, sourceDigests)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodPost, url, bytes.NewReader(body))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "application/octet-stream")
+
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		respBody, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.Equal(t, len(deletedDigests)*replica.CompareDigestsRecordLength, len(respBody))
+
+		for i, want := range deletedDigests {
+			off := i * replica.CompareDigestsRecordLength
+			rec := respBody[off : off+replica.CompareDigestsRecordLength]
+			gotID, err := uuid.FromBytes(rec[:16])
+			require.NoError(t, err)
+			assert.Equal(t, want.ID, gotID.String())
+			assert.Equal(t, uint64(want.UpdateTime), binary.BigEndian.Uint64(rec[16:24]))
+			assert.Equal(t, want.Deleted, rec[24]&replica.CompareDigestsFlagDeleted != 0,
+				"record %d: Deleted flag mismatch", i)
+		}
+	})
 }

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -8364,6 +8364,13 @@ func init() {
           "x-nullable": true,
           "x-omitempty": true
         },
+        "initShieldCpuEveryN": {
+          "description": "Number of objects processed between scheduler yield points during hashtree initialisation scan. Yielding periodically lets query goroutines make forward progress during the potentially long on-disk scan.",
+          "type": "integer",
+          "format": "int64",
+          "x-nullable": true,
+          "x-omitempty": true
+        },
         "loggingFrequency": {
           "description": "Interval in seconds at which async replication logs its status.",
           "type": "integer",
@@ -8394,13 +8401,6 @@ func init() {
         },
         "propagationConcurrency": {
           "description": "Maximum number of concurrent propagation workers.",
-          "type": "integer",
-          "format": "int64",
-          "x-nullable": true,
-          "x-omitempty": true
-        },
-        "propagationDelay": {
-          "description": "Delay in milliseconds before newly added or updated objects are propagated.",
           "type": "integer",
           "format": "int64",
           "x-nullable": true,
@@ -18353,6 +18353,13 @@ func init() {
           "x-nullable": true,
           "x-omitempty": true
         },
+        "initShieldCpuEveryN": {
+          "description": "Number of objects processed between scheduler yield points during hashtree initialisation scan. Yielding periodically lets query goroutines make forward progress during the potentially long on-disk scan.",
+          "type": "integer",
+          "format": "int64",
+          "x-nullable": true,
+          "x-omitempty": true
+        },
         "loggingFrequency": {
           "description": "Interval in seconds at which async replication logs its status.",
           "type": "integer",
@@ -18383,13 +18390,6 @@ func init() {
         },
         "propagationConcurrency": {
           "description": "Maximum number of concurrent propagation workers.",
-          "type": "integer",
-          "format": "int64",
-          "x-nullable": true,
-          "x-omitempty": true
-        },
-        "propagationDelay": {
-          "description": "Delay in milliseconds before newly added or updated objects are propagated.",
           "type": "integer",
           "format": "int64",
           "x-nullable": true,

--- a/adapters/repos/db/async_repair_nil_shard_integration_test.go
+++ b/adapters/repos/db/async_repair_nil_shard_integration_test.go
@@ -1,0 +1,349 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	routerTypes "github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	entreplication "github.com/weaviate/weaviate/entities/replication"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	runtimecfg "github.com/weaviate/weaviate/usecases/config/runtime"
+	"github.com/weaviate/weaviate/usecases/dynsemaphore"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/usecases/objects"
+	"github.com/weaviate/weaviate/usecases/replica"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+)
+
+// TestIndexNilShardGuard verifies that Index.HashTreeLevel and
+// Index.CompareDigests return a non-nil error when the requested shard is
+// absent from the index's shards map.
+//
+// Before the fix both methods silently returned (nil, nil). The hashbeater
+// interpreted an empty/nil levelDigests slice as "no differences found" and
+// marked the target as fully compared, preventing any further propagation
+// attempts. The fix changes the nil-shard guard from:
+//
+//	return nil, nil
+//
+// to:
+//
+//	return nil, fmt.Errorf("shard %q is not yet initialized on this node", shardName)
+//
+// so that the hashbeater treats the failure as a transient error and retries.
+func TestIndexNilShardGuard(t *testing.T) {
+	ctx := context.Background()
+	const class = "NilShardGuardTest"
+
+	_, idx := testShard(t, ctx, class)
+
+	// nonexistent is guaranteed to be absent: testShard stores exactly one
+	// shard under a random name; "nonexistent-shard" will never collide.
+	const nonexistent = "nonexistent-shard"
+
+	disc := hashtree.NewBitset(hashtree.NodesCount(1))
+	disc.Set(0) // mark root as "to compare"
+
+	t.Run("HashTreeLevelReturnsError", func(t *testing.T) {
+		_, err := idx.HashTreeLevel(ctx, nonexistent, 0, disc)
+		require.Error(t, err, "HashTreeLevel must return an error for a nil shard, not (nil, nil)")
+		assert.Contains(t, err.Error(), "not yet initialized")
+	})
+
+	t.Run("CompareDigestsReturnsError", func(t *testing.T) {
+		_, err := idx.CompareDigests(ctx, nonexistent, nil)
+		require.Error(t, err, "CompareDigests must return an error for a nil shard, not (nil, nil)")
+		assert.Contains(t, err.Error(), "not yet initialized")
+	})
+}
+
+// nilThenEmptyClient simulates a remote node whose shard transitions from
+// "not yet initialized" to "initialized but empty".
+//
+// While !initialized it returns an error from HashTreeLevel (reproducing
+// the nil-shard state after a node restart during RAFT catch-up). After
+// setInitialized() is called it returns all-zero digests from an empty
+// HashTree, causing the source to detect a diff and propagate objects.
+//
+// Once objects are received via OverwriteObjects they are considered
+// present on the target; CompareDigests will no longer report them as
+// missing so the hashbeater stops re-propagating them after the first
+// successful round.
+type nilThenEmptyClient struct {
+	FakeReplicationClient
+
+	initialized atomic.Bool
+	emptyHT     *hashtree.HashTree
+	emptyBuf    []hashtree.Digest
+
+	mu          sync.Mutex
+	propagated  []string        // IDs received via OverwriteObjects
+	receivedIDs map[string]bool // tracks which IDs have been propagated to this target
+}
+
+func newNilThenEmptyClient(t *testing.T, height int) *nilThenEmptyClient {
+	t.Helper()
+	ht, err := hashtree.NewHashTree(height)
+	require.NoError(t, err)
+	return &nilThenEmptyClient{
+		emptyHT:     ht,
+		emptyBuf:    make([]hashtree.Digest, hashtree.LeavesCount(height)),
+		receivedIDs: make(map[string]bool),
+	}
+}
+
+func (c *nilThenEmptyClient) setInitialized() { c.initialized.Store(true) }
+
+func (c *nilThenEmptyClient) HashTreeLevel(
+	_ context.Context, _, _, shard string,
+	level int, discriminant *hashtree.Bitset,
+) ([]hashtree.Digest, error) {
+	if !c.initialized.Load() {
+		return nil, fmt.Errorf("shard %q is not yet initialized on this node", shard)
+	}
+	// Return all-zero digests from the empty HashTree. This guarantees that
+	// hashtree.LevelDiff sees a non-zero XOR against the source (which has
+	// objects), causing the hashbeater to proceed to range scanning.
+	count, err := c.emptyHT.Level(level, discriminant, c.emptyBuf)
+	if err != nil {
+		return nil, err
+	}
+	result := make([]hashtree.Digest, count)
+	copy(result, c.emptyBuf[:count])
+	return result, nil
+}
+
+func (c *nilThenEmptyClient) CompareDigests(
+	_ context.Context, _, _, _ string,
+	sourceDigests []routerTypes.RepairResponse,
+) ([]routerTypes.RepairResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	// Report only objects that have not yet been received via OverwriteObjects
+	// as missing (UpdateTime == 0). Once propagated they are considered
+	// present on this target, so subsequent hashbeats find no diff and stop
+	// re-propagating the same objects.
+	var missing []routerTypes.RepairResponse
+	for _, d := range sourceDigests {
+		if !c.receivedIDs[d.ID] {
+			missing = append(missing, routerTypes.RepairResponse{ID: d.ID, UpdateTime: 0})
+		}
+	}
+	return missing, nil
+}
+
+func (c *nilThenEmptyClient) OverwriteObjects(
+	_ context.Context, _, _, _ string,
+	objs []*objects.VObject,
+) ([]routerTypes.RepairResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, obj := range objs {
+		if obj != nil && obj.LatestObject != nil {
+			id := string(obj.LatestObject.ID)
+			c.propagated = append(c.propagated, id)
+			c.receivedIDs[id] = true
+		}
+	}
+	return nil, nil
+}
+
+func (c *nilThenEmptyClient) propagatedCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.propagated)
+}
+
+// withTwoNodeReplication returns an indexOpt that replaces the index's
+// replicator with a two-node setup ("node1" local, "node2" target) backed by
+// the supplied client. It also initialises asyncReplicationWorkersLimiter so
+// that the hashbeater can acquire worker permits without panicking.
+func withTwoNodeReplication(t *testing.T, client replica.Client) func(*Index) {
+	t.Helper()
+	return func(idx *Index) {
+		logger, _ := test.NewNullLogger()
+
+		const (
+			localNode  = "node1"
+			remoteNode = "node2"
+			localAddr  = "http://node1:8080"
+			remoteAddr = "http://node2:8080"
+		)
+
+		localReplica := routerTypes.Replica{NodeName: localNode, ShardName: "shard1", HostAddr: localAddr}
+		remoteReplica := routerTypes.Replica{NodeName: remoteNode, ShardName: "shard1", HostAddr: remoteAddr}
+
+		readReplicaSet := routerTypes.ReadReplicaSet{Replicas: []routerTypes.Replica{localReplica, remoteReplica}}
+		readPlan := routerTypes.ReadRoutingPlan{
+			LocalHostname: localAddr,
+			ReplicaSet:    readReplicaSet,
+		}
+
+		mockRouter := routerTypes.NewMockRouter(t)
+		mockRouter.EXPECT().
+			GetWriteReplicasLocation(mock.Anything, mock.Anything, mock.Anything).
+			Return(routerTypes.WriteReplicaSet{Replicas: []routerTypes.Replica{localReplica, remoteReplica}}, nil).
+			Maybe()
+		mockRouter.EXPECT().
+			GetReadReplicasLocation(mock.Anything, mock.Anything, mock.Anything).
+			Return(readReplicaSet, nil).
+			Maybe()
+		mockRouter.EXPECT().
+			AllHostnames().
+			Return([]string{localAddr, remoteAddr}).
+			Maybe()
+		// CollectShardDifferences uses BuildRoutingPlanOptions + BuildReadRoutingPlan.
+		mockRouter.EXPECT().
+			BuildRoutingPlanOptions(mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(routerTypes.RoutingPlanBuildOptions{}).
+			Maybe()
+		mockRouter.EXPECT().
+			BuildReadRoutingPlan(mock.Anything).
+			Return(readPlan, nil).
+			Maybe()
+
+		nodeResolver := cluster.NewMockNodeResolver(t)
+		nodeResolver.EXPECT().NodeHostname(localNode).Return(localAddr, true).Maybe()
+		nodeResolver.EXPECT().NodeHostname(remoteNode).Return(remoteAddr, true).Maybe()
+
+		rep, err := replica.NewReplicator(
+			idx.Config.ClassName.String(),
+			mockRouter,
+			nodeResolver,
+			localNode,
+			func() string { return models.ReplicationConfigDeletionStrategyNoAutomatedResolution },
+			client,
+			monitoring.GetMetrics(),
+			logger,
+		)
+		require.NoError(t, err)
+		idx.replicator = rep
+		idx.router = mockRouter
+
+		// asyncReplicationWorkersLimiter must be non-nil before the hashbeater
+		// goroutine calls asyncReplicationWorkerAcquire.
+		idx.asyncReplicationWorkersLimiter = dynsemaphore.NewDynamicWeighted(func() int64 { return 1 })
+
+		// globalreplicationConfig must be non-nil: asyncReplicationGloballyDisabled
+		// calls globalreplicationConfig.AsyncReplicationDisabled.Get() which panics
+		// on a nil pointer if globalreplicationConfig is unset.
+		idx.globalreplicationConfig = &entreplication.GlobalConfig{
+			AsyncReplicationDisabled: runtimecfg.NewDynamicValue(false),
+		}
+	}
+}
+
+// TestAsyncRepairObjectInsertionNilShardRetry is the integration equivalent of
+// the acceptance test TestAsyncRepairObjectInsertionScenario. It exercises the
+// full async-replication path with a target whose shard starts nil (simulating
+// the post-restart RAFT catch-up window) and verifies that:
+//
+//  1. The hashbeater retries when HashTreeLevel returns an error instead of
+//     treating (nil, nil) as "no differences found".
+//  2. All objects are propagated once the target shard becomes available.
+func TestAsyncRepairObjectInsertionNilShardRetry(t *testing.T) {
+	const (
+		class  = "AsyncRepairNilShardRetry"
+		n      = 10
+		height = 1
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	client := newNilThenEmptyClient(t, height)
+	sl, _ := testShard(t, ctx, class, withTwoNodeReplication(t, client))
+	s, ok := sl.(*Shard)
+	require.True(t, ok)
+
+	// Insert N objects with deterministic UUIDs so the test is reproducible.
+	for i := range n {
+		id := strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", i+1))
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, id, int64(i+1))))
+	}
+
+	// DigestObjectsInRange (called inside objectsToPropagateWithinRange) uses a
+	// disk-only cursor. Flush memtables so that all N objects are visible on disk.
+	require.NoError(t, s.store.FlushMemtables(ctx))
+
+	// Enable async replication with fast tick rates so the test completes
+	// in seconds rather than the production 30 s interval.
+	// aliveNodesCheckingFrequency is intentionally long so that nt.C does not
+	// fire during the test (it would call setLastComparedNodes and interfere).
+	cfg := AsyncReplicationConfig{
+		hashtreeHeight:              height,
+		frequency:                   2 * time.Second,
+		frequencyWhilePropagating:   500 * time.Millisecond,
+		aliveNodesCheckingFrequency: 10 * time.Minute,
+		diffPerNodeTimeout:          10 * time.Second,
+		prePropagationTimeout:       10 * time.Second,
+		propagationTimeout:          10 * time.Second,
+		propagationLimit:            1_000,
+		propagationConcurrency:      1,
+		propagationBatchSize:        100,
+		diffBatchSize:               100,
+		loggingFrequency:            1 * time.Second,
+		initShieldCPUEveryN:         1,
+	}
+	require.NoError(t, s.SetAsyncReplicationState(ctx, cfg, true))
+	t.Cleanup(func() {
+		_ = s.SetAsyncReplicationState(context.Background(), cfg, false)
+	})
+
+	// AsyncReplicationEnabled() returns true only when ReplicationFactor > 1
+	// AND AsyncReplicationEnabled is true. Without both flags, handleHashbeatWakeup
+	// skips every beat. Set them now — after SetAsyncReplicationState has
+	// initialised the hashtree with the correct config — so that initShard did
+	// not call initAsyncReplication with a zero-value AsyncReplicationConfig.
+	func() {
+		s.index.replicationConfigLock.Lock()
+		defer s.index.replicationConfigLock.Unlock()
+		s.index.Config.ReplicationFactor = 2
+		s.index.Config.AsyncReplicationEnabled = true
+	}()
+
+	// Wait for the hashtree init scan to complete so that the source's root
+	// digest reflects all N on-disk objects before the first hashbeat.
+	awaitHashtreeInitialized(t, s)
+
+	// Give the first hashbeat time to fire and fail (target shard is nil →
+	// HashTreeLevel returns error → backoff ≥ 1 s). 1.5 s is enough.
+	time.Sleep(1500 * time.Millisecond)
+	assert.Equal(t, 0, client.propagatedCount(),
+		"no objects should be propagated while the target shard is nil")
+
+	// Switch the target to "empty shard" phase. The next hashbeat (fired by
+	// ft.C after cfg.frequency = 2 s) will now see a diff and propagate all
+	// N objects via OverwriteObjects.
+	client.setInitialized()
+
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.Equal(ct, n, client.propagatedCount(),
+			"all %d objects must be propagated after target shard becomes available", n)
+	}, 30*time.Second, 200*time.Millisecond,
+		"objects were not asynchronously propagated after target shard became available")
+}

--- a/adapters/repos/db/fakes_for_tests.go
+++ b/adapters/repos/db/fakes_for_tests.go
@@ -560,6 +560,12 @@ func (c *FakeReplicationClient) DigestObjectsInRange(ctx context.Context, host, 
 	return nil, nil
 }
 
+func (c *FakeReplicationClient) CompareDigests(ctx context.Context, host, index, shard string,
+	digests []types.RepairResponse,
+) ([]types.RepairResponse, error) {
+	return nil, nil
+}
+
 func (c *FakeReplicationClient) HashTreeLevel(ctx context.Context, host, index, shard string, level int,
 	discriminant *hashtree.Bitset,
 ) (digests []hashtree.Digest, err error) {

--- a/adapters/repos/db/helper_for_test.go
+++ b/adapters/repos/db/helper_for_test.go
@@ -39,6 +39,7 @@ import (
 	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/cluster"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/dynsemaphore"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/replica"
@@ -438,6 +439,10 @@ func setupTestShardWithSettings(t *testing.T, ctx context.Context, class *models
 		router:                 mockRouter,
 	}
 	idx.closingCtx, idx.closingCancel = context.WithCancel(context.Background())
+	// asyncReplicationWorkersLimiter must be non-nil before the hashbeater
+	// goroutine calls asyncReplicationWorkerAcquire. NewIndex always sets it,
+	// but this helper constructs the Index directly via struct literal.
+	idx.asyncReplicationWorkersLimiter = dynsemaphore.NewDynamicWeighted(func() int64 { return 8 })
 	idx.initCycleCallbacksNoop()
 	for _, opt := range indexOpts {
 		opt(idx)

--- a/adapters/repos/db/index_async_replication.go
+++ b/adapters/repos/db/index_async_replication.go
@@ -162,17 +162,6 @@ func asyncReplicationConfigFromModel(multiTenancyEnabled bool, cfg *models.Repli
 		return AsyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_PROPAGATION_LIMIT", err)
 	}
 
-	propagationDelay := defaultPropagationDelay
-	if cfg.PropagationDelay != nil {
-		propagationDelay = time.Duration(*cfg.PropagationDelay) * time.Millisecond
-	}
-
-	config.propagationDelay, err = optParseDuration(
-		os.Getenv("ASYNC_REPLICATION_PROPAGATION_DELAY"), propagationDelay)
-	if err != nil {
-		return AsyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_PROPAGATION_DELAY", err)
-	}
-
 	propagationConcurrency := defaultPropagationConcurrency
 	if cfg.PropagationConcurrency != nil {
 		propagationConcurrency = int(*cfg.PropagationConcurrency)
@@ -193,6 +182,23 @@ func asyncReplicationConfigFromModel(multiTenancyEnabled bool, cfg *models.Repli
 		os.Getenv("ASYNC_REPLICATION_PROPAGATION_BATCH_SIZE"), propagationBatchSize, minPropagationBatchSize, maxPropagationBatchSize)
 	if err != nil {
 		return AsyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_PROPAGATION_BATCH_SIZE", err)
+	}
+
+	initShieldCPUEveryN := defaultInitShieldCPUEveryN
+	if cfg.InitShieldCPUEveryN != nil {
+		v := *cfg.InitShieldCPUEveryN
+		if v < int64(minInitShieldCPUEveryN) || v > int64(maxInitShieldCPUEveryN) {
+			return AsyncReplicationConfig{}, fmt.Errorf(
+				"initShieldCPUEveryN value %d out of range: min %d, max %d",
+				v, minInitShieldCPUEveryN, maxInitShieldCPUEveryN)
+		}
+		initShieldCPUEveryN = int(v)
+	}
+
+	config.initShieldCPUEveryN, err = optParseInt(
+		os.Getenv("ASYNC_REPLICATION_INIT_SHIELD_CPU_EVERY_N"), initShieldCPUEveryN, minInitShieldCPUEveryN, maxInitShieldCPUEveryN)
+	if err != nil {
+		return AsyncReplicationConfig{}, fmt.Errorf("%s: %w", "ASYNC_REPLICATION_INIT_SHIELD_CPU_EVERY_N", err)
 	}
 
 	return config, err

--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -194,6 +194,20 @@ type Bucket struct {
 	shouldSkipKey func(key []byte, ctx context.Context) (bool, error)
 
 	skipSecondaryKeyCheck bool
+
+	// flushCallback is an optional function called after each successful
+	// memtable flush. It is called in a non-blocking fashion (fire-and-forget)
+	// to avoid delaying the flush cycle. Protected by flushCallbackMu.
+	flushCallback   func()
+	flushCallbackMu sync.Mutex
+
+	// objectFlushCallback is called inside FlushAndSwitch after the flushing
+	// memtable has been written to disk but before the new segment is added to
+	// the segment group. It receives an iterator over the flushed entries and a
+	// function to look up existing on-disk values (pre-new-segment).
+	// Only invoked for StrategyReplace buckets.
+	objectFlushCallback   ObjectFlushCallback
+	objectFlushCallbackMu sync.Mutex
 }
 
 func NewBucketCreator() *Bucket { return &Bucket{} }
@@ -387,14 +401,6 @@ func (b *Bucket) IterateObjects(ctx context.Context, f func(object *storobj.Obje
 	return nil
 }
 
-func (b *Bucket) pauseCompaction(ctx context.Context) error {
-	return b.disk.pauseCompaction(ctx)
-}
-
-func (b *Bucket) resumeCompaction(ctx context.Context) error {
-	return b.disk.resumeCompaction(ctx)
-}
-
 // ApplyToObjectDigests iterates over all objects in the bucket, both in memtable
 // and on disk, and applies the given function to each object.
 // The afterInMemCallback is called after the in-memory memtable has been processed.
@@ -402,30 +408,12 @@ func (b *Bucket) resumeCompaction(ctx context.Context) error {
 // objects have been processed.
 // The function f is called for each object, and if it returns an error, the
 // processing is stopped and the error is returned.
-// Note: this function pauses compaction while it is running, to ensure a consistent view of the data.
+// Cursor stability is guaranteed by the consistent-view mechanism (ref-counted segment
+// snapshots); compaction may proceed concurrently and old segments are only dropped
+// once this function returns and the cursor is closed.
 func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 	afterInMemCallback func(), f func(uuidBytes []byte, updateTime int64) error,
 ) error {
-	err := b.pauseCompaction(ctx)
-	if err != nil {
-		afterInMemCallback()
-		return fmt.Errorf("pausing compaction: %w", err)
-	}
-	defer func() {
-		ec := errorcompounder.New()
-
-		if err != nil {
-			ec.AddWrapf(err, "during ApplyToObjectDigests")
-		}
-
-		err = b.resumeCompaction(ctx)
-		if err != nil {
-			ec.AddWrapf(err, "resuming compaction after ApplyToObjectDigests")
-		}
-
-		err = ec.ToError()
-	}()
-
 	// note: it's important to first create the on disk cursor so to avoid potential double scanning over flushing memtable
 	onDiskCursor := b.CursorOnDisk()
 	defer onDiskCursor.Close()
@@ -433,7 +421,7 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 	inmemProcessedDocIDs := make(map[uint64]struct{})
 
 	// note: read-write access to active and flushing memtable will be blocked only during the scope of this inner function
-	err = func() error {
+	err := func() error {
 		defer afterInMemCallback()
 
 		inMemCursor := b.CursorInMem()
@@ -478,6 +466,35 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 
 			if err := f(k, updateTime); err != nil {
 				return fmt.Errorf("callback on object '%d' failed: %w", docID, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ApplyToOnDiskObjectDigests iterates over objects stored in on-disk segments
+// only (memtables are not scanned) and calls fn for each object. For keys that
+// appear in multiple segments the latest version is returned (segment group
+// deduplication). Tombstoned entries are skipped.
+//
+// This is the disk-only counterpart of ApplyToObjectDigests, intended for
+// initialising state that should reflect durable on-disk data exclusively.
+func (b *Bucket) ApplyToOnDiskObjectDigests(ctx context.Context, fn func(uuidBytes []byte, updateTime int64) error) error {
+	onDiskCursor := b.CursorOnDisk()
+	defer onDiskCursor.Close()
+
+	for k, v := onDiskCursor.First(); k != nil; k, v = onDiskCursor.Next() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			_, updateTime, err := storobj.DocIDAndTimeFromBinary(v)
+			if err != nil || updateTime < 1 {
+				continue
+			}
+			if err := fn(k, updateTime); err != nil {
+				return err
 			}
 		}
 	}
@@ -571,6 +588,41 @@ func (b *Bucket) Get(key []byte) ([]byte, error) {
 
 func (b *Bucket) GetErrDeleted(key []byte) ([]byte, error) {
 	return b.get(key)
+}
+
+// GetDiskOnlyConsistentView returns a consistent snapshot of the on-disk
+// segments without acquiring flushLock or capturing memtable references.
+// Only maintenanceLock (briefly) and segmentRefCounterLock are taken to
+// ref-count the segments, preventing compaction from removing them while the
+// view is live.
+//
+// The caller must call view.ReleaseView() when all lookups are complete to
+// decrement the segment ref-counts and allow compaction to proceed.
+//
+// Use this together with GetErrDeletedOnDisk for batch operations that must
+// not touch memtables and want to amortise lock acquisition across many keys.
+func (b *Bucket) GetDiskOnlyConsistentView() BucketConsistentView {
+	diskSegments, releaseDiskSegments := b.disk.getConsistentViewOfSegments()
+	return BucketConsistentView{
+		Disk:    diskSegments,
+		release: releaseDiskSegments,
+		Bucket:  b,
+	}
+}
+
+// GetErrDeletedOnDisk looks up key in the on-disk segments of the pre-acquired
+// view, skipping both the active and flushing memtables entirely. The caller
+// must hold the view for the duration of all lookups and release it via
+// view.ReleaseView() when done.
+//
+// Returns lsmkv.ErrDeleted if the key has a tombstone in the segments (note:
+// disk tombstones do not carry a deletion timestamp), lsmkv.NotFound if absent
+// from disk, or nil error with the value if found.
+//
+// Use this for batch lookups where a single consistent view is shared across
+// many keys to amortise lock acquisition cost.
+func (b *Bucket) GetErrDeletedOnDisk(key []byte, view BucketConsistentView) ([]byte, error) {
+	return b.getFromSegmentGroup(key, view.Disk)
 }
 
 func (b *Bucket) get(key []byte) ([]byte, error) {
@@ -1484,10 +1536,10 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 		b.metrics.ObserveBucketShutdownDurationByStrategy(b.strategy, time.Since(start))
 	}()
 
-	if err := b.disk.shutdown(ctx); err != nil {
-		return err
-	}
-
+	// Unregister flush callbacks before anything else: this blocks until any
+	// in-progress auto-flush (flushAndSwitchIfThresholdsMet) completes and
+	// prevents new ones from starting.  b.disk is still fully accessible here,
+	// which is required by fireObjectFlushCallbackForActiveMem below.
 	if err := b.flushCallbackCtrl.Unregister(ctx); err != nil {
 		return fmt.Errorf("long-running flush in progress: %w", ctx.Err())
 	}
@@ -1514,7 +1566,17 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 		b.active.setAveragePropertyLength(avgPropLength, propLengthCount)
 	}
 
-	if b.shouldReuseWAL() {
+	reuseWAL := b.shouldReuseWAL()
+	if !reuseWAL {
+		// Fire objectFlushCallback for the active memtable before flushing it to
+		// disk.  b.disk is still accessible at this point (not yet shut down), so
+		// getConsistentViewOfSegments can snapshot the current on-disk segments
+		// and the callback receives the correct pre-flush disk state — matching
+		// the semantics used in FlushAndSwitch.
+		b.fireObjectFlushCallbackForActiveMem()
+	}
+
+	if reuseWAL {
 		if err := b.active.flushWAL(); err != nil {
 			b.flushLock.Unlock()
 			return err
@@ -1526,6 +1588,13 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 		}
 	}
 	b.flushLock.Unlock()
+
+	// Shut down disk segments after the active memtable has been flushed and
+	// the objectFlushCallback has been fired, so that any hashtree saved by
+	// mayStopAsyncReplication reflects the fully up-to-date on-disk state.
+	if err := b.disk.shutdown(ctx); err != nil {
+		return err
+	}
 
 	if b.flushing == nil {
 		// active has flushing, no one else was currently flushing, it's safe to
@@ -1600,6 +1669,14 @@ func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAb
 				b.memtableThreshold = uint64(next)
 			}
 		}
+
+		b.flushCallbackMu.Lock()
+		cb := b.flushCallback
+		b.flushCallbackMu.Unlock()
+		if cb != nil {
+			cb()
+		}
+
 		return true
 	}
 	return false
@@ -1607,6 +1684,78 @@ func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAb
 
 func (b *Bucket) getAndUpdateWritesSinceLastSync() bool {
 	return b.active.getAndUpdateWritesSinceLastSync(b.logger)
+}
+
+// SetFlushCallback registers a function to be called after each successful
+// memtable flush. The callback is invoked in a non-blocking, fire-and-forget
+// manner so it must not block. Pass nil to clear a previously set callback.
+func (b *Bucket) SetFlushCallback(fn func()) {
+	b.flushCallbackMu.Lock()
+	b.flushCallback = fn
+	b.flushCallbackMu.Unlock()
+}
+
+// ObjectFlushCallback is called inside FlushAndSwitch after the flushing
+// memtable has been written to disk but before the new segment is added to the
+// segment group. This allows the caller to observe exactly which objects were
+// durably persisted and update derived state (e.g. a hashtree) accordingly.
+//
+// forEachFlushedObject iterates all entries in the flushed memtable in key
+// order, providing raw key bytes, raw value bytes, and a tombstone flag.
+//
+// lookupOnDisk looks up a key in the existing segment group, which at this
+// point does NOT yet include the newly flushed segment. This lets callers
+// retrieve the previous on-disk value for a key before the flush overwrites it.
+//
+// The callback is invoked synchronously in the flush goroutine and must not
+// perform long-blocking I/O. Only invoked for StrategyReplace buckets.
+type ObjectFlushCallback func(
+	forEachFlushedObject func(fn func(key []byte, value []byte, tombstone bool)),
+	lookupOnDisk func(key []byte) ([]byte, bool),
+)
+
+// SetObjectFlushCallback registers a callback to be called inside FlushAndSwitch
+// after the flushing memtable has been written to disk but before the new segment
+// is added to the segment group. Pass nil to clear a previously set callback.
+func (b *Bucket) SetObjectFlushCallback(fn ObjectFlushCallback) {
+	b.objectFlushCallbackMu.Lock()
+	b.objectFlushCallback = fn
+	b.objectFlushCallbackMu.Unlock()
+}
+
+// fireObjectFlushCallbackForActiveMem fires the objectFlushCallback for the
+// current active memtable using the same semantics as FlushAndSwitch: each key
+// in the active memtable is paired with its pre-flush on-disk value so the
+// callback can correctly XOR-in/XOR-out the digest delta.
+//
+// Must be called while b.flushLock is held by the caller and before
+// b.disk.shutdown so that getConsistentViewOfSegments remains accessible.
+// Has no effect for non-StrategyReplace buckets or when no callback is registered.
+func (b *Bucket) fireObjectFlushCallbackForActiveMem() {
+	b.objectFlushCallbackMu.Lock()
+	objCb := b.objectFlushCallback
+	b.objectFlushCallbackMu.Unlock()
+
+	if objCb == nil || b.strategy != StrategyReplace {
+		return
+	}
+
+	// b.active is safe to access here: the caller holds b.flushLock, and
+	// flushCallbackCtrl has already been unregistered so no concurrent
+	// auto-flush can switch b.active underneath us.
+	diskSegments, releaseDiskSegments := b.disk.getConsistentViewOfSegments()
+	defer releaseDiskSegments()
+
+	forEachFlushed := func(fn func(key []byte, value []byte, tombstone bool)) {
+		if m, ok := b.active.(*Memtable); ok {
+			m.ForEachReplaceEntry(fn)
+		}
+	}
+	lookupOnDisk := func(key []byte) ([]byte, bool) {
+		v, err := b.disk.getWithSegmentList(key, diskSegments)
+		return v, err == nil && len(v) > 0
+	}
+	objCb(forEachFlushed, lookupOnDisk)
 }
 
 // UpdateStatus is used by the parent shard to communicate to the bucket
@@ -1727,6 +1876,33 @@ func (b *Bucket) FlushAndSwitch() error {
 	segment, err := b.disk.initAndPrecomputeNewSegment(segmentPath)
 	if err != nil {
 		return fmt.Errorf("precompute metadata: %w", err)
+	}
+
+	// Invoke the object-flush callback before adding the new segment to the
+	// segment group. At this point the flushing memtable is still accessible
+	// and b.disk does NOT yet contain the new segment, so lookupOnDisk returns
+	// the pre-flush on-disk value for any key.
+	b.objectFlushCallbackMu.Lock()
+	objCb := b.objectFlushCallback
+	b.objectFlushCallbackMu.Unlock()
+
+	if objCb != nil && b.strategy == StrategyReplace {
+		flushing := b.flushing
+		// Snapshot the current on-disk segments and hold the ref-count for the
+		// duration of the callback so that compaction cannot drop them underneath us.
+		diskSegments, releaseDiskSegments := b.disk.getConsistentViewOfSegments()
+
+		forEachFlushed := func(fn func(key []byte, value []byte, tombstone bool)) {
+			if m, ok := flushing.(*Memtable); ok {
+				m.ForEachReplaceEntry(fn)
+			}
+		}
+		lookupOnDisk := func(key []byte) ([]byte, bool) {
+			v, err := b.disk.getWithSegmentList(key, diskSegments)
+			return v, err == nil && len(v) > 0
+		}
+		objCb(forEachFlushed, lookupOnDisk)
+		releaseDiskSegments()
 	}
 
 	if err := b.atomicallyAddDiskSegmentAndRemoveFlushing(segment); err != nil {

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -742,3 +742,16 @@ func (m *Memtable) extractRoaringSetRange() *roaringsetrange.Memtable {
 	result := m.roaringSetRange
 	return result
 }
+
+// ForEachReplaceEntry iterates over all key-value entries in a Replace-strategy
+// memtable, calling fn for each entry in ascending key order. fn receives the
+// raw key bytes, the raw value bytes, and a tombstone flag (true = deletion).
+// This is a no-op for non-Replace strategies or an empty memtable.
+func (m *Memtable) ForEachReplaceEntry(fn func(key []byte, value []byte, tombstone bool)) {
+	if m.strategy != StrategyReplace || m.key == nil {
+		return
+	}
+	for _, node := range m.key.flattenInOrder() {
+		fn(node.key, node.value, node.tombstone)
+	}
+}

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -527,14 +527,6 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 	return sg, nil
 }
 
-func (sg *SegmentGroup) pauseCompaction(ctx context.Context) error {
-	return sg.compactionCallbackCtrl.Deactivate(ctx)
-}
-
-func (sg *SegmentGroup) resumeCompaction(_ context.Context) error {
-	return sg.compactionCallbackCtrl.Activate()
-}
-
 func (sg *SegmentGroup) makeExistsOn(segments []Segment) existsOnLowerSegmentsFn {
 	return func(key []byte) (bool, error) {
 		if len(segments) == 0 {

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -2189,6 +2189,65 @@ func (_c *MockShardLike_ObjectDigestsInRange_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// CompareDigests provides a mock function with given fields: ctx, sourceDigests
+func (_m *MockShardLike) CompareDigests(ctx context.Context, sourceDigests []types.RepairResponse) ([]types.RepairResponse, error) {
+	ret := _m.Called(ctx, sourceDigests)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CompareDigests")
+	}
+
+	var r0 []types.RepairResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []types.RepairResponse) ([]types.RepairResponse, error)); ok {
+		return rf(ctx, sourceDigests)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []types.RepairResponse) []types.RepairResponse); ok {
+		r0 = rf(ctx, sourceDigests)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]types.RepairResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []types.RepairResponse) error); ok {
+		r1 = rf(ctx, sourceDigests)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockShardLike_CompareDigests_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CompareDigests'
+type MockShardLike_CompareDigests_Call struct {
+	*mock.Call
+}
+
+// CompareDigests is a helper method to define mock.On call
+//   - ctx context.Context
+//   - sourceDigests []types.RepairResponse
+func (_e *MockShardLike_Expecter) CompareDigests(ctx interface{}, sourceDigests interface{}) *MockShardLike_CompareDigests_Call {
+	return &MockShardLike_CompareDigests_Call{Call: _e.mock.On("CompareDigests", ctx, sourceDigests)}
+}
+
+func (_c *MockShardLike_CompareDigests_Call) Run(run func(ctx context.Context, sourceDigests []types.RepairResponse)) *MockShardLike_CompareDigests_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]types.RepairResponse))
+	})
+	return _c
+}
+
+func (_c *MockShardLike_CompareDigests_Call) Return(objs []types.RepairResponse, err error) *MockShardLike_CompareDigests_Call {
+	_c.Call.Return(objs, err)
+	return _c
+}
+
+func (_c *MockShardLike_CompareDigests_Call) RunAndReturn(run func(context.Context, []types.RepairResponse) ([]types.RepairResponse, error)) *MockShardLike_CompareDigests_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // ObjectList provides a mock function with given fields: ctx, limit, sort, cursor, _a4, className
 func (_m *MockShardLike) ObjectList(ctx context.Context, limit int, sort []filters.Sort, cursor *filters.Cursor, _a4 additional.Properties, className schema.ClassName) ([]*storobj.Object, error) {
 	ret := _m.Called(ctx, limit, sort, cursor, _a4, className)

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -177,6 +177,14 @@ func (db *DB) DigestObjectsInRange(ctx context.Context, className, shardName str
 	return index.DigestObjectsInRange(ctx, shardName, initialUUID, finalUUID, limit)
 }
 
+func (db *DB) CompareDigests(ctx context.Context, className, shardName string, digests []types.RepairResponse) ([]types.RepairResponse, error) {
+	index, pr := db.replicatedIndex(className)
+	if pr != nil {
+		return nil, pr.FirstError()
+	}
+	return index.CompareDigests(ctx, shardName, digests)
+}
+
 func (db *DB) HashTreeLevel(ctx context.Context, className, shardName string, level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error) {
 	index, pr := db.replicatedIndex(className)
 	if pr != nil {
@@ -867,6 +875,21 @@ func (i *Index) IncomingDigestObjectsInRange(ctx context.Context,
 	return i.DigestObjectsInRange(ctx, shardName, initialUUID, finalUUID, limit)
 }
 
+func (i *Index) CompareDigests(ctx context.Context,
+	shardName string, sourceDigests []types.RepairResponse,
+) ([]types.RepairResponse, error) {
+	shard, release, err := i.GetShard(ctx, shardName)
+	if err != nil {
+		return nil, fmt.Errorf("%w: shard %q", err, shardName)
+	}
+	defer release()
+	if shard == nil {
+		return nil, fmt.Errorf("shard %q is not yet initialized on this node", shardName)
+	}
+
+	return shard.CompareDigests(ctx, sourceDigests)
+}
+
 func (i *Index) HashTreeLevel(ctx context.Context,
 	shardName string, level int, discriminant *hashtree.Bitset,
 ) (digests []hashtree.Digest, err error) {
@@ -876,7 +899,7 @@ func (i *Index) HashTreeLevel(ctx context.Context,
 	}
 	defer release()
 	if shard == nil {
-		return nil, nil
+		return nil, fmt.Errorf("shard %q is not yet initialized on this node", shardName)
 	}
 
 	return shard.HashTreeLevel(ctx, level, discriminant)

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -97,6 +97,7 @@ type ShardLike interface {
 	MultiObjectByID(ctx context.Context, query []multi.Identifier) ([]*storobj.Object, error)
 	ObjectDigests(ctx context.Context, query []multi.Identifier) ([]types.RepairResponse, error)
 	ObjectDigestsInRange(ctx context.Context, initialUUID, finalUUID strfmt.UUID, limit int) (objs []types.RepairResponse, err error)
+	CompareDigests(ctx context.Context, sourceDigests []types.RepairResponse) ([]types.RepairResponse, error)
 	ID() string // Get the shard id
 	drop(keepFiles bool) error
 	HaltForTransfer(ctx context.Context, offloading bool, inactivityTimeout time.Duration) error
@@ -228,17 +229,29 @@ type Shard struct {
 	queues        map[string]*VectorIndexQueue
 
 	// async replication
-	asyncReplicationRWMux           sync.RWMutex
-	targetNodeOverrides             additional.AsyncReplicationTargetNodeOverrides
-	asyncReplicationConfig          AsyncReplicationConfig
-	hashtree                        hashtree.AggregatedHashTree
-	hashtreeFullyInitialized        bool
-	minimalHashtreeInitializationCh chan struct{}
-	asyncReplicationCancelFunc      context.CancelFunc
+	asyncReplicationRWMux      sync.RWMutex
+	targetNodeOverrides        additional.AsyncReplicationTargetNodeOverrides
+	asyncReplicationConfig     AsyncReplicationConfig
+	hashtree                   hashtree.AggregatedHashTree
+	hashtreeFullyInitialized   bool
+	hashtreeFlushFailed        bool // set by performShutdown on FlushAndSwitch error; prevents stale .ht dump
+	asyncReplicationCancelFunc context.CancelFunc
+
+	// hashbeatNotifyCh is set by initHashBeater and cleared by mayStopAsyncReplication.
+	// External callers (e.g. flush callbacks) send to this channel to wake the
+	// hashbeater immediately without waiting for the next periodic tick.
+	// All accesses are protected by asyncReplicationRWMux.
+	hashbeatNotifyCh chan struct{}
 
 	lastComparedHosts                 []string
 	lastComparedHostsMux              sync.RWMutex
 	asyncReplicationStatsByTargetNode map[string]*hashBeatHostStats
+	// asyncReplicationStatsMux guards asyncReplicationStatsByTargetNode
+	// independently of asyncReplicationRWMux. This prevents the per-iteration
+	// stats write (in handleHashbeatWakeup) from write-locking asyncReplicationRWMux,
+	// which would stall every concurrent object write and query via writer-preference.
+	// Lock ordering when both are needed: asyncReplicationRWMux before asyncReplicationStatsMux.
+	asyncReplicationStatsMux sync.RWMutex
 
 	haltForTransferMux               sync.Mutex
 	haltForTransferInactivityTimeout time.Duration

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -17,8 +17,10 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sync"
 	"time"
@@ -51,14 +53,13 @@ const (
 	defaultHashtreeHeightMultiTenant   = 10
 	defaultFrequency                   = 30 * time.Second
 	defaultFrequencyWhilePropagating   = 5 * time.Second
-	defaultAliveNodesCheckingFrequency = 30 * time.Second
+	defaultAliveNodesCheckingFrequency = 10 * time.Second
 	defaultLoggingFrequency            = 60 * time.Second
 	defaultDiffBatchSize               = 1_000
 	defaultDiffPerNodeTimeout          = 10 * time.Second
 	defaultPrePropagationTimeout       = 300 * time.Second
-	defaultPropagationTimeout          = 60 * time.Second
-	defaultPropagationLimit            = 1_000
-	defaultPropagationDelay            = 30 * time.Second
+	defaultPropagationTimeout          = 180 * time.Second
+	defaultPropagationLimit            = 5_000
 	defaultPropagationConcurrency      = 1
 	defaultPropagationBatchSize        = 100
 
@@ -79,6 +80,10 @@ const (
 
 	minPropagationBatchSize = 1
 	maxPropagationBatchSize = 1_000
+
+	defaultInitShieldCPUEveryN = 10_000
+	minInitShieldCPUEveryN     = 1
+	maxInitShieldCPUEveryN     = 1_000_000
 )
 
 type AsyncReplicationConfig struct {
@@ -93,12 +98,25 @@ type AsyncReplicationConfig struct {
 	prePropagationTimeout       time.Duration
 	propagationTimeout          time.Duration
 	propagationLimit            int
-	propagationDelay            time.Duration
 	propagationConcurrency      int
 	propagationBatchSize        int
+	// initShieldCPUEveryN is the number of objects processed between
+	// runtime.Gosched() calls during the on-disk phase of hashtree
+	// initialization. Yielding periodically lets query goroutines make forward
+	// progress and prevents the init scan from monopolising CPU during the
+	// (potentially long) full-shard scan.
+	initShieldCPUEveryN int
 }
 
-func (s *Shard) initAsyncReplication(config AsyncReplicationConfig) (err error) {
+// initAsyncReplication initialises async-replication state for the shard.
+// It must be called while holding asyncReplicationRWMux for writing.
+//
+// If the function loaded a cached hashtree from disk it returns a non-nil
+// afterRelease callback.  The caller MUST invoke afterRelease() after
+// releasing asyncReplicationRWMux; calling it while the lock is still held
+// would deadlock (the hashbeater trigger goroutine sends on the channel,
+// and object-write goroutines wait on the same lock).
+func (s *Shard) initAsyncReplication(config AsyncReplicationConfig) (afterRelease func(), err error) {
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 
 	ctx, cancelFunc := context.WithCancel(context.Background())
@@ -106,16 +124,27 @@ func (s *Shard) initAsyncReplication(config AsyncReplicationConfig) (err error) 
 
 	s.asyncReplicationConfig = config
 
+	// Register flush-time hooks on the objects bucket:
+	//   - objectFlushCallback updates the hashtree with exactly the objects
+	//     that were durably persisted in the flush (before the new segment is
+	//     visible to readers), keeping the hashtree consistent with on-disk data.
+	//   - flushCallback wakes the hashbeater after the segment is added so that
+	//     newly flushed objects are propagated without waiting for the next tick.
+	if bucket != nil {
+		bucket.SetObjectFlushCallback(s.updateHashtreeOnFlush)
+		bucket.SetFlushCallback(s.notifyHashbeat)
+	}
+
 	start := time.Now()
 
 	if err := os.MkdirAll(s.pathHashTree(), os.ModePerm); err != nil {
-		return err
+		return nil, err
 	}
 
 	// load the most recent hashtree file
 	dirEntries, err := os.ReadDir(s.pathHashTree())
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	for i := len(dirEntries) - 1; i >= 0; i-- {
@@ -159,16 +188,16 @@ func (s *Shard) initAsyncReplication(config AsyncReplicationConfig) (err error) 
 
 		err = f.Close()
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		err = os.Remove(hashtreeFilename)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		if err := diskio.Fsync(s.pathHashTree()); err != nil {
-			return fmt.Errorf("fsync hashtree directory %q: %w", s.pathHashTree(), err)
+			return nil, fmt.Errorf("fsync hashtree directory %q: %w", s.pathHashTree(), err)
 		}
 
 		if s.hashtree != nil && s.hashtree.Height() != config.hashtreeHeight {
@@ -186,17 +215,27 @@ func (s *Shard) initAsyncReplication(config AsyncReplicationConfig) (err error) 
 			WithField("took", fmt.Sprintf("%v", time.Since(start))).
 			Info("hashtree successfully initialized")
 
-		s.initHashBeater(ctx, config)
-		return nil
+		// Set hashbeatNotifyCh now while we already hold the write lock.
+		// We must NOT call initHashBeater here: initHashBeater tries to
+		// re-acquire the write lock and would deadlock (initAsyncReplication
+		// is always invoked while the caller holds asyncReplicationRWMux).
+		// Instead, return a callback that the caller must invoke after
+		// releasing the lock.
+		propagationRequired := make(chan struct{}, 1)
+		s.hashbeatNotifyCh = propagationRequired
+		capturedCtx := ctx
+		capturedConfig := config
+		return func() {
+			s.startHashbeaterGoroutines(capturedCtx, capturedConfig, propagationRequired)
+		}, nil
 	}
 
 	s.hashtree, err = hashtree.NewHashTree(config.hashtreeHeight)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	s.hashtreeFullyInitialized = false
-	s.minimalHashtreeInitializationCh = make(chan struct{})
 
 	enterrors.GoWrapper(func() {
 		for i := 0; ; i++ {
@@ -226,12 +265,11 @@ func (s *Shard) initAsyncReplication(config AsyncReplicationConfig) (err error) 
 
 			s.asyncReplicationRWMux.Lock()
 			s.hashtree.Reset()
-			s.minimalHashtreeInitializationCh = make(chan struct{})
 			s.asyncReplicationRWMux.Unlock()
 		}
 	}, s.index.logger)
 
-	return nil
+	return nil, nil
 }
 
 func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig, bucket *lsmkv.Bucket) (err error) {
@@ -251,17 +289,13 @@ func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig,
 		s.metrics.ObserveAsyncReplicationHashTreeInitDuration(time.Since(start))
 	}()
 
-	releaseInitialization := func() {
-		s.asyncReplicationRWMux.RLock()
-		defer s.asyncReplicationRWMux.RUnlock()
-
-		close(s.minimalHashtreeInitializationCh)
-	}
-
+	// Scan only on-disk segments: the hashtree now reflects durable (flushed)
+	// data exclusively. In-memory objects will be added when their memtables are
+	// flushed via updateHashtreeOnFlush.
 	objCount := 0
 	prevProgressLogging := time.Now()
 
-	err = bucket.ApplyToObjectDigests(ctx, releaseInitialization, func(uuidBytes []byte, updateTime int64) error {
+	err = bucket.ApplyToOnDiskObjectDigests(ctx, func(uuidBytes []byte, updateTime int64) error {
 		if time.Since(prevProgressLogging) >= config.loggingFrequency {
 			s.index.logger.
 				WithField("action", "async_replication").
@@ -273,17 +307,22 @@ func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig,
 			prevProgressLogging = time.Now()
 		}
 
-		s.asyncReplicationRWMux.RLock()
-		defer s.asyncReplicationRWMux.RUnlock()
-
 		obj := &storobj.Object{}
 		obj.Object.LastUpdateTimeUnix = updateTime
+		s.asyncReplicationRWMux.RLock()
 		err := s.mayUpsertObjectHashTree(obj, uuidBytes, objectInsertStatus{})
+		s.asyncReplicationRWMux.RUnlock()
 		if err != nil {
 			return err
 		}
 
 		objCount++
+
+		// Yield to the Go scheduler periodically: on-disk scans can run for
+		// minutes on large shards and starve query goroutines on the same thread.
+		if config.initShieldCPUEveryN > 0 && objCount%config.initShieldCPUEveryN == 0 {
+			runtime.Gosched()
+		}
 
 		return nil
 	})
@@ -292,9 +331,9 @@ func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig,
 	}
 
 	s.asyncReplicationRWMux.Lock()
-	defer s.asyncReplicationRWMux.Unlock()
 
 	if s.hashtree == nil {
+		s.asyncReplicationRWMux.Unlock()
 		s.index.logger.
 			WithField("action", "async_replication").
 			WithField("class_name", s.class.Class).
@@ -304,7 +343,12 @@ func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig,
 	}
 
 	s.hashtreeFullyInitialized = true
+	s.asyncReplicationRWMux.Unlock()
 
+	// initHashBeater is called outside the write lock: the trigger goroutine it
+	// spawns immediately sends on an unbuffered channel, which blocks until the
+	// hashbeater goroutine picks it up. Holding the write lock across goroutine
+	// scheduling would stall every concurrent object write and HashTreeLevel RPC.
 	s.index.logger.
 		WithField("action", "async_replication").
 		WithField("class_name", s.class.Class).
@@ -318,20 +362,63 @@ func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig,
 	return nil
 }
 
-func (s *Shard) waitForMinimalHashTreeInitialization(ctx context.Context) error {
-	if s.hashtree == nil || s.hashtreeFullyInitialized {
-		return nil
+// updateHashtreeOnFlush is called by the lsmkv objects bucket inside
+// FlushAndSwitch, after the flushing memtable has been durably written to disk
+// but before the new segment is added to the segment group.
+//
+// For each entry in the flushed memtable it computes the XOR delta needed to
+// keep the hashtree consistent with on-disk data:
+//   - XOR out the previous on-disk digest (if the key existed on disk before).
+//   - XOR in the new digest (unless the entry is a tombstone / deletion).
+//
+// Deltas are collected without holding any lock (lookupOnDisk is safe for
+// concurrent reads) and then applied atomically under the write lock to
+// minimise the time writes are stalled.
+func (s *Shard) updateHashtreeOnFlush(
+	forEachFlushedObject func(fn func(key []byte, value []byte, tombstone bool)),
+	lookupOnDisk func(key []byte) ([]byte, bool),
+) {
+	type leafDelta struct {
+		leaf   uint64
+		digest [16 + 8]byte
 	}
 
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-s.minimalHashtreeInitializationCh:
-		return nil
-	}
-}
+	var deltas []leafDelta
 
-func (s *Shard) mayStopAsyncReplication() {
+	forEachFlushedObject(func(key []byte, value []byte, tombstone bool) {
+		if len(key) != 16 {
+			return
+		}
+
+		leaf := s.hashtreeLeafFor(key)
+
+		// XOR out old on-disk value (if any).
+		if oldValue, found := lookupOnDisk(key); found {
+			_, oldUpdateTime, err := storobj.DocIDAndTimeFromBinary(oldValue)
+			if err == nil && oldUpdateTime > 0 {
+				var d [16 + 8]byte
+				copy(d[:16], key)
+				binary.BigEndian.PutUint64(d[16:], uint64(oldUpdateTime))
+				deltas = append(deltas, leafDelta{leaf, d})
+			}
+		}
+
+		// XOR in new value unless this entry is a deletion tombstone.
+		if !tombstone {
+			_, newUpdateTime, err := storobj.DocIDAndTimeFromBinary(value)
+			if err == nil && newUpdateTime > 0 {
+				var d [16 + 8]byte
+				copy(d[:16], key)
+				binary.BigEndian.PutUint64(d[16:], uint64(newUpdateTime))
+				deltas = append(deltas, leafDelta{leaf, d})
+			}
+		}
+	})
+
+	if len(deltas) == 0 {
+		return
+	}
+
 	s.asyncReplicationRWMux.Lock()
 	defer s.asyncReplicationRWMux.Unlock()
 
@@ -339,12 +426,44 @@ func (s *Shard) mayStopAsyncReplication() {
 		return
 	}
 
+	for _, delta := range deltas {
+		s.hashtree.AggregateLeafWith(delta.leaf, delta.digest[:])
+	}
+}
+
+func (s *Shard) mayStopAsyncReplication() {
+	s.asyncReplicationRWMux.Lock()
+
+	if s.hashtree == nil {
+		s.asyncReplicationRWMux.Unlock()
+		return
+	}
+
 	s.asyncReplicationCancelFunc()
 
-	if s.hashtreeFullyInitialized {
+	// Capture the hashtree pointer and dump eligibility before clearing state
+	// so that dumpHashTreeOf can be called outside the write lock. Holding the
+	// write lock during I/O would block all concurrent reads (e.g. hashbeat)
+	// for the duration of the serialization.
+	var capturedHT hashtree.AggregatedHashTree
+	if s.hashtreeFullyInitialized && !s.hashtreeFlushFailed {
+		capturedHT = s.hashtree
+	}
+
+	s.hashtree = nil
+	s.hashtreeFullyInitialized = false
+	s.hashtreeFlushFailed = false
+	s.hashbeatNotifyCh = nil
+
+	if bucket := s.store.Bucket(helpers.ObjectsBucketLSM); bucket != nil {
+		bucket.SetObjectFlushCallback(nil)
+		bucket.SetFlushCallback(nil)
+	}
+	s.asyncReplicationRWMux.Unlock()
+
+	if capturedHT != nil {
 		// the hashtree needs to be fully in sync with stored data before it can be persisted
-		err := s.dumpHashTree()
-		if err != nil {
+		if err := s.dumpHashTreeOf(capturedHT); err != nil {
 			s.index.logger.
 				WithField("action", "async_replication").
 				WithField("class_name", s.class.Class).
@@ -352,33 +471,69 @@ func (s *Shard) mayStopAsyncReplication() {
 				Errorf("store hashtree failed: %v", err)
 		}
 	}
-
-	s.hashtree = nil
-	s.hashtreeFullyInitialized = false
 }
 
 func (s *Shard) SetAsyncReplicationState(_ context.Context, config AsyncReplicationConfig, enabled bool) error {
-	s.asyncReplicationRWMux.Lock()
-	defer s.asyncReplicationRWMux.Unlock()
+	var afterRelease func()
 
-	if enabled {
-		if s.hashtree != nil {
+	err := func() error {
+		s.asyncReplicationRWMux.Lock()
+		defer s.asyncReplicationRWMux.Unlock()
+
+		if enabled {
+			if s.hashtree != nil {
+				return nil
+			}
+			var err error
+			afterRelease, err = s.initAsyncReplication(config)
+			return err
+		}
+
+		if s.hashtree == nil {
 			return nil
 		}
 
-		return s.initAsyncReplication(config)
-	}
+		s.asyncReplicationCancelFunc()
 
-	if s.hashtree == nil {
+		// Capture before clearing so afterRelease can persist the hashtree
+		// outside the write lock (same pattern as mayStopAsyncReplication).
+		var capturedHT hashtree.AggregatedHashTree
+		if s.hashtreeFullyInitialized && !s.hashtreeFlushFailed {
+			capturedHT = s.hashtree
+		}
+
+		s.hashtree = nil
+		s.hashtreeFullyInitialized = false
+		s.hashtreeFlushFailed = false
+		s.hashbeatNotifyCh = nil
+		if bucket := s.store.Bucket(helpers.ObjectsBucketLSM); bucket != nil {
+			bucket.SetObjectFlushCallback(nil)
+			bucket.SetFlushCallback(nil)
+		}
+		s.asyncReplicationStatsMux.Lock()
+		s.asyncReplicationStatsByTargetNode = nil
+		s.asyncReplicationStatsMux.Unlock()
+
+		if capturedHT != nil {
+			afterRelease = func() {
+				if err := s.dumpHashTreeOf(capturedHT); err != nil {
+					s.index.logger.
+						WithField("action", "async_replication").
+						WithField("class_name", s.class.Class).
+						WithField("shard_name", s.name).
+						Errorf("store hashtree failed: %v", err)
+				}
+			}
+		}
+
 		return nil
+	}()
+	if err != nil {
+		return err
 	}
-
-	s.asyncReplicationCancelFunc()
-
-	s.hashtree = nil
-	s.asyncReplicationStatsByTargetNode = nil
-	s.hashtreeFullyInitialized = false
-
+	if afterRelease != nil {
+		afterRelease()
+	}
 	return nil
 }
 
@@ -424,7 +579,9 @@ func (s *Shard) removeTargetNodeOverride(ctx context.Context, targetNodeOverride
 			// existing upper time bound is <= to the override being removed (eg if the override to remove
 			// is "before" the existing override, don't remove it)
 			if existing.Equal(&targetNodeOverrideToRemove) && existing.UpperTimeBound <= targetNodeOverrideToRemove.UpperTimeBound {
+				s.asyncReplicationStatsMux.Lock()
 				delete(s.asyncReplicationStatsByTargetNode, existing.TargetNode)
+				s.asyncReplicationStatsMux.Unlock()
 				continue
 			}
 			newTargetNodeOverrides = append(newTargetNodeOverrides, existing)
@@ -452,13 +609,13 @@ func (s *Shard) removeAllTargetNodeOverrides(ctx context.Context) error {
 }
 
 func (s *Shard) getAsyncReplicationStats(ctx context.Context) []*models.AsyncReplicationStatus {
-	s.asyncReplicationRWMux.RLock()
-	defer s.asyncReplicationRWMux.RUnlock()
+	s.asyncReplicationStatsMux.RLock()
+	defer s.asyncReplicationStatsMux.RUnlock()
 
 	asyncReplicationStatsToReturn := make([]*models.AsyncReplicationStatus, 0, len(s.asyncReplicationStatsByTargetNode))
 	for targetNodeName, asyncReplicationStats := range s.asyncReplicationStatsByTargetNode {
 		asyncReplicationStatsToReturn = append(asyncReplicationStatsToReturn, &models.AsyncReplicationStatus{
-			ObjectsPropagated:       uint64(asyncReplicationStats.localObjectsPropagationCount) - uint64(asyncReplicationStats.objectsNotResolved),
+			ObjectsPropagated:       uint64(max(0, asyncReplicationStats.localObjectsPropagationCount-asyncReplicationStats.objectsNotResolved)),
 			StartDiffTimeUnixMillis: asyncReplicationStats.hashtreeDiffStartTime.UnixMilli(),
 			TargetNode:              targetNodeName,
 		})
@@ -467,41 +624,65 @@ func (s *Shard) getAsyncReplicationStats(ctx context.Context) []*models.AsyncRep
 	return asyncReplicationStatsToReturn
 }
 
-func (s *Shard) dumpHashTree() error {
+// dumpHashTreeOf serializes ht to a new file in s.pathHashTree() using an
+// atomic write-rename pattern: it writes to a <name>.tmp file first, syncs,
+// then renames to the final name so that a crash mid-write never leaves a
+// truncated or partially-written hashtree file on disk.
+func (s *Shard) dumpHashTreeOf(ht hashtree.AggregatedHashTree) (err error) {
 	var b [8]byte
 	binary.BigEndian.PutUint64(b[:], uint64(time.Now().UnixNano()))
 
-	hashtreeFilename := filepath.Join(s.pathHashTree(), fmt.Sprintf("hashtree-%x.ht", string(b[:])))
+	dir := s.pathHashTree()
+	finalFilename := filepath.Join(dir, fmt.Sprintf("hashtree-%x.ht", b[:]))
+	tmpFilename := finalFilename + ".tmp"
 
-	f, err := os.OpenFile(hashtreeFilename, os.O_CREATE|os.O_WRONLY|os.O_APPEND, os.ModePerm)
+	f, err := os.OpenFile(tmpFilename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.ModePerm)
 	if err != nil {
-		return fmt.Errorf("storing hashtree %q: %w", hashtreeFilename, err)
+		return fmt.Errorf("storing hashtree %q: %w", tmpFilename, err)
 	}
+	// Ensure the fd is always closed even on early error returns. The explicit
+	// Close before os.Rename sets closed=true so the deferred close is a no-op
+	// on the happy path (double-closing an *os.File returns an error).
+	// On error the .tmp file is left on disk but will be ignored on reload
+	// (only .ht files without the .tmp suffix are loaded).
+	var closed bool
+	defer func() {
+		if !closed {
+			if closeErr := f.Close(); closeErr != nil && err == nil {
+				err = fmt.Errorf("closing hashtree %q: %w", tmpFilename, closeErr)
+			}
+		}
+	}()
 
 	w := bufio.NewWriter(f)
 
-	_, err = s.hashtree.Serialize(w)
+	_, err = ht.Serialize(w)
 	if err != nil {
-		return fmt.Errorf("storing hashtree %q: %w", hashtreeFilename, err)
+		return fmt.Errorf("storing hashtree %q: %w", tmpFilename, err)
 	}
 
 	err = w.Flush()
 	if err != nil {
-		return fmt.Errorf("storing hashtree %q: %w", hashtreeFilename, err)
+		return fmt.Errorf("flushing hashtree %q: %w", tmpFilename, err)
 	}
 
 	err = f.Sync()
 	if err != nil {
-		return fmt.Errorf("storing hashtree %q: %w", hashtreeFilename, err)
+		return fmt.Errorf("syncing hashtree %q: %w", tmpFilename, err)
 	}
 
-	err = f.Close()
-	if err != nil {
-		return fmt.Errorf("closing hashtree %q: %w", hashtreeFilename, err)
+	// Close explicitly before rename so the fd is released on all platforms.
+	closed = true
+	if err = f.Close(); err != nil {
+		return fmt.Errorf("closing hashtree %q: %w", tmpFilename, err)
 	}
 
-	if err := diskio.Fsync(s.pathHashTree()); err != nil {
-		return fmt.Errorf("fsync hashtree directory %q: %w", s.pathHashTree(), err)
+	if err = os.Rename(tmpFilename, finalFilename); err != nil {
+		return fmt.Errorf("renaming hashtree %q -> %q: %w", tmpFilename, finalFilename, err)
+	}
+
+	if err := diskio.Fsync(dir); err != nil {
+		return fmt.Errorf("fsync hashtree directory %q: %w", dir, err)
 	}
 
 	return nil
@@ -515,10 +696,17 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 		return nil, fmt.Errorf("hashtree not initialized on shard %q", s.ID())
 	}
 
-	// TODO (jeroiraz): reusable pool of digests slices
-	digests = make([]hashtree.Digest, hashtree.LeavesCount(level+1))
+	// discriminant is level-local: size must equal nodesAtLevel(level) = LeavesCount(level).
+	// A size mismatch indicates a height mismatch between source and replica.
+	expectedSize := hashtree.LeavesCount(level)
+	if discriminant.Size() != expectedSize {
+		return nil, fmt.Errorf("hashtree level %d: discriminant size %d, expected %d (possible height mismatch)",
+			level, discriminant.Size(), expectedSize)
+	}
 
-	n, err := s.hashtree.Level(level, discriminant, digests)
+	digests = make([]hashtree.Digest, expectedSize)
+
+	n, err := s.hashtree.LevelLocal(level, discriminant, digests)
 	if err != nil {
 		return nil, err
 	}
@@ -526,16 +714,85 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 	return digests[:n], nil
 }
 
-func (s *Shard) initHashBeater(ctx context.Context, config AsyncReplicationConfig) {
-	// channel is used to "wake up" the hashbeater when a change occurs that
-	// requires propagation, e.g. a new target node override is added
-	// it's buffered to ensure that multiple changes occurring in a short time
-	// frame only cause one wake-up
-	propagationRequired := make(chan struct{})
+// notifyHashbeat wakes the hashbeater goroutine without blocking.
+// It is safe to call from any goroutine, including flush callbacks.
+// If the hashbeater is not running (e.g. async replication is disabled),
+// the call is a no-op.
+//
+// The underlying channel is buffered (capacity 1), so a notification sent
+// while the hashbeater is mid-run is queued and picked up immediately when
+// the current run finishes.  A second concurrent notification is dropped
+// (the pending one already covers it).
+func (s *Shard) notifyHashbeat() {
+	s.asyncReplicationRWMux.RLock()
+	ch := s.hashbeatNotifyCh
+	s.asyncReplicationRWMux.RUnlock()
 
+	if ch == nil {
+		return
+	}
+
+	select {
+	case ch <- struct{}{}:
+	default:
+		// hashbeat already notified or currently running; the next periodic
+		// tick will cover any objects flushed between now and then.
+	}
+}
+
+func (s *Shard) initHashBeater(ctx context.Context, config AsyncReplicationConfig) {
+	// propagationRequired is used to wake the hashbeater when a change requires
+	// propagation (e.g. a new target node override is added or a memtable flush
+	// completes making new objects available for digest reads).
+	// The channel is created here and published to s.hashbeatNotifyCh so that
+	// notifyHashbeat() can also send to it. The goroutines below capture the
+	// local variable directly — they must not read s.hashbeatNotifyCh because it
+	// can be set to nil concurrently by mayStopAsyncReplication /
+	// SetAsyncReplicationState.
+	propagationRequired := make(chan struct{}, 1)
+	s.asyncReplicationRWMux.Lock()
+	if s.hashtree == nil {
+		// async replication was disabled while initHashtree was running;
+		// do not start the hashbeater.
+		s.asyncReplicationRWMux.Unlock()
+		return
+	}
+	s.hashbeatNotifyCh = propagationRequired
+	s.asyncReplicationRWMux.Unlock()
+
+	s.startHashbeaterGoroutines(ctx, config, propagationRequired)
+}
+
+// startHashbeaterGoroutines starts the hashbeater and its trigger goroutine.
+// propagationRequired is the channel used to wake the hashbeater; it must
+// already be stored in s.hashbeatNotifyCh before calling this function.
+//
+// Must NOT be called while holding asyncReplicationRWMux: the trigger goroutine
+// immediately sends on the propagationRequired channel, and object-write
+// goroutines acquire the read lock — holding the write lock across that
+// scheduling point would stall every concurrent object-write and HashTreeLevel
+// RPC that acquires the read lock.
+func (s *Shard) startHashbeaterGoroutines(ctx context.Context, config AsyncReplicationConfig, propagationRequired chan struct{}) {
 	var lastHashbeat time.Time
 	var lastHashbeatPropagatedObjects bool
 	var lastHashbeatMux sync.Mutex
+
+	// Per-target root snapshots updated after every non-failure cycle
+	// (err == nil, ErrNoDiffFound, or ErrHashtreeRootUnchanged). Passed to
+	// CollectShardDifferences as skipStateByTarget so it can short-circuit after
+	// the level-0 RPC (1 round-trip) instead of walking the full tree when:
+	//   Case A: objects were sent last cycle AND remote root unchanged
+	//           (remote memtable not yet flushed, disk-only view is stale).
+	//   Case B: nothing was sent last cycle AND neither root changed
+	//           (both sides idle, no new data to reconcile).
+	lastLocalRootByTarget := make(map[string]hashtree.Digest)
+	lastRemoteRootByTarget := make(map[string]hashtree.Digest)
+	// lastPropagatedToTarget tracks whether the last successful cycle actually
+	// sent at least one object to a given target node. Local deletions triggered
+	// by a remoteDeleted verdict are deliberately excluded: they do not cause the
+	// remote hashtree to change, so "waiting for the remote to flush" (Case A)
+	// must not be triggered when the work was only local-side cleanup.
+	lastPropagatedToTarget := make(map[string]bool)
 
 	enterrors.GoWrapper(func() {
 		s.metrics.IncAsyncReplicationHashbeaterRunning()
@@ -557,7 +814,11 @@ func (s *Shard) initHashBeater(ctx context.Context, config AsyncReplicationConfi
 
 		var lastLog time.Time
 
-		backoffTimer := interval.NewBackoffTimer(1*time.Second, 3*time.Second, 5*time.Second)
+		// workerAcquireBackoff is separate from hashbeatBackoff so that
+		// semaphore-contention failures and hashbeat failures don't inflate
+		// each other's retry intervals.
+		workerAcquireBackoff := interval.NewBackoffTimer(1*time.Second, 3*time.Second, 5*time.Second)
+		hashbeatBackoff := interval.NewBackoffTimer(1*time.Second, 3*time.Second, 5*time.Second)
 
 		for {
 			select {
@@ -567,34 +828,41 @@ func (s *Shard) initHashBeater(ctx context.Context, config AsyncReplicationConfi
 				shouldStop := func() bool {
 					err := s.index.asyncReplicationWorkerAcquire(ctx)
 					if err != nil {
-						s.index.logger.
-							WithField("action", "async_replication").
-							WithField("class_name", s.class.Class).
-							WithField("shard_name", s.name).
-							Warn(err)
+						if time.Since(lastLog) >= config.loggingFrequency {
+							lastLog = time.Now()
+							s.index.logger.
+								WithField("action", "async_replication").
+								WithField("class_name", s.class.Class).
+								WithField("shard_name", s.name).
+								Warn(err)
+						}
 
 						if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 							return true
 						}
 
 						select {
-						case <-time.After(backoffTimer.CurrentInterval()):
+						case <-time.After(workerAcquireBackoff.CurrentInterval()):
 						case <-ctx.Done():
 							return true
 						}
-						backoffTimer.IncreaseInterval()
+						workerAcquireBackoff.IncreaseInterval()
 						return false
 					}
+					workerAcquireBackoff.Reset()
 					defer s.index.asyncReplicationWorkerRelease()
 
 					return s.handleHashbeatWakeup(
 						ctx,
 						config,
-						backoffTimer,
+						hashbeatBackoff,
 						&lastLog,
 						&lastHashbeat,
 						&lastHashbeatPropagatedObjects,
 						&lastHashbeatMux,
+						lastLocalRootByTarget,
+						lastRemoteRootByTarget,
+						lastPropagatedToTarget,
 					)
 				}()
 				if shouldStop {
@@ -613,10 +881,18 @@ func (s *Shard) initHashBeater(ctx context.Context, config AsyncReplicationConfi
 	// note that the hashbeater itself also has a frequency ticker to ensure that
 	// propagation occurs at least every frequency interval even if no changes in
 	// alive nodes occur
-	propagationRequired <- struct{}{}
 	enterrors.GoWrapper(func() {
 		s.metrics.IncAsyncReplicationHashbeatTriggerRunning()
 		defer s.metrics.DecAsyncReplicationHashbeatTriggerRunning()
+
+		// fire an initial hashbeat immediately on startup; guard with ctx.Done
+		// so the goroutine does not leak if the context is cancelled before the
+		// hashbeater goroutine has a chance to receive from the capacity-1 channel.
+		select {
+		case propagationRequired <- struct{}{}:
+		case <-ctx.Done():
+			return
+		}
 
 		nt := time.NewTicker(config.aliveNodesCheckingFrequency)
 		defer nt.Stop()
@@ -632,16 +908,19 @@ func (s *Shard) initHashBeater(ctx context.Context, config AsyncReplicationConfi
 				comparedHosts := s.getLastComparedHosts()
 				aliveHosts := s.allAliveHostnames()
 
-				slices.Sort(comparedHosts)
-				slices.Sort(aliveHosts)
-
-				if !slices.Equal(comparedHosts, aliveHosts) {
+				// Only trigger when there is at least one newly alive node that was
+				// not present in the last comparison. A node going down does not
+				// warrant a hashbeat because there is nothing to propagate to it.
+				hasNewAliveNode := hasNewElement(aliveHosts, comparedHosts)
+				if hasNewAliveNode {
 					select {
 					case <-ctx.Done():
 						return
 					case propagationRequired <- struct{}{}:
 					}
+				}
 
+				if hasNewAliveNode || len(aliveHosts) != len(comparedHosts) {
 					s.setLastComparedNodes(aliveHosts)
 				}
 			case <-ft.C:
@@ -671,6 +950,9 @@ func (s *Shard) handleHashbeatWakeup(
 	lastHashbeat *time.Time,
 	lastHashbeatPropagatedObjects *bool,
 	lastHashbeatMux *sync.Mutex,
+	lastLocalRootByTarget map[string]hashtree.Digest,
+	lastRemoteRootByTarget map[string]hashtree.Digest,
+	lastPropagatedToTarget map[string]bool,
 ) (shouldStop bool) {
 	targetNodeOverridesLen := func() int {
 		s.asyncReplicationRWMux.RLock()
@@ -697,28 +979,29 @@ func (s *Shard) handleHashbeatWakeup(
 		return false
 	}
 
-	stats, err := s.hashBeat(ctx, config)
+	stats, err := s.hashBeat(ctx, config, lastLocalRootByTarget, lastRemoteRootByTarget, lastPropagatedToTarget)
 
 	// update the shard stats for the target node
 	func() {
-		s.asyncReplicationRWMux.Lock()
-		defer s.asyncReplicationRWMux.Unlock()
+		s.asyncReplicationStatsMux.Lock()
+		defer s.asyncReplicationStatsMux.Unlock()
 
 		if s.asyncReplicationStatsByTargetNode == nil {
 			s.asyncReplicationStatsByTargetNode = make(map[string]*hashBeatHostStats)
 		}
-		if (err == nil || errors.Is(err, replica.ErrNoDiffFound)) && stats != nil {
+		if (err == nil || errors.Is(err, replica.ErrNoDiffFound) || errors.Is(err, replica.ErrHashtreeRootUnchanged)) && stats != nil {
 			for _, stat := range stats {
 				if stat != nil {
 					s.index.logger.WithFields(logrus.Fields{
-						"shard_name":                      s.name,
-						"target_node_name":                stat.targetNodeName,
-						"hashtree_diff_took":              stat.hashtreeDiffTook,
-						"object_digests_diff_took":        stat.objectDigestsDiffTook,
-						"local_object_digests_count":      stat.localObjectDigestsCount,
-						"remote_object_digests_count":     stat.remoteObjectDigestsCount,
-						"local_objects_propagation_count": stat.localObjectsPropagationCount,
-						"local_objects_propagation_took":  stat.localObjectsPropagationTook,
+						"shard_name":                           s.name,
+						"target_node_name":                     stat.targetNodeName,
+						"hashtree_diff_took":                   stat.hashtreeDiffTook,
+						"object_digests_diff_took":             stat.objectDigestsDiffTook,
+						"local_object_digests_count":           stat.localObjectDigestsCount,
+						"remote_object_digests_count":          stat.remoteObjectDigestsCount,
+						"objects_queued_for_propagation_count": stat.objectsQueuedForPropagationCount,
+						"local_objects_propagation_count":      stat.localObjectsPropagationCount,
+						"local_objects_propagation_took":       stat.localObjectsPropagationTook,
 					}).Debug("updating async replication stats")
 					s.asyncReplicationStatsByTargetNode[stat.targetNodeName] = stat
 				}
@@ -750,6 +1033,24 @@ func (s *Shard) handleHashbeatWakeup(
 			return false
 		}
 
+		if errors.Is(err, replica.ErrHashtreeRootUnchanged) {
+			if time.Since(*lastLog) >= config.loggingFrequency {
+				*lastLog = time.Now()
+				s.index.logger.
+					WithField("action", "async_replication").
+					WithField("class_name", s.class.Class).
+					WithField("shard_name", s.name).
+					Debug("hashbeat skipped: target hashtree unchanged since last propagation, awaiting flush")
+			}
+
+			backoffTimer.Reset()
+			lastHashbeatMux.Lock()
+			*lastHashbeat = time.Now()
+			*lastHashbeatPropagatedObjects = true // keep fast poll cadence
+			lastHashbeatMux.Unlock()
+			return false
+		}
+
 		if time.Since(*lastLog) >= config.loggingFrequency {
 			*lastLog = time.Now()
 			s.index.logger.
@@ -759,7 +1060,11 @@ func (s *Shard) handleHashbeatWakeup(
 				Warnf("hashbeat iteration failed: %v", err)
 		}
 
-		time.Sleep(backoffTimer.CurrentInterval())
+		select {
+		case <-time.After(backoffTimer.CurrentInterval()):
+		case <-ctx.Done():
+			return true
+		}
 		backoffTimer.IncreaseInterval()
 		lastHashbeatMux.Lock()
 		*lastHashbeat = time.Now()
@@ -769,6 +1074,16 @@ func (s *Shard) handleHashbeatWakeup(
 	}
 
 	statsHaveObjectsPropagated := false
+	for _, stat := range stats {
+		// Use localObjectsPropagationCount (objects actually sent to target via
+		// Overwrite) rather than objectsQueuedForPropagationCount (which also
+		// counts remoteDeleted local-only deletions). This keeps the fast-poll
+		// cadence consistent with the Case A skip condition in HadWork.
+		if stat.localObjectsPropagationCount > 0 {
+			statsHaveObjectsPropagated = true
+		}
+	}
+
 	if time.Since(*lastLog) >= config.loggingFrequency {
 		*lastLog = time.Now()
 
@@ -782,12 +1097,28 @@ func (s *Shard) handleHashbeatWakeup(
 				WithField("object_digests_diff_took", stat.objectDigestsDiffTook).
 				WithField("local_object_digests_count", stat.localObjectDigestsCount).
 				WithField("remote_object_digests_count", stat.remoteObjectDigestsCount).
+				WithField("objects_queued_for_propagation_count", stat.objectsQueuedForPropagationCount).
 				WithField("local_objects_propagation_count", stat.localObjectsPropagationCount).
 				WithField("local_objects_propagation_took", stat.localObjectsPropagationTook).
 				Debug("hashbeat iteration successfully completed")
+		}
+	}
 
-			if stat.localObjectDigestsCount > 0 {
-				statsHaveObjectsPropagated = true
+	// Record the per-target root snapshots for the next cycle so that
+	// CollectShardDifferences can short-circuit after the level-0 RPC.
+	for _, stat := range stats {
+		if stat != nil && stat.targetNodeName != "" {
+			lastLocalRootByTarget[stat.targetNodeName] = stat.localHashtreeRoot
+			lastRemoteRootByTarget[stat.targetNodeName] = stat.remoteHashtreeRoot
+			// For replica.ErrHashtreeRootUnchanged, preserve the previous prevHadWork
+			// value so Case A keeps firing on subsequent 3 s cycles until the
+			// remote actually flushes.  On all other paths (success, ErrNoDiffFound)
+			// record whether we genuinely sent objects to the target this cycle.
+			// Local-only deletions (remoteDeleted verdicts) are excluded: they do
+			// not change the remote hashtree, so "waiting for remote flush" must
+			// not be triggered when no objects were sent.
+			if !errors.Is(err, replica.ErrHashtreeRootUnchanged) {
+				lastPropagatedToTarget[stat.targetNodeName] = stat.localObjectsPropagationCount > 0
 			}
 		}
 	}
@@ -812,26 +1143,54 @@ func (s *Shard) getLastComparedHosts() []string {
 	s.lastComparedHostsMux.RLock()
 	defer s.lastComparedHostsMux.RUnlock()
 
-	return s.lastComparedHosts
+	// Return a copy so the caller cannot mutate the live backing array.
+	return slices.Clone(s.lastComparedHosts)
 }
 
 func (s *Shard) allAliveHostnames() []string {
 	return s.index.router.AllHostnames()
 }
 
-type hashBeatHostStats struct {
-	targetNodeName               string
-	hashtreeDiffStartTime        time.Time
-	hashtreeDiffTook             time.Duration
-	objectDigestsDiffTook        time.Duration
-	localObjectDigestsCount      int
-	remoteObjectDigestsCount     int
-	localObjectsPropagationCount int
-	localObjectsPropagationTook  time.Duration
-	objectsNotResolved           int
+// hasNewElement reports whether any element of candidates is absent from existing.
+func hasNewElement(candidates, existing []string) bool {
+	set := make(map[string]struct{}, len(existing))
+	for _, h := range existing {
+		set[h] = struct{}{}
+	}
+	for _, h := range candidates {
+		if _, ok := set[h]; !ok {
+			return true
+		}
+	}
+	return false
 }
 
-func (s *Shard) hashBeat(ctx context.Context, config AsyncReplicationConfig) (stats []*hashBeatHostStats, err error) {
+type hashBeatHostStats struct {
+	targetNodeName                   string
+	hashtreeDiffStartTime            time.Time
+	hashtreeDiffTook                 time.Duration
+	objectDigestsDiffTook            time.Duration
+	localObjectDigestsCount          int
+	remoteObjectDigestsCount         int // digests sent to remote for comparison
+	objectsQueuedForPropagationCount int // objects queued for propagation (stale/missing on remote after tiebreak)
+	localObjectsPropagationCount     int
+	localObjectsPropagationTook      time.Duration
+	objectsNotResolved               int
+	// localHashtreeRoot and remoteHashtreeRoot record the level-0 digests
+	// compared in this cycle. handleHashbeatWakeup stores them so that hashBeat
+	// can skip the expensive CompareDigests + propagation pass when neither side
+	// has flushed its memtable since the previous propagation cycle.
+	localHashtreeRoot  hashtree.Digest
+	remoteHashtreeRoot hashtree.Digest
+}
+
+func (s *Shard) hashBeat(
+	ctx context.Context,
+	config AsyncReplicationConfig,
+	lastLocalRootByTarget map[string]hashtree.Digest,
+	lastRemoteRootByTarget map[string]hashtree.Digest,
+	lastPropagatedToTarget map[string]bool,
+) (stats []*hashBeatHostStats, err error) {
 	start := time.Now()
 
 	s.metrics.IncAsyncReplicationIterationCount()
@@ -840,7 +1199,7 @@ func (s *Shard) hashBeat(ctx context.Context, config AsyncReplicationConfig) (st
 	defer func() {
 		s.metrics.DecAsyncReplicationIterationRunning()
 
-		if err != nil && !errors.Is(err, replica.ErrNoDiffFound) {
+		if err != nil && !errors.Is(err, replica.ErrNoDiffFound) && !errors.Is(err, replica.ErrHashtreeRootUnchanged) {
 			s.metrics.IncAsyncReplicationIterationFailureCount()
 			return
 		}
@@ -866,9 +1225,21 @@ func (s *Shard) hashBeat(ctx context.Context, config AsyncReplicationConfig) (st
 
 	hashtreeDiffStart := time.Now()
 
-	shardDiffReader, err := s.index.replicator.CollectShardDifferences(ctx, s.name, ht, config.diffPerNodeTimeout, targetNodeOverridesSnapshot)
+	// Build per-target skip state so CollectShardDifferences can short-circuit
+	// after the level-0 RPC (1 round-trip) instead of walking the full tree
+	// (up to Height RPCs) when Case A or Case B conditions are met.
+	skipStates := make(map[string]replica.ShardDiffSkipState, len(lastRemoteRootByTarget))
+	for target, remoteRoot := range lastRemoteRootByTarget {
+		skipStates[target] = replica.ShardDiffSkipState{
+			LocalRoot:  lastLocalRootByTarget[target],
+			RemoteRoot: remoteRoot,
+			HadWork:    lastPropagatedToTarget[target],
+		}
+	}
+
+	shardDiffReader, err := s.index.replicator.CollectShardDifferences(ctx, s.name, ht, config.diffPerNodeTimeout, targetNodeOverridesSnapshot, skipStates)
 	if err != nil {
-		if errors.Is(err, replica.ErrNoDiffFound) && len(targetNodeOverridesSnapshot) > 0 {
+		if (errors.Is(err, replica.ErrNoDiffFound) || errors.Is(err, replica.ErrHashtreeRootUnchanged)) && len(targetNodeOverridesSnapshot) > 0 {
 			stats := make([]*hashBeatHostStats, 0, len(targetNodeOverridesSnapshot))
 			for _, o := range targetNodeOverridesSnapshot {
 				stats = append(stats, &hashBeatHostStats{
@@ -877,6 +1248,17 @@ func (s *Shard) hashBeat(ctx context.Context, config AsyncReplicationConfig) (st
 				})
 			}
 			return stats, err
+		}
+		if errors.Is(err, replica.ErrHashtreeRootUnchanged) || errors.Is(err, replica.ErrNoDiffFound) {
+			// Skip conditions were met after just the level-0 RPC.
+			// Return stats with the roots captured during that single round-trip.
+			return []*hashBeatHostStats{{
+				targetNodeName:        shardDiffReader.TargetNodeName,
+				hashtreeDiffStartTime: hashtreeDiffStart,
+				hashtreeDiffTook:      time.Since(hashtreeDiffStart),
+				localHashtreeRoot:     shardDiffReader.LocalHashtreeRoot,
+				remoteHashtreeRoot:    shardDiffReader.RemoteHashtreeRoot,
+			}}, err
 		}
 		return nil, fmt.Errorf("collecting hashtree differences: %w", err)
 	}
@@ -890,6 +1272,12 @@ func (s *Shard) hashBeat(ctx context.Context, config AsyncReplicationConfig) (st
 
 	localObjectDigestsCount := 0
 	remoteObjectDigestsCount := 0
+	objectsQueuedForPropagationCount := 0
+	// localDeletedCount tracks objects deleted locally due to remoteDeleted
+	// verdicts from CompareDigests. It is added to len(localObjectsToPropagate)
+	// when computing the remaining propagation capacity so that tombstone
+	// conflict resolutions are bounded by the same limit as live propagations.
+	localDeletedCount := 0
 
 	localObjectsToPropagate := make([]strfmt.UUID, 0, config.propagationLimit)
 	localUpdateTimeByUUID := make(map[strfmt.UUID]int64, config.propagationLimit)
@@ -898,7 +1286,7 @@ func (s *Shard) hashBeat(ctx context.Context, config AsyncReplicationConfig) (st
 	objectDigestsDiffCtx, cancel := context.WithTimeout(ctx, config.prePropagationTimeout)
 	defer cancel()
 
-	for len(localObjectsToPropagate) < config.propagationLimit {
+	for len(localObjectsToPropagate)+localDeletedCount < config.propagationLimit {
 		initialLeaf, finalLeaf, err := rangeReader.Next()
 		if err != nil {
 			if errors.Is(err, hashtree.ErrNoMoreRanges) {
@@ -914,7 +1302,7 @@ func (s *Shard) hashBeat(ctx context.Context, config AsyncReplicationConfig) (st
 			shardDiffReader.TargetNodeName,
 			initialLeaf,
 			finalLeaf,
-			config.propagationLimit-len(localObjectsToPropagate),
+			config.propagationLimit-len(localObjectsToPropagate)-localDeletedCount,
 			targetNodeOverridesSnapshot,
 		)
 		if err != nil {
@@ -929,8 +1317,26 @@ func (s *Shard) hashBeat(ctx context.Context, config AsyncReplicationConfig) (st
 
 		localObjectDigestsCount += localObjsCountWithinRange
 		remoteObjectDigestsCount += remoteObjsCountWithinRange
+		objectsQueuedForPropagationCount += len(objsToPropagateWithinRange)
 
 		for _, obj := range objsToPropagateWithinRange {
+			if obj.remoteDeleted {
+				// Target has already applied the deletion strategy and instructed
+				// deletion; apply it locally without re-checking the strategy.
+				//
+				// Use time.Time{} (Go zero) when the deletion timestamp is unknown
+				// (remoteStaleUpdateTime==0) so shard_write_delete.go calls
+				// bucket.Delete (no timestamp) rather than bucket.DeleteWith(epoch).
+				var deletionTime time.Time
+				if obj.remoteStaleUpdateTime != 0 {
+					deletionTime = time.UnixMilli(obj.remoteStaleUpdateTime)
+				}
+				if err := s.DeleteObject(ctx, obj.uuid, deletionTime); err != nil {
+					return nil, fmt.Errorf("deleting locally conflicted object: %w", err)
+				}
+				localDeletedCount++
+				continue
+			}
 			localObjectsToPropagate = append(localObjectsToPropagate, obj.uuid)
 			localUpdateTimeByUUID[obj.uuid] = obj.lastUpdateTime
 			remoteStaleUpdateTimeByUUID[obj.uuid] = obj.remoteStaleUpdateTime
@@ -947,11 +1353,11 @@ func (s *Shard) hashBeat(ctx context.Context, config AsyncReplicationConfig) (st
 		propagationCtx, cancel := context.WithTimeout(ctx, config.propagationTimeout)
 		defer cancel()
 
-		resp, err := s.propagateObjects(propagationCtx, config, shardDiffReader.TargetNodeAddress, localObjectsToPropagate, remoteStaleUpdateTimeByUUID)
-		if err != nil {
-			return nil, fmt.Errorf("propagating local objects: %w", err)
-		}
+		resp, propagateErr := s.propagateObjects(propagationCtx, config, shardDiffReader.TargetNodeAddress, localObjectsToPropagate, remoteStaleUpdateTimeByUUID)
 
+		// Process conflict responses from successful batches even when some
+		// batches failed, so deletion conflicts are resolved before we surface
+		// the error. Failed objects will be retried on the next hashtree diff.
 		for _, r := range resp {
 			// NOTE: deleted objects are not propagated but locally deleted when conflict is detected
 
@@ -974,19 +1380,26 @@ func (s *Shard) hashBeat(ctx context.Context, config AsyncReplicationConfig) (st
 				}
 			}
 		}
+
+		if propagateErr != nil {
+			return nil, fmt.Errorf("propagating local objects: %w", propagateErr)
+		}
 	}
 
 	return []*hashBeatHostStats{
 		{
-			targetNodeName:               shardDiffReader.TargetNodeName,
-			hashtreeDiffStartTime:        hashtreeDiffStart,
-			hashtreeDiffTook:             hashtreeDiffTook,
-			objectDigestsDiffTook:        objectDigestsDiffTook,
-			localObjectDigestsCount:      localObjectDigestsCount,
-			remoteObjectDigestsCount:     remoteObjectDigestsCount,
-			localObjectsPropagationCount: len(localObjectsToPropagate),
-			localObjectsPropagationTook:  time.Since(objectsPropagationStart),
-			objectsNotResolved:           objectsNotResolved,
+			targetNodeName:                   shardDiffReader.TargetNodeName,
+			hashtreeDiffStartTime:            hashtreeDiffStart,
+			hashtreeDiffTook:                 hashtreeDiffTook,
+			objectDigestsDiffTook:            objectDigestsDiffTook,
+			localObjectDigestsCount:          localObjectDigestsCount,
+			remoteObjectDigestsCount:         remoteObjectDigestsCount,
+			objectsQueuedForPropagationCount: objectsQueuedForPropagationCount,
+			localObjectsPropagationCount:     len(localObjectsToPropagate),
+			localObjectsPropagationTook:      time.Since(objectsPropagationStart),
+			objectsNotResolved:               objectsNotResolved,
+			localHashtreeRoot:                shardDiffReader.LocalHashtreeRoot,
+			remoteHashtreeRoot:               shardDiffReader.RemoteHashtreeRoot,
 		},
 	}, nil
 }
@@ -1022,8 +1435,25 @@ type objectToPropagate struct {
 	uuid                  strfmt.UUID
 	lastUpdateTime        int64
 	remoteStaleUpdateTime int64
+	// remoteDeleted is true when CompareDigests on the target reported that the
+	// target has tombstoned this object and the configured deletion strategy
+	// instructs the source to delete. When set, the object must NOT be
+	// propagated; instead the source deletes its own local copy.
+	remoteDeleted bool
 }
 
+// objectsToPropagateWithinRange determines which local objects in the given
+// hashtree leaf range the source must propagate to targetNodeAddress.
+//
+// For each local batch it:
+//  1. Fetches local digests via DigestObjectsInRange.
+//  2. Filters out objects that are too recent (per maxUpdateTime).
+//  3. Sends the remaining digests to the target via a single CompareDigests
+//     round-trip. The target returns only those UUIDs that need action:
+//     missing/stale entries (source must propagate) and tombstoned entries
+//     where the deletion strategy instructs the source to delete locally.
+//     This collapses the former O(N_local_batches × N_remote_batches) nested
+//     HTTP scan to O(N_local_batches) round-trips.
 func (s *Shard) objectsToPropagateWithinRange(ctx context.Context, config AsyncReplicationConfig,
 	targetNodeAddress, targetNodeName string, initialLeaf, finalLeaf uint64, limit int,
 	targetNodeOverrides additional.AsyncReplicationTargetNodeOverrides,
@@ -1041,8 +1471,23 @@ func (s *Shard) objectsToPropagateWithinRange(ctx context.Context, config AsyncR
 		return localObjectsCount, remoteObjectsCount, objectsToPropagate, err
 	}
 
+	// Compute the threshold once per call so all batches use a consistent
+	// cut-off. Recomputing inside the loop would allow the threshold to drift
+	// between batches, producing inconsistent eligibility decisions for objects
+	// whose UpdateTime sits close to the boundary.
+	maxUpdateTime := s.getHashBeatMaxUpdateTime(targetNodeName, targetNodeOverrides)
+
+	// localNodeName is used as a tiebreaker for equal-timestamp conflicts: the
+	// node with the lexicographically lower name wins and propagates its version.
+	localNodeName := s.index.replicator.LocalNodeName()
+
 	currLocalUUIDBytes := make([]byte, 16)
 	binary.BigEndian.PutUint64(currLocalUUIDBytes, initialLeaf<<(64-hashtreeHeight))
+
+	// filteredDigests and localDigestsByUUID are declared outside the loop and
+	// reset on each iteration to avoid per-batch heap allocations on this hot path.
+	filteredDigests := make([]types.RepairResponse, 0, config.diffBatchSize)
+	localDigestsByUUID := make(map[uuid.UUID]types.RepairResponse, config.diffBatchSize)
 
 	for limit > 0 && bytes.Compare(currLocalUUIDBytes, finalUUIDBytes) < 1 {
 		if ctx.Err() != nil {
@@ -1062,132 +1507,129 @@ func (s *Shard) objectsToPropagateWithinRange(ctx context.Context, config AsyncR
 		}
 
 		if len(allLocalDigests) == 0 {
-			// no more local objects need to be propagated in this iteration
 			break
 		}
 
-		localObjectsCount += len(allLocalDigests)
-
-		// iteration should stop when all local digests within the range has been read
-
-		lastLocalUUID := strfmt.UUID(allLocalDigests[len(allLocalDigests)-1].ID)
-
-		lastLocalUUIDBytes, err := bytesFromUUID(lastLocalUUID)
+		lastLocalUUIDBytes, err := bytesFromUUID(strfmt.UUID(allLocalDigests[len(allLocalDigests)-1].ID))
 		if err != nil {
 			return localObjectsCount, remoteObjectsCount, objectsToPropagate, err
 		}
 
-		localDigestsByUUID := make(map[string]types.RepairResponse, len(allLocalDigests))
-
-		// filter out too recent local digests to avoid object propagation when all the nodes may be alive
-		// or if an upper time bound is configured for shard replica movement
-		maxUpdateTime := s.getHashBeatMaxUpdateTime(config, targetNodeName, targetNodeOverrides)
-
+		// Filter out objects that are too recent to propagate.
+		// localDigestsByUUID uses uuid.UUID ([16]byte) keys to avoid per-entry
+		// string allocations on this hot path.
+		filteredDigests = filteredDigests[:0]
+		clear(localDigestsByUUID)
 		for _, d := range allLocalDigests {
-			if d.UpdateTime <= maxUpdateTime {
-				localDigestsByUUID[d.ID] = d
+			if d.UpdateTime > maxUpdateTime {
+				continue
 			}
-		}
-		if len(localDigestsByUUID) == 0 {
-			// local digests are all too recent, so we can stop now
-			break
-		}
-
-		remoteStaleUpdateTime := make(map[string]int64, len(localDigestsByUUID))
-
-		if len(localDigestsByUUID) > 0 {
-			// fetch digests from remote host in order to avoid sending unnecessary objects
-			for currRemoteUUIDBytes := currLocalUUIDBytes; bytes.Compare(currRemoteUUIDBytes, lastLocalUUIDBytes) < 1; {
-				if ctx.Err() != nil {
-					return localObjectsCount, remoteObjectsCount, objectsToPropagate, ctx.Err()
-				}
-
-				currRemoteUUID, err := uuidFromBytes(currRemoteUUIDBytes)
-				if err != nil {
-					return localObjectsCount, remoteObjectsCount, objectsToPropagate, err
-				}
-
-				// TODO could speed up by passing through the target node override upper time bound here
-				remoteDigests, err := s.index.replicator.DigestObjectsInRange(ctx,
-					s.name, targetNodeAddress, currRemoteUUID, lastLocalUUID, config.diffBatchSize)
-				if err != nil {
-					return localObjectsCount, remoteObjectsCount, objectsToPropagate, fmt.Errorf("fetching remote object digests: %w", err)
-				}
-
-				if len(remoteDigests) == 0 {
-					// no more digests in remote host
-					break
-				}
-
-				remoteObjectsCount += len(remoteDigests)
-
-				for _, d := range remoteDigests {
-					localDigest, ok := localDigestsByUUID[d.ID]
-					if ok {
-						if localDigest.UpdateTime <= d.UpdateTime {
-							// older or up to date objects are not propagated
-							delete(localDigestsByUUID, d.ID)
-
-							if len(localDigestsByUUID) == 0 {
-								// no more local objects need to be propagated in this iteration
-								break
-							}
-						} else {
-							// older object is subject to be overwriten
-							remoteStaleUpdateTime[d.ID] = d.UpdateTime
-						}
-					}
-				}
-
-				if len(localDigestsByUUID) == 0 {
-					// no more local objects need to be propagated in this iteration
-					break
-				}
-
-				if len(remoteDigests) < config.diffBatchSize {
-					break
-				}
-
-				lastRemoteUUID := strfmt.UUID(remoteDigests[len(remoteDigests)-1].ID)
-
-				lastRemoteUUIDBytes, err := bytesFromUUID(lastRemoteUUID)
-				if err != nil {
-					return localObjectsCount, remoteObjectsCount, objectsToPropagate, err
-				}
-
-				overflow := incToNextLexValue(lastRemoteUUIDBytes)
-				if overflow {
-					// no more remote digests need to be fetched
-					break
-				}
-
-				currRemoteUUIDBytes = lastRemoteUUIDBytes
+			key, err := uuid.Parse(d.ID)
+			if err != nil {
+				// A local digest with an unparseable UUID indicates data corruption;
+				// log and skip rather than silently diverging the two collections.
+				s.index.logger.WithField("uuid", d.ID).
+					Error("async replication: skipping local digest with invalid UUID")
+				continue
 			}
+			filteredDigests = append(filteredDigests, d)
+			localDigestsByUUID[key] = d
+		}
+		// Count only the objects eligible for comparison (after recency filtering),
+		// so the stat reflects actual CompareDigests traffic, not objects scanned.
+		localObjectsCount += len(filteredDigests)
+
+		if len(filteredDigests) == 0 {
+			// All objects in this batch are too recent to propagate, but later
+			// UUID ranges may still contain eligible objects (DigestObjectsInRange
+			// returns results ordered by UUID, not by UpdateTime). Advance past
+			// this batch and keep scanning instead of stopping here.
+			if len(allLocalDigests) < currBatchSize {
+				break
+			}
+			overflow := incToNextLexValue(lastLocalUUIDBytes)
+			if overflow {
+				break
+			}
+			currLocalUUIDBytes = lastLocalUUIDBytes
+			continue
 		}
 
-		for _, obj := range localDigestsByUUID {
+		// Single round-trip: target responds with only the UUIDs that need
+		// propagation (missing or stale on target), eliminating the inner loop.
+		staleDigests, err := s.index.replicator.CompareDigests(ctx, s.name, targetNodeAddress, filteredDigests)
+		if err != nil {
+			return localObjectsCount, remoteObjectsCount, objectsToPropagate, fmt.Errorf("comparing digests with remote: %w", err)
+		}
+
+		// remoteObjectsCount tracks digests sent to the remote for comparison,
+		// i.e. the volume of the CompareDigests request. Objects queued for
+		// propagation (stale/missing on remote after tiebreak) are a subset of
+		// this and are captured separately via objectsQueuedForPropagationCount
+		// at the call site.
+		remoteObjectsCount += len(filteredDigests)
+
+		propagated := 0
+		for _, stale := range staleDigests {
+			key, err := uuid.Parse(stale.ID)
+			if err != nil {
+				// An invalid UUID in a remote stale digest indicates a protocol or
+				// remote bug; log it so the issue is visible rather than silently
+				// skipping objects that may need propagation.
+				s.index.logger.WithField("uuid", stale.ID).
+					Error("async replication: skipping stale digest from remote with invalid UUID")
+				continue
+			}
+			localDigest, ok := localDigestsByUUID[key]
+			if !ok {
+				continue
+			}
+
+			// Target has already applied the deletion strategy and instructed this
+			// source node to delete the object locally (Deleted=true) or to propagate
+			// the live object (Deleted=false, normal stale path below).
+			if stale.Deleted {
+				objectsToPropagate = append(objectsToPropagate, objectToPropagate{
+					uuid:                  strfmt.UUID(stale.ID),
+					lastUpdateTime:        localDigest.UpdateTime,
+					remoteStaleUpdateTime: stale.UpdateTime,
+					remoteDeleted:         true,
+				})
+				propagated++
+				continue
+			}
+
+			// Equal-timestamp guard: CompareDigests no longer returns objects where
+			// source and target hold the same UpdateTime (they are not stale).
+			// This check is retained as a defensive guard in case a caller path
+			// produces a stale entry with a matching timestamp; it prevents the
+			// source from re-propagating an object it just successfully delivered.
+			if stale.UpdateTime != 0 && stale.UpdateTime == localDigest.UpdateTime &&
+				localNodeName >= targetNodeName {
+				continue
+			}
 			objectsToPropagate = append(objectsToPropagate, objectToPropagate{
-				uuid:                  strfmt.UUID(obj.ID),
-				lastUpdateTime:        obj.UpdateTime,
-				remoteStaleUpdateTime: remoteStaleUpdateTime[obj.ID],
+				uuid:                  strfmt.UUID(stale.ID),
+				lastUpdateTime:        localDigest.UpdateTime,
+				remoteStaleUpdateTime: stale.UpdateTime, // 0 means missing from target
 			})
+			propagated++
 		}
 
 		if len(allLocalDigests) < currBatchSize {
-			// no more local objects need to be propagated
 			break
 		}
 
-		// to avoid reading the last uuid in the next iteration
 		overflow := incToNextLexValue(lastLocalUUIDBytes)
 		if overflow {
-			// no more local objects need to be propagated
 			break
 		}
 
 		currLocalUUIDBytes = lastLocalUUIDBytes
-
-		limit -= len(localDigestsByUUID)
+		// Decrement by objects actually queued for propagation so that limit
+		// reflects remaining propagation capacity, not objects scanned.
+		// Scanning many already-up-to-date objects should not exhaust the limit.
+		limit -= propagated
 	}
 
 	// Note: propagations == 0 means local shard is laying behind remote shard,
@@ -1199,7 +1641,7 @@ func (s *Shard) objectsToPropagateWithinRange(ctx context.Context, config AsyncR
 // getHashBeatMaxUpdateTime returns the maximum update time for the hash beat.
 // If our local node and the target node have an upper time bound configured, use the
 // configured upper time bound instead of the default one
-func (s *Shard) getHashBeatMaxUpdateTime(config AsyncReplicationConfig, targetNodeName string, targetNodeOverrides additional.AsyncReplicationTargetNodeOverrides) int64 {
+func (s *Shard) getHashBeatMaxUpdateTime(targetNodeName string, targetNodeOverrides additional.AsyncReplicationTargetNodeOverrides) int64 {
 	localNodeName := s.index.replicator.LocalNodeName()
 	for _, override := range targetNodeOverrides {
 		if override.Equal(&additional.AsyncReplicationTargetNodeOverride{
@@ -1211,7 +1653,7 @@ func (s *Shard) getHashBeatMaxUpdateTime(config AsyncReplicationConfig, targetNo
 			return override.UpperTimeBound
 		}
 	}
-	return time.Now().Add(-config.propagationDelay).UnixMilli()
+	return math.MaxInt64
 }
 
 func (s *Shard) propagateObjects(ctx context.Context, config AsyncReplicationConfig, host string,
@@ -1234,89 +1676,129 @@ func (s *Shard) propagateObjects(ctx context.Context, config AsyncReplicationCon
 		err  error
 	}
 
-	var wg sync.WaitGroup
+	// workerWg tracks active worker goroutines (not individual batches).
+	// This is the key invariant: workerWg reaches zero only when every worker
+	// goroutine has fully exited, which guarantees that all resultCh sends have
+	// already completed before the closer goroutine closes the channel.
+	var workerWg sync.WaitGroup
 
-	batchCh := make(chan []strfmt.UUID, len(objectsToPropagate)/config.propagationBatchSize+1)
-	resultCh := make(chan workerResponse, len(objectsToPropagate)/config.propagationBatchSize+1)
+	// cancelCause cancels workerCtx and records the first cause (e.g. a panic).
+	// All workers and in-flight requests are bound to workerCtx so they stop
+	// promptly when one worker fails.
+	workerCtx, cancelCause := context.WithCancelCause(ctx)
+	defer cancelCause(nil)
+
+	numBatches := len(objectsToPropagate)/config.propagationBatchSize + 1
+	batchCh := make(chan []strfmt.UUID, numBatches)
+	// resultCh capacity covers one response per batch plus one panic error per
+	// worker, ensuring the recovery defer never blocks before workerWg.Done fires.
+	resultCh := make(chan workerResponse, numBatches+config.propagationConcurrency)
 
 	for range config.propagationConcurrency {
+		workerWg.Add(1)
 		enterrors.GoWrapper(func() {
+			// workerWg.Done is deferred first so it runs last (LIFO), after the
+			// recovery defer below has already sent to resultCh.  This guarantees
+			// that every resultCh send from this goroutine completes before the
+			// closer goroutine's workerWg.Wait() unblocks and closes resultCh.
+			defer workerWg.Done()
+			// Recover panics so they are surfaced as errors rather than silently
+			// swallowed by GoWrapper's logger.  cancelCause stops all other workers
+			// via workerCtx; they drain batchCh without processing (see below).
+			defer func() {
+				if r := recover(); r != nil {
+					panicErr := fmt.Errorf("worker panic: %v", r)
+					s.index.logger.WithField("action", "async_replication_propagate").
+						WithField("class_name", s.class.Class).
+						WithField("shard_name", s.name).
+						Errorf("recovered panic in propagateObjects worker: %v", r)
+					cancelCause(panicErr)
+					resultCh <- workerResponse{err: panicErr}
+				}
+			}()
 			for uuidBatch := range batchCh {
-				func() {
-					defer wg.Done()
-					localObjs, err := s.MultiObjectByID(ctx, wrapIDsInMulti(uuidBatch))
-					if err != nil {
-						resultCh <- workerResponse{
-							err: fmt.Errorf("fetching local objects: %w", err),
-						}
-						return
+				// When workerCtx is cancelled (panic in another worker or parent
+				// cancellation), drain remaining batches without processing.
+				// batchCh is closed by the producer after all batches are sent, so
+				// this loop always terminates without needing a separate WaitGroup.
+				if workerCtx.Err() != nil {
+					continue
+				}
+
+				localObjs, err := s.MultiObjectByID(workerCtx, wrapIDsInMulti(uuidBatch))
+				if err != nil {
+					resultCh <- workerResponse{
+						err: fmt.Errorf("fetching local objects: %w", err),
+					}
+					continue
+				}
+
+				batch := make([]*objects.VObject, 0, len(localObjs))
+
+				for _, obj := range localObjs {
+					if obj == nil {
+						// local object was deleted meanwhile
+						continue
 					}
 
-					batch := make([]*objects.VObject, 0, len(localObjs))
+					var vectors map[string][]float32
+					var multiVectors map[string][][]float32
 
-					for _, obj := range localObjs {
-						if obj == nil {
-							// local object was deleted meanwhile
-							continue
-						}
-
-						var vectors map[string][]float32
-						var multiVectors map[string][][]float32
-
-						if obj.Vectors != nil {
-							vectors = make(map[string][]float32, len(obj.Vectors))
-							for targetVector, v := range obj.Vectors {
-								vectors[targetVector] = v
-							}
-						}
-						if obj.MultiVectors != nil {
-							multiVectors = make(map[string][][]float32, len(obj.MultiVectors))
-							for targetVector, v := range obj.MultiVectors {
-								multiVectors[targetVector] = v
-							}
-						}
-
-						obj := &objects.VObject{
-							ID:                      obj.ID(),
-							LastUpdateTimeUnixMilli: obj.LastUpdateTimeUnix(),
-							LatestObject:            &obj.Object,
-							Vector:                  obj.Vector,
-							Vectors:                 vectors,
-							MultiVectors:            multiVectors,
-							StaleUpdateTime:         remoteStaleUpdateTime[obj.ID()],
-						}
-
-						batch = append(batch, obj)
-					}
-
-					if len(batch) > 0 {
-						resp, err := s.index.replicator.Overwrite(ctx, host, s.class.Class, s.name, batch)
-
-						resultCh <- workerResponse{
-							resp: resp,
-							err:  err,
+					if obj.Vectors != nil {
+						vectors = make(map[string][]float32, len(obj.Vectors))
+						for targetVector, v := range obj.Vectors {
+							vectors[targetVector] = v
 						}
 					}
-				}()
+					if obj.MultiVectors != nil {
+						multiVectors = make(map[string][][]float32, len(obj.MultiVectors))
+						for targetVector, v := range obj.MultiVectors {
+							multiVectors[targetVector] = v
+						}
+					}
+
+					obj := &objects.VObject{
+						ID:                      obj.ID(),
+						LastUpdateTimeUnixMilli: obj.LastUpdateTimeUnix(),
+						LatestObject:            &obj.Object,
+						Vector:                  obj.Vector,
+						Vectors:                 vectors,
+						MultiVectors:            multiVectors,
+						StaleUpdateTime:         remoteStaleUpdateTime[obj.ID()],
+					}
+
+					batch = append(batch, obj)
+				}
+
+				if len(batch) > 0 {
+					resp, err := s.index.replicator.Overwrite(workerCtx, host, s.class.Class, s.name, batch)
+
+					resultCh <- workerResponse{
+						resp: resp,
+						err:  err,
+					}
+				}
 			}
 		}, s.index.logger)
 	}
 
+	// Send all batches upfront (batchCh is pre-sized to fit them all without
+	// blocking), then close batchCh so workers exit their range loop naturally
+	// once all items are consumed — no separate WaitGroup per batch needed.
 	for i := 0; i < len(objectsToPropagate); {
 		actualBatchSize := config.propagationBatchSize
 		if i+actualBatchSize > len(objectsToPropagate) {
 			actualBatchSize = len(objectsToPropagate) - i
 		}
 
-		wg.Add(1)
 		batchCh <- objectsToPropagate[i : i+actualBatchSize]
 
 		i += actualBatchSize
 	}
+	close(batchCh)
 
 	enterrors.GoWrapper(func() {
-		wg.Wait()
-		close(batchCh)
+		workerWg.Wait()
 		close(resultCh)
 	}, s.index.logger)
 
@@ -1324,16 +1806,22 @@ func (s *Shard) propagateObjects(ctx context.Context, config AsyncReplicationCon
 
 	for r := range resultCh {
 		if r.err != nil {
-			ec.Add(err)
+			ec.Add(r.err)
 			continue
 		}
 
 		res = append(res, r.resp...)
 	}
 
-	if len(res) > 0 {
-		return res, nil
+	// If workerCtx was cancelled (parent timeout, panic, etc.) but no worker
+	// managed to emit an error (e.g. all workers hit the drain-continue path
+	// before executing any work), surface the cancellation cause so callers
+	// are not misled by a nil error.
+	if err := ec.ToError(); err != nil {
+		return res, err
 	}
-
-	return nil, ec.ToError()
+	if cause := context.Cause(workerCtx); cause != nil {
+		return res, cause
+	}
+	return res, nil
 }

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -1,0 +1,1047 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	routerTypes "github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storobj"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/usecases/objects"
+	"github.com/weaviate/weaviate/usecases/replica"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+)
+
+// uuidLow and uuidHigh are deterministic UUIDs with clear binary ordering:
+// uuidLow starts with 0x00 (lower half of UUID space),
+// uuidHigh starts with 0xF0 (upper half of UUID space).
+// This guarantees DigestObjectsInRange always returns them in the same order.
+const (
+	uuidLow  = strfmt.UUID("00000000-0000-0000-0000-000000000001")
+	uuidHigh = strfmt.UUID("f0000000-0000-0000-0000-000000000001")
+	uuidMid  = strfmt.UUID("70000000-0000-0000-0000-000000000001")
+)
+
+// tsFarPast is a timestamp (Unix ms) well in the past (1970-01-01 00:00:01 UTC).
+const tsFarPast int64 = 1
+
+// testObj builds a storobj with a known UUID and UpdateTime. The UpdateTime is
+// stored as-is by PutObject (not overwritten by the shard layer).
+func testObjWithTime(class string, id strfmt.UUID, updateTime int64) *storobj.Object {
+	return &storobj.Object{
+		MarshallerVersion: 1,
+		Object: models.Object{
+			ID:                 id,
+			Class:              class,
+			LastUpdateTimeUnix: updateTime,
+		},
+	}
+}
+
+// equalTimestampReplicationClient is a test double that echoes every digest
+// back with its UpdateTime unchanged, simulating an equal-timestamp conflict
+// where the remote holds the same version as the source.
+type equalTimestampReplicationClient struct {
+	FakeReplicationClient
+}
+
+func (c *equalTimestampReplicationClient) CompareDigests(
+	_ context.Context, _, _, _ string, digests []routerTypes.RepairResponse,
+) ([]routerTypes.RepairResponse, error) {
+	echo := make([]routerTypes.RepairResponse, len(digests))
+	copy(echo, digests)
+	return echo, nil
+}
+
+// allStaleReplicationClient is a test double that reports every digest it
+// receives as missing on the remote side (UpdateTime == 0).
+type allStaleReplicationClient struct {
+	FakeReplicationClient
+}
+
+func (c *allStaleReplicationClient) CompareDigests(
+	_ context.Context, _, _, _ string, digests []routerTypes.RepairResponse,
+) ([]routerTypes.RepairResponse, error) {
+	stale := make([]routerTypes.RepairResponse, len(digests))
+	for i, d := range digests {
+		stale[i] = routerTypes.RepairResponse{ID: d.ID, UpdateTime: 0}
+	}
+	return stale, nil
+}
+
+// withReplicationClient returns an indexOpt that replaces the index's
+// replicator with a new one backed by the given client. This allows tests to
+// control what CompareDigests returns without modifying production code.
+func withReplicationClient(t *testing.T, client replica.Client) func(*Index) {
+	t.Helper()
+	return func(idx *Index) {
+		logger, _ := test.NewNullLogger()
+
+		mockRouter := routerTypes.NewMockRouter(t)
+		localReplica := routerTypes.Replica{NodeName: "node1", ShardName: "shard1", HostAddr: "127.0.0.1"}
+		mockRouter.EXPECT().
+			GetWriteReplicasLocation(mock.Anything, mock.Anything, mock.Anything).
+			Return(routerTypes.WriteReplicaSet{Replicas: []routerTypes.Replica{localReplica}}, nil).
+			Maybe()
+		mockRouter.EXPECT().
+			GetReadReplicasLocation(mock.Anything, mock.Anything, mock.Anything).
+			Return(routerTypes.ReadReplicaSet{Replicas: []routerTypes.Replica{localReplica}}, nil).
+			Maybe()
+
+		nodeResolver := cluster.NewMockNodeResolver(t)
+
+		rep, err := replica.NewReplicator(
+			idx.Config.ClassName.String(),
+			mockRouter,
+			nodeResolver,
+			"node1",
+			func() string { return models.ReplicationConfigDeletionStrategyNoAutomatedResolution },
+			client,
+			monitoring.GetMetrics(),
+			logger,
+		)
+		require.NoError(t, err)
+		idx.replicator = rep
+	}
+}
+
+// fullRangeConfig returns an AsyncReplicationConfig that scans the entire UUID
+// space (hashtreeHeight=1 → 2 leaves) in batches of batchSize objects.
+func fullRangeConfig(batchSize int) AsyncReplicationConfig {
+	return AsyncReplicationConfig{
+		hashtreeHeight: 1,
+		diffBatchSize:  batchSize,
+	}
+}
+
+// ─── Shard.CompareDigests ────────────────────────────────────────────────────
+
+// withDeletionStrategy returns an indexOpt that sets the deletion strategy on
+// the index config, allowing CompareDigests tombstone handling to be tested
+// without a full cluster setup.
+func withDeletionStrategy(strategy string) func(*Index) {
+	return func(idx *Index) {
+		idx.Config.DeletionStrategy = strategy
+	}
+}
+
+// flushShard forces all pending memtable data to disk so that CompareDigests
+// (which uses GetErrDeletedOnDisk and is therefore disk-only) can observe the
+// objects and tombstones written by PutObject / DeleteObject.
+func flushShard(t *testing.T, ctx context.Context, shard ShardLike) {
+	t.Helper()
+	s, ok := shard.(*Shard)
+	require.True(t, ok, "flushShard: expected *Shard, got %T", shard)
+	require.NoError(t, s.store.FlushMemtables(ctx))
+}
+
+// concreteShard unwraps the *Shard from a ShardLike returned by testShard.
+// testShard passes EnableLazyLoadShards=true which causes initShard to create
+// a real *Shard directly (not a LazyLoadShard wrapper).
+func concreteShard(t *testing.T, sl ShardLike) *Shard {
+	t.Helper()
+	s, ok := sl.(*Shard)
+	require.True(t, ok, "expected *Shard from testShard (EnableLazyLoadShards=true)")
+	return s
+}
+
+// TestShardCompareDigests validates the server-side CompareDigests logic:
+// missing objects are returned with UpdateTime==0, stale objects with the local
+// UpdateTime, and up-to-date objects are not returned at all.
+func TestShardCompareDigests(t *testing.T) {
+	ctx := context.Background()
+	const class = "CompareDigestsTest"
+
+	// localTime is the timestamp stored on the shard for the known objects.
+	const localTime int64 = 1_000_000
+
+	t.Run("MissingObject", func(t *testing.T) {
+		shard, _ := testShard(t, ctx, class)
+		// Shard is empty — every source digest is missing.
+		source := []routerTypes.RepairResponse{
+			{ID: string(uuidLow), UpdateTime: localTime + 1},
+		}
+		result, err := shard.CompareDigests(ctx, source)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, string(uuidLow), result[0].ID)
+		assert.Equal(t, int64(0), result[0].UpdateTime, "missing object must have UpdateTime==0")
+	})
+
+	t.Run("StaleLocalObject", func(t *testing.T) {
+		shard, _ := testShard(t, ctx, class)
+		require.NoError(t, shard.PutObject(ctx, testObjWithTime(class, uuidLow, localTime)))
+		flushShard(t, ctx, shard)
+
+		// Source claims a newer version → local is stale.
+		source := []routerTypes.RepairResponse{
+			{ID: string(uuidLow), UpdateTime: localTime + 1},
+		}
+		result, err := shard.CompareDigests(ctx, source)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		assert.Equal(t, string(uuidLow), result[0].ID)
+		assert.Equal(t, localTime, result[0].UpdateTime,
+			"stale object must carry local UpdateTime so caller can use it as remoteStaleUpdateTime")
+	})
+
+	t.Run("SourceStrictlyOlder", func(t *testing.T) {
+		shard, _ := testShard(t, ctx, class)
+		require.NoError(t, shard.PutObject(ctx, testObjWithTime(class, uuidLow, localTime)))
+		flushShard(t, ctx, shard)
+
+		// Source has a strictly older version → local is ahead, not returned.
+		source := []routerTypes.RepairResponse{
+			{ID: string(uuidLow), UpdateTime: localTime - 1},
+		}
+		result, err := shard.CompareDigests(ctx, source)
+		require.NoError(t, err)
+		assert.Empty(t, result, "object where local is strictly newer must not be returned")
+	})
+
+	t.Run("EqualTimestamp", func(t *testing.T) {
+		shard, _ := testShard(t, ctx, class)
+		require.NoError(t, shard.PutObject(ctx, testObjWithTime(class, uuidLow, localTime)))
+		flushShard(t, ctx, shard)
+
+		// Source and target have the same UpdateTime: both nodes hold the object
+		// at the same logical time, so no propagation is needed. Returning
+		// equal-timestamp objects would cause re-propagation of recently-delivered
+		// objects and exhaust the propagation limit.
+		source := []routerTypes.RepairResponse{
+			{ID: string(uuidLow), UpdateTime: localTime},
+		}
+		result, err := shard.CompareDigests(ctx, source)
+		require.NoError(t, err)
+		assert.Empty(t, result, "equal-timestamp object must not be returned (both nodes already in sync)")
+	})
+
+	// ObjectInMemtableRecognizedAsPresent verifies the fix for the bug where
+	// async replication re-propagated the same objects every hashbeat cycle:
+	//
+	// When the source propagates objects to the target, those objects land in
+	// the target's memtable before being flushed to disk.  If CompareDigests
+	// used disk-only lookups, the target would report them as missing on the
+	// next hashbeat cycle (before flush), causing the source to re-propagate
+	// the same objects and exhaust the propagationLimit — preventing genuinely
+	// stale objects in later UUID ranges from ever being reached.
+	//
+	// CompareDigests must consult the full bucket (memtable + disk) so that
+	// recently-propagated objects are correctly identified as already present.
+	// Tombstoned tests verify that CompareDigests applies the configured
+	// deletion conflict strategy on the target side for tombstoned objects.
+	//
+	// deletionTs is the timestamp used for all DeleteObject calls below.
+	// sourceNewerTs  > deletionTs  → source live object is newer than the tombstone.
+	// sourceSameTs  == deletionTs  → equal timestamp; deletion should win.
+	// sourceOlderTs  < deletionTs  → deletion is newer than the source object.
+	const (
+		deletionTs    int64 = 2_000_000
+		sourceNewerTs int64 = 3_000_000
+		sourceSameTs  int64 = deletionTs
+		sourceOlderTs int64 = 1_000
+	)
+
+	t.Run("Tombstoned/NoAutomatedResolution", func(t *testing.T) {
+		// Strategy=NoAutomatedResolution: tombstone must be suppressed regardless
+		// of timestamps so the source neither propagates nor deletes.
+		shard, _ := testShard(t, ctx, class,
+			withDeletionStrategy(models.ReplicationConfigDeletionStrategyNoAutomatedResolution))
+		require.NoError(t, shard.PutObject(ctx, testObjWithTime(class, uuidLow, localTime)))
+		require.NoError(t, shard.DeleteObject(ctx, uuidLow, time.UnixMilli(deletionTs)))
+		flushShard(t, ctx, shard)
+
+		for _, sourceTs := range []int64{sourceOlderTs, sourceSameTs, sourceNewerTs} {
+			result, err := shard.CompareDigests(ctx, []routerTypes.RepairResponse{
+				{ID: string(uuidLow), UpdateTime: sourceTs},
+			})
+			require.NoError(t, err)
+			assert.Empty(t, result, "NoAutomatedResolution: tombstone must not be reported (sourceTs=%d)", sourceTs)
+		}
+	})
+
+	t.Run("Tombstoned/DeleteOnConflict", func(t *testing.T) {
+		// Strategy=DeleteOnConflict: deletion always wins, instruct source to
+		// delete regardless of timestamps.
+		shard, _ := testShard(t, ctx, class,
+			withDeletionStrategy(models.ReplicationConfigDeletionStrategyDeleteOnConflict))
+		require.NoError(t, shard.PutObject(ctx, testObjWithTime(class, uuidLow, localTime)))
+		require.NoError(t, shard.DeleteObject(ctx, uuidLow, time.UnixMilli(deletionTs)))
+		flushShard(t, ctx, shard)
+
+		for _, sourceTs := range []int64{sourceOlderTs, sourceSameTs, sourceNewerTs} {
+			result, err := shard.CompareDigests(ctx, []routerTypes.RepairResponse{
+				{ID: string(uuidLow), UpdateTime: sourceTs},
+			})
+			require.NoError(t, err)
+			require.Len(t, result, 1, "DeleteOnConflict: tombstone must always be reported (sourceTs=%d)", sourceTs)
+			assert.True(t, result[0].Deleted, "DeleteOnConflict: result must have Deleted=true")
+			assert.Equal(t, deletionTs, result[0].UpdateTime, "DeleteOnConflict: UpdateTime must be the deletion timestamp")
+		}
+	})
+
+	t.Run("Tombstoned/TimeBasedResolution_SourceNewer", func(t *testing.T) {
+		// Strategy=TimeBasedResolution, source strictly newer than tombstone:
+		// return as a normal stale entry (no Deleted flag) so source propagates
+		// the live object to restore it on this shard.
+		shard, _ := testShard(t, ctx, class,
+			withDeletionStrategy(models.ReplicationConfigDeletionStrategyTimeBasedResolution))
+		require.NoError(t, shard.PutObject(ctx, testObjWithTime(class, uuidLow, localTime)))
+		require.NoError(t, shard.DeleteObject(ctx, uuidLow, time.UnixMilli(deletionTs)))
+		flushShard(t, ctx, shard)
+
+		result, err := shard.CompareDigests(ctx, []routerTypes.RepairResponse{
+			{ID: string(uuidLow), UpdateTime: sourceNewerTs},
+		})
+		require.NoError(t, err)
+		require.Len(t, result, 1, "TimeBased/SourceNewer: stale entry must be returned so source propagates")
+		assert.False(t, result[0].Deleted, "TimeBased/SourceNewer: Deleted must be false — source should propagate")
+		assert.Equal(t, deletionTs, result[0].UpdateTime, "TimeBased/SourceNewer: UpdateTime must be the deletion timestamp")
+	})
+
+	t.Run("Tombstoned/TimeBasedResolution_DeletionNewer", func(t *testing.T) {
+		// Strategy=TimeBasedResolution, deletion is newer: instruct source to delete.
+		shard, _ := testShard(t, ctx, class,
+			withDeletionStrategy(models.ReplicationConfigDeletionStrategyTimeBasedResolution))
+		require.NoError(t, shard.PutObject(ctx, testObjWithTime(class, uuidLow, localTime)))
+		require.NoError(t, shard.DeleteObject(ctx, uuidLow, time.UnixMilli(deletionTs)))
+		flushShard(t, ctx, shard)
+
+		result, err := shard.CompareDigests(ctx, []routerTypes.RepairResponse{
+			{ID: string(uuidLow), UpdateTime: sourceOlderTs},
+		})
+		require.NoError(t, err)
+		require.Len(t, result, 1, "TimeBased/DeletionNewer: tombstone must be reported so source deletes")
+		assert.True(t, result[0].Deleted, "TimeBased/DeletionNewer: Deleted must be true")
+		assert.Equal(t, deletionTs, result[0].UpdateTime)
+	})
+
+	t.Run("Tombstoned/TimeBasedResolution_EqualTimestamps", func(t *testing.T) {
+		// Strategy=TimeBasedResolution, timestamps are equal: deletion wins
+		// (condition is strictly greater-than, so equal falls to the delete path).
+		shard, _ := testShard(t, ctx, class,
+			withDeletionStrategy(models.ReplicationConfigDeletionStrategyTimeBasedResolution))
+		require.NoError(t, shard.PutObject(ctx, testObjWithTime(class, uuidLow, localTime)))
+		require.NoError(t, shard.DeleteObject(ctx, uuidLow, time.UnixMilli(deletionTs)))
+		flushShard(t, ctx, shard)
+
+		result, err := shard.CompareDigests(ctx, []routerTypes.RepairResponse{
+			{ID: string(uuidLow), UpdateTime: sourceSameTs},
+		})
+		require.NoError(t, err)
+		require.Len(t, result, 1, "TimeBased/EqualTimestamps: deletion wins on tie")
+		assert.True(t, result[0].Deleted, "TimeBased/EqualTimestamps: Deleted must be true")
+	})
+
+	t.Run("Tombstoned/TimeBasedResolution_UnknownDeletionTime", func(t *testing.T) {
+		// Strategy=TimeBasedResolution with an unknown deletion timestamp (zero):
+		// cannot determine winner, so conservatively instruct source to delete.
+		shard, _ := testShard(t, ctx, class,
+			withDeletionStrategy(models.ReplicationConfigDeletionStrategyTimeBasedResolution))
+		require.NoError(t, shard.PutObject(ctx, testObjWithTime(class, uuidLow, localTime)))
+		// DeleteObject with zero time stores a tombstone without a timestamp.
+		require.NoError(t, shard.DeleteObject(ctx, uuidLow, time.Time{}))
+		flushShard(t, ctx, shard)
+
+		result, err := shard.CompareDigests(ctx, []routerTypes.RepairResponse{
+			{ID: string(uuidLow), UpdateTime: sourceNewerTs},
+		})
+		require.NoError(t, err)
+		require.Len(t, result, 1, "TimeBased/UnknownDeletionTime: must conservatively instruct deletion")
+		assert.True(t, result[0].Deleted)
+		assert.Equal(t, int64(0), result[0].UpdateTime, "UpdateTime must be zero when deletion timestamp is unknown")
+	})
+
+	t.Run("MixedBatch", func(t *testing.T) {
+		shard, _ := testShard(t, ctx, class)
+		require.NoError(t, shard.PutObject(ctx, testObjWithTime(class, uuidLow, localTime))) // stale
+		require.NoError(t, shard.PutObject(ctx, testObjWithTime(class, uuidMid, localTime))) // up-to-date
+		// uuidHigh is not inserted → missing
+		flushShard(t, ctx, shard)
+
+		source := []routerTypes.RepairResponse{
+			{ID: string(uuidLow), UpdateTime: localTime + 1}, // source newer → stale local
+			{ID: string(uuidMid), UpdateTime: localTime - 1}, // source older → up-to-date local
+			{ID: string(uuidHigh), UpdateTime: localTime},    // not on shard → missing
+		}
+		result, err := shard.CompareDigests(ctx, source)
+		require.NoError(t, err)
+		require.Len(t, result, 2, "only stale and missing objects should be returned")
+
+		byID := make(map[string]routerTypes.RepairResponse, len(result))
+		for _, r := range result {
+			byID[r.ID] = r
+		}
+		stale, ok := byID[string(uuidLow)]
+		require.True(t, ok, "stale object must be present")
+		assert.Equal(t, localTime, stale.UpdateTime)
+
+		missing, ok := byID[string(uuidHigh)]
+		require.True(t, ok, "missing object must be present")
+		assert.Equal(t, int64(0), missing.UpdateTime)
+
+		_, ok = byID[string(uuidMid)]
+		assert.False(t, ok, "up-to-date object must not be present")
+	})
+
+	t.Run("EmptyInput", func(t *testing.T) {
+		shard, _ := testShard(t, ctx, class)
+		result, err := shard.CompareDigests(ctx, nil)
+		require.NoError(t, err)
+		assert.Nil(t, result)
+
+		result, err = shard.CompareDigests(ctx, []routerTypes.RepairResponse{})
+		require.NoError(t, err)
+		assert.Nil(t, result)
+	})
+}
+
+// ─── objectsToPropagateWithinRange ───────────────────────────────────────────
+
+// TestObjectsToPropagateWithinRange covers the scanning and filtering logic
+// inside objectsToPropagateWithinRange. Tests use well-known UUIDs so that
+// batch ordering is deterministic. Objects must be flushed to disk before
+// scanning because DigestObjectsInRange uses CursorOnDisk and skips memtables.
+func TestObjectsToPropagateWithinRange(t *testing.T) {
+	ctx := context.Background()
+	const class = "PropagateRangeTest"
+
+	// concreteShard returns the *Shard from a testShard call.
+	// testShard passes EnableLazyLoadShards=true as the disableLazyLoad flag,
+	// so initShard creates a real *Shard directly (not a LazyLoadShard).
+	concreteShard := func(t *testing.T, sl ShardLike) *Shard {
+		t.Helper()
+		s, ok := sl.(*Shard)
+		require.True(t, ok, "expected *Shard from testShard (EnableLazyLoadShards=true disables lazy loading)")
+		return s
+	}
+
+	t.Run("EmptyShard", func(t *testing.T) {
+		sl, idx := testShard(t, ctx, class)
+		s := concreteShard(t, sl)
+		cfg := fullRangeConfig(100)
+
+		local, remote, objs, err := s.objectsToPropagateWithinRange(
+			ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 0, local)
+		assert.Equal(t, 0, remote)
+		assert.Empty(t, objs)
+		_ = idx
+	})
+
+	// MemtableObjectsNotPropagated verifies that objects still in the memtable
+	// (not yet flushed to disk) are invisible to DigestObjectsInRange and are
+	// therefore not propagated in the current hashbeat cycle.
+	t.Run("MemtableObjectsNotPropagated", func(t *testing.T) {
+		sl, idx := testShard(t, ctx, class)
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidLow, tsFarPast)))
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidHigh, tsFarPast)))
+
+		s := concreteShard(t, sl)
+		cfg := fullRangeConfig(100)
+
+		local, remote, objs, err := s.objectsToPropagateWithinRange(
+			ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 0, local, "memtable objects must not be returned by disk-only scan")
+		assert.Equal(t, 0, remote, "CompareDigests must not be called when no on-disk objects found")
+		assert.Empty(t, objs)
+		_ = idx
+	})
+
+	// SourceBehindRemote verifies the no-op path: source objects are all
+	// up-to-date on the remote (CompareDigests returns nothing stale), so no
+	// objects are queued for propagation even though they were scanned and compared.
+	t.Run("SourceBehindRemote", func(t *testing.T) {
+		sl, idx := testShard(t, ctx, class)
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidLow, tsFarPast)))
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidHigh, tsFarPast)))
+
+		s := concreteShard(t, sl)
+		require.NoError(t, s.store.FlushMemtables(ctx))
+		cfg := fullRangeConfig(100)
+
+		local, remote, objs, err := s.objectsToPropagateWithinRange(
+			ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 2, local)
+		assert.Equal(t, 2, remote, "both objects must have been sent to remote for comparison")
+		assert.Empty(t, objs, "remote is up-to-date → nothing to propagate")
+		_ = idx
+	})
+
+	// LimitEnforcement verifies that the propagation limit caps the number of
+	// objects queued, not the number scanned. Uses allStaleReplicationClient so
+	// every compared digest is returned as stale (UpdateTime==0, missing).
+	t.Run("LimitEnforcement", func(t *testing.T) {
+		const limit = 1
+		sl, idx := testShard(t, ctx, class)
+		// Insert two eligible objects; both will be reported as stale by the client.
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidLow, tsFarPast)))
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidHigh, tsFarPast)))
+
+		sl2, idx2 := testShard(t, ctx, class, withReplicationClient(t, &allStaleReplicationClient{}))
+		require.NoError(t, sl2.PutObject(ctx, testObjWithTime(class, uuidLow, tsFarPast)))
+		require.NoError(t, sl2.PutObject(ctx, testObjWithTime(class, uuidHigh, tsFarPast)))
+
+		s := concreteShard(t, sl2)
+		require.NoError(t, s.store.FlushMemtables(ctx))
+		cfg := fullRangeConfig(100)
+
+		_, _, objs, err := s.objectsToPropagateWithinRange(
+			ctx, cfg, "http://fake", "node2", 0, 1, limit, nil,
+		)
+		require.NoError(t, err)
+		assert.LessOrEqual(t, len(objs), limit,
+			"number of queued propagations must not exceed the limit")
+		_ = sl
+		_ = idx
+		_ = idx2
+	})
+
+	// EqualTimestampTiebreaker verifies that when source and target have the same
+	// UpdateTime for an object (a conflict), the node with the lexicographically
+	// lower name propagates and the other does not.
+	//
+	// The test shard's replicator reports local node name "node1".
+	// "node0" < "node1" < "node2" lexicographically.
+	t.Run("EqualTimestampTiebreaker", func(t *testing.T) {
+		// equalTimestampClient reports every digest as having the same UpdateTime
+		// as the source sent, simulating an equal-timestamp conflict on the remote.
+		equalTimestampClient := &equalTimestampReplicationClient{}
+
+		sl, idx := testShard(t, ctx, class, withReplicationClient(t, equalTimestampClient))
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidLow, tsFarPast)))
+		s := concreteShard(t, sl)
+		require.NoError(t, s.store.FlushMemtables(ctx))
+		cfg := fullRangeConfig(100)
+
+		t.Run("LocalWins_LowerName", func(t *testing.T) {
+			// local="node1", target="node2": "node1" < "node2" → local wins → propagate.
+			_, _, objs, err := s.objectsToPropagateWithinRange(
+				ctx, cfg, "http://fake", "node2", 0, 1, 100, nil,
+			)
+			require.NoError(t, err)
+			assert.Len(t, objs, 1, "local node wins tiebreak → must propagate")
+		})
+
+		t.Run("LocalLoses_HigherName", func(t *testing.T) {
+			// local="node1", target="node0": "node1" > "node0" → local loses → skip.
+			_, _, objs, err := s.objectsToPropagateWithinRange(
+				ctx, cfg, "http://fake", "node0", 0, 1, 100, nil,
+			)
+			require.NoError(t, err)
+			assert.Empty(t, objs, "local node loses tiebreak → must not propagate")
+		})
+		_ = idx
+	})
+}
+
+// ─── Async Replication Lifecycle ─────────────────────────────────────────────
+
+// minAsyncReplicationConfig returns a valid AsyncReplicationConfig suitable
+// for unit tests that enable async replication.  All ticker durations are
+// non-zero (time.NewTicker panics on zero) but large enough that background
+// goroutines don't fire during the test lifetime.
+func minAsyncReplicationConfig() AsyncReplicationConfig {
+	return AsyncReplicationConfig{
+		hashtreeHeight:              1,
+		frequency:                   10 * time.Minute,
+		frequencyWhilePropagating:   10 * time.Minute,
+		aliveNodesCheckingFrequency: 10 * time.Minute,
+		diffBatchSize:               100,
+		propagationLimit:            100,
+		propagationConcurrency:      1,
+		propagationBatchSize:        10,
+		diffPerNodeTimeout:          5 * time.Second,
+		prePropagationTimeout:       5 * time.Second,
+		propagationTimeout:          5 * time.Second,
+		initShieldCPUEveryN:         1,
+	}
+}
+
+// awaitHashtreeInitialized polls hashtreeFullyInitialized until it is true or
+// the deadline fires.  Since writes no longer update the hashtree, the init
+// goroutine is the only writer; polling under RLock is safe and race-free.
+func awaitHashtreeInitialized(t *testing.T, s *Shard) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		s.asyncReplicationRWMux.RLock()
+		defer s.asyncReplicationRWMux.RUnlock()
+		return s.hashtreeFullyInitialized
+	}, 10*time.Second, 10*time.Millisecond, "hashtree did not become fully initialized within timeout")
+}
+
+// TestAsyncReplicationEnableDisableCycle verifies the shard can be cycled
+// through enable → disable → re-enable without panicking or deadlocking, and
+// that hashtree state is correctly managed across transitions.
+func TestAsyncReplicationEnableDisableCycle(t *testing.T) {
+	ctx := context.Background()
+	const class = "AsyncReplicationLifecycleTest"
+
+	config := minAsyncReplicationConfig()
+	sl, _ := testShard(t, ctx, class)
+	s := concreteShard(t, sl)
+
+	// First enable: spawns init goroutine; hashtree must be allocated.
+	require.NoError(t, s.SetAsyncReplicationState(context.Background(), config, true))
+	s.asyncReplicationRWMux.RLock()
+	assert.NotNil(t, s.hashtree, "hashtree must be allocated after first enable")
+	s.asyncReplicationRWMux.RUnlock()
+
+	// Disable: cancels the init goroutine and clears all state.
+	require.NoError(t, s.SetAsyncReplicationState(context.Background(), config, false))
+	s.asyncReplicationRWMux.RLock()
+	assert.Nil(t, s.hashtree, "hashtree must be nil after disable")
+	assert.False(t, s.hashtreeFullyInitialized)
+	s.asyncReplicationRWMux.RUnlock()
+
+	// Re-enable: must work without panic or deadlock.
+	require.NoError(t, s.SetAsyncReplicationState(context.Background(), config, true))
+	s.asyncReplicationRWMux.RLock()
+	assert.NotNil(t, s.hashtree, "hashtree must be re-allocated after re-enable")
+	s.asyncReplicationRWMux.RUnlock()
+
+	// Wait for the init goroutine on the (empty) shard to finish.
+	awaitHashtreeInitialized(t, s)
+
+	// Idempotent enable: no-op when already enabled.
+	require.NoError(t, s.SetAsyncReplicationState(context.Background(), config, true))
+	require.NoError(t, s.SetAsyncReplicationState(context.Background(), config, true))
+
+	// Final cleanup.
+	require.NoError(t, s.SetAsyncReplicationState(context.Background(), config, false))
+}
+
+// TestInitScanPopulatesHashtree validates that objects on disk when async
+// replication is enabled are correctly registered in the hashtree by the init
+// scan (ApplyToOnDiskObjectDigests), producing a non-zero root digest.
+func TestInitScanPopulatesHashtree(t *testing.T) {
+	ctx := context.Background()
+	const class = "InitScanHashtreeTest"
+
+	sl, _ := testShard(t, ctx, class)
+	s := concreteShard(t, sl)
+
+	// Objects must be flushed to disk before enabling async replication:
+	// initHashtree only scans on-disk segments (no memtables).
+	for _, id := range []strfmt.UUID{uuidLow, uuidMid, uuidHigh} {
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, id, tsFarPast)))
+	}
+	require.NoError(t, s.store.FlushMemtables(ctx))
+
+	cfg := minAsyncReplicationConfig()
+	require.NoError(t, s.SetAsyncReplicationState(context.Background(), cfg, true))
+	awaitHashtreeInitialized(t, s)
+
+	s.asyncReplicationRWMux.RLock()
+	require.NotNil(t, s.hashtree)
+	root := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+
+	require.NotEqual(t, hashtree.Digest{}, root,
+		"hashtree root must be non-zero: on-disk objects must have been registered by init scan")
+
+	require.NoError(t, s.SetAsyncReplicationState(context.Background(), cfg, false))
+}
+
+// TestHashtreeUpdateOnFlush verifies that objects are NOT in the hashtree while
+// they are in the memtable, and ARE registered after the memtable is flushed to
+// disk.  This is the core invariant of the flush-time hashtree update: the
+// hashtree always reflects durable (on-disk) data only.
+//
+// The test does not assume a specific initial root value (the shard may have
+// residual on-disk data from initialization).  Instead it verifies the relative
+// change: inserts do not change the root, but a flush does.
+func TestHashtreeUpdateOnFlush(t *testing.T) {
+	ctx := context.Background()
+	const class = "HashtreeFlushTest"
+
+	sl, _ := testShard(t, ctx, class)
+	s := concreteShard(t, sl)
+
+	// Enable on the shard; init scan of on-disk segments completes quickly.
+	cfg := minAsyncReplicationConfig()
+	require.NoError(t, s.SetAsyncReplicationState(context.Background(), cfg, true))
+	awaitHashtreeInitialized(t, s)
+
+	// Record baseline root after init (captures whatever is already on disk).
+	s.asyncReplicationRWMux.RLock()
+	rootAfterInit := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+
+	// Insert objects — they land in the memtable, not on disk yet.
+	for _, id := range []strfmt.UUID{uuidLow, uuidMid, uuidHigh} {
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, id, tsFarPast)))
+	}
+
+	// Root must be unchanged: writes do not update the hashtree.
+	s.asyncReplicationRWMux.RLock()
+	rootAfterInsert := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+	require.Equal(t, rootAfterInit, rootAfterInsert,
+		"hashtree root must not change on write: objects are only registered at flush time")
+
+	// Flush to disk — updateHashtreeOnFlush fires synchronously inside FlushAndSwitch.
+	require.NoError(t, s.store.FlushMemtables(ctx))
+
+	// Root must have changed: the flushed objects are now registered.
+	s.asyncReplicationRWMux.RLock()
+	rootAfterFlush := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+	require.NotEqual(t, rootAfterInsert, rootAfterFlush,
+		"hashtree root must change after flush: updateHashtreeOnFlush must have registered the objects")
+
+	require.NoError(t, s.SetAsyncReplicationState(context.Background(), cfg, false))
+}
+
+// ─── propagateObjects ─────────────────────────────────────────────────────────
+
+// overwriteRecordingClient records every VObject batch sent via OverwriteObjects.
+// All other methods delegate to FakeReplicationClient (no-ops / zero values).
+type overwriteRecordingClient struct {
+	FakeReplicationClient
+	mu      sync.Mutex
+	batches [][]*objects.VObject
+}
+
+func (c *overwriteRecordingClient) OverwriteObjects(_ context.Context, _, _, _ string, objs []*objects.VObject) ([]routerTypes.RepairResponse, error) {
+	batch := make([]*objects.VObject, len(objs))
+	copy(batch, objs)
+	c.mu.Lock()
+	c.batches = append(c.batches, batch)
+	c.mu.Unlock()
+	return nil, nil
+}
+
+// panicOverwriteClient panics on every OverwriteObjects call to simulate a
+// worker-level panic inside propagateObjects.
+type panicOverwriteClient struct{ FakeReplicationClient }
+
+func (*panicOverwriteClient) OverwriteObjects(_ context.Context, _, _, _ string, _ []*objects.VObject) ([]routerTypes.RepairResponse, error) {
+	panic("injected test panic")
+}
+
+// blockingOverwriteClient blocks until the context is cancelled, letting tests
+// verify that propagateObjects terminates promptly on context cancellation.
+type blockingOverwriteClient struct{ FakeReplicationClient }
+
+func (*blockingOverwriteClient) OverwriteObjects(ctx context.Context, _, _, _ string, _ []*objects.VObject) ([]routerTypes.RepairResponse, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+// propagationTestConfig returns an AsyncReplicationConfig configured for
+// propagateObjects unit tests with the given worker count and batch size.
+func propagationTestConfig(concurrency, batchSize int) AsyncReplicationConfig {
+	return AsyncReplicationConfig{
+		propagationConcurrency: concurrency,
+		propagationBatchSize:   batchSize,
+	}
+}
+
+// TestPropagateObjects verifies three important properties of propagateObjects:
+//
+//  1. HappyPath – all objects are collected and forwarded to the replication
+//     client without error.
+//
+//  2. WorkerPanicSurfacedAsError – a panic inside a worker goroutine is
+//     surfaced as a non-nil error and the function returns without deadlocking.
+//     Before the fix, the drain-loop defer would steal batches from healthy
+//     workers, GoWrapper would silently swallow the panic, and propagateObjects
+//     could return nil while objects were never propagated.
+//
+//  3. ContextCancellationNoDeadlock – when the parent context is cancelled
+//     mid-flight, propagateObjects returns promptly; wg accounting via the
+//     workerCtx drain path keeps channels and the WaitGroup consistent.
+func TestPropagateObjects(t *testing.T) {
+	ctx := context.Background()
+	const class = "PropagateObjectsTest"
+	const deadline = 5 * time.Second
+
+	// awaitDone runs f in a goroutine and fails the test if it does not return
+	// within deadline.  It is the deadlock detector for all sub-tests.
+	awaitDone := func(t *testing.T, f func()) {
+		t.Helper()
+		done := make(chan struct{})
+		go func() { f(); close(done) }()
+		select {
+		case <-done:
+		case <-time.After(deadline):
+			t.Fatal("propagateObjects did not return within the deadline (possible deadlock)")
+		}
+	}
+
+	concreteShard := func(t *testing.T, sl ShardLike) *Shard {
+		t.Helper()
+		s, ok := sl.(*Shard)
+		require.True(t, ok, "expected *Shard from testShard (EnableLazyLoadShards=true)")
+		return s
+	}
+
+	// insertObjects inserts n objects into the shard and returns their UUIDs.
+	insertObjects := func(t *testing.T, sl ShardLike, n int) []strfmt.UUID {
+		t.Helper()
+		uuids := make([]strfmt.UUID, n)
+		for i := range n {
+			id := strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", i+1))
+			uuids[i] = id
+			require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, id, tsFarPast)))
+		}
+		return uuids
+	}
+
+	t.Run("HappyPath", func(t *testing.T) {
+		client := &overwriteRecordingClient{}
+		sl, _ := testShard(t, ctx, class, withReplicationClient(t, client))
+		s := concreteShard(t, sl)
+
+		const n = 6
+		uuids := insertObjects(t, sl, n)
+		cfg := propagationTestConfig(2, 2) // 2 workers, batches of 2 → 3 batches
+
+		var err error
+		awaitDone(t, func() {
+			_, err = s.propagateObjects(ctx, cfg, "http://fake-host", uuids, nil)
+		})
+
+		require.NoError(t, err)
+		client.mu.Lock()
+		totalSent := 0
+		for _, batch := range client.batches {
+			totalSent += len(batch)
+		}
+		client.mu.Unlock()
+		assert.Equal(t, n, totalSent, "all objects must have been forwarded to the replication client")
+	})
+
+	t.Run("WorkerPanicSurfacedAsError", func(t *testing.T) {
+		sl, _ := testShard(t, ctx, class, withReplicationClient(t, &panicOverwriteClient{}))
+		s := concreteShard(t, sl)
+
+		uuids := insertObjects(t, sl, 6)
+		cfg := propagationTestConfig(2, 2)
+
+		var err error
+		awaitDone(t, func() {
+			_, err = s.propagateObjects(ctx, cfg, "http://fake-host", uuids, nil)
+		})
+
+		require.Error(t, err, "a worker panic must be surfaced as a non-nil error")
+		assert.Contains(t, err.Error(), "panic")
+	})
+
+	t.Run("ContextCancellationNoDeadlock", func(t *testing.T) {
+		sl, _ := testShard(t, ctx, class, withReplicationClient(t, &blockingOverwriteClient{}))
+		s := concreteShard(t, sl)
+
+		uuids := insertObjects(t, sl, 4)
+		cfg := propagationTestConfig(2, 2)
+
+		cancelCtx, cancel := context.WithCancel(ctx)
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			cancel()
+		}()
+
+		awaitDone(t, func() {
+			_, _ = s.propagateObjects(cancelCtx, cfg, "http://fake-host", uuids, nil)
+		})
+	})
+}
+
+// ─── Shutdown hashtree persistence ───────────────────────────────────────────
+
+// htFilesInDir returns all .ht files found directly inside dir.
+func htFilesInDir(t *testing.T, dir string) []os.DirEntry {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	var ht []os.DirEntry
+	for _, e := range entries {
+		if !e.IsDir() && filepath.Ext(e.Name()) == ".ht" {
+			ht = append(ht, e)
+		}
+	}
+	return ht
+}
+
+// TestShutdownHashtreePersistsMemtableObjects is the core regression test for
+// the bug fixed in shard_shutdown.go: Bucket.Shutdown flushes the active
+// memtable via b.active.flush() which does NOT fire objectFlushCallback, so
+// objects that were still in the memtable at shutdown time were missing from
+// the saved .ht file.
+//
+// The fix calls bucket.FlushAndSwitch() explicitly before store.Shutdown so
+// that updateHashtreeOnFlush fires and the hashtree includes every object that
+// lands on disk during the shutdown flush.
+func TestShutdownHashtreePersistsMemtableObjects(t *testing.T) {
+	ctx := context.Background()
+	const class = "ShutdownHashtreeMemtableTest"
+
+	sl, _ := testShard(t, ctx, class)
+	s := concreteShard(t, sl)
+
+	cfg := minAsyncReplicationConfig()
+	require.NoError(t, s.SetAsyncReplicationState(ctx, cfg, true))
+	awaitHashtreeInitialized(t, s)
+
+	// Capture baseline root after init (the shard may have pre-existing state).
+	s.asyncReplicationRWMux.RLock()
+	rootAfterInit := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+
+	// Insert objects — they land in the memtable only, not yet on disk.
+	for _, id := range []strfmt.UUID{uuidLow, uuidMid, uuidHigh} {
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, id, tsFarPast)))
+	}
+
+	// Hashtree must still equal the baseline: writes go to memtable only; the
+	// hashtree reflects durable (flushed) data exclusively.
+	s.asyncReplicationRWMux.RLock()
+	rootAfterInsert := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+	require.Equal(t, rootAfterInit, rootAfterInsert,
+		"hashtree must not change while objects are only in the memtable")
+
+	// Capture the hashtree directory path before shutdown destroys the shard.
+	htPath := s.pathHashTree()
+
+	// Shutdown: performShutdown calls FlushAndSwitch (our fix) so that
+	// updateHashtreeOnFlush fires, then mayStopAsyncReplication saves the .ht.
+	require.NoError(t, sl.Shutdown(ctx))
+
+	// Exactly one .ht file must have been written.
+	htFiles := htFilesInDir(t, htPath)
+	require.Len(t, htFiles, 1, "exactly one .ht file must be written on shutdown")
+
+	// The persisted hashtree must differ from the pre-shutdown baseline: the
+	// memtable objects must have been registered via updateHashtreeOnFlush
+	// during the shutdown FlushAndSwitch call.
+	f, err := os.Open(filepath.Join(htPath, htFiles[0].Name()))
+	require.NoError(t, err)
+	defer f.Close()
+	ht, err := hashtree.DeserializeHashTree(bufio.NewReader(f))
+	require.NoError(t, err)
+	require.NotEqual(t, rootAfterInit, ht.Root(),
+		"persisted hashtree must include the objects that were in the memtable at shutdown")
+}
+
+// TestMayStopAsyncReplicationSkipsDumpOnFlushFailure verifies the guard
+// introduced to prevent a stale .ht file from being saved when the pre-dump
+// FlushAndSwitch fails.
+//
+// When hashtreeFlushFailed is true, mayStopAsyncReplication must:
+//   - NOT write a .ht file (a stale file is worse than no file; on restart
+//     initHashtree will re-scan from disk and produce a correct hashtree).
+//   - Reset hashtreeFlushFailed to false.
+//   - Still clean up all other async replication state (hashtree → nil, etc.).
+func TestMayStopAsyncReplicationSkipsDumpOnFlushFailure(t *testing.T) {
+	ctx := context.Background()
+	const class = "SkipDumpOnFlushFailureTest"
+
+	sl, _ := testShard(t, ctx, class)
+	s := concreteShard(t, sl)
+	t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+
+	cfg := minAsyncReplicationConfig()
+	require.NoError(t, s.SetAsyncReplicationState(ctx, cfg, true))
+	awaitHashtreeInitialized(t, s)
+
+	htPath := s.pathHashTree()
+
+	// Simulate a FlushAndSwitch failure during performShutdown.
+	// hashtreeFlushFailed is written outside asyncReplicationRWMux in
+	// production (single-goroutine shutdown path); it is safe to set here
+	// because the test is the only goroutine touching the shard at this point.
+	s.hashtreeFlushFailed = true
+
+	s.mayStopAsyncReplication()
+
+	// No .ht file must have been written.
+	require.Empty(t, htFilesInDir(t, htPath),
+		"no .ht file must be written when hashtreeFlushFailed is set")
+
+	// The flag must be reset so that a subsequent re-enable can dump correctly.
+	require.False(t, s.hashtreeFlushFailed,
+		"hashtreeFlushFailed must be reset to false by mayStopAsyncReplication")
+
+	// All other async replication state must be cleaned up.
+	require.Nil(t, s.hashtree, "hashtree must be nil after mayStopAsyncReplication")
+	require.False(t, s.hashtreeFullyInitialized,
+		"hashtreeFullyInitialized must be false after mayStopAsyncReplication")
+}
+
+// TestMayStopAsyncReplicationDumpsHashtreeOnSuccess verifies the happy path:
+// when hashtreeFlushFailed is false (the default), mayStopAsyncReplication
+// writes a .ht file that can be loaded on the next startup.
+func TestMayStopAsyncReplicationDumpsHashtreeOnSuccess(t *testing.T) {
+	ctx := context.Background()
+	const class = "DumpHashtreeOnSuccessTest"
+
+	sl, _ := testShard(t, ctx, class)
+	s := concreteShard(t, sl)
+	t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+
+	// Put objects and flush to disk so the hashtree has non-zero state after
+	// the init scan.
+	for _, id := range []strfmt.UUID{uuidLow, uuidMid, uuidHigh} {
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, id, tsFarPast)))
+	}
+	flushShard(t, ctx, sl)
+
+	cfg := minAsyncReplicationConfig()
+	require.NoError(t, s.SetAsyncReplicationState(ctx, cfg, true))
+	awaitHashtreeInitialized(t, s)
+
+	htPath := s.pathHashTree()
+
+	// hashtreeFlushFailed is false by default — dump should proceed.
+	require.False(t, s.hashtreeFlushFailed)
+	s.mayStopAsyncReplication()
+
+	htFiles := htFilesInDir(t, htPath)
+	require.Len(t, htFiles, 1,
+		".ht file must be written when hashtreeFullyInitialized is true and hashtreeFlushFailed is false")
+
+	// The persisted root must be non-zero: on-disk objects were registered by
+	// the init scan.
+	f, err := os.Open(filepath.Join(htPath, htFiles[0].Name()))
+	require.NoError(t, err)
+	defer f.Close()
+	ht, err := hashtree.DeserializeHashTree(bufio.NewReader(f))
+	require.NoError(t, err)
+	require.NotEqual(t, hashtree.Digest{}, ht.Root(),
+		"persisted hashtree root must be non-zero: on-disk objects must have been registered")
+}

--- a/adapters/repos/db/shard_async_replication_trigger_test.go
+++ b/adapters/repos/db/shard_async_replication_trigger_test.go
@@ -1,0 +1,165 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestHasNewElement covers the core predicate that controls whether the
+// hashbeat trigger goroutine fires when the set of alive nodes changes.
+//
+// The invariant being enforced: a hashbeat should only be triggered when at
+// least one node that was absent in the previous check is now alive.  A node
+// going down is not a reason to trigger, because there is nothing to propagate
+// to an unreachable peer.
+func TestHasNewElement(t *testing.T) {
+	tests := []struct {
+		name       string
+		candidates []string // current alive nodes
+		existing   []string // nodes from last comparison
+		want       bool
+	}{
+		{
+			name:       "no change - same nodes",
+			candidates: []string{"node1", "node2"},
+			existing:   []string{"node1", "node2"},
+			want:       false,
+		},
+		{
+			name:       "no change - both empty",
+			candidates: []string{},
+			existing:   []string{},
+			want:       false,
+		},
+		{
+			name:       "node went down - should NOT trigger",
+			candidates: []string{"node1"},
+			existing:   []string{"node1", "node2"},
+			want:       false,
+		},
+		{
+			name:       "all nodes went down - should NOT trigger",
+			candidates: []string{},
+			existing:   []string{"node1", "node2"},
+			want:       false,
+		},
+		{
+			name:       "new node joined - should trigger",
+			candidates: []string{"node1", "node2", "node3"},
+			existing:   []string{"node1", "node2"},
+			want:       true,
+		},
+		{
+			name:       "first node appeared from empty - should trigger",
+			candidates: []string{"node1"},
+			existing:   []string{},
+			want:       true,
+		},
+		{
+			name:       "node went down AND a different new node joined - should trigger",
+			candidates: []string{"node1", "node3"},
+			existing:   []string{"node1", "node2"},
+			want:       true, // node3 is new even though node2 left
+		},
+		{
+			name:       "completely different node set - should trigger",
+			candidates: []string{"node3", "node4"},
+			existing:   []string{"node1", "node2"},
+			want:       true,
+		},
+		{
+			name:       "order does not matter - same nodes different order",
+			candidates: []string{"node2", "node1"},
+			existing:   []string{"node1", "node2"},
+			want:       false,
+		},
+		{
+			name:       "nil candidates - should NOT trigger",
+			candidates: nil,
+			existing:   []string{"node1"},
+			want:       false,
+		},
+		{
+			name:       "nil existing - new node should trigger",
+			candidates: []string{"node1"},
+			existing:   nil,
+			want:       true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := hasNewElement(tc.candidates, tc.existing)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestHashbeatTriggerStateUpdate verifies the condition used to decide whether
+// setLastComparedNodes should be called: it must update whenever the topology
+// changes in either direction (new node OR node gone), not only when a new
+// node appears.
+func TestHashbeatTriggerStateUpdate(t *testing.T) {
+	shouldUpdateState := func(aliveHosts, comparedHosts []string) bool {
+		return hasNewElement(aliveHosts, comparedHosts) || len(aliveHosts) != len(comparedHosts)
+	}
+
+	tests := []struct {
+		name          string
+		aliveHosts    []string
+		comparedHosts []string
+		wantTrigger   bool // should fire hashbeat
+		wantUpdate    bool // should update stored state
+	}{
+		{
+			name:          "no change",
+			aliveHosts:    []string{"node1", "node2"},
+			comparedHosts: []string{"node1", "node2"},
+			wantTrigger:   false,
+			wantUpdate:    false,
+		},
+		{
+			name:          "node went down",
+			aliveHosts:    []string{"node1"},
+			comparedHosts: []string{"node1", "node2"},
+			wantTrigger:   false,
+			wantUpdate:    true, // state should still be updated for next comparison
+		},
+		{
+			name:          "node came back up",
+			aliveHosts:    []string{"node1", "node2"},
+			comparedHosts: []string{"node1"},
+			wantTrigger:   true,
+			wantUpdate:    true,
+		},
+		{
+			name:          "node replaced by different node",
+			aliveHosts:    []string{"node1", "node3"},
+			comparedHosts: []string{"node1", "node2"},
+			wantTrigger:   true,
+			wantUpdate:    true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotTrigger := hasNewElement(tc.aliveHosts, tc.comparedHosts)
+			gotUpdate := shouldUpdateState(tc.aliveHosts, tc.comparedHosts)
+
+			assert.Equal(t, tc.wantTrigger, gotTrigger, "hashbeat trigger mismatch")
+			assert.Equal(t, tc.wantUpdate, gotUpdate, "state update mismatch")
+		})
+	}
+}

--- a/adapters/repos/db/shard_backup.go
+++ b/adapters/repos/db/shard_backup.go
@@ -270,6 +270,14 @@ func (s *Shard) mayForceResumeMaintenanceCycles(ctx context.Context, forced bool
 		s.haltForTransferCancel()
 	}
 
+	// Flush any memtables written during the halted period so that all
+	// objects are on disk before compaction and async replication resume.
+	// This prevents a race where the async replication catch-up phase
+	// (CursorOnDisk) misses objects that are still in the memtable.
+	if err := s.store.FlushMemtables(ctx); err != nil {
+		return fmt.Errorf("flush memtables on resume: %w", err)
+	}
+
 	g := enterrors.NewErrorGroupWrapper(s.index.logger)
 
 	g.Go(func() error {

--- a/adapters/repos/db/shard_init_lsm.go
+++ b/adapters/repos/db/shard_init_lsm.go
@@ -93,12 +93,17 @@ func (s *Shard) initNonVector(ctx context.Context, class *models.Class) error {
 
 	// Object bucket must be available, initAsyncReplication depends on it
 	if s.index.AsyncReplicationEnabled() {
-		s.asyncReplicationRWMux.Lock()
-		defer s.asyncReplicationRWMux.Unlock()
-
-		err = s.initAsyncReplication(s.index.AsyncReplicationConfig())
+		var afterRelease func()
+		func() {
+			s.asyncReplicationRWMux.Lock()
+			defer s.asyncReplicationRWMux.Unlock()
+			afterRelease, err = s.initAsyncReplication(s.index.AsyncReplicationConfig())
+		}()
 		if err != nil {
 			return fmt.Errorf("init async replication on shard %q: %w", s.ID(), err)
+		}
+		if afterRelease != nil {
+			afterRelease()
 		}
 	} else if s.index.replicationEnabled() {
 		s.index.logger.Debugf("async replication disabled on shard %q", s.ID())

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -382,6 +382,13 @@ func (l *LazyLoadShard) ObjectDigestsInRange(ctx context.Context,
 	return l.shard.ObjectDigestsInRange(ctx, initialUUID, finalUUID, limit)
 }
 
+func (l *LazyLoadShard) CompareDigests(ctx context.Context, sourceDigests []types.RepairResponse) ([]types.RepairResponse, error) {
+	if err := l.Load(ctx); err != nil {
+		return nil, err
+	}
+	return l.shard.CompareDigests(ctx, sourceDigests)
+}
+
 func (l *LazyLoadShard) ID() string {
 	return shardId(l.shardOpts.index.ID(), l.shardOpts.name)
 }

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -35,6 +35,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/filters"
+	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/multi"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
@@ -44,8 +45,7 @@ import (
 )
 
 func (s *Shard) ObjectDigestErrDeleted(ctx context.Context, id strfmt.UUID) (types.RepairResponse, error) {
-	s.activityTrackerRead.Add(1)
-
+	// Replication-internal operation: do not count as user read activity.
 	idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
 	if err != nil {
 		return types.RepairResponse{}, err
@@ -64,8 +64,6 @@ func (s *Shard) ObjectDigestErrDeleted(ctx context.Context, id strfmt.UUID) (typ
 	replicaObj := types.RepairResponse{
 		ID:         id.String(),
 		UpdateTime: updateTime,
-		// TODO: use version when supported
-		Version: 0,
 	}
 
 	return replicaObj, nil
@@ -131,8 +129,7 @@ func (s *Shard) MultiObjectByID(ctx context.Context, query []multi.Identifier) (
 }
 
 func (s *Shard) ObjectDigests(ctx context.Context, query []multi.Identifier) ([]types.RepairResponse, error) {
-	s.activityTrackerRead.Add(1)
-
+	// Replication-internal operation: do not count as user read activity.
 	objects := make([]types.RepairResponse, len(query))
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
@@ -169,24 +166,23 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 	initialUUID, finalUUID strfmt.UUID, limit int) (
 	objs []types.RepairResponse, err error,
 ) {
-	initialUUIDBytes, err := uuid.MustParse(initialUUID.String()).MarshalBinary()
+	initialUUID16, err := uuid.Parse(initialUUID.String())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid initial UUID %q: %w", initialUUID, err)
 	}
-
-	finalUUIDBytes, err := uuid.MustParse(finalUUID.String()).MarshalBinary()
+	finalUUID16, err := uuid.Parse(finalUUID.String())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid final UUID %q: %w", finalUUID, err)
 	}
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 
-	cursor := bucket.Cursor()
+	cursor := bucket.CursorOnDisk()
 	defer cursor.Close()
 
 	n := 0
 
-	for k, v := cursor.Seek(initialUUIDBytes); n < limit && k != nil && bytes.Compare(k, finalUUIDBytes) < 1; k, v = cursor.Next() {
+	for k, v := cursor.Seek(initialUUID16[:]); n < limit && k != nil && bytes.Compare(k, finalUUID16[:]) < 1; k, v = cursor.Next() {
 		if ctx.Err() != nil {
 			return objs, ctx.Err()
 		}
@@ -204,8 +200,6 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 		replicaObj := types.RepairResponse{
 			ID:         uuidParsed.String(),
 			UpdateTime: updateTime,
-			// TODO: use version when supported
-			Version: 0,
 		}
 
 		objs = append(objs, replicaObj)
@@ -214,6 +208,148 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 	}
 
 	return objs, nil
+}
+
+// CompareDigests identifies which of the caller's sourceDigests require
+// action on the source side. It returns three categories:
+//   - Missing: object absent from this shard; returned with UpdateTime==0.
+//   - Stale: source has a strictly newer UpdateTime; returned with the local
+//     UpdateTime so the caller can use it as remoteStaleUpdateTime.
+//   - Tombstoned: object is deleted on this shard. The configured deletion
+//     strategy is applied here on the target side:
+//     NoAutomatedResolution → suppressed (not returned).
+//     DeleteOnConflict      → returned with Deleted=true.
+//     TimeBasedResolution   → returned with Deleted=true when deletion is
+//     same-or-newer; returned as a normal stale entry when source is strictly
+//     newer so the source propagates the live object to restore it.
+//     Note: tombstones flushed to on-disk segments lose their deletion
+//     timestamp. When deletionTime==0, TimeBasedResolution conservatively
+//     treats deletion as the winner regardless of the source's UpdateTime.
+//
+// Equal-timestamp objects (source and target hold the same UpdateTime) are NOT
+// returned: the hashtree digest for an object is hash(uuid, updateTime), so two
+// nodes holding the same object at the same time produce identical leaf digests.
+// The hashtree diff will not detect them as differing, meaning CompareDigests is
+// never called for such objects during a hashbeat that is already in sync.
+// Returning them would cause the source to re-propagate objects it just
+// successfully delivered (and already present on disk after the next flush),
+// exhausting the propagation limit and preventing genuinely stale objects
+// from being reached.
+//
+// Algorithm: one shared on-disk consistent view is acquired once; then one
+// GetErrDeletedOnDisk call per source UUID — O(N_source × log N_local) —
+// amortising the segment ref-count lock acquisition across the entire batch.
+// Only on-disk segments are consulted, consistent with ObjectDigestsInRange
+// using CursorOnDisk on the source side.
+func (s *Shard) CompareDigests(ctx context.Context, sourceDigests []types.RepairResponse) ([]types.RepairResponse, error) {
+	// Replication-internal operation: do not count as user read activity.
+	if len(sourceDigests) == 0 {
+		return nil, nil
+	}
+
+	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	view := bucket.GetDiskOnlyConsistentView()
+	defer view.ReleaseView()
+
+	var result []types.RepairResponse
+	for _, d := range sourceDigests {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		u, err := uuid.Parse(d.ID)
+		if err != nil {
+			return nil, fmt.Errorf("parse source uuid %q: %w", d.ID, err)
+		}
+
+		v, err := bucket.GetErrDeletedOnDisk(u[:], view)
+		if err != nil {
+			if errors.Is(err, entlsmkv.Deleted) {
+				// Key is tombstoned on this shard.  Extract the deletion timestamp
+				// when available (written by recent deletes); older tombstones or
+				// those from compacted segments may carry no timestamp (zero).
+				var deletionTime int64
+				var errDeleted entlsmkv.ErrDeleted
+				if errors.As(err, &errDeleted) && !errDeleted.DeletionTime().IsZero() {
+					deletionTime = errDeleted.DeletionTime().UnixMilli()
+				}
+
+				// Apply the deletion conflict strategy on the target side so the
+				// source can act on the verdict without needing to re-read strategy.
+				switch s.index.DeletionStrategy() {
+				case models.ReplicationConfigDeletionStrategyNoAutomatedResolution:
+					// No automated resolution: suppress the tombstone so the source
+					// neither propagates nor deletes — leave the conflict for manual
+					// handling.
+					continue
+
+				case models.ReplicationConfigDeletionStrategyDeleteOnConflict:
+					// Deletion always wins: instruct source to delete its live copy.
+					result = append(result, types.RepairResponse{
+						ID:         d.ID,
+						Deleted:    true,
+						UpdateTime: deletionTime,
+					})
+
+				case models.ReplicationConfigDeletionStrategyTimeBasedResolution:
+					if deletionTime > 0 && d.UpdateTime > deletionTime {
+						// Source's live object is strictly newer than the local tombstone:
+						// return as a normal stale entry so the source propagates the live
+						// object to this shard (overwriting the tombstone).
+						result = append(result, types.RepairResponse{ID: d.ID, UpdateTime: deletionTime})
+					} else {
+						// Local deletion is same-or-newer, or deletion time is unknown:
+						// instruct source to delete its live copy.
+						result = append(result, types.RepairResponse{
+							ID:         d.ID,
+							Deleted:    true,
+							UpdateTime: deletionTime,
+						})
+					}
+
+				default:
+					// Unknown strategy: behave conservatively like NoAutomatedResolution.
+					continue
+				}
+				continue
+			}
+			if errors.Is(err, entlsmkv.NotFound) {
+				// Key is absent from this shard — source must propagate.
+				result = append(result, types.RepairResponse{ID: d.ID, UpdateTime: 0})
+				continue
+			}
+			return nil, fmt.Errorf("get object %q: %w", d.ID, err)
+		}
+
+		if v == nil {
+			// Safety guard: GetErrDeletedOnDisk returns NotFound for absent keys
+			// (handled above), but treat unexpected nil as absent to avoid a nil dereference.
+			result = append(result, types.RepairResponse{ID: d.ID, UpdateTime: 0})
+			continue
+		}
+
+		_, localTime, err := storobj.DocIDAndTimeFromBinary(v)
+		if err != nil {
+			return nil, fmt.Errorf("extract update time for %q: %w", d.ID, err)
+		}
+
+		if d.UpdateTime > localTime {
+			// Source has a strictly newer version — this shard is stale and the
+			// source must propagate.
+			//
+			// Equal-timestamp (d.UpdateTime == localTime) is intentionally NOT
+			// returned: objects with the same UpdateTime on both nodes have
+			// identical hashtree digests (hash(uuid, updateTime)), so the
+			// hashtree diff cannot detect them as differing in the first place.
+			// Returning them would only cause the source to re-propagate objects
+			// it just successfully delivered (same version already in target
+			// memtable or on disk), exhausting the propagation limit and
+			// preventing genuinely stale objects from being reached.
+			result = append(result, types.RepairResponse{ID: d.ID, UpdateTime: localTime})
+		}
+	}
+
+	return result, nil
 }
 
 // TODO: This does an actual read which is not really needed, if we see this
@@ -795,14 +931,6 @@ func (s *Shard) uuidFromDocID(docID uint64) (strfmt.UUID, error) {
 }
 
 func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error {
-	s.asyncReplicationRWMux.RLock()
-	defer s.asyncReplicationRWMux.RUnlock()
-
-	err := s.waitForMinimalHashTreeInitialization(ctx)
-	if err != nil {
-		return err
-	}
-
 	idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
 	if err != nil {
 		return err
@@ -828,7 +956,7 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 
 	// we need the doc ID so we can clean up inverted indices currently
 	// pointing to this object
-	docID, updateTime, err := storobj.DocIDAndTimeFromBinary(existing)
+	docID, _, err := storobj.DocIDAndTimeFromBinary(existing)
 	if err != nil {
 		return errors.Wrap(err, "get existing doc id from object binary")
 	}
@@ -843,10 +971,6 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 	}
 	if err != nil {
 		return errors.Wrap(err, "delete object from bucket")
-	}
-
-	if err = s.mayDeleteObjectHashTree(idBytes, updateTime); err != nil {
-		return errors.Wrap(err, "object deletion in hashtree")
 	}
 
 	err = s.cleanupInvertedIndexOnDelete(existing, docID)

--- a/adapters/repos/db/shard_shutdown.go
+++ b/adapters/repos/db/shard_shutdown.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	"github.com/weaviate/weaviate/entities/storagestate"
@@ -114,7 +115,54 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 	).Unregister(ctx)
 	ec.Add(err)
 
-	s.mayStopAsyncReplication()
+	// Cancel async replication goroutines before the store shuts down so
+	// they don't run concurrently with store shutdown. The objectFlushCallback
+	// is intentionally kept registered here so that the explicit FlushAndSwitch
+	// below fires updateHashtreeOnFlush, bringing the hashtree fully in sync
+	// with on-disk state before mayStopAsyncReplication persists it.
+	// NOTE: Bucket.Shutdown (called inside store.Shutdown below) flushes the
+	// active memtable via b.active.flush() directly, which does NOT fire
+	// objectFlushCallback. We therefore call FlushAndSwitch explicitly so the
+	// hashtree is updated before mayStopAsyncReplication dumps it to disk.
+	func() {
+		s.asyncReplicationRWMux.Lock()
+		defer s.asyncReplicationRWMux.Unlock()
+		if s.hashtree != nil && s.asyncReplicationCancelFunc != nil {
+			s.asyncReplicationCancelFunc()
+		}
+	}()
+
+	// Flush any in-memtable objects through FlushAndSwitch so that
+	// objectFlushCallback (updateHashtreeOnFlush) fires and the hashtree
+	// is fully consistent with on-disk state before mayStopAsyncReplication
+	// dumps it. Bucket.Shutdown calls b.active.flush() directly and does not
+	// fire the callback, so this explicit flush is required.
+	// On failure, set hashtreeFlushFailed so mayStopAsyncReplication skips the
+	// dump. A stale .ht file is worse than none: loading it on restart bypasses
+	// initHashtree's corrective disk scan. hashtreeFlushFailed is not protected
+	// by asyncReplicationRWMux because it is only written here (under
+	// shutdownLock) and read by mayStopAsyncReplication (called below, same
+	// goroutine) — initHashtree never touches it, so there is no race.
+	func() {
+		s.asyncReplicationRWMux.RLock()
+		hashtreeActive := s.hashtree != nil
+		s.asyncReplicationRWMux.RUnlock()
+		if !hashtreeActive || s.store == nil {
+			return
+		}
+		bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+		if bucket == nil {
+			return
+		}
+		if err := bucket.FlushAndSwitch(); err != nil {
+			s.index.logger.
+				WithField("action", "async_replication_shutdown").
+				WithField("class_name", s.index.Config.ClassName.String()).
+				WithField("shard_name", s.name).
+				Warnf("failed to flush objects bucket before hashtree dump, skipping hashtree persistence: %v", err)
+			s.hashtreeFlushFailed = true
+		}
+	}()
 
 	_ = s.ForEachVectorQueue(func(targetVector string, queue *VectorIndexQueue) error {
 		if err = queue.Flush(); err != nil {
@@ -158,6 +206,12 @@ func (s *Shard) performShutdown(ctx context.Context) (err error) {
 		err = s.store.Shutdown(ctx)
 		ec.AddWrapf(err, "stop lsmkv store")
 	}
+
+	// Called after store.Shutdown to ensure the store is fully stopped before
+	// mayStopAsyncReplication unregisters flush callbacks and dumps the hashtree.
+	// The hashtree was already brought in sync by the explicit FlushAndSwitch
+	// above; store.Shutdown's internal flush (b.active.flush) fires no callback.
+	s.mayStopAsyncReplication()
 
 	if s.dynamicVectorIndexDB != nil {
 		err = s.dynamicVectorIndexDB.Close()

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -29,14 +29,6 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 		return err
 	}
 
-	s.asyncReplicationRWMux.RLock()
-	defer s.asyncReplicationRWMux.RUnlock()
-
-	err := s.waitForMinimalHashTreeInitialization(ctx)
-	if err != nil {
-		return err
-	}
-
 	idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
 	if err != nil {
 		return err
@@ -62,7 +54,7 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 
 	// we need the doc ID so we can clean up inverted indices currently
 	// pointing to this object
-	docID, updateTime, err := storobj.DocIDAndTimeFromBinary(existing)
+	docID, _, err := storobj.DocIDAndTimeFromBinary(existing)
 	if err != nil {
 		return fmt.Errorf("get existing doc id from object binary: %w", err)
 	}
@@ -77,10 +69,6 @@ func (s *Shard) DeleteObject(ctx context.Context, id strfmt.UUID, deletionTime t
 	}
 	if err != nil {
 		return fmt.Errorf("delete object from bucket: %w", err)
-	}
-
-	if err = s.mayDeleteObjectHashTree(idBytes, updateTime); err != nil {
-		return fmt.Errorf("object deletion in hashtree: %w", err)
 	}
 
 	err = s.cleanupInvertedIndexOnDelete(existing, docID)
@@ -153,38 +141,6 @@ func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) erro
 			return err
 		}
 	}
-
-	return nil
-}
-
-func (s *Shard) mayDeleteObjectHashTree(uuidBytes []byte, updateTime int64) error {
-	if s.hashtree == nil {
-		return nil
-	}
-
-	return s.deleteObjectHashTree(uuidBytes, updateTime)
-}
-
-func (s *Shard) deleteObjectHashTree(uuidBytes []byte, updateTime int64) error {
-	if len(uuidBytes) != 16 {
-		return fmt.Errorf("invalid object uuid")
-	}
-
-	if updateTime < 1 {
-		return fmt.Errorf("invalid object update time")
-	}
-
-	leaf := s.hashtreeLeafFor(uuidBytes)
-
-	var objectDigest [16 + 8]byte
-
-	copy(objectDigest[:], uuidBytes)
-	binary.BigEndian.PutUint64(objectDigest[16:], uint64(updateTime))
-
-	// object deletion is treated as non-existent,
-	// that because deletion time or tombstone may not be available
-
-	s.hashtree.AggregateLeafWith(leaf, objectDigest[:])
 
 	return nil
 }

--- a/adapters/repos/db/shard_write_merge.go
+++ b/adapters/repos/db/shard_write_merge.go
@@ -128,17 +128,10 @@ func (s *Shard) mergeObjectInStorage(ctx context.Context, merge objects.MergeDoc
 
 	// wrapped in function to handle lock/unlock
 	if err := func() error {
-		s.asyncReplicationRWMux.RLock()
-		defer s.asyncReplicationRWMux.RUnlock()
-
-		err := s.waitForMinimalHashTreeInitialization(ctx)
-		if err != nil {
-			return err
-		}
-
 		lock.Lock()
 		defer lock.Unlock()
 
+		var err error
 		prevObj, err = fetchObject(bucket, idBytes)
 		if err != nil {
 			return errors.Wrap(err, "get bucket")
@@ -170,10 +163,6 @@ func (s *Shard) mergeObjectInStorage(ctx context.Context, merge objects.MergeDoc
 
 		if err := s.upsertObjectDataLSM(bucket, idBytes, objBytes, status.docID); err != nil {
 			return errors.Wrap(err, "upsert object data")
-		}
-
-		if err := s.mayUpsertObjectHashTree(obj, idBytes, status); err != nil {
-			return errors.Wrap(err, "object merge in hashtree")
 		}
 
 		return nil
@@ -215,14 +204,6 @@ func (s *Shard) mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDo
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 	out := mutableMergeResult{}
 
-	s.asyncReplicationRWMux.RLock()
-	defer s.asyncReplicationRWMux.RUnlock()
-
-	err := s.waitForMinimalHashTreeInitialization(ctx)
-	if err != nil {
-		return out, err
-	}
-
 	// see comment in shard_write_put.go::putObjectLSM
 	lock := &s.docIdLock[s.uuidToIdLockPoolId(idBytes)]
 	lock.Lock()
@@ -261,10 +242,6 @@ func (s *Shard) mutableMergeObjectLSM(ctx context.Context, merge objects.MergeDo
 
 	if err := s.upsertObjectDataLSM(bucket, idBytes, objBytes, status.docID); err != nil {
 		return out, errors.Wrap(err, "upsert object data")
-	}
-
-	if err := s.mayUpsertObjectHashTree(obj, idBytes, status); err != nil {
-		return out, fmt.Errorf("object merge in hashtree: %w", err)
 	}
 
 	// do not updated inverted index, since this requires delta analysis, which

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -242,14 +242,6 @@ func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes [
 
 	// wrapped in function to handle lock/unlock
 	if err := func() error {
-		s.asyncReplicationRWMux.RLock()
-		defer s.asyncReplicationRWMux.RUnlock()
-
-		err := s.waitForMinimalHashTreeInitialization(ctx)
-		if err != nil {
-			return err
-		}
-
 		lock.Lock()
 		defer lock.Unlock()
 
@@ -280,10 +272,6 @@ func (s *Shard) putObjectLSM(ctx context.Context, obj *storobj.Object, idBytes [
 			return errors.Wrap(err, "upsert object data")
 		}
 		s.metrics.PutObjectUpsertObject(before)
-
-		if err := s.mayUpsertObjectHashTree(obj, idBytes, status); err != nil {
-			return errors.Wrap(err, "object creation in hashtree")
-		}
 
 		return nil
 	}(); err != nil {

--- a/entities/models/replication_async_config.go
+++ b/entities/models/replication_async_config.go
@@ -46,6 +46,9 @@ type ReplicationAsyncConfig struct {
 	// Height of the hashtree used for diffing.
 	HashtreeHeight *int64 `json:"hashtreeHeight,omitempty"`
 
+	// Number of objects processed between scheduler yield points during hashtree initialisation scan. Yielding periodically lets query goroutines make forward progress during the potentially long on-disk scan.
+	InitShieldCPUEveryN *int64 `json:"initShieldCpuEveryN,omitempty"`
+
 	// Interval in seconds at which async replication logs its status.
 	LoggingFrequency *int64 `json:"loggingFrequency,omitempty"`
 
@@ -60,9 +63,6 @@ type ReplicationAsyncConfig struct {
 
 	// Maximum number of concurrent propagation workers.
 	PropagationConcurrency *int64 `json:"propagationConcurrency,omitempty"`
-
-	// Delay in milliseconds before newly added or updated objects are propagated.
-	PropagationDelay *int64 `json:"propagationDelay,omitempty"`
 
 	// Maximum number of objects to propagate in a single async replication run.
 	PropagationLimit *int64 `json:"propagationLimit,omitempty"`

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -2289,13 +2289,6 @@
           "x-nullable": true,
           "x-omitempty": true
         },
-        "propagationDelay": {
-          "description": "Delay in milliseconds before newly added or updated objects are propagated.",
-          "type": "integer",
-          "format": "int64",
-          "x-nullable": true,
-          "x-omitempty": true
-        },
         "propagationConcurrency": {
           "description": "Maximum number of concurrent propagation workers.",
           "type": "integer",
@@ -2305,6 +2298,13 @@
         },
         "propagationBatchSize": {
           "description": "Number of objects to include in a single propagation batch.",
+          "type": "integer",
+          "format": "int64",
+          "x-nullable": true,
+          "x-omitempty": true
+        },
+        "initShieldCpuEveryN": {
+          "description": "Number of objects processed between scheduler yield points during hashtree initialisation scan. Yielding periodically lets query goroutines make forward progress during the potentially long on-disk scan.",
           "type": "integer",
           "format": "int64",
           "x-nullable": true,

--- a/test/acceptance/replication/async_replication/async_repair_deletes_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_deletes_test.go
@@ -12,7 +12,6 @@
 package replication
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -20,46 +19,37 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/acceptance/replication/common"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
 
 func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectDeleteScenario() {
 	t := suite.T()
-	mainCtx := context.Background()
-
-	clusterSize := 3
-
-	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
-	defer cancel()
-
-	compose, err := docker.New().
-		WithWeaviateCluster(clusterSize).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
 
 	paragraphClass := articles.ParagraphsClass()
 
+	t.Cleanup(func() {
+		// best-effort: ignore error if class was never created
+		helper.Client(t).Schema.SchemaObjectsDelete(
+			schema.NewSchemaObjectsDeleteParams().WithClassName(paragraphClass.Class),
+			nil,
+		)
+	})
+
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:           int64(clusterSize),
+			Factor:           3,
 			DeletionStrategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
 			AsyncEnabled:     true,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 
-		helper.SetupClient(compose.GetWeaviate().URI())
+		helper.SetupClient(suite.compose.GetWeaviate().URI())
 		helper.CreateClass(t, paragraphClass)
 	})
 
@@ -74,16 +64,16 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectDeleteScenario() {
 				Object()
 		}
 
-		common.CreateObjectsCL(t, compose.GetWeaviate().URI(), batch, types.ConsistencyLevelAll)
+		common.CreateObjectsCL(t, suite.compose.GetWeaviate().URI(), batch, types.ConsistencyLevelAll)
 	})
 
 	node := 2
 
 	t.Run(fmt.Sprintf("stop node %d", node), func(t *testing.T) {
-		common.StopNodeAt(ctx, t, compose, node)
+		common.StopNodeAt(suite.suiteCtx, t, suite.compose, node)
 	})
 
-	host := compose.GetWeaviate().URI()
+	host := suite.compose.GetWeaviate().URI()
 	helper.SetupClient(host)
 
 	for _, id := range paragraphIDs {
@@ -91,7 +81,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectDeleteScenario() {
 	}
 
 	t.Run(fmt.Sprintf("restart node %d", node), func(t *testing.T) {
-		common.StartNodeAt(ctx, t, compose, node)
+		common.StartNodeAt(suite.suiteCtx, t, suite.compose, node)
 	})
 
 	t.Run("verify that all nodes are running", func(t *testing.T) {
@@ -103,7 +93,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectDeleteScenario() {
 			require.NotNil(ct, body.Payload)
 
 			resp := body.Payload
-			require.Len(ct, resp.Nodes, clusterSize)
+			require.Len(ct, resp.Nodes, 3)
 			for _, n := range resp.Nodes {
 				require.NotNil(ct, n.Status)
 				require.Equal(ct, "HEALTHY", *n.Status)
@@ -113,7 +103,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectDeleteScenario() {
 
 	t.Run(fmt.Sprintf("all the objects should have been deleted from node %d", node), func(t *testing.T) {
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			resp := common.GQLGet(t, compose.ContainerURI(node), "Paragraph", types.ConsistencyLevelOne)
+			resp := common.GQLGet(t, suite.compose.ContainerURI(node), "Paragraph", types.ConsistencyLevelOne)
 			require.Len(ct, resp, 0)
 		}, 120*time.Second, 5*time.Second, "not all the objects have been asynchronously replicated")
 	})

--- a/test/acceptance/replication/async_replication/async_repair_insertions_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_insertions_test.go
@@ -12,7 +12,6 @@
 package replication
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -20,52 +19,43 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/acceptance/replication/common"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
 
 func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectInsertionScenario() {
 	t := suite.T()
-	mainCtx := context.Background()
-
-	clusterSize := 3
-
-	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
-	defer cancel()
-
-	compose, err := docker.New().
-		WithWeaviateCluster(clusterSize).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
 
 	paragraphClass := articles.ParagraphsClass()
 
+	t.Cleanup(func() {
+		// best-effort: ignore error if class was never created
+		helper.Client(t).Schema.SchemaObjectsDelete(
+			schema.NewSchemaObjectsDeleteParams().WithClassName(paragraphClass.Class),
+			nil,
+		)
+	})
+
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       int64(clusterSize),
+			Factor:       3,
 			AsyncEnabled: true,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 
-		helper.SetupClient(compose.GetWeaviate().URI())
+		helper.SetupClient(suite.compose.GetWeaviate().URI())
 		helper.CreateClass(t, paragraphClass)
 	})
 
 	node := 2
 
 	t.Run(fmt.Sprintf("stop node %d", node), func(t *testing.T) {
-		common.StopNodeAt(ctx, t, compose, node)
+		common.StopNodeAt(suite.suiteCtx, t, suite.compose, node)
 	})
 
 	t.Run("insert paragraphs", func(t *testing.T) {
@@ -76,11 +66,11 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectInsertionScenario()
 				Object()
 		}
 
-		common.CreateObjectsCL(t, compose.GetWeaviate().URI(), batch, types.ConsistencyLevelOne)
+		common.CreateObjectsCL(t, suite.compose.GetWeaviate().URI(), batch, types.ConsistencyLevelOne)
 	})
 
 	t.Run(fmt.Sprintf("restart node %d", node), func(t *testing.T) {
-		common.StartNodeAt(ctx, t, compose, node)
+		common.StartNodeAt(suite.suiteCtx, t, suite.compose, node)
 	})
 
 	t.Run("verify that all nodes are running", func(t *testing.T) {
@@ -92,7 +82,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectInsertionScenario()
 			require.NotNil(ct, body.Payload)
 
 			resp := body.Payload
-			require.Len(ct, resp.Nodes, clusterSize)
+			require.Len(ct, resp.Nodes, 3)
 			for _, n := range resp.Nodes {
 				require.NotNil(ct, n.Status)
 				require.Equal(ct, "HEALTHY", *n.Status)
@@ -102,7 +92,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectInsertionScenario()
 
 	t.Run(fmt.Sprintf("assert node %d has all the objects", node), func(t *testing.T) {
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			resp := common.GQLGet(t, compose.ContainerURI(node), "Paragraph", types.ConsistencyLevelOne)
+			resp := common.GQLGet(t, suite.compose.ContainerURI(node), "Paragraph", types.ConsistencyLevelOne)
 			require.Len(ct, resp, len(paragraphIDs))
 		}, 120*time.Second, 5*time.Second, "not all the objects have been asynchronously replicated")
 	})

--- a/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
@@ -12,7 +12,6 @@
 package replication
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -25,7 +24,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/acceptance/replication/common"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
@@ -52,33 +50,25 @@ import (
 //   - Verify that the resurrected node contains all objects
 func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 	t := suite.T()
-	mainCtx := context.Background()
 
 	var (
-		clusterSize = 3
 		tenantName  = "tenant-0"
 		objectCount = 100
 	)
 
-	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
-	defer cancel()
-
-	compose, err := docker.New().
-		WithWeaviateCluster(clusterSize).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
-
 	paragraphClass := articles.ParagraphsClass()
+
+	t.Cleanup(func() {
+		// best-effort: ignore error if class was never created
+		helper.Client(t).Schema.SchemaObjectsDelete(
+			schema.NewSchemaObjectsDeleteParams().WithClassName(paragraphClass.Class),
+			nil,
+		)
+	})
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       int64(clusterSize),
+			Factor:       3,
 			AsyncEnabled: true,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
@@ -87,7 +77,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 			Enabled:              true,
 		}
 
-		helper.SetupClient(compose.GetWeaviate().URI())
+		helper.SetupClient(suite.compose.GetWeaviate().URI())
 		helper.CreateClass(t, paragraphClass)
 	})
 
@@ -97,7 +87,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 	})
 
 	t.Run("stop node 2", func(t *testing.T) {
-		common.StopNodeAt(ctx, t, compose, 2)
+		common.StopNodeAt(suite.suiteCtx, t, suite.compose, 2)
 	})
 
 	// Activate/insert tenants while node 2 is down
@@ -109,11 +99,11 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 				WithTenant(tenantName).
 				Object()
 		}
-		common.CreateObjectsCL(t, compose.GetWeaviate().URI(), batch, types.ConsistencyLevelOne)
+		common.CreateObjectsCL(t, suite.compose.GetWeaviate().URI(), batch, types.ConsistencyLevelOne)
 	})
 
 	t.Run("start node 2", func(t *testing.T) {
-		common.StartNodeAt(ctx, t, compose, 2)
+		common.StartNodeAt(suite.suiteCtx, t, suite.compose, 2)
 	})
 
 	t.Run("verify that all nodes are running", func(t *testing.T) {
@@ -125,7 +115,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 			require.NotNil(ct, body.Payload)
 
 			resp := body.Payload
-			require.Len(ct, resp.Nodes, clusterSize)
+			require.Len(ct, resp.Nodes, 3)
 			for _, n := range resp.Nodes {
 				require.NotNil(ct, n.Status)
 				require.Equal(ct, "HEALTHY", *n.Status)
@@ -135,7 +125,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 
 	t.Run("validate async object propagation", func(t *testing.T) {
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			resp := common.GQLTenantGet(t, compose.GetWeaviateNode(2).URI(), paragraphClass.Class, types.ConsistencyLevelOne, tenantName)
+			resp := common.GQLTenantGet(t, suite.compose.GetWeaviateNode(2).URI(), paragraphClass.Class, types.ConsistencyLevelOne, tenantName)
 			require.Len(ct, resp, objectCount)
 		}, 120*time.Second, 5*time.Second, "not all the objects have been asynchronously replicated")
 	})
@@ -156,33 +146,25 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 //     when it was loaded/activated
 func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantConfigUpdate() {
 	t := suite.T()
-	mainCtx := context.Background()
 
 	var (
-		clusterSize = 3
 		tenantName  = "tenant-0"
 		objectCount = 100
 	)
 
-	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
-	defer cancel()
-
-	compose, err := docker.New().
-		WithWeaviateCluster(clusterSize).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
-
 	paragraphClass := articles.ParagraphsClass()
+
+	t.Cleanup(func() {
+		// best-effort: ignore error if class was never created
+		helper.Client(t).Schema.SchemaObjectsDelete(
+			schema.NewSchemaObjectsDeleteParams().WithClassName(paragraphClass.Class),
+			nil,
+		)
+	})
 
 	t.Run("create schema with async replication disabled", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       int64(clusterSize),
+			Factor:       3,
 			AsyncEnabled: false,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
@@ -191,7 +173,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 			Enabled:              true,
 		}
 
-		helper.SetupClient(compose.GetWeaviate().URI())
+		helper.SetupClient(suite.compose.GetWeaviate().URI())
 		helper.CreateClass(t, paragraphClass)
 	})
 
@@ -216,7 +198,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 	})
 
 	t.Run("stop node 2", func(t *testing.T) {
-		common.StopNodeAt(ctx, t, compose, 2)
+		common.StopNodeAt(suite.suiteCtx, t, suite.compose, 2)
 	})
 
 	t.Run("insert paragraphs (this will activate the tenant)", func(t *testing.T) {
@@ -227,11 +209,11 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 				WithTenant(tenantName).
 				Object()
 		}
-		common.CreateObjectsCL(t, compose.GetWeaviate().URI(), batch, types.ConsistencyLevelOne)
+		common.CreateObjectsCL(t, suite.compose.GetWeaviate().URI(), batch, types.ConsistencyLevelOne)
 	})
 
 	t.Run("start node 2", func(t *testing.T) {
-		common.StartNodeAt(ctx, t, compose, 2)
+		common.StartNodeAt(suite.suiteCtx, t, suite.compose, 2)
 	})
 
 	t.Run("verify that all nodes are running", func(t *testing.T) {
@@ -243,7 +225,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 			require.NotNil(ct, body.Payload)
 
 			resp := body.Payload
-			require.Len(ct, resp.Nodes, clusterSize)
+			require.Len(ct, resp.Nodes, 3)
 			for _, n := range resp.Nodes {
 				require.NotNil(ct, n.Status)
 				require.Equal(ct, "HEALTHY", *n.Status)
@@ -253,7 +235,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 
 	t.Run("validate async object propagation to restarted node", func(t *testing.T) {
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			resp := common.GQLTenantGet(t, compose.GetWeaviateNode(2).URI(), paragraphClass.Class, types.ConsistencyLevelOne, tenantName)
+			resp := common.GQLTenantGet(t, suite.compose.GetWeaviateNode(2).URI(), paragraphClass.Class, types.ConsistencyLevelOne, tenantName)
 			require.Len(ct, resp, objectCount)
 		}, 120*time.Second, 5*time.Second, "not all the objects have been asynchronously replicated to the restarted node")
 	})

--- a/test/acceptance/replication/async_replication/async_repair_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/verbosity"
@@ -61,10 +62,48 @@ var (
 
 type AsyncReplicationTestSuite struct {
 	suite.Suite
+	compose  *docker.DockerCompose
+	suiteCtx context.Context
+}
+
+func (suite *AsyncReplicationTestSuite) SetupSuite() {
+	suite.T().Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
+	suite.suiteCtx = context.Background()
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithText2VecContextionary().
+		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "5").
+		WithWeaviateEnv("PERSISTENCE_MAX_REUSE_WAL_SIZE", "0").
+		Start(suite.suiteCtx)
+	suite.Require().NoError(err)
+	suite.compose = compose
+	helper.SetupClient(compose.GetWeaviate().URI())
+}
+
+func (suite *AsyncReplicationTestSuite) TearDownSuite() {
+	if suite.compose != nil {
+		if err := suite.compose.Terminate(suite.suiteCtx); err != nil {
+			suite.T().Logf("failed to terminate test containers: %s", err.Error())
+		}
+	}
 }
 
 func (suite *AsyncReplicationTestSuite) SetupTest() {
-	suite.T().Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
+	t := suite.T()
+	helper.SetupClient(suite.compose.GetWeaviate().URI())
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		verbose := verbosity.OutputVerbose
+		params := nodes.NewNodesGetClassParams().WithOutput(&verbose)
+		body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+		require.NoError(ct, clientErr)
+		require.NotNil(ct, body.Payload)
+		resp := body.Payload
+		require.Len(ct, resp.Nodes, 3)
+		for _, n := range resp.Nodes {
+			require.NotNil(ct, n.Status)
+			require.Equal(ct, "HEALTHY", *n.Status)
+		}
+	}, 30*time.Second, 500*time.Millisecond)
 }
 
 func TestAsyncReplicationTestSuite(t *testing.T) {
@@ -73,25 +112,20 @@ func TestAsyncReplicationTestSuite(t *testing.T) {
 
 func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 	t := suite.T()
-	mainCtx := context.Background()
 
-	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
-	defer cancel()
-
-	compose, err := docker.New().
-		WithWeaviateCluster(3).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
-
-	helper.SetupClient(compose.GetWeaviate().URI())
 	paragraphClass := articles.ParagraphsClass()
 	articleClass := articles.ArticlesClass()
+
+	t.Cleanup(func() {
+		helper.Client(t).Schema.SchemaObjectsDelete(
+			schema.NewSchemaObjectsDeleteParams().WithClassName(paragraphClass.Class),
+			nil,
+		)
+		helper.Client(t).Schema.SchemaObjectsDelete(
+			schema.NewSchemaObjectsDeleteParams().WithClassName(articleClass.Class),
+			nil,
+		)
+	})
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
@@ -115,7 +149,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 				WithContents(fmt.Sprintf("paragraph#%d", i)).
 				Object()
 		}
-		common.CreateObjects(t, compose.GetWeaviate().URI(), batch)
+		common.CreateObjects(t, suite.compose.GetWeaviate().URI(), batch)
 	})
 
 	t.Run("insert articles", func(t *testing.T) {
@@ -126,11 +160,11 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 				WithTitle(fmt.Sprintf("Article#%d", i)).
 				Object()
 		}
-		common.CreateObjects(t, compose.GetWeaviateNode(2).URI(), batch)
+		common.CreateObjects(t, suite.compose.GetWeaviateNode(2).URI(), batch)
 	})
 
 	t.Run("stop node 3", func(t *testing.T) {
-		common.StopNodeAt(ctx, t, compose, 3)
+		common.StopNodeAt(suite.suiteCtx, t, suite.compose, 3)
 	})
 
 	repairObj := models.Object{
@@ -142,11 +176,11 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 	}
 
 	t.Run("add new object to node one", func(t *testing.T) {
-		common.CreateObjectCL(t, compose.GetWeaviate().URI(), &repairObj, types.ConsistencyLevelOne)
+		common.CreateObjectCL(t, suite.compose.GetWeaviate().URI(), &repairObj, types.ConsistencyLevelOne)
 	})
 
 	t.Run("restart node 3", func(t *testing.T) {
-		common.StartNodeAt(ctx, t, compose, 3)
+		common.StartNodeAt(suite.suiteCtx, t, suite.compose, 3)
 	})
 
 	t.Run("verify that all nodes are running", func(t *testing.T) {
@@ -168,7 +202,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 
 	t.Run("assert new object read repair was made", func(t *testing.T) {
 		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
-			resp, err := common.GetObjectCL(t, compose.GetWeaviateNode(3).URI(),
+			resp, err := common.GetObjectCL(t, suite.compose.GetWeaviateNode(3).URI(),
 				repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
 			assert.Nil(ct, err)
 			assert.NotNil(ct, resp)
@@ -188,15 +222,15 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 	}
 
 	t.Run("stop node 2", func(t *testing.T) {
-		common.StopNodeAt(ctx, t, compose, 2)
+		common.StopNodeAt(suite.suiteCtx, t, suite.compose, 2)
 	})
 
 	t.Run("replace object", func(t *testing.T) {
-		common.UpdateObjectCL(t, compose.GetWeaviateNode(3).URI(), &replaceObj, types.ConsistencyLevelOne)
+		common.UpdateObjectCL(t, suite.compose.GetWeaviateNode(3).URI(), &replaceObj, types.ConsistencyLevelOne)
 	})
 
 	t.Run("restart node 2", func(t *testing.T) {
-		common.StartNodeAt(ctx, t, compose, 2)
+		common.StartNodeAt(suite.suiteCtx, t, suite.compose, 2)
 	})
 
 	t.Run("verify that all nodes are running", func(t *testing.T) {
@@ -218,12 +252,12 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 
 	t.Run("assert updated object read repair was made", func(t *testing.T) {
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			exists, err := common.ObjectExistsCL(t, compose.GetWeaviateNode(2).URI(),
+			exists, err := common.ObjectExistsCL(t, suite.compose.GetWeaviateNode(2).URI(),
 				replaceObj.Class, replaceObj.ID, types.ConsistencyLevelOne)
 			require.Nil(ct, err)
 			require.True(ct, exists)
 
-			resp, err := common.GetObjectCL(t, compose.GetWeaviate().URI(),
+			resp, err := common.GetObjectCL(t, suite.compose.GetWeaviate().URI(),
 				repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
 			require.Nil(ct, err)
 			require.NotNil(ct, resp)

--- a/test/acceptance/replication/async_replication/async_repair_updates_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_updates_test.go
@@ -12,7 +12,6 @@
 package replication
 
 import (
-	"context"
 	"fmt"
 	"math/rand"
 	"testing"
@@ -21,52 +20,43 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/acceptance/replication/common"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
 
 func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectUpdateScenario() {
 	t := suite.T()
-	mainCtx := context.Background()
-
-	clusterSize := 3
-
-	ctx, cancel := context.WithTimeout(mainCtx, 10*time.Minute)
-	defer cancel()
-
-	compose, err := docker.New().
-		WithWeaviateCluster(clusterSize).
-		WithText2VecContextionary().
-		Start(ctx)
-	require.Nil(t, err)
-	defer func() {
-		if err := compose.Terminate(ctx); err != nil {
-			t.Fatalf("failed to terminate test containers: %s", err.Error())
-		}
-	}()
 
 	paragraphClass := articles.ParagraphsClass()
 
+	t.Cleanup(func() {
+		// best-effort: ignore error if class was never created
+		helper.Client(t).Schema.SchemaObjectsDelete(
+			schema.NewSchemaObjectsDeleteParams().WithClassName(paragraphClass.Class),
+			nil,
+		)
+	})
+
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       int64(clusterSize),
+			Factor:       3,
 			AsyncEnabled: true,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 
-		helper.SetupClient(compose.GetWeaviate().URI())
+		helper.SetupClient(suite.compose.GetWeaviate().URI())
 		helper.CreateClass(t, paragraphClass)
 	})
 
 	node := 2
 
 	t.Run(fmt.Sprintf("stop node %d", node), func(t *testing.T) {
-		common.StopNodeAt(ctx, t, compose, node)
+		common.StopNodeAt(suite.suiteCtx, t, suite.compose, node)
 	})
 
 	t.Run("upsert paragraphs", func(t *testing.T) {
@@ -81,17 +71,17 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectUpdateScenario() {
 		// choose one more node to insert the objects into
 		var targetNode int
 		for {
-			targetNode = 1 + rand.Intn(clusterSize)
+			targetNode = 1 + rand.Intn(3)
 			if targetNode != node {
 				break
 			}
 		}
 
-		common.CreateObjectsCL(t, compose.GetWeaviateNode(targetNode).URI(), batch, types.ConsistencyLevelOne)
+		common.CreateObjectsCL(t, suite.compose.GetWeaviateNode(targetNode).URI(), batch, types.ConsistencyLevelOne)
 	})
 
 	t.Run(fmt.Sprintf("restart node %d", node), func(t *testing.T) {
-		common.StartNodeAt(ctx, t, compose, node)
+		common.StartNodeAt(suite.suiteCtx, t, suite.compose, node)
 		time.Sleep(5 * time.Second)
 	})
 
@@ -104,7 +94,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectUpdateScenario() {
 			require.NotNil(ct, body.Payload)
 
 			resp := body.Payload
-			require.Len(ct, resp.Nodes, clusterSize)
+			require.Len(ct, resp.Nodes, 3)
 			for _, n := range resp.Nodes {
 				require.NotNil(ct, n.Status)
 				require.Equal(ct, "HEALTHY", *n.Status)
@@ -114,11 +104,11 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectUpdateScenario() {
 
 	t.Run(fmt.Sprintf("assert node %d has all the objects at its latest version", node), func(t *testing.T) {
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
-			count := common.CountObjects(t, compose.GetWeaviateNode(node).URI(), paragraphClass.Class)
+			count := common.CountObjects(t, suite.compose.GetWeaviateNode(node).URI(), paragraphClass.Class)
 			require.EqualValues(ct, len(paragraphIDs), count)
 
 			for i, id := range paragraphIDs {
-				resp, err := common.GetObjectCL(t, compose.GetWeaviateNode(node).URI(), paragraphClass.Class, id, types.ConsistencyLevelOne)
+				resp, err := common.GetObjectCL(t, suite.compose.GetWeaviateNode(node).URI(), paragraphClass.Class, id, types.ConsistencyLevelOne)
 				require.NoError(ct, err)
 				require.NotNil(ct, resp)
 				require.Equal(ct, id, resp.ID)

--- a/test/acceptance/replication/common/crud_ops.go
+++ b/test/acceptance/replication/common/crud_ops.go
@@ -14,7 +14,9 @@ package common
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +24,7 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/client/graphql"
 	"github.com/weaviate/weaviate/client/nodes"
 	"github.com/weaviate/weaviate/client/objects"
 	"github.com/weaviate/weaviate/cluster/router/types"
@@ -30,7 +33,6 @@ import (
 	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
-	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 )
 
 // stopNodeAt stops the node container at the given index.
@@ -122,14 +124,32 @@ func GetTenantObject(t *testing.T, host, class string, id strfmt.UUID, tenant st
 
 func ObjectExistsCL(t *testing.T, host, class string, id strfmt.UUID, cl types.ConsistencyLevel) (bool, error) {
 	t.Helper()
-	helper.SetupClient(host)
-	return helper.ObjectExistsCL(t, class, id, cl)
+	c := helper.ClientAt(host)
+	cls := string(cl)
+	req := objects.NewObjectsClassHeadParams().
+		WithClassName(class).WithID(id).WithConsistencyLevel(&cls)
+	resp, err := c.Objects.ObjectsClassHead(req, nil)
+	notFoundErr := objects.NewObjectsClassHeadNotFound()
+	if errors.As(err, &notFoundErr) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return resp.IsCode(http.StatusNoContent), nil
 }
 
 func GetObjectCL(t *testing.T, host, class string, id strfmt.UUID, cl types.ConsistencyLevel) (*models.Object, error) {
 	t.Helper()
-	helper.SetupClient(host)
-	return helper.GetObjectCL(t, class, id, cl)
+	c := helper.ClientAt(host)
+	cls := string(cl)
+	req := objects.NewObjectsClassGetParams().WithID(id).WithClassName(class)
+	req.ConsistencyLevel = &cls
+	getResp, err := c.Objects.ObjectsClassGet(req, nil)
+	if err != nil {
+		return nil, err
+	}
+	return getResp.Payload, nil
 }
 
 func GetObjectFromNode(t *testing.T, host, class string, id strfmt.UUID, nodename string) (*models.Object, error) {
@@ -252,97 +272,121 @@ func DeleteTenantObjects(t *testing.T, host, class string, path []string, valueT
 
 func GQLGet(t *testing.T, host, class string, cl types.ConsistencyLevel, fields ...string) []interface{} {
 	t.Helper()
-	helper.SetupClient(host)
-
 	if cl == "" {
 		cl = types.ConsistencyLevelQuorum
 	}
-
 	q := fmt.Sprintf("{Get {%s (consistencyLevel: %s)", class, cl) + " {%s}}}"
 	if len(fields) == 0 {
 		fields = []string{"_additional{id isConsistent vector}"}
 	}
 	q = fmt.Sprintf(q, strings.Join(fields, " "))
-
-	return GQLDo(t, class, q)
+	return GQLDo(t, host, class, q)
 }
 
 func GQLGetNearVec(t *testing.T, host, class string, vec []interface{}, cl types.ConsistencyLevel, fields ...string) []interface{} {
 	t.Helper()
-	helper.SetupClient(host)
-
 	if cl == "" {
 		cl = types.ConsistencyLevelQuorum
 	}
-
 	q := fmt.Sprintf("{Get {%s (consistencyLevel: %s, nearVector: {vector: %s, certainty: 0.8})",
 		class, cl, Vec2String(vec)) + " {%s}}}"
 	if len(fields) == 0 {
 		fields = []string{"_additional{id isConsistent}"}
 	}
 	q = fmt.Sprintf(q, strings.Join(fields, " "))
-
-	return GQLDo(t, class, q)
+	return GQLDo(t, host, class, q)
 }
 
-func GQLDo(t *testing.T, class, query string) []interface{} {
+// GQLDo executes a raw GraphQL query against the node at the given host and
+// returns the "Get.<class>" slice from the response.  It uses
+// helper.ClientAt(host) so it does NOT touch the global helper.ServerHost /
+// helper.ServerPort state, making it safe to call from concurrent goroutines
+// (e.g. inside EventuallyWithT callbacks).
+func GQLDo(t *testing.T, host, class, query string) []interface{} {
 	t.Helper()
-	resp := graphqlhelper.AssertGraphQL(t, helper.RootAuth, query)
-
-	result := resp.Get("Get").Get(class)
-	return result.Result.([]interface{})
+	c := helper.ClientAt(host)
+	params := graphql.NewGraphqlPostParams().
+		WithBody(&models.GraphQLQuery{Query: query})
+	resp, err := c.Graphql.GraphqlPost(params, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Payload)
+	if len(resp.Payload.Errors) != 0 {
+		j, _ := json.Marshal(resp.Payload.Errors)
+		t.Fatalf("GraphQL resolved to an error: %s", string(j))
+	}
+	data := resp.Payload.Data["Get"]
+	if data == nil {
+		return nil
+	}
+	result := data.(map[string]interface{})[class]
+	if result == nil {
+		return nil
+	}
+	return result.([]interface{})
 }
 
 func GQLTenantGet(t *testing.T, host, class string, cl types.ConsistencyLevel,
 	tenant string, fields ...string,
 ) []interface{} {
 	t.Helper()
-	helper.SetupClient(host)
-
 	if cl == "" {
 		cl = types.ConsistencyLevelQuorum
 	}
-
 	q := fmt.Sprintf("{Get {%s (tenant: %q, consistencyLevel: %s, limit: 1000)", class, tenant, cl) + " {%s}}}"
 	if len(fields) == 0 {
 		fields = []string{"_additional{id isConsistent}"}
 	}
 	q = fmt.Sprintf(q, strings.Join(fields, " "))
-
-	resp := graphqlhelper.AssertGraphQL(t, helper.RootAuth, q)
-
-	result := resp.Get("Get").Get(class)
-	return result.Result.([]interface{})
+	c := helper.ClientAt(host)
+	params := graphql.NewGraphqlPostParams().
+		WithBody(&models.GraphQLQuery{Query: q})
+	resp, err := c.Graphql.GraphqlPost(params, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Payload)
+	if len(resp.Payload.Errors) != 0 {
+		j, _ := json.Marshal(resp.Payload.Errors)
+		t.Fatalf("GraphQL resolved to an error: %s", string(j))
+	}
+	data := resp.Payload.Data["Get"]
+	if data == nil {
+		return nil
+	}
+	result := data.(map[string]interface{})[class]
+	if result == nil {
+		return nil
+	}
+	return result.([]interface{})
 }
 
 func CountObjects(t *testing.T, host, class string) int64 {
-	helper.SetupClient(host)
-
+	t.Helper()
 	q := fmt.Sprintf(`{Aggregate{%s{meta{count}}}}`, class)
-
-	resp := graphqlhelper.AssertGraphQL(t, helper.RootAuth, q)
-
-	result := resp.Get("Aggregate").Get(class).AsSlice()
-	require.Len(t, result, 1)
-	meta := result[0].(map[string]interface{})["meta"].(map[string]interface{})
+	c := helper.ClientAt(host)
+	params := graphql.NewGraphqlPostParams().
+		WithBody(&models.GraphQLQuery{Query: q})
+	resp, err := c.Graphql.GraphqlPost(params, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Payload)
+	agg := resp.Payload.Data["Aggregate"].(map[string]interface{})[class].([]interface{})
+	require.Len(t, agg, 1)
+	meta := agg[0].(map[string]interface{})["meta"].(map[string]interface{})
 	count, err := meta["count"].(json.Number).Int64()
 	require.Nil(t, err)
 	return count
 }
 
-func CountTenantObjects(t *testing.T, host, class string,
-	tenant string,
-) int64 {
+func CountTenantObjects(t *testing.T, host, class string, tenant string) int64 {
 	t.Helper()
-	helper.SetupClient(host)
-
 	q := fmt.Sprintf(`{Aggregate{%s(tenant: %q){meta{count}}}}`, class, tenant)
-
-	resp := graphqlhelper.AssertGraphQL(t, helper.RootAuth, q)
-
-	result := resp.Get("Aggregate").Get(class).AsSlice()
-	require.Len(t, result, 1)
-	meta := result[0].(map[string]interface{})["meta"].(map[string]interface{})
+	c := helper.ClientAt(host)
+	params := graphql.NewGraphqlPostParams().
+		WithBody(&models.GraphQLQuery{Query: q})
+	resp, err := c.Graphql.GraphqlPost(params, nil)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Payload)
+	agg := resp.Payload.Data["Aggregate"].(map[string]interface{})[class].([]interface{})
+	require.Len(t, agg, 1)
+	meta := agg[0].(map[string]interface{})["meta"].(map[string]interface{})
 	count, err := meta["count"].(json.Number).Int64()
 	require.Nil(t, err)
 	return count
@@ -350,10 +394,9 @@ func CountTenantObjects(t *testing.T, host, class string,
 
 func GetNodes(t *testing.T, host string) *models.NodesStatusResponse {
 	t.Helper()
-	helper.SetupClient(host)
 	verbose := verbosity.OutputVerbose
 	params := nodes.NewNodesGetParams().WithOutput(&verbose)
-	resp, err := helper.Client(t).Nodes.NodesGet(params, nil)
+	resp, err := helper.ClientAt(host).Nodes.NodesGet(params, nil)
 	helper.AssertRequestOk(t, resp, err, nil)
 	return resp.Payload
 }

--- a/test/acceptance/replication/replica_replication/fast/endpoints_test.go
+++ b/test/acceptance/replication/replica_replication/fast/endpoints_test.go
@@ -49,6 +49,8 @@ func (suite *ReplicationTestSuite) SetupSuite() {
 		WithWeaviateEnv("REPLICATION_ENGINE_MAX_WORKERS", "100").
 		WithWeaviateEnv("REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT", "5s").
 		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
+		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "5").
+		WithWeaviateEnv("PERSISTENCE_MAX_REUSE_WAL_SIZE", "0").
 		Start(ctx)
 	require.Nil(t, err)
 	if cancel != nil {

--- a/test/acceptance/replication/replica_replication/fast/mutating_data_test.go
+++ b/test/acceptance/replication/replica_replication/fast/mutating_data_test.go
@@ -56,9 +56,24 @@ func test(suite *ReplicationTestSuite, strategy string) {
 		AutoTenantCreation:   true,
 	}
 
+	// Pin async replication settings to the old defaults so the MOVE operation
+	// completes within the 300s test timeout. The global defaults were reduced
+	// to lower resource usage, which increased the minimum time for a MOVE.
+	aliveNodesCheckingFrequency := int64(5000) // ms: 5s (default changed to 30s)
+	frequencyWhilePropagating := int64(3000)   // ms: 3s (default changed to 5s)
+	propagationConcurrency := int64(5)         // (default changed to 1)
+	propagationLimit := int64(10_000)          // (default changed to 1k)
+	maxWorkers := int64(10)                    // multi-tenant (default changed to 5, cap is 10)
 	cls.ReplicationConfig = &models.ReplicationConfig{
 		Factor:           int64(2),
 		DeletionStrategy: strategy,
+		AsyncConfig: &models.ReplicationAsyncConfig{
+			AliveNodesCheckingFrequency: &aliveNodesCheckingFrequency,
+			FrequencyWhilePropagating:   &frequencyWhilePropagating,
+			PropagationConcurrency:      &propagationConcurrency,
+			PropagationLimit:            &propagationLimit,
+			MaxWorkers:                  &maxWorkers,
+		},
 	}
 
 	// Create the class

--- a/test/acceptance/replication/replica_replication/fast/not_implemented_test.go
+++ b/test/acceptance/replication/replica_replication/fast/not_implemented_test.go
@@ -44,6 +44,7 @@ func (suite *ReplicationNotImplementedTestSuite) SetupSuite() {
 	compose, err := docker.New().
 		WithWeaviateCluster(3).
 		WithWeaviateEnv("REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT", "5s").
+		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "5").
 		Start(ctx)
 	require.Nil(t, err)
 	if cancel != nil {

--- a/test/acceptance/replication/replica_replication/fast/replica_replication_test.go
+++ b/test/acceptance/replication/replica_replication/fast/replica_replication_test.go
@@ -73,6 +73,8 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementHappyPath() {
 		WithText2VecContextionary().
 		WithWeaviateEnv("REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT", "5s").
 		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
+		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "5").
+		WithWeaviateEnv("PERSISTENCE_MAX_REUSE_WAL_SIZE", "0").
 		Start(ctx)
 	require.Nil(t, err)
 	defer func() {
@@ -138,6 +140,17 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementHappyPath() {
 				assert.Equal(ct, "HEALTHY", *n.Status)
 			}
 		}, 15*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("wait for paragraph class to be visible on all nodes", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			params := nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(paragraphClass.Class)
+			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+			require.NoError(ct, clientErr)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, 3)
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 
 	var uuid strfmt.UUID
@@ -221,6 +234,10 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementHappyPath() {
 		common.StopNodeAt(ctx, t, compose, sourceNode)
 	})
 
+	// Re-setup the client to point to node3 (the replication target) since the source node was stopped
+	// and may have been the node the client was originally configured to use.
+	helper.SetupClient(compose.ContainerURI(3))
+
 	t.Run("assert data is available for paragraph on node3 with consistency level one", func(t *testing.T) {
 		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
 			for _, objId := range paragraphIDs {
@@ -259,6 +276,7 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementTenantHappyPath()
 		WithText2VecContextionary().
 		WithWeaviateEnv("REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT", "5s").
 		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
+		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "5").
 		Start(ctx)
 	require.Nil(t, err)
 	defer func() {

--- a/test/acceptance/replication/replica_replication/scale/scale_test.go
+++ b/test/acceptance/replication/replica_replication/scale/scale_test.go
@@ -65,6 +65,8 @@ func (suite *ScaleTestSuite) TestScalingSingleTenant() {
 		WithText2VecContextionary().
 		WithWeaviateEnv("REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT", "5s").
 		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
+		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "5").
+		WithWeaviateEnv("PERSISTENCE_MAX_REUSE_WAL_SIZE", "0").
 		Start(ctx)
 	require.Nil(t, err)
 	defer func() {
@@ -261,6 +263,7 @@ func (suite *ScaleTestSuite) TestScalingMultiTenant() {
 		WithText2VecContextionary().
 		WithWeaviateEnv("REPLICA_MOVEMENT_MINIMUM_ASYNC_WAIT", "5s").
 		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
+		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "5").
 		Start(ctx)
 	require.Nil(t, err)
 	defer func() {

--- a/test/acceptance/replication/replica_replication/slow/large_shard_test.go
+++ b/test/acceptance/replication/replica_replication/slow/large_shard_test.go
@@ -33,6 +33,8 @@ func (suite *ReplicationTestSuite) TestReplicationReplicateOfLargeShard() {
 		WithWeaviateCluster(3).
 		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
 		WithWeaviateEnv("REPLICATION_ENGINE_FILE_COPY_CHUNK_SIZE", "10485760"). // 10 MB
+		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "5").
+		WithWeaviateEnv("PERSISTENCE_MAX_REUSE_WAL_SIZE", "0").
 		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {

--- a/test/acceptance/replication/replica_replication/slow/scale_out_test.go
+++ b/test/acceptance/replication/replica_replication/slow/scale_out_test.go
@@ -42,6 +42,8 @@ func (suite *ReplicationTestSuite) TestReplicationReplicateScaleOut() {
 		WithWeaviateCluster(3).
 		WithWeaviateEnv("REPLICATION_ENGINE_MAX_WORKERS", "10").
 		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
+		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "5").
+		WithWeaviateEnv("PERSISTENCE_MAX_REUSE_WAL_SIZE", "0").
 		Start(mainCtx)
 	require.Nil(t, err)
 	defer func() {

--- a/test/acceptance/replication/replica_replication/slow/slow_file_copy_test.go
+++ b/test/acceptance/replication/replica_replication/slow/slow_file_copy_test.go
@@ -61,6 +61,8 @@ func (suite *ReplicationTestSuite) TestReplicaMovementOneWriteExtraSlowFileCopy(
 		WithText2VecContextionary().
 		WithWeaviateEnv("WEAVIATE_TEST_COPY_REPLICA_SLEEP", "20s").
 		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
+		WithWeaviateEnv("PERSISTENCE_MEMTABLES_FLUSH_DIRTY_AFTER_SECONDS", "5").
+		WithWeaviateEnv("PERSISTENCE_MAX_REUSE_WAL_SIZE", "0").
 		Start(ctx)
 	require.Nil(t, err)
 	defer func() {

--- a/test/acceptance/schema/update_class_async_replication_test.go
+++ b/test/acceptance/schema/update_class_async_replication_test.go
@@ -64,9 +64,9 @@ func TestUpdateClassAsyncReplicationConfig(t *testing.T) {
 				PrePropagationTimeout:       int64Ptr(600),
 				PropagationTimeout:          int64Ptr(120),
 				PropagationLimit:            int64Ptr(50000),
-				PropagationDelay:            int64Ptr(45000),
 				PropagationConcurrency:      int64Ptr(10),
 				PropagationBatchSize:        int64Ptr(500),
+				InitShieldCPUEveryN:         int64Ptr(5000),
 			},
 		},
 		{
@@ -83,9 +83,9 @@ func TestUpdateClassAsyncReplicationConfig(t *testing.T) {
 				PrePropagationTimeout:       int64Ptr(300),
 				PropagationTimeout:          int64Ptr(60),
 				PropagationLimit:            int64Ptr(10000),
-				PropagationDelay:            int64Ptr(10000),
 				PropagationConcurrency:      int64Ptr(2),
 				PropagationBatchSize:        int64Ptr(100),
+				InitShieldCPUEveryN:         int64Ptr(20000),
 			},
 		},
 	}
@@ -152,9 +152,9 @@ func requireAsyncConfigEquals(
 	requireOptionalInt64(expected.PrePropagationTimeout, actual.PrePropagationTimeout)
 	requireOptionalInt64(expected.PropagationTimeout, actual.PropagationTimeout)
 	requireOptionalInt64(expected.PropagationLimit, actual.PropagationLimit)
-	requireOptionalInt64(expected.PropagationDelay, actual.PropagationDelay)
 	requireOptionalInt64(expected.PropagationConcurrency, actual.PropagationConcurrency)
 	requireOptionalInt64(expected.PropagationBatchSize, actual.PropagationBatchSize)
+	requireOptionalInt64(expected.InitShieldCPUEveryN, actual.InitShieldCPUEveryN)
 }
 
 func TestUpdateClassAsyncReplicationValidation(t *testing.T) {

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -105,7 +105,6 @@ func startWeaviate(ctx context.Context,
 		wait.ForListeningPort(httpPort),
 		wait.ForHTTP(wellKnownEndpoint).WithPort(httpPort),
 	}
-
 	// Expose the cluster API port (CLUSTER_DATA_BIND_PORT) if configured.
 	// This allows tests to access /v1/cluster/* endpoints from the host.
 	var (
@@ -133,6 +132,7 @@ func startWeaviate(ctx context.Context,
 		exposedPorts = append(exposedPorts, "6060/tcp")
 		waitStrategies = append(waitStrategies, wait.ForListeningPort(debugPort))
 	}
+
 	req := testcontainers.ContainerRequest{
 		FromDockerfile: fromDockerFile,
 		Image:          weaviateImage,

--- a/test/helper/client.go
+++ b/test/helper/client.go
@@ -31,6 +31,7 @@ package helper
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/go-openapi/runtime"
@@ -40,6 +41,21 @@ import (
 	apiclient "github.com/weaviate/weaviate/client"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
+
+// ClientAt creates a Weaviate client that connects to the given URI (host:port)
+// without modifying any global state. This is safe to call concurrently and
+// should be preferred over SetupClient+Client in tests that may run goroutines
+// concurrently (e.g. inside EventuallyWithT callbacks).
+func ClientAt(uri string) *apiclient.Weaviate {
+	scheme, hostPort := parseScheme(uri)
+	host, port := "", ""
+	res := strings.Split(hostPort, ":")
+	if len(res) == 2 {
+		host, port = res[0], res[1]
+	}
+	transport := httptransport.New(fmt.Sprintf("%s:%s", host, port), "/v1", []string{scheme})
+	return apiclient.New(transport, strfmt.Default)
+}
 
 // Create a client that logs with t.Logf, if a *testing.T is provided.
 // If there is no test case at hand, pass in nil to disable logging.

--- a/usecases/classification/integrationtest/fakes_for_integration_test.go
+++ b/usecases/classification/integrationtest/fakes_for_integration_test.go
@@ -637,6 +637,12 @@ func (c *fakeReplicationClient) DigestObjectsInRange(ctx context.Context, host, 
 	return nil, nil
 }
 
+func (c *fakeReplicationClient) CompareDigests(ctx context.Context, host, index, shard string,
+	digests []types.RepairResponse,
+) ([]types.RepairResponse, error) {
+	return nil, nil
+}
+
 func (c *fakeReplicationClient) HashTreeLevel(ctx context.Context, host, index, shard string, level int,
 	discriminant *hashtree.Bitset,
 ) (digests []hashtree.Digest, err error) {

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -43,6 +43,13 @@ var (
 	ErrRead     = errors.New("read error")
 
 	ErrNoDiffFound = errors.New("no diff found")
+
+	// ErrHashtreeRootUnchanged is returned by CollectShardDifferences when the
+	// remote node's hashtree root has not changed since the last propagation
+	// cycle, meaning the remote has not yet flushed the objects that were sent
+	// to it. The caller should keep the fast-poll cadence active and skip the
+	// full CompareDigests + propagation pass until the remote root changes.
+	ErrHashtreeRootUnchanged = errors.New("hashtree root unchanged since last propagation cycle")
 )
 
 type (
@@ -314,10 +321,31 @@ func (f *Finder) checkShardConsistency(ctx context.Context,
 	return result.Value, result.Err
 }
 
+// ShardDiffSkipState carries the prior-cycle root snapshots and work flag for
+// a single target node. When provided to CollectShardDifferences, the function
+// short-circuits after the level-0 RPC if the skip conditions are met, saving
+// the remaining (Height-1) RPCs needed for the full tree walk.
+type ShardDiffSkipState struct {
+	LocalRoot  hashtree.Digest
+	RemoteRoot hashtree.Digest
+	// HadWork is true when the prior cycle actually sent objects to this target.
+	// Local-only deletions (remoteDeleted verdicts) must NOT set this flag
+	// because they do not change the remote hashtree.
+	HadWork bool
+}
+
 type ShardDifferenceReader struct {
 	TargetNodeName    string
 	TargetNodeAddress string
 	RangeReader       hashtree.AggregatedHashTreeRangeReader
+	// LocalHashtreeRoot and RemoteHashtreeRoot are the level-0 digests observed
+	// at the time of comparison. They are zero when the comparison was skipped
+	// before the level-0 RPC (e.g. early ErrNoDiffFound from target-node
+	// overrides). The caller stores these in its per-target tracking maps so
+	// that the next call to CollectShardDifferences can short-circuit after
+	// the level-0 RPC when the skip conditions (Case A or Case B) are met.
+	LocalHashtreeRoot  hashtree.Digest
+	RemoteHashtreeRoot hashtree.Digest
 }
 
 // CollectShardDifferences collects the differences between the local node and the target nodes.
@@ -325,9 +353,20 @@ type ShardDifferenceReader struct {
 // If no differences are found, it returns ErrNoDiffFound.
 // When ErrNoDiffFound is returned as the error, the returned *ShardDifferenceReader may exist
 // and have some (but not all) of its fields set.
+//
+// skipStateByTarget is optional (may be nil). When provided, after the level-0
+// RPC (which fetches both root digests with a single round-trip) the function
+// checks skip conditions against the stored prior-cycle roots:
+//   - Case A (ErrHashtreeRootUnchanged): remote root unchanged AND prior cycle sent objects →
+//     remote hasn't flushed yet; return immediately to keep the fast-poll cadence.
+//   - Case B (ErrNoDiffFound): both roots unchanged AND prior cycle sent nothing →
+//     nothing has changed; skip the remaining levels.
+//
+// In both cases the full tree walk (up to Height-1 additional RPCs) is avoided.
 func (f *Finder) CollectShardDifferences(ctx context.Context,
 	shardName string, ht hashtree.AggregatedHashTree, diffTimeoutPerNode time.Duration,
 	targetNodeOverrides []additional.AsyncReplicationTargetNodeOverride,
+	skipStateByTarget map[string]ShardDiffSkipState,
 ) (diffReader *ShardDifferenceReader, err error) {
 	options := f.router.BuildRoutingPlanOptions(shardName, shardName, types.ConsistencyLevelOne, "")
 	routingPlan, err := f.router.BuildReadRoutingPlan(options)
@@ -339,14 +378,33 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 		ctx, cancel := context.WithTimeout(ctx, diffTimeoutPerNode)
 		defer cancel()
 
+		// Assumes the remote shard's hashtree has the same height as the local one.
+		// A height mismatch will be caught implicitly: the remote will return a
+		// different digest count than expected, which is treated as an error below.
 		diff := hashtree.NewBitset(hashtree.NodesCount(ht.Height()))
 
+		// NOTE: the traversal is not atomic — concurrent writes to ht between level
+		// reads may cause false-positive diff ranges. This is acceptable: propagation
+		// is idempotent and false negatives cannot occur (a difference present at
+		// traversal start will always be detected).
 		digests := make([]hashtree.Digest, hashtree.LeavesCount(ht.Height()))
 
 		diff.Set(0) // init comparison at root level
 
-		for l := 0; l <= ht.Height(); l++ {
-			_, err := ht.Level(l, diff, digests)
+		// Compare levels 0 through Height-1, skipping the leaf level.
+		// The leaf-level HashTreeLevel response can be very large (up to
+		// 2^height × 16 bytes per call), while skipping it costs at most 2×
+		// wider UUID ranges in the subsequent DigestObjectsInRange scans.
+		// For a height-0 tree the root IS the leaf, so we must include it.
+		loopBound := ht.Height()
+		if loopBound == 0 {
+			loopBound = 1
+		}
+		// localRoot and remoteRoot are captured at level 0 (the tree root) so the
+		// caller can detect whether either side has flushed since the last cycle.
+		var localRoot, remoteRoot hashtree.Digest
+		for l := 0; l < loopBound; l++ {
+			n, err := ht.Level(l, diff, digests)
 			if err != nil {
 				return nil, fmt.Errorf("%q: %w", targetNodeAddress, err)
 			}
@@ -355,9 +413,48 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 			if err != nil {
 				return nil, fmt.Errorf("%q: %w", targetNodeAddress, err)
 			}
-			if len(levelDigests) == 0 {
-				// no differences were found
-				break
+			if len(levelDigests) != n {
+				// Remote returned fewer or more digests than the discriminant requested.
+				// This indicates a height mismatch or an inconsistent remote state.
+				// Return an error so the caller can try the next replica rather than
+				// silently treating the shard as in-sync or panicking in LevelDiff.
+				return nil, fmt.Errorf("%q: level %d: expected %d digests from remote, got %d",
+					targetNodeAddress, l, n, len(levelDigests))
+			}
+
+			if l == 0 && n > 0 {
+				localRoot = digests[0]
+				remoteRoot = levelDigests[0]
+
+				// Short-circuit using only the root digests — avoids the remaining
+				// (Height-1) level RPCs when a skip condition is met.
+				if prior, ok := skipStateByTarget[targetNodeName]; ok {
+					remoteRootUnchanged := remoteRoot == prior.RemoteRoot
+					localRootUnchanged := localRoot == prior.LocalRoot
+					if remoteRootUnchanged && prior.HadWork {
+						// Case A: objects were propagated last cycle but the remote
+						// hasn't flushed its memtable yet. Signal the caller to keep
+						// the fast-poll cadence without re-running the expensive scan.
+						return &ShardDifferenceReader{
+							TargetNodeName:     targetNodeName,
+							TargetNodeAddress:  targetNodeAddress,
+							LocalHashtreeRoot:  localRoot,
+							RemoteHashtreeRoot: remoteRoot,
+						}, ErrHashtreeRootUnchanged
+					}
+					if remoteRootUnchanged && localRootUnchanged && !prior.HadWork {
+						// Case B: nothing was propagated last cycle and neither side
+						// has changed — the next full scan would find the same empty
+						// result. Return ErrNoDiffFound so the caller drops back to
+						// the slow-poll cadence.
+						return &ShardDifferenceReader{
+							TargetNodeName:     targetNodeName,
+							TargetNodeAddress:  targetNodeAddress,
+							LocalHashtreeRoot:  localRoot,
+							RemoteHashtreeRoot: remoteRoot,
+						}, ErrNoDiffFound
+					}
+				}
 			}
 
 			levelDiffCount := hashtree.LevelDiff(l, diff, digests, levelDigests)
@@ -367,17 +464,26 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 			}
 		}
 
+		// Expand any non-leaf bits set by LevelDiff to their leaf-level
+		// descendants so that HashTreeDiffReader (which scans only leaf
+		// positions) can enumerate the differing UUID ranges.
+		expandDiscriminantToLeaves(diff, ht.Height())
+
 		if diff.SetCount() == 0 {
 			return &ShardDifferenceReader{
-				TargetNodeName:    targetNodeName,
-				TargetNodeAddress: targetNodeAddress,
+				TargetNodeName:     targetNodeName,
+				TargetNodeAddress:  targetNodeAddress,
+				LocalHashtreeRoot:  localRoot,
+				RemoteHashtreeRoot: remoteRoot,
 			}, ErrNoDiffFound
 		}
 
 		return &ShardDifferenceReader{
-			TargetNodeName:    targetNodeName,
-			TargetNodeAddress: targetNodeAddress,
-			RangeReader:       ht.NewRangeReader(diff),
+			TargetNodeName:     targetNodeName,
+			TargetNodeAddress:  targetNodeAddress,
+			RangeReader:        ht.NewRangeReader(diff),
+			LocalHashtreeRoot:  localRoot,
+			RemoteHashtreeRoot: remoteRoot,
 		}, nil
 	}
 
@@ -399,9 +505,9 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 	replicaNodeNames := make([]string, 0, len(routingPlan.Replicas()))
 	replicasHostAddrs := make([]string, 0, len(routingPlan.HostAddresses()))
 	for _, replica := range targetNodesToUse {
-		replicaNodeNames = append(replicaNodeNames, replica)
 		replicaHostAddr, ok := f.nodeResolver.NodeHostname(replica)
 		if ok {
+			replicaNodeNames = append(replicaNodeNames, replica)
 			replicasHostAddrs = append(replicasHostAddrs, replicaHostAddr)
 		}
 	}
@@ -425,6 +531,12 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 
 		diffReader, err := collectDiffForTargetNode(targetNodeAddress, targetNodeName)
 		if err != nil {
+			if errors.Is(err, ErrHashtreeRootUnchanged) {
+				// Case A skip: return immediately so the caller can preserve the
+				// fast-poll cadence for this specific target. Do not continue to
+				// other targets — the skip state is per-target.
+				return diffReader, err
+			}
 			if !errors.Is(err, ErrNoDiffFound) {
 				ec.Add(err)
 			}
@@ -442,10 +554,48 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 	return &ShardDifferenceReader{}, ErrNoDiffFound
 }
 
+// expandDiscriminantToLeaves expands every non-leaf set bit in diff to its two
+// leaf-level descendants, working top-down level by level. After stopping the
+// comparison loop at height-1 (to skip the largest HashTreeLevel response),
+// the discriminant has bits set at internal-node positions. HashTreeDiffReader
+// only scans leaf positions, so this expansion is required before constructing
+// the RangeReader.
+//
+// False positives are possible (both leaves under a differing parent are marked
+// even if only one truly differs), but DigestObjectsInRange handles the
+// fine-grained reconciliation, and propagation is idempotent.
+func expandDiscriminantToLeaves(diff *hashtree.Bitset, height int) {
+	for l := 0; l < height; l++ {
+		offset := hashtree.InnerNodesCount(l)
+		count := hashtree.LeavesCount(l)
+		for j := 0; j < count; j++ {
+			node := offset + j
+			if diff.IsSet(node) {
+				diff.Set(2*node + 1)
+				diff.Set(2*node + 2)
+				diff.Unset(node)
+			}
+		}
+	}
+}
+
 func (f *Finder) DigestObjectsInRange(ctx context.Context,
 	shardName string, host string, initialUUID, finalUUID strfmt.UUID, limit int,
 ) (ds []types.RepairResponse, err error) {
 	return f.client.DigestObjectsInRange(ctx, host, f.class, shardName, initialUUID, finalUUID, limit)
+}
+
+// CompareDigests sends the source's local digests to the target node and
+// returns a subset requiring source-side action: objects that are missing on
+// the target, stale on the target (source has a strictly newer UpdateTime), or
+// equal-timestamp conflicts where both nodes hold the same UpdateTime but may
+// have diverged. The caller is responsible for applying a deterministic
+// tiebreaker (e.g. node-name comparison) to equal-timestamp conflicts before
+// deciding whether to propagate.
+func (f *Finder) CompareDigests(ctx context.Context,
+	shardName string, host string, digests []types.RepairResponse,
+) ([]types.RepairResponse, error) {
+	return f.client.CompareDigests(ctx, host, f.class, shardName, digests)
 }
 
 // Overwrite specified object with most recent contents

--- a/usecases/replica/finder_internal_test.go
+++ b/usecases/replica/finder_internal_test.go
@@ -1,0 +1,152 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
+)
+
+// TestExpandDiscriminantToLeaves verifies that non-leaf bits are correctly
+// expanded to leaf-level descendants, matching the result of a full DiffUsing
+// traversal.
+func TestExpandDiscriminantToLeaves(t *testing.T) {
+	t.Run("NoDiff", func(t *testing.T) {
+		// All-zero discriminant: no bits anywhere → expand is a no-op
+		height := 4
+		diff := hashtree.NewBitset(hashtree.NodesCount(height))
+		expandDiscriminantToLeaves(diff, height)
+		require.Zero(t, diff.SetCount())
+	})
+
+	t.Run("AllLeavesViaSingleRoot", func(t *testing.T) {
+		// Set only the root bit; expanding must produce all leaf bits.
+		height := 3
+		diff := hashtree.NewBitset(hashtree.NodesCount(height))
+		diff.Set(0)
+
+		expandDiscriminantToLeaves(diff, height)
+
+		// Only leaf bits should remain.
+		firstLeaf := hashtree.NodesCount(height - 1)
+		leafCount := hashtree.LeavesCount(height)
+		require.Equal(t, leafCount, diff.SetCount())
+		for i := 0; i < leafCount; i++ {
+			require.True(t, diff.IsSet(firstLeaf+i), "leaf %d should be set", i)
+		}
+		// Internal bits should be cleared.
+		for i := 0; i < firstLeaf; i++ {
+			require.False(t, diff.IsSet(i), "internal node %d should not be set", i)
+		}
+	})
+
+	t.Run("PartialDiff", func(t *testing.T) {
+		// Simulate stopping at height-1: set the left child of the root only.
+		// After expansion the leaves under that child should be set.
+		height := 3
+		diff := hashtree.NewBitset(hashtree.NodesCount(height))
+		diff.Set(1) // left child of root (level-1 node 0)
+
+		expandDiscriminantToLeaves(diff, height)
+
+		// Left subtree leaves: nodes 7,8,9,10 (left half of level 3)
+		require.Equal(t, 4, diff.SetCount())
+		firstLeaf := hashtree.NodesCount(height - 1)
+		for i := 0; i < 4; i++ {
+			require.True(t, diff.IsSet(firstLeaf+i))
+		}
+		for i := 4; i < 8; i++ {
+			require.False(t, diff.IsSet(firstLeaf+i))
+		}
+	})
+
+	t.Run("LeafBitsAlreadySet", func(t *testing.T) {
+		// Bits already at the leaf level must not be touched by expansion.
+		height := 2
+		diff := hashtree.NewBitset(hashtree.NodesCount(height))
+		firstLeaf := hashtree.NodesCount(height - 1)
+		diff.Set(firstLeaf + 1) // leaf 1
+
+		expandDiscriminantToLeaves(diff, height)
+
+		require.Equal(t, 1, diff.SetCount())
+		require.True(t, diff.IsSet(firstLeaf+1))
+	})
+
+	t.Run("EquivalenceWithDiffUsing", func(t *testing.T) {
+		// Build two trees with known differences. Use DiffUsing (full traversal)
+		// to get the true leaf discriminant. Then simulate the skip-leaf-level
+		// approach: run the comparison loop up to height-1 and call
+		// expandDiscriminantToLeaves. The resulting leaf bits must be a superset
+		// of the DiffUsing result (false positives are allowed; false negatives
+		// are not).
+		height := 4
+		ht1, err := hashtree.NewHashTree(height)
+		require.NoError(t, err)
+		ht2, err := hashtree.NewHashTree(height)
+		require.NoError(t, err)
+
+		// Populate: leaf 5 differs, leaf 11 differs.
+		require.NoError(t, ht1.AggregateLeafWith(5, []byte("a")))
+		require.NoError(t, ht2.AggregateLeafWith(5, []byte("b")))
+		require.NoError(t, ht1.AggregateLeafWith(11, []byte("c")))
+		require.NoError(t, ht2.AggregateLeafWith(11, []byte("d")))
+
+		// Full-traversal ground truth.
+		trueDiff, err := ht1.Diff(ht2)
+		require.NoError(t, err)
+
+		// Simulate stopped-at-H-1 discriminant: manually replicate what
+		// LevelDiff produces up through level height-1.
+		leavesCount := hashtree.LeavesCount(height)
+		digests1 := make([]hashtree.Digest, leavesCount)
+		digests2 := make([]hashtree.Digest, leavesCount)
+
+		diff := hashtree.NewBitset(hashtree.NodesCount(height))
+		diff.Set(0)
+
+		for l := 0; l < height; l++ {
+			_, err := ht1.Level(l, diff, digests1)
+			require.NoError(t, err)
+			_, err = ht2.Level(l, diff, digests2)
+			require.NoError(t, err)
+			cnt := hashtree.LevelDiff(l, diff, digests1, digests2)
+			if cnt == 0 {
+				break
+			}
+		}
+
+		expandDiscriminantToLeaves(diff, height)
+
+		// Every leaf that is set in trueDiff must also be set in our result.
+		firstLeaf := hashtree.NodesCount(height - 1)
+		for i := 0; i < leavesCount; i++ {
+			node := firstLeaf + i
+			if trueDiff.IsSet(node) {
+				require.True(t, diff.IsSet(node),
+					"leaf %d: trueDiff has it set but expanded diff does not", i)
+			}
+		}
+	})
+
+	t.Run("Height0", func(t *testing.T) {
+		// height=0: the single node is both root and leaf; expandDiscriminantToLeaves
+		// must be a no-op (loop runs 0 times).
+		diff := hashtree.NewBitset(hashtree.NodesCount(0))
+		diff.Set(0)
+		expandDiscriminantToLeaves(diff, 0)
+		require.True(t, diff.IsSet(0))
+		require.Equal(t, 1, diff.SetCount())
+	})
+}

--- a/usecases/replica/finder_test.go
+++ b/usecases/replica/finder_test.go
@@ -13,12 +13,15 @@ package replica_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/cluster/router/types"
 	"github.com/weaviate/weaviate/entities/additional"
@@ -26,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/replica"
+	"github.com/weaviate/weaviate/usecases/replica/hashtree"
 )
 
 func genInputs(node, shard string, updateTime int64, ids []strfmt.UUID) ([]*storobj.Object, []types.RepairResponse) {
@@ -1108,4 +1112,322 @@ func TestFinderCheckConsistencyOne(t *testing.T) {
 			assert.Equal(t, want, xs)
 		})
 	}
+}
+
+// TestCollectShardDifferences exercises the full traversal + skip-leaf-level +
+// expandDiscriminantToLeaves path end-to-end using a mock RClient.
+func TestCollectShardDifferences(t *testing.T) {
+	const (
+		class  = "C1"
+		shard  = "S0"
+		height = 3
+	)
+	nodes := []string{"A", "B"}
+	ctx := context.Background()
+
+	makeTree := func(t *testing.T) hashtree.AggregatedHashTree {
+		t.Helper()
+		ht, err := hashtree.NewHashTree(height)
+		require.NoError(t, err)
+		return ht
+	}
+
+	// mockRemoteWith registers a HashTreeLevel handler that answers using ht2.
+	// The mock receives the global discriminant (no HTTP extraction in mock path)
+	// so ht2.Level is the correct call to mirror what the real server does.
+	mockRemoteWith := func(f *fakeFactory, ht2 hashtree.AggregatedHashTree) {
+		f.RClient.EXPECT().HashTreeLevel(
+			mock.Anything, "B", class, shard, mock.Anything, mock.Anything,
+		).RunAndReturn(func(_ context.Context, _, _, _ string, level int, discriminant *hashtree.Bitset) ([]hashtree.Digest, error) {
+			digests := make([]hashtree.Digest, hashtree.LeavesCount(height))
+			n, err := ht2.Level(level, discriminant, digests)
+			return digests[:n], err
+		}).Maybe()
+	}
+
+	t.Run("NoDiff", func(t *testing.T) {
+		// Both trees are empty: roots are equal → ErrNoDiffFound after level 0.
+		f := newFakeFactory(t, class, shard, nodes, false)
+		finder := f.newFinder("A")
+
+		ht1 := makeTree(t)
+		ht2 := makeTree(t)
+		mockRemoteWith(f, ht2)
+
+		dr, err := finder.CollectShardDifferences(ctx, shard, ht1, 5*time.Second, nil, nil)
+		require.ErrorIs(t, err, replica.ErrNoDiffFound)
+		require.NotNil(t, dr)
+	})
+
+	t.Run("KnownDiff", func(t *testing.T) {
+		// Leaf 5 differs between ht1 and ht2. The skip-leaf optimisation means
+		// the reader covers a superset of the true diff; leaf 5 must be included.
+		f := newFakeFactory(t, class, shard, nodes, false)
+		finder := f.newFinder("A")
+
+		ht1 := makeTree(t)
+		ht2 := makeTree(t)
+		require.NoError(t, ht1.AggregateLeafWith(5, []byte("a")))
+		require.NoError(t, ht2.AggregateLeafWith(5, []byte("b")))
+		mockRemoteWith(f, ht2)
+
+		dr, err := finder.CollectShardDifferences(ctx, shard, ht1, 5*time.Second, nil, nil)
+		require.NoError(t, err)
+		require.NotNil(t, dr)
+		require.Equal(t, "B", dr.TargetNodeName)
+		require.Equal(t, "B", dr.TargetNodeAddress)
+		require.NotNil(t, dr.RangeReader)
+
+		// Drain the range reader. Leaf 5 must be covered by at least one range.
+		covered := false
+		for {
+			from, to, nextErr := dr.RangeReader.Next()
+			if errors.Is(nextErr, hashtree.ErrNoMoreRanges) {
+				break
+			}
+			require.NoError(t, nextErr)
+			if from <= 5 && 5 <= to {
+				covered = true
+			}
+		}
+		require.True(t, covered, "leaf 5 must be covered by at least one diff range")
+	})
+
+	t.Run("RemoteError", func(t *testing.T) {
+		// HashTreeLevel returns a transport error; CollectShardDifferences must
+		// propagate it (not silently treat the shard as in-sync).
+		f := newFakeFactory(t, class, shard, nodes, false)
+		finder := f.newFinder("A")
+
+		ht1 := makeTree(t)
+
+		f.RClient.EXPECT().HashTreeLevel(
+			mock.Anything, "B", class, shard, mock.Anything, mock.Anything,
+		).Return(nil, fmt.Errorf("connection refused")).Once()
+
+		_, err := finder.CollectShardDifferences(ctx, shard, ht1, 5*time.Second, nil, nil)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, replica.ErrNoDiffFound)
+	})
+
+	t.Run("DigestCountMismatch", func(t *testing.T) {
+		// Remote returns 0 digests when 1 is expected (height mismatch simulation).
+		// CollectShardDifferences must return an error rather than panicking or
+		// silently treating the shard as in-sync.
+		f := newFakeFactory(t, class, shard, nodes, false)
+		finder := f.newFinder("A")
+
+		ht1 := makeTree(t)
+		require.NoError(t, ht1.AggregateLeafWith(2, []byte("y")))
+
+		f.RClient.EXPECT().HashTreeLevel(
+			mock.Anything, "B", class, shard, mock.Anything, mock.Anything,
+		).Return([]hashtree.Digest{}, nil).Once()
+
+		_, err := finder.CollectShardDifferences(ctx, shard, ht1, 5*time.Second, nil, nil)
+		require.Error(t, err)
+		require.NotErrorIs(t, err, replica.ErrNoDiffFound)
+	})
+
+	t.Run("SkipCaseA_HashTreeRootUnchanged", func(t *testing.T) {
+		// Trees differ (leaf 5 has different data). Skip state carries the
+		// current roots with HadWork=true (objects were sent last cycle).
+		// CollectShardDifferences must return ErrHashtreeRootUnchanged after
+		// exactly one HashTreeLevel call (level 0 only — no deeper walk).
+		f := newFakeFactory(t, class, shard, nodes, false)
+		finder := f.newFinder("A")
+
+		ht1 := makeTree(t)
+		ht2 := makeTree(t)
+		require.NoError(t, ht1.AggregateLeafWith(5, []byte("a")))
+		require.NoError(t, ht2.AggregateLeafWith(5, []byte("b")))
+
+		localRoot := ht1.Root()
+		remoteRoot := ht2.Root()
+
+		// Expect exactly one HashTreeLevel call (level 0); deeper levels must
+		// not be reached.
+		f.RClient.EXPECT().HashTreeLevel(
+			mock.Anything, "B", class, shard, 0, mock.Anything,
+		).RunAndReturn(func(_ context.Context, _, _, _ string, level int, discriminant *hashtree.Bitset) ([]hashtree.Digest, error) {
+			digests := make([]hashtree.Digest, hashtree.LeavesCount(height))
+			n, err := ht2.Level(level, discriminant, digests)
+			return digests[:n], err
+		}).Once()
+
+		skipStates := map[string]replica.ShardDiffSkipState{
+			"B": {LocalRoot: localRoot, RemoteRoot: remoteRoot, HadWork: true},
+		}
+
+		dr, err := finder.CollectShardDifferences(ctx, shard, ht1, 5*time.Second, nil, skipStates)
+		require.ErrorIs(t, err, replica.ErrHashtreeRootUnchanged)
+		require.NotNil(t, dr)
+		require.Equal(t, "B", dr.TargetNodeName)
+		require.Equal(t, localRoot, dr.LocalHashtreeRoot)
+		require.Equal(t, remoteRoot, dr.RemoteHashtreeRoot)
+	})
+
+	t.Run("SkipCaseB_NoDiff", func(t *testing.T) {
+		// Trees differ (leaf 3 has different data). Skip state carries the
+		// current roots with HadWork=false (nothing was sent last cycle).
+		// CollectShardDifferences must return ErrNoDiffFound after exactly
+		// one HashTreeLevel call (level 0 only — the full walk is avoided).
+		//
+		// Note: Case B fires inside collectDiffForTargetNode and returns
+		// ErrNoDiffFound, which causes the outer loop to continue to the next
+		// target (correct: other targets may have real differences). With a
+		// single remote target the outer loop falls through to the final
+		// ErrNoDiffFound return, which carries an empty ShardDifferenceReader.
+		f := newFakeFactory(t, class, shard, nodes, false)
+		finder := f.newFinder("A")
+
+		ht1 := makeTree(t)
+		ht2 := makeTree(t)
+		require.NoError(t, ht1.AggregateLeafWith(3, []byte("x")))
+		require.NoError(t, ht2.AggregateLeafWith(3, []byte("y")))
+
+		localRoot := ht1.Root()
+		remoteRoot := ht2.Root()
+
+		// Expect exactly one HashTreeLevel call (level 0); deeper levels must
+		// not be reached because the skip fires after the root comparison.
+		f.RClient.EXPECT().HashTreeLevel(
+			mock.Anything, "B", class, shard, 0, mock.Anything,
+		).RunAndReturn(func(_ context.Context, _, _, _ string, level int, discriminant *hashtree.Bitset) ([]hashtree.Digest, error) {
+			digests := make([]hashtree.Digest, hashtree.LeavesCount(height))
+			n, err := ht2.Level(level, discriminant, digests)
+			return digests[:n], err
+		}).Once()
+
+		skipStates := map[string]replica.ShardDiffSkipState{
+			"B": {LocalRoot: localRoot, RemoteRoot: remoteRoot, HadWork: false},
+		}
+
+		_, err := finder.CollectShardDifferences(ctx, shard, ht1, 5*time.Second, nil, skipStates)
+		require.ErrorIs(t, err, replica.ErrNoDiffFound)
+	})
+
+	t.Run("NoSkipWhenRemoteRootChanged", func(t *testing.T) {
+		// Trees differ (leaf 7 has different data). Skip state carries a
+		// *stale* remote root (from before the remote flushed). The current
+		// remote root differs from the stored one, so neither Case A nor
+		// Case B applies. The full walk must proceed and find the diff.
+		f := newFakeFactory(t, class, shard, nodes, false)
+		finder := f.newFinder("A")
+
+		ht1 := makeTree(t)
+		ht2 := makeTree(t)
+		require.NoError(t, ht1.AggregateLeafWith(7, []byte("p")))
+		require.NoError(t, ht2.AggregateLeafWith(7, []byte("q")))
+
+		localRoot := ht1.Root()
+		// Use a zeroed digest to simulate a stale prior remote root that
+		// doesn't match ht2's current root.
+		staleRemoteRoot := hashtree.Digest{}
+
+		mockRemoteWith(f, ht2)
+
+		skipStates := map[string]replica.ShardDiffSkipState{
+			"B": {LocalRoot: localRoot, RemoteRoot: staleRemoteRoot, HadWork: true},
+		}
+
+		dr, err := finder.CollectShardDifferences(ctx, shard, ht1, 5*time.Second, nil, skipStates)
+		require.NoError(t, err)
+		require.NotNil(t, dr)
+		require.NotNil(t, dr.RangeReader)
+
+		covered := false
+		for {
+			from, to, nextErr := dr.RangeReader.Next()
+			if errors.Is(nextErr, hashtree.ErrNoMoreRanges) {
+				break
+			}
+			require.NoError(t, nextErr)
+			if from <= 7 && 7 <= to {
+				covered = true
+			}
+		}
+		require.True(t, covered, "leaf 7 must be covered when skip does not apply")
+	})
+
+	t.Run("SkipCaseA_MultiCycle", func(t *testing.T) {
+		// Verifies that Case A (ErrHashtreeRootUnchanged) fires on consecutive
+		// cycles when the remote root remains unchanged, i.e. that the caller's
+		// HadWork=true is correctly preserved between cycles and is not reset to
+		// false by the ErrHashtreeRootUnchanged return.
+		//
+		// Cycle 1: HadWork=true, remote root unchanged → Case A (level-0 only).
+		// Cycle 2: HadWork=true still (preserved), remote root still unchanged
+		//          → Case A again (level-0 only).
+		// Cycle 3: stale prior remote root (simulates remote flush) → no skip,
+		//          full walk finds diff at leaf 5.
+		f := newFakeFactory(t, class, shard, nodes, false)
+		finder := f.newFinder("A")
+
+		ht1 := makeTree(t)
+		ht2 := makeTree(t)
+		require.NoError(t, ht1.AggregateLeafWith(5, []byte("a")))
+		require.NoError(t, ht2.AggregateLeafWith(5, []byte("b")))
+
+		localRoot := ht1.Root()
+		remoteRoot := ht2.Root()
+
+		makeRemoteHandler := func() func(context.Context, string, string, string, int, *hashtree.Bitset) ([]hashtree.Digest, error) {
+			return func(_ context.Context, _, _, _ string, level int, discriminant *hashtree.Bitset) ([]hashtree.Digest, error) {
+				digests := make([]hashtree.Digest, hashtree.LeavesCount(height))
+				n, err := ht2.Level(level, discriminant, digests)
+				return digests[:n], err
+			}
+		}
+
+		// Cycles 1 & 2: only the level-0 call is expected (Case A fires before
+		// deeper levels are reached).
+		f.RClient.EXPECT().HashTreeLevel(
+			mock.Anything, "B", class, shard, 0, mock.Anything,
+		).RunAndReturn(makeRemoteHandler()).Once()
+		f.RClient.EXPECT().HashTreeLevel(
+			mock.Anything, "B", class, shard, 0, mock.Anything,
+		).RunAndReturn(makeRemoteHandler()).Once()
+
+		// Cycle 3: full walk after remote root changes.
+		f.RClient.EXPECT().HashTreeLevel(
+			mock.Anything, "B", class, shard, mock.Anything, mock.Anything,
+		).RunAndReturn(makeRemoteHandler()).Maybe()
+
+		// Cycle 1.
+		_, err := finder.CollectShardDifferences(ctx, shard, ht1, 5*time.Second, nil,
+			map[string]replica.ShardDiffSkipState{
+				"B": {LocalRoot: localRoot, RemoteRoot: remoteRoot, HadWork: true},
+			})
+		require.ErrorIs(t, err, replica.ErrHashtreeRootUnchanged, "cycle 1: expected Case A skip")
+
+		// Cycle 2: same skip state to simulate caller preserving HadWork=true.
+		_, err = finder.CollectShardDifferences(ctx, shard, ht1, 5*time.Second, nil,
+			map[string]replica.ShardDiffSkipState{
+				"B": {LocalRoot: localRoot, RemoteRoot: remoteRoot, HadWork: true},
+			})
+		require.ErrorIs(t, err, replica.ErrHashtreeRootUnchanged, "cycle 2: expected Case A skip")
+
+		// Cycle 3: stale prior remote root → skip does not apply → full walk.
+		dr, err := finder.CollectShardDifferences(ctx, shard, ht1, 5*time.Second, nil,
+			map[string]replica.ShardDiffSkipState{
+				"B": {LocalRoot: localRoot, RemoteRoot: hashtree.Digest{}, HadWork: true},
+			})
+		require.NoError(t, err, "cycle 3: expected full walk after flush")
+		require.NotNil(t, dr)
+		require.NotNil(t, dr.RangeReader)
+
+		covered := false
+		for {
+			from, to, nextErr := dr.RangeReader.Next()
+			if errors.Is(nextErr, hashtree.ErrNoMoreRanges) {
+				break
+			}
+			require.NoError(t, nextErr)
+			if from <= 5 && 5 <= to {
+				covered = true
+			}
+		}
+		require.True(t, covered, "leaf 5 must be covered when skip does not apply")
+	})
 }

--- a/usecases/replica/hashtree/aggregated_hashtree.go
+++ b/usecases/replica/hashtree/aggregated_hashtree.go
@@ -19,6 +19,10 @@ type AggregatedHashTree interface {
 	Sync()
 	Root() Digest
 	Level(level int, discriminant *Bitset, digests []Digest) (n int, err error)
+	// LevelLocal works like Level but interprets the discriminant as level-local:
+	// bit i corresponds to the i-th node at the given level (global index
+	// InnerNodesCount(level)+i). discriminant.Size() must equal LeavesCount(level).
+	LevelLocal(level int, discriminant *Bitset, digests []Digest) (n int, err error)
 	Reset()
 	Clone() AggregatedHashTree
 

--- a/usecases/replica/hashtree/bitset.go
+++ b/usecases/replica/hashtree/bitset.go
@@ -131,6 +131,21 @@ func (bset *Bitset) Unmarshal(b []byte) error {
 	return nil
 }
 
+// ExtractSlice returns a new Bitset of size count containing the bits at
+// positions [offset, offset+count) from this bitset. Used to produce a
+// level-local discriminant (size = nodesAtLevel(level)) from the full-tree
+// discriminant (size = NodesCount(height)) before sending it over the wire,
+// reducing per-call payload by a factor of (height+1) across a full traversal.
+func (bset *Bitset) ExtractSlice(offset, count int) *Bitset {
+	result := NewBitset(count)
+	for i := 0; i < count; i++ {
+		if bset.IsSet(offset + i) {
+			result.Set(i)
+		}
+	}
+	return result
+}
+
 func (bset *Bitset) Clone() *Bitset {
 	clone := &Bitset{
 		size:     bset.size,

--- a/usecases/replica/hashtree/bitset_test.go
+++ b/usecases/replica/hashtree/bitset_test.go
@@ -17,6 +17,91 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBitsetExtractSlice(t *testing.T) {
+	t.Run("BasicExtraction", func(t *testing.T) {
+		bset := NewBitset(10)
+		bset.Set(3)
+		bset.Set(5)
+		bset.Set(7)
+
+		// Extract bits [3, 8) → local indices 0,2,4 should be set
+		result := bset.ExtractSlice(3, 5)
+
+		require.Equal(t, 5, result.Size())
+		require.True(t, result.IsSet(0))  // global 3
+		require.False(t, result.IsSet(1)) // global 4
+		require.True(t, result.IsSet(2))  // global 5
+		require.False(t, result.IsSet(3)) // global 6
+		require.True(t, result.IsSet(4))  // global 7
+		require.Equal(t, 3, result.SetCount())
+	})
+
+	t.Run("CrossWordBoundary", func(t *testing.T) {
+		// Bits straddle the 64-bit word boundary at position 63/64
+		bset := NewBitset(128)
+		bset.Set(62)
+		bset.Set(63)
+		bset.Set(64)
+		bset.Set(65)
+
+		result := bset.ExtractSlice(60, 10)
+
+		require.Equal(t, 10, result.Size())
+		require.True(t, result.IsSet(2)) // global 62
+		require.True(t, result.IsSet(3)) // global 63
+		require.True(t, result.IsSet(4)) // global 64
+		require.True(t, result.IsSet(5)) // global 65
+		require.Equal(t, 4, result.SetCount())
+	})
+
+	t.Run("FullRange", func(t *testing.T) {
+		bset := NewBitset(8)
+		bset.Set(1)
+		bset.Set(4)
+		bset.Set(7)
+
+		result := bset.ExtractSlice(0, 8)
+
+		require.Equal(t, 8, result.Size())
+		require.Equal(t, 3, result.SetCount())
+		require.True(t, result.IsSet(1))
+		require.True(t, result.IsSet(4))
+		require.True(t, result.IsSet(7))
+	})
+
+	t.Run("EmptySlice", func(t *testing.T) {
+		bset := NewBitset(16)
+		bset.Set(5)
+
+		result := bset.ExtractSlice(0, 4) // does not include bit 5
+		require.Equal(t, 4, result.Size())
+		require.Equal(t, 0, result.SetCount())
+	})
+
+	t.Run("LevelLocalEquivalence", func(t *testing.T) {
+		// ExtractSlice(InnerNodesCount(l), LeavesCount(l)) must produce the
+		// same digest selection as a full-tree discriminant for level l.
+		height := 4
+		for level := 0; level <= height; level++ {
+			global := NewBitset(NodesCount(height))
+			// Set every other node at this level in the global discriminant
+			offset := InnerNodesCount(level)
+			count := LeavesCount(level) // nodesAtLevel(level)
+			for i := 0; i < count; i += 2 {
+				global.Set(offset + i)
+			}
+
+			local := global.ExtractSlice(offset, count)
+			require.Equal(t, count, local.Size())
+			require.Equal(t, (count+1)/2, local.SetCount()) // ceil(count/2)
+			for i := 0; i < count; i++ {
+				require.Equal(t, global.IsSet(offset+i), local.IsSet(i),
+					"level %d, node %d", level, i)
+			}
+		}
+	})
+}
+
 func TestBitSet(t *testing.T) {
 	bsetSize := 2 << 15
 

--- a/usecases/replica/hashtree/compact_hashtree.go
+++ b/usecases/replica/hashtree/compact_hashtree.go
@@ -121,6 +121,10 @@ func (ht *CompactHashTree) Level(level int, discriminant *Bitset, digests []Dige
 	return ht.hashtree.Level(level, discriminant, digests)
 }
 
+func (ht *CompactHashTree) LevelLocal(level int, discriminant *Bitset, digests []Digest) (n int, err error) {
+	return ht.hashtree.LevelLocal(level, discriminant, digests)
+}
+
 func (ht *CompactHashTree) Reset() {
 	ht.hashtree.Reset()
 }

--- a/usecases/replica/hashtree/hashtree.go
+++ b/usecases/replica/hashtree/hashtree.go
@@ -224,6 +224,51 @@ func (ht *HashTree) Level(level int, discriminant *Bitset, digests []Digest) (n 
 	return n, nil
 }
 
+// LevelLocal is like Level but the discriminant is level-local: its size must
+// be exactly nodesAtLevel(level) = LeavesCount(level), and bit i selects the
+// i-th node at the given level (global index InnerNodesCount(level)+i).
+// This avoids sending the full NodesCount(height)-sized discriminant over the
+// wire; callers use Bitset.ExtractSlice to produce the level-local view.
+func (ht *HashTree) LevelLocal(level int, discriminant *Bitset, digests []Digest) (n int, err error) {
+	ht.mux.Lock()
+	defer ht.mux.Unlock()
+
+	if level < 0 {
+		return 0, fmt.Errorf("%w: invalid level(%d)", ErrIllegalArguments, level)
+	}
+
+	if level > ht.height {
+		return 0, fmt.Errorf("%w: level(%d) is too high for current height(%d)", ErrIllegalState, level, ht.height)
+	}
+
+	if discriminant == nil {
+		return 0, fmt.Errorf("%w: nil discriminant provided", ErrIllegalArguments)
+	}
+
+	expectedSize := nodesAtLevel(level)
+	if discriminant.Size() != expectedSize {
+		return 0, fmt.Errorf("%w: discriminant size %d does not match expected %d for level %d",
+			ErrIllegalArguments, discriminant.Size(), expectedSize, level)
+	}
+
+	if len(digests) < expectedSize {
+		return 0, fmt.Errorf("%w: output buffer has not enough capacity", ErrIllegalArguments)
+	}
+
+	ht.sync()
+
+	offset := InnerNodesCount(level)
+
+	for i := 0; i < expectedSize; i++ {
+		if discriminant.IsSet(i) {
+			digests[n] = ht.nodes[offset+i]
+			n++
+		}
+	}
+
+	return n, nil
+}
+
 func (ht *HashTree) Clone() AggregatedHashTree {
 	ht.mux.Lock()
 	defer ht.mux.Unlock()

--- a/usecases/replica/hashtree/hashtree_test.go
+++ b/usecases/replica/hashtree/hashtree_test.go
@@ -129,6 +129,62 @@ func TestBigHashTree(t *testing.T) {
 	require.Equal(t, 1, n)
 }
 
+func TestLevelLocal(t *testing.T) {
+	height := 4
+
+	ht, err := NewHashTree(height)
+	require.NoError(t, err)
+
+	leavesCount := LeavesCount(height)
+	for i := 0; i < leavesCount; i++ {
+		err = ht.AggregateLeafWith(uint64(i), []byte(fmt.Sprintf("val%d", i)))
+		require.NoError(t, err)
+	}
+
+	digests1 := make([]Digest, leavesCount)
+	digests2 := make([]Digest, leavesCount)
+
+	for level := 0; level <= height; level++ {
+		t.Run(fmt.Sprintf("level%d", level), func(t *testing.T) {
+			// Build a global discriminant with every other node set at this level
+			global := NewBitset(NodesCount(height))
+			offset := InnerNodesCount(level)
+			count := LeavesCount(level) // nodesAtLevel(level)
+			for i := 0; i < count; i += 2 {
+				global.Set(offset + i)
+			}
+
+			// Level() with global discriminant
+			n1, err := ht.Level(level, global, digests1)
+			require.NoError(t, err)
+
+			// LevelLocal() with extracted level-local discriminant
+			local := global.ExtractSlice(offset, count)
+			n2, err := ht.LevelLocal(level, local, digests2)
+			require.NoError(t, err)
+
+			require.Equal(t, n1, n2)
+			require.Equal(t, digests1[:n1], digests2[:n2])
+		})
+	}
+
+	t.Run("SizeMismatch", func(t *testing.T) {
+		_, err := ht.LevelLocal(2, NewBitset(1), digests1)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	t.Run("NilDiscriminant", func(t *testing.T) {
+		_, err := ht.LevelLocal(0, nil, digests1)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	t.Run("LevelTooHigh", func(t *testing.T) {
+		local := NewBitset(LeavesCount(height + 1))
+		_, err := ht.LevelLocal(height+1, local, digests1)
+		require.ErrorIs(t, err, ErrIllegalState)
+	})
+}
+
 func TestHashTreeComparisonOneLeafAtATime(t *testing.T) {
 	height := 0
 

--- a/usecases/replica/mock_r_client.go
+++ b/usecases/replica/mock_r_client.go
@@ -173,6 +173,68 @@ func (_c *MockRClient_DigestObjectsInRange_Call) RunAndReturn(run func(context.C
 	return _c
 }
 
+// CompareDigests provides a mock function with given fields: ctx, host, index, shard, digests
+func (_m *MockRClient) CompareDigests(ctx context.Context, host string, index string, shard string, digests []types.RepairResponse) ([]types.RepairResponse, error) {
+	ret := _m.Called(ctx, host, index, shard, digests)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CompareDigests")
+	}
+
+	var r0 []types.RepairResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, []types.RepairResponse) ([]types.RepairResponse, error)); ok {
+		return rf(ctx, host, index, shard, digests)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, []types.RepairResponse) []types.RepairResponse); ok {
+		r0 = rf(ctx, host, index, shard, digests)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]types.RepairResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, []types.RepairResponse) error); ok {
+		r1 = rf(ctx, host, index, shard, digests)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockRClient_CompareDigests_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CompareDigests'
+type MockRClient_CompareDigests_Call struct {
+	*mock.Call
+}
+
+// CompareDigests is a helper method to define mock.On call
+//   - ctx context.Context
+//   - host string
+//   - index string
+//   - shard string
+//   - digests []types.RepairResponse
+func (_e *MockRClient_Expecter) CompareDigests(ctx interface{}, host interface{}, index interface{}, shard interface{}, digests interface{}) *MockRClient_CompareDigests_Call {
+	return &MockRClient_CompareDigests_Call{Call: _e.mock.On("CompareDigests", ctx, host, index, shard, digests)}
+}
+
+func (_c *MockRClient_CompareDigests_Call) Run(run func(ctx context.Context, host string, index string, shard string, digests []types.RepairResponse)) *MockRClient_CompareDigests_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].([]types.RepairResponse))
+	})
+	return _c
+}
+
+func (_c *MockRClient_CompareDigests_Call) Return(_a0 []types.RepairResponse, _a1 error) *MockRClient_CompareDigests_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockRClient_CompareDigests_Call) RunAndReturn(run func(context.Context, string, string, string, []types.RepairResponse) ([]types.RepairResponse, error)) *MockRClient_CompareDigests_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FetchObject provides a mock function with given fields: _a0, host, index, shard, id, props, _a6, numRetries
 func (_m *MockRClient) FetchObject(_a0 context.Context, host string, index string, shard string, id strfmt.UUID, props search.SelectProperties, _a6 additional.Properties, numRetries int) (Replica, error) {
 	ret := _m.Called(_a0, host, index, shard, id, props, _a6, numRetries)

--- a/usecases/replica/payload.go
+++ b/usecases/replica/payload.go
@@ -1,0 +1,40 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replica
+
+// DigestObjectsInRangeRecordLength is the size in bytes of a single binary
+// digest record used by the digestsInRange endpoint.
+// Each record encodes:
+//
+//	bytes  0–15  UUID (RFC-4122 binary form, big-endian)
+//	bytes 16–23  UpdateTime (int64 big-endian, Unix milliseconds)
+//
+// The Err and Deleted fields of RepairResponse are not part of the wire
+// format and are therefore omitted — ObjectDigestsInRange never populates them.
+const DigestObjectsInRangeRecordLength = 24
+
+// CompareDigestsRecordLength is the size in bytes of a single binary record
+// used by the compareDigests endpoint. Each record encodes:
+//
+//	bytes  0–15  UUID (RFC-4122 binary form, big-endian)
+//	bytes 16–23  UpdateTime (int64 big-endian, Unix milliseconds)
+//	byte    24   Flags (see CompareDigestsFlagDeleted)
+//
+// The Err field of RepairResponse is not part of the wire format.
+const CompareDigestsRecordLength = 25
+
+// CompareDigestsFlagDeleted is set in the flags byte (byte 24) of a
+// CompareDigests record when the target has determined that the source must
+// delete its copy of the object — either because a tombstone exists and the
+// DeleteOnConflict strategy is active, or because the tombstone timestamp
+// wins under TimeBasedResolution.
+const CompareDigestsFlagDeleted byte = 0x01

--- a/usecases/replica/transport.go
+++ b/usecases/replica/transport.go
@@ -32,13 +32,6 @@ const (
 	SchemaVersionKey = "schema_version"
 )
 
-// DigestObjectsInRangeRecordLength is the size in bytes of a single binary
-// record returned by the digestsInRange endpoint. Each record encodes a UUID
-// (16 bytes, RFC-4122 binary form) followed by the object's UpdateTime (8
-// bytes, int64 big-endian). The Err and Deleted fields of RepairResponse are
-// not populated by ObjectDigestsInRange and are therefore omitted.
-const DigestObjectsInRangeRecordLength = 24
-
 // Client is used to read and write objects on replicas
 type Client interface {
 	RClient
@@ -226,6 +219,15 @@ type RClient interface {
 	DigestObjectsInRange(ctx context.Context, host, index, shard string,
 		initialUUID, finalUUID strfmt.UUID, limit int) ([]types.RepairResponse, error)
 
+	// CompareDigests sends the source node's local digests to the target and
+	// receives back the subset requiring source-side action: missing objects
+	// (UpdateTime==0), stale objects (source strictly newer), and
+	// equal-timestamp conflicts so the source can apply a node-name tiebreaker.
+	// This collapses the O(N_remote_pages) nested HTTP scan in
+	// objectsToPropagateWithinRange to a single round-trip per local batch.
+	CompareDigests(ctx context.Context, host, index, shard string,
+		digests []types.RepairResponse) ([]types.RepairResponse, error)
+
 	HashTreeLevel(ctx context.Context, host, index, shard string, level int,
 		discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
 }
@@ -274,6 +276,16 @@ func (fc FinderClient) DigestObjectsInRange(ctx context.Context,
 	initialUUID, finalUUID strfmt.UUID, limit int,
 ) ([]types.RepairResponse, error) {
 	return fc.cl.DigestObjectsInRange(ctx, host, index, shard, initialUUID, finalUUID, limit)
+}
+
+// CompareDigests sends local digests to the target and returns those requiring
+// source-side action: missing objects, stale objects, and equal-timestamp
+// conflicts for node-name tiebreaking.
+func (fc FinderClient) CompareDigests(ctx context.Context,
+	host, index, shard string,
+	digests []types.RepairResponse,
+) ([]types.RepairResponse, error) {
+	return fc.cl.CompareDigests(ctx, host, index, shard, digests)
 }
 
 // FullReads read full objects

--- a/usecases/replica/types/mock_replicator.go
+++ b/usecases/replica/types/mock_replicator.go
@@ -271,6 +271,67 @@ func (_c *MockReplicator_DigestObjectsInRange_Call) RunAndReturn(run func(contex
 	return _c
 }
 
+// CompareDigests provides a mock function with given fields: ctx, className, shardName, digests
+func (_m *MockReplicator) CompareDigests(ctx context.Context, className string, shardName string, digests []routertypes.RepairResponse) ([]routertypes.RepairResponse, error) {
+	ret := _m.Called(ctx, className, shardName, digests)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CompareDigests")
+	}
+
+	var r0 []routertypes.RepairResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, []routertypes.RepairResponse) ([]routertypes.RepairResponse, error)); ok {
+		return rf(ctx, className, shardName, digests)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, []routertypes.RepairResponse) []routertypes.RepairResponse); ok {
+		r0 = rf(ctx, className, shardName, digests)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]routertypes.RepairResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, []routertypes.RepairResponse) error); ok {
+		r1 = rf(ctx, className, shardName, digests)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockReplicator_CompareDigests_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CompareDigests'
+type MockReplicator_CompareDigests_Call struct {
+	*mock.Call
+}
+
+// CompareDigests is a helper method to define mock.On call
+//   - ctx context.Context
+//   - className string
+//   - shardName string
+//   - digests []routertypes.RepairResponse
+func (_e *MockReplicator_Expecter) CompareDigests(ctx interface{}, className interface{}, shardName interface{}, digests interface{}) *MockReplicator_CompareDigests_Call {
+	return &MockReplicator_CompareDigests_Call{Call: _e.mock.On("CompareDigests", ctx, className, shardName, digests)}
+}
+
+func (_c *MockReplicator_CompareDigests_Call) Run(run func(ctx context.Context, className string, shardName string, digests []routertypes.RepairResponse)) *MockReplicator_CompareDigests_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].([]routertypes.RepairResponse))
+	})
+	return _c
+}
+
+func (_c *MockReplicator_CompareDigests_Call) Return(result []routertypes.RepairResponse, err error) *MockReplicator_CompareDigests_Call {
+	_c.Call.Return(result, err)
+	return _c
+}
+
+func (_c *MockReplicator_CompareDigests_Call) RunAndReturn(run func(context.Context, string, string, []routertypes.RepairResponse) ([]routertypes.RepairResponse, error)) *MockReplicator_CompareDigests_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // FetchObject provides a mock function with given fields: ctx, className, shardName, id
 func (_m *MockReplicator) FetchObject(ctx context.Context, className string, shardName string, id strfmt.UUID) (replica.Replica, error) {
 	ret := _m.Called(ctx, className, shardName, id)

--- a/usecases/replica/types/replicator.go
+++ b/usecases/replica/types/replicator.go
@@ -41,6 +41,13 @@ type Replicator interface {
 	DigestObjects(ctx context.Context, className, shardName string, ids []strfmt.UUID) (result []types.RepairResponse, err error)
 	DigestObjectsInRange(ctx context.Context, className, shardName string,
 		initialUUID, finalUUID strfmt.UUID, limit int) (result []types.RepairResponse, err error)
+	// CompareDigests receives the source node's local digests and returns the
+	// subset that requires attention on the source side: objects missing from
+	// this node (UpdateTime==0), objects stale on this node (source has a
+	// strictly newer UpdateTime), and equal-timestamp conflicts (both nodes
+	// hold the same UpdateTime) so the source can apply a node-name tiebreaker.
+	CompareDigests(ctx context.Context, className, shardName string,
+		digests []types.RepairResponse) ([]types.RepairResponse, error)
 	HashTreeLevel(ctx context.Context, className, shardName string,
 		level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
 }


### PR DESCRIPTION
### What's being changed:

This pull request adds a new binary protocol endpoint for efficiently comparing object digests between replica nodes, along with comprehensive client and server support, and full test coverage. The main goal is to enable a source node to send its local object digests to a target node and receive only the actionable differences (missing, stale, or deleted objects), using a compact wire format for performance.

The most important changes are:

**Replication Client and Protocol Implementation**
- Added `CompareDigests` method to `replicationClient`, which sends a binary-encoded list of digests to a target node and decodes the binary response, returning only those digests that require action (missing, stale, or tombstoned objects). This uses a fixed 25-byte record format for each digest.
- Implemented `readCompareDigestsBinaryStream` helper to decode the binary response from the target node, extracting the actionable digests and handling the deleted flag.

**Server Handler and Routing**
- Introduced the `/objects/compareDigests` POST endpoint, with a handler (`postCompareDigests`) that decodes the binary request, delegates to the replicator's `CompareDigests`, and encodes the binary response. The endpoint enforces a 4 MiB request size limit and validates the binary payload. [[1]](diffhunk://#diff-edda0c88ff94e97f6c3ac75f5476b8e85ae1d1f388fc2a8282e31d3790c8232fR75-R77) [[2]](diffhunk://#diff-edda0c88ff94e97f6c3ac75f5476b8e85ae1d1f388fc2a8282e31d3790c8232fR89-R90) [[3]](diffhunk://#diff-edda0c88ff94e97f6c3ac75f5476b8e85ae1d1f388fc2a8282e31d3790c8232fR248-R255) [[4]](diffhunk://#diff-edda0c88ff94e97f6c3ac75f5476b8e85ae1d1f388fc2a8282e31d3790c8232fR554-R641)
- Updated the fake replicator used in tests to implement a stub `CompareDigests` method for compatibility.

**Testing**
- Added a comprehensive test suite for the replication client's `CompareDigests` method, covering binary encoding/decoding, response handling (including deleted flags), error scenarios, and integration with the new endpoint.
- Extended the maintenance mode tests to include the new `/objects/compareDigests` endpoint.

**Supporting Changes**
- Updated imports and utility code to support the new protocol and tests, including binary and UUID handling. [[1]](diffhunk://#diff-58fbff669f58982f32d3c23e449466ead5029fbcb632aacc7f032dda37e5a155R17-R20) [[2]](diffhunk://#diff-58fbff669f58982f32d3c23e449466ead5029fbcb632aacc7f032dda37e5a155R29-R37)

These changes together provide a robust, efficient, and well-tested mechanism for replica nodes to synchronize object state using a binary protocol.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
