### PR TITLE
Fix cycle callbacks to include dynamic index

### DIFF
--- a/adapters/repos/db/index_cyclecallbacks.go
+++ b/adapters/repos/db/index_cyclecallbacks.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
+	dynamicent "github.com/weaviate/weaviate/entities/vectorindex/dynamic"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 )
 
@@ -44,8 +45,11 @@ func (index *Index) initCycleCallbacks() {
 	routinesN := concurrency.TimesNUMCPU(index.Config.CycleManagerRoutinesFactor)
 
 	vectorTombstoneCleanupIntervalSeconds := hnsw.DefaultCleanupIntervalSeconds
-	if hnswUserConfig, ok := index.GetVectorIndexConfig("").(hnsw.UserConfig); ok {
-		vectorTombstoneCleanupIntervalSeconds = hnswUserConfig.CleanupIntervalSeconds
+	switch cfg := index.GetVectorIndexConfig("").(type) {
+	case hnsw.UserConfig:
+		vectorTombstoneCleanupIntervalSeconds = cfg.CleanupIntervalSeconds
+	case dynamicent.UserConfig:
+		vectorTombstoneCleanupIntervalSeconds = cfg.HnswUC.CleanupIntervalSeconds
 	}
 
 	id := func(elems ...string) string {

--- a/adapters/repos/db/shard_init_vector.go
+++ b/adapters/repos/db/shard_init_vector.go
@@ -180,6 +180,7 @@ func (s *Shard) initVectorIndex(ctx context.Context,
 				vectorIndexUserConfig)
 		}
 		s.index.cycleCallbacks.vectorCommitLoggerCycle.Start()
+		s.index.cycleCallbacks.vectorTombstoneCleanupCycle.Start()
 
 		// a shard can actually have multiple vector indexes:
 		// - the main index, which is used for all normal object vectors

--- a/adapters/repos/db/shard_test.go
+++ b/adapters/repos/db/shard_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	hnswindex "github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/models"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/storagestate"
@@ -856,6 +857,61 @@ func TestShard_UpgradeIndex(t *testing.T) {
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		assert.Zero(t, q.Size())
 	}, 300*time.Second, 1*time.Second)
+}
+
+func TestShard_DynamicIndexStartsTombstoneCleanupCycle(t *testing.T) {
+	t.Setenv("ASYNC_INDEXING", "true")
+
+	ctx := context.Background()
+	className := "TombstoneClass"
+
+	tests := []struct {
+		name          string
+		config        schemaConfig.VectorIndexConfig
+		expectRunning bool
+	}{
+		{
+			name:          "dynamic starts tombstone cleanup cycle",
+			config:        dynamic.NewDefaultUserConfig(),
+			expectRunning: true,
+		},
+		{
+			name:          "hnsw starts tombstone cleanup cycle",
+			config:        hnsw.NewDefaultUserConfig(),
+			expectRunning: true,
+		},
+		{
+			name:          "flat does not start tombstone cleanup cycle",
+			config:        flat.NewDefaultUserConfig(),
+			expectRunning: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var tombstoneCycle cyclemanager.CycleManager
+
+			opts := []func(*Index){
+				func(i *Index) {
+					i.vectorIndexUserConfig = tt.config
+					i.Config.DisableLazyLoadShards = true
+					tombstoneCycle = i.cycleCallbacks.vectorTombstoneCleanupCycle
+				},
+			}
+
+			shd, _ := testShardWithSettings(t, ctx, &models.Class{Class: className}, tt.config, false, true, opts...)
+
+			defer func(path string) {
+				err := os.RemoveAll(path)
+				if err != nil {
+					fmt.Println(err)
+				}
+			}(shd.Index().Config.RootPath)
+
+			require.Equal(t, tt.expectRunning, tombstoneCycle.Running(),
+				"vectorTombstoneCleanupCycle.Running()")
+		})
+	}
 }
 
 func TestShard_RequantizeIndex(t *testing.T) {


### PR DESCRIPTION
### What's being changed:
- Dynamic index cycle manager tombstone cycles were not registering for HNSW
- Impact would be tombstone cycles not running for dynamic index
- Addition this fixes the interval config in the case of the dynamic index

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
