### PR TITLE
fix: persist compression metadata after preloading vectors to avoid data loss on restart

### DIFF
--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -109,7 +109,6 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 				return fmt.Errorf("compressing vectors: %w", err)
 			}
 		}
-		h.compressor.PersistCompression(h.commitLog)
 	} else if cfg.BQ.Enabled {
 		var err error
 		if singleVector {
@@ -150,6 +149,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 			})
 	}
 
+	h.compressor.PersistCompression(h.commitLog)
 	h.compressed.Store(true)
 	h.cache.Drop()
 	return nil


### PR DESCRIPTION
### What's being changed:

Move `PersistCompression` in `compress()` to after the Preload loop for PQ/SQ.

Previously, compression metadata was written to the HNSW commit log before
the compressed vectors were written to the LSM bucket. If the process was
interrupted between the two, the commit log would claim "compressed" on
restart but the compressed bucket would be empty, causing
"entrypoint was deleted in the object store" errors.

The RQ path (`checkAndCompress`) already had the correct ordering.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
