### PR TITLE
chore: only disable alter schema drop vector index endpoint

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -35,7 +35,7 @@ services:
       TRACK_VECTOR_DIMENSIONS: "true"
       QUERY_MAXIMUM_RESULTS: 10005
       OBJECTS_TTL_DELETE_SCHEDULE: "@every 12h"
-      ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS: "true"
+      ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT: "true"
 
       # necessary for the metrics tests, some metrics only exist once segments
       # are flushed. If we wait to long the before run is completely in

--- a/test/acceptance/alter_schema/alter_schema_test.go
+++ b/test/acceptance/alter_schema/alter_schema_test.go
@@ -28,7 +28,7 @@ func TestProperties_SingleNode(t *testing.T) {
 		ctx := context.Background()
 		compose, err = docker.New().
 			WithWeaviate().
-			WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS", "true").
+			WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true").
 			WithText2VecModel2Vec().
 			Start(ctx)
 		require.NoError(t, err)
@@ -56,7 +56,7 @@ func TestProperties_Cluster(t *testing.T) {
 	ctx := context.Background()
 	compose, err := docker.New().
 		WithWeaviateCluster(3).
-		WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS", "true").
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true").
 		WithText2VecModel2Vec().
 		Start(ctx)
 	require.NoError(t, err)

--- a/test/acceptance/authz/alter_schema_operations_test.go
+++ b/test/acceptance/authz/alter_schema_operations_test.go
@@ -36,7 +36,7 @@ func TestAuthzDeleteClassPropertyIndex(t *testing.T) {
 		map[string]string{customUser: customKey},
 		nil,
 		false,
-		map[string]string{"ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS": "true"},
+		map[string]string{"ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT": "true"},
 	)
 	defer down()
 

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -193,7 +193,7 @@ func Test_Schema_Authorization(t *testing.T) {
 
 	t.Run("verify the tested methods require correct permissions from the Authorizer", func(t *testing.T) {
 		principal := &models.Principal{}
-		t.Setenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS", "true")
+		t.Setenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true")
 		for _, test := range tests {
 			t.Run(test.methodName, func(t *testing.T) {
 				authorizer := mocks.NewMockAuthorizer()

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -100,9 +100,6 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 func (h *Handler) DeleteClassPropertyIndex(ctx context.Context, principal *models.Principal,
 	class *models.Class, className, propertyName, indexName string,
 ) error {
-	if !entcfg.Enabled(os.Getenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS")) {
-		return fmt.Errorf("alter schema endpoints are experimental and disabled by default, set the environment variable ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS=true to enable them")
-	}
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil {
 		return err
 	}
@@ -167,8 +164,8 @@ func (h *Handler) DeleteClassPropertyIndex(ctx context.Context, principal *model
 func (h *Handler) DeleteClassVectorIndex(ctx context.Context, principal *models.Principal,
 	className, vectorIndexName string,
 ) error {
-	if !entcfg.Enabled(os.Getenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS")) {
-		return fmt.Errorf("alter schema endpoints are experimental and disabled by default, set the environment variable ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS=true to enable them")
+	if !entcfg.Enabled(os.Getenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT")) {
+		return fmt.Errorf("alter schema drop vector index endpoint is experimental and disabled by default, set the environment variable ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT=true to enable it")
 	}
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil {
 		return err

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -784,7 +784,7 @@ func (pdt *fakePropertyDataType) ContainsClass(name schema.ClassName) bool {
 }
 
 func TestHandler_DeleteClassVectorIndex(t *testing.T) {
-	t.Setenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_ENDPOINTS", "true")
+	t.Setenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true")
 	ctx := context.Background()
 
 	t.Run("class not found returns error", func(t *testing.T) {


### PR DESCRIPTION
### What's being changed:

This PR only disables alter schema drop vector index endpoint.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
