### PR TITLE
feat: add name to CycleManager with start/stop logging

### DIFF
--- a/adapters/repos/db/index_cyclecallbacks.go
+++ b/adapters/repos/db/index_cyclecallbacks.go
@@ -48,9 +48,12 @@ func (index *Index) initCycleCallbacks() {
 		vectorTombstoneCleanupIntervalSeconds = hnswUserConfig.CleanupIntervalSeconds
 	}
 
-	id := func(elems ...string) string {
-		elems = append([]string{"index", index.ID()}, elems...)
+	cm := func(elems ...string) string {
+		elems = append([]string{index.ID()}, elems...)
 		return strings.Join(elems, "/")
+	}
+	id := func(elems ...string) string {
+		return "index/" + cm(elems...)
 	}
 
 	var compactionCycle cyclemanager.CycleManager
@@ -61,26 +64,27 @@ func (index *Index) initCycleCallbacks() {
 	if !index.Config.SeparateObjectsCompactions {
 		compactionCallbacks = cyclemanager.NewCallbackGroup(id("compaction"), index.logger, routinesN)
 		compactionCycle = cyclemanager.NewManager(
+			cm("compaction"),
 			cyclemanager.CompactionCycleTicker(),
 			compactionCallbacks.CycleCallback, index.logger)
 		compactionAuxCycle = cyclemanager.NewManagerNoop()
 	} else {
-		routinesNDiv2 := routinesN / 2
-		if routinesNDiv2 < 1 {
-			routinesNDiv2 = 1
-		}
+		routinesNDiv2 := max(routinesN/2, 1)
 		compactionCallbacks = cyclemanager.NewCallbackGroup(id("compaction-non-objects"), index.logger, routinesNDiv2)
 		compactionCycle = cyclemanager.NewManager(
+			cm("compaction-non-objects"),
 			cyclemanager.CompactionCycleTicker(),
 			compactionCallbacks.CycleCallback, index.logger)
 		compactionAuxCallbacks = cyclemanager.NewCallbackGroup(id("compaction-objects"), index.logger, routinesNDiv2)
 		compactionAuxCycle = cyclemanager.NewManager(
+			cm("compaction-objects"),
 			cyclemanager.CompactionCycleTicker(),
 			compactionAuxCallbacks.CycleCallback, index.logger)
 	}
 
 	flushCallbacks := cyclemanager.NewCallbackGroup(id("flush"), index.logger, routinesN)
 	flushCycle := cyclemanager.NewManager(
+		cm("flush"),
 		cyclemanager.MemtableFlushCycleTicker(),
 		flushCallbacks.CycleCallback, index.logger)
 
@@ -102,21 +106,25 @@ func (index *Index) initCycleCallbacks() {
 	// update: switched to dynamic intervals with values between 500ms and 10s
 	// introduced to address https://github.com/weaviate/weaviate/issues/2783
 	vectorCommitLoggerCycle := cyclemanager.NewManager(
+		cm("vector", "commit_logger"),
 		cyclemanager.HnswCommitLoggerCycleTicker(),
 		vectorCommitLoggerCallbacks.CycleCallback, index.logger)
 
 	vectorTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup(id("vector", "tombstone_cleanup"), index.logger, routinesN)
 	vectorTombstoneCleanupCycle := cyclemanager.NewManager(
+		cm("vector", "tombstone_cleanup"),
 		cyclemanager.NewFixedTicker(time.Duration(vectorTombstoneCleanupIntervalSeconds)*time.Second),
 		vectorTombstoneCleanupCallbacks.CycleCallback, index.logger)
 
 	geoPropsCommitLoggerCallbacks := cyclemanager.NewCallbackGroup(id("geo_props", "commit_logger"), index.logger, routinesN)
 	geoPropsCommitLoggerCycle := cyclemanager.NewManager(
+		cm("geo_props", "commit_logger"),
 		cyclemanager.GeoCommitLoggerCycleTicker(),
 		geoPropsCommitLoggerCallbacks.CycleCallback, index.logger)
 
 	geoPropsTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup(id("geo_props", "tombstone_cleanup"), index.logger, routinesN)
 	geoPropsTombstoneCleanupCycle := cyclemanager.NewManager(
+		cm("geo_props", "tombstone_cleanup"),
 		cyclemanager.NewFixedTicker(hnsw.DefaultCleanupIntervalSeconds*time.Second),
 		geoPropsTombstoneCleanupCallbacks.CycleCallback, index.logger)
 

--- a/adapters/repos/db/lsmkv/bucket_threshold_test.go
+++ b/adapters/repos/db/lsmkv/bucket_threshold_test.go
@@ -44,7 +44,7 @@ func TestWriteAheadLogThreshold_Replace(t *testing.T) {
 	tolerance := 4.
 
 	flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
-	flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
+	flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
 	flushCycle.Start()
 
 	bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -148,7 +148,7 @@ func TestMemtableThreshold_Replace(t *testing.T) {
 	tolerance := 4.
 
 	flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
-	flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
+	flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
 	flushCycle.Start()
 
 	bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -243,7 +243,7 @@ func TestMemtableFlushesIfDirty(t *testing.T) {
 		dirName := t.TempDir()
 
 		flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
-		flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
+		flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
 		flushCycle.Start()
 
 		bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -288,7 +288,7 @@ func TestMemtableFlushesIfDirty(t *testing.T) {
 		dirName := t.TempDir()
 
 		flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
-		flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
+		flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
 		flushCycle.Start()
 
 		bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,
@@ -337,7 +337,7 @@ func TestMemtableFlushesIfDirty(t *testing.T) {
 		dirName := t.TempDir()
 
 		flushCallbacks := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
-		flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
+		flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
 		flushCycle.Start()
 
 		bucket, err := NewBucketCreator().NewBucket(testCtx(), dirName, "", nullLogger(), nil,

--- a/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
+++ b/adapters/repos/db/lsmkv/concurrent_writing_integration_test.go
@@ -137,6 +137,7 @@ func TestConcurrentWriting_Set(t *testing.T) {
 
 	flushGroup := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
 	cyclemanager.NewManager(
+		"flush",
 		cyclemanager.NewFixedTicker(5*time.Millisecond),
 		flushGroup.CycleCallback,
 		nullLogger()).Start()
@@ -231,6 +232,7 @@ func TestConcurrentWriting_RoaringSet(t *testing.T) {
 
 	flushGroup := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
 	cyclemanager.NewManager(
+		"flush",
 		cyclemanager.NewFixedTicker(5*time.Millisecond),
 		flushGroup.CycleCallback,
 		logger).Start()
@@ -320,6 +322,7 @@ func TestConcurrentWriting_RoaringSetRange(t *testing.T) {
 
 	flushGroup := cyclemanager.NewCallbackGroup("flush", nullLogger(), 1)
 	cyclemanager.NewManager(
+		"flush",
 		cyclemanager.NewFixedTicker(5*time.Millisecond),
 		flushGroup.CycleCallback,
 		nullLogger()).Start()

--- a/adapters/repos/db/vector/hnsw/backup_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/backup_integration_test.go
@@ -43,6 +43,7 @@ func TestBackup_Integration(t *testing.T) {
 
 	parentCommitLoggerCallbacks := cyclemanager.NewCallbackGroup("parentCommitLogger", logger, 1)
 	parentCommitLoggerCycle := cyclemanager.NewManager(
+		"commit-logger",
 		cyclemanager.HnswCommitLoggerCycleTicker(),
 		parentCommitLoggerCallbacks.CycleCallback, logger)
 	parentCommitLoggerCycle.Start()
@@ -52,6 +53,7 @@ func TestBackup_Integration(t *testing.T) {
 
 	parentTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup("parentTombstoneCleanup", logger, 1)
 	parentTombstoneCleanupCycle := cyclemanager.NewManager(
+		"tombstone-cleanup",
 		cyclemanager.NewFixedTicker(enthnsw.DefaultCleanupIntervalSeconds*time.Second),
 		parentTombstoneCleanupCallbacks.CycleCallback, logger)
 	parentTombstoneCleanupCycle.Start()

--- a/adapters/repos/db/vector/hnsw/commit_logger_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_test.go
@@ -174,7 +174,7 @@ func createTestCommitLoggerWithOptions(t *testing.T, scratchDir string, name str
 	logger, _ := test.NewNullLogger()
 	cbg := cyclemanager.NewCallbackGroup("test", logger, 10)
 	ticker := cyclemanager.NewLinearTicker(50*time.Millisecond, 60*time.Millisecond, 1)
-	cm := cyclemanager.NewManager(ticker, cbg.CycleCallback, logger)
+	cm := cyclemanager.NewManager("commit-logger", ticker, cbg.CycleCallback, logger)
 	cl, err := NewCommitLogger(scratchDir, name, logger, cbg, options...)
 	require.Nil(t, err)
 	cl.InitMaintenance()

--- a/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
+++ b/adapters/repos/db/vector/hnsw/index_too_many_links_bug_integration_test.go
@@ -54,6 +54,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 
 	parentCommitLoggerCallbacks := cyclemanager.NewCallbackGroup("parentCommitLogger", logger, 1)
 	parentCommitLoggerCycle := cyclemanager.NewManager(
+		"commit-logger",
 		cyclemanager.HnswCommitLoggerCycleTicker(),
 		parentCommitLoggerCallbacks.CycleCallback, logger)
 	parentCommitLoggerCycle.Start()
@@ -63,6 +64,7 @@ func Test_NoRace_ManySmallCommitlogs(t *testing.T) {
 
 	parentTombstoneCleanupCallbacks := cyclemanager.NewCallbackGroup("parentTombstoneCleanup", logger, 1)
 	parentTombstoneCleanupCycle := cyclemanager.NewManager(
+		"tombstone-cleanup",
 		cyclemanager.NewFixedTicker(1),
 		parentTombstoneCleanupCallbacks.CycleCallback, logger)
 	parentTombstoneCleanupCycle.Start()

--- a/adapters/repos/db/vector/hnsw/periodic_tombstone_removal_test.go
+++ b/adapters/repos/db/vector/hnsw/periodic_tombstone_removal_test.go
@@ -37,6 +37,7 @@ func TestPeriodicTombstoneRemoval(t *testing.T) {
 	cleanupIntervalSeconds := 1
 	tombstoneCallbacks := cyclemanager.NewCallbackGroup("tombstone", logger, 1)
 	tombstoneCleanupCycle := cyclemanager.NewManager(
+		"tombstone-cleanup",
 		cyclemanager.NewFixedTicker(time.Duration(cleanupIntervalSeconds)*time.Second),
 		tombstoneCallbacks.CycleCallback, logger)
 	tombstoneCleanupCycle.Start()
@@ -103,6 +104,7 @@ func TestTombstoneCleanupBlockedUntilCachePrefilled(t *testing.T) {
 	cleanupIntervalSeconds := 1
 	tombstoneCallbacks := cyclemanager.NewCallbackGroup("tombstone", logger, 1)
 	tombstoneCleanupCycle := cyclemanager.NewManager(
+		"tombstone-cleanup",
 		cyclemanager.NewFixedTicker(time.Duration(cleanupIntervalSeconds)*time.Second),
 		tombstoneCallbacks.CycleCallback, logger)
 	tombstoneCleanupCycle.Start()

--- a/entities/cyclemanager/cyclecallbackctrl_test.go
+++ b/entities/cyclemanager/cyclecallbackctrl_test.go
@@ -40,7 +40,7 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCombinedCallbackCtrl(2, logger, ctrl1, ctrl2)
 
-		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
+		cycle := NewManager("test", NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -70,7 +70,7 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCombinedCallbackCtrl(2, logger, ctrl1, ctrl2)
 
-		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
+		cycle := NewManager("test", NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -99,7 +99,7 @@ func TestCycleCombineCallbackCtrl_Unregister(t *testing.T) {
 		ctrlLong := callbacks.Register("long", callbackLong)
 		combinedCtrl := NewCombinedCallbackCtrl(2, logger, ctrlShort, ctrlLong)
 
-		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
+		cycle := NewManager("test", NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -138,7 +138,7 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCombinedCallbackCtrl(2, logger, ctrl1, ctrl2)
 
-		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
+		cycle := NewManager("test", NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -168,7 +168,7 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		ctrl2 := callbacks.Register("c2", callback2)
 		combinedCtrl := NewCombinedCallbackCtrl(2, logger, ctrl1, ctrl2)
 
-		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
+		cycle := NewManager("test", NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -197,7 +197,7 @@ func TestCycleCombineCallbackCtrl_Deactivate(t *testing.T) {
 		ctrlLong := callbacks.Register("long", callbackLong)
 		combinedCtrl := NewCombinedCallbackCtrl(2, logger, ctrlShort, ctrlLong)
 
-		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
+		cycle := NewManager("test", NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 
@@ -236,7 +236,7 @@ func TestCycleCombineCallbackCtrl_Activate(t *testing.T) {
 		ctrl2 := callbacks.Register("c2", callback2, AsInactive())
 		combinedCtrl := NewCombinedCallbackCtrl(2, logger, ctrl1, ctrl2)
 
-		cycle := NewManager(NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
+		cycle := NewManager("test", NewFixedTicker(100*time.Millisecond), callbacks.CycleCallback, logger)
 		cycle.Start()
 		defer cycle.StopAndWait(ctx)
 

--- a/entities/cyclemanager/cyclecallbackgroup_test.go
+++ b/entities/cyclemanager/cyclecallbackgroup_test.go
@@ -238,7 +238,7 @@ func TestCycleCallback_Parallel(t *testing.T) {
 		// should be called with 60, 60, ... intervals
 		callbacks.Register("c3", callback3, WithIntervals(intervals3))
 
-		cm := NewManager(ticker, callbacks.CycleCallback, logger)
+		cm := NewManager("test", ticker, callbacks.CycleCallback, logger)
 		cm.Start()
 		time.Sleep(400 * time.Millisecond)
 		cm.StopAndWait(context.Background())
@@ -1233,7 +1233,7 @@ func TestCycleCallback_Sequential(t *testing.T) {
 		// should be called with 60, 60, ... intervals
 		callbacks.Register("c3", callback3, WithIntervals(intervals3))
 
-		cm := NewManager(ticker, callbacks.CycleCallback, logger)
+		cm := NewManager("test", ticker, callbacks.CycleCallback, logger)
 		cm.Start()
 		time.Sleep(400 * time.Millisecond)
 		cm.StopAndWait(context.Background())

--- a/entities/cyclemanager/cyclemanager.go
+++ b/entities/cyclemanager/cyclemanager.go
@@ -38,6 +38,7 @@ type CycleManager interface {
 type cycleManager struct {
 	sync.RWMutex
 
+	name          string
 	cycleCallback CycleCallback
 	cycleTicker   CycleTicker
 	running       bool
@@ -49,8 +50,9 @@ type cycleManager struct {
 	logger logrus.FieldLogger
 }
 
-func NewManager(cycleTicker CycleTicker, cycleCallback CycleCallback, logger logrus.FieldLogger) CycleManager {
+func NewManager(name string, cycleTicker CycleTicker, cycleCallback CycleCallback, logger logrus.FieldLogger) CycleManager {
 	return &cycleManager{
+		name:          name,
 		cycleCallback: cycleCallback,
 		cycleTicker:   cycleTicker,
 		running:       false,
@@ -66,8 +68,11 @@ func (c *cycleManager) Start() {
 	defer c.Unlock()
 
 	if c.running {
+		c.logger.WithFields(logrus.Fields{"name": c.name, "action": "cyclemanager"}).Info("cycle manager not started, already running")
 		return
 	}
+
+	c.logger.WithFields(logrus.Fields{"name": c.name, "action": "cyclemanager"}).Info("cycle manager started")
 
 	enterrors.GoWrapper(func() {
 		c.cycleTicker.Start()
@@ -196,6 +201,9 @@ func (c *cycleManager) handleStopRequest(stopped bool) {
 	c.running = !stopped
 	c.stopContexts = nil
 	c.stopResults = nil
+	if stopped {
+		c.logger.WithFields(logrus.Fields{"name": c.name, "action": "cyclemanager"}).Info("cycle manager stopped")
+	}
 }
 
 func NewManagerNoop() CycleManager {

--- a/entities/cyclemanager/cyclemanager_test.go
+++ b/entities/cyclemanager/cyclemanager_test.go
@@ -74,7 +74,7 @@ func TestCycleManager_beforeTimeout(t *testing.T) {
 	var cm CycleManager
 
 	t.Run("create new", func(t *testing.T) {
-		cm = NewManager(NewFixedTicker(cycleInterval), p.cycleCallback, logger)
+		cm = NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
 		assert.False(t, cm.Running())
 	})
@@ -112,7 +112,7 @@ func TestCycleManager_beforeTimeoutWithWait(t *testing.T) {
 	var cm CycleManager
 
 	t.Run("create new", func(t *testing.T) {
-		cm = NewManager(NewFixedTicker(cycleInterval), p.cycleCallback, logger)
+		cm = NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
 		assert.False(t, cm.Running())
 	})
@@ -142,7 +142,7 @@ func TestCycleManager_timeout(t *testing.T) {
 	stopTimeout := 12 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	cm := NewManager(NewFixedTicker(cycleInterval), p.cycleCallback, logger)
+	cm := NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
 	t.Run("timeout is reached", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
@@ -179,7 +179,7 @@ func TestCycleManager_timeoutWithWait(t *testing.T) {
 	stopTimeout := 12 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	cm := NewManager(NewFixedTicker(cycleInterval), p.cycleCallback, logger)
+	cm := NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
 	t.Run("timeout is reached", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
@@ -210,7 +210,7 @@ func TestCycleManager_doesNotStartMultipleTimes(t *testing.T) {
 	startCount := 5
 
 	p := newProvider(cycleDuration, uint(startCount))
-	cm := NewManager(NewFixedTicker(cycleInterval), p.cycleCallback, logger)
+	cm := NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
 	t.Run("multiple starts", func(t *testing.T) {
 		for i := 0; i < startCount; i++ {
@@ -234,7 +234,7 @@ func TestCycleManager_doesNotStartMultipleTimesWithWait(t *testing.T) {
 	startCount := 5
 
 	p := newProvider(cycleDuration, uint(startCount))
-	cm := NewManager(NewFixedTicker(cycleInterval), p.cycleCallback, logger)
+	cm := NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
 	t.Run("multiple starts", func(t *testing.T) {
 		for i := 0; i < startCount; i++ {
@@ -258,7 +258,7 @@ func TestCycleManager_handlesMultipleStops(t *testing.T) {
 	stopCount := 5
 
 	p := newProvider(cycleDuration, 1)
-	cm := NewManager(NewFixedTicker(cycleInterval), p.cycleCallback, logger)
+	cm := NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
 	t.Run("multiple stops", func(t *testing.T) {
 		cm.Start()
@@ -283,7 +283,7 @@ func TestCycleManager_stopsIfNotAllContextsAreCancelled(t *testing.T) {
 	stopTimeout := 5 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	cm := NewManager(NewFixedTicker(cycleInterval), p.cycleCallback, logger)
+	cm := NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
 	t.Run("multiple stops, few cancelled", func(t *testing.T) {
 		timeout1Ctx, cancel1 := context.WithTimeout(context.Background(), stopTimeout)
@@ -314,7 +314,7 @@ func TestCycleManager_doesNotStopIfAllContextsAreCancelled(t *testing.T) {
 	stopTimeout := 50 * time.Millisecond
 
 	p := newProvider(cycleDuration, 1)
-	cm := NewManager(NewFixedTicker(cycleInterval), p.cycleCallback, logger)
+	cm := NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
 	t.Run("multiple stops, few cancelled", func(t *testing.T) {
 		timeout1Ctx, cancel1 := context.WithTimeout(context.Background(), stopTimeout)
@@ -354,7 +354,7 @@ func TestCycleManager_cycleCallbackStoppedDueToFrequentStopChecks(t *testing.T) 
 
 	// despite cycleDuration is 30ms, cycle callback checks every 20ms (300/15) if it needs to be stopped
 	p := newProviderAbortable(cycleDuration, 1, 15)
-	cm := NewManager(NewFixedTicker(cycleInterval), p.cycleCallback, logger)
+	cm := NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
 	t.Run("cycle function stopped before timeout reached", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
@@ -384,7 +384,7 @@ func TestCycleManager_cycleCallbackNotStoppedDueToRareStopChecks(t *testing.T) {
 
 	// despite cycleDuration is 30ms, cycle callback checks every 150ms (300/2) if it needs to be stopped
 	p := newProviderAbortable(cycleDuration, 1, 2)
-	cm := NewManager(NewFixedTicker(cycleInterval), p.cycleCallback, logger)
+	cm := NewManager("test", NewFixedTicker(cycleInterval), p.cycleCallback, logger)
 
 	t.Run("timeout reached", func(t *testing.T) {
 		timeoutCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)

--- a/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv/replace_bucket_acceptance_test.go
@@ -47,9 +47,9 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 
 	flushCallbacks := cyclemanager.NewCallbackGroup("flush", logger, 1)
 	compactionCallbacks := cyclemanager.NewCallbackGroup("compaction", logger, 1)
-	flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
+	flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
 	flushCycle.Start()
-	compactionCycle := cyclemanager.NewManager(cyclemanager.CompactionCycleTicker(), compactionCallbacks.CycleCallback, logger)
+	compactionCycle := cyclemanager.NewManager("compaction", cyclemanager.CompactionCycleTicker(), compactionCallbacks.CycleCallback, logger)
 	compactionCycle.Start()
 
 	bucket, err := c.NewBucket(ctx, filepath.Join(dir, "my-bucket"), "", logger, nil,

--- a/test/acceptance_lsmkv_long_running/replace_bucket_acceptance_test.go
+++ b/test/acceptance_lsmkv_long_running/replace_bucket_acceptance_test.go
@@ -58,9 +58,9 @@ func TestLSMKV_ReplaceBucket(t *testing.T) {
 
 	flushCallbacks := cyclemanager.NewCallbackGroup("flush", logger, 1)
 	compactionCallbacks := cyclemanager.NewCallbackGroup("compaction", logger, 1)
-	flushCycle := cyclemanager.NewManager(cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
+	flushCycle := cyclemanager.NewManager("flush", cyclemanager.MemtableFlushCycleTicker(), flushCallbacks.CycleCallback, logger)
 	flushCycle.Start()
-	compactionCycle := cyclemanager.NewManager(cyclemanager.CompactionCycleTicker(), compactionCallbacks.CycleCallback, logger)
+	compactionCycle := cyclemanager.NewManager("compaction", cyclemanager.CompactionCycleTicker(), compactionCallbacks.CycleCallback, logger)
 	compactionCycle.Start()
 
 	logger.Info("loading bucket")


### PR DESCRIPTION
### What's being changed:

NewManager now accepts a name as its first argument. The name is included in info-level log entries emitted when a cycle manager starts, stops, or is skipped because it is already running. All log entries carry "name" and "action" fields.


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
