### PR TITLE
fix: write nil marker for cleaned tombstone nodes in HNSW snapshots

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -713,28 +713,28 @@ func (l *hnswCommitLogger) writeStateTo(state *DeserializationResult, wr io.Writ
 			_, tombstoneIsCleaned := state.TombstonesDeleted[n.id]
 
 			if hasATombstone && tombstoneIsCleaned {
-				// if the node has been deleted but its tombstone has been cleaned up
-				// we can write a nil node
+				// If the node has been deleted and its tombstone has been cleaned up,
+				// write a nil marker. We must NOT skip the block write below - the
+				// marker must be written to preserve position alignment in the snapshot.
 				if err := writeByte(&buf, 0); err != nil {
 					return err
 				}
-				continue
-			}
-
-			if hasATombstone {
-				_ = writeByte(&buf, 1)
 			} else {
-				_ = writeByte(&buf, 2)
-			}
+				if hasATombstone {
+					_ = writeByte(&buf, 1)
+				} else {
+					_ = writeByte(&buf, 2)
+				}
 
-			_ = writeUint32(&buf, uint32(n.level))
+				_ = writeUint32(&buf, uint32(n.level))
 
-			connData := n.connections.Data()
-			_ = writeUint32(&buf, uint32(len(connData)))
+				connData := n.connections.Data()
+				_ = writeUint32(&buf, uint32(len(connData)))
 
-			_, err = buf.Write(connData)
-			if err != nil {
-				return errors.Wrapf(err, "write connections data for node %d", n.id)
+				_, err = buf.Write(connData)
+				if err != nil {
+					return errors.Wrapf(err, "write connections data for node %d", n.id)
+				}
 			}
 		} else {
 			// nil node

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
@@ -1405,6 +1405,102 @@ func TestMetadataWriteAndRestore(t *testing.T) {
 
 		require.NotEqual(t, state.Nodes, restoredState.Nodes)
 	})
+
+	// Regression test for: https://github.com/weaviate/weaviate/issues/192
+	// When a node has both a tombstone AND the tombstone has been cleaned
+	// (TombstonesDeleted), the snapshot writer must still write a nil marker
+	// for that position. Previously, the code would skip writing entirely
+	// due to an erroneous `continue` statement, causing position misalignment.
+	t.Run("v3 - cleaned tombstone nodes are written as nil markers", func(t *testing.T) {
+		// Create a state with 10 nodes where some have cleaned tombstones
+		state := &DeserializationResult{
+			Entrypoint:        0,
+			Level:             3,
+			Compressed:        false,
+			Nodes:             make([]*vertex, 10),
+			Tombstones:        make(map[uint64]struct{}),
+			TombstonesDeleted: make(map[uint64]struct{}),
+		}
+
+		c, err := packedconn.NewWithMaxLayer(2)
+		require.NoError(t, err)
+		c.ReplaceLayer(0, []uint64{1, 2, 3})
+
+		// Node 0: normal node
+		state.Nodes[0] = &vertex{id: 0, level: 3, connections: c}
+
+		// Node 1: nil (never existed)
+		state.Nodes[1] = nil
+
+		// Node 2: tombstoned but NOT cleaned - should be written as tombstone marker (1)
+		state.Nodes[2] = &vertex{id: 2, level: 1, connections: c}
+		state.Tombstones[2] = struct{}{}
+
+		// Node 3: tombstoned AND cleaned - should be written as nil marker (0)
+		// This is the case that was buggy - the continue statement skipped writing
+		state.Nodes[3] = &vertex{id: 3, level: 2, connections: c}
+		state.Tombstones[3] = struct{}{}
+		state.TombstonesDeleted[3] = struct{}{}
+
+		// Node 4: normal node
+		state.Nodes[4] = &vertex{id: 4, level: 1, connections: c}
+
+		// Node 5: another tombstoned AND cleaned node
+		state.Nodes[5] = &vertex{id: 5, level: 2, connections: c}
+		state.Tombstones[5] = struct{}{}
+		state.TombstonesDeleted[5] = struct{}{}
+
+		// Nodes 6-9: normal nodes to verify position alignment
+		for i := 6; i < 10; i++ {
+			state.Nodes[i] = &vertex{id: uint64(i), level: i % 3, connections: c}
+		}
+
+		dir := t.TempDir()
+		id := "test"
+		cl := createTestCommitLoggerForSnapshots(t, dir, id)
+
+		// Write snapshot
+		snapshotPath := filepath.Join(snapshotDirectory(dir, id), "test.snapshot")
+		err = cl.writeSnapshot(state, snapshotPath)
+		require.NoError(t, err)
+
+		// Read snapshot back
+		restoredState, err := cl.readSnapshot(snapshotPath)
+		require.NoError(t, err)
+
+		// Verify all 10 positions exist
+		require.Len(t, restoredState.Nodes, 10, "all 10 node positions must be preserved")
+
+		// Node 0: should be restored as normal node
+		require.NotNil(t, restoredState.Nodes[0], "node 0 should exist")
+		require.Equal(t, uint64(0), restoredState.Nodes[0].id)
+		require.Equal(t, 3, restoredState.Nodes[0].level)
+
+		// Node 1: should be nil
+		require.Nil(t, restoredState.Nodes[1], "node 1 should be nil")
+
+		// Node 2: should be restored as tombstoned node
+		require.NotNil(t, restoredState.Nodes[2], "node 2 should exist (tombstoned)")
+		require.Equal(t, uint64(2), restoredState.Nodes[2].id)
+		_, hasTombstone := restoredState.Tombstones[2]
+		require.True(t, hasTombstone, "node 2 should have tombstone")
+
+		// Node 3: should be nil (cleaned tombstone) - THIS IS THE CRITICAL CHECK
+		require.Nil(t, restoredState.Nodes[3], "node 3 should be nil (cleaned tombstone)")
+
+		// Node 4: should be normal node - position alignment check
+		require.NotNil(t, restoredState.Nodes[4], "node 4 should exist")
+		require.Equal(t, uint64(4), restoredState.Nodes[4].id)
+
+		// Node 5: should be nil (cleaned tombstone)
+		require.Nil(t, restoredState.Nodes[5], "node 5 should be nil (cleaned tombstone)")
+
+		// Nodes 6-9: verify position alignment was preserved
+		for i := 6; i < 10; i++ {
+			require.NotNil(t, restoredState.Nodes[i], "node %d should exist", i)
+			require.Equal(t, uint64(i), restoredState.Nodes[i].id, "node %d should have correct id", i)
+		}
+	})
 }
 
 var connsSlice1 = []uint64{


### PR DESCRIPTION
When a node had both a tombstone and the tombstone was cleaned                                                                           (TombstonesDeleted), the snapshot writer would skip writing the
nil marker due to an erroneous `continue` statement. This caused
position misalignment in the snapshot, leading to phantom nodes
after restart that could cause "relativeID out of bounds" errors
during cold-cache multi-vector searches.

The fix removes the `continue` and restructures the code so cleaned tombstone nodes fall through to the block-writing logic, preserving position alignment.

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
