### PR TITLE
[DO NOT MERGE] Fix S3 backup module scheme prepending for S3-compatible providers

### DIFF
--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strings"
 	"time"
 
 	"github.com/minio/minio-go/v7"
@@ -108,7 +109,15 @@ func (s *s3Client) HomeDir(backupID, overrideBucket, overridePath string) string
 		remoteBucket = overrideBucket
 	}
 
-	return "s3://" + path.Join(remoteBucket, remotePath, s.makeObjectName(backupID))
+	// Check if the bucket already includes a scheme (e.g. https:// for
+	// S3-compatible providers like DigitalOcean Spaces). If so, preserve
+	// the original scheme instead of prepending s3://.
+	scheme := "s3://"
+	if idx := strings.Index(remoteBucket, "://"); idx != -1 {
+		scheme = remoteBucket[:idx+3]
+		remoteBucket = remoteBucket[idx+3:]
+	}
+	return scheme + path.Join(remoteBucket, remotePath, s.makeObjectName(backupID))
 }
 
 func (s *s3Client) AllBackups(ctx context.Context,

--- a/modules/backup-s3/client_test.go
+++ b/modules/backup-s3/client_test.go
@@ -1,0 +1,77 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modstgs3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHomeDir(t *testing.T) {
+	tests := []struct {
+		name           string
+		bucket         string
+		backupPath     string
+		backupID       string
+		overrideBucket string
+		overridePath   string
+		expected       string
+	}{
+		{
+			name:     "standard s3 bucket",
+			bucket:   "my-bucket",
+			backupID: "backup-1",
+			expected: "s3://my-bucket/backup-1",
+		},
+		{
+			name:           "with override bucket",
+			bucket:         "my-bucket",
+			backupID:       "backup-1",
+			overrideBucket: "other-bucket",
+			expected:       "s3://other-bucket/backup-1",
+		},
+		{
+			name:         "with override path",
+			bucket:       "my-bucket",
+			backupID:     "backup-1",
+			overridePath: "custom/path",
+			expected:     "s3://my-bucket/custom/path/backup-1",
+		},
+		{
+			name:     "bucket with https scheme",
+			bucket:   "https://nyc3.digitaloceanspaces.com/my-bucket",
+			backupID: "backup-1",
+			expected: "https://nyc3.digitaloceanspaces.com/my-bucket/backup-1",
+		},
+		{
+			name:           "override bucket with https scheme",
+			bucket:         "my-bucket",
+			backupID:       "backup-1",
+			overrideBucket: "https://nyc3.digitaloceanspaces.com/other-bucket",
+			expected:       "https://nyc3.digitaloceanspaces.com/other-bucket/backup-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &s3Client{
+				config: &clientConfig{
+					Bucket:     tt.bucket,
+					BackupPath: tt.backupPath,
+				},
+			}
+			result := client.HomeDir(tt.backupID, tt.overrideBucket, tt.overridePath)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `HomeDir()` in the S3 backup module unconditionally prepending `s3://` to bucket URLs that already have a scheme (e.g. `https://` for DigitalOcean Spaces)
- The method now detects an existing scheme and preserves it, avoiding malformed URLs like `s3://https://...`
- Added unit tests for `HomeDir()` covering standard S3, override bucket/path, and HTTPS scheme scenarios

## Test plan
- [x] Unit tests pass: `go test -run TestHomeDir ./modules/backup-s3/...`
- [ ] Manual verification with DigitalOcean Spaces or another S3-compatible provider using `https://` bucket URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)