### PR TITLE
Collection export: Speed up snapshotting with concurrent tenant de-activation

### DIFF
--- a/adapters/repos/db/export.go
+++ b/adapters/repos/db/export.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"sync/atomic"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
@@ -199,81 +200,66 @@ func (i *Index) snapshotShardsForExport(ctx context.Context, shardNames []string
 		results[idx].ShardName = name
 	}
 
-	// Snapshot with non-blocking TryRLock so that shards whose lock is held
-	// by a concurrent operation (e.g. tenant deactivation) are deferred.
-	// Each iteration processes the uncontested shards; the loop retries the
-	// rest until every shard has been handled or the context is cancelled.
-	pending := make([]int, len(shardNames))
-	for idx := range shardNames {
-		pending[idx] = idx
-	}
-
-	for len(pending) > 0 {
-		pending = i.trySnapshotShards(ctx, pending, shardNames, exportID, class, isMT, snapshotsRoot, results)
-		if ctx.Err() != nil {
-			cleanupSnapshotResults(results)
-			return nil, ctx.Err()
-		}
-	}
-
-	return results, nil
-}
-
-// trySnapshotShards attempts to snapshot each shard in pending using a
-// non-blocking TryRLock. Successfully locked shards are snapshotted; the
-// rest are returned so the caller can retry.
-func (i *Index) trySnapshotShards(
-	ctx context.Context,
-	pending []int,
-	shardNames []string,
-	exportID string,
-	class *models.Class,
-	isMT bool,
-	snapshotsRoot string,
-	results []export.ShardSnapshotResult,
-) (deferred []int) {
+	// Dispatch loop with TryRLock: shards whose lock is held by a concurrent
+	// operation (e.g. tenant deactivation) are re-queued so uncontested shards
+	// proceed without waiting. The error group's SetLimit caps parallelism;
+	// eg.Go blocks the dispatcher when all slots are busy.
 	eg, egCtx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
 	eg.SetLimit(runtime.GOMAXPROCS(0))
 
-	// One flag per pending entry; written only by the owning goroutine.
-	contested := make([]bool, len(pending))
+	retry := make(chan int, len(shardNames))
+	for idx := range shardNames {
+		retry <- idx
+	}
 
-	for i2, idx := range pending {
-		shardName := shardNames[idx]
+	var remaining atomic.Int64
+	remaining.Store(int64(len(shardNames)))
+	done := make(chan struct{})
 
-		eg.Go(func() error {
-			if !i.shardCreateLocks.TryRLock(shardName) {
-				contested[i2] = true
+shardLoop:
+	for {
+		select {
+		case <-done:
+			break shardLoop
+		case <-egCtx.Done():
+			break shardLoop
+		case idx := <-retry:
+			shardName := shardNames[idx]
+
+			eg.Go(func() error {
+				if !i.shardCreateLocks.TryRLock(shardName) {
+					retry <- idx
+					return nil
+				}
+				defer i.shardCreateLocks.RUnlock(shardName)
+
+				snapshotName := lsmkv.SafeSnapshotName(exportID, string(i.Config.ClassName), shardName)
+				snapResult, skipReason, err := i.snapshotLocalShardLocked(
+					egCtx, class, isMT, shardName, snapshotsRoot, snapshotName)
+				if err != nil {
+					return fmt.Errorf("snapshot shard %s/%s: %w", i.Config.ClassName, shardName, err)
+				}
+				if snapResult == nil {
+					results[idx].SkipReason = skipReason
+				} else {
+					results[idx].SnapshotDir = snapResult.SnapshotDir
+					results[idx].Strategy = snapResult.Strategy
+				}
+
+				if remaining.Add(-1) == 0 {
+					close(done)
+				}
 				return nil
-			}
-			defer i.shardCreateLocks.RUnlock(shardName)
-
-			snapshotName := lsmkv.SafeSnapshotName(exportID, string(i.Config.ClassName), shardName)
-			snapResult, skipReason, err := i.snapshotLocalShardLocked(egCtx, class, isMT, shardName, snapshotsRoot, snapshotName)
-			if err != nil {
-				return fmt.Errorf("snapshot shard %s/%s: %w", i.Config.ClassName, shardName, err)
-			}
-			if snapResult == nil {
-				results[idx].SkipReason = skipReason
-			} else {
-				results[idx].SnapshotDir = snapResult.SnapshotDir
-				results[idx].Strategy = snapResult.Strategy
-			}
-			return nil
-		}, shardName)
+			}, shardName)
+		}
 	}
 
 	if err := eg.Wait(); err != nil {
 		cleanupSnapshotResults(results)
-		return nil
+		return nil, err
 	}
 
-	for j, skip := range contested {
-		if skip {
-			deferred = append(deferred, pending[j])
-		}
-	}
-	return deferred
+	return results, nil
 }
 
 func cleanupSnapshotResults(results []export.ShardSnapshotResult) {

--- a/adapters/repos/db/export.go
+++ b/adapters/repos/db/export.go
@@ -19,6 +19,7 @@ import (
 	"runtime"
 	"sort"
 	"sync/atomic"
+	"time"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
@@ -29,6 +30,14 @@ import (
 	"github.com/weaviate/weaviate/usecases/multitenancy"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
+
+// lockPollInterval is how long a snapshot worker sleeps between TryRLock
+// attempts while waiting for a contended shardCreateLocks entry. It also
+// rate-limits the re-queue path to avoid goroutine churn when many shards
+// are write-locked simultaneously. Short enough that the added latency
+// (vs. event-driven wake-up) is negligible compared to typical lock hold
+// times (shard load/unload), long enough to keep CPU overhead trivial.
+const lockPollInterval = 5 * time.Millisecond
 
 // ShardOwnership returns a map of node name to shard names for a given class.
 // Shards are distributed across their replica nodes using a least-loaded
@@ -194,6 +203,10 @@ func (i *Index) snapshotShardsForExport(ctx context.Context, shardNames []string
 	isMT := multitenancy.IsMultiTenant(class.MultiTenancyConfig)
 	snapshotsRoot := i.snapshotsPath()
 
+	if len(shardNames) == 0 {
+		return nil, nil
+	}
+
 	// Pre-allocate one result per shard
 	results := make([]export.ShardSnapshotResult, len(shardNames))
 	for idx, name := range shardNames {
@@ -205,7 +218,8 @@ func (i *Index) snapshotShardsForExport(ctx context.Context, shardNames []string
 	// proceed without waiting. The error group's SetLimit caps parallelism;
 	// eg.Go blocks the dispatcher when all slots are busy.
 	eg, egCtx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
-	eg.SetLimit(runtime.GOMAXPROCS(0))
+	workers := runtime.GOMAXPROCS(0)
+	eg.SetLimit(workers)
 
 	retry := make(chan int, len(shardNames))
 	for idx := range shardNames {
@@ -227,9 +241,23 @@ shardLoop:
 			shardName := shardNames[idx]
 
 			eg.Go(func() error {
-				if !i.shardCreateLocks.TryRLock(shardName) {
-					retry <- idx
-					return nil
+				// Acquire the shard's read lock. On contention we either
+				// yield the worker slot to another shard (when there are
+				// more shards than slots) or poll until the writer releases.
+				// Both paths respect egCtx so parent-context cancellation
+				// unblocks promptly, and the sleep caps CPU/goroutine churn
+				// when many shards are write-locked at once.
+				for !i.shardCreateLocks.TryRLock(shardName) {
+					select {
+					case <-egCtx.Done():
+						return egCtx.Err()
+					case <-time.After(lockPollInterval):
+					}
+					if remaining.Load() > int64(workers) {
+						// More shards than worker slots — let another shard use this slot.
+						retry <- idx
+						return nil
+					}
 				}
 				defer i.shardCreateLocks.RUnlock(shardName)
 
@@ -255,6 +283,10 @@ shardLoop:
 	}
 
 	if err := eg.Wait(); err != nil {
+		cleanupSnapshotResults(results)
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
 		cleanupSnapshotResults(results)
 		return nil, err
 	}

--- a/adapters/repos/db/export.go
+++ b/adapters/repos/db/export.go
@@ -245,18 +245,33 @@ shardLoop:
 				// yield the worker slot to another shard (when there are
 				// more shards than slots) or poll until the writer releases.
 				// Both paths respect egCtx so parent-context cancellation
-				// unblocks promptly, and the sleep caps CPU/goroutine churn
-				// when many shards are write-locked at once.
-				for !i.shardCreateLocks.TryRLock(shardName) {
-					select {
-					case <-egCtx.Done():
-						return egCtx.Err()
-					case <-time.After(lockPollInterval):
-					}
-					if remaining.Load() > int64(workers) {
-						// More shards than worker slots — let another shard use this slot.
-						retry <- idx
-						return nil
+				// unblocks promptly, and the ticker caps CPU/goroutine churn
+				// when many shards are write-locked at once. The ticker is
+				// only allocated on the contended path so uncontested shards
+				// pay no timer overhead.
+				if !i.shardCreateLocks.TryRLock(shardName) {
+					ticker := time.NewTicker(lockPollInterval)
+					defer ticker.Stop()
+					for {
+						select {
+						case <-egCtx.Done():
+							return egCtx.Err()
+						case <-ticker.C:
+						}
+						if remaining.Load() > int64(workers) {
+							// More shards than worker slots — let another shard use this slot.
+							// Guard the send with egCtx so we never block if the dispatcher
+							// has already exited (e.g. via cancellation).
+							select {
+							case retry <- idx:
+								return nil
+							case <-egCtx.Done():
+								return egCtx.Err()
+							}
+						}
+						if i.shardCreateLocks.TryRLock(shardName) {
+							break
+						}
 					}
 				}
 				defer i.shardCreateLocks.RUnlock(shardName)

--- a/adapters/repos/db/export.go
+++ b/adapters/repos/db/export.go
@@ -193,19 +193,63 @@ func (i *Index) snapshotShardsForExport(ctx context.Context, shardNames []string
 	isMT := multitenancy.IsMultiTenant(class.MultiTenancyConfig)
 	snapshotsRoot := i.snapshotsPath()
 
-	// Pre-allocate one result per shard. Each goroutine writes to its own
-	// index so no synchronisation is needed on the slice elements.
+	// Pre-allocate one result per shard
 	results := make([]export.ShardSnapshotResult, len(shardNames))
+	for idx, name := range shardNames {
+		results[idx].ShardName = name
+	}
 
+	// Snapshot with non-blocking TryRLock so that shards whose lock is held
+	// by a concurrent operation (e.g. tenant deactivation) are deferred.
+	// Each iteration processes the uncontested shards; the loop retries the
+	// rest until every shard has been handled or the context is cancelled.
+	pending := make([]int, len(shardNames))
+	for idx := range shardNames {
+		pending[idx] = idx
+	}
+
+	for len(pending) > 0 {
+		pending = i.trySnapshotShards(ctx, pending, shardNames, exportID, class, isMT, snapshotsRoot, results)
+		if ctx.Err() != nil {
+			cleanupSnapshotResults(results)
+			return nil, ctx.Err()
+		}
+	}
+
+	return results, nil
+}
+
+// trySnapshotShards attempts to snapshot each shard in pending using a
+// non-blocking TryRLock. Successfully locked shards are snapshotted; the
+// rest are returned so the caller can retry.
+func (i *Index) trySnapshotShards(
+	ctx context.Context,
+	pending []int,
+	shardNames []string,
+	exportID string,
+	class *models.Class,
+	isMT bool,
+	snapshotsRoot string,
+	results []export.ShardSnapshotResult,
+) (deferred []int) {
 	eg, egCtx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
 	eg.SetLimit(runtime.GOMAXPROCS(0))
 
-	for idx, shardName := range shardNames {
-		results[idx].ShardName = shardName
+	// One flag per pending entry; written only by the owning goroutine.
+	contested := make([]bool, len(pending))
+
+	for i2, idx := range pending {
+		shardName := shardNames[idx]
 
 		eg.Go(func() error {
+			if !i.shardCreateLocks.TryRLock(shardName) {
+				contested[i2] = true
+				return nil
+			}
+			defer i.shardCreateLocks.RUnlock(shardName)
+
 			snapshotName := lsmkv.SafeSnapshotName(exportID, string(i.Config.ClassName), shardName)
-			snapResult, skipReason, err := i.snapshotLocalShard(egCtx, class, isMT, shardName, snapshotsRoot, snapshotName)
+			snapResult, skipReason, err := i.snapshotLocalShardLocked(egCtx, class, isMT, shardName, snapshotsRoot, snapshotName)
 			if err != nil {
 				return fmt.Errorf("snapshot shard %s/%s: %w", i.Config.ClassName, shardName, err)
 			}
@@ -220,17 +264,24 @@ func (i *Index) snapshotShardsForExport(ctx context.Context, shardNames []string
 	}
 
 	if err := eg.Wait(); err != nil {
-		// Clean up any snapshot dirs created by goroutines that succeeded
-		// before the error group was cancelled.
-		for _, r := range results {
-			if r.SnapshotDir != "" {
-				os.RemoveAll(r.SnapshotDir)
-			}
-		}
-		return nil, err
+		cleanupSnapshotResults(results)
+		return nil
 	}
 
-	return results, nil
+	for j, skip := range contested {
+		if skip {
+			deferred = append(deferred, pending[j])
+		}
+	}
+	return deferred
+}
+
+func cleanupSnapshotResults(results []export.ShardSnapshotResult) {
+	for _, r := range results {
+		if r.SnapshotDir != "" {
+			os.RemoveAll(r.SnapshotDir)
+		}
+	}
 }
 
 // shouldSkipTenant checks the RAFT-based tenant status and returns a skip
@@ -259,26 +310,13 @@ func (i *Index) shouldSkipTenant(class *models.Class, shardName string) (string,
 	}
 }
 
-// snapshotLocalShard snapshots a shard based on its local state. This method holds
-// shardCreateLocks.RLock for the entire operation to prevent races with concurrent
-// shard loading/unloading.
-//
-// For MT classes the tenant status check (shouldSkipTenant) runs under the
-// same lock so that the status cannot change between the check and the
-// snapshot.
-//
-// The local state determines *how* to snapshot: if the shard is loaded
-// (including unloaded lazy shards) it is snapshotted from the live bucket;
-// if not, it is snapshotted directly from disk.
-func (i *Index) snapshotLocalShard(
+// snapshotLocalShardLocked snapshots a shard based on its local state.
+// The caller must hold shardCreateLocks.RLock(shardName) for the duration
+// of the call.
+func (i *Index) snapshotLocalShardLocked(
 	ctx context.Context, class *models.Class, isMT bool, shardName string,
 	snapshotsRoot, snapshotName string,
 ) (*export.ShardSnapshotResult, string, error) {
-	// Hold the shard lock for the entire operation so that no concurrent
-	// load/unload can change the local shard state during the snapshot.
-	i.shardCreateLocks.RLock(shardName)
-	defer i.shardCreateLocks.RUnlock(shardName)
-
 	if isMT {
 		// this is using the RAFT state and not the local state, so there might be a race between these two. We accept
 		// this here as any action concurrent with the export might or might not be reflected in the export.

--- a/adapters/repos/db/export_test.go
+++ b/adapters/repos/db/export_test.go
@@ -12,9 +12,17 @@
 package db
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	esync "github.com/weaviate/weaviate/entities/sync"
 )
 
 func TestAssignShardsToNodes(t *testing.T) {
@@ -98,5 +106,81 @@ func TestAssignShardsToNodes(t *testing.T) {
 			result := assignShardsToNodes(tt.input)
 			assert.Equal(t, tt.expected, result)
 		})
+	}
+}
+
+func newTestIndexForSnapshot(t *testing.T, className string) *Index {
+	t.Helper()
+	return &Index{
+		Config: IndexConfig{
+			RootPath:  t.TempDir(),
+			ClassName: schema.ClassName(className),
+		},
+		getSchema: &fakeSchemaGetter{
+			schema: schema.Schema{
+				Objects: &models.Schema{
+					Classes: []*models.Class{{Class: className}},
+				},
+			},
+		},
+		logger:           logrus.New(),
+		shardCreateLocks: esync.NewKeyRWLocker(),
+	}
+}
+
+// TestSnapshotShardsForExport_EmptyShardNames asserts that passing an empty
+// shardNames slice returns immediately with no results and no error. Without
+// the early return, the dispatch loop blocks forever on a select with an empty
+// retry channel and a done channel that nobody closes.
+func TestSnapshotShardsForExport_EmptyShardNames(t *testing.T) {
+	idx := newTestIndexForSnapshot(t, "TestClass")
+
+	done := make(chan error, 1)
+	go func() {
+		res, err := idx.snapshotShardsForExport(context.Background(), nil, "export-id")
+		assert.Empty(t, res)
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(5 * time.Second):
+		t.Fatal("snapshotShardsForExport hung on empty shardNames — dispatch loop deadlock")
+	}
+}
+
+// TestSnapshotShardsForExport_CancelUnblocksLockedShard asserts that a
+// write-locked shard doesn't prevent context cancellation from unblocking
+// snapshotShardsForExport. The worker polls TryRLock with a select on
+// egCtx.Done(), so when the parent ctx is cancelled the function must
+// return within a short interval regardless of lock state.
+func TestSnapshotShardsForExport_CancelUnblocksLockedShard(t *testing.T) {
+	idx := newTestIndexForSnapshot(t, "TestClass")
+
+	// Write-lock the shard so TryRLock always fails.
+	shardName := "shard-0"
+	idx.shardCreateLocks.Lock(shardName)
+	defer idx.shardCreateLocks.Unlock(shardName)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := idx.snapshotShardsForExport(ctx, []string{shardName}, "export-id")
+		done <- err
+	}()
+
+	// Let the worker enter the polling loop.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(2 * time.Second):
+		t.Fatal("snapshotShardsForExport did not respect context cancellation while holding a contended lock")
 	}
 }

--- a/adapters/repos/db/export_test.go
+++ b/adapters/repos/db/export_test.go
@@ -166,19 +166,30 @@ func TestSnapshotShardsForExport_CancelUnblocksLockedShard(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	started := make(chan struct{})
 	done := make(chan error, 1)
 	go func() {
+		close(started)
 		_, err := idx.snapshotShardsForExport(ctx, []string{shardName}, "export-id")
 		done <- err
 	}()
+	<-started
 
-	// Let the worker enter the polling loop.
-	time.Sleep(50 * time.Millisecond)
+	// Confirm the function is actually blocking (worker is in the polling
+	// loop) before cancelling — otherwise we could end up testing the
+	// dispatcher-exit path instead of the polling-loop-exit path. A few
+	// poll intervals are plenty to enter the select on the ticker; if the
+	// function returns during this window the test setup is broken.
+	select {
+	case err := <-done:
+		t.Fatalf("snapshotShardsForExport returned before cancellation (lock not actually contended): %v", err)
+	case <-time.After(4 * lockPollInterval):
+	}
+
 	cancel()
 
 	select {
 	case err := <-done:
-		require.Error(t, err)
 		require.ErrorIs(t, err, context.Canceled)
 	case <-time.After(2 * time.Second):
 		t.Fatal("snapshotShardsForExport did not respect context cancellation while holding a contended lock")

--- a/entities/sync/sync.go
+++ b/entities/sync/sync.go
@@ -106,6 +106,16 @@ func (s *KeyRWLocker) RLock(ID string) {
 	iLock.RLock()
 }
 
+// TryRLock attempts to acquire a read lock without blocking.
+// Returns true if the lock was acquired, false otherwise.
+func (s *KeyRWLocker) TryRLock(ID string) bool {
+	iLock := &sync.RWMutex{}
+	iLocks, _ := s.m.LoadOrStore(ID, iLock)
+
+	iLock = iLocks.(*sync.RWMutex)
+	return iLock.TryRLock()
+}
+
 // RUnlock it runlocks a specific item by it's ID
 func (s *KeyRWLocker) RUnlock(ID string) {
 	iLocks, _ := s.m.Load(ID)

--- a/entities/sync/sync_test.go
+++ b/entities/sync/sync_test.go
@@ -312,6 +312,32 @@ func TestKeyRWLockerLockUnlock(t *testing.T) {
 	r.False(rwMutexRLocked(lock.(*sync.RWMutex)))
 }
 
+func TestKeyRWLockerTryRLock(t *testing.T) {
+	s := NewKeyRWLocker()
+
+	t.Run("succeeds when unlocked", func(t *testing.T) {
+		require.True(t, s.TryRLock("k1"))
+		s.RUnlock("k1")
+	})
+
+	t.Run("succeeds multiple times (shared read lock)", func(t *testing.T) {
+		require.True(t, s.TryRLock("k2"))
+		require.True(t, s.TryRLock("k2"))
+		s.RUnlock("k2")
+		s.RUnlock("k2")
+	})
+
+	t.Run("fails when write-locked", func(t *testing.T) {
+		s.Lock("k3")
+		require.False(t, s.TryRLock("k3"))
+		s.Unlock("k3")
+
+		// succeeds again after unlock
+		require.True(t, s.TryRLock("k3"))
+		s.RUnlock("k3")
+	})
+}
+
 func TestContextMutex(t *testing.T) {
 	m := newContextMutex()
 	require.False(t, contextMutexLocked(m))

--- a/usecases/export/participant.go
+++ b/usecases/export/participant.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	reservationTimeout          = 30 * time.Second
+	reservationTimeout          = 2 * time.Minute
 	defaultStatusFlushInterval  = 10 * time.Second
 	defaultSiblingCheckInterval = 1 * time.Minute
 


### PR DESCRIPTION
### What's being changed:

Exports against multi-tenant classes could hang (and time out the 2PC reservation) when a tenant operation (deactivation etc) was concurrently holding the shard's write lock (shardCreateLocks).

Now we use a TryLock and re-queue the shard in case the lock is already blocked by someone else. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
