### PR TITLE
Fix MMR diversity selection to apply globally at coordinator in multi shard deployments

### DIFF
--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -2210,6 +2210,42 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors []models.V
 		shardCap = len(readPlan.Shards()) * limit
 	}
 
+	// When there are multiple shards with distinct data, suppress per-shard MMR
+	// selection and apply it globally at the coordinator after merging all
+	// candidates. Per-shard MMR causes each shard to independently optimise
+	// diversity over only its local subset; the coordinator's final distance
+	// re-sort then destroys the global diversity guarantee.
+	numShards := len(readPlan.Shards())
+	shardSelection := selection
+	shardAdditionalProps := additionalProps
+	isMultiShardMMR := selection != nil && numShards > 1
+	if isMultiShardMMR {
+		shardSelection = nil
+		// Request vectors from each shard so the coordinator can compute
+		// inter-object distances for the global MMR pass.
+		targetVector := ""
+		if len(targetVectors) > 0 {
+			targetVector = targetVectors[0]
+		}
+		if targetVector == "" {
+			shardAdditionalProps.Vector = true
+		} else {
+			hasTV := false
+			for _, v := range shardAdditionalProps.Vectors {
+				if v == targetVector {
+					hasTV = true
+					break
+				}
+			}
+			if !hasTV {
+				vecs := make([]string, len(shardAdditionalProps.Vectors)+1)
+				copy(vecs, shardAdditionalProps.Vectors)
+				vecs[len(shardAdditionalProps.Vectors)] = targetVector
+				shardAdditionalProps.Vectors = vecs
+			}
+		}
+	}
+
 	eg := enterrors.NewErrorGroupWrapper(i.logger, "tenant:", tenant)
 	// When running in fractional CPU environments, _NUMCPU will be 1
 	// Most cloud deployments of Weaviate are in HA clusters with rf=3
@@ -2228,7 +2264,7 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors []models.V
 
 	remoteSearch := func(shardName string) error {
 		// If we have no local shard or if we force the query to reach all replicas
-		remoteShardObject, remoteShardScores, err2 := i.remoteShardSearch(ctx, searchVectors, targetVectors, dist, limit, localFilters, sort, groupBy, additionalProps, targetCombination, properties, tenant, shardName, selection)
+		remoteShardObject, remoteShardScores, err2 := i.remoteShardSearch(ctx, searchVectors, targetVectors, dist, limit, localFilters, sort, groupBy, shardAdditionalProps, targetCombination, properties, tenant, shardName, shardSelection)
 		if err2 != nil {
 			return fmt.Errorf(
 				"remote shard object search %s: %w", shardName, err2)
@@ -2248,7 +2284,7 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors []models.V
 		defer release()
 
 		if shard != nil {
-			localShardResult, localShardScores, err1 := i.localShardSearch(ctx, searchVectors, targetVectors, dist, limit, localFilters, sort, groupBy, additionalProps, targetCombination, properties, tenant, shardName, selection)
+			localShardResult, localShardScores, err1 := i.localShardSearch(ctx, searchVectors, targetVectors, dist, limit, localFilters, sort, groupBy, shardAdditionalProps, targetCombination, properties, tenant, shardName, shardSelection)
 			if err1 != nil {
 				return fmt.Errorf(
 					"local shard object search %s: %w", shard.ID(), err1)
@@ -2306,26 +2342,41 @@ func (i *Index) objectVectorSearch(ctx context.Context, searchVectors []models.V
 		}
 	}
 
-	if selection != nil {
+	if selection != nil && !isMultiShardMMR {
+		// Single-shard path: per-shard MMR was applied, update limit to reflect
+		// the final result count for any downstream truncation.
 		limit = int(selection.MMR.Limit)
 	}
 
-	if len(readPlan.Shards()) == 1 {
+	if numShards == 1 {
 		return out, dists, nil
 	}
 
-	if len(readPlan.Shards()) > 1 && groupBy != nil {
-		return i.mergeGroups(out, dists, groupBy, limit, len(readPlan.Shards()))
+	if numShards > 1 && groupBy != nil {
+		return i.mergeGroups(out, dists, groupBy, limit, numShards)
 	}
 
-	if len(readPlan.Shards()) > 1 && len(sort) > 0 {
+	if numShards > 1 && len(sort) > 0 {
 		return i.sort(out, dists, sort, limit)
 	}
 
-	out, dists = newDistancesSorter().sort(out, dists)
-	if limit > 0 && len(out) > limit {
-		out = out[:limit]
-		dists = dists[:limit]
+	if isMultiShardMMR {
+		// Apply MMR globally across the merged candidate pool from all shards.
+		targetVector := ""
+		if len(targetVectors) > 0 {
+			targetVector = targetVectors[0]
+		}
+		var globalMMRErr error
+		out, dists, globalMMRErr = i.applyGlobalMMR(ctx, selection, targetVector, out, dists, additionalProps)
+		if globalMMRErr != nil {
+			return nil, nil, fmt.Errorf("global MMR selection: %w", globalMMRErr)
+		}
+	} else {
+		out, dists = newDistancesSorter().sort(out, dists)
+		if limit > 0 && len(out) > limit {
+			out = out[:limit]
+			dists = dists[:limit]
+		}
 	}
 
 	if i.anyShardHasMultipleReplicasRead(tenant, readPlan.Shards()) {

--- a/adapters/repos/db/index_mmr.go
+++ b/adapters/repos/db/index_mmr.go
@@ -1,0 +1,155 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
+	selector "github.com/weaviate/weaviate/adapters/repos/db/vector/selection"
+	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/searchparams"
+	"github.com/weaviate/weaviate/entities/storobj"
+	vectorIndexCommon "github.com/weaviate/weaviate/entities/vectorindex/common"
+)
+
+// applyGlobalMMR applies MMR post-processing to a merged pool of objects
+// collected from all shards. Unlike per-shard MMR, this enforces diversity
+// globally across the full candidate pool rather than independently per shard.
+//
+// objects and dists need not be pre-sorted; this function sorts them
+// internally before running the greedy MMR selection.
+//
+// objects must carry vector payloads for the relevant targetVector (the caller
+// is responsible for setting additionalProps.Vector/Vectors before issuing
+// shard queries). originalAdditionalProps is used only to decide whether to
+// strip the vector from returned objects after selection.
+func (i *Index) applyGlobalMMR(
+	ctx context.Context,
+	selection *searchparams.Selection,
+	targetVector string,
+	objects []*storobj.Object,
+	dists []float32,
+	originalAdditionalProps additional.Properties,
+) ([]*storobj.Object, []float32, error) {
+	// Sort all candidates by ascending distance so that the best item is
+	// first — the MMR greedy loop seeds from the nearest candidate.
+	objects, dists = newDistancesSorter().sort(objects, dists)
+
+	n := len(objects)
+	if n == 0 || selection == nil || selection.MMR == nil {
+		return objects, dists, nil
+	}
+
+	// Build the distance provider from the target vector's index config.
+	var distProv distancer.Provider
+	cfg := i.GetVectorIndexConfig(targetVector)
+	switch cfg.DistanceName() {
+	case "", vectorIndexCommon.DistanceCosine:
+		distProv = distancer.NewCosineDistanceProvider()
+	case vectorIndexCommon.DistanceDot:
+		distProv = distancer.NewDotProductProvider()
+	case vectorIndexCommon.DistanceL2Squared:
+		distProv = distancer.NewL2SquaredProvider()
+	case vectorIndexCommon.DistanceManhattan:
+		distProv = distancer.NewManhattanProvider()
+	case vectorIndexCommon.DistanceHamming:
+		distProv = distancer.NewHammingProvider()
+	default:
+		distProv = distancer.NewCosineDistanceProvider()
+	}
+
+	distFn := func(a, b []float32) (float32, error) {
+		return distProv.SingleDist(a, b)
+	}
+
+	// Assign sequential fake uint64 IDs and pre-build a vector lookup slice.
+	// Using sequential indices lets us map selected IDs back to objects without
+	// a separate hash-map lookup.
+	ids := make([]uint64, n)
+	vecMap := make([][]float32, n)
+	for idx, obj := range objects {
+		ids[idx] = uint64(idx)
+		if targetVector == "" {
+			vecMap[idx] = obj.Vector
+		} else if obj.Vectors != nil {
+			vecMap[idx] = obj.Vectors[targetVector]
+		}
+	}
+
+	vecForID := func(_ context.Context, id uint64) ([]float32, error) {
+		if int(id) >= len(vecMap) {
+			return nil, fmt.Errorf("global MMR: vecForID out of range: %d", id)
+		}
+		return vecMap[id], nil
+	}
+
+	k := int(selection.MMR.Limit)
+	sel, err := selector.New(selection, distFn, vecForID, k)
+	if err != nil {
+		return nil, nil, fmt.Errorf("global MMR selector: %w", err)
+	}
+	if sel == nil {
+		// No selection algorithm active — simple truncation.
+		if k > 0 && len(objects) > k {
+			objects = objects[:k]
+			dists = dists[:k]
+		}
+		return objects, dists, nil
+	}
+
+	selectedIDs, selectedDists, err := sel.Select(ctx, ids, dists)
+	if err != nil {
+		return nil, nil, fmt.Errorf("global MMR select: %w", err)
+	}
+
+	// Map sequential IDs back to original objects.
+	result := make([]*storobj.Object, len(selectedIDs))
+	resultDists := make([]float32, len(selectedIDs))
+	for j, id := range selectedIDs {
+		result[j] = objects[id] // id == sequential index into objects slice
+		resultDists[j] = selectedDists[j]
+	}
+
+	// Strip vectors from results if the user did not originally request them.
+	// They were only fetched internally to enable coordinator-level MMR.
+	if targetVector == "" {
+		if !originalAdditionalProps.Vector {
+			for _, obj := range result {
+				obj.Vector = nil
+			}
+		}
+	} else {
+		tvRequested := originalAdditionalProps.IncludeAllTargetVectors
+		if !tvRequested {
+			for _, v := range originalAdditionalProps.Vectors {
+				if v == targetVector {
+					tvRequested = true
+					break
+				}
+			}
+		}
+		if !tvRequested {
+			for _, obj := range result {
+				if obj.Vectors != nil {
+					delete(obj.Vectors, targetVector)
+					if len(obj.Vectors) == 0 {
+						obj.Vectors = nil
+					}
+				}
+			}
+		}
+	}
+
+	return result, resultDists, nil
+}


### PR DESCRIPTION
Per-shard MMR caused each shard to independently optimise diversity over only its local candidate subset. The coordinator then re-sorted all per-shard outputs by raw distance before truncating, destroying the global diversity guarantee — resulting in all returned objects coming from the closest cluster when multiple shards were involved.

The fix suppresses MMR at the shard level when numShards > 1, requests object vectors from shards so the coordinator has the data it needs, then applies a single global MMR pass across the merged candidate pool via the new applyGlobalMMR method in index_mmr.go.

Single-shard behaviour is unchanged.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
