### PR TITLE
fix: optimize zstd encoder usage in replication client and implement decoder pooling

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -57,17 +57,23 @@ const (
 
 type replicationClient struct {
 	retryClient
+	zstdEncoder *zstd.Encoder
 }
 
 var _ (replica.Client) = (*replicationClient)(nil)
 
-func NewReplicationClient(httpClient *http.Client) *replicationClient {
+func NewReplicationClient(httpClient *http.Client) (*replicationClient, error) {
+	enc, err := zstd.NewWriter(nil)
+	if err != nil {
+		return nil, fmt.Errorf("create zstd encoder: %w", err)
+	}
 	return &replicationClient{
 		retryClient: retryClient{
 			client:  httpClient,
 			retryer: newRetryer(),
 		},
-	}
+		zstdEncoder: enc,
+	}, nil
 }
 
 // FetchObject fetches one object it exits
@@ -190,12 +196,7 @@ func (c *replicationClient) HashTreeLevel(ctx context.Context,
 		return nil, fmt.Errorf("marshal hashtree level input: %w", err)
 	}
 
-	enc, err := zstd.NewWriter(nil)
-	if err != nil {
-		return nil, fmt.Errorf("create zstd encoder: %w", err)
-	}
-	defer enc.Close()
-	bodyBytes := enc.EncodeAll(body, make([]byte, 0, len(body)))
+	bodyBytes := c.zstdEncoder.EncodeAll(body, make([]byte, 0, len(body)))
 
 	ctx, cancel := context.WithTimeout(ctx, c.timeoutUnit*20)
 	defer cancel()
@@ -254,12 +255,7 @@ func (c *replicationClient) OverwriteObjects(ctx context.Context,
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	enc, err := zstd.NewWriter(nil)
-	if err != nil {
-		return nil, fmt.Errorf("create zstd encoder: %w", err)
-	}
-	defer enc.Close()
-	bodyCompressed := enc.EncodeAll(body, make([]byte, 0, len(body)))
+	bodyCompressed := c.zstdEncoder.EncodeAll(body, make([]byte, 0, len(body)))
 
 	req, err := newHttpReplicaRequest(
 		ctx, http.MethodPut, host, index, shard,

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -863,7 +863,8 @@ func TestExpBackOff(t *testing.T) {
 
 func newReplicationClient(t *testing.T, httpClient *http.Client) *replicationClient {
 	t.Helper()
-	c := NewReplicationClient(httpClient)
+	c, err := NewReplicationClient(httpClient)
+	require.NoError(t, err)
 	c.minBackOff = time.Millisecond * 1
 	c.maxBackOff = time.Millisecond * 8
 	c.timeoutUnit = time.Millisecond * 20

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -59,6 +59,24 @@ const (
 	responseQueueFull    = "too many buffered requests"
 )
 
+// zstdDecoderPool pools *zstd.Decoder instances to avoid the allocation cost
+// of zstd.NewReader on every compressed request. When the pool is empty, New
+// returns nil; the call site falls back to newZstdDecoder() to surface the
+// construction error explicitly.
+var zstdDecoderPool = sync.Pool{
+	New: func() any {
+		dec, err := zstd.NewReader(nil)
+		if err != nil {
+			return nil
+		}
+		return dec
+	},
+}
+
+func newZstdDecoder() (*zstd.Decoder, error) {
+	return zstd.NewReader(nil)
+}
+
 var (
 	regxObject = regexp.MustCompile(`\/replicas\/indices\/(` + cl + `)` +
 		`\/shards\/(` + sh + `)\/objects\/(` + ob + `)(\/[0-9]{1,64})?`)
@@ -625,11 +643,25 @@ func readRequestBodyWithOptionalCompression(
 		return nil, fmt.Errorf("compression algorithm unsupported: %s", compressionHeader)
 	}
 
-	zstdr, err := zstd.NewReader(body)
-	if err != nil {
-		return nil, fmt.Errorf("create zstd reader: %w", err)
+	zstdr, ok := zstdDecoderPool.Get().(*zstd.Decoder)
+	if !ok || zstdr == nil {
+		// pool.New failed; call directly to surface the underlying error
+		var err error
+		zstdr, err = newZstdDecoder()
+		if err != nil {
+			return nil, fmt.Errorf("create zstd decoder: %w", err)
+		}
 	}
-	defer zstdr.Close()
+	if err := zstdr.Reset(body); err != nil {
+		// decoder is closed; discard it, pool.New will allocate a fresh one
+		return nil, fmt.Errorf("reset zstd decoder: %w", err)
+	}
+	defer func() {
+		if err := zstdr.Reset(nil); err == nil {
+			zstdDecoderPool.Put(zstdr)
+		}
+		// if Reset(nil) errors the decoder is closed; drop it, pool.New will create a fresh one
+	}()
 
 	b, err := io.ReadAll(zstdr)
 	if err != nil {

--- a/adapters/handlers/rest/clusterapi/overwrite_objects_integration_test.go
+++ b/adapters/handlers/rest/clusterapi/overwrite_objects_integration_test.go
@@ -130,7 +130,8 @@ func TestOverwriteObjectsClientServerIntegration(t *testing.T) {
 
 	// Use the real replication client with the test server's HTTP client so
 	// requests are routed to the in-process server without TLS.
-	c := clients.NewReplicationClient(server.Client())
+	c, err := clients.NewReplicationClient(server.Client())
+	require.NoError(t, err)
 
 	// server.URL is "http://host:port"; strip the scheme for the client which
 	// constructs the URL itself.

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -382,7 +382,10 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	// TODO: configure http transport for efficient intra-cluster comm
 	remoteIndexClient := clients.NewRemoteIndex(appState.ClusterHttpClient)
 	remoteNodesClient := clients.NewRemoteNode(appState.ClusterHttpClient)
-	restReplicationClient := clients.NewReplicationClient(appState.ClusterHttpClient)
+	restReplicationClient, err := clients.NewReplicationClient(appState.ClusterHttpClient)
+	if err != nil {
+		appState.Logger.WithField("action", "startup").Fatalf("failed to create replication client: %v", err)
+	}
 
 	// Set up gRPC connection manager (needed for both file replication and replication gRPC client)
 	grpcConfig := appState.ServerConfig.Config.GRPC

--- a/adapters/repos/db/aggregations_integration_test.go
+++ b/adapters/repos/db/aggregations_integration_test.go
@@ -72,12 +72,14 @@ func Test_Aggregations(t *testing.T) {
 	mockNodeSelector := cluster.NewMockNodeSelector(t)
 	mockNodeSelector.EXPECT().LocalName().Return("node1").Maybe()
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return(srv.URL[7:], true).Maybe()
+	replicaClient, err := clients.NewReplicationClient(&http.Client{})
+	require.Nil(t, err)
 	repo, err := New(logger, "node1", Config{
 		MemtablesFlushDirtyAfter:  60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		MaxImportGoroutinesFactor: 1,
-	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, clients.NewReplicationClient(&http.Client{}), nil, memwatch.NewDummyMonitor(),
+	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, replicaClient, nil, memwatch.NewDummyMonitor(),
 		mockNodeSelector, mockSchemaReader, mockReplicationFSMReader)
 	require.Nil(t, err)
 	repo.SetSchemaGetter(schemaGetter)
@@ -138,12 +140,14 @@ func Test_Aggregations_MultiShard(t *testing.T) {
 	mockNodeSelector := cluster.NewMockNodeSelector(t)
 	mockNodeSelector.EXPECT().LocalName().Return("node1").Maybe()
 	mockNodeSelector.EXPECT().NodeHostname(mock.Anything).Return(srv.URL[7:], true).Maybe()
+	replicaClient2, err := clients.NewReplicationClient(&http.Client{})
+	require.Nil(t, err)
 	repo, err := New(logger, "node1", Config{
 		MemtablesFlushDirtyAfter:  60,
 		RootPath:                  dirName,
 		QueryMaximumResults:       10000,
 		MaxImportGoroutinesFactor: 1,
-	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, clients.NewReplicationClient(&http.Client{}), nil, memwatch.NewDummyMonitor(),
+	}, &FakeRemoteClient{}, mockNodeSelector, &FakeRemoteNodeClient{}, replicaClient2, nil, memwatch.NewDummyMonitor(),
 		mockNodeSelector, mockSchemaReader, mockReplicationFSMReader)
 	require.Nil(t, err)
 	repo.SetSchemaGetter(schemaGetter)

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -95,7 +95,10 @@ func (n *node) init(t *testing.T, dirName string, allNodes *[]*node, shardingSta
 
 	client := clients.NewRemoteIndex(&http.Client{})
 	nodesClient := clients.NewRemoteNode(&http.Client{})
-	replicaClient := clients.NewReplicationClient(&http.Client{})
+	replicaClient, err := clients.NewReplicationClient(&http.Client{})
+	if err != nil {
+		t.Fatalf("failed to create replication client: %v", err)
+	}
 
 	// Create schema manager first so the mock can reference it
 	n.schemaManager = &fakeSchemaManager{

--- a/adapters/repos/db/index_test.go
+++ b/adapters/repos/db/index_test.go
@@ -168,7 +168,11 @@ func TestIndex_aggregateCount(t *testing.T) {
 						router,
 						cluster.NewMockNodeResolver(t),
 						"node-1",
-						clients.NewReplicationClient(&http.Client{}),
+						func() replica.Client {
+							c, err := clients.NewReplicationClient(&http.Client{})
+							require.NoError(t, err)
+							return c
+						}(),
 						replicaMetrics,
 						logger,
 						func() string { return "Delete" }),

--- a/usecases/replica/coordinator_test.go
+++ b/usecases/replica/coordinator_test.go
@@ -264,7 +264,8 @@ func Test_coordinatorPush(t *testing.T) {
 				replicas[i], replicas[j] = replicas[j], replicas[i]
 			}
 
-			client := clients.NewReplicationClient(&http.Client{})
+			client, err := clients.NewReplicationClient(&http.Client{})
+			require.NoError(t, err)
 			coordinator := replica.NewWriteCoordinator[replica.SimpleResponse, error](
 				client,
 				setupRouter(cl, replicas),
@@ -458,7 +459,8 @@ func Test_coordinatorPull(t *testing.T) {
 				{NodeName: "node3", ShardName: shard, HostAddr: tt.node3.URL[7:]},
 			}
 
-			client := clients.NewReplicationClient(&http.Client{})
+			client, err := clients.NewReplicationClient(&http.Client{})
+			require.NoError(t, err)
 			coordinator := replica.NewReadCoordinator[types.RepairResponse](
 				setupRouter(cl, replicas),
 				metrics,


### PR DESCRIPTION
### What's being changed:

This pull request optimizes the use of Zstandard (zstd) compression and decompression in the replication client and REST handler. The main improvements are the reuse of encoder and decoder instances to reduce allocation overhead and improve performance, especially under high load.

**Replication client optimizations:**

* The `replicationClient` now initializes a single `zstd.Encoder` instance (`zstdEncoder`) during construction and reuses it for all compression operations, removing the need to create and close a new encoder for every request. [[1]](diffhunk://#diff-9c6b07b40ed868288b28472fd7e8e41e994cfdaad151ca02a8442e772453a922R60-R72) [[2]](diffhunk://#diff-9c6b07b40ed868288b28472fd7e8e41e994cfdaad151ca02a8442e772453a922L193-R196) [[3]](diffhunk://#diff-9c6b07b40ed868288b28472fd7e8e41e994cfdaad151ca02a8442e772453a922L257-R255)

**REST handler optimizations:**

* Introduced a `sync.Pool` named `zstdDecoderPool` to efficiently reuse `zstd.Decoder` instances, significantly reducing the cost of decoder allocation for each compressed request.
* Updated the `readRequestBodyWithOptionalCompression` function to use the pooled decoder, resetting and returning it to the pool after use, instead of creating and closing a new decoder each time.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
