### PR TITLE
fix: nil pointer panic in UpdateLastUsedTimestamp for unknown users

### DIFF
--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -314,6 +314,18 @@ func TestLastUsedTime(t *testing.T) {
 	require.Equal(t, user[userId].LastUsedAt, updateTime)
 }
 
+func TestUpdateLastUsedTimestamp_NonExistentUser(t *testing.T) {
+	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	require.NoError(t, err)
+
+	// Should not panic when updating timestamp for a user that doesn't exist
+	require.NotPanics(t, func() {
+		dynUsers.UpdateLastUsedTimestamp(map[string]time.Time{
+			"non-existent-user": time.Now(),
+		})
+	})
+}
+
 func TestImportingAndSuspendingStaticKeys(t *testing.T) {
 	dynUsers, err := NewDBUser(t.TempDir(), true, log)
 	require.NoError(t, err)

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -317,10 +317,16 @@ func (c *DBUser) UpdateLastUsedTimestamp(users map[string]time.Time) {
 	defer c.lock.RUnlock()
 
 	for userID, lastUsed := range users {
-		if c.data.Users[userID].LastUsedAt.Before(lastUsed) {
-			c.data.Users[userID].Lock()
-			c.data.Users[userID].LastUsedAt = lastUsed
-			c.data.Users[userID].Unlock()
+		user, ok := c.data.Users[userID]
+		if !ok {
+			continue
+		}
+		if user.LastUsedAt.Before(lastUsed) {
+			func() {
+				user.Lock()
+				defer user.Unlock()
+				user.LastUsedAt = lastUsed
+			}()
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Fixes a nil pointer dereference panic in `DBUser.UpdateLastUsedTimestamp` that crashes all nodes when the usage metrics logic runs and encounters a user ID that doesn't exist in the local user map.

## Root Cause

`UpdateLastUsedTimestamp` receives a map of user IDs and timestamps from remote nodes via the cluster API (`RemoteApiKey.GetUserStatus`). It accesses `c.data.Users[userID]` (a `map[string]*User`) without checking for nil. When a user ID exists on one node but not locally (e.g., recently deleted user, or RAFT state not yet fully synced), the map returns `nil` and `.LastUsedAt.Before(lastUsed)` panics.

This was observed in production on v1.36.6 across all three nodes in a WCD cluster, causing pod restarts and user impact. The secondary panics seen in the replication path (`putOverwriteObjects`/`Unmarshal`) were collateral from the node crash-restart turbulence.

## Fix

Added a nil guard: if the user ID is not present locally, skip the update. This is correct behavior — we should not update timestamps for users we don't know about.

## Test plan

- [x] Added `TestUpdateLastUsedTimestamp_NonExistentUser` that verifies no panic when updating timestamps for non-existent users
- [x] Existing `TestLastUsedTime` continues to pass (normal update flow unaffected)
- [x] Full `apikey` package test suite passes with `-race` (18/18 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)