### PR TITLE
Add usage-do module for DigitalOcean Spaces compatibility

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -141,6 +141,7 @@ import (
 	modvoyageai "github.com/weaviate/weaviate/modules/text2vec-voyageai"
 	modweaviateembed "github.com/weaviate/weaviate/modules/text2vec-weaviate"
 	modusagegcs "github.com/weaviate/weaviate/modules/usage-gcs"
+	modusagedo "github.com/weaviate/weaviate/modules/usage-do"
 	modusages3 "github.com/weaviate/weaviate/modules/usage-s3"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/composer"
@@ -1927,6 +1928,14 @@ func registerModules(appState *state.State) error {
 			Debug("enabled module")
 	}
 
+	if _, ok := enabledModules[modusagedo.Name]; ok {
+		appState.Modules.Register(modusagedo.New())
+		appState.Logger.
+			WithField("action", "startup").
+			WithField("module", modusagedo.Name).
+			Debug("enabled module")
+	}
+
 	appState.Logger.
 		WithField("action", "startup").
 		Debug("completed registering modules")
@@ -1949,6 +1958,13 @@ func postInitModules(appState *state.State) {
 		// Initialize usage service for S3
 		if usageS3Module := appState.Modules.GetByName(modusages3.Name); usageS3Module != nil {
 			if usageModuleWithService, ok := usageS3Module.(modulecapabilities.ModuleWithUsageService); ok {
+				usageService := usage.NewService(appState.SchemaManager, appState.DB, appState.Modules, usageModuleWithService.Logger())
+				usageModuleWithService.SetUsageService(usageService)
+			}
+		}
+		// Initialize usage service for DigitalOcean Spaces
+		if usageDOModule := appState.Modules.GetByName(modusagedo.Name); usageDOModule != nil {
+			if usageModuleWithService, ok := usageDOModule.(modulecapabilities.ModuleWithUsageService); ok {
 				usageService := usage.NewService(appState.SchemaManager, appState.DB, appState.Modules, usageModuleWithService.Logger())
 				usageModuleWithService.SetUsageService(usageService)
 			}

--- a/modules/usage-do/module.go
+++ b/modules/usage-do/module.go
@@ -1,0 +1,189 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package usagedo
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/weaviate/weaviate/entities/modulecapabilities"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
+	common "github.com/weaviate/weaviate/usecases/modulecomponents/usage"
+)
+
+const (
+	Name = "usage-do"
+)
+
+// module is the DigitalOcean Spaces usage module using the common base
+type module struct {
+	*common.BaseModule
+	doStorage *DOStorage
+}
+
+func New() *module {
+	return &module{}
+}
+
+func (m *module) SetUsageService(usageService any) {
+	m.BaseModule.SetUsageService(usageService)
+}
+
+func (m *module) Name() string {
+	return Name
+}
+
+func (m *module) Type() modulecapabilities.ModuleType {
+	return modulecapabilities.Usage
+}
+
+func (m *module) Init(ctx context.Context, params moduletools.ModuleInitParams) error {
+	// Parse usage configuration from environment
+	config := params.GetConfig()
+	if err := common.ParseCommonUsageConfig(config); err != nil {
+		return err
+	}
+	if err := parseDOConfig(config); err != nil {
+		return err
+	}
+
+	// Validate required configuration
+	if config.Usage.DOBucket.Get() == "" && !config.RuntimeOverrides.Enabled {
+		return fmt.Errorf("DigitalOcean Spaces bucket name not configured - set USAGE_DO_BUCKET environment variable or enable runtime overrides with RUNTIME_OVERRIDES_ENABLED=true")
+	}
+
+	if config.Usage.DORegion.Get() == "" {
+		return fmt.Errorf("DigitalOcean Spaces region not configured - set USAGE_DO_REGION environment variable (e.g. nyc3, sfo3, ams3)")
+	}
+
+	// Initialize logger
+	logger := params.GetLogger().WithField("component", Name)
+
+	// Create metrics first
+	metrics := common.NewMetrics(params.GetMetricsRegisterer(), Name)
+
+	// Build endpoint from region if not explicitly set
+	endpoint := config.Usage.DOEndpoint.Get()
+	if endpoint == "" {
+		endpoint = fmt.Sprintf("https://%s.digitaloceanspaces.com", config.Usage.DORegion.Get())
+		config.Usage.DOEndpoint = runtime.NewDynamicValue(endpoint)
+	}
+
+	// Create DO storage backend with metrics
+	doStorage, err := NewDOStorage(ctx, logger, metrics, config.Usage.DORegion.Get(), endpoint)
+	if err != nil {
+		return fmt.Errorf("failed to create DigitalOcean Spaces storage: %w", err)
+	}
+
+	m.doStorage = doStorage
+
+	// Update storage configuration (this may have empty bucket initially)
+	storageConfig := m.buildDOConfig(config)
+	if _, err := m.doStorage.UpdateConfig(storageConfig); err != nil {
+		return fmt.Errorf("failed to configure DigitalOcean Spaces storage: %w", err)
+	}
+
+	// Create base module with DO storage
+	m.BaseModule = common.NewBaseModule(Name, m.doStorage)
+
+	// Initialize base module with metrics
+	if err := m.InitializeCommon(ctx, config, logger, metrics); err != nil {
+		return err
+	}
+
+	// Build log fields, omitting empty values for cleaner output
+	logFields := map[string]interface{}{
+		"node_id":             config.Cluster.Hostname,
+		"collection_interval": config.Usage.ScrapeInterval.Get().String(),
+		"do_region":           config.Usage.DORegion.Get(),
+		"do_endpoint":         config.Usage.DOEndpoint.Get(),
+	}
+
+	if bucket := config.Usage.DOBucket.Get(); bucket != "" {
+		logFields["do_bucket"] = bucket
+	} else if config.RuntimeOverrides.Enabled {
+		logFields["do_bucket"] = "[pending runtime overrides]"
+	}
+
+	if prefix := config.Usage.DOPrefix.Get(); prefix != "" {
+		logFields["do_prefix"] = prefix
+	} else if config.RuntimeOverrides.Enabled {
+		logFields["do_prefix"] = "[pending runtime overrides]"
+	}
+
+	logger.WithFields(logFields).Info("initializing usage-do module with configuration")
+
+	return nil
+}
+
+func (m *module) buildDOConfig(config *config.Config) common.StorageConfig {
+	storageConfig := common.StorageConfig{
+		NodeID: config.Cluster.Hostname,
+	}
+
+	if config.Usage.DOBucket != nil {
+		storageConfig.Bucket = config.Usage.DOBucket.Get()
+	}
+	if config.Usage.DOPrefix != nil {
+		storageConfig.Prefix = config.Usage.DOPrefix.Get()
+	}
+	if config.Usage.PolicyVersion != nil {
+		storageConfig.Version = config.Usage.PolicyVersion.Get()
+	}
+
+	return storageConfig
+}
+
+func parseDOConfig(config *config.Config) error {
+	doBucket := ""
+	if v := os.Getenv("USAGE_DO_BUCKET"); v != "" {
+		doBucket = v
+	} else if config.Usage.DOBucket != nil {
+		doBucket = config.Usage.DOBucket.Get()
+	}
+	config.Usage.DOBucket = runtime.NewDynamicValue(doBucket)
+
+	doPrefix := ""
+	if v := os.Getenv("USAGE_DO_PREFIX"); v != "" {
+		doPrefix = v
+	} else if config.Usage.DOPrefix != nil {
+		doPrefix = config.Usage.DOPrefix.Get()
+	}
+	config.Usage.DOPrefix = runtime.NewDynamicValue(doPrefix)
+
+	doRegion := ""
+	if v := os.Getenv("USAGE_DO_REGION"); v != "" {
+		doRegion = v
+	} else if config.Usage.DORegion != nil {
+		doRegion = config.Usage.DORegion.Get()
+	}
+	config.Usage.DORegion = runtime.NewDynamicValue(doRegion)
+
+	doEndpoint := ""
+	if v := os.Getenv("USAGE_DO_ENDPOINT"); v != "" {
+		doEndpoint = v
+	} else if config.Usage.DOEndpoint != nil {
+		doEndpoint = config.Usage.DOEndpoint.Get()
+	}
+	config.Usage.DOEndpoint = runtime.NewDynamicValue(doEndpoint)
+
+	return nil
+}
+
+// verify we implement the required interfaces
+var (
+	_ = modulecapabilities.ModuleWithClose(New())
+	_ = modulecapabilities.ModuleWithUsageService(New())
+)

--- a/modules/usage-do/module_test.go
+++ b/modules/usage-do/module_test.go
@@ -1,0 +1,426 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package usagedo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	clusterusage "github.com/weaviate/weaviate/cluster/usage"
+	"github.com/weaviate/weaviate/entities/moduletools"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
+	common "github.com/weaviate/weaviate/usecases/modulecomponents/usage"
+	usagetypes "github.com/weaviate/weaviate/usecases/modulecomponents/usage/types"
+)
+
+func TestModule_Name(t *testing.T) {
+	m := New()
+	assert.Equal(t, "usage-do", m.Name())
+}
+
+func TestModule_Type(t *testing.T) {
+	m := New()
+	assert.Equal(t, "Usage", string(m.Type()))
+}
+
+func TestModule_Init_Success(t *testing.T) {
+	t.Setenv("USAGE_DO_BUCKET", "test-bucket")
+	t.Setenv("USAGE_DO_REGION", "nyc3")
+	t.Setenv("CLUSTER_IN_LOCALHOST", "true")
+
+	config := &config.Config{
+		Cluster: cluster.Config{
+			Hostname: "test-node",
+		},
+		Usage: usagetypes.UsageConfig{
+			ScrapeInterval: runtime.NewDynamicValue(5 * time.Minute),
+			PolicyVersion:  runtime.NewDynamicValue("2025-06-01"),
+		},
+	}
+
+	logger := logrus.New()
+	registry := prometheus.NewRegistry()
+
+	params := moduletools.NewMockModuleInitParams(t)
+	params.EXPECT().GetLogger().Return(logger)
+	params.EXPECT().GetConfig().Return(config)
+	params.EXPECT().GetMetricsRegisterer().Return(registry)
+
+	m := New()
+	err := m.Init(context.Background(), params)
+	require.NoError(t, err)
+
+	assert.NotNil(t, m.BaseModule)
+	assert.NotNil(t, m.doStorage)
+}
+
+func TestModule_Init_DefaultEndpoint(t *testing.T) {
+	t.Setenv("USAGE_DO_BUCKET", "test-bucket")
+	t.Setenv("USAGE_DO_REGION", "sfo3")
+	t.Setenv("CLUSTER_IN_LOCALHOST", "true")
+
+	cfg := &config.Config{
+		Cluster: cluster.Config{
+			Hostname: "test-node",
+		},
+		Usage: usagetypes.UsageConfig{
+			ScrapeInterval: runtime.NewDynamicValue(5 * time.Minute),
+			PolicyVersion:  runtime.NewDynamicValue("2025-06-01"),
+		},
+	}
+
+	params := moduletools.NewMockModuleInitParams(t)
+	params.EXPECT().GetLogger().Return(logrus.New())
+	params.EXPECT().GetConfig().Return(cfg)
+	params.EXPECT().GetMetricsRegisterer().Return(prometheus.NewRegistry())
+
+	m := New()
+	err := m.Init(context.Background(), params)
+	require.NoError(t, err)
+
+	// Endpoint should be auto-derived from region
+	assert.Equal(t, "https://sfo3.digitaloceanspaces.com", cfg.Usage.DOEndpoint.Get())
+}
+
+func TestModule_Init_CustomEndpoint(t *testing.T) {
+	t.Setenv("USAGE_DO_BUCKET", "test-bucket")
+	t.Setenv("USAGE_DO_REGION", "nyc3")
+	t.Setenv("USAGE_DO_ENDPOINT", "https://custom-endpoint.example.com")
+	t.Setenv("CLUSTER_IN_LOCALHOST", "true")
+
+	cfg := &config.Config{
+		Cluster: cluster.Config{
+			Hostname: "test-node",
+		},
+		Usage: usagetypes.UsageConfig{
+			ScrapeInterval: runtime.NewDynamicValue(5 * time.Minute),
+			PolicyVersion:  runtime.NewDynamicValue("2025-06-01"),
+		},
+	}
+
+	params := moduletools.NewMockModuleInitParams(t)
+	params.EXPECT().GetLogger().Return(logrus.New())
+	params.EXPECT().GetConfig().Return(cfg)
+	params.EXPECT().GetMetricsRegisterer().Return(prometheus.NewRegistry())
+
+	m := New()
+	err := m.Init(context.Background(), params)
+	require.NoError(t, err)
+
+	// Custom endpoint should be preserved
+	assert.Equal(t, "https://custom-endpoint.example.com", cfg.Usage.DOEndpoint.Get())
+}
+
+func TestModule_Init_MissingBucket(t *testing.T) {
+	t.Setenv("USAGE_DO_REGION", "nyc3")
+
+	cfg := &config.Config{
+		Cluster: cluster.Config{
+			Hostname: "test-node",
+		},
+		Usage: usagetypes.UsageConfig{
+			ScrapeInterval: runtime.NewDynamicValue(5 * time.Minute),
+			PolicyVersion:  runtime.NewDynamicValue("2025-06-01"),
+		},
+	}
+
+	params := moduletools.NewMockModuleInitParams(t)
+	params.EXPECT().GetConfig().Return(cfg)
+
+	m := New()
+	err := m.Init(context.Background(), params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bucket name not configured")
+}
+
+func TestModule_Init_MissingRegion(t *testing.T) {
+	t.Setenv("USAGE_DO_BUCKET", "test-bucket")
+
+	cfg := &config.Config{
+		Cluster: cluster.Config{
+			Hostname: "test-node",
+		},
+		Usage: usagetypes.UsageConfig{
+			ScrapeInterval: runtime.NewDynamicValue(5 * time.Minute),
+			PolicyVersion:  runtime.NewDynamicValue("2025-06-01"),
+		},
+	}
+
+	params := moduletools.NewMockModuleInitParams(t)
+	params.EXPECT().GetConfig().Return(cfg)
+
+	m := New()
+	err := m.Init(context.Background(), params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "region not configured")
+}
+
+func TestModule_Init_MissingHostname(t *testing.T) {
+	t.Setenv("USAGE_DO_BUCKET", "test-bucket")
+	t.Setenv("USAGE_DO_REGION", "nyc3")
+	t.Setenv("CLUSTER_IN_LOCALHOST", "true")
+
+	params := moduletools.NewMockModuleInitParams(t)
+	params.EXPECT().GetConfig().Return(&config.Config{
+		Cluster: cluster.Config{
+			Hostname: "", // Empty hostname
+		},
+		Usage: usagetypes.UsageConfig{
+			ScrapeInterval: runtime.NewDynamicValue(5 * time.Minute),
+			PolicyVersion:  runtime.NewDynamicValue("2025-06-01"),
+		},
+	})
+	params.EXPECT().GetLogger().Return(logrus.New())
+	params.EXPECT().GetMetricsRegisterer().Return(prometheus.NewRegistry())
+
+	m := New()
+	err := m.Init(context.Background(), params)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cluster hostname is not set")
+}
+
+func TestModule_BuildDOConfig(t *testing.T) {
+	m := New()
+
+	cfg := &config.Config{
+		Cluster: cluster.Config{
+			Hostname: "test-node",
+		},
+		Usage: usagetypes.UsageConfig{
+			DOBucket:      runtime.NewDynamicValue("test-bucket"),
+			DOPrefix:      runtime.NewDynamicValue("test-prefix"),
+			PolicyVersion: runtime.NewDynamicValue("2025-06-01"),
+		},
+	}
+
+	storageConfig := m.buildDOConfig(cfg)
+
+	assert.Equal(t, "test-node", storageConfig.NodeID)
+	assert.Equal(t, "test-bucket", storageConfig.Bucket)
+	assert.Equal(t, "test-prefix", storageConfig.Prefix)
+	assert.Equal(t, "2025-06-01", storageConfig.Version)
+}
+
+func TestModule_BuildDOConfig_EmptyValues(t *testing.T) {
+	m := New()
+
+	cfg := &config.Config{
+		Cluster: cluster.Config{
+			Hostname: "test-node",
+		},
+		Usage: usagetypes.UsageConfig{},
+	}
+
+	storageConfig := m.buildDOConfig(cfg)
+
+	assert.Equal(t, "test-node", storageConfig.NodeID)
+	assert.Equal(t, "", storageConfig.Bucket)
+	assert.Equal(t, "", storageConfig.Prefix)
+	assert.Equal(t, "", storageConfig.Version)
+}
+
+func TestModule_SetUsageService(t *testing.T) {
+	t.Setenv("USAGE_DO_BUCKET", "test-bucket")
+	t.Setenv("USAGE_DO_REGION", "nyc3")
+	t.Setenv("CLUSTER_IN_LOCALHOST", "true")
+
+	m := New()
+
+	cfg := &config.Config{
+		Cluster: cluster.Config{
+			Hostname: "test-node",
+		},
+		Usage: usagetypes.UsageConfig{
+			ScrapeInterval: runtime.NewDynamicValue(5 * time.Minute),
+			PolicyVersion:  runtime.NewDynamicValue("2025-06-01"),
+		},
+	}
+
+	logger := logrus.New()
+	registry := prometheus.NewRegistry()
+
+	params := moduletools.NewMockModuleInitParams(t)
+	params.EXPECT().GetLogger().Return(logger)
+	params.EXPECT().GetConfig().Return(cfg)
+	params.EXPECT().GetMetricsRegisterer().Return(registry)
+
+	// Initialize the module first
+	err := m.Init(context.Background(), params)
+	require.NoError(t, err)
+
+	// Test with valid service after initialization
+	usageService := clusterusage.NewMockService(t)
+	usageService.EXPECT().SetJitterInterval(mock.Anything).Return()
+
+	assert.NotPanics(t, func() {
+		m.SetUsageService(usageService)
+	})
+	assert.NotNil(t, m.BaseModule)
+}
+
+func TestParseDOConfig(t *testing.T) {
+	tests := []struct {
+		name             string
+		envVars          map[string]string
+		existingBucket   string
+		existingPrefix   string
+		existingRegion   string
+		existingEndpoint string
+		expectedBucket   string
+		expectedPrefix   string
+		expectedRegion   string
+		expectedEndpoint string
+	}{
+		{
+			name: "all environment variables set",
+			envVars: map[string]string{
+				"USAGE_DO_BUCKET":   "env-bucket",
+				"USAGE_DO_PREFIX":   "env-prefix",
+				"USAGE_DO_REGION":   "nyc3",
+				"USAGE_DO_ENDPOINT": "https://nyc3.digitaloceanspaces.com",
+			},
+			expectedBucket:   "env-bucket",
+			expectedPrefix:   "env-prefix",
+			expectedRegion:   "nyc3",
+			expectedEndpoint: "https://nyc3.digitaloceanspaces.com",
+		},
+		{
+			name:             "no environment variables, empty config",
+			envVars:          map[string]string{},
+			expectedBucket:   "",
+			expectedPrefix:   "",
+			expectedRegion:   "",
+			expectedEndpoint: "",
+		},
+		{
+			name:             "no environment variables but config has existing values",
+			envVars:          map[string]string{},
+			existingBucket:   "existing-bucket",
+			existingPrefix:   "existing-prefix",
+			existingRegion:   "ams3",
+			existingEndpoint: "https://ams3.digitaloceanspaces.com",
+			expectedBucket:   "existing-bucket",
+			expectedPrefix:   "existing-prefix",
+			expectedRegion:   "ams3",
+			expectedEndpoint: "https://ams3.digitaloceanspaces.com",
+		},
+		{
+			name: "env vars take priority over existing config",
+			envVars: map[string]string{
+				"USAGE_DO_BUCKET": "env-bucket",
+				"USAGE_DO_REGION": "sfo3",
+			},
+			existingBucket:   "existing-bucket",
+			existingPrefix:   "existing-prefix",
+			existingRegion:   "nyc3",
+			existingEndpoint: "https://nyc3.digitaloceanspaces.com",
+			expectedBucket:   "env-bucket",
+			expectedPrefix:   "existing-prefix",
+			expectedRegion:   "sfo3",
+			expectedEndpoint: "https://nyc3.digitaloceanspaces.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for k, v := range tt.envVars {
+				t.Setenv(k, v)
+			}
+
+			cfg := &config.Config{
+				Usage: usagetypes.UsageConfig{
+					ScrapeInterval: runtime.NewDynamicValue(5 * time.Minute),
+					PolicyVersion:  runtime.NewDynamicValue("2025-06-01"),
+				},
+			}
+
+			if tt.existingBucket != "" {
+				cfg.Usage.DOBucket = runtime.NewDynamicValue(tt.existingBucket)
+			}
+			if tt.existingPrefix != "" {
+				cfg.Usage.DOPrefix = runtime.NewDynamicValue(tt.existingPrefix)
+			}
+			if tt.existingRegion != "" {
+				cfg.Usage.DORegion = runtime.NewDynamicValue(tt.existingRegion)
+			}
+			if tt.existingEndpoint != "" {
+				cfg.Usage.DOEndpoint = runtime.NewDynamicValue(tt.existingEndpoint)
+			}
+
+			err := parseDOConfig(cfg)
+			assert.NoError(t, err)
+
+			require.NotNil(t, cfg.Usage.DOBucket)
+			assert.Equal(t, tt.expectedBucket, cfg.Usage.DOBucket.Get())
+
+			require.NotNil(t, cfg.Usage.DOPrefix)
+			assert.Equal(t, tt.expectedPrefix, cfg.Usage.DOPrefix.Get())
+
+			require.NotNil(t, cfg.Usage.DORegion)
+			assert.Equal(t, tt.expectedRegion, cfg.Usage.DORegion.Get())
+
+			require.NotNil(t, cfg.Usage.DOEndpoint)
+			assert.Equal(t, tt.expectedEndpoint, cfg.Usage.DOEndpoint.Get())
+		})
+	}
+}
+
+func TestModule_MetricsPrefixGeneration(t *testing.T) {
+	registry := prometheus.NewRegistry()
+	metrics := common.NewMetrics(registry, "usage-do")
+
+	assert.NotNil(t, metrics)
+	assert.NotNil(t, metrics.OperationTotal)
+	assert.NotNil(t, metrics.OperationLatency)
+	assert.NotNil(t, metrics.ResourceCount)
+	assert.NotNil(t, metrics.UploadedFileSize)
+
+	metrics.OperationTotal.WithLabelValues("test", "success").Inc()
+	metrics.ResourceCount.WithLabelValues("collections").Set(1)
+	metrics.UploadedFileSize.Set(100)
+
+	metricFamilies, err := registry.Gather()
+	require.NoError(t, err)
+
+	foundMetrics := make(map[string]bool)
+	for _, mf := range metricFamilies {
+		foundMetrics[mf.GetName()] = true
+	}
+
+	expectedPrefixes := []string{
+		"weaviate_usage_do_operations_total",
+		"weaviate_usage_do_resource_count",
+		"weaviate_usage_do_uploaded_file_size_bytes",
+	}
+
+	for _, expectedName := range expectedPrefixes {
+		assert.True(t, foundMetrics[expectedName], "Expected metric %s not found", expectedName)
+	}
+}
+
+func TestModule_InterfaceCompliance(t *testing.T) {
+	m := New()
+	assert.NotNil(t, m)
+
+	_ = m.Name()
+	_ = m.Type()
+	m.SetUsageService("test")
+}

--- a/modules/usage-do/storage.go
+++ b/modules/usage-do/storage.go
@@ -1,0 +1,165 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package usagedo
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/sirupsen/logrus"
+
+	"github.com/weaviate/weaviate/cluster/usage/types"
+	common "github.com/weaviate/weaviate/usecases/modulecomponents/usage"
+)
+
+// DOStorage implements the StorageBackend interface for DigitalOcean Spaces
+type DOStorage struct {
+	*common.BaseStorage
+	s3Client *s3.Client
+}
+
+// NewDOStorage creates a new DigitalOcean Spaces storage backend.
+// DigitalOcean Spaces is S3-compatible but requires an explicit region and
+// endpoint in the format https://{region}.digitaloceanspaces.com.
+func NewDOStorage(ctx context.Context, logger logrus.FieldLogger, metrics *common.Metrics, region, endpoint string) (*DOStorage, error) {
+	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
+	if err != nil {
+		return nil, fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
+		o.BaseEndpoint = aws.String(endpoint)
+		o.UsePathStyle = true
+	})
+
+	return &DOStorage{
+		BaseStorage: common.NewBaseStorage(logger, metrics),
+		s3Client:    s3Client,
+	}, nil
+}
+
+// VerifyPermissions checks if the backend can access the storage location
+func (s *DOStorage) VerifyPermissions(ctx context.Context) error {
+	if s.s3Client == nil {
+		return fmt.Errorf("DigitalOcean Spaces client is not initialized")
+	}
+
+	// During initialization, bucket may not be configured yet due to runtime overrides
+	// being loaded after module initialization.
+	if s.BucketName == "" {
+		s.Logger.Debug("DigitalOcean Spaces bucket not configured yet - skipping permission verification")
+		return nil
+	}
+
+	s.LogVerificationStart()
+
+	if s.IsLocalhostEnvironment() {
+		return nil
+	}
+
+	// Create context with timeout to report early in case of invalid permissions
+	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	_, err := s.s3Client.ListObjectsV2(timeoutCtx, &s3.ListObjectsV2Input{
+		Bucket:  aws.String(s.BucketName),
+		MaxKeys: aws.Int32(1),
+	})
+	if err != nil {
+		return fmt.Errorf("DigitalOcean Spaces permission check failed for bucket %s: %w", s.BucketName, err)
+	}
+
+	s.LogVerificationSuccess()
+	return nil
+}
+
+// UploadUsageData uploads the usage data to the storage backend
+func (s *DOStorage) UploadUsageData(ctx context.Context, usage *types.Report) error {
+	if s.s3Client == nil {
+		return fmt.Errorf("DigitalOcean Spaces client is not initialized")
+	}
+
+	data, err := s.MarshalUsageData(usage)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket:      aws.String(s.BucketName),
+		Key:         aws.String(s.ConstructObjectKey(usage.CollectingTime)),
+		Body:        bytes.NewReader(data),
+		ContentType: aws.String("application/json"),
+		Metadata: map[string]string{
+			"version": usage.Version,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to upload to DigitalOcean Spaces: %w", err)
+	}
+
+	s.RecordUploadMetrics(len(data))
+	return nil
+}
+
+// Close cleans up resources
+func (s *DOStorage) Close() error {
+	return nil
+}
+
+// UpdateConfig updates the backend configuration from the provided config
+func (s *DOStorage) UpdateConfig(config common.StorageConfig) (bool, error) {
+	// Store old bucket name to detect changes
+	oldBucketName := s.BucketName
+
+	// Update the configuration
+	configChanged := s.UpdateCommonConfig(config)
+
+	if !configChanged {
+		return configChanged, nil
+	}
+
+	// If bucket name changed, verify permissions
+	if oldBucketName != s.BucketName {
+		s.Logger.WithFields(logrus.Fields{
+			"old_bucket": oldBucketName,
+			"new_bucket": s.BucketName,
+		}).Info("DigitalOcean Spaces bucket name changed")
+	}
+
+	if !config.VerifyPermissions {
+		s.Logger.Info("permission verification skipped after bucket change (disabled by configuration)")
+		return configChanged, nil
+	}
+
+	s.Logger.Info("verifying permissions")
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if err := s.VerifyPermissions(ctx); err != nil {
+		s.Logger.WithError(err).Error("DigitalOcean Spaces permission verification failed after bucket change")
+		return configChanged, err
+	}
+	s.Logger.Info("DigitalOcean Spaces permissions verified successfully")
+
+	return configChanged, nil
+}
+
+// verify we implement the required interfaces
+var (
+	doStorage, _ = NewDOStorage(context.Background(), logrus.New(), &common.Metrics{}, "us-east-1", "https://nyc3.digitaloceanspaces.com")
+	_            = common.StorageBackend(doStorage)
+)

--- a/usecases/modulecomponents/usage/base_module.go
+++ b/usecases/modulecomponents/usage/base_module.go
@@ -358,6 +358,14 @@ func (b *BaseModule) buildStorageConfig() StorageConfig {
 		config.Prefix = b.config.Usage.GCSPrefix.Get()
 	}
 
+	if b.config.Usage.DOBucket != nil {
+		config.Bucket = b.config.Usage.DOBucket.Get()
+	}
+
+	if b.config.Usage.DOPrefix != nil {
+		config.Prefix = b.config.Usage.DOPrefix.Get()
+	}
+
 	return config
 }
 

--- a/usecases/modulecomponents/usage/types/types.go
+++ b/usecases/modulecomponents/usage/types/types.go
@@ -25,6 +25,11 @@ type UsageConfig struct {
 	S3Bucket *runtime.DynamicValue[string] `json:"usage_s3_bucket" yaml:"usage_s3_bucket"`
 	S3Prefix *runtime.DynamicValue[string] `json:"usage_s3_prefix" yaml:"usage_s3_prefix"`
 
+	DOBucket   *runtime.DynamicValue[string] `json:"usage_do_bucket" yaml:"usage_do_bucket"`
+	DOPrefix   *runtime.DynamicValue[string] `json:"usage_do_prefix" yaml:"usage_do_prefix"`
+	DORegion   *runtime.DynamicValue[string] `json:"usage_do_region" yaml:"usage_do_region"`
+	DOEndpoint *runtime.DynamicValue[string] `json:"usage_do_endpoint" yaml:"usage_do_endpoint"`
+
 	ScrapeInterval      *runtime.DynamicValue[time.Duration] `json:"usage_scrape_interval" yaml:"usage_scrape_interval"`
 	ShardJitterInterval *runtime.DynamicValue[time.Duration] `json:"usage_shard_jitter_interval" yaml:"usage_shard_jitter_interval"`
 	PolicyVersion       *runtime.DynamicValue[string]        `json:"usage_policy_version" yaml:"usage_policy_version"`


### PR DESCRIPTION
The usage-s3 module fails with "a region must be set when sending requests to S3" when used with DigitalOcean Spaces because DO Spaces requires an explicit region and endpoint. This adds a dedicated usage-do module that configures the S3-compatible client with the region and auto-derives the endpoint (https://{region}.digitaloceanspaces.com).

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
