### PR TITLE
Use hardlinks in test to mirror production

### DIFF
--- a/adapters/repos/db/backup_integration_test.go
+++ b/adapters/repos/db/backup_integration_test.go
@@ -627,12 +627,20 @@ func backupWithSizes(
 ) backupChunkResult {
 	t.Helper()
 
+	// Use staging dir (hard-linked snapshot) if available, matching production
+	// behavior in usecases/backup/backend.go. The live data path may have files
+	// rotated (e.g. HNSW commitlog) between descriptor creation and backup writing.
+	effectivePath := sourceDataPath
+	if classDescs[0].StagingDir != "" {
+		effectivePath = classDescs[0].StagingDir
+	}
+
 	var result backupChunkResult
 
 	for _, sd := range classDescs[0].Shards {
 		fileSizes := make(map[string]int64, len(sd.Files))
 		for _, relPath := range sd.Files {
-			info, err := os.Stat(filepath.Join(sourceDataPath, relPath))
+			info, err := os.Stat(filepath.Join(effectivePath, relPath))
 			if err == nil && info.Mode().IsRegular() {
 				fileSizes[relPath] = info.Size()
 				result.fileSizes = append(result.fileSizes, info.Size())
@@ -645,7 +653,7 @@ func backupWithSizes(
 
 		for {
 			var buf bytes.Buffer
-			z, rc, err := backupUC.NewZip(sourceDataPath, int(backupUC.NoCompression), chunkSize, 0, splitFileSize)
+			z, rc, err := backupUC.NewZip(effectivePath, int(backupUC.NoCompression), chunkSize, 0, splitFileSize)
 			require.NoError(t, err)
 
 			type writeResult struct {
@@ -694,6 +702,12 @@ func restoreAndVerify(
 ) {
 	t.Helper()
 
+	// Use staging dir when available (hard-linked snapshot), same as backupWithSizes.
+	effectivePath := sourceDataPath
+	if classDescs[0].StagingDir != "" {
+		effectivePath = classDescs[0].StagingDir
+	}
+
 	restoreDir := t.TempDir()
 
 	var wg sync.WaitGroup
@@ -718,7 +732,7 @@ func restoreAndVerify(
 
 	for _, sd := range classDescs[0].Shards {
 		for _, relPath := range sd.Files {
-			originalPath := filepath.Join(sourceDataPath, relPath)
+			originalPath := filepath.Join(effectivePath, relPath)
 			restoredPath := filepath.Join(restoreDir, relPath)
 
 			original, err := os.ReadFile(originalPath)


### PR DESCRIPTION
### What's being changed:

Fixes a flaky tests by using the hardlink dir for the test instead of the live dir. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
