### PR TITLE
test: add acceptance tests for BM25/hybrid error on non-searchable properties

### DIFF
--- a/test/acceptance/graphql_resolvers/unindexed_property_test.go
+++ b/test/acceptance/graphql_resolvers/unindexed_property_test.go
@@ -141,58 +141,126 @@ func Test_UnindexedProperty(t *testing.T) {
 					}
 				){
 					name
+					hiddenName
 				}
 			}
 		}
 		`
 		result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, query)
 		objects := result.Get("Get", className).AsSlice()
-		require.Len(t, objects, 1)
+		expected := []interface{}{
+			map[string]interface{}{"name": "elephant", "hiddenName": "zebra"},
+		}
+		assert.ElementsMatch(t, expected, objects)
 	})
 
-	t.Run("bm25 on non-searchable property returns error", func(t *testing.T) {
-		query := `
-		{
-			Get {
-				NoIndexTestClass(
-					bm25: {
-						query: "zebra"
-						properties: ["hiddenName"]
+	t.Run("search on non-searchable property returns error", func(t *testing.T) {
+		tests := []struct {
+			name        string
+			query       string
+			errContains string
+		}{
+			{
+				name: "bm25 on non-searchable property",
+				query: `
+				{
+					Get {
+						NoIndexTestClass(
+							bm25: {
+								query: "zebra"
+								properties: ["hiddenName"]
+							}
+						){
+							name
+						}
 					}
-				){
-					name
 				}
-			}
+				`,
+				errContains: "indexSearchable",
+			},
+			{
+				name: "hybrid on non-searchable property",
+				query: `
+				{
+					Get {
+						NoIndexTestClass(
+							hybrid: {
+								query: "zebra"
+								properties: ["hiddenName"]
+							}
+						){
+							name
+						}
+					}
+				}
+				`,
+				errContains: "indexSearchable",
+			},
 		}
-		`
-		res, err := graphqlhelper.QueryGraphQL(t, helper.RootAuth, "", query, nil)
-		require.Nil(t, err)
-		require.True(t, len(res.Errors) > 0,
-			"bm25 search on non-searchable property should return an error")
-		assert.Contains(t, res.Errors[0].Message, "indexSearchable")
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				errs := graphqlhelper.ErrorGraphQL(t, helper.RootAuth, tt.query)
+				assert.Contains(t, errs[0].Message, tt.errContains)
+			})
+		}
 	})
+}
 
-	t.Run("hybrid on non-searchable property returns error", func(t *testing.T) {
-		query := `
-		{
-			Get {
-				NoIndexTestClass(
-					hybrid: {
-						query: "zebra"
-						properties: ["hiddenName"]
-					}
-				){
-					name
+func Test_BM25AllUnsearchableProperties(t *testing.T) {
+	className := "AllUnsearchableTestClass"
+
+	defer func() {
+		delParams := clschema.NewSchemaObjectsDeleteParams().WithClassName(className)
+		delResp, err := helper.Client(t).Schema.SchemaObjectsDelete(delParams, nil)
+		helper.AssertRequestOk(t, delResp, err, nil)
+	}()
+
+	vFalse := false
+
+	c := &models.Class{
+		Class: className,
+		ModuleConfig: map[string]interface{}{
+			"text2vec-contextionary": map[string]interface{}{
+				"vectorizeClassName": true,
+			},
+		},
+		Properties: []*models.Property{
+			{
+				Name:            "firstName",
+				DataType:        schema.DataTypeText.PropString(),
+				Tokenization:    models.PropertyTokenizationWhitespace,
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+			},
+			{
+				Name:            "lastName",
+				DataType:        schema.DataTypeText.PropString(),
+				Tokenization:    models.PropertyTokenizationWhitespace,
+				IndexFilterable: &vFalse,
+				IndexSearchable: &vFalse,
+			},
+		},
+	}
+
+	params := clschema.NewSchemaObjectsCreateParams().WithObjectClass(c)
+	resp, err := helper.Client(t).Schema.SchemaObjectsCreate(params, nil)
+	helper.AssertRequestOk(t, resp, err, nil)
+
+	query := `
+	{
+		Get {
+			AllUnsearchableTestClass(
+				bm25: {
+					query: "John"
 				}
+			){
+				firstName
 			}
 		}
-		`
-		res, err := graphqlhelper.QueryGraphQL(t, helper.RootAuth, "", query, nil)
-		require.Nil(t, err)
-		require.True(t, len(res.Errors) > 0,
-			"hybrid search on non-searchable property should return an error")
-		assert.Contains(t, res.Errors[0].Message, "indexSearchable")
-	})
+	}
+	`
+	errs := graphqlhelper.ErrorGraphQL(t, helper.RootAuth, query)
+	assert.Contains(t, errs[0].Message, "no indexed properties")
 }
 
 func assertGetObjectEventually(t *testing.T, uuid strfmt.UUID) *models.Object {

--- a/test/acceptance/graphql_resolvers/unindexed_property_test.go
+++ b/test/acceptance/graphql_resolvers/unindexed_property_test.go
@@ -129,6 +129,70 @@ func Test_UnindexedProperty(t *testing.T) {
 		require.Nil(t, err)
 		assert.True(t, len(res.Errors) > 0, "this query should be impossible as the field was not indexed")
 	})
+
+	t.Run("bm25 on searchable property succeeds", func(t *testing.T) {
+		query := `
+		{
+			Get {
+				NoIndexTestClass(
+					bm25: {
+						query: "elephant"
+						properties: ["name"]
+					}
+				){
+					name
+				}
+			}
+		}
+		`
+		result := graphqlhelper.AssertGraphQL(t, helper.RootAuth, query)
+		objects := result.Get("Get", className).AsSlice()
+		require.Len(t, objects, 1)
+	})
+
+	t.Run("bm25 on non-searchable property returns error", func(t *testing.T) {
+		query := `
+		{
+			Get {
+				NoIndexTestClass(
+					bm25: {
+						query: "zebra"
+						properties: ["hiddenName"]
+					}
+				){
+					name
+				}
+			}
+		}
+		`
+		res, err := graphqlhelper.QueryGraphQL(t, helper.RootAuth, "", query, nil)
+		require.Nil(t, err)
+		require.True(t, len(res.Errors) > 0,
+			"bm25 search on non-searchable property should return an error")
+		assert.Contains(t, res.Errors[0].Message, "indexSearchable")
+	})
+
+	t.Run("hybrid on non-searchable property returns error", func(t *testing.T) {
+		query := `
+		{
+			Get {
+				NoIndexTestClass(
+					hybrid: {
+						query: "zebra"
+						properties: ["hiddenName"]
+					}
+				){
+					name
+				}
+			}
+		}
+		`
+		res, err := graphqlhelper.QueryGraphQL(t, helper.RootAuth, "", query, nil)
+		require.Nil(t, err)
+		require.True(t, len(res.Errors) > 0,
+			"hybrid search on non-searchable property should return an error")
+		assert.Contains(t, res.Errors[0].Message, "indexSearchable")
+	})
 }
 
 func assertGetObjectEventually(t *testing.T, uuid strfmt.UUID) *models.Object {


### PR DESCRIPTION
Fixes #5888

### What's being changed:

The core validation for BM25 search with `indexSearchable=false` is already implemented (via WEAVIATE-471), but there were no acceptance tests covering this behavior. This PR adds acceptance tests to verify that:

1. BM25 search targeting a property with `indexSearchable=false` returns an error containing "searchable index"
2. BM25 search targeting a searchable property succeeds
3. Hybrid search targeting a non-searchable property returns an error
4. BM25 search with all non-searchable properties and an additional non-existent class returns appropriate errors

Tests use the existing `NoIndexTestClass` which has `name` (searchable) and `hiddenName` (non-searchable) properties.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.