### PR TITLE
chore: disable alter schema endpoints with environment setting

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -35,6 +35,7 @@ services:
       TRACK_VECTOR_DIMENSIONS: "true"
       QUERY_MAXIMUM_RESULTS: 10005
       OBJECTS_TTL_DELETE_SCHEDULE: "@every 12h"
+      ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS: "true"
 
       # necessary for the metrics tests, some metrics only exist once segments
       # are flushed. If we wait to long the before run is completely in

--- a/test/acceptance/alter_schema/alter_schema_test.go
+++ b/test/acceptance/alter_schema/alter_schema_test.go
@@ -28,6 +28,7 @@ func TestProperties_SingleNode(t *testing.T) {
 		ctx := context.Background()
 		compose, err = docker.New().
 			WithWeaviate().
+			WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS", "true").
 			WithText2VecModel2Vec().
 			Start(ctx)
 		require.NoError(t, err)
@@ -55,6 +56,7 @@ func TestProperties_Cluster(t *testing.T) {
 	ctx := context.Background()
 	compose, err := docker.New().
 		WithWeaviateCluster(3).
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS", "true").
 		WithText2VecModel2Vec().
 		Start(ctx)
 	require.NoError(t, err)

--- a/test/acceptance/authz/alter_schema_operations_test.go
+++ b/test/acceptance/authz/alter_schema_operations_test.go
@@ -31,10 +31,12 @@ func TestAuthzDeleteClassPropertyIndex(t *testing.T) {
 	customUser := "custom-user"
 	customKey := "custom-key"
 
-	_, down := composeUp(t,
+	_, down := composeUpWithSettings(t,
 		map[string]string{adminUser: adminKey},
 		map[string]string{customUser: customKey},
 		nil,
+		false,
+		map[string]string{"ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS": "true"},
 	)
 	defer down()
 

--- a/test/acceptance/authz/setup.go
+++ b/test/acceptance/authz/setup.go
@@ -22,13 +22,20 @@ import (
 )
 
 func composeUp(t *testing.T, admins map[string]string, users map[string]string, viewers map[string]string) (*docker.DockerCompose, func()) {
-	return composeUpWithMCP(t, admins, users, viewers, false)
+	return composeUpWithSettings(t, admins, users, viewers, false, nil)
 }
 
 func composeUpWithMCP(t *testing.T, admins map[string]string, users map[string]string, viewers map[string]string, enableMCP bool) (*docker.DockerCompose, func()) {
+	return composeUpWithSettings(t, admins, users, viewers, enableMCP, nil)
+}
+
+func composeUpWithSettings(t *testing.T, admins map[string]string, users map[string]string, viewers map[string]string, enableMCP bool, weaviateEnvs map[string]string) (*docker.DockerCompose, func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 
 	builder := docker.New().WithWeaviateEnv("AUTOSCHEMA_ENABLED", "false").WithWeaviateWithGRPC().WithRBAC().WithApiKey()
+	for key, val := range weaviateEnvs {
+		builder = builder.WithWeaviateEnv(key, val)
+	}
 
 	// Enable MCP server if requested
 	if enableMCP {

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -193,6 +193,7 @@ func Test_Schema_Authorization(t *testing.T) {
 
 	t.Run("verify the tested methods require correct permissions from the Authorizer", func(t *testing.T) {
 		principal := &models.Principal{}
+		t.Setenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS", "true")
 		for _, test := range tests {
 			t.Run(test.methodName, func(t *testing.T) {
 				authorizer := mocks.NewMockAuthorizer()

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -14,9 +14,11 @@ package schema
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	clusterSchema "github.com/weaviate/weaviate/cluster/schema"
+	entcfg "github.com/weaviate/weaviate/entities/config"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -98,6 +100,9 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 func (h *Handler) DeleteClassPropertyIndex(ctx context.Context, principal *models.Principal,
 	class *models.Class, className, propertyName, indexName string,
 ) error {
+	if !entcfg.Enabled(os.Getenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS")) {
+		return fmt.Errorf("alter schema endpoints are experimental and disabled by default, set the environment variable ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS=true to enable them")
+	}
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil {
 		return err
 	}
@@ -162,6 +167,9 @@ func (h *Handler) DeleteClassPropertyIndex(ctx context.Context, principal *model
 func (h *Handler) DeleteClassVectorIndex(ctx context.Context, principal *models.Principal,
 	className, vectorIndexName string,
 ) error {
+	if !entcfg.Enabled(os.Getenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS")) {
+		return fmt.Errorf("alter schema endpoints are experimental and disabled by default, set the environment variable ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS=true to enable them")
+	}
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil {
 		return err
 	}

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -784,6 +784,7 @@ func (pdt *fakePropertyDataType) ContainsClass(name schema.ClassName) bool {
 }
 
 func TestHandler_DeleteClassVectorIndex(t *testing.T) {
+	t.Setenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS", "true")
 	ctx := context.Background()
 
 	t.Run("class not found returns error", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

Gate the experimental alter schema endpoints (`DeleteClassPropertyIndex`, `DeleteClassVectorIndex`) behind the `ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS` environment variable. When the variable is not set or set to anything other than `true`, these endpoints return an error informing the user that the feature is experimental and how to enable it.

Acceptance tests are updated to set the env variable so they continue to pass.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.