### PR TITLE
Nested object filtering — Part 4: batched writes, delete path, and prefix-bounded reads

### DIFF
--- a/adapters/repos/db/inverted/row_reader_roaring_set.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set.go
@@ -56,9 +56,11 @@ func NewRowReaderRoaringSet(bucket *lsmkv.Bucket, value []byte, operator filters
 }
 
 // NewRowReaderRoaringSetWithPrefix creates a RowReaderRoaringSet that restricts
-// cursor-based reads to keys beginning with keyPrefix. value must already
-// include keyPrefix as a leading byte sequence. Used for nested property
-// buckets where the key format is keyPrefix+encodedValue.
+// cursor-based reads to keys beginning with keyPrefix. value is the bare value
+// (or LIKE pattern) — keyPrefix is prepended internally when constructing seek
+// keys, and is stripped from returned keys before they are passed to ReadFn.
+// Used for nested property buckets where the on-disk key format is
+// keyPrefix+encodedValue.
 func NewRowReaderRoaringSetWithPrefix(bucket *lsmkv.Bucket, value []byte,
 	operator filters.Operator, keyOnly bool, keyPrefix []byte,
 ) *RowReaderRoaringSet {
@@ -79,7 +81,8 @@ func (rr *RowReaderRoaringSet) fullKey() []byte {
 	if len(rr.keyPrefix) == 0 {
 		return rr.value
 	}
-	return append(rr.keyPrefix, rr.value...)
+	n := len(rr.keyPrefix)
+	return append(rr.keyPrefix[:n:n], rr.value...)
 }
 
 // bareKey strips keyPrefix from k, returning just the value portion.
@@ -256,7 +259,8 @@ func (rr *RowReaderRoaringSet) like(ctx context.Context,
 
 	if like.optimizable {
 		// Seek to prefix+like.min so we start at the right position in the bucket.
-		seekMin = append(rr.keyPrefix, like.min...)
+		n := len(rr.keyPrefix)
+		seekMin = append(rr.keyPrefix[:n:n], like.min...)
 		initialK, initialV = c.Seek(seekMin)
 	} else if len(rr.keyPrefix) > 0 {
 		initialK, initialV = c.Seek(rr.keyPrefix)

--- a/adapters/repos/db/inverted/row_reader_roaring_set.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set.go
@@ -29,6 +29,10 @@ type RowReaderRoaringSet struct {
 	newCursor  func() lsmkv.CursorRoaringSet
 	getter     func(key []byte) (*sroar.Bitmap, func(), error)
 	isDenyList bool
+	// keyPrefix, when non-nil, restricts cursor-based reads to keys that start
+	// with this prefix. Used for nested property buckets where multiple
+	// sub-properties share a single bucket, keyed by hash8(path)+encodedValue.
+	keyPrefix []byte
 }
 
 // If keyOnly is set, the RowReaderRoaringSet will request key-only cursors
@@ -48,6 +52,51 @@ func NewRowReaderRoaringSet(bucket *lsmkv.Bucket, value []byte, operator filters
 		operator:  operator,
 		newCursor: newCursor,
 		getter:    getter,
+	}
+}
+
+// NewRowReaderRoaringSetWithPrefix creates a RowReaderRoaringSet that restricts
+// cursor-based reads to keys beginning with keyPrefix. value must already
+// include keyPrefix as a leading byte sequence. Used for nested property
+// buckets where the key format is keyPrefix+encodedValue.
+func NewRowReaderRoaringSetWithPrefix(bucket *lsmkv.Bucket, value []byte,
+	operator filters.Operator, keyOnly bool, keyPrefix []byte,
+) *RowReaderRoaringSet {
+	rr := NewRowReaderRoaringSet(bucket, value, operator, keyOnly)
+	rr.keyPrefix = keyPrefix
+	return rr
+}
+
+// inPrefix reports whether k starts with rr.keyPrefix. Always true when no
+// prefix is set (standard flat-property behaviour).
+func (rr *RowReaderRoaringSet) inPrefix(k []byte) bool {
+	return len(rr.keyPrefix) == 0 || bytes.HasPrefix(k, rr.keyPrefix)
+}
+
+// fullKey returns keyPrefix+value. When no prefix is set it returns value
+// directly to avoid an allocation on the common flat-property path.
+func (rr *RowReaderRoaringSet) fullKey() []byte {
+	if len(rr.keyPrefix) == 0 {
+		return rr.value
+	}
+	return append(rr.keyPrefix, rr.value...)
+}
+
+// bareKey strips keyPrefix from k, returning just the value portion.
+// For flat properties (no prefix) this is a no-op.
+func (rr *RowReaderRoaringSet) bareKey(k []byte) []byte {
+	return k[len(rr.keyPrefix):]
+}
+
+// ctxExpired reports whether ctx has been cancelled or timed out. It uses a
+// non-blocking channel receive, which avoids the mutex acquisition that
+// ctx.Err() performs on every call — important for tight cursor loops.
+func ctxExpired(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+		return nil
 	}
 }
 
@@ -95,12 +144,16 @@ func (rr *RowReaderRoaringSet) Read(ctx context.Context, readFn ReadFn) error {
 func (rr *RowReaderRoaringSet) equal(ctx context.Context,
 	readFn ReadFn,
 ) error {
-	v, eqRelease, err := rr.equalHelper(ctx)
+	if err := ctxExpired(ctx); err != nil {
+		return err
+	}
+
+	v, release, err := rr.getter(rr.fullKey())
 	if err != nil {
 		return err
 	}
 
-	_, err = readFn(rr.value, v, eqRelease)
+	_, err = readFn(rr.value, v, release)
 	return err
 }
 
@@ -119,16 +172,17 @@ func (rr *RowReaderRoaringSet) greaterThan(ctx context.Context,
 	c := rr.newCursor()
 	defer c.Close()
 
-	for k, v := c.Seek(rr.value); k != nil; k, v = c.Next() {
-		if err := ctx.Err(); err != nil {
+	fk := rr.fullKey()
+	for k, v := c.Seek(fk); k != nil && rr.inPrefix(k); k, v = c.Next() {
+		if err := ctxExpired(ctx); err != nil {
 			return err
 		}
 
-		if bytes.Equal(k, rr.value) && !allowEqual {
+		if bytes.Equal(k, fk) && !allowEqual {
 			continue
 		}
 
-		if continueReading, err := readFn(k, v, noopRelease); err != nil {
+		if continueReading, err := readFn(rr.bareKey(k), v, noopRelease); err != nil {
 			return err
 		} else if !continueReading {
 			break
@@ -138,25 +192,39 @@ func (rr *RowReaderRoaringSet) greaterThan(ctx context.Context,
 	return nil
 }
 
-// lessThan reads from the very begging to the specified  value. The last
-// matching row is only included if allowEqual==true, otherwise it ends one
-// prior to that.
+// lessThan reads from the very beginning (or from the keyPrefix boundary if
+// set) to the specified value. The last matching row is only included if
+// allowEqual==true, otherwise it ends one prior to that.
 func (rr *RowReaderRoaringSet) lessThan(ctx context.Context,
 	readFn ReadFn, allowEqual bool,
 ) error {
 	c := rr.newCursor()
 	defer c.Close()
 
-	for k, v := c.First(); k != nil && bytes.Compare(k, rr.value) < 1; k, v = c.Next() {
-		if err := ctx.Err(); err != nil {
+	// When a prefix is set, start at the prefix boundary rather than the very
+	// first key in the bucket, so we don't read unrelated sub-properties.
+	var initialK []byte
+	var initialV *sroar.Bitmap
+	if len(rr.keyPrefix) > 0 {
+		initialK, initialV = c.Seek(rr.keyPrefix)
+	} else {
+		initialK, initialV = c.First()
+	}
+
+	fk := rr.fullKey()
+	cmpLimit := 0 // lessThan: k < fk → Compare(k,fk) < 0
+	if allowEqual {
+		cmpLimit = 1 // lessThanEqual: k <= fk → Compare(k,fk) < 1
+	}
+	// inPrefix is not needed here: Seek(keyPrefix) guarantees no lower-prefix
+	// keys appear, and bytes.Compare(k, fk) >= cmpLimit stops the loop before
+	// any higher-prefix key, since those sort after fk = keyPrefix+value.
+	for k, v := initialK, initialV; k != nil && bytes.Compare(k, fk) < cmpLimit; k, v = c.Next() {
+		if err := ctxExpired(ctx); err != nil {
 			return err
 		}
 
-		if bytes.Equal(k, rr.value) && !allowEqual {
-			continue
-		}
-
-		if continueReading, err := readFn(k, v, noopRelease); err != nil {
+		if continueReading, err := readFn(rr.bareKey(k), v, noopRelease); err != nil {
 			return err
 		} else if !continueReading {
 			break
@@ -169,6 +237,9 @@ func (rr *RowReaderRoaringSet) lessThan(ctx context.Context,
 func (rr *RowReaderRoaringSet) like(ctx context.Context,
 	readFn ReadFn,
 ) error {
+	// rr.value is always the LIKE pattern string (e.g. "Ber*"), never the full
+	// prefixed key. For prefix-bounded reads the cursor is positioned at
+	// keyPrefix+like.min and matched against k[len(keyPrefix):].
 	like, err := parseLikeRegexp(rr.value)
 	if err != nil {
 		return fmt.Errorf("parse like value: %w", err)
@@ -178,40 +249,43 @@ func (rr *RowReaderRoaringSet) like(ctx context.Context,
 	defer c.Close()
 
 	var (
-		initialK   []byte
-		initialV   *sroar.Bitmap
-		likeMinLen int
+		initialK []byte
+		initialV *sroar.Bitmap
+		seekMin  []byte // full seek key used for the optimizable early-abort check
 	)
 
 	if like.optimizable {
-		initialK, initialV = c.Seek(like.min)
-		likeMinLen = len(like.min)
+		// Seek to prefix+like.min so we start at the right position in the bucket.
+		seekMin = append(rr.keyPrefix, like.min...)
+		initialK, initialV = c.Seek(seekMin)
+	} else if len(rr.keyPrefix) > 0 {
+		initialK, initialV = c.Seek(rr.keyPrefix)
 	} else {
 		initialK, initialV = c.First()
 	}
 
-	for k, v := initialK, initialV; k != nil; k, v = c.Next() {
-		if err := ctx.Err(); err != nil {
+	for k, v := initialK, initialV; k != nil && rr.inPrefix(k); k, v = c.Next() {
+		if err := ctxExpired(ctx); err != nil {
 			return err
 		}
 
 		if like.optimizable {
-			// if the query is optimizable, i.e. it doesn't start with a wildcard, we
-			// can abort once we've moved past the point where the fixed characters
-			// no longer match
-			if len(k) < likeMinLen {
+			// Abort once we've moved past the fixed characters of the LIKE pattern.
+			if len(k) < len(seekMin) {
 				break
 			}
-			if bytes.Compare(like.min, k[:likeMinLen]) == -1 {
+			if bytes.Compare(seekMin, k[:len(seekMin)]) == -1 {
 				break
 			}
 		}
 
-		if !like.regexp.Match(k) {
+		// Match the regex against the value portion of the key only (strip prefix).
+		keyValue := k[len(rr.keyPrefix):]
+		if !like.regexp.Match(keyValue) {
 			continue
 		}
 
-		if continueReading, err := readFn(k, v, noopRelease); err != nil {
+		if continueReading, err := readFn(rr.bareKey(k), v, noopRelease); err != nil {
 			return err
 		} else if !continueReading {
 			break
@@ -219,13 +293,4 @@ func (rr *RowReaderRoaringSet) like(ctx context.Context,
 	}
 
 	return nil
-}
-
-// equalHelper exists, because the Equal and NotEqual operators share this functionality
-func (rr *RowReaderRoaringSet) equalHelper(ctx context.Context) (*sroar.Bitmap, func(), error) {
-	if err := ctx.Err(); err != nil {
-		return nil, noopRelease, err
-	}
-
-	return rr.getter(rr.value)
 }

--- a/adapters/repos/db/inverted/row_reader_roaring_set_test.go
+++ b/adapters/repos/db/inverted/row_reader_roaring_set_test.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
@@ -190,7 +191,7 @@ func TestRowReaderRoaringSet(t *testing.T) {
 
 		t.Run(tc.name, func(t *testing.T) {
 			result := []readResult{}
-			rowReader := createRowReaderRoaringSet([]byte(tc.value), tc.operator, data)
+			rowReader := createRowReaderRoaringSet([]byte(tc.value), tc.operator, nil, data)
 			rowReader.Read(ctx, func(k []byte, v *sroar.Bitmap, release func()) (bool, error) {
 				result = append(result, readResult{k, v, release})
 				return true, nil
@@ -214,7 +215,7 @@ func TestRowReaderRoaringSet(t *testing.T) {
 			}
 
 			result := []readResult{}
-			rowReader := createRowReaderRoaringSet([]byte(tc.value), tc.operator, data)
+			rowReader := createRowReaderRoaringSet([]byte(tc.value), tc.operator, nil, data)
 			rowReader.Read(ctx, func(k []byte, v *sroar.Bitmap, release func()) (bool, error) {
 				result = append(result, readResult{k, v, release})
 				if len(result) >= limit {
@@ -281,18 +282,219 @@ func (c *dummyCursorRoaringSet) Close() {
 	c.closed = true
 }
 
-func createRowReaderRoaringSet(value []byte, operator filters.Operator, data []kvData) *RowReaderRoaringSet {
+// createRowReaderRoaringSet is the single base constructor for all row reader
+// tests. keyPrefix may be nil for flat-property (no prefix) tests.
+func createRowReaderRoaringSet(value []byte, operator filters.Operator,
+	keyPrefix []byte, data []kvData,
+) *RowReaderRoaringSet {
 	return &RowReaderRoaringSet{
 		value:     value,
 		operator:  operator,
+		keyPrefix: keyPrefix,
 		newCursor: func() lsmkv.CursorRoaringSet { return &dummyCursorRoaringSet{data: data} },
 		getter: func(key []byte) (*sroar.Bitmap, func(), error) {
-			for i := 0; i < len(data); i++ {
+			for i := range data {
 				if bytes.Equal([]byte(data[i].k), key) {
 					return roaringset.NewBitmap(data[i].v...), noopRelease, nil
 				}
 			}
 			return nil, noopRelease, entlsmkv.NotFound
 		},
+	}
+}
+
+// TestRowReaderRoaringSetWithPrefix verifies that cursor-based reads stay
+// within the bounds of the supplied key prefix and do not bleed into entries
+// belonging to other prefixes stored in the same bucket.
+//
+// The bucket contains three groups of entries (sorted by full key):
+//
+//	prefix0 (0x00): "aaa", "bbb"                  ← sorts BEFORE prefixA
+//	prefixA (0x01): "aaa", "bbb", "ccc", "ddd"    ← middle prefix
+//	prefixB (0x02): "aaa", "bbb"                  ← sorts AFTER prefixA
+//
+// All three prefixes are tested to cover edge cases at the start, middle,
+// and end of the bucket. Both returned keys and docIDs are validated.
+func TestRowReaderRoaringSetWithPrefix(t *testing.T) {
+	prefix0 := []byte{0x00}
+	prefixA := []byte{0x01}
+	prefixB := []byte{0x02}
+
+	pk := func(prefix []byte, val string) string {
+		return string(append(append([]byte{}, prefix...), val...))
+	}
+
+	// Bucket data — must be in ascending key order for the dummy cursor.
+	data := []kvData{
+		{pk(prefix0, "aaa"), []uint64{901, 902}},
+		{pk(prefix0, "bbb"), []uint64{903, 904}},
+		{pk(prefixA, "aaa"), []uint64{1, 2, 3}},
+		{pk(prefixA, "bbb"), []uint64{11, 22, 33}},
+		{pk(prefixA, "ccc"), []uint64{111, 222, 333}},
+		{pk(prefixA, "ddd"), []uint64{1111, 2222, 3333}},
+		{pk(prefixB, "aaa"), []uint64{801, 802}},
+		{pk(prefixB, "bbb"), []uint64{803, 804}},
+	}
+
+	ctx := context.Background()
+
+	tests := []struct {
+		name         string
+		prefix       []byte
+		value        []byte
+		operator     filters.Operator
+		expected     []kvData // bare key (no prefix) + expected docIDs
+		wantDenyList bool
+	}{
+		// prefix0 — first prefix in bucket
+		// greaterThan must not bleed into prefixA; lessThan has nothing before it.
+		{
+			name:   "prefix0/equal",
+			prefix: prefix0, value: []byte("aaa"), operator: filters.OperatorEqual,
+			expected: []kvData{{"aaa", []uint64{901, 902}}},
+		},
+		{
+			name:   "prefix0/greaterThan no bleed into prefixA",
+			prefix: prefix0, value: []byte("bbb"), operator: filters.OperatorGreaterThan,
+			expected: []kvData{},
+		},
+		{
+			name:   "prefix0/greaterThanEqual",
+			prefix: prefix0, value: []byte("bbb"), operator: filters.OperatorGreaterThanEqual,
+			expected: []kvData{{"bbb", []uint64{903, 904}}},
+		},
+		{
+			name:   "prefix0/lessThan nothing before first entry",
+			prefix: prefix0, value: []byte("aaa"), operator: filters.OperatorLessThan,
+			expected: []kvData{},
+		},
+		{
+			name:   "prefix0/lessThan",
+			prefix: prefix0, value: []byte("bbb"), operator: filters.OperatorLessThan,
+			expected: []kvData{{"aaa", []uint64{901, 902}}},
+		},
+		{
+			name:   "prefix0/like full wildcard",
+			prefix: prefix0, value: []byte("*"), operator: filters.OperatorLike,
+			expected: []kvData{{"aaa", []uint64{901, 902}}, {"bbb", []uint64{903, 904}}},
+		},
+		{
+			name:   "prefix0/notEqual",
+			prefix: prefix0, value: []byte("aaa"), operator: filters.OperatorNotEqual,
+			expected:     []kvData{{"aaa", []uint64{901, 902}}},
+			wantDenyList: true,
+		},
+
+		// prefixA — middle prefix, bleed possible in both directions
+		{
+			name:   "prefixA/equal",
+			prefix: prefixA, value: []byte("bbb"), operator: filters.OperatorEqual,
+			expected: []kvData{{"bbb", []uint64{11, 22, 33}}},
+		},
+		{
+			name:   "prefixA/greaterThan stops at upper boundary",
+			prefix: prefixA, value: []byte("bbb"), operator: filters.OperatorGreaterThan,
+			expected: []kvData{{"ccc", []uint64{111, 222, 333}}, {"ddd", []uint64{1111, 2222, 3333}}},
+		},
+		{
+			name:   "prefixA/greaterThanEqual",
+			prefix: prefixA, value: []byte("bbb"), operator: filters.OperatorGreaterThanEqual,
+			expected: []kvData{{"bbb", []uint64{11, 22, 33}}, {"ccc", []uint64{111, 222, 333}}, {"ddd", []uint64{1111, 2222, 3333}}},
+		},
+		{
+			name:   "prefixA/greaterThan last entry no bleed into prefixB",
+			prefix: prefixA, value: []byte("ddd"), operator: filters.OperatorGreaterThan,
+			expected: []kvData{},
+		},
+		{
+			name:   "prefixA/lessThan starts at lower boundary no bleed into prefix0",
+			prefix: prefixA, value: []byte("ccc"), operator: filters.OperatorLessThan,
+			expected: []kvData{{"aaa", []uint64{1, 2, 3}}, {"bbb", []uint64{11, 22, 33}}},
+		},
+		{
+			name:   "prefixA/lessThanEqual",
+			prefix: prefixA, value: []byte("ccc"), operator: filters.OperatorLessThanEqual,
+			expected: []kvData{{"aaa", []uint64{1, 2, 3}}, {"bbb", []uint64{11, 22, 33}}, {"ccc", []uint64{111, 222, 333}}},
+		},
+		{
+			name:   "prefixA/lessThan first entry no bleed into prefix0",
+			prefix: prefixA, value: []byte("aaa"), operator: filters.OperatorLessThan,
+			expected: []kvData{},
+		},
+		{
+			name:   "prefixA/like wildcard-suffix stays within prefix",
+			prefix: prefixA, value: []byte("b*"), operator: filters.OperatorLike,
+			expected: []kvData{{"bbb", []uint64{11, 22, 33}}},
+		},
+		{
+			name:   "prefixA/like wildcard-prefix stays within prefix",
+			prefix: prefixA, value: []byte("*b"), operator: filters.OperatorLike,
+			expected: []kvData{{"bbb", []uint64{11, 22, 33}}},
+		},
+		{
+			name:   "prefixA/like full wildcard returns only prefixA entries",
+			prefix: prefixA, value: []byte("*"), operator: filters.OperatorLike,
+			expected: []kvData{{"aaa", []uint64{1, 2, 3}}, {"bbb", []uint64{11, 22, 33}}, {"ccc", []uint64{111, 222, 333}}, {"ddd", []uint64{1111, 2222, 3333}}},
+		},
+		{
+			name:   "prefixA/notEqual",
+			prefix: prefixA, value: []byte("bbb"), operator: filters.OperatorNotEqual,
+			expected:     []kvData{{"bbb", []uint64{11, 22, 33}}},
+			wantDenyList: true,
+		},
+
+		// prefixB — last prefix in bucket
+		// greaterThan past last entry must return nothing; lessThan must not bleed into prefixA.
+		{
+			name:   "prefixB/equal",
+			prefix: prefixB, value: []byte("aaa"), operator: filters.OperatorEqual,
+			expected: []kvData{{"aaa", []uint64{801, 802}}},
+		},
+		{
+			name:   "prefixB/greaterThan nothing past last entry",
+			prefix: prefixB, value: []byte("bbb"), operator: filters.OperatorGreaterThan,
+			expected: []kvData{},
+		},
+		{
+			name:   "prefixB/greaterThan",
+			prefix: prefixB, value: []byte("aaa"), operator: filters.OperatorGreaterThan,
+			expected: []kvData{{"bbb", []uint64{803, 804}}},
+		},
+		{
+			name:   "prefixB/lessThan no bleed into prefixA",
+			prefix: prefixB, value: []byte("aaa"), operator: filters.OperatorLessThan,
+			expected: []kvData{},
+		},
+		{
+			name:   "prefixB/lessThanEqual",
+			prefix: prefixB, value: []byte("bbb"), operator: filters.OperatorLessThanEqual,
+			expected: []kvData{{"aaa", []uint64{801, 802}}, {"bbb", []uint64{803, 804}}},
+		},
+		{
+			name:   "prefixB/like full wildcard returns only prefixB entries",
+			prefix: prefixB, value: []byte("*"), operator: filters.OperatorLike,
+			expected: []kvData{{"aaa", []uint64{801, 802}}, {"bbb", []uint64{803, 804}}},
+		},
+		{
+			name:   "prefixB/notEqual",
+			prefix: prefixB, value: []byte("aaa"), operator: filters.OperatorNotEqual,
+			expected:     []kvData{{"aaa", []uint64{801, 802}}},
+			wantDenyList: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rr := createRowReaderRoaringSet(tt.value, tt.operator, tt.prefix, data)
+
+			got := []kvData{}
+			err := rr.Read(ctx, func(k []byte, v *sroar.Bitmap, release func()) (bool, error) {
+				got = append(got, kvData{string(k), v.ToArray()})
+				return true, nil
+			})
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, got)
+			assert.Equal(t, tt.wantDenyList, rr.isDenyList)
+		})
 	}
 }

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -74,10 +74,30 @@ func (b *Bucket) RoaringSetAddBatch(entries []RoaringSetBatchEntry) error {
 		return err
 	}
 
-	active, release := b.getActiveMemtableForWrite()
+	active, release, err := b.getActiveMemtableForWrite()
+	if err != nil {
+		return err
+	}
 	defer release()
 
 	return active.roaringSetAddBatch(entries)
+}
+
+// RoaringSetRemoveBatch removes multiple key-values pairs from the bucket under
+// a single flushLock acquisition and a single memtable lock acquisition,
+// reducing lock overhead compared to calling RoaringSetRemoveOne in a loop.
+func (b *Bucket) RoaringSetRemoveBatch(entries []RoaringSetBatchEntry) error {
+	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
+		return err
+	}
+
+	active, release, err := b.getActiveMemtableForWrite()
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	return active.roaringSetRemoveBatch(entries)
 }
 
 func (b *Bucket) RoaringSetAddBitmap(key []byte, bm *sroar.Bitmap) error {

--- a/adapters/repos/db/lsmkv/bucket_roaring_set.go
+++ b/adapters/repos/db/lsmkv/bucket_roaring_set.go
@@ -60,6 +60,26 @@ func (b *Bucket) RoaringSetAddList(key []byte, values []uint64) error {
 	return active.roaringSetAddList(key, values)
 }
 
+// RoaringSetBatchEntry is a key-values pair for use with RoaringSetAddBatch.
+type RoaringSetBatchEntry struct {
+	Key    []byte
+	Values []uint64
+}
+
+// RoaringSetAddBatch writes multiple key-values pairs to the bucket under
+// a single flushLock acquisition and a single memtable lock acquisition,
+// reducing lock overhead compared to calling RoaringSetAddList in a loop.
+func (b *Bucket) RoaringSetAddBatch(entries []RoaringSetBatchEntry) error {
+	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
+		return err
+	}
+
+	active, release := b.getActiveMemtableForWrite()
+	defer release()
+
+	return active.roaringSetAddBatch(entries)
+}
+
 func (b *Bucket) RoaringSetAddBitmap(key []byte, bm *sroar.Bitmap) error {
 	if err := CheckStrategyRoaringSet(b.strategy); err != nil {
 		return err

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -83,6 +83,7 @@ type memtable interface {
 	roaringSetAddBitmap(key []byte, bm *sroar.Bitmap) error
 	roaringSetRemoveOne(key []byte, value uint64) error
 	roaringSetRemoveList(key []byte, values []uint64) error
+	roaringSetRemoveBatch(entries []RoaringSetBatchEntry) error
 	roaringSetRemoveBitmap(key []byte, bm *sroar.Bitmap) error
 	roaringSetAddRemoveSlices(key []byte, additions []uint64, deletions []uint64) error
 	roaringSetGet(key []byte) (roaringset.BitmapLayer, error)

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -79,6 +79,7 @@ type memtable interface {
 
 	roaringSetAddOne(key []byte, value uint64) error
 	roaringSetAddList(key []byte, values []uint64) error
+	roaringSetAddBatch(entries []RoaringSetBatchEntry) error
 	roaringSetAddBitmap(key []byte, bm *sroar.Bitmap) error
 	roaringSetRemoveOne(key []byte, value uint64) error
 	roaringSetRemoveList(key []byte, values []uint64) error

--- a/adapters/repos/db/lsmkv/memtable_roaring_set.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set.go
@@ -131,6 +131,40 @@ func (m *Memtable) roaringSetRemoveList(key []byte, values []uint64) error {
 	return nil
 }
 
+// roaringSetRemoveBatch removes multiple key-values pairs under a single
+// memtable lock acquisition. Commit log nodes are pre-allocated outside the
+// lock to keep the critical section as short as possible.
+func (m *Memtable) roaringSetRemoveBatch(entries []RoaringSetBatchEntry) error {
+	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
+		return err
+	}
+
+	// Pre-allocate all commit log nodes outside the lock.
+	nodes := make([]*roaringset.SegmentNodeList, len(entries))
+	totalValues := 0
+	for i, e := range entries {
+		node, err := roaringset.NewSegmentNodeList(e.Key, []uint64{}, e.Values)
+		if err != nil {
+			return fmt.Errorf("create node for commit log: %w", err)
+		}
+		nodes[i] = node
+		totalValues += len(e.Values)
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	for i, node := range nodes {
+		if err := m.roaringSetAddCommitLog(node); err != nil {
+			return err
+		}
+		m.roaringSet.Insert(entries[i].Key, roaringset.Insert{Deletions: entries[i].Values})
+	}
+
+	m.roaringSetAdjustMeta(totalValues)
+	return nil
+}
+
 func (m *Memtable) roaringSetRemoveBitmap(key []byte, bm *sroar.Bitmap) error {
 	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
 		return err

--- a/adapters/repos/db/lsmkv/memtable_roaring_set.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set.go
@@ -45,6 +45,40 @@ func (m *Memtable) roaringSetAddList(key []byte, values []uint64) error {
 	return nil
 }
 
+// roaringSetAddBatch writes multiple key-values pairs under a single
+// memtable lock acquisition. Commit log nodes are pre-allocated outside the
+// lock to keep the critical section as short as possible.
+func (m *Memtable) roaringSetAddBatch(entries []RoaringSetBatchEntry) error {
+	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
+		return err
+	}
+
+	// Pre-allocate all commit log nodes outside the lock.
+	nodes := make([]*roaringset.SegmentNodeList, len(entries))
+	totalValues := 0
+	for i, e := range entries {
+		node, err := roaringset.NewSegmentNodeList(e.Key, e.Values, []uint64{})
+		if err != nil {
+			return fmt.Errorf("create node for commit log: %w", err)
+		}
+		nodes[i] = node
+		totalValues += len(e.Values)
+	}
+
+	m.Lock()
+	defer m.Unlock()
+
+	for i, node := range nodes {
+		if err := m.roaringSetAddCommitLog(node); err != nil {
+			return err
+		}
+		m.roaringSet.Insert(entries[i].Key, roaringset.Insert{Additions: entries[i].Values})
+	}
+
+	m.roaringSetAdjustMeta(totalValues)
+	return nil
+}
+
 func (m *Memtable) roaringSetAddBitmap(key []byte, bm *sroar.Bitmap) error {
 	if err := CheckStrategyRoaringSet(m.strategy); err != nil {
 		return err

--- a/adapters/repos/db/lsmkv/memtable_roaring_set.go
+++ b/adapters/repos/db/lsmkv/memtable_roaring_set.go
@@ -55,27 +55,30 @@ func (m *Memtable) roaringSetAddBatch(entries []RoaringSetBatchEntry) error {
 
 	// Pre-allocate all commit log nodes outside the lock.
 	nodes := make([]*roaringset.SegmentNodeList, len(entries))
-	totalValues := 0
 	for i, e := range entries {
 		node, err := roaringset.NewSegmentNodeList(e.Key, e.Values, []uint64{})
 		if err != nil {
 			return fmt.Errorf("create node for commit log: %w", err)
 		}
 		nodes[i] = node
-		totalValues += len(e.Values)
 	}
 
 	m.Lock()
 	defer m.Unlock()
 
+	var insertedValues int
 	for i, node := range nodes {
 		if err := m.roaringSetAddCommitLog(node); err != nil {
+			if insertedValues > 0 {
+				m.roaringSetAdjustMeta(insertedValues)
+			}
 			return err
 		}
 		m.roaringSet.Insert(entries[i].Key, roaringset.Insert{Additions: entries[i].Values})
+		insertedValues += len(entries[i].Values)
 	}
 
-	m.roaringSetAdjustMeta(totalValues)
+	m.roaringSetAdjustMeta(insertedValues)
 	return nil
 }
 
@@ -141,27 +144,30 @@ func (m *Memtable) roaringSetRemoveBatch(entries []RoaringSetBatchEntry) error {
 
 	// Pre-allocate all commit log nodes outside the lock.
 	nodes := make([]*roaringset.SegmentNodeList, len(entries))
-	totalValues := 0
 	for i, e := range entries {
 		node, err := roaringset.NewSegmentNodeList(e.Key, []uint64{}, e.Values)
 		if err != nil {
 			return fmt.Errorf("create node for commit log: %w", err)
 		}
 		nodes[i] = node
-		totalValues += len(e.Values)
 	}
 
 	m.Lock()
 	defer m.Unlock()
 
+	var deletedValues int
 	for i, node := range nodes {
 		if err := m.roaringSetAddCommitLog(node); err != nil {
+			if deletedValues > 0 {
+				m.roaringSetAdjustMeta(deletedValues)
+			}
 			return err
 		}
 		m.roaringSet.Insert(entries[i].Key, roaringset.Insert{Deletions: entries[i].Values})
+		deletedValues += len(entries[i].Values)
 	}
 
-	m.roaringSetAdjustMeta(totalValues)
+	m.roaringSetAdjustMeta(deletedValues)
 	return nil
 }
 

--- a/adapters/repos/db/shard_write_inverted_lsm_nested.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_nested.go
@@ -17,6 +17,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 )
 
 func (s *Shard) extendNestedInvertedIndicesLSM(nestedProps []inverted.NestedProperty, docID uint64) error {
@@ -43,15 +44,18 @@ func (s *Shard) extendNestedFilterableIndex(np inverted.NestedProperty, docID ui
 		return fmt.Errorf("nested prop %q: no filterable value bucket found", np.Name)
 	}
 
+	entries := make([]lsmkv.RoaringSetBatchEntry, 0, len(np.Values))
 	for _, v := range np.Values {
 		if !v.HasFilterableIndex {
 			continue
 		}
-		key := nested.ValueKey(v.Path, v.Data)
-		positions := nested.OrDocID(v.Positions, docID)
-		if err := bucket.RoaringSetAddList(key, positions); err != nil {
-			return fmt.Errorf("nested prop %q path %q: add filterable value: %w", np.Name, v.Path, err)
-		}
+		entries = append(entries, lsmkv.RoaringSetBatchEntry{
+			Key:    nested.ValueKey(v.Path, v.Data),
+			Values: nested.OrDocID(v.Positions, docID),
+		})
+	}
+	if err := bucket.RoaringSetAddBatch(entries); err != nil {
+		return fmt.Errorf("nested prop %q: add filterable values: %w", np.Name, err)
 	}
 	return nil
 }
@@ -66,20 +70,21 @@ func (s *Shard) extendNestedMetaIndex(np inverted.NestedProperty, docID uint64) 
 		return fmt.Errorf("nested prop %q: no meta bucket found", np.Name)
 	}
 
+	entries := make([]lsmkv.RoaringSetBatchEntry, 0, len(np.Idx)+len(np.Exists))
 	for _, idx := range np.Idx {
-		key := nested.IdxKey(idx.Path, idx.Index)
-		positions := nested.OrDocID(idx.Positions, docID)
-		if err := bucket.RoaringSetAddList(key, positions); err != nil {
-			return fmt.Errorf("nested prop %q: add _idx %q[%d]: %w", np.Name, idx.Path, idx.Index, err)
-		}
+		entries = append(entries, lsmkv.RoaringSetBatchEntry{
+			Key:    nested.IdxKey(idx.Path, idx.Index),
+			Values: nested.OrDocID(idx.Positions, docID),
+		})
 	}
-
 	for _, exists := range np.Exists {
-		key := nested.ExistsKey(exists.Path)
-		positions := nested.OrDocID(exists.Positions, docID)
-		if err := bucket.RoaringSetAddList(key, positions); err != nil {
-			return fmt.Errorf("nested prop %q: add _exists %q: %w", np.Name, exists.Path, err)
-		}
+		entries = append(entries, lsmkv.RoaringSetBatchEntry{
+			Key:    nested.ExistsKey(exists.Path),
+			Values: nested.OrDocID(exists.Positions, docID),
+		})
+	}
+	if err := bucket.RoaringSetAddBatch(entries); err != nil {
+		return fmt.Errorf("nested prop %q: add meta entries: %w", np.Name, err)
 	}
 	return nil
 }

--- a/adapters/repos/db/shard_write_inverted_lsm_nested.go
+++ b/adapters/repos/db/shard_write_inverted_lsm_nested.go
@@ -20,6 +20,52 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 )
 
+func (s *Shard) deleteNestedInvertedIndicesLSM(nestedProps []inverted.NestedProperty, docID uint64) error {
+	for _, np := range nestedProps {
+		if err := s.deleteNestedFilterableIndex(np, docID); err != nil {
+			return err
+		}
+		// TODO: delete nested searchable index (Phase 2)
+		// TODO: delete nested rangeable index (Phase 3)
+		if err := s.deleteNestedMetaIndex(np, docID); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (s *Shard) deleteNestedFilterableIndex(np inverted.NestedProperty, docID uint64) error {
+	if !np.HasFilterableIndex {
+		return nil
+	}
+
+	bucket := s.store.Bucket(helpers.BucketNestedFromPropNameLSM(np.Name))
+	if bucket == nil {
+		return fmt.Errorf("nested prop %q: no filterable value bucket found", np.Name)
+	}
+
+	if err := bucket.RoaringSetRemoveBatch(nestedFilterableEntries(np, docID)); err != nil {
+		return fmt.Errorf("nested prop %q: remove filterable values: %w", np.Name, err)
+	}
+	return nil
+}
+
+func (s *Shard) deleteNestedMetaIndex(np inverted.NestedProperty, docID uint64) error {
+	if len(np.Idx) == 0 && len(np.Exists) == 0 {
+		return nil
+	}
+
+	bucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(np.Name))
+	if bucket == nil {
+		return fmt.Errorf("nested prop %q: no meta bucket found", np.Name)
+	}
+
+	if err := bucket.RoaringSetRemoveBatch(nestedMetaEntries(np, docID)); err != nil {
+		return fmt.Errorf("nested prop %q: remove meta entries: %w", np.Name, err)
+	}
+	return nil
+}
+
 func (s *Shard) extendNestedInvertedIndicesLSM(nestedProps []inverted.NestedProperty, docID uint64) error {
 	for _, np := range nestedProps {
 		if err := s.extendNestedFilterableIndex(np, docID); err != nil {
@@ -44,17 +90,7 @@ func (s *Shard) extendNestedFilterableIndex(np inverted.NestedProperty, docID ui
 		return fmt.Errorf("nested prop %q: no filterable value bucket found", np.Name)
 	}
 
-	entries := make([]lsmkv.RoaringSetBatchEntry, 0, len(np.Values))
-	for _, v := range np.Values {
-		if !v.HasFilterableIndex {
-			continue
-		}
-		entries = append(entries, lsmkv.RoaringSetBatchEntry{
-			Key:    nested.ValueKey(v.Path, v.Data),
-			Values: nested.OrDocID(v.Positions, docID),
-		})
-	}
-	if err := bucket.RoaringSetAddBatch(entries); err != nil {
+	if err := bucket.RoaringSetAddBatch(nestedFilterableEntries(np, docID)); err != nil {
 		return fmt.Errorf("nested prop %q: add filterable values: %w", np.Name, err)
 	}
 	return nil
@@ -70,6 +106,27 @@ func (s *Shard) extendNestedMetaIndex(np inverted.NestedProperty, docID uint64) 
 		return fmt.Errorf("nested prop %q: no meta bucket found", np.Name)
 	}
 
+	if err := bucket.RoaringSetAddBatch(nestedMetaEntries(np, docID)); err != nil {
+		return fmt.Errorf("nested prop %q: add meta entries: %w", np.Name, err)
+	}
+	return nil
+}
+
+func nestedFilterableEntries(np inverted.NestedProperty, docID uint64) []lsmkv.RoaringSetBatchEntry {
+	entries := make([]lsmkv.RoaringSetBatchEntry, 0, len(np.Values))
+	for _, v := range np.Values {
+		if !v.HasFilterableIndex {
+			continue
+		}
+		entries = append(entries, lsmkv.RoaringSetBatchEntry{
+			Key:    nested.ValueKey(v.Path, v.Data),
+			Values: nested.OrDocID(v.Positions, docID),
+		})
+	}
+	return entries
+}
+
+func nestedMetaEntries(np inverted.NestedProperty, docID uint64) []lsmkv.RoaringSetBatchEntry {
 	entries := make([]lsmkv.RoaringSetBatchEntry, 0, len(np.Idx)+len(np.Exists))
 	for _, idx := range np.Idx {
 		entries = append(entries, lsmkv.RoaringSetBatchEntry{
@@ -83,8 +140,5 @@ func (s *Shard) extendNestedMetaIndex(np inverted.NestedProperty, docID uint64) 
 			Values: nested.OrDocID(exists.Positions, docID),
 		})
 	}
-	if err := bucket.RoaringSetAddBatch(entries); err != nil {
-		return fmt.Errorf("nested prop %q: add meta entries: %w", np.Name, err)
-	}
-	return nil
+	return entries
 }

--- a/adapters/repos/db/shard_write_put.go
+++ b/adapters/repos/db/shard_write_put.go
@@ -510,8 +510,6 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 			return fmt.Errorf("analyze previous object: %w", err)
 		}
 	}
-	_ = prevNestedProps // TODO(Step 8): delete previous nested props on update
-
 	// if object updated (with or without docID changed)
 	if status.docIDChanged || status.docIDPreserved {
 		if err := s.subtractPropLengths(prevProps); err != nil {
@@ -557,6 +555,9 @@ func (s *Shard) updateInvertedIndexLSM(object *storobj.Object,
 		// TODO: metrics
 		if err := s.deleteFromInvertedIndicesLSM(propsToDel, nilpropsToDel, status.oldDocID); err != nil {
 			return fmt.Errorf("delete inverted indices props: %w", err)
+		}
+		if err := s.deleteNestedInvertedIndicesLSM(prevNestedProps, status.oldDocID); err != nil {
+			return fmt.Errorf("delete nested inverted indices: %w", err)
 		}
 		if s.index.Config.TrackVectorDimensions {
 			err = prevObject.IterateThroughVectorDimensions(func(targetVector string, dims int) error {


### PR DESCRIPTION
## Nested object filtering — Part 4: batched writes, delete path, and prefix-bounded reads

  Fourth PR in the nested object filtering series, building on Part 3 (LSM storage and write path).

  ### What's in this PR

  **Batched nested writes** — adds `RoaringSetAddBatch` to `Bucket` and `roaringSetAddBatch` to `Memtable`, allowing all key-value pairs for a single nested property to be written under one `flushLock.RLock` and one memtable lock acquisition instead of one per entry. Commit log nodes are pre-allocated outside the lock to keep the critical section short. `extendNestedFilterableIndex` and `extendNestedMetaIndex` are updated to use the batch API — for a document with many nested elements (e.g. doc123 with 31 meta entries) this reduces lock round-trips from 62 to 2.

  **Nested delete path** — adds `RoaringSetRemoveBatch` to `Bucket` and `roaringSetRemoveBatch` to `Memtable`, mirroring the batch add path. `deleteNestedInvertedIndicesLSM` re-analyzes the stored object to reconstruct the exact positions that were written, then removes them via a single batch call per bucket. Shared `nestedFilterableEntries` / `nestedMetaEntries` helpers eliminate duplication between the extend and delete functions. Wired into `updateInvertedIndexLSM` alongside the existing flat-property delete.

  **Prefix-bounded `RowReaderRoaringSet`** — adds `NewRowReaderRoaringSetWithPrefix` and a `keyPrefix` field. When set, all cursor-based operators are bounded to keys starting with the prefix, preventing reads from bleeding into adjacent sub-properties that share the same bucket. Callers receive bare data values (prefix stripped) regardless of whether a prefix is in use. All six operators (`equal`, `notEqual`, `greaterThan`, `greaterThanEqual`, `lessThan`, `lessThanEqual`, `like`) are correctly bounded, with tests covering all three prefix positions (first, middle, last entry in bucket).

  ### What comes next

  Part 5 will add the filter read path: searcher extraction for nested dot-notation paths and routing to the position-aware resolution machinery.

  ## Test plan

  - [ ] `go test ./adapters/repos/db/inverted/...` — prefix-bounded reader tests and all inverted index tests pass
  - [ ] `go test ./adapters/repos/db/lsmkv/...` — batch add/remove tests pass
  - [ ] `go test ./adapters/repos/db/...` — no regressions across the full DB package