### PR TITLE
Nested object filtering — Part 6: correlated AND resolution plan and executor

### DIFF
--- a/adapters/repos/db/inverted/nested/bitmap.go
+++ b/adapters/repos/db/inverted/nested/bitmap.go
@@ -133,7 +133,8 @@ func MaskRootLeaf(bm *sroar.Bitmap) *sroar.Bitmap {
 }
 
 // AndAll returns the intersection of all bitmaps on raw positions. Inputs are
-// not modified. Returns an empty bitmap if bitmaps is empty.
+// not modified. Returns an empty bitmap if bitmaps is empty or if the running
+// intersection becomes empty mid-loop (further ANDs cannot change the result).
 func AndAll(bitmaps []*sroar.Bitmap) *sroar.Bitmap {
 	if len(bitmaps) == 0 {
 		return sroar.NewBitmap()
@@ -141,6 +142,9 @@ func AndAll(bitmaps []*sroar.Bitmap) *sroar.Bitmap {
 	result := bitmaps[0].Clone()
 	for _, bm := range bitmaps[1:] {
 		result.And(bm)
+		if result.IsEmpty() {
+			return result
+		}
 	}
 	return result
 }
@@ -148,7 +152,8 @@ func AndAll(bitmaps []*sroar.Bitmap) *sroar.Bitmap {
 // AndAllMaskLeaf zeroes the leaf bits of each bitmap and ANDs them all,
 // returning root+docID values present across every input. Use this to find
 // which document-element pairs satisfy all conditions simultaneously.
-// Returns an empty bitmap if bitmaps is empty.
+// Returns an empty bitmap if bitmaps is empty or if the running intersection
+// becomes empty mid-loop (further ANDs cannot change the result).
 func AndAllMaskLeaf(bitmaps []*sroar.Bitmap) *sroar.Bitmap {
 	if len(bitmaps) == 0 {
 		return sroar.NewBitmap()
@@ -156,6 +161,9 @@ func AndAllMaskLeaf(bitmaps []*sroar.Bitmap) *sroar.Bitmap {
 	result := MaskLeaf(bitmaps[0])
 	for _, bm := range bitmaps[1:] {
 		result.AndMasked(bm, zeroLeafBits)
+		if result.IsEmpty() {
+			return result
+		}
 	}
 	return result
 }

--- a/adapters/repos/db/inverted/nested/bitmap.go
+++ b/adapters/repos/db/inverted/nested/bitmap.go
@@ -118,15 +118,60 @@ func ValidateLeafIdx(leafIdx int) error {
 	return nil
 }
 
-// MaskLeafPositions zeroes the leaf bits in all bitmap values, keeping
-// root+docID. Use this for cross-subtree checks where leaf differences
-// should be erased.
-func MaskLeafPositions(bm *sroar.Bitmap) *sroar.Bitmap {
+// MaskLeaf zeroes the leaf bits of every value in bm, collapsing positions
+// to root+docID granularity. Values that differed only in leaf_idx become
+// identical after masking, allowing element-level alignment across sub-trees.
+func MaskLeaf(bm *sroar.Bitmap) *sroar.Bitmap {
 	return bm.Masked(zeroLeafBits)
 }
 
-// MaskAllPositions zeroes both root and leaf bits, keeping only docID.
-// Use this for final result extraction.
-func MaskAllPositions(bm *sroar.Bitmap) *sroar.Bitmap {
+// MaskRootLeaf zeroes both root and leaf bits of every value in bm, keeping
+// only the docID. Use this as the final step to extract plain document IDs
+// from a position bitmap.
+func MaskRootLeaf(bm *sroar.Bitmap) *sroar.Bitmap {
 	return bm.Masked(zeroRootBits & zeroLeafBits)
+}
+
+// AndAll returns the intersection of all bitmaps on raw positions. Inputs are
+// not modified. Returns an empty bitmap if bitmaps is empty.
+func AndAll(bitmaps []*sroar.Bitmap) *sroar.Bitmap {
+	if len(bitmaps) == 0 {
+		return sroar.NewBitmap()
+	}
+	result := bitmaps[0].Clone()
+	for _, bm := range bitmaps[1:] {
+		result.And(bm)
+	}
+	return result
+}
+
+// AndAllMaskLeaf zeroes the leaf bits of each bitmap and ANDs them all,
+// returning root+docID values present across every input. Use this to find
+// which document-element pairs satisfy all conditions simultaneously.
+// Returns an empty bitmap if bitmaps is empty.
+func AndAllMaskLeaf(bitmaps []*sroar.Bitmap) *sroar.Bitmap {
+	if len(bitmaps) == 0 {
+		return sroar.NewBitmap()
+	}
+	result := MaskLeaf(bitmaps[0])
+	for _, bm := range bitmaps[1:] {
+		result.AndMasked(bm, zeroLeafBits)
+	}
+	return result
+}
+
+// MaskLeafAnd intersects a and b on raw positions and zeroes the leaf bits of
+// the result, returning root+docID values. Both a and b must be raw position
+// bitmaps. Equivalent to MaskLeaf(sroar.And(a, b)) but avoids allocating the
+// intermediate AND bitmap.
+func MaskLeafAnd(a, b *sroar.Bitmap) *sroar.Bitmap {
+	return sroar.MaskedAnd(a, b, zeroLeafBits)
+}
+
+// AndWithMaskLeaf intersects a with b after zeroing b's leaf bits, returning
+// root+docID values. a must already be leaf-masked (e.g. from MaskLeaf or
+// AndAllMaskLeaf); only b is leaf-masked before the AND. Avoids allocating an
+// intermediate masked copy of b.
+func AndWithMaskLeaf(a, b *sroar.Bitmap) *sroar.Bitmap {
+	return a.Clone().AndMasked(b, zeroLeafBits)
 }

--- a/adapters/repos/db/inverted/nested/bitmap_test.go
+++ b/adapters/repos/db/inverted/nested/bitmap_test.go
@@ -181,7 +181,7 @@ func TestValidateLeafIdx(t *testing.T) {
 	assert.Error(t, ValidateLeafIdx(-1))
 }
 
-func TestMaskLeafPositions(t *testing.T) {
+func TestMaskLeaf(t *testing.T) {
 	bm := sroar.NewBitmap()
 	// addresses[0].city="Berlin" in doc 123 with positions l3, l4
 	bm.Set(Encode(1, 3, 123))
@@ -191,7 +191,7 @@ func TestMaskLeafPositions(t *testing.T) {
 	// Same in doc 456
 	bm.Set(Encode(1, 3, 456))
 
-	masked := MaskLeafPositions(bm)
+	masked := MaskLeaf(bm)
 
 	// After masking leaf bits, all positions with same root+docID collapse
 	arr := masked.ToArray()
@@ -202,7 +202,7 @@ func TestMaskLeafPositions(t *testing.T) {
 	}
 }
 
-func TestMaskAllPositions(t *testing.T) {
+func TestMaskRootLeaf(t *testing.T) {
 	bm := sroar.NewBitmap()
 	// Object array: root=1 in doc 999, root=2 in doc 999
 	bm.Set(Encode(1, 3, 999))
@@ -211,7 +211,7 @@ func TestMaskAllPositions(t *testing.T) {
 	// Different doc
 	bm.Set(Encode(1, 1, 888))
 
-	stripped := MaskAllPositions(bm)
+	stripped := MaskRootLeaf(bm)
 
 	arr := stripped.ToArray()
 	assert.Len(t, arr, 2) // d999 and d888
@@ -267,9 +267,9 @@ func TestMaskPosThenAND_CrossSubtree(t *testing.T) {
 	makeBm.Set(Encode(1, 7, 123))
 	makeBm.Set(Encode(1, 8, 123))
 
-	// MaskLeafPositions to erase leaf differences
-	maskedCity := MaskLeafPositions(cityBm)
-	maskedMake := MaskLeafPositions(makeBm)
+	// MaskLeaf to erase leaf differences
+	maskedCity := MaskLeaf(cityBm)
+	maskedMake := MaskLeaf(makeBm)
 
 	result := maskedCity.And(maskedMake)
 	arr := result.ToArray()
@@ -282,4 +282,81 @@ func TestConstants(t *testing.T) {
 	assert.Equal(t, 1<<14, MaxRoots)
 	assert.Equal(t, 1<<14, MaxLeavesPerRoot)
 	assert.Equal(t, uint64(0x0000000FFFFFFFFF), uint64(MaxDocID))
+}
+
+func TestAndAll(t *testing.T) {
+	t.Run("empty input returns empty bitmap", func(t *testing.T) {
+		result := AndAll(nil)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("single bitmap returned as clone", func(t *testing.T) {
+		bm := sroar.NewBitmap()
+		bm.SetMany([]uint64{1, 2, 3})
+		result := AndAll([]*sroar.Bitmap{bm})
+		assert.Equal(t, bm.ToArray(), result.ToArray())
+		// original unmodified
+		assert.Equal(t, []uint64{1, 2, 3}, bm.ToArray())
+	})
+
+	t.Run("intersection of two bitmaps", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.SetMany([]uint64{1, 2, 3, 4})
+		b := sroar.NewBitmap()
+		b.SetMany([]uint64{2, 4, 6})
+		result := AndAll([]*sroar.Bitmap{a, b})
+		assert.Equal(t, []uint64{2, 4}, result.ToArray())
+		// inputs unmodified
+		assert.Equal(t, []uint64{1, 2, 3, 4}, a.ToArray())
+	})
+
+	t.Run("three bitmaps intersection", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.SetMany([]uint64{1, 2, 3, 4, 5})
+		b := sroar.NewBitmap()
+		b.SetMany([]uint64{2, 3, 4})
+		c := sroar.NewBitmap()
+		c.SetMany([]uint64{3, 4, 5})
+		result := AndAll([]*sroar.Bitmap{a, b, c})
+		assert.Equal(t, []uint64{3, 4}, result.ToArray())
+	})
+}
+
+func TestAndAllMaskLeaf(t *testing.T) {
+	// Use two positions from the same doc but different leaf indices.
+	// After MaskLeaf, both become root+docID and should AND together.
+	doc := uint64(42)
+	posA := Encode(1, 3, doc) // root=1 leaf=3 doc=42
+	posB := Encode(1, 7, doc) // root=1 leaf=7 doc=42 (different leaf)
+	posC := Encode(2, 3, doc) // root=2 leaf=3 doc=42 (different root)
+
+	t.Run("same root different leaf — AND succeeds after masking", func(t *testing.T) {
+		bmA := sroar.NewBitmap()
+		bmA.Set(posA)
+		bmB := sroar.NewBitmap()
+		bmB.Set(posB)
+		result := AndAllMaskLeaf([]*sroar.Bitmap{bmA, bmB})
+		// After masking leaf bits: both become Encode(1, 0, 42) → AND non-empty
+		require.False(t, result.IsEmpty())
+		// Result contains root+docID only (leaf zeroed)
+		assert.Equal(t, uint16(0), DecodeLeafIdx(result.ToArray()[0]))
+		assert.Equal(t, uint16(1), DecodeRootIdx(result.ToArray()[0]))
+	})
+
+	t.Run("different root — AND gives empty after masking", func(t *testing.T) {
+		bmA := sroar.NewBitmap()
+		bmA.Set(posA) // root=1
+		bmC := sroar.NewBitmap()
+		bmC.Set(posC) // root=2
+		result := AndAllMaskLeaf([]*sroar.Bitmap{bmA, bmC})
+		// After masking: root=1|doc=42 vs root=2|doc=42 → no overlap
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("inputs not modified", func(t *testing.T) {
+		bmA := sroar.NewBitmap()
+		bmA.Set(posA)
+		AndAllMaskLeaf([]*sroar.Bitmap{bmA})
+		assert.Equal(t, []uint64{posA}, bmA.ToArray())
+	})
 }

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -318,6 +318,28 @@ func mergeDocIDs(operator filters.Operator, dbms []*docBitmap) []*docBitmap {
 }
 
 func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
+	dbm, err := pv.fetchBitmap(ctx, s, limit)
+	if err != nil {
+		return nil, err
+	}
+	if pv.isNested {
+		// The nested value bucket stores positions (root|leaf|docID) rather than
+		// plain docIDs. Strip position bits to extract the docID-only bitmap.
+		dbm.docIDs = nested.MaskAllPositions(dbm.docIDs)
+	}
+	return dbm, nil
+}
+
+// fetchRawPositions is like fetchDocIDs but returns the raw position bitmap
+// without stripping the root/leaf bits. Only valid for nested properties
+// (pv.isNested == true). Used by the correlated resolution path which needs
+// full positions to apply MaskLeafPositions AND or the _idx loop.
+func (pv *propValuePair) fetchRawPositions(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
+	return pv.fetchBitmap(ctx, s, limit)
+}
+
+// fetchBitmap is the shared implementation for fetchDocIDs and fetchRawPositions.
+func (pv *propValuePair) fetchBitmap(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
 	// TODO text_rbm_inverted_index find better way check whether prop len
 	if strings.HasSuffix(pv.prop, filters.InternalPropertyLength) &&
 		!pv.Class.InvertedIndexConfig.IndexPropertyLength {
@@ -352,11 +374,6 @@ func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int
 	dbm, err := s.docBitmap(ctx, b, limit, pv)
 	if err != nil {
 		return nil, err
-	}
-	if pv.isNested {
-		// The nested value bucket stores positions (root|leaf|docID) rather than
-		// plain docIDs. Strip position bits to extract the docID-only bitmap.
-		dbm.docIDs = nested.MaskAllPositions(dbm.docIDs)
 	}
 	return &dbm, nil
 }

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -325,7 +325,7 @@ func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int
 	if pv.isNested {
 		// The nested value bucket stores positions (root|leaf|docID) rather than
 		// plain docIDs. Strip position bits to extract the docID-only bitmap.
-		dbm.docIDs = nested.MaskAllPositions(dbm.docIDs)
+		dbm.docIDs = nested.MaskRootLeaf(dbm.docIDs)
 	}
 	return dbm, nil
 }
@@ -333,7 +333,7 @@ func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int
 // fetchRawPositions is like fetchDocIDs but returns the raw position bitmap
 // without stripping the root/leaf bits. Only valid for nested properties
 // (pv.isNested == true). Used by the correlated resolution path which needs
-// full positions to apply MaskLeafPositions AND or the _idx loop.
+// full positions to apply MaskLeaf AND or the _idx loop.
 func (pv *propValuePair) fetchRawPositions(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
 	return pv.fetchBitmap(ctx, s, limit)
 }

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -334,6 +334,8 @@ func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int
 // without stripping the root/leaf bits. Only valid for nested properties
 // (pv.isNested == true). Used by the correlated resolution path which needs
 // full positions to apply MaskLeaf AND or the _idx loop.
+//
+//nolint:unused //used by correlated resolution in the next commits
 func (pv *propValuePair) fetchRawPositions(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
 	return pv.fetchBitmap(ctx, s, limit)
 }

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -57,13 +57,7 @@ func (s *Searcher) extractNestedProp(filter *filters.Clause, path string,
 // NestedProperty. Returns an error if any segment is not found.
 func findNestedLeaf(segments []string, props []*models.NestedProperty) (*models.NestedProperty, error) {
 	for i, seg := range segments {
-		var found *models.NestedProperty
-		for _, np := range props {
-			if np.Name == seg {
-				found = np
-				break
-			}
-		}
+		found := findNestedPropByName(props, seg)
 		if found == nil {
 			return nil, fmt.Errorf("sub-property %q not found", seg)
 		}

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -189,3 +189,13 @@ func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, path, 
 		Class:              class,
 	}, nil
 }
+
+// findNestedPropByName returns the NestedProperty with the given name, or nil.
+func findNestedPropByName(props []*models.NestedProperty, name string) *models.NestedProperty {
+	for _, np := range props {
+		if np.Name == name {
+			return np
+		}
+	}
+	return nil
+}

--- a/adapters/repos/db/inverted/searcher_nested_executor.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor.go
@@ -1,0 +1,174 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"slices"
+	"sort"
+
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+)
+
+// bitmapsByCard implements sort.Interface to sort a bitmap slice and its
+// precomputed cardinality slice together in a single pass, avoiding repeated
+// GetCardinality calls during comparison.
+type bitmapsByCard struct {
+	bitmaps []*sroar.Bitmap
+	cards   []int
+}
+
+func (s bitmapsByCard) Len() int           { return len(s.bitmaps) }
+func (s bitmapsByCard) Less(i, j int) bool { return s.cards[i] < s.cards[j] }
+func (s bitmapsByCard) Swap(i, j int) {
+	s.bitmaps[i], s.bitmaps[j] = s.bitmaps[j], s.bitmaps[i]
+	s.cards[i], s.cards[j] = s.cards[j], s.cards[i]
+}
+
+// applyDirectAnd intersects all raw position bitmaps and strips to docIDs.
+// Implements the directAnd operation: positions are naturally aligned so a
+// plain bitmap AND followed by MaskRootLeaf gives correct results.
+func applyDirectAnd(positionBitmaps []*sroar.Bitmap) *sroar.Bitmap {
+	return nested.MaskRootLeaf(nested.AndAll(positionBitmaps))
+}
+
+// applyMaskLeafAnd zeroes leaf bits on each bitmap, ANDs them, and strips to
+// docIDs. Implements the maskLeafAnd operation: aligns on root+docID so paths
+// from different subtrees or a single-object LCA are correctly combined.
+func applyMaskLeafAnd(positionBitmaps []*sroar.Bitmap) *sroar.Bitmap {
+	return nested.MaskRootLeaf(nested.AndAllMaskLeaf(positionBitmaps))
+}
+
+// applyIdxLoop implements the idxLoopAnd operation. It iterates over all
+// _idx.{lcaPath}[N] entries in the meta bucket and verifies that all
+// conditions fall under the same array element N before accumulating results.
+//
+// Optimisations applied:
+//  1. Conditions are sorted by cardinality (most selective first) so the
+//     early-exit check triggers as soon as possible in the inner loop.
+//  2. MaskLeaf is computed once per condition before the loop and
+//     reused for the global pre-filter, avoiding repeated masking.
+//  3. Per-element pre-check: preFilter AND maskedElem is computed (1 alloc)
+//     before the expensive K-condition processing (2K allocs). Elements where
+//     no document can match all conditions are skipped cheaply. Because
+//     preFilter ⊆ maskedBitmaps[i] for all i, this also implies each
+//     individual condition overlaps the element — no per-condition skip is
+//     needed inside the inner loop.
+//  4. Early termination when result already contains all documents in preFilter.
+//
+// Algorithm:
+//
+//	maskedBitmaps[i] = MaskLeaf(positionBitmaps[i])  for each i
+//	preFilter = AND of all maskedBitmaps
+//	if preFilter empty → return empty
+//	for each _idx.{lcaPath}[N] entry:
+//	    maskedElem = MaskLeaf(elem[N])
+//	    if preFilter AND maskedElem empty → skip element cheaply
+//	    partial = MaskLeaf(bm[0] AND elem[N]) AND ...
+//	    result = result OR partial
+//	    if result covers all docs in preFilter → stop early
+//	return MaskRootLeaf(result)
+func applyIdxLoop(
+	ctx context.Context,
+	metaBucket *lsmkv.Bucket,
+	lcaPath string,
+	positionBitmaps []*sroar.Bitmap,
+) (*sroar.Bitmap, error) {
+	if metaBucket == nil {
+		return nil, fmt.Errorf("applyIdxLoop: meta bucket is nil for path %q", lcaPath)
+	}
+	if len(positionBitmaps) == 0 {
+		return nil, fmt.Errorf("applyIdxLoop: no position bitmaps provided for path %q", lcaPath)
+	}
+	if len(positionBitmaps) == 1 {
+		return nested.MaskRootLeaf(positionBitmaps[0]), nil
+	}
+
+	// Optimisation 1: sort conditions by cardinality ascending so the most
+	// selective condition is checked first and triggers early exit sooner.
+	// Cardinalities are precomputed into a parallel slice so GetCardinality
+	// (O(containers)) is called exactly once per bitmap rather than O(n log n)
+	// times during sorting. Both slices are kept in sync via bitmapsByCard.
+	sorted := slices.Clone(positionBitmaps)
+	cards := make([]int, len(sorted))
+	for i, bm := range sorted {
+		cards[i] = bm.GetCardinality()
+	}
+	sort.Sort(bitmapsByCard{sorted, cards})
+
+	// Optimisation 2: build global pre-filter as the AND of all leaf-masked
+	// conditions. Using the sorted order means the most selective bitmap is
+	// ANDed first, shrinking the result fastest and reducing subsequent work.
+	preFilter := nested.AndAllMaskLeaf(sorted)
+	preFilterCard := preFilter.GetCardinality()
+	if preFilterCard == 0 {
+		return sroar.NewBitmap(), nil
+	}
+
+	if err := ctxExpired(ctx); err != nil {
+		return nil, err
+	}
+
+	idxPrefix := nested.PathPrefix("_idx." + lcaPath)
+	result := sroar.NewBitmap()
+
+	c := metaBucket.CursorRoaringSet()
+	defer c.Close()
+
+	for k, elemBitmap := c.Seek(nested.IdxKey(lcaPath, 0)); k != nil; k, elemBitmap = c.Next() {
+		if err := ctxExpired(ctx); err != nil {
+			return nil, err
+		}
+		if !bytes.HasPrefix(k, idxPrefix) {
+			break
+		}
+		if elemBitmap.IsEmpty() {
+			continue
+		}
+
+		// Optimisation 3: per-element pre-check using the precomputed masked
+		// element. One allocation to skip the entire K-condition processing when
+		// no document has all conditions satisfied within this element.
+		if nested.AndWithMaskLeaf(preFilter, elemBitmap).IsEmpty() {
+			continue
+		}
+
+		// Full K-condition processing: intersect each condition with element N.
+		// No per-condition pre-check is needed: the global pre-check above
+		// guarantees every condition overlaps this element, because
+		// preFilter ⊆ MaskLeaf(sorted[i]) for all i.
+		partial := nested.MaskLeafAnd(sorted[0], elemBitmap)
+		empty := partial.IsEmpty()
+		for _, bm := range sorted[1:] {
+			if empty {
+				break
+			}
+			partial.And(nested.MaskLeafAnd(bm, elemBitmap))
+			empty = partial.IsEmpty()
+		}
+
+		if !empty {
+			result.Or(partial)
+			// Optimisation 4: stop early if result already covers all docs that
+			// preFilter could yield — further elements can only add duplicates.
+			if result.GetCardinality() >= preFilterCard {
+				break
+			}
+		}
+	}
+
+	return nested.MaskRootLeaf(result), nil
+}

--- a/adapters/repos/db/inverted/searcher_nested_executor_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_integration_test.go
@@ -1,0 +1,321 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package inverted
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+)
+
+// newIdxBucket creates a temporary lsmkv store and an empty RoaringSet bucket
+// for use as the _idx meta bucket in applyIdxLoop tests.
+func newIdxBucket(t *testing.T) *lsmkv.Bucket {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	store, err := lsmkv.New(t.TempDir(), t.TempDir(), logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	require.NoError(t, store.CreateOrLoadBucket(context.Background(),
+		"testmeta", lsmkv.WithStrategy(lsmkv.StrategyRoaringSet)))
+	return store.Bucket("testmeta")
+}
+
+// writeIdx writes positions for a single array element into the meta bucket.
+// positions should already have the real docID encoded (not docID=0 templates).
+func writeIdx(t *testing.T, bucket *lsmkv.Bucket, path string, elemIdx int, positions []uint64) {
+	t.Helper()
+	require.NoError(t, bucket.RoaringSetAddList(nested.IdxKey(path, elemIdx), positions))
+}
+
+// ---- applyIdxLoop integration tests ----------------------------------------
+
+func TestApplyIdxLoopIntegration(t *testing.T) {
+	const (
+		doc5 = uint64(5)
+		doc7 = uint64(7)
+		doc9 = uint64(9)
+	)
+
+	// -------------------------------------------------------------------------
+	// Preconditions requiring a real (non-nil) bucket
+	// -------------------------------------------------------------------------
+
+	t.Run("zero bitmaps returns error", func(t *testing.T) {
+		bucket := newIdxBucket(t)
+		_, err := applyIdxLoop(context.Background(), bucket, "cars", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no position bitmaps")
+	})
+
+	t.Run("one bitmap returns MaskRootLeaf fast-path without cursor scan", func(t *testing.T) {
+		bucket := newIdxBucket(t)
+		// Write an idx entry that would produce a different result if scanned.
+		writeIdx(t, bucket, "cars", 0, []uint64{nested.Encode(1, 1, doc5), nested.Encode(1, 2, doc5)})
+
+		pos511 := nested.Encode(1, 1, doc5)
+		result, err := applyIdxLoop(context.Background(), bucket, "cars", []*sroar.Bitmap{roaringset.NewBitmap(pos511)})
+		require.NoError(t, err)
+		// Fast-path: returns MaskRootLeaf(bitmap[0]), ignoring the bucket entirely.
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
+	})
+
+	t.Run("context already cancelled returns error", func(t *testing.T) {
+		bucket := newIdxBucket(t)
+		writeIdx(t, bucket, "cars", 0, []uint64{nested.Encode(1, 1, doc5)})
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancel immediately
+
+		pos511 := nested.Encode(1, 1, doc5)
+		pos512 := nested.Encode(1, 2, doc5)
+		_, err := applyIdxLoop(ctx, bucket, "cars", []*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512)})
+		require.Error(t, err)
+	})
+
+	// -------------------------------------------------------------------------
+	// Core same-element semantics
+	// -------------------------------------------------------------------------
+
+	t.Run("two conditions both in element 0 — doc returned", func(t *testing.T) {
+		// cars = [{tires:[{width:205}], accessories:[{type:"spoiler"}]}]
+		// condA = tires.width matches at root=1,leaf=1
+		// condB = accessories.type matches at root=1,leaf=2
+		// Both are within cars[0] → should return doc5.
+		bucket := newIdxBucket(t)
+		writeIdx(t, bucket, "cars", 0, []uint64{
+			nested.Encode(1, 1, doc5), // leaf=1 (tires[0].width)
+			nested.Encode(1, 2, doc5), // leaf=2 (accessories[0].type)
+		})
+
+		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5))
+		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5))
+		result, err := applyIdxLoop(context.Background(), bucket, "cars", []*sroar.Bitmap{condA, condB})
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
+	})
+
+	t.Run("two conditions in different elements — empty result", func(t *testing.T) {
+		// condA matches cars[0], condB matches cars[1] — different elements.
+		bucket := newIdxBucket(t)
+		writeIdx(t, bucket, "cars", 0, []uint64{nested.Encode(1, 1, doc5)})
+		writeIdx(t, bucket, "cars", 1, []uint64{nested.Encode(2, 1, doc5)})
+
+		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5)) // in cars[0]
+		condB := roaringset.NewBitmap(nested.Encode(2, 1, doc5)) // in cars[1]
+		result, err := applyIdxLoop(context.Background(), bucket, "cars", []*sroar.Bitmap{condA, condB})
+		require.NoError(t, err)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("two conditions both in element 1 (not element 0) — doc returned", func(t *testing.T) {
+		// Verifies that the cursor scans past element 0 to find the match in element 1.
+		bucket := newIdxBucket(t)
+		writeIdx(t, bucket, "cars", 0, []uint64{nested.Encode(1, 1, doc5)}) // condA only
+		writeIdx(t, bucket, "cars", 1, []uint64{
+			nested.Encode(2, 1, doc5),
+			nested.Encode(2, 2, doc5),
+		})
+
+		condA := roaringset.NewBitmap(nested.Encode(2, 1, doc5)) // in cars[1]
+		condB := roaringset.NewBitmap(nested.Encode(2, 2, doc5)) // in cars[1]
+		result, err := applyIdxLoop(context.Background(), bucket, "cars", []*sroar.Bitmap{condA, condB})
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
+	})
+
+	t.Run("three conditions all in same element — doc returned", func(t *testing.T) {
+		bucket := newIdxBucket(t)
+		writeIdx(t, bucket, "cars", 0, []uint64{
+			nested.Encode(1, 1, doc5),
+			nested.Encode(1, 2, doc5),
+			nested.Encode(1, 3, doc5),
+		})
+
+		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5))
+		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5))
+		condC := roaringset.NewBitmap(nested.Encode(1, 3, doc5))
+		result, err := applyIdxLoop(context.Background(), bucket, "cars",
+			[]*sroar.Bitmap{condA, condB, condC})
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
+	})
+
+	t.Run("three conditions — two in element 0, third only in element 1 — empty", func(t *testing.T) {
+		bucket := newIdxBucket(t)
+		writeIdx(t, bucket, "cars", 0, []uint64{
+			nested.Encode(1, 1, doc5),
+			nested.Encode(1, 2, doc5),
+		})
+		writeIdx(t, bucket, "cars", 1, []uint64{nested.Encode(2, 1, doc5)})
+
+		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5)) // cars[0]
+		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5)) // cars[0]
+		condC := roaringset.NewBitmap(nested.Encode(2, 1, doc5)) // cars[1] only
+		result, err := applyIdxLoop(context.Background(), bucket, "cars",
+			[]*sroar.Bitmap{condA, condB, condC})
+		require.NoError(t, err)
+		assert.True(t, result.IsEmpty())
+	})
+
+	// -------------------------------------------------------------------------
+	// Multiple documents
+	// -------------------------------------------------------------------------
+
+	t.Run("two docs — one matches same element, one has split conditions", func(t *testing.T) {
+		// doc5: condA and condB both in cars[0] → match
+		// doc7: condA in cars[0], condB in cars[1] → no match
+		bucket := newIdxBucket(t)
+		writeIdx(t, bucket, "cars", 0, []uint64{
+			nested.Encode(1, 1, doc5),
+			nested.Encode(1, 2, doc5),
+			nested.Encode(1, 1, doc7), // doc7's condA
+		})
+		writeIdx(t, bucket, "cars", 1, []uint64{
+			nested.Encode(2, 1, doc7), // doc7's condB (wrong element)
+		})
+
+		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7))
+		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5), nested.Encode(2, 1, doc7))
+		result, err := applyIdxLoop(context.Background(), bucket, "cars",
+			[]*sroar.Bitmap{condA, condB})
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
+	})
+
+	t.Run("two docs both satisfy conditions in their respective elements", func(t *testing.T) {
+		// doc5: both conditions in cars[0]
+		// doc7: both conditions in cars[0] (both at root=1)
+		bucket := newIdxBucket(t)
+		writeIdx(t, bucket, "cars", 0, []uint64{
+			nested.Encode(1, 1, doc5),
+			nested.Encode(1, 2, doc5),
+			nested.Encode(1, 1, doc7),
+			nested.Encode(1, 2, doc7),
+		})
+
+		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7))
+		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5), nested.Encode(1, 2, doc7))
+		result, err := applyIdxLoop(context.Background(), bucket, "cars",
+			[]*sroar.Bitmap{condA, condB})
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5, doc7}, result.ToArray())
+	})
+
+	t.Run("three docs — only middle one satisfies same-element constraint", func(t *testing.T) {
+		// doc5: condA in cars[0], condB in cars[1] → no match
+		// doc7: condA and condB both in cars[0]     → match
+		// doc9: condA in cars[0], condB in cars[1] → no match
+		bucket := newIdxBucket(t)
+		writeIdx(t, bucket, "cars", 0, []uint64{
+			nested.Encode(1, 1, doc5),
+			nested.Encode(1, 1, doc7),
+			nested.Encode(1, 2, doc7),
+			nested.Encode(1, 1, doc9),
+		})
+		writeIdx(t, bucket, "cars", 1, []uint64{
+			nested.Encode(2, 1, doc5),
+			nested.Encode(2, 1, doc9),
+		})
+
+		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7), nested.Encode(1, 1, doc9))
+		condB := roaringset.NewBitmap(nested.Encode(2, 1, doc5), nested.Encode(1, 2, doc7), nested.Encode(2, 1, doc9))
+		result, err := applyIdxLoop(context.Background(), bucket, "cars",
+			[]*sroar.Bitmap{condA, condB})
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc7}, result.ToArray())
+	})
+
+	// -------------------------------------------------------------------------
+	// Edge cases
+	// -------------------------------------------------------------------------
+
+	t.Run("preFilter empty — cursor never opened", func(t *testing.T) {
+		// condA matches doc5, condB matches doc7 — no overlap at root+docID level,
+		// so preFilter is empty and the function returns early.
+		bucket := newIdxBucket(t)
+		writeIdx(t, bucket, "cars", 0, []uint64{
+			nested.Encode(1, 1, doc5),
+			nested.Encode(1, 2, doc7),
+		})
+
+		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5)) // only doc5
+		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc7)) // only doc7
+		result, err := applyIdxLoop(context.Background(), bucket, "cars",
+			[]*sroar.Bitmap{condA, condB})
+		require.NoError(t, err)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("no idx entries for path — empty result", func(t *testing.T) {
+		// Bucket exists but has no _idx.cars entries.
+		bucket := newIdxBucket(t)
+
+		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5))
+		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5))
+		result, err := applyIdxLoop(context.Background(), bucket, "cars",
+			[]*sroar.Bitmap{condA, condB})
+		require.NoError(t, err)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("conditions match but no idx entry covers both positions — empty", func(t *testing.T) {
+		// Both conditions match doc5, but the idx entry for element 0 only covers
+		// condA's position — condB's position is absent from that element.
+		bucket := newIdxBucket(t)
+		writeIdx(t, bucket, "cars", 0, []uint64{nested.Encode(1, 1, doc5)}) // only leaf=1
+
+		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5))
+		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5)) // leaf=2 not in element 0
+		result, err := applyIdxLoop(context.Background(), bucket, "cars",
+			[]*sroar.Bitmap{condA, condB})
+		require.NoError(t, err)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("multiple elements only one contains both conditions", func(t *testing.T) {
+		// Five elements, conditions only co-occur in element 3.
+		bucket := newIdxBucket(t)
+		for i := 0; i < 5; i++ {
+			root := uint16(i + 1)
+			if i == 3 {
+				writeIdx(t, bucket, "cars", i, []uint64{
+					nested.Encode(root, 1, doc5),
+					nested.Encode(root, 2, doc5),
+				})
+			} else {
+				writeIdx(t, bucket, "cars", i, []uint64{nested.Encode(root, 1, doc5)})
+			}
+		}
+
+		condA := roaringset.NewBitmap(nested.Encode(4, 1, doc5)) // only in element 3 (root=4)
+		condB := roaringset.NewBitmap(nested.Encode(4, 2, doc5)) // only in element 3 (root=4)
+		result, err := applyIdxLoop(context.Background(), bucket, "cars",
+			[]*sroar.Bitmap{condA, condB})
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
+	})
+}

--- a/adapters/repos/db/inverted/searcher_nested_executor_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_test.go
@@ -1,0 +1,167 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+)
+
+// ---- applyDirectAnd --------------------------------------------------------
+
+func TestApplyDirectAnd(t *testing.T) {
+	const (
+		doc5 = uint64(5)
+		doc7 = uint64(7)
+	)
+	// Positions for doc5 at different root/leaf coordinates.
+	pos511 := nested.Encode(1, 1, doc5) // root=1 leaf=1 docID=5
+	pos512 := nested.Encode(1, 2, doc5) // root=1 leaf=2 docID=5 — same root+docID, different leaf
+	pos521 := nested.Encode(2, 1, doc5) // root=2 leaf=1 docID=5 — different root
+	pos711 := nested.Encode(1, 1, doc7) // root=1 leaf=1 docID=7 — different doc
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		assert.True(t, applyDirectAnd(nil).IsEmpty())
+	})
+
+	t.Run("single bitmap returns docIDs", func(t *testing.T) {
+		assert.Equal(t, []uint64{doc5}, applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511)}).ToArray())
+	})
+
+	t.Run("exact same raw position in both bitmaps — match", func(t *testing.T) {
+		result := applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos511)})
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
+	})
+
+	t.Run("same root+docID different leaf — no match (requires exact position)", func(t *testing.T) {
+		// directAnd requires identical raw positions; leaf difference breaks the AND.
+		result := applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512)})
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("different root — no match", func(t *testing.T) {
+		result := applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos521)})
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("different docID — no match", func(t *testing.T) {
+		result := applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos711)})
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("three bitmaps — intersection of all", func(t *testing.T) {
+		result := applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511, pos521), roaringset.NewBitmap(pos511, pos711), roaringset.NewBitmap(pos511)})
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
+	})
+
+	t.Run("multiple matching docs", func(t *testing.T) {
+		result := applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511, pos711), roaringset.NewBitmap(pos511, pos711)})
+		assert.Equal(t, []uint64{doc5, doc7}, result.ToArray())
+	})
+
+	t.Run("inputs not modified", func(t *testing.T) {
+		a, b := roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos511)
+		applyDirectAnd([]*sroar.Bitmap{a, b})
+		assert.Equal(t, []uint64{pos511}, a.ToArray())
+		assert.Equal(t, []uint64{pos511}, b.ToArray())
+	})
+}
+
+// ---- applyMaskLeafAnd ------------------------------------------------------
+
+func TestApplyMaskLeafAnd(t *testing.T) {
+	const (
+		doc5 = uint64(5)
+		doc7 = uint64(7)
+	)
+	pos511 := nested.Encode(1, 1, doc5)
+	pos512 := nested.Encode(1, 2, doc5) // same root+docID, different leaf
+	pos513 := nested.Encode(1, 3, doc5) // same root+docID, yet another leaf
+	pos521 := nested.Encode(2, 1, doc5) // different root, same docID
+	pos711 := nested.Encode(1, 1, doc7) // same root+leaf, different docID
+
+	t.Run("empty input returns empty", func(t *testing.T) {
+		assert.True(t, applyMaskLeafAnd(nil).IsEmpty())
+	})
+
+	t.Run("single bitmap returns docIDs", func(t *testing.T) {
+		assert.Equal(t, []uint64{doc5}, applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511)}).ToArray())
+	})
+
+	t.Run("same raw position — match", func(t *testing.T) {
+		result := applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos511)})
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
+	})
+
+	t.Run("same root+docID different leaf — match (leaf is zeroed before AND)", func(t *testing.T) {
+		// This is the key difference from directAnd: leaf bits are erased so
+		// positions that differ only in leaf_idx — i.e. siblings within the same
+		// element — are treated as identical.
+		result := applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512)})
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
+	})
+
+	t.Run("three bitmaps same root+docID different leaves — match", func(t *testing.T) {
+		result := applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512), roaringset.NewBitmap(pos513)})
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
+	})
+
+	t.Run("different root same docID — no match (root encodes element identity)", func(t *testing.T) {
+		result := applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos521)})
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("different docID — no match", func(t *testing.T) {
+		result := applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos711)})
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("multiple matching docs", func(t *testing.T) {
+		pos712 := nested.Encode(1, 2, doc7)
+		result := applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511, pos711), roaringset.NewBitmap(pos512, pos712)})
+		assert.Equal(t, []uint64{doc5, doc7}, result.ToArray())
+	})
+
+	t.Run("inputs not modified", func(t *testing.T) {
+		a, b := roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512)
+		applyMaskLeafAnd([]*sroar.Bitmap{a, b})
+		assert.Equal(t, []uint64{pos511}, a.ToArray())
+		assert.Equal(t, []uint64{pos512}, b.ToArray())
+	})
+}
+
+// ---- applyIdxLoop preconditions (no lsmkv required) ------------------------
+
+func TestApplyIdxLoopPreconditions(t *testing.T) {
+	pos511 := nested.Encode(1, 1, 5)
+	pos512 := nested.Encode(1, 2, 5)
+
+	t.Run("nil metaBucket returns error regardless of bitmaps", func(t *testing.T) {
+		_, err := applyIdxLoop(context.Background(), nil, "cars", []*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512)})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "meta bucket is nil")
+		assert.Contains(t, err.Error(), "cars")
+	})
+
+	t.Run("nil metaBucket checked before bitmap count", func(t *testing.T) {
+		// Even with zero bitmaps the nil-bucket error fires first.
+		_, err := applyIdxLoop(context.Background(), nil, "cars", nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "meta bucket is nil")
+	})
+}

--- a/adapters/repos/db/inverted/searcher_nested_plan.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan.go
@@ -1,0 +1,305 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// nestedCorrelation describes which bitmap operation should combine two nested
+// filter conditions to achieve correct same-element semantics.
+type nestedCorrelation int
+
+const (
+	// directAnd: positions are naturally aligned (scalar siblings at the same
+	// element level, or ancestor/descendant). Standard bitmap AND on full 64-bit
+	// values gives correct results.
+	directAnd nestedCorrelation = iota
+
+	// maskLeafAnd: paths are in different subtrees of a single object node with
+	// no shared intermediate object[] array. Zero the leaf bits (keep root+docID)
+	// then AND to align on document identity.
+	maskLeafAnd
+
+	// idxLoopAnd: paths are in different subtrees of a shared object[] array.
+	// Must iterate _idx.{lcaPath}[N] to verify both conditions fall under the
+	// same array element.
+	idxLoopAnd
+)
+
+// pathRelationship holds the result of nestedPathsRelationship.
+type pathRelationship struct {
+	kind    nestedCorrelation
+	lcaPath string // set for idxLoopAnd: dot-notation path of the LCA array
+}
+
+// nestedPathsRelationship classifies the correlation between N relative nested
+// filter paths (stripped of the root property name) and returns which bitmap
+// operation should be used to combine them.
+//
+// rootDT is the DataType of the root property (DataTypeObject or
+// DataTypeObjectArray). rootProps are its NestedProperties.
+//
+// Decision rules applied to the group LCA (longest common prefix of all paths):
+//  1. Any path is an ancestor of the others (empty remaining) → directAnd
+//  2. Any path is a direct scalar at the LCA level (inherits all positions,
+//     superset of siblings) → directAnd
+//  3. No path goes through a sub-array (all scalar siblings at LCA level,
+//     identical positions) → directAnd
+//  4. At least one path has a sub-array:
+//     – LCA is intermediate object[] → idxLoopAnd (leaf_idx encodes element
+//     identity and is zeroed by MaskLeafPositions)
+//     – LCA is single object or root object[] → maskLeafAnd
+func nestedPathsRelationship(
+	paths []string,
+	rootDT schema.DataType,
+	rootProps []*models.NestedProperty,
+) (pathRelationship, error) {
+	if len(paths) <= 1 {
+		// Zero or one condition — no correlation needed.
+		return pathRelationship{kind: directAnd}, nil
+	}
+
+	// Compute the group LCA as the longest common prefix of all paths.
+	lcaSegs := strings.Split(paths[0], ".")
+	for _, p := range paths[1:] {
+		segs := strings.Split(p, ".")
+		i := 0
+		for i < len(lcaSegs) && i < len(segs) && lcaSegs[i] == segs[i] {
+			i++
+		}
+		lcaSegs = lcaSegs[:i]
+	}
+
+	// Compute remaining segments for each path after the LCA.
+	rems := make([][]string, len(paths))
+	for i, p := range paths {
+		segs := strings.Split(p, ".")
+		rems[i] = segs[len(lcaSegs):]
+		// Empty remaining means this path IS the LCA — ancestor of all others.
+		if len(rems[i]) == 0 {
+			return pathRelationship{kind: directAnd}, nil
+		}
+	}
+
+	lcaDT, lcaProps := nodeTypeAndProps(lcaSegs, rootDT, rootProps)
+
+	if !schema.IsNested(lcaDT) {
+		return pathRelationship{}, fmt.Errorf("nested path correlation requires object or object[] property, got %q", lcaDT)
+	}
+
+	// Direct AND: for a binary pair, a scalar property at the LCA level inherits
+	// ALL leaf positions of its parent element (superset of the other's positions).
+	// This shortcut does NOT extend to N>2: a scalar is a superset of each
+	// sibling individually, but ANDing two non-scalar siblings may produce empty
+	// results even when a document satisfies all conditions in the same element.
+	// Example: make + colors + accessories.type on a Tesla car — direct AND of
+	// {l4..l9} ∩ {l9} ∩ {l7} = {} even though all three match the same car.
+	if len(rems) == 2 {
+		if isScalarAtLevel(rems[0], lcaProps) || isScalarAtLevel(rems[1], lcaProps) {
+			return pathRelationship{kind: directAnd}, nil
+		}
+	}
+
+	// Direct AND: no path goes through a sub-array — all are scalar siblings at
+	// the same element level with identical positions.
+	allSimple := true
+	for _, rem := range rems {
+		if containsObjectArray(rem, lcaProps) {
+			allSimple = false
+			break
+		}
+	}
+	if allSimple {
+		return pathRelationship{kind: directAnd}, nil
+	}
+
+	// At least one path descends into a further sub-array. For intermediate
+	// object[] arrays the leaf_idx encodes element identity and is zeroed by
+	// MaskLeafPositions, so the _idx loop is required. At the root level or
+	// under a single object, root_idx or docID alignment is sufficient.
+	lcaPath := strings.Join(lcaSegs, ".")
+	if lcaDT == schema.DataTypeObjectArray && lcaPath != "" {
+		return pathRelationship{kind: idxLoopAnd, lcaPath: lcaPath}, nil
+	}
+	return pathRelationship{kind: maskLeafAnd}, nil
+}
+
+// nodeTypeAndProps walks segs through the nested schema and returns the
+// DataType and NestedProperties at the node identified by segs. For an empty
+// segs slice it returns (rootDT, rootProps) — the root.
+func nodeTypeAndProps(
+	segs []string,
+	rootDT schema.DataType,
+	rootProps []*models.NestedProperty,
+) (schema.DataType, []*models.NestedProperty) {
+	dt := rootDT
+	props := rootProps
+	for _, seg := range segs {
+		np := findNestedPropByName(props, seg)
+		if np == nil {
+			return dt, props
+		}
+		dt = schema.DataType(np.DataType[0])
+		props = np.NestedProperties
+	}
+	return dt, props
+}
+
+// findNestedPropByName returns the NestedProperty with the given name, or nil.
+func findNestedPropByName(props []*models.NestedProperty, name string) *models.NestedProperty {
+	for _, np := range props {
+		if np.Name == name {
+			return np
+		}
+	}
+	return nil
+}
+
+// isScalarAtLevel returns true if segs is a single segment that resolves to a
+// non-array, non-nested scalar property (text, int, number, bool, date, uuid).
+// Such a property inherits ALL leaf positions of its parent element, making it
+// a superset of any sibling's positions and safe for Direct AND.
+func isScalarAtLevel(segs []string, props []*models.NestedProperty) bool {
+	if len(segs) != 1 {
+		return false
+	}
+	np := findNestedPropByName(props, segs[0])
+	if np == nil {
+		return false
+	}
+	dt := schema.DataType(np.DataType[0])
+	return !schema.IsNested(dt) && !schema.IsScalarArrayType(dt)
+}
+
+// containsObjectArray returns true if any segment in segs resolves to a
+// DataTypeObjectArray property in the given schema level — indicating the path
+// passes through a nested array that introduces element-level positions.
+func containsObjectArray(segs []string, props []*models.NestedProperty) bool {
+	for _, seg := range segs {
+		np := findNestedPropByName(props, seg)
+		if np == nil {
+			return false
+		}
+		if schema.DataType(np.DataType[0]) == schema.DataTypeObjectArray {
+			return true
+		}
+		props = np.NestedProperties
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Resolution plan
+// ---------------------------------------------------------------------------
+
+// resolutionPlan is a recursive tree that describes how to combine a set of
+// nested filter conditions to achieve correct same-element semantics.
+//
+// Leaf nodes (groups == nil) hold a flat list of relative paths that share a
+// common LCA and are combined with op. Interior maskLeafAnd nodes hold
+// sub-plans for each first-level sub-tree group.
+//
+// Examples:
+//
+//	addresses.city + addresses.postcode + cars.make + cars.colors
+//	→ maskLeafAnd
+//	    ├── directAnd  [addresses.city, addresses.postcode]
+//	    └── directAnd  [cars.make, cars.colors]
+//
+//	addresses.city + addresses.postcode + cars.tires.width + cars.accessories.type
+//	→ maskLeafAnd
+//	    ├── directAnd      [addresses.city, addresses.postcode]
+//	    └── idxLoopAnd("cars") [cars.tires.width, cars.accessories.type]
+//
+//	cars.tires.width + cars.colors + cars.accessories.type
+//	→ idxLoopAnd("cars") [cars.tires.width, cars.colors, cars.accessories.type]
+type resolutionPlan struct {
+	op      nestedCorrelation // operation to apply at this node
+	lcaPath string            // set for idxLoopAnd: LCA array path (relative)
+	groups  []*resolutionPlan // set for maskLeafAnd: one sub-plan per sub-tree
+	paths   []string          // set for leaf nodes: full relative paths
+}
+
+// buildResolutionPlan constructs a resolutionPlan for the given relative nested
+// paths (stripped of the root property name). rootDT and rootProps describe the
+// root property's schema. The same rootDT/rootProps are used for ALL recursive
+// calls so that nestedPathsRelationship always operates in the correct
+// position-encoding context.
+//
+// Algorithm:
+//  1. Group paths by first segment. If there are multiple groups the operation
+//     is always maskLeafAnd — nestedPathsRelationship is not needed.
+//  2. For a single group, call nestedPathsRelationship to determine whether it
+//     is directAnd or idxLoopAnd.
+func buildResolutionPlan(
+	paths []string,
+	rootDT schema.DataType,
+	rootProps []*models.NestedProperty,
+) (*resolutionPlan, error) {
+	if len(paths) <= 1 {
+		return &resolutionPlan{op: directAnd, paths: paths}, nil
+	}
+
+	// Group paths by first segment, preserving insertion order.
+	seen := map[string]bool{}
+	order := []string{}
+	byFirst := map[string][]string{}
+	for _, p := range paths {
+		first, _, _ := strings.Cut(p, ".")
+		if !seen[first] {
+			seen[first] = true
+			order = append(order, first)
+		}
+		byFirst[first] = append(byFirst[first], p)
+	}
+
+	if len(order) > 1 {
+		// Paths span multiple sub-trees → always maskLeafAnd.
+		// nestedPathsRelationship is not needed: cross-subtree divergence always
+		// requires MaskLeafPositions AND to align on root+docID.
+		subPlans := make([]*resolutionPlan, 0, len(order))
+		for _, first := range order {
+			subPlan, err := buildResolutionPlan(byFirst[first], rootDT, rootProps)
+			if err != nil {
+				return nil, err
+			}
+			subPlans = append(subPlans, subPlan)
+		}
+		return &resolutionPlan{op: maskLeafAnd, groups: subPlans}, nil
+	}
+
+	// Single group: all paths share the same first segment.
+	// Use nestedPathsRelationship to determine the operation.
+	rel, err := nestedPathsRelationship(paths, rootDT, rootProps)
+	if err != nil {
+		return nil, err
+	}
+
+	switch rel.kind {
+	case directAnd:
+		return &resolutionPlan{op: directAnd, paths: paths}, nil
+	case idxLoopAnd:
+		return &resolutionPlan{op: idxLoopAnd, lcaPath: rel.lcaPath, paths: paths}, nil
+	case maskLeafAnd:
+		// maskLeafAnd within a single group means paths diverge under a sub-object
+		// node. Return a leaf maskLeafAnd — the executor will apply MaskLeafPositions
+		// AND across the paths.
+		return &resolutionPlan{op: maskLeafAnd, paths: paths}, nil
+	}
+
+	return nil, fmt.Errorf("buildResolutionPlan: unhandled correlation kind %d", rel.kind)
+}

--- a/adapters/repos/db/inverted/searcher_nested_plan.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan.go
@@ -61,7 +61,7 @@ type pathRelationship struct {
 //     identical positions) → directAnd
 //  4. At least one path has a sub-array:
 //     – LCA is intermediate object[] → idxLoopAnd (leaf_idx encodes element
-//     identity and is zeroed by MaskLeafPositions)
+//     identity and is zeroed by MaskLeaf)
 //     – LCA is single object or root object[] → maskLeafAnd
 func nestedPathsRelationship(
 	paths []string,
@@ -129,7 +129,7 @@ func nestedPathsRelationship(
 
 	// At least one path descends into a further sub-array. For intermediate
 	// object[] arrays the leaf_idx encodes element identity and is zeroed by
-	// MaskLeafPositions, so the _idx loop is required. At the root level or
+	// MaskLeaf, so the _idx loop is required. At the root level or
 	// under a single object, root_idx or docID alignment is sufficient.
 	lcaPath := strings.Join(lcaSegs, ".")
 	if lcaDT == schema.DataTypeObjectArray && lcaPath != "" {
@@ -270,7 +270,7 @@ func buildResolutionPlan(
 	if len(order) > 1 {
 		// Paths span multiple sub-trees → always maskLeafAnd.
 		// nestedPathsRelationship is not needed: cross-subtree divergence always
-		// requires MaskLeafPositions AND to align on root+docID.
+		// requires MaskLeaf AND to align on root+docID.
 		subPlans := make([]*resolutionPlan, 0, len(order))
 		for _, first := range order {
 			subPlan, err := buildResolutionPlan(byFirst[first], rootDT, rootProps)
@@ -296,7 +296,7 @@ func buildResolutionPlan(
 		return &resolutionPlan{op: idxLoopAnd, lcaPath: rel.lcaPath, paths: paths}, nil
 	case maskLeafAnd:
 		// maskLeafAnd within a single group means paths diverge under a sub-object
-		// node. Return a leaf maskLeafAnd — the executor will apply MaskLeafPositions
+		// node. Return a leaf maskLeafAnd — the executor will apply MaskLeaf
 		// AND across the paths.
 		return &resolutionPlan{op: maskLeafAnd, paths: paths}, nil
 	}

--- a/adapters/repos/db/inverted/searcher_nested_plan.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan.go
@@ -40,168 +40,6 @@ const (
 	idxLoopAnd
 )
 
-// pathRelationship holds the result of nestedPathsRelationship.
-type pathRelationship struct {
-	kind    nestedCorrelation
-	lcaPath string // set for idxLoopAnd: dot-notation path of the LCA array
-}
-
-// nestedPathsRelationship classifies the correlation between N relative nested
-// filter paths (stripped of the root property name) and returns which bitmap
-// operation should be used to combine them.
-//
-// rootDT is the DataType of the root property (DataTypeObject or
-// DataTypeObjectArray). rootProps are its NestedProperties.
-//
-// Decision rules applied to the group LCA (longest common prefix of all paths):
-//  1. Any path is an ancestor of the others (empty remaining) → directAnd
-//  2. Any path is a direct scalar at the LCA level (inherits all positions,
-//     superset of siblings) → directAnd
-//  3. No path goes through a sub-array (all scalar siblings at LCA level,
-//     identical positions) → directAnd
-//  4. At least one path has a sub-array:
-//     – LCA is intermediate object[] → idxLoopAnd (leaf_idx encodes element
-//     identity and is zeroed by MaskLeaf)
-//     – LCA is single object or root object[] → maskLeafAnd
-func nestedPathsRelationship(
-	paths []string,
-	rootDT schema.DataType,
-	rootProps []*models.NestedProperty,
-) (pathRelationship, error) {
-	if len(paths) <= 1 {
-		// Zero or one condition — no correlation needed.
-		return pathRelationship{kind: directAnd}, nil
-	}
-
-	// Compute the group LCA as the longest common prefix of all paths.
-	lcaSegs := strings.Split(paths[0], ".")
-	for _, p := range paths[1:] {
-		segs := strings.Split(p, ".")
-		i := 0
-		for i < len(lcaSegs) && i < len(segs) && lcaSegs[i] == segs[i] {
-			i++
-		}
-		lcaSegs = lcaSegs[:i]
-	}
-
-	// Compute remaining segments for each path after the LCA.
-	rems := make([][]string, len(paths))
-	for i, p := range paths {
-		segs := strings.Split(p, ".")
-		rems[i] = segs[len(lcaSegs):]
-		// Empty remaining means this path IS the LCA — ancestor of all others.
-		if len(rems[i]) == 0 {
-			return pathRelationship{kind: directAnd}, nil
-		}
-	}
-
-	lcaDT, lcaProps := nodeTypeAndProps(lcaSegs, rootDT, rootProps)
-
-	if !schema.IsNested(lcaDT) {
-		return pathRelationship{}, fmt.Errorf("nested path correlation requires object or object[] property, got %q", lcaDT)
-	}
-
-	// Direct AND: for a binary pair, a scalar property at the LCA level inherits
-	// ALL leaf positions of its parent element (superset of the other's positions).
-	// This shortcut does NOT extend to N>2: a scalar is a superset of each
-	// sibling individually, but ANDing two non-scalar siblings may produce empty
-	// results even when a document satisfies all conditions in the same element.
-	// Example: make + colors + accessories.type on a Tesla car — direct AND of
-	// {l4..l9} ∩ {l9} ∩ {l7} = {} even though all three match the same car.
-	if len(rems) == 2 {
-		if isScalarAtLevel(rems[0], lcaProps) || isScalarAtLevel(rems[1], lcaProps) {
-			return pathRelationship{kind: directAnd}, nil
-		}
-	}
-
-	// Direct AND: no path goes through a sub-array — all are scalar siblings at
-	// the same element level with identical positions.
-	allSimple := true
-	for _, rem := range rems {
-		if containsObjectArray(rem, lcaProps) {
-			allSimple = false
-			break
-		}
-	}
-	if allSimple {
-		return pathRelationship{kind: directAnd}, nil
-	}
-
-	// At least one path descends into a further sub-array. For intermediate
-	// object[] arrays the leaf_idx encodes element identity and is zeroed by
-	// MaskLeaf, so the _idx loop is required. At the root level or
-	// under a single object, root_idx or docID alignment is sufficient.
-	lcaPath := strings.Join(lcaSegs, ".")
-	if lcaDT == schema.DataTypeObjectArray && lcaPath != "" {
-		return pathRelationship{kind: idxLoopAnd, lcaPath: lcaPath}, nil
-	}
-	return pathRelationship{kind: maskLeafAnd}, nil
-}
-
-// nodeTypeAndProps walks segs through the nested schema and returns the
-// DataType and NestedProperties at the node identified by segs. For an empty
-// segs slice it returns (rootDT, rootProps) — the root.
-func nodeTypeAndProps(
-	segs []string,
-	rootDT schema.DataType,
-	rootProps []*models.NestedProperty,
-) (schema.DataType, []*models.NestedProperty) {
-	dt := rootDT
-	props := rootProps
-	for _, seg := range segs {
-		np := findNestedPropByName(props, seg)
-		if np == nil {
-			return dt, props
-		}
-		dt = schema.DataType(np.DataType[0])
-		props = np.NestedProperties
-	}
-	return dt, props
-}
-
-// findNestedPropByName returns the NestedProperty with the given name, or nil.
-func findNestedPropByName(props []*models.NestedProperty, name string) *models.NestedProperty {
-	for _, np := range props {
-		if np.Name == name {
-			return np
-		}
-	}
-	return nil
-}
-
-// isScalarAtLevel returns true if segs is a single segment that resolves to a
-// non-array, non-nested scalar property (text, int, number, bool, date, uuid).
-// Such a property inherits ALL leaf positions of its parent element, making it
-// a superset of any sibling's positions and safe for Direct AND.
-func isScalarAtLevel(segs []string, props []*models.NestedProperty) bool {
-	if len(segs) != 1 {
-		return false
-	}
-	np := findNestedPropByName(props, segs[0])
-	if np == nil {
-		return false
-	}
-	dt := schema.DataType(np.DataType[0])
-	return !schema.IsNested(dt) && !schema.IsScalarArrayType(dt)
-}
-
-// containsObjectArray returns true if any segment in segs resolves to a
-// DataTypeObjectArray property in the given schema level — indicating the path
-// passes through a nested array that introduces element-level positions.
-func containsObjectArray(segs []string, props []*models.NestedProperty) bool {
-	for _, seg := range segs {
-		np := findNestedPropByName(props, seg)
-		if np == nil {
-			return false
-		}
-		if schema.DataType(np.DataType[0]) == schema.DataTypeObjectArray {
-			return true
-		}
-		props = np.NestedProperties
-	}
-	return false
-}
-
 // ---------------------------------------------------------------------------
 // Resolution plan
 // ---------------------------------------------------------------------------
@@ -222,58 +60,105 @@ func containsObjectArray(segs []string, props []*models.NestedProperty) bool {
 //
 //	addresses.city + addresses.postcode + cars.tires.width + cars.accessories.type
 //	→ maskLeafAnd
-//	    ├── directAnd      [addresses.city, addresses.postcode]
-//	    └── idxLoopAnd("cars") [cars.tires.width, cars.accessories.type]
+//	    ├── directAnd           [addresses.city, addresses.postcode]
+//	    └── idxLoopAnd("cars")
+//	            ├── directAnd   [cars.tires.width]
+//	            └── directAnd   [cars.accessories.type]
 //
-//	cars.tires.width + cars.colors + cars.accessories.type
-//	→ idxLoopAnd("cars") [cars.tires.width, cars.colors, cars.accessories.type]
+//	cars.tires.width + cars.accessories.type + cars.accessories.color
+//	→ idxLoopAnd("cars")
+//	    ├── directAnd   [cars.tires.width]
+//	    └── directAnd   [cars.accessories.type, cars.accessories.color]
 type resolutionPlan struct {
 	op      nestedCorrelation // operation to apply at this node
 	lcaPath string            // set for idxLoopAnd: LCA array path (relative)
-	groups  []*resolutionPlan // set for maskLeafAnd: one sub-plan per sub-tree
-	paths   []string          // set for leaf nodes: full relative paths
+	groups  []*resolutionPlan // set for maskLeafAnd interior OR idxLoopAnd interior:
+	//                           one sub-plan per pathRem sub-tree beneath the LCA
+	paths []string // set for leaf nodes (no sub-groups): full relative paths
 }
 
-// buildResolutionPlan constructs a resolutionPlan for the given relative nested
-// paths (stripped of the root property name). rootDT and rootProps describe the
-// root property's schema. The same rootDT/rootProps are used for ALL recursive
-// calls so that nestedPathsRelationship always operates in the correct
-// position-encoding context.
+// resolutionPlanBuilder constructs a resolutionPlan for a set of relative
+// nested filter paths. dt and props describe the root property's schema.
+//
+// Paths are split to segments exactly once and all internal work is done in
+// segment space. The schema context is threaded downward so each recursive
+// level starts from its LCA's schema rather than re-walking from the root.
 //
 // Algorithm:
-//  1. Group paths by first segment. If there are multiple groups the operation
-//     is always maskLeafAnd — nestedPathsRelationship is not needed.
-//  2. For a single group, call nestedPathsRelationship to determine whether it
-//     is directAnd or idxLoopAnd.
-func buildResolutionPlan(
+//  1. Group paths by first segment, preserving order.
+//  2. Multiple groups → interior maskLeafAnd; classify each group.
+//  3. Single group → classifyLeaf:
+//     a. Strip ancestor paths (pathRem == empty): their bitmaps are supersets of
+//     all siblings and are no-ops in any AND — exclude from further logic.
+//     b. Binary pair where one remainder is a direct scalar at the LCA level
+//     (inherits all parent positions, superset of siblings) → directAnd
+//     c. No remainder passes through a sub-array → directAnd
+//     d/e. At least one remainder has a sub-array → recurse with stripped segs
+//     and LCA-level schema:
+//     · LCA is intermediate object[] → idxLoopAnd(lcaPath) with groups
+//     · LCA is plain object or root object[] → maskLeafAnd with groups
+type resolutionPlanBuilder struct {
+	dt    schema.DataType
+	props []*models.NestedProperty
+}
+
+// newResolutionPlanBuilder returns a resolutionPlanBuilder for the given root
+// property schema. Call build on the result to produce a resolutionPlan.
+func newResolutionPlanBuilder(dt schema.DataType, props []*models.NestedProperty) *resolutionPlanBuilder {
+	return &resolutionPlanBuilder{dt: dt, props: props}
+}
+
+// build is the entry point. Returns an error if paths is empty.
+func (b *resolutionPlanBuilder) build(paths []string) (*resolutionPlan, error) {
+	if len(paths) == 0 {
+		return nil, fmt.Errorf("resolutionPlanBuilder: no paths provided")
+	}
+	if len(paths) == 1 {
+		return &resolutionPlan{op: directAnd, paths: paths}, nil
+	}
+	pathsSegs := make([][]string, len(paths))
+	for i, p := range paths {
+		pathsSegs[i] = strings.Split(p, ".")
+	}
+	return b.planFromSegs(pathsSegs, paths, b.dt, b.props)
+}
+
+// planFromSegs groups paths by first segment and dispatches to classifyLeaf.
+// pathsSegs[i] is the pre-split form of paths[i]; dt/props is the schema at
+// the current nesting level.
+func (b *resolutionPlanBuilder) planFromSegs(
+	pathsSegs [][]string,
 	paths []string,
-	rootDT schema.DataType,
-	rootProps []*models.NestedProperty,
+	dt schema.DataType,
+	props []*models.NestedProperty,
 ) (*resolutionPlan, error) {
-	if len(paths) <= 1 {
+	if len(pathsSegs) <= 1 {
 		return &resolutionPlan{op: directAnd, paths: paths}, nil
 	}
 
-	// Group paths by first segment, preserving insertion order.
 	seen := map[string]bool{}
 	order := []string{}
-	byFirst := map[string][]string{}
-	for _, p := range paths {
-		first, _, _ := strings.Cut(p, ".")
+	byFirst := map[string][]int{}
+	for i, pathSegs := range pathsSegs {
+		first := pathSegs[0]
 		if !seen[first] {
 			seen[first] = true
 			order = append(order, first)
 		}
-		byFirst[first] = append(byFirst[first], p)
+		byFirst[first] = append(byFirst[first], i)
 	}
 
 	if len(order) > 1 {
-		// Paths span multiple sub-trees → always maskLeafAnd.
-		// nestedPathsRelationship is not needed: cross-subtree divergence always
-		// requires MaskLeaf AND to align on root+docID.
 		subPlans := make([]*resolutionPlan, 0, len(order))
 		for _, first := range order {
-			subPlan, err := buildResolutionPlan(byFirst[first], rootDT, rootProps)
+			idxs := byFirst[first]
+			groupPathSegs := make([][]string, len(idxs))
+			groupPaths := make([]string, len(idxs))
+			for j, idx := range idxs {
+				groupPathSegs[j] = pathsSegs[idx]
+				groupPaths[j] = paths[idx]
+			}
+			subPlan, err := b.classifyLeaf(groupPathSegs, groupPaths, dt, props)
 			if err != nil {
 				return nil, err
 			}
@@ -282,24 +167,151 @@ func buildResolutionPlan(
 		return &resolutionPlan{op: maskLeafAnd, groups: subPlans}, nil
 	}
 
-	// Single group: all paths share the same first segment.
-	// Use nestedPathsRelationship to determine the operation.
-	rel, err := nestedPathsRelationship(paths, rootDT, rootProps)
+	return b.classifyLeaf(pathsSegs, paths, dt, props)
+}
+
+// classifyLeaf classifies a set of pre-split paths that all share a common
+// first segment by computing their LCA and applying the decision rules.
+func (b *resolutionPlanBuilder) classifyLeaf(
+	pathsSegs [][]string,
+	paths []string,
+	dt schema.DataType,
+	props []*models.NestedProperty,
+) (*resolutionPlan, error) {
+	if len(pathsSegs) == 0 {
+		return nil, fmt.Errorf("resolutionPlanBuilder: no paths provided")
+	}
+	if len(pathsSegs) == 1 {
+		return &resolutionPlan{op: directAnd, paths: paths}, nil
+	}
+
+	lcaLen := len(pathsSegs[0])
+	for _, ps := range pathsSegs[1:] {
+		i := 0
+		for i < lcaLen && i < len(ps) && pathsSegs[0][i] == ps[i] {
+			i++
+		}
+		lcaLen = i
+	}
+
+	// 3a: exclude ancestor paths — they are supersets of all siblings (no-ops).
+	var activePathSegs [][]string
+	var activePaths []string
+	for i, pathSegs := range pathsSegs {
+		if len(pathSegs) > lcaLen {
+			activePathSegs = append(activePathSegs, pathSegs)
+			activePaths = append(activePaths, paths[i])
+		}
+	}
+	if len(activePaths) <= 1 {
+		return &resolutionPlan{op: directAnd, paths: activePaths}, nil
+	}
+
+	lcaPathSegs := pathsSegs[0][:lcaLen]
+	lcaDT, lcaProps := b.nodeTypeAndProps(lcaPathSegs, dt, props)
+	if !schema.IsNested(lcaDT) {
+		return nil, fmt.Errorf("resolutionPlanBuilder: LCA node %q is not object or object[], got %q",
+			strings.Join(lcaPathSegs, "."), lcaDT)
+	}
+
+	activePathRems := make([][]string, len(activePathSegs))
+	for i, pathSegs := range activePathSegs {
+		activePathRems[i] = pathSegs[lcaLen:]
+	}
+
+	// 3b/3c: directAnd suffices when positions are naturally aligned.
+	if b.isDirectAndEligible(activePathRems, lcaProps) {
+		return &resolutionPlan{op: directAnd, paths: activePaths}, nil
+	}
+
+	// 3d/3e: element-level correlation required.
+	innerPlan, err := b.planFromSegs(activePathRems, activePaths, lcaDT, lcaProps)
 	if err != nil {
 		return nil, err
 	}
 
-	switch rel.kind {
-	case directAnd:
-		return &resolutionPlan{op: directAnd, paths: paths}, nil
-	case idxLoopAnd:
-		return &resolutionPlan{op: idxLoopAnd, lcaPath: rel.lcaPath, paths: paths}, nil
-	case maskLeafAnd:
-		// maskLeafAnd within a single group means paths diverge under a sub-object
-		// node. Return a leaf maskLeafAnd — the executor will apply MaskLeaf
-		// AND across the paths.
-		return &resolutionPlan{op: maskLeafAnd, paths: paths}, nil
+	if lcaDT == schema.DataTypeObjectArray {
+		if lcaPath := strings.Join(lcaPathSegs, "."); lcaPath != "" {
+			return &resolutionPlan{op: idxLoopAnd, lcaPath: lcaPath, groups: b.extractGroups(innerPlan)}, nil
+		}
 	}
+	return &resolutionPlan{op: maskLeafAnd, groups: b.extractGroups(innerPlan)}, nil
+}
 
-	return nil, fmt.Errorf("buildResolutionPlan: unhandled correlation kind %d", rel.kind)
+// isDirectAndEligible returns true when a plain bitmap AND gives correct
+// same-element results without an idx loop:
+//   - 3b: binary pair where one remainder is a direct scalar at the LCA level
+//   - 3c: no remainder passes through a sub-array
+func (b *resolutionPlanBuilder) isDirectAndEligible(pathRems [][]string, lcaProps []*models.NestedProperty) bool {
+	if len(pathRems) == 2 {
+		if b.isScalarAtLevel(pathRems[0], lcaProps) || b.isScalarAtLevel(pathRems[1], lcaProps) {
+			return true
+		}
+	}
+	for _, pathRem := range pathRems {
+		if b.containsObjectArray(pathRem, lcaProps) {
+			return false
+		}
+	}
+	return true
+}
+
+// extractGroups lifts the sub-groups of an interior maskLeafAnd node so they
+// can be used directly as groups of the outer operation, or wraps a single
+// plan as a one-element slice.
+func (b *resolutionPlanBuilder) extractGroups(plan *resolutionPlan) []*resolutionPlan {
+	if plan.op == maskLeafAnd && len(plan.groups) > 0 {
+		return plan.groups
+	}
+	return []*resolutionPlan{plan}
+}
+
+// nodeTypeAndProps walks pathSegs through the nested schema and returns the
+// DataType and NestedProperties at that node. An empty slice returns (dt, props).
+func (b *resolutionPlanBuilder) nodeTypeAndProps(
+	pathSegs []string,
+	dt schema.DataType,
+	props []*models.NestedProperty,
+) (schema.DataType, []*models.NestedProperty) {
+	for _, pathSeg := range pathSegs {
+		np := findNestedPropByName(props, pathSeg)
+		if np == nil {
+			return dt, props
+		}
+		dt = schema.DataType(np.DataType[0])
+		props = np.NestedProperties
+	}
+	return dt, props
+}
+
+// isScalarAtLevel returns true if pathSegs is a single segment resolving to a
+// non-array, non-nested scalar property. Such a property inherits ALL leaf
+// positions of its parent element and is a superset of any sibling's positions.
+func (b *resolutionPlanBuilder) isScalarAtLevel(pathSegs []string, props []*models.NestedProperty) bool {
+	if len(pathSegs) != 1 {
+		return false
+	}
+	np := findNestedPropByName(props, pathSegs[0])
+	if np == nil {
+		return false
+	}
+	dt := schema.DataType(np.DataType[0])
+	return !schema.IsNested(dt) && !schema.IsScalarArrayType(dt)
+}
+
+// containsObjectArray returns true if any segment in pathSegs resolves to a
+// DataTypeObjectArray property — the path passes through a nested array that
+// introduces element-level positions.
+func (b *resolutionPlanBuilder) containsObjectArray(pathSegs []string, props []*models.NestedProperty) bool {
+	for _, pathSeg := range pathSegs {
+		np := findNestedPropByName(props, pathSeg)
+		if np == nil {
+			return false
+		}
+		if schema.DataType(np.DataType[0]) == schema.DataTypeObjectArray {
+			return true
+		}
+		props = np.NestedProperties
+	}
+	return false
 }

--- a/adapters/repos/db/inverted/searcher_nested_plan_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_test.go
@@ -1,0 +1,518 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// correlationTestProps returns the shared test schema used across all plan
+// tests (same structure as the design summary):
+//
+//	nestedObject: object {
+//	  name:   text
+//	  owner:  object  { firstname, lastname text; nicknames text[] }
+//	  addresses: object[] { city, postcode text; numbers number[] }
+//	  tags:   text[]
+//	  cars:   object[] {
+//	    make:        text
+//	    tires:       object[] { width int; radiuses int[] }
+//	    accessories: object[] { type text }
+//	    colors:      text[]
+//	  }
+//	}
+func correlationTestProps() []*models.NestedProperty {
+	vTrue := true
+	return []*models.NestedProperty{
+		{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+		{
+			Name:     "owner",
+			DataType: schema.DataTypeObject.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "firstname", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+				{Name: "lastname", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+				{Name: "nicknames", DataType: schema.DataTypeTextArray.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+			},
+		},
+		{
+			Name:     "addresses",
+			DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+				{Name: "postcode", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+				{Name: "numbers", DataType: schema.DataTypeNumberArray.PropString(), IndexFilterable: &vTrue},
+			},
+		},
+		{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+		{
+			Name:     "cars",
+			DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+				{
+					Name:     "tires",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+						{Name: "radiuses", DataType: schema.DataTypeIntArray.PropString(), IndexFilterable: &vTrue},
+					},
+				},
+				{
+					Name:     "accessories",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "type", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+					},
+				},
+				{Name: "colors", DataType: schema.DataTypeTextArray.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+			},
+		},
+	}
+}
+
+func TestNestedPathRelationship(t *testing.T) {
+	props := correlationTestProps()
+	objDT := schema.DataTypeObject
+	arrDT := schema.DataTypeObjectArray
+
+	tests := []struct {
+		name     string
+		pathA    string
+		pathB    string
+		rootDT   schema.DataType
+		wantKind nestedCorrelation
+		wantLCA  string
+	}{
+		// --- ancestor / descendant → directAnd ---
+		{
+			name:  "identical paths",
+			pathA: "addresses.city", pathB: "addresses.city", rootDT: objDT,
+			wantKind: directAnd,
+		},
+		{
+			name:  "one is prefix of other",
+			pathA: "cars", pathB: "cars.make", rootDT: objDT,
+			wantKind: directAnd,
+		},
+
+		// --- scalar siblings at same array element → directAnd ---
+		{
+			name:  "addresses.city and addresses.postcode (scalar siblings in object[])",
+			pathA: "addresses.city", pathB: "addresses.postcode", rootDT: objDT,
+			wantKind: directAnd,
+		},
+		{
+			name:  "owner.firstname and owner.lastname (scalar siblings in object)",
+			pathA: "owner.firstname", pathB: "owner.lastname", rootDT: objDT,
+			wantKind: directAnd,
+		},
+		{
+			name:  "cars.make and cars.colors (scalar siblings in cars object[])",
+			pathA: "cars.make", pathB: "cars.colors", rootDT: objDT,
+			wantKind: directAnd,
+		},
+		{
+			name:  "tires.width and tires.radiuses (scalar siblings in tires object[])",
+			pathA: "cars.tires.width", pathB: "cars.tires.radiuses", rootDT: objDT,
+			wantKind: directAnd,
+		},
+
+		// --- different subtrees in object[] → idxLoopAnd ---
+		{
+			name:  "cars.tires.width and cars.colors (tires is sub-array of cars)",
+			pathA: "cars.tires.width", pathB: "cars.colors", rootDT: objDT,
+			wantKind: idxLoopAnd, wantLCA: "cars",
+		},
+		{
+			name:  "cars.tires.width and cars.make (tires sub-array, make scalar)",
+			pathA: "cars.tires.width", pathB: "cars.make", rootDT: objDT,
+			wantKind: directAnd, // make is scalar → inherits all car positions (superset)
+		},
+		{
+			name:  "cars.tires.radiuses and cars.tires.width diverge at tires level",
+			pathA: "cars.tires.radiuses", pathB: "cars.tires.width", rootDT: objDT,
+			wantKind: directAnd, // both scalar at tires element level
+		},
+
+		// --- diverge at root of object[] → maskLeafAnd ---
+		// root_idx already distinguishes root elements so MaskLeafPositions AND
+		// is sufficient; no _idx metadata is emitted at root level.
+		{
+			name:  "diverge at root of object[] property",
+			pathA: "addresses.city", pathB: "cars.make", rootDT: arrDT,
+			wantKind: maskLeafAnd,
+		},
+
+		// --- different root sub-properties of single object → maskLeafAnd ---
+		{
+			name:  "addresses.city and cars.make under single object",
+			pathA: "addresses.city", pathB: "cars.make", rootDT: objDT,
+			wantKind: maskLeafAnd,
+		},
+		{
+			name:  "owner.firstname and addresses.city under single object",
+			pathA: "owner.firstname", pathB: "addresses.city", rootDT: objDT,
+			wantKind: maskLeafAnd,
+		},
+
+		// --- owner (object) with one path having sub-array → directAnd
+		//     (scalar firstname inherits all owner positions, superset of nicknames) ---
+		{
+			name:  "owner.firstname and owner.nicknames (scalar vs text[])",
+			pathA: "owner.firstname", pathB: "owner.nicknames", rootDT: objDT,
+			wantKind: directAnd,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rel, err := nestedPathsRelationship([]string{tt.pathA, tt.pathB}, tt.rootDT, props)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantKind, rel.kind)
+			if tt.wantKind == idxLoopAnd {
+				assert.Equal(t, tt.wantLCA, rel.lcaPath)
+			}
+		})
+	}
+}
+
+func TestNestedPathRelationshipInvalidDT(t *testing.T) {
+	props := correlationTestProps()
+	_, err := nestedPathsRelationship([]string{"addresses.city", "cars.make"}, schema.DataTypeText, props)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "object or object[]")
+}
+
+func TestNestedPathsRelationshipMulti(t *testing.T) {
+	props := correlationTestProps()
+	objDT := schema.DataTypeObject
+
+	tests := []struct {
+		name     string
+		paths    []string
+		wantKind nestedCorrelation
+		wantLCA  string
+	}{
+		// --- degenerate cases ---
+		{name: "empty paths", paths: []string{}, wantKind: directAnd},
+		{name: "single path", paths: []string{"addresses.city"}, wantKind: directAnd},
+
+		// --- cars.make + cars.colors + cars.accessories.type ---
+		// The scalar superset rule only holds for N=2. With N=3, make is a superset
+		// of each sibling, but colors ∩ accessories.type may be empty even when a
+		// document satisfies all three in the same car (e.g. Tesla: make={l4..l9},
+		// colors={l9}, accessories.type={l7} → direct AND gives {} incorrectly).
+		// idxLoopAnd on cars is required.
+		{
+			name:     "cars.make + cars.colors + cars.accessories.type (scalar rule N=2 only)",
+			paths:    []string{"cars.make", "cars.colors", "cars.accessories.type"},
+			wantKind: idxLoopAnd, wantLCA: "cars",
+		},
+		{
+			name:     "cars.make + cars.tires.width + cars.accessories.type (scalar rule N=2 only)",
+			paths:    []string{"cars.make", "cars.tires.width", "cars.accessories.type"},
+			wantKind: idxLoopAnd, wantLCA: "cars",
+		},
+
+		// --- without a scalar at cars level → idxLoopAnd on cars ---
+		// colors is text[] (not a further object[]), accessories is object[]
+		// → at least one sub-array present without a scalar rescue
+		{
+			name:     "cars.colors + cars.accessories.type (no scalar, accessories is sub-array)",
+			paths:    []string{"cars.colors", "cars.accessories.type"},
+			wantKind: idxLoopAnd, wantLCA: "cars",
+		},
+		// tires and accessories are both sub-arrays under cars
+		{
+			name:     "cars.tires.width + cars.accessories.type (two sub-arrays under cars)",
+			paths:    []string{"cars.tires.width", "cars.accessories.type"},
+			wantKind: idxLoopAnd, wantLCA: "cars",
+		},
+		// all three without make: tires, colors, accessories
+		{
+			name:     "cars.tires.width + cars.colors + cars.accessories.type (no scalar)",
+			paths:    []string{"cars.tires.width", "cars.colors", "cars.accessories.type"},
+			wantKind: idxLoopAnd, wantLCA: "cars",
+		},
+		// four paths at cars level, none scalar
+		{
+			name:     "cars.tires.width + cars.tires.radiuses + cars.colors + cars.accessories.type",
+			paths:    []string{"cars.tires.width", "cars.tires.radiuses", "cars.colors", "cars.accessories.type"},
+			wantKind: idxLoopAnd, wantLCA: "cars",
+		},
+
+		// --- scalar rescues within tires sub-array ---
+		// tires.width is scalar at tires level → superset of radiuses → directAnd
+		{
+			name:     "cars.tires.width + cars.tires.radiuses (width is scalar at tires level)",
+			paths:    []string{"cars.tires.width", "cars.tires.radiuses"},
+			wantKind: directAnd,
+		},
+		// adding tires.width to a cross-cars pair still requires idxLoopAnd on cars
+		{
+			name:     "cars.tires.width + cars.tires.radiuses + cars.accessories.type (LCA still cars)",
+			paths:    []string{"cars.tires.width", "cars.tires.radiuses", "cars.accessories.type"},
+			wantKind: idxLoopAnd, wantLCA: "cars",
+		},
+
+		// --- addresses level ---
+		// city is scalar → superset of postcode and numbers → directAnd
+		{
+			name:     "addresses.city + addresses.postcode + addresses.numbers (city is scalar)",
+			paths:    []string{"addresses.city", "addresses.postcode", "addresses.numbers"},
+			wantKind: directAnd,
+		},
+		// postcode is also scalar → directAnd even without city
+		{
+			name:     "addresses.postcode + addresses.numbers (postcode is scalar)",
+			paths:    []string{"addresses.postcode", "addresses.numbers"},
+			wantKind: directAnd,
+		},
+
+		// --- cross-subtree at root (maskLeafAnd) ---
+		{
+			name:     "owner.firstname + addresses.city + cars.make (diverge at root)",
+			paths:    []string{"owner.firstname", "addresses.city", "cars.make"},
+			wantKind: maskLeafAnd,
+		},
+		// "name" is a scalar at root level but scalar rule only applies for N=2;
+		// addresses goes through an object[], so maskLeafAnd for the root.
+		{
+			name:     "name + owner.firstname + addresses.city + cars.make (four subtrees at root)",
+			paths:    []string{"name", "owner.firstname", "addresses.city", "cars.make"},
+			wantKind: maskLeafAnd,
+		},
+		// Paths from two different sub-trees (addresses and cars) diverge at the
+		// root of a single object. LCA = root (DataTypeObject) → maskLeafAnd.
+		// MaskLeafPositions AND aligns on root=1 + docID giving correct doc-level
+		// results even though addresses and cars have disjoint leaf positions.
+		{
+			name:     "addresses.city + addresses.postcode + cars.make + cars.colors (mixed subtrees at root)",
+			paths:    []string{"addresses.city", "addresses.postcode", "cars.make", "cars.colors"},
+			wantKind: maskLeafAnd,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rel, err := nestedPathsRelationship(tt.paths, objDT, props)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantKind, rel.kind)
+			if tt.wantKind == idxLoopAnd {
+				assert.Equal(t, tt.wantLCA, rel.lcaPath)
+			}
+		})
+	}
+}
+
+func TestBuildResolutionPlan(t *testing.T) {
+	props := correlationTestProps()
+	objDT := schema.DataTypeObject
+
+	tests := []struct {
+		name  string
+		paths []string
+		check func(t *testing.T, plan *resolutionPlan)
+	}{
+		{
+			// directAnd [addresses.city]
+			name:  "single path",
+			paths: []string{"addresses.city"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, directAnd, p.op)
+				assert.Equal(t, []string{"addresses.city"}, p.paths)
+				assert.Nil(t, p.groups)
+			},
+		},
+		{
+			// directAnd [addresses.city, addresses.postcode]
+			name:  "scalar siblings in addresses → directAnd leaf",
+			paths: []string{"addresses.city", "addresses.postcode"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, directAnd, p.op)
+				assert.ElementsMatch(t, []string{"addresses.city", "addresses.postcode"}, p.paths)
+				assert.Nil(t, p.groups)
+			},
+		},
+		{
+			// idxLoopAnd("cars") [cars.tires.width, cars.accessories.type]
+			name:  "cars.tires.width + cars.accessories.type → idxLoopAnd on cars",
+			paths: []string{"cars.tires.width", "cars.accessories.type"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, idxLoopAnd, p.op)
+				assert.Equal(t, "cars", p.lcaPath)
+			},
+		},
+		{
+			// maskLeafAnd
+			//   ├── directAnd [addresses.city, addresses.postcode]
+			//   └── directAnd [cars.make, cars.colors]
+			name:  "addresses.city + addresses.postcode + cars.make + cars.colors → maskLeafAnd with two directAnd groups",
+			paths: []string{"addresses.city", "addresses.postcode", "cars.make", "cars.colors"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, maskLeafAnd, p.op)
+				require.Len(t, p.groups, 2)
+
+				// find each group by paths content
+				var addrGroup, carsGroup *resolutionPlan
+				for _, g := range p.groups {
+					for _, path := range g.paths {
+						if path != "" && path[:4] == "addr" {
+							addrGroup = g
+						} else if path != "" && path[:4] == "cars" {
+							carsGroup = g
+						}
+					}
+				}
+				require.NotNil(t, addrGroup)
+				require.NotNil(t, carsGroup)
+				assert.Equal(t, directAnd, addrGroup.op)
+				assert.ElementsMatch(t, []string{"addresses.city", "addresses.postcode"}, addrGroup.paths)
+				assert.Equal(t, directAnd, carsGroup.op)
+				assert.ElementsMatch(t, []string{"cars.make", "cars.colors"}, carsGroup.paths)
+			},
+		},
+		{
+			// maskLeafAnd
+			//   ├── directAnd          [addresses.city, addresses.postcode]
+			//   └── idxLoopAnd("cars") [cars.tires.width, cars.accessories.type]
+			name:  "addresses.city + addresses.postcode + cars.tires.width + cars.accessories.type → maskLeafAnd: directAnd + idxLoopAnd",
+			paths: []string{"addresses.city", "addresses.postcode", "cars.tires.width", "cars.accessories.type"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, maskLeafAnd, p.op)
+				require.Len(t, p.groups, 2)
+
+				var addrGroup, carsGroup *resolutionPlan
+				for _, g := range p.groups {
+					for _, path := range g.paths {
+						if len(path) > 4 && path[:4] == "addr" {
+							addrGroup = g
+						} else if len(path) > 4 && path[:4] == "cars" {
+							carsGroup = g
+						}
+					}
+				}
+				require.NotNil(t, addrGroup, "addresses group not found")
+				require.NotNil(t, carsGroup, "cars group not found")
+				assert.Equal(t, directAnd, addrGroup.op)
+				assert.Equal(t, idxLoopAnd, carsGroup.op)
+				assert.Equal(t, "cars", carsGroup.lcaPath)
+			},
+		},
+		{
+			// idxLoopAnd("cars") [cars.tires.width, cars.colors, cars.accessories.type]
+			name:  "cars.tires.width + cars.colors + cars.accessories.type → idxLoopAnd on cars",
+			paths: []string{"cars.tires.width", "cars.colors", "cars.accessories.type"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, idxLoopAnd, p.op)
+				assert.Equal(t, "cars", p.lcaPath)
+			},
+		},
+		{
+			// directAnd [owner.firstname, owner.lastname]
+			name:  "owner.firstname + owner.lastname → directAnd (scalar siblings in object)",
+			paths: []string{"owner.firstname", "owner.lastname"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, directAnd, p.op)
+				assert.ElementsMatch(t, []string{"owner.firstname", "owner.lastname"}, p.paths)
+			},
+		},
+		{
+			// maskLeafAnd
+			//   ├── directAnd [owner.firstname]
+			//   └── directAnd [addresses.city]
+			name:  "owner.firstname + addresses.city → maskLeafAnd with two groups",
+			paths: []string{"owner.firstname", "addresses.city"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, maskLeafAnd, p.op)
+				assert.Len(t, p.groups, 2)
+			},
+		},
+		{
+			// maskLeafAnd                          (same as sorted-order variant)
+			//   ├── directAnd [cars.make, cars.colors]
+			//   └── directAnd [addresses.city, addresses.postcode]
+			// Paths are interleaved — cars.make, addresses.city, cars.colors, addresses.postcode.
+			// The plan must still produce the same two groups regardless of input order.
+			name:  "interleaved cars and addresses paths → same grouping as sorted order",
+			paths: []string{"cars.make", "addresses.city", "cars.colors", "addresses.postcode"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, maskLeafAnd, p.op)
+				require.Len(t, p.groups, 2)
+
+				byFirst := map[string]*resolutionPlan{}
+				for _, g := range p.groups {
+					for _, path := range g.paths {
+						first, _, _ := strings.Cut(path, ".")
+						byFirst[first] = g
+						break
+					}
+				}
+
+				carsGroup := byFirst["cars"]
+				addrGroup := byFirst["addresses"]
+				require.NotNil(t, carsGroup, "cars group missing")
+				require.NotNil(t, addrGroup, "addresses group missing")
+
+				assert.Equal(t, directAnd, carsGroup.op)
+				assert.ElementsMatch(t, []string{"cars.make", "cars.colors"}, carsGroup.paths)
+				assert.Equal(t, directAnd, addrGroup.op)
+				assert.ElementsMatch(t, []string{"addresses.city", "addresses.postcode"}, addrGroup.paths)
+			},
+		},
+		{
+			// maskLeafAnd
+			//   ├── idxLoopAnd("cars") [cars.tires.width, cars.accessories.type]
+			//   └── directAnd          [addresses.city, addresses.postcode]
+			// Paths are interleaved: cars.tires.width, addresses.city, cars.accessories.type, addresses.postcode.
+			name:  "interleaved deep cars and addresses paths",
+			paths: []string{"cars.tires.width", "addresses.city", "cars.accessories.type", "addresses.postcode"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, maskLeafAnd, p.op)
+				require.Len(t, p.groups, 2)
+
+				byFirst := map[string]*resolutionPlan{}
+				for _, g := range p.groups {
+					for _, path := range g.paths {
+						first, _, _ := strings.Cut(path, ".")
+						byFirst[first] = g
+						break
+					}
+				}
+
+				carsGroup := byFirst["cars"]
+				addrGroup := byFirst["addresses"]
+				require.NotNil(t, carsGroup, "cars group missing")
+				require.NotNil(t, addrGroup, "addresses group missing")
+
+				assert.Equal(t, idxLoopAnd, carsGroup.op)
+				assert.Equal(t, "cars", carsGroup.lcaPath)
+				assert.Equal(t, directAnd, addrGroup.op)
+				assert.ElementsMatch(t, []string{"addresses.city", "addresses.postcode"}, addrGroup.paths)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan, err := buildResolutionPlan(tt.paths, objDT, props)
+			require.NoError(t, err)
+			tt.check(t, plan)
+		})
+	}
+}

--- a/adapters/repos/db/inverted/searcher_nested_plan_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_test.go
@@ -150,7 +150,7 @@ func TestNestedPathRelationship(t *testing.T) {
 		},
 
 		// --- diverge at root of object[] → maskLeafAnd ---
-		// root_idx already distinguishes root elements so MaskLeafPositions AND
+		// root_idx already distinguishes root elements so MaskLeaf AND
 		// is sufficient; no _idx metadata is emitted at root level.
 		{
 			name:  "diverge at root of object[] property",
@@ -299,7 +299,7 @@ func TestNestedPathsRelationshipMulti(t *testing.T) {
 		},
 		// Paths from two different sub-trees (addresses and cars) diverge at the
 		// root of a single object. LCA = root (DataTypeObject) → maskLeafAnd.
-		// MaskLeafPositions AND aligns on root=1 + docID giving correct doc-level
+		// MaskLeaf AND aligns on root=1 + docID giving correct doc-level
 		// results even though addresses and cars have disjoint leaf positions.
 		{
 			name:     "addresses.city + addresses.postcode + cars.make + cars.colors (mixed subtrees at root)",

--- a/adapters/repos/db/inverted/searcher_nested_plan_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_test.go
@@ -31,7 +31,7 @@ import (
 //	  tags:   text[]
 //	  cars:   object[] {
 //	    make:        text
-//	    tires:       object[] { width int; radiuses int[] }
+//	    tires:       object[] { width int; radiuses int[]; bolts object[]{size int}; caps object[]{color text} }
 //	    accessories: object[] { type text }
 //	    colors:      text[]
 //	  }
@@ -70,6 +70,21 @@ func correlationTestProps() []*models.NestedProperty {
 					NestedProperties: []*models.NestedProperty{
 						{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
 						{Name: "radiuses", DataType: schema.DataTypeIntArray.PropString(), IndexFilterable: &vTrue},
+						// bolts and caps are sub-arrays of tires, enabling nested idxLoopAnd tests.
+						{
+							Name:     "bolts",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{Name: "size", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+							},
+						},
+						{
+							Name:     "caps",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{Name: "color", DataType: schema.DataTypeText.PropString(), Tokenization: "word", IndexFilterable: &vTrue},
+							},
+						},
 					},
 				},
 				{
@@ -85,236 +100,344 @@ func correlationTestProps() []*models.NestedProperty {
 	}
 }
 
-func TestNestedPathRelationship(t *testing.T) {
+func TestBuildResolutionPlanLeafOps(t *testing.T) {
 	props := correlationTestProps()
 	objDT := schema.DataTypeObject
 	arrDT := schema.DataTypeObjectArray
 
+	// These cases all verify the top-level op (and lcaPath where relevant).
+	// Cross-subtree pairs produce an interior maskLeafAnd; same-subtree pairs
+	// produce a leaf or an idxLoopAnd.  The comments show the logical plan.
 	tests := []struct {
-		name     string
-		pathA    string
-		pathB    string
-		rootDT   schema.DataType
-		wantKind nestedCorrelation
-		wantLCA  string
+		name    string
+		pathA   string
+		pathB   string
+		rootDT  schema.DataType
+		wantOp  nestedCorrelation
+		wantLCA string
 	}{
-		// --- ancestor / descendant → directAnd ---
+		// ancestor / descendant
+		// → directAnd [addresses.city]  (identical paths: deduplicated to one)
 		{
 			name:  "identical paths",
 			pathA: "addresses.city", pathB: "addresses.city", rootDT: objDT,
-			wantKind: directAnd,
+			wantOp: directAnd,
 		},
+		// → directAnd [cars.make]  ("cars" ancestor excluded as superset)
 		{
 			name:  "one is prefix of other",
 			pathA: "cars", pathB: "cars.make", rootDT: objDT,
-			wantKind: directAnd,
+			wantOp: directAnd,
 		},
 
-		// --- scalar siblings at same array element → directAnd ---
+		// scalar siblings (inherit all parent-element positions) → directAnd
+		// → directAnd [addresses.city, addresses.postcode]
 		{
 			name:  "addresses.city and addresses.postcode (scalar siblings in object[])",
 			pathA: "addresses.city", pathB: "addresses.postcode", rootDT: objDT,
-			wantKind: directAnd,
+			wantOp: directAnd,
 		},
+		// → directAnd [owner.firstname, owner.lastname]
 		{
 			name:  "owner.firstname and owner.lastname (scalar siblings in object)",
 			pathA: "owner.firstname", pathB: "owner.lastname", rootDT: objDT,
-			wantKind: directAnd,
+			wantOp: directAnd,
 		},
+		// → directAnd [cars.make, cars.colors]
 		{
 			name:  "cars.make and cars.colors (scalar siblings in cars object[])",
 			pathA: "cars.make", pathB: "cars.colors", rootDT: objDT,
-			wantKind: directAnd,
+			wantOp: directAnd,
 		},
+		// → directAnd [cars.tires.width, cars.tires.radiuses]
 		{
 			name:  "tires.width and tires.radiuses (scalar siblings in tires object[])",
 			pathA: "cars.tires.width", pathB: "cars.tires.radiuses", rootDT: objDT,
-			wantKind: directAnd,
+			wantOp: directAnd,
 		},
 
-		// --- different subtrees in object[] → idxLoopAnd ---
+		// different sub-arrays under intermediate object[] → idxLoopAnd
+		// → idxLoopAnd("cars")
+		//       ├── directAnd [cars.tires.width]
+		//       └── directAnd [cars.colors]
 		{
 			name:  "cars.tires.width and cars.colors (tires is sub-array of cars)",
 			pathA: "cars.tires.width", pathB: "cars.colors", rootDT: objDT,
-			wantKind: idxLoopAnd, wantLCA: "cars",
+			wantOp: idxLoopAnd, wantLCA: "cars",
 		},
+		// make is scalar at cars level → superset of tires.width positions → directAnd
+		// → directAnd [cars.tires.width, cars.make]
 		{
-			name:  "cars.tires.width and cars.make (tires sub-array, make scalar)",
+			name:  "cars.tires.width and cars.make (tires sub-array, make scalar superset)",
 			pathA: "cars.tires.width", pathB: "cars.make", rootDT: objDT,
-			wantKind: directAnd, // make is scalar → inherits all car positions (superset)
+			wantOp: directAnd,
 		},
+		// → directAnd [cars.tires.radiuses, cars.tires.width]
 		{
-			name:  "cars.tires.radiuses and cars.tires.width diverge at tires level",
+			name:  "cars.tires.radiuses and cars.tires.width (both scalar at tires level)",
 			pathA: "cars.tires.radiuses", pathB: "cars.tires.width", rootDT: objDT,
-			wantKind: directAnd, // both scalar at tires element level
+			wantOp: directAnd,
 		},
 
-		// --- diverge at root of object[] → maskLeafAnd ---
-		// root_idx already distinguishes root elements so MaskLeaf AND
-		// is sufficient; no _idx metadata is emitted at root level.
+		// diverge at root of object[] → maskLeafAnd (root_idx aligns elements)
+		// → maskLeafAnd
+		//       ├── directAnd [addresses.city]
+		//       └── directAnd [cars.make]
 		{
 			name:  "diverge at root of object[] property",
 			pathA: "addresses.city", pathB: "cars.make", rootDT: arrDT,
-			wantKind: maskLeafAnd,
+			wantOp: maskLeafAnd,
 		},
 
-		// --- different root sub-properties of single object → maskLeafAnd ---
+		// diverge at root of single object → maskLeafAnd
+		// → maskLeafAnd
+		//       ├── directAnd [addresses.city]
+		//       └── directAnd [cars.make]
 		{
 			name:  "addresses.city and cars.make under single object",
 			pathA: "addresses.city", pathB: "cars.make", rootDT: objDT,
-			wantKind: maskLeafAnd,
+			wantOp: maskLeafAnd,
 		},
+		// → maskLeafAnd
+		//       ├── directAnd [owner.firstname]
+		//       └── directAnd [addresses.city]
 		{
 			name:  "owner.firstname and addresses.city under single object",
 			pathA: "owner.firstname", pathB: "addresses.city", rootDT: objDT,
-			wantKind: maskLeafAnd,
+			wantOp: maskLeafAnd,
 		},
 
-		// --- owner (object) with one path having sub-array → directAnd
-		//     (scalar firstname inherits all owner positions, superset of nicknames) ---
+		// firstname is scalar at owner level → superset of nicknames (text[]) → directAnd
+		// → directAnd [owner.firstname, owner.nicknames]
 		{
 			name:  "owner.firstname and owner.nicknames (scalar vs text[])",
 			pathA: "owner.firstname", pathB: "owner.nicknames", rootDT: objDT,
-			wantKind: directAnd,
+			wantOp: directAnd,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rel, err := nestedPathsRelationship([]string{tt.pathA, tt.pathB}, tt.rootDT, props)
+			// Use buildResolutionPlan with the pair; cross-subtree pairs produce a
+			// maskLeafAnd interior node — check only the top-level op.
+			plan, err := newResolutionPlanBuilder(tt.rootDT, props).build([]string{tt.pathA, tt.pathB})
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantKind, rel.kind)
-			if tt.wantKind == idxLoopAnd {
-				assert.Equal(t, tt.wantLCA, rel.lcaPath)
+			// For cross-subtree pairs the plan is an interior maskLeafAnd with groups;
+			// for same-subtree pairs it is a leaf. Either way the top-level op matches.
+			assert.Equal(t, tt.wantOp, plan.op)
+			if tt.wantOp == idxLoopAnd {
+				assert.Equal(t, tt.wantLCA, plan.lcaPath)
 			}
 		})
 	}
 }
 
-func TestNestedPathRelationshipInvalidDT(t *testing.T) {
+func TestBuildResolutionPlanNoPaths(t *testing.T) {
 	props := correlationTestProps()
-	_, err := nestedPathsRelationship([]string{"addresses.city", "cars.make"}, schema.DataTypeText, props)
+	_, err := newResolutionPlanBuilder(schema.DataTypeObject, props).build(nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no paths")
+}
+
+func TestBuildResolutionPlanInvalidDT(t *testing.T) {
+	props := correlationTestProps()
+	// cars.make is DataTypeText (non-nested); paths that go deeper share the
+	// same first-segment group, reaching the LCA check with a scalar LCA node.
+	_, err := newResolutionPlanBuilder(schema.DataTypeObject, props).
+		build([]string{"cars.make.foo", "cars.make.bar"})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "object or object[]")
 }
 
-func TestNestedPathsRelationshipMulti(t *testing.T) {
+func TestBuildResolutionPlanMultiPath(t *testing.T) {
 	props := correlationTestProps()
 	objDT := schema.DataTypeObject
 
 	tests := []struct {
-		name     string
-		paths    []string
-		wantKind nestedCorrelation
-		wantLCA  string
+		name    string
+		paths   []string
+		wantOp  nestedCorrelation
+		wantLCA string
 	}{
-		// --- degenerate cases ---
-		{name: "empty paths", paths: []string{}, wantKind: directAnd},
-		{name: "single path", paths: []string{"addresses.city"}, wantKind: directAnd},
+		// empty paths is a programming error → expect error, not a plan
+		// → directAnd [addresses.city]
+		{name: "single path", paths: []string{"addresses.city"}, wantOp: directAnd},
 
-		// --- cars.make + cars.colors + cars.accessories.type ---
-		// The scalar superset rule only holds for N=2. With N=3, make is a superset
-		// of each sibling, but colors ∩ accessories.type may be empty even when a
-		// document satisfies all three in the same car (e.g. Tesla: make={l4..l9},
-		// colors={l9}, accessories.type={l7} → direct AND gives {} incorrectly).
-		// idxLoopAnd on cars is required.
+		// N=3: scalar-superset rule (3b) only applies for N=2 → idxLoopAnd
+		// → idxLoopAnd("cars")
+		//       ├── directAnd [cars.make]
+		//       ├── directAnd [cars.colors]
+		//       └── directAnd [cars.accessories.type]
 		{
-			name:     "cars.make + cars.colors + cars.accessories.type (scalar rule N=2 only)",
-			paths:    []string{"cars.make", "cars.colors", "cars.accessories.type"},
-			wantKind: idxLoopAnd, wantLCA: "cars",
+			name:   "cars.make + cars.colors + cars.accessories.type (N=3, scalar rule N=2 only)",
+			paths:  []string{"cars.make", "cars.colors", "cars.accessories.type"},
+			wantOp: idxLoopAnd, wantLCA: "cars",
 		},
+		// → idxLoopAnd("cars")
+		//       ├── directAnd [cars.make]
+		//       ├── directAnd [cars.tires.width]
+		//       └── directAnd [cars.accessories.type]
 		{
-			name:     "cars.make + cars.tires.width + cars.accessories.type (scalar rule N=2 only)",
-			paths:    []string{"cars.make", "cars.tires.width", "cars.accessories.type"},
-			wantKind: idxLoopAnd, wantLCA: "cars",
+			name:   "cars.make + cars.tires.width + cars.accessories.type (N=3)",
+			paths:  []string{"cars.make", "cars.tires.width", "cars.accessories.type"},
+			wantOp: idxLoopAnd, wantLCA: "cars",
+		},
+		// → idxLoopAnd("cars")
+		//       ├── directAnd [cars.colors]
+		//       └── directAnd [cars.accessories.type]
+		{
+			name:   "cars.colors + cars.accessories.type (no scalar, accessories is sub-array)",
+			paths:  []string{"cars.colors", "cars.accessories.type"},
+			wantOp: idxLoopAnd, wantLCA: "cars",
+		},
+		// → idxLoopAnd("cars")
+		//       ├── directAnd [cars.tires.width]
+		//       └── directAnd [cars.accessories.type]
+		{
+			name:   "cars.tires.width + cars.accessories.type (two sub-arrays under cars)",
+			paths:  []string{"cars.tires.width", "cars.accessories.type"},
+			wantOp: idxLoopAnd, wantLCA: "cars",
+		},
+		// → idxLoopAnd("cars")
+		//       ├── directAnd [cars.tires.width]
+		//       ├── directAnd [cars.colors]
+		//       └── directAnd [cars.accessories.type]
+		{
+			name:   "cars.tires.width + cars.colors + cars.accessories.type (no scalar)",
+			paths:  []string{"cars.tires.width", "cars.colors", "cars.accessories.type"},
+			wantOp: idxLoopAnd, wantLCA: "cars",
+		},
+		// tires.width and tires.radiuses are scalar siblings → merged into one group
+		// → idxLoopAnd("cars")
+		//       ├── directAnd [cars.tires.width, cars.tires.radiuses]
+		//       ├── directAnd [cars.colors]
+		//       └── directAnd [cars.accessories.type]
+		{
+			name:   "cars.tires.width + cars.tires.radiuses + cars.colors + cars.accessories.type",
+			paths:  []string{"cars.tires.width", "cars.tires.radiuses", "cars.colors", "cars.accessories.type"},
+			wantOp: idxLoopAnd, wantLCA: "cars",
 		},
 
-		// --- without a scalar at cars level → idxLoopAnd on cars ---
-		// colors is text[] (not a further object[]), accessories is object[]
-		// → at least one sub-array present without a scalar rescue
-		{
-			name:     "cars.colors + cars.accessories.type (no scalar, accessories is sub-array)",
-			paths:    []string{"cars.colors", "cars.accessories.type"},
-			wantKind: idxLoopAnd, wantLCA: "cars",
-		},
-		// tires and accessories are both sub-arrays under cars
-		{
-			name:     "cars.tires.width + cars.accessories.type (two sub-arrays under cars)",
-			paths:    []string{"cars.tires.width", "cars.accessories.type"},
-			wantKind: idxLoopAnd, wantLCA: "cars",
-		},
-		// all three without make: tires, colors, accessories
-		{
-			name:     "cars.tires.width + cars.colors + cars.accessories.type (no scalar)",
-			paths:    []string{"cars.tires.width", "cars.colors", "cars.accessories.type"},
-			wantKind: idxLoopAnd, wantLCA: "cars",
-		},
-		// four paths at cars level, none scalar
-		{
-			name:     "cars.tires.width + cars.tires.radiuses + cars.colors + cars.accessories.type",
-			paths:    []string{"cars.tires.width", "cars.tires.radiuses", "cars.colors", "cars.accessories.type"},
-			wantKind: idxLoopAnd, wantLCA: "cars",
-		},
-
-		// --- scalar rescues within tires sub-array ---
 		// tires.width is scalar at tires level → superset of radiuses → directAnd
+		// → directAnd [cars.tires.width, cars.tires.radiuses]
 		{
-			name:     "cars.tires.width + cars.tires.radiuses (width is scalar at tires level)",
-			paths:    []string{"cars.tires.width", "cars.tires.radiuses"},
-			wantKind: directAnd,
+			name:   "cars.tires.width + cars.tires.radiuses (scalar at tires level)",
+			paths:  []string{"cars.tires.width", "cars.tires.radiuses"},
+			wantOp: directAnd,
 		},
-		// adding tires.width to a cross-cars pair still requires idxLoopAnd on cars
+		// tires pair is scalar-rescued; accessories diverges under cars → idxLoopAnd
+		// → idxLoopAnd("cars")
+		//       ├── directAnd [cars.tires.width, cars.tires.radiuses]
+		//       └── directAnd [cars.accessories.type]
 		{
-			name:     "cars.tires.width + cars.tires.radiuses + cars.accessories.type (LCA still cars)",
-			paths:    []string{"cars.tires.width", "cars.tires.radiuses", "cars.accessories.type"},
-			wantKind: idxLoopAnd, wantLCA: "cars",
-		},
-
-		// --- addresses level ---
-		// city is scalar → superset of postcode and numbers → directAnd
-		{
-			name:     "addresses.city + addresses.postcode + addresses.numbers (city is scalar)",
-			paths:    []string{"addresses.city", "addresses.postcode", "addresses.numbers"},
-			wantKind: directAnd,
-		},
-		// postcode is also scalar → directAnd even without city
-		{
-			name:     "addresses.postcode + addresses.numbers (postcode is scalar)",
-			paths:    []string{"addresses.postcode", "addresses.numbers"},
-			wantKind: directAnd,
+			name:   "cars.tires.width + cars.tires.radiuses + cars.accessories.type (LCA still cars)",
+			paths:  []string{"cars.tires.width", "cars.tires.radiuses", "cars.accessories.type"},
+			wantOp: idxLoopAnd, wantLCA: "cars",
 		},
 
-		// --- cross-subtree at root (maskLeafAnd) ---
+		// city is scalar at addresses level → superset of postcode and numbers → directAnd
+		// → directAnd [addresses.city, addresses.postcode, addresses.numbers]
 		{
-			name:     "owner.firstname + addresses.city + cars.make (diverge at root)",
-			paths:    []string{"owner.firstname", "addresses.city", "cars.make"},
-			wantKind: maskLeafAnd,
+			name:   "addresses.city + addresses.postcode + addresses.numbers (city is scalar)",
+			paths:  []string{"addresses.city", "addresses.postcode", "addresses.numbers"},
+			wantOp: directAnd,
 		},
-		// "name" is a scalar at root level but scalar rule only applies for N=2;
-		// addresses goes through an object[], so maskLeafAnd for the root.
+		// → directAnd [addresses.postcode, addresses.numbers]
 		{
-			name:     "name + owner.firstname + addresses.city + cars.make (four subtrees at root)",
-			paths:    []string{"name", "owner.firstname", "addresses.city", "cars.make"},
-			wantKind: maskLeafAnd,
+			name:   "addresses.postcode + addresses.numbers (postcode is scalar)",
+			paths:  []string{"addresses.postcode", "addresses.numbers"},
+			wantOp: directAnd,
 		},
-		// Paths from two different sub-trees (addresses and cars) diverge at the
-		// root of a single object. LCA = root (DataTypeObject) → maskLeafAnd.
-		// MaskLeaf AND aligns on root=1 + docID giving correct doc-level
-		// results even though addresses and cars have disjoint leaf positions.
+
+		// "cars" ancestor excluded as superset; descendants need idxLoopAnd
+		// → idxLoopAnd("cars")
+		//       ├── directAnd [cars.tires.width]
+		//       └── directAnd [cars.accessories.type]
 		{
-			name:     "addresses.city + addresses.postcode + cars.make + cars.colors (mixed subtrees at root)",
-			paths:    []string{"addresses.city", "addresses.postcode", "cars.make", "cars.colors"},
-			wantKind: maskLeafAnd,
+			name:   "cars + cars.tires.width + cars.accessories.type — ancestor excluded",
+			paths:  []string{"cars", "cars.tires.width", "cars.accessories.type"},
+			wantOp: idxLoopAnd, wantLCA: "cars",
+		},
+		// "cars" ancestor excluded; only cars.make remains → directAnd
+		// → directAnd [cars.make]
+		{
+			name:   "cars + cars.make (ancestor path only)",
+			paths:  []string{"cars", "cars.make"},
+			wantOp: directAnd,
+		},
+
+		// accessories.type and accessories.color must be in the same accessories element,
+		// not just the same car → rem sub-grouping puts them in one directAnd sub-plan
+		// → idxLoopAnd("cars")
+		//       ├── directAnd [cars.tires.width]
+		//       └── directAnd [cars.accessories.type, cars.accessories.color]
+		{
+			name:   "cars.tires.width + cars.accessories.type + cars.accessories.color",
+			paths:  []string{"cars.tires.width", "cars.accessories.type", "cars.accessories.color"},
+			wantOp: idxLoopAnd, wantLCA: "cars",
+		},
+
+		// bolts and caps both live under cars.tires → LCA is "cars.tires" directly,
+		// so a single (non-nested) idxLoopAnd at that combined path is produced
+		// → idxLoopAnd("cars.tires")
+		//       ├── directAnd [cars.tires.bolts.size]
+		//       └── directAnd [cars.tires.caps.color]
+		{
+			name:   "cars.tires.bolts.size + cars.tires.caps.color — idxLoopAnd at cars.tires",
+			paths:  []string{"cars.tires.bolts.size", "cars.tires.caps.color"},
+			wantOp: idxLoopAnd, wantLCA: "cars.tires",
+		},
+		// adding accessories.type forces divergence at the cars level: tires and
+		// accessories are different subtrees → LCA = "cars". The tires sub-group
+		// itself diverges under tires (bolts vs caps) → nested idxLoopAnd("tires")
+		// → idxLoopAnd("cars")
+		//       ├── idxLoopAnd("tires")
+		//       │       ├── directAnd [cars.tires.bolts.size]
+		//       │       └── directAnd [cars.tires.caps.color]
+		//       └── directAnd [cars.accessories.type]
+		{
+			name:   "cars.tires.bolts.size + cars.tires.caps.color + cars.accessories.type — nested idxLoopAnd",
+			paths:  []string{"cars.tires.bolts.size", "cars.tires.caps.color", "cars.accessories.type"},
+			wantOp: idxLoopAnd, wantLCA: "cars",
+		},
+
+		// cross-subtree at root → maskLeafAnd
+		// → maskLeafAnd
+		//       ├── directAnd [owner.firstname]
+		//       ├── directAnd [addresses.city]
+		//       └── directAnd [cars.make]
+		{
+			name:   "owner.firstname + addresses.city + cars.make (diverge at root)",
+			paths:  []string{"owner.firstname", "addresses.city", "cars.make"},
+			wantOp: maskLeafAnd,
+		},
+		// → maskLeafAnd
+		//       ├── directAnd [name]
+		//       ├── directAnd [owner.firstname]
+		//       ├── directAnd [addresses.city]
+		//       └── directAnd [cars.make]
+		{
+			name:   "name + owner.firstname + addresses.city + cars.make (four subtrees)",
+			paths:  []string{"name", "owner.firstname", "addresses.city", "cars.make"},
+			wantOp: maskLeafAnd,
+		},
+		// → maskLeafAnd
+		//       ├── directAnd [addresses.city, addresses.postcode]
+		//       └── directAnd [cars.make, cars.colors]
+		{
+			name:   "addresses.city + addresses.postcode + cars.make + cars.colors (mixed subtrees)",
+			paths:  []string{"addresses.city", "addresses.postcode", "cars.make", "cars.colors"},
+			wantOp: maskLeafAnd,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			rel, err := nestedPathsRelationship(tt.paths, objDT, props)
+			plan, err := newResolutionPlanBuilder(objDT, props).build(tt.paths)
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantKind, rel.kind)
-			if tt.wantKind == idxLoopAnd {
-				assert.Equal(t, tt.wantLCA, rel.lcaPath)
+			assert.Equal(t, tt.wantOp, plan.op)
+			if tt.wantOp == idxLoopAnd {
+				assert.Equal(t, tt.wantLCA, plan.lcaPath)
 			}
 		})
 	}
@@ -330,7 +453,7 @@ func TestBuildResolutionPlan(t *testing.T) {
 		check func(t *testing.T, plan *resolutionPlan)
 	}{
 		{
-			// directAnd [addresses.city]
+			// → directAnd [addresses.city]
 			name:  "single path",
 			paths: []string{"addresses.city"},
 			check: func(t *testing.T, p *resolutionPlan) {
@@ -340,7 +463,7 @@ func TestBuildResolutionPlan(t *testing.T) {
 			},
 		},
 		{
-			// directAnd [addresses.city, addresses.postcode]
+			// → directAnd [addresses.city, addresses.postcode]
 			name:  "scalar siblings in addresses → directAnd leaf",
 			paths: []string{"addresses.city", "addresses.postcode"},
 			check: func(t *testing.T, p *resolutionPlan) {
@@ -350,7 +473,9 @@ func TestBuildResolutionPlan(t *testing.T) {
 			},
 		},
 		{
-			// idxLoopAnd("cars") [cars.tires.width, cars.accessories.type]
+			// → idxLoopAnd("cars")
+			//       ├── directAnd [cars.tires.width]
+			//       └── directAnd [cars.accessories.type]
 			name:  "cars.tires.width + cars.accessories.type → idxLoopAnd on cars",
 			paths: []string{"cars.tires.width", "cars.accessories.type"},
 			check: func(t *testing.T, p *resolutionPlan) {
@@ -359,9 +484,9 @@ func TestBuildResolutionPlan(t *testing.T) {
 			},
 		},
 		{
-			// maskLeafAnd
-			//   ├── directAnd [addresses.city, addresses.postcode]
-			//   └── directAnd [cars.make, cars.colors]
+			// → maskLeafAnd
+			//       ├── directAnd [addresses.city, addresses.postcode]
+			//       └── directAnd [cars.make, cars.colors]
 			name:  "addresses.city + addresses.postcode + cars.make + cars.colors → maskLeafAnd with two directAnd groups",
 			paths: []string{"addresses.city", "addresses.postcode", "cars.make", "cars.colors"},
 			check: func(t *testing.T, p *resolutionPlan) {
@@ -388,9 +513,11 @@ func TestBuildResolutionPlan(t *testing.T) {
 			},
 		},
 		{
-			// maskLeafAnd
-			//   ├── directAnd          [addresses.city, addresses.postcode]
-			//   └── idxLoopAnd("cars") [cars.tires.width, cars.accessories.type]
+			// → maskLeafAnd
+			//       ├── directAnd           [addresses.city, addresses.postcode]
+			//       └── idxLoopAnd("cars")
+			//               ├── directAnd   [cars.tires.width]
+			//               └── directAnd   [cars.accessories.type]
 			name:  "addresses.city + addresses.postcode + cars.tires.width + cars.accessories.type → maskLeafAnd: directAnd + idxLoopAnd",
 			paths: []string{"addresses.city", "addresses.postcode", "cars.tires.width", "cars.accessories.type"},
 			check: func(t *testing.T, p *resolutionPlan) {
@@ -399,32 +526,128 @@ func TestBuildResolutionPlan(t *testing.T) {
 
 				var addrGroup, carsGroup *resolutionPlan
 				for _, g := range p.groups {
-					for _, path := range g.paths {
-						if len(path) > 4 && path[:4] == "addr" {
-							addrGroup = g
-						} else if len(path) > 4 && path[:4] == "cars" {
-							carsGroup = g
-						}
+					if g.op == idxLoopAnd && g.lcaPath == "cars" {
+						carsGroup = g
+					} else if g.op == directAnd {
+						addrGroup = g
 					}
 				}
 				require.NotNil(t, addrGroup, "addresses group not found")
 				require.NotNil(t, carsGroup, "cars group not found")
 				assert.Equal(t, directAnd, addrGroup.op)
+				assert.ElementsMatch(t, []string{"addresses.city", "addresses.postcode"}, addrGroup.paths)
 				assert.Equal(t, idxLoopAnd, carsGroup.op)
 				assert.Equal(t, "cars", carsGroup.lcaPath)
 			},
 		},
 		{
-			// idxLoopAnd("cars") [cars.tires.width, cars.colors, cars.accessories.type]
-			name:  "cars.tires.width + cars.colors + cars.accessories.type → idxLoopAnd on cars",
+			// → idxLoopAnd("cars")
+			//       ├── directAnd [cars.tires.width]
+			//       ├── directAnd [cars.colors]
+			//       └── directAnd [cars.accessories.type]
+			name:  "cars.tires.width + cars.colors + cars.accessories.type → idxLoopAnd on cars with groups",
 			paths: []string{"cars.tires.width", "cars.colors", "cars.accessories.type"},
 			check: func(t *testing.T, p *resolutionPlan) {
 				assert.Equal(t, idxLoopAnd, p.op)
 				assert.Equal(t, "cars", p.lcaPath)
+				// Three distinct rem first-segments → three sub-plans.
+				require.Len(t, p.groups, 3)
+				assert.Nil(t, p.paths)
+				for _, g := range p.groups {
+					assert.Equal(t, directAnd, g.op)
+					assert.Len(t, g.paths, 1)
+				}
 			},
 		},
 		{
-			// directAnd [owner.firstname, owner.lastname]
+			// accessories.type and accessories.color must be in the same accessories
+			// element — rem sub-grouping puts them in one directAnd plan.
+			// Sub-plans carry the original full paths.
+			// → idxLoopAnd("cars")
+			//       ├── directAnd [cars.tires.width]
+			//       └── directAnd [cars.accessories.type, cars.accessories.color]
+			name:  "cars.tires.width + cars.accessories.type + cars.accessories.color → idxLoopAnd with two groups",
+			paths: []string{"cars.tires.width", "cars.accessories.type", "cars.accessories.color"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, idxLoopAnd, p.op)
+				assert.Equal(t, "cars", p.lcaPath)
+				require.Len(t, p.groups, 2)
+				assert.Nil(t, p.paths)
+
+				// Identify groups by their path contents (not first-segment cut,
+				// since full paths all start with "cars.").
+				var tiresGroup, accGroup *resolutionPlan
+				for _, g := range p.groups {
+					if assert.Equal(t, directAnd, g.op) {
+						if len(g.paths) == 1 {
+							tiresGroup = g
+						} else {
+							accGroup = g
+						}
+					}
+				}
+				require.NotNil(t, tiresGroup, "tires group missing")
+				require.NotNil(t, accGroup, "accessories group missing")
+				assert.ElementsMatch(t, []string{"cars.tires.width"}, tiresGroup.paths)
+				assert.ElementsMatch(t, []string{"cars.accessories.type", "cars.accessories.color"}, accGroup.paths)
+			},
+		},
+		{
+			// Both paths share LCA "cars.tires" → single idxLoopAnd at that path.
+			// No nesting: the loop iterates _idx.cars.tires[N] entries directly.
+			// → idxLoopAnd("cars.tires")
+			//       ├── directAnd [cars.tires.bolts.size]
+			//       └── directAnd [cars.tires.caps.color]
+			name:  "cars.tires.bolts.size + cars.tires.caps.color → idxLoopAnd at cars.tires",
+			paths: []string{"cars.tires.bolts.size", "cars.tires.caps.color"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, idxLoopAnd, p.op)
+				assert.Equal(t, "cars.tires", p.lcaPath)
+				require.Len(t, p.groups, 2)
+				for _, g := range p.groups {
+					assert.Equal(t, directAnd, g.op)
+					assert.Len(t, g.paths, 1)
+				}
+			},
+		},
+		{
+			// accessories.type forces divergence at the cars level; the tires sub-group
+			// diverges further under tires (bolts vs caps) → nested idxLoopAnd("tires")
+			// inside idxLoopAnd("cars"). Sub-plans carry original full paths.
+			// → idxLoopAnd("cars")
+			//       ├── idxLoopAnd("tires")
+			//       │       ├── directAnd [cars.tires.bolts.size]
+			//       │       └── directAnd [cars.tires.caps.color]
+			//       └── directAnd [cars.accessories.type]
+			name:  "cars.tires.bolts.size + cars.tires.caps.color + cars.accessories.type → nested idxLoopAnd",
+			paths: []string{"cars.tires.bolts.size", "cars.tires.caps.color", "cars.accessories.type"},
+			check: func(t *testing.T, p *resolutionPlan) {
+				assert.Equal(t, idxLoopAnd, p.op)
+				assert.Equal(t, "cars", p.lcaPath)
+				require.Len(t, p.groups, 2)
+
+				var tiresLoop, accGroup *resolutionPlan
+				for _, g := range p.groups {
+					if g.op == idxLoopAnd {
+						tiresLoop = g
+					} else {
+						accGroup = g
+					}
+				}
+				require.NotNil(t, tiresLoop, "tires idxLoopAnd missing")
+				require.NotNil(t, accGroup, "accessories directAnd missing")
+
+				assert.Equal(t, "tires", tiresLoop.lcaPath)
+				require.Len(t, tiresLoop.groups, 2)
+				for _, g := range tiresLoop.groups {
+					assert.Equal(t, directAnd, g.op)
+				}
+				assert.Equal(t, directAnd, accGroup.op)
+				assert.ElementsMatch(t, []string{"cars.accessories.type"}, accGroup.paths)
+			},
+		},
+		{
+			// → directAnd [owner.firstname, owner.lastname]
 			name:  "owner.firstname + owner.lastname → directAnd (scalar siblings in object)",
 			paths: []string{"owner.firstname", "owner.lastname"},
 			check: func(t *testing.T, p *resolutionPlan) {
@@ -433,9 +656,9 @@ func TestBuildResolutionPlan(t *testing.T) {
 			},
 		},
 		{
-			// maskLeafAnd
-			//   ├── directAnd [owner.firstname]
-			//   └── directAnd [addresses.city]
+			// → maskLeafAnd
+			//       ├── directAnd [owner.firstname]
+			//       └── directAnd [addresses.city]
 			name:  "owner.firstname + addresses.city → maskLeafAnd with two groups",
 			paths: []string{"owner.firstname", "addresses.city"},
 			check: func(t *testing.T, p *resolutionPlan) {
@@ -444,11 +667,10 @@ func TestBuildResolutionPlan(t *testing.T) {
 			},
 		},
 		{
-			// maskLeafAnd                          (same as sorted-order variant)
-			//   ├── directAnd [cars.make, cars.colors]
-			//   └── directAnd [addresses.city, addresses.postcode]
-			// Paths are interleaved — cars.make, addresses.city, cars.colors, addresses.postcode.
-			// The plan must still produce the same two groups regardless of input order.
+			// Paths are interleaved but grouping is order-independent.
+			// → maskLeafAnd
+			//       ├── directAnd [cars.make, cars.colors]
+			//       └── directAnd [addresses.city, addresses.postcode]
 			name:  "interleaved cars and addresses paths → same grouping as sorted order",
 			paths: []string{"cars.make", "addresses.city", "cars.colors", "addresses.postcode"},
 			check: func(t *testing.T, p *resolutionPlan) {
@@ -476,27 +698,28 @@ func TestBuildResolutionPlan(t *testing.T) {
 			},
 		},
 		{
-			// maskLeafAnd
-			//   ├── idxLoopAnd("cars") [cars.tires.width, cars.accessories.type]
-			//   └── directAnd          [addresses.city, addresses.postcode]
-			// Paths are interleaved: cars.tires.width, addresses.city, cars.accessories.type, addresses.postcode.
+			// Paths are interleaved but grouping is order-independent.
+			// → maskLeafAnd
+			//       ├── directAnd           [addresses.city, addresses.postcode]
+			//       └── idxLoopAnd("cars")
+			//               ├── directAnd   [cars.tires.width]
+			//               └── directAnd   [cars.accessories.type]
 			name:  "interleaved deep cars and addresses paths",
 			paths: []string{"cars.tires.width", "addresses.city", "cars.accessories.type", "addresses.postcode"},
 			check: func(t *testing.T, p *resolutionPlan) {
 				assert.Equal(t, maskLeafAnd, p.op)
 				require.Len(t, p.groups, 2)
 
-				byFirst := map[string]*resolutionPlan{}
+				// Identify groups by op+lcaPath rather than path prefix, since
+				// sub-plans now carry LCA-stripped paths (e.g. "tires.width").
+				var carsGroup, addrGroup *resolutionPlan
 				for _, g := range p.groups {
-					for _, path := range g.paths {
-						first, _, _ := strings.Cut(path, ".")
-						byFirst[first] = g
-						break
+					if g.op == idxLoopAnd && g.lcaPath == "cars" {
+						carsGroup = g
+					} else if g.op == directAnd {
+						addrGroup = g
 					}
 				}
-
-				carsGroup := byFirst["cars"]
-				addrGroup := byFirst["addresses"]
 				require.NotNil(t, carsGroup, "cars group missing")
 				require.NotNil(t, addrGroup, "addresses group missing")
 
@@ -510,7 +733,7 @@ func TestBuildResolutionPlan(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			plan, err := buildResolutionPlan(tt.paths, objDT, props)
+			plan, err := newResolutionPlanBuilder(objDT, props).build(tt.paths)
 			require.NoError(t, err)
 			tt.check(t, plan)
 		})


### PR DESCRIPTION
## Nested object filtering — Part 6: correlated AND resolution plan and executor

  Sixth PR in the nested object filtering series, building on Part 5 (filter validation, execution, and integration tests). This PR   implements the position-aware correlated AND resolution needed to ensure `addresses.city = "Berlin" AND addresses.postcode = "10115"` matches only documents where both conditions are met by the **same** array element.

  ### What's in this PR

  **Raw position fetch** — extracts a shared `fetchBitmap` helper from `fetchDocIDs` so the correlated resolution path can obtain raw position bitmaps (`root|leaf|docID`) without stripping them. `fetchRawPositions` returns positions intact for use by the plan executor.

  **Resolution plan builder** (`searcher_nested_plan.go`) — classifies N relative nested filter paths and builds a recursive
  `resolutionPlan` tree:
  - `directAnd` — positions naturally aligned (scalar siblings, ancestor/descendant)
  - `maskLeafAnd` — cross-subtree or root-level divergence; zeros leaf bits before AND to align on root+docID
  - `idxLoopAnd` — intermediate `object[]` where leaf_idx encodes element identity; iterates `_idx.{path}[N]` meta entries to enforce same-element semantics

  Example plan for `addresses.city + addresses.postcode + cars.tires.width + cars.accessories.type`:
```  
maskLeafAnd
  ├── directAnd [addresses.city, addresses.postcode]
  └── idxLoopAnd("cars") [cars.tires.width, cars.accessories.type]
```

  **Bitmap helpers** (`nested/bitmap.go`) — new allocation-efficient operations including `MaskLeaf`, `MaskRootLeaf`, `AndAll`, `AndAllMaskLeaf`, `MaskLeafAnd`, and `AndWithMaskLeaf`, each designed to minimise intermediate bitmap allocations using sroar's fused mask+AND operations.

  **Resolution plan executor** (`searcher_nested_executor.go`) — executes `resolutionPlan` trees against pre-fetched position bitmaps:
  - `directAnd`: plain bitmap AND (exact position match)
  - `maskLeafAnd`: zeros leaf bits then ANDs, aligning on root+docID
  - `idxLoopAnd`: iterates `_idx.{path}[N]` cursor with four optimisations — cardinality-sorted conditions for early exit, per-element pre-filter (one alloc to skip K-condition processing), global pre-filter as AND of all leaf-masked conditions, and early termination when result covers all possible matches

  **Plan builder refactor** — resolutionPlanBuilder restructured as a struct with methods; segment manipulation happens once at `build()` entry; schema context threaded downward to avoid root re-traversal on recursive calls; nested `idxLoopAnd` support added for conditions in separate sub-arrays (e.g. `cars.tires.bolts` vs `cars.tires.caps`).

  ### What comes next

  Part 7 will wire the resolution plan and executor into `resolveDocIDs`, replacing the current per-condition independent lookup with the position-aware correlated resolution for AND filters on the same nested property.

  ## Test plan

  - [ ] `go test ./adapters/repos/db/inverted/...` — plan builder and executor unit tests pass
  - [ ] `go test -tags integrationTest ./adapters/repos/db/inverted/...` — executor integration tests with real lsmkv buckets pass