### PR TITLE
Collection export: Use lazy pipelines to avoid empty parquet files

### DIFF
--- a/test/modules/export-s3/export_test.go
+++ b/test/modules/export-s3/export_test.go
@@ -922,6 +922,11 @@ func TestExport_MultiTenant_AllCold(t *testing.T) {
 	assert.Equal(t, "SKIPPED", progressEmpty.Status, "empty cold tenant should be SKIPPED")
 	assert.Equal(t, int64(0), progressEmpty.ObjectsExported)
 
+	// S3-level check: the empty tenant must have produced no parquet
+	// objects at all.
+	assert.Empty(t, listTenantParquetKeys(t, exportID, className, "tenantEmpty"),
+		"empty cold tenant must produce no parquet files")
+
 	// All tenants must remain COLD — the export must not activate them.
 	tenantsResp, err := helper.GetTenants(t, className)
 	require.NoError(t, err)
@@ -929,6 +934,98 @@ func TestExport_MultiTenant_AllCold(t *testing.T) {
 		require.Equal(t, models.TenantActivityStatusCOLD, tenant.ActivityStatus,
 			"tenant %s should still be COLD after export", tenant.Name)
 	}
+
+	verifyParquetMetadata(t, exportID, className, true)
+}
+
+// TestExport_MultiTenant_HotEmptyTenants verifies that a multi-tenant
+// export with a mix of populated and empty HOT tenants produces parquet
+// files only for the populated tenants. Empty tenants must appear as
+// SKIPPED in the shard status and must not create any parquet objects
+// on the backend.
+func TestExport_MultiTenant_HotEmptyTenants(t *testing.T) {
+	className := sanitizeClassName(t.Name())
+	exportID := strings.ToLower(sanitizeClassName(t.Name()))
+
+	helper.CreateClass(t, &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{Name: "text", DataType: []string{"text"}},
+		},
+		ReplicationConfig:  &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+	})
+	defer helper.DeleteClass(t, className)
+
+	// Populated and empty tenants are interleaved by name so the
+	// worker pool scans them in mixed order.
+	//
+	// Tenant names must not contain underscores; see listTenantParquetKeys.
+	populated := []string{"tenantA", "tenantC", "tenantE"}
+	empty := []string{"tenantB", "tenantD", "tenantF"}
+
+	allTenants := make([]*models.Tenant, 0, len(populated)+len(empty))
+	for _, name := range populated {
+		allTenants = append(allTenants, &models.Tenant{Name: name})
+	}
+	for _, name := range empty {
+		allTenants = append(allTenants, &models.Tenant{Name: name})
+	}
+	helper.CreateTenants(t, className, allTenants)
+
+	// Only populate the "populated" tenants. Empty tenants are created
+	// but receive no objects — they stay HOT by default.
+	var allObjects []*models.Object
+	for _, name := range populated {
+		objects := makeObjects(className, name, 25)
+		helper.CreateObjectsBatchCL(t, objects, types.ConsistencyLevelAll)
+		allObjects = append(allObjects, objects...)
+	}
+
+	_, err := exporttest.CreateExport(t, "s3", exportID, []string{className})
+	require.NoError(t, err)
+
+	exporttest.ExpectExportEventuallySucceeded(t, "s3", exportID)
+
+	resp, err := exporttest.ExportStatus(t, "s3", exportID)
+	require.NoError(t, err)
+	require.Equal(t, "SUCCESS", resp.Payload.Status)
+
+	require.NotNil(t, resp.Payload.ShardStatus)
+	shardStatus := resp.Payload.ShardStatus[className]
+	require.NotNil(t, shardStatus, "expected shard status for class %s", className)
+
+	// Populated tenants: SUCCESS with 25 objects each, and at least one
+	// parquet file per tenant in S3.
+	for _, name := range populated {
+		progress, ok := shardStatus[name]
+		require.True(t, ok, "expected shard status for tenant %s", name)
+		assert.Equal(t, "SUCCESS", progress.Status,
+			"populated tenant %s should be SUCCESS", name)
+		assert.Equal(t, int64(25), progress.ObjectsExported,
+			"populated tenant %s should have 25 objects exported", name)
+
+		assert.NotEmpty(t, listTenantParquetKeys(t, exportID, className, name),
+			"populated tenant %s should produce at least one parquet file", name)
+	}
+
+	// Empty tenants: SKIPPED with no objects exported, and zero
+	// parquet files on the backend.
+	for _, name := range empty {
+		progress, ok := shardStatus[name]
+		require.True(t, ok, "expected shard status for tenant %s", name)
+		assert.Equal(t, "SKIPPED", progress.Status,
+			"empty tenant %s should be SKIPPED", name)
+		assert.Equal(t, int64(0), progress.ObjectsExported,
+			"empty tenant %s should have 0 objects exported", name)
+
+		assert.Empty(t, listTenantParquetKeys(t, exportID, className, name),
+			"empty tenant %s must produce no parquet files", name)
+	}
+
+	// Every expected object ID must appear exactly once in the
+	// aggregated parquet output across all populated tenants.
+	verifyParquetExport(t, exportID, className, allObjects)
 
 	verifyParquetMetadata(t, exportID, className, true)
 }
@@ -1147,6 +1244,35 @@ func listParquetKeys(t *testing.T, exportID, className string) []string {
 	t.Helper()
 
 	prefix := fmt.Sprintf("%s/%s", exportID, className)
+	resp, err := s3Client.ListObjectsV2(context.Background(), &s3.ListObjectsV2Input{
+		Bucket: aws.String(s3Bucket),
+		Prefix: aws.String(prefix),
+	})
+	require.NoError(t, err, "failed to list objects with prefix %s", prefix)
+
+	var keys []string
+	for _, obj := range resp.Contents {
+		key := aws.ToString(obj.Key)
+		if strings.HasSuffix(key, ".parquet") {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+// listTenantParquetKeys lists S3 parquet keys that belong to a specific
+// tenant (shard). Parquet filenames follow the format
+// "{className}_{shardName}_{rangeIndex:04d}.parquet", so matching on the
+// "{className}_{tenantName}_" prefix isolates a single tenant. The trailing
+// underscore prevents partial-match false positives between tenant names
+// that share a prefix (e.g. "tenant" vs "tenantA"). Tenant names used in
+// tests must therefore not contain underscores.
+func listTenantParquetKeys(t *testing.T, exportID, className, tenantName string) []string {
+	t.Helper()
+	require.NotContains(t, tenantName, "_",
+		"tenant name must not contain underscores; would break prefix isolation")
+
+	prefix := fmt.Sprintf("%s/%s_%s_", exportID, className, tenantName)
 	resp, err := s3Client.ListObjectsV2(context.Background(), &s3.ListObjectsV2Input{
 		Bucket: aws.String(s3Bucket),
 		Prefix: aws.String(prefix),

--- a/usecases/export/parallel_scan.go
+++ b/usecases/export/parallel_scan.go
@@ -53,18 +53,27 @@ func (j *scanJob) execute() {
 	// no upload goroutine, no backend object, no misleading "closed pipe"
 	// log noise on shards that have no data (e.g. an empty MT tenant).
 	var pipeline *rangePipeline
-	// getWriter is called exactly once by scanRangeToWriter — on the first
-	// row. If the range is empty it is never called at all.
+	// getWriter is guarded by sync.Once so that at most one pipeline is
+	// ever created per range, regardless of how scanRangeToWriter evolves.
+	// If the range is empty, getWriter is never called at all.
+	var once sync.Once
+	var initErr error
 	getWriter := func() (*ParquetWriter, error) {
-		p, err := startRangeWriter(j.ctx, j.writerCfg, j.rangeIndex)
-		if err != nil {
-			return nil, fmt.Errorf("start range writer %d: %w", j.rangeIndex, err)
+		once.Do(func() {
+			p, err := startRangeWriter(j.ctx, j.writerCfg, j.rangeIndex)
+			if err != nil {
+				initErr = fmt.Errorf("start range writer %d: %w", j.rangeIndex, err)
+				return
+			}
+			pipeline = p
+		})
+		if initErr != nil {
+			return nil, initErr
 		}
-		pipeline = p
 		return pipeline.writer, nil
 	}
 
-	_, scanErr := scanRangeToWriter(j.ctx, j.bucket, j.keyRange.start, j.keyRange.end, getWriter)
+	scanErr := scanRangeToWriter(j.ctx, j.bucket, j.keyRange.start, j.keyRange.end, getWriter)
 
 	if pipeline == nil {
 		// Empty range — no upload was started. Propagate any scan
@@ -151,7 +160,7 @@ func scanRangeToWriter(
 	bucket *lsmkv.Bucket,
 	startKey, endKey []byte,
 	getWriter func() (*ParquetWriter, error),
-) (int, error) {
+) error {
 	cursor := bucket.Cursor()
 	defer cursor.Close()
 
@@ -162,7 +171,6 @@ func scanRangeToWriter(
 		key, val = cursor.Seek(startKey)
 	}
 
-	var n int
 	var writer *ParquetWriter
 	for key != nil {
 		if endKey != nil && bytes.Compare(key, endKey) >= 0 {
@@ -171,18 +179,18 @@ func scanRangeToWriter(
 
 		select {
 		case <-ctx.Done():
-			return n, ctx.Err()
+			return ctx.Err()
 		default:
 		}
 
 		fields, err := storobj.ExportFieldsFromBinary(val)
 		if err != nil {
-			return n, fmt.Errorf("extract export fields: %w", err)
+			return fmt.Errorf("extract export fields: %w", err)
 		}
 
 		if writer == nil {
 			if writer, err = getWriter(); err != nil {
-				return n, err
+				return err
 			}
 		}
 
@@ -197,14 +205,13 @@ func scanRangeToWriter(
 		}
 
 		if err := writer.WriteRow(row); err != nil {
-			return n, fmt.Errorf("write row to parquet: %w", err)
+			return fmt.Errorf("write row to parquet: %w", err)
 		}
 
-		n++
 		key, val = cursor.Next()
 	}
 
-	return n, nil
+	return nil
 }
 
 // rangeWriterConfig holds shared configuration for all range writers of a shard.

--- a/usecases/export/parallel_scan.go
+++ b/usecases/export/parallel_scan.go
@@ -31,8 +31,9 @@ type keyRange struct {
 	start, end []byte
 }
 
-// scanJob is a self-contained unit of work: scan one key range, create a
-// per-range writer pipeline, write directly to it, and upload.
+// scanJob is a self-contained unit of work: scan one key range, lazily
+// create a per-range writer pipeline on the first row, write directly to
+// it, and upload.
 type scanJob struct {
 	ctx        context.Context // per-shard context
 	bucket     *lsmkv.Bucket
@@ -46,18 +47,32 @@ type scanJob struct {
 func (j *scanJob) execute() {
 	defer j.wg.Done()
 
-	pipeline, err := startRangeWriter(j.ctx, j.writerCfg, j.rangeIndex)
-	if err != nil {
-		j.setErr(fmt.Errorf("start range writer %d: %w", j.rangeIndex, err))
-		return
+	// Lazy pipeline creation: defer creating the upload pipeline (and
+	// starting the upload goroutine) until the first row is actually
+	// scanned. This avoids any backend interaction for empty ranges —
+	// no upload goroutine, no backend object, no misleading "closed pipe"
+	// log noise on shards that have no data (e.g. an empty MT tenant).
+	var pipeline *rangePipeline
+	// getWriter is called exactly once by scanRangeToWriter — on the first
+	// row. If the range is empty it is never called at all.
+	getWriter := func() (*ParquetWriter, error) {
+		p, err := startRangeWriter(j.ctx, j.writerCfg, j.rangeIndex)
+		if err != nil {
+			return nil, fmt.Errorf("start range writer %d: %w", j.rangeIndex, err)
+		}
+		pipeline = p
+		return pipeline.writer, nil
 	}
 
-	n, scanErr := scanRangeToWriter(j.ctx, j.bucket, j.keyRange.start, j.keyRange.end, pipeline.writer)
+	_, scanErr := scanRangeToWriter(j.ctx, j.bucket, j.keyRange.start, j.keyRange.end, getWriter)
 
-	if scanErr == nil && n == 0 {
-		// No rows scanned — discard the upload so no empty parquet file
-		// is written to the backend.
-		pipeline.CloseEmpty()
+	if pipeline == nil {
+		// Empty range — no upload was started. Propagate any scan
+		// error (e.g. context cancellation, malformed first row, or
+		// pipeline creation failure).
+		if scanErr != nil {
+			j.setErr(scanErr)
+		}
 		return
 	}
 
@@ -124,8 +139,10 @@ func computeNumRanges(count, parallelism int) int {
 	return max(numRanges, 1)
 }
 
-// scanRangeToWriter scans [startKey, endKey) using a Cursor and writes
-// rows directly to a ParquetWriter. If endKey is nil, scans to the end.
+// scanRangeToWriter scans [startKey, endKey) using a Cursor. The writer
+// is obtained lazily via getWriter on the first row, so empty ranges
+// never create a writer (and thus never start an upload). If endKey is
+// nil, scans to the end.
 //
 // Progress reporting is handled by the writer's onFlush callback, which
 // fires after each batch of rows is flushed to the underlying io.Writer.
@@ -133,7 +150,7 @@ func scanRangeToWriter(
 	ctx context.Context,
 	bucket *lsmkv.Bucket,
 	startKey, endKey []byte,
-	writer *ParquetWriter,
+	getWriter func() (*ParquetWriter, error),
 ) (int, error) {
 	cursor := bucket.Cursor()
 	defer cursor.Close()
@@ -146,6 +163,7 @@ func scanRangeToWriter(
 	}
 
 	var n int
+	var writer *ParquetWriter
 	for key != nil {
 		if endKey != nil && bytes.Compare(key, endKey) >= 0 {
 			break
@@ -160,6 +178,12 @@ func scanRangeToWriter(
 		fields, err := storobj.ExportFieldsFromBinary(val)
 		if err != nil {
 			return n, fmt.Errorf("extract export fields: %w", err)
+		}
+
+		if writer == nil {
+			if writer, err = getWriter(); err != nil {
+				return n, err
+			}
 		}
 
 		row := ParquetRow{
@@ -197,21 +221,14 @@ type rangeWriterConfig struct {
 // rangePipeline bundles a per-range ParquetWriter, buffered pipe, and upload
 // goroutine. The buffered pipe decouples scan speed from upload speed so that
 // LSM cursors are not held open waiting on network I/O.
+//
+// The pipeline is created lazily by scanJob.execute on the first row scanned,
+// so empty ranges never instantiate a pipeline at all — there is no
+// CloseEmpty/abort path to worry about.
 type rangePipeline struct {
-	pr         *bufferedPipeReader
 	pw         *bufferedPipeWriter
 	writer     *ParquetWriter
 	uploadDone <-chan error
-}
-
-// CloseEmpty tears down the pipeline without completing the upload. Used when
-// the scan produced no rows so that no empty parquet file reaches the backend.
-func (rp *rangePipeline) CloseEmpty() {
-	rp.writer.onFlush = nil
-	_ = rp.writer.Close()
-	rp.pr.Close()
-	rp.pw.Close()
-	<-rp.uploadDone
 }
 
 // Shutdown closes the writer pipeline and waits for the upload to finish.
@@ -297,7 +314,6 @@ func startRangeWriter(ctx context.Context, cfg *rangeWriterConfig, rangeIndex in
 	}
 
 	return &rangePipeline{
-		pr:         pr,
 		pw:         pw,
 		writer:     writer,
 		uploadDone: uploadDone,

--- a/usecases/export/parallel_scan_test.go
+++ b/usecases/export/parallel_scan_test.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"runtime"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -246,17 +247,27 @@ func TestComputeNumRanges(t *testing.T) {
 }
 
 // scanToRows is a test helper that calls scanRangeToWriter with an in-memory
-// ParquetWriter and returns the decoded rows (or error).
+// ParquetWriter and returns the decoded rows (or error). The writer is
+// created lazily on first row, matching production behavior.
 func scanToRows(t *testing.T, ctx context.Context, bucket *lsmkv.Bucket, start, end []byte) ([]ParquetRow, error) {
 	t.Helper()
 	var buf bytes.Buffer
-	writer, err := NewParquetWriter(&buf)
-	require.NoError(t, err)
+	var writer *ParquetWriter
 
-	_, scanErr := scanRangeToWriter(ctx, bucket, start, end, writer)
-	require.NoError(t, writer.Close())
+	_, scanErr := scanRangeToWriter(ctx, bucket, start, end, func() (*ParquetWriter, error) {
+		var err error
+		writer, err = NewParquetWriter(&buf)
+		return writer, err
+	})
+	if writer != nil {
+		require.NoError(t, writer.Close())
+	}
 	if scanErr != nil {
 		return nil, scanErr
+	}
+	if writer == nil {
+		// Empty range — no writer was created.
+		return nil, nil
 	}
 	return readParquetRows(t, buf.Bytes()), nil
 }
@@ -369,6 +380,78 @@ func TestScanRangeToWriter(t *testing.T) {
 
 		_, err := scanToRows(t, ctx, bucket, nil, nil)
 		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	// Regression for the lazy pipeline change: getWriter must NOT be
+	// invoked when the range is empty, otherwise an upload pipeline
+	// would be created (and its upload goroutine started) for nothing.
+	t.Run("getWriter is not called for empty range", func(t *testing.T) {
+		t.Parallel()
+		var calls int
+		_, err := scanRangeToWriter(context.Background(), bucket,
+			makeKey(numObjects+10), makeKey(numObjects+20),
+			func() (*ParquetWriter, error) {
+				calls++
+				return nil, fmt.Errorf("getWriter must not be called for empty range")
+			})
+		require.NoError(t, err)
+		assert.Equal(t, 0, calls)
+	})
+
+	t.Run("getWriter is not called for entirely empty bucket", func(t *testing.T) {
+		t.Parallel()
+		emptyStore, _ := createTestStore(t, 0)
+		t.Cleanup(func() { emptyStore.Shutdown(context.Background()) })
+		emptyBucket := emptyStore.Bucket(helpers.ObjectsBucketLSM)
+		require.NotNil(t, emptyBucket)
+
+		var calls int
+		n, err := scanRangeToWriter(context.Background(), emptyBucket, nil, nil,
+			func() (*ParquetWriter, error) {
+				calls++
+				return nil, fmt.Errorf("getWriter must not be called for empty bucket")
+			})
+		require.NoError(t, err)
+		assert.Equal(t, 0, n)
+		assert.Equal(t, 0, calls)
+	})
+
+	// getWriter failure on the first row must propagate as a scan error.
+	t.Run("getWriter failure propagates as scan error", func(t *testing.T) {
+		t.Parallel()
+		wantErr := fmt.Errorf("create writer failed")
+		n, err := scanRangeToWriter(context.Background(), bucket, nil, nil,
+			func() (*ParquetWriter, error) {
+				return nil, wantErr
+			})
+		require.ErrorIs(t, err, wantErr)
+		assert.Equal(t, 0, n)
+	})
+
+	// Regression: when ExportFieldsFromBinary fails before getWriter is
+	// ever invoked, the lazy pipeline must not be created.
+	t.Run("corrupt first object never calls getWriter", func(t *testing.T) {
+		t.Parallel()
+
+		corruptStore, _ := createTestStore(t, 0)
+		t.Cleanup(func() { corruptStore.Shutdown(context.Background()) })
+		corruptBucket := corruptStore.Bucket(helpers.ObjectsBucketLSM)
+
+		corruptKey := make([]byte, 8)
+		binary.BigEndian.PutUint64(corruptKey, 0)
+		require.NoError(t, corruptBucket.Put(corruptKey, []byte("corrupt")))
+		require.NoError(t, corruptBucket.FlushAndSwitch())
+
+		var calls int
+		n, err := scanRangeToWriter(context.Background(), corruptBucket, nil, nil,
+			func() (*ParquetWriter, error) {
+				calls++
+				return nil, fmt.Errorf("should not be called")
+			})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "extract export fields")
+		assert.Equal(t, 0, n)
+		assert.Equal(t, 0, calls, "getWriter must not be called when first object is corrupt")
 	})
 
 	t.Run("computed ranges cover all objects without duplicates or gaps", func(t *testing.T) {
@@ -611,13 +694,16 @@ func TestRangePipelineShutdown(t *testing.T) {
 }
 
 // failingWriteBackend embeds fakeBackend but returns an error from Write
-// after draining the reader (so the pipe doesn't deadlock).
+// after draining the reader (so the pipe doesn't deadlock). WriteCalls
+// counts how many times Write was invoked.
 type failingWriteBackend struct {
 	fakeBackend
-	writeErr error
+	writeErr   error
+	writeCalls atomic.Int64
 }
 
 func (b *failingWriteBackend) Write(_ context.Context, _, _, _, _ string, r backup.ReadCloserWithError) (int64, error) {
+	b.writeCalls.Add(1)
 	_, err := io.ReadAll(r)
 	r.CloseWithError(err)
 	return 0, b.writeErr
@@ -711,6 +797,119 @@ func TestScanJobExecute(t *testing.T) {
 		// during writer.Close() which happens before we read uploadDone.
 		assert.Equal(t, int64(10), written)
 	})
+
+	// An empty range must not create the upload pipeline or call
+	// backend.Write at all.
+	t.Run("empty range never touches the backend", func(t *testing.T) {
+		t.Parallel()
+
+		// Bucket with zero objects — the lazy pipeline must not start.
+		store, _ := createTestStore(t, 0)
+		t.Cleanup(func() { store.Shutdown(context.Background()) })
+		bucket := store.Bucket(helpers.ObjectsBucketLSM)
+
+		// A backend that counts Write calls. The assertion below verifies
+		// that no Write is ever made for an empty range.
+		backend := &failingWriteBackend{writeErr: fmt.Errorf("unexpected Write on empty range")}
+		logger, _ := test.NewNullLogger()
+		cfg := &rangeWriterConfig{
+			backend:   backend,
+			req:       &ExportRequest{ID: "test", Bucket: "b", Path: "p"},
+			className: "TestClass",
+			shardName: "Tenant-134",
+			isMT:      true,
+			logger:    logger,
+		}
+
+		var wg sync.WaitGroup
+		var gotErr error
+		var written int64
+		cfg.onFlush = func(n int64) { written += n }
+
+		wg.Add(1)
+		job := scanJob{
+			ctx:        context.Background(),
+			bucket:     bucket,
+			keyRange:   keyRange{start: nil, end: nil},
+			rangeIndex: 0,
+			writerCfg:  cfg,
+			wg:         &wg,
+			setErr:     func(err error) { gotErr = err },
+		}
+		job.execute()
+		wg.Wait()
+
+		require.NoError(t, gotErr, "empty range must not produce a setErr call")
+		assert.Equal(t, int64(0), written, "empty range must not write any rows")
+		assert.Zero(t, backend.writeCalls.Load(), "empty range must not call backend.Write")
+	})
+
+	// Regression for the lazy pipeline: corrupt data at different positions
+	// must propagate the scan error and only create the pipeline when at
+	// least one valid row was scanned first.
+	corruptDataTests := []struct {
+		name             string
+		validObjects     int   // valid objects inserted before the corrupt one
+		expectWriteCalls int64 // 0 = pipeline never created, 1 = pipeline created and shut down
+	}{
+		{
+			name:             "corrupt first object — pipeline never created",
+			validObjects:     0,
+			expectWriteCalls: 0,
+		},
+		{
+			name:             "corrupt later object — pipeline created and shut down",
+			validObjects:     5,
+			expectWriteCalls: 1,
+		},
+	}
+
+	for _, tc := range corruptDataTests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store, _ := createTestStore(t, tc.validObjects)
+			t.Cleanup(func() { store.Shutdown(context.Background()) })
+			bucket := store.Bucket(helpers.ObjectsBucketLSM)
+
+			corruptKey := make([]byte, 8)
+			binary.BigEndian.PutUint64(corruptKey, uint64(tc.validObjects))
+			require.NoError(t, bucket.Put(corruptKey, []byte("corrupt")))
+			require.NoError(t, bucket.FlushAndSwitch())
+
+			backend := &failingWriteBackend{writeErr: fmt.Errorf("upload error")}
+			logger, _ := test.NewNullLogger()
+			cfg := &rangeWriterConfig{
+				backend:   backend,
+				req:       &ExportRequest{ID: "test", Bucket: "b", Path: "p"},
+				className: "TestClass",
+				shardName: "shard0",
+				logger:    logger,
+			}
+
+			var wg sync.WaitGroup
+			var gotErr error
+			cfg.onFlush = func(n int64) {}
+
+			wg.Add(1)
+			job := scanJob{
+				ctx:        context.Background(),
+				bucket:     bucket,
+				keyRange:   keyRange{start: nil, end: nil},
+				rangeIndex: 0,
+				writerCfg:  cfg,
+				wg:         &wg,
+				setErr:     func(err error) { gotErr = err },
+			}
+			job.execute()
+			wg.Wait()
+
+			require.Error(t, gotErr)
+			assert.Contains(t, gotErr.Error(), "extract export fields")
+			assert.Equal(t, tc.expectWriteCalls, backend.writeCalls.Load(),
+				"backend.Write call count")
+		})
+	}
 }
 
 // readParquetRows reads all ParquetRow entries from a parquet file in memory.
@@ -765,7 +964,9 @@ func TestParquetWriter_OnFlush(t *testing.T) {
 			callbacks = append(callbacks, n)
 		}
 
-		_, err = scanRangeToWriter(context.Background(), bucket, nil, nil, writer)
+		_, err = scanRangeToWriter(context.Background(), bucket, nil, nil, func() (*ParquetWriter, error) {
+			return writer, nil
+		})
 		require.NoError(t, err)
 		require.NoError(t, writer.Close())
 
@@ -801,7 +1002,9 @@ func TestParquetWriter_OnFlush(t *testing.T) {
 			callbacks = append(callbacks, n)
 		}
 
-		_, err = scanRangeToWriter(context.Background(), bucket, nil, nil, writer)
+		_, err = scanRangeToWriter(context.Background(), bucket, nil, nil, func() (*ParquetWriter, error) {
+			return writer, nil
+		})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "extract export fields")
 

--- a/usecases/export/parallel_scan_test.go
+++ b/usecases/export/parallel_scan_test.go
@@ -254,7 +254,7 @@ func scanToRows(t *testing.T, ctx context.Context, bucket *lsmkv.Bucket, start, 
 	var buf bytes.Buffer
 	var writer *ParquetWriter
 
-	_, scanErr := scanRangeToWriter(ctx, bucket, start, end, func() (*ParquetWriter, error) {
+	scanErr := scanRangeToWriter(ctx, bucket, start, end, func() (*ParquetWriter, error) {
 		var err error
 		writer, err = NewParquetWriter(&buf)
 		return writer, err
@@ -388,7 +388,7 @@ func TestScanRangeToWriter(t *testing.T) {
 	t.Run("getWriter is not called for empty range", func(t *testing.T) {
 		t.Parallel()
 		var calls int
-		_, err := scanRangeToWriter(context.Background(), bucket,
+		err := scanRangeToWriter(context.Background(), bucket,
 			makeKey(numObjects+10), makeKey(numObjects+20),
 			func() (*ParquetWriter, error) {
 				calls++
@@ -406,13 +406,12 @@ func TestScanRangeToWriter(t *testing.T) {
 		require.NotNil(t, emptyBucket)
 
 		var calls int
-		n, err := scanRangeToWriter(context.Background(), emptyBucket, nil, nil,
+		err := scanRangeToWriter(context.Background(), emptyBucket, nil, nil,
 			func() (*ParquetWriter, error) {
 				calls++
 				return nil, fmt.Errorf("getWriter must not be called for empty bucket")
 			})
 		require.NoError(t, err)
-		assert.Equal(t, 0, n)
 		assert.Equal(t, 0, calls)
 	})
 
@@ -420,12 +419,11 @@ func TestScanRangeToWriter(t *testing.T) {
 	t.Run("getWriter failure propagates as scan error", func(t *testing.T) {
 		t.Parallel()
 		wantErr := fmt.Errorf("create writer failed")
-		n, err := scanRangeToWriter(context.Background(), bucket, nil, nil,
+		err := scanRangeToWriter(context.Background(), bucket, nil, nil,
 			func() (*ParquetWriter, error) {
 				return nil, wantErr
 			})
 		require.ErrorIs(t, err, wantErr)
-		assert.Equal(t, 0, n)
 	})
 
 	// Regression: when ExportFieldsFromBinary fails before getWriter is
@@ -443,14 +441,13 @@ func TestScanRangeToWriter(t *testing.T) {
 		require.NoError(t, corruptBucket.FlushAndSwitch())
 
 		var calls int
-		n, err := scanRangeToWriter(context.Background(), corruptBucket, nil, nil,
+		err := scanRangeToWriter(context.Background(), corruptBucket, nil, nil,
 			func() (*ParquetWriter, error) {
 				calls++
 				return nil, fmt.Errorf("should not be called")
 			})
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "extract export fields")
-		assert.Equal(t, 0, n)
 		assert.Equal(t, 0, calls, "getWriter must not be called when first object is corrupt")
 	})
 
@@ -964,7 +961,7 @@ func TestParquetWriter_OnFlush(t *testing.T) {
 			callbacks = append(callbacks, n)
 		}
 
-		_, err = scanRangeToWriter(context.Background(), bucket, nil, nil, func() (*ParquetWriter, error) {
+		err = scanRangeToWriter(context.Background(), bucket, nil, nil, func() (*ParquetWriter, error) {
 			return writer, nil
 		})
 		require.NoError(t, err)
@@ -1002,7 +999,7 @@ func TestParquetWriter_OnFlush(t *testing.T) {
 			callbacks = append(callbacks, n)
 		}
 
-		_, err = scanRangeToWriter(context.Background(), bucket, nil, nil, func() (*ParquetWriter, error) {
+		err = scanRangeToWriter(context.Background(), bucket, nil, nil, func() (*ParquetWriter, error) {
 			return writer, nil
 		})
 		require.Error(t, err)


### PR DESCRIPTION
### What's being changed:

This resolves a problem that empty tenants would produce an empty parquet file AND a log error because the pipeline is closed premuturely.

This PR changes the pipeline to be lazyly created when an object is actually written which resolves the problem 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
