### PR TITLE
Fix access-check race in multi-node Azure backup Initialize

### DIFF
--- a/modules/backup-azure/client.go
+++ b/modules/backup-azure/client.go
@@ -20,6 +20,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
@@ -45,9 +46,16 @@ type azureClient struct {
 	serviceURL string
 	dataPath   string
 	logger     logrus.FieldLogger
+	nodeID     string        // hostname, used to make access-check paths unique across nodes
+	counter    atomic.Uint64 // monotonic counter for unique access-check paths within a node
 }
 
 func newClient(ctx context.Context, config *clientConfig, dataPath string, logger logrus.FieldLogger) (*azureClient, error) {
+	nodeID, err := os.Hostname()
+	if err != nil {
+		nodeID = strconv.Itoa(os.Getpid())
+	}
+
 	connectionString := os.Getenv("AZURE_STORAGE_CONNECTION_STRING")
 	if connectionString != "" {
 		client, err := azblob.NewClientFromConnectionString(connectionString, nil)
@@ -67,7 +75,7 @@ func newClient(ctx context.Context, config *clientConfig, dataPath string, logge
 				}
 			}
 		}
-		return &azureClient{client, *config, serviceURL, dataPath, logger}, nil
+		return &azureClient{client: client, config: *config, serviceURL: serviceURL, dataPath: dataPath, logger: logger, nodeID: nodeID}, nil
 	}
 
 	// Your account name and key can be obtained from the Azure Portal.
@@ -91,7 +99,7 @@ func newClient(ctx context.Context, config *clientConfig, dataPath string, logge
 		if err != nil {
 			return nil, err
 		}
-		return &azureClient{client, *config, serviceURL, dataPath, logger}, nil
+		return &azureClient{client: client, config: *config, serviceURL: serviceURL, dataPath: dataPath, logger: logger, nodeID: nodeID}, nil
 	}
 
 	options := &azblob.ClientOptions{
@@ -108,7 +116,7 @@ func newClient(ctx context.Context, config *clientConfig, dataPath string, logge
 	if err != nil {
 		return nil, err
 	}
-	return &azureClient{client, *config, serviceURL, dataPath, logger}, nil
+	return &azureClient{client: client, config: *config, serviceURL: serviceURL, dataPath: dataPath, logger: logger, nodeID: nodeID}, nil
 }
 
 func (a *azureClient) HomeDir(backupID, overrideBucket, overridePath string) string {
@@ -220,7 +228,10 @@ func (a *azureClient) PutObject(ctx context.Context, backupID, key, overrideBuck
 }
 
 func (a *azureClient) Initialize(ctx context.Context, backupID, overrideBucket, overridePath string) error {
-	key := "access-check"
+	// Each call gets a unique access-check file so concurrent Initialize calls
+	// from different nodes (or the same node) never interfere with each other.
+	seq := a.counter.Add(1)
+	key := "access-check-" + a.nodeID + "-" + strconv.FormatUint(seq, 10)
 
 	if err := a.PutObject(ctx, backupID, key, overrideBucket, overridePath, []byte("")); err != nil {
 		return errors.Wrap(err, "failed to access-check Azure backup module")


### PR DESCRIPTION
## Summary

- Apply the same race-condition fix from #10989 (GCS) to the **Azure** backup module's `Initialize()` access-check
- Each `Initialize()` call now writes and deletes its own unique access-check blob, keyed by hostname + atomic counter, so concurrent calls from different nodes never collide

## Problem

Same root cause as #10989 but in `modules/backup-azure/client.go`:

`Initialize()` validates Azure Blob write/delete access by creating a temporary `access-check` blob and immediately deleting it. The blob path was **not node-specific** — all nodes used the same `{backupID}/access-check` path.

During the export/backup commit phase, the coordinator fans out `commitNode()` to all participants concurrently. Each participant calls `Initialize()`. The coordinator's local participant consistently wins (warm connection + no gRPC hop), deletes the shared blob before remote nodes reach their `DeleteBlob` call. Unlike S3's `minio.RemoveObject` (which returns 204 even for non-existent objects), Azure's `DeleteBlob` returns an error for non-existent blobs → **deterministic failure on every multi-node export or backup attempt**.

## Fix

Give each `Initialize()` call a unique blob path by appending the node's hostname and a per-client atomic counter:

```
Before: {path}/{exportID}/access-check          ← shared, races
After:  {path}/{exportID}/access-check-weaviate-0-1  ← unique per call
        {path}/{exportID}/access-check-weaviate-1-1
        {path}/{exportID}/access-check-weaviate-2-1
```

Falls back to PID if `os.Hostname()` fails.

### What's being changed:

`modules/backup-azure/client.go`:
- Add `nodeID` (hostname) and `counter` (atomic uint64) fields to `azureClient`
- `newClient()` captures hostname at creation time (falls back to PID)
- `Initialize()` builds a unique key per call: `access-check-{nodeID}-{seq}`

**S3** (`minio.RemoveObject`) and **filesystem** (`Initialize()` is a no-op) are unaffected.

## Test plan

- [ ] Deploy multi-node cluster with Azure blob storage backend
- [ ] Trigger concurrent collection export/backup across all nodes
- [ ] Verify no 404/BlobNotFound errors on access-check deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)