### PR TITLE
Fix S3 backup client: HomeDir path doubling and Initialize cleanup with path overrides

### DIFF
--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -91,24 +91,20 @@ func (s *s3Client) getClient(ctx context.Context) (*minio.Client, error) {
 	return s.client, nil
 }
 
-func (s *s3Client) makeObjectName(parts ...string) string {
+func (s *s3Client) makeObjectName(overridePath string, parts ...string) string {
 	base := path.Join(parts...)
+	if overridePath != "" {
+		return path.Join(overridePath, base)
+	}
 	return path.Join(s.config.BackupPath, base)
 }
 
 func (s *s3Client) HomeDir(backupID, overrideBucket, overridePath string) string {
 	remoteBucket := s.config.Bucket
-	remotePath := s.config.BackupPath
-
-	if overridePath != "" {
-		remotePath = path.Join(overridePath)
-	}
-
 	if overrideBucket != "" {
 		remoteBucket = overrideBucket
 	}
-
-	return "s3://" + path.Join(remoteBucket, remotePath, backupID)
+	return "s3://" + path.Join(remoteBucket, s.makeObjectName(overridePath, backupID))
 }
 
 func (s *s3Client) AllBackups(ctx context.Context,
@@ -168,11 +164,7 @@ func (s *s3Client) GetObject(ctx context.Context, backupID, key, overrideBucket,
 	if err != nil {
 		return nil, errors.Wrap(err, "get object: failed to get client")
 	}
-	remotePath := s.makeObjectName(backupID, key)
-
-	if overridePath != "" {
-		remotePath = path.Join(overridePath, backupID, key)
-	}
+	remotePath := s.makeObjectName(overridePath, backupID, key)
 
 	bucket := s.config.Bucket
 	if overrideBucket != "" {
@@ -217,7 +209,7 @@ func (s *s3Client) PutObject(ctx context.Context, backupID, key, overrideBucket,
 		return errors.Wrap(err, "put object: failed to get client")
 	}
 
-	remotePath := s.makeObjectName(backupID, key)
+	remotePath := s.makeObjectName(overridePath, backupID, key)
 	opt := minio.PutObjectOptions{
 		ContentType:    "application/octet-stream",
 		PartSize:       MINIO_MIN_PART_SIZE,
@@ -225,10 +217,6 @@ func (s *s3Client) PutObject(ctx context.Context, backupID, key, overrideBucket,
 	}
 	reader := bytes.NewReader(byes)
 	objectSize := int64(len(byes))
-
-	if overridePath != "" {
-		remotePath = path.Join(overridePath, backupID, key)
-	}
 
 	bucket := s.config.Bucket
 	if overrideBucket != "" {
@@ -260,9 +248,13 @@ func (s *s3Client) Initialize(ctx context.Context, backupID, overrideBucket, ove
 		return errors.Wrap(err, "failed to access-check s3 backup module")
 	}
 
-	objectName := s.makeObjectName(backupID, key)
+	bucket := s.config.Bucket
+	if overrideBucket != "" {
+		bucket = overrideBucket
+	}
+	objectName := s.makeObjectName(overridePath, backupID, key)
 	opt := minio.RemoveObjectOptions{}
-	if err := client.RemoveObject(ctx, s.config.Bucket, objectName, opt); err != nil {
+	if err := client.RemoveObject(ctx, bucket, objectName, opt); err != nil {
 		return errors.Wrap(err, "failed to remove access-check s3 backup module")
 	}
 
@@ -275,10 +267,7 @@ func (s *s3Client) WriteToFile(ctx context.Context, backupID, key, destPath, ove
 	if err != nil {
 		return errors.Wrap(err, "write to file: cannot get client")
 	}
-	remotePath := s.makeObjectName(backupID, key)
-	if overridePath != "" {
-		remotePath = path.Join(overridePath, backupID, key)
-	}
+	remotePath := s.makeObjectName(overridePath, backupID, key)
 
 	bucket := s.config.Bucket
 	if overrideBucket != "" {
@@ -310,16 +299,12 @@ func (s *s3Client) Write(ctx context.Context, backupID, key, overrideBucket, ove
 	if err != nil {
 		return -1, errors.Wrap(err, "write: cannot get client")
 	}
-	remotePath := s.makeObjectName(backupID, key)
+	remotePath := s.makeObjectName(overridePath, backupID, key)
 	opt := minio.PutObjectOptions{
 		ContentType:      "application/octet-stream",
 		DisableMultipart: false,
 		PartSize:         MINIO_MIN_PART_SIZE,
 		SendContentMd5:   true,
-	}
-
-	if overridePath != "" {
-		remotePath = path.Join(overridePath, backupID, key)
 	}
 
 	bucket := s.config.Bucket
@@ -345,11 +330,7 @@ func (s *s3Client) Read(ctx context.Context, backupID, key, overrideBucket, over
 	if err != nil {
 		return -1, errors.Wrap(err, "read: cannot get client")
 	}
-	remotePath := s.makeObjectName(backupID, key)
-
-	if overridePath != "" {
-		remotePath = path.Join(overridePath, backupID, key)
-	}
+	remotePath := s.makeObjectName(overridePath, backupID, key)
 
 	bucket := s.config.Bucket
 	if overrideBucket != "" {

--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -108,7 +108,7 @@ func (s *s3Client) HomeDir(backupID, overrideBucket, overridePath string) string
 		remoteBucket = overrideBucket
 	}
 
-	return "s3://" + path.Join(remoteBucket, remotePath, s.makeObjectName(backupID))
+	return "s3://" + path.Join(remoteBucket, remotePath, backupID)
 }
 
 func (s *s3Client) AllBackups(ctx context.Context,

--- a/modules/backup-s3/client_test.go
+++ b/modules/backup-s3/client_test.go
@@ -1,0 +1,133 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modstgs3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMakeObjectName(t *testing.T) {
+	tests := []struct {
+		name         string
+		backupPath   string
+		overridePath string
+		parts        []string
+		expected     string
+	}{
+		{
+			name:       "no override uses BackupPath",
+			backupPath: "base/path",
+			parts:      []string{"backup-id", "file.json"},
+			expected:   "base/path/backup-id/file.json",
+		},
+		{
+			name:         "override replaces BackupPath entirely",
+			backupPath:   "base/path",
+			overridePath: "override/path",
+			parts:        []string{"backup-id", "file.json"},
+			expected:     "override/path/backup-id/file.json",
+		},
+		{
+			name:     "empty BackupPath no override",
+			parts:    []string{"backup-id", "key"},
+			expected: "backup-id/key",
+		},
+		{
+			name:         "override with empty BackupPath",
+			overridePath: "tenant-id",
+			parts:        []string{"export-1"},
+			expected:     "tenant-id/export-1",
+		},
+		{
+			name:         "same override and BackupPath do not double",
+			backupPath:   "tenant-id",
+			overridePath: "tenant-id",
+			parts:        []string{"export-1", "meta.json"},
+			expected:     "tenant-id/export-1/meta.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &s3Client{config: &clientConfig{BackupPath: tt.backupPath}}
+			got := c.makeObjectName(tt.overridePath, tt.parts...)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+func TestHomeDir(t *testing.T) {
+	tests := []struct {
+		name           string
+		backupPath     string
+		bucket         string
+		backupID       string
+		overrideBucket string
+		overridePath   string
+		expected       string
+	}{
+		{
+			name:     "default bucket, empty BackupPath",
+			bucket:   "my-bucket",
+			backupID: "backup-1",
+			expected: "s3://my-bucket/backup-1",
+		},
+		{
+			name:       "non-empty BackupPath, no override",
+			bucket:     "my-bucket",
+			backupPath: "tenant-id",
+			backupID:   "backup-1",
+			expected:   "s3://my-bucket/tenant-id/backup-1",
+		},
+		{
+			name:           "override path only",
+			bucket:         "my-bucket",
+			backupID:       "backup-1",
+			overrideBucket: "my-bucket",
+			overridePath:   "override-path",
+			expected:       "s3://my-bucket/override-path/backup-1",
+		},
+		{
+			name:           "override both bucket and path",
+			bucket:         "my-bucket",
+			backupPath:     "default-path",
+			backupID:       "backup-1",
+			overrideBucket: "other-bucket",
+			overridePath:   "tenant-path",
+			expected:       "s3://other-bucket/tenant-path/backup-1",
+		},
+		{
+			// Regression: when BackupPath == overridePath the path must not appear twice.
+			// This was the original bug reported against WCS exports.
+			name:           "override path equals BackupPath does not duplicate segment",
+			bucket:         "my-bucket",
+			backupPath:     "tenant-id",
+			backupID:       "export-1",
+			overrideBucket: "my-bucket",
+			overridePath:   "tenant-id",
+			expected:       "s3://my-bucket/tenant-id/export-1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &s3Client{config: &clientConfig{
+				Bucket:     tt.bucket,
+				BackupPath: tt.backupPath,
+			}}
+			got := c.HomeDir(tt.backupID, tt.overrideBucket, tt.overridePath)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}

--- a/test/modules/backup-s3/backup_backend_test.go
+++ b/test/modules/backup-s3/backup_backend_test.go
@@ -109,6 +109,16 @@ func moduleLevelStoreBackupMeta(t *testing.T, override bool, containerName, over
 			assert.Nil(t, err)
 		})
 
+		t.Run("access-check object is cleaned up after Initialize", func(t *testing.T) {
+			// Initialize must remove the temporary access-check probe from the
+			// correct bucket/path. If it used the wrong location the probe would
+			// be left behind and this GetObject call would succeed instead of
+			// returning ErrNotFound.
+			_, err := s3.GetObject(testCtx, backupID, "access-check", overrideBucket, overridePath)
+			assert.IsType(t, backup.ErrNotFound{}, err,
+				"access-check object should be removed after Initialize; got err: %v", err)
+		})
+
 		t.Run("backup meta does not exist yet", func(t *testing.T) {
 			meta, err := s3.GetObject(testCtx, backupID, metadataFilename, overrideBucket, overridePath)
 			assert.Nil(t, meta)


### PR DESCRIPTION
## Motivation

Two bugs in the S3 backup client caused problems for WCS-style exports and backups where `overrideBucket` / `overridePath` differ from the module's default config:

1. **`HomeDir` doubled the path segment** when `overridePath` was equal to `config.BackupPath`. The old code set `remotePath = overridePath` then called `makeObjectName(backupID)` — which always prepended `config.BackupPath`. When both values were the same tenant-scoped prefix (a common WCS pattern), the segment appeared twice in the returned URI.

2. **`Initialize` leaked its access-check probe object** when either override was set. It called `PutObject` (which already handled the overrides) to write the probe, but removed it using `makeObjectName` without the override *and* against `config.Bucket` instead of `overrideBucket`. The mismatch left the probe orphaned, bypassing the cleanup intended to confirm write-then-delete access.

## Approach

The root cause of both bugs was that `makeObjectName` unconditionally prepended `config.BackupPath`, forcing every caller to manually redo the override logic in parallel — an error-prone pattern that GCS and Azure had already moved away from.

The fix aligns S3 with the GCS/Azure pattern: `makeObjectName` now takes `overridePath` as its first argument and uses it in place of `config.BackupPath` when non-empty. All per-method override blocks are deleted; `makeObjectName` is the single source of truth for path construction.

`Initialize` also gains the missing `overrideBucket` resolution that was already present in every other method.

## Key areas for review

- `modules/backup-s3/client.go:makeObjectName` — the refactored helper; verify that the override-vs-default branching matches the GCS/Azure implementations exactly
- `modules/backup-s3/client.go:HomeDir` — previously called `makeObjectName(backupID)` after setting `remotePath`; now delegates fully to `makeObjectName(overridePath, backupID)`
- `modules/backup-s3/client.go:Initialize` — the bucket resolution that was missing before; the probe is now written and removed from the same bucket/path

## Risks and mitigations

- **Path regression for existing backups**: `makeObjectName` behaviour is identical when `overridePath` is empty — it falls through to `config.BackupPath`, same as before. No on-disk path changes for users not using the override parameter.
- **Behaviour change for override users**: any caller that previously supplied `overridePath` equal to `config.BackupPath` would have gotten a doubled path. After this change they get the correct path. This is a bug fix, not a behavioural change for correct usage.
- **Initialize side-effects**: the probe is a temporary sentinel (written, then immediately deleted). Changing the delete target from the wrong bucket/path to the correct one means the probe is now reliably cleaned up. The only observable difference is the absence of an orphaned object — which the new integration-test assertion verifies.

## Testing

**Unit tests** (`modules/backup-s3/client_test.go` — new file):
- `TestMakeObjectName`: covers empty `BackupPath`, non-empty `BackupPath` with no override, override replacing `BackupPath`, and the regression case where both are equal (confirming no doubling).
- `TestHomeDir`: covers all four combinations of default/override bucket and path, plus the explicit regression case for the doubled-segment bug.

**Integration test** (`test/modules/backup-s3/backup_backend_test.go`): after `Initialize` completes (with and without overrides), asserts that a `GetObject` for the `access-check` key returns `ErrNotFound` — proving the probe was written to and deleted from the correct location.

🤖 Generated with [Claude Code](https://claude.com/claude-code)