### PR TITLE
Nested object filtering — Part 7: correlated AND resolution

### DIFF
--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -46,12 +46,13 @@ type propValuePair struct {
 	// isNested marks a filter on a nested (object/object[]) property. When set:
 	//   - prop is the top-level property name (used for bucket name resolution)
 	//   - value is the bare encoded value (without prefix)
-	//   - nestedKeyPrefix is hash8(dottedPath), used to bound cursor reads and
-	//     to construct the full bucket key: nestedKeyPrefix+value
+	//   - nestedRelPath is the dot-notation path relative to prop
+	//     (e.g. "city" or "owner.firstname"); hash8(nestedRelPath) gives the
+	//     key prefix used to bound cursor reads and build the bucket key
 	//   - the result bitmap contains positions that are stripped to docIDs
-	isNested        bool
-	nestedKeyPrefix []byte
-	Class           *models.Class // The schema
+	isNested      bool
+	nestedRelPath string
+	Class         *models.Class // The schema
 }
 
 func newPropValuePair(class *models.Class) (*propValuePair, error) {

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -25,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
 )
 
 type propValuePair struct {
@@ -52,7 +54,13 @@ type propValuePair struct {
 	//   - the result bitmap contains positions that are stripped to docIDs
 	isNested      bool
 	nestedRelPath string
-	Class         *models.Class // The schema
+	// childrenFromTokenization is true when this compound AND was produced by
+	// multi-token text tokenization (e.g. city = "New York" produces
+	// AND[token:"new", token:"york"]). All children are tokens of the same
+	// property value and must share the same leaf position, so they are
+	// combined with raw AndAll rather than MaskLeafAndAll.
+	childrenFromTokenization bool
+	Class                    *models.Class // The schema
 }
 
 func newPropValuePair(class *models.Class) (*propValuePair, error) {
@@ -73,7 +81,35 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 
 	ln := len(pv.children)
 	switch pv.operator {
-	case filters.OperatorAnd, filters.OperatorOr:
+	case filters.OperatorAnd:
+		switch ln {
+		case 0:
+			return nil, fmt.Errorf("no children for operator %q", pv.operator.Name())
+		case 1:
+			return pv.children[0].resolveDocIDs(ctx, s, limit)
+		default:
+			if groups := pv.extractNestedCorrelatedGroups(); groups != nil {
+				// Resolve nested conditions with position-aware same-element semantics.
+				// pv.children now holds only the flat conditions (if any).
+				result, err := pv.resolveNestedCorrelatedAnd(ctx, s, groups)
+				if err != nil {
+					return nil, err
+				}
+				if len(pv.children) == 0 {
+					return result, nil
+				}
+				// AND in remaining flat conditions via the existing AND machinery.
+				remainingResult, err := pv.resolveDocIDsAndOr(ctx, s)
+				if err != nil {
+					return nil, err
+				}
+				result.docIDs.And(remainingResult.docIDs)
+				return result, nil
+			}
+			return pv.resolveDocIDsAndOr(ctx, s)
+		}
+
+	case filters.OperatorOr:
 		switch ln {
 		case 0:
 			return nil, fmt.Errorf("no children for operator %q", pv.operator.Name())
@@ -416,4 +452,154 @@ func (pv *propValuePair) getBucketName() string {
 		return helpers.BucketSearchableFromPropNameLSM(pv.prop)
 	}
 	return ""
+}
+
+// extractNestedCorrelatedGroups classifies pv's AND children for correlated
+// nested resolution. Nested conditions are grouped by root property name;
+// flat (non-nested) conditions remain in pv.children so that resolveDocIDsAndOr
+// can be called on the same instance if any are left.
+//
+// Returns nil when no nested groups were found (pv.children is unchanged).
+// On a non-nil return pv.children contains only the flat conditions.
+func (pv *propValuePair) extractNestedCorrelatedGroups() map[string][]*propValuePair {
+	if len(pv.children) == 0 {
+		return nil
+	}
+	groups := make(map[string][]*propValuePair)
+	var flat []*propValuePair
+	for _, child := range pv.children {
+		switch {
+		case child.isNested:
+			groups[child.prop] = append(groups[child.prop], child)
+		case child.operator == filters.OperatorAnd && child.childrenFromTokenization && len(child.children) > 0:
+			// Tokenization-produced compound AND (e.g. city = "New York" →
+			// AND[token:"new", token:"york"]): keep as a unit in its prop's group.
+			// childrenFromTokenization guarantees all tokens share one property.
+			groups[child.children[0].prop] = append(groups[child.children[0].prop], child)
+		default:
+			// Non-nested condition: keep in pv.children for regular resolution.
+			flat = append(flat, child)
+		}
+	}
+	if len(groups) == 0 {
+		return nil
+	}
+	pv.children = flat
+	return groups
+}
+
+// positionBitmaps groups pre-fetched raw position bitmaps for a single nested path,
+// split by origin so the executor can apply the correct combining strategy:
+//   - tokens: from childrenFromTokenization compound ANDs (multi-token text);
+//     combined with AndAll — all tokens must share the same leaf position.
+//   - independent: from direct leaf conditions (e.g. scalar array values);
+//     combined with MaskLeafAndAll when there are multiple — values may be at
+//     different leaf positions within the same parent element.
+type positionBitmaps struct {
+	tokens      []*sroar.Bitmap
+	independent []*sroar.Bitmap
+}
+
+// resolveNestedCorrelatedAnd resolves only the nested correlated groups. For
+// each prop group it builds a resolution plan and executes it; the per-group
+// docID results are AND'd together. Flat (non-nested) conditions are not
+// handled here — the caller is responsible for combining this result with any
+// remaining conditions via the existing resolveDocIDsAndOr machinery.
+func (pv *propValuePair) resolveNestedCorrelatedAnd(
+	ctx context.Context,
+	s *Searcher,
+	groups map[string][]*propValuePair,
+) (*docBitmap, error) {
+	var result *sroar.Bitmap
+
+	for prop, children := range groups {
+		dbm, err := pv.resolveNestedCorrelatedAndGroup(ctx, s, prop, children)
+		if err != nil {
+			return nil, err
+		}
+		if result == nil {
+			result = dbm.docIDs
+		} else {
+			result.And(dbm.docIDs)
+		}
+	}
+
+	if result == nil {
+		empty := newDocBitmap()
+		return &empty, nil
+	}
+	out := newDocBitmap()
+	out.docIDs = result
+	return &out, nil
+}
+
+// resolveNestedCorrelatedAndGroup resolves one prop group using position-aware
+// correlation. It builds a resolutionPlan for the group's paths, pre-computes
+// raw position bitmaps, and executes the plan to enforce same-element semantics.
+func (pv *propValuePair) resolveNestedCorrelatedAndGroup(
+	ctx context.Context,
+	s *Searcher,
+	prop string,
+	children []*propValuePair,
+) (*docBitmap, error) {
+	// Build positionsByPath: fetch raw position bitmaps per pvp and route into
+	// the correct bucket slot based on origin (token vs independent).
+	positionsByPath := make(map[string]*positionBitmaps, len(children))
+	pathOrder := make([]string, 0, len(children))
+
+	fetchAndRoute := func(leaf *propValuePair, isToken bool) error {
+		dbm, err := leaf.fetchRawPositions(ctx, s, 0)
+		if err != nil {
+			return err
+		}
+		path := leaf.nestedRelPath
+		if _, exists := positionsByPath[path]; !exists {
+			positionsByPath[path] = &positionBitmaps{}
+			pathOrder = append(pathOrder, path)
+		}
+		if isToken {
+			positionsByPath[path].tokens = append(positionsByPath[path].tokens, dbm.docIDs)
+		} else {
+			positionsByPath[path].independent = append(positionsByPath[path].independent, dbm.docIDs)
+		}
+		return nil
+	}
+
+	for _, child := range children {
+		if child.isNested {
+			if err := fetchAndRoute(child, false); err != nil {
+				return nil, fmt.Errorf("nested correlated AND: fetch bitmap for %q: %w", child.nestedRelPath, err)
+			}
+		} else {
+			// Tokenization compound AND: grandchildren are tokens of the same value.
+			for _, gc := range child.children {
+				if err := fetchAndRoute(gc, true); err != nil {
+					return nil, fmt.Errorf("nested correlated AND: fetch bitmap for %q: %w", gc.nestedRelPath, err)
+				}
+			}
+		}
+	}
+
+	// Find the root property's schema to build the resolution plan.
+	rootProp, err := schema.GetPropertyByName(pv.Class, prop)
+	if err != nil {
+		return nil, fmt.Errorf("nested correlated AND: root property %q not found in schema: %w", prop, err)
+	}
+	rootDT := schema.DataType(rootProp.DataType[0])
+
+	plan, err := newResolutionPlanBuilder(rootDT, rootProp.NestedProperties).build(pathOrder)
+	if err != nil {
+		return nil, fmt.Errorf("nested correlated AND: build plan for %q: %w", prop, err)
+	}
+
+	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(prop))
+
+	docIDs, err := newResolutionPlanExecutor(plan, positionsByPath, metaBucket).execute(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("nested correlated AND: execute for %q: %w", prop, err)
+	}
+
+	dbm := newDocBitmap()
+	dbm.docIDs = docIDs
+	return &dbm, nil
 }

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -29,6 +29,31 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
+// nestedInfo groups fields that are only relevant for nested (object/object[])
+// property filters. The zero value represents a non-nested node.
+//
+// isNested and isCorrelated are mutually exclusive — a node is either a leaf
+// or a group, never both:
+//
+// When isNested is set (leaf node):
+//   - prop on the parent propValuePair is the top-level property name
+//   - value is the bare encoded value (without prefix)
+//   - relPath is the dot-notation path relative to prop
+//     (e.g. "city" or "owner.firstname")
+//   - the result bitmap contains positions that are stripped to docIDs
+//
+// When isCorrelated is set (AND group node):
+//   - prop on the parent propValuePair is the root property name
+//   - all children require position-aware same-element resolution
+//   - childrenFromTokenization marks a compound AND from multi-token text;
+//     its children are tokens that must share the same leaf position
+type nestedInfo struct {
+	isNested                 bool
+	relPath                  string
+	isCorrelated             bool
+	childrenFromTokenization bool
+}
+
 type propValuePair struct {
 	prop     string
 	operator filters.Operator
@@ -45,25 +70,7 @@ type propValuePair struct {
 	hasFilterableIndex bool
 	hasSearchableIndex bool
 	hasRangeableIndex  bool
-	// isNested marks a filter on a nested (object/object[]) property. When set:
-	//   - prop is the top-level property name (used for bucket name resolution)
-	//   - value is the bare encoded value (without prefix)
-	//   - nestedRelPath is the dot-notation path relative to prop
-	//     (e.g. "city" or "owner.firstname"); hash8(nestedRelPath) gives the
-	//     key prefix used to bound cursor reads and build the bucket key
-	//   - the result bitmap contains positions that are stripped to docIDs
-	isNested      bool
-	nestedRelPath string
-	// childrenFromTokenization is true when this compound AND was produced by
-	// multi-token text tokenization (e.g. city = "New York" produces
-	// AND[token:"new", token:"york"]). All children are tokens of the same
-	// property value and must share the same leaf position, so they are
-	// combined with raw AndAll rather than MaskLeafAndAll.
-	childrenFromTokenization bool
-	// isCorrelatedNested marks an AND node created during filter extraction to
-	// group nested conditions for a single root property. prop holds the root
-	// property name. All children require position-aware same-element resolution.
-	isCorrelatedNested bool
+	nested             nestedInfo
 	Class              *models.Class // The schema
 }
 
@@ -81,7 +88,7 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 
 	// Correlated nested AND created during extraction: all children target the
 	// same root property (stored in pv.prop) and require same-element semantics.
-	if pv.isCorrelatedNested {
+	if pv.nested.isCorrelated {
 		return pv.resolveNestedCorrelated(ctx, s)
 	}
 
@@ -341,7 +348,7 @@ func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int
 	if err != nil {
 		return nil, err
 	}
-	if pv.isNested {
+	if pv.nested.isNested {
 		// The nested value bucket stores positions (root|leaf|docID) rather than
 		// plain docIDs. Strip position bits to extract the docID-only bitmap.
 		dbm.docIDs = nested.MaskRootLeaf(dbm.docIDs)
@@ -351,10 +358,8 @@ func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int
 
 // fetchRawPositions is like fetchDocIDs but returns the raw position bitmap
 // without stripping the root/leaf bits. Only valid for nested properties
-// (pv.isNested == true). Used by the correlated resolution path which needs
+// (pv.nested.isNested == true). Used by the correlated resolution path which needs
 // full positions to apply MaskLeaf AND or the _idx loop.
-//
-//nolint:unused //used by correlated resolution in the next commits
 func (pv *propValuePair) fetchRawPositions(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
 	return pv.fetchBitmap(ctx, s, limit)
 }
@@ -400,7 +405,7 @@ func (pv *propValuePair) fetchBitmap(ctx context.Context, s *Searcher, limit int
 }
 
 func (pv *propValuePair) getBucketName() string {
-	if pv.isNested {
+	if pv.nested.isNested {
 		if pv.hasFilterableIndex {
 			return helpers.BucketNestedFromPropNameLSM(pv.prop)
 		}
@@ -462,7 +467,7 @@ func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searche
 		if err != nil {
 			return err
 		}
-		path := leaf.nestedRelPath
+		path := leaf.nested.relPath
 		if _, exists := positionsByPath[path]; !exists {
 			positionsByPath[path] = &positionBitmaps{}
 			pathOrder = append(pathOrder, path)
@@ -476,17 +481,17 @@ func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searche
 	}
 
 	for _, child := range pv.children {
-		if child.isNested {
+		if child.nested.isNested {
 			// When pv itself is a tokenization compound AND, its children are tokens
 			// of the same value and must share the same leaf position → route as tokens.
-			if err := fetchAndRoute(child, pv.childrenFromTokenization); err != nil {
-				return nil, fmt.Errorf("nested correlated AND: fetch bitmap for %q: %w", child.nestedRelPath, err)
+			if err := fetchAndRoute(child, pv.nested.childrenFromTokenization); err != nil {
+				return nil, fmt.Errorf("nested correlated AND: fetch bitmap for %q: %w", child.nested.relPath, err)
 			}
 		} else {
 			// Tokenization compound AND child: grandchildren are tokens of the same value.
 			for _, gc := range child.children {
 				if err := fetchAndRoute(gc, true); err != nil {
-					return nil, fmt.Errorf("nested correlated AND: fetch bitmap for %q: %w", gc.nestedRelPath, err)
+					return nil, fmt.Errorf("nested correlated AND: fetch bitmap for %q: %w", gc.nested.relPath, err)
 				}
 			}
 		}

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -60,7 +60,11 @@ type propValuePair struct {
 	// property value and must share the same leaf position, so they are
 	// combined with raw AndAll rather than MaskLeafAndAll.
 	childrenFromTokenization bool
-	Class                    *models.Class // The schema
+	// isCorrelatedNested marks an AND node created during filter extraction to
+	// group nested conditions for a single root property. prop holds the root
+	// property name. All children require position-aware same-element resolution.
+	isCorrelatedNested bool
+	Class              *models.Class // The schema
 }
 
 func newPropValuePair(class *models.Class) (*propValuePair, error) {
@@ -75,41 +79,19 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 		return nil, err
 	}
 
+	// Correlated nested AND created during extraction: all children target the
+	// same root property (stored in pv.prop) and require same-element semantics.
+	if pv.isCorrelatedNested {
+		return pv.resolveNestedCorrelated(ctx, s)
+	}
+
 	if pv.operator.OnValue() {
 		return pv.fetchDocIDs(ctx, s, limit)
 	}
 
 	ln := len(pv.children)
 	switch pv.operator {
-	case filters.OperatorAnd:
-		switch ln {
-		case 0:
-			return nil, fmt.Errorf("no children for operator %q", pv.operator.Name())
-		case 1:
-			return pv.children[0].resolveDocIDs(ctx, s, limit)
-		default:
-			if groups := pv.extractNestedCorrelatedGroups(); groups != nil {
-				// Resolve nested conditions with position-aware same-element semantics.
-				// pv.children now holds only the flat conditions (if any).
-				result, err := pv.resolveNestedCorrelatedAnd(ctx, s, groups)
-				if err != nil {
-					return nil, err
-				}
-				if len(pv.children) == 0 {
-					return result, nil
-				}
-				// AND in remaining flat conditions via the existing AND machinery.
-				remainingResult, err := pv.resolveDocIDsAndOr(ctx, s)
-				if err != nil {
-					return nil, err
-				}
-				result.docIDs.And(remainingResult.docIDs)
-				return result, nil
-			}
-			return pv.resolveDocIDsAndOr(ctx, s)
-		}
-
-	case filters.OperatorOr:
+	case filters.OperatorAnd, filters.OperatorOr:
 		switch ln {
 		case 0:
 			return nil, fmt.Errorf("no children for operator %q", pv.operator.Name())
@@ -454,40 +436,6 @@ func (pv *propValuePair) getBucketName() string {
 	return ""
 }
 
-// extractNestedCorrelatedGroups classifies pv's AND children for correlated
-// nested resolution. Nested conditions are grouped by root property name;
-// flat (non-nested) conditions remain in pv.children so that resolveDocIDsAndOr
-// can be called on the same instance if any are left.
-//
-// Returns nil when no nested groups were found (pv.children is unchanged).
-// On a non-nil return pv.children contains only the flat conditions.
-func (pv *propValuePair) extractNestedCorrelatedGroups() map[string][]*propValuePair {
-	if len(pv.children) == 0 {
-		return nil
-	}
-	groups := make(map[string][]*propValuePair)
-	var flat []*propValuePair
-	for _, child := range pv.children {
-		switch {
-		case child.isNested:
-			groups[child.prop] = append(groups[child.prop], child)
-		case child.operator == filters.OperatorAnd && child.childrenFromTokenization && len(child.children) > 0:
-			// Tokenization-produced compound AND (e.g. city = "New York" →
-			// AND[token:"new", token:"york"]): keep as a unit in its prop's group.
-			// childrenFromTokenization guarantees all tokens share one property.
-			groups[child.children[0].prop] = append(groups[child.children[0].prop], child)
-		default:
-			// Non-nested condition: keep in pv.children for regular resolution.
-			flat = append(flat, child)
-		}
-	}
-	if len(groups) == 0 {
-		return nil
-	}
-	pv.children = flat
-	return groups
-}
-
 // positionBitmaps groups pre-fetched raw position bitmaps for a single nested path,
 // split by origin so the executor can apply the correct combining strategy:
 //   - tokens: from childrenFromTokenization compound ANDs (multi-token text);
@@ -500,52 +448,14 @@ type positionBitmaps struct {
 	independent []*sroar.Bitmap
 }
 
-// resolveNestedCorrelatedAnd resolves only the nested correlated groups. For
-// each prop group it builds a resolution plan and executes it; the per-group
-// docID results are AND'd together. Flat (non-nested) conditions are not
-// handled here — the caller is responsible for combining this result with any
-// remaining conditions via the existing resolveDocIDsAndOr machinery.
-func (pv *propValuePair) resolveNestedCorrelatedAnd(
-	ctx context.Context,
-	s *Searcher,
-	groups map[string][]*propValuePair,
-) (*docBitmap, error) {
-	var result *sroar.Bitmap
-
-	for prop, children := range groups {
-		dbm, err := pv.resolveNestedCorrelatedAndGroup(ctx, s, prop, children)
-		if err != nil {
-			return nil, err
-		}
-		if result == nil {
-			result = dbm.docIDs
-		} else {
-			result.And(dbm.docIDs)
-		}
-	}
-
-	if result == nil {
-		empty := newDocBitmap()
-		return &empty, nil
-	}
-	out := newDocBitmap()
-	out.docIDs = result
-	return &out, nil
-}
-
-// resolveNestedCorrelatedAndGroup resolves one prop group using position-aware
+// resolveNestedCorrelated resolves one prop group using position-aware
 // correlation. It builds a resolutionPlan for the group's paths, pre-computes
 // raw position bitmaps, and executes the plan to enforce same-element semantics.
-func (pv *propValuePair) resolveNestedCorrelatedAndGroup(
-	ctx context.Context,
-	s *Searcher,
-	prop string,
-	children []*propValuePair,
-) (*docBitmap, error) {
+func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searcher) (*docBitmap, error) {
 	// Build positionsByPath: fetch raw position bitmaps per pvp and route into
 	// the correct bucket slot based on origin (token vs independent).
-	positionsByPath := make(map[string]*positionBitmaps, len(children))
-	pathOrder := make([]string, 0, len(children))
+	positionsByPath := make(map[string]*positionBitmaps, len(pv.children))
+	pathOrder := make([]string, 0, len(pv.children))
 
 	fetchAndRoute := func(leaf *propValuePair, isToken bool) error {
 		dbm, err := leaf.fetchRawPositions(ctx, s, 0)
@@ -565,13 +475,15 @@ func (pv *propValuePair) resolveNestedCorrelatedAndGroup(
 		return nil
 	}
 
-	for _, child := range children {
+	for _, child := range pv.children {
 		if child.isNested {
-			if err := fetchAndRoute(child, false); err != nil {
+			// When pv itself is a tokenization compound AND, its children are tokens
+			// of the same value and must share the same leaf position → route as tokens.
+			if err := fetchAndRoute(child, pv.childrenFromTokenization); err != nil {
 				return nil, fmt.Errorf("nested correlated AND: fetch bitmap for %q: %w", child.nestedRelPath, err)
 			}
 		} else {
-			// Tokenization compound AND: grandchildren are tokens of the same value.
+			// Tokenization compound AND child: grandchildren are tokens of the same value.
 			for _, gc := range child.children {
 				if err := fetchAndRoute(gc, true); err != nil {
 					return nil, fmt.Errorf("nested correlated AND: fetch bitmap for %q: %w", gc.nestedRelPath, err)
@@ -581,22 +493,22 @@ func (pv *propValuePair) resolveNestedCorrelatedAndGroup(
 	}
 
 	// Find the root property's schema to build the resolution plan.
-	rootProp, err := schema.GetPropertyByName(pv.Class, prop)
+	rootProp, err := schema.GetPropertyByName(pv.Class, pv.prop)
 	if err != nil {
-		return nil, fmt.Errorf("nested correlated AND: root property %q not found in schema: %w", prop, err)
+		return nil, fmt.Errorf("nested correlated AND: root property %q not found in schema: %w", pv.prop, err)
 	}
 	rootDT := schema.DataType(rootProp.DataType[0])
 
 	plan, err := newResolutionPlanBuilder(rootDT, rootProp.NestedProperties).build(pathOrder)
 	if err != nil {
-		return nil, fmt.Errorf("nested correlated AND: build plan for %q: %w", prop, err)
+		return nil, fmt.Errorf("nested correlated AND: build plan for %q: %w", pv.prop, err)
 	}
 
-	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(prop))
+	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(pv.prop))
 
 	docIDs, err := newResolutionPlanExecutor(plan, positionsByPath, metaBucket).execute(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("nested correlated AND: execute for %q: %w", prop, err)
+		return nil, fmt.Errorf("nested correlated AND: execute for %q: %w", pv.prop, err)
 	}
 
 	dbm := newDocBitmap()

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -1,0 +1,319 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package inverted
+
+import (
+	"context"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// ---------------------------------------------------------------------------
+// Test schema and helpers
+// ---------------------------------------------------------------------------
+
+// correlationTestClass returns a minimal class with nested object-array
+// properties used across resolveNestedCorrelatedAnd tests.
+//
+//	addresses: object[] { city text, postcode text }
+//	cars:      object[] { make text, tires object[]{width int}, accessories object[]{type text} }
+//	name:      text  (flat, non-nested)
+func correlationTestClass() *models.Class {
+	vTrue := true
+	return &models.Class{
+		Class: "TestClass",
+		Properties: []*models.Property{
+			{
+				Name:     "addresses",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{Name: "city", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+					{Name: "postcode", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+				},
+			},
+			{
+				Name:     "cars",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{Name: "make", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+					{
+						Name:     "tires",
+						DataType: schema.DataTypeObjectArray.PropString(),
+						NestedProperties: []*models.NestedProperty{
+							{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+						},
+					},
+					{
+						Name:     "accessories",
+						DataType: schema.DataTypeObjectArray.PropString(),
+						NestedProperties: []*models.NestedProperty{
+							{Name: "type", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+						},
+					},
+				},
+			},
+			{Name: "name", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+		},
+	}
+}
+
+// newNestedTestSearcher creates a minimal Searcher backed by a temporary lsmkv store
+// and pre-creates the given bucket names with RoaringSet strategy.
+func newNestedTestSearcher(t *testing.T, bucketNames ...string) (*Searcher, *lsmkv.Store) {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	store, err := lsmkv.New(t.TempDir(), t.TempDir(), logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+
+	for _, name := range bucketNames {
+		require.NoError(t, store.CreateOrLoadBucket(context.Background(),
+			name, lsmkv.WithStrategy(lsmkv.StrategyRoaringSet)))
+	}
+
+	bitmapFactory := roaringset.NewBitmapFactory(
+		roaringset.NewBitmapBufPoolNoop(), func() uint64 { return 1_000_000 })
+
+	class := correlationTestClass()
+	searcher := NewSearcher(logger, store, func(string) *models.Class { return class },
+		nil, nil, fakeStopwordDetector{}, 2,
+		func() bool { return false }, "",
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+
+	return searcher, store
+}
+
+// writeNestedValue writes position bitmaps for a (path, term) pair into a
+// nested value bucket. positions should have the real docID already OR'd in.
+func writeNestedValue(t *testing.T, bucket *lsmkv.Bucket, relPath, term string, positions []uint64) {
+	t.Helper()
+	key := nested.ValueKey(relPath, []byte(term))
+	require.NoError(t, bucket.RoaringSetAddList(key, positions))
+}
+
+// makeLeafPvp builds a nested leaf propValuePair suitable for testing.
+func makeLeafPvp(class *models.Class, prop, relPath, term string) *propValuePair {
+	return &propValuePair{
+		prop:               prop,
+		value:              []byte(term),
+		operator:           filters.OperatorEqual,
+		nestedRelPath:      relPath,
+		hasFilterableIndex: true,
+		isNested:           true,
+		Class:              class,
+	}
+}
+
+// makeAndPvp wraps children in an AND propValuePair (used to represent the
+// outer AND filter node that resolveNestedCorrelatedAnd is called on).
+func makeAndPvp(class *models.Class, children ...*propValuePair) *propValuePair {
+	return &propValuePair{
+		operator: filters.OperatorAnd,
+		children: children,
+		Class:    class,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestResolveNestedCorrelatedAnd(t *testing.T) {
+	const (
+		doc5 = uint64(5)
+		doc7 = uint64(7)
+	)
+
+	t.Run("directAnd — scalar siblings in addresses[]", func(t *testing.T) {
+		// addresses = [{city:"berlin", postcode:"10115"}]
+		// addresses.city AND addresses.postcode must match the same element.
+		// Scalar siblings inherit all positions of their parent element → directAnd.
+		//
+		// Expected: doc5 returned (both conditions match same element).
+
+		bucketName := helpers.BucketNestedFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, bucketName)
+		class := correlationTestClass()
+
+		// addresses[0] for doc5: root=1, leaf=1
+		pos := nested.Encode(1, 1, doc5)
+		b := store.Bucket(bucketName)
+		writeNestedValue(t, b, "city", "berlin", []uint64{pos})
+		writeNestedValue(t, b, "postcode", "10115", []uint64{pos})
+
+		pv := makeAndPvp(class,
+			makeLeafPvp(class, "addresses", "city", "berlin"),
+			makeLeafPvp(class, "addresses", "postcode", "10115"),
+		)
+		groups := pv.extractNestedCorrelatedGroups()
+		require.NotNil(t, groups)
+
+		result, err := pv.resolveNestedCorrelatedAnd(context.Background(), searcher, groups)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("directAnd — scalar siblings, different docs only partial match", func(t *testing.T) {
+		// doc5: city="berlin", postcode="10115" (both present → match)
+		// doc7: city="berlin", postcode="99999" (postcode doesn't match → no match)
+
+		bucketName := helpers.BucketNestedFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, bucketName)
+		class := correlationTestClass()
+
+		b := store.Bucket(bucketName)
+		writeNestedValue(t, b, "city", "berlin", []uint64{
+			nested.Encode(1, 1, doc5),
+			nested.Encode(1, 1, doc7),
+		})
+		writeNestedValue(t, b, "postcode", "10115", []uint64{nested.Encode(1, 1, doc5)})
+
+		pv := makeAndPvp(class,
+			makeLeafPvp(class, "addresses", "city", "berlin"),
+			makeLeafPvp(class, "addresses", "postcode", "10115"),
+		)
+		groups := pv.extractNestedCorrelatedGroups()
+		require.NotNil(t, groups)
+
+		result, err := pv.resolveNestedCorrelatedAnd(context.Background(), searcher, groups)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("idxLoopAnd — both conditions in same cars element → match", func(t *testing.T) {
+		// cars = [{tires:[{width:205}], accessories:[{type:"spoiler"}]}]
+		// cars.tires.width AND cars.accessories.type must be in the same car.
+		// tires and accessories are different sub-arrays → idxLoopAnd("cars").
+		//
+		// Expected: doc5 returned.
+
+		nestedBucket := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, nestedBucket, metaBucket)
+		class := correlationTestClass()
+
+		// cars[0]: root=1, tires[0]=leaf1, accessories[0]=leaf2
+		tiresPos := nested.Encode(1, 1, doc5)
+		accPos := nested.Encode(1, 2, doc5)
+
+		nb := store.Bucket(nestedBucket)
+		// Encode width as big-endian int64
+		widthVal := make([]byte, 8)
+		widthVal[7] = 205 // value 205
+		require.NoError(t, nb.RoaringSetAddList(nested.ValueKey("tires.width", widthVal), []uint64{tiresPos}))
+		writeNestedValue(t, nb, "accessories.type", "spoiler", []uint64{accPos})
+
+		// idx entry for cars[0]: all positions within that element
+		mb := store.Bucket(metaBucket)
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 0), []uint64{tiresPos, accPos}))
+
+		pv := makeAndPvp(class,
+			&propValuePair{
+				prop: "cars", value: widthVal, operator: filters.OperatorEqual,
+				nestedRelPath: "tires.width", hasFilterableIndex: true,
+				isNested: true, Class: class,
+			},
+			makeLeafPvp(class, "cars", "accessories.type", "spoiler"),
+		)
+		groups := pv.extractNestedCorrelatedGroups()
+		require.NotNil(t, groups)
+
+		result, err := pv.resolveNestedCorrelatedAnd(context.Background(), searcher, groups)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("idxLoopAnd — conditions in different cars elements → empty", func(t *testing.T) {
+		// cars = [{tires:[{width:205}]}, {accessories:[{type:"spoiler"}]}]
+		// tires.width is in cars[0], accessories.type is in cars[1] → no same-car match.
+
+		nestedBucket := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, nestedBucket, metaBucket)
+		class := correlationTestClass()
+
+		tiresPos := nested.Encode(1, 1, doc5) // cars[0]
+		accPos := nested.Encode(2, 1, doc5)   // cars[1]
+
+		nb := store.Bucket(nestedBucket)
+		widthVal := make([]byte, 8)
+		widthVal[7] = 205
+		require.NoError(t, nb.RoaringSetAddList(nested.ValueKey("tires.width", widthVal), []uint64{tiresPos}))
+		writeNestedValue(t, nb, "accessories.type", "spoiler", []uint64{accPos})
+
+		mb := store.Bucket(metaBucket)
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 0), []uint64{tiresPos}))
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 1), []uint64{accPos}))
+
+		pv := makeAndPvp(class,
+			&propValuePair{
+				prop: "cars", value: widthVal, operator: filters.OperatorEqual,
+				nestedRelPath: "tires.width", hasFilterableIndex: true,
+				isNested: true, Class: class,
+			},
+			makeLeafPvp(class, "cars", "accessories.type", "spoiler"),
+		)
+		groups := pv.extractNestedCorrelatedGroups()
+		require.NotNil(t, groups)
+
+		result, err := pv.resolveNestedCorrelatedAnd(context.Background(), searcher, groups)
+		require.NoError(t, err)
+		assert.True(t, result.docIDs.IsEmpty())
+	})
+
+	t.Run("multi-prop groups — cars AND addresses correlated independently", func(t *testing.T) {
+		// conditions: cars.make="tesla" AND addresses.city="berlin"
+		// Each prop group is resolved independently then AND'd.
+		// Expected: doc5 (has both), doc7 excluded (only cars.make matches).
+
+		carsBucket := helpers.BucketNestedFromPropNameLSM("cars")
+		addrBucket := helpers.BucketNestedFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, carsBucket, addrBucket)
+		class := correlationTestClass()
+
+		cb := store.Bucket(carsBucket)
+		writeNestedValue(t, cb, "make", "tesla",
+			[]uint64{nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7)})
+
+		ab := store.Bucket(addrBucket)
+		writeNestedValue(t, ab, "city", "berlin", []uint64{nested.Encode(1, 1, doc5)})
+
+		pv := makeAndPvp(class,
+			makeLeafPvp(class, "cars", "make", "tesla"),
+			makeLeafPvp(class, "addresses", "city", "berlin"),
+		)
+		groups := pv.extractNestedCorrelatedGroups()
+		require.NotNil(t, groups)
+		assert.Len(t, groups, 2)
+
+		result, err := pv.resolveNestedCorrelatedAnd(context.Background(), searcher, groups)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+}

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -36,7 +36,7 @@ import (
 // ---------------------------------------------------------------------------
 
 // correlationTestClass returns a minimal class with nested object-array
-// properties used across resolveNestedCorrelatedAnd tests.
+// properties used across resolveNestedCorrelated tests.
 //
 //	addresses: object[] { city text, postcode text }
 //	cars:      object[] { make text, tires object[]{width int}, accessories object[]{type text} }
@@ -130,8 +130,18 @@ func makeLeafPvp(class *models.Class, prop, relPath, term string) *propValuePair
 	}
 }
 
-// makeAndPvp wraps children in an AND propValuePair (used to represent the
-// outer AND filter node that resolveNestedCorrelatedAnd is called on).
+// makeCorrelatedPvp wraps children in an isCorrelatedNested AND node for prop.
+func makeCorrelatedPvp(class *models.Class, prop string, children ...*propValuePair) *propValuePair {
+	return &propValuePair{
+		operator:           filters.OperatorAnd,
+		isCorrelatedNested: true,
+		prop:               prop,
+		children:           children,
+		Class:              class,
+	}
+}
+
+// makeAndPvp wraps children in a plain AND propValuePair.
 func makeAndPvp(class *models.Class, children ...*propValuePair) *propValuePair {
 	return &propValuePair{
 		operator: filters.OperatorAnd,
@@ -167,14 +177,11 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		writeNestedValue(t, b, "city", "berlin", []uint64{pos})
 		writeNestedValue(t, b, "postcode", "10115", []uint64{pos})
 
-		pv := makeAndPvp(class,
+		pv := makeCorrelatedPvp(class, "addresses",
 			makeLeafPvp(class, "addresses", "city", "berlin"),
 			makeLeafPvp(class, "addresses", "postcode", "10115"),
 		)
-		groups := pv.extractNestedCorrelatedGroups()
-		require.NotNil(t, groups)
-
-		result, err := pv.resolveNestedCorrelatedAnd(context.Background(), searcher, groups)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
@@ -194,14 +201,11 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		})
 		writeNestedValue(t, b, "postcode", "10115", []uint64{nested.Encode(1, 1, doc5)})
 
-		pv := makeAndPvp(class,
+		pv := makeCorrelatedPvp(class, "addresses",
 			makeLeafPvp(class, "addresses", "city", "berlin"),
 			makeLeafPvp(class, "addresses", "postcode", "10115"),
 		)
-		groups := pv.extractNestedCorrelatedGroups()
-		require.NotNil(t, groups)
-
-		result, err := pv.resolveNestedCorrelatedAnd(context.Background(), searcher, groups)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
@@ -233,7 +237,7 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		mb := store.Bucket(metaBucket)
 		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 0), []uint64{tiresPos, accPos}))
 
-		pv := makeAndPvp(class,
+		pv := makeCorrelatedPvp(class, "cars",
 			&propValuePair{
 				prop: "cars", value: widthVal, operator: filters.OperatorEqual,
 				nestedRelPath: "tires.width", hasFilterableIndex: true,
@@ -241,10 +245,7 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 			},
 			makeLeafPvp(class, "cars", "accessories.type", "spoiler"),
 		)
-		groups := pv.extractNestedCorrelatedGroups()
-		require.NotNil(t, groups)
-
-		result, err := pv.resolveNestedCorrelatedAnd(context.Background(), searcher, groups)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
@@ -271,7 +272,7 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 0), []uint64{tiresPos}))
 		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 1), []uint64{accPos}))
 
-		pv := makeAndPvp(class,
+		pv := makeCorrelatedPvp(class, "cars",
 			&propValuePair{
 				prop: "cars", value: widthVal, operator: filters.OperatorEqual,
 				nestedRelPath: "tires.width", hasFilterableIndex: true,
@@ -279,17 +280,14 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 			},
 			makeLeafPvp(class, "cars", "accessories.type", "spoiler"),
 		)
-		groups := pv.extractNestedCorrelatedGroups()
-		require.NotNil(t, groups)
-
-		result, err := pv.resolveNestedCorrelatedAnd(context.Background(), searcher, groups)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
 		assert.True(t, result.docIDs.IsEmpty())
 	})
 
 	t.Run("multi-prop groups — cars AND addresses correlated independently", func(t *testing.T) {
 		// conditions: cars.make="tesla" AND addresses.city="berlin"
-		// Each prop group is resolved independently then AND'd.
+		// Each prop group is resolved independently then AND'd via the outer AND node.
 		// Expected: doc5 (has both), doc7 excluded (only cars.make matches).
 
 		carsBucket := helpers.BucketNestedFromPropNameLSM("cars")
@@ -304,15 +302,17 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		ab := store.Bucket(addrBucket)
 		writeNestedValue(t, ab, "city", "berlin", []uint64{nested.Encode(1, 1, doc5)})
 
+		// groupNestedByProp creates one isCorrelatedNested node per prop;
+		// here we build the same structure directly.
 		pv := makeAndPvp(class,
-			makeLeafPvp(class, "cars", "make", "tesla"),
-			makeLeafPvp(class, "addresses", "city", "berlin"),
+			makeCorrelatedPvp(class, "cars",
+				makeLeafPvp(class, "cars", "make", "tesla"),
+			),
+			makeCorrelatedPvp(class, "addresses",
+				makeLeafPvp(class, "addresses", "city", "berlin"),
+			),
 		)
-		groups := pv.extractNestedCorrelatedGroups()
-		require.NotNil(t, groups)
-		assert.Len(t, groups, 2)
-
-		result, err := pv.resolveNestedCorrelatedAnd(context.Background(), searcher, groups)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -104,7 +104,7 @@ func newNestedTestSearcher(t *testing.T, bucketNames ...string) (*Searcher, *lsm
 	class := correlationTestClass()
 	searcher := NewSearcher(logger, store, func(string) *models.Class { return class },
 		nil, nil, stopwords.NewProvider(fakeStopwordDetector{}, nil), 2,
-		func() bool { return false }, "",
+		func() bool { return false }, nil, "",
 		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
 
 	return searcher, store

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -102,7 +103,7 @@ func newNestedTestSearcher(t *testing.T, bucketNames ...string) (*Searcher, *lsm
 
 	class := correlationTestClass()
 	searcher := NewSearcher(logger, store, func(string) *models.Class { return class },
-		nil, nil, fakeStopwordDetector{}, 2,
+		nil, nil, stopwords.NewProvider(fakeStopwordDetector{}, nil), 2,
 		func() bool { return false }, "",
 		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
 
@@ -123,9 +124,8 @@ func makeLeafPvp(class *models.Class, prop, relPath, term string) *propValuePair
 		prop:               prop,
 		value:              []byte(term),
 		operator:           filters.OperatorEqual,
-		nestedRelPath:      relPath,
 		hasFilterableIndex: true,
-		isNested:           true,
+		nested:             nestedInfo{isNested: true, relPath: relPath},
 		Class:              class,
 	}
 }
@@ -133,11 +133,11 @@ func makeLeafPvp(class *models.Class, prop, relPath, term string) *propValuePair
 // makeCorrelatedPvp wraps children in an isCorrelatedNested AND node for prop.
 func makeCorrelatedPvp(class *models.Class, prop string, children ...*propValuePair) *propValuePair {
 	return &propValuePair{
-		operator:           filters.OperatorAnd,
-		isCorrelatedNested: true,
-		prop:               prop,
-		children:           children,
-		Class:              class,
+		operator: filters.OperatorAnd,
+		nested:   nestedInfo{isCorrelated: true},
+		prop:     prop,
+		children: children,
+		Class:    class,
 	}
 }
 
@@ -240,8 +240,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		pv := makeCorrelatedPvp(class, "cars",
 			&propValuePair{
 				prop: "cars", value: widthVal, operator: filters.OperatorEqual,
-				nestedRelPath: "tires.width", hasFilterableIndex: true,
-				isNested: true, Class: class,
+				hasFilterableIndex: true,
+				nested:             nestedInfo{isNested: true, relPath: "tires.width"}, Class: class,
 			},
 			makeLeafPvp(class, "cars", "accessories.type", "spoiler"),
 		)
@@ -275,8 +275,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		pv := makeCorrelatedPvp(class, "cars",
 			&propValuePair{
 				prop: "cars", value: widthVal, operator: filters.OperatorEqual,
-				nestedRelPath: "tires.width", hasFilterableIndex: true,
-				isNested: true, Class: class,
+				hasFilterableIndex: true,
+				nested:             nestedInfo{isNested: true, relPath: "tires.width"}, Class: class,
 			},
 			makeLeafPvp(class, "cars", "accessories.type", "spoiler"),
 		)

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
 )
 
 // nestedPvp builds a minimal nested leaf propValuePair.
@@ -25,9 +26,14 @@ func nestedPvp(prop, relPath string) *propValuePair {
 }
 
 // compoundAndPvp builds a compound AND propValuePair as produced by multi-token
-// text tokenization (childrenFromTokenization=true).
+// text tokenization (childrenFromTokenization=true, isCorrelatedNested=true).
+// prop is derived from the first child, mirroring buildNestedTextFilterPair.
 func compoundAndPvp(children ...*propValuePair) *propValuePair {
-	return &propValuePair{operator: filters.OperatorAnd, children: children, childrenFromTokenization: true}
+	var prop string
+	if len(children) > 0 {
+		prop = children[0].prop
+	}
+	return &propValuePair{operator: filters.OperatorAnd, children: children, childrenFromTokenization: true, isCorrelatedNested: true, prop: prop}
 }
 
 // userNestedAndPvp builds a compound AND propValuePair as produced by user
@@ -37,32 +43,64 @@ func userNestedAndPvp(children ...*propValuePair) *propValuePair {
 	return &propValuePair{operator: filters.OperatorAnd, children: children}
 }
 
-func TestNestedCorrelatedGroup(t *testing.T) {
+// wantChild describes one expected element in the groupNestedByProp output.
+type wantChild struct {
+	// correlatedProp is non-empty when the output child should be an
+	// isCorrelatedNested=true AND node wrapping conditions for that prop.
+	correlatedProp string
+	// groupSize is the number of children inside the correlated group.
+	// Only inspected when correlatedProp is non-empty.
+	groupSize int
+	// isPlain is true when the output child should be a plain (non-correlated)
+	// node, passed through unchanged from the input.
+	isPlain bool
+}
+
+func TestGroupNestedByProp(t *testing.T) {
 	flatPvp := func() *propValuePair {
 		return &propValuePair{prop: "name", operator: filters.OperatorEqual}
 	}
+	class := &models.Class{Class: "TestClass"}
 
 	tests := []struct {
-		name          string
-		children      []*propValuePair
-		wantNilGroups bool           // groups == nil (unresolvable)
-		wantGroups    map[string]int // expected group sizes by prop name
-		wantOthers    int            // expected number of flat/other conditions
+		name     string
+		children []*propValuePair
+		want     []wantChild
 	}{
-		// --- all nested, single prop group ---
+		// output: (empty — passthrough)
 		{
-			name:       "single nested child",
-			children:   []*propValuePair{nestedPvp("addresses", "city")},
-			wantGroups: map[string]int{"addresses": 1},
+			name:     "empty children",
+			children: nil,
+			want:     nil,
 		},
+
+		// output:
+		// └── addresses.city
+		// Single-child group is kept as a plain child with no wrapper.
 		{
-			name: "two nested children same prop",
+			name:     "single nested child — no wrapper",
+			children: []*propValuePair{nestedPvp("addresses", "city")},
+			want:     []wantChild{{isPlain: true}},
+		},
+
+		// output:
+		// └── correlated(addresses)
+		//     ├── city
+		//     └── postcode
+		{
+			name: "two nested children same prop — wrapped",
 			children: []*propValuePair{
 				nestedPvp("addresses", "city"),
 				nestedPvp("addresses", "postcode"),
 			},
-			wantGroups: map[string]int{"addresses": 2},
+			want: []wantChild{{correlatedProp: "addresses", groupSize: 2}},
 		},
+
+		// output:
+		// └── correlated(cars)
+		//     ├── make
+		//     ├── tires.width
+		//     └── accessories.type
 		{
 			name: "three nested children same prop",
 			children: []*propValuePair{
@@ -70,39 +108,59 @@ func TestNestedCorrelatedGroup(t *testing.T) {
 				nestedPvp("cars", "tires.width"),
 				nestedPvp("cars", "accessories.type"),
 			},
-			wantGroups: map[string]int{"cars": 3},
+			want: []wantChild{{correlatedProp: "cars", groupSize: 3}},
 		},
+
+		// output:
+		// └── correlated(addresses)
+		//     ├── AND(city, city)  ← tokenization compound, treated as one unit
+		//     └── postcode
 		{
-			// Compound AND from multi-token text is kept as a single unit.
 			name: "compound AND (multi-token text) same prop",
 			children: []*propValuePair{
 				compoundAndPvp(nestedPvp("addresses", "city"), nestedPvp("addresses", "city")),
 				nestedPvp("addresses", "postcode"),
 			},
-			wantGroups: map[string]int{"addresses": 2}, // 1 compound + 1 direct
+			want: []wantChild{{correlatedProp: "addresses", groupSize: 2}},
 		},
+
+		// output:
+		// └── correlated(cars)
+		//     ├── make
+		//     └── AND(tires.width, tires.width)  ← tokenization compound
 		{
 			name: "direct and compound children same prop",
 			children: []*propValuePair{
 				nestedPvp("cars", "make"),
 				compoundAndPvp(nestedPvp("cars", "tires.width"), nestedPvp("cars", "tires.width")),
 			},
-			wantGroups: map[string]int{"cars": 2},
+			want: []wantChild{{correlatedProp: "cars", groupSize: 2}},
 		},
 
-		// --- multiple prop groups, all nested ---
+		// output:
+		// ├── addresses.city
+		// └── cars.make
+		// Each prop has only one condition — no wrapper created for either.
 		{
-			// Conditions spanning two props produce two separate groups, each
-			// resolved with its own same-element semantics.
-			name: "two props — two groups",
+			name: "two props — single-child groups, no wrappers",
 			children: []*propValuePair{
 				nestedPvp("addresses", "city"),
 				nestedPvp("cars", "make"),
 			},
-			wantGroups: map[string]int{"addresses": 1, "cars": 1},
+			want: []wantChild{
+				{isPlain: true},
+				{isPlain: true},
+			},
 		},
+
+		// output:
+		// ├── correlated(cars)       ← first-seen order preserved
+		// │   ├── tires.width
+		// │   └── accessories.type
+		// └── correlated(addresses)
+		//     ├── city
+		//     └── postcode
 		{
-			// Interleaved multi-prop conditions are grouped correctly.
 			name: "four conditions across two props interleaved",
 			children: []*propValuePair{
 				nestedPvp("cars", "tires.width"),
@@ -110,26 +168,39 @@ func TestNestedCorrelatedGroup(t *testing.T) {
 				nestedPvp("cars", "accessories.type"),
 				nestedPvp("addresses", "postcode"),
 			},
-			wantGroups: map[string]int{"cars": 2, "addresses": 2},
+			want: []wantChild{
+				{correlatedProp: "cars", groupSize: 2},
+				{correlatedProp: "addresses", groupSize: 2},
+			},
 		},
 
-		// --- mixed nested + flat: groups returned, flat conditions go into remaining ---
+		// output:
+		// ├── correlated(cars)
+		// │   ├── tires.width
+		// │   └── accessories.type
+		// └── name  ← flat, emitted at its original position
 		{
-			// Flat property alongside nested conditions: nested groups still get
-			// same-element semantics; the flat condition goes into remaining.
 			name: "nested and flat property mixed",
 			children: []*propValuePair{
 				nestedPvp("cars", "tires.width"),
 				flatPvp(),
 				nestedPvp("cars", "accessories.type"),
 			},
-			wantGroups: map[string]int{"cars": 2},
-			wantOthers: 1,
+			want: []wantChild{
+				{correlatedProp: "cars", groupSize: 2},
+				{isPlain: true},
+			},
 		},
+
+		// output:
+		// ├── correlated(cars)
+		// │   ├── tires.width
+		// │   └── accessories.type
+		// ├── correlated(addresses)
+		// │   ├── city
+		// │   └── postcode
+		// └── name  ← flat
 		{
-			// Full mixed: two nested groups + one flat property.
-			// cars and addresses each get correlated resolution; name is resolved
-			// normally and AND'd with the correlated results.
 			name: "cars + addresses + flat mixed",
 			children: []*propValuePair{
 				nestedPvp("cars", "tires.width"),
@@ -138,23 +209,33 @@ func TestNestedCorrelatedGroup(t *testing.T) {
 				nestedPvp("addresses", "postcode"),
 				flatPvp(),
 			},
-			wantGroups: map[string]int{"cars": 2, "addresses": 2},
-			wantOthers: 1,
+			want: []wantChild{
+				{correlatedProp: "cars", groupSize: 2},
+				{correlatedProp: "addresses", groupSize: 2},
+				{isPlain: true},
+			},
 		},
+
+		// output:
+		// ├── addresses.city               ← single-child group, no wrapper
+		// └── AND(addresses.postcode, name) ← flat: childrenFromTokenization=false
 		{
-			// Compound AND with a non-nested grandchild is treated as a flat
-			// condition (goes to remaining, not into a nested group).
-			name: "compound AND with non-nested grandchild goes to remaining",
+			name: "compound AND with non-nested grandchild goes to flat",
 			children: []*propValuePair{
 				nestedPvp("addresses", "city"),
 				userNestedAndPvp(nestedPvp("addresses", "postcode"), flatPvp()),
 			},
-			wantGroups: map[string]int{"addresses": 1},
-			wantOthers: 1,
+			want: []wantChild{
+				{isPlain: true},
+				{isPlain: true},
+			},
 		},
+
+		// output:
+		// ├── addresses.city         ← single-child group, no wrapper
+		// └── OR(addresses.postcode) ← flat: not an AND node
 		{
-			// OR compound child: not a valid correlated condition, goes to remaining.
-			name: "non-AND compound child goes to remaining",
+			name: "non-AND compound child goes to flat",
 			children: []*propValuePair{
 				nestedPvp("addresses", "city"),
 				{
@@ -162,40 +243,30 @@ func TestNestedCorrelatedGroup(t *testing.T) {
 					children: []*propValuePair{nestedPvp("addresses", "postcode")},
 				},
 			},
-			wantGroups: map[string]int{"addresses": 1},
-			wantOthers: 1,
+			want: []wantChild{
+				{isPlain: true},
+				{isPlain: true},
+			},
 		},
 
-		// --- nil groups (truly unresolvable) ---
+		// output:
+		// └── AND(addresses.city, cars.make) ← flat: childrenFromTokenization=false
 		{
-			name:          "empty children",
-			wantNilGroups: true,
-		},
-
-		// --- compound AND with mixed props → goes to remaining, NOT unresolvable ---
-		// AND(addresses.city, cars.make) is a perfectly valid user filter that
-		// means "doc has a matching address city AND a matching car make".
-		// When nested inside another AND as a compound AND child, it is treated
-		// as an opaque condition in remaining: resolveDocIDsAndOr recurses into it
-		// and applies correlated resolution on its children independently.
-		{
-			// A user-constructed AND(addresses.city, cars.make) nested as a
-			// compound AND child: resolves correctly via the remaining path.
-			name: "compound AND(addresses.city, cars.make) — goes to remaining",
+			name: "compound AND(addresses.city, cars.make) — goes to flat",
 			children: []*propValuePair{
 				userNestedAndPvp(
 					nestedPvp("addresses", "city"),
 					nestedPvp("cars", "make"),
 				),
 			},
-			// groups is nil because no direct nested children exist at this level,
-			// but the user AND goes to remaining, not causing unresolvability.
-			wantNilGroups: true,
+			want: []wantChild{{isPlain: true}},
 		},
+
+		// output:
+		// ├── addresses.city                      ← single-child group, no wrapper
+		// └── AND(addresses.postcode, cars.make)  ← flat: childrenFromTokenization=false
 		{
-			// Valid nested alongside user AND with mixed props: the user AND
-			// goes to remaining, the direct nested child forms a group.
-			name: "nested + user AND(addresses, cars) — nested groups, user AND in remaining",
+			name: "nested + user AND(addresses, cars) — no wrapper, user AND in flat",
 			children: []*propValuePair{
 				nestedPvp("addresses", "city"),
 				userNestedAndPvp(
@@ -203,26 +274,33 @@ func TestNestedCorrelatedGroup(t *testing.T) {
 					nestedPvp("cars", "make"),
 				),
 			},
-			wantGroups: map[string]int{"addresses": 1},
-			wantOthers: 1,
+			want: []wantChild{
+				{isPlain: true},
+				{isPlain: true},
+			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			pv := &propValuePair{operator: filters.OperatorAnd, children: tt.children}
-			groups := pv.extractNestedCorrelatedGroups()
-			if tt.wantNilGroups {
-				assert.Nil(t, groups)
+			result := groupNestedByProp(tt.children, class)
+			if tt.want == nil {
+				// nil or empty input → passthrough (may be nil or empty slice)
+				assert.Empty(t, result)
 				return
 			}
-			require.NotNil(t, groups)
-			assert.Equal(t, len(tt.wantGroups), len(groups), "number of groups")
-			for prop, wantSize := range tt.wantGroups {
-				assert.Len(t, groups[prop], wantSize, "group size for prop %q", prop)
+			require.Len(t, result, len(tt.want), "output length")
+			for i, wc := range tt.want {
+				child := result[i]
+				if wc.correlatedProp != "" {
+					assert.True(t, child.isCorrelatedNested, "child[%d] should be correlated", i)
+					assert.Equal(t, filters.OperatorAnd, child.operator, "child[%d] operator", i)
+					assert.Equal(t, wc.correlatedProp, child.prop, "child[%d] prop", i)
+					assert.Len(t, child.children, wc.groupSize, "child[%d] group size", i)
+				} else {
+					assert.False(t, child.isCorrelatedNested, "child[%d] should not be correlated", i)
+				}
 			}
-			// pv.children now holds only the flat conditions.
-			assert.Len(t, pv.children, tt.wantOthers, "remaining (flat) children count")
 		})
 	}
 }

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_test.go
@@ -22,7 +22,7 @@ import (
 
 // nestedPvp builds a minimal nested leaf propValuePair.
 func nestedPvp(prop, relPath string) *propValuePair {
-	return &propValuePair{isNested: true, prop: prop, nestedRelPath: relPath}
+	return &propValuePair{nested: nestedInfo{isNested: true, relPath: relPath}, prop: prop}
 }
 
 // compoundAndPvp builds a compound AND propValuePair as produced by multi-token
@@ -33,7 +33,7 @@ func compoundAndPvp(children ...*propValuePair) *propValuePair {
 	if len(children) > 0 {
 		prop = children[0].prop
 	}
-	return &propValuePair{operator: filters.OperatorAnd, children: children, childrenFromTokenization: true, isCorrelatedNested: true, prop: prop}
+	return &propValuePair{operator: filters.OperatorAnd, children: children, nested: nestedInfo{isCorrelated: true, childrenFromTokenization: true}, prop: prop}
 }
 
 // userNestedAndPvp builds a compound AND propValuePair as produced by user
@@ -293,12 +293,12 @@ func TestGroupNestedByProp(t *testing.T) {
 			for i, wc := range tt.want {
 				child := result[i]
 				if wc.correlatedProp != "" {
-					assert.True(t, child.isCorrelatedNested, "child[%d] should be correlated", i)
+					assert.True(t, child.nested.isCorrelated, "child[%d] should be correlated", i)
 					assert.Equal(t, filters.OperatorAnd, child.operator, "child[%d] operator", i)
 					assert.Equal(t, wc.correlatedProp, child.prop, "child[%d] prop", i)
 					assert.Len(t, child.children, wc.groupSize, "child[%d] group size", i)
 				} else {
-					assert.False(t, child.isCorrelatedNested, "child[%d] should not be correlated", i)
+					assert.False(t, child.nested.isCorrelated, "child[%d] should not be correlated", i)
 				}
 			}
 		})

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_test.go
@@ -1,0 +1,228 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/filters"
+)
+
+// nestedPvp builds a minimal nested leaf propValuePair.
+func nestedPvp(prop, relPath string) *propValuePair {
+	return &propValuePair{isNested: true, prop: prop, nestedRelPath: relPath}
+}
+
+// compoundAndPvp builds a compound AND propValuePair as produced by multi-token
+// text tokenization (childrenFromTokenization=true).
+func compoundAndPvp(children ...*propValuePair) *propValuePair {
+	return &propValuePair{operator: filters.OperatorAnd, children: children, childrenFromTokenization: true}
+}
+
+// userNestedAndPvp builds a compound AND propValuePair as produced by user
+// filter construction (childrenFromTokenization=false). Used to model cases
+// like AND(addresses.city, cars.make) where the AND is not from tokenization.
+func userNestedAndPvp(children ...*propValuePair) *propValuePair {
+	return &propValuePair{operator: filters.OperatorAnd, children: children}
+}
+
+func TestNestedCorrelatedGroup(t *testing.T) {
+	flatPvp := func() *propValuePair {
+		return &propValuePair{prop: "name", operator: filters.OperatorEqual}
+	}
+
+	tests := []struct {
+		name          string
+		children      []*propValuePair
+		wantNilGroups bool           // groups == nil (unresolvable)
+		wantGroups    map[string]int // expected group sizes by prop name
+		wantOthers    int            // expected number of flat/other conditions
+	}{
+		// --- all nested, single prop group ---
+		{
+			name:       "single nested child",
+			children:   []*propValuePair{nestedPvp("addresses", "city")},
+			wantGroups: map[string]int{"addresses": 1},
+		},
+		{
+			name: "two nested children same prop",
+			children: []*propValuePair{
+				nestedPvp("addresses", "city"),
+				nestedPvp("addresses", "postcode"),
+			},
+			wantGroups: map[string]int{"addresses": 2},
+		},
+		{
+			name: "three nested children same prop",
+			children: []*propValuePair{
+				nestedPvp("cars", "make"),
+				nestedPvp("cars", "tires.width"),
+				nestedPvp("cars", "accessories.type"),
+			},
+			wantGroups: map[string]int{"cars": 3},
+		},
+		{
+			// Compound AND from multi-token text is kept as a single unit.
+			name: "compound AND (multi-token text) same prop",
+			children: []*propValuePair{
+				compoundAndPvp(nestedPvp("addresses", "city"), nestedPvp("addresses", "city")),
+				nestedPvp("addresses", "postcode"),
+			},
+			wantGroups: map[string]int{"addresses": 2}, // 1 compound + 1 direct
+		},
+		{
+			name: "direct and compound children same prop",
+			children: []*propValuePair{
+				nestedPvp("cars", "make"),
+				compoundAndPvp(nestedPvp("cars", "tires.width"), nestedPvp("cars", "tires.width")),
+			},
+			wantGroups: map[string]int{"cars": 2},
+		},
+
+		// --- multiple prop groups, all nested ---
+		{
+			// Conditions spanning two props produce two separate groups, each
+			// resolved with its own same-element semantics.
+			name: "two props — two groups",
+			children: []*propValuePair{
+				nestedPvp("addresses", "city"),
+				nestedPvp("cars", "make"),
+			},
+			wantGroups: map[string]int{"addresses": 1, "cars": 1},
+		},
+		{
+			// Interleaved multi-prop conditions are grouped correctly.
+			name: "four conditions across two props interleaved",
+			children: []*propValuePair{
+				nestedPvp("cars", "tires.width"),
+				nestedPvp("addresses", "city"),
+				nestedPvp("cars", "accessories.type"),
+				nestedPvp("addresses", "postcode"),
+			},
+			wantGroups: map[string]int{"cars": 2, "addresses": 2},
+		},
+
+		// --- mixed nested + flat: groups returned, flat conditions go into remaining ---
+		{
+			// Flat property alongside nested conditions: nested groups still get
+			// same-element semantics; the flat condition goes into remaining.
+			name: "nested and flat property mixed",
+			children: []*propValuePair{
+				nestedPvp("cars", "tires.width"),
+				flatPvp(),
+				nestedPvp("cars", "accessories.type"),
+			},
+			wantGroups: map[string]int{"cars": 2},
+			wantOthers: 1,
+		},
+		{
+			// Full mixed: two nested groups + one flat property.
+			// cars and addresses each get correlated resolution; name is resolved
+			// normally and AND'd with the correlated results.
+			name: "cars + addresses + flat mixed",
+			children: []*propValuePair{
+				nestedPvp("cars", "tires.width"),
+				nestedPvp("addresses", "city"),
+				nestedPvp("cars", "accessories.type"),
+				nestedPvp("addresses", "postcode"),
+				flatPvp(),
+			},
+			wantGroups: map[string]int{"cars": 2, "addresses": 2},
+			wantOthers: 1,
+		},
+		{
+			// Compound AND with a non-nested grandchild is treated as a flat
+			// condition (goes to remaining, not into a nested group).
+			name: "compound AND with non-nested grandchild goes to remaining",
+			children: []*propValuePair{
+				nestedPvp("addresses", "city"),
+				userNestedAndPvp(nestedPvp("addresses", "postcode"), flatPvp()),
+			},
+			wantGroups: map[string]int{"addresses": 1},
+			wantOthers: 1,
+		},
+		{
+			// OR compound child: not a valid correlated condition, goes to remaining.
+			name: "non-AND compound child goes to remaining",
+			children: []*propValuePair{
+				nestedPvp("addresses", "city"),
+				{
+					operator: filters.OperatorOr,
+					children: []*propValuePair{nestedPvp("addresses", "postcode")},
+				},
+			},
+			wantGroups: map[string]int{"addresses": 1},
+			wantOthers: 1,
+		},
+
+		// --- nil groups (truly unresolvable) ---
+		{
+			name:          "empty children",
+			wantNilGroups: true,
+		},
+
+		// --- compound AND with mixed props → goes to remaining, NOT unresolvable ---
+		// AND(addresses.city, cars.make) is a perfectly valid user filter that
+		// means "doc has a matching address city AND a matching car make".
+		// When nested inside another AND as a compound AND child, it is treated
+		// as an opaque condition in remaining: resolveDocIDsAndOr recurses into it
+		// and applies correlated resolution on its children independently.
+		{
+			// A user-constructed AND(addresses.city, cars.make) nested as a
+			// compound AND child: resolves correctly via the remaining path.
+			name: "compound AND(addresses.city, cars.make) — goes to remaining",
+			children: []*propValuePair{
+				userNestedAndPvp(
+					nestedPvp("addresses", "city"),
+					nestedPvp("cars", "make"),
+				),
+			},
+			// groups is nil because no direct nested children exist at this level,
+			// but the user AND goes to remaining, not causing unresolvability.
+			wantNilGroups: true,
+		},
+		{
+			// Valid nested alongside user AND with mixed props: the user AND
+			// goes to remaining, the direct nested child forms a group.
+			name: "nested + user AND(addresses, cars) — nested groups, user AND in remaining",
+			children: []*propValuePair{
+				nestedPvp("addresses", "city"),
+				userNestedAndPvp(
+					nestedPvp("addresses", "postcode"),
+					nestedPvp("cars", "make"),
+				),
+			},
+			wantGroups: map[string]int{"addresses": 1},
+			wantOthers: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pv := &propValuePair{operator: filters.OperatorAnd, children: tt.children}
+			groups := pv.extractNestedCorrelatedGroups()
+			if tt.wantNilGroups {
+				assert.Nil(t, groups)
+				return
+			}
+			require.NotNil(t, groups)
+			assert.Equal(t, len(tt.wantGroups), len(groups), "number of groups")
+			for prop, wantSize := range tt.wantGroups {
+				assert.Len(t, groups[prop], wantSize, "group size for prop %q", prop)
+			}
+			// pv.children now holds only the flat conditions.
+			assert.Len(t, pv.children, tt.wantOthers, "remaining (flat) children count")
+		})
+	}
+}

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -479,23 +479,22 @@ func (s *Searcher) extractPropValuePairs(ctx context.Context,
 
 // groupNestedByProp rewrites a flat slice of AND children so that conditions
 // targeting the same top-level nested property are grouped into a single
-// isCorrelatedNested AND node that the resolver will handle with position-aware
+// nested.isCorrelated AND node that the resolver will handle with position-aware
 // same-element semantics. Flat (non-nested) conditions and nested conditions
 // from different props are returned unchanged in their original order.
 //
 // A child is eligible for grouping when it is:
-//   - a direct nested leaf (isNested == true), or
-//   - a tokenization-produced compound AND (childrenFromTokenization == true)
-//     whose first grandchild is nested — all grandchildren share the same prop.
+//   - a direct nested leaf (nested.isNested == true), or
+//   - a tokenization-produced compound AND (nested.isCorrelated == true)
 //
 // If no nested children are found, the original slice is returned as-is.
 // Single-child groups are kept as plain children (no wrapper node created).
 // nestedPropName returns the root property name for a child eligible for
 // correlated grouping, or "" if the child is flat and should pass through.
-// Eligible children are direct nested leaves (isNested == true) or
-// tokenization-produced compound ANDs (isCorrelatedNested == true).
+// Eligible children are direct nested leaves or tokenization compound ANDs
+// (both marked via nested.isNested or nested.isCorrelated respectively).
 func nestedPropName(child *propValuePair) string {
-	if child.isNested || child.isCorrelatedNested {
+	if child.nested.isNested || child.nested.isCorrelated {
 		return child.prop
 	}
 	return ""
@@ -539,11 +538,11 @@ func groupNestedByProp(children []*propValuePair, class *models.Class) []*propVa
 			result = append(result, group[0])
 		} else {
 			result = append(result, &propValuePair{
-				operator:           filters.OperatorAnd,
-				isCorrelatedNested: true,
-				prop:               prop,
-				children:           group,
-				Class:              class,
+				operator: filters.OperatorAnd,
+				nested:   nestedInfo{isCorrelated: true},
+				prop:     prop,
+				children: group,
+				Class:    class,
 			})
 		}
 	}

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -494,6 +494,9 @@ func (s *Searcher) extractPropValuePairs(ctx context.Context,
 // Eligible children are direct nested leaves or tokenization compound ANDs
 // (both marked via nested.isNested or nested.isCorrelated respectively).
 func nestedPropName(child *propValuePair) string {
+	if child == nil {
+		return ""
+	}
 	if child.nested.isNested || child.nested.isCorrelated {
 		return child.prop
 	}

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -347,6 +347,9 @@ func (s *Searcher) extractPropValuePair(
 		if err != nil {
 			return nil, err
 		}
+		if filter.Operator == filters.OperatorAnd {
+			children = groupNestedByProp(children, class)
+		}
 		out.children = children
 		out.operator = filter.Operator
 		return out, nil
@@ -472,6 +475,79 @@ func (s *Searcher) extractPropValuePairs(ctx context.Context,
 		return nil, ErrOnlyStopwords
 	}
 	return children, nil
+}
+
+// groupNestedByProp rewrites a flat slice of AND children so that conditions
+// targeting the same top-level nested property are grouped into a single
+// isCorrelatedNested AND node that the resolver will handle with position-aware
+// same-element semantics. Flat (non-nested) conditions and nested conditions
+// from different props are returned unchanged in their original order.
+//
+// A child is eligible for grouping when it is:
+//   - a direct nested leaf (isNested == true), or
+//   - a tokenization-produced compound AND (childrenFromTokenization == true)
+//     whose first grandchild is nested — all grandchildren share the same prop.
+//
+// If no nested children are found, the original slice is returned as-is.
+// Single-child groups are kept as plain children (no wrapper node created).
+// nestedPropName returns the root property name for a child eligible for
+// correlated grouping, or "" if the child is flat and should pass through.
+// Eligible children are direct nested leaves (isNested == true) or
+// tokenization-produced compound ANDs (isCorrelatedNested == true).
+func nestedPropName(child *propValuePair) string {
+	if child.isNested || child.isCorrelatedNested {
+		return child.prop
+	}
+	return ""
+}
+
+func groupNestedByProp(children []*propValuePair, class *models.Class) []*propValuePair {
+	// First pass: build groups per prop (preserving first-seen order).
+	groups := make(map[string][]*propValuePair)
+	var propOrder []string
+	for _, child := range children {
+		prop := nestedPropName(child)
+		if prop == "" {
+			continue
+		}
+		if _, seen := groups[prop]; !seen {
+			propOrder = append(propOrder, prop)
+		}
+		groups[prop] = append(groups[prop], child)
+	}
+	if len(groups) == 0 {
+		return children
+	}
+
+	// Second pass: reconstruct the children slice, replacing multi-condition
+	// nested groups with a single isCorrelatedNested AND node. Single-condition
+	// groups are kept as plain children. Flat conditions retain their position.
+	result := make([]*propValuePair, 0, len(children))
+	emitted := make(map[string]bool, len(propOrder))
+	for _, child := range children {
+		prop := nestedPropName(child)
+		if prop == "" {
+			result = append(result, child)
+			continue
+		}
+		if emitted[prop] {
+			continue
+		}
+		emitted[prop] = true
+		group := groups[prop]
+		if len(group) == 1 {
+			result = append(result, group[0])
+		} else {
+			result = append(result, &propValuePair{
+				operator:           filters.OperatorAnd,
+				isCorrelatedNested: true,
+				prop:               prop,
+				children:           group,
+				Class:              class,
+			})
+		}
+	}
+	return result
 }
 
 func (s *Searcher) extractReferenceFilter(prop *models.Property,

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -99,8 +99,8 @@ func (s *Searcher) docBitmapInvertedRoaringSet(ctx context.Context, b *lsmkv.Buc
 	}
 
 	var rr *RowReaderRoaringSet
-	if pv.isNested {
-		rr = NewRowReaderRoaringSetWithPrefix(b, pv.value, pv.operator, false, nested.PathPrefix(pv.nestedRelPath))
+	if pv.nested.isNested {
+		rr = NewRowReaderRoaringSetWithPrefix(b, pv.value, pv.operator, false, nested.PathPrefix(pv.nested.relPath))
 	} else {
 		rr = NewRowReaderRoaringSet(b, pv.value, pv.operator, false)
 	}

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/filters"
@@ -97,7 +98,12 @@ func (s *Searcher) docBitmapInvertedRoaringSet(ctx context.Context, b *lsmkv.Buc
 		return true, nil
 	}
 
-	rr := NewRowReaderRoaringSetWithPrefix(b, pv.value, pv.operator, false, pv.nestedKeyPrefix)
+	var rr *RowReaderRoaringSet
+	if pv.isNested {
+		rr = NewRowReaderRoaringSetWithPrefix(b, pv.value, pv.operator, false, nested.PathPrefix(pv.nestedRelPath))
+	} else {
+		rr = NewRowReaderRoaringSet(b, pv.value, pv.operator, false)
+	}
 	if err := rr.Read(ctx, readFn); err != nil {
 		return out, fmt.Errorf("read row: %w", err)
 	}

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -142,7 +142,7 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propN
 	if len(pvps) == 1 {
 		return pvps[0], nil
 	}
-	return &propValuePair{operator: filters.OperatorAnd, children: pvps, Class: class}, nil
+	return &propValuePair{operator: filters.OperatorAnd, children: pvps, childrenFromTokenization: true, Class: class}, nil
 }
 
 // buildNestedPrimitiveFilterPair handles non-text primitive types (int,

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -142,7 +142,7 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propN
 	if len(pvps) == 1 {
 		return pvps[0], nil
 	}
-	return &propValuePair{operator: filters.OperatorAnd, children: pvps, childrenFromTokenization: true, Class: class}, nil
+	return &propValuePair{operator: filters.OperatorAnd, children: pvps, childrenFromTokenization: true, isCorrelatedNested: true, prop: propName, Class: class}, nil
 }
 
 // buildNestedPrimitiveFilterPair handles non-text primitive types (int,

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -78,13 +77,12 @@ func (s *Searcher) buildNestedFilterPair(filter *filters.Clause, path, propName 
 	// property (e.g. "city", "owner.firstname"), not the full filter path
 	// (e.g. "event.city"). Strip the top-level property name.
 	relativePath := strings.TrimPrefix(path, propName+".")
-	keyPrefix := nested.PathPrefix(relativePath)
 	dt := schema.DataType(leaf.DataType[0])
 	switch dt {
 	case schema.DataTypeText, schema.DataTypeTextArray:
-		return s.buildNestedTextFilterPair(filter, path, propName, leaf, keyPrefix, class)
+		return s.buildNestedTextFilterPair(filter, path, propName, leaf, relativePath, class)
 	default:
-		return s.buildNestedPrimitiveFilterPair(filter, path, propName, dt, keyPrefix, class)
+		return s.buildNestedPrimitiveFilterPair(filter, path, propName, dt, relativePath, class)
 	}
 }
 
@@ -96,7 +94,7 @@ func (s *Searcher) buildNestedFilterPair(filter *filters.Clause, path, propName 
 // ASCII folding, wildcard handling) was aligned with extractTokenizableProp
 // manually. Consider extracting a shared helper to avoid future divergence.
 func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propName string,
-	leaf *models.NestedProperty, keyPrefix []byte, class *models.Class,
+	leaf *models.NestedProperty, relativePath string, class *models.Class,
 ) (*propValuePair, error) {
 	valueStr, ok := filter.Value.Value.(string)
 	if !ok {
@@ -130,7 +128,7 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propN
 		pvps = append(pvps, &propValuePair{
 			prop:               propName,
 			value:              []byte(term),
-			nestedKeyPrefix:    keyPrefix,
+			nestedRelPath:      relativePath,
 			operator:           filter.Operator,
 			hasFilterableIndex: true,
 			isNested:           true,
@@ -150,7 +148,7 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propN
 // buildNestedPrimitiveFilterPair handles non-text primitive types (int,
 // number, bool, date and their array variants).
 func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, path, propName string,
-	dt schema.DataType, keyPrefix []byte, class *models.Class,
+	dt schema.DataType, relativePath string, class *models.Class,
 ) (*propValuePair, error) {
 	// Map array types to their scalar equivalent — each array element is stored
 	// individually in the nested bucket, so filtering works the same way.
@@ -182,7 +180,7 @@ func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, path, 
 	return &propValuePair{
 		prop:               propName,
 		value:              encodedValue,
-		nestedKeyPrefix:    keyPrefix,
+		nestedRelPath:      relativePath,
 		operator:           filter.Operator,
 		hasFilterableIndex: true,
 		isNested:           true,

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -128,10 +128,9 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propN
 		pvps = append(pvps, &propValuePair{
 			prop:               propName,
 			value:              []byte(term),
-			nestedRelPath:      relativePath,
 			operator:           filter.Operator,
 			hasFilterableIndex: true,
-			isNested:           true,
+			nested:             nestedInfo{isNested: true, relPath: relativePath},
 			Class:              class,
 		})
 	}
@@ -142,7 +141,7 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propN
 	if len(pvps) == 1 {
 		return pvps[0], nil
 	}
-	return &propValuePair{operator: filters.OperatorAnd, children: pvps, childrenFromTokenization: true, isCorrelatedNested: true, prop: propName, Class: class}, nil
+	return &propValuePair{operator: filters.OperatorAnd, children: pvps, nested: nestedInfo{isCorrelated: true, childrenFromTokenization: true}, prop: propName, Class: class}, nil
 }
 
 // buildNestedPrimitiveFilterPair handles non-text primitive types (int,
@@ -180,10 +179,9 @@ func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, path, 
 	return &propValuePair{
 		prop:               propName,
 		value:              encodedValue,
-		nestedRelPath:      relativePath,
 		operator:           filter.Operator,
 		hasFilterableIndex: true,
-		isNested:           true,
+		nested:             nestedInfo{isNested: true, relPath: relativePath},
 		Class:              class,
 	}, nil
 }

--- a/adapters/repos/db/inverted/searcher_nested_executor.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor.go
@@ -38,23 +38,9 @@ func (s bitmapsByCard) Swap(i, j int) {
 	s.cards[i], s.cards[j] = s.cards[j], s.cards[i]
 }
 
-// applyDirectAnd intersects all raw position bitmaps and strips to docIDs.
-// Implements the directAnd operation: positions are naturally aligned so a
-// plain bitmap AND followed by MaskRootLeaf gives correct results.
-func applyDirectAnd(positionBitmaps []*sroar.Bitmap) *sroar.Bitmap {
-	return nested.MaskRootLeaf(nested.AndAll(positionBitmaps))
-}
-
-// applyMaskLeafAnd zeroes leaf bits on each bitmap, ANDs them, and strips to
-// docIDs. Implements the maskLeafAnd operation: aligns on root+docID so paths
-// from different subtrees or a single-object LCA are correctly combined.
-func applyMaskLeafAnd(positionBitmaps []*sroar.Bitmap) *sroar.Bitmap {
-	return nested.MaskRootLeaf(nested.AndAllMaskLeaf(positionBitmaps))
-}
-
-// applyIdxLoop implements the idxLoopAnd operation. It iterates over all
-// _idx.{lcaPath}[N] entries in the meta bucket and verifies that all
-// conditions fall under the same array element N before accumulating results.
+// runIdxLoop iterates _idx.{lcaPath}[N] entries and verifies all conditions
+// fall within the same array element. Returns a root+docID bitmap (leaf bits
+// zeroed, root bits preserved); the caller applies MaskRootLeaf if needed.
 //
 // Optimisations applied:
 //  1. Conditions are sorted by cardinality (most selective first) so the
@@ -64,37 +50,31 @@ func applyMaskLeafAnd(positionBitmaps []*sroar.Bitmap) *sroar.Bitmap {
 //  3. Per-element pre-check: preFilter AND maskedElem is computed (1 alloc)
 //     before the expensive K-condition processing (2K allocs). Elements where
 //     no document can match all conditions are skipped cheaply. Because
-//     preFilter ⊆ maskedBitmaps[i] for all i, this also implies each
+//     preFilter ⊆ MaskLeaf(sorted[i]) for all i, this also implies each
 //     individual condition overlaps the element — no per-condition skip is
 //     needed inside the inner loop.
 //  4. Early termination when result already contains all documents in preFilter.
 //
 // Algorithm:
 //
-//	maskedBitmaps[i] = MaskLeaf(positionBitmaps[i])  for each i
-//	preFilter = AND of all maskedBitmaps
+//	preFilter = AndAllMaskLeaf(sorted)
 //	if preFilter empty → return empty
 //	for each _idx.{lcaPath}[N] entry:
-//	    maskedElem = MaskLeaf(elem[N])
-//	    if preFilter AND maskedElem empty → skip element cheaply
-//	    partial = MaskLeaf(bm[0] AND elem[N]) AND ...
+//	    if preFilter AND MaskLeaf(elem[N]) empty → skip element cheaply
+//	    partial = MaskLeafAnd(bm[0], elem[N]) AND MaskLeafAnd(bm[1], elem[N]) AND ...
 //	    result = result OR partial
 //	    if result covers all docs in preFilter → stop early
-//	return MaskRootLeaf(result)
-func applyIdxLoop(
+//	return result  (root+docID; caller applies MaskRootLeaf if needed)
+func (e *resolutionPlanExecutor) runIdxLoop(
 	ctx context.Context,
-	metaBucket *lsmkv.Bucket,
 	lcaPath string,
 	positionBitmaps []*sroar.Bitmap,
 ) (*sroar.Bitmap, error) {
-	if metaBucket == nil {
-		return nil, fmt.Errorf("applyIdxLoop: meta bucket is nil for path %q", lcaPath)
-	}
 	if len(positionBitmaps) == 0 {
-		return nil, fmt.Errorf("applyIdxLoop: no position bitmaps provided for path %q", lcaPath)
+		return nil, fmt.Errorf("runIdxLoop: no position bitmaps provided for path %q", lcaPath)
 	}
 	if len(positionBitmaps) == 1 {
-		return nested.MaskRootLeaf(positionBitmaps[0]), nil
+		return nested.MaskLeaf(positionBitmaps[0]), nil
 	}
 
 	// Optimisation 1: sort conditions by cardinality ascending so the most
@@ -125,7 +105,7 @@ func applyIdxLoop(
 	idxPrefix := nested.PathPrefix("_idx." + lcaPath)
 	result := sroar.NewBitmap()
 
-	c := metaBucket.CursorRoaringSet()
+	c := e.metaBucket.CursorRoaringSet()
 	defer c.Close()
 
 	for k, elemBitmap := c.Seek(nested.IdxKey(lcaPath, 0)); k != nil; k, elemBitmap = c.Next() {
@@ -170,5 +150,124 @@ func applyIdxLoop(
 		}
 	}
 
-	return nested.MaskRootLeaf(result), nil
+	return result, nil
+}
+
+// resolutionPlanExecutor executes a resolutionPlan for a correlated nested AND.
+// bitmapsByPath maps each relative nested path to its pre-computed raw position
+// bitmap. metaBucket is the _idx meta bucket for the root nested property; it
+// may be nil when no idxLoopAnd node is in the plan.
+//
+// TODO aliszka:nested_filtering bitmapsByPath holds bare *sroar.Bitmap values
+// with no associated release functions. Bitmaps fetched via fetchRawPositions
+// may be backed by pooled buffers that must be returned to the pool after use.
+// Add a releases []func() field and defer-call all of them at the end of
+// execute() so pooled buffers are correctly returned. See Option A in notes.
+type resolutionPlanExecutor struct {
+	plan          *resolutionPlan
+	bitmapsByPath map[string]*sroar.Bitmap
+	metaBucket    *lsmkv.Bucket
+}
+
+// newResolutionPlanExecutor returns an executor ready to run a resolutionPlan.
+func newResolutionPlanExecutor(
+	plan *resolutionPlan,
+	bitmapsByPath map[string]*sroar.Bitmap,
+	metaBucket *lsmkv.Bucket,
+) *resolutionPlanExecutor {
+	return &resolutionPlanExecutor{plan: plan, bitmapsByPath: bitmapsByPath, metaBucket: metaBucket}
+}
+
+// execute runs the plan and returns a docID-only bitmap.
+// MaskRootLeaf is applied once at the top; all recursive calls work with
+// partially-preserved position bits.
+func (e *resolutionPlanExecutor) execute(ctx context.Context) (*sroar.Bitmap, error) {
+	bm, err := e.executeNode(ctx, e.plan)
+	if err != nil {
+		return nil, err
+	}
+	return nested.MaskRootLeaf(bm), nil
+}
+
+// executeNode dispatches to the appropriate handler based on plan.op.
+// Each handler owns both the interior-groups and leaf-paths cases for its op.
+func (e *resolutionPlanExecutor) executeNode(ctx context.Context, plan *resolutionPlan) (*sroar.Bitmap, error) {
+	switch plan.op {
+	case directAnd:
+		return e.executeDirectAnd(plan)
+	case maskLeafAnd:
+		return e.executeMaskLeafAnd(ctx, plan)
+	case idxLoopAnd:
+		return e.executeIdxLoopAnd(ctx, plan)
+	}
+	return nil, fmt.Errorf("executeNode: unhandled op %d", plan.op)
+}
+
+// executeDirectAnd handles directAnd nodes. Positions are naturally aligned
+// (scalar siblings or ancestor/descendant), so a plain AND suffices.
+// directAnd is always a leaf node — no groups.
+func (e *resolutionPlanExecutor) executeDirectAnd(plan *resolutionPlan) (*sroar.Bitmap, error) {
+	bitmaps, err := e.fetchBitmaps(plan.paths)
+	if err != nil {
+		return nil, err
+	}
+	return nested.AndAll(bitmaps), nil
+}
+
+// executeMaskLeafAnd handles maskLeafAnd nodes. Zeros the leaf bits of each
+// input bitmap and ANDs them, aligning on root+docID. Handles both interior
+// nodes (sub-groups are recursively executed) and leaf nodes (paths fetched).
+func (e *resolutionPlanExecutor) executeMaskLeafAnd(ctx context.Context, plan *resolutionPlan) (*sroar.Bitmap, error) {
+	bitmaps, err := e.collectBitmaps(ctx, plan)
+	if err != nil {
+		return nil, err
+	}
+	return nested.AndAllMaskLeaf(bitmaps), nil
+}
+
+// executeIdxLoopAnd handles idxLoopAnd nodes. Verifies that all conditions land
+// within the same array element by iterating _idx.{lcaPath}[N] meta entries.
+// Handles both interior nodes (sub-groups executed first) and leaf nodes
+// (paths fetched directly). Returns root+docID.
+func (e *resolutionPlanExecutor) executeIdxLoopAnd(ctx context.Context, plan *resolutionPlan) (*sroar.Bitmap, error) {
+	if e.metaBucket == nil {
+		return nil, fmt.Errorf("executeIdxLoopAnd: meta bucket is nil for path %q", plan.lcaPath)
+	}
+	bitmaps, err := e.collectBitmaps(ctx, plan)
+	if err != nil {
+		return nil, err
+	}
+	return e.runIdxLoop(ctx, plan.lcaPath, bitmaps)
+}
+
+// collectBitmaps executes each sub-group of an interior maskLeafAnd or
+// idxLoopAnd node and returns the resulting bitmaps. maskLeafAnd and
+// idxLoopAnd nodes always have groups — flat paths are only used by directAnd,
+// which never calls this method.
+func (e *resolutionPlanExecutor) collectBitmaps(ctx context.Context, plan *resolutionPlan) ([]*sroar.Bitmap, error) {
+	if len(plan.groups) == 0 {
+		return nil, fmt.Errorf("collectBitmaps: %d node has no groups", plan.op)
+	}
+	bitmaps := make([]*sroar.Bitmap, 0, len(plan.groups))
+	for _, group := range plan.groups {
+		bm, err := e.executeNode(ctx, group)
+		if err != nil {
+			return nil, err
+		}
+		bitmaps = append(bitmaps, bm)
+	}
+	return bitmaps, nil
+}
+
+// fetchBitmaps returns the pre-computed position bitmap for each path.
+func (e *resolutionPlanExecutor) fetchBitmaps(paths []string) ([]*sroar.Bitmap, error) {
+	bitmaps := make([]*sroar.Bitmap, 0, len(paths))
+	for _, path := range paths {
+		bm, ok := e.bitmapsByPath[path]
+		if !ok {
+			return nil, fmt.Errorf("fetchBitmaps: no bitmap for path %q", path)
+		}
+		bitmaps = append(bitmaps, bm)
+	}
+	return bitmaps, nil
 }

--- a/adapters/repos/db/inverted/searcher_nested_executor.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor.go
@@ -154,28 +154,28 @@ func (e *resolutionPlanExecutor) runIdxLoop(
 }
 
 // resolutionPlanExecutor executes a resolutionPlan for a correlated nested AND.
-// bitmapsByPath maps each relative nested path to its pre-computed raw position
+// positionsByPath maps each relative nested path to its pre-computed raw position
 // bitmap. metaBucket is the _idx meta bucket for the root nested property; it
 // may be nil when no idxLoopAnd node is in the plan.
 //
-// TODO aliszka:nested_filtering bitmapsByPath holds bare *sroar.Bitmap values
-// with no associated release functions. Bitmaps fetched via fetchRawPositions
-// may be backed by pooled buffers that must be returned to the pool after use.
-// Add a releases []func() field and defer-call all of them at the end of
-// execute() so pooled buffers are correctly returned. See Option A in notes.
+// TODO aliszka:nested_filtering positionBitmaps bitmaps have no associated release
+// functions. Bitmaps fetched via fetchRawPositions may be backed by pooled
+// buffers that must be returned to the pool after use. Add a releases []func()
+// field and defer-call all of them at the end of execute() so pooled buffers
+// are correctly returned. See Option A in notes.
 type resolutionPlanExecutor struct {
 	plan          *resolutionPlan
-	bitmapsByPath map[string]*sroar.Bitmap
+	positionsByPath map[string]*positionBitmaps
 	metaBucket    *lsmkv.Bucket
 }
 
 // newResolutionPlanExecutor returns an executor ready to run a resolutionPlan.
 func newResolutionPlanExecutor(
 	plan *resolutionPlan,
-	bitmapsByPath map[string]*sroar.Bitmap,
+	positionsByPath map[string]*positionBitmaps,
 	metaBucket *lsmkv.Bucket,
 ) *resolutionPlanExecutor {
-	return &resolutionPlanExecutor{plan: plan, bitmapsByPath: bitmapsByPath, metaBucket: metaBucket}
+	return &resolutionPlanExecutor{plan: plan, positionsByPath: positionsByPath, metaBucket: metaBucket}
 }
 
 // execute runs the plan and returns a docID-only bitmap.
@@ -259,15 +259,53 @@ func (e *resolutionPlanExecutor) collectBitmaps(ctx context.Context, plan *resol
 	return bitmaps, nil
 }
 
-// fetchBitmaps returns the pre-computed position bitmap for each path.
+// fetchBitmaps returns one combined position bitmap per path by calling
+// combinePositionBitmaps. All merging logic is encapsulated here in the executor.
 func (e *resolutionPlanExecutor) fetchBitmaps(paths []string) ([]*sroar.Bitmap, error) {
 	bitmaps := make([]*sroar.Bitmap, 0, len(paths))
 	for _, path := range paths {
-		bm, ok := e.bitmapsByPath[path]
+		positions, ok := e.positionsByPath[path]
 		if !ok {
-			return nil, fmt.Errorf("fetchBitmaps: no bitmap for path %q", path)
+			return nil, fmt.Errorf("fetchBitmaps: no positions for path %q", path)
 		}
-		bitmaps = append(bitmaps, bm)
+		bitmaps = append(bitmaps, combinePositionBitmaps(positions))
 	}
 	return bitmaps, nil
+}
+
+// combinePositionBitmaps merges the pre-fetched bitmaps in a positionBitmaps into one bitmap:
+//   - tokens are combined with AndAll — all tokens must share the same leaf
+//     position (multi-token text values like "New York" → ["new", "york"]).
+//   - A single independent bitmap is returned raw — no combining needed.
+//   - Multiple independent bitmaps are combined with MaskLeafAndAll — the
+//     values may be at different leaf positions (scalar array elements) but
+//     must belong to the same parent element (same root_idx).
+//   - When both tokens and independent bitmaps are present, the two partial
+//     results are aligned at root+docID level via MaskLeafAndAll.
+func combinePositionBitmaps(positions *positionBitmaps) *sroar.Bitmap {
+	var tokensResult *sroar.Bitmap
+	if len(positions.tokens) > 0 {
+		tokensResult = nested.AndAll(positions.tokens)
+	}
+
+	var independentResult *sroar.Bitmap
+	switch len(positions.independent) {
+	case 0:
+		// nothing
+	case 1:
+		independentResult = positions.independent[0] // single value: keep raw
+	default:
+		independentResult = nested.AndAllMaskLeaf(positions.independent)
+	}
+
+	switch {
+	case tokensResult == nil:
+		return independentResult
+	case independentResult == nil:
+		return tokensResult
+	default:
+		// Both present: align at root+docID so they can be in different
+		// leaf positions within the same parent element.
+		return nested.AndAllMaskLeaf([]*sroar.Bitmap{tokensResult, independentResult})
+	}
 }

--- a/adapters/repos/db/inverted/searcher_nested_executor.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor.go
@@ -164,9 +164,9 @@ func (e *resolutionPlanExecutor) runIdxLoop(
 // field and defer-call all of them at the end of execute() so pooled buffers
 // are correctly returned. See Option A in notes.
 type resolutionPlanExecutor struct {
-	plan          *resolutionPlan
+	plan            *resolutionPlan
 	positionsByPath map[string]*positionBitmaps
-	metaBucket    *lsmkv.Bucket
+	metaBucket      *lsmkv.Bucket
 }
 
 // newResolutionPlanExecutor returns an executor ready to run a resolutionPlan.

--- a/adapters/repos/db/inverted/searcher_nested_executor_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_integration_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
@@ -28,7 +27,7 @@ import (
 )
 
 // newIdxBucket creates a temporary lsmkv store and an empty RoaringSet bucket
-// for use as the _idx meta bucket in applyIdxLoop tests.
+// for use as the _idx meta bucket in executeResolutionPlan tests.
 func newIdxBucket(t *testing.T) *lsmkv.Bucket {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
@@ -51,9 +50,9 @@ func writeIdx(t *testing.T, bucket *lsmkv.Bucket, path string, elemIdx int, posi
 	require.NoError(t, bucket.RoaringSetAddList(nested.IdxKey(path, elemIdx), positions))
 }
 
-// ---- applyIdxLoop integration tests ----------------------------------------
+// ---- executeResolutionPlan with idxLoopAnd integration tests ----------------
 
-func TestApplyIdxLoopIntegration(t *testing.T) {
+func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 	const (
 		doc5 = uint64(5)
 		doc7 = uint64(7)
@@ -64,20 +63,13 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 	// Preconditions requiring a real (non-nil) bucket
 	// -------------------------------------------------------------------------
 
-	t.Run("zero bitmaps returns error", func(t *testing.T) {
-		bucket := newIdxBucket(t)
-		_, err := applyIdxLoop(context.Background(), bucket, "cars", nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "no position bitmaps")
-	})
-
 	t.Run("one bitmap returns MaskRootLeaf fast-path without cursor scan", func(t *testing.T) {
 		bucket := newIdxBucket(t)
 		// Write an idx entry that would produce a different result if scanned.
 		writeIdx(t, bucket, "cars", 0, []uint64{nested.Encode(1, 1, doc5), nested.Encode(1, 2, doc5)})
 
-		pos511 := nested.Encode(1, 1, doc5)
-		result, err := applyIdxLoop(context.Background(), bucket, "cars", []*sroar.Bitmap{roaringset.NewBitmap(pos511)})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", roaringset.NewBitmap(nested.Encode(1, 1, doc5)))
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		// Fast-path: returns MaskRootLeaf(bitmap[0]), ignoring the bucket entirely.
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
@@ -88,11 +80,13 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 		writeIdx(t, bucket, "cars", 0, []uint64{nested.Encode(1, 1, doc5)})
 
 		ctx, cancel := context.WithCancel(context.Background())
-		cancel() // cancel immediately
+		cancel()
 
-		pos511 := nested.Encode(1, 1, doc5)
-		pos512 := nested.Encode(1, 2, doc5)
-		_, err := applyIdxLoop(ctx, bucket, "cars", []*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512)})
+		plan, bitmapsByPath := idxLoopAndPlan("cars",
+			roaringset.NewBitmap(nested.Encode(1, 1, doc5)),
+			roaringset.NewBitmap(nested.Encode(1, 2, doc5)),
+		)
+		_, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(ctx)
 		require.Error(t, err)
 	})
 
@@ -113,7 +107,8 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 
 		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5))
 		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5))
-		result, err := applyIdxLoop(context.Background(), bucket, "cars", []*sroar.Bitmap{condA, condB})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
@@ -126,7 +121,8 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 
 		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5)) // in cars[0]
 		condB := roaringset.NewBitmap(nested.Encode(2, 1, doc5)) // in cars[1]
-		result, err := applyIdxLoop(context.Background(), bucket, "cars", []*sroar.Bitmap{condA, condB})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -142,7 +138,8 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 
 		condA := roaringset.NewBitmap(nested.Encode(2, 1, doc5)) // in cars[1]
 		condB := roaringset.NewBitmap(nested.Encode(2, 2, doc5)) // in cars[1]
-		result, err := applyIdxLoop(context.Background(), bucket, "cars", []*sroar.Bitmap{condA, condB})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
@@ -158,8 +155,8 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5))
 		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5))
 		condC := roaringset.NewBitmap(nested.Encode(1, 3, doc5))
-		result, err := applyIdxLoop(context.Background(), bucket, "cars",
-			[]*sroar.Bitmap{condA, condB, condC})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB, condC)
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
@@ -175,8 +172,8 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5)) // cars[0]
 		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5)) // cars[0]
 		condC := roaringset.NewBitmap(nested.Encode(2, 1, doc5)) // cars[1] only
-		result, err := applyIdxLoop(context.Background(), bucket, "cars",
-			[]*sroar.Bitmap{condA, condB, condC})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB, condC)
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -200,15 +197,13 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 
 		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7))
 		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5), nested.Encode(2, 1, doc7))
-		result, err := applyIdxLoop(context.Background(), bucket, "cars",
-			[]*sroar.Bitmap{condA, condB})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
 
 	t.Run("two docs both satisfy conditions in their respective elements", func(t *testing.T) {
-		// doc5: both conditions in cars[0]
-		// doc7: both conditions in cars[0] (both at root=1)
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
 			nested.Encode(1, 1, doc5),
@@ -219,8 +214,8 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 
 		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7))
 		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5), nested.Encode(1, 2, doc7))
-		result, err := applyIdxLoop(context.Background(), bucket, "cars",
-			[]*sroar.Bitmap{condA, condB})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5, doc7}, result.ToArray())
 	})
@@ -243,8 +238,8 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 
 		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7), nested.Encode(1, 1, doc9))
 		condB := roaringset.NewBitmap(nested.Encode(2, 1, doc5), nested.Encode(1, 2, doc7), nested.Encode(2, 1, doc9))
-		result, err := applyIdxLoop(context.Background(), bucket, "cars",
-			[]*sroar.Bitmap{condA, condB})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc7}, result.ToArray())
 	})
@@ -264,8 +259,8 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 
 		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5)) // only doc5
 		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc7)) // only doc7
-		result, err := applyIdxLoop(context.Background(), bucket, "cars",
-			[]*sroar.Bitmap{condA, condB})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -276,8 +271,8 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 
 		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5))
 		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5))
-		result, err := applyIdxLoop(context.Background(), bucket, "cars",
-			[]*sroar.Bitmap{condA, condB})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -290,8 +285,8 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 
 		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5))
 		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5)) // leaf=2 not in element 0
-		result, err := applyIdxLoop(context.Background(), bucket, "cars",
-			[]*sroar.Bitmap{condA, condB})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -313,8 +308,8 @@ func TestApplyIdxLoopIntegration(t *testing.T) {
 
 		condA := roaringset.NewBitmap(nested.Encode(4, 1, doc5)) // only in element 3 (root=4)
 		condB := roaringset.NewBitmap(nested.Encode(4, 2, doc5)) // only in element 3 (root=4)
-		result, err := applyIdxLoop(context.Background(), bucket, "cars",
-			[]*sroar.Bitmap{condA, condB})
+		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
+		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})

--- a/adapters/repos/db/inverted/searcher_nested_executor_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_test.go
@@ -29,45 +29,45 @@ import (
 
 // directAndPlan builds a directAnd plan and bitmapsByPath from the given
 // bitmaps. Paths are auto-generated as "p1", "p2", …
-func directAndPlan(bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*sroar.Bitmap) {
+func directAndPlan(bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*positionBitmaps) {
 	paths := make([]string, len(bitmaps))
-	bitmapsByPath := make(map[string]*sroar.Bitmap, len(bitmaps))
+	positionsByPath := make(map[string]*positionBitmaps, len(bitmaps))
 	for i, bm := range bitmaps {
 		path := fmt.Sprintf("p%d", i+1)
 		paths[i] = path
-		bitmapsByPath[path] = bm
+		positionsByPath[path] = &positionBitmaps{independent: []*sroar.Bitmap{bm}}
 	}
-	return &resolutionPlan{op: directAnd, paths: paths}, bitmapsByPath
+	return &resolutionPlan{op: directAnd, paths: paths}, positionsByPath
 }
 
 // maskLeafAndPlan builds a maskLeafAnd interior plan where each bitmap becomes
 // one directAnd sub-group.
-func maskLeafAndPlan(bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*sroar.Bitmap) {
+func maskLeafAndPlan(bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*positionBitmaps) {
 	groups := make([]*resolutionPlan, len(bitmaps))
-	bitmapsByPath := make(map[string]*sroar.Bitmap, len(bitmaps))
+	positionsByPath := make(map[string]*positionBitmaps, len(bitmaps))
 	for i, bm := range bitmaps {
 		path := fmt.Sprintf("p%d", i+1)
 		groups[i] = &resolutionPlan{op: directAnd, paths: []string{path}}
-		bitmapsByPath[path] = bm
+		positionsByPath[path] = &positionBitmaps{independent: []*sroar.Bitmap{bm}}
 	}
-	return &resolutionPlan{op: maskLeafAnd, groups: groups}, bitmapsByPath
+	return &resolutionPlan{op: maskLeafAnd, groups: groups}, positionsByPath
 }
 
 // idxLoopAndPlan builds an idxLoopAnd plan where each bitmap becomes one
 // directAnd sub-group.
-func idxLoopAndPlan(lcaPath string, bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*sroar.Bitmap) {
+func idxLoopAndPlan(lcaPath string, bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*positionBitmaps) {
 	groups := make([]*resolutionPlan, len(bitmaps))
-	bitmapsByPath := make(map[string]*sroar.Bitmap, len(bitmaps))
+	positionsByPath := make(map[string]*positionBitmaps, len(bitmaps))
 	for i, bm := range bitmaps {
 		path := fmt.Sprintf("p%d", i+1)
 		groups[i] = &resolutionPlan{op: directAnd, paths: []string{path}}
-		bitmapsByPath[path] = bm
+		positionsByPath[path] = &positionBitmaps{independent: []*sroar.Bitmap{bm}}
 	}
-	return &resolutionPlan{op: idxLoopAnd, lcaPath: lcaPath, groups: groups}, bitmapsByPath
+	return &resolutionPlan{op: idxLoopAnd, lcaPath: lcaPath, groups: groups}, positionsByPath
 }
 
 // exec is a shorthand for executeResolutionPlan with no meta bucket.
-func exec(t *testing.T, plan *resolutionPlan, bitmapsByPath map[string]*sroar.Bitmap) *sroar.Bitmap {
+func exec(t *testing.T, plan *resolutionPlan, bitmapsByPath map[string]*positionBitmaps) *sroar.Bitmap {
 	t.Helper()
 	result, err := newResolutionPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
 	require.NoError(t, err)

--- a/adapters/repos/db/inverted/searcher_nested_executor_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_test.go
@@ -13,6 +13,7 @@ package inverted
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,69 +23,133 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 )
 
-// ---- applyDirectAnd --------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Plan-building helpers
+// ---------------------------------------------------------------------------
 
-func TestApplyDirectAnd(t *testing.T) {
+// directAndPlan builds a directAnd plan and bitmapsByPath from the given
+// bitmaps. Paths are auto-generated as "p1", "p2", …
+func directAndPlan(bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*sroar.Bitmap) {
+	paths := make([]string, len(bitmaps))
+	bitmapsByPath := make(map[string]*sroar.Bitmap, len(bitmaps))
+	for i, bm := range bitmaps {
+		path := fmt.Sprintf("p%d", i+1)
+		paths[i] = path
+		bitmapsByPath[path] = bm
+	}
+	return &resolutionPlan{op: directAnd, paths: paths}, bitmapsByPath
+}
+
+// maskLeafAndPlan builds a maskLeafAnd interior plan where each bitmap becomes
+// one directAnd sub-group.
+func maskLeafAndPlan(bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*sroar.Bitmap) {
+	groups := make([]*resolutionPlan, len(bitmaps))
+	bitmapsByPath := make(map[string]*sroar.Bitmap, len(bitmaps))
+	for i, bm := range bitmaps {
+		path := fmt.Sprintf("p%d", i+1)
+		groups[i] = &resolutionPlan{op: directAnd, paths: []string{path}}
+		bitmapsByPath[path] = bm
+	}
+	return &resolutionPlan{op: maskLeafAnd, groups: groups}, bitmapsByPath
+}
+
+// idxLoopAndPlan builds an idxLoopAnd plan where each bitmap becomes one
+// directAnd sub-group.
+func idxLoopAndPlan(lcaPath string, bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*sroar.Bitmap) {
+	groups := make([]*resolutionPlan, len(bitmaps))
+	bitmapsByPath := make(map[string]*sroar.Bitmap, len(bitmaps))
+	for i, bm := range bitmaps {
+		path := fmt.Sprintf("p%d", i+1)
+		groups[i] = &resolutionPlan{op: directAnd, paths: []string{path}}
+		bitmapsByPath[path] = bm
+	}
+	return &resolutionPlan{op: idxLoopAnd, lcaPath: lcaPath, groups: groups}, bitmapsByPath
+}
+
+// exec is a shorthand for executeResolutionPlan with no meta bucket.
+func exec(t *testing.T, plan *resolutionPlan, bitmapsByPath map[string]*sroar.Bitmap) *sroar.Bitmap {
+	t.Helper()
+	result, err := newResolutionPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+	require.NoError(t, err)
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// directAnd
+// ---------------------------------------------------------------------------
+
+func TestExecuteResolutionPlanDirectAnd(t *testing.T) {
 	const (
 		doc5 = uint64(5)
 		doc7 = uint64(7)
 	)
-	// Positions for doc5 at different root/leaf coordinates.
 	pos511 := nested.Encode(1, 1, doc5) // root=1 leaf=1 docID=5
-	pos512 := nested.Encode(1, 2, doc5) // root=1 leaf=2 docID=5 — same root+docID, different leaf
-	pos521 := nested.Encode(2, 1, doc5) // root=2 leaf=1 docID=5 — different root
-	pos711 := nested.Encode(1, 1, doc7) // root=1 leaf=1 docID=7 — different doc
+	pos512 := nested.Encode(1, 2, doc5) // same root+docID, different leaf
+	pos521 := nested.Encode(2, 1, doc5) // different root
+	pos711 := nested.Encode(1, 1, doc7) // different doc
 
 	t.Run("empty input returns empty", func(t *testing.T) {
-		assert.True(t, applyDirectAnd(nil).IsEmpty())
+		plan, bitmapsByPath := directAndPlan()
+		assert.True(t, exec(t, plan, bitmapsByPath).IsEmpty())
 	})
 
 	t.Run("single bitmap returns docIDs", func(t *testing.T) {
-		assert.Equal(t, []uint64{doc5}, applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511)}).ToArray())
+		plan, bitmapsByPath := directAndPlan(roaringset.NewBitmap(pos511))
+		assert.Equal(t, []uint64{doc5}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("exact same raw position in both bitmaps — match", func(t *testing.T) {
-		result := applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos511)})
-		assert.Equal(t, []uint64{doc5}, result.ToArray())
+		plan, bitmapsByPath := directAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos511))
+		assert.Equal(t, []uint64{doc5}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("same root+docID different leaf — no match (requires exact position)", func(t *testing.T) {
-		// directAnd requires identical raw positions; leaf difference breaks the AND.
-		result := applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512)})
-		assert.True(t, result.IsEmpty())
+		plan, bitmapsByPath := directAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512))
+		assert.True(t, exec(t, plan, bitmapsByPath).IsEmpty())
 	})
 
 	t.Run("different root — no match", func(t *testing.T) {
-		result := applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos521)})
-		assert.True(t, result.IsEmpty())
+		plan, bitmapsByPath := directAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos521))
+		assert.True(t, exec(t, plan, bitmapsByPath).IsEmpty())
 	})
 
 	t.Run("different docID — no match", func(t *testing.T) {
-		result := applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos711)})
-		assert.True(t, result.IsEmpty())
+		plan, bitmapsByPath := directAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos711))
+		assert.True(t, exec(t, plan, bitmapsByPath).IsEmpty())
 	})
 
 	t.Run("three bitmaps — intersection of all", func(t *testing.T) {
-		result := applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511, pos521), roaringset.NewBitmap(pos511, pos711), roaringset.NewBitmap(pos511)})
-		assert.Equal(t, []uint64{doc5}, result.ToArray())
+		plan, bitmapsByPath := directAndPlan(
+			roaringset.NewBitmap(pos511, pos521),
+			roaringset.NewBitmap(pos511, pos711),
+			roaringset.NewBitmap(pos511),
+		)
+		assert.Equal(t, []uint64{doc5}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("multiple matching docs", func(t *testing.T) {
-		result := applyDirectAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511, pos711), roaringset.NewBitmap(pos511, pos711)})
-		assert.Equal(t, []uint64{doc5, doc7}, result.ToArray())
+		plan, bitmapsByPath := directAndPlan(
+			roaringset.NewBitmap(pos511, pos711),
+			roaringset.NewBitmap(pos511, pos711),
+		)
+		assert.Equal(t, []uint64{doc5, doc7}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("inputs not modified", func(t *testing.T) {
-		a, b := roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos511)
-		applyDirectAnd([]*sroar.Bitmap{a, b})
+		a := roaringset.NewBitmap(pos511)
+		b := roaringset.NewBitmap(pos511)
+		plan, bitmapsByPath := directAndPlan(a, b)
+		exec(t, plan, bitmapsByPath)
 		assert.Equal(t, []uint64{pos511}, a.ToArray())
 		assert.Equal(t, []uint64{pos511}, b.ToArray())
 	})
 }
 
-// ---- applyMaskLeafAnd ------------------------------------------------------
+// ---------------------------------------------------------------------------
+// maskLeafAnd
+// ---------------------------------------------------------------------------
 
-func TestApplyMaskLeafAnd(t *testing.T) {
+func TestExecuteResolutionPlanMaskLeafAnd(t *testing.T) {
 	const (
 		doc5 = uint64(5)
 		doc7 = uint64(7)
@@ -95,73 +160,75 @@ func TestApplyMaskLeafAnd(t *testing.T) {
 	pos521 := nested.Encode(2, 1, doc5) // different root, same docID
 	pos711 := nested.Encode(1, 1, doc7) // same root+leaf, different docID
 
-	t.Run("empty input returns empty", func(t *testing.T) {
-		assert.True(t, applyMaskLeafAnd(nil).IsEmpty())
-	})
-
 	t.Run("single bitmap returns docIDs", func(t *testing.T) {
-		assert.Equal(t, []uint64{doc5}, applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511)}).ToArray())
+		plan, bitmapsByPath := maskLeafAndPlan(roaringset.NewBitmap(pos511))
+		assert.Equal(t, []uint64{doc5}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("same raw position — match", func(t *testing.T) {
-		result := applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos511)})
-		assert.Equal(t, []uint64{doc5}, result.ToArray())
+		plan, bitmapsByPath := maskLeafAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos511))
+		assert.Equal(t, []uint64{doc5}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("same root+docID different leaf — match (leaf is zeroed before AND)", func(t *testing.T) {
-		// This is the key difference from directAnd: leaf bits are erased so
-		// positions that differ only in leaf_idx — i.e. siblings within the same
-		// element — are treated as identical.
-		result := applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512)})
-		assert.Equal(t, []uint64{doc5}, result.ToArray())
+		plan, bitmapsByPath := maskLeafAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512))
+		assert.Equal(t, []uint64{doc5}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("three bitmaps same root+docID different leaves — match", func(t *testing.T) {
-		result := applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512), roaringset.NewBitmap(pos513)})
-		assert.Equal(t, []uint64{doc5}, result.ToArray())
+		plan, bitmapsByPath := maskLeafAndPlan(
+			roaringset.NewBitmap(pos511),
+			roaringset.NewBitmap(pos512),
+			roaringset.NewBitmap(pos513),
+		)
+		assert.Equal(t, []uint64{doc5}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("different root same docID — no match (root encodes element identity)", func(t *testing.T) {
-		result := applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos521)})
-		assert.True(t, result.IsEmpty())
+		plan, bitmapsByPath := maskLeafAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos521))
+		assert.True(t, exec(t, plan, bitmapsByPath).IsEmpty())
 	})
 
 	t.Run("different docID — no match", func(t *testing.T) {
-		result := applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos711)})
-		assert.True(t, result.IsEmpty())
+		plan, bitmapsByPath := maskLeafAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos711))
+		assert.True(t, exec(t, plan, bitmapsByPath).IsEmpty())
 	})
 
 	t.Run("multiple matching docs", func(t *testing.T) {
 		pos712 := nested.Encode(1, 2, doc7)
-		result := applyMaskLeafAnd([]*sroar.Bitmap{roaringset.NewBitmap(pos511, pos711), roaringset.NewBitmap(pos512, pos712)})
-		assert.Equal(t, []uint64{doc5, doc7}, result.ToArray())
+		plan, bitmapsByPath := maskLeafAndPlan(
+			roaringset.NewBitmap(pos511, pos711),
+			roaringset.NewBitmap(pos512, pos712),
+		)
+		assert.Equal(t, []uint64{doc5, doc7}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("inputs not modified", func(t *testing.T) {
-		a, b := roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512)
-		applyMaskLeafAnd([]*sroar.Bitmap{a, b})
+		a := roaringset.NewBitmap(pos511)
+		b := roaringset.NewBitmap(pos512)
+		plan, bitmapsByPath := maskLeafAndPlan(a, b)
+		exec(t, plan, bitmapsByPath)
 		assert.Equal(t, []uint64{pos511}, a.ToArray())
 		assert.Equal(t, []uint64{pos512}, b.ToArray())
 	})
 }
 
-// ---- applyIdxLoop preconditions (no lsmkv required) ------------------------
+// ---------------------------------------------------------------------------
+// idxLoopAnd preconditions (no lsmkv required)
+// ---------------------------------------------------------------------------
 
-func TestApplyIdxLoopPreconditions(t *testing.T) {
+func TestExecuteResolutionPlanIdxLoopPreconditions(t *testing.T) {
 	pos511 := nested.Encode(1, 1, 5)
 	pos512 := nested.Encode(1, 2, 5)
 
-	t.Run("nil metaBucket returns error regardless of bitmaps", func(t *testing.T) {
-		_, err := applyIdxLoop(context.Background(), nil, "cars", []*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512)})
+	t.Run("nil metaBucket returns error", func(t *testing.T) {
+		plan, bitmapsByPath := idxLoopAndPlan("cars",
+			roaringset.NewBitmap(pos511),
+			roaringset.NewBitmap(pos512),
+		)
+		_, err := newResolutionPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "meta bucket is nil")
 		assert.Contains(t, err.Error(), "cars")
-	})
-
-	t.Run("nil metaBucket checked before bitmap count", func(t *testing.T) {
-		// Even with zero bitmaps the nil-bucket error fires first.
-		_, err := applyIdxLoop(context.Background(), nil, "cars", nil)
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "meta bucket is nil")
 	})
 }

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
@@ -120,7 +119,7 @@ func TestExtractNestedProp(t *testing.T) {
 				require.Len(t, pv.children, 2)
 				for _, child := range pv.children {
 					assert.Equal(t, "nested", child.prop)
-					assert.Equal(t, nested.PathPrefix("title"), child.nestedKeyPrefix)
+					assert.Equal(t, "title", child.nestedRelPath)
 					assert.True(t, child.isNested)
 					assert.True(t, child.hasFilterableIndex)
 				}
@@ -190,7 +189,7 @@ func TestExtractNestedProp(t *testing.T) {
 			}
 			relativePath := tt.path[strings.Index(tt.path, ".")+1:]
 			assert.Equal(t, tt.wantProp, pv.prop)
-			assert.Equal(t, nested.PathPrefix(relativePath), pv.nestedKeyPrefix)
+			assert.Equal(t, relativePath, pv.nestedRelPath)
 			assert.True(t, pv.isNested)
 			assert.True(t, pv.hasFilterableIndex)
 			if tt.wantValue != nil {
@@ -250,7 +249,7 @@ func TestExtractPropValuePairNestedRouting(t *testing.T) {
 			relativePath := tt.path[strings.Index(tt.path, ".")+1:]
 			assert.Equal(t, tt.wantProp, pv.prop)
 			assert.Equal(t, tt.wantNested, pv.isNested)
-			assert.Equal(t, nested.PathPrefix(relativePath), pv.nestedKeyPrefix)
+			assert.Equal(t, relativePath, pv.nestedRelPath)
 			assert.Equal(t, tt.operator, pv.operator)
 		})
 	}

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -119,18 +119,18 @@ func TestExtractNestedProp(t *testing.T) {
 			valueType: schema.DataTypeText, value: "hello world",
 			verify: func(t *testing.T, pv *propValuePair) {
 				// output:
-				// └── correlated(nested) ← isCorrelatedNested=true, childrenFromTokenization=true
+				// └── correlated(nested) ← nested.isCorrelated=true, nested.childrenFromTokenization=true
 				//     ├── title:"hello"
 				//     └── title:"world"
 				require.Equal(t, filters.OperatorAnd, pv.operator)
-				assert.True(t, pv.isCorrelatedNested, "compound AND should be marked isCorrelatedNested")
-				assert.True(t, pv.childrenFromTokenization, "compound AND should be marked childrenFromTokenization")
+				assert.True(t, pv.nested.isCorrelated, "compound AND should be marked nested.isCorrelated")
+				assert.True(t, pv.nested.childrenFromTokenization, "compound AND should be marked nested.childrenFromTokenization")
 				assert.Equal(t, "nested", pv.prop)
 				require.Len(t, pv.children, 2)
 				for _, child := range pv.children {
 					assert.Equal(t, "nested", child.prop)
-					assert.Equal(t, "title", child.nestedRelPath)
-					assert.True(t, child.isNested)
+					assert.Equal(t, "title", child.nested.relPath)
+					assert.True(t, child.nested.isNested)
 					assert.True(t, child.hasFilterableIndex)
 				}
 				assert.Equal(t, []byte("hello"), pv.children[0].value)
@@ -199,8 +199,8 @@ func TestExtractNestedProp(t *testing.T) {
 			}
 			relativePath := tt.path[strings.Index(tt.path, ".")+1:]
 			assert.Equal(t, tt.wantProp, pv.prop)
-			assert.Equal(t, relativePath, pv.nestedRelPath)
-			assert.True(t, pv.isNested)
+			assert.Equal(t, relativePath, pv.nested.relPath)
+			assert.True(t, pv.nested.isNested)
 			assert.True(t, pv.hasFilterableIndex)
 			if tt.wantValue != nil {
 				assert.Equal(t, tt.wantValue, pv.value)
@@ -211,7 +211,7 @@ func TestExtractNestedProp(t *testing.T) {
 
 // TestExtractPropValuePairNestedGrouping verifies that extractPropValuePair
 // correctly groups nested AND children via groupNestedByProp, with special
-// attention to multi-token text conditions (isCorrelatedNested + childrenFromTokenization).
+// attention to multi-token text conditions (nested.isCorrelated + nested.childrenFromTokenization).
 func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 	s := newTestSearcher()
 
@@ -225,7 +225,7 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 	t.Run("standalone multi-token nested text", func(t *testing.T) {
 		// input:  nested.title = "hello world"
 		// output:
-		// └── correlated(nested)  ← isCorrelatedNested=true, childrenFromTokenization=true
+		// └── correlated(nested)  ← nested.isCorrelated=true, nested.childrenFromTokenization=true
 		//     ├── title:"hello"
 		//     └── title:"world"
 		clause := makeNestedFilterClause("nested.title", filters.OperatorEqual, schema.DataTypeText, "hello world")
@@ -233,8 +233,8 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, filters.OperatorAnd, pv.operator)
-		assert.True(t, pv.isCorrelatedNested)
-		assert.True(t, pv.childrenFromTokenization)
+		assert.True(t, pv.nested.isCorrelated)
+		assert.True(t, pv.nested.childrenFromTokenization)
 		assert.Equal(t, "nested", pv.prop)
 		require.Len(t, pv.children, 2)
 		assert.Equal(t, []byte("hello"), pv.children[0].value)
@@ -244,8 +244,8 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 	t.Run("multi-token nested text alongside scalar nested condition", func(t *testing.T) {
 		// input:  AND(nested.title = "hello world", nested.city = "berlin")
 		// output:
-		// └── correlated(nested)        ← isCorrelatedNested=true, childrenFromTokenization=false
-		//     ├── correlated(nested)    ← isCorrelatedNested=true, childrenFromTokenization=true (title tokens)
+		// └── correlated(nested)        ← nested.isCorrelated=true, nested.childrenFromTokenization=false
+		//     ├── correlated(nested)    ← nested.isCorrelated=true, nested.childrenFromTokenization=true (title tokens)
 		//     │   ├── title:"hello"
 		//     │   └── title:"world"
 		//     └── city:"berlin"
@@ -258,15 +258,15 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		require.Len(t, pv.children, 1, "both conditions grouped under one correlated(nested) node")
 
 		group := pv.children[0]
-		assert.True(t, group.isCorrelatedNested)
-		assert.False(t, group.childrenFromTokenization)
+		assert.True(t, group.nested.isCorrelated)
+		assert.False(t, group.nested.childrenFromTokenization)
 		assert.Equal(t, "nested", group.prop)
 		require.Len(t, group.children, 2)
 
 		// first child: the tokenization compound AND for "hello world"
 		tokenAnd := group.children[0]
-		assert.True(t, tokenAnd.isCorrelatedNested)
-		assert.True(t, tokenAnd.childrenFromTokenization)
+		assert.True(t, tokenAnd.nested.isCorrelated)
+		assert.True(t, tokenAnd.nested.childrenFromTokenization)
 		assert.Equal(t, filters.OperatorAnd, tokenAnd.operator)
 		require.Len(t, tokenAnd.children, 2)
 		assert.Equal(t, []byte("hello"), tokenAnd.children[0].value)
@@ -274,10 +274,10 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 
 		// second child: the scalar city leaf
 		cityLeaf := group.children[1]
-		assert.True(t, cityLeaf.isNested)
-		assert.False(t, cityLeaf.isCorrelatedNested)
+		assert.True(t, cityLeaf.nested.isNested)
+		assert.False(t, cityLeaf.nested.isCorrelated)
 		assert.Equal(t, []byte("berlin"), cityLeaf.value)
-		assert.Equal(t, "city", cityLeaf.nestedRelPath)
+		assert.Equal(t, "city", cityLeaf.nested.relPath)
 	})
 }
 
@@ -330,8 +330,8 @@ func TestExtractPropValuePairNestedRouting(t *testing.T) {
 
 			relativePath := tt.path[strings.Index(tt.path, ".")+1:]
 			assert.Equal(t, tt.wantProp, pv.prop)
-			assert.Equal(t, tt.wantNested, pv.isNested)
-			assert.Equal(t, relativePath, pv.nestedRelPath)
+			assert.Equal(t, tt.wantNested, pv.nested.isNested)
+			assert.Equal(t, relativePath, pv.nested.relPath)
 			assert.Equal(t, tt.operator, pv.operator)
 		})
 	}

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
@@ -66,10 +67,12 @@ func nestedSearcherClass() *models.Class {
 
 func newTestSearcher() *Searcher {
 	class := nestedSearcherClass()
+	logger, _ := test.NewNullLogger()
 	return &Searcher{
 		getClass:               func(name string) *models.Class { return class },
 		stopwordProvider:       stopwords.NewProvider(fakeStopwordDetector{}, nil),
 		isFallbackToSearchable: func() bool { return false },
+		logger:                 logger,
 	}
 }
 
@@ -115,7 +118,14 @@ func TestExtractNestedProp(t *testing.T) {
 			path: "nested.title", operator: filters.OperatorEqual,
 			valueType: schema.DataTypeText, value: "hello world",
 			verify: func(t *testing.T, pv *propValuePair) {
+				// output:
+				// └── correlated(nested) ← isCorrelatedNested=true, childrenFromTokenization=true
+				//     ├── title:"hello"
+				//     └── title:"world"
 				require.Equal(t, filters.OperatorAnd, pv.operator)
+				assert.True(t, pv.isCorrelatedNested, "compound AND should be marked isCorrelatedNested")
+				assert.True(t, pv.childrenFromTokenization, "compound AND should be marked childrenFromTokenization")
+				assert.Equal(t, "nested", pv.prop)
 				require.Len(t, pv.children, 2)
 				for _, child := range pv.children {
 					assert.Equal(t, "nested", child.prop)
@@ -197,6 +207,78 @@ func TestExtractNestedProp(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestExtractPropValuePairNestedGrouping verifies that extractPropValuePair
+// correctly groups nested AND children via groupNestedByProp, with special
+// attention to multi-token text conditions (isCorrelatedNested + childrenFromTokenization).
+func TestExtractPropValuePairNestedGrouping(t *testing.T) {
+	s := newTestSearcher()
+
+	andClause := func(operands ...filters.Clause) *filters.Clause {
+		return &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}
+	}
+	leaf := func(path string, value string) filters.Clause {
+		return *makeNestedFilterClause(path, filters.OperatorEqual, schema.DataTypeText, value)
+	}
+
+	t.Run("standalone multi-token nested text", func(t *testing.T) {
+		// input:  nested.title = "hello world"
+		// output:
+		// └── correlated(nested)  ← isCorrelatedNested=true, childrenFromTokenization=true
+		//     ├── title:"hello"
+		//     └── title:"world"
+		clause := makeNestedFilterClause("nested.title", filters.OperatorEqual, schema.DataTypeText, "hello world")
+		pv, err := s.extractPropValuePair(t.Context(), clause, "Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorAnd, pv.operator)
+		assert.True(t, pv.isCorrelatedNested)
+		assert.True(t, pv.childrenFromTokenization)
+		assert.Equal(t, "nested", pv.prop)
+		require.Len(t, pv.children, 2)
+		assert.Equal(t, []byte("hello"), pv.children[0].value)
+		assert.Equal(t, []byte("world"), pv.children[1].value)
+	})
+
+	t.Run("multi-token nested text alongside scalar nested condition", func(t *testing.T) {
+		// input:  AND(nested.title = "hello world", nested.city = "berlin")
+		// output:
+		// └── correlated(nested)        ← isCorrelatedNested=true, childrenFromTokenization=false
+		//     ├── correlated(nested)    ← isCorrelatedNested=true, childrenFromTokenization=true (title tokens)
+		//     │   ├── title:"hello"
+		//     │   └── title:"world"
+		//     └── city:"berlin"
+		pv, err := s.extractPropValuePair(t.Context(),
+			andClause(leaf("nested.title", "hello world"), leaf("nested.city", "berlin")),
+			"Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorAnd, pv.operator)
+		require.Len(t, pv.children, 1, "both conditions grouped under one correlated(nested) node")
+
+		group := pv.children[0]
+		assert.True(t, group.isCorrelatedNested)
+		assert.False(t, group.childrenFromTokenization)
+		assert.Equal(t, "nested", group.prop)
+		require.Len(t, group.children, 2)
+
+		// first child: the tokenization compound AND for "hello world"
+		tokenAnd := group.children[0]
+		assert.True(t, tokenAnd.isCorrelatedNested)
+		assert.True(t, tokenAnd.childrenFromTokenization)
+		assert.Equal(t, filters.OperatorAnd, tokenAnd.operator)
+		require.Len(t, tokenAnd.children, 2)
+		assert.Equal(t, []byte("hello"), tokenAnd.children[0].value)
+		assert.Equal(t, []byte("world"), tokenAnd.children[1].value)
+
+		// second child: the scalar city leaf
+		cityLeaf := group.children[1]
+		assert.True(t, cityLeaf.isNested)
+		assert.False(t, cityLeaf.isCorrelatedNested)
+		assert.Equal(t, []byte("berlin"), cityLeaf.value)
+		assert.Equal(t, "city", cityLeaf.nestedRelPath)
+	})
 }
 
 // TestExtractPropValuePairNestedRouting verifies that extractPropValuePair


### PR DESCRIPTION
## Nested object filtering — Part 7: correlated AND resolution

  Seventh PR in the nested object filtering series, building on Part 6 (resolution plan and executor). This PR wires the resolution plan and executor into the filter pipeline, ensuring that `addresses.city = "Berlin" AND addresses.postcode = "10115"` only matches documents where both conditions are satisfied by the **same** array element.

  ### What's in this PR

  **`nestedRelPath` on `propValuePair`** — adds a `nestedRelPath string` field (dot-notation path relative to the root property, e.g. `"city"`, `"owner.firstname"`) and removes the redundant `nestedKeyPrefix []byte` field, which was simply `hash8(nestedRelPath)` and can be computed on demand via `nested.PathPrefix(pv.nestedRelPath)`.

  **Resolution plan executor wiring** — `resolutionPlanExecutor` refactored to hold `positionsByPath map[string]*positionBitmaps` (pre-fetched position bitmaps split by origin) rather than raw `propValuePair` slices. A new `positionBitmaps{tokens, independent}` type separates tokenization-compound bitmaps (combined with `AndAll` — same leaf required) from independent bitmaps (combined with `MaskLeafAndAll` — different leaves allowed within same parent).

  **Correlated AND resolution wiring** — `resolveDocIDs` routes qualifying AND nodes through position-aware resolution:
  - `groupNestedByProp` (called at extraction time in `extractPropValuePairs`) groups nested conditions by root property into `isCorrelated=true` AND nodes; flat conditions pass through unchanged
  - `resolveNestedCorrelated` builds `positionsByPath`, constructs a `resolutionPlan` via `newResolutionPlanBuilder`, and executes it to enforce same-element semantics
  - Multi-token text tokenization (`childrenFromTokenization`) is handled correctly: tokens must share the same leaf position so they go into the `tokens` bucket and are combined with raw `AndAll`
  - Standalone multi-token nested text (e.g. `addresses.city = "New York"` alone) also uses position-aware resolution — `isCorrelated` is set at tokenization time

  **Restructuring from temporary to permanent** — the initial "detect at resolve time" approach is replaced by extraction-time grouping: `groupNestedByProp` runs inside `extractPropValuePairs` for AND nodes, making each AND node in the tree homogeneous.
  `extractNestedCorrelatedGroups` and `resolveNestedCorrelatedAnd` are removed; AND/OR cases in `resolveDocIDs` are merged back.

  **`nestedInfo` struct** — the four nested-related fields on `propValuePair` (`isNested`, `nestedRelPath`, `isCorrelated`,
  `childrenFromTokenization`) are grouped into a single `nested nestedInfo` value struct. `isNested` and `isCorrelated` are documented as mutually exclusive — a node is either a leaf or a group, never both.

  ### Tests

  - `prop_value_pairs_nested_test.go` — unit tests for `groupNestedByProp` covering nested grouping, multi-prop groups, mixed nested+flat, tokenization compound ANDs vs user-constructed ANDs
  - `prop_value_pairs_nested_integration_test.go` — integration tests for `resolveNestedCorrelated` covering `directAnd` scalar siblings, `idxLoopAnd` same/different car elements, multi-prop groups
  - `searcher_nested_test.go` — extraction flag tests verifying `nested.isCorrelated`, `nested.childrenFromTokenization`, and grouping structure after `extractPropValuePair`

  ## Test plan

  - [ ] `go test ./adapters/repos/db/inverted/...` — all nested resolution and grouping tests pass
  - [ ] `go test -tags integrationTest ./adapters/repos/db/inverted/...` — correlated AND integration tests pass
  - [ ] `go test -tags integrationTest ./adapters/repos/db/...` — full shard pipeline integration tests pass