### PR TITLE
test: improve async deletion verification in crash recovery test

### DIFF
--- a/test/acceptance/compaction/crash_recovery_test.go
+++ b/test/acceptance/compaction/crash_recovery_test.go
@@ -172,9 +172,12 @@ func TestAsyncDeletion_CrashRecovery(t *testing.T) {
 	// Re-point the helper client at the potentially-remapped port.
 	helper.SetupClient(compose.GetWeaviate().URI())
 
-	// After restart, the startup cleanup in segment_group.go must have removed
-	// all .deleteme files.
-	deletemeAfter := countDeletemeSegments(ctx, container, collection, shardName, "objects")
-	assert.Equal(t, 0, deletemeAfter,
-		"startup cleanup must remove all .deleteme files")
+	// After restart, the startup cleanup in segment_group.go must remove
+	// all .deleteme files. Use Eventually because the cleanup runs asynchronously
+	// and may not have completed immediately after the node becomes ready.
+	require.Eventually(t, func() bool {
+		deletemeAfter := countDeletemeSegments(ctx, container, collection, shardName, "objects")
+		fmt.Printf("  [poll] post-restart deleteme=%d\n", deletemeAfter)
+		return deletemeAfter == 0
+	}, 60*time.Second, 2*time.Second, "startup cleanup must remove all .deleteme files")
 }


### PR DESCRIPTION
### What's being changed:

This pull request improves the reliability of the crash recovery test by ensuring that the test waits for asynchronous cleanup to complete after a node restart. The main change is to use `require.Eventually` to poll for the removal of `.deleteme` files, rather than checking immediately.

Test reliability improvement:

* Updated the `TestAsyncDeletion_CrashRecovery` test in `crash_recovery_test.go` to use `require.Eventually` for checking that all `.deleteme` files are removed after restart, accounting for the asynchronous nature of the cleanup process.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
