### PR TITLE
[MCP] Refactor permissions

### DIFF
--- a/adapters/handlers/mcp/create/objects_upsert.go
+++ b/adapters/handlers/mcp/create/objects_upsert.go
@@ -30,11 +30,14 @@ func (c *WeaviateCreator) UpsertObject(ctx context.Context, req mcp.CallToolRequ
 	})
 	log.Debug("upserting objects")
 
-	// Authorize MCP-level update permission (covers upsert).
+	// Authorize MCP-level CREATE and UPDATE permissions (upsert requires both).
 	// Collection-level data authorization (CREATE/UPDATE per collection) is
 	// enforced by batchManager.AddObjects (see usecases/objects/batch_add.go).
-	principal, err := c.Authorize(ctx, req, authorization.UPDATE)
+	principal, err := c.Authorize(ctx, req, authorization.CREATE)
 	if err != nil {
+		return nil, err
+	}
+	if _, err := c.Authorize(ctx, req, authorization.UPDATE); err != nil {
 		return nil, err
 	}
 

--- a/adapters/handlers/mcp/create/objects_upsert.go
+++ b/adapters/handlers/mcp/create/objects_upsert.go
@@ -30,13 +30,11 @@ func (c *WeaviateCreator) UpsertObject(ctx context.Context, req mcp.CallToolRequ
 	})
 	log.Debug("upserting objects")
 
-	// Authorize for CREATE and UPDATE operations
-	principal, err := c.Authorize(ctx, req, authorization.CREATE)
+	// Authorize MCP-level update permission (covers upsert).
+	// Collection-level data authorization (CREATE/UPDATE per collection) is
+	// enforced by batchManager.AddObjects (see usecases/objects/batch_add.go).
+	principal, err := c.Authorize(ctx, req, authorization.UPDATE)
 	if err != nil {
-		return nil, err
-	}
-
-	if _, err := c.Authorize(ctx, req, authorization.UPDATE); err != nil {
 		return nil, err
 	}
 

--- a/adapters/handlers/mcp/create/schema.go
+++ b/adapters/handlers/mcp/create/schema.go
@@ -52,7 +52,7 @@ func Tools(creator *WeaviateCreator, configs map[string]internal.ToolConfig) []s
 			"Upserts (inserts or updates) one or more objects into a collection in batch. Supports batch operations for efficient bulk inserts and updates.")),
 		mcp.WithInputSchema[UpsertObjectArgs](),
 		mcp.WithReadOnlyHintAnnotation(false),
-		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(true),
 		mcp.WithIdempotentHintAnnotation(true),
 	)
 	internal.ApplySchemaDescriptions(&tool, toolName, configs)

--- a/adapters/handlers/mcp/create/schema.go
+++ b/adapters/handlers/mcp/create/schema.go
@@ -51,6 +51,9 @@ func Tools(creator *WeaviateCreator, configs map[string]internal.ToolConfig) []s
 		mcp.WithDescription(internal.GetDescription(configs, toolName,
 			"Upserts (inserts or updates) one or more objects into a collection in batch. Supports batch operations for efficient bulk inserts and updates.")),
 		mcp.WithInputSchema[UpsertObjectArgs](),
+		mcp.WithReadOnlyHintAnnotation(false),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
 	)
 	internal.ApplySchemaDescriptions(&tool, toolName, configs)
 	return []server.ServerTool{

--- a/adapters/handlers/mcp/read/schema.go
+++ b/adapters/handlers/mcp/read/schema.go
@@ -47,6 +47,9 @@ func Tools(reader *WeaviateReader, configs map[string]internal.ToolConfig) []ser
 		mcp.WithDescription(internal.GetDescription(configs, getConfigName,
 			"Retrieves collection configuration(s). If collection_name is provided, returns only that collection's config. Otherwise returns all collections.")),
 		mcp.WithInputSchema[GetCollectionConfigArgs](),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
 	)
 	internal.ApplySchemaDescriptions(&getConfigTool, getConfigName, configs)
 
@@ -56,6 +59,9 @@ func Tools(reader *WeaviateReader, configs map[string]internal.ToolConfig) []ser
 		mcp.WithDescription(internal.GetDescription(configs, tenantsName,
 			"Lists the tenants of a collection in the database.")),
 		mcp.WithInputSchema[GetTenantsArgs](),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
 	)
 	internal.ApplySchemaDescriptions(&tenantsTool, tenantsName, configs)
 

--- a/adapters/handlers/mcp/search/schema.go
+++ b/adapters/handlers/mcp/search/schema.go
@@ -47,6 +47,9 @@ func Tools(searcher *WeaviateSearcher, configs map[string]internal.ToolConfig) [
 		mcp.WithDescription(internal.GetDescription(configs, toolName,
 			"Performs hybrid search (vector + keyword) for data in a collection.")),
 		mcp.WithInputSchema[QueryHybridArgs](),
+		mcp.WithReadOnlyHintAnnotation(true),
+		mcp.WithDestructiveHintAnnotation(false),
+		mcp.WithIdempotentHintAnnotation(true),
 	)
 	internal.ApplySchemaDescriptions(&tool, toolName, configs)
 	return []server.ServerTool{

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -8409,6 +8409,7 @@ func init() {
             "delete_aliases",
             "assign_and_revoke_groups",
             "read_groups",
+            "create_mcp",
             "read_mcp",
             "update_mcp"
           ]
@@ -18806,6 +18807,7 @@ func init() {
             "delete_aliases",
             "assign_and_revoke_groups",
             "read_groups",
+            "create_mcp",
             "read_mcp",
             "update_mcp"
           ]

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -8409,7 +8409,8 @@ func init() {
             "delete_aliases",
             "assign_and_revoke_groups",
             "read_groups",
-            "manage_mcp"
+            "read_mcp",
+            "update_mcp"
           ]
         },
         "aliases": {
@@ -18809,7 +18810,8 @@ func init() {
             "delete_aliases",
             "assign_and_revoke_groups",
             "read_groups",
-            "manage_mcp"
+            "read_mcp",
+            "update_mcp"
           ]
         },
         "aliases": {

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -8486,10 +8486,6 @@ func init() {
             }
           }
         },
-        "mcp": {
-          "description": "resources applicable for MCP actions",
-          "type": "object"
-        },
         "nodes": {
           "description": "Resources applicable for cluster actions.",
           "type": "object",
@@ -18886,10 +18882,6 @@ func init() {
               "$ref": "#/definitions/GroupType"
             }
           }
-        },
-        "mcp": {
-          "description": "resources applicable for MCP actions",
-          "type": "object"
         },
         "nodes": {
           "description": "Resources applicable for cluster actions.",

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -51,9 +51,6 @@ type Permission struct {
 	// groups
 	Groups *PermissionGroups `json:"groups,omitempty"`
 
-	// resources applicable for MCP actions
-	Mcp interface{} `json:"mcp,omitempty"`
-
 	// nodes
 	Nodes *PermissionNodes `json:"nodes,omitempty"`
 

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -30,10 +30,9 @@ import (
 //
 // swagger:model Permission
 type Permission struct {
-
 	// Allowed actions in weaviate.
 	// Required: true
-	// Enum: [manage_backups read_cluster create_data read_data update_data delete_data read_nodes create_roles read_roles update_roles delete_roles create_collections read_collections update_collections delete_collections assign_and_revoke_users create_users read_users update_users delete_users create_tenants read_tenants update_tenants delete_tenants create_replicate read_replicate update_replicate delete_replicate create_aliases read_aliases update_aliases delete_aliases assign_and_revoke_groups read_groups manage_mcp]
+	// Enum: [manage_backups read_cluster create_data read_data update_data delete_data read_nodes create_roles read_roles update_roles delete_roles create_collections read_collections update_collections delete_collections assign_and_revoke_users create_users read_users update_users delete_users create_tenants read_tenants update_tenants delete_tenants create_replicate read_replicate update_replicate delete_replicate create_aliases read_aliases update_aliases delete_aliases assign_and_revoke_groups read_groups read_mcp update_mcp]
 	Action *string `json:"action"`
 
 	// aliases
@@ -128,7 +127,7 @@ var permissionTypeActionPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["manage_backups","read_cluster","create_data","read_data","update_data","delete_data","read_nodes","create_roles","read_roles","update_roles","delete_roles","create_collections","read_collections","update_collections","delete_collections","assign_and_revoke_users","create_users","read_users","update_users","delete_users","create_tenants","read_tenants","update_tenants","delete_tenants","create_replicate","read_replicate","update_replicate","delete_replicate","create_aliases","read_aliases","update_aliases","delete_aliases","assign_and_revoke_groups","read_groups","manage_mcp"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["manage_backups","read_cluster","create_data","read_data","update_data","delete_data","read_nodes","create_roles","read_roles","update_roles","delete_roles","create_collections","read_collections","update_collections","delete_collections","assign_and_revoke_users","create_users","read_users","update_users","delete_users","create_tenants","read_tenants","update_tenants","delete_tenants","create_replicate","read_replicate","update_replicate","delete_replicate","create_aliases","read_aliases","update_aliases","delete_aliases","assign_and_revoke_groups","read_groups","read_mcp","update_mcp"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -240,8 +239,11 @@ const (
 	// PermissionActionReadGroups captures enum value "read_groups"
 	PermissionActionReadGroups string = "read_groups"
 
-	// PermissionActionManageMcp captures enum value "manage_mcp"
-	PermissionActionManageMcp string = "manage_mcp"
+	// PermissionActionReadMcp captures enum value "read_mcp"
+	PermissionActionReadMcp string = "read_mcp"
+
+	// PermissionActionUpdateMcp captures enum value "update_mcp"
+	PermissionActionUpdateMcp string = "update_mcp"
 )
 
 // prop value enum
@@ -253,7 +255,6 @@ func (m *Permission) validateActionEnum(path, location string, value string) err
 }
 
 func (m *Permission) validateAction(formats strfmt.Registry) error {
-
 	if err := validate.Required("action", "body", m.Action); err != nil {
 		return err
 	}
@@ -507,7 +508,6 @@ func (m *Permission) ContextValidate(ctx context.Context, formats strfmt.Registr
 }
 
 func (m *Permission) contextValidateAliases(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Aliases != nil {
 		if err := m.Aliases.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -523,7 +523,6 @@ func (m *Permission) contextValidateAliases(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Backups != nil {
 		if err := m.Backups.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -539,7 +538,6 @@ func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateCollections(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Collections != nil {
 		if err := m.Collections.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -555,7 +553,6 @@ func (m *Permission) contextValidateCollections(ctx context.Context, formats str
 }
 
 func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Data != nil {
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -571,7 +568,6 @@ func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Reg
 }
 
 func (m *Permission) contextValidateGroups(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Groups != nil {
 		if err := m.Groups.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -587,7 +583,6 @@ func (m *Permission) contextValidateGroups(ctx context.Context, formats strfmt.R
 }
 
 func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Nodes != nil {
 		if err := m.Nodes.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -603,7 +598,6 @@ func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Re
 }
 
 func (m *Permission) contextValidateReplicate(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Replicate != nil {
 		if err := m.Replicate.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -619,7 +613,6 @@ func (m *Permission) contextValidateReplicate(ctx context.Context, formats strfm
 }
 
 func (m *Permission) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Roles != nil {
 		if err := m.Roles.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -635,7 +628,6 @@ func (m *Permission) contextValidateRoles(ctx context.Context, formats strfmt.Re
 }
 
 func (m *Permission) contextValidateTenants(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Tenants != nil {
 		if err := m.Tenants.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -651,7 +643,6 @@ func (m *Permission) contextValidateTenants(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateUsers(ctx context.Context, formats strfmt.Registry) error {
-
 	if m.Users != nil {
 		if err := m.Users.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -688,7 +679,6 @@ func (m *Permission) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionAliases
 type PermissionAliases struct {
-
 	// A string that specifies which aliases this permission applies to. Can be an exact alias name or a regex pattern. The default value `*` applies the permission to all aliases.
 	Alias *string `json:"alias,omitempty"`
 
@@ -728,7 +718,6 @@ func (m *PermissionAliases) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionBackups
 type PermissionBackups struct {
-
 	// A string that specifies which collections this permission applies to. Can be an exact collection name or a regex pattern. The default value `*` applies the permission to all collections.
 	Collection *string `json:"collection,omitempty"`
 }
@@ -765,7 +754,6 @@ func (m *PermissionBackups) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionCollections
 type PermissionCollections struct {
-
 	// A string that specifies which collections this permission applies to. Can be an exact collection name or a regex pattern. The default value `*` applies the permission to all collections.
 	Collection *string `json:"collection,omitempty"`
 }
@@ -802,7 +790,6 @@ func (m *PermissionCollections) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionData
 type PermissionData struct {
-
 	// A string that specifies which collections this permission applies to. Can be an exact collection name or a regex pattern. The default value `*` applies the permission to all collections.
 	Collection *string `json:"collection,omitempty"`
 
@@ -845,7 +832,6 @@ func (m *PermissionData) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionGroups
 type PermissionGroups struct {
-
 	// A string that specifies which groups this permission applies to. Can be an exact group name or a regex pattern. The default value `*` applies the permission to all groups.
 	Group *string `json:"group,omitempty"`
 
@@ -899,7 +885,6 @@ func (m *PermissionGroups) ContextValidate(ctx context.Context, formats strfmt.R
 }
 
 func (m *PermissionGroups) contextValidateGroupType(ctx context.Context, formats strfmt.Registry) error {
-
 	if err := m.GroupType.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("groups" + "." + "groupType")
@@ -934,7 +919,6 @@ func (m *PermissionGroups) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionNodes
 type PermissionNodes struct {
-
 	// A string that specifies which collections this permission applies to. Can be an exact collection name or a regex pattern. The default value `*` applies the permission to all collections.
 	Collection *string `json:"collection,omitempty"`
 
@@ -1026,7 +1010,6 @@ func (m *PermissionNodes) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionReplicate
 type PermissionReplicate struct {
-
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -1066,7 +1049,6 @@ func (m *PermissionReplicate) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionRoles
 type PermissionRoles struct {
-
 	// A string that specifies which roles this permission applies to. Can be an exact role name or a regex pattern. The default value `*` applies the permission to all roles.
 	Role *string `json:"role,omitempty"`
 
@@ -1158,7 +1140,6 @@ func (m *PermissionRoles) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionTenants
 type PermissionTenants struct {
-
 	// A string that specifies which collections this permission applies to. Can be an exact collection name or a regex pattern. The default value `*` applies the permission to all collections.
 	Collection *string `json:"collection,omitempty"`
 
@@ -1198,7 +1179,6 @@ func (m *PermissionTenants) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionUsers
 type PermissionUsers struct {
-
 	// A string that specifies which users this permission applies to. Can be an exact user name or a regex pattern. The default value `*` applies the permission to all users.
 	Users *string `json:"users,omitempty"`
 }

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -33,7 +33,7 @@ type Permission struct {
 
 	// Allowed actions in weaviate.
 	// Required: true
-	// Enum: [manage_backups read_cluster create_data read_data update_data delete_data read_nodes create_roles read_roles update_roles delete_roles create_collections read_collections update_collections delete_collections assign_and_revoke_users create_users read_users update_users delete_users create_tenants read_tenants update_tenants delete_tenants create_replicate read_replicate update_replicate delete_replicate create_aliases read_aliases update_aliases delete_aliases assign_and_revoke_groups read_groups read_mcp update_mcp]
+	// Enum: [manage_backups read_cluster create_data read_data update_data delete_data read_nodes create_roles read_roles update_roles delete_roles create_collections read_collections update_collections delete_collections assign_and_revoke_users create_users read_users update_users delete_users create_tenants read_tenants update_tenants delete_tenants create_replicate read_replicate update_replicate delete_replicate create_aliases read_aliases update_aliases delete_aliases assign_and_revoke_groups read_groups create_mcp read_mcp update_mcp]
 	Action *string `json:"action"`
 
 	// aliases
@@ -125,7 +125,7 @@ var permissionTypeActionPropEnum []interface{}
 
 func init() {
 	var res []string
-	if err := json.Unmarshal([]byte(`["manage_backups","read_cluster","create_data","read_data","update_data","delete_data","read_nodes","create_roles","read_roles","update_roles","delete_roles","create_collections","read_collections","update_collections","delete_collections","assign_and_revoke_users","create_users","read_users","update_users","delete_users","create_tenants","read_tenants","update_tenants","delete_tenants","create_replicate","read_replicate","update_replicate","delete_replicate","create_aliases","read_aliases","update_aliases","delete_aliases","assign_and_revoke_groups","read_groups","read_mcp","update_mcp"]`), &res); err != nil {
+	if err := json.Unmarshal([]byte(`["manage_backups","read_cluster","create_data","read_data","update_data","delete_data","read_nodes","create_roles","read_roles","update_roles","delete_roles","create_collections","read_collections","update_collections","delete_collections","assign_and_revoke_users","create_users","read_users","update_users","delete_users","create_tenants","read_tenants","update_tenants","delete_tenants","create_replicate","read_replicate","update_replicate","delete_replicate","create_aliases","read_aliases","update_aliases","delete_aliases","assign_and_revoke_groups","read_groups","create_mcp","read_mcp","update_mcp"]`), &res); err != nil {
 		panic(err)
 	}
 	for _, v := range res {
@@ -236,6 +236,9 @@ const (
 
 	// PermissionActionReadGroups captures enum value "read_groups"
 	PermissionActionReadGroups string = "read_groups"
+
+	// PermissionActionCreateMcp captures enum value "create_mcp"
+	PermissionActionCreateMcp string = "create_mcp"
 
 	// PermissionActionReadMcp captures enum value "read_mcp"
 	PermissionActionReadMcp string = "read_mcp"

--- a/entities/models/permission.go
+++ b/entities/models/permission.go
@@ -30,6 +30,7 @@ import (
 //
 // swagger:model Permission
 type Permission struct {
+
 	// Allowed actions in weaviate.
 	// Required: true
 	// Enum: [manage_backups read_cluster create_data read_data update_data delete_data read_nodes create_roles read_roles update_roles delete_roles create_collections read_collections update_collections delete_collections assign_and_revoke_users create_users read_users update_users delete_users create_tenants read_tenants update_tenants delete_tenants create_replicate read_replicate update_replicate delete_replicate create_aliases read_aliases update_aliases delete_aliases assign_and_revoke_groups read_groups read_mcp update_mcp]
@@ -255,6 +256,7 @@ func (m *Permission) validateActionEnum(path, location string, value string) err
 }
 
 func (m *Permission) validateAction(formats strfmt.Registry) error {
+
 	if err := validate.Required("action", "body", m.Action); err != nil {
 		return err
 	}
@@ -508,6 +510,7 @@ func (m *Permission) ContextValidate(ctx context.Context, formats strfmt.Registr
 }
 
 func (m *Permission) contextValidateAliases(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Aliases != nil {
 		if err := m.Aliases.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -523,6 +526,7 @@ func (m *Permission) contextValidateAliases(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Backups != nil {
 		if err := m.Backups.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -538,6 +542,7 @@ func (m *Permission) contextValidateBackups(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateCollections(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Collections != nil {
 		if err := m.Collections.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -553,6 +558,7 @@ func (m *Permission) contextValidateCollections(ctx context.Context, formats str
 }
 
 func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Data != nil {
 		if err := m.Data.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -568,6 +574,7 @@ func (m *Permission) contextValidateData(ctx context.Context, formats strfmt.Reg
 }
 
 func (m *Permission) contextValidateGroups(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Groups != nil {
 		if err := m.Groups.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -583,6 +590,7 @@ func (m *Permission) contextValidateGroups(ctx context.Context, formats strfmt.R
 }
 
 func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Nodes != nil {
 		if err := m.Nodes.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -598,6 +606,7 @@ func (m *Permission) contextValidateNodes(ctx context.Context, formats strfmt.Re
 }
 
 func (m *Permission) contextValidateReplicate(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Replicate != nil {
 		if err := m.Replicate.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -613,6 +622,7 @@ func (m *Permission) contextValidateReplicate(ctx context.Context, formats strfm
 }
 
 func (m *Permission) contextValidateRoles(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Roles != nil {
 		if err := m.Roles.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -628,6 +638,7 @@ func (m *Permission) contextValidateRoles(ctx context.Context, formats strfmt.Re
 }
 
 func (m *Permission) contextValidateTenants(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Tenants != nil {
 		if err := m.Tenants.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -643,6 +654,7 @@ func (m *Permission) contextValidateTenants(ctx context.Context, formats strfmt.
 }
 
 func (m *Permission) contextValidateUsers(ctx context.Context, formats strfmt.Registry) error {
+
 	if m.Users != nil {
 		if err := m.Users.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
@@ -679,6 +691,7 @@ func (m *Permission) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionAliases
 type PermissionAliases struct {
+
 	// A string that specifies which aliases this permission applies to. Can be an exact alias name or a regex pattern. The default value `*` applies the permission to all aliases.
 	Alias *string `json:"alias,omitempty"`
 
@@ -718,6 +731,7 @@ func (m *PermissionAliases) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionBackups
 type PermissionBackups struct {
+
 	// A string that specifies which collections this permission applies to. Can be an exact collection name or a regex pattern. The default value `*` applies the permission to all collections.
 	Collection *string `json:"collection,omitempty"`
 }
@@ -754,6 +768,7 @@ func (m *PermissionBackups) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionCollections
 type PermissionCollections struct {
+
 	// A string that specifies which collections this permission applies to. Can be an exact collection name or a regex pattern. The default value `*` applies the permission to all collections.
 	Collection *string `json:"collection,omitempty"`
 }
@@ -790,6 +805,7 @@ func (m *PermissionCollections) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionData
 type PermissionData struct {
+
 	// A string that specifies which collections this permission applies to. Can be an exact collection name or a regex pattern. The default value `*` applies the permission to all collections.
 	Collection *string `json:"collection,omitempty"`
 
@@ -832,6 +848,7 @@ func (m *PermissionData) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionGroups
 type PermissionGroups struct {
+
 	// A string that specifies which groups this permission applies to. Can be an exact group name or a regex pattern. The default value `*` applies the permission to all groups.
 	Group *string `json:"group,omitempty"`
 
@@ -885,6 +902,7 @@ func (m *PermissionGroups) ContextValidate(ctx context.Context, formats strfmt.R
 }
 
 func (m *PermissionGroups) contextValidateGroupType(ctx context.Context, formats strfmt.Registry) error {
+
 	if err := m.GroupType.ContextValidate(ctx, formats); err != nil {
 		if ve, ok := err.(*errors.Validation); ok {
 			return ve.ValidateName("groups" + "." + "groupType")
@@ -919,6 +937,7 @@ func (m *PermissionGroups) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionNodes
 type PermissionNodes struct {
+
 	// A string that specifies which collections this permission applies to. Can be an exact collection name or a regex pattern. The default value `*` applies the permission to all collections.
 	Collection *string `json:"collection,omitempty"`
 
@@ -1010,6 +1029,7 @@ func (m *PermissionNodes) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionReplicate
 type PermissionReplicate struct {
+
 	// string or regex. if a specific collection name, if left empty it will be ALL or *
 	Collection *string `json:"collection,omitempty"`
 
@@ -1049,6 +1069,7 @@ func (m *PermissionReplicate) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionRoles
 type PermissionRoles struct {
+
 	// A string that specifies which roles this permission applies to. Can be an exact role name or a regex pattern. The default value `*` applies the permission to all roles.
 	Role *string `json:"role,omitempty"`
 
@@ -1140,6 +1161,7 @@ func (m *PermissionRoles) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionTenants
 type PermissionTenants struct {
+
 	// A string that specifies which collections this permission applies to. Can be an exact collection name or a regex pattern. The default value `*` applies the permission to all collections.
 	Collection *string `json:"collection,omitempty"`
 
@@ -1179,6 +1201,7 @@ func (m *PermissionTenants) UnmarshalBinary(b []byte) error {
 //
 // swagger:model PermissionUsers
 type PermissionUsers struct {
+
 	// A string that specifies which users this permission applies to. Can be an exact user name or a regex pattern. The default value `*` applies the permission to all users.
 	Users *string `json:"users,omitempty"`
 }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -345,6 +345,7 @@
             "delete_aliases",
             "assign_and_revoke_groups",
             "read_groups",
+            "create_mcp",
             "read_mcp",
             "update_mcp"
           ]

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -350,7 +350,8 @@
             "delete_aliases",
             "assign_and_revoke_groups",
             "read_groups",
-            "manage_mcp"
+            "read_mcp",
+            "update_mcp"
           ]
         }
       },

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -307,11 +307,6 @@
             }
           }
         },
-        "mcp": {
-          "type": "object",
-          "description": "resources applicable for MCP actions",
-          "properties": {}
-        },
         "action": {
           "type": "string",
           "description": "Allowed actions in weaviate.",

--- a/test/acceptance/authz/mcp_test.go
+++ b/test/acceptance/authz/mcp_test.go
@@ -98,7 +98,6 @@ func TestMCPServerAuthZ(t *testing.T) {
 		Permissions: []*models.Permission{
 			{
 				Action: &authorization.ReadMcp,
-				Mcp:    make(map[string]any),
 			},
 			{
 				Action: &authorization.ReadCollections,
@@ -183,11 +182,9 @@ func TestMCPServerCollectionLevelAuthZ(t *testing.T) {
 		Permissions: []*models.Permission{
 			{
 				Action: &authorization.ReadMcp,
-				Mcp:    make(map[string]any),
 			},
 			{
 				Action: &authorization.UpdateMcp,
-				Mcp:    make(map[string]any),
 			},
 			{
 				Action: &authorization.ReadCollections,
@@ -352,7 +349,7 @@ func TestMCPPermissionSeparation(t *testing.T) {
 	helper.CreateRole(t, adminKey, &models.Role{
 		Name: &readRole,
 		Permissions: []*models.Permission{
-			{Action: &authorization.ReadMcp, Mcp: make(map[string]any)},
+			{Action: &authorization.ReadMcp},
 			{Action: &authorization.ReadCollections, Collections: &models.PermissionCollections{Collection: &className}},
 			{Action: &authorization.ReadData, Data: &models.PermissionData{Collection: &className}},
 		},
@@ -367,7 +364,7 @@ func TestMCPPermissionSeparation(t *testing.T) {
 	helper.CreateRole(t, adminKey, &models.Role{
 		Name: &writeRole,
 		Permissions: []*models.Permission{
-			{Action: &authorization.UpdateMcp, Mcp: make(map[string]any)},
+			{Action: &authorization.UpdateMcp},
 			{Action: &authorization.CreateData, Data: &models.PermissionData{Collection: &className}},
 			{Action: &authorization.UpdateData, Data: &models.PermissionData{Collection: &className}},
 		},

--- a/test/acceptance/authz/mcp_test.go
+++ b/test/acceptance/authz/mcp_test.go
@@ -181,6 +181,9 @@ func TestMCPServerCollectionLevelAuthZ(t *testing.T) {
 		Name: &roleName,
 		Permissions: []*models.Permission{
 			{
+				Action: &authorization.CreateMcp,
+			},
+			{
 				Action: &authorization.ReadMcp,
 			},
 			{
@@ -364,6 +367,7 @@ func TestMCPPermissionSeparation(t *testing.T) {
 	helper.CreateRole(t, adminKey, &models.Role{
 		Name: &writeRole,
 		Permissions: []*models.Permission{
+			{Action: &authorization.CreateMcp},
 			{Action: &authorization.UpdateMcp},
 			{Action: &authorization.CreateData, Data: &models.PermissionData{Collection: &className}},
 			{Action: &authorization.UpdateData, Data: &models.PermissionData{Collection: &className}},

--- a/test/acceptance/authz/mcp_test.go
+++ b/test/acceptance/authz/mcp_test.go
@@ -97,7 +97,7 @@ func TestMCPServerAuthZ(t *testing.T) {
 		Name: &roleName,
 		Permissions: []*models.Permission{
 			{
-				Action: &authorization.ManageMcp,
+				Action: &authorization.ReadMcp,
 				Mcp:    make(map[string]any),
 			},
 			{
@@ -175,14 +175,18 @@ func TestMCPServerCollectionLevelAuthZ(t *testing.T) {
 		}, adminKey))
 	}
 
-	// Create a role with MCP permission + data permissions scoped to AllowedCollection only
+	// Create a role with MCP read + update permissions + data permissions scoped to AllowedCollection only
 	roleName := "collection-scoped-mcp-role"
 	helper.DeleteRole(t, adminKey, roleName)
 	helper.CreateRole(t, adminKey, &models.Role{
 		Name: &roleName,
 		Permissions: []*models.Permission{
 			{
-				Action: &authorization.ManageMcp,
+				Action: &authorization.ReadMcp,
+				Mcp:    make(map[string]any),
+			},
+			{
+				Action: &authorization.UpdateMcp,
 				Mcp:    make(map[string]any),
 			},
 			{
@@ -301,5 +305,150 @@ func TestMCPServerCollectionLevelAuthZ(t *testing.T) {
 			require.NotEqual(t, forbiddenClass, c.Class,
 				"user should not see ForbiddenCollection in unfiltered get-config response")
 		}
+	})
+}
+
+// TestMCPPermissionSeparation verifies that read_mcp and update_mcp permissions
+// are enforced independently: a read-only user cannot upsert, and a write-only
+// user cannot search or list collections.
+func TestMCPPermissionSeparation(t *testing.T) {
+	adminUser := "admin-user"
+	adminKey := "admin-key"
+	readUser := "read-user"
+	readKey := "read-key"
+	writeUser := "write-user"
+	writeKey := "write-key"
+
+	compose, down := composeUpWithMCP(t,
+		map[string]string{adminUser: adminKey},
+		map[string]string{readUser: readKey, writeUser: writeKey},
+		nil, true)
+	defer down()
+
+	mcpURL := fmt.Sprintf("http://%s", compose.GetWeaviate().McpURI())
+	adminAuth := helper.CreateAuth(adminKey)
+
+	// Create a test collection
+	className := "PermTestCollection"
+	helper.DeleteClassWithAuthz(t, className, adminAuth)
+	helper.CreateClassAuth(t, &models.Class{
+		Class: className,
+		Properties: []*models.Property{
+			{Name: "content", DataType: schema.DataTypeText.PropString()},
+		},
+		Vectorizer: "none",
+	}, adminKey)
+	defer helper.DeleteClassWithAuthz(t, className, adminAuth)
+
+	// Insert test data as admin
+	require.NoError(t, helper.CreateObjectAuth(t, &models.Object{
+		Class:      className,
+		Properties: map[string]interface{}{"content": "test content"},
+	}, adminKey))
+
+	// Create read-only role: read_mcp + read_collections + read_data
+	readRole := "mcp-read-only-role"
+	helper.DeleteRole(t, adminKey, readRole)
+	helper.CreateRole(t, adminKey, &models.Role{
+		Name: &readRole,
+		Permissions: []*models.Permission{
+			{Action: &authorization.ReadMcp, Mcp: make(map[string]any)},
+			{Action: &authorization.ReadCollections, Collections: &models.PermissionCollections{Collection: &className}},
+			{Action: &authorization.ReadData, Data: &models.PermissionData{Collection: &className}},
+		},
+	})
+	defer helper.DeleteRole(t, adminKey, readRole)
+	helper.AssignRoleToUser(t, adminKey, readRole, readUser)
+	defer helper.RevokeRoleFromUser(t, adminKey, readRole, readUser)
+
+	// Create write-only role: update_mcp + create_data + update_data
+	writeRole := "mcp-write-only-role"
+	helper.DeleteRole(t, adminKey, writeRole)
+	helper.CreateRole(t, adminKey, &models.Role{
+		Name: &writeRole,
+		Permissions: []*models.Permission{
+			{Action: &authorization.UpdateMcp, Mcp: make(map[string]any)},
+			{Action: &authorization.CreateData, Data: &models.PermissionData{Collection: &className}},
+			{Action: &authorization.UpdateData, Data: &models.PermissionData{Collection: &className}},
+		},
+	})
+	defer helper.DeleteRole(t, adminKey, writeRole)
+	helper.AssignRoleToUser(t, adminKey, writeRole, writeUser)
+	defer helper.RevokeRoleFromUser(t, adminKey, writeRole, writeUser)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	pureKeyword := float64(0)
+
+	// --- Read-only user tests ---
+
+	t.Run("read user can call get-config", func(t *testing.T) {
+		var resp read.GetCollectionConfigResp
+		err := callToolOnceWithAuth(ctx, t, mcpURL, "weaviate-collections-get-config", readKey,
+			read.GetCollectionConfigArgs{CollectionName: className}, &resp)
+		require.NoError(t, err)
+		require.Len(t, resp.Collections, 1)
+	})
+
+	t.Run("read user can call hybrid search", func(t *testing.T) {
+		var resp search.QueryHybridResp
+		err := callToolOnceWithAuth(ctx, t, mcpURL, "weaviate-query-hybrid", readKey,
+			search.QueryHybridArgs{
+				Query:          "test",
+				CollectionName: className,
+				Alpha:          &pureKeyword,
+			}, &resp)
+		require.NoError(t, err)
+	})
+
+	t.Run("read user cannot call upsert", func(t *testing.T) {
+		var resp create.UpsertObjectResp
+		err := callToolOnceWithAuth(ctx, t, mcpURL, "weaviate-objects-upsert", readKey,
+			create.UpsertObjectArgs{
+				CollectionName: className,
+				Objects: []create.ObjectToUpsert{
+					{Properties: map[string]any{"content": "should fail"}},
+				},
+			}, &resp)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "forbidden")
+	})
+
+	// --- Write-only user tests ---
+
+	t.Run("write user cannot call get-config", func(t *testing.T) {
+		var resp read.GetCollectionConfigResp
+		err := callToolOnceWithAuth(ctx, t, mcpURL, "weaviate-collections-get-config", writeKey,
+			read.GetCollectionConfigArgs{CollectionName: className}, &resp)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "forbidden")
+	})
+
+	t.Run("write user cannot call hybrid search", func(t *testing.T) {
+		var resp search.QueryHybridResp
+		err := callToolOnceWithAuth(ctx, t, mcpURL, "weaviate-query-hybrid", writeKey,
+			search.QueryHybridArgs{
+				Query:          "test",
+				CollectionName: className,
+				Alpha:          &pureKeyword,
+			}, &resp)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "forbidden")
+	})
+
+	t.Run("write user can call upsert", func(t *testing.T) {
+		var resp create.UpsertObjectResp
+		err := callToolOnceWithAuth(ctx, t, mcpURL, "weaviate-objects-upsert", writeKey,
+			create.UpsertObjectArgs{
+				CollectionName: className,
+				Objects: []create.ObjectToUpsert{
+					{Properties: map[string]any{"content": "write user object"}},
+				},
+			}, &resp)
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 1)
+		require.Empty(t, resp.Results[0].Error)
+		require.NotEmpty(t, resp.Results[0].ID)
 	})
 }

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -479,7 +479,7 @@ func permission(policy []string, validatePath bool) (*models.Permission, error) 
 			GroupType: models.GroupType(splits[1]),
 		}
 	case authorization.McpDomain:
-		permission.Mcp = make(map[string]any)
+		// do nothing
 	case *authorization.All:
 		permission.Backups = authorization.AllBackups
 		permission.Data = authorization.AllData

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -147,7 +147,8 @@ var (
 	UpdateAliases = "update_aliases"
 	DeleteAliases = "delete_aliases"
 
-	ManageMcp = "manage_mcp"
+	ReadMcp   = "read_mcp"
+	UpdateMcp = "update_mcp"
 
 	availableWeaviateActions = []string{
 		// Roles domain
@@ -205,6 +206,10 @@ var (
 		ReadAliases,
 		UpdateAliases,
 		DeleteAliases,
+
+		// MCP domain
+		ReadMcp,
+		UpdateMcp,
 	}
 )
 

--- a/usecases/auth/authorization/types.go
+++ b/usecases/auth/authorization/types.go
@@ -147,6 +147,7 @@ var (
 	UpdateAliases = "update_aliases"
 	DeleteAliases = "delete_aliases"
 
+	CreateMcp = "create_mcp"
 	ReadMcp   = "read_mcp"
 	UpdateMcp = "update_mcp"
 
@@ -208,6 +209,7 @@ var (
 		DeleteAliases,
 
 		// MCP domain
+		CreateMcp,
 		ReadMcp,
 		UpdateMcp,
 	}


### PR DESCRIPTION
### What's being changed

Replaces the single `manage_mcp` RBAC permission with three granular permissions, adds correct MCP tool annotations, and removes the `mcp` resource field from the Permission model for consistency with other action-only permissions like `read_cluster`.

#### Permission split: `manage_mcp` → `create_mcp` + `read_mcp` + `update_mcp`

| Permission | Verb | Tools |
|-----------|------|-------|
| `read_mcp` | READ | `weaviate-collections-get-config`, `weaviate-tenants-list`, `weaviate-query-hybrid` |
| `create_mcp` + `update_mcp` | CREATE + UPDATE | `weaviate-objects-upsert` (requires both) |

The permissions are enforced independently:
- A user with only `read_mcp` can search and list but cannot upsert
- A user with only `create_mcp` + `update_mcp` can upsert but cannot search or list
- Collection-level data authorization (CREATE/UPDATE per collection) continues to be enforced by `batchManager.AddObjects`

This model allows future granular control — e.g., Stage 2 delete tools can require a separate `delete_mcp` permission.

#### Remove `mcp` resource field from Permission model

Previously, MCP permissions returned `{"action": "manage_mcp", "mcp": {}}` with an empty `mcp` object. This was inconsistent with other action-only permissions like `read_cluster` which return just `{"action": "read_cluster"}`. The `mcp` property has been removed from the OpenAPI Permission schema, and the casbin conversion no longer populates it.

#### Tool annotations

Sets correct [MCP tool annotations](https://modelcontextprotocol.io/specification/2025-03-26/server/tools) per tool:

| Tool | readOnlyHint | destructiveHint | idempotentHint |
|------|-------------|----------------|---------------|
| `weaviate-collections-get-config` | true | false | true |
| `weaviate-tenants-list` | true | false | true |
| `weaviate-query-hybrid` | true | false | true |
| `weaviate-objects-upsert` | false | true | true |

Previously all tools used mcp-go defaults (`readOnlyHint: false, destructiveHint: true`), which incorrectly marked read-only tools as destructive and caused MCP clients to prompt for unnecessary confirmations.

#### Files changed

- `usecases/auth/authorization/types.go` — `CreateMcp`, `ReadMcp`, `UpdateMcp` constants replacing `ManageMcp`
- `usecases/auth/authorization/conv/casbin_types.go` — MCP domain no longer sets `permission.Mcp` field
- `openapi-specs/schema.json` + regenerated `embedded_spec.go`, `entities/models/permission.go` — removed `mcp` property, updated action enum
- `adapters/handlers/mcp/create/objects_upsert.go` — requires both CREATE and UPDATE verbs at MCP level
- `adapters/handlers/mcp/{create,read,search}/schema.go` — tool annotation hints
- `test/acceptance/authz/mcp_test.go` — new `TestMCPPermissionSeparation` (6 subtests), updated existing tests