### PR TITLE
fix: validate PQ segments is positive during schema creation

### DIFF
--- a/entities/vectorindex/hnsw/config.go
+++ b/entities/vectorindex/hnsw/config.go
@@ -306,7 +306,12 @@ func (u *UserConfig) validate() error {
 		return fmt.Errorf("invalid hnsw config: more than a single compression methods enabled")
 	}
 
-	err := ValidateRQConfig(u.RQ)
+	err := ValidatePQConfig(u.PQ)
+	if err != nil {
+		return fmt.Errorf("invalid hnsw config: %w", err)
+	}
+
+	err = ValidateRQConfig(u.RQ)
 	if err != nil {
 		return err
 	}

--- a/entities/vectorindex/hnsw/config_test.go
+++ b/entities/vectorindex/hnsw/config_test.go
@@ -788,6 +788,28 @@ func Test_UserConfig(t *testing.T) {
 			expectErrMsg: "invalid hnsw config: filterStrategy must be either 'sweeping' or 'acorn'",
 		},
 		{
+			name: "with pq enabled and negative segments",
+			input: map[string]interface{}{
+				"pq": map[string]interface{}{
+					"enabled":  true,
+					"segments": float64(-128),
+				},
+			},
+			expectErr:    true,
+			expectErrMsg: "invalid hnsw config: pq segments must be a positive integer",
+		},
+		{
+			name: "with pq enabled and zero segments",
+			input: map[string]interface{}{
+				"pq": map[string]interface{}{
+					"enabled":  true,
+					"segments": float64(0),
+				},
+			},
+			expectErr:    true,
+			expectErrMsg: "invalid hnsw config: pq segments must be a positive integer",
+		},
+		{
 			name: "acorn enabled, all defaults",
 			input: map[string]interface{}{
 				"filterStrategy": "acorn",

--- a/entities/vectorindex/hnsw/pq_config.go
+++ b/entities/vectorindex/hnsw/pq_config.go
@@ -76,6 +76,11 @@ func ValidatePQConfig(cfg PQConfig) error {
 	if !cfg.Enabled {
 		return nil
 	}
+
+	if cfg.Segments <= 0 {
+		return fmt.Errorf("pq segments must be a positive integer")
+	}
+
 	err := validEncoder(cfg.Encoder.Type)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Problem

The PQ (Product Quantization) configuration accepts negative or zero values for the segments parameter without validation during schema creation. This can lead to a DoS vulnerability because:

1. The validation logic only checks `vector_dimensions % segments == 0`
2. In Go, `128 % -128 == 0` evaluates to true, bypassing validation
3. The system accepts the negative segment value without throwing an HTTP 400
4. This causes a panic during background PQ training, crashing the database

## Solution

This PR adds validation in two places:

1. **ValidatePQConfig()** in `pq_config.go`: Added a check that `segments > 0` when PQ is enabled
2. **validate()** in `config.go`: Added a call to `ValidatePQConfig()` during schema validation (this was missing)

## Changes

- `entities/vectorindex/hnsw/pq_config.go`: Added segments > 0 validation
- `entities/vectorindex/hnsw/config.go`: Added call to ValidatePQConfig in validate()
- `entities/vectorindex/hnsw/config_test.go`: Added test cases for negative and zero segments

## Testing

Added test cases:
- `with pq enabled and negative segments` - expects error
- `with pq enabled and zero segments` - expects error

All existing tests pass.

Fixes #10771