### PR TITLE
feat: implement keyword highlighting for BM25 and hybrid search

### DIFF
--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -188,6 +188,7 @@ func (b *classBuilder) additionalFields(classProperties graphql.Fields, class *m
 	additionalProperties["score"] = b.additionalScoreField()
 	additionalProperties["explainScore"] = b.additionalExplainScoreField()
 	additionalProperties["queryProfile"] = b.additionalQueryProfileField()
+	additionalProperties["highlight"] = b.additionalHighlightField(class)
 	additionalProperties["group"] = b.additionalGroupField(classProperties, class)
 	if replicationEnabled(class) {
 		additionalProperties["isConsistent"] = b.isConsistentField()
@@ -356,5 +357,24 @@ func (b *classBuilder) additionalGroupField(classProperties graphql.Fields, clas
 				},
 			},
 		}),
+	}
+}
+
+func (b *classBuilder) additionalHighlightField(class *models.Class) *graphql.Field {
+	return &graphql.Field{
+		Description: "Keyword-match highlights: matched snippets per property with <em> tags",
+		Type: graphql.NewList(graphql.NewObject(graphql.ObjectConfig{
+			Name: fmt.Sprintf("%sAdditionalHighlight", class.Class),
+			Fields: graphql.Fields{
+				"property": &graphql.Field{
+					Type:        graphql.String,
+					Description: "The property name that contains the match",
+				},
+				"fragments": &graphql.Field{
+					Type:        graphql.NewList(graphql.String),
+					Description: "Text snippets with matched terms wrapped in <em>…</em>",
+				},
+			},
+		})),
 	}
 }

--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -590,7 +590,7 @@ func (ac *additionalCheck) isAdditional(parentName, name string) bool {
 			name == "distance" || name == "id" || name == "vector" || name == "vectors" ||
 			name == "creationTimeUnix" || name == "lastUpdateTimeUnix" ||
 			name == "score" || name == "explainScore" || name == "isConsistent" ||
-			name == "group" || name == "queryProfile" {
+			name == "group" || name == "queryProfile" || name == "highlight" {
 			return true
 		}
 		if ac.isModuleAdditional(name) {
@@ -699,6 +699,10 @@ func extractProperties(className string, selections *ast.SelectionSet,
 						}
 						if additionalProperty == "queryProfile" {
 							additionalProps.QueryProfile = true
+							continue
+						}
+						if additionalProperty == "highlight" {
+							additionalProps.Highlight = true
 							continue
 						}
 						if additionalProperty == "lastUpdateTimeUnix" {

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -484,6 +484,21 @@ func (b *BM25Searcher) getTopKObjects(topKHeap *priorityqueue.Queue[[]*terms.Doc
 		}
 	}
 
+	if additional.Highlight {
+		for k := range objs {
+			if objs[k] == nil {
+				continue
+			}
+			highlights := generateObjectHighlights(objs[k], allRequests)
+			if len(highlights) > 0 {
+				if objs[k].AdditionalProperties() == nil {
+					objs[k].Object.Additional = make(map[string]interface{})
+				}
+				objs[k].Object.Additional["highlight"] = highlights
+			}
+		}
+	}
+
 	objs, scores = b.sortResultsByExternalId(objs, scores)
 
 	return objs, scores, nil

--- a/adapters/repos/db/inverted/highlight.go
+++ b/adapters/repos/db/inverted/highlight.go
@@ -1,0 +1,174 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/weaviate/weaviate/entities/storobj"
+)
+
+const (
+	highlightFragmentSize = 200
+	highlightMaxFragments = 3
+	highlightOpenTag      = "<em>"
+	highlightCloseTag     = "</em>"
+)
+
+// generateObjectHighlights returns a slice of { property, fragments } maps
+// for every text property in obj that contains at least one query term.
+// Results are stored directly into obj.Object.Additional["highlight"].
+func generateObjectHighlights(obj *storobj.Object, queryTerms []string) []map[string]interface{} {
+	if obj == nil || obj.Object.Properties == nil || len(queryTerms) == 0 {
+		return nil
+	}
+
+	props, ok := obj.Object.Properties.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	pattern := buildTermsPattern(queryTerms)
+	if pattern == "" {
+		return nil
+	}
+
+	re, err := regexp.Compile("(?i)(" + pattern + ")")
+	if err != nil {
+		return nil
+	}
+
+	var results []map[string]interface{}
+
+	for propName, propVal := range props {
+		texts := extractStrings(propVal)
+		if len(texts) == 0 {
+			continue
+		}
+
+		var frags []string
+		for _, text := range texts {
+			remaining := highlightMaxFragments - len(frags)
+			if remaining <= 0 {
+				break
+			}
+			frags = append(frags, buildFragments(text, re, highlightFragmentSize, remaining)...)
+		}
+
+		if len(frags) > 0 {
+			results = append(results, map[string]interface{}{
+				"property":  propName,
+				"fragments": frags,
+			})
+		}
+	}
+
+	return results
+}
+
+// extractStrings pulls string values out of a property value
+// (handles plain string, []string, and []interface{}).
+func extractStrings(v interface{}) []string {
+	switch val := v.(type) {
+	case string:
+		return []string{val}
+	case []string:
+		return val
+	case []interface{}:
+		out := make([]string, 0, len(val))
+		for _, item := range val {
+			if s, ok := item.(string); ok {
+				out = append(out, s)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// buildTermsPattern builds a regex alternation from the query terms,
+// properly quoting each term so special characters are treated literally.
+func buildTermsPattern(terms []string) string {
+	parts := make([]string, 0, len(terms))
+	for _, t := range terms {
+		if t != "" {
+			parts = append(parts, regexp.QuoteMeta(t))
+		}
+	}
+	return strings.Join(parts, "|")
+}
+
+// buildFragments returns up to maxFragments non-overlapping snippets of
+// ~fragmentSize bytes, each centred on a match and with terms wrapped in
+// <em>…</em>.
+func buildFragments(text string, re *regexp.Regexp, fragmentSize, maxFragments int) []string {
+	if maxFragments <= 0 || text == "" {
+		return nil
+	}
+
+	matches := re.FindAllStringIndex(text, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+
+	half := fragmentSize / 2
+	var fragments []string
+	lastEnd := 0
+
+	for _, m := range matches {
+		if len(fragments) >= maxFragments {
+			break
+		}
+
+		// Centre the window on the match.
+		start := m[0] - half
+		if start < 0 {
+			start = 0
+		}
+		start = safeRuneStart(text, start)
+
+		end := start + fragmentSize
+		if end > len(text) {
+			end = len(text)
+		}
+		end = safeRuneEnd(text, end)
+
+		// Skip if this window overlaps the previous one.
+		if start < lastEnd {
+			continue
+		}
+		lastEnd = end
+
+		snippet := text[start:end]
+		highlighted := re.ReplaceAllString(snippet, highlightOpenTag+"$1"+highlightCloseTag)
+		fragments = append(fragments, highlighted)
+	}
+
+	return fragments
+}
+
+// safeRuneStart moves pos backward until it sits on a valid UTF-8 rune boundary.
+func safeRuneStart(s string, pos int) int {
+	for pos > 0 && (s[pos]&0xC0) == 0x80 {
+		pos--
+	}
+	return pos
+}
+
+// safeRuneEnd moves pos forward until it sits on a valid UTF-8 rune boundary.
+func safeRuneEnd(s string, pos int) int {
+	for pos < len(s) && (s[pos]&0xC0) == 0x80 {
+		pos++
+	}
+	return pos
+}

--- a/entities/additional/classification.go
+++ b/entities/additional/classification.go
@@ -44,6 +44,9 @@ type Properties struct {
 	// QueryProfile enables per-shard query profiling data collection and return.
 	QueryProfile bool `json:"queryProfile"`
 
+	// Highlight requests keyword-match snippets in _additional.highlight
+	Highlight bool `json:"highlight"`
+
 	// The User is not interested in returning props, we can skip any costly
 	// operation that isn't required.
 	NoProps bool `json:"noProps"`

--- a/entities/additional/highlights.go
+++ b/entities/additional/highlights.go
@@ -1,0 +1,17 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package additional
+
+type HighlightResult struct {
+	Property  string   `json:"property"`
+	Fragments []string `json:"fragments"`
+}

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -504,6 +504,12 @@ func (e *Explorer) searchResultsToGetResponseWithType(ctx context.Context, input
 			additionalProperties["explainScore"] = res.ExplainScore
 		}
 
+		if params.AdditionalProperties.Highlight {
+			if h, ok := res.AdditionalProperties["highlight"]; ok && h != nil {
+				additionalProperties["highlight"] = h
+			}
+		}
+
 		if params.AdditionalProperties.Vector {
 			additionalProperties["vector"] = res.Vector
 		}


### PR DESCRIPTION
## Description

Implements keyword search result highlighting for BM25 and hybrid search,
resolving #2567. When `highlight` is requested in `_additional`, each result
returns text snippets with matched query terms wrapped in `<em>` tags.

## Changes

- `entities/additional/highlight.go` — new `HighlightResult` struct
- `entities/additional/classification.go` — added `Highlight bool` to `Properties`
- `adapters/repos/db/inverted/highlight.go` — core snippet-generation logic
- `adapters/repos/db/inverted/bm25_searcher.go` — populate highlights in `getTopKObjects`
- `adapters/handlers/graphql/local/get/class_builder.go` — expose `highlight` in `_additional` GraphQL schema
- `adapters/handlers/graphql/local/get/class_builder_fields.go` — parse `highlight` from query AST
- `usecases/traverser/explorer.go` — forward highlights to final response

## Example

**Query:**
\```graphql
{
  Get {
    Article(bm25: { query: "fashion" }) {
      title
      _additional {
        highlight { property fragments }
      }
    }
  }
}
\```

**Response:**
\```json
{
  "_additional": {
    "highlight": [
      {
        "property": "title",
        "fragments": ["2020's biggest <em>fashion</em> trends"]
      }
    ]
  }
}
\```

## Notes

- Fragment window: 200 chars, max 3 fragments per property
- Case-insensitive matching
- UTF-8 safe (no mid-rune slicing)
- Highlighting is lazy: only runs when `highlight` is explicitly requested,
  zero cost for queries that don't need it
- Works with BM25 (`bm25:`) and hybrid search