### PR TITLE
Add default vector index setting

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -2188,6 +2188,7 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		registered.QuerySlowLogThreshold = appState.ServerConfig.Config.QuerySlowLogThreshold
 		registered.InvertedSorterDisabled = appState.ServerConfig.Config.InvertedSorterDisabled
 		registered.DefaultQuantization = appState.ServerConfig.Config.DefaultQuantization
+		registered.DefaultVectorIndexType = appState.ServerConfig.Config.DefaultVectorIndexType
 		registered.DefaultShardingCount = appState.ServerConfig.Config.DefaultShardingCount
 		registered.ReplicatedIndicesRequestQueueEnabled = appState.ServerConfig.Config.Cluster.RequestQueueConfig.IsEnabled
 		registered.RaftDrainSleep = appState.ServerConfig.Config.Raft.DrainSleep

--- a/test/acceptance/schema/default_vector_index_test.go
+++ b/test/acceptance/schema/default_vector_index_test.go
@@ -1,0 +1,78 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+func TestDefaultVectorIndexEmpty(t *testing.T) {
+	mainCtx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviate().
+		Start(mainCtx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(mainCtx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	t.Run("no env defaults to hnsw", func(t *testing.T) {
+		cls := articles.ParagraphsClass()
+		cls.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
+
+		helper.DeleteClass(t, cls.Class)
+		helper.CreateClass(t, cls)
+
+		got := helper.GetClass(t, cls.Class)
+		require.Equal(t, "hnsw", got.VectorIndexType)
+	})
+}
+
+func TestDefaultVectorIndexHfresh(t *testing.T) {
+	mainCtx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviate().
+		WithWeaviateEnv("DEFAULT_VECTOR_INDEX", "hfresh").
+		Start(mainCtx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(mainCtx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	t.Run("env set to hfresh defaults to hfresh", func(t *testing.T) {
+		cls := articles.ParagraphsClass()
+		cls.ReplicationConfig = &models.ReplicationConfig{Factor: 1}
+
+		helper.DeleteClass(t, cls.Class)
+		helper.CreateClass(t, cls)
+
+		got := helper.GetClass(t, cls.Class)
+		require.Equal(t, "hfresh", got.VectorIndexType)
+	})
+}

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -239,7 +239,8 @@ type Config struct {
 	DefaultQuantization *runtime.DynamicValue[string] `json:"default_quantization" yaml:"default_quantization"`
 
 	// New classes will be created with this vector index type instead of HNSW.
-	DefaultVectorIndexType string `json:"default_vector_index_type" yaml:"default_vector_index_type"`
+	// Valid values: "hnsw", "flat", "dynamic", "hfresh".
+	DefaultVectorIndexType *runtime.DynamicValue[string] `json:"default_vector_index" yaml:"default_vector_index"`
 
 	// New classes will be created with this shard count instead of the cluster node count.
 	// A value of 0 means use the cluster node count (default behavior).

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -238,6 +238,9 @@ type Config struct {
 	// New classes will be created with the default quantization
 	DefaultQuantization *runtime.DynamicValue[string] `json:"default_quantization" yaml:"default_quantization"`
 
+	// New classes will be created with this vector index type instead of HNSW.
+	DefaultVectorIndexType string `json:"default_vector_index_type" yaml:"default_vector_index_type"`
+
 	// New classes will be created with this shard count instead of the cluster node count.
 	// A value of 0 means use the cluster node count (default behavior).
 	DefaultShardingCount *runtime.DynamicValue[int] `json:"default_sharding_count" yaml:"default_sharding_count"`

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -559,6 +559,15 @@ func FromEnv(config *Config) error {
 	}
 	config.DefaultQuantization = configRuntime.NewDynamicValue(defaultQuantization)
 
+	if v := os.Getenv("DEFAULT_VECTOR_INDEX"); v != "" {
+		v = strings.ToLower(v)
+		validTypes := []string{"hnsw", "flat", "dynamic", "hfresh"}
+		if !slices.Contains(validTypes, v) {
+			return fmt.Errorf("invalid DEFAULT_VECTOR_INDEX %q, must be one of: %v", v, validTypes)
+		}
+		config.DefaultVectorIndexType = v
+	}
+
 	defaultShardingCount := 0
 	if err := parseNonNegativeInt(
 		"DEFAULT_SHARDING_COUNT",

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -559,14 +559,15 @@ func FromEnv(config *Config) error {
 	}
 	config.DefaultQuantization = configRuntime.NewDynamicValue(defaultQuantization)
 
+	defaultVectorIndexType := ""
 	if v := os.Getenv("DEFAULT_VECTOR_INDEX"); v != "" {
-		v = strings.ToLower(v)
+		defaultVectorIndexType = strings.ToLower(v)
 		validTypes := []string{"hnsw", "flat", "dynamic", "hfresh"}
-		if !slices.Contains(validTypes, v) {
-			return fmt.Errorf("invalid DEFAULT_VECTOR_INDEX %q, must be one of: %v", v, validTypes)
+		if !slices.Contains(validTypes, defaultVectorIndexType) {
+			return fmt.Errorf("invalid DEFAULT_VECTOR_INDEX %q, must be one of: %v", defaultVectorIndexType, validTypes)
 		}
-		config.DefaultVectorIndexType = v
 	}
+	config.DefaultVectorIndexType = configRuntime.NewDynamicValue(defaultVectorIndexType)
 
 	defaultShardingCount := 0
 	if err := parseNonNegativeInt(

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -1642,6 +1642,41 @@ func TestEnvironmentExportDefaultBucket(t *testing.T) {
 	}
 }
 
+func TestEnvironmentDefaultVectorIndex(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		expected    string
+		expectedErr string
+	}{
+		{"not set", "", "", ""},
+		{"hnsw", "hnsw", "hnsw", ""},
+		{"flat", "flat", "flat", ""},
+		{"dynamic", "dynamic", "dynamic", ""},
+		{"hfresh", "hfresh", "hfresh", ""},
+		{"uppercase FLAT", "FLAT", "flat", ""},
+		{"mixed case Hnsw", "Hnsw", "hnsw", ""},
+		{"invalid value", "invalid", "", `invalid DEFAULT_VECTOR_INDEX "invalid"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.value != "" {
+				t.Setenv("DEFAULT_VECTOR_INDEX", tt.value)
+			}
+			conf := Config{}
+			err := FromEnv(&conf)
+
+			if tt.expectedErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.expected, conf.DefaultVectorIndexType)
+			}
+		})
+	}
+}
+
 func TestEnvironmentAsyncIndexing(t *testing.T) {
 	factors := []struct {
 		name     string

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -1671,7 +1671,7 @@ func TestEnvironmentDefaultVectorIndex(t *testing.T) {
 				assert.Contains(t, err.Error(), tt.expectedErr)
 			} else {
 				require.NoError(t, err)
-				assert.Equal(t, tt.expected, conf.DefaultVectorIndexType)
+				assert.Equal(t, tt.expected, conf.DefaultVectorIndexType.Get())
 			}
 		})
 	}

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -52,6 +52,7 @@ type WeaviateRuntimeConfig struct {
 	ReplicatedIndicesRequestQueueEnabled *runtime.DynamicValue[bool]          `json:"replicated_indices_request_queue_enabled" yaml:"replicated_indices_request_queue_enabled"`
 	OperationalMode                      *runtime.DynamicValue[string]        `json:"operational_mode" yaml:"operational_mode"`
 	DefaultQuantization                  *runtime.DynamicValue[string]        `yaml:"default_quantization" json:"default_quantization"`
+	DefaultVectorIndexType               *runtime.DynamicValue[string]        `yaml:"default_vector_index" json:"default_vector_index"`
 	DefaultShardingCount                 *runtime.DynamicValue[int]           `yaml:"default_sharding_count" json:"default_sharding_count"`
 
 	ObjectsTTLDeleteSchedule      *runtime.DynamicValue[string]        `json:"objects_ttl_delete_schedule" yaml:"objects_ttl_delete_schedule"`

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -459,7 +459,11 @@ func (h *Handler) setClassDefaults(class *models.Class, globalCfg replication.Gl
 		}
 
 		if class.VectorIndexType == "" {
-			class.VectorIndexType = vectorindex.DefaultVectorIndexType
+			if h.config.DefaultVectorIndexType != "" {
+				class.VectorIndexType = h.config.DefaultVectorIndexType
+			} else {
+				class.VectorIndexType = vectorindex.DefaultVectorIndexType
+			}
 		}
 
 		if h.config.DefaultVectorDistanceMetric != "" {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -459,8 +459,8 @@ func (h *Handler) setClassDefaults(class *models.Class, globalCfg replication.Gl
 		}
 
 		if class.VectorIndexType == "" {
-			if h.config.DefaultVectorIndexType != "" {
-				class.VectorIndexType = h.config.DefaultVectorIndexType
+			if v := h.config.DefaultVectorIndexType.Get(); v != "" {
+				class.VectorIndexType = v
 			} else {
 				class.VectorIndexType = vectorindex.DefaultVectorIndexType
 			}

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -2979,7 +2979,7 @@ func Test_SetClassDefaults_DefaultVectorIndexType(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			handler, _ := newTestHandler(t, &fakeDB{})
-			handler.config.DefaultVectorIndexType = tt.defaultIndexType
+			handler.config.DefaultVectorIndexType = runtime.NewDynamicValue(tt.defaultIndexType)
 
 			class := &models.Class{
 				VectorIndexType:   tt.classIndexType,

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -2928,6 +2928,70 @@ func Test_SetClassDefaults(t *testing.T) {
 	}
 }
 
+func Test_SetClassDefaults_DefaultVectorIndexType(t *testing.T) {
+	t.Parallel()
+	globalCfg := replication.GlobalConfig{MinimumFactor: 1}
+
+	tests := []struct {
+		name              string
+		defaultIndexType  string
+		classIndexType    string
+		expectedIndexType string
+	}{
+		{
+			name:              "no env, no class type => hnsw default",
+			defaultIndexType:  "",
+			classIndexType:    "",
+			expectedIndexType: vectorindex.VectorIndexTypeHNSW,
+		},
+		{
+			name:              "env set to flat, no class type => flat",
+			defaultIndexType:  vectorindex.VectorIndexTypeFLAT,
+			classIndexType:    "",
+			expectedIndexType: vectorindex.VectorIndexTypeFLAT,
+		},
+		{
+			name:              "env set to dynamic, no class type => dynamic",
+			defaultIndexType:  vectorindex.VectorIndexTypeDYNAMIC,
+			classIndexType:    "",
+			expectedIndexType: vectorindex.VectorIndexTypeDYNAMIC,
+		},
+		{
+			name:              "env set to hfresh, no class type => hfresh",
+			defaultIndexType:  vectorindex.VectorIndexTypeHFresh,
+			classIndexType:    "",
+			expectedIndexType: vectorindex.VectorIndexTypeHFresh,
+		},
+		{
+			name:              "env set to flat, class explicitly hnsw => hnsw preserved",
+			defaultIndexType:  vectorindex.VectorIndexTypeFLAT,
+			classIndexType:    vectorindex.VectorIndexTypeHNSW,
+			expectedIndexType: vectorindex.VectorIndexTypeHNSW,
+		},
+		{
+			name:              "env set to hnsw, no class type => hnsw",
+			defaultIndexType:  vectorindex.VectorIndexTypeHNSW,
+			classIndexType:    "",
+			expectedIndexType: vectorindex.VectorIndexTypeHNSW,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, _ := newTestHandler(t, &fakeDB{})
+			handler.config.DefaultVectorIndexType = tt.defaultIndexType
+
+			class := &models.Class{
+				VectorIndexType:   tt.classIndexType,
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+			}
+			err := handler.setClassDefaults(class, globalCfg)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedIndexType, class.VectorIndexType)
+		})
+	}
+}
+
 func Test_GetConsistentClass_WithAlias(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
### What's being changed:
- Allow Weaviate's default vector index type to be configured via `DEFAULT_VECTOR_INDEX`
- Defaults to HNSW
- Validates setting one of `hnsw`, `dynamic`, `flat`, `hfresh` case insensitive


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.
