### PR TITLE
Nested object filtering — Part 2: write path analysis

### DIFF
--- a/adapters/repos/db/inverted/analyzer.go
+++ b/adapters/repos/db/inverted/analyzer.go
@@ -54,13 +54,13 @@ type NestedValue struct {
 	Positions []uint64 // positions with docID=0
 }
 
-// NestedResult holds all analyzed values and metadata from position
+// NestedProperty holds all analyzed values and metadata from position
 // assignment of a single nested property.
-type NestedResult struct {
-	PropName string         // top-level property name (for bucket naming)
-	Values   []NestedValue  // analyzed values for the value bucket
-	Idx      []NestedMeta   // _idx metadata entries
-	Exists   []NestedMeta   // _exists metadata entries
+type NestedProperty struct {
+	Name   string        // top-level property name (for bucket naming)
+	Values []NestedValue // analyzed values for the value bucket
+	Idx    []NestedMeta  // _idx metadata entries
+	Exists []NestedMeta  // _exists metadata entries
 }
 
 // NestedMeta is an _idx or _exists metadata entry from position assignment.

--- a/adapters/repos/db/inverted/analyzer.go
+++ b/adapters/repos/db/inverted/analyzer.go
@@ -44,6 +44,32 @@ type NilProperty struct {
 	AddToPropertyLength bool
 }
 
+// NestedValue is a single analyzed value from a nested property, ready to
+// be written to the value bucket. The key in the bucket will be
+// hash8(Path) + Data; the bitmap values will be Positions with the real
+// docID ORed in.
+type NestedValue struct {
+	Path      string   // dot-notation path, e.g. "addresses.city"
+	Data      []byte   // analyzed value bytes
+	Positions []uint64 // positions with docID=0
+}
+
+// NestedResult holds all analyzed values and metadata from position
+// assignment of a single nested property.
+type NestedResult struct {
+	PropName string         // top-level property name (for bucket naming)
+	Values   []NestedValue  // analyzed values for the value bucket
+	Idx      []NestedMeta   // _idx metadata entries
+	Exists   []NestedMeta   // _exists metadata entries
+}
+
+// NestedMeta is an _idx or _exists metadata entry from position assignment.
+type NestedMeta struct {
+	Path      string   // e.g. "addresses" for _idx, "owner.firstname" for _exists
+	Index     int      // 0-based element index (only used for _idx; -1 for _exists)
+	Positions []uint64 // positions with docID=0
+}
+
 func DedupItems(props []Property) []Property {
 	for i := range props {
 		seen := map[string]struct{}{}

--- a/adapters/repos/db/inverted/nested/assign.go
+++ b/adapters/repos/db/inverted/nested/assign.go
@@ -13,7 +13,9 @@ package nested
 
 import (
 	"fmt"
+	"time"
 
+	"github.com/google/uuid"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -306,8 +308,14 @@ func (w *walker) walkScalarArray(path string, dt schema.DataType,
 		return nil
 	}
 
-	// Iterate directly over the concrete slice type — handles both the original
-	// []any form and typed slices produced by JSON round-trips ([]string etc.).
+	// Iterate directly over the concrete slice type. Values arrive in different
+	// forms depending on the write path:
+	//   - API/JSON path: enrichSchemaTypes converts []interface{} to []string,
+	//     []float64, or []bool based on the element type.
+	//   - Internal paths (e.g. direct programmatic insertion without a JSON
+	//     round-trip) may produce []int, []time.Time, or []uuid.UUID.
+	// All cases are handled defensively so that walkScalarArray remains correct
+	// regardless of how the caller obtained the value.
 	switch v := val.(type) {
 	case []any:
 		for i, elem := range v {
@@ -328,6 +336,24 @@ func (w *walker) walkScalarArray(path string, dt schema.DataType,
 			}
 		}
 	case []bool:
+		for i, elem := range v {
+			if err := appendElem(i, elem); err != nil {
+				return nil, err
+			}
+		}
+	case []int:
+		for i, elem := range v {
+			if err := appendElem(i, elem); err != nil {
+				return nil, err
+			}
+		}
+	case []time.Time:
+		for i, elem := range v {
+			if err := appendElem(i, elem); err != nil {
+				return nil, err
+			}
+		}
+	case []uuid.UUID:
 		for i, elem := range v {
 			if err := appendElem(i, elem); err != nil {
 				return nil, err

--- a/adapters/repos/db/inverted/nested/assign.go
+++ b/adapters/repos/db/inverted/nested/assign.go
@@ -279,25 +279,17 @@ func (w *walker) walkNestedArray(path string, dt schema.DataType,
 func (w *walker) walkScalarArray(path string, dt schema.DataType,
 	val any, np *models.NestedProperty,
 ) ([]uint64, error) {
-	arr, ok := val.([]any)
-	if !ok {
-		return nil, fmt.Errorf("expected []any for %s, got %T", path, val)
-	}
-
-	if len(arr) == 0 {
-		return nil, nil
-	}
-
 	scalarDT := schema.ScalarFromArrayType(dt)
 	var allPositions []uint64
 
-	for i, elem := range arr {
+	// appendElem records a single array element directly — elem is assignable
+	// to PositionedValue.Value (type any) without an intermediate []any copy.
+	appendElem := func(i int, elem any) error {
 		pos, err := w.nextLeaf()
 		if err != nil {
-			return nil, fmt.Errorf("scalar array %s[%d]: %w", path, i, err)
+			return fmt.Errorf("scalar array %s[%d]: %w", path, i, err)
 		}
 		positions := []uint64{pos}
-
 		w.result.Values = append(w.result.Values, PositionedValue{
 			Path:         path,
 			Value:        elem,
@@ -305,14 +297,48 @@ func (w *walker) walkScalarArray(path string, dt schema.DataType,
 			Tokenization: np.Tokenization,
 			Positions:    positions,
 		})
-
 		w.result.Idx = append(w.result.Idx, IdxEntry{
 			Path:      path,
 			Index:     i,
 			Positions: positions,
 		})
-
 		allPositions = append(allPositions, pos)
+		return nil
+	}
+
+	// Iterate directly over the concrete slice type — handles both the original
+	// []any form and typed slices produced by JSON round-trips ([]string etc.).
+	switch v := val.(type) {
+	case []any:
+		for i, elem := range v {
+			if err := appendElem(i, elem); err != nil {
+				return nil, err
+			}
+		}
+	case []string:
+		for i, elem := range v {
+			if err := appendElem(i, elem); err != nil {
+				return nil, err
+			}
+		}
+	case []float64:
+		for i, elem := range v {
+			if err := appendElem(i, elem); err != nil {
+				return nil, err
+			}
+		}
+	case []bool:
+		for i, elem := range v {
+			if err := appendElem(i, elem); err != nil {
+				return nil, err
+			}
+		}
+	default:
+		return nil, fmt.Errorf("expected []any for %s, got %T", path, val)
+	}
+
+	if len(allPositions) == 0 {
+		return nil, nil
 	}
 
 	w.result.Exists = append(w.result.Exists, ExistsEntry{

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -29,26 +30,26 @@ import (
 
 func (a *Analyzer) Object(input map[string]any, props []*models.Property,
 	uuid strfmt.UUID,
-) ([]Property, error) {
+) ([]Property, []NestedResult, error) {
 	propsMap := map[string]*models.Property{}
 	for _, prop := range props {
 		propsMap[prop.Name] = prop
 	}
 
-	properties, err := a.analyzeProps(propsMap, input)
+	properties, nestedResults, err := a.analyzeProps(propsMap, input)
 	if err != nil {
-		return nil, fmt.Errorf("analyze props: %w", err)
+		return nil, nil, fmt.Errorf("analyze props: %w", err)
 	}
 
 	idProp, err := a.analyzeIDProp(uuid)
 	if err != nil {
-		return nil, fmt.Errorf("analyze uuid prop: %w", err)
+		return nil, nil, fmt.Errorf("analyze uuid prop: %w", err)
 	}
 	properties = append(properties, *idProp)
 
 	tsProps, err := a.analyzeTimestampProps(input)
 	if err != nil {
-		return nil, fmt.Errorf("analyze timestamp props: %w", err)
+		return nil, nil, fmt.Errorf("analyze timestamp props: %w", err)
 	}
 	// tsProps will be nil here if weaviate is
 	// not setup to index by timestamps
@@ -56,42 +57,54 @@ func (a *Analyzer) Object(input map[string]any, props []*models.Property,
 		properties = append(properties, tsProps...)
 	}
 
-	return properties, nil
+	return properties, nestedResults, nil
 }
 
 func (a *Analyzer) analyzeProps(propsMap map[string]*models.Property,
 	input map[string]any,
-) ([]Property, error) {
+) ([]Property, []NestedResult, error) {
 	var out []Property
+	var nestedOut []NestedResult
 	for key, prop := range propsMap {
 		if len(prop.DataType) < 1 {
-			return nil, fmt.Errorf("prop %q has no datatype", prop.Name)
-		}
-
-		if !HasAnyInvertedIndex(prop) {
-			continue
+			return nil, nil, fmt.Errorf("prop %q has no datatype", prop.Name)
 		}
 
 		if schema.IsBlobLikeDataType(prop.DataType) {
 			continue
 		}
 
+		if _, ok := schema.AsNested(prop.DataType); ok {
+			nr, err := a.analyzeNestedProp(prop, input[key])
+			if err != nil {
+				return nil, nil, fmt.Errorf("analyze nested prop %q: %w", key, err)
+			}
+			if nr != nil {
+				nestedOut = append(nestedOut, *nr)
+			}
+			continue
+		}
+
+		if !HasAnyInvertedIndex(prop) {
+			continue
+		}
+
 		if schema.IsRefDataType(prop.DataType) {
 			if err := a.extendPropertiesWithReference(&out, prop, input, key); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		} else if schema.IsArrayDataType(prop.DataType) {
 			if err := a.extendPropertiesWithArrayType(&out, prop, input, key); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		} else {
 			if err := a.extendPropertiesWithPrimitive(&out, prop, input, key); err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 		}
 
 	}
-	return out, nil
+	return out, nestedOut, nil
 }
 
 func (a *Analyzer) analyzeIDProp(id strfmt.UUID) (*Property, error) {
@@ -644,3 +657,176 @@ const (
 	HasSearchableIndexPropLength = false
 	HasRangeableIndexPropLength  = false
 )
+
+// analyzeNestedProp runs position assignment on a nested property value,
+// then analyzes each leaf value into bytes suitable for indexing.
+func (a *Analyzer) analyzeNestedProp(prop *models.Property, value any) (*NestedResult, error) {
+	if value == nil {
+		return nil, nil
+	}
+
+	assignResult, err := nested.AssignPositions(prop, value)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(assignResult.Values) == 0 && len(assignResult.Idx) == 0 && len(assignResult.Exists) == 0 {
+		return nil, nil
+	}
+
+	var values []NestedValue
+	for _, pv := range assignResult.Values {
+		analyzed, err := a.analyzeNestedValue(pv)
+		if err != nil {
+			return nil, fmt.Errorf("analyze value at %q: %w", pv.Path, err)
+		}
+		values = append(values, analyzed...)
+	}
+
+	idx := make([]NestedMeta, len(assignResult.Idx))
+	for i, entry := range assignResult.Idx {
+		idx[i] = NestedMeta{
+			Path:      entry.Path,
+			Index:     entry.Index,
+			Positions: entry.Positions,
+		}
+	}
+
+	exists := make([]NestedMeta, len(assignResult.Exists))
+	for i, entry := range assignResult.Exists {
+		exists[i] = NestedMeta{
+			Path:      entry.Path,
+			Index:     -1,
+			Positions: entry.Positions,
+		}
+	}
+
+	return &NestedResult{
+		PropName: prop.Name,
+		Values:   values,
+		Idx:      idx,
+		Exists:   exists,
+	}, nil
+}
+
+// analyzeNestedValue converts a raw positioned value into one or more
+// NestedValue entries with analyzed byte representations. Text values
+// may produce multiple entries (one per token).
+func (a *Analyzer) analyzeNestedValue(pv nested.PositionedValue) ([]NestedValue, error) {
+	switch pv.DataType {
+	case schema.DataTypeText:
+		asString, ok := pv.Value.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string for %s, got %T", pv.Path, pv.Value)
+		}
+		items := a.Text(pv.Tokenization, asString)
+		out := make([]NestedValue, len(items))
+		for i, item := range items {
+			out[i] = NestedValue{Path: pv.Path, Data: item.Data, Positions: pv.Positions}
+		}
+		return out, nil
+
+	case schema.DataTypeInt:
+		asInt, err := toInt64(pv.Value)
+		if err != nil {
+			return nil, fmt.Errorf("expected int for %s: %w", pv.Path, err)
+		}
+		items, err := a.Int(asInt)
+		if err != nil {
+			return nil, err
+		}
+		return []NestedValue{{Path: pv.Path, Data: items[0].Data, Positions: pv.Positions}}, nil
+
+	case schema.DataTypeNumber:
+		asFloat, ok := pv.Value.(float64)
+		if !ok {
+			return nil, fmt.Errorf("expected float64 for %s, got %T", pv.Path, pv.Value)
+		}
+		items, err := a.Float(asFloat)
+		if err != nil {
+			return nil, err
+		}
+		return []NestedValue{{Path: pv.Path, Data: items[0].Data, Positions: pv.Positions}}, nil
+
+	case schema.DataTypeBoolean:
+		asBool, ok := pv.Value.(bool)
+		if !ok {
+			return nil, fmt.Errorf("expected bool for %s, got %T", pv.Path, pv.Value)
+		}
+		items, err := a.Bool(asBool)
+		if err != nil {
+			return nil, err
+		}
+		return []NestedValue{{Path: pv.Path, Data: items[0].Data, Positions: pv.Positions}}, nil
+
+	case schema.DataTypeDate:
+		asInt, err := dateToInt64(pv.Value)
+		if err != nil {
+			return nil, fmt.Errorf("expected date for %s: %w", pv.Path, err)
+		}
+		items, err := a.Int(asInt)
+		if err != nil {
+			return nil, err
+		}
+		return []NestedValue{{Path: pv.Path, Data: items[0].Data, Positions: pv.Positions}}, nil
+
+	case schema.DataTypeUUID:
+		asUUID, err := toUUID(pv.Value)
+		if err != nil {
+			return nil, fmt.Errorf("expected uuid for %s: %w", pv.Path, err)
+		}
+		items, err := a.UUID(asUUID)
+		if err != nil {
+			return nil, err
+		}
+		return []NestedValue{{Path: pv.Path, Data: items[0].Data, Positions: pv.Positions}}, nil
+
+	default:
+		return nil, nil
+	}
+}
+
+func toInt64(v any) (int64, error) {
+	switch val := v.(type) {
+	case float64:
+		return int64(val), nil
+	case int64:
+		return val, nil
+	case int:
+		return int64(val), nil
+	case json.Number:
+		f, err := val.Float64()
+		if err != nil {
+			return 0, err
+		}
+		return int64(f), nil
+	default:
+		return 0, fmt.Errorf("cannot convert %T to int64", v)
+	}
+}
+
+func dateToInt64(v any) (int64, error) {
+	switch val := v.(type) {
+	case time.Time:
+		return val.UnixNano(), nil
+	case string:
+		t, err := time.Parse(time.RFC3339Nano, val)
+		if err != nil {
+			return 0, fmt.Errorf("parse date string: %w", err)
+		}
+		return t.UnixNano(), nil
+	default:
+		return 0, fmt.Errorf("expected time.Time or string, got %T", v)
+	}
+}
+
+func toUUID(v any) (uuid.UUID, error) {
+	switch val := v.(type) {
+	case uuid.UUID:
+		return val, nil
+	case string:
+		return uuid.Parse(val)
+	default:
+		return uuid.UUID{}, fmt.Errorf("expected uuid.UUID or string, got %T", v)
+	}
+}

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -74,6 +74,11 @@ func (a *Analyzer) analyzeProps(propsMap map[string]*models.Property,
 		}
 
 		if _, ok := schema.AsNested(prop.DataType); ok {
+			// TODO aliszka:nested_filtering respect top-level indexFilterable/
+			// indexSearchable/indexRangeable settings for nested properties. Currently
+			// these are ignored — the nested write path bypasses HasAnyInvertedIndex
+			// and always indexes. The interaction between the top-level setting and
+			// per-nested-property settings needs design discussion before implementing.
 			nr, err := a.analyzeNestedProp(prop, input[key])
 			if err != nil {
 				return nil, nil, fmt.Errorf("analyze nested prop %q: %w", key, err)
@@ -242,7 +247,7 @@ func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []any) (*Prope
 		return nil, nil
 	}
 
-	var items []Countable
+	items := make([]Countable, 0, len(values))
 	for _, value := range values {
 		analyzed, err := a.analyzeValue(scalarDT, "", "", nil, value)
 		if err != nil {

--- a/adapters/repos/db/inverted/objects.go
+++ b/adapters/repos/db/inverted/objects.go
@@ -25,18 +25,17 @@ import (
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
-	"github.com/weaviate/weaviate/usecases/objects/validation"
 )
 
 func (a *Analyzer) Object(input map[string]any, props []*models.Property,
 	uuid strfmt.UUID,
-) ([]Property, []NestedResult, error) {
+) ([]Property, []NestedProperty, error) {
 	propsMap := map[string]*models.Property{}
 	for _, prop := range props {
 		propsMap[prop.Name] = prop
 	}
 
-	properties, nestedResults, err := a.analyzeProps(propsMap, input)
+	properties, nestedProps, err := a.analyzeProps(propsMap, input)
 	if err != nil {
 		return nil, nil, fmt.Errorf("analyze props: %w", err)
 	}
@@ -57,14 +56,14 @@ func (a *Analyzer) Object(input map[string]any, props []*models.Property,
 		properties = append(properties, tsProps...)
 	}
 
-	return properties, nestedResults, nil
+	return properties, nestedProps, nil
 }
 
 func (a *Analyzer) analyzeProps(propsMap map[string]*models.Property,
 	input map[string]any,
-) ([]Property, []NestedResult, error) {
+) ([]Property, []NestedProperty, error) {
 	var out []Property
-	var nestedOut []NestedResult
+	var nestedOut []NestedProperty
 	for key, prop := range propsMap {
 		if len(prop.DataType) < 1 {
 			return nil, nil, fmt.Errorf("prop %q has no datatype", prop.Name)
@@ -217,131 +216,48 @@ func (a *Analyzer) extendPropertiesWithPrimitive(properties *[]Property,
 }
 
 func (a *Analyzer) analyzeArrayProp(prop *models.Property, values []any) (*Property, error) {
-	var items []Countable
-	hasFilterableIndex := HasFilterableIndex(prop)
-	hasSearchableIndex := HasSearchableIndex(prop)
-	hasRangeableIndex := HasRangeableIndex(prop)
+	dt := schema.DataType(prop.DataType[0])
 
-	switch dt := schema.DataType(prop.DataType[0]); dt {
-	case schema.DataTypeTextArray:
-		hasFilterableIndex = hasFilterableIndex && !a.isFallbackToSearchable()
+	// Text arrays need special handling: TextArray aggregates term frequencies
+	// across all elements, which per-element analyzeValue calls cannot do.
+	if dt == schema.DataTypeTextArray {
 		in, err := stringsFromValues(prop, values)
 		if err != nil {
 			return nil, err
 		}
-		items = a.TextArray(prop.Tokenization, in, prop.Name, prop.TextAnalyzer)
-	case schema.DataTypeIntArray:
-		in := make([]int64, len(values))
-		for i, value := range values {
-			if asJsonNumber, ok := value.(json.Number); ok {
-				var err error
-				value, err = asJsonNumber.Float64()
-				if err != nil {
-					return nil, err
-				}
-			}
+		hasFilterableIndex := HasFilterableIndex(prop) && !a.isFallbackToSearchable()
+		return &Property{
+			Name:               prop.Name,
+			Items:              a.TextArray(prop.Tokenization, in, prop.Name, prop.TextAnalyzer),
+			Length:             len(values),
+			HasFilterableIndex: hasFilterableIndex,
+			HasSearchableIndex: HasSearchableIndex(prop),
+			HasRangeableIndex:  HasRangeableIndex(prop),
+		}, nil
+	}
 
-			if asFloat, ok := value.(float64); ok {
-				// unmarshaling from json into a dynamic schema will assume every number
-				// is a float64
-				value = int64(asFloat)
-			}
-
-			asInt, ok := value.(int64)
-			if !ok {
-				return nil, fmt.Errorf("expected property %s to be of type int64, but got %T", prop.Name, value)
-			}
-			in[i] = asInt
-		}
-
-		var err error
-		items, err = a.IntArray(in)
-		if err != nil {
-			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
-		}
-	case schema.DataTypeNumberArray:
-		in := make([]float64, len(values))
-		for i, value := range values {
-			if asJsonNumber, ok := value.(json.Number); ok {
-				var err error
-				value, err = asJsonNumber.Float64()
-				if err != nil {
-					return nil, err
-				}
-			}
-
-			asFloat, ok := value.(float64)
-			if !ok {
-				return nil, fmt.Errorf("expected property %s to be of type float64, but got %T", prop.Name, value)
-			}
-			in[i] = asFloat
-		}
-
-		var err error
-		items, err = a.FloatArray(in) // convert to int before analyzing
-		if err != nil {
-			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
-		}
-	case schema.DataTypeBooleanArray:
-		in := make([]bool, len(values))
-		for i, value := range values {
-			asBool, ok := value.(bool)
-			if !ok {
-				return nil, fmt.Errorf("expected property %s to be of type bool, but got %T", prop.Name, value)
-			}
-			in[i] = asBool
-		}
-
-		var err error
-		items, err = a.BoolArray(in) // convert to int before analyzing
-		if err != nil {
-			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
-		}
-	case schema.DataTypeDateArray:
-		in := make([]int64, len(values))
-		for i, value := range values {
-			// dates can be either a date-string or directly a time object. Try to parse both
-			if asTime, okTime := value.(time.Time); okTime {
-				in[i] = asTime.UnixNano()
-			} else if asString, okString := value.(string); okString {
-				parsedTime, err := time.Parse(time.RFC3339Nano, asString)
-				if err != nil {
-					return nil, fmt.Errorf("parse time: %w", err)
-				}
-				in[i] = parsedTime.UnixNano()
-			} else {
-				return nil, fmt.Errorf("expected property %s to be a time-string or time object, but got %T", prop.Name, value)
-			}
-		}
-
-		var err error
-		items, err = a.IntArray(in)
-		if err != nil {
-			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
-		}
-	case schema.DataTypeUUIDArray:
-		parsed, err := validation.ParseUUIDArray(values)
-		if err != nil {
-			return nil, fmt.Errorf("parse uuid array: %w", err)
-		}
-
-		items, err = a.UUIDArray(parsed)
-		if err != nil {
-			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
-		}
-
-	default:
-		// ignore unsupported prop type
+	scalarDT := schema.ScalarFromArrayType(dt)
+	if scalarDT == dt {
+		// unknown array type
 		return nil, nil
+	}
+
+	var items []Countable
+	for _, value := range values {
+		analyzed, err := a.analyzeValue(scalarDT, "", "", nil, value)
+		if err != nil {
+			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
+		}
+		items = append(items, analyzed...)
 	}
 
 	return &Property{
 		Name:               prop.Name,
 		Items:              items,
 		Length:             len(values),
-		HasFilterableIndex: hasFilterableIndex,
-		HasSearchableIndex: hasSearchableIndex,
-		HasRangeableIndex:  hasRangeableIndex,
+		HasFilterableIndex: HasFilterableIndex(prop),
+		HasSearchableIndex: HasSearchableIndex(prop),
+		HasRangeableIndex:  HasRangeableIndex(prop),
 	}, nil
 }
 
@@ -358,106 +274,24 @@ func stringsFromValues(prop *models.Property, values []any) ([]string, error) {
 }
 
 func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Property, error) {
-	var items []Countable
-	propertyLength := -1 // will be overwritten for string/text, signals not to add the other types.
+	dt := schema.DataType(prop.DataType[0])
+	items, err := a.analyzeValue(dt, prop.Tokenization, prop.Name, prop.TextAnalyzer, value)
+	if err != nil {
+		return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
+	}
+	if items == nil {
+		return nil, nil
+	}
+
+	propertyLength := -1
 	hasFilterableIndex := HasFilterableIndex(prop)
 	hasSearchableIndex := HasSearchableIndex(prop)
-	hasRangeableIndex := HasRangeableIndex(prop)
 
-	switch dt := schema.DataType(prop.DataType[0]); dt {
-	case schema.DataTypeText:
+	if dt == schema.DataTypeText {
 		hasFilterableIndex = hasFilterableIndex && !a.isFallbackToSearchable()
-		asString, ok := value.(string)
-		if !ok {
-			return nil, fmt.Errorf("expected property %s to be of type string, but got %T", prop.Name, value)
-		}
-		items = a.Text(prop.Tokenization, asString, prop.Name, prop.TextAnalyzer)
-		propertyLength = utf8.RuneCountInString(asString)
-	case schema.DataTypeInt:
-		if asFloat, ok := value.(float64); ok {
-			// unmarshaling from json into a dynamic schema will assume every number
-			// is a float64
-			value = int64(asFloat)
-		}
-
-		if asInt, ok := value.(int); ok {
-			// when merging an existing object we may retrieve an untyped int
-			value = int64(asInt)
-		}
-
-		asInt, ok := value.(int64)
-		if !ok {
-			return nil, fmt.Errorf("expected property %s to be of type int64, but got %T", prop.Name, value)
-		}
-
-		var err error
-		items, err = a.Int(asInt)
-		if err != nil {
-			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
-		}
-	case schema.DataTypeNumber:
-		asFloat, ok := value.(float64)
-		if !ok {
-			return nil, fmt.Errorf("expected property %s to be of type float64, but got %T", prop.Name, value)
-		}
-
-		var err error
-		items, err = a.Float(asFloat) // convert to int before analyzing
-		if err != nil {
-			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
-		}
-	case schema.DataTypeBoolean:
-		asBool, ok := value.(bool)
-		if !ok {
-			return nil, fmt.Errorf("expected property %s to be of type bool, but got %T", prop.Name, value)
-		}
-
-		var err error
-		items, err = a.Bool(asBool) // convert to int before analyzing
-		if err != nil {
-			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
-		}
-	case schema.DataTypeDate:
-		var err error
 		if asString, ok := value.(string); ok {
-			// for example when patching the date may have been loaded as a string
-			value, err = time.Parse(time.RFC3339Nano, asString)
-			if err != nil {
-				return nil, fmt.Errorf("parse stringified timestamp: %w", err)
-			}
+			propertyLength = utf8.RuneCountInString(asString)
 		}
-		asTime, ok := value.(time.Time)
-		if !ok {
-			return nil, fmt.Errorf("expected property %s to be time.Time, but got %T", prop.Name, value)
-		}
-
-		items, err = a.Int(asTime.UnixNano())
-		if err != nil {
-			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
-		}
-	case schema.DataTypeUUID:
-		var err error
-
-		if asString, ok := value.(string); ok {
-			// for example when patching the uuid may have been loaded as a string
-			value, err = uuid.Parse(asString)
-			if err != nil {
-				return nil, fmt.Errorf("parse stringified uuid: %w", err)
-			}
-		}
-
-		asUUID, ok := value.(uuid.UUID)
-		if !ok {
-			return nil, fmt.Errorf("expected property %s to be uuid.UUID, but got %T", prop.Name, value)
-		}
-
-		items, err = a.UUID(asUUID)
-		if err != nil {
-			return nil, fmt.Errorf("analyze property %s: %w", prop.Name, err)
-		}
-	default:
-		// ignore unsupported prop type
-		return nil, nil
 	}
 
 	return &Property{
@@ -466,8 +300,61 @@ func (a *Analyzer) analyzePrimitiveProp(prop *models.Property, value any) (*Prop
 		Length:             propertyLength,
 		HasFilterableIndex: hasFilterableIndex,
 		HasSearchableIndex: hasSearchableIndex,
-		HasRangeableIndex:  hasRangeableIndex,
+		HasRangeableIndex:  HasRangeableIndex(prop),
 	}, nil
+}
+
+// analyzeValue converts a raw value to analyzed Countable items based on
+// data type. Shared by analyzePrimitiveProp and analyzeNestedValue.
+// propName and textAnalyzer are used for custom text analyzer configuration;
+// pass "" and nil for nested properties which do not support custom analyzers.
+func (a *Analyzer) analyzeValue(dt schema.DataType, tokenization, propName string, textAnalyzer *models.TextAnalyzerConfig, value any) ([]Countable, error) {
+	switch dt {
+	case schema.DataTypeText:
+		asString, ok := value.(string)
+		if !ok {
+			return nil, fmt.Errorf("expected string, got %T", value)
+		}
+		return a.Text(tokenization, asString, propName, textAnalyzer), nil
+
+	case schema.DataTypeInt:
+		asInt, err := toInt64(value)
+		if err != nil {
+			return nil, err
+		}
+		return a.Int(asInt)
+
+	case schema.DataTypeNumber:
+		asFloat, ok := value.(float64)
+		if !ok {
+			return nil, fmt.Errorf("expected float64, got %T", value)
+		}
+		return a.Float(asFloat)
+
+	case schema.DataTypeBoolean:
+		asBool, ok := value.(bool)
+		if !ok {
+			return nil, fmt.Errorf("expected bool, got %T", value)
+		}
+		return a.Bool(asBool)
+
+	case schema.DataTypeDate:
+		asInt, err := dateToInt64(value)
+		if err != nil {
+			return nil, err
+		}
+		return a.Int(asInt)
+
+	case schema.DataTypeUUID:
+		asUUID, err := toUUID(value)
+		if err != nil {
+			return nil, err
+		}
+		return a.UUID(asUUID)
+
+	default:
+		return nil, nil
+	}
 }
 
 // extendPropertiesWithReference extends the specified properties arrays with
@@ -660,7 +547,7 @@ const (
 
 // analyzeNestedProp runs position assignment on a nested property value,
 // then analyzes each leaf value into bytes suitable for indexing.
-func (a *Analyzer) analyzeNestedProp(prop *models.Property, value any) (*NestedResult, error) {
+func (a *Analyzer) analyzeNestedProp(prop *models.Property, value any) (*NestedProperty, error) {
 	if value == nil {
 		return nil, nil
 	}
@@ -674,7 +561,7 @@ func (a *Analyzer) analyzeNestedProp(prop *models.Property, value any) (*NestedR
 		return nil, nil
 	}
 
-	var values []NestedValue
+	values := make([]NestedValue, 0, len(assignResult.Values))
 	for _, pv := range assignResult.Values {
 		analyzed, err := a.analyzeNestedValue(pv)
 		if err != nil {
@@ -701,11 +588,11 @@ func (a *Analyzer) analyzeNestedProp(prop *models.Property, value any) (*NestedR
 		}
 	}
 
-	return &NestedResult{
-		PropName: prop.Name,
-		Values:   values,
-		Idx:      idx,
-		Exists:   exists,
+	return &NestedProperty{
+		Name:   prop.Name,
+		Values: values,
+		Idx:    idx,
+		Exists: exists,
 	}, nil
 }
 
@@ -713,77 +600,19 @@ func (a *Analyzer) analyzeNestedProp(prop *models.Property, value any) (*NestedR
 // NestedValue entries with analyzed byte representations. Text values
 // may produce multiple entries (one per token).
 func (a *Analyzer) analyzeNestedValue(pv nested.PositionedValue) ([]NestedValue, error) {
-	switch pv.DataType {
-	case schema.DataTypeText:
-		asString, ok := pv.Value.(string)
-		if !ok {
-			return nil, fmt.Errorf("expected string for %s, got %T", pv.Path, pv.Value)
-		}
-		items := a.Text(pv.Tokenization, asString)
-		out := make([]NestedValue, len(items))
-		for i, item := range items {
-			out[i] = NestedValue{Path: pv.Path, Data: item.Data, Positions: pv.Positions}
-		}
-		return out, nil
-
-	case schema.DataTypeInt:
-		asInt, err := toInt64(pv.Value)
-		if err != nil {
-			return nil, fmt.Errorf("expected int for %s: %w", pv.Path, err)
-		}
-		items, err := a.Int(asInt)
-		if err != nil {
-			return nil, err
-		}
-		return []NestedValue{{Path: pv.Path, Data: items[0].Data, Positions: pv.Positions}}, nil
-
-	case schema.DataTypeNumber:
-		asFloat, ok := pv.Value.(float64)
-		if !ok {
-			return nil, fmt.Errorf("expected float64 for %s, got %T", pv.Path, pv.Value)
-		}
-		items, err := a.Float(asFloat)
-		if err != nil {
-			return nil, err
-		}
-		return []NestedValue{{Path: pv.Path, Data: items[0].Data, Positions: pv.Positions}}, nil
-
-	case schema.DataTypeBoolean:
-		asBool, ok := pv.Value.(bool)
-		if !ok {
-			return nil, fmt.Errorf("expected bool for %s, got %T", pv.Path, pv.Value)
-		}
-		items, err := a.Bool(asBool)
-		if err != nil {
-			return nil, err
-		}
-		return []NestedValue{{Path: pv.Path, Data: items[0].Data, Positions: pv.Positions}}, nil
-
-	case schema.DataTypeDate:
-		asInt, err := dateToInt64(pv.Value)
-		if err != nil {
-			return nil, fmt.Errorf("expected date for %s: %w", pv.Path, err)
-		}
-		items, err := a.Int(asInt)
-		if err != nil {
-			return nil, err
-		}
-		return []NestedValue{{Path: pv.Path, Data: items[0].Data, Positions: pv.Positions}}, nil
-
-	case schema.DataTypeUUID:
-		asUUID, err := toUUID(pv.Value)
-		if err != nil {
-			return nil, fmt.Errorf("expected uuid for %s: %w", pv.Path, err)
-		}
-		items, err := a.UUID(asUUID)
-		if err != nil {
-			return nil, err
-		}
-		return []NestedValue{{Path: pv.Path, Data: items[0].Data, Positions: pv.Positions}}, nil
-
-	default:
+	items, err := a.analyzeValue(pv.DataType, pv.Tokenization, "", nil, pv.Value)
+	if err != nil {
+		return nil, err
+	}
+	if items == nil {
 		return nil, nil
 	}
+
+	out := make([]NestedValue, len(items))
+	for i, item := range items {
+		out[i] = NestedValue{Path: pv.Path, Data: item.Data, Positions: pv.Positions}
+	}
+	return out, nil
 }
 
 func toInt64(v any) (int64, error) {

--- a/adapters/repos/db/inverted/objects_test.go
+++ b/adapters/repos/db/inverted/objects_test.go
@@ -84,7 +84,7 @@ func TestAnalyzeObject(t *testing.T) {
 				DataType: []string{"uuid[]"},
 			},
 		}
-		res, err := a.Object(sch, props, strfmt.UUID(uuid))
+		res, _, err := a.Object(sch, props, strfmt.UUID(uuid))
 		require.Nil(t, err)
 
 		expectedDescription := []Countable{
@@ -275,7 +275,7 @@ func TestAnalyzeObject(t *testing.T) {
 				DataType: []string{"number[]"},
 			},
 		}
-		res, err := a.Object(sch, props, strfmt.UUID(uuid))
+		res, _, err := a.Object(sch, props, strfmt.UUID(uuid))
 		require.Nil(t, err)
 
 		expectedDescriptions := []Countable{
@@ -454,7 +454,7 @@ func TestAnalyzeObject(t *testing.T) {
 					DataType: []string{"RefClass"},
 				},
 			}
-			res, err := a.Object(schema, props, strfmt.UUID(uuid))
+			res, _, err := a.Object(schema, props, strfmt.UUID(uuid))
 			require.Nil(t, err)
 
 			expectedRefCount := []Countable{
@@ -513,7 +513,7 @@ func TestAnalyzeObject(t *testing.T) {
 					DataType: []string{"RefClass"},
 				},
 			}
-			res, err := a.Object(schema, props, strfmt.UUID(uuid))
+			res, _, err := a.Object(schema, props, strfmt.UUID(uuid))
 			require.Nil(t, err)
 
 			expectedRefCount := []Countable{
@@ -563,7 +563,7 @@ func TestAnalyzeObject(t *testing.T) {
 					DataType: []string{"RefClass"},
 				},
 			}
-			res, err := a.Object(schema, props, strfmt.UUID(uuid))
+			res, _, err := a.Object(schema, props, strfmt.UUID(uuid))
 			require.Nil(t, err)
 
 			expectedRefCount := []Countable{
@@ -619,7 +619,7 @@ func TestAnalyzeObject(t *testing.T) {
 					DataType: []string{"SomeClass"},
 				},
 			}
-			res, err := a.Object(sch, props, strfmt.UUID(uuid))
+			res, _, err := a.Object(sch, props, strfmt.UUID(uuid))
 			require.Nil(t, err)
 
 			expectedUUID := []Countable{
@@ -670,7 +670,7 @@ func TestAnalyzeObject(t *testing.T) {
 			},
 		}
 
-		res, err := a.Object(sch, props, uuid)
+		res, _, err := a.Object(sch, props, uuid)
 		require.Nil(t, err)
 		require.Len(t, res, 4)
 

--- a/adapters/repos/db/inverted_reindexer.go
+++ b/adapters/repos/db/inverted_reindexer.go
@@ -269,7 +269,7 @@ func (r *ShardInvertedReindexer) reindexProperties(ctx context.Context, reindexa
 				Debugf("iterating through objects: %d done", i)
 		}
 		docID := object.DocID
-		properties, nilProperties, err := r.shard.AnalyzeObject(object)
+		properties, nilProperties, _, err := r.shard.AnalyzeObject(object)
 		if err != nil {
 			return errors.Wrapf(err, "failed analyzying object")
 		}

--- a/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
+++ b/adapters/repos/db/inverted_reindexer_map_to_blockmax.go
@@ -1252,7 +1252,7 @@ func uuidObjectsIteratorAsync(logger logrus.FieldLogger, shard ShardLike, lastKe
 			}
 
 			if obj.LastUpdateTimeUnix() < reindexStarted.UnixMilli() {
-				props, _, err := shard.AnalyzeObject(obj)
+				props, _, _, err := shard.AnalyzeObject(obj)
 				if err != nil {
 					mdCh <- &migrationData{err: fmt.Errorf("analyzing object '%s': %w", ik.String(), err)}
 					break

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -969,7 +969,7 @@ func (m *Migrator) RecountProperties(ctx context.Context) error {
 		// Iterate over all shards
 		err = index.IterateObjects(ctx, func(index *Index, shard ShardLike, object *storobj.Object) error {
 			count = count + 1
-			props, _, err := shard.AnalyzeObject(object)
+			props, _, _, err := shard.AnalyzeObject(object)
 			if err != nil {
 				m.logger.WithField("error", err).Error("could not analyze object")
 				return nil

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -248,7 +248,7 @@ func (_c *MockShardLike_Aggregate_Call) RunAndReturn(run func(context.Context, a
 }
 
 // AnalyzeObject provides a mock function with given fields: _a0
-func (_m *MockShardLike) AnalyzeObject(_a0 *storobj.Object) ([]inverted.Property, []inverted.NilProperty, error) {
+func (_m *MockShardLike) AnalyzeObject(_a0 *storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedResult, error) {
 	ret := _m.Called(_a0)
 
 	if len(ret) == 0 {
@@ -257,8 +257,9 @@ func (_m *MockShardLike) AnalyzeObject(_a0 *storobj.Object) ([]inverted.Property
 
 	var r0 []inverted.Property
 	var r1 []inverted.NilProperty
-	var r2 error
-	if rf, ok := ret.Get(0).(func(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, error)); ok {
+	var r2 []inverted.NestedResult
+	var r3 error
+	if rf, ok := ret.Get(0).(func(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedResult, error)); ok {
 		return rf(_a0)
 	}
 	if rf, ok := ret.Get(0).(func(*storobj.Object) []inverted.Property); ok {
@@ -277,13 +278,21 @@ func (_m *MockShardLike) AnalyzeObject(_a0 *storobj.Object) ([]inverted.Property
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(*storobj.Object) error); ok {
+	if rf, ok := ret.Get(2).(func(*storobj.Object) []inverted.NestedResult); ok {
 		r2 = rf(_a0)
 	} else {
-		r2 = ret.Error(2)
+		if ret.Get(2) != nil {
+			r2 = ret.Get(2).([]inverted.NestedResult)
+		}
 	}
 
-	return r0, r1, r2
+	if rf, ok := ret.Get(3).(func(*storobj.Object) error); ok {
+		r3 = rf(_a0)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
 }
 
 // MockShardLike_AnalyzeObject_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'AnalyzeObject'
@@ -304,12 +313,12 @@ func (_c *MockShardLike_AnalyzeObject_Call) Run(run func(_a0 *storobj.Object)) *
 	return _c
 }
 
-func (_c *MockShardLike_AnalyzeObject_Call) Return(_a0 []inverted.Property, _a1 []inverted.NilProperty, _a2 error) *MockShardLike_AnalyzeObject_Call {
-	_c.Call.Return(_a0, _a1, _a2)
+func (_c *MockShardLike_AnalyzeObject_Call) Return(_a0 []inverted.Property, _a1 []inverted.NilProperty, _a2 []inverted.NestedResult, _a3 error) *MockShardLike_AnalyzeObject_Call {
+	_c.Call.Return(_a0, _a1, _a2, _a3)
 	return _c
 }
 
-func (_c *MockShardLike_AnalyzeObject_Call) RunAndReturn(run func(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, error)) *MockShardLike_AnalyzeObject_Call {
+func (_c *MockShardLike_AnalyzeObject_Call) RunAndReturn(run func(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedResult, error)) *MockShardLike_AnalyzeObject_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/adapters/repos/db/mock_shard_like.go
+++ b/adapters/repos/db/mock_shard_like.go
@@ -248,7 +248,7 @@ func (_c *MockShardLike_Aggregate_Call) RunAndReturn(run func(context.Context, a
 }
 
 // AnalyzeObject provides a mock function with given fields: _a0
-func (_m *MockShardLike) AnalyzeObject(_a0 *storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedResult, error) {
+func (_m *MockShardLike) AnalyzeObject(_a0 *storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedProperty, error) {
 	ret := _m.Called(_a0)
 
 	if len(ret) == 0 {
@@ -257,9 +257,9 @@ func (_m *MockShardLike) AnalyzeObject(_a0 *storobj.Object) ([]inverted.Property
 
 	var r0 []inverted.Property
 	var r1 []inverted.NilProperty
-	var r2 []inverted.NestedResult
+	var r2 []inverted.NestedProperty
 	var r3 error
-	if rf, ok := ret.Get(0).(func(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedResult, error)); ok {
+	if rf, ok := ret.Get(0).(func(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedProperty, error)); ok {
 		return rf(_a0)
 	}
 	if rf, ok := ret.Get(0).(func(*storobj.Object) []inverted.Property); ok {
@@ -278,11 +278,11 @@ func (_m *MockShardLike) AnalyzeObject(_a0 *storobj.Object) ([]inverted.Property
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(*storobj.Object) []inverted.NestedResult); ok {
+	if rf, ok := ret.Get(2).(func(*storobj.Object) []inverted.NestedProperty); ok {
 		r2 = rf(_a0)
 	} else {
 		if ret.Get(2) != nil {
-			r2 = ret.Get(2).([]inverted.NestedResult)
+			r2 = ret.Get(2).([]inverted.NestedProperty)
 		}
 	}
 
@@ -313,12 +313,12 @@ func (_c *MockShardLike_AnalyzeObject_Call) Run(run func(_a0 *storobj.Object)) *
 	return _c
 }
 
-func (_c *MockShardLike_AnalyzeObject_Call) Return(_a0 []inverted.Property, _a1 []inverted.NilProperty, _a2 []inverted.NestedResult, _a3 error) *MockShardLike_AnalyzeObject_Call {
+func (_c *MockShardLike_AnalyzeObject_Call) Return(_a0 []inverted.Property, _a1 []inverted.NilProperty, _a2 []inverted.NestedProperty, _a3 error) *MockShardLike_AnalyzeObject_Call {
 	_c.Call.Return(_a0, _a1, _a2, _a3)
 	return _c
 }
 
-func (_c *MockShardLike_AnalyzeObject_Call) RunAndReturn(run func(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedResult, error)) *MockShardLike_AnalyzeObject_Call {
+func (_c *MockShardLike_AnalyzeObject_Call) RunAndReturn(run func(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedProperty, error)) *MockShardLike_AnalyzeObject_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -109,7 +109,7 @@ type ShardLike interface {
 	GetFileMetadata(ctx context.Context, relativeFilePath string) (file.FileMetadata, error)
 	GetFile(ctx context.Context, relativeFilePath string) (io.ReadCloser, error)
 	SetPropertyLengths(props []inverted.Property) error
-	AnalyzeObject(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, error)
+	AnalyzeObject(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedResult, error)
 	Aggregate(ctx context.Context, params aggregation.Params, modules *modules.Provider) (*aggregation.Result, error)
 	HashTreeLevel(ctx context.Context, level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
 	MergeObject(ctx context.Context, object objects.MergeDocument) error

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -109,7 +109,7 @@ type ShardLike interface {
 	GetFileMetadata(ctx context.Context, relativeFilePath string) (file.FileMetadata, error)
 	GetFile(ctx context.Context, relativeFilePath string) (io.ReadCloser, error)
 	SetPropertyLengths(props []inverted.Property) error
-	AnalyzeObject(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedResult, error)
+	AnalyzeObject(*storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedProperty, error)
 	Aggregate(ctx context.Context, params aggregation.Params, modules *modules.Provider) (*aggregation.Result, error)
 	HashTreeLevel(ctx context.Context, level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error)
 	MergeObject(ctx context.Context, object objects.MergeDocument) error

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -555,7 +555,7 @@ func (l *LazyLoadShard) SetPropertyLengths(props []inverted.Property) error {
 	return l.shard.SetPropertyLengths(props)
 }
 
-func (l *LazyLoadShard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedResult, error) {
+func (l *LazyLoadShard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedProperty, error) {
 	l.mustLoad()
 	return l.shard.AnalyzeObject(object)
 }

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -555,7 +555,7 @@ func (l *LazyLoadShard) SetPropertyLengths(props []inverted.Property) error {
 	return l.shard.SetPropertyLengths(props)
 }
 
-func (l *LazyLoadShard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []inverted.NilProperty, error) {
+func (l *LazyLoadShard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedResult, error) {
 	l.mustLoad()
 	return l.shard.AnalyzeObject(object)
 }

--- a/adapters/repos/db/shard_write_delete.go
+++ b/adapters/repos/db/shard_write_delete.go
@@ -141,7 +141,7 @@ func (s *Shard) cleanupInvertedIndexOnDelete(previous []byte, docID uint64) erro
 		return fmt.Errorf("unmarshal previous object: %w", err)
 	}
 
-	previousProps, previousNilProps, err := s.AnalyzeObject(previousObject)
+	previousProps, previousNilProps, _, err := s.AnalyzeObject(previousObject)
 	if err != nil {
 		return fmt.Errorf("analyze previous object: %w", err)
 	}

--- a/adapters/repos/db/shard_write_inverted.go
+++ b/adapters/repos/db/shard_write_inverted.go
@@ -29,10 +29,10 @@ func isPropertyForLength(dt schema.DataType) bool {
 	}
 }
 
-func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []inverted.NilProperty, error) {
+func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedResult, error) {
 	c := s.index.getSchema.ReadOnlyClass(object.Class().String())
 	if c == nil {
-		return nil, nil, fmt.Errorf("could not find class %s in schema", object.Class().String())
+		return nil, nil, nil, fmt.Errorf("could not find class %s in schema", object.Class().String())
 	}
 
 	var schemaMap map[string]interface{}
@@ -42,7 +42,7 @@ func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []in
 	} else {
 		maybeSchemaMap, ok := object.Properties().(map[string]interface{})
 		if !ok {
-			return nil, nil, fmt.Errorf("expected schema to be map, but got %T", object.Properties())
+			return nil, nil, nil, fmt.Errorf("expected schema to be map, but got %T", object.Properties())
 		}
 		schemaMap = maybeSchemaMap
 	}
@@ -79,6 +79,6 @@ func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []in
 		schemaMap[filters.InternalPropLastUpdateTimeUnix] = object.Object.LastUpdateTimeUnix
 	}
 
-	props, err := inverted.NewAnalyzer(s.isFallbackToSearchable, object.Class().String()).Object(schemaMap, c.Properties, object.ID())
-	return props, nilProps, err
+	props, nestedResults, err := inverted.NewAnalyzer(s.isFallbackToSearchable, object.Class().String()).Object(schemaMap, c.Properties, object.ID())
+	return props, nilProps, nestedResults, err
 }

--- a/adapters/repos/db/shard_write_inverted.go
+++ b/adapters/repos/db/shard_write_inverted.go
@@ -29,7 +29,7 @@ func isPropertyForLength(dt schema.DataType) bool {
 	}
 }
 
-func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedResult, error) {
+func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []inverted.NilProperty, []inverted.NestedProperty, error) {
 	c := s.index.getSchema.ReadOnlyClass(object.Class().String())
 	if c == nil {
 		return nil, nil, nil, fmt.Errorf("could not find class %s in schema", object.Class().String())
@@ -79,6 +79,6 @@ func (s *Shard) AnalyzeObject(object *storobj.Object) ([]inverted.Property, []in
 		schemaMap[filters.InternalPropLastUpdateTimeUnix] = object.Object.LastUpdateTimeUnix
 	}
 
-	props, nestedResults, err := inverted.NewAnalyzer(s.isFallbackToSearchable, object.Class().String()).Object(schemaMap, c.Properties, object.ID())
-	return props, nilProps, nestedResults, err
+	props, nestedProps, err := inverted.NewAnalyzer(s.isFallbackToSearchable, object.Class().String()).Object(schemaMap, c.Properties, object.ID())
+	return props, nilProps, nestedProps, err
 }

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -447,7 +447,7 @@ func (s *Shard) upsertObjectDataLSM(bucket *lsmkv.Bucket, id []byte, data []byte
 func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 	status objectInsertStatus, prevObject *storobj.Object,
 ) error {
-	props, nilprops, err := s.AnalyzeObject(object)
+	props, nilprops, _, err := s.AnalyzeObject(object)
 	if err != nil {
 		return errors.Wrap(err, "analyze next object")
 	}
@@ -456,7 +456,7 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 	var prevNilprops []inverted.NilProperty
 
 	if prevObject != nil {
-		prevProps, prevNilprops, err = s.AnalyzeObject(prevObject)
+		prevProps, prevNilprops, _, err = s.AnalyzeObject(prevObject)
 		if err != nil {
 			return fmt.Errorf("analyze previous object: %w", err)
 		}

--- a/test/acceptance/grpc/grpc_mixed_vectors_test.go
+++ b/test/acceptance/grpc/grpc_mixed_vectors_test.go
@@ -155,6 +155,7 @@ func TestGRPC_MixedVectors(t *testing.T) {
 						}
 					}
 				})
+				require.NotEmpty(t, resp.Results)
 				require.Equal(t, "Dune", resp.Results[0].Properties.NonRefProps.Fields["title"].GetTextValue())
 			})
 		})


### PR DESCRIPTION
## Nested object filtering — Part 2: write path analysis

  Second PR in the nested object filtering series, building on Part 1 (position encoding and assignment).

  ### What's in this PR

  **Write path analysis** — routes nested (`object` / `object[]`) properties through `AssignPositions` during `analyzeProps`, then analyzes each positioned leaf value into bytes using the existing `Analyzer` methods. Introduces `NestedProperty` as the output type carrying three sets of results:
  - `Values` — analyzed leaf values ready for LSM storage
  - `Idx` entries — per-element position sets for same-element correlation
  - `Exists` entries — per-path presence sets for null/presence checks

  Updates `Object` / `analyzeProps` return signatures, `ShardLike` interface, and all callers (`shard_write_put`,
  `shard_write_inverted`, `inverted_reindexer`, `migrator`) to propagate nested results through the write path.

  **Shared `analyzeValue` helper** — eliminates duplicated type-dispatch logic that existed independently in `analyzePrimitiveProp` and `analyzeNestedValue`. The new method centralises text, int, number, boolean, date, and UUID encoding; both callers wrap the result into their respective output types. `analyzeArrayProp` is also refactored to reuse `analyzeValue` per element for non-text types, with text arrays keeping `TextArray` for correct cross-element term frequency aggregation.

  ### What comes next

  Part 3 will add the LSM bucket writes and shard integration so that nested values, `_idx`, and `_exists` entries are actually
  persisted on object insert/update/delete.

  ## Test plan

  - [ ] `go test ./adapters/repos/db/inverted/...` — analysis tests pass including updated `objects_test.go`
  - [ ] `go test ./adapters/repos/db/...` — no regressions across the full DB package