### PR TITLE
Fix inverted logic in checkContext causing document count mismatch

### DIFF
--- a/adapters/repos/db/shard_write_batch_objects.go
+++ b/adapters/repos/db/shard_write_batch_objects.go
@@ -448,14 +448,14 @@ func (ob *objectsBatcher) setErrorAtIndex(err error, index int) {
 // has error'd, it marks all objects which have not previously error'd yet with
 // the ctx error
 func (ob *objectsBatcher) checkContext(ctx context.Context) bool {
-	if err := ctx.Err(); err != nil {
-		for i, err := range ob.errs {
-			if err == nil {
+	if ctxErr := ctx.Err(); ctxErr != nil {
+		for i, objErr := range ob.errs {
+			if objErr != nil {
 				// already has an error, ignore
 				continue
 			}
 
-			ob.errs[i] = errors.Wrapf(err,
+			ob.errs[i] = errors.Wrapf(ctxErr,
 				"inverted indexing complete, about to start vector indexing")
 		}
 


### PR DESCRIPTION
## Problem

The `checkContext` function in `shard_write_batch_objects.go` had two critical bugs that caused silent data loss during batch writes under timeout/CPU pressure:

1. **Variable shadowing**: The loop variable `err` shadowed the context error from `ctx.Err()`
2. **Inverted logic**: The condition `if err == nil` was backwards - it skipped objects WITHOUT errors instead of objects WITH errors

## Impact

When the context timed out or was cancelled:
- Objects that had no prior errors were silently ignored (not marked with the context error)
- The context error never propagated back to the client
- This caused the document count mismatch reported in #10805

## Fix

- Renamed `err` to `ctxErr` for the context error
- Renamed loop variable `err` to `objErr` to avoid shadowing
- Changed condition from `if objErr == nil` to `if objErr != nil` so we skip objects that already have errors

Now when the context errors, objects without prior errors are correctly marked with the context error.

Fixes #10805