### PR TITLE
Nested object filtering — Part 8: IsNull support and arr[N] positional filtering

### DIFF
--- a/adapters/repos/db/inverted/nested/assign.go
+++ b/adapters/repos/db/inverted/nested/assign.go
@@ -120,6 +120,14 @@ func AssignPositions(prop *models.Property, value any) (*AssignResult, error) {
 			return nil, fmt.Errorf("walk element %d of %q: %w", i, prop.Name, err)
 		}
 
+		// Root-level _idx entry: records which positions belong to root element i.
+		// Required for arr[N] positional filtering (e.g. "addresses[1].city = X").
+		result.Idx = append(result.Idx, IdxEntry{
+			Path:      "",
+			Index:     i,
+			Positions: elemPositions,
+		})
+
 		allPositions = append(allPositions, elemPositions...)
 	}
 

--- a/adapters/repos/db/inverted/nested/assign_test.go
+++ b/adapters/repos/db/inverted/nested/assign_test.go
@@ -691,8 +691,8 @@ func assertDoc123(t *testing.T, schema []*models.NestedProperty) {
 	assertValue(t, result, "cars.colors", "orange", positions(1, 10))
 	assertValue(t, result, "name", "subdoc_123", positions(1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
 
-	// Idx: 14 entries
-	require.Len(t, result.Idx, 14)
+	// Idx: 15 entries (14 sub-array + 1 root)
+	require.Len(t, result.Idx, 15)
 	assertIdx(t, result, "owner", 0, positions(1, 1, 2))
 	assertIdx(t, result, "owner.nicknames", 0, positions(1, 1))
 	assertIdx(t, result, "owner.nicknames", 1, positions(1, 2))
@@ -707,6 +707,8 @@ func assertDoc123(t *testing.T, schema []*models.NestedProperty) {
 	assertIdx(t, result, "cars.tires.radiuses", 1, positions(1, 8))
 	assertIdx(t, result, "cars.colors", 0, positions(1, 9))
 	assertIdx(t, result, "cars.colors", 1, positions(1, 10))
+	// root-level _idx entry for arr[N] positional filtering
+	assertIdx(t, result, "", 0, positions(1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
 
 	// Exists: 17 entries
 	require.Len(t, result.Exists, 17)
@@ -848,8 +850,8 @@ func assertDoc124(t *testing.T, schema []*models.NestedProperty) {
 	assertValue(t, result, "cars.colors", "white", positions(1, 11))
 	assertValue(t, result, "name", "subdoc_124", positions(1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
 
-	// Idx: 16 entries (aggregated by path+index)
-	require.Len(t, result.Idx, 16)
+	// Idx: 17 entries (16 sub-array + 1 root, aggregated by path+index)
+	require.Len(t, result.Idx, 17)
 	assertIdx(t, result, "owner", 0, positions(1, 1))
 	assertIdx(t, result, "owner.nicknames", 0, positions(1, 1))
 	assertIdx(t, result, "addresses", 0, positions(1, 2))
@@ -865,6 +867,8 @@ func assertDoc124(t *testing.T, schema []*models.NestedProperty) {
 	assertIdx(t, result, "cars.tires.radiuses", 0, positions(1, 7))
 	assertIdx(t, result, "cars.tires.radiuses", 1, positions(1, 8))
 	assertIdx(t, result, "cars.colors", 0, positions(1, 11))
+	// root-level _idx entry for arr[N] positional filtering
+	assertIdx(t, result, "", 0, positions(1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
 
 	// Exists: 23 raw entries, 17 unique paths (aggregated)
 	require.Len(t, result.Exists, 23)
@@ -980,8 +984,8 @@ func assertDoc125(t *testing.T, schema []*models.NestedProperty) {
 	assertValue(t, result, "cars.make", "Tesla", positions(1, 4, 5, 6, 7, 8, 9))
 	assertValue(t, result, "name", "subdoc_125", positions(1, 1, 2, 3, 4, 5, 6, 7, 8, 9))
 
-	// Idx: 12 entries (no owner.nicknames — Anna has no nicknames)
-	require.Len(t, result.Idx, 12)
+	// Idx: 13 entries (12 sub-array + 1 root; no owner.nicknames — Anna has no nicknames)
+	require.Len(t, result.Idx, 13)
 	assertIdx(t, result, "owner", 0, positions(1, 1))
 	assertIdx(t, result, "addresses", 0, positions(1, 2))
 	assertIdx(t, result, "addresses.numbers", 0, positions(1, 2))
@@ -994,6 +998,8 @@ func assertDoc125(t *testing.T, schema []*models.NestedProperty) {
 	assertIdx(t, result, "cars.accessories", 0, positions(1, 7))
 	assertIdx(t, result, "cars.accessories", 1, positions(1, 8))
 	assertIdx(t, result, "cars.colors", 0, positions(1, 9))
+	// root-level _idx entry for arr[N] positional filtering
+	assertIdx(t, result, "", 0, positions(1, 1, 2, 3, 4, 5, 6, 7, 8, 9))
 
 	// Exists: 19 raw entries, 17 unique paths (no owner.nicknames)
 	// accessories.type appears twice (one per leaf element)
@@ -1204,8 +1210,8 @@ func assertDoc999(t *testing.T, schema []*models.NestedProperty) {
 	assertValue(t, result, "cars.make", "Tesla", positions(2, 4, 5, 6, 7, 8, 9))
 	assertValue(t, result, "name", "subdoc_125", positions(2, 1, 2, 3, 4, 5, 6, 7, 8, 9))
 
-	// Idx: 28 (16 from r1/Justin + 12 from r2/Anna)
-	require.Len(t, result.Idx, 28)
+	// Idx: 30 (16 from r1/Justin + 12 from r2/Anna + 2 root entries)
+	require.Len(t, result.Idx, 30)
 	assertIdx(t, result, "owner", 0, append(positions(1, 1), positions(2, 1)...))
 	assertIdx(t, result, "owner.nicknames", 0, positions(1, 1))
 	assertIdx(t, result, "addresses", 0, append(positions(1, 2), positions(2, 2)...))
@@ -1224,6 +1230,9 @@ func assertDoc999(t *testing.T, schema []*models.NestedProperty) {
 	assertIdx(t, result, "cars.accessories", 0, positions(2, 7))
 	assertIdx(t, result, "cars.accessories", 1, positions(2, 8))
 	assertIdx(t, result, "cars.colors", 0, append(positions(1, 11), positions(2, 9)...))
+	// root-level _idx entries for arr[N] positional filtering
+	assertIdx(t, result, "", 0, positions(1, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11))
+	assertIdx(t, result, "", 1, positions(2, 1, 2, 3, 4, 5, 6, 7, 8, 9))
 
 	// Exists: 40 raw entries (23 from r1 + 17 from r2)
 	require.Len(t, result.Exists, 41) // 23 + 17 + 1 root

--- a/adapters/repos/db/inverted/objects_nested_test.go
+++ b/adapters/repos/db/inverted/objects_nested_test.go
@@ -746,7 +746,7 @@ func assertAnalyzeDoc123(t *testing.T, analyzer *Analyzer, prop *models.Property
 	assert.Contains(t, valuePaths, "addresses.city")
 	assert.Contains(t, valuePaths, "addresses.postcode")
 
-	assert.Len(t, result.Idx, 14)
+	assert.Len(t, result.Idx, 15)
 	assert.Len(t, result.Exists, 17)
 }
 
@@ -798,7 +798,7 @@ func assertAnalyzeDoc124(t *testing.T, analyzer *Analyzer, prop *models.Property
 	assert.Equal(t, 2, valuePaths["cars.make"])
 	assert.Equal(t, 1, valuePaths["cars.colors"])
 
-	assert.Len(t, result.Idx, 16)
+	assert.Len(t, result.Idx, 17)
 	assert.Len(t, result.Exists, 23)
 }
 
@@ -841,7 +841,7 @@ func assertAnalyzeDoc125(t *testing.T, analyzer *Analyzer, prop *models.Property
 	assert.Equal(t, 1, valuePaths["cars.colors"])
 	assert.Equal(t, 1, valuePaths["cars.make"])
 
-	assert.Len(t, result.Idx, 12)
+	assert.Len(t, result.Idx, 13)
 	assert.Len(t, result.Exists, 19)
 }
 
@@ -918,7 +918,7 @@ func assertAnalyzeDoc999(t *testing.T, analyzer *Analyzer, prop *models.Property
 	assert.Equal(t, 2, valuePaths["cars.colors"])
 	assert.Equal(t, 2, valuePaths["cars.accessories.type"])
 
-	assert.Len(t, result.Idx, 28)
+	assert.Len(t, result.Idx, 30)
 	assert.Len(t, result.Exists, 41)
 }
 

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -92,6 +92,12 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 		return pv.resolveNestedCorrelated(ctx, s)
 	}
 
+	// Nested IsNull reads _exists entries from the metadata bucket rather than
+	// going through the standard value-bucket path.
+	if pv.operator == filters.OperatorIsNull && pv.nested.isNested {
+		return pv.fetchNestedIsNull(s)
+	}
+
 	if pv.operator.OnValue() {
 		return pv.fetchDocIDs(ctx, s, limit)
 	}
@@ -354,6 +360,32 @@ func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int
 		dbm.docIDs = nested.MaskRootLeaf(dbm.docIDs)
 	}
 	return dbm, nil
+}
+
+// fetchNestedIsNull resolves an IsNull filter for a nested property by reading
+// the existence bitmap from the metadata bucket. relPath="" checks root-level
+// existence (e.g. "addresses IsNull"); a non-empty relPath checks sub-property
+// existence (e.g. "addresses.city IsNull").
+//
+// IsNull=false (property exists) → allowlist of matching docIDs.
+// IsNull=true  (property absent) → denylist (complement) of matching docIDs.
+func (pv *propValuePair) fetchNestedIsNull(s *Searcher) (*docBitmap, error) {
+	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(pv.prop))
+	if metaBucket == nil {
+		return nil, errors.Errorf("nested IsNull: meta bucket for %q not found — is it indexed?", pv.prop)
+	}
+
+	positions, release, err := metaBucket.RoaringSetGet(nested.ExistsKey(pv.nested.relPath))
+	if err != nil {
+		return nil, fmt.Errorf("nested IsNull: read exists key for %q: %w", pv.prop, err)
+	}
+	defer release()
+
+	dbm := newDocBitmap()
+	dbm.docIDs = nested.MaskRootLeaf(positions)
+	// pv.value is a little-endian bool: 0x01 = true (IsNull — property absent → denylist).
+	dbm.isDenyList = len(pv.value) > 0 && pv.value[0] == 0x01
+	return &dbm, nil
 }
 
 // fetchRawPositions is like fetchDocIDs but returns the raw position bitmap

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -16,17 +16,15 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/errorcompounder"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/entities/filters"
+	filternested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 )
 
 // nestedInfo groups fields that are only relevant for nested (object/object[])
@@ -52,6 +50,11 @@ type nestedInfo struct {
 	relPath                  string
 	isCorrelated             bool
 	childrenFromTokenization bool
+	// arrayIndices holds positional constraints from arr[N] filter syntax.
+	// Each entry (filternested.ArrayIndex) restricts the matching positions to the
+	// specified array element. Multiple entries support multi-level indexing
+	// (e.g. cars[1].tags[2]).
+	arrayIndices []filternested.ArrayIndex
 }
 
 type propValuePair struct {
@@ -92,10 +95,15 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 		return pv.resolveNestedCorrelated(ctx, s)
 	}
 
-	// Nested IsNull reads _exists entries from the metadata bucket rather than
-	// going through the standard value-bucket path.
-	if pv.operator == filters.OperatorIsNull && pv.nested.isNested {
-		return pv.fetchNestedIsNull(s)
+	// All nested-specific dispatch: IsNull, value filters, and correlated AND
+	// are all routed here so nested logic stays out of the flat fetch path.
+	if pv.nested.isNested {
+		switch {
+		case pv.operator == filters.OperatorIsNull:
+			return pv.fetchNestedIsNull(s)
+		case pv.operator.OnValue():
+			return pv.fetchNestedDocIDs(ctx, s, limit)
+		}
 	}
 
 	if pv.operator.OnValue() {
@@ -349,55 +357,13 @@ func mergeDocIDs(operator filters.Operator, dbms []*docBitmap) []*docBitmap {
 	return dbms[:1]
 }
 
+// fetchDocIDs resolves a value filter on a flat (non-nested) property.
 func (pv *propValuePair) fetchDocIDs(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
-	dbm, err := pv.fetchBitmap(ctx, s, limit)
-	if err != nil {
-		return nil, err
-	}
-	if pv.nested.isNested {
-		// The nested value bucket stores positions (root|leaf|docID) rather than
-		// plain docIDs. Strip position bits to extract the docID-only bitmap.
-		dbm.docIDs = nested.MaskRootLeaf(dbm.docIDs)
-	}
-	return dbm, nil
+	return pv.readFromBucket(ctx, s, limit)
 }
 
-// fetchNestedIsNull resolves an IsNull filter for a nested property by reading
-// the existence bitmap from the metadata bucket. relPath="" checks root-level
-// existence (e.g. "addresses IsNull"); a non-empty relPath checks sub-property
-// existence (e.g. "addresses.city IsNull").
-//
-// IsNull=false (property exists) → allowlist of matching docIDs.
-// IsNull=true  (property absent) → denylist (complement) of matching docIDs.
-func (pv *propValuePair) fetchNestedIsNull(s *Searcher) (*docBitmap, error) {
-	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(pv.prop))
-	if metaBucket == nil {
-		return nil, errors.Errorf("nested IsNull: meta bucket for %q not found — is it indexed?", pv.prop)
-	}
-
-	positions, release, err := metaBucket.RoaringSetGet(nested.ExistsKey(pv.nested.relPath))
-	if err != nil {
-		return nil, fmt.Errorf("nested IsNull: read exists key for %q: %w", pv.prop, err)
-	}
-	defer release()
-
-	dbm := newDocBitmap()
-	dbm.docIDs = nested.MaskRootLeaf(positions)
-	// pv.value is a little-endian bool: 0x01 = true (IsNull — property absent → denylist).
-	dbm.isDenyList = len(pv.value) > 0 && pv.value[0] == 0x01
-	return &dbm, nil
-}
-
-// fetchRawPositions is like fetchDocIDs but returns the raw position bitmap
-// without stripping the root/leaf bits. Only valid for nested properties
-// (pv.nested.isNested == true). Used by the correlated resolution path which needs
-// full positions to apply MaskLeaf AND or the _idx loop.
-func (pv *propValuePair) fetchRawPositions(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
-	return pv.fetchBitmap(ctx, s, limit)
-}
-
-// fetchBitmap is the shared implementation for fetchDocIDs and fetchRawPositions.
-func (pv *propValuePair) fetchBitmap(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
+// readFromBucket is the shared low-level implementation for all fetch methods.
+func (pv *propValuePair) readFromBucket(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
 	// TODO text_rbm_inverted_index find better way check whether prop len
 	if strings.HasSuffix(pv.prop, filters.InternalPropertyLength) &&
 		!pv.Class.InvertedIndexConfig.IndexPropertyLength {
@@ -471,84 +437,4 @@ func (pv *propValuePair) getBucketName() string {
 		return helpers.BucketSearchableFromPropNameLSM(pv.prop)
 	}
 	return ""
-}
-
-// positionBitmaps groups pre-fetched raw position bitmaps for a single nested path,
-// split by origin so the executor can apply the correct combining strategy:
-//   - tokens: from childrenFromTokenization compound ANDs (multi-token text);
-//     combined with AndAll — all tokens must share the same leaf position.
-//   - independent: from direct leaf conditions (e.g. scalar array values);
-//     combined with MaskLeafAndAll when there are multiple — values may be at
-//     different leaf positions within the same parent element.
-type positionBitmaps struct {
-	tokens      []*sroar.Bitmap
-	independent []*sroar.Bitmap
-}
-
-// resolveNestedCorrelated resolves one prop group using position-aware
-// correlation. It builds a resolutionPlan for the group's paths, pre-computes
-// raw position bitmaps, and executes the plan to enforce same-element semantics.
-func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searcher) (*docBitmap, error) {
-	// Build positionsByPath: fetch raw position bitmaps per pvp and route into
-	// the correct bucket slot based on origin (token vs independent).
-	positionsByPath := make(map[string]*positionBitmaps, len(pv.children))
-	pathOrder := make([]string, 0, len(pv.children))
-
-	fetchAndRoute := func(leaf *propValuePair, isToken bool) error {
-		dbm, err := leaf.fetchRawPositions(ctx, s, 0)
-		if err != nil {
-			return err
-		}
-		path := leaf.nested.relPath
-		if _, exists := positionsByPath[path]; !exists {
-			positionsByPath[path] = &positionBitmaps{}
-			pathOrder = append(pathOrder, path)
-		}
-		if isToken {
-			positionsByPath[path].tokens = append(positionsByPath[path].tokens, dbm.docIDs)
-		} else {
-			positionsByPath[path].independent = append(positionsByPath[path].independent, dbm.docIDs)
-		}
-		return nil
-	}
-
-	for _, child := range pv.children {
-		if child.nested.isNested {
-			// When pv itself is a tokenization compound AND, its children are tokens
-			// of the same value and must share the same leaf position → route as tokens.
-			if err := fetchAndRoute(child, pv.nested.childrenFromTokenization); err != nil {
-				return nil, fmt.Errorf("nested correlated AND: fetch bitmap for %q: %w", child.nested.relPath, err)
-			}
-		} else {
-			// Tokenization compound AND child: grandchildren are tokens of the same value.
-			for _, gc := range child.children {
-				if err := fetchAndRoute(gc, true); err != nil {
-					return nil, fmt.Errorf("nested correlated AND: fetch bitmap for %q: %w", gc.nested.relPath, err)
-				}
-			}
-		}
-	}
-
-	// Find the root property's schema to build the resolution plan.
-	rootProp, err := schema.GetPropertyByName(pv.Class, pv.prop)
-	if err != nil {
-		return nil, fmt.Errorf("nested correlated AND: root property %q not found in schema: %w", pv.prop, err)
-	}
-	rootDT := schema.DataType(rootProp.DataType[0])
-
-	plan, err := newResolutionPlanBuilder(rootDT, rootProp.NestedProperties).build(pathOrder)
-	if err != nil {
-		return nil, fmt.Errorf("nested correlated AND: build plan for %q: %w", pv.prop, err)
-	}
-
-	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(pv.prop))
-
-	docIDs, err := newResolutionPlanExecutor(plan, positionsByPath, metaBucket).execute(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("nested correlated AND: execute for %q: %w", pv.prop, err)
-	}
-
-	dbm := newDocBitmap()
-	dbm.docIDs = docIDs
-	return &dbm, nil
 }

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -1,0 +1,183 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// fetchNestedDocIDs resolves a value filter on a nested property, returning
+// docID-only results. It fetches raw positions, applies any arr[N] index
+// constraints, then strips position bits to extract plain docIDs.
+func (pv *propValuePair) fetchNestedDocIDs(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
+	dbm, err := pv.fetchNestedPositions(ctx, s, limit)
+	if err != nil {
+		return nil, err
+	}
+	dbm.docIDs = nested.MaskRootLeaf(dbm.docIDs)
+	return dbm, nil
+}
+
+// fetchNestedIsNull resolves an IsNull filter for a nested property by reading
+// the existence bitmap from the metadata bucket. relPath="" checks root-level
+// existence (e.g. "addresses IsNull"); a non-empty relPath checks sub-property
+// existence (e.g. "addresses.city IsNull").
+//
+// IsNull=false (property exists) → allowlist of matching docIDs.
+// IsNull=true  (property absent) → denylist (complement) of matching docIDs.
+func (pv *propValuePair) fetchNestedIsNull(s *Searcher) (*docBitmap, error) {
+	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(pv.prop))
+	if metaBucket == nil {
+		return nil, errors.Errorf("nested IsNull: meta bucket for %q not found — is it indexed?", pv.prop)
+	}
+
+	positions, release, err := metaBucket.RoaringSetGet(nested.ExistsKey(pv.nested.relPath))
+	if err != nil {
+		return nil, fmt.Errorf("nested IsNull: read exists key for %q: %w", pv.prop, err)
+	}
+	defer release()
+
+	if err := pv.restrictByNestedIdx(s, positions); err != nil {
+		return nil, err
+	}
+
+	dbm := newDocBitmap()
+	dbm.docIDs = nested.MaskRootLeaf(positions)
+	// pv.value is a little-endian bool: 0x01 = true (IsNull — property absent → denylist).
+	dbm.isDenyList = len(pv.value) > 0 && pv.value[0] == 0x01
+	return &dbm, nil
+}
+
+// fetchNestedPositions fetches the raw position bitmap for a nested value
+// filter and applies any arr[N] index constraints. Positions are not stripped
+// to docIDs — callers that need docIDs use fetchNestedDocIDs instead; the
+// correlated resolution path (resolveNestedCorrelated) uses this directly.
+func (pv *propValuePair) fetchNestedPositions(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
+	dbm, err := pv.readFromBucket(ctx, s, limit)
+	if err != nil {
+		return nil, err
+	}
+	if err := pv.restrictByNestedIdx(s, dbm.docIDs); err != nil {
+		return nil, err
+	}
+	return dbm, nil
+}
+
+// restrictByNestedIdx restricts a position bitmap to the specific array
+// elements recorded in pv.nested.arrayIndices. For each constraint it reads
+// IdxKey(relPath, index) from the nested metadata bucket and ANDs it into
+// the bitmap in place. No-op when arrayIndices is empty.
+func (pv *propValuePair) restrictByNestedIdx(s *Searcher, positions *sroar.Bitmap) error {
+	if len(pv.nested.arrayIndices) == 0 {
+		return nil
+	}
+	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(pv.prop))
+	if metaBucket == nil {
+		return fmt.Errorf("nested [N] filter: meta bucket for %q not found — is it indexed?", pv.prop)
+	}
+	for _, ai := range pv.nested.arrayIndices {
+		idxPositions, release, err := metaBucket.RoaringSetGet(nested.IdxKey(ai.RelPath, ai.Index))
+		if err != nil {
+			return fmt.Errorf("nested [N] filter: read idx key for %q[%d]: %w", ai.RelPath, ai.Index, err)
+		}
+		positions.And(idxPositions)
+		release()
+	}
+	return nil
+}
+
+// positionBitmaps groups pre-fetched raw position bitmaps for a single nested path,
+// split by origin so the executor can apply the correct combining strategy:
+//   - tokens: from childrenFromTokenization compound ANDs (multi-token text);
+//     combined with AndAll — all tokens must share the same leaf position.
+//   - independent: from direct leaf conditions (e.g. scalar array values);
+//     combined with MaskLeafAndAll when there are multiple — values may be at
+//     different leaf positions within the same parent element.
+type positionBitmaps struct {
+	tokens      []*sroar.Bitmap
+	independent []*sroar.Bitmap
+}
+
+// resolveNestedCorrelated resolves one prop group using position-aware
+// correlation. It builds a resolutionPlan for the group's paths, pre-computes
+// raw position bitmaps, and executes the plan to enforce same-element semantics.
+func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searcher) (*docBitmap, error) {
+	// Build positionsByPath: fetch raw position bitmaps per pvp and route into
+	// the correct bucket slot based on origin (token vs independent).
+	positionsByPath := make(map[string]*positionBitmaps, len(pv.children))
+	pathOrder := make([]string, 0, len(pv.children))
+
+	fetchAndRoute := func(leaf *propValuePair, isToken bool) error {
+		dbm, err := leaf.fetchNestedPositions(ctx, s, 0)
+		if err != nil {
+			return err
+		}
+		path := leaf.nested.relPath
+		if _, exists := positionsByPath[path]; !exists {
+			positionsByPath[path] = &positionBitmaps{}
+			pathOrder = append(pathOrder, path)
+		}
+		if isToken {
+			positionsByPath[path].tokens = append(positionsByPath[path].tokens, dbm.docIDs)
+		} else {
+			positionsByPath[path].independent = append(positionsByPath[path].independent, dbm.docIDs)
+		}
+		return nil
+	}
+
+	for _, child := range pv.children {
+		if child.nested.isNested {
+			// When pv itself is a tokenization compound AND, its children are tokens
+			// of the same value and must share the same leaf position → route as tokens.
+			if err := fetchAndRoute(child, pv.nested.childrenFromTokenization); err != nil {
+				return nil, fmt.Errorf("nested correlated AND: fetch bitmap for %q: %w", child.nested.relPath, err)
+			}
+		} else {
+			// Tokenization compound AND child: grandchildren are tokens of the same value.
+			for _, gc := range child.children {
+				if err := fetchAndRoute(gc, true); err != nil {
+					return nil, fmt.Errorf("nested correlated AND: fetch bitmap for %q: %w", gc.nested.relPath, err)
+				}
+			}
+		}
+	}
+
+	// Find the root property's schema to build the resolution plan.
+	rootProp, err := schema.GetPropertyByName(pv.Class, pv.prop)
+	if err != nil {
+		return nil, fmt.Errorf("nested correlated AND: root property %q not found in schema: %w", pv.prop, err)
+	}
+	rootDT := schema.DataType(rootProp.DataType[0])
+
+	plan, err := newResolutionPlanBuilder(rootDT, rootProp.NestedProperties).build(pathOrder)
+	if err != nil {
+		return nil, fmt.Errorf("nested correlated AND: build plan for %q: %w", pv.prop, err)
+	}
+
+	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(pv.prop))
+
+	docIDs, err := newResolutionPlanExecutor(plan, positionsByPath, metaBucket).execute(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("nested correlated AND: execute for %q: %w", pv.prop, err)
+	}
+
+	dbm := newDocBitmap()
+	dbm.docIDs = docIDs
+	return &dbm, nil
+}

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -317,3 +317,313 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 }
+
+// ---------------------------------------------------------------------------
+// IsNull tests
+// ---------------------------------------------------------------------------
+
+// isNullTestClass returns a class used across IsNull integration tests:
+//
+//	addresses: object[] { city: text }
+//	meta:      object   { isbn: text }
+//	container: object[] {
+//	  owner: object   { name: text }   ← intermediate object
+//	  items: object[] { tag:  text }   ← intermediate object[]
+//	}
+func isNullTestClass() *models.Class {
+	vTrue := true
+	return &models.Class{
+		Class: "TestClass",
+		Properties: []*models.Property{
+			{
+				Name:     "addresses",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{Name: "city", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+				},
+			},
+			{
+				Name:     "meta",
+				DataType: schema.DataTypeObject.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{Name: "isbn", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+				},
+			},
+			{
+				Name:     "container",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{
+						Name:     "owner",
+						DataType: schema.DataTypeObject.PropString(),
+						NestedProperties: []*models.NestedProperty{
+							{Name: "name", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+						},
+					},
+					{
+						Name:     "items",
+						DataType: schema.DataTypeObjectArray.PropString(),
+						NestedProperties: []*models.NestedProperty{
+							{Name: "tag", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+// writeNestedExists writes an _exists metadata entry to a meta bucket.
+func writeNestedExists(t *testing.T, bucket *lsmkv.Bucket, relPath string, positions []uint64) {
+	t.Helper()
+	require.NoError(t, bucket.RoaringSetAddList(nested.ExistsKey(relPath), positions))
+}
+
+// makeIsNullPvp builds a propValuePair for a nested IsNull filter.
+func makeIsNullPvp(class *models.Class, prop, relPath string, isNullTrue bool) *propValuePair {
+	var val byte
+	if isNullTrue {
+		val = 0x01
+	}
+	return &propValuePair{
+		prop:     prop,
+		value:    []byte{val},
+		operator: filters.OperatorIsNull,
+		nested:   nestedInfo{isNested: true, relPath: relPath},
+		Class:    class,
+	}
+}
+
+func TestNestedIsNull(t *testing.T) {
+	// position helpers — docID is the identifying part after MaskRootLeaf
+	pos := func(docID uint64) uint64 { return nested.Encode(1, 1, docID) }
+
+	t.Run("object[] — root IsNull", func(t *testing.T) {
+		// output:
+		// addresses IsNull false → {doc1, doc2}  (have at least one element)
+		// addresses IsNull true  → denylist {doc1, doc2}  (complement = doc3 and beyond)
+		const (
+			doc1 = uint64(1) // has addresses with city
+			doc2 = uint64(2) // has addresses without city
+		)
+
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, metaBucket)
+		class := isNullTestClass()
+
+		mb := store.Bucket(metaBucket)
+		// doc1 has addresses with city; doc2 has addresses without city; doc3 has none.
+		writeNestedExists(t, mb, "", []uint64{pos(doc1), pos(doc2)})
+		writeNestedExists(t, mb, "city", []uint64{pos(doc1)})
+
+		for _, tt := range []struct {
+			name           string
+			isNull         bool
+			wantIsDenyList bool
+			wantDocIDs     []uint64 // bitmap contents (denylist bitmap or allowlist bitmap)
+		}{
+			{"IsNull false — allowlist of docs with addresses", false, false, []uint64{doc1, doc2}},
+			{"IsNull true  — denylist of docs with addresses", true, true, []uint64{doc1, doc2}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				pv := makeIsNullPvp(class, "addresses", "", tt.isNull)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantIsDenyList, result.isDenyList)
+				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
+			})
+		}
+	})
+
+	t.Run("object[] — sub-property IsNull", func(t *testing.T) {
+		// output:
+		// addresses.city IsNull false → allowlist {doc1}        (has at least one address with city)
+		// addresses.city IsNull true  → denylist  {doc1}        (complement = doc2, doc3, …)
+		const (
+			doc1 = uint64(1) // has addresses with city
+			doc2 = uint64(2) // has addresses without city
+		)
+
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, metaBucket)
+		class := isNullTestClass()
+
+		mb := store.Bucket(metaBucket)
+		// doc1 has addresses with city; doc2 has addresses but no city; doc3 has none.
+		writeNestedExists(t, mb, "", []uint64{pos(doc1), pos(doc2)})
+		writeNestedExists(t, mb, "city", []uint64{pos(doc1)})
+
+		for _, tt := range []struct {
+			name           string
+			isNull         bool
+			wantIsDenyList bool
+			wantDocIDs     []uint64
+		}{
+			{"IsNull false — allowlist of docs with city", false, false, []uint64{doc1}},
+			{"IsNull true  — denylist of docs with city", true, true, []uint64{doc1}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				pv := makeIsNullPvp(class, "addresses", "city", tt.isNull)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantIsDenyList, result.isDenyList)
+				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
+			})
+		}
+	})
+
+	t.Run("object — root IsNull", func(t *testing.T) {
+		// output:
+		// meta IsNull false → allowlist {doc4, doc6}       (both have meta)
+		// meta IsNull true  → denylist  {doc4, doc6}       (complement = doc5 and beyond)
+		const (
+			doc4 = uint64(4) // has meta with isbn
+			doc6 = uint64(6) // has meta but no isbn
+		)
+
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("meta")
+		searcher, store := newNestedTestSearcher(t, metaBucket)
+		class := isNullTestClass()
+
+		mb := store.Bucket(metaBucket)
+		// doc4 has meta with isbn; doc6 has meta but no isbn; doc5 has no meta.
+		writeNestedExists(t, mb, "", []uint64{pos(doc4), pos(doc6)})
+		writeNestedExists(t, mb, "isbn", []uint64{pos(doc4)})
+
+		for _, tt := range []struct {
+			name           string
+			isNull         bool
+			wantIsDenyList bool
+			wantDocIDs     []uint64
+		}{
+			{"IsNull false — allowlist of docs with meta", false, false, []uint64{doc4, doc6}},
+			{"IsNull true  — denylist of docs with meta", true, true, []uint64{doc4, doc6}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				pv := makeIsNullPvp(class, "meta", "", tt.isNull)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantIsDenyList, result.isDenyList)
+				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
+			})
+		}
+	})
+
+	t.Run("object — sub-property IsNull", func(t *testing.T) {
+		// output:
+		// meta.isbn IsNull false → allowlist {doc4}         (has isbn)
+		// meta.isbn IsNull true  → denylist  {doc4}         (complement = doc6, doc5, …)
+		// doc6 has meta but no isbn → not in ExistsKey("isbn"), returned by IsNull true via complement
+		const (
+			doc4 = uint64(4) // has meta with isbn
+			doc6 = uint64(6) // has meta but no isbn
+		)
+
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("meta")
+		searcher, store := newNestedTestSearcher(t, metaBucket)
+		class := isNullTestClass()
+
+		mb := store.Bucket(metaBucket)
+		// doc4 has meta with isbn; doc6 has meta but no isbn; doc5 has no meta.
+		writeNestedExists(t, mb, "", []uint64{pos(doc4), pos(doc6)})
+		writeNestedExists(t, mb, "isbn", []uint64{pos(doc4)})
+
+		for _, tt := range []struct {
+			name           string
+			isNull         bool
+			wantIsDenyList bool
+			wantDocIDs     []uint64
+		}{
+			{"IsNull false — allowlist of docs with isbn", false, false, []uint64{doc4}},
+			{"IsNull true  — denylist of docs with isbn", true, true, []uint64{doc4}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				pv := makeIsNullPvp(class, "meta", "isbn", tt.isNull)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantIsDenyList, result.isDenyList)
+				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
+			})
+		}
+	})
+
+	t.Run("object[] — intermediate object sub-property IsNull", func(t *testing.T) {
+		// output:
+		// container.owner IsNull false → allowlist {doc7}  (has owner)
+		// container.owner IsNull true  → denylist  {doc7}  (complement = doc8, doc9, …)
+		// doc8 has container with items but no owner → in complement for IsNull true
+
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("container")
+		searcher, store := newNestedTestSearcher(t, metaBucket)
+		class := isNullTestClass()
+
+		const (
+			doc7 = uint64(7) // container with owner (no items)
+			doc8 = uint64(8) // container with items (no owner)
+		)
+
+		mb := store.Bucket(metaBucket)
+		// doc7: container element exists, owner exists
+		// doc8: container element exists, items exist, but no owner
+		writeNestedExists(t, mb, "", []uint64{pos(doc7), pos(doc8)})
+		writeNestedExists(t, mb, "owner", []uint64{pos(doc7)})
+		writeNestedExists(t, mb, "items", []uint64{pos(doc8)})
+
+		for _, tt := range []struct {
+			name           string
+			isNull         bool
+			wantIsDenyList bool
+			wantDocIDs     []uint64
+		}{
+			{"IsNull false — allowlist of docs with owner", false, false, []uint64{doc7}},
+			{"IsNull true  — denylist of docs with owner", true, true, []uint64{doc7}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				pv := makeIsNullPvp(class, "container", "owner", tt.isNull)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantIsDenyList, result.isDenyList)
+				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
+			})
+		}
+	})
+
+	t.Run("object[] — intermediate object[] sub-property IsNull", func(t *testing.T) {
+		// output:
+		// container.items IsNull false → allowlist {doc8}  (has items)
+		// container.items IsNull true  → denylist  {doc8}  (complement = doc7, doc9, …)
+		// doc7 has container with owner but no items → in complement for IsNull true
+
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("container")
+		searcher, store := newNestedTestSearcher(t, metaBucket)
+		class := isNullTestClass()
+
+		const (
+			doc7 = uint64(7) // container with owner (no items)
+			doc8 = uint64(8) // container with items (no owner)
+		)
+
+		mb := store.Bucket(metaBucket)
+		writeNestedExists(t, mb, "", []uint64{pos(doc7), pos(doc8)})
+		writeNestedExists(t, mb, "owner", []uint64{pos(doc7)})
+		writeNestedExists(t, mb, "items", []uint64{pos(doc8)})
+
+		for _, tt := range []struct {
+			name           string
+			isNull         bool
+			wantIsDenyList bool
+			wantDocIDs     []uint64
+		}{
+			{"IsNull false — allowlist of docs with items", false, false, []uint64{doc8}},
+			{"IsNull true  — denylist of docs with items", true, true, []uint64{doc8}},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				pv := makeIsNullPvp(class, "container", "items", tt.isNull)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantIsDenyList, result.isDenyList)
+				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
+			})
+		}
+	})
+}

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
+	filternested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -312,6 +313,69 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 				makeLeafPvp(class, "addresses", "city", "berlin"),
 			),
 		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("correlated AND with arr[N] — cars[1].make AND cars[1].tires.width same car element", func(t *testing.T) {
+		// Both conditions target cars[1] (root=2). The arr[N] restriction is
+		// applied inside fetchNestedPositions before the correlated AND executes,
+		// so the resolution plan sees already-restricted bitmaps and correctly
+		// enforces same-element semantics within the indexed car.
+		//
+		// doc5: cars[0] (root=1): make="tesla", no tires
+		//       cars[1] (root=2): make="bmw",   tires[0].width=205
+		// doc7: cars[0] (root=1): make="bmw",   tires[0].width=205 (wrong car index)
+		// filter: cars[1].make="bmw" AND cars[1].tires.width=205 → only doc5
+
+		nestedBucket := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, nestedBucket, metaBucket)
+		class := correlationTestClass()
+
+		nb := store.Bucket(nestedBucket)
+		// doc5 cars[0].make=tesla (root=1), cars[1].make=bmw (root=2)
+		writeNestedValue(t, nb, "make", "tesla", []uint64{nested.Encode(1, 1, doc5)})
+		writeNestedValue(t, nb, "make", "bmw", []uint64{nested.Encode(2, 1, doc5), nested.Encode(1, 1, doc7)})
+		// doc5 cars[1].tires[0].width=205 (root=2,leaf=2); doc7 cars[0].tires[0].width=205 (root=1,leaf=2)
+		widthVal := make([]byte, 8)
+		widthVal[7] = 205
+		require.NoError(t, nb.RoaringSetAddList(nested.ValueKey("tires.width", widthVal),
+			[]uint64{nested.Encode(2, 2, doc5), nested.Encode(1, 2, doc7)}))
+
+		mb := store.Bucket(metaBucket)
+		// root-level idx: cars[0] and cars[1]
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 0),
+			[]uint64{nested.Encode(1, 1, doc5), nested.Encode(1, 2, doc7), nested.Encode(1, 1, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 1),
+			[]uint64{nested.Encode(2, 1, doc5), nested.Encode(2, 2, doc5)}))
+		// tires idx within any car
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tires", 0),
+			[]uint64{nested.Encode(2, 2, doc5), nested.Encode(1, 2, doc7)}))
+		// meta idx for correlated AND
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 0),
+			[]uint64{nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7), nested.Encode(1, 2, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 1),
+			[]uint64{nested.Encode(2, 1, doc5), nested.Encode(2, 2, doc5)}))
+
+		makePvp := func(relPath, value string) *propValuePair {
+			pv := makeLeafPvp(class, "cars", relPath, value)
+			pv.nested.arrayIndices = []filternested.ArrayIndex{{RelPath: "", Index: 1}}
+			return pv
+		}
+		widthPvp := &propValuePair{
+			prop: "cars", value: widthVal, operator: filters.OperatorEqual,
+			hasFilterableIndex: true,
+			nested: nestedInfo{
+				isNested:     true,
+				relPath:      "tires.width",
+				arrayIndices: []filternested.ArrayIndex{{RelPath: "", Index: 1}},
+			},
+			Class: class,
+		}
+
+		pv := makeCorrelatedPvp(class, "cars", makePvp("make", "bmw"), widthPvp)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
@@ -625,5 +689,278 @@ func TestNestedIsNull(t *testing.T) {
 				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
 			})
 		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// arr[N] positional filtering tests
+// ---------------------------------------------------------------------------
+
+func TestNestedArrayIndexFilter(t *testing.T) {
+	const (
+		doc1 = uint64(1) // addresses[0].city="berlin", addresses[1].city="paris"
+		doc2 = uint64(2) // addresses[0].city="paris"  (no second address)
+	)
+
+	posAddr := func(root uint16, leaf uint16, docID uint64) uint64 {
+		return nested.Encode(root, leaf, docID)
+	}
+
+	t.Run("root index — addresses[1].city = berlin", func(t *testing.T) {
+		// output:
+		// addresses[1].city = "berlin"
+		// → only doc1 has a second address (root=2) with city=berlin
+		// → doc2 has no second address → empty
+
+		valueBucket := helpers.BucketNestedFromPropNameLSM("addresses")
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, valueBucket, metaBucket)
+		class := isNullTestClass()
+
+		vb := store.Bucket(valueBucket)
+		// doc1: addresses[0] root=1 leaf=1, addresses[1] root=2 leaf=1
+		writeNestedValue(t, vb, "city", "berlin", []uint64{
+			posAddr(1, 1, doc1), // addresses[0].city=berlin (doc1)
+			posAddr(2, 1, doc1), // addresses[1].city=berlin (doc1)
+		})
+		writeNestedValue(t, vb, "city", "paris", []uint64{
+			posAddr(1, 1, doc2), // addresses[0].city=paris (doc2)
+		})
+
+		// _idx entries: IdxKey("", 0) → all positions in addresses[0]
+		//               IdxKey("", 1) → all positions in addresses[1]
+		mb := store.Bucket(metaBucket)
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 0), []uint64{
+			posAddr(1, 1, doc1), posAddr(1, 1, doc2),
+		}))
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 1), []uint64{
+			posAddr(2, 1, doc1), // only doc1 has a second address
+		}))
+
+		pv := makeLeafPvp(class, "addresses", "city", "berlin")
+		pv.nested.arrayIndices = []filternested.ArrayIndex{{RelPath: "", Index: 1}}
+
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc1}, result.docIDs.ToArray())
+	})
+
+	t.Run("root index out of range — addresses[5].city returns empty", func(t *testing.T) {
+		valueBucket := helpers.BucketNestedFromPropNameLSM("addresses")
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, valueBucket, metaBucket)
+		class := isNullTestClass()
+
+		vb := store.Bucket(valueBucket)
+		writeNestedValue(t, vb, "city", "berlin", []uint64{posAddr(1, 1, doc1)})
+
+		mb := store.Bucket(metaBucket)
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 0), []uint64{posAddr(1, 1, doc1)}))
+		// No IdxKey("", 5) entry → intersection will be empty
+
+		pv := makeLeafPvp(class, "addresses", "city", "berlin")
+		pv.nested.arrayIndices = []filternested.ArrayIndex{{RelPath: "", Index: 5}}
+
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.True(t, result.docIDs.IsEmpty())
+	})
+
+	t.Run("IsNull with root index — addresses[1] IsNull false", func(t *testing.T) {
+		// addresses[1] IsNull false → docs that have a second address element
+		// doc1: addresses[0] (root=1) and addresses[1] (root=2)
+		// doc2: addresses[0] (root=1) only
+
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, metaBucket)
+		class := isNullTestClass()
+
+		mb := store.Bucket(metaBucket)
+		writeNestedExists(t, mb, "", []uint64{posAddr(1, 1, doc1), posAddr(2, 1, doc1), posAddr(1, 1, doc2)})
+		writeNestedExists(t, mb, "city", []uint64{posAddr(1, 1, doc1), posAddr(2, 1, doc1), posAddr(1, 1, doc2)})
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 0), []uint64{posAddr(1, 1, doc1), posAddr(1, 1, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 1), []uint64{posAddr(2, 1, doc1)}))
+
+		pv := makeIsNullPvp(class, "addresses", "", false)
+		pv.nested.arrayIndices = []filternested.ArrayIndex{{RelPath: "", Index: 1}}
+
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.False(t, result.isDenyList)
+		assert.Equal(t, []uint64{doc1}, result.docIDs.ToArray())
+	})
+
+	t.Run("IsNull with sub-property index — addresses[1].city IsNull false", func(t *testing.T) {
+		// addresses[1].city IsNull false → docs where the second address has city set
+		// doc1: addresses[0].city set, addresses[1].city set
+		// doc2: addresses[0].city set, no second address
+		// doc3: addresses[0] exists but no city, addresses[1].city set → doc3 has second address with city
+
+		const doc3 = uint64(3)
+
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, metaBucket)
+		class := isNullTestClass()
+
+		mb := store.Bucket(metaBucket)
+		// root-level exists: doc1 has two addresses, doc2 and doc3 have one each
+		writeNestedExists(t, mb, "", []uint64{posAddr(1, 1, doc1), posAddr(2, 1, doc1), posAddr(1, 1, doc2), posAddr(1, 1, doc3), posAddr(2, 1, doc3)})
+		// city exists: doc1 both addresses, doc2 first address, doc3 only second address
+		writeNestedExists(t, mb, "city", []uint64{posAddr(1, 1, doc1), posAddr(2, 1, doc1), posAddr(1, 1, doc2), posAddr(2, 1, doc3)})
+		// root idx entries
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 0), []uint64{posAddr(1, 1, doc1), posAddr(1, 1, doc2), posAddr(1, 1, doc3)}))
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 1), []uint64{posAddr(2, 1, doc1), posAddr(2, 1, doc3)}))
+
+		pv := makeIsNullPvp(class, "addresses", "city", false)
+		pv.nested.arrayIndices = []filternested.ArrayIndex{{RelPath: "", Index: 1}}
+
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		// doc1 and doc3 both have addresses[1].city set; doc2 has no addresses[1]
+		assert.False(t, result.isDenyList)
+		assert.Equal(t, []uint64{doc1, doc3}, result.docIDs.ToArray())
+	})
+}
+
+func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
+	vTrue := true
+	carsClass := func() *models.Class {
+		return &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "cars",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+						{
+							Name:     "tires",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	posAt := func(root, leaf uint16, docID uint64) uint64 { return nested.Encode(root, leaf, docID) }
+
+	const (
+		doc1 = uint64(1)
+		doc2 = uint64(2)
+	)
+
+	t.Run("scalar array index — cars.tags[2] = german", func(t *testing.T) {
+		// doc1: cars[0].tags = ["english", "premium", "german"]
+		//   tags[0]=posAt(1,1,doc1)  tags[1]=posAt(1,2,doc1)  tags[2]=posAt(1,3,doc1)
+		// doc2: cars[0].tags = ["german", "luxury"]
+		//   tags[0]=posAt(1,1,doc2)  tags[1]=posAt(1,2,doc2)
+		// filter: cars.tags[2] = "german" → only doc1 (doc2's "german" is at tags[0])
+
+		valueBucket := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, valueBucket, metaBucket)
+		class := carsClass()
+
+		vb := store.Bucket(valueBucket)
+		writeNestedValue(t, vb, "tags", "english", []uint64{posAt(1, 1, doc1)})
+		writeNestedValue(t, vb, "tags", "premium", []uint64{posAt(1, 2, doc1)})
+		writeNestedValue(t, vb, "tags", "german", []uint64{posAt(1, 3, doc1), posAt(1, 1, doc2)})
+		writeNestedValue(t, vb, "tags", "luxury", []uint64{posAt(1, 2, doc2)})
+
+		mb := store.Bucket(metaBucket)
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tags", 0), []uint64{posAt(1, 1, doc1), posAt(1, 1, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tags", 1), []uint64{posAt(1, 2, doc1), posAt(1, 2, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tags", 2), []uint64{posAt(1, 3, doc1)}))
+
+		pv := makeLeafPvp(class, "cars", "tags", "german")
+		pv.nested.arrayIndices = []filternested.ArrayIndex{{RelPath: "tags", Index: 2}}
+
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc1}, result.docIDs.ToArray())
+	})
+
+	t.Run("object array index — cars.tires[0].width = 205", func(t *testing.T) {
+		// doc1: cars[0].tires[0].width=205 (posAt(1,1,doc1)), tires[1].width=225 (posAt(1,2,doc1))
+		// doc2: cars[0].tires[0].width=225 (posAt(1,1,doc2)), tires[1].width=205 (posAt(1,2,doc2))
+		// filter: cars.tires[0].width = 205 → only doc1
+		// (doc2 has width=205 but only at tires[1], not tires[0])
+
+		valueBucket := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, valueBucket, metaBucket)
+		class := carsClass()
+
+		widthVal205 := make([]byte, 8)
+		widthVal205[7] = 205
+		widthVal225 := make([]byte, 8)
+		widthVal225[7] = 225
+
+		vb := store.Bucket(valueBucket)
+		require.NoError(t, vb.RoaringSetAddList(nested.ValueKey("tires.width", widthVal205), []uint64{posAt(1, 1, doc1), posAt(1, 2, doc2)}))
+		require.NoError(t, vb.RoaringSetAddList(nested.ValueKey("tires.width", widthVal225), []uint64{posAt(1, 2, doc1), posAt(1, 1, doc2)}))
+
+		mb := store.Bucket(metaBucket)
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tires", 0), []uint64{posAt(1, 1, doc1), posAt(1, 1, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tires", 1), []uint64{posAt(1, 2, doc1), posAt(1, 2, doc2)}))
+
+		pv := &propValuePair{
+			prop: "cars", value: widthVal205, operator: filters.OperatorEqual,
+			hasFilterableIndex: true,
+			nested: nestedInfo{
+				isNested:     true,
+				relPath:      "tires.width",
+				arrayIndices: []filternested.ArrayIndex{{RelPath: "tires", Index: 0}},
+			},
+			Class: class,
+		}
+
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc1}, result.docIDs.ToArray())
+	})
+
+	t.Run("multi-level indexes — cars[1].tags[2] = german", func(t *testing.T) {
+		// doc1: cars[0] (root=1): tags=["english"]
+		//       cars[1] (root=2): tags=["english","premium","german"]
+		//         tags[0]=posAt(2,1,doc1)  tags[1]=posAt(2,2,doc1)  tags[2]=posAt(2,3,doc1)
+		// doc2: cars[0] (root=1): tags=["german","luxury"]
+		//         tags[0]=posAt(1,1,doc2)  tags[1]=posAt(1,2,doc2)
+		// filter: cars[1].tags[2] = "german" → only doc1
+		// (doc2's "german" is in cars[0].tags[0], wrong car AND wrong tag index)
+
+		valueBucket := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, valueBucket, metaBucket)
+		class := carsClass()
+
+		vb := store.Bucket(valueBucket)
+		writeNestedValue(t, vb, "tags", "english", []uint64{posAt(1, 1, doc1), posAt(2, 1, doc1)})
+		writeNestedValue(t, vb, "tags", "premium", []uint64{posAt(2, 2, doc1)})
+		writeNestedValue(t, vb, "tags", "german", []uint64{posAt(2, 3, doc1), posAt(1, 1, doc2)})
+		writeNestedValue(t, vb, "tags", "luxury", []uint64{posAt(1, 2, doc2)})
+
+		mb := store.Bucket(metaBucket)
+		// root-level cars elements
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 0), []uint64{posAt(1, 1, doc1), posAt(1, 1, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 1), []uint64{posAt(2, 1, doc1), posAt(2, 2, doc1), posAt(2, 3, doc1)}))
+		// tags positions per index within their parent car
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tags", 0), []uint64{posAt(1, 1, doc1), posAt(2, 1, doc1), posAt(1, 1, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tags", 1), []uint64{posAt(2, 2, doc1), posAt(1, 2, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tags", 2), []uint64{posAt(2, 3, doc1)}))
+
+		pv := makeLeafPvp(class, "cars", "tags", "german")
+		pv.nested.arrayIndices = []filternested.ArrayIndex{
+			{RelPath: "", Index: 1},     // cars[1]
+			{RelPath: "tags", Index: 2}, // tags[2]
+		}
+
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc1}, result.docIDs.ToArray())
 	})
 }

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -33,6 +33,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/sorter"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/inverted"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -364,7 +365,11 @@ func (s *Searcher) extractPropValuePair(
 
 	// on value or non-nested filter
 	props := filter.On.Slice()
-	propName := props[0]
+	// Strip any arr[N] index from the first segment so that "addresses[1].city"
+	// correctly resolves to the "addresses" property in the schema.
+	// Only the first segment is cleaned here; extractNestedProp receives the
+	// original props[0] so that [N] indices on sub-paths are preserved.
+	propName := nested.RootPropName(props[0])
 
 	if s.onInternalProp(propName) {
 		return s.extractInternalProp(propName, filter.Value.Type, filter.Value.Value, filter.Operator, class)
@@ -389,7 +394,7 @@ func (s *Searcher) extractPropValuePair(
 	}
 
 	if _, ok := schema.AsNested(property.DataType); ok {
-		return s.extractNestedProp(filter, propName, property, class)
+		return s.extractNestedProp(filter, props[0], property, class)
 	}
 
 	if s.onRefProp(property) && len(props) != 1 {

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -29,7 +29,13 @@ func (s *Searcher) extractNestedProp(filter *filters.Clause, path string,
 	prop *models.Property, class *models.Class,
 ) (*propValuePair, error) {
 	if filter.Operator == filters.OperatorIsNull {
-		return nil, fmt.Errorf("IsNull is not yet supported for nested properties")
+		// relPath is "" for top-level existence (e.g. "addresses IsNull true")
+		// or the sub-path (e.g. "city" for "addresses.city IsNull true").
+		var relPath string
+		if strings.HasPrefix(path, prop.Name+".") {
+			relPath = path[len(prop.Name)+1:]
+		}
+		return s.buildNestedIsNullPair(filter, prop.Name, relPath, class)
 	}
 
 	segments := strings.Split(path, ".")
@@ -183,6 +189,23 @@ func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, path, 
 		hasFilterableIndex: true,
 		nested:             nestedInfo{isNested: true, relPath: relativePath},
 		Class:              class,
+	}, nil
+}
+
+// buildNestedIsNullPair builds a propValuePair for an IsNull filter on a
+// nested property. relPath is "" for top-level existence (e.g. "addresses IsNull")
+// or the dot-notation sub-path (e.g. "city" for "addresses.city IsNull").
+func (s *Searcher) buildNestedIsNullPair(filter *filters.Clause, propName, relPath string, class *models.Class) (*propValuePair, error) {
+	value, err := s.extractBoolValue(filter.Value.Value)
+	if err != nil {
+		return nil, fmt.Errorf("nested IsNull %q: encode bool: %w", propName, err)
+	}
+	return &propValuePair{
+		prop:     propName,
+		value:    value,
+		operator: filters.OperatorIsNull,
+		nested:   nestedInfo{isNested: true, relPath: relPath},
+		Class:    class,
 	}, nil
 }
 

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -13,34 +13,29 @@ package inverted
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/tokenizer"
 )
 
 // extractNestedProp builds a propValuePair for a dot-notation nested property
-// filter such as "addresses.city = 'Berlin'". It walks the schema to find the
-// leaf NestedProperty, encodes the filter value, and sets isNested=true so
-// the execution path uses the nested bucket and strips positions to docIDs.
+// filter such as "addresses.city = 'Berlin'" or "addresses[1].city = 'Berlin'".
+// It walks the schema to find the leaf NestedProperty, encodes the filter value,
+// and sets isNested=true so the execution path uses the nested bucket and strips
+// positions to docIDs. Any arr[N] index markers are parsed into arrayIndices.
 func (s *Searcher) extractNestedProp(filter *filters.Clause, path string,
 	prop *models.Property, class *models.Class,
 ) (*propValuePair, error) {
+	cleanRelPath, cleanRelSegs, arrayIndices := nested.ParseIndexedPath(path)
+
 	if filter.Operator == filters.OperatorIsNull {
-		// relPath is "" for top-level existence (e.g. "addresses IsNull true")
-		// or the sub-path (e.g. "city" for "addresses.city IsNull true").
-		var relPath string
-		if strings.HasPrefix(path, prop.Name+".") {
-			relPath = path[len(prop.Name)+1:]
-		}
-		return s.buildNestedIsNullPair(filter, prop.Name, relPath, class)
+		return s.buildNestedIsNullPair(filter, prop.Name, cleanRelPath, arrayIndices, class)
 	}
 
-	segments := strings.Split(path, ".")
-	// segments[0] is the top-level prop already fetched; walk segments[1:] to the leaf.
-	leaf, err := findNestedLeaf(segments[1:], prop.NestedProperties)
+	leaf, err := findNestedLeaf(cleanRelSegs, prop.NestedProperties)
 	if err != nil {
 		return nil, fmt.Errorf("nested path %q: %w", path, err)
 	}
@@ -55,14 +50,14 @@ func (s *Searcher) extractNestedProp(filter *filters.Clause, path string,
 		return nil, fmt.Errorf("nested property %q is not filterable", path)
 	}
 
-	return s.buildNestedFilterPair(filter, path, segments[0], leaf, class)
+	return s.buildNestedFilterPair(filter, prop.Name, path, cleanRelPath, arrayIndices, leaf, class)
 }
 
 // findNestedLeaf walks segments through nestedProps to locate the leaf
 // NestedProperty. Returns an error if any segment is not found.
 func findNestedLeaf(segments []string, props []*models.NestedProperty) (*models.NestedProperty, error) {
 	for i, seg := range segments {
-		found := findNestedPropByName(props, seg)
+		found := nested.FindNestedProp(props, seg)
 		if found == nil {
 			return nil, fmt.Errorf("sub-property %q not found", seg)
 		}
@@ -76,19 +71,15 @@ func findNestedLeaf(segments []string, props []*models.NestedProperty) (*models.
 
 // buildNestedFilterPair encodes the filter value for the given leaf type and
 // returns the corresponding propValuePair(s).
-func (s *Searcher) buildNestedFilterPair(filter *filters.Clause, path, propName string,
-	leaf *models.NestedProperty, class *models.Class,
+func (s *Searcher) buildNestedFilterPair(filter *filters.Clause, propName, fullPath, relPath string,
+	arrayIndices []nested.ArrayIndex, leaf *models.NestedProperty, class *models.Class,
 ) (*propValuePair, error) {
-	// Keys in the nested bucket use only the path relative to the top-level
-	// property (e.g. "city", "owner.firstname"), not the full filter path
-	// (e.g. "event.city"). Strip the top-level property name.
-	relativePath := strings.TrimPrefix(path, propName+".")
 	dt := schema.DataType(leaf.DataType[0])
 	switch dt {
 	case schema.DataTypeText, schema.DataTypeTextArray:
-		return s.buildNestedTextFilterPair(filter, path, propName, leaf, relativePath, class)
+		return s.buildNestedTextFilterPair(filter, propName, fullPath, relPath, leaf, arrayIndices, class)
 	default:
-		return s.buildNestedPrimitiveFilterPair(filter, path, propName, dt, relativePath, class)
+		return s.buildNestedPrimitiveFilterPair(filter, propName, fullPath, relPath, dt, arrayIndices, class)
 	}
 }
 
@@ -99,12 +90,12 @@ func (s *Searcher) buildNestedFilterPair(filter *filters.Clause, path, propName 
 // TODO aliszka:nested_filtering the tokenization pipeline here (stopwords,
 // ASCII folding, wildcard handling) was aligned with extractTokenizableProp
 // manually. Consider extracting a shared helper to avoid future divergence.
-func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propName string,
-	leaf *models.NestedProperty, relativePath string, class *models.Class,
+func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, propName, fullPath, relPath string,
+	leaf *models.NestedProperty, arrayIndices []nested.ArrayIndex, class *models.Class,
 ) (*propValuePair, error) {
 	valueStr, ok := filter.Value.Value.(string)
 	if !ok {
-		return nil, fmt.Errorf("nested path %q: expected string value, got %T", path, filter.Value.Value)
+		return nil, fmt.Errorf("nested path %q: expected string value, got %T", fullPath, filter.Value.Value)
 	}
 
 	var terms []string
@@ -120,7 +111,7 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propN
 		if leaf.Tokenization == models.PropertyTokenizationWord {
 			d, err := s.stopwordProvider.GetForNested(leaf)
 			if err != nil {
-				return nil, fmt.Errorf("nested path %q: get stopwords: %w", path, err)
+				return nil, fmt.Errorf("nested path %q: get stopwords: %w", fullPath, err)
 			}
 			sw = d
 		}
@@ -136,7 +127,7 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propN
 			value:              []byte(term),
 			operator:           filter.Operator,
 			hasFilterableIndex: true,
-			nested:             nestedInfo{isNested: true, relPath: relativePath},
+			nested:             nestedInfo{isNested: true, relPath: relPath, arrayIndices: arrayIndices},
 			Class:              class,
 		})
 	}
@@ -152,8 +143,8 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, path, propN
 
 // buildNestedPrimitiveFilterPair handles non-text primitive types (int,
 // number, bool, date and their array variants).
-func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, path, propName string,
-	dt schema.DataType, relativePath string, class *models.Class,
+func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, propName, fullPath, relPath string,
+	dt schema.DataType, arrayIndices []nested.ArrayIndex, class *models.Class,
 ) (*propValuePair, error) {
 	// Map array types to their scalar equivalent — each array element is stored
 	// individually in the nested bucket, so filtering works the same way.
@@ -176,10 +167,10 @@ func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, path, 
 	case schema.DataTypeDate:
 		encodedValue, err = s.extractDateValue(filter.Value.Value)
 	default:
-		return nil, fmt.Errorf("nested path %q: unsupported leaf type %q", path, dt)
+		return nil, fmt.Errorf("nested path %q: unsupported leaf type %q", fullPath, dt)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("nested path %q: encode value: %w", path, err)
+		return nil, fmt.Errorf("nested path %q: encode value: %w", fullPath, err)
 	}
 
 	return &propValuePair{
@@ -187,15 +178,16 @@ func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, path, 
 		value:              encodedValue,
 		operator:           filter.Operator,
 		hasFilterableIndex: true,
-		nested:             nestedInfo{isNested: true, relPath: relativePath},
+		nested:             nestedInfo{isNested: true, relPath: relPath, arrayIndices: arrayIndices},
 		Class:              class,
 	}, nil
 }
 
 // buildNestedIsNullPair builds a propValuePair for an IsNull filter on a
-// nested property. relPath is "" for top-level existence (e.g. "addresses IsNull")
+// nested property. relPath is "" for root-level existence (e.g. "addresses IsNull")
 // or the dot-notation sub-path (e.g. "city" for "addresses.city IsNull").
-func (s *Searcher) buildNestedIsNullPair(filter *filters.Clause, propName, relPath string, class *models.Class) (*propValuePair, error) {
+// arrayIndices carries any arr[N] constraints from the filter path.
+func (s *Searcher) buildNestedIsNullPair(filter *filters.Clause, propName, relPath string, arrayIndices []nested.ArrayIndex, class *models.Class) (*propValuePair, error) {
 	value, err := s.extractBoolValue(filter.Value.Value)
 	if err != nil {
 		return nil, fmt.Errorf("nested IsNull %q: encode bool: %w", propName, err)
@@ -204,17 +196,7 @@ func (s *Searcher) buildNestedIsNullPair(filter *filters.Clause, propName, relPa
 		prop:     propName,
 		value:    value,
 		operator: filters.OperatorIsNull,
-		nested:   nestedInfo{isNested: true, relPath: relPath},
+		nested:   nestedInfo{isNested: true, relPath: relPath, arrayIndices: arrayIndices},
 		Class:    class,
 	}, nil
-}
-
-// findNestedPropByName returns the NestedProperty with the given name, or nil.
-func findNestedPropByName(props []*models.NestedProperty, name string) *models.NestedProperty {
-	for _, np := range props {
-		if np.Name == name {
-			return np
-		}
-	}
-	return nil
 }

--- a/adapters/repos/db/inverted/searcher_nested_plan.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -274,7 +275,7 @@ func (b *resolutionPlanBuilder) nodeTypeAndProps(
 	props []*models.NestedProperty,
 ) (schema.DataType, []*models.NestedProperty) {
 	for _, pathSeg := range pathSegs {
-		np := findNestedPropByName(props, pathSeg)
+		np := nested.FindNestedProp(props, pathSeg)
 		if np == nil {
 			return dt, props
 		}
@@ -291,7 +292,7 @@ func (b *resolutionPlanBuilder) isScalarAtLevel(pathSegs []string, props []*mode
 	if len(pathSegs) != 1 {
 		return false
 	}
-	np := findNestedPropByName(props, pathSegs[0])
+	np := nested.FindNestedProp(props, pathSegs[0])
 	if np == nil {
 		return false
 	}
@@ -304,7 +305,7 @@ func (b *resolutionPlanBuilder) isScalarAtLevel(pathSegs []string, props []*mode
 // introduces element-level positions.
 func (b *resolutionPlanBuilder) containsObjectArray(pathSegs []string, props []*models.NestedProperty) bool {
 	for _, pathSeg := range pathSegs {
-		np := findNestedPropByName(props, pathSeg)
+		np := nested.FindNestedProp(props, pathSeg)
 		if np == nil {
 			return false
 		}

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -162,10 +162,52 @@ func TestExtractNestedProp(t *testing.T) {
 			wantProp: "nested", wantValue: []byte("Alice"),
 		},
 		{
-			name: "IsNull returns error",
+			name: "root IsNull false — relPath is empty",
+			path: "nested", operator: filters.OperatorIsNull,
+			valueType: schema.DataTypeBoolean, value: false,
+			verify: func(t *testing.T, pv *propValuePair) {
+				assert.Equal(t, filters.OperatorIsNull, pv.operator)
+				assert.Equal(t, "nested", pv.prop)
+				assert.True(t, pv.nested.isNested)
+				assert.Equal(t, "", pv.nested.relPath) // root-level existence
+				assert.Equal(t, []byte{0x00}, pv.value)
+			},
+		},
+		{
+			name: "root IsNull true — relPath is empty, denylist value",
+			path: "nested", operator: filters.OperatorIsNull,
+			valueType: schema.DataTypeBoolean, value: true,
+			verify: func(t *testing.T, pv *propValuePair) {
+				assert.Equal(t, filters.OperatorIsNull, pv.operator)
+				assert.Equal(t, "nested", pv.prop)
+				assert.True(t, pv.nested.isNested)
+				assert.Equal(t, "", pv.nested.relPath) // root-level existence
+				assert.Equal(t, []byte{0x01}, pv.value)
+			},
+		},
+		{
+			name: "IsNull false — produces nested isNull pair",
+			path: "nested.city", operator: filters.OperatorIsNull,
+			valueType: schema.DataTypeBoolean, value: false,
+			verify: func(t *testing.T, pv *propValuePair) {
+				assert.Equal(t, filters.OperatorIsNull, pv.operator)
+				assert.Equal(t, "nested", pv.prop)
+				assert.True(t, pv.nested.isNested)
+				assert.Equal(t, "city", pv.nested.relPath)
+				assert.Equal(t, []byte{0x00}, pv.value) // false = property exists
+			},
+		},
+		{
+			name: "IsNull true — produces nested isNull pair with denylist value",
 			path: "nested.city", operator: filters.OperatorIsNull,
 			valueType: schema.DataTypeBoolean, value: true,
-			wantErr: "IsNull",
+			verify: func(t *testing.T, pv *propValuePair) {
+				assert.Equal(t, filters.OperatorIsNull, pv.operator)
+				assert.Equal(t, "nested", pv.prop)
+				assert.True(t, pv.nested.isNested)
+				assert.Equal(t, "city", pv.nested.relPath)
+				assert.Equal(t, []byte{0x01}, pv.value) // true = property absent
+			},
 		},
 		{
 			name: "non-filterable leaf returns error",

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -209,6 +210,65 @@ func TestExtractNestedProp(t *testing.T) {
 				assert.Equal(t, []byte{0x01}, pv.value) // true = property absent
 			},
 		},
+		// --- indexed paths: arrayIndices populated, relPath clean ---
+		{
+			name: "root index — nested[0].city",
+			path: "nested[0].city", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeText, value: "Berlin",
+			verify: func(t *testing.T, pv *propValuePair) {
+				assert.Equal(t, "nested", pv.prop)
+				assert.Equal(t, "city", pv.nested.relPath)
+				assert.True(t, pv.nested.isNested)
+				require.Len(t, pv.nested.arrayIndices, 1)
+				assert.Equal(t, nested.ArrayIndex{RelPath: "", Index: 0}, pv.nested.arrayIndices[0])
+			},
+		},
+		{
+			name: "sub-property index — nested.numbers[1]",
+			path: "nested.numbers[1]", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeInt, value: 7,
+			verify: func(t *testing.T, pv *propValuePair) {
+				assert.Equal(t, "nested", pv.prop)
+				assert.Equal(t, "numbers", pv.nested.relPath)
+				assert.True(t, pv.nested.isNested)
+				require.Len(t, pv.nested.arrayIndices, 1)
+				assert.Equal(t, nested.ArrayIndex{RelPath: "numbers", Index: 1}, pv.nested.arrayIndices[0])
+			},
+		},
+		{
+			name: "multi-level index — nested[0].owner.firstname (two-level path, root indexed)",
+			path: "nested[0].owner.firstname", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeText, value: "Alice",
+			verify: func(t *testing.T, pv *propValuePair) {
+				assert.Equal(t, "nested", pv.prop)
+				assert.Equal(t, "owner.firstname", pv.nested.relPath)
+				assert.True(t, pv.nested.isNested)
+				require.Len(t, pv.nested.arrayIndices, 1)
+				assert.Equal(t, nested.ArrayIndex{RelPath: "", Index: 0}, pv.nested.arrayIndices[0])
+			},
+		},
+		{
+			name: "multi-level indexes — nested[0].numbers[2]",
+			path: "nested[0].numbers[2]", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeInt, value: 7,
+			verify: func(t *testing.T, pv *propValuePair) {
+				assert.Equal(t, "nested", pv.prop)
+				assert.Equal(t, "numbers", pv.nested.relPath)
+				assert.True(t, pv.nested.isNested)
+				require.Len(t, pv.nested.arrayIndices, 2)
+				assert.Equal(t, nested.ArrayIndex{RelPath: "", Index: 0}, pv.nested.arrayIndices[0])
+				assert.Equal(t, nested.ArrayIndex{RelPath: "numbers", Index: 2}, pv.nested.arrayIndices[1])
+			},
+		},
+		{
+			name: "no index — arrayIndices empty",
+			path: "nested.city", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeText, value: "Berlin",
+			verify: func(t *testing.T, pv *propValuePair) {
+				assert.Equal(t, "city", pv.nested.relPath)
+				assert.Empty(t, pv.nested.arrayIndices)
+			},
+		},
 		{
 			name: "non-filterable leaf returns error",
 			path: "nested.skipped", operator: filters.OperatorEqual,
@@ -362,6 +422,19 @@ func TestExtractPropValuePairNestedRouting(t *testing.T) {
 			valueType: schema.DataTypeText, value: "Ber*",
 			wantProp: "nested", wantNested: true,
 		},
+		// indexed paths: [N] stripped for schema lookup, arrayIndices populated
+		{
+			name: "root index routes to nested — nested[0].city",
+			path: "nested[0].city", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeText, value: "Berlin",
+			wantProp: "nested", wantNested: true,
+		},
+		{
+			name: "sub-property index routes to nested — nested.numbers[2]",
+			path: "nested.numbers[2]", operator: filters.OperatorEqual,
+			valueType: schema.DataTypeInt, value: 7,
+			wantProp: "nested", wantNested: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -370,11 +443,11 @@ func TestExtractPropValuePairNestedRouting(t *testing.T) {
 			pv, err := s.extractPropValuePair(t.Context(), clause, "Article")
 			require.NoError(t, err)
 
-			relativePath := tt.path[strings.Index(tt.path, ".")+1:]
 			assert.Equal(t, tt.wantProp, pv.prop)
 			assert.Equal(t, tt.wantNested, pv.nested.isNested)
-			assert.Equal(t, relativePath, pv.nested.relPath)
 			assert.Equal(t, tt.operator, pv.operator)
+			// relPath must not contain any [N] markers
+			assert.NotContains(t, pv.nested.relPath, "[")
 		})
 	}
 }

--- a/entities/filters/filters_validator.go
+++ b/entities/filters/filters_validator.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"github.com/pkg/errors"
+	"github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -81,7 +82,9 @@ func validateClause(authorizedGetClass func(string) (*models.Class, error), cw *
 		propName = schema.PropertyName(lengthPropName)
 	}
 
-	prop, err := schema.GetPropertyByName(class, propName.String())
+	// Strip any [N] index from the first path segment so that "nested[0].city"
+	// correctly resolves to the "nested" property in the schema.
+	prop, err := schema.GetPropertyByName(class, nested.RootPropName(propName.String()))
 	if err != nil {
 		return err
 	}

--- a/entities/filters/filters_validator.go
+++ b/entities/filters/filters_validator.go
@@ -84,9 +84,24 @@ func validateClause(authorizedGetClass func(string) (*models.Class, error), cw *
 
 	// Strip any [N] index from the first path segment so that "nested[0].city"
 	// correctly resolves to the "nested" property in the schema.
-	prop, err := schema.GetPropertyByName(class, nested.RootPropName(propName.String()))
+	rootName := nested.RootPropName(propName.String())
+	prop, err := schema.GetPropertyByName(class, rootName)
 	if err != nil {
 		return err
+	}
+
+	// [N] indexing is only meaningful for nested object[] properties. If the
+	// user wrote it on a flat property the positional intent would otherwise
+	// be silently dropped (e.g. "tagsArray[0]" would degrade to "tagsArray"),
+	// so reject it at validation time. Inspect the first path segment
+	// directly so this branch only triggers when the user actually wrote [N];
+	// any other malformed dotted input falls through to a more appropriate
+	// error path below.
+	if nested.SplitPath(propName.String())[0].HasIndex {
+		if _, ok := schema.AsNested(prop.DataType); !ok {
+			return fmt.Errorf("property %q: [N] indexing is only supported on nested object[] properties",
+				propName)
+		}
 	}
 
 	if _, ok := schema.AsNested(prop.DataType); ok {

--- a/entities/filters/filters_validator.go
+++ b/entities/filters/filters_validator.go
@@ -86,16 +86,16 @@ func validateClause(authorizedGetClass func(string) (*models.Class, error), cw *
 		return err
 	}
 
+	if _, ok := schema.AsNested(prop.DataType); ok {
+		return validateNestedProp(prop, propName, isPropLengthFilter, cw)
+	}
+
 	if cw.getOperator() == OperatorIsNull {
 		if !cw.isType(schema.DataTypeBoolean) {
 			return errors.Errorf("operator IsNull requires a booleanValue, got %v instead",
 				cw.getValueNameFromType())
 		}
 		return nil
-	}
-
-	if _, ok := schema.AsNested(prop.DataType); ok {
-		return validateNestedProp(prop, propName, isPropLengthFilter, cw)
 	}
 
 	if isPropLengthFilter {

--- a/entities/filters/filters_validator_nested.go
+++ b/entities/filters/filters_validator_nested.go
@@ -13,8 +13,8 @@ package filters
 
 import (
 	"fmt"
-	"strings"
 
+	"github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -29,53 +29,65 @@ func validateNestedProp(prop *models.Property, propName schema.PropertyName, isP
 		return fmt.Errorf("property length filtering is not supported for nested properties")
 	}
 
-	if cw.getOperator() == OperatorIsNull {
-		if !cw.isType(schema.DataTypeBoolean) {
-			return errors.Errorf("operator IsNull requires a booleanValue, got %v instead",
-				cw.getValueNameFromType())
+	pathSegs := nested.SplitPath(string(propName))
+
+	// Check whether a [N] index was applied to the root property itself.
+	if pathSegs[0].HasIndex {
+		rootDT := schema.DataType(prop.DataType[0])
+		if _, ok := schema.IsArrayType(rootDT); !ok {
+			return fmt.Errorf("property %q is of type %q — [N] indexing requires an array type",
+				pathSegs[0].Name, rootDT)
 		}
-		// Root-level IsNull (e.g. "addresses IsNull true") has no sub-path — valid.
-		if !strings.Contains(string(propName), ".") {
-			return nil
-		}
-		// Sub-property IsNull (e.g. "addresses.city IsNull true"): walk the path
-		// to verify it exists but skip leaf type validation (IsNull accepts boolean
-		// for any property type).
-		return validateNestedPathClause(prop, propName, cw)
 	}
 
-	if !strings.Contains(string(propName), ".") {
+	if cw.getOperator() == OperatorIsNull {
+		if !cw.isType(schema.DataTypeBoolean) {
+			return fmt.Errorf("operator IsNull requires a booleanValue, got %v instead",
+				cw.getValueNameFromType())
+		}
+		// Root-level IsNull (no sub-path) — valid.
+		if len(pathSegs) == 1 {
+			return nil
+		}
+		// Sub-property IsNull: walk the path to verify it exists.
+		return validateNestedPathClause(pathSegs[1:], prop.NestedProperties, propName, cw)
+	}
+
+	if len(pathSegs) == 1 {
 		return fmt.Errorf("property %q is of type %q; use dot notation to filter on a sub-property",
 			propName, schema.DataType(prop.DataType[0]))
 	}
 
-	return validateNestedPathClause(prop, propName, cw)
+	return validateNestedPathClause(pathSegs[1:], prop.NestedProperties, propName, cw)
 }
 
-// validateNestedPathClause validates a dot-notation filter path such as
-// "addresses.city" or "cars.tires.width". prop is the already-fetched
-// top-level object/object[] property; segments[1:] are walked through
-// its NestedProperties to locate the primitive leaf.
-func validateNestedPathClause(prop *models.Property, propName schema.PropertyName, cw *clauseWrapper) error {
-	segments := strings.Split(string(propName), ".")
-
-	// Walk segments[1:] through nested properties. segments[0] is the
-	// top-level prop, already fetched and verified as object/object[].
-	nestedProps := prop.NestedProperties
-	for i, seg := range segments[1:] {
-		np := findNestedProp(nestedProps, seg)
+// validateNestedPathClause validates sub-property segments of a nested filter
+// path. subSegs are the segments after the root (already resolved by the caller);
+// nestedProps are the root property's NestedProperties. propName is used only
+// for error messages.
+func validateNestedPathClause(relSegs []nested.PathSegment, nestedProps []*models.NestedProperty, propName schema.PropertyName, cw *clauseWrapper) error {
+	for i, seg := range relSegs {
+		np := nested.FindNestedProp(nestedProps, seg.Name)
 		if np == nil {
-			return fmt.Errorf("nested path %q: sub-property %q not found", propName, seg)
+			return fmt.Errorf("nested path %q: sub-property %q not found", propName, seg.Name)
 		}
 
-		isLast := i == len(segments[1:])-1
+		isLast := i == len(relSegs)-1
 		dt := schema.DataType(np.DataType[0])
+
+		// Indexing is only valid on array types.
+		if seg.HasIndex {
+			if _, ok := schema.IsArrayType(dt); !ok {
+				return fmt.Errorf("nested path %q: sub-property %q is of type %q — [N] indexing requires an array type",
+					propName, seg.Name, dt)
+			}
+		}
 
 		if !isLast {
 			// Intermediate sub-property must be object or object[].
 			if !schema.IsNested(dt) {
 				return fmt.Errorf("nested path %q: sub-property %q must be object or object[], got %q",
-					propName, seg, dt)
+					propName, seg.Name, dt)
 			}
 			nestedProps = np.NestedProperties
 		} else {
@@ -88,29 +100,20 @@ func validateNestedPathClause(prop *models.Property, propName schema.PropertyNam
 			if schema.IsNested(dt) {
 				return fmt.Errorf("nested path %q: sub-property %q is of type %q; "+
 					"filtering on object types is not supported, specify a primitive sub-property",
-					propName, seg, dt)
+					propName, seg.Name, dt)
 			}
 			// TODO aliszka:nested_filtering when rangeable / searchable nested
 			// filtering support is added, add corresponding
 			// schema.IsNestedRangeable and schema.IsNestedSearchable checks
 			// alongside the filterable check below.
 			if !schema.IsNestedFilterable(np) {
-				return fmt.Errorf("nested path %q: sub-property %q is not filterable", propName, seg)
+				return fmt.Errorf("nested path %q: sub-property %q is not filterable", propName, seg.Name)
 			}
 			return validateNestedLeafType(propName, np, cw)
 		}
 	}
 
-	// Unreachable: caller guarantees propName contains '.' so segments[1:] is non-empty.
-	return nil
-}
-
-func findNestedProp(props []*models.NestedProperty, name string) *models.NestedProperty {
-	for _, np := range props {
-		if np.Name == name {
-			return np
-		}
-	}
+	// Unreachable: caller guarantees relSegs is non-empty.
 	return nil
 }
 

--- a/entities/filters/filters_validator_nested.go
+++ b/entities/filters/filters_validator_nested.go
@@ -29,6 +29,21 @@ func validateNestedProp(prop *models.Property, propName schema.PropertyName, isP
 		return fmt.Errorf("property length filtering is not supported for nested properties")
 	}
 
+	if cw.getOperator() == OperatorIsNull {
+		if !cw.isType(schema.DataTypeBoolean) {
+			return errors.Errorf("operator IsNull requires a booleanValue, got %v instead",
+				cw.getValueNameFromType())
+		}
+		// Root-level IsNull (e.g. "addresses IsNull true") has no sub-path — valid.
+		if !strings.Contains(string(propName), ".") {
+			return nil
+		}
+		// Sub-property IsNull (e.g. "addresses.city IsNull true"): walk the path
+		// to verify it exists but skip leaf type validation (IsNull accepts boolean
+		// for any property type).
+		return validateNestedPathClause(prop, propName, cw)
+	}
+
 	if !strings.Contains(string(propName), ".") {
 		return fmt.Errorf("property %q is of type %q; use dot notation to filter on a sub-property",
 			propName, schema.DataType(prop.DataType[0]))
@@ -64,6 +79,11 @@ func validateNestedPathClause(prop *models.Property, propName schema.PropertyNam
 			}
 			nestedProps = np.NestedProperties
 		} else {
+			// IsNull on any leaf type — including object/object[] — is valid:
+			// it checks existence, not value.
+			if cw.getOperator() == OperatorIsNull {
+				return nil
+			}
 			// Leaf sub-property must be a filterable primitive, not object/object[].
 			if schema.IsNested(dt) {
 				return fmt.Errorf("nested path %q: sub-property %q is of type %q; "+
@@ -98,6 +118,12 @@ func findNestedProp(props []*models.NestedProperty, name string) *models.NestedP
 // the primitive leaf NestedProperty. Mirrors the type-check logic in
 // validateClause for flat properties.
 func validateNestedLeafType(propName schema.PropertyName, np *models.NestedProperty, cw *clauseWrapper) error {
+	// IsNull checks existence, not value — its boolean value is valid for any
+	// leaf type regardless of the property's data type.
+	if cw.getOperator() == OperatorIsNull {
+		return nil
+	}
+
 	if isUUIDType(np.DataType[0]) {
 		return validateUUIDType(propName, cw)
 	}

--- a/entities/filters/filters_validator_nested_test.go
+++ b/entities/filters/filters_validator_nested_test.go
@@ -68,6 +68,15 @@ func nestedClass() *models.Class {
 					},
 				},
 			},
+			{
+				// object[] at the top level — valid target for root [N] indexing
+				Name:     "items",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{Name: "value", DataType: schema.DataTypeText.PropString(), IndexFilterable: &boolTrue},
+					{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &boolTrue},
+				},
+			},
 		},
 	}
 }
@@ -183,6 +192,69 @@ func TestValidateNestedPathClause(t *testing.T) {
 			valueType: schema.DataTypeText,
 			value:     "x",
 			wantErr:   `property "nested" is of type "object"; use dot notation to filter on a sub-property`,
+		},
+		// --- indexed paths: [N] stripped before schema lookup ---
+		{
+			// nested is DataTypeObject (not object[]) — use items which is object[]
+			name:      "root index on object[] — items[1].value",
+			propName:  "items[1].value",
+			valueType: schema.DataTypeText,
+			value:     "hello",
+		},
+		{
+			name:      "sub-property index — nested.tags[1]",
+			propName:  "nested.tags[1]",
+			valueType: schema.DataTypeText,
+			value:     "tag",
+		},
+		{
+			// items[1].tags[0]: root object[] index + scalar array sub-property index
+			name:      "multi-level indexes — items[1].tags[0]",
+			propName:  "items[1].tags[0]",
+			valueType: schema.DataTypeText,
+			value:     "tag",
+		},
+		{
+			name:      "object array sub-property with index — nested.addresses[0].city",
+			propName:  "nested.addresses[0].city",
+			valueType: schema.DataTypeText,
+			value:     "Berlin",
+		},
+		{
+			name:      "non-existent sub-property with index still rejected",
+			propName:  "nested.missing[1]",
+			valueType: schema.DataTypeText,
+			value:     "x",
+			wantErr:   `sub-property "missing" not found`,
+		},
+		// --- index on non-array types is rejected ---
+		{
+			name:      "root object (not object[]) with index rejected",
+			propName:  "nested[0].city",
+			valueType: schema.DataTypeText,
+			value:     "Berlin",
+			wantErr:   `"nested" is of type "object" — [N] indexing requires an array type`,
+		},
+		{
+			name:      "scalar sub-property with index rejected",
+			propName:  "nested.name[1]",
+			valueType: schema.DataTypeText,
+			value:     "x",
+			wantErr:   `sub-property "name" is of type "text" — [N] indexing requires an array type`,
+		},
+		{
+			name:      "int sub-property with index rejected",
+			propName:  "nested.count[0]",
+			valueType: schema.DataTypeInt,
+			value:     42,
+			wantErr:   `sub-property "count" is of type "int" — [N] indexing requires an array type`,
+		},
+		{
+			name:      "object (not object[]) sub-property with index rejected",
+			propName:  "nested.owner[0].firstname",
+			valueType: schema.DataTypeText,
+			value:     "Alice",
+			wantErr:   `sub-property "owner" is of type "object" — [N] indexing requires an array type`,
 		},
 	}
 

--- a/entities/filters/filters_validator_nested_test.go
+++ b/entities/filters/filters_validator_nested_test.go
@@ -224,13 +224,77 @@ func TestValidateNestedLengthFilter(t *testing.T) {
 }
 
 func TestValidateNestedIsNull(t *testing.T) {
-	// IsNull is validated by the existing check before the nested path
-	// delegation, so it passes for any property type including nested.
-	cl := &Clause{
-		Operator: OperatorIsNull,
-		Value:    &Value{Value: true, Type: schema.DataTypeBoolean},
-		On:       &Path{Class: "Article", Property: "nested.name"},
+	isNullClause := func(propName string) *Clause {
+		return &Clause{
+			Operator: OperatorIsNull,
+			Value:    &Value{Value: true, Type: schema.DataTypeBoolean},
+			On:       &Path{Class: "Article", Property: schema.PropertyName(propName)},
+		}
 	}
-	err := validateClause(nestedGetClass, newClauseWrapper(cl))
-	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		propName string
+		wantErr  string
+	}{
+		// root-level IsNull (no dot notation) — checks object existence
+		{
+			name:     "root object IsNull — no dot, valid",
+			propName: "nested",
+		},
+		// sub-property IsNull on text — bool value accepted regardless of leaf type
+		{
+			name:     "sub-property text IsNull",
+			propName: "nested.name",
+		},
+		// sub-property IsNull on int — bool value accepted regardless of leaf type
+		{
+			name:     "sub-property int IsNull",
+			propName: "nested.count",
+		},
+		// sub-property IsNull on text[] — bool value accepted regardless of leaf type
+		{
+			name:     "sub-property textArray IsNull",
+			propName: "nested.tags",
+		},
+		// sub-property inside nested object[]
+		{
+			name:     "nested object[] sub-property IsNull",
+			propName: "nested.addresses.city",
+		},
+		// nested object sub-property IsNull — leaf is object, valid for IsNull
+		{
+			name:     "nested object sub-property (nested.owner) IsNull",
+			propName: "nested.owner",
+		},
+		// nested object[] sub-property IsNull — leaf is object[], valid for IsNull
+		{
+			name:     "nested object[] sub-property (nested.addresses) IsNull",
+			propName: "nested.addresses",
+		},
+		// two-level path through nested object, int leaf
+		{
+			name:     "two-level path nested.owner.age IsNull",
+			propName: "nested.owner.age",
+		},
+		// non-existent sub-property is now rejected — path is validated
+		{
+			name:     "non-existent sub-property rejected",
+			propName: "nested.missing",
+			wantErr:  `"missing" not found`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cl := isNullClause(tt.propName)
+			err := validateClause(nestedGetClass, newClauseWrapper(cl))
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
 }

--- a/entities/filters/filters_validator_nested_test.go
+++ b/entities/filters/filters_validator_nested_test.go
@@ -43,6 +43,7 @@ func nestedClass() *models.Class {
 		Class: "Article",
 		Properties: []*models.Property{
 			{Name: "title", DataType: schema.DataTypeText.PropString()},
+			{Name: "tagsArray", DataType: schema.DataTypeTextArray.PropString()},
 			{
 				Name:     "nested",
 				DataType: schema.DataTypeObject.PropString(),
@@ -255,6 +256,36 @@ func TestValidateNestedPathClause(t *testing.T) {
 			valueType: schema.DataTypeText,
 			value:     "Alice",
 			wantErr:   `sub-property "owner" is of type "object" — [N] indexing requires an array type`,
+		},
+		// --- [N] on flat (non-nested) properties is rejected, so positional
+		// intent is never silently dropped ---
+		{
+			name:      "[N] rejected on flat array property",
+			propName:  "tagsArray[0]",
+			valueType: schema.DataTypeText,
+			value:     "x",
+			wantErr:   `[N] indexing is only supported on nested object[] properties`,
+		},
+		{
+			name:      "[N] rejected on flat scalar property",
+			propName:  "title[0]",
+			valueType: schema.DataTypeText,
+			value:     "x",
+			wantErr:   `[N] indexing is only supported on nested object[] properties`,
+		},
+		{
+			// A dotted path on a flat property must not be misreported as a
+			// "[N] indexing" error — the path contains no [N], so the
+			// [N]-rejection branch must not fire. The current code falls
+			// through and allows the filter (treating "title.foo" as a filter
+			// on the flat "title" prop); whether that's correct is a separate
+			// concern. This test asserts only that the [N] branch is gated
+			// by an actual [N], not by a stripped dot.
+			name:      "dotted path on flat property does not produce [N] error",
+			propName:  "title.foo",
+			valueType: schema.DataTypeText,
+			value:     "x",
+			wantErr:   "",
 		},
 	}
 

--- a/entities/filters/nested/path.go
+++ b/entities/filters/nested/path.go
@@ -1,0 +1,115 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package nested
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// PathSegment represents one component of a parsed nested filter path.
+// Name is the clean property name without any [N] suffix.
+type PathSegment struct {
+	Name     string
+	HasIndex bool
+	Index    int
+}
+
+// SplitPath splits a dot-notation nested filter path into PathSegments, each
+// with the clean property name and any [N] index extracted.
+// "addresses[1].city" → [{Name:"addresses", HasIndex:true, Index:1}, {Name:"city"}]
+func SplitPath(path string) []PathSegment {
+	raw := strings.Split(path, ".")
+	segs := make([]PathSegment, len(raw))
+	for i, s := range raw {
+		clean, idx, hasIdx := parseSegmentIndex(s)
+		segs[i] = PathSegment{Name: clean, HasIndex: hasIdx, Index: idx}
+	}
+	return segs
+}
+
+// ArrayIndex records a single positional constraint from an arr[N] filter.
+// RelPath is the path to the indexed array relative to the root property
+// ("" for root elements, "tags" for a sub-array). Index is 0-based.
+type ArrayIndex struct {
+	RelPath string
+	Index   int
+}
+
+// ParseIndexedPath parses a full nested filter path (e.g. "cars[1].tags[2]"),
+// strips all [N] index markers, and returns:
+//   - cleanRelPath: the clean relative path without the root property name or indices
+//     (e.g. "tags" for "cars[1].tags[2]", "city" for "addresses[1].city")
+//   - cleanRelSegs: the same path as a pre-split slice for direct use with schema walking
+//   - arrayIndices: one entry per [N] occurrence with its relative path and 0-based index
+func ParseIndexedPath(path string) (cleanRelPath string, cleanRelSegs []string, arrayIndices []ArrayIndex) {
+	pathSegs := SplitPath(path)
+	cleanNames := make([]string, len(pathSegs))
+	for i, seg := range pathSegs {
+		cleanNames[i] = seg.Name
+		if seg.HasIndex {
+			var relPath string
+			if i > 0 {
+				relPath = strings.Join(cleanNames[1:i+1], ".")
+			}
+			arrayIndices = append(arrayIndices, ArrayIndex{RelPath: relPath, Index: seg.Index})
+		}
+	}
+	if len(cleanNames) > 1 {
+		cleanRelSegs = cleanNames[1:]
+		cleanRelPath = strings.Join(cleanRelSegs, ".")
+	}
+	return cleanRelPath, cleanRelSegs, arrayIndices
+}
+
+// RootPropName returns the top-level property name from a nested filter
+// path, stripping any [N] index. "addresses[1].city" → "addresses".
+func RootPropName(path string) string {
+	first := strings.SplitN(path, ".", 2)[0]
+	clean, _, _ := parseSegmentIndex(first)
+	return clean
+}
+
+// parseSegmentIndex extracts an optional [N] suffix from a path segment.
+// The closing bracket must be the very last character of the segment.
+// "tags[2]" → ("tags", 2, true); "tags" → ("tags", 0, false).
+func parseSegmentIndex(seg string) (clean string, index int, hasIndex bool) {
+	// The closing bracket must be the very last character.
+	if len(seg) == 0 || seg[len(seg)-1] != ']' {
+		return seg, 0, false
+	}
+	start := strings.Index(seg, "[")
+	if start < 0 {
+		return seg, 0, false
+	}
+	end := len(seg) - 1
+	if end <= start {
+		return seg, 0, false
+	}
+	idx, err := strconv.Atoi(seg[start+1 : end])
+	if err != nil || idx < 0 {
+		return seg, 0, false
+	}
+	return seg[:start], idx, true
+}
+
+// FindNestedProp returns the NestedProperty with the given name, or nil.
+func FindNestedProp(props []*models.NestedProperty, name string) *models.NestedProperty {
+	for _, np := range props {
+		if np.Name == name {
+			return np
+		}
+	}
+	return nil
+}

--- a/entities/filters/nested/path_test.go
+++ b/entities/filters/nested/path_test.go
@@ -1,0 +1,179 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package nested
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSegmentIndex(t *testing.T) {
+	tests := []struct {
+		name      string
+		seg       string
+		wantClean string
+		wantIdx   int
+		wantHas   bool
+	}{
+		// valid cases
+		{"index at end", "tags[2]", "tags", 2, true},
+		{"zero index", "tags[0]", "tags", 0, true},
+		{"multi-digit index", "cars[10]", "cars", 10, true},
+		{"index only — empty name", "[3]", "", 3, true},
+		// no index
+		{"plain segment", "tags", "tags", 0, false},
+		{"empty string", "", "", 0, false},
+		// bracket not at the end — treated as no index
+		{"bracket in the middle", "ta[2]gs", "ta[2]gs", 0, false},
+		{"trailing chars after bracket", "tags[2]x", "tags[2]x", 0, false},
+		// malformed
+		{"empty index", "tags[]", "tags[]", 0, false},
+		{"negative index", "tags[-1]", "tags[-1]", 0, false},
+		{"non-numeric index", "tags[abc]", "tags[abc]", 0, false},
+		{"unclosed bracket", "tags[", "tags[", 0, false},
+		{"no opening bracket", "tags]", "tags]", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clean, idx, has := parseSegmentIndex(tt.seg)
+			assert.Equal(t, tt.wantClean, clean)
+			assert.Equal(t, tt.wantIdx, idx)
+			assert.Equal(t, tt.wantHas, has)
+		})
+	}
+}
+
+func TestSplitPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want []PathSegment
+	}{
+		{
+			name: "single segment no index",
+			path: "addresses",
+			want: []PathSegment{{Name: "addresses"}},
+		},
+		{
+			name: "single segment with index",
+			path: "addresses[1]",
+			want: []PathSegment{{Name: "addresses", HasIndex: true, Index: 1}},
+		},
+		{
+			name: "two segments no index",
+			path: "addresses.city",
+			want: []PathSegment{{Name: "addresses"}, {Name: "city"}},
+		},
+		{
+			name: "root index with sub-property",
+			path: "addresses[1].city",
+			want: []PathSegment{{Name: "addresses", HasIndex: true, Index: 1}, {Name: "city"}},
+		},
+		{
+			name: "sub-property index",
+			path: "cars.tags[2]",
+			want: []PathSegment{{Name: "cars"}, {Name: "tags", HasIndex: true, Index: 2}},
+		},
+		{
+			name: "multi-level indexes",
+			path: "cars[1].tags[2]",
+			want: []PathSegment{
+				{Name: "cars", HasIndex: true, Index: 1},
+				{Name: "tags", HasIndex: true, Index: 2},
+			},
+		},
+		{
+			name: "three segments no index",
+			path: "cars.tires.width",
+			want: []PathSegment{{Name: "cars"}, {Name: "tires"}, {Name: "width"}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, SplitPath(tt.path))
+		})
+	}
+}
+
+func TestParseIndexedPath(t *testing.T) {
+	tests := []struct {
+		name             string
+		path             string
+		wantRelPath      string
+		wantArrayIndices []ArrayIndex
+	}{
+		{
+			name:        "no index — plain nested path unchanged",
+			path:        "addresses.city",
+			wantRelPath: "city",
+		},
+		{
+			name:             "root-level index — addresses[1].city",
+			path:             "addresses[1].city",
+			wantRelPath:      "city",
+			wantArrayIndices: []ArrayIndex{{RelPath: "", Index: 1}},
+		},
+		{
+			name:             "leaf scalar array index — cars.tires.radiuses[2]",
+			path:             "cars.tires.radiuses[2]",
+			wantRelPath:      "tires.radiuses",
+			wantArrayIndices: []ArrayIndex{{RelPath: "tires.radiuses", Index: 2}},
+		},
+		{
+			name:             "multi-level index — cars[1].tags[2]",
+			path:             "cars[1].tags[2]",
+			wantRelPath:      "tags",
+			wantArrayIndices: []ArrayIndex{{RelPath: "", Index: 1}, {RelPath: "tags", Index: 2}},
+		},
+		{
+			name:             "root only with index — addresses[1]",
+			path:             "addresses[1]",
+			wantRelPath:      "",
+			wantArrayIndices: []ArrayIndex{{RelPath: "", Index: 1}},
+		},
+		{
+			name:             "zero index — tags[0]",
+			path:             "cars.tags[0]",
+			wantRelPath:      "tags",
+			wantArrayIndices: []ArrayIndex{{RelPath: "tags", Index: 0}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			relPath, _, arrayIndices := ParseIndexedPath(tt.path)
+			assert.Equal(t, tt.wantRelPath, relPath)
+			assert.Equal(t, tt.wantArrayIndices, arrayIndices)
+		})
+	}
+}
+
+func TestRootPropName(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"addresses.city", "addresses"},
+		{"addresses[1].city", "addresses"},
+		{"addresses[1]", "addresses"},
+		{"cars[0].tires.width", "cars"},
+		{"name", "name"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.want, RootPropName(tt.path))
+		})
+	}
+}


### PR DESCRIPTION
## Nested object filtering — Part 8: IsNull support and arr[N] positional filtering

  Eighth PR in the nested object filtering series, building on Part 7 (correlated AND resolution). This PR adds two new 
  filter capabilities: `IsNull` checks for nested properties and positional `arr[N]` access.

  ### IsNull support

  Implements `addresses IsNull true/false` and `addresses.city IsNull true/false` using the `_exists` entries already written to the nested metadata bucket:

  - **`IsNull=false`** — allowlist of docIDs where at least one element has the property set
  - **`IsNull=true`** — denylist (complement) — documents where no element has the property

  `fetchNestedIsNull` reads `ExistsKey(relPath)` from the metadata bucket, applies any `arr[N]` index constraints (see below), strips positions to docIDs, and returns an allowlist or denylist based on the encoded bool.

  Validation routes all nested IsNull variants through `validateNestedProp` before the flat early return: root-level IsNull (no dot notation), sub-property on any leaf type including `object`/`object[]`, and non-existent path rejection all work correctly. Applying `[N]` to a non-array property is rejected.

  ### arr[N] positional filtering

  Adds positional array element access: `addresses[1].city = "berlin"`, `cars.tags[2] = "german"`, `cars[1].tags[2] = "german"`.

  **Write path** — `AssignPositions` now writes a root-level `IdxEntry{Path:"", Index:i}` for each root element, enabling `IdxKey("", N)` lookups alongside the existing sub-array `IdxKey("path", N)` entries.

  **Path parsing** — new `entities/filters/nested` package with `PathSegment`, `SplitPath`, `ParseIndexedPath`, `RootPropName`, `ArrayIndex`, and `ParseSegmentIndex`. All dot-splitting in the validator and filter extraction now goes through this package; no code outside it knows how paths are segmented.

  **Validation** — `validateNestedPathClause` uses `SplitPath` and validates that `[N]` is only applied to array types (`object[]`, scalar arrays); applying it to scalars or single objects is rejected with a clear error.

  **Resolution** — `restrictByNestedIdx` ANDs `IdxKey(ai.RelPath, ai.Index)` from the metadata bucket into the position bitmap for each `ArrayIndex` entry. Applied inside `fetchNestedPositions` (covers both standalone value filters and the correlated AND path via `resolveNestedCorrelated`) and `fetchNestedIsNull`.

  **Refactoring** — `fetchBitmap` → `readFromBucket`, `fetchRawPositions` → `fetchNestedPositions`, `applyArrayIndices` → `restrictByNestedIdx`. All nested fetch methods extracted to `prop_value_pairs_nested.go`; `resolveDocIDs` routes all nested dispatch (isCorrelated, IsNull, value filter) before the flat path.

  ### Tests

  - Extraction tests verifying `arrayIndices` population for single, multi-level, and no-index paths
  - Validation tests covering valid indexed paths, non-array index rejection, and non-existent path rejection
  - Integration tests: root index, out-of-range index, IsNull with root and sub-property index, scalar array index, object array index, multi-level indexes, and correlated AND with `arr[N]` constraints

  ## Test plan

  - [ ] `go test ./entities/filters/...` — IsNull and arr[N] validation tests pass
  - [ ] `go test ./adapters/repos/db/inverted/...` — extraction and unit tests pass
  - [ ] `go test -tags integrationTest ./adapters/repos/db/inverted/...` — integration tests pass