### PR TITLE
Nested object filtering — Part 5: filter validation, execution, and integration tests

### DIFF
--- a/adapters/repos/db/inverted/nested/keys.go
+++ b/adapters/repos/db/inverted/nested/keys.go
@@ -19,32 +19,38 @@ import (
 
 const hashSize = 8 // xxHash64 produces 8 bytes
 
+// hashKey is the shared primitive: allocate a buffer, write
+// xxhash.Sum64String(input) as 8 big-endian bytes, then append suffix.
+func hashKey(input string, suffix []byte) []byte {
+	key := make([]byte, hashSize+len(suffix))
+	binary.BigEndian.PutUint64(key, xxhash.Sum64String(input))
+	copy(key[hashSize:], suffix)
+	return key
+}
+
+// PathPrefix returns the 8-byte hash prefix for a dot-notation property path.
+// Used as keyPrefix on RowReaderRoaringSet when reading from a nested bucket.
+func PathPrefix(path string) []byte {
+	return hashKey(path, nil)
+}
+
 // ValueKey builds the key for the nested value bucket:
 // hash8(path) + analyzedValue.
 func ValueKey(path string, analyzedValue []byte) []byte {
-	key := make([]byte, hashSize+len(analyzedValue))
-	binary.BigEndian.PutUint64(key, xxhash.Sum64String(path))
-	copy(key[hashSize:], analyzedValue)
-	return key
+	return hashKey(path, analyzedValue)
 }
 
 // IdxKey builds the key for an _idx metadata entry:
 // hash8("_idx." + path) + BE16(index).
 func IdxKey(path string, index int) []byte {
-	key := make([]byte, hashSize+2)
-	binary.BigEndian.PutUint64(key, xxhash.Sum64String("_idx."+path))
-	binary.BigEndian.PutUint16(key[hashSize:], uint16(index))
-	return key
+	return hashKey("_idx."+path, binary.BigEndian.AppendUint16(nil, uint16(index)))
 }
 
 // ExistsKey builds the key for an _exists metadata entry:
 // hash8("_exists." + path) for named paths, or hash8("_exists") for root.
 func ExistsKey(path string) []byte {
-	key := make([]byte, hashSize)
 	if path == "" {
-		binary.BigEndian.PutUint64(key, xxhash.Sum64String("_exists"))
-	} else {
-		binary.BigEndian.PutUint64(key, xxhash.Sum64String("_exists."+path))
+		return hashKey("_exists", nil)
 	}
-	return key
+	return hashKey("_exists."+path, nil)
 }

--- a/adapters/repos/db/inverted/nested/keys_test.go
+++ b/adapters/repos/db/inverted/nested/keys_test.go
@@ -20,6 +20,23 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestPathPrefix(t *testing.T) {
+	t.Run("returns 8-byte xxhash of path", func(t *testing.T) {
+		prefix := PathPrefix("addresses.city")
+		require.Len(t, prefix, 8)
+		assert.Equal(t, xxhash.Sum64String("addresses.city"), binary.BigEndian.Uint64(prefix))
+	})
+
+	t.Run("different paths produce different prefixes", func(t *testing.T) {
+		assert.NotEqual(t, PathPrefix("addresses.city"), PathPrefix("addresses.postcode"))
+	})
+
+	t.Run("matches first 8 bytes of ValueKey for same path", func(t *testing.T) {
+		path := "addresses.city"
+		assert.Equal(t, PathPrefix(path), ValueKey(path, []byte("Berlin"))[:8])
+	})
+}
+
 func TestValueKey(t *testing.T) {
 	t.Run("hash prefix followed by value", func(t *testing.T) {
 		value := []byte("Berlin")

--- a/adapters/repos/db/inverted/objects_nested.go
+++ b/adapters/repos/db/inverted/objects_nested.go
@@ -21,42 +21,6 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
-// Per-property index predicates — one function per index type, used both
-// in the Has* helpers below and in collectNestedIndexConfig.
-
-func isNestedFilterable(prop *models.NestedProperty) bool {
-	if prop.IndexFilterable == nil {
-		return true
-	}
-	return *prop.IndexFilterable
-}
-
-func isNestedSearchable(np *models.NestedProperty, dt schema.DataType) bool {
-	switch dt {
-	case schema.DataTypeText, schema.DataTypeTextArray:
-		if np.IndexSearchable == nil {
-			return true
-		}
-		return *np.IndexSearchable
-	default:
-		return false
-	}
-}
-
-func isNestedRangeable(np *models.NestedProperty, dt schema.DataType) bool {
-	switch dt {
-	case schema.DataTypeInt, schema.DataTypeIntArray,
-		schema.DataTypeNumber, schema.DataTypeNumberArray,
-		schema.DataTypeDate, schema.DataTypeDateArray:
-		if np.IndexRangeFilters == nil {
-			return false
-		}
-		return *np.IndexRangeFilters
-	default:
-		return false
-	}
-}
-
 // Has* helpers — check whether any descendant of a top-level Property has a
 // given index type enabled. Used to decide which buckets to create.
 
@@ -68,7 +32,7 @@ func HasNestedFilterableIndex(prop *models.Property) bool {
 }
 
 func hasNestedFilterableRecursive(prop *models.NestedProperty) bool {
-	return isNestedFilterable(prop) ||
+	return schema.IsNestedFilterable(prop) ||
 		slices.ContainsFunc(prop.NestedProperties, hasNestedFilterableRecursive)
 }
 
@@ -81,7 +45,7 @@ func HasNestedSearchableIndex(prop *models.Property) bool {
 
 func hasNestedSearchableRecursive(prop *models.NestedProperty) bool {
 	dt := schema.DataType(prop.DataType[0])
-	return isNestedSearchable(prop, dt) ||
+	return schema.IsNestedSearchable(prop, dt) ||
 		slices.ContainsFunc(prop.NestedProperties, hasNestedSearchableRecursive)
 }
 
@@ -94,7 +58,7 @@ func HasNestedRangeableIndex(prop *models.Property) bool {
 
 func hasNestedRangeableRecursive(prop *models.NestedProperty) bool {
 	dt := schema.DataType(prop.DataType[0])
-	return isNestedRangeable(prop, dt) ||
+	return schema.IsNestedRangeable(prop, dt) ||
 		slices.ContainsFunc(prop.NestedProperties, hasNestedRangeableRecursive)
 }
 
@@ -107,9 +71,9 @@ func HasAnyNestedInvertedIndex(prop *models.Property) bool {
 
 func hasAnyNestedInvertedIndexRecursive(prop *models.NestedProperty) bool {
 	dt := schema.DataType(prop.DataType[0])
-	return isNestedFilterable(prop) ||
-		isNestedSearchable(prop, dt) ||
-		isNestedRangeable(prop, dt) ||
+	return schema.IsNestedFilterable(prop) ||
+		schema.IsNestedSearchable(prop, dt) ||
+		schema.IsNestedRangeable(prop, dt) ||
 		slices.ContainsFunc(prop.NestedProperties, hasAnyNestedInvertedIndexRecursive)
 }
 
@@ -138,9 +102,9 @@ func collectNestedIndexConfig(prefix string, props []*models.NestedProperty) map
 		dt := schema.DataType(np.DataType[0])
 		if !schema.IsNested(dt) {
 			configs[path] = nestedIndexConfig{
-				filterable: isNestedFilterable(np),
-				searchable: isNestedSearchable(np, dt),
-				rangeable:  isNestedRangeable(np, dt),
+				filterable: schema.IsNestedFilterable(np),
+				searchable: schema.IsNestedSearchable(np, dt),
+				rangeable:  schema.IsNestedRangeable(np, dt),
 			}
 		}
 		maps.Copy(configs, collectNestedIndexConfig(path, np.NestedProperties))

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -42,7 +43,15 @@ type propValuePair struct {
 	hasFilterableIndex bool
 	hasSearchableIndex bool
 	hasRangeableIndex  bool
-	Class              *models.Class // The schema
+	// isNested marks a filter on a nested (object/object[]) property. When set:
+	//   - prop is the top-level property name (used for bucket name resolution)
+	//   - value is the bare encoded value (without prefix)
+	//   - nestedKeyPrefix is hash8(dottedPath), used to bound cursor reads and
+	//     to construct the full bucket key: nestedKeyPrefix+value
+	//   - the result bitmap contains positions that are stripped to docIDs
+	isNested        bool
+	nestedKeyPrefix []byte
+	Class           *models.Class // The schema
 }
 
 func newPropValuePair(class *models.Class) (*propValuePair, error) {
@@ -344,10 +353,22 @@ func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int
 	if err != nil {
 		return nil, err
 	}
+	if pv.isNested {
+		// The nested value bucket stores positions (root|leaf|docID) rather than
+		// plain docIDs. Strip position bits to extract the docID-only bitmap.
+		dbm.docIDs = nested.MaskAllPositions(dbm.docIDs)
+	}
 	return &dbm, nil
 }
 
 func (pv *propValuePair) getBucketName() string {
+	if pv.isNested {
+		if pv.hasFilterableIndex {
+			return helpers.BucketNestedFromPropNameLSM(pv.prop)
+		}
+		return ""
+	}
+
 	if pv.hasRangeableIndex {
 		switch pv.operator {
 		// decide whether handle equal/not_equal with rangeable index

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -385,6 +385,10 @@ func (s *Searcher) extractPropValuePair(
 		return nil, err
 	}
 
+	if _, ok := schema.AsNested(property.DataType); ok {
+		return s.extractNestedProp(filter, propName, property, class)
+	}
+
 	if s.onRefProp(property) && len(props) != 1 {
 		return s.extractReferenceFilter(property, filter, class)
 	}

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -97,7 +97,7 @@ func (s *Searcher) docBitmapInvertedRoaringSet(ctx context.Context, b *lsmkv.Buc
 		return true, nil
 	}
 
-	rr := NewRowReaderRoaringSet(b, pv.value, pv.operator, false)
+	rr := NewRowReaderRoaringSetWithPrefix(b, pv.value, pv.operator, false, pv.nestedKeyPrefix)
 	if err := rr.Read(ctx, readFn); err != nil {
 		return out, fmt.Errorf("read row: %w", err)
 	}

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -1,0 +1,175 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/tokenizer"
+)
+
+// extractNestedProp builds a propValuePair for a dot-notation nested property
+// filter such as "addresses.city = 'Berlin'". It walks the schema to find the
+// leaf NestedProperty, encodes the filter value, and sets isNested=true so
+// the execution path uses the nested bucket and strips positions to docIDs.
+func (s *Searcher) extractNestedProp(filter *filters.Clause, path string,
+	prop *models.Property, class *models.Class,
+) (*propValuePair, error) {
+	if filter.Operator == filters.OperatorIsNull {
+		return nil, fmt.Errorf("IsNull is not yet supported for nested properties")
+	}
+
+	segments := strings.Split(path, ".")
+	// segments[0] is the top-level prop already fetched; walk segments[1:] to the leaf.
+	leaf, err := findNestedLeaf(segments[1:], prop.NestedProperties)
+	if err != nil {
+		return nil, fmt.Errorf("nested path %q: %w", path, err)
+	}
+
+	if !isNestedFilterable(leaf) {
+		return nil, fmt.Errorf("nested property %q is not filterable", path)
+	}
+
+	return s.buildNestedFilterPair(filter, path, segments[0], leaf, class)
+}
+
+// findNestedLeaf walks segments through nestedProps to locate the leaf
+// NestedProperty. Returns an error if any segment is not found.
+func findNestedLeaf(segments []string, props []*models.NestedProperty) (*models.NestedProperty, error) {
+	for i, seg := range segments {
+		var found *models.NestedProperty
+		for _, np := range props {
+			if np.Name == seg {
+				found = np
+				break
+			}
+		}
+		if found == nil {
+			return nil, fmt.Errorf("sub-property %q not found", seg)
+		}
+		if i == len(segments)-1 {
+			return found, nil
+		}
+		props = found.NestedProperties
+	}
+	return nil, fmt.Errorf("empty path")
+}
+
+// buildNestedFilterPair encodes the filter value for the given leaf type and
+// returns the corresponding propValuePair(s).
+func (s *Searcher) buildNestedFilterPair(filter *filters.Clause, path, propName string,
+	leaf *models.NestedProperty, class *models.Class,
+) (*propValuePair, error) {
+	// Keys in the nested bucket use only the path relative to the top-level
+	// property (e.g. "city", "owner.firstname"), not the full filter path
+	// (e.g. "event.city"). Strip the top-level property name.
+	relativePath := strings.TrimPrefix(path, propName+".")
+	keyPrefix := nested.PathPrefix(relativePath)
+	dt := schema.DataType(leaf.DataType[0])
+	switch dt {
+	case schema.DataTypeText, schema.DataTypeTextArray:
+		return s.buildNestedTextFilterPair(filter, path, propName, leaf.Tokenization, keyPrefix, class)
+	default:
+		return s.buildNestedPrimitiveFilterPair(filter, path, propName, dt, keyPrefix, class)
+	}
+}
+
+// buildNestedTextFilterPair handles tokenizable text properties. Multiple
+// tokens produce multiple propValuePairs combined with AND, mirroring
+// extractTokenizableProp for flat properties.
+func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propName, tokenization string,
+	keyPrefix []byte, class *models.Class,
+) (*propValuePair, error) {
+	valueStr, ok := filter.Value.Value.(string)
+	if !ok {
+		return nil, fmt.Errorf("nested path %q: expected string value, got %T", path, filter.Value.Value)
+	}
+
+	var terms []string
+	if filter.Operator == filters.OperatorLike {
+		terms = tokenizer.TokenizeWithWildcardsForClass(tokenization, valueStr, class.Class)
+	} else {
+		terms = tokenizer.TokenizeForClass(tokenization, valueStr, class.Class)
+	}
+
+	pvps := make([]*propValuePair, 0, len(terms))
+	for _, term := range terms {
+		if s.stopwords.IsStopword(term) {
+			continue
+		}
+		pvps = append(pvps, &propValuePair{
+			prop:               propName,
+			value:              []byte(term),
+			nestedKeyPrefix:    keyPrefix,
+			operator:           filter.Operator,
+			hasFilterableIndex: true,
+			isNested:           true,
+			Class:              class,
+		})
+	}
+
+	if len(pvps) == 0 {
+		return nil, ErrOnlyStopwords
+	}
+	if len(pvps) == 1 {
+		return pvps[0], nil
+	}
+	return &propValuePair{operator: filters.OperatorAnd, children: pvps, Class: class}, nil
+}
+
+// buildNestedPrimitiveFilterPair handles non-text primitive types (int,
+// number, bool, date and their array variants).
+func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, path, propName string,
+	dt schema.DataType, keyPrefix []byte, class *models.Class,
+) (*propValuePair, error) {
+	// Map array types to their scalar equivalent — each array element is stored
+	// individually in the nested bucket, so filtering works the same way.
+	scalar := dt
+	if base, ok := schema.IsArrayType(dt); ok {
+		scalar = base
+	}
+
+	var (
+		encodedValue []byte
+		err          error
+	)
+	switch scalar {
+	case schema.DataTypeInt:
+		encodedValue, err = s.extractIntValue(filter.Value.Value)
+	case schema.DataTypeNumber:
+		encodedValue, err = s.extractNumberValue(filter.Value.Value)
+	case schema.DataTypeBoolean:
+		encodedValue, err = s.extractBoolValue(filter.Value.Value)
+	case schema.DataTypeDate:
+		encodedValue, err = s.extractDateValue(filter.Value.Value)
+	default:
+		return nil, fmt.Errorf("nested path %q: unsupported leaf type %q", path, dt)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("nested path %q: encode value: %w", path, err)
+	}
+
+	return &propValuePair{
+		prop:               propName,
+		value:              encodedValue,
+		nestedKeyPrefix:    keyPrefix,
+		operator:           filter.Operator,
+		hasFilterableIndex: true,
+		isNested:           true,
+		Class:              class,
+	}, nil
+}

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -82,7 +82,7 @@ func (s *Searcher) buildNestedFilterPair(filter *filters.Clause, path, propName 
 	dt := schema.DataType(leaf.DataType[0])
 	switch dt {
 	case schema.DataTypeText, schema.DataTypeTextArray:
-		return s.buildNestedTextFilterPair(filter, path, propName, leaf.Tokenization, keyPrefix, class)
+		return s.buildNestedTextFilterPair(filter, path, propName, leaf, keyPrefix, class)
 	default:
 		return s.buildNestedPrimitiveFilterPair(filter, path, propName, dt, keyPrefix, class)
 	}
@@ -91,8 +91,12 @@ func (s *Searcher) buildNestedFilterPair(filter *filters.Clause, path, propName 
 // buildNestedTextFilterPair handles tokenizable text properties. Multiple
 // tokens produce multiple propValuePairs combined with AND, mirroring
 // extractTokenizableProp for flat properties.
-func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propName, tokenization string,
-	keyPrefix []byte, class *models.Class,
+//
+// TODO aliszka:nested_filtering the tokenization pipeline here (stopwords,
+// ASCII folding, wildcard handling) was aligned with extractTokenizableProp
+// manually. Consider extracting a shared helper to avoid future divergence.
+func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propName string,
+	leaf *models.NestedProperty, keyPrefix []byte, class *models.Class,
 ) (*propValuePair, error) {
 	valueStr, ok := filter.Value.Value.(string)
 	if !ok {
@@ -101,16 +105,28 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propN
 
 	var terms []string
 	if filter.Operator == filters.OperatorLike {
-		terms = tokenizer.TokenizeWithWildcardsForClass(tokenization, valueStr, class.Class)
+		text := valueStr
+		if leaf.TextAnalyzer != nil && leaf.TextAnalyzer.ASCIIFold {
+			ignore := tokenizer.BuildIgnoreSet(leaf.TextAnalyzer.ASCIIFoldIgnore)
+			text = tokenizer.FoldASCII(text, ignore)
+		}
+		terms = tokenizer.TokenizeWithWildcardsForClass(leaf.Tokenization, text, class.Class)
 	} else {
-		terms = tokenizer.TokenizeForClass(tokenization, valueStr, class.Class)
+		var sw tokenizer.StopwordDetector
+		if leaf.Tokenization == models.PropertyTokenizationWord {
+			d, err := s.stopwordProvider.GetForNested(leaf)
+			if err != nil {
+				return nil, fmt.Errorf("nested path %q: get stopwords: %w", path, err)
+			}
+			sw = d
+		}
+		prepared := tokenizer.NewPreparedAnalyzer(leaf.TextAnalyzer)
+		result := tokenizer.Analyze(valueStr, leaf.Tokenization, class.Class, prepared, sw)
+		terms = result.Query
 	}
 
 	pvps := make([]*propValuePair, 0, len(terms))
 	for _, term := range terms {
-		if s.stopwords.IsStopword(term) {
-			continue
-		}
 		pvps = append(pvps, &propValuePair{
 			prop:               propName,
 			value:              []byte(term),

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -40,7 +40,13 @@ func (s *Searcher) extractNestedProp(filter *filters.Clause, path string,
 		return nil, fmt.Errorf("nested path %q: %w", path, err)
 	}
 
-	if !isNestedFilterable(leaf) {
+	// TODO aliszka:nested_filtering when rangeable / searchable nested
+	// filtering support is added, add corresponding schema.IsNestedRangeable
+	// and schema.IsNestedSearchable checks alongside the filterable check
+	// below. The validator currently rejects non-filterable leaves at parse
+	// time; the check below stays as a defensive safeguard for any code path
+	// that bypasses validation.
+	if !schema.IsNestedFilterable(leaf) {
 		return nil, fmt.Errorf("nested property %q is not filterable", path)
 	}
 

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -1,0 +1,256 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// nestedSearcherClass is the test schema used across all extractNestedProp tests:
+//
+//	Article {
+//	  nested: object {
+//	    city:    text  (field tokenization, filterable)
+//	    title:   text  (word tokenization, filterable)
+//	    count:   int   (filterable)
+//	    numbers: int[] (filterable)
+//	    skipped: text  (filterable=false)
+//	    owner: object {
+//	      firstname: text (field tokenization, filterable)
+//	    }
+//	  }
+//	}
+func nestedSearcherClass() *models.Class {
+	f := func(v bool) *bool { return &v }
+	return &models.Class{
+		Class: "Article",
+		Properties: []*models.Property{
+			{
+				Name:     "nested",
+				DataType: schema.DataTypeObject.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: "field", IndexFilterable: f(true)},
+					{Name: "title", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: f(true)},
+					{Name: "count", DataType: schema.DataTypeInt.PropString(), IndexFilterable: f(true)},
+					{Name: "numbers", DataType: schema.DataTypeIntArray.PropString(), IndexFilterable: f(true)},
+					{Name: "skipped", DataType: schema.DataTypeText.PropString(), Tokenization: "field", IndexFilterable: f(false)},
+					{
+						Name:     "owner",
+						DataType: schema.DataTypeObject.PropString(),
+						NestedProperties: []*models.NestedProperty{
+							{Name: "firstname", DataType: schema.DataTypeText.PropString(), Tokenization: "field", IndexFilterable: f(true)},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func newTestSearcher() *Searcher {
+	class := nestedSearcherClass()
+	return &Searcher{
+		getClass:               func(name string) *models.Class { return class },
+		stopwords:              fakeStopwordDetector{},
+		isFallbackToSearchable: func() bool { return false },
+	}
+}
+
+func makeNestedFilterClause(propName string, operator filters.Operator, valueType schema.DataType, value any) *filters.Clause {
+	return &filters.Clause{
+		Operator: operator,
+		Value:    &filters.Value{Type: valueType, Value: value},
+		On:       &filters.Path{Class: "Article", Property: schema.PropertyName(propName)},
+	}
+}
+
+func TestExtractNestedProp(t *testing.T) {
+	s := newTestSearcher()
+	class := nestedSearcherClass()
+	prop := class.Properties[0] // "nested"
+
+	intVal42, err := s.extractIntValue(42)
+	require.NoError(t, err)
+	intVal7, err := s.extractIntValue(7)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name      string
+		path      string
+		operator  filters.Operator
+		valueType schema.DataType
+		value     any
+		// expected success fields
+		wantProp  string
+		wantValue []byte
+		// optional extra check for complex cases (e.g. multi-token AND)
+		verify  func(t *testing.T, pv *propValuePair)
+		wantErr string
+	}{
+		{
+			name: "text equal single token field tokenization",
+			path: "nested.city", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeText, value: "Berlin",
+			wantProp: "nested", wantValue: []byte("Berlin"),
+		},
+		{
+			name: "text equal two tokens word tokenization produces AND children",
+			path: "nested.title", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeText, value: "hello world",
+			verify: func(t *testing.T, pv *propValuePair) {
+				require.Equal(t, filters.OperatorAnd, pv.operator)
+				require.Len(t, pv.children, 2)
+				for _, child := range pv.children {
+					assert.Equal(t, "nested", child.prop)
+					assert.Equal(t, nested.PathPrefix("title"), child.nestedKeyPrefix)
+					assert.True(t, child.isNested)
+					assert.True(t, child.hasFilterableIndex)
+				}
+				assert.Equal(t, []byte("hello"), pv.children[0].value)
+				assert.Equal(t, []byte("world"), pv.children[1].value)
+			},
+		},
+		{
+			name: "text like pattern passed as-is",
+			path: "nested.city", operator: filters.OperatorLike,
+			valueType: schema.DataTypeText, value: "Ber*",
+			wantProp: "nested", wantValue: []byte("Ber*"),
+		},
+		{
+			name: "int equal",
+			path: "nested.count", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeInt, value: 42,
+			wantProp: "nested", wantValue: intVal42,
+		},
+		{
+			name: "int array mapped to scalar int encoding",
+			path: "nested.numbers", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeInt, value: 7,
+			wantProp: "nested", wantValue: intVal7,
+		},
+		{
+			name: "two-level path",
+			path: "nested.owner.firstname", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeText, value: "Alice",
+			wantProp: "nested", wantValue: []byte("Alice"),
+		},
+		{
+			name: "IsNull returns error",
+			path: "nested.city", operator: filters.OperatorIsNull,
+			valueType: schema.DataTypeBoolean, value: true,
+			wantErr: "IsNull",
+		},
+		{
+			name: "non-filterable leaf returns error",
+			path: "nested.skipped", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeText, value: "x",
+			wantErr: "not filterable",
+		},
+		{
+			name: "non-existent sub-property returns error",
+			path: "nested.missing", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeText, value: "x",
+			wantErr: `"missing" not found`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clause := makeNestedFilterClause(tt.path, tt.operator, tt.valueType, tt.value)
+			pv, err := s.extractNestedProp(clause, tt.path, prop, class)
+
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			if tt.verify != nil {
+				tt.verify(t, pv)
+				return
+			}
+			relativePath := tt.path[strings.Index(tt.path, ".")+1:]
+			assert.Equal(t, tt.wantProp, pv.prop)
+			assert.Equal(t, nested.PathPrefix(relativePath), pv.nestedKeyPrefix)
+			assert.True(t, pv.isNested)
+			assert.True(t, pv.hasFilterableIndex)
+			if tt.wantValue != nil {
+				assert.Equal(t, tt.wantValue, pv.value)
+			}
+		})
+	}
+}
+
+// TestExtractPropValuePairNestedRouting verifies that extractPropValuePair
+// correctly detects nested paths and delegates to extractNestedProp,
+// producing the same propValuePair as a direct call would.
+func TestExtractPropValuePairNestedRouting(t *testing.T) {
+	s := newTestSearcher()
+
+	tests := []struct {
+		name       string
+		path       string
+		operator   filters.Operator
+		valueType  schema.DataType
+		value      any
+		wantProp   string // expected pv.prop (top-level name)
+		wantNested bool
+	}{
+		{
+			name: "text equal routes to nested",
+			path: "nested.city", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeText, value: "Berlin",
+			wantProp: "nested", wantNested: true,
+		},
+		{
+			name: "int equal routes to nested",
+			path: "nested.count", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeInt, value: 42,
+			wantProp: "nested", wantNested: true,
+		},
+		{
+			name: "two-level path routes to nested",
+			path: "nested.owner.firstname", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeText, value: "Alice",
+			wantProp: "nested", wantNested: true,
+		},
+		{
+			name: "like routes to nested",
+			path: "nested.city", operator: filters.OperatorLike,
+			valueType: schema.DataTypeText, value: "Ber*",
+			wantProp: "nested", wantNested: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clause := makeNestedFilterClause(tt.path, tt.operator, tt.valueType, tt.value)
+			pv, err := s.extractPropValuePair(t.Context(), clause, "Article")
+			require.NoError(t, err)
+
+			relativePath := tt.path[strings.Index(tt.path, ".")+1:]
+			assert.Equal(t, tt.wantProp, pv.prop)
+			assert.Equal(t, tt.wantNested, pv.isNested)
+			assert.Equal(t, nested.PathPrefix(relativePath), pv.nestedKeyPrefix)
+			assert.Equal(t, tt.operator, pv.operator)
+		})
+	}
+}

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -68,7 +69,7 @@ func newTestSearcher() *Searcher {
 	class := nestedSearcherClass()
 	return &Searcher{
 		getClass:               func(name string) *models.Class { return class },
-		stopwords:              fakeStopwordDetector{},
+		stopwordProvider:       stopwords.NewProvider(fakeStopwordDetector{}, nil),
 		isFallbackToSearchable: func() bool { return false },
 	}
 }

--- a/adapters/repos/db/inverted/stopwords/provider.go
+++ b/adapters/repos/db/inverted/stopwords/provider.go
@@ -86,6 +86,23 @@ func (p *Provider) Get(prop *models.Property) (StopwordDetector, error) {
 	return NewDetectorFromPreset(preset)
 }
 
+// GetForNested returns the stopword detector to use for a nested property,
+// applying the same preset-resolution logic as Get but reading from
+// NestedProperty.TextAnalyzer instead of Property.TextAnalyzer.
+func (p *Provider) GetForNested(leaf *models.NestedProperty) (StopwordDetector, error) {
+	if p == nil {
+		return nil, nil
+	}
+	if leaf == nil || leaf.TextAnalyzer == nil || leaf.TextAnalyzer.StopwordPreset == "" {
+		return p.fallback, nil
+	}
+	preset := leaf.TextAnalyzer.StopwordPreset
+	if d, ok := p.presets[preset]; ok {
+		return d, nil
+	}
+	return NewDetectorFromPreset(preset)
+}
+
 // Fallback returns the collection-level detector. Useful for call sites that
 // don't have a property in hand (e.g. shard-write deletes that build a
 // generic searcher).

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -1,0 +1,1025 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/dto"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/usecases/objects"
+)
+
+// TestNestedFilteringViaShardWritePath exercises nested property filtering
+// end-to-end using the full production write and search pipelines:
+//
+//	write: repo.PutObject → putObjectLSM → updateInvertedIndexLSM
+//	            → extendNestedInvertedIndicesLSM → RoaringSetAddBatch
+//	read:  repo.Search → Searcher → extractNestedProp
+//	            → docBitmapInvertedRoaringSet → MaskAllPositions
+//
+// A shared filterCase table is run against both sub-tests, with each case
+// declaring its expected result set explicitly for each sub-test:
+//
+//   - doc123/124/125: design document reference objects stored as nestedObject
+//     (DataTypeObject). All operators, deeply nested paths, AND/OR.
+//   - doc998/999: same data stored as nestedArray (DataTypeObjectArray).
+//     doc998 = [doc123Data] (one root), doc999 = [doc124Data, doc125Data]
+//     (two roots) — verifies object[] behaves identically to object.
+func TestNestedFilteringViaShardWritePath(t *testing.T) {
+	const nestedClass = "Article"
+	vTrue := true
+
+	fullNestedProps := []*models.NestedProperty{
+		{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+		{
+			Name:     "owner",
+			DataType: schema.DataTypeObject.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "firstname", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+				{Name: "lastname", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+				{Name: "nicknames", DataType: schema.DataTypeTextArray.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+			},
+		},
+		{
+			Name:     "addresses",
+			DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+				{Name: "postcode", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+				{Name: "numbers", DataType: schema.DataTypeNumberArray.PropString(), IndexFilterable: &vTrue},
+			},
+		},
+		{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+		{
+			Name:     "cars",
+			DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+				{
+					Name:     "tires",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+						{Name: "radiuses", DataType: schema.DataTypeIntArray.PropString(), IndexFilterable: &vTrue},
+					},
+				},
+				{
+					Name:     "accessories",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "type", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+					},
+				},
+				{Name: "colors", DataType: schema.DataTypeTextArray.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+			},
+		},
+	}
+
+	const (
+		id123 = strfmt.UUID("00000000-0000-0000-0000-000000000123")
+		id124 = strfmt.UUID("00000000-0000-0000-0000-000000000124")
+		id125 = strfmt.UUID("00000000-0000-0000-0000-000000000125")
+		id998 = strfmt.UUID("00000000-0000-0000-0000-000000000998")
+		id999 = strfmt.UUID("00000000-0000-0000-0000-000000000999")
+	)
+
+	makeFilter := func(path string, op filters.Operator, vt schema.DataType, val any) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: op,
+			Value:    &filters.Value{Type: vt, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(a, b *filters.LocalFilter) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: []filters.Clause{*a.Root, *b.Root},
+		}}
+	}
+	orFilter := func(a, b *filters.LocalFilter) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorOr,
+			Operands: []filters.Clause{*a.Root, *b.Root},
+		}}
+	}
+
+	// UUIDs used in the update sub-tests — defined here so filterCases can
+	// reference them directly.
+	const (
+		id200 = strfmt.UUID("00000000-0000-0000-0000-000000000200")
+		id201 = strfmt.UUID("00000000-0000-0000-0000-000000000201")
+		id300 = strfmt.UUID("00000000-0000-0000-0000-000000000300")
+	)
+
+	// f builds a filter from a relative sub-path and operator.
+	f := func(subPath string, op filters.Operator, vt schema.DataType, val any) func(string) *filters.LocalFilter {
+		return func(p string) *filters.LocalFilter { return makeFilter(p+"."+subPath, op, vt, val) }
+	}
+
+	// filterCase holds the filter builder and the expected document IDs for
+	// every sub-test operation directly — no derived helper methods needed.
+	//
+	// Object type sub-tests use doc123/id123, doc124/id124, doc125/id125.
+	// Array type sub-tests use doc998/id998 (=[doc123Data]) and
+	// doc999/id999 (=[doc124Data,doc125Data]).
+	// Delete sub-tests remove doc123 / doc998 respectively.
+	// Update sub-tests replace id201 (doc123Data→doc125Data) /
+	// id300 ([doc123Data]→[doc124Data,doc125Data]).
+	type filterCase struct {
+		name             string
+		filter           func(propName string) *filters.LocalFilter
+		matchesObjectAdd []strfmt.UUID // object type: after write
+		matchesArrayAdd  []strfmt.UUID // array type:  after write
+		matchesObjectDel []strfmt.UUID // object type: after deleting doc123
+		matchesArrayDel  []strfmt.UUID // array type:  after deleting doc998
+		matchesObjectUpd []strfmt.UUID // object type: after updating id201 with doc125Data
+		matchesArrayUpd  []strfmt.UUID // array type:  after updating id300 with [doc124,doc125]
+	}
+
+	e := []strfmt.UUID{} // empty — no match
+
+	filterCases := []filterCase{
+		// owner sub-properties
+		{
+			name: "owner.firstname Marsha", filter: f("owner.firstname", filters.OperatorEqual, schema.DataTypeText, "marsha"),
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			name: "owner.firstname Justin", filter: f("owner.firstname", filters.OperatorEqual, schema.DataTypeText, "justin"),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "owner.firstname Anna", filter: f("owner.firstname", filters.OperatorEqual, schema.DataTypeText, "anna"),
+			matchesObjectAdd: []strfmt.UUID{id125}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "owner.nicknames Marshmallow", filter: f("owner.nicknames", filters.OperatorEqual, schema.DataTypeText, "marshmallow"),
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			name: "owner.nicknames watch", filter: f("owner.nicknames", filters.OperatorEqual, schema.DataTypeText, "watch"),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		// addresses
+		{
+			name: "addresses.city Berlin", filter: f("addresses.city", filters.OperatorEqual, schema.DataTypeText, "berlin"),
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			name: "addresses.city Madrid", filter: f("addresses.city", filters.OperatorEqual, schema.DataTypeText, "madrid"),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "addresses.city London", filter: f("addresses.city", filters.OperatorEqual, schema.DataTypeText, "london"),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "addresses.city Paris", filter: f("addresses.city", filters.OperatorEqual, schema.DataTypeText, "paris"),
+			matchesObjectAdd: []strfmt.UUID{id125}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "addresses.city Munich no match", filter: f("addresses.city", filters.OperatorEqual, schema.DataTypeText, "munich"),
+			matchesObjectAdd: e, matchesArrayAdd: e,
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			name: "addresses.numbers == 1123", filter: f("addresses.numbers", filters.OperatorEqual, schema.DataTypeNumber, float64(1123)),
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			name: "addresses.numbers > 200", filter: f("addresses.numbers", filters.OperatorGreaterThan, schema.DataTypeNumber, float64(200)),
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			name: "addresses.numbers >= 124", filter: f("addresses.numbers", filters.OperatorGreaterThanEqual, schema.DataTypeNumber, float64(124)),
+			matchesObjectAdd: []strfmt.UUID{id123, id124, id125}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id124, id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200, id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "addresses.numbers < 125", filter: f("addresses.numbers", filters.OperatorLessThan, schema.DataTypeNumber, float64(125)),
+			matchesObjectAdd: []strfmt.UUID{id123, id124}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "addresses.numbers <= 125", filter: f("addresses.numbers", filters.OperatorLessThanEqual, schema.DataTypeNumber, float64(125)),
+			matchesObjectAdd: []strfmt.UUID{id123, id124, id125}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id124, id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200, id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		// tags
+		{
+			name: "tags german", filter: f("tags", filters.OperatorEqual, schema.DataTypeText, "german"),
+			matchesObjectAdd: []strfmt.UUID{id123, id124}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "tags electric", filter: f("tags", filters.OperatorEqual, schema.DataTypeText, "electric"),
+			matchesObjectAdd: []strfmt.UUID{id125}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "tags premium", filter: f("tags", filters.OperatorEqual, schema.DataTypeText, "premium"),
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		// cars
+		{
+			name: "cars.make BMW", filter: f("cars.make", filters.OperatorEqual, schema.DataTypeText, "bmw"),
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			name: "cars.make Audi", filter: f("cars.make", filters.OperatorEqual, schema.DataTypeText, "audi"),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.make Kia", filter: f("cars.make", filters.OperatorEqual, schema.DataTypeText, "kia"),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.make Tesla", filter: f("cars.make", filters.OperatorEqual, schema.DataTypeText, "tesla"),
+			matchesObjectAdd: []strfmt.UUID{id125}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.colors white", filter: f("cars.colors", filters.OperatorEqual, schema.DataTypeText, "white"),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.accessories.type charger", filter: f("cars.accessories.type", filters.OperatorEqual, schema.DataTypeText, "charger"),
+			matchesObjectAdd: []strfmt.UUID{id125}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		// tires.width — deeply nested int, all four comparison operators
+		{
+			name: "cars.tires.width == 225", filter: f("cars.tires.width", filters.OperatorEqual, schema.DataTypeInt, 225),
+			matchesObjectAdd: []strfmt.UUID{id123, id124}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.tires.width == 205", filter: f("cars.tires.width", filters.OperatorEqual, schema.DataTypeInt, 205),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.tires.width == 245", filter: f("cars.tires.width", filters.OperatorEqual, schema.DataTypeInt, 245),
+			matchesObjectAdd: []strfmt.UUID{id125}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.tires.width > 240", filter: f("cars.tires.width", filters.OperatorGreaterThan, schema.DataTypeInt, 240),
+			matchesObjectAdd: []strfmt.UUID{id125}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.tires.width >= 225", filter: f("cars.tires.width", filters.OperatorGreaterThanEqual, schema.DataTypeInt, 225),
+			matchesObjectAdd: []strfmt.UUID{id123, id124, id125}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id124, id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200, id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.tires.width < 200", filter: f("cars.tires.width", filters.OperatorLessThan, schema.DataTypeInt, 200),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.tires.width <= 205", filter: f("cars.tires.width", filters.OperatorLessThanEqual, schema.DataTypeInt, 205),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.tires.width <= 225", filter: f("cars.tires.width", filters.OperatorLessThanEqual, schema.DataTypeInt, 225),
+			matchesObjectAdd: []strfmt.UUID{id123, id124}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		// tires.radiuses — int array
+		{
+			name: "cars.tires.radiuses == 19", filter: f("cars.tires.radiuses", filters.OperatorEqual, schema.DataTypeInt, 19),
+			matchesObjectAdd: []strfmt.UUID{id123, id125}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.tires.radiuses == 17", filter: f("cars.tires.radiuses", filters.OperatorEqual, schema.DataTypeInt, 17),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.tires.radiuses == 20", filter: f("cars.tires.radiuses", filters.OperatorEqual, schema.DataTypeInt, 20),
+			matchesObjectAdd: []strfmt.UUID{id125}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		// compound AND / OR
+		{
+			name: "Berlin AND BMW",
+			filter: func(p string) *filters.LocalFilter {
+				return andFilter(makeFilter(p+".addresses.city", filters.OperatorEqual, schema.DataTypeText, "berlin"),
+					makeFilter(p+".cars.make", filters.OperatorEqual, schema.DataTypeText, "bmw"))
+			},
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			name: "Anna AND Tesla",
+			filter: func(p string) *filters.LocalFilter {
+				return andFilter(makeFilter(p+".owner.firstname", filters.OperatorEqual, schema.DataTypeText, "anna"),
+					makeFilter(p+".cars.make", filters.OperatorEqual, schema.DataTypeText, "tesla"))
+			},
+			matchesObjectAdd: []strfmt.UUID{id125}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "Berlin AND Justin (empty)",
+			filter: func(p string) *filters.LocalFilter {
+				return andFilter(makeFilter(p+".addresses.city", filters.OperatorEqual, schema.DataTypeText, "berlin"),
+					makeFilter(p+".owner.firstname", filters.OperatorEqual, schema.DataTypeText, "justin"))
+			},
+			matchesObjectAdd: e, matchesArrayAdd: e,
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			name: "Berlin OR Paris",
+			filter: func(p string) *filters.LocalFilter {
+				return orFilter(makeFilter(p+".addresses.city", filters.OperatorEqual, schema.DataTypeText, "berlin"),
+					makeFilter(p+".addresses.city", filters.OperatorEqual, schema.DataTypeText, "paris"))
+			},
+			matchesObjectAdd: []strfmt.UUID{id123, id125}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		// LIKE operator — exercises the prefix-bounded cursor in RowReaderRoaringSet.
+		// Word tokenization lowercases input, so patterns must also be lowercase.
+		{
+			name: "owner.firstname LIKE mar* (prefix)", filter: f("owner.firstname", filters.OperatorLike, schema.DataTypeText, "mar*"),
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			name: "owner.firstname LIKE *ustin (suffix)", filter: f("owner.firstname", filters.OperatorLike, schema.DataTypeText, "*ustin"),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "owner.firstname LIKE ann* (prefix)", filter: f("owner.firstname", filters.OperatorLike, schema.DataTypeText, "ann*"),
+			matchesObjectAdd: []strfmt.UUID{id125}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "owner.firstname LIKE *a (Marsha and Anna)", filter: f("owner.firstname", filters.OperatorLike, schema.DataTypeText, "*a"),
+			matchesObjectAdd: []strfmt.UUID{id123, id125}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "addresses.city LIKE ber*", filter: f("addresses.city", filters.OperatorLike, schema.DataTypeText, "ber*"),
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			name: "cars.make LIKE bm*", filter: f("cars.make", filters.OperatorLike, schema.DataTypeText, "bm*"),
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			name: "cars.make LIKE *ia (Kia)", filter: f("cars.make", filters.OperatorLike, schema.DataTypeText, "*ia"),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			name: "cars.make LIKE tesl*", filter: f("cars.make", filters.OperatorLike, schema.DataTypeText, "tesl*"),
+			matchesObjectAdd: []strfmt.UUID{id125}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		// NotEqual — deny-list semantics: fetches matching positions, strips to
+		// docIDs, then inverts against all documents in the shard.
+		{
+			// "marsha" removed after update (id201 becomes Anna) → deny list empty
+			// → all remaining docs returned.
+			name: "owner.firstname != marsha", filter: f("owner.firstname", filters.OperatorNotEqual, schema.DataTypeText, "marsha"),
+			matchesObjectAdd: []strfmt.UUID{id124, id125}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124, id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200, id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		// ContainsAny / ContainsAll / ContainsNone — decomposed into individual
+		// Equal clauses by extractContains, each re-dispatched through
+		// extractPropValuePair which routes them to extractNestedProp.
+		{
+			// ContainsAny: german(id123,id124) ∪ electric(id125) = all three
+			name: "tags ContainsAny [german, electric]", filter: f("tags", filters.ContainsAny, schema.DataTypeText, []string{"german", "electric"}),
+			matchesObjectAdd: []strfmt.UUID{id123, id124, id125}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id124, id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200, id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			// ContainsAny: premium(id123) ∪ electric(id125) = {id123,id125}
+			name: "tags ContainsAny [premium, electric]", filter: f("tags", filters.ContainsAny, schema.DataTypeText, []string{"premium", "electric"}),
+			matchesObjectAdd: []strfmt.UUID{id123, id125}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			// ContainsAll: german(id123,id124) ∩ sedan(id124) = {id124}
+			name: "tags ContainsAll [german, sedan]", filter: f("tags", filters.ContainsAll, schema.DataTypeText, []string{"german", "sedan"}),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: []strfmt.UUID{id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
+		},
+		{
+			// ContainsAll: german(id123,id124) ∩ premium(id123) = {id123}
+			name: "tags ContainsAll [german, premium]", filter: f("tags", filters.ContainsAll, schema.DataTypeText, []string{"german", "premium"}),
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			// ContainsNone: NOT(electric(id125) ∪ sedan(id124)) = {id123}
+			// Array: electric and sedan both in id999 → NOT({id999}) = {id998}
+			name: "tags ContainsNone [electric, sedan]", filter: f("tags", filters.ContainsNone, schema.DataTypeText, []string{"electric", "sedan"}),
+			matchesObjectAdd: []strfmt.UUID{id123}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: e, matchesArrayDel: e,
+			matchesObjectUpd: e, matchesArrayUpd: e,
+		},
+		{
+			// ContainsNone: NOT(premium(id123) ∪ electric(id125)) = {id124}
+			// After delete/update: premium gone, electric still present.
+			name: "tags ContainsNone [premium, electric]", filter: f("tags", filters.ContainsNone, schema.DataTypeText, []string{"premium", "electric"}),
+			matchesObjectAdd: []strfmt.UUID{id124}, matchesArrayAdd: e,
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: e,
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: e,
+		},
+		{
+			// Step 10a deny-list operates at document level: doc999 contains Justin
+			// in element 0, so the whole document is excluded even though element 1
+			// (Anna) would satisfy the condition. Element-level precision requires
+			// Step 10b. After array delete/update the only remaining document also
+			// contains Justin, so all array results are empty.
+			name: "owner.firstname != justin", filter: f("owner.firstname", filters.OperatorNotEqual, schema.DataTypeText, "justin"),
+			matchesObjectAdd: []strfmt.UUID{id123, id125}, matchesArrayAdd: []strfmt.UUID{id998},
+			matchesObjectDel: []strfmt.UUID{id125}, matchesArrayDel: e,
+			matchesObjectUpd: []strfmt.UUID{id201}, matchesArrayUpd: e,
+		},
+	}
+
+	// Shared document data. doc999 reuses doc124Data and doc125Data as its
+	// two root elements, so defining them once avoids duplication.
+	doc123Data := map[string]any{
+		"name": "subdoc_123",
+		"owner": map[string]any{
+			"firstname": "Marsha", "lastname": "Mallow",
+			"nicknames": []any{"Marshmallow", "M&M"},
+		},
+		"addresses": []any{
+			map[string]any{"city": "Berlin", "postcode": "10115", "numbers": []any{float64(123), float64(1123)}},
+		},
+		"tags": []any{"german", "premium"},
+		"cars": []any{
+			map[string]any{
+				"make":   "BMW",
+				"tires":  []any{map[string]any{"width": float64(225), "radiuses": []any{float64(18), float64(19)}}},
+				"colors": []any{"black", "orange"},
+			},
+		},
+	}
+	doc124Data := map[string]any{
+		"name": "subdoc_124",
+		"owner": map[string]any{
+			"firstname": "Justin", "lastname": "Time",
+			"nicknames": []any{"watch"},
+		},
+		"addresses": []any{
+			map[string]any{"city": "Madrid", "postcode": "28001", "numbers": []any{float64(124)}},
+			map[string]any{"city": "London", "postcode": "SW1"},
+		},
+		"tags": []any{"german", "japanese", "sedan"},
+		"cars": []any{
+			map[string]any{
+				"make": "Audi",
+				"tires": []any{
+					map[string]any{"width": float64(205), "radiuses": []any{float64(17), float64(18)}},
+					map[string]any{"width": float64(225)},
+				},
+			},
+			map[string]any{
+				"make":   "Kia",
+				"tires":  []any{map[string]any{"width": float64(195), "radiuses": []any{}}},
+				"colors": []any{"white"},
+			},
+		},
+	}
+	doc125Data := map[string]any{
+		"name": "subdoc_125",
+		"owner": map[string]any{
+			"firstname": "Anna", "lastname": "Wanna",
+		},
+		"addresses": []any{
+			map[string]any{"city": "Paris", "postcode": "75001", "numbers": []any{float64(125)}},
+		},
+		"tags": []any{"electric"},
+		"cars": []any{
+			map[string]any{
+				"make":        "Tesla",
+				"tires":       []any{map[string]any{"width": float64(245), "radiuses": []any{float64(18), float64(19), float64(20)}}},
+				"accessories": []any{map[string]any{"type": "charger"}, map[string]any{"type": "mats"}},
+				"colors":      []any{"yellow"},
+			},
+		},
+	}
+	// doc123 (Marsha/Berlin/BMW), doc124 (Justin/Madrid+London/Audi+Kia),
+	// doc125 (Anna/Paris/Tesla) — primary design document examples.
+	t.Run("doc123 doc124 doc125 object type", func(t *testing.T) {
+		class := &models.Class{
+			Class:             nestedClass,
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{
+				{Name: "nestedObject", DataType: schema.DataTypeObject.PropString(), NestedProperties: fullNestedProps},
+			},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+
+		docs := []models.Object{
+			{Class: nestedClass, ID: id123, Properties: map[string]any{"nestedObject": doc123Data}},
+			{Class: nestedClass, ID: id124, Properties: map[string]any{"nestedObject": doc124Data}},
+			{Class: nestedClass, ID: id125, Properties: map[string]any{"nestedObject": doc125Data}},
+		}
+
+		for i := range docs {
+			require.NoError(t, db.PutObject(ctx, &docs[i], nil, nil, nil, nil, 0))
+		}
+
+		search := func(t *testing.T, f *filters.LocalFilter) []strfmt.UUID {
+			t.Helper()
+			res, err := db.Search(ctx, dto.GetParams{
+				ClassName:  nestedClass,
+				Pagination: &filters.Pagination{Limit: 100},
+				Filters:    f,
+			})
+			require.NoError(t, err)
+			ids := make([]strfmt.UUID, len(res))
+			for i, r := range res {
+				ids[i] = r.ID
+			}
+			return ids
+		}
+
+		for _, tc := range filterCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.ElementsMatch(t, tc.matchesObjectAdd, search(t, tc.filter("nestedObject")))
+			})
+		}
+	})
+
+	// Both doc998 and doc999 use nestedArray: object[].
+	// doc998 wraps doc123Data as a single root element — same data as doc123 but
+	// via object[] rather than object, verifying the two types are equivalent.
+	// doc999 wraps doc124Data and doc125Data as two root elements.
+	t.Run("doc998 one root doc999 two roots object array", func(t *testing.T) {
+		class := &models.Class{
+			Class:             nestedClass,
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{
+				{Name: "nestedArray", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: fullNestedProps},
+			},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+
+		docs := []models.Object{
+			// doc998: doc123Data as a single-root object[] — same data as doc123 in sub-test 1.
+			{Class: nestedClass, ID: id998, Properties: map[string]any{"nestedArray": []any{doc123Data}}},
+			// doc999: doc124Data + doc125Data as two-root object[].
+			{Class: nestedClass, ID: id999, Properties: map[string]any{"nestedArray": []any{doc124Data, doc125Data}}},
+		}
+
+		for i := range docs {
+			require.NoError(t, db.PutObject(ctx, &docs[i], nil, nil, nil, nil, 0))
+		}
+
+		search := func(t *testing.T, f *filters.LocalFilter) []strfmt.UUID {
+			t.Helper()
+			res, err := db.Search(ctx, dto.GetParams{
+				ClassName:  nestedClass,
+				Pagination: &filters.Pagination{Limit: 100},
+				Filters:    f,
+			})
+			require.NoError(t, err)
+			ids := make([]strfmt.UUID, len(res))
+			for i, r := range res {
+				ids[i] = r.ID
+			}
+			return ids
+		}
+
+		for _, tc := range filterCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.ElementsMatch(t, tc.matchesArrayAdd, search(t, tc.filter("nestedArray")))
+			})
+		}
+	})
+
+	// After deleting doc123, all filters that previously matched it must now
+	// return only doc124/doc125 — verifying the delete path removes all
+	// nested positions correctly.
+	t.Run("doc123/124/125 delete doc123 object type", func(t *testing.T) {
+		class := &models.Class{
+			Class:             nestedClass,
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{
+				{Name: "nestedObject", DataType: schema.DataTypeObject.PropString(), NestedProperties: fullNestedProps},
+			},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+
+		for _, obj := range []models.Object{
+			{Class: nestedClass, ID: id123, Properties: map[string]any{"nestedObject": doc123Data}},
+			{Class: nestedClass, ID: id124, Properties: map[string]any{"nestedObject": doc124Data}},
+			{Class: nestedClass, ID: id125, Properties: map[string]any{"nestedObject": doc125Data}},
+		} {
+			require.NoError(t, db.PutObject(ctx, &obj, nil, nil, nil, nil, 0))
+		}
+
+		require.NoError(t, db.DeleteObject(ctx, nestedClass, id123, time.Now(), nil, "", 0))
+
+		search := func(t *testing.T, f *filters.LocalFilter) []strfmt.UUID {
+			t.Helper()
+			res, err := db.Search(ctx, dto.GetParams{ClassName: nestedClass, Pagination: &filters.Pagination{Limit: 100}, Filters: f})
+			require.NoError(t, err)
+			ids := make([]strfmt.UUID, len(res))
+			for i, r := range res {
+				ids[i] = r.ID
+			}
+			return ids
+		}
+
+		for _, tc := range filterCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.ElementsMatch(t, tc.matchesObjectDel, search(t, tc.filter("nestedObject")))
+			})
+		}
+	})
+
+	// After deleting doc998, filters must return only doc999 — verifying the
+	// delete path works correctly for the object[] type as well.
+	t.Run("doc998/999 delete doc998 array type", func(t *testing.T) {
+		class := &models.Class{
+			Class:             nestedClass,
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{
+				{Name: "nestedArray", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: fullNestedProps},
+			},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+
+		for _, obj := range []models.Object{
+			{Class: nestedClass, ID: id998, Properties: map[string]any{"nestedArray": []any{doc123Data}}},
+			{Class: nestedClass, ID: id999, Properties: map[string]any{"nestedArray": []any{doc124Data, doc125Data}}},
+		} {
+			require.NoError(t, db.PutObject(ctx, &obj, nil, nil, nil, nil, 0))
+		}
+
+		require.NoError(t, db.DeleteObject(ctx, nestedClass, id998, time.Now(), nil, "", 0))
+
+		search := func(t *testing.T, f *filters.LocalFilter) []strfmt.UUID {
+			t.Helper()
+			res, err := db.Search(ctx, dto.GetParams{ClassName: nestedClass, Pagination: &filters.Pagination{Limit: 100}, Filters: f})
+			require.NoError(t, err)
+			ids := make([]strfmt.UUID, len(res))
+			for i, r := range res {
+				ids[i] = r.ID
+			}
+			return ids
+		}
+
+		for _, tc := range filterCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.ElementsMatch(t, tc.matchesArrayDel, search(t, tc.filter("nestedArray")))
+			})
+		}
+	})
+
+	// Update test: id201 is written with doc123Data, id200 with doc124Data, then
+	// id201 is updated to doc125Data. After the update:
+	//   id200 = doc124Data  (unchanged)
+	//   id201 = doc125Data  (was doc123Data, now replaced)
+	// Filters must no longer return any doc123Data results, exercising that the
+	// delete-then-reindex path in updateInvertedIndexLSM removes old positions.
+	t.Run("update doc123→doc125 object type", func(t *testing.T) {
+		class := &models.Class{
+			Class:             nestedClass,
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{
+				{Name: "nestedObject", DataType: schema.DataTypeObject.PropString(), NestedProperties: fullNestedProps},
+			},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+
+		// Insert id201 = doc123Data and id200 = doc124Data.
+		require.NoError(t, db.PutObject(ctx, &models.Object{Class: nestedClass, ID: id201, Properties: map[string]any{"nestedObject": doc123Data}}, nil, nil, nil, nil, 0))
+		require.NoError(t, db.PutObject(ctx, &models.Object{Class: nestedClass, ID: id200, Properties: map[string]any{"nestedObject": doc124Data}}, nil, nil, nil, nil, 0))
+
+		// Update id201: replace doc123Data with doc125Data.
+		require.NoError(t, db.PutObject(ctx, &models.Object{Class: nestedClass, ID: id201, Properties: map[string]any{"nestedObject": doc125Data}}, nil, nil, nil, nil, 0))
+
+		search := func(t *testing.T, f *filters.LocalFilter) []strfmt.UUID {
+			t.Helper()
+			res, err := db.Search(ctx, dto.GetParams{ClassName: nestedClass, Pagination: &filters.Pagination{Limit: 100}, Filters: f})
+			require.NoError(t, err)
+			ids := make([]strfmt.UUID, len(res))
+			for i, r := range res {
+				ids[i] = r.ID
+			}
+			return ids
+		}
+
+		for _, tc := range filterCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.ElementsMatch(t, tc.matchesObjectUpd, search(t, tc.filter("nestedObject")))
+			})
+		}
+	})
+
+	// Update test for the array type: id300 is written with [doc123Data] (same
+	// as doc998), then updated to [doc124Data, doc125Data] (same as doc999).
+	// After the update id300 holds doc999Data; doc123Data is gone. Filters must
+	// return id300 wherever they previously matched doc999 data, and nothing
+	// where they previously matched doc998 data.
+	t.Run("update doc998→doc999 array type", func(t *testing.T) {
+		class := &models.Class{
+			Class:             nestedClass,
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{
+				{Name: "nestedArray", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: fullNestedProps},
+			},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+
+		// Insert id300 = [doc123Data] (doc998 equivalent).
+		require.NoError(t, db.PutObject(ctx, &models.Object{Class: nestedClass, ID: id300, Properties: map[string]any{"nestedArray": []any{doc123Data}}}, nil, nil, nil, nil, 0))
+
+		// Update id300: replace with [doc124Data, doc125Data] (doc999 equivalent).
+		require.NoError(t, db.PutObject(ctx, &models.Object{Class: nestedClass, ID: id300, Properties: map[string]any{"nestedArray": []any{doc124Data, doc125Data}}}, nil, nil, nil, nil, 0))
+
+		search := func(t *testing.T, f *filters.LocalFilter) []strfmt.UUID {
+			t.Helper()
+			res, err := db.Search(ctx, dto.GetParams{ClassName: nestedClass, Pagination: &filters.Pagination{Limit: 100}, Filters: f})
+			require.NoError(t, err)
+			ids := make([]strfmt.UUID, len(res))
+			for i, r := range res {
+				ids[i] = r.ID
+			}
+			return ids
+		}
+
+		for _, tc := range filterCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.ElementsMatch(t, tc.matchesArrayUpd, search(t, tc.filter("nestedArray")))
+			})
+		}
+	})
+
+	makeBatch := func(objs ...models.Object) objects.BatchObjects {
+		batch := make(objects.BatchObjects, len(objs))
+		for i := range objs {
+			batch[i] = objects.BatchObject{OriginalIndex: i, Object: &objs[i], UUID: objs[i].ID}
+		}
+		return batch
+	}
+
+	putBatch := func(t *testing.T, db *DB, ctx context.Context, batch objects.BatchObjects) {
+		t.Helper()
+		res, err := db.BatchPutObjects(ctx, batch, nil, 0)
+		require.NoError(t, err)
+		for _, r := range res {
+			require.NoError(t, r.Err)
+		}
+	}
+
+	// Batch write: same as the individual-write add sub-tests but all documents
+	// inserted in a single BatchPutObjects call, verifying the batch write path
+	// exercises the same nested index pipeline.
+	t.Run("batch write doc123/124/125 object type", func(t *testing.T) {
+		class := &models.Class{
+			Class:             nestedClass,
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{
+				{Name: "nestedObject", DataType: schema.DataTypeObject.PropString(), NestedProperties: fullNestedProps},
+			},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+
+		putBatch(t, db, ctx, makeBatch(
+			models.Object{Class: nestedClass, ID: id123, Properties: map[string]any{"nestedObject": doc123Data}},
+			models.Object{Class: nestedClass, ID: id124, Properties: map[string]any{"nestedObject": doc124Data}},
+			models.Object{Class: nestedClass, ID: id125, Properties: map[string]any{"nestedObject": doc125Data}},
+		))
+
+		search := func(t *testing.T, f *filters.LocalFilter) []strfmt.UUID {
+			t.Helper()
+			res, err := db.Search(ctx, dto.GetParams{ClassName: nestedClass, Pagination: &filters.Pagination{Limit: 100}, Filters: f})
+			require.NoError(t, err)
+			ids := make([]strfmt.UUID, len(res))
+			for i, r := range res {
+				ids[i] = r.ID
+			}
+			return ids
+		}
+
+		for _, tc := range filterCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.ElementsMatch(t, tc.matchesObjectAdd, search(t, tc.filter("nestedObject")))
+			})
+		}
+	})
+
+	t.Run("batch write doc998/999 array type", func(t *testing.T) {
+		class := &models.Class{
+			Class:             nestedClass,
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{
+				{Name: "nestedArray", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: fullNestedProps},
+			},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+
+		putBatch(t, db, ctx, makeBatch(
+			models.Object{Class: nestedClass, ID: id998, Properties: map[string]any{"nestedArray": []any{doc123Data}}},
+			models.Object{Class: nestedClass, ID: id999, Properties: map[string]any{"nestedArray": []any{doc124Data, doc125Data}}},
+		))
+
+		search := func(t *testing.T, f *filters.LocalFilter) []strfmt.UUID {
+			t.Helper()
+			res, err := db.Search(ctx, dto.GetParams{ClassName: nestedClass, Pagination: &filters.Pagination{Limit: 100}, Filters: f})
+			require.NoError(t, err)
+			ids := make([]strfmt.UUID, len(res))
+			for i, r := range res {
+				ids[i] = r.ID
+			}
+			return ids
+		}
+
+		for _, tc := range filterCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.ElementsMatch(t, tc.matchesArrayAdd, search(t, tc.filter("nestedArray")))
+			})
+		}
+	})
+
+	// Batch update: a second BatchPutObjects call with the same UUID overwrites
+	// the existing document, exercising the delete-then-reindex path just as
+	// individual PutObject updates do.
+	t.Run("batch update doc123→doc125 object type", func(t *testing.T) {
+		class := &models.Class{
+			Class:             nestedClass,
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{
+				{Name: "nestedObject", DataType: schema.DataTypeObject.PropString(), NestedProperties: fullNestedProps},
+			},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+
+		putBatch(t, db, ctx, makeBatch(
+			models.Object{Class: nestedClass, ID: id201, Properties: map[string]any{"nestedObject": doc123Data}},
+			models.Object{Class: nestedClass, ID: id200, Properties: map[string]any{"nestedObject": doc124Data}},
+		))
+		putBatch(t, db, ctx, makeBatch(
+			models.Object{Class: nestedClass, ID: id201, Properties: map[string]any{"nestedObject": doc125Data}},
+		))
+
+		search := func(t *testing.T, f *filters.LocalFilter) []strfmt.UUID {
+			t.Helper()
+			res, err := db.Search(ctx, dto.GetParams{ClassName: nestedClass, Pagination: &filters.Pagination{Limit: 100}, Filters: f})
+			require.NoError(t, err)
+			ids := make([]strfmt.UUID, len(res))
+			for i, r := range res {
+				ids[i] = r.ID
+			}
+			return ids
+		}
+
+		for _, tc := range filterCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.ElementsMatch(t, tc.matchesObjectUpd, search(t, tc.filter("nestedObject")))
+			})
+		}
+	})
+
+	t.Run("batch update doc998→doc999 array type", func(t *testing.T) {
+		class := &models.Class{
+			Class:             nestedClass,
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{
+				{Name: "nestedArray", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: fullNestedProps},
+			},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+
+		putBatch(t, db, ctx, makeBatch(
+			models.Object{Class: nestedClass, ID: id300, Properties: map[string]any{"nestedArray": []any{doc123Data}}},
+		))
+		putBatch(t, db, ctx, makeBatch(
+			models.Object{Class: nestedClass, ID: id300, Properties: map[string]any{"nestedArray": []any{doc124Data, doc125Data}}},
+		))
+
+		search := func(t *testing.T, f *filters.LocalFilter) []strfmt.UUID {
+			t.Helper()
+			res, err := db.Search(ctx, dto.GetParams{ClassName: nestedClass, Pagination: &filters.Pagination{Limit: 100}, Filters: f})
+			require.NoError(t, err)
+			ids := make([]strfmt.UUID, len(res))
+			for i, r := range res {
+				ids[i] = r.ID
+			}
+			return ids
+		}
+
+		for _, tc := range filterCases {
+			t.Run(tc.name, func(t *testing.T) {
+				assert.ElementsMatch(t, tc.matchesArrayUpd, search(t, tc.filter("nestedArray")))
+			})
+		}
+	})
+}

--- a/entities/filters/filters_validator.go
+++ b/entities/filters/filters_validator.go
@@ -94,6 +94,10 @@ func validateClause(authorizedGetClass func(string) (*models.Class, error), cw *
 		return nil
 	}
 
+	if _, ok := schema.AsNested(prop.DataType); ok {
+		return validateNestedProp(prop, propName, isPropLengthFilter, cw)
+	}
+
 	if isPropLengthFilter {
 		if !cw.isType(schema.DataTypeInt) {
 			return errors.Errorf("Filtering for property length requires IntValue, got %q instead",

--- a/entities/filters/filters_validator_nested.go
+++ b/entities/filters/filters_validator_nested.go
@@ -1,0 +1,113 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package filters
+
+import (
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// validateNestedProp is the single entry point for all validation of nested
+// (object/object[]) properties. It handles three cases:
+//   - len(nested) or len(nested.path): length filtering is not supported
+//   - nested == "x": no dot notation, direct filter on object type is not supported
+//   - nested.city == "x": valid dot-notation path, delegated to validateNestedPathClause
+func validateNestedProp(prop *models.Property, propName schema.PropertyName, isPropLengthFilter bool, cw *clauseWrapper) error {
+	if isPropLengthFilter {
+		return errors.Errorf("property length filtering is not supported for nested properties")
+	}
+
+	if !strings.Contains(string(propName), ".") {
+		return errors.Errorf("property %q is of type %q; use dot notation to filter on a sub-property",
+			propName, schema.DataType(prop.DataType[0]))
+	}
+
+	return validateNestedPathClause(prop, propName, cw)
+}
+
+// validateNestedPathClause validates a dot-notation filter path such as
+// "addresses.city" or "cars.tires.width". prop is the already-fetched
+// top-level object/object[] property; segments[1:] are walked through
+// its NestedProperties to locate the primitive leaf.
+func validateNestedPathClause(prop *models.Property, propName schema.PropertyName, cw *clauseWrapper) error {
+	segments := strings.Split(string(propName), ".")
+
+	// Walk segments[1:] through nested properties. segments[0] is the
+	// top-level prop, already fetched and verified as object/object[].
+	nestedProps := prop.NestedProperties
+	for i, seg := range segments[1:] {
+		np := findNestedProp(nestedProps, seg)
+		if np == nil {
+			return errors.Errorf("nested path %q: sub-property %q not found", propName, seg)
+		}
+
+		isLast := i == len(segments[1:])-1
+		dt := schema.DataType(np.DataType[0])
+
+		if !isLast {
+			// Intermediate sub-property must be object or object[].
+			if !schema.IsNested(dt) {
+				return errors.Errorf("nested path %q: sub-property %q must be object or object[], got %q",
+					propName, seg, dt)
+			}
+			nestedProps = np.NestedProperties
+		} else {
+			// Leaf sub-property must be a filterable primitive, not object/object[].
+			if schema.IsNested(dt) {
+				return errors.Errorf("nested path %q: sub-property %q is of type %q; "+
+					"filtering on object types is not supported, specify a primitive sub-property",
+					propName, seg, dt)
+			}
+			return validateNestedLeafType(propName, np, cw)
+		}
+	}
+
+	// Unreachable: caller guarantees propName contains '.' so segments[1:] is non-empty.
+	return nil
+}
+
+func findNestedProp(props []*models.NestedProperty, name string) *models.NestedProperty {
+	for _, np := range props {
+		if np.Name == name {
+			return np
+		}
+	}
+	return nil
+}
+
+// validateNestedLeafType checks that the filter value type is compatible with
+// the primitive leaf NestedProperty. Mirrors the type-check logic in
+// validateClause for flat properties.
+func validateNestedLeafType(propName schema.PropertyName, np *models.NestedProperty, cw *clauseWrapper) error {
+	if isUUIDType(np.DataType[0]) {
+		return validateUUIDType(propName, cw)
+	}
+
+	dt := schema.DataType(np.DataType[0])
+
+	if baseType, ok := schema.IsArrayType(dt); ok {
+		if !cw.isType(baseType) {
+			return errors.Errorf("nested path %q: data type filter cannot use %q on type %q, use %q instead",
+				propName, cw.getValueNameFromType(), dt, valueNameFromDataType(baseType))
+		}
+		return nil
+	}
+
+	if !cw.isType(dt) {
+		return errors.Errorf("nested path %q: data type filter cannot use %q on type %q, use %q instead",
+			propName, cw.getValueNameFromType(), dt, valueNameFromDataType(dt))
+	}
+	return nil
+}

--- a/entities/filters/filters_validator_nested.go
+++ b/entities/filters/filters_validator_nested.go
@@ -12,9 +12,9 @@
 package filters
 
 import (
+	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -26,11 +26,11 @@ import (
 //   - nested.city == "x": valid dot-notation path, delegated to validateNestedPathClause
 func validateNestedProp(prop *models.Property, propName schema.PropertyName, isPropLengthFilter bool, cw *clauseWrapper) error {
 	if isPropLengthFilter {
-		return errors.Errorf("property length filtering is not supported for nested properties")
+		return fmt.Errorf("property length filtering is not supported for nested properties")
 	}
 
 	if !strings.Contains(string(propName), ".") {
-		return errors.Errorf("property %q is of type %q; use dot notation to filter on a sub-property",
+		return fmt.Errorf("property %q is of type %q; use dot notation to filter on a sub-property",
 			propName, schema.DataType(prop.DataType[0]))
 	}
 
@@ -50,7 +50,7 @@ func validateNestedPathClause(prop *models.Property, propName schema.PropertyNam
 	for i, seg := range segments[1:] {
 		np := findNestedProp(nestedProps, seg)
 		if np == nil {
-			return errors.Errorf("nested path %q: sub-property %q not found", propName, seg)
+			return fmt.Errorf("nested path %q: sub-property %q not found", propName, seg)
 		}
 
 		isLast := i == len(segments[1:])-1
@@ -59,16 +59,23 @@ func validateNestedPathClause(prop *models.Property, propName schema.PropertyNam
 		if !isLast {
 			// Intermediate sub-property must be object or object[].
 			if !schema.IsNested(dt) {
-				return errors.Errorf("nested path %q: sub-property %q must be object or object[], got %q",
+				return fmt.Errorf("nested path %q: sub-property %q must be object or object[], got %q",
 					propName, seg, dt)
 			}
 			nestedProps = np.NestedProperties
 		} else {
 			// Leaf sub-property must be a filterable primitive, not object/object[].
 			if schema.IsNested(dt) {
-				return errors.Errorf("nested path %q: sub-property %q is of type %q; "+
+				return fmt.Errorf("nested path %q: sub-property %q is of type %q; "+
 					"filtering on object types is not supported, specify a primitive sub-property",
 					propName, seg, dt)
+			}
+			// TODO aliszka:nested_filtering when rangeable / searchable nested
+			// filtering support is added, add corresponding
+			// schema.IsNestedRangeable and schema.IsNestedSearchable checks
+			// alongside the filterable check below.
+			if !schema.IsNestedFilterable(np) {
+				return fmt.Errorf("nested path %q: sub-property %q is not filterable", propName, seg)
 			}
 			return validateNestedLeafType(propName, np, cw)
 		}
@@ -99,14 +106,14 @@ func validateNestedLeafType(propName schema.PropertyName, np *models.NestedPrope
 
 	if baseType, ok := schema.IsArrayType(dt); ok {
 		if !cw.isType(baseType) {
-			return errors.Errorf("nested path %q: data type filter cannot use %q on type %q, use %q instead",
+			return fmt.Errorf("nested path %q: data type filter cannot use %q on type %q, use %q instead",
 				propName, cw.getValueNameFromType(), dt, valueNameFromDataType(baseType))
 		}
 		return nil
 	}
 
 	if !cw.isType(dt) {
-		return errors.Errorf("nested path %q: data type filter cannot use %q on type %q, use %q instead",
+		return fmt.Errorf("nested path %q: data type filter cannot use %q on type %q, use %q instead",
 			propName, cw.getValueNameFromType(), dt, valueNameFromDataType(dt))
 	}
 	return nil

--- a/entities/filters/filters_validator_nested_test.go
+++ b/entities/filters/filters_validator_nested_test.go
@@ -1,0 +1,243 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package filters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// nestedClass builds the shared test class used across nested filter tests:
+//
+//	Article {
+//	  nested: object {
+//	    name: text
+//	    count: int
+//	    tags: text[]
+//	    owner: object {
+//	      firstname: text
+//	      age: int
+//	    }
+//	    addresses: object[] {
+//	      city: text
+//	      postcode: text
+//	    }
+//	  }
+//	}
+func nestedClass() *models.Class {
+	boolTrue := true
+	return &models.Class{
+		Class: "Article",
+		Properties: []*models.Property{
+			{Name: "title", DataType: schema.DataTypeText.PropString()},
+			{
+				Name:     "nested",
+				DataType: schema.DataTypeObject.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{Name: "name", DataType: schema.DataTypeText.PropString(), IndexFilterable: &boolTrue},
+					{Name: "count", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &boolTrue},
+					{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &boolTrue},
+					{
+						Name:     "owner",
+						DataType: schema.DataTypeObject.PropString(),
+						NestedProperties: []*models.NestedProperty{
+							{Name: "firstname", DataType: schema.DataTypeText.PropString(), IndexFilterable: &boolTrue},
+							{Name: "age", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &boolTrue},
+						},
+					},
+					{
+						Name:     "addresses",
+						DataType: schema.DataTypeObjectArray.PropString(),
+						NestedProperties: []*models.NestedProperty{
+							{Name: "city", DataType: schema.DataTypeText.PropString(), IndexFilterable: &boolTrue},
+							{Name: "postcode", DataType: schema.DataTypeText.PropString(), IndexFilterable: &boolTrue},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func nestedGetClass(name string) (*models.Class, error) {
+	return nestedClass(), nil
+}
+
+func makeNestedClause(propName string, valueType schema.DataType, value any) *Clause {
+	return &Clause{
+		Operator: OperatorEqual,
+		Value:    &Value{Value: value, Type: valueType},
+		On:       &Path{Class: "Article", Property: schema.PropertyName(propName)},
+	}
+}
+
+func TestValidateNestedPathClause(t *testing.T) {
+	tests := []struct {
+		name      string
+		propName  string
+		valueType schema.DataType
+		value     any
+		wantErr   string
+	}{
+		{
+			name:      "one-level text",
+			propName:  "nested.name",
+			valueType: schema.DataTypeText,
+			value:     "hello",
+		},
+		{
+			name:      "one-level int",
+			propName:  "nested.count",
+			valueType: schema.DataTypeInt,
+			value:     42,
+		},
+		{
+			name:      "one-level text array",
+			propName:  "nested.tags",
+			valueType: schema.DataTypeText,
+			value:     "tag1",
+		},
+		{
+			name:      "two-level text",
+			propName:  "nested.owner.firstname",
+			valueType: schema.DataTypeText,
+			value:     "Alice",
+		},
+		{
+			name:      "two-level int",
+			propName:  "nested.owner.age",
+			valueType: schema.DataTypeInt,
+			value:     30,
+		},
+		{
+			name:      "object array leaf text",
+			propName:  "nested.addresses.city",
+			valueType: schema.DataTypeText,
+			value:     "Berlin",
+		},
+		{
+			name:      "wrong value type for text prop",
+			propName:  "nested.name",
+			valueType: schema.DataTypeInt,
+			value:     42,
+			wantErr:   `nested path "nested.name": data type filter cannot use "valueInt" on type "text"`,
+		},
+		{
+			name:      "wrong value type for int prop",
+			propName:  "nested.count",
+			valueType: schema.DataTypeText,
+			value:     "hello",
+			wantErr:   `nested path "nested.count": data type filter cannot use "valueText" on type "int"`,
+		},
+		{
+			name:      "non-existent leaf",
+			propName:  "nested.missing",
+			valueType: schema.DataTypeText,
+			value:     "x",
+			wantErr:   `nested path "nested.missing": sub-property "missing" not found`,
+		},
+		{
+			name:      "non-existent intermediate",
+			propName:  "nested.missing.city",
+			valueType: schema.DataTypeText,
+			value:     "x",
+			wantErr:   `nested path "nested.missing.city": sub-property "missing" not found`,
+		},
+		{
+			name:      "intermediate is not object",
+			propName:  "nested.name.something",
+			valueType: schema.DataTypeText,
+			value:     "x",
+			wantErr:   `nested path "nested.name.something": sub-property "name" must be object or object[]`,
+		},
+		{
+			name:      "leaf is object type",
+			propName:  "nested.owner",
+			valueType: schema.DataTypeText,
+			value:     "x",
+			wantErr:   `nested path "nested.owner": sub-property "owner" is of type "object"`,
+		},
+		{
+			name:      "leaf is object array type",
+			propName:  "nested.addresses",
+			valueType: schema.DataTypeText,
+			value:     "x",
+			wantErr:   `nested path "nested.addresses": sub-property "addresses" is of type "object[]"`,
+		},
+		{
+			name:      "filter directly on object prop without dot",
+			propName:  "nested",
+			valueType: schema.DataTypeText,
+			value:     "x",
+			wantErr:   `property "nested" is of type "object"; use dot notation to filter on a sub-property`,
+		},
+		{
+			name:      "filter directly on object array prop without dot",
+			propName:  "nested.addresses",
+			valueType: schema.DataTypeText,
+			value:     "x",
+			wantErr:   `nested path "nested.addresses": sub-property "addresses" is of type "object[]"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cl := makeNestedClause(tt.propName, tt.valueType, tt.value)
+			err := validateClause(nestedGetClass, newClauseWrapper(cl))
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateNestedLengthFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		propName string
+	}{
+		{name: "len on top-level nested prop", propName: "len(nested)"},
+		{name: "len on nested path", propName: "len(nested.name)"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cl := &Clause{
+				Operator: OperatorEqual,
+				Value:    &Value{Value: 5, Type: schema.DataTypeInt},
+				On:       &Path{Class: "Article", Property: schema.PropertyName(tt.propName)},
+			}
+			err := validateClause(nestedGetClass, newClauseWrapper(cl))
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), "property length filtering is not supported for nested properties")
+		})
+	}
+}
+
+func TestValidateNestedIsNull(t *testing.T) {
+	// IsNull is validated by the existing check before the nested path
+	// delegation, so it passes for any property type including nested.
+	cl := &Clause{
+		Operator: OperatorIsNull,
+		Value:    &Value{Value: true, Type: schema.DataTypeBoolean},
+		On:       &Path{Class: "Article", Property: "nested.name"},
+	}
+	err := validateClause(nestedGetClass, newClauseWrapper(cl))
+	require.NoError(t, err)
+}

--- a/entities/filters/filters_validator_nested_test.go
+++ b/entities/filters/filters_validator_nested_test.go
@@ -184,13 +184,6 @@ func TestValidateNestedPathClause(t *testing.T) {
 			value:     "x",
 			wantErr:   `property "nested" is of type "object"; use dot notation to filter on a sub-property`,
 		},
-		{
-			name:      "filter directly on object array prop without dot",
-			propName:  "nested.addresses",
-			valueType: schema.DataTypeText,
-			value:     "x",
-			wantErr:   `nested path "nested.addresses": sub-property "addresses" is of type "object[]"`,
-		},
 	}
 
 	for _, tt := range tests {

--- a/entities/schema/nested_property.go
+++ b/entities/schema/nested_property.go
@@ -1,0 +1,76 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import "github.com/weaviate/weaviate/entities/models"
+
+// Default values applied when a NestedProperty's index setting is unset
+// (the pointer field is nil). Each index type has its own default:
+//   - filterable defaults to true (matches flat-property behaviour: a
+//     property is filterable unless explicitly disabled).
+//   - searchable defaults to true (matches flat-property behaviour for
+//     text types; ignored for non-text types).
+//   - rangeable defaults to false (opt-in for numeric/date types to
+//     avoid creating the rangeable bucket unless requested).
+const (
+	NestedIndexFilterableDefault = true
+	NestedIndexSearchableDefault = true
+	NestedIndexRangeableDefault  = false
+)
+
+// IsNestedFilterable reports whether the filterable index is enabled on
+// the given nested property. Returns NestedIndexFilterableDefault when
+// IndexFilterable is unset.
+func IsNestedFilterable(np *models.NestedProperty) bool {
+	if np.IndexFilterable == nil {
+		return NestedIndexFilterableDefault
+	}
+	return *np.IndexFilterable
+}
+
+// IsNestedSearchable reports whether the searchable index is enabled on
+// the given nested property for the given data type. The searchable index
+// is only meaningful for text and text-array types; for all other types
+// the result is false regardless of the flag. Returns
+// NestedIndexSearchableDefault when IndexSearchable is unset on a text
+// type.
+func IsNestedSearchable(np *models.NestedProperty, dt DataType) bool {
+	switch dt {
+	case DataTypeText, DataTypeTextArray:
+		if np.IndexSearchable == nil {
+			return NestedIndexSearchableDefault
+		}
+		return *np.IndexSearchable
+	default:
+		return false
+	}
+}
+
+// IsNestedRangeable reports whether the rangeable index is enabled on
+// the given nested property for the given data type. The rangeable index
+// is only meaningful for int/number/date types (and their array variants);
+// for all other types the result is false regardless of the flag. Returns
+// NestedIndexRangeableDefault when IndexRangeFilters is unset on a
+// supported type.
+func IsNestedRangeable(np *models.NestedProperty, dt DataType) bool {
+	switch dt {
+	case DataTypeInt, DataTypeIntArray,
+		DataTypeNumber, DataTypeNumberArray,
+		DataTypeDate, DataTypeDateArray:
+		if np.IndexRangeFilters == nil {
+			return NestedIndexRangeableDefault
+		}
+		return *np.IndexRangeFilters
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
## Nested object filtering — Part 5: filter validation, execution, and integration tests

  Fifth PR in the nested object filtering series, building on Part 4 (batched writes, delete path, prefix-bounded reads).

  ### What's in this PR

  **Filter validation** — routes all validation for `object`/`object[]` properties through a dedicated gate in `validateClause`. Three
  cases handled:
  - `len(nested)` / `len(nested.path)` — property length filtering on nested properties is rejected with a clear error
  - `nested == "x"` — direct filter on object type without dot notation is rejected with a hint to use dot notation
  - `nested.city == "x"` — valid dot-notation path, delegated to `validateNestedPathClause` which walks the schema to the leaf and validates the filter value type

  **Filter execution** — wires dot-notation nested paths into the full filter execution pipeline with "any element matches" semantics:
  - `searcher.go`: single hook after `GetPropertyByName` — if the property is nested, delegates to `extractNestedProp`
  - `searcher_nested.go`: walks the schema to the leaf `NestedProperty`, verifies it is filterable, and dispatches to
  `buildNestedTextFilterPair` (tokenizes, produces AND for multi-token) or `buildNestedPrimitiveFilterPair` (encodes
  int/number/bool/date and their array variants)
  - `prop_value_pairs.go`: `getBucketName` routes nested props to the nested value bucket; `fetchDocIDs` strips position bits to plain docIDs after the read
  - `searcher_doc_bitmap.go`: passes the `nestedKeyPrefix` (hash of the dot-notation path) to `NewRowReaderRoaringSetWithPrefix` to bound cursor reads to the correct sub-property

  **End-to-end integration tests** — `TestNestedFilteringViaShardWritePath` exercises the complete write-and-search stack using the reference documents from the design summary (Marsha/Berlin/BMW, Justin/Madrid+London/Audi+Kia, Anna/Paris/Tesla). Ten sub-tests cover both `PutObject` and `BatchPutObjects` paths, with filter coverage including equality, range, LIKE patterns, ContainsAny/All/None, AND/OR compounds, all primitive types, and deeply nested paths up to 4 levels.

  ### What comes next

  Part 6 will add position-aware correlated AND resolution — ensuring that `addresses.city = "Berlin" AND addresses.postcode = "10115"` matches only documents where both conditions are met by the **same** array element.

  ## Test plan

  - [ ] `go test ./entities/filters/...` — nested filter validation tests pass
  - [ ] `go test ./adapters/repos/db/inverted/...` — nested searcher tests pass
  - [ ] `go test -tags integrationTest ./adapters/repos/db/...` — end-to-end shard pipeline integration tests pass