### PR TITLE
hfresh: fix metrics reporting

### DIFF
--- a/adapters/repos/db/vector/hfresh/hnsw.go
+++ b/adapters/repos/db/vector/hfresh/hnsw.go
@@ -104,7 +104,6 @@ func (i *HNSWIndex) Insert(id uint64, centroid *Centroid) error {
 		return errors.Wrap(err, "add to hnsw")
 	}
 	i.counter.Add(1)
-	i.metrics.AddPostings(1)
 
 	return nil
 }
@@ -112,7 +111,6 @@ func (i *HNSWIndex) Insert(id uint64, centroid *Centroid) error {
 func (i *HNSWIndex) MarkAsDeleted(id uint64) error {
 	if i.Exists(id) {
 		i.counter.Add(-1)
-		i.metrics.AddPostings(-1)
 		return i.hnsw.Delete(id)
 	}
 	return nil

--- a/adapters/repos/db/vector/hfresh/index_metadata.go
+++ b/adapters/repos/db/vector/hfresh/index_metadata.go
@@ -223,7 +223,7 @@ func (h *HFresh) restoreMetrics() error {
 
 	postingsCount := h.PostingMap.Size()
 	h.Centroids.counter.Store(int32(postingsCount))
-	h.metrics.AddPostings(postingsCount)
+	h.metrics.SetPostings(postingsCount)
 
 	return nil
 }

--- a/adapters/repos/db/vector/hfresh/index_metadata.go
+++ b/adapters/repos/db/vector/hfresh/index_metadata.go
@@ -216,10 +216,10 @@ func (h *HFresh) restoreMetrics() error {
 	reassignCount := h.taskQueue.reassignQueue.Size()
 	analyzeCount := h.taskQueue.analyzeQueue.Size()
 
-	h.metrics.SetSplitCount(splitCount)
-	h.metrics.SetMergeCount(mergeCount)
-	h.metrics.SetReassignCount(reassignCount)
-	h.metrics.SetAnalyzeCount(analyzeCount)
+	h.metrics.SetPendingSplitTasks(splitCount)
+	h.metrics.SetPendingMergeTasks(mergeCount)
+	h.metrics.SetPendingReassignTasks(reassignCount)
+	h.metrics.SetPendingAnalyzeTasks(analyzeCount)
 
 	postingsCount := h.PostingMap.Size()
 	h.Centroids.counter.Store(int32(postingsCount))

--- a/adapters/repos/db/vector/hfresh/metrics.go
+++ b/adapters/repos/db/vector/hfresh/metrics.go
@@ -161,14 +161,6 @@ func (m *Metrics) DeleteVector(start time.Time) {
 	m.delete.Inc()
 }
 
-func (m *Metrics) AddPostings(delta int) {
-	if !m.enabled {
-		return
-	}
-
-	m.postings.Add(float64(delta))
-}
-
 func (m *Metrics) SetPostings(count int) {
 	if !m.enabled {
 		return

--- a/adapters/repos/db/vector/hfresh/metrics.go
+++ b/adapters/repos/db/vector/hfresh/metrics.go
@@ -177,22 +177,6 @@ func (m *Metrics) ObservePostingSize(size float64) {
 	m.postingSize.Observe(size)
 }
 
-func (m *Metrics) EnqueueAnalyzeTask() {
-	if !m.enabled {
-		return
-	}
-
-	m.analyzePending.Inc()
-}
-
-func (m *Metrics) DequeueAnalyzeTask() {
-	if !m.enabled {
-		return
-	}
-
-	m.analyzePending.Dec()
-}
-
 func (m *Metrics) AnalyzeDuration(start time.Time) {
 	if !m.enabled {
 		return
@@ -215,22 +199,6 @@ func (m *Metrics) SetPendingAnalyzeTasks(count int64) {
 	}
 
 	m.analyzePending.Set(float64(count))
-}
-
-func (m *Metrics) EnqueueSplitTask() {
-	if !m.enabled {
-		return
-	}
-
-	m.splitsPending.Inc()
-}
-
-func (m *Metrics) DequeueSplitTask() {
-	if !m.enabled {
-		return
-	}
-
-	m.splitsPending.Dec()
 }
 
 func (m *Metrics) SplitDuration(start time.Time) {
@@ -257,22 +225,6 @@ func (m *Metrics) SetPendingSplitTasks(count int64) {
 	m.splitsPending.Set(float64(count))
 }
 
-func (m *Metrics) EnqueueMergeTask() {
-	if !m.enabled {
-		return
-	}
-
-	m.mergesPending.Inc()
-}
-
-func (m *Metrics) DequeueMergeTask() {
-	if !m.enabled {
-		return
-	}
-
-	m.mergesPending.Dec()
-}
-
 func (m *Metrics) MergeDuration(start time.Time) {
 	if !m.enabled {
 		return
@@ -295,22 +247,6 @@ func (m *Metrics) SetPendingMergeTasks(count int64) {
 	}
 
 	m.mergesPending.Set(float64(count))
-}
-
-func (m *Metrics) EnqueueReassignTask() {
-	if !m.enabled {
-		return
-	}
-
-	m.reassignsPending.Inc()
-}
-
-func (m *Metrics) DequeueReassignTask() {
-	if !m.enabled {
-		return
-	}
-
-	m.reassignsPending.Dec()
 }
 
 func (m *Metrics) ReassignDuration(start time.Time) {

--- a/adapters/repos/db/vector/hfresh/metrics.go
+++ b/adapters/repos/db/vector/hfresh/metrics.go
@@ -169,6 +169,14 @@ func (m *Metrics) AddPostings(delta int) {
 	m.postings.Add(float64(delta))
 }
 
+func (m *Metrics) SetPostings(count int) {
+	if !m.enabled {
+		return
+	}
+
+	m.postings.Set(float64(count))
+}
+
 func (m *Metrics) ObservePostingSize(size float64) {
 	if !m.enabled {
 		return

--- a/adapters/repos/db/vector/hfresh/metrics.go
+++ b/adapters/repos/db/vector/hfresh/metrics.go
@@ -209,7 +209,7 @@ func (m *Metrics) IncAnalyzeCount() {
 	m.analyzeCount.Inc()
 }
 
-func (m *Metrics) SetAnalyzeCount(count int64) {
+func (m *Metrics) SetPendingAnalyzeTasks(count int64) {
 	if !m.enabled {
 		return
 	}
@@ -249,7 +249,7 @@ func (m *Metrics) IncSplitCount() {
 	m.splitCount.Inc()
 }
 
-func (m *Metrics) SetSplitCount(count int64) {
+func (m *Metrics) SetPendingSplitTasks(count int64) {
 	if !m.enabled {
 		return
 	}
@@ -289,7 +289,7 @@ func (m *Metrics) IncMergeCount() {
 	m.mergeCount.Inc()
 }
 
-func (m *Metrics) SetMergeCount(count int64) {
+func (m *Metrics) SetPendingMergeTasks(count int64) {
 	if !m.enabled {
 		return
 	}
@@ -329,7 +329,7 @@ func (m *Metrics) IncReassignCount() {
 	m.reassignCount.Inc()
 }
 
-func (m *Metrics) SetReassignCount(count int64) {
+func (m *Metrics) SetPendingReassignTasks(count int64) {
 	if !m.enabled {
 		return
 	}

--- a/adapters/repos/db/vector/hfresh/metrics.go
+++ b/adapters/repos/db/vector/hfresh/metrics.go
@@ -214,7 +214,7 @@ func (m *Metrics) SetAnalyzeCount(count int64) {
 		return
 	}
 
-	m.analyzePending.Add(float64(count))
+	m.analyzePending.Set(float64(count))
 }
 
 func (m *Metrics) EnqueueSplitTask() {
@@ -254,7 +254,7 @@ func (m *Metrics) SetSplitCount(count int64) {
 		return
 	}
 
-	m.splitsPending.Add(float64(count))
+	m.splitsPending.Set(float64(count))
 }
 
 func (m *Metrics) EnqueueMergeTask() {
@@ -294,7 +294,7 @@ func (m *Metrics) SetMergeCount(count int64) {
 		return
 	}
 
-	m.mergesPending.Add(float64(count))
+	m.mergesPending.Set(float64(count))
 }
 
 func (m *Metrics) EnqueueReassignTask() {
@@ -334,7 +334,7 @@ func (m *Metrics) SetReassignCount(count int64) {
 		return
 	}
 
-	m.reassignsPending.Add(float64(count))
+	m.reassignsPending.Set(float64(count))
 }
 
 func (m *Metrics) CentroidSearchDuration(start time.Time) {

--- a/adapters/repos/db/vector/hfresh/posting_map.go
+++ b/adapters/repos/db/vector/hfresh/posting_map.go
@@ -115,6 +115,7 @@ func (v *PostingMap) CountAllVectors(ctx context.Context) (uint64, error) {
 // It is safe to read the cache concurrently.
 func (v *PostingMap) SetVectorIDs(ctx context.Context, postingID uint64, posting Posting) error {
 	defer v.setSizeMetricIfDue(ctx)
+	defer func() { v.metrics.SetPostings(v.Size()) }()
 
 	if len(posting) == 0 {
 		err := v.bucket.Delete(ctx, postingID)
@@ -195,12 +196,14 @@ func (v *PostingMap) FastAddVectorID(ctx context.Context, postingID uint64, vect
 	}
 
 	v.metrics.ObservePostingSize(float64(count))
+	v.metrics.SetPostings(v.Size())
 	return uint32(count), nil
 }
 
 // Restore loads all postings from disk into memory. It should be called during startup to populate the in-memory cache.
 func (v *PostingMap) Restore(ctx context.Context) error {
 	defer v.setSizeMetricIfDue(ctx)
+	defer func() { v.metrics.SetPostings(v.Size()) }()
 
 	return v.bucket.Iter(ctx, func(u uint64, ppm PackedPostingMetadata) error {
 		v.data.Store(u, &PostingMetadata{PackedPostingMetadata: ppm})

--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -298,11 +298,17 @@ func (tq *TaskQueue) EnqueueReassign(postingID uint64, vecID uint64, version Vec
 	return nil
 }
 
-// Flush the vector index after a batch is processed.
+// Flush the vector index after a batch is processed
+// and update pending metrics now that the queue sizes have been decremented.
 func (tq *TaskQueue) OnBatchProcessed() {
 	if err := tq.index.Flush(); err != nil {
 		tq.index.logger.WithError(err).Error("failed to flush vector index")
 	}
+
+	tq.index.metrics.SetPendingAnalyzeTasks(tq.analyzeQueue.Size())
+	tq.index.metrics.SetPendingSplitTasks(tq.splitQueue.Size())
+	tq.index.metrics.SetPendingMergeTasks(tq.mergeQueue.Size())
+	tq.index.metrics.SetPendingReassignTasks(tq.reassignQueue.Size())
 }
 
 func (tq *TaskQueue) DecodeTask(data []byte) (queue.Task, error) {
@@ -372,7 +378,6 @@ func (t *AnalyzeTask) Execute(ctx context.Context) error {
 		return err
 	}
 
-	t.idx.metrics.SetPendingAnalyzeTasks(t.idx.taskQueue.analyzeQueue.Size())
 	t.idx.metrics.IncAnalyzeCount()
 	return nil
 }
@@ -401,7 +406,6 @@ func (t *SplitTask) Execute(ctx context.Context) error {
 		return err
 	}
 
-	t.idx.metrics.SetPendingSplitTasks(t.idx.taskQueue.splitQueue.Size())
 	t.idx.metrics.IncSplitCount()
 	return nil
 }
@@ -431,7 +435,6 @@ func (t *MergeTask) Execute(ctx context.Context) error {
 		return err
 	}
 
-	t.idx.metrics.SetPendingMergeTasks(t.idx.taskQueue.mergeQueue.Size())
 	t.idx.metrics.IncMergeCount()
 	return nil
 }
@@ -460,7 +463,6 @@ func (t *ReassignTask) Execute(ctx context.Context) error {
 		return err
 	}
 
-	t.idx.metrics.SetPendingReassignTasks(t.idx.taskQueue.reassignQueue.Size())
 	t.idx.metrics.IncReassignCount()
 	return nil
 }

--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -249,7 +249,7 @@ func (tq *TaskQueue) EnqueueAnalyze(postingID uint64) error {
 		return errors.Wrap(err, "failed to push analyze operation to queue")
 	}
 
-	tq.index.metrics.EnqueueAnalyzeTask()
+	tq.index.metrics.SetPendingAnalyzeTasks(tq.analyzeQueue.Size())
 	return nil
 }
 
@@ -263,7 +263,7 @@ func (tq *TaskQueue) EnqueueSplit(postingID uint64) error {
 		return errors.Wrap(err, "failed to push split operation to queue")
 	}
 
-	tq.index.metrics.EnqueueSplitTask()
+	tq.index.metrics.SetPendingSplitTasks(tq.splitQueue.Size())
 
 	return nil
 }
@@ -278,7 +278,7 @@ func (tq *TaskQueue) EnqueueMerge(postingID uint64) error {
 		return errors.Wrap(err, "failed to push merge operation to queue")
 	}
 
-	tq.index.metrics.EnqueueMergeTask()
+	tq.index.metrics.SetPendingMergeTasks(tq.mergeQueue.Size())
 
 	return nil
 }
@@ -293,7 +293,7 @@ func (tq *TaskQueue) EnqueueReassign(postingID uint64, vecID uint64, version Vec
 		return errors.Wrap(err, "failed to push reassign operation to queue")
 	}
 
-	tq.index.metrics.EnqueueReassignTask()
+	tq.index.metrics.SetPendingReassignTasks(tq.reassignQueue.Size())
 
 	return nil
 }

--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -372,7 +372,7 @@ func (t *AnalyzeTask) Execute(ctx context.Context) error {
 		return err
 	}
 
-	t.idx.metrics.DequeueAnalyzeTask()
+	t.idx.metrics.SetPendingAnalyzeTasks(t.idx.taskQueue.analyzeQueue.Size())
 	t.idx.metrics.IncAnalyzeCount()
 	return nil
 }
@@ -401,7 +401,7 @@ func (t *SplitTask) Execute(ctx context.Context) error {
 		return err
 	}
 
-	t.idx.metrics.DequeueSplitTask()
+	t.idx.metrics.SetPendingSplitTasks(t.idx.taskQueue.splitQueue.Size())
 	t.idx.metrics.IncSplitCount()
 	return nil
 }
@@ -431,7 +431,7 @@ func (t *MergeTask) Execute(ctx context.Context) error {
 		return err
 	}
 
-	t.idx.metrics.DequeueMergeTask()
+	t.idx.metrics.SetPendingMergeTasks(t.idx.taskQueue.mergeQueue.Size())
 	t.idx.metrics.IncMergeCount()
 	return nil
 }
@@ -460,7 +460,7 @@ func (t *ReassignTask) Execute(ctx context.Context) error {
 		return err
 	}
 
-	t.idx.metrics.DequeueReassignTask()
+	t.idx.metrics.SetPendingReassignTasks(t.idx.taskQueue.reassignQueue.Size())
 	t.idx.metrics.IncReassignCount()
 	return nil
 }


### PR DESCRIPTION
### What's being changed:

This changes the way HFresh reports metrics about pending tasks to ensure metrics are always in sync with the content of the queues.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
