### PR TITLE
fix(multi2vec-google): add support for Google AI Studio API Key headers

### DIFF
--- a/modules/multi2vec-google/clients/google.go
+++ b/modules/multi2vec-google/clients/google.go
@@ -134,7 +134,7 @@ func (v *google) sendRequest(ctx context.Context,
 		return 0, nil, errors.Wrap(err, "create POST request")
 	}
 
-	apiKey, err := v.getApiKey(ctx)
+	apiKey, err := v.getApiKey(ctx, v.useGeminiApi(config))
 	if err != nil {
 		return 0, nil, errors.Wrapf(err, "Google API Key")
 	}
@@ -236,8 +236,8 @@ func (v *google) checkResponse(statusCode int, googleApiError *googleApiError) e
 	return nil
 }
 
-func (v *google) getApiKey(ctx context.Context) (string, error) {
-	return v.googleApiKey.GetApiKey(ctx, v.apiKey, false, v.useGoogleAuth)
+func (v *google) getApiKey(ctx context.Context, useGenerativeAIEndpoint bool) (string, error) {
+	return v.googleApiKey.GetApiKey(ctx, v.apiKey, useGenerativeAIEndpoint, v.useGoogleAuth)
 }
 
 func (v *google) getEmbeddingsFromVertexResponse(statusCode int, bodyBytes []byte) (

--- a/modules/multi2vec-google/clients/google_test.go
+++ b/modules/multi2vec-google/clients/google_test.go
@@ -199,6 +199,192 @@ func TestClient(t *testing.T) {
 	})
 }
 
+func TestGetApiKeyWithGeminiHeaders(t *testing.T) {
+	geminiConfig := ent.VectorizationConfig{
+		ApiEndpoint: "generativelanguage.googleapis.com",
+		Model:       "gemini-embedding-2-preview",
+	}
+
+	tests := []struct {
+		name       string
+		headerKey  string
+		headerVal  string
+		envApiKey  string
+		wantApiKey string
+		wantErr    bool
+	}{
+		{
+			name:       "X-Goog-Studio-Api-Key header",
+			headerKey:  "X-Goog-Studio-Api-Key",
+			headerVal:  "studio-key-1",
+			wantApiKey: "studio-key-1",
+		},
+		{
+			name:       "X-Google-Studio-Api-Key header",
+			headerKey:  "X-Google-Studio-Api-Key",
+			headerVal:  "studio-key-2",
+			wantApiKey: "studio-key-2",
+		},
+		{
+			name:       "X-Goog-Api-Key header falls through for Gemini",
+			headerKey:  "X-Goog-Api-Key",
+			headerVal:  "goog-key",
+			wantApiKey: "goog-key",
+		},
+		{
+			name:       "X-Palm-Api-Key header falls through for Gemini",
+			headerKey:  "X-Palm-Api-Key",
+			headerVal:  "palm-key",
+			wantApiKey: "palm-key",
+		},
+		{
+			name:       "env api key used as fallback",
+			envApiKey:  "env-key",
+			wantApiKey: "env-key",
+		},
+		{
+			name:    "no key returns error",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(&fakeGeminiHandler{t: t})
+			defer server.Close()
+			c := &google{
+				apiKey:       tt.envApiKey,
+				httpClient:   &http.Client{},
+				googleApiKey: apikey.NewGoogleApiKey(),
+				urlBuilderFn: func(apiEndpoint, location, projectID, model string) string {
+					return server.URL
+				},
+				logger: nullLogger(),
+			}
+			ctx := context.Background()
+			if tt.headerKey != "" {
+				ctx = context.WithValue(ctx, tt.headerKey, []string{tt.headerVal})
+			}
+
+			res, err := c.Vectorize(ctx, []string{"hello"}, nil, nil, nil, geminiConfig)
+
+			if tt.wantErr {
+				require.NotNil(t, err)
+				assert.Contains(t, err.Error(), "no api key found")
+			} else {
+				require.Nil(t, err)
+				assert.NotNil(t, res)
+			}
+		})
+	}
+}
+
+func TestGetApiKeyVertexHeadersNotUsedForGemini(t *testing.T) {
+	// Vertex-specific headers (X-Goog-Vertex-Api-Key) should NOT work for Gemini endpoint
+	server := httptest.NewServer(&fakeGeminiHandler{t: t})
+	defer server.Close()
+	c := &google{
+		apiKey:       "",
+		httpClient:   &http.Client{},
+		googleApiKey: apikey.NewGoogleApiKey(),
+		urlBuilderFn: func(apiEndpoint, location, projectID, model string) string {
+			return server.URL
+		},
+		logger: nullLogger(),
+	}
+	ctx := context.WithValue(context.Background(), "X-Goog-Vertex-Api-Key", []string{"vertex-key"})
+
+	_, err := c.Vectorize(ctx, []string{"hello"}, nil, nil, nil, ent.VectorizationConfig{
+		ApiEndpoint: "generativelanguage.googleapis.com",
+		Model:       "gemini-embedding-2-preview",
+	})
+
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "no api key found")
+}
+
+func TestGetApiKeyVertexHeaders(t *testing.T) {
+	vertexConfig := ent.VectorizationConfig{
+		Location:  "us-central1",
+		ProjectID: "my-project",
+		Model:     "multimodalembedding",
+	}
+
+	tests := []struct {
+		name       string
+		headerKey  string
+		headerVal  string
+		envApiKey  string
+		wantApiKey string
+	}{
+		{
+			name:       "X-Goog-Vertex-Api-Key header",
+			headerKey:  "X-Goog-Vertex-Api-Key",
+			headerVal:  "vertex-key-1",
+			wantApiKey: "vertex-key-1",
+		},
+		{
+			name:       "X-Google-Vertex-Api-Key header",
+			headerKey:  "X-Google-Vertex-Api-Key",
+			headerVal:  "vertex-key-2",
+			wantApiKey: "vertex-key-2",
+		},
+		{
+			name:       "X-Goog-Api-Key header falls through for Vertex",
+			headerKey:  "X-Goog-Api-Key",
+			headerVal:  "goog-key",
+			wantApiKey: "goog-key",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(&fakeHandler{t: t})
+			defer server.Close()
+			c := &google{
+				apiKey:       tt.envApiKey,
+				httpClient:   &http.Client{},
+				googleApiKey: apikey.NewGoogleApiKey(),
+				urlBuilderFn: func(apiEndpoint, location, projectID, model string) string {
+					return server.URL
+				},
+				logger: nullLogger(),
+			}
+			ctx := context.WithValue(context.Background(), tt.headerKey, []string{tt.headerVal})
+
+			res, err := c.Vectorize(ctx, []string{"hello"}, nil, nil, nil, vertexConfig)
+
+			require.Nil(t, err)
+			assert.NotNil(t, res)
+		})
+	}
+}
+
+func TestGeminiStudioHeaderNotUsedForVertex(t *testing.T) {
+	// Studio-specific headers should NOT work for Vertex endpoint
+	server := httptest.NewServer(&fakeHandler{t: t})
+	defer server.Close()
+	c := &google{
+		apiKey:       "",
+		httpClient:   &http.Client{},
+		googleApiKey: apikey.NewGoogleApiKey(),
+		urlBuilderFn: func(apiEndpoint, location, projectID, model string) string {
+			return server.URL
+		},
+		logger: nullLogger(),
+	}
+	ctx := context.WithValue(context.Background(), "X-Goog-Studio-Api-Key", []string{"studio-key"})
+
+	_, err := c.Vectorize(ctx, []string{"hello"}, nil, nil, nil, ent.VectorizationConfig{
+		Location:  "us-central1",
+		ProjectID: "my-project",
+		Model:     "multimodalembedding",
+	})
+
+	require.NotNil(t, err)
+	assert.Contains(t, err.Error(), "no api key found")
+}
+
 func TestGeminiClient(t *testing.T) {
 	t.Run("when all is fine we vectorize audio via Gemini API", func(t *testing.T) {
 		server := httptest.NewServer(&fakeGeminiHandler{t: t})


### PR DESCRIPTION
### What's being changed:

This PR adds support for Google AI Studio API Key headers in `multi2vec-google` module.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
