### PR TITLE
Nested object filtering — Part 9: flat execution plan and arr[N] cross-index fix

### DIFF
--- a/adapters/repos/db/inverted/nested/assign.go
+++ b/adapters/repos/db/inverted/nested/assign.go
@@ -393,5 +393,5 @@ func joinPath(prefix, name string) string {
 	if prefix == "" {
 		return name
 	}
-	return prefix + "." + name
+	return JoinRelPath([]string{prefix, name})
 }

--- a/adapters/repos/db/inverted/nested/path.go
+++ b/adapters/repos/db/inverted/nested/path.go
@@ -1,0 +1,32 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package nested
+
+import "strings"
+
+const pathSep = "."
+
+// SplitRelPath splits a dot-notation relative nested path into its property
+// name segments. The inverse of JoinRelPath.
+//
+//	SplitRelPath("cars.tires.width") → ["cars", "tires", "width"]
+func SplitRelPath(path string) []string {
+	return strings.Split(path, pathSep)
+}
+
+// JoinRelPath joins property name segments into a dot-notation relative path.
+// The inverse of SplitRelPath.
+//
+//	JoinRelPath(["cars", "tires", "width"]) → "cars.tires.width"
+func JoinRelPath(segs []string) string {
+	return strings.Join(segs, pathSep)
+}

--- a/adapters/repos/db/inverted/objects_nested.go
+++ b/adapters/repos/db/inverted/objects_nested.go
@@ -16,7 +16,7 @@ import (
 	"maps"
 	"slices"
 
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -125,7 +125,7 @@ func (a *Analyzer) analyzeNestedProp(prop *models.Property, value any) (*NestedP
 		return nil, nil
 	}
 
-	assignResult, err := nested.AssignPositions(prop, value)
+	assignResult, err := invnested.AssignPositions(prop, value)
 	if err != nil {
 		return nil, err
 	}
@@ -191,7 +191,7 @@ func (a *Analyzer) analyzeNestedProp(prop *models.Property, value any) (*NestedP
 // analyzeNestedValue converts a raw positioned value into one or more
 // NestedValue entries with analyzed byte representations. Text values
 // may produce multiple entries (one per token).
-func (a *Analyzer) analyzeNestedValue(pv nested.PositionedValue, cfg nestedIndexConfig) ([]NestedValue, error) {
+func (a *Analyzer) analyzeNestedValue(pv invnested.PositionedValue, cfg nestedIndexConfig) ([]NestedValue, error) {
 	// TODO aliszka:nested_filtering verify whether pv.PropName (leaf nested property
 	// name, e.g. "city") is the correct identifier for the text analyzer lookup,
 	// or whether the top-level property name (e.g. "addresses") should be used instead.

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -23,7 +23,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/entities/filters"
-	filternested "github.com/weaviate/weaviate/entities/filters/nested"
+	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 )
 
@@ -54,7 +54,7 @@ type nestedInfo struct {
 	// Each entry (filternested.ArrayIndex) restricts the matching positions to the
 	// specified array element. Multiple entries support multi-level indexing
 	// (e.g. cars[1].tags[2]).
-	arrayIndices []filternested.ArrayIndex
+	arrayIndices []filnested.ArrayIndex
 }
 
 type propValuePair struct {

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -23,39 +23,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/entities/filters"
-	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 )
-
-// nestedInfo groups fields that are only relevant for nested (object/object[])
-// property filters. The zero value represents a non-nested node.
-//
-// isNested and isCorrelated are mutually exclusive — a node is either a leaf
-// or a group, never both:
-//
-// When isNested is set (leaf node):
-//   - prop on the parent propValuePair is the top-level property name
-//   - value is the bare encoded value (without prefix)
-//   - relPath is the dot-notation path relative to prop
-//     (e.g. "city" or "owner.firstname")
-//   - the result bitmap contains positions that are stripped to docIDs
-//
-// When isCorrelated is set (AND group node):
-//   - prop on the parent propValuePair is the root property name
-//   - all children require position-aware same-element resolution
-//   - childrenFromTokenization marks a compound AND from multi-token text;
-//     its children are tokens that must share the same leaf position
-type nestedInfo struct {
-	isNested                 bool
-	relPath                  string
-	isCorrelated             bool
-	childrenFromTokenization bool
-	// arrayIndices holds positional constraints from arr[N] filter syntax.
-	// Each entry (filternested.ArrayIndex) restricts the matching positions to the
-	// specified array element. Multiple entries support multi-level indexing
-	// (e.g. cars[1].tags[2]).
-	arrayIndices []filnested.ArrayIndex
-}
 
 type propValuePair struct {
 	prop     string

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -18,7 +18,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
@@ -30,7 +30,7 @@ func (pv *propValuePair) fetchNestedDocIDs(ctx context.Context, s *Searcher, lim
 	if err != nil {
 		return nil, err
 	}
-	dbm.docIDs = nested.MaskRootLeaf(dbm.docIDs)
+	dbm.docIDs = invnested.MaskRootLeaf(dbm.docIDs)
 	return dbm, nil
 }
 
@@ -47,7 +47,7 @@ func (pv *propValuePair) fetchNestedIsNull(s *Searcher) (*docBitmap, error) {
 		return nil, errors.Errorf("nested IsNull: meta bucket for %q not found — is it indexed?", pv.prop)
 	}
 
-	positions, release, err := metaBucket.RoaringSetGet(nested.ExistsKey(pv.nested.relPath))
+	positions, release, err := metaBucket.RoaringSetGet(invnested.ExistsKey(pv.nested.relPath))
 	if err != nil {
 		return nil, fmt.Errorf("nested IsNull: read exists key for %q: %w", pv.prop, err)
 	}
@@ -58,7 +58,7 @@ func (pv *propValuePair) fetchNestedIsNull(s *Searcher) (*docBitmap, error) {
 	}
 
 	dbm := newDocBitmap()
-	dbm.docIDs = nested.MaskRootLeaf(positions)
+	dbm.docIDs = invnested.MaskRootLeaf(positions)
 	// pv.value is a little-endian bool: 0x01 = true (IsNull — property absent → denylist).
 	dbm.isDenyList = len(pv.value) > 0 && pv.value[0] == 0x01
 	return &dbm, nil
@@ -92,7 +92,7 @@ func (pv *propValuePair) restrictByNestedIdx(s *Searcher, positions *sroar.Bitma
 		return fmt.Errorf("nested [N] filter: meta bucket for %q not found — is it indexed?", pv.prop)
 	}
 	for _, ai := range pv.nested.arrayIndices {
-		idxPositions, release, err := metaBucket.RoaringSetGet(nested.IdxKey(ai.RelPath, ai.Index))
+		idxPositions, release, err := metaBucket.RoaringSetGet(invnested.IdxKey(ai.RelPath, ai.Index))
 		if err != nil {
 			return fmt.Errorf("nested [N] filter: read idx key for %q[%d]: %w", ai.RelPath, ai.Index, err)
 		}
@@ -121,7 +121,7 @@ func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searche
 	// Build positionsByPath: fetch raw position bitmaps per pvp and route into
 	// the correct bucket slot based on origin (token vs independent).
 	positionsByPath := make(map[string]*positionBitmaps, len(pv.children))
-	pathOrder := make([]string, 0, len(pv.children))
+	paths := make([]string, 0, len(pv.children))
 
 	fetchAndRoute := func(leaf *propValuePair, isToken bool) error {
 		dbm, err := leaf.fetchNestedPositions(ctx, s, 0)
@@ -131,7 +131,7 @@ func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searche
 		path := leaf.nested.relPath
 		if _, exists := positionsByPath[path]; !exists {
 			positionsByPath[path] = &positionBitmaps{}
-			pathOrder = append(pathOrder, path)
+			paths = append(paths, path)
 		}
 		if isToken {
 			positionsByPath[path].tokens = append(positionsByPath[path].tokens, dbm.docIDs)
@@ -158,21 +158,30 @@ func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searche
 		}
 	}
 
-	// Find the root property's schema to build the resolution plan.
+	// Find the root property's schema so the plan builder can locate intermediate
+	// object[] arrays and determine same-element semantics for each group.
 	rootProp, err := schema.GetPropertyByName(pv.Class, pv.prop)
 	if err != nil {
 		return nil, fmt.Errorf("nested correlated AND: root property %q not found in schema: %w", pv.prop, err)
 	}
-	rootDT := schema.DataType(rootProp.DataType[0])
 
-	plan, err := newResolutionPlanBuilder(rootDT, rootProp.NestedProperties).build(pathOrder)
+	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(pv.prop))
+	if metaBucket == nil {
+		return nil, fmt.Errorf("nested correlated AND: meta bucket for %q not found — is it indexed?", pv.prop)
+	}
+
+	// Compute per-path condition counts (tokens, independents) for the plan builder.
+	counts := make(conditionCounts, len(positionsByPath))
+	for path, positions := range positionsByPath {
+		counts[path] = [2]int{len(positions.tokens), len(positions.independent)}
+	}
+
+	plan, err := newExecutionPlanBuilder(rootProp.NestedProperties).build(paths, counts)
 	if err != nil {
 		return nil, fmt.Errorf("nested correlated AND: build plan for %q: %w", pv.prop, err)
 	}
 
-	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(pv.prop))
-
-	docIDs, err := newResolutionPlanExecutor(plan, positionsByPath, metaBucket).execute(ctx)
+	docIDs, err := newPlanExecutor(plan, positionsByPath, metaBucket).execute(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("nested correlated AND: execute for %q: %w", pv.prop, err)
 	}

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -14,13 +14,60 @@ package inverted
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/schema"
 )
+
+// nestedInfo groups fields that are only relevant for nested (object/object[])
+// property filters. The zero value represents a non-nested node.
+//
+// isNested and isCorrelated are mutually exclusive — a node is either a leaf
+// or a group, never both:
+//
+// When isNested is set (leaf node):
+//   - prop on the parent propValuePair is the top-level property name
+//   - value is the bare encoded value (without prefix)
+//   - relPath is the dot-notation path relative to prop
+//     (e.g. "city" or "owner.firstname")
+//   - the result bitmap contains positions that are stripped to docIDs
+//
+// When isCorrelated is set (AND group node):
+//   - prop on the parent propValuePair is the root property name
+//   - all children require position-aware same-element resolution
+//   - childrenFromTokenization marks a compound AND from multi-token text;
+//     its children are tokens that must share the same leaf position
+type nestedInfo struct {
+	isNested                 bool
+	relPath                  string
+	isCorrelated             bool
+	childrenFromTokenization bool
+	arrayIndices             arrayIndices
+}
+
+// arrayIndices holds positional constraints from arr[N] filter syntax.
+// Each entry restricts matching positions to the specified array element.
+// Multiple entries support multi-level indexing (e.g. cars[1].tags[2]).
+type arrayIndices []filnested.ArrayIndex
+
+// groupKey returns a string that uniquely identifies the set of arr[N] constraints.
+// Two conditions with the same groupKey are safe to combine in a correlated AND
+// (same-element semantics); different keys require independent resolution.
+func (a arrayIndices) groupKey() string {
+	if len(a) == 0 {
+		return ""
+	}
+	var key strings.Builder
+	for _, ai := range a {
+		fmt.Fprintf(&key, "%s[%d]", ai.RelPath, ai.Index)
+	}
+	return key.String()
+}
 
 // fetchNestedDocIDs resolves a value filter on a nested property, returning
 // docID-only results. It fetches raw positions, applies any arr[N] index
@@ -117,11 +164,49 @@ type positionBitmaps struct {
 // resolveNestedCorrelated resolves one prop group using position-aware
 // correlation. It builds a resolutionPlan for the group's paths, pre-computes
 // raw position bitmaps, and executes the plan to enforce same-element semantics.
+//
+// When children carry conflicting arr[N] constraints (e.g. cars[1].X and
+// cars[0].Y), they are partitioned by their arrayIndices key and each partition
+// is resolved independently. The per-partition results are ANDed at docID level
+// so that a document is returned only when it satisfies all partitions — without
+// incorrectly requiring conditions from different explicit elements to land in
+// the same element.
 func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searcher) (*docBitmap, error) {
+	groups := groupChildrenByArrayIndicesKey(pv.children)
+	switch len(groups) {
+	case 0:
+		return nil, fmt.Errorf("nested correlated AND: no condition groups for %q", pv.prop)
+	case 1:
+		return pv.resolveNestedCorrelatedGroup(ctx, s, groups[0])
+	default:
+		// Multiple groups with conflicting arr[N] constraints: resolve each group
+		// independently using same-element semantics, then AND the docID results.
+		first, err := pv.resolveNestedCorrelatedGroup(ctx, s, groups[0])
+		if err != nil {
+			return nil, err
+		}
+		combined := first.docIDs
+		for _, group := range groups[1:] {
+			dbm, err := pv.resolveNestedCorrelatedGroup(ctx, s, group)
+			if err != nil {
+				return nil, err
+			}
+			combined.And(dbm.docIDs)
+		}
+		result := newDocBitmap()
+		result.docIDs = combined
+		return &result, nil
+	}
+}
+
+// resolveNestedCorrelatedGroup resolves a single set of children using
+// position-aware same-element correlation. All children must have compatible
+// arrayIndices (same arr[N] constraints at every level).
+func (pv *propValuePair) resolveNestedCorrelatedGroup(ctx context.Context, s *Searcher, children []*propValuePair) (*docBitmap, error) {
 	// Build positionsByPath: fetch raw position bitmaps per pvp and route into
 	// the correct bucket slot based on origin (token vs independent).
-	positionsByPath := make(map[string]*positionBitmaps, len(pv.children))
-	paths := make([]string, 0, len(pv.children))
+	positionsByPath := make(map[string]*positionBitmaps, len(children))
+	paths := make([]string, 0, len(children))
 
 	fetchAndRoute := func(leaf *propValuePair, isToken bool) error {
 		dbm, err := leaf.fetchNestedPositions(ctx, s, 0)
@@ -141,7 +226,7 @@ func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searche
 		return nil
 	}
 
-	for _, child := range pv.children {
+	for _, child := range children {
 		if child.nested.isNested {
 			// When pv itself is a tokenization compound AND, its children are tokens
 			// of the same value and must share the same leaf position → route as tokens.
@@ -189,4 +274,32 @@ func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searche
 	dbm := newDocBitmap()
 	dbm.docIDs = docIDs
 	return &dbm, nil
+}
+
+// groupChildrenByArrayIndicesKey partitions the children of a correlated AND
+// node by their arr[N] constraint key. Children with the same key can be
+// combined with same-element semantics; children with different keys must be
+// resolved independently. A single group is returned when all children are
+// compatible (the common case when no arr[N] constraints are used).
+func groupChildrenByArrayIndicesKey(children []*propValuePair) [][]*propValuePair {
+	seen := map[string]int{} // key → index into groups
+	var groups [][]*propValuePair
+
+	for _, child := range children {
+		var key string
+		if child.nested.isNested {
+			key = child.nested.arrayIndices.groupKey()
+		} else if len(child.children) > 0 {
+			// Tokenization compound AND: all grandchildren share the same arrayIndices.
+			key = child.children[0].nested.arrayIndices.groupKey()
+		}
+		if idx, ok := seen[key]; ok {
+			groups[idx] = append(groups[idx], child)
+		} else {
+			seen[key] = len(groups)
+			groups = append(groups, []*propValuePair{child})
+		}
+	}
+
+	return groups
 }

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -656,7 +656,7 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 
 		makePvp := func(relPath, value string) *propValuePair {
 			pv := makeLeafPvp(class, "cars", relPath, value)
-			pv.invnested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 1}}
+			pv.nested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 1}}
 			return pv
 		}
 		widthPvp := &propValuePair{
@@ -2082,7 +2082,7 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 		}))
 
 		pv := makeLeafPvp(class, "addresses", "city", "berlin")
-		pv.invnested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 1}}
+		pv.nested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 1}}
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
@@ -2103,7 +2103,7 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 		// No IdxKey("", 5) entry → intersection will be empty
 
 		pv := makeLeafPvp(class, "addresses", "city", "berlin")
-		pv.invnested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 5}}
+		pv.nested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 5}}
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
@@ -2126,7 +2126,7 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1), []uint64{posAddr(2, 1, doc1)}))
 
 		pv := makeIsNullPvp(class, "addresses", "", false)
-		pv.invnested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 1}}
+		pv.nested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 1}}
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
@@ -2156,7 +2156,7 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1), []uint64{posAddr(2, 1, doc1), posAddr(2, 1, doc3)}))
 
 		pv := makeIsNullPvp(class, "addresses", "city", false)
-		pv.invnested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 1}}
+		pv.nested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 1}}
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
@@ -2221,7 +2221,7 @@ func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("tags", 2), []uint64{posAt(1, 3, doc1)}))
 
 		pv := makeLeafPvp(class, "cars", "tags", "german")
-		pv.invnested.arrayIndices = []filnested.ArrayIndex{{RelPath: "tags", Index: 2}}
+		pv.nested.arrayIndices = []filnested.ArrayIndex{{RelPath: "tags", Index: 2}}
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
@@ -2298,7 +2298,7 @@ func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("tags", 2), []uint64{posAt(2, 3, doc1)}))
 
 		pv := makeLeafPvp(class, "cars", "tags", "german")
-		pv.invnested.arrayIndices = []filnested.ArrayIndex{
+		pv.nested.arrayIndices = []filnested.ArrayIndex{
 			{RelPath: "", Index: 1},     // cars[1]
 			{RelPath: "tags", Index: 2}, // tags[2]
 		}
@@ -2429,8 +2429,8 @@ func newSearcherForClass(t *testing.T, class *models.Class, bucketNames ...strin
 	bitmapFactory := roaringset.NewBitmapFactory(
 		roaringset.NewBitmapBufPoolNoop(), func() uint64 { return 1_000_000 })
 	searcher := NewSearcher(logger, store, func(string) *models.Class { return class },
-		nil, nil, fakeStopwordDetector{}, 2,
-		func() bool { return false }, "",
+		nil, nil, stopwords.NewProvider(fakeStopwordDetector{}, nil), 2,
+		func() bool { return false }, nil, "",
 		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
 	return searcher, store
 }
@@ -3456,4 +3456,1015 @@ func TestNestedFilteringComprehensive(t *testing.T) {
 			})
 		})
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Full-pipeline extraction tests for IsNull and arr[N]
+// ---------------------------------------------------------------------------
+//
+// The existing TestNestedIsNull and TestNestedArrayIndexFilter tests verify the
+// resolution side (fetchNestedIsNull, restrictByNestedIdx) using manually
+// constructed propValuePairs. The tests below verify the full extraction →
+// resolution pipeline via extractPropValuePair for both DataTypeObject ("nested")
+// and DataTypeObjectArray ("nestedArray"), which exercises:
+//
+//   IsNull: buildNestedIsNullPair produces relPath relative to the root property —
+//     "nested.addresses" → ExistsKey("addresses"), not ExistsKey("") as used when
+//     "addresses" IS the root property.
+//
+//   arr[N]: ParseIndexedPath strips the root property name and produces
+//     arrayIndices with RelPath relative to the root — "nested.addresses[1].city"
+//     → RelPath:"addresses", IdxKey("addresses",1), distinct from IdxKey("",1)
+//     used when "addresses" IS the root property.
+//
+// The nestedArray variants additionally exercise multiple root elements (root_idx>1)
+// to verify that IsNull and arr[N] work correctly across array elements.
+
+// TestNestedFilteringIsNull verifies IsNull filters end-to-end via extractPropValuePair
+// for both DataTypeObject ("nested") and DataTypeObjectArray ("nestedArray").
+func TestNestedFilteringIsNull(t *testing.T) {
+	class := planTestClass()
+
+	for _, prop := range []string{"nested", "nestedArray"} {
+		t.Run(prop, func(t *testing.T) {
+			const (
+				doc5 = uint64(5) // has addresses with city
+				doc7 = uint64(7) // has addresses without city
+			)
+
+			// For DataTypeObject root=1 always; for DataTypeObjectArray use root=1
+			// (single-element scenario — same position layout as nested).
+			pos := func(docID uint64) uint64 { return invnested.Encode(1, 1, docID) }
+
+			// Only the meta bucket is needed for IsNull.
+			metaBucketName := helpers.BucketNestedMetaFromPropNameLSM(prop)
+			searcher, store := newSearcherForClass(t, class, metaBucketName)
+			mb := store.Bucket(metaBucketName)
+
+			// Exists entries relative to the root property.
+			// ExistsKey("addresses"): docs with any addresses element.
+			// ExistsKey("addresses.city"): docs with city present in any address.
+			writeNestedExists(t, mb, "addresses", []uint64{pos(doc5), pos(doc7)})
+			writeNestedExists(t, mb, "addresses.city", []uint64{pos(doc5)})
+
+			isNullClause := func(path string, isNull bool) *filters.Clause {
+				return &filters.Clause{
+					Operator: filters.OperatorIsNull,
+					Value:    &filters.Value{Type: schema.DataTypeBoolean, Value: isNull},
+					On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(path)},
+				}
+			}
+
+			t.Run("root sub-property IsNull false — allowlist", func(t *testing.T) {
+				// prop+".addresses" → relPath="addresses" → ExistsKey("addresses") → [doc5,doc7]
+				pv, err := searcher.extractPropValuePair(context.Background(),
+					isNullClause(prop+".addresses", false), "PlanTestClass")
+				require.NoError(t, err)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.False(t, result.isDenyList)
+				assert.Equal(t, []uint64{doc5, doc7}, result.docIDs.ToArray())
+			})
+
+			t.Run("root sub-property IsNull true — denylist", func(t *testing.T) {
+				pv, err := searcher.extractPropValuePair(context.Background(),
+					isNullClause(prop+".addresses", true), "PlanTestClass")
+				require.NoError(t, err)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.True(t, result.isDenyList)
+				assert.Equal(t, []uint64{doc5, doc7}, result.docIDs.ToArray())
+			})
+
+			t.Run("deep sub-property IsNull false — allowlist", func(t *testing.T) {
+				// prop+".addresses.city" → relPath="addresses.city" → ExistsKey("addresses.city") → [doc5]
+				pv, err := searcher.extractPropValuePair(context.Background(),
+					isNullClause(prop+".addresses.city", false), "PlanTestClass")
+				require.NoError(t, err)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.False(t, result.isDenyList)
+				assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+			})
+
+			t.Run("deep sub-property IsNull true — denylist", func(t *testing.T) {
+				pv, err := searcher.extractPropValuePair(context.Background(),
+					isNullClause(prop+".addresses.city", true), "PlanTestClass")
+				require.NoError(t, err)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.True(t, result.isDenyList)
+				assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+			})
+
+			if prop == "nestedArray" {
+				t.Run("nestedArray — IsNull across multiple root elements", func(t *testing.T) {
+					// doc8: nestedArray[1] (root=2) has addresses with city —
+					// verify that IsNull correctly reads exists entries from any root element.
+					const doc8 = uint64(8)
+					writeNestedExists(t, mb, "addresses", []uint64{invnested.Encode(2, 1, doc8)})
+					writeNestedExists(t, mb, "addresses.city", []uint64{invnested.Encode(2, 1, doc8)})
+
+					pv, err := searcher.extractPropValuePair(context.Background(),
+						isNullClause(prop+".addresses.city", false), "PlanTestClass")
+					require.NoError(t, err)
+					result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+					require.NoError(t, err)
+					assert.False(t, result.isDenyList)
+					// doc5 (root=1) and doc8 (root=2) both have city → both returned
+					assert.Equal(t, []uint64{doc5, doc8}, result.docIDs.ToArray())
+				})
+			}
+		})
+	}
+}
+
+// TestNestedFilteringArrayIndex verifies arr[N] filters end-to-end via extractPropValuePair
+// for both DataTypeObject ("nested") and DataTypeObjectArray ("nestedArray").
+func TestNestedFilteringArrayIndex(t *testing.T) {
+	class := planTestClass()
+
+	sortableInt := func(v int) []byte {
+		b, err := ent.LexicographicallySortableInt64(int64(v))
+		require.NoError(t, err)
+		return b
+	}
+	width205 := sortableInt(205)
+
+	for _, prop := range []string{"nested", "nestedArray"} {
+		t.Run(prop, func(t *testing.T) {
+			const (
+				doc5 = uint64(5)
+				doc7 = uint64(7)
+			)
+
+			// For DataTypeObject root=1 always. For DataTypeObjectArray, tests use a
+			// single-element scenario (root=1) for the shared cases, then add a
+			// multi-root sub-test specific to nestedArray.
+			enc := func(root, leaf uint16, docID uint64) uint64 {
+				return invnested.Encode(root, leaf, docID)
+			}
+			// e1 is a shorthand for root=1 (the common single-element case).
+			e1 := func(leaf uint16, docID uint64) uint64 { return enc(1, leaf, docID) }
+
+			t.Run("arr[N] value filter — second address", func(t *testing.T) {
+				// prop+".addresses[1].city = berlin"
+				// ParseIndexedPath: cleanRelPath="addresses.city",
+				//   arrayIndices=[{RelPath:"addresses", Index:1}]
+				// restrictByNestedIdx reads IdxKey("addresses",1) — distinct from
+				// IdxKey("",1) used when "addresses" IS the root property.
+				//
+				// doc5: addresses[0].city="paris"(leaf=1), addresses[1].city="berlin"(leaf=2)
+				// doc7: addresses[0].city="berlin"(leaf=1) only — no second address
+				valueBucketName := helpers.BucketNestedFromPropNameLSM(prop)
+				metaBucketName := helpers.BucketNestedMetaFromPropNameLSM(prop)
+				searcher, store := newSearcherForClass(t, class, valueBucketName, metaBucketName)
+				vb := store.Bucket(valueBucketName)
+				mb := store.Bucket(metaBucketName)
+
+				writeNestedValue(t, vb, "addresses.city", "paris", []uint64{e1(1, doc5)})
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{e1(2, doc5), e1(1, doc7)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("addresses", 0),
+					[]uint64{e1(1, doc5), e1(1, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("addresses", 1),
+					[]uint64{e1(2, doc5)})) // only doc5 has a second address
+
+				f := &filters.Clause{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeText, Value: "berlin"},
+					On: &filters.Path{
+						Class:    "PlanTestClass",
+						Property: schema.PropertyName(prop + ".addresses[1].city"),
+					},
+				}
+				pv, err := searcher.extractPropValuePair(context.Background(), f, "PlanTestClass")
+				require.NoError(t, err)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+			})
+
+			t.Run("arr[N] out of range returns empty", func(t *testing.T) {
+				valueBucketName := helpers.BucketNestedFromPropNameLSM(prop)
+				metaBucketName := helpers.BucketNestedMetaFromPropNameLSM(prop)
+				searcher, store := newSearcherForClass(t, class, valueBucketName, metaBucketName)
+				vb := store.Bucket(valueBucketName)
+				mb := store.Bucket(metaBucketName)
+
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{e1(1, doc5)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("addresses", 0), []uint64{e1(1, doc5)}))
+
+				f := &filters.Clause{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeText, Value: "berlin"},
+					On: &filters.Path{
+						Class:    "PlanTestClass",
+						Property: schema.PropertyName(prop + ".addresses[5].city"),
+					},
+				}
+				pv, err := searcher.extractPropValuePair(context.Background(), f, "PlanTestClass")
+				require.NoError(t, err)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.True(t, result.docIDs.IsEmpty())
+			})
+
+			t.Run("arr[N] + correlated AND — cars[1].make=bmw AND cars[1].tires.width=205", func(t *testing.T) {
+				// Both conditions carry arrayIndices=[{RelPath:"cars", Index:1}].
+				// restrictByNestedIdx pre-filters each bitmap to cars[1] positions
+				// before the executor runs, so doc7 (no cars[1]) correctly gets no match.
+				//
+				// doc5: cars[0]={make:"tesla"}(leaf=1), cars[1]={make:"bmw",tires[0]}(leaf=2)
+				// doc7: cars[0]={make:"bmw",tires[0]}(leaf=1) only — no cars[1]
+				valueBucketName := helpers.BucketNestedFromPropNameLSM(prop)
+				metaBucketName := helpers.BucketNestedMetaFromPropNameLSM(prop)
+				searcher, store := newSearcherForClass(t, class, valueBucketName, metaBucketName)
+				vb := store.Bucket(valueBucketName)
+				mb := store.Bucket(metaBucketName)
+
+				writeNestedValue(t, vb, "cars.make", "tesla", []uint64{e1(1, doc5)})
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{e1(2, doc5), e1(1, doc7)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205),
+					[]uint64{e1(2, doc5), e1(1, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
+					[]uint64{e1(1, doc5), e1(1, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
+					[]uint64{e1(2, doc5)})) // only doc5 has a second car
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0),
+					[]uint64{e1(2, doc5), e1(1, doc7)}))
+
+				f := &filters.Clause{
+					Operator: filters.OperatorAnd,
+					Operands: []filters.Clause{
+						{
+							Operator: filters.OperatorEqual,
+							Value:    &filters.Value{Type: schema.DataTypeText, Value: "bmw"},
+							On: &filters.Path{
+								Class:    "PlanTestClass",
+								Property: schema.PropertyName(prop + ".cars[1].make"),
+							},
+						},
+						{
+							Operator: filters.OperatorEqual,
+							Value:    &filters.Value{Type: schema.DataTypeInt, Value: 205},
+							On: &filters.Path{
+								Class:    "PlanTestClass",
+								Property: schema.PropertyName(prop + ".cars[1].tires.width"),
+							},
+						},
+					},
+				}
+				pv, err := searcher.extractPropValuePair(context.Background(), f, "PlanTestClass")
+				require.NoError(t, err)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+			})
+
+			if prop == "nestedArray" {
+				t.Run("nestedArray — arr[N] across multiple root elements", func(t *testing.T) {
+					// doc5: nestedArray[0] has addresses[0]="paris"(leaf=1), addresses[1]="berlin"(leaf=2)
+					// doc8: nestedArray[1] (root=2) has addresses[1]="berlin"(leaf=2)
+					// Filter: addresses[1].city = "berlin" must return both doc5 and doc8.
+					const doc8 = uint64(8)
+					valueBucketName := helpers.BucketNestedFromPropNameLSM(prop)
+					metaBucketName := helpers.BucketNestedMetaFromPropNameLSM(prop)
+					searcher, store := newSearcherForClass(t, class, valueBucketName, metaBucketName)
+					vb := store.Bucket(valueBucketName)
+					mb := store.Bucket(metaBucketName)
+
+					// doc5 in nestedArray[0] (root=1)
+					writeNestedValue(t, vb, "addresses.city", "paris", []uint64{enc(1, 1, doc5)})
+					writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{enc(1, 2, doc5)})
+					require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("addresses", 0), []uint64{enc(1, 1, doc5)}))
+					require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("addresses", 1), []uint64{enc(1, 2, doc5)}))
+
+					// doc8 in nestedArray[1] (root=2): only addresses[1] present
+					writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{enc(2, 2, doc8)})
+					require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("addresses", 1), []uint64{enc(2, 2, doc8)}))
+
+					f := &filters.Clause{
+						Operator: filters.OperatorEqual,
+						Value:    &filters.Value{Type: schema.DataTypeText, Value: "berlin"},
+						On: &filters.Path{
+							Class:    "PlanTestClass",
+							Property: schema.PropertyName(prop + ".addresses[1].city"),
+						},
+					}
+					pv, err := searcher.extractPropValuePair(context.Background(), f, "PlanTestClass")
+					require.NoError(t, err)
+					result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+					require.NoError(t, err)
+					// Both doc5 (root=1, addresses[1]) and doc8 (root=2, addresses[1]) match
+					assert.Equal(t, []uint64{doc5, doc8}, result.docIDs.ToArray())
+				})
+			}
+		})
+	}
+}
+
+// TestNestedFilteringArrayIndexLevelsAndCombinations verifies arr[N] filtering
+// at every nesting depth and in AND/OR combinations with different index values.
+//
+// Level coverage (all use the "nestedArray: DataTypeObjectArray" root property):
+//
+//	root  — nestedArray[N].cars.colors   selects which nestedArray element
+//	mid-1 — nestedArray.cars[N].colors   selects which car element
+//	mid-2 — nestedArray.cars.tires[N].width selects which tire element
+//
+// Combination coverage:
+//
+//	AND same index  — cars[1].colors="red" AND cars[1].make="bmw"                            → correct
+//	AND diff-car    — cars[1].colors="red" AND cars[0].colors="blue"  → partitioned, correct
+//	OR  diff-car    — cars[1].colors="red" OR  cars[0].colors="blue"  → union, correct
+//	AND diff-root   — nestedArray[1].cars.colors="red" AND nestedArray[0].cars.colors="blue" → partitioned, correct
+//	OR  diff-root   — nestedArray[1].cars.colors="red" OR  nestedArray[0].cars.colors="blue" → union, correct
+//
+// "Partitioned" means groupChildrenByArrayIndicesKey detected conflicting arr[N]
+// constraints and resolved each group independently, ANDing results at docID level.
+func TestNestedFilteringArrayIndexLevelsAndCombinations(t *testing.T) {
+	const (
+		doc5 = uint64(5)
+		doc7 = uint64(7)
+	)
+
+	sortableInt := func(v int) []byte {
+		b, err := ent.LexicographicallySortableInt64(int64(v))
+		require.NoError(t, err)
+		return b
+	}
+	width205 := sortableInt(205)
+	width305 := sortableInt(305)
+
+	class := planTestClass()
+	prop := "nestedArray"
+
+	enc := func(root, leaf uint16, docID uint64) uint64 { return invnested.Encode(root, leaf, docID) }
+	e1 := func(leaf uint16, docID uint64) uint64 { return enc(1, leaf, docID) }
+
+	vbName := helpers.BucketNestedFromPropNameLSM(prop)
+	mbName := helpers.BucketNestedMetaFromPropNameLSM(prop)
+
+	newSearcher := func(t *testing.T) (*Searcher, *lsmkv.Store) {
+		t.Helper()
+		return newSearcherForClass(t, class, vbName, mbName)
+	}
+
+	textFlt := func(path, value string) filters.Clause {
+		return filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: value},
+			On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + "." + path)},
+		}
+	}
+	textRootFlt := func(fullPath, value string) filters.Clause {
+		return filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: value},
+			On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + fullPath)},
+		}
+	}
+	intRootFlt := func(fullPath string, v int) filters.Clause {
+		return filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeInt, Value: v},
+			On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + fullPath)},
+		}
+	}
+	and := func(ops ...filters.Clause) *filters.Clause {
+		return &filters.Clause{Operator: filters.OperatorAnd, Operands: ops}
+	}
+	or := func(ops ...filters.Clause) *filters.Clause {
+		return &filters.Clause{Operator: filters.OperatorOr, Operands: ops}
+	}
+
+	run := func(t *testing.T, searcher *Searcher, f *filters.Clause, want []uint64) {
+		t.Helper()
+		pv, err := searcher.extractPropValuePair(context.Background(), f, "PlanTestClass")
+		require.NoError(t, err)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, want, result.docIDs.ToArray())
+	}
+
+	// -------------------------------------------------------------------------
+	// Root-level arr[N]: nestedArray[0] vs nestedArray[1]
+	//
+	// doc5: nestedArray[0]={cars:[{colors:["blue"]}]}, nestedArray[1]={cars:[{colors:["red"]}]}
+	// doc7: nestedArray[0]={cars:[{colors:["red"]}]}
+	//
+	// [0].cars.colors="red" → IdxKey("",0) → doc7 only (doc5 nestedArray[0] has blue)
+	// [1].cars.colors="red" → IdxKey("",1) → doc5 only (only doc5 has a second element)
+	// -------------------------------------------------------------------------
+	t.Run("root arr[N] — nestedArray[N].cars.colors", func(t *testing.T) {
+		searcher, store := newSearcher(t)
+		vb, mb := store.Bucket(vbName), store.Bucket(mbName)
+
+		writeNestedValue(t, vb, "cars.colors", "blue", []uint64{enc(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.colors", "red", []uint64{enc(2, 1, doc5), enc(1, 1, doc7)})
+
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 0), []uint64{enc(1, 1, doc5), enc(1, 1, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1), []uint64{enc(2, 1, doc5)}))
+
+		t.Run("[0].cars.colors=red — doc7 (doc5 has blue in element 0)", func(t *testing.T) {
+			run(t, searcher, &filters.Clause{
+				Operator: filters.OperatorEqual,
+				Value:    &filters.Value{Type: schema.DataTypeText, Value: "red"},
+				On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + "[0].cars.colors")},
+			}, []uint64{doc7})
+		})
+		t.Run("[1].cars.colors=red — doc5 only (only doc5 has element 1)", func(t *testing.T) {
+			run(t, searcher, &filters.Clause{
+				Operator: filters.OperatorEqual,
+				Value:    &filters.Value{Type: schema.DataTypeText, Value: "red"},
+				On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + "[1].cars.colors")},
+			}, []uint64{doc5})
+		})
+	})
+
+	// -------------------------------------------------------------------------
+	// Intermediate-1 arr[N]: cars[0] vs cars[1] within a single nestedArray element
+	//
+	// doc5: nestedArray[0]={cars:[{colors:["blue"]},{colors:["red"]}]}
+	// doc7: nestedArray[0]={cars:[{colors:["red"]}]}
+	//
+	// cars[0].colors="red" → IdxKey("cars",0) → doc7 (doc5 has blue in cars[0])
+	// cars[1].colors="red" → IdxKey("cars",1) → doc5 (only doc5 has cars[1])
+	// -------------------------------------------------------------------------
+	t.Run("mid-1 arr[N] — nestedArray.cars[N].colors", func(t *testing.T) {
+		searcher, store := newSearcher(t)
+		vb, mb := store.Bucket(vbName), store.Bucket(mbName)
+
+		writeNestedValue(t, vb, "cars.colors", "blue", []uint64{e1(1, doc5)})
+		writeNestedValue(t, vb, "cars.colors", "red", []uint64{e1(2, doc5), e1(1, doc7)})
+
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{e1(1, doc5), e1(1, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{e1(2, doc5)}))
+
+		t.Run("cars[0].colors=red — doc7 (doc5 has blue in cars[0])", func(t *testing.T) {
+			run(t, searcher, &filters.Clause{
+				Operator: filters.OperatorEqual,
+				Value:    &filters.Value{Type: schema.DataTypeText, Value: "red"},
+				On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + ".cars[0].colors")},
+			}, []uint64{doc7})
+		})
+		t.Run("cars[1].colors=red — doc5 only (only doc5 has cars[1])", func(t *testing.T) {
+			run(t, searcher, &filters.Clause{
+				Operator: filters.OperatorEqual,
+				Value:    &filters.Value{Type: schema.DataTypeText, Value: "red"},
+				On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + ".cars[1].colors")},
+			}, []uint64{doc5})
+		})
+	})
+
+	// -------------------------------------------------------------------------
+	// Intermediate-2 arr[N]: tires[0] vs tires[1] within cars[0]
+	//
+	// doc5: cars[0]={tires:[{width:305},{width:205}]}  — 205 is in tires[1]
+	// doc7: cars[0]={tires:[{width:205}]}              — 205 is in tires[0]
+	//
+	// tires[0].width=205 → IdxKey("cars.tires",0) → doc7
+	// tires[1].width=205 → IdxKey("cars.tires",1) → doc5
+	// -------------------------------------------------------------------------
+	t.Run("mid-2 arr[N] — nestedArray.cars.tires[N].width", func(t *testing.T) {
+		searcher, store := newSearcher(t)
+		vb, mb := store.Bucket(vbName), store.Bucket(mbName)
+
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width305), []uint64{e1(1, doc5)}))
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{e1(2, doc5), e1(1, doc7)}))
+
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{e1(1, doc5), e1(1, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 1), []uint64{e1(2, doc5)}))
+
+		t.Run("tires[0].width=205 — doc7 (doc5 has 305 in tires[0])", func(t *testing.T) {
+			run(t, searcher, &filters.Clause{
+				Operator: filters.OperatorEqual,
+				Value:    &filters.Value{Type: schema.DataTypeInt, Value: 205},
+				On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + ".cars.tires[0].width")},
+			}, []uint64{doc7})
+		})
+		t.Run("tires[1].width=205 — doc5 only (only doc5 has tires[1])", func(t *testing.T) {
+			run(t, searcher, &filters.Clause{
+				Operator: filters.OperatorEqual,
+				Value:    &filters.Value{Type: schema.DataTypeInt, Value: 205},
+				On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + ".cars.tires[1].width")},
+			}, []uint64{doc5})
+		})
+	})
+
+	// -------------------------------------------------------------------------
+	// AND same car index: cars[1].colors="red" AND cars[1].make="bmw"
+	//
+	// Both restricted to cars[1]. Correlated AND (groupRunIdxLoop) correctly
+	// enforces same-car-element — doc5 has both in cars[1], doc7 has red but no make.
+	//
+	// doc5: cars[0]={colors:["blue"]}, cars[1]={colors:["red"],make:"bmw"}
+	// doc7: cars[0]={colors:["blue"]}, cars[1]={colors:["red"]}  (no make in cars[1])
+	// -------------------------------------------------------------------------
+	t.Run("AND same car index — cars[1].colors=red AND cars[1].make=bmw", func(t *testing.T) {
+		searcher, store := newSearcher(t)
+		vb, mb := store.Bucket(vbName), store.Bucket(mbName)
+
+		writeNestedValue(t, vb, "cars.colors", "blue", []uint64{e1(1, doc5), e1(1, doc7)})
+		writeNestedValue(t, vb, "cars.colors", "red", []uint64{e1(2, doc5), e1(2, doc7)})
+		writeNestedValue(t, vb, "cars.make", "bmw", []uint64{e1(2, doc5)})
+
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{e1(1, doc5), e1(1, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{e1(2, doc5), e1(2, doc7)}))
+
+		run(t, searcher, and(textFlt("cars[1].colors", "red"), textFlt("cars[1].make", "bmw")),
+			[]uint64{doc5})
+	})
+
+	// -------------------------------------------------------------------------
+	// AND/OR different car indices
+	//
+	// cars[1].colors="red" AND cars[0].colors="blue":
+	//   groupChildrenByArrayIndicesKey detects conflicting arr[N] constraints
+	//   ({cars:1} vs {cars:0}) and partitions into two independent groups.
+	//   Each group is resolved with same-element semantics, results are ANDed
+	//   at docID level → doc5 (which has blue in cars[0] AND red in cars[1]) matches.
+	//
+	// cars[1].colors="red" OR cars[0].colors="blue":
+	//   OR resolves each condition independently via fetchNestedDocIDs → union.
+	//   cars[1].red → {doc5}; cars[0].blue → {doc5, doc7} → {doc5, doc7}.
+	//
+	// doc5: cars[0]={colors:["blue"]}, cars[1]={colors:["red"]}
+	// doc7: cars[0]={colors:["blue"]}, cars[1]={colors:["blue"]}
+	// -------------------------------------------------------------------------
+	t.Run("AND different car indices — cars[1].colors=red AND cars[0].colors=blue", func(t *testing.T) {
+		searcher, store := newSearcher(t)
+		vb, mb := store.Bucket(vbName), store.Bucket(mbName)
+
+		writeNestedValue(t, vb, "cars.colors", "blue", []uint64{e1(1, doc5), e1(1, doc7), e1(2, doc7)})
+		writeNestedValue(t, vb, "cars.colors", "red", []uint64{e1(2, doc5)})
+
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{e1(1, doc5), e1(1, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{e1(2, doc5), e1(2, doc7)}))
+
+		// doc5: red in cars[1] AND blue in cars[0] → each partition resolves independently → match.
+		// doc7: red absent in cars[1]... wait, doc7 has blue in both cars → cars[1].red partition is empty → no match.
+		run(t, searcher, and(textFlt("cars[1].colors", "red"), textFlt("cars[0].colors", "blue")),
+			[]uint64{doc5})
+	})
+
+	t.Run("OR different car indices — cars[1].colors=red OR cars[0].colors=blue", func(t *testing.T) {
+		searcher, store := newSearcher(t)
+		vb, mb := store.Bucket(vbName), store.Bucket(mbName)
+
+		writeNestedValue(t, vb, "cars.colors", "blue", []uint64{e1(1, doc5), e1(1, doc7), e1(2, doc7)})
+		writeNestedValue(t, vb, "cars.colors", "red", []uint64{e1(2, doc5)})
+
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{e1(1, doc5), e1(1, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{e1(2, doc5), e1(2, doc7)}))
+
+		// cars[1].red → {doc5}; cars[0].blue → {doc5,doc7} → union {doc5,doc7}
+		run(t, searcher, or(textFlt("cars[1].colors", "red"), textFlt("cars[0].colors", "blue")),
+			[]uint64{doc5, doc7})
+	})
+
+	// -------------------------------------------------------------------------
+	// AND/OR different nestedArray root indices
+	//
+	// nestedArray[1].cars.colors="red" AND nestedArray[0].cars.colors="blue":
+	//   groupChildrenByArrayIndicesKey detects conflicting arr[N] constraints
+	//   ({[1]} vs {[0]}) and partitions into two independent groups.
+	//   Each resolves independently (single condition each → groupAndAll or
+	//   groupAndAllMaskLeaf), results ANDed at docID level → doc5 matches.
+	//
+	// nestedArray[1].cars.colors="red" OR nestedArray[0].cars.colors="blue":
+	//   OR resolves each independently → union.
+	//   [1].red → {doc5}; [0].blue → {doc5, doc7} → {doc5, doc7}.
+	//
+	// doc5: nestedArray[0].cars[0].colors="blue" (root=1,leaf=1)
+	//       nestedArray[1].cars[0].colors="red"  (root=2,leaf=1)
+	// doc7: nestedArray[0].cars[0].colors="blue" (root=1,leaf=1)
+	// -------------------------------------------------------------------------
+	t.Run("AND different root indices — nestedArray[1].cars.colors=red AND nestedArray[0].cars.colors=blue", func(t *testing.T) {
+		searcher, store := newSearcher(t)
+		vb, mb := store.Bucket(vbName), store.Bucket(mbName)
+
+		writeNestedValue(t, vb, "cars.colors", "blue", []uint64{enc(1, 1, doc5), enc(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.colors", "red", []uint64{enc(2, 1, doc5)})
+
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 0), []uint64{enc(1, 1, doc5), enc(1, 1, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1), []uint64{enc(2, 1, doc5)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
+			[]uint64{enc(1, 1, doc5), enc(1, 1, doc7), enc(2, 1, doc5)}))
+
+		// partitioned: [1].red group → {doc5}; [0].blue group → {doc5,doc7}; AND → {doc5}
+		run(t, searcher,
+			and(textRootFlt("[1].cars.colors", "red"), textRootFlt("[0].cars.colors", "blue")),
+			[]uint64{doc5})
+	})
+
+	t.Run("OR different root indices — nestedArray[1].cars.colors=red OR nestedArray[0].cars.colors=blue", func(t *testing.T) {
+		searcher, store := newSearcher(t)
+		vb, mb := store.Bucket(vbName), store.Bucket(mbName)
+
+		writeNestedValue(t, vb, "cars.colors", "blue", []uint64{enc(1, 1, doc5), enc(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.colors", "red", []uint64{enc(2, 1, doc5)})
+
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 0), []uint64{enc(1, 1, doc5), enc(1, 1, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1), []uint64{enc(2, 1, doc5)}))
+
+		// [1].red → {doc5}; [0].blue → {doc5,doc7} → union {doc5,doc7}
+		run(t, searcher,
+			or(textRootFlt("[1].cars.colors", "red"), textRootFlt("[0].cars.colors", "blue")),
+			[]uint64{doc5, doc7})
+	})
+
+	_ = width305 // used in mid-2 test
+	_ = intRootFlt
+}
+
+// TestNestedFilteringIsNullAndMultiLevelArrayIndex verifies arr[N] and IsNull
+func TestNestedFilteringIsNullAndMultiLevelArrayIndex(t *testing.T) {
+	const (
+		doc5 = uint64(5)
+		doc7 = uint64(7)
+		doc8 = uint64(8)
+	)
+
+	class := planTestClass()
+
+	enc := func(root, leaf uint16, docID uint64) uint64 { return invnested.Encode(root, leaf, docID) }
+	e1 := func(leaf uint16, docID uint64) uint64 { return enc(1, leaf, docID) }
+
+	run := func(t *testing.T, searcher *Searcher, f *filters.Clause, want []uint64) {
+		t.Helper()
+		pv, err := searcher.extractPropValuePair(context.Background(), f, "PlanTestClass")
+		require.NoError(t, err)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, want, result.docIDs.ToArray())
+	}
+	runDeny := func(t *testing.T, searcher *Searcher, f *filters.Clause, wantDeny bool, want []uint64) {
+		t.Helper()
+		pv, err := searcher.extractPropValuePair(context.Background(), f, "PlanTestClass")
+		require.NoError(t, err)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, wantDeny, result.isDenyList)
+		assert.Equal(t, want, result.docIDs.ToArray())
+	}
+
+	isNullFlt := func(path string, isNull bool) *filters.Clause {
+		return &filters.Clause{
+			Operator: filters.OperatorIsNull,
+			Value:    &filters.Value{Type: schema.DataTypeBoolean, Value: isNull},
+			On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(path)},
+		}
+	}
+	textFlt := func(path, value string) *filters.Clause {
+		return &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: value},
+			On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(path)},
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Case 1: IsNull + arr[N] via extractPropValuePair
+	//
+	// "nested.addresses[1] IsNull false":
+	//   ParseIndexedPath → cleanRelPath="addresses", arrayIndices=[{RelPath:"addresses",Index:1}]
+	//   buildNestedIsNullPair: reads ExistsKey("addresses"), restricts by IdxKey("addresses",1).
+	//
+	// "nested.addresses[1].city IsNull false":
+	//   cleanRelPath="addresses.city", same arrayIndices.
+	//   Reads ExistsKey("addresses.city"), restricts by IdxKey("addresses",1).
+	//
+	// doc5: addresses[0](leaf=1,city) + addresses[1](leaf=2,city) — both arr elements, both have city
+	// doc7: addresses[0](leaf=1,city) only         — no second address element
+	// doc8: addresses[0](leaf=1,city) + addresses[1](leaf=2,no city) — second element exists but no city
+	//
+	// addresses[1] IsNull false → {doc5, doc8} (both have a second element)
+	// addresses[1].city IsNull false → {doc5}   (only doc5 has city in second element)
+	// -------------------------------------------------------------------------
+	t.Run("IsNull + arr[N] — addresses[1] IsNull and addresses[1].city IsNull", func(t *testing.T) {
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("nested")
+		searcher, store := newSearcherForClass(t, class, metaBucketName)
+		mb := store.Bucket(metaBucketName)
+
+		// ExistsKey("addresses"): all positions where addresses has any element
+		writeNestedExists(t, mb, "addresses", []uint64{
+			e1(1, doc5), e1(2, doc5), // doc5 has two addresses
+			e1(1, doc7),              // doc7 has one address
+			e1(1, doc8), e1(2, doc8), // doc8 has two addresses
+		})
+		// ExistsKey("addresses.city"): positions where city is present in any address
+		writeNestedExists(t, mb, "addresses.city", []uint64{
+			e1(1, doc5), e1(2, doc5), // doc5: city in both addresses
+			e1(1, doc7), // doc7: city only in addresses[0]
+			e1(1, doc8), // doc8: city only in addresses[0]; addresses[1] has no city
+		})
+		// IdxKey("addresses", 0): positions in addresses[0] element
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("addresses", 0),
+			[]uint64{e1(1, doc5), e1(1, doc7), e1(1, doc8)}))
+		// IdxKey("addresses", 1): positions in addresses[1] element
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("addresses", 1),
+			[]uint64{e1(2, doc5), e1(2, doc8)})) // only doc5 and doc8 have a second address
+
+		// "addresses[1] IsNull false" → allowlist of docs with a second address element
+		runDeny(t, searcher, isNullFlt("nested.addresses[1]", false), false, []uint64{doc5, doc8})
+		// "addresses[1] IsNull true" → denylist (complement)
+		runDeny(t, searcher, isNullFlt("nested.addresses[1]", true), true, []uint64{doc5, doc8})
+		// "addresses[1].city IsNull false" → only doc5 has city in addresses[1]
+		runDeny(t, searcher, isNullFlt("nested.addresses[1].city", false), false, []uint64{doc5})
+		// "addresses[1].city IsNull true" → denylist
+		runDeny(t, searcher, isNullFlt("nested.addresses[1].city", true), true, []uint64{doc5})
+	})
+
+	// -------------------------------------------------------------------------
+	// Case 2: scalar array arr[N] via extractPropValuePair
+	//
+	// "nested.cars.colors[2] = red":
+	//   ParseIndexedPath → cleanRelPath="cars.colors", arrayIndices=[{RelPath:"cars.colors",Index:2}]
+	//   restrictByNestedIdx reads IdxKey("cars.colors",2) — only positions that are
+	//   the third element (index 2) of the cars.colors scalar array.
+	//
+	// doc5: cars[0]={colors:["blue","green","red"]}
+	//   colors[0]→leaf=1, colors[1]→leaf=2, colors[2]→leaf=3  ("red" at index 2)
+	// doc7: cars[0]={colors:["red"]}
+	//   colors[0]→leaf=1 only  ("red" at index 0, NOT index 2)
+	// -------------------------------------------------------------------------
+	t.Run("scalar array arr[N] — nested.cars.colors[2] = red", func(t *testing.T) {
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("nested")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("nested")
+		searcher, store := newSearcherForClass(t, class, valueBucketName, metaBucketName)
+		vb, mb := store.Bucket(valueBucketName), store.Bucket(metaBucketName)
+
+		writeNestedValue(t, vb, "cars.colors", "blue", []uint64{e1(1, doc5)})
+		writeNestedValue(t, vb, "cars.colors", "green", []uint64{e1(2, doc5)})
+		writeNestedValue(t, vb, "cars.colors", "red", []uint64{e1(3, doc5), e1(1, doc7)})
+
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.colors", 0), []uint64{e1(1, doc5), e1(1, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.colors", 1), []uint64{e1(2, doc5)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.colors", 2), []uint64{e1(3, doc5)}))
+
+		// doc5 has red at colors[2]; doc7 has red only at colors[0] → not matched
+		run(t, searcher, textFlt("nested.cars.colors[2]", "red"), []uint64{doc5})
+	})
+
+	// -------------------------------------------------------------------------
+	// Case 3: multi-level arr[N] via extractPropValuePair
+	//
+	// "nested.cars[1].colors[2] = red":
+	//   ParseIndexedPath → cleanRelPath="cars.colors",
+	//   arrayIndices=[{RelPath:"cars",Index:1},{RelPath:"cars.colors",Index:2}]
+	//   restrictByNestedIdx applies BOTH constraints in order:
+	//   1. AND with IdxKey("cars",1)     → keep only positions in cars[1]
+	//   2. AND with IdxKey("cars.colors",2) → keep only the third color element
+	//
+	// doc5: cars[0]={colors:["x"]}, cars[1]={colors:["a","b","red"]}
+	//   cars[0]: leaf=1; cars[1]: colors[0]→leaf=2, colors[1]→leaf=3, colors[2]→leaf=4 ("red")
+	// doc7: cars[0]={colors:["a","b","red"]}, cars[1]={colors:["red"]}
+	//   cars[0]: colors[0]→leaf=1, colors[1]→leaf=2, colors[2]→leaf=3 ("red" at index 2 of cars[0])
+	//   cars[1]: colors[0]→leaf=4 ("red" at index 0 of cars[1], NOT index 2)
+	//
+	// Restriction to cars[1] first eliminates doc7's red-in-cars[0].
+	// Restriction to colors[2] then eliminates doc7's red-in-cars[1]-at-index-0.
+	// Only doc5 has red at cars[1].colors[2].
+	// -------------------------------------------------------------------------
+	t.Run("multi-level arr[N] — nested.cars[1].colors[2] = red", func(t *testing.T) {
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("nested")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("nested")
+		searcher, store := newSearcherForClass(t, class, valueBucketName, metaBucketName)
+		vb, mb := store.Bucket(valueBucketName), store.Bucket(metaBucketName)
+
+		// doc5: cars[0]={colors:["x"]}→leaf=1; cars[1]={colors:["a"(leaf=2),"b"(leaf=3),"red"(leaf=4)]}
+		writeNestedValue(t, vb, "cars.colors", "x", []uint64{e1(1, doc5)})
+		writeNestedValue(t, vb, "cars.colors", "a", []uint64{e1(2, doc5)})
+		writeNestedValue(t, vb, "cars.colors", "b", []uint64{e1(3, doc5)})
+		writeNestedValue(t, vb, "cars.colors", "red", []uint64{e1(4, doc5), e1(3, doc7), e1(4, doc7)})
+		// doc7: cars[0]={colors:["a"(leaf=1),"b"(leaf=2),"red"(leaf=3)]}; cars[1]={colors:["red"(leaf=4)]}
+		writeNestedValue(t, vb, "cars.colors", "a", []uint64{e1(1, doc7)})
+		writeNestedValue(t, vb, "cars.colors", "b", []uint64{e1(2, doc7)})
+
+		// IdxKey("cars", 0) and ("cars", 1): which positions belong to each car
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{e1(1, doc5), e1(1, doc7), e1(2, doc7), e1(3, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{e1(2, doc5), e1(3, doc5), e1(4, doc5), e1(4, doc7)}))
+		// IdxKey("cars.colors", N): which positions are the Nth color element across all cars
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.colors", 0), []uint64{e1(1, doc5), e1(1, doc7), e1(2, doc5)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.colors", 1), []uint64{e1(3, doc5), e1(2, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.colors", 2), []uint64{e1(4, doc5), e1(3, doc7)}))
+
+		// Only doc5 has red at cars[1].colors[2] (leaf=4).
+		// doc7 has red at cars[0].colors[2] (leaf=3, excluded by cars[1] restriction)
+		// and at cars[1].colors[0] (leaf=4, excluded by colors[2] restriction).
+		run(t, searcher, textFlt("nested.cars[1].colors[2]", "red"), []uint64{doc5})
+	})
+
+	// -------------------------------------------------------------------------
+	// Case 4: same-partition arr[N] correlated AND via extractPropValuePair
+	//
+	// "nestedArray[1].addresses.city=berlin AND nestedArray[1].cars.make=bmw":
+	//   Both conditions share arrayIndices=[{RelPath:"",Index:1}] (root-level nestedArray[1]).
+	//   groupChildrenByArrayIndicesKey: same key → single partition → correlated AND.
+	//   After restriction to IdxKey("",1), conditions from different sub-trees
+	//   (addresses and cars) are combined via the correlated AND executor.
+	//   Plan: two separate groupAndAll groups (addresses, cars), combined at docID level.
+	//
+	// doc5: nestedArray[1]={addresses[0]→leaf=1(city:"berlin"), cars[0]→leaf=2(make:"bmw")}
+	// doc7: nestedArray[1]={addresses[0]→leaf=1(city:"berlin"), cars[0]→leaf=2(make:"ford")}
+	//        → berlin matches but bmw does not → doc7 excluded
+	// -------------------------------------------------------------------------
+	t.Run("same-partition arr[N] correlated AND — nestedArray[1].addresses.city AND nestedArray[1].cars.make", func(t *testing.T) {
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("nestedArray")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("nestedArray")
+		searcher, store := newSearcherForClass(t, class, valueBucketName, metaBucketName)
+		vb, mb := store.Bucket(valueBucketName), store.Bucket(metaBucketName)
+
+		// nestedArray[1] (root=2): addresses[0]→leaf=1, cars[0]→leaf=2
+		writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{enc(2, 1, doc5), enc(2, 1, doc7)})
+		writeNestedValue(t, vb, "cars.make", "bmw", []uint64{enc(2, 2, doc5)})
+		writeNestedValue(t, vb, "cars.make", "ford", []uint64{enc(2, 2, doc7)})
+
+		// Root-level idx: all positions belonging to nestedArray[1]
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1),
+			[]uint64{enc(2, 1, doc5), enc(2, 2, doc5), enc(2, 1, doc7), enc(2, 2, doc7)}))
+
+		f := &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: []filters.Clause{
+				{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeText, Value: "berlin"},
+					On: &filters.Path{
+						Class:    "PlanTestClass",
+						Property: schema.PropertyName("nestedArray[1].addresses.city"),
+					},
+				},
+				{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeText, Value: "bmw"},
+					On: &filters.Path{
+						Class:    "PlanTestClass",
+						Property: schema.PropertyName("nestedArray[1].cars.make"),
+					},
+				},
+			},
+		}
+		run(t, searcher, f, []uint64{doc5})
+	})
+}
+
+// TestNestedFilteringMixedArrayIndexConstraints verifies AND filters where one
+// condition carries an arr[N] constraint and another does not. The unconstrained
+// condition is resolved as "any element satisfies it"; the constrained condition
+// is resolved only for the specified element. Results are ANDed at docID level.
+//
+// This is exercised at two nesting depths:
+//
+//	Root:         nestedArray.addresses.city="berlin"  (any root element)
+//	              AND nestedArray[1].cars.make="bmw"   (root element 1 only)
+//
+//	Intermediate: nested.cars.colors="red"            (any car element)
+//	              AND nested.cars[1].make="bmw"        (car element 1 only)
+func TestNestedFilteringMixedArrayIndexConstraints(t *testing.T) {
+	const (
+		doc5 = uint64(5)
+		doc7 = uint64(7)
+		doc8 = uint64(8)
+	)
+
+	class := planTestClass()
+	enc := func(root, leaf uint16, docID uint64) uint64 { return invnested.Encode(root, leaf, docID) }
+	e1 := func(leaf uint16, docID uint64) uint64 { return enc(1, leaf, docID) }
+
+	run := func(t *testing.T, searcher *Searcher, f *filters.Clause, want []uint64) {
+		t.Helper()
+		pv, err := searcher.extractPropValuePair(context.Background(), f, "PlanTestClass")
+		require.NoError(t, err)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, want, result.docIDs.ToArray())
+	}
+
+	// -------------------------------------------------------------------------
+	// Root-level: nestedArray.addresses.city="berlin" AND nestedArray[1].cars.make="bmw"
+	//
+	// groupChildrenByArrayIndicesKey: key="" vs key="[1]" → two partitions.
+	// Partition "" (unconstrained): fetches city="berlin" from any nestedArray element.
+	// Partition "[1]" (restricted):  fetches make="bmw" restricted to IdxKey("",1).
+	// Combined: docs where (any element has berlin) AND (element [1] has bmw).
+	//
+	// doc5: nestedArray[1]={addresses[city:berlin](leaf=1), cars[make:bmw](leaf=2)}
+	//         → berlin anywhere ✓ + bmw in [1] ✓ → returned
+	// doc7: nestedArray[0]={addresses[city:berlin](root=1,leaf=1)}
+	//       nestedArray[1]={cars[make:bmw](root=2,leaf=1)}
+	//         → berlin in [0] satisfies unconstrained ✓ + bmw in [1] ✓ → returned
+	// doc8: nestedArray[1]={cars[make:bmw](root=2,leaf=1)}, no berlin anywhere
+	//         → unconstrained partition empty → not returned
+	// -------------------------------------------------------------------------
+	t.Run("root-level — unconstrained city AND nestedArray[1].cars.make=bmw", func(t *testing.T) {
+		prop := "nestedArray"
+		vbn := helpers.BucketNestedFromPropNameLSM(prop)
+		mbn := helpers.BucketNestedMetaFromPropNameLSM(prop)
+		searcher, store := newSearcherForClass(t, class, vbn, mbn)
+		vb, mb := store.Bucket(vbn), store.Bucket(mbn)
+
+		// doc5: nestedArray[1] has berlin(root=2,leaf=1) and bmw(root=2,leaf=2)
+		writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{enc(2, 1, doc5)})
+		writeNestedValue(t, vb, "cars.make", "bmw", []uint64{enc(2, 2, doc5)})
+		// doc7: nestedArray[0] has berlin(root=1,leaf=1); nestedArray[1] has bmw(root=2,leaf=1)
+		writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{enc(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.make", "bmw", []uint64{enc(2, 1, doc7)})
+		// doc8: nestedArray[1] has bmw(root=2,leaf=1) but no berlin anywhere
+		writeNestedValue(t, vb, "cars.make", "bmw", []uint64{enc(2, 1, doc8)})
+
+		// IdxKey("",1): all positions in nestedArray[1] across all documents
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1),
+			[]uint64{enc(2, 1, doc5), enc(2, 2, doc5), enc(2, 1, doc7), enc(2, 1, doc8)}))
+
+		f := &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: []filters.Clause{
+				{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeText, Value: "berlin"},
+					On: &filters.Path{
+						Class:    "PlanTestClass",
+						Property: schema.PropertyName(prop + ".addresses.city"),
+					},
+				},
+				{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeText, Value: "bmw"},
+					On: &filters.Path{
+						Class:    "PlanTestClass",
+						Property: schema.PropertyName(prop + "[1].cars.make"),
+					},
+				},
+			},
+		}
+		// doc5 and doc7 both match: doc5 has berlin+bmw in [1]; doc7 has berlin
+		// in [0] (satisfies unconstrained) and bmw in [1]. doc8 has no berlin.
+		run(t, searcher, f, []uint64{doc5, doc7})
+	})
+
+	// -------------------------------------------------------------------------
+	// Intermediate-level: nested.cars.colors="red" AND nested.cars[1].make="bmw"
+	//
+	// groupChildrenByArrayIndicesKey: key="" vs key="cars[1]" → two partitions.
+	// Partition "" (unconstrained): fetches colors="red" from any car element.
+	// Partition "cars[1]" (restricted): fetches make="bmw" restricted to IdxKey("cars",1).
+	// Combined: docs where (any car has red) AND (cars[1] has bmw).
+	//
+	// doc5: cars[0]={colors:["green"](leaf=1)}, cars[1]={colors:["red"](leaf=2),make:"bmw"(leaf=2)}
+	//         → red in cars[1] satisfies unconstrained ✓ + bmw in cars[1] ✓ → returned
+	// doc7: cars[0]={colors:["red"](leaf=1)}, cars[1]={make:"bmw"(leaf=2)}
+	//         → red in cars[0] satisfies unconstrained ✓ + bmw in cars[1] ✓ → returned
+	// doc8: cars[0]={make:"tesla"(leaf=1)}, cars[1]={make:"bmw"(leaf=2)}, no red anywhere
+	//         → unconstrained (red) partition empty → not returned
+	// -------------------------------------------------------------------------
+	t.Run("intermediate-level — unconstrained colors AND nested.cars[1].make=bmw", func(t *testing.T) {
+		prop := "nested"
+		vbn := helpers.BucketNestedFromPropNameLSM(prop)
+		mbn := helpers.BucketNestedMetaFromPropNameLSM(prop)
+		searcher, store := newSearcherForClass(t, class, vbn, mbn)
+		vb, mb := store.Bucket(vbn), store.Bucket(mbn)
+
+		// doc5: cars[0].colors[0]="green"→leaf=1; cars[1].colors[0]="red"→leaf=2; cars[1].make="bmw"→leaf=2
+		writeNestedValue(t, vb, "cars.colors", "green", []uint64{e1(1, doc5)})
+		writeNestedValue(t, vb, "cars.colors", "red", []uint64{e1(2, doc5)})
+		writeNestedValue(t, vb, "cars.make", "bmw", []uint64{e1(2, doc5)})
+		// doc7: cars[0].colors[0]="red"→leaf=1; cars[1].make="bmw"→leaf=2
+		writeNestedValue(t, vb, "cars.colors", "red", []uint64{e1(1, doc7)})
+		writeNestedValue(t, vb, "cars.make", "bmw", []uint64{e1(2, doc7)})
+		// doc8: cars[0].make="tesla"→leaf=1; cars[1].make="bmw"→leaf=2; no colors
+		writeNestedValue(t, vb, "cars.make", "tesla", []uint64{e1(1, doc8)})
+		writeNestedValue(t, vb, "cars.make", "bmw", []uint64{e1(2, doc8)})
+
+		// IdxKey("cars",1): positions belonging to cars[1] across all documents
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
+			[]uint64{e1(2, doc5), e1(2, doc7), e1(2, doc8)}))
+
+		f := &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: []filters.Clause{
+				{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeText, Value: "red"},
+					On: &filters.Path{
+						Class:    "PlanTestClass",
+						Property: schema.PropertyName(prop + ".cars.colors"),
+					},
+				},
+				{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeText, Value: "bmw"},
+					On: &filters.Path{
+						Class:    "PlanTestClass",
+						Property: schema.PropertyName(prop + ".cars[1].make"),
+					},
+				},
+			},
+		}
+		// doc5: red in cars[1] (any car ✓) + bmw in cars[1] ✓ → returned
+		// doc7: red in cars[0] (any car ✓) + bmw in cars[1] ✓ → returned
+		// doc8: no red in any car → not returned
+		run(t, searcher, f, []uint64{doc5, doc7})
+	})
 }

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -21,13 +21,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 	"github.com/weaviate/weaviate/entities/filters"
-	filternested "github.com/weaviate/weaviate/entities/filters/nested"
+	filnested "github.com/weaviate/weaviate/entities/filters/nested"
+	ent "github.com/weaviate/weaviate/entities/inverted"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/config"
@@ -61,6 +62,7 @@ func correlationTestClass() *models.Class {
 				DataType: schema.DataTypeObjectArray.PropString(),
 				NestedProperties: []*models.NestedProperty{
 					{Name: "make", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+					{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
 					{
 						Name:     "tires",
 						DataType: schema.DataTypeObjectArray.PropString(),
@@ -115,7 +117,7 @@ func newNestedTestSearcher(t *testing.T, bucketNames ...string) (*Searcher, *lsm
 // nested value bucket. positions should have the real docID already OR'd in.
 func writeNestedValue(t *testing.T, bucket *lsmkv.Bucket, relPath, term string, positions []uint64) {
 	t.Helper()
-	key := nested.ValueKey(relPath, []byte(term))
+	key := invnested.ValueKey(relPath, []byte(term))
 	require.NoError(t, bucket.RoaringSetAddList(key, positions))
 }
 
@@ -168,15 +170,15 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		//
 		// Expected: doc5 returned (both conditions match same element).
 
-		bucketName := helpers.BucketNestedFromPropNameLSM("addresses")
-		searcher, store := newNestedTestSearcher(t, bucketName)
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, helpers.BucketNestedMetaFromPropNameLSM("addresses"))
 		class := correlationTestClass()
 
 		// addresses[0] for doc5: root=1, leaf=1
-		pos := nested.Encode(1, 1, doc5)
-		b := store.Bucket(bucketName)
-		writeNestedValue(t, b, "city", "berlin", []uint64{pos})
-		writeNestedValue(t, b, "postcode", "10115", []uint64{pos})
+		pos := invnested.Encode(1, 1, doc5)
+		vb := store.Bucket(valueBucketName)
+		writeNestedValue(t, vb, "city", "berlin", []uint64{pos})
+		writeNestedValue(t, vb, "postcode", "10115", []uint64{pos})
 
 		pv := makeCorrelatedPvp(class, "addresses",
 			makeLeafPvp(class, "addresses", "city", "berlin"),
@@ -191,16 +193,16 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		// doc5: city="berlin", postcode="10115" (both present → match)
 		// doc7: city="berlin", postcode="99999" (postcode doesn't match → no match)
 
-		bucketName := helpers.BucketNestedFromPropNameLSM("addresses")
-		searcher, store := newNestedTestSearcher(t, bucketName)
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, helpers.BucketNestedMetaFromPropNameLSM("addresses"))
 		class := correlationTestClass()
 
-		b := store.Bucket(bucketName)
-		writeNestedValue(t, b, "city", "berlin", []uint64{
-			nested.Encode(1, 1, doc5),
-			nested.Encode(1, 1, doc7),
+		vb := store.Bucket(valueBucketName)
+		writeNestedValue(t, vb, "city", "berlin", []uint64{
+			invnested.Encode(1, 1, doc5),
+			invnested.Encode(1, 1, doc7),
 		})
-		writeNestedValue(t, b, "postcode", "10115", []uint64{nested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "postcode", "10115", []uint64{invnested.Encode(1, 1, doc5)})
 
 		pv := makeCorrelatedPvp(class, "addresses",
 			makeLeafPvp(class, "addresses", "city", "berlin"),
@@ -218,25 +220,25 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		//
 		// Expected: doc5 returned.
 
-		nestedBucket := helpers.BucketNestedFromPropNameLSM("cars")
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("cars")
-		searcher, store := newNestedTestSearcher(t, nestedBucket, metaBucket)
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
 		class := correlationTestClass()
 
 		// cars[0]: root=1, tires[0]=leaf1, accessories[0]=leaf2
-		tiresPos := nested.Encode(1, 1, doc5)
-		accPos := nested.Encode(1, 2, doc5)
+		tiresPos := invnested.Encode(1, 1, doc5)
+		accPos := invnested.Encode(1, 2, doc5)
 
-		nb := store.Bucket(nestedBucket)
+		vb := store.Bucket(valueBucketName)
 		// Encode width as big-endian int64
 		widthVal := make([]byte, 8)
 		widthVal[7] = 205 // value 205
-		require.NoError(t, nb.RoaringSetAddList(nested.ValueKey("tires.width", widthVal), []uint64{tiresPos}))
-		writeNestedValue(t, nb, "accessories.type", "spoiler", []uint64{accPos})
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("tires.width", widthVal), []uint64{tiresPos}))
+		writeNestedValue(t, vb, "accessories.type", "spoiler", []uint64{accPos})
 
 		// idx entry for cars[0]: all positions within that element
-		mb := store.Bucket(metaBucket)
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 0), []uint64{tiresPos, accPos}))
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{tiresPos, accPos}))
 
 		pv := makeCorrelatedPvp(class, "cars",
 			&propValuePair{
@@ -255,23 +257,23 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		// cars = [{tires:[{width:205}]}, {accessories:[{type:"spoiler"}]}]
 		// tires.width is in cars[0], accessories.type is in cars[1] → no same-car match.
 
-		nestedBucket := helpers.BucketNestedFromPropNameLSM("cars")
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("cars")
-		searcher, store := newNestedTestSearcher(t, nestedBucket, metaBucket)
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
 		class := correlationTestClass()
 
-		tiresPos := nested.Encode(1, 1, doc5) // cars[0]
-		accPos := nested.Encode(2, 1, doc5)   // cars[1]
+		tiresPos := invnested.Encode(1, 1, doc5) // cars[0]
+		accPos := invnested.Encode(2, 1, doc5)   // cars[1]
 
-		nb := store.Bucket(nestedBucket)
+		vb := store.Bucket(valueBucketName)
 		widthVal := make([]byte, 8)
 		widthVal[7] = 205
-		require.NoError(t, nb.RoaringSetAddList(nested.ValueKey("tires.width", widthVal), []uint64{tiresPos}))
-		writeNestedValue(t, nb, "accessories.type", "spoiler", []uint64{accPos})
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("tires.width", widthVal), []uint64{tiresPos}))
+		writeNestedValue(t, vb, "accessories.type", "spoiler", []uint64{accPos})
 
-		mb := store.Bucket(metaBucket)
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 0), []uint64{tiresPos}))
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 1), []uint64{accPos}))
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{tiresPos}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{accPos}))
 
 		pv := makeCorrelatedPvp(class, "cars",
 			&propValuePair{
@@ -291,17 +293,19 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		// Each prop group is resolved independently then AND'd via the outer AND node.
 		// Expected: doc5 (has both), doc7 excluded (only cars.make matches).
 
-		carsBucket := helpers.BucketNestedFromPropNameLSM("cars")
-		addrBucket := helpers.BucketNestedFromPropNameLSM("addresses")
-		searcher, store := newNestedTestSearcher(t, carsBucket, addrBucket)
+		carsBucketName := helpers.BucketNestedFromPropNameLSM("cars")
+		addrBucketName := helpers.BucketNestedFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t,
+			carsBucketName, helpers.BucketNestedMetaFromPropNameLSM("cars"),
+			addrBucketName, helpers.BucketNestedMetaFromPropNameLSM("addresses"))
 		class := correlationTestClass()
 
-		cb := store.Bucket(carsBucket)
-		writeNestedValue(t, cb, "make", "tesla",
-			[]uint64{nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7)})
+		carsVb := store.Bucket(carsBucketName)
+		writeNestedValue(t, carsVb, "make", "tesla",
+			[]uint64{invnested.Encode(1, 1, doc5), invnested.Encode(1, 1, doc7)})
 
-		ab := store.Bucket(addrBucket)
-		writeNestedValue(t, ab, "city", "berlin", []uint64{nested.Encode(1, 1, doc5)})
+		addrVb := store.Bucket(addrBucketName)
+		writeNestedValue(t, addrVb, "city", "berlin", []uint64{invnested.Encode(1, 1, doc5)})
 
 		// groupNestedByProp creates one isCorrelatedNested node per prop;
 		// here we build the same structure directly.
@@ -312,6 +316,297 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 			makeCorrelatedPvp(class, "addresses",
 				makeLeafPvp(class, "addresses", "city", "berlin"),
 			),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("multiple conditions same relPath — cars.colors = black AND cars.colors = orange", func(t *testing.T) {
+		// Two conditions share the same relPath "colors" (scalar text[]).
+		// Both go into positionsByPath["colors"].independent (multiple independents).
+		// combinePositionBitmaps calls AndAllMaskLeaf → leaf bits zeroed but root bits
+		// preserved, so same-element semantics hold across multiple car elements.
+		//
+		// doc5: cars[0] (root=1) has colors=["black"(leaf=1), "orange"(leaf=2)]
+		//        → both in same car element → match
+		// doc7: cars[0] (root=1) has colors=["black"(leaf=1)]
+		//       cars[1] (root=2) has colors=["orange"(leaf=1)]
+		//        → colors split across different cars → no match
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, helpers.BucketNestedMetaFromPropNameLSM("cars"))
+		class := correlationTestClass()
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: both colors in same car (root=1, leaves 1 and 2)
+		writeNestedValue(t, vb, "colors", "black", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "colors", "orange", []uint64{invnested.Encode(1, 2, doc5)})
+		// doc7: colors split across two different cars (root=1 and root=2)
+		writeNestedValue(t, vb, "colors", "black", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "colors", "orange", []uint64{invnested.Encode(2, 1, doc7)})
+
+		pv := makeCorrelatedPvp(class, "cars",
+			makeLeafPvp(class, "cars", "colors", "black"),
+			makeLeafPvp(class, "cars", "colors", "orange"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("multiple conditions same relPath + different relPath — cars.colors AND cars.make", func(t *testing.T) {
+		// Three conditions: two share relPath "colors" (multiple independents → leaf-masked),
+		// one is "make" (single independent → raw). The resolution plan produces
+		// maskLeafAnd[directAnd["colors"], directAnd["make"]], which re-masks
+		// the already-zeroed colors bitmap and masks the raw make bitmap before AND.
+		//
+		// doc5: cars[0] (root=1): colors=["black","orange"], make="bmw"  → match
+		// doc7: cars[0] (root=1): colors=["black","orange"], make="ford" → wrong make → no match
+		// doc7 also has cars[1] (root=2): make="bmw" — but that car lacks both colors,
+		// so the combined condition is not satisfied within any single car element.
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, helpers.BucketNestedMetaFromPropNameLSM("cars"))
+		class := correlationTestClass()
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: one car (root=1) with both colors (leaves 1,2) and correct make (inherits both)
+		writeNestedValue(t, vb, "colors", "black", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "colors", "orange", []uint64{invnested.Encode(1, 2, doc5)})
+		writeNestedValue(t, vb, "make", "bmw", []uint64{invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5)})
+		// doc7: car[0] (root=1) has both colors but wrong make; car[1] (root=2) has right make but no colors
+		writeNestedValue(t, vb, "colors", "black", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "colors", "orange", []uint64{invnested.Encode(1, 2, doc7)})
+		writeNestedValue(t, vb, "make", "ford", []uint64{invnested.Encode(1, 1, doc7), invnested.Encode(1, 2, doc7)})
+		writeNestedValue(t, vb, "make", "bmw", []uint64{invnested.Encode(2, 1, doc7)})
+
+		pv := makeCorrelatedPvp(class, "cars",
+			makeLeafPvp(class, "cars", "colors", "black"),
+			makeLeafPvp(class, "cars", "colors", "orange"),
+			makeLeafPvp(class, "cars", "make", "bmw"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("same relPath through two intermediate object[] levels — cities[].garages[].cars[].tags same car", func(t *testing.T) {
+		// Schema: cities: object[] { garages: object[] { cars: object[] { tags: text[] } } }
+		//
+		// cities.garages.cars.tags = "german" AND cities.garages.cars.tags = "electric"
+		//
+		// Two intermediate DataTypeObjectArray levels: "garages" (first) and
+		// "garages.cars" (deepest/last). lastIntermediateObjectArray returns "garages.cars",
+		// so runIdxLoop("garages.cars", ...) iterates _idx.garages.cars[N] entries.
+		//
+		// Using the FIRST array level ("garages") would be wrong: _idx.garages[0] contains
+		// ALL positions in garages[0], including tags from different cars — doc7 would
+		// incorrectly match because both tags land in the same garage element.
+		//
+		// doc5: cities[0] (root=1): garages[0]: cars[0].tags = ["german"(leaf=1), "electric"(leaf=2)]
+		//        → both tags in the same car → match
+		// doc7: cities[0] (root=1): garages[0]: cars[0].tags = ["german"(leaf=1)]
+		//                                        cars[1].tags = ["electric"(leaf=2)]
+		//        → same garage, DIFFERENT cars → no match
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "cities",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "garages",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{
+									Name:     "cars",
+									DataType: schema.DataTypeObjectArray.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("cities")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("cities")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: cities[0].garages[0].cars[0].tags = ["german", "electric"]
+		// Leaf counter within cities[0] (root=1): german=1, electric=2
+		writeNestedValue(t, vb, "garages.cars.tags", "german", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "garages.cars.tags", "electric", []uint64{invnested.Encode(1, 2, doc5)})
+		// doc7: cities[0].garages[0].cars[0].tags=["german"], cars[1].tags=["electric"]
+		// Leaf counter within cities[0] (root=1): german=1 (cars[0]), electric=2 (cars[1])
+		writeNestedValue(t, vb, "garages.cars.tags", "german", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "garages.cars.tags", "electric", []uint64{invnested.Encode(1, 2, doc7)})
+
+		mb := store.Bucket(metaBucketName)
+		// _idx.garages[0]: ALL positions within any document's first garage element.
+		// Both docs have both tags inside garages[0], so this level is insufficient for
+		// same-car checking — doc7 would wrongly match if we stopped here.
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5),
+			invnested.Encode(1, 1, doc7), invnested.Encode(1, 2, doc7),
+		}))
+		// _idx.garages.cars[0]: positions within the first car of any garage in any city.
+		// doc5's cars[0] has both tags; doc7's cars[0] has only "german".
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages.cars", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5), // doc5 cars[0]: both tags
+			invnested.Encode(1, 1, doc7), // doc7 cars[0]: german only
+		}))
+		// _idx.garages.cars[1]: positions within the second car of any garage in any city.
+		// Only doc7's cars[1] exists here (has "electric").
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages.cars", 1), []uint64{
+			invnested.Encode(1, 2, doc7), // doc7 cars[1]: electric only
+		}))
+
+		pv := makeCorrelatedPvp(class, "cities",
+			makeLeafPvp(class, "cities", "garages.cars.tags", "german"),
+			makeLeafPvp(class, "cities", "garages.cars.tags", "electric"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("same relPath through intermediate object[] — tags must be in the same car, not just same garage", func(t *testing.T) {
+		// Schema: garages: object[] { cars: object[] { tags: text[] } }
+		//
+		// garages.cars.tags = "german" AND garages.cars.tags = "electric"
+		//
+		// Both conditions hit the same relPath "cars.tags" and land in
+		// positionsByPath["cars.tags"].independent. "cars" is a DataTypeObjectArray
+		// within garages, so the fix in resolveNestedCorrelated detects this and
+		// calls runIdxLoop("cars", [germanBm, electricBm]) before plan building.
+		// This enforces same-car semantics, not just same-garage semantics.
+		//
+		// doc5: garages[0] (root=1): cars[0].tags = ["german"(leaf=1), "electric"(leaf=2)]
+		//        → both tags in the same car element → match
+		// doc7: garages[0] (root=1): cars[0].tags = ["german"(leaf=1)]
+		//                             cars[1].tags = ["electric"(leaf=2)]
+		//        → tags in different cars within the same garage → NO match
+		//        (without the fix, AndAllMaskLeaf would match doc7 because both
+		//         tags land in garages[0] (root=1) after leaf masking)
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "garages",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "cars",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("garages")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("garages")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: garages[0].cars[0].tags = ["german", "electric"] — leaves 1 and 2
+		writeNestedValue(t, vb, "cars.tags", "german", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.tags", "electric", []uint64{invnested.Encode(1, 2, doc5)})
+		// doc7: garages[0].cars[0].tags = ["german"] (leaf=1)
+		//        garages[0].cars[1].tags = ["electric"] (leaf=2 — continues depth-first in garages[0])
+		writeNestedValue(t, vb, "cars.tags", "german", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.tags", "electric", []uint64{invnested.Encode(1, 2, doc7)})
+
+		// _idx entries in the garages meta bucket.
+		// cars[0]: doc5's cars[0] has both tags; doc7's cars[0] has only "german".
+		// cars[1]: doc7's cars[1] has "electric".
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5), // doc5 cars[0]: both tags
+			invnested.Encode(1, 1, doc7), // doc7 cars[0]: german only
+		}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{
+			invnested.Encode(1, 2, doc7), // doc7 cars[1]: electric only
+		}))
+
+		pv := makeCorrelatedPvp(class, "garages",
+			makeLeafPvp(class, "garages", "cars.tags", "german"),
+			makeLeafPvp(class, "garages", "cars.tags", "electric"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("cars at intermediate level — garages[].cars[].colors = black AND orange", func(t *testing.T) {
+		// Schema: garages: object[] { cars: object[] { colors: text[] } }
+		// Both conditions share relPath "cars.colors" → multiple independents →
+		// preResolveSamePath calls runIdxLoop("cars") to enforce same-car semantics.
+		//
+		// doc5: garages[0] (root=1): cars[0].colors=["black"(leaf=1), "orange"(leaf=2)]
+		//        → both colors inside the same car → match
+		// doc7: garages[0] (root=1): cars[0].colors=["black"(leaf=1)]
+		//       garages[1] (root=2): cars[0].colors=["orange"(leaf=1)]
+		//        → colors split across two different garage elements (different root_idx) → no match
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("garages")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("garages")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "garages",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "cars",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{Name: "colors", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: garages[0].cars[0].colors = ["black"(leaf=1), "orange"(leaf=2)]
+		writeNestedValue(t, vb, "cars.colors", "black", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.colors", "orange", []uint64{invnested.Encode(1, 2, doc5)})
+		// doc7: black in garages[0].cars[0] (root=1,leaf=1), orange in garages[1].cars[0] (root=2,leaf=1)
+		writeNestedValue(t, vb, "cars.colors", "black", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.colors", "orange", []uint64{invnested.Encode(2, 1, doc7)})
+
+		mb := store.Bucket(metaBucketName)
+		// _idx.cars[0]: positions of the first car across all garages and docs.
+		// doc5's garages[0].cars[0] has both colors; each of doc7's garages has one.
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5), // doc5 garages[0].cars[0]
+			invnested.Encode(1, 1, doc7), // doc7 garages[0].cars[0]
+			invnested.Encode(2, 1, doc7), // doc7 garages[1].cars[0]
+		}))
+
+		pv := makeCorrelatedPvp(class, "garages",
+			makeLeafPvp(class, "garages", "cars.colors", "black"),
+			makeLeafPvp(class, "garages", "cars.colors", "orange"),
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
@@ -329,39 +624,39 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		// doc7: cars[0] (root=1): make="bmw",   tires[0].width=205 (wrong car index)
 		// filter: cars[1].make="bmw" AND cars[1].tires.width=205 → only doc5
 
-		nestedBucket := helpers.BucketNestedFromPropNameLSM("cars")
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("cars")
-		searcher, store := newNestedTestSearcher(t, nestedBucket, metaBucket)
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
 		class := correlationTestClass()
 
-		nb := store.Bucket(nestedBucket)
+		vb := store.Bucket(valueBucketName)
 		// doc5 cars[0].make=tesla (root=1), cars[1].make=bmw (root=2)
-		writeNestedValue(t, nb, "make", "tesla", []uint64{nested.Encode(1, 1, doc5)})
-		writeNestedValue(t, nb, "make", "bmw", []uint64{nested.Encode(2, 1, doc5), nested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "make", "tesla", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "make", "bmw", []uint64{invnested.Encode(2, 1, doc5), invnested.Encode(1, 1, doc7)})
 		// doc5 cars[1].tires[0].width=205 (root=2,leaf=2); doc7 cars[0].tires[0].width=205 (root=1,leaf=2)
 		widthVal := make([]byte, 8)
 		widthVal[7] = 205
-		require.NoError(t, nb.RoaringSetAddList(nested.ValueKey("tires.width", widthVal),
-			[]uint64{nested.Encode(2, 2, doc5), nested.Encode(1, 2, doc7)}))
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("tires.width", widthVal),
+			[]uint64{invnested.Encode(2, 2, doc5), invnested.Encode(1, 2, doc7)}))
 
-		mb := store.Bucket(metaBucket)
+		mb := store.Bucket(metaBucketName)
 		// root-level idx: cars[0] and cars[1]
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 0),
-			[]uint64{nested.Encode(1, 1, doc5), nested.Encode(1, 2, doc7), nested.Encode(1, 1, doc7)}))
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 1),
-			[]uint64{nested.Encode(2, 1, doc5), nested.Encode(2, 2, doc5)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 0),
+			[]uint64{invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc7), invnested.Encode(1, 1, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1),
+			[]uint64{invnested.Encode(2, 1, doc5), invnested.Encode(2, 2, doc5)}))
 		// tires idx within any car
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tires", 0),
-			[]uint64{nested.Encode(2, 2, doc5), nested.Encode(1, 2, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("tires", 0),
+			[]uint64{invnested.Encode(2, 2, doc5), invnested.Encode(1, 2, doc7)}))
 		// meta idx for correlated AND
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 0),
-			[]uint64{nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7), nested.Encode(1, 2, doc7)}))
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("cars", 1),
-			[]uint64{nested.Encode(2, 1, doc5), nested.Encode(2, 2, doc5)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
+			[]uint64{invnested.Encode(1, 1, doc5), invnested.Encode(1, 1, doc7), invnested.Encode(1, 2, doc7)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
+			[]uint64{invnested.Encode(2, 1, doc5), invnested.Encode(2, 2, doc5)}))
 
 		makePvp := func(relPath, value string) *propValuePair {
 			pv := makeLeafPvp(class, "cars", relPath, value)
-			pv.nested.arrayIndices = []filternested.ArrayIndex{{RelPath: "", Index: 1}}
+			pv.invnested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 1}}
 			return pv
 		}
 		widthPvp := &propValuePair{
@@ -370,7 +665,7 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 			nested: nestedInfo{
 				isNested:     true,
 				relPath:      "tires.width",
-				arrayIndices: []filternested.ArrayIndex{{RelPath: "", Index: 1}},
+				arrayIndices: []filnested.ArrayIndex{{RelPath: "", Index: 1}},
 			},
 			Class: class,
 		}
@@ -379,6 +674,1055 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("idxLoopAnd at intermediate LCA — garages[].cars[].tires.width AND garages[].cars[].accessories.type", func(t *testing.T) {
+		// Schema: garages: object[] { cars: object[] { tires: object[]{width:int}, accessories: object[]{type:text} } }
+		// relPaths within garages bucket share first segment "cars":
+		//   "cars.tires.width" and "cars.accessories.type"
+		// → classifyLeaf: LCA = "cars" (DataTypeObjectArray), both rems pass through sub-arrays
+		// → idxLoopAnd("cars"), iterating _idx.cars[N] entries in the garages meta bucket.
+		//
+		// This is distinct from the existing "idxLoopAnd" tests, which actually resolve via
+		// maskLeafAnd (tires and accessories have different first segments within the cars bucket).
+		// Here the LCA is an *intermediate* node below the root property.
+		//
+		// doc5: garages[0] (root=1): cars[0] has tires[0].width=205 (leaf=1) AND accessories[0].type="spoiler" (leaf=2)
+		//       → both conditions inside the same car element → match
+		// doc7: garages[0] (root=1): cars[0] has tires[0].width=205 (leaf=1)
+		//       garages[1] (root=2): cars[0] has accessories[0].type="spoiler" (leaf=1)
+		//       → conditions in different garage elements → no match
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "garages",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "cars",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{
+									Name:     "tires",
+									DataType: schema.DataTypeObjectArray.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+									},
+								},
+								{
+									Name:     "accessories",
+									DataType: schema.DataTypeObjectArray.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{Name: "type", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("garages")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("garages")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+
+		widthVal := make([]byte, 8)
+		widthVal[7] = 205
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: garages[0].cars[0] — tires at leaf=1, accessories at leaf=2
+		tiresD5 := invnested.Encode(1, 1, doc5)
+		accD5 := invnested.Encode(1, 2, doc5)
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", widthVal), []uint64{tiresD5}))
+		writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{accD5})
+		// doc7: tires in garages[0].cars[0] (root=1, leaf=1), accessories in garages[1].cars[0] (root=2, leaf=1)
+		tiresD7 := invnested.Encode(1, 1, doc7)
+		accD7 := invnested.Encode(2, 1, doc7)
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", widthVal), []uint64{tiresD7}))
+		writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{accD7})
+
+		// _idx.cars[0]: positions belonging to cars[0] of *any* garage across all docs.
+		// For doc5: cars[0] has both tires and accessories.
+		// For doc7: cars[0] holds tires (root=1) and cars[0] holds accessories (root=2) —
+		//   both are the first car of their respective garage elements.
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{
+			tiresD5, accD5, // doc5 garages[0].cars[0]
+			tiresD7, accD7, // doc7: first car of each garage
+		}))
+
+		pv := makeCorrelatedPvp(class, "garages",
+			&propValuePair{
+				prop: "garages", value: widthVal, operator: filters.OperatorEqual,
+				hasFilterableIndex: true,
+				nested:             nestedInfo{isNested: true, relPath: "cars.tires.width"},
+				Class:              class,
+			},
+			&propValuePair{
+				prop: "garages", value: []byte("spoiler"), operator: filters.OperatorEqual,
+				hasFilterableIndex: true,
+				nested:             nestedInfo{isNested: true, relPath: "cars.accessories.type"},
+				Class:              class,
+			},
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("tokens — multi-token text: both tokens must share the same leaf position", func(t *testing.T) {
+		// Simulates a multi-token query ("new york" → ["new", "york"]) where
+		// childrenFromTokenization=true routes both token bitmaps to
+		// positionBitmaps.tokens. combinePositionBitmaps calls AndAll(tokens),
+		// which requires both tokens to appear at the *exact same* leaf position.
+		//
+		// doc5: addresses[0].city = "new york" — both tokens stored at Encode(1,1,doc5)
+		//       (same value occurrence → same leaf)
+		// doc7: addresses[0].city = "new" at Encode(1,1,doc7)
+		//       addresses[1].city = "york" at Encode(2,1,doc7)
+		//       → tokens at different leaf positions → AndAll = empty → no match
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, helpers.BucketNestedMetaFromPropNameLSM("addresses"))
+		class := correlationTestClass()
+
+		vb := store.Bucket(valueBucketName)
+		writeNestedValue(t, vb, "city", "new", []uint64{invnested.Encode(1, 1, doc5), invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "city", "york", []uint64{invnested.Encode(1, 1, doc5), invnested.Encode(2, 1, doc7)})
+
+		pv := &propValuePair{
+			operator: filters.OperatorAnd,
+			nested:   nestedInfo{isCorrelated: true, childrenFromTokenization: true},
+			prop:     "addresses",
+			children: []*propValuePair{
+				makeLeafPvp(class, "addresses", "city", "new"),
+				makeLeafPvp(class, "addresses", "city", "york"),
+			},
+			Class: class,
+		}
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("one condition has zero positions — empty result propagates without error", func(t *testing.T) {
+		// addresses.city="berlin" has data, but postcode="10115" is never written.
+		// combinePositionBitmaps returns an empty bitmap for postcode.
+		// AndAllMaskLeaf([cityBm, emptyBm]) = empty → result is empty.
+		// Verifies that a missing term/bucket does not panic or return an error.
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, helpers.BucketNestedMetaFromPropNameLSM("addresses"))
+		class := correlationTestClass()
+
+		vb := store.Bucket(valueBucketName)
+		writeNestedValue(t, vb, "city", "berlin", []uint64{invnested.Encode(1, 1, doc5)})
+		// postcode "10115" is intentionally never written — the bucket key will be absent.
+
+		pv := makeCorrelatedPvp(class, "addresses",
+			makeLeafPvp(class, "addresses", "city", "berlin"),
+			makeLeafPvp(class, "addresses", "postcode", "10115"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.True(t, result.docIDs.IsEmpty())
+	})
+
+	t.Run("idxLoopAnd K=3 — three sub-array conditions all must be in the same car element", func(t *testing.T) {
+		// Schema: garages: object[] { cars: object[] { tires, accessories, stickers (each object[]) } }
+		// Three relPaths share first segment "cars" → idxLoopAnd("cars") with K=3 groups.
+		// runIdxLoop sorts all three bitmaps by cardinality and applies the preFilter
+		// optimisation, then processes each cars[N] element.
+		//
+		// doc5: garages[0] (root=1): cars[0] has all three — tires(leaf=1), accessories(leaf=2), stickers(leaf=3)
+		//       → all three conditions in the same car → match
+		// doc7: garages[0] (root=1): cars[0] has tires(leaf=1) and accessories(leaf=2)
+		//                             cars[1] has stickers(leaf=3)
+		//       → stickers in a different car element → no match
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "garages",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "cars",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{
+									Name:     "tires",
+									DataType: schema.DataTypeObjectArray.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+									},
+								},
+								{
+									Name:     "accessories",
+									DataType: schema.DataTypeObjectArray.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{Name: "type", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+									},
+								},
+								{
+									Name:     "stickers",
+									DataType: schema.DataTypeObjectArray.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{Name: "color", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("garages")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("garages")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+
+		widthVal := make([]byte, 8)
+		widthVal[7] = 205
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: all three in cars[0], leaves 1/2/3 assigned depth-first within garages[0]
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", widthVal),
+			[]uint64{invnested.Encode(1, 1, doc5)}))
+		writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{invnested.Encode(1, 2, doc5)})
+		writeNestedValue(t, vb, "cars.stickers.color", "red", []uint64{invnested.Encode(1, 3, doc5)})
+		// doc7: tires and accessories in cars[0]; stickers in cars[1]
+		// Leaf counter is continuous within garages[0]: cars[0].tires=1, cars[0].acc=2, cars[1].stickers=3
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", widthVal),
+			[]uint64{invnested.Encode(1, 1, doc7)}))
+		writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{invnested.Encode(1, 2, doc7)})
+		writeNestedValue(t, vb, "cars.stickers.color", "red", []uint64{invnested.Encode(1, 3, doc7)})
+
+		mb := store.Bucket(metaBucketName)
+		// _idx.cars[0]: positions inside any document's first car element
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5), invnested.Encode(1, 3, doc5), // doc5 cars[0]
+			invnested.Encode(1, 1, doc7), invnested.Encode(1, 2, doc7), // doc7 cars[0] (no stickers here)
+		}))
+		// _idx.cars[1]: positions inside any document's second car element (doc7 only)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{
+			invnested.Encode(1, 3, doc7), // doc7 cars[1].stickers[0]
+		}))
+
+		pv := makeCorrelatedPvp(class, "garages",
+			&propValuePair{
+				prop: "garages", value: widthVal, operator: filters.OperatorEqual,
+				hasFilterableIndex: true,
+				nested:             nestedInfo{isNested: true, relPath: "cars.tires.width"},
+				Class:              class,
+			},
+			&propValuePair{
+				prop: "garages", value: []byte("spoiler"), operator: filters.OperatorEqual,
+				hasFilterableIndex: true,
+				nested:             nestedInfo{isNested: true, relPath: "cars.accessories.type"},
+				Class:              class,
+			},
+			&propValuePair{
+				prop: "garages", value: []byte("red"), operator: filters.OperatorEqual,
+				hasFilterableIndex: true,
+				nested:             nestedInfo{isNested: true, relPath: "cars.stickers.color"},
+				Class:              class,
+			},
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("idxLoopAnd — matching element is cars[2], not cars[0] or cars[1]", func(t *testing.T) {
+		// The idx loop must walk past two non-matching elements before finding the match.
+		// Verifies the cursor iteration and the per-element pre-check skip behaviour.
+		//
+		// doc5: garages[0] (root=1):
+		//   cars[0]: only tires[0] (leaf=1)           — accessories absent → skip
+		//   cars[1]: only accessories[0] (leaf=2)      — tires absent → skip
+		//   cars[2]: tires[0](leaf=3) + accessories[0](leaf=4) → match
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "garages",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "cars",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{
+									Name:     "tires",
+									DataType: schema.DataTypeObjectArray.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+									},
+								},
+								{
+									Name:     "accessories",
+									DataType: schema.DataTypeObjectArray.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{Name: "type", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("garages")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("garages")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+
+		widthVal := make([]byte, 8)
+		widthVal[7] = 205
+
+		vb := store.Bucket(valueBucketName)
+		// Only cars[2] has both conditions. Leaves are assigned depth-first within garages[0]:
+		//   cars[0].tires[0]=1, cars[1].accessories[0]=2, cars[2].tires[0]=3, cars[2].accessories[0]=4
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", widthVal),
+			[]uint64{invnested.Encode(1, 3, doc5)}))
+		writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{invnested.Encode(1, 4, doc5)})
+
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{invnested.Encode(1, 1, doc5)})) // only tires
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{invnested.Encode(1, 2, doc5)})) // only accessories
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 2), []uint64{
+			invnested.Encode(1, 3, doc5), invnested.Encode(1, 4, doc5), // both conditions
+		}))
+
+		pv := makeCorrelatedPvp(class, "garages",
+			&propValuePair{
+				prop: "garages", value: widthVal, operator: filters.OperatorEqual,
+				hasFilterableIndex: true,
+				nested:             nestedInfo{isNested: true, relPath: "cars.tires.width"},
+				Class:              class,
+			},
+			&propValuePair{
+				prop: "garages", value: []byte("spoiler"), operator: filters.OperatorEqual,
+				hasFilterableIndex: true,
+				nested:             nestedInfo{isNested: true, relPath: "cars.accessories.type"},
+				Class:              class,
+			},
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("directAnd scalar siblings — garages[].cars.make AND garages[].cars.model same element", func(t *testing.T) {
+		// Schema: garages: object[] { cars: object[] { make: text, model: text } }
+		// relPaths "cars.make" and "cars.model" share first segment "cars" → classifyLeaf.
+		// LCA = "cars" (DataTypeObjectArray). isScalarAtLevel("make") → true → directAnd.
+		//
+		// Scalar properties inherit ALL positions of their parent element (Phase 3 of
+		// walkObject), so make and model for the same car share an identical position set.
+		// directAnd on raw positions correctly aligns them.
+		//
+		// doc5: garages[0].cars[0] = {make:"tesla", model:"s"} → both at leaf=1 → match
+		// doc7: garages[0].cars[0] = {make:"tesla", model:"escape"} (leaf=1)
+		//       garages[0].cars[1] = {make:"ford",  model:"s"}     (leaf=2)
+		//       → make="tesla" at leaf=1, model="s" at leaf=2 → different positions → no match
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "garages",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "cars",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{Name: "make", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+								{Name: "model", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("garages")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, helpers.BucketNestedMetaFromPropNameLSM("garages"))
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: cars[0] is the only car — element gets leaf=1; scalars inherit that position.
+		writeNestedValue(t, vb, "cars.make", "tesla", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.model", "s", []uint64{invnested.Encode(1, 1, doc5)})
+		// doc7: cars[0] (leaf=1) has make="tesla"; cars[1] (leaf=2) has model="s".
+		writeNestedValue(t, vb, "cars.make", "tesla", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.model", "s", []uint64{invnested.Encode(1, 2, doc7)})
+
+		pv := makeCorrelatedPvp(class, "garages",
+			makeLeafPvp(class, "garages", "cars.make", "tesla"),
+			makeLeafPvp(class, "garages", "cars.model", "s"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("three documents — only the one with both conditions in the same element matches", func(t *testing.T) {
+		// Tests bitmap isolation across three documents at once.
+		//
+		// doc3: addresses[0] = {city:"berlin", postcode:"10115"} → same element → match
+		// doc5: addresses[0].city="berlin", addresses[1].postcode="10115"
+		//       → correct values but in different elements → no match
+		// doc7: addresses[0] = {city:"hamburg", postcode:"10115"}
+		//       → wrong city value → no match
+		//
+		// After maskLeafAnd: only doc3 has both values at root=1; doc5 has root=1 for
+		// city but root=2 for postcode; doc7 provides no "berlin" position.
+		const doc3 = uint64(3)
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, helpers.BucketNestedMetaFromPropNameLSM("addresses"))
+		class := correlationTestClass()
+
+		vb := store.Bucket(valueBucketName)
+		writeNestedValue(t, vb, "city", "berlin", []uint64{
+			invnested.Encode(1, 1, doc3), // doc3 addresses[0]
+			invnested.Encode(1, 1, doc5), // doc5 addresses[0]
+		})
+		writeNestedValue(t, vb, "postcode", "10115", []uint64{
+			invnested.Encode(1, 1, doc3), // doc3 addresses[0]
+			invnested.Encode(2, 1, doc5), // doc5 addresses[1]
+			invnested.Encode(1, 1, doc7), // doc7 addresses[0] (wrong city, correct postcode)
+		})
+
+		pv := makeCorrelatedPvp(class, "addresses",
+			makeLeafPvp(class, "addresses", "city", "berlin"),
+			makeLeafPvp(class, "addresses", "postcode", "10115"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc3}, result.docIDs.ToArray())
+	})
+
+	// -----------------------------------------------------------------------
+	// Known bugs — these tests are expected to FAIL until fixed.
+	// -----------------------------------------------------------------------
+
+	t.Run("multiple conditions same relPath AND another relPath through same intermediate array", func(t *testing.T) {
+		// garages.cars.tags = "german" AND garages.cars.tags = "electric" AND garages.cars.tires.width = 205
+		//
+		// Plan: idxLoopAnd("cars") [ directAnd["cars.tags"], directAnd["cars.tires.width"] ]
+		//
+		// combinePositionBitmaps for "cars.tags" (2 independents, lcaPath="cars") calls an inner
+		// runIdxLoop("cars", [germanBm, electricBm]) and returns a leaf-masked tagsResult (leaf=0).
+		// The outer runIdxLoop then receives [tagsResult(leaf=0), widthBm(raw)].
+		// MaskLeafAnd(tagsResult, elemBitmap) is always empty because elemBitmap has real leaf
+		// positions while tagsResult has leaf=0 — no intersection possible.
+		// Result: empty — doc5 (all three conditions in the same car) is never returned.
+		//
+		// doc5: garages[0].cars[0]: tags=["german"(leaf=1),"electric"(leaf=2)], tires[0].width=205(leaf=3)
+		//       → all conditions in the same car → should match
+		// doc7: garages[0].cars[0]: tags=["german"(leaf=1),"electric"(leaf=2)]
+		//       garages[0].cars[1]: tires[0].width=205(leaf=3)
+		//       → tags and width in different cars → should NOT match
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "garages",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "cars",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+								{
+									Name:     "tires",
+									DataType: schema.DataTypeObjectArray.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("garages")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("garages")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+
+		widthVal := make([]byte, 8)
+		widthVal[7] = 205
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: cars[0] holds all three conditions (tags depth-first: leaf=1,2; tires[0]: leaf=3)
+		writeNestedValue(t, vb, "cars.tags", "german", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.tags", "electric", []uint64{invnested.Encode(1, 2, doc5)})
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", widthVal),
+			[]uint64{invnested.Encode(1, 3, doc5)}))
+		// doc7: tags in cars[0] (leaves 1,2), width in cars[1] (leaf 3 — depth-first continues)
+		writeNestedValue(t, vb, "cars.tags", "german", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.tags", "electric", []uint64{invnested.Encode(1, 2, doc7)})
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", widthVal),
+			[]uint64{invnested.Encode(1, 3, doc7)}))
+
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5), invnested.Encode(1, 3, doc5), // doc5 all in cars[0]
+			invnested.Encode(1, 1, doc7), invnested.Encode(1, 2, doc7), // doc7 tags in cars[0]
+		}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{
+			invnested.Encode(1, 3, doc7), // doc7 width in cars[1]
+		}))
+
+		pv := makeCorrelatedPvp(class, "garages",
+			makeLeafPvp(class, "garages", "cars.tags", "german"),
+			makeLeafPvp(class, "garages", "cars.tags", "electric"),
+			&propValuePair{
+				prop: "garages", value: widthVal, operator: filters.OperatorEqual,
+				hasFilterableIndex: true,
+				nested:             nestedInfo{isNested: true, relPath: "cars.tires.width"},
+				Class:              class,
+			},
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("two relPaths with multiple conditions through same intermediate array — same-car semantics", func(t *testing.T) {
+		// garages.cars.tags = "german" AND garages.cars.tags = "electric"
+		// AND garages.cars.labels = "red" AND garages.cars.labels = "blue"
+		//
+		// Plan: directAnd["cars.tags", "cars.labels"] — tags and labels are both DataTypeTextArray
+		// so isDirectAndEligible returns true (neither rem contains a DataTypeObjectArray).
+		//
+		// combinePositionBitmaps for each path (2 independents each, lcaPath="cars") calls an
+		// inner runIdxLoop("cars") and returns a leaf-masked result. AndAll of two leaf-masked
+		// bitmaps only verifies same-root (same garage), not same-car. Doc7 incorrectly matches
+		// because its tags are in cars[0] and its labels are in cars[1] — the two inner loops
+		// each confirm their conditions within SOME car of garages[0], but the outer AndAll does
+		// not verify that one car satisfies both.
+		//
+		// doc5: garages[0].cars[0]: tags=["german","electric"], labels=["red","blue"] → should match
+		// doc7: garages[0].cars[0]: tags=["german","electric"]
+		//       garages[0].cars[1]: labels=["red","blue"]
+		//       → conditions in different cars → should NOT match
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "garages",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "cars",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+								{Name: "labels", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("garages")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("garages")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: cars[0] holds all four values (tags: leaf=1,2; labels: leaf=3,4)
+		writeNestedValue(t, vb, "cars.tags", "german", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.tags", "electric", []uint64{invnested.Encode(1, 2, doc5)})
+		writeNestedValue(t, vb, "cars.labels", "red", []uint64{invnested.Encode(1, 3, doc5)})
+		writeNestedValue(t, vb, "cars.labels", "blue", []uint64{invnested.Encode(1, 4, doc5)})
+		// doc7: tags in cars[0] (leaf=1,2), labels in cars[1] (leaf=3,4 — depth-first continues)
+		writeNestedValue(t, vb, "cars.tags", "german", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.tags", "electric", []uint64{invnested.Encode(1, 2, doc7)})
+		writeNestedValue(t, vb, "cars.labels", "red", []uint64{invnested.Encode(1, 3, doc7)})
+		writeNestedValue(t, vb, "cars.labels", "blue", []uint64{invnested.Encode(1, 4, doc7)})
+
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5),
+			invnested.Encode(1, 3, doc5), invnested.Encode(1, 4, doc5), // doc5 all in cars[0]
+			invnested.Encode(1, 1, doc7), invnested.Encode(1, 2, doc7), // doc7 tags in cars[0]
+		}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{
+			invnested.Encode(1, 3, doc7), invnested.Encode(1, 4, doc7), // doc7 labels in cars[1]
+		}))
+
+		pv := makeCorrelatedPvp(class, "garages",
+			makeLeafPvp(class, "garages", "cars.tags", "german"),
+			makeLeafPvp(class, "garages", "cars.tags", "electric"),
+			makeLeafPvp(class, "garages", "cars.labels", "red"),
+			makeLeafPvp(class, "garages", "cars.labels", "blue"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+	// -----------------------------------------------------------------------
+	// Known bugs — tokens + independent mixed in the same directAnd path.
+	//
+	// combinePositions returns a leaf-masked result when a path has both tokens
+	// and one or more independents (case 1 with tokens → AndAllMaskLeaf, or
+	// default → AndAllMaskLeaf). When that masked bitmap participates in
+	// executeDirectAnd's AndAll alongside a raw bitmap from another path, the
+	// intersection is always empty because the leaf bits differ. The tests below
+	// confirm the bug for independent=1 and independent>1, for the common array
+	// element being the root property (intermediate plain object LCA) and being
+	// intermediate (intermediate ObjectArray LCA).
+	// -----------------------------------------------------------------------
+
+	// tokenCompound builds a non-isNested compound AND whose children are
+	// routed as tokens by resolveNestedCorrelated. The outer correlated pvp's
+	// childrenFromTokenization is false, so this non-isNested child enters the
+	// else branch and its grandchildren become tokens for the given relPath.
+	tokenCompound := func(class *models.Class, prop, relPath string, terms ...string) *propValuePair {
+		children := make([]*propValuePair, len(terms))
+		for i, term := range terms {
+			children[i] = makeLeafPvp(class, prop, relPath, term)
+		}
+		return &propValuePair{
+			operator: filters.OperatorAnd,
+			nested:   nestedInfo{}, // isNested=false → grandchildren become tokens
+			children: children,
+			Class:    class,
+		}
+	}
+
+	t.Run("BUG — tokens + independent=1, root array (intermediate plain-object LCA)", func(t *testing.T) {
+		// Schema: addresses: object[] { owner: object { tags: text[], name: text } }
+		//
+		// Filter: owner.tags = "new york" (tokenized → ["new","york"])
+		//         AND owner.tags = "berlin"  (1 independent)
+		//         AND owner.name = "alice"
+		//
+		// positionsByPath["owner.tags"] = {tokens:[new,york], independent:[berlin]}
+		// positionsByPath["owner.name"] = {independent:[alice]}
+		//
+		// multiConditionPaths["owner.tags"] = false  (len(independent)=1)
+		// Plan: directAnd["owner.tags","owner.name"]  (LCA=owner object, name scalar → rule 3b)
+		//
+		// combinePositions("owner.tags"):
+		//   tokensResult = AndAll([new,york]) = {E(1,1,d5)}          ← raw
+		//   case 1 with tokens: AndAllMaskLeaf([{E(1,1)},{E(1,2)}])  ← MASKED
+		// combinePositions("owner.name"): {E(1,1), E(1,2)}           ← RAW
+		// AndAll([MASKED, RAW]) = {}                                  ← BUG: mixing types
+		//
+		// doc5: addresses[0].owner.tags=["new york"(leaf=1),"berlin"(leaf=2)], name="alice" → should match
+		// doc7: addresses[0].owner.tags=["new york"], addresses[1].owner.tags=["berlin"]    → should NOT match
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{{
+				Name:     "addresses",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{{
+					Name:     "owner",
+					DataType: schema.DataTypeObject.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+						{Name: "name", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+					},
+				}},
+			}},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("addresses")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+		vb := store.Bucket(valueBucketName)
+
+		// doc5: addr[0].owner.tags=["new york"(leaf=1),"berlin"(leaf=2)], name inherits {leaf1,leaf2}
+		writeNestedValue(t, vb, "owner.tags", "new", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "owner.tags", "york", []uint64{invnested.Encode(1, 1, doc5)}) // same leaf as "new"
+		writeNestedValue(t, vb, "owner.tags", "berlin", []uint64{invnested.Encode(1, 2, doc5)})
+		writeNestedValue(t, vb, "owner.name", "alice", []uint64{invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5)})
+
+		// doc7: "new york" in addr[0], "berlin" in addr[1] → different addresses → should NOT match
+		writeNestedValue(t, vb, "owner.tags", "new", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "owner.tags", "york", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "owner.tags", "berlin", []uint64{invnested.Encode(2, 1, doc7)})
+		writeNestedValue(t, vb, "owner.name", "alice", []uint64{invnested.Encode(1, 1, doc7)})
+
+		pv := makeCorrelatedPvp(class, "addresses",
+			tokenCompound(class, "addresses", "owner.tags", "new", "york"),
+			makeLeafPvp(class, "addresses", "owner.tags", "berlin"),
+			makeLeafPvp(class, "addresses", "owner.name", "alice"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("BUG — tokens + independent>1, root array (intermediate plain-object LCA)", func(t *testing.T) {
+		// Schema: addresses: object[] { owner: object { title: text, name: text } }
+		//
+		// Filter: owner.title = "new york" (tokens) AND owner.title = "berlin" (ind1)
+		//         AND owner.title = "tech" (ind2)  AND owner.name = "alice"
+		//
+		// positionsByPath["owner.title"] = {tokens:[new,york], independent:[berlin,tech]}
+		// positionsByPath["owner.name"]  = {independent:[alice]}
+		//
+		// multiConditionPaths["owner.title"] = true (len(independent)=2)
+		// 3c extension: multiConditionPaths["owner.title"]=true AND isScalarArrayAtLevel(["title"])=false
+		//               (title is DataTypeText, not text[]) → check does NOT fire → directAnd!
+		//
+		// combinePositions("owner.title"):
+		//   default: AndAllMaskLeaf([tokensResult, berlin, tech]) → MASKED
+		// combinePositions("owner.name"): raw
+		// AndAll([MASKED, RAW]) = {}  ← BUG
+		//
+		// owner has no sub-arrays → single leaf=1 per address; all title bitmaps at leaf=1.
+		// doc5: all conditions in addr[0].owner (leaf=1) → should match
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{{
+				Name:     "addresses",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{{
+					Name:     "owner",
+					DataType: schema.DataTypeObject.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "title", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+						{Name: "name", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+					},
+				}},
+			}},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("addresses")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+		vb := store.Bucket(valueBucketName)
+
+		// doc5: addr[0].owner has no sub-arrays → owner element gets leaf=1
+		// title and name both inherit owner's single position.
+		writeNestedValue(t, vb, "owner.title", "new", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "owner.title", "york", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "owner.title", "berlin", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "owner.title", "tech", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "owner.name", "alice", []uint64{invnested.Encode(1, 1, doc5)})
+
+		// doc7: tokens in addr[0], independents spread across addr[1] and addr[2] → no match
+		writeNestedValue(t, vb, "owner.title", "new", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "owner.title", "york", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "owner.title", "berlin", []uint64{invnested.Encode(2, 1, doc7)})
+		writeNestedValue(t, vb, "owner.title", "tech", []uint64{invnested.Encode(3, 1, doc7)})
+		writeNestedValue(t, vb, "owner.name", "alice", []uint64{invnested.Encode(1, 1, doc7)})
+
+		pv := makeCorrelatedPvp(class, "addresses",
+			tokenCompound(class, "addresses", "owner.title", "new", "york"),
+			makeLeafPvp(class, "addresses", "owner.title", "berlin"),
+			makeLeafPvp(class, "addresses", "owner.title", "tech"),
+			makeLeafPvp(class, "addresses", "owner.name", "alice"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("BUG — tokens + independent=1, intermediate ObjectArray LCA", func(t *testing.T) {
+		// Schema: garages: object[] { cars: object[] { tags: text[], make: text } }
+		//
+		// Filter: cars.tags = "new york" (tokens) AND cars.tags = "berlin" (ind=1)
+		//         AND cars.make = "tesla"
+		//
+		// positionsByPath["cars.tags"] = {tokens:[new,york], independent:[berlin]}
+		// positionsByPath["cars.make"] = {independent:[tesla]}
+		//
+		// multiConditionPaths["cars.tags"] = false (len(independent)=1)
+		// Plan: directAnd["cars.tags","cars.make"]  (LCA=cars ObjectArray, make scalar → rule 3b)
+		//
+		// combinePositions("cars.tags"):
+		//   case 1 + tokens: AndAllMaskLeaf([tokensResult, berlinBm]) → MASKED E(1,0,d5)
+		// combinePositions("cars.make"):
+		//   case 1 no tokens: raw {E(1,1,d5), E(1,2,d5)}
+		// AndAll([MASKED, RAW]) = {}  ← BUG
+		//
+		// doc5: garages[0].cars[0].tags=["new york"(leaf=1),"berlin"(leaf=2)], make→{1,2} → should match
+		// doc7: cars[0].tags=["new york"], cars[1].tags=["berlin"], cars[0].make="tesla"  → should NOT match
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{{
+				Name:     "garages",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{{
+					Name:     "cars",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+						{Name: "make", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+					},
+				}},
+			}},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("garages")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("garages")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+		vb := store.Bucket(valueBucketName)
+
+		// doc5: garages[0].cars[0].tags=["new york"(leaf=1),"berlin"(leaf=2)], make inherits {1,2}
+		writeNestedValue(t, vb, "cars.tags", "new", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.tags", "york", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.tags", "berlin", []uint64{invnested.Encode(1, 2, doc5)})
+		writeNestedValue(t, vb, "cars.make", "tesla", []uint64{invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5)})
+
+		// doc7: "new york" in cars[0](leaf=1), "berlin" in cars[1](leaf=2), tesla in cars[0] only
+		writeNestedValue(t, vb, "cars.tags", "new", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.tags", "york", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.tags", "berlin", []uint64{invnested.Encode(1, 2, doc7)})
+		writeNestedValue(t, vb, "cars.make", "tesla", []uint64{invnested.Encode(1, 1, doc7)})
+
+		// _idx.cars[N] entries required for idxLoopAnd("cars").
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5), // doc5 cars[0]: both tags + make
+			invnested.Encode(1, 1, doc7), // doc7 cars[0]: "new york" + tesla
+		}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{
+			invnested.Encode(1, 2, doc7), // doc7 cars[1]: "berlin"
+		}))
+
+		pv := makeCorrelatedPvp(class, "garages",
+			tokenCompound(class, "garages", "cars.tags", "new", "york"),
+			makeLeafPvp(class, "garages", "cars.tags", "berlin"),
+			makeLeafPvp(class, "garages", "cars.make", "tesla"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("BUG — tokens + independent>1, intermediate ObjectArray LCA", func(t *testing.T) {
+		// Schema: garages: object[] { cars: object[] { make: text, model: text } }
+		//
+		// Filter: cars.make = "new york" (tokens) AND cars.make = "berlin" (ind1)
+		//         AND cars.make = "tech" (ind2)  AND cars.model = "s"
+		//
+		// positionsByPath["cars.make"]  = {tokens:[new,york], independent:[berlin,tech]}
+		// positionsByPath["cars.model"] = {independent:[s]}
+		//
+		// multiConditionPaths["cars.make"] = true (len(independent)=2)
+		// 3c extension: multiConditionPaths["cars.make"]=true AND isScalarArrayAtLevel(["make"])=false
+		//               (make is DataTypeText, not text[]) → does NOT fire → directAnd!
+		//
+		// combinePositions("cars.make"):
+		//   default: AndAllMaskLeaf([tokensResult, berlin, tech]) → MASKED
+		// combinePositions("cars.model"): raw
+		// AndAll([MASKED, RAW]) = {}  ← BUG
+		//
+		// cars with no sub-arrays → each car gets one leaf.
+		// doc5: garages[0].cars[0] — all conditions at leaf=1 → should match
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{{
+				Name:     "garages",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{{
+					Name:     "cars",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "make", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+						{Name: "model", DataType: schema.DataTypeText.PropString(), IndexFilterable: &vTrue},
+					},
+				}},
+			}},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("garages")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("garages")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+		vb := store.Bucket(valueBucketName)
+
+		// doc5: garages[0].cars[0] has no sub-arrays → cars[0] element gets leaf=1.
+		// make and model both inherit cars[0]'s single position E(1,1,d5).
+		writeNestedValue(t, vb, "cars.make", "new", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.make", "york", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.make", "berlin", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.make", "tech", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.model", "s", []uint64{invnested.Encode(1, 1, doc5)})
+
+		// doc7: tokens in cars[0](leaf=1), berlin in cars[1](leaf=2), model "s" in cars[2](leaf=3)
+		writeNestedValue(t, vb, "cars.make", "new", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.make", "york", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.make", "berlin", []uint64{invnested.Encode(1, 2, doc7)})
+		writeNestedValue(t, vb, "cars.make", "tech", []uint64{invnested.Encode(1, 2, doc7)})
+		writeNestedValue(t, vb, "cars.model", "s", []uint64{invnested.Encode(1, 3, doc7)})
+
+		// _idx.cars[N] entries for idxLoopAnd("cars") on "cars.make" (tokens+2 independents → masked).
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{
+			invnested.Encode(1, 1, doc5), // doc5 cars[0]
+			invnested.Encode(1, 1, doc7), // doc7 cars[0]: tokens only
+		}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{
+			invnested.Encode(1, 2, doc7), // doc7 cars[1]: berlin+tech
+		}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 2), []uint64{
+			invnested.Encode(1, 3, doc7), // doc7 cars[2]: model "s"
+		}))
+
+		pv := makeCorrelatedPvp(class, "garages",
+			tokenCompound(class, "garages", "cars.make", "new", "york"),
+			makeLeafPvp(class, "garages", "cars.make", "berlin"),
+			makeLeafPvp(class, "garages", "cars.make", "tech"),
+			makeLeafPvp(class, "garages", "cars.model", "s"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("root array — multiple tags + make, no idx entries needed", func(t *testing.T) {
+		// cars.tags = "german" AND cars.tags = "electric" AND cars.make = "honda"
+		//
+		// cars is the root-level object[]. root_idx in the position encoding already
+		// identifies which car element each value belongs to, so AndAllMaskLeaf
+		// suffices — no _idx.cars[N] entries are needed.
+		//
+		// Plan: two groups (different first segment under cars):
+		//   "tags" (2 independents → isMasked, lcaPath="") → groupAndAllMaskLeaf
+		//   "make" (1 independent → !isMasked, lcaPath="") → groupAndAll
+		// Neither group triggers groupRunIdxLoop.
+		//
+		// doc5: cars[0] (root=1) has tags=["german"(leaf=1),"electric"(leaf=2)], make="honda"(leaf=3) → match
+		// doc7: cars[0] (root=1) has tags=["german"(leaf=1),"electric"(leaf=2)]
+		//       cars[1] (root=2) has make="honda"(leaf=1) → tags and make in different cars → no match
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		// Meta bucket is required by resolveNestedCorrelated, but intentionally left
+		// empty — this test proves that no _idx entries are accessed or needed.
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+		class := correlationTestClass()
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: all three values in cars[0] (root=1), different leaf positions
+		writeNestedValue(t, vb, "tags", "german", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "tags", "electric", []uint64{invnested.Encode(1, 2, doc5)})
+		writeNestedValue(t, vb, "make", "honda", []uint64{invnested.Encode(1, 3, doc5)})
+		// doc7: tags in cars[0] (root=1), make in cars[1] (root=2) — split across elements
+		writeNestedValue(t, vb, "tags", "german", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "tags", "electric", []uint64{invnested.Encode(1, 2, doc7)})
+		writeNestedValue(t, vb, "make", "honda", []uint64{invnested.Encode(2, 1, doc7)})
+
+		pv := makeCorrelatedPvp(class, "cars",
+			makeLeafPvp(class, "cars", "tags", "german"),
+			makeLeafPvp(class, "cars", "tags", "electric"),
+			makeLeafPvp(class, "cars", "make", "honda"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("[regression] groupAndAllMaskLeaf must not be used for intermediate array LCA", func(t *testing.T) {
+		// Proof that groupRunIdxLoop is required when lcaPath!="", even for a
+		// single-segment (depth-1) LCA such as "cars" within "garages".
+		//
+		// root_idx encodes the GARAGES element; leaf_idx is a depth-first counter
+		// within that garages element. After MaskLeaf, all positions within the same
+		// garages element collapse to {root=garages_idx, leaf=0, doc}. Two conditions
+		// landing in *different* cars within the same garage therefore become
+		// indistinguishable — groupAndAllMaskLeaf would produce a false positive.
+		//
+		// Schema: garages: object[] { cars: object[] { tags: text[] } }
+		//
+		// doc5: garages[0].cars[0].tags = ["german", "electric"]
+		//         → both tags in the SAME car → match
+		// doc7: garages[0].cars[0].tags = ["german"]
+		//       garages[0].cars[1].tags = ["electric"]
+		//         → tags in DIFFERENT cars, same garage
+		//         → groupRunIdxLoop correctly returns empty
+		//         → groupAndAllMaskLeaf would wrongly return doc7 (false positive)
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "garages",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "cars",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("garages")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("garages")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+		vb := store.Bucket(valueBucketName)
+		mb := store.Bucket(metaBucketName)
+
+		// doc5: garages[0] (root=1) — cars[0].tags = ["german"(leaf=1), "electric"(leaf=2)]
+		writeNestedValue(t, vb, "cars.tags", "german", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.tags", "electric", []uint64{invnested.Encode(1, 2, doc5)})
+		// doc7: garages[0] (root=1) — cars[0].tags=["german"(leaf=1)], cars[1].tags=["electric"(leaf=2)]
+		writeNestedValue(t, vb, "cars.tags", "german", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.tags", "electric", []uint64{invnested.Encode(1, 2, doc7)})
+
+		// _idx.cars[0]: positions of cars[0] across both documents
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5), // doc5 cars[0]: both tags
+			invnested.Encode(1, 1, doc7), // doc7 cars[0]: german only
+		}))
+		// _idx.cars[1]: positions of cars[1] — only doc7 has a second car
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{
+			invnested.Encode(1, 2, doc7), // doc7 cars[1]: electric only
+		}))
+
+		// After MaskLeaf, doc7's two conditions both collapse to {root=1,leaf=0,doc7}
+		// — identical to doc5's. groupAndAllMaskLeaf would return both docs.
+		// groupRunIdxLoop iterates _idx.cars[N]: no single cars element contains
+		// both tags for doc7, so doc7 is correctly excluded.
+		pv := makeCorrelatedPvp(class, "garages",
+			makeLeafPvp(class, "garages", "cars.tags", "german"),
+			makeLeafPvp(class, "garages", "cars.tags", "electric"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray(),
+			"doc7 must not match: tags in different cars collapse to same masked position "+
+				"but groupRunIdxLoop correctly requires them to be in the same car element")
 	})
 }
 
@@ -440,7 +1784,7 @@ func isNullTestClass() *models.Class {
 // writeNestedExists writes an _exists metadata entry to a meta bucket.
 func writeNestedExists(t *testing.T, bucket *lsmkv.Bucket, relPath string, positions []uint64) {
 	t.Helper()
-	require.NoError(t, bucket.RoaringSetAddList(nested.ExistsKey(relPath), positions))
+	require.NoError(t, bucket.RoaringSetAddList(invnested.ExistsKey(relPath), positions))
 }
 
 // makeIsNullPvp builds a propValuePair for a nested IsNull filter.
@@ -460,7 +1804,7 @@ func makeIsNullPvp(class *models.Class, prop, relPath string, isNullTrue bool) *
 
 func TestNestedIsNull(t *testing.T) {
 	// position helpers — docID is the identifying part after MaskRootLeaf
-	pos := func(docID uint64) uint64 { return nested.Encode(1, 1, docID) }
+	pos := func(docID uint64) uint64 { return invnested.Encode(1, 1, docID) }
 
 	t.Run("object[] — root IsNull", func(t *testing.T) {
 		// output:
@@ -471,11 +1815,11 @@ func TestNestedIsNull(t *testing.T) {
 			doc2 = uint64(2) // has addresses without city
 		)
 
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
-		searcher, store := newNestedTestSearcher(t, metaBucket)
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, metaBucketName)
 		class := isNullTestClass()
 
-		mb := store.Bucket(metaBucket)
+		mb := store.Bucket(metaBucketName)
 		// doc1 has addresses with city; doc2 has addresses without city; doc3 has none.
 		writeNestedExists(t, mb, "", []uint64{pos(doc1), pos(doc2)})
 		writeNestedExists(t, mb, "city", []uint64{pos(doc1)})
@@ -508,11 +1852,11 @@ func TestNestedIsNull(t *testing.T) {
 			doc2 = uint64(2) // has addresses without city
 		)
 
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
-		searcher, store := newNestedTestSearcher(t, metaBucket)
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, metaBucketName)
 		class := isNullTestClass()
 
-		mb := store.Bucket(metaBucket)
+		mb := store.Bucket(metaBucketName)
 		// doc1 has addresses with city; doc2 has addresses but no city; doc3 has none.
 		writeNestedExists(t, mb, "", []uint64{pos(doc1), pos(doc2)})
 		writeNestedExists(t, mb, "city", []uint64{pos(doc1)})
@@ -545,11 +1889,11 @@ func TestNestedIsNull(t *testing.T) {
 			doc6 = uint64(6) // has meta but no isbn
 		)
 
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("meta")
-		searcher, store := newNestedTestSearcher(t, metaBucket)
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("meta")
+		searcher, store := newNestedTestSearcher(t, metaBucketName)
 		class := isNullTestClass()
 
-		mb := store.Bucket(metaBucket)
+		mb := store.Bucket(metaBucketName)
 		// doc4 has meta with isbn; doc6 has meta but no isbn; doc5 has no meta.
 		writeNestedExists(t, mb, "", []uint64{pos(doc4), pos(doc6)})
 		writeNestedExists(t, mb, "isbn", []uint64{pos(doc4)})
@@ -583,11 +1927,11 @@ func TestNestedIsNull(t *testing.T) {
 			doc6 = uint64(6) // has meta but no isbn
 		)
 
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("meta")
-		searcher, store := newNestedTestSearcher(t, metaBucket)
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("meta")
+		searcher, store := newNestedTestSearcher(t, metaBucketName)
 		class := isNullTestClass()
 
-		mb := store.Bucket(metaBucket)
+		mb := store.Bucket(metaBucketName)
 		// doc4 has meta with isbn; doc6 has meta but no isbn; doc5 has no meta.
 		writeNestedExists(t, mb, "", []uint64{pos(doc4), pos(doc6)})
 		writeNestedExists(t, mb, "isbn", []uint64{pos(doc4)})
@@ -617,8 +1961,8 @@ func TestNestedIsNull(t *testing.T) {
 		// container.owner IsNull true  → denylist  {doc7}  (complement = doc8, doc9, …)
 		// doc8 has container with items but no owner → in complement for IsNull true
 
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("container")
-		searcher, store := newNestedTestSearcher(t, metaBucket)
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("container")
+		searcher, store := newNestedTestSearcher(t, metaBucketName)
 		class := isNullTestClass()
 
 		const (
@@ -626,7 +1970,7 @@ func TestNestedIsNull(t *testing.T) {
 			doc8 = uint64(8) // container with items (no owner)
 		)
 
-		mb := store.Bucket(metaBucket)
+		mb := store.Bucket(metaBucketName)
 		// doc7: container element exists, owner exists
 		// doc8: container element exists, items exist, but no owner
 		writeNestedExists(t, mb, "", []uint64{pos(doc7), pos(doc8)})
@@ -658,8 +2002,8 @@ func TestNestedIsNull(t *testing.T) {
 		// container.items IsNull true  → denylist  {doc8}  (complement = doc7, doc9, …)
 		// doc7 has container with owner but no items → in complement for IsNull true
 
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("container")
-		searcher, store := newNestedTestSearcher(t, metaBucket)
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("container")
+		searcher, store := newNestedTestSearcher(t, metaBucketName)
 		class := isNullTestClass()
 
 		const (
@@ -667,7 +2011,7 @@ func TestNestedIsNull(t *testing.T) {
 			doc8 = uint64(8) // container with items (no owner)
 		)
 
-		mb := store.Bucket(metaBucket)
+		mb := store.Bucket(metaBucketName)
 		writeNestedExists(t, mb, "", []uint64{pos(doc7), pos(doc8)})
 		writeNestedExists(t, mb, "owner", []uint64{pos(doc7)})
 		writeNestedExists(t, mb, "items", []uint64{pos(doc8)})
@@ -703,7 +2047,7 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 	)
 
 	posAddr := func(root uint16, leaf uint16, docID uint64) uint64 {
-		return nested.Encode(root, leaf, docID)
+		return invnested.Encode(root, leaf, docID)
 	}
 
 	t.Run("root index — addresses[1].city = berlin", func(t *testing.T) {
@@ -712,12 +2056,12 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 		// → only doc1 has a second address (root=2) with city=berlin
 		// → doc2 has no second address → empty
 
-		valueBucket := helpers.BucketNestedFromPropNameLSM("addresses")
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
-		searcher, store := newNestedTestSearcher(t, valueBucket, metaBucket)
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("addresses")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
 		class := isNullTestClass()
 
-		vb := store.Bucket(valueBucket)
+		vb := store.Bucket(valueBucketName)
 		// doc1: addresses[0] root=1 leaf=1, addresses[1] root=2 leaf=1
 		writeNestedValue(t, vb, "city", "berlin", []uint64{
 			posAddr(1, 1, doc1), // addresses[0].city=berlin (doc1)
@@ -729,16 +2073,16 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 
 		// _idx entries: IdxKey("", 0) → all positions in addresses[0]
 		//               IdxKey("", 1) → all positions in addresses[1]
-		mb := store.Bucket(metaBucket)
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 0), []uint64{
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 0), []uint64{
 			posAddr(1, 1, doc1), posAddr(1, 1, doc2),
 		}))
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 1), []uint64{
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1), []uint64{
 			posAddr(2, 1, doc1), // only doc1 has a second address
 		}))
 
 		pv := makeLeafPvp(class, "addresses", "city", "berlin")
-		pv.nested.arrayIndices = []filternested.ArrayIndex{{RelPath: "", Index: 1}}
+		pv.invnested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 1}}
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
@@ -746,20 +2090,20 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 	})
 
 	t.Run("root index out of range — addresses[5].city returns empty", func(t *testing.T) {
-		valueBucket := helpers.BucketNestedFromPropNameLSM("addresses")
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
-		searcher, store := newNestedTestSearcher(t, valueBucket, metaBucket)
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("addresses")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
 		class := isNullTestClass()
 
-		vb := store.Bucket(valueBucket)
+		vb := store.Bucket(valueBucketName)
 		writeNestedValue(t, vb, "city", "berlin", []uint64{posAddr(1, 1, doc1)})
 
-		mb := store.Bucket(metaBucket)
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 0), []uint64{posAddr(1, 1, doc1)}))
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 0), []uint64{posAddr(1, 1, doc1)}))
 		// No IdxKey("", 5) entry → intersection will be empty
 
 		pv := makeLeafPvp(class, "addresses", "city", "berlin")
-		pv.nested.arrayIndices = []filternested.ArrayIndex{{RelPath: "", Index: 5}}
+		pv.invnested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 5}}
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
@@ -771,18 +2115,18 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 		// doc1: addresses[0] (root=1) and addresses[1] (root=2)
 		// doc2: addresses[0] (root=1) only
 
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
-		searcher, store := newNestedTestSearcher(t, metaBucket)
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, metaBucketName)
 		class := isNullTestClass()
 
-		mb := store.Bucket(metaBucket)
+		mb := store.Bucket(metaBucketName)
 		writeNestedExists(t, mb, "", []uint64{posAddr(1, 1, doc1), posAddr(2, 1, doc1), posAddr(1, 1, doc2)})
 		writeNestedExists(t, mb, "city", []uint64{posAddr(1, 1, doc1), posAddr(2, 1, doc1), posAddr(1, 1, doc2)})
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 0), []uint64{posAddr(1, 1, doc1), posAddr(1, 1, doc2)}))
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 1), []uint64{posAddr(2, 1, doc1)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 0), []uint64{posAddr(1, 1, doc1), posAddr(1, 1, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1), []uint64{posAddr(2, 1, doc1)}))
 
 		pv := makeIsNullPvp(class, "addresses", "", false)
-		pv.nested.arrayIndices = []filternested.ArrayIndex{{RelPath: "", Index: 1}}
+		pv.invnested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 1}}
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
@@ -798,21 +2142,21 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 
 		const doc3 = uint64(3)
 
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
-		searcher, store := newNestedTestSearcher(t, metaBucket)
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("addresses")
+		searcher, store := newNestedTestSearcher(t, metaBucketName)
 		class := isNullTestClass()
 
-		mb := store.Bucket(metaBucket)
+		mb := store.Bucket(metaBucketName)
 		// root-level exists: doc1 has two addresses, doc2 and doc3 have one each
 		writeNestedExists(t, mb, "", []uint64{posAddr(1, 1, doc1), posAddr(2, 1, doc1), posAddr(1, 1, doc2), posAddr(1, 1, doc3), posAddr(2, 1, doc3)})
 		// city exists: doc1 both addresses, doc2 first address, doc3 only second address
 		writeNestedExists(t, mb, "city", []uint64{posAddr(1, 1, doc1), posAddr(2, 1, doc1), posAddr(1, 1, doc2), posAddr(2, 1, doc3)})
 		// root idx entries
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 0), []uint64{posAddr(1, 1, doc1), posAddr(1, 1, doc2), posAddr(1, 1, doc3)}))
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 1), []uint64{posAddr(2, 1, doc1), posAddr(2, 1, doc3)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 0), []uint64{posAddr(1, 1, doc1), posAddr(1, 1, doc2), posAddr(1, 1, doc3)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1), []uint64{posAddr(2, 1, doc1), posAddr(2, 1, doc3)}))
 
 		pv := makeIsNullPvp(class, "addresses", "city", false)
-		pv.nested.arrayIndices = []filternested.ArrayIndex{{RelPath: "", Index: 1}}
+		pv.invnested.arrayIndices = []filnested.ArrayIndex{{RelPath: "", Index: 1}}
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
@@ -846,7 +2190,7 @@ func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
 		}
 	}
 
-	posAt := func(root, leaf uint16, docID uint64) uint64 { return nested.Encode(root, leaf, docID) }
+	posAt := func(root, leaf uint16, docID uint64) uint64 { return invnested.Encode(root, leaf, docID) }
 
 	const (
 		doc1 = uint64(1)
@@ -860,24 +2204,24 @@ func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
 		//   tags[0]=posAt(1,1,doc2)  tags[1]=posAt(1,2,doc2)
 		// filter: cars.tags[2] = "german" → only doc1 (doc2's "german" is at tags[0])
 
-		valueBucket := helpers.BucketNestedFromPropNameLSM("cars")
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("cars")
-		searcher, store := newNestedTestSearcher(t, valueBucket, metaBucket)
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
 		class := carsClass()
 
-		vb := store.Bucket(valueBucket)
+		vb := store.Bucket(valueBucketName)
 		writeNestedValue(t, vb, "tags", "english", []uint64{posAt(1, 1, doc1)})
 		writeNestedValue(t, vb, "tags", "premium", []uint64{posAt(1, 2, doc1)})
 		writeNestedValue(t, vb, "tags", "german", []uint64{posAt(1, 3, doc1), posAt(1, 1, doc2)})
 		writeNestedValue(t, vb, "tags", "luxury", []uint64{posAt(1, 2, doc2)})
 
-		mb := store.Bucket(metaBucket)
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tags", 0), []uint64{posAt(1, 1, doc1), posAt(1, 1, doc2)}))
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tags", 1), []uint64{posAt(1, 2, doc1), posAt(1, 2, doc2)}))
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tags", 2), []uint64{posAt(1, 3, doc1)}))
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("tags", 0), []uint64{posAt(1, 1, doc1), posAt(1, 1, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("tags", 1), []uint64{posAt(1, 2, doc1), posAt(1, 2, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("tags", 2), []uint64{posAt(1, 3, doc1)}))
 
 		pv := makeLeafPvp(class, "cars", "tags", "german")
-		pv.nested.arrayIndices = []filternested.ArrayIndex{{RelPath: "tags", Index: 2}}
+		pv.invnested.arrayIndices = []filnested.ArrayIndex{{RelPath: "tags", Index: 2}}
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
@@ -890,9 +2234,9 @@ func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
 		// filter: cars.tires[0].width = 205 → only doc1
 		// (doc2 has width=205 but only at tires[1], not tires[0])
 
-		valueBucket := helpers.BucketNestedFromPropNameLSM("cars")
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("cars")
-		searcher, store := newNestedTestSearcher(t, valueBucket, metaBucket)
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
 		class := carsClass()
 
 		widthVal205 := make([]byte, 8)
@@ -900,13 +2244,13 @@ func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
 		widthVal225 := make([]byte, 8)
 		widthVal225[7] = 225
 
-		vb := store.Bucket(valueBucket)
-		require.NoError(t, vb.RoaringSetAddList(nested.ValueKey("tires.width", widthVal205), []uint64{posAt(1, 1, doc1), posAt(1, 2, doc2)}))
-		require.NoError(t, vb.RoaringSetAddList(nested.ValueKey("tires.width", widthVal225), []uint64{posAt(1, 2, doc1), posAt(1, 1, doc2)}))
+		vb := store.Bucket(valueBucketName)
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("tires.width", widthVal205), []uint64{posAt(1, 1, doc1), posAt(1, 2, doc2)}))
+		require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("tires.width", widthVal225), []uint64{posAt(1, 2, doc1), posAt(1, 1, doc2)}))
 
-		mb := store.Bucket(metaBucket)
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tires", 0), []uint64{posAt(1, 1, doc1), posAt(1, 1, doc2)}))
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tires", 1), []uint64{posAt(1, 2, doc1), posAt(1, 2, doc2)}))
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("tires", 0), []uint64{posAt(1, 1, doc1), posAt(1, 1, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("tires", 1), []uint64{posAt(1, 2, doc1), posAt(1, 2, doc2)}))
 
 		pv := &propValuePair{
 			prop: "cars", value: widthVal205, operator: filters.OperatorEqual,
@@ -914,7 +2258,7 @@ func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
 			nested: nestedInfo{
 				isNested:     true,
 				relPath:      "tires.width",
-				arrayIndices: []filternested.ArrayIndex{{RelPath: "tires", Index: 0}},
+				arrayIndices: []filnested.ArrayIndex{{RelPath: "tires", Index: 0}},
 			},
 			Class: class,
 		}
@@ -933,28 +2277,28 @@ func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
 		// filter: cars[1].tags[2] = "german" → only doc1
 		// (doc2's "german" is in cars[0].tags[0], wrong car AND wrong tag index)
 
-		valueBucket := helpers.BucketNestedFromPropNameLSM("cars")
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("cars")
-		searcher, store := newNestedTestSearcher(t, valueBucket, metaBucket)
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("cars")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("cars")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
 		class := carsClass()
 
-		vb := store.Bucket(valueBucket)
+		vb := store.Bucket(valueBucketName)
 		writeNestedValue(t, vb, "tags", "english", []uint64{posAt(1, 1, doc1), posAt(2, 1, doc1)})
 		writeNestedValue(t, vb, "tags", "premium", []uint64{posAt(2, 2, doc1)})
 		writeNestedValue(t, vb, "tags", "german", []uint64{posAt(2, 3, doc1), posAt(1, 1, doc2)})
 		writeNestedValue(t, vb, "tags", "luxury", []uint64{posAt(1, 2, doc2)})
 
-		mb := store.Bucket(metaBucket)
+		mb := store.Bucket(metaBucketName)
 		// root-level cars elements
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 0), []uint64{posAt(1, 1, doc1), posAt(1, 1, doc2)}))
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("", 1), []uint64{posAt(2, 1, doc1), posAt(2, 2, doc1), posAt(2, 3, doc1)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 0), []uint64{posAt(1, 1, doc1), posAt(1, 1, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1), []uint64{posAt(2, 1, doc1), posAt(2, 2, doc1), posAt(2, 3, doc1)}))
 		// tags positions per index within their parent car
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tags", 0), []uint64{posAt(1, 1, doc1), posAt(2, 1, doc1), posAt(1, 1, doc2)}))
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tags", 1), []uint64{posAt(2, 2, doc1), posAt(1, 2, doc2)}))
-		require.NoError(t, mb.RoaringSetAddList(nested.IdxKey("tags", 2), []uint64{posAt(2, 3, doc1)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("tags", 0), []uint64{posAt(1, 1, doc1), posAt(2, 1, doc1), posAt(1, 1, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("tags", 1), []uint64{posAt(2, 2, doc1), posAt(1, 2, doc2)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("tags", 2), []uint64{posAt(2, 3, doc1)}))
 
 		pv := makeLeafPvp(class, "cars", "tags", "german")
-		pv.nested.arrayIndices = []filternested.ArrayIndex{
+		pv.invnested.arrayIndices = []filnested.ArrayIndex{
 			{RelPath: "", Index: 1},     // cars[1]
 			{RelPath: "tags", Index: 2}, // tags[2]
 		}
@@ -963,4 +2307,1153 @@ func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc1}, result.docIDs.ToArray())
 	})
+}
+
+// ---------------------------------------------------------------------------
+// Plan-case integration tests
+// ---------------------------------------------------------------------------
+//
+// Each case is parameterized and runs twice: once for "nested" (DataTypeObject)
+// and once for "nestedArray" (DataTypeObjectArray). Filters are constructed via
+// filters.Clause and resolved through extractPropValuePair, exercising the full
+// extraction + resolution pipeline alongside the position resolvers.
+
+// planTestClass returns a class with two root properties sharing the same nested
+// schema (matching correlationTestProps from the plan unit tests):
+//
+//	"nested"      DataTypeObject      — single root element (root=1 always)
+//	"nestedArray" DataTypeObjectArray — root index identifies array elements
+//
+// Both properties carry the same NestedProperties so all plan cases can be
+// verified on both a plain-object and an object-array root.
+func planTestClass() *models.Class {
+	vTrue := true
+	tok := models.PropertyTokenizationField // exact-match; no splitting or casing
+
+	// nested builds a NestedProperty with exact-match tokenization. Tokenization
+	// is ignored for non-text types (int, int[], etc.) so one helper suffices.
+	nested := func(name string, dt []string) *models.NestedProperty {
+		return &models.NestedProperty{Name: name, DataType: dt, IndexFilterable: &vTrue, Tokenization: tok}
+	}
+
+	subProps := []*models.NestedProperty{
+		nested("name", schema.DataTypeText.PropString()),
+		{
+			Name:     "owner",
+			DataType: schema.DataTypeObject.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				nested("firstname", schema.DataTypeText.PropString()),
+				nested("lastname", schema.DataTypeText.PropString()),
+				nested("nicknames", schema.DataTypeTextArray.PropString()),
+			},
+		},
+		{
+			Name:     "addresses",
+			DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				nested("city", schema.DataTypeText.PropString()),
+				nested("postcode", schema.DataTypeText.PropString()),
+			},
+		},
+		nested("tags", schema.DataTypeTextArray.PropString()),
+		{
+			Name:     "cars",
+			DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				nested("make", schema.DataTypeText.PropString()),
+				nested("colors", schema.DataTypeTextArray.PropString()),
+				{
+					Name:     "tires",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						nested("width", schema.DataTypeInt.PropString()),
+						nested("radiuses", schema.DataTypeIntArray.PropString()),
+						{
+							Name:     "bolts",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								nested("size", schema.DataTypeInt.PropString()),
+							},
+						},
+						{
+							Name:     "caps",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								nested("color", schema.DataTypeText.PropString()),
+							},
+						},
+					},
+				},
+				{
+					Name:     "accessories",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						nested("type", schema.DataTypeText.PropString()),
+					},
+				},
+			},
+		},
+	}
+
+	mkProp := func(name string, dt []string) *models.Property {
+		return &models.Property{
+			Name:             name,
+			DataType:         dt,
+			NestedProperties: subProps,
+		}
+	}
+
+	return &models.Class{
+		Class: "PlanTestClass",
+		Properties: []*models.Property{
+			mkProp("nested", schema.DataTypeObject.PropString()),
+			mkProp("nestedArray", schema.DataTypeObjectArray.PropString()),
+		},
+	}
+}
+
+// newSearcherForClass creates a minimal Searcher backed by the given class.
+func newSearcherForClass(t *testing.T, class *models.Class, bucketNames ...string) (*Searcher, *lsmkv.Store) {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	store, err := lsmkv.New(t.TempDir(), t.TempDir(), logger, nil, nil,
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop(),
+		cyclemanager.NewCallbackGroupNoop())
+	require.NoError(t, err)
+	t.Cleanup(func() { store.Shutdown(context.Background()) })
+	for _, name := range bucketNames {
+		require.NoError(t, store.CreateOrLoadBucket(context.Background(),
+			name, lsmkv.WithStrategy(lsmkv.StrategyRoaringSet)))
+	}
+	bitmapFactory := roaringset.NewBitmapFactory(
+		roaringset.NewBitmapBufPoolNoop(), func() uint64 { return 1_000_000 })
+	searcher := NewSearcher(logger, store, func(string) *models.Class { return class },
+		nil, nil, fakeStopwordDetector{}, 2,
+		func() bool { return false }, "",
+		config.DefaultQueryNestedCrossReferenceLimit, bitmapFactory)
+	return searcher, store
+}
+
+func TestPlanCasesIntegration(t *testing.T) {
+	const (
+		doc5 = uint64(5)
+		doc7 = uint64(7)
+		doc9 = uint64(9) // same-root, different-intermediate split (nestedArray only)
+	)
+
+	// E1 encodes a position with root=1, the given leaf, and docID.
+	E1 := func(leaf uint16, docID uint64) uint64 { return invnested.Encode(1, leaf, docID) }
+	// E encodes a position with the given root, leaf, and docID (for cross-root tests).
+	E := func(root, leaf uint16, docID uint64) uint64 { return invnested.Encode(root, leaf, docID) }
+
+	// sortableInt encodes an integer for bucket writes, matching extractIntValue output.
+	sortableInt := func(v int) []byte {
+		b, err := ent.LexicographicallySortableInt64(int64(v))
+		require.NoError(t, err)
+		return b
+	}
+
+	width205 := sortableInt(205)
+	radius17 := sortableInt(17)
+	size10 := sortableInt(10)
+
+	class := planTestClass()
+
+	// filter clause builders
+	textFlt := func(propPath, value string) filters.Clause {
+		return filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: value},
+			On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(propPath)},
+		}
+	}
+	intFlt := func(propPath string, v int) filters.Clause {
+		return filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeInt, Value: v},
+			On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(propPath)},
+		}
+	}
+	and := func(ops ...filters.Clause) *filters.Clause {
+		return &filters.Clause{Operator: filters.OperatorAnd, Operands: ops}
+	}
+
+	type planCase struct {
+		name string
+		// nestedSetup writes positions for the "nested" (DataTypeObject) property.
+		// doc7 splits conditions at the intermediate level (e.g. different sub-array
+		// elements within root=1), which is the only interesting negative case for a
+		// plain object with a single root.
+		nestedSetup func(t *testing.T, vb, mb *lsmkv.Bucket)
+		// nestedArraySetup writes positions for the "nestedArray" (DataTypeObjectArray)
+		// property. It must test TWO distinct negative cases:
+		//   doc7: cross-root split — conditions in nestedArray[0] (root=1) vs
+		//         nestedArray[1] (root=2), verifying root_idx enforcement.
+		//   doc9: same-root, different-intermediate split — conditions within a single
+		//         nestedArray element but in different sub-array elements (e.g. different
+		//         cars[] or tires[] elements), verifying intermediate idx enforcement.
+		nestedArraySetup func(t *testing.T, vb, mb *lsmkv.Bucket)
+		// filter builds the filter clause for the given root property name.
+		filter func(prop string) *filters.Clause
+	}
+
+	cases := []planCase{
+		{
+			// Plan: single group, groupAndAll, lcaPath="".
+			// nested  doc7: wrong lastname at same position.
+			// nestedArray doc7: firstname in nestedArray[0], lastname in nestedArray[1] → cross-root.
+			// nestedArray doc9: nestedArray[0] has two owner elements — but owner is DataTypeObject
+			//   (not array), so there is no meaningful intermediate split. doc9 uses a second
+			//   nestedArray[0] with a non-matching lastname to cover the wrong-value path.
+			name: "owner — scalar siblings in plain object, groupAndAll lcaPath empty",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "owner.firstname", "john", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "owner.firstname", "jane", []uint64{E1(1, doc7)})
+				writeNestedValue(t, vb, "owner.lastname", "doe", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "owner.lastname", "smith", []uint64{E1(1, doc7)})
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "owner.firstname", "john", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "owner.lastname", "doe", []uint64{E1(1, doc5)})
+				// doc7: firstname in nestedArray[0] (root=1), lastname in nestedArray[1] (root=2)
+				writeNestedValue(t, vb, "owner.firstname", "john", []uint64{E(1, 1, doc7)})
+				writeNestedValue(t, vb, "owner.lastname", "doe", []uint64{E(2, 1, doc7)})
+				// doc9: both in same nestedArray[0] but wrong value — owner is plain object so
+				// there is no intermediate array level to split across
+				writeNestedValue(t, vb, "owner.firstname", "john", []uint64{E(1, 1, doc9)})
+				writeNestedValue(t, vb, "owner.lastname", "smith", []uint64{E(1, 1, doc9)})
+			},
+			filter: func(prop string) *filters.Clause {
+				return and(textFlt(prop+".owner.firstname", "john"), textFlt(prop+".owner.lastname", "doe"))
+			},
+		},
+		{
+			// Plan: single group, groupAndAll, lcaPath="cars".
+			// nested  doc7: make in cars[0], colors in cars[1] within root=1.
+			// nestedArray doc7: make in nestedArray[0].cars[0] (root=1), colors in nestedArray[1].cars[0] (root=2).
+			// nestedArray doc9: nestedArray[0] has cars[0]={make} and cars[1]={colors}
+			//   → same root, different cars elements → AndAll positions don't overlap → no match.
+			name: "cars — scalar + text[] siblings, groupAndAll lcaPath cars",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E1(1, doc5), E1(1, doc7)})
+				writeNestedValue(t, vb, "cars.colors", "red", []uint64{E1(1, doc5), E1(2, doc7)})
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				// doc5: cars[0]={make,colors} — colors[0]→leaf=1; make inherits leaf=1
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "cars.colors", "red", []uint64{E1(1, doc5)})
+				// doc7 cross-root: make in nestedArray[0] (root=1), colors in nestedArray[1] (root=2)
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E(1, 1, doc7)})
+				writeNestedValue(t, vb, "cars.colors", "red", []uint64{E(2, 1, doc7)})
+				// doc9 same-root intermediate split: nestedArray[0].cars[0]={make}, cars[1]={colors}
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E(1, 1, doc9)})
+				writeNestedValue(t, vb, "cars.colors", "red", []uint64{E(1, 2, doc9)})
+			},
+			filter: func(prop string) *filters.Clause {
+				return and(textFlt(prop+".cars.make", "bmw"), textFlt(prop+".cars.colors", "red"))
+			},
+		},
+		{
+			// Plan: single group, groupAndAll, lcaPath="cars.tires". No idx needed.
+			// nested  doc7: width in tires[0], radiuses in tires[1] within root=1.
+			// nestedArray doc7: width in nestedArray[0].tires[0] (root=1), radiuses in nestedArray[1].tires[0] (root=2).
+			// nestedArray doc9: nestedArray[0].cars[0].tires[0]={width}, tires[1]={radiuses}
+			//   → same root, same car, different tires elements → positions don't overlap → no match.
+			name: "tires — scalar siblings, groupAndAll lcaPath cars.tires",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E1(1, doc5), E1(1, doc7)}))
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.radiuses", radius17), []uint64{E1(1, doc5), E1(2, doc7)}))
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				// doc5: tires[0]={width,radiuses} — both at leaf=1
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E1(1, doc5)}))
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.radiuses", radius17), []uint64{E1(1, doc5)}))
+				// doc7 cross-root
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(1, 1, doc7)}))
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.radiuses", radius17), []uint64{E(2, 1, doc7)}))
+				// doc9 same-root intermediate: tires[0]={width}, tires[1]={radiuses}
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(1, 1, doc9)}))
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.radiuses", radius17), []uint64{E(1, 2, doc9)}))
+			},
+			filter: func(prop string) *filters.Clause {
+				return and(intFlt(prop+".cars.tires.width", 205), intFlt(prop+".cars.tires.radiuses", 17))
+			},
+		},
+		{
+			// Plan: single group, groupRunIdxLoop, lcaPath="cars.tires".
+			// nested  doc7: bolts in tires[0], caps in tires[1] within root=1.
+			// nestedArray doc7: bolts in nestedArray[0].tires[0] (root=1), caps in nestedArray[1].tires[0] (root=2).
+			// nestedArray doc9: nestedArray[0].cars[0].tires[0]={bolts}, tires[1]={caps}
+			//   → same root, same car, different tires → runIdxLoop: no tires element has both → no match.
+			name: "tires sub-arrays — groupRunIdxLoop lcaPath cars.tires",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E1(1, doc5), E1(1, doc7)}))
+				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E1(2, doc5), E1(2, doc7)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E1(1, doc5), E1(2, doc5)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E1(1, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 1), []uint64{E1(2, doc7)}))
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				// doc5: tires[0]={bolts(leaf=1),caps(leaf=2)} — both in same tires element
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E1(1, doc5)}))
+				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E1(2, doc5)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E1(1, doc5), E1(2, doc5)}))
+				// doc7 cross-root: bolts in nestedArray[0].tires[0] (root=1), caps in nestedArray[1].tires[0] (root=2)
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E(1, 1, doc7)}))
+				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E(2, 1, doc7)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E(1, 1, doc7), E(2, 1, doc7)}))
+				// doc9 same-root intermediate: tires[0]={bolts}, tires[1]={caps} within nestedArray[0]
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E(1, 1, doc9)}))
+				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E(1, 2, doc9)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E(1, 1, doc9)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 1), []uint64{E(1, 2, doc9)}))
+			},
+			filter: func(prop string) *filters.Clause {
+				return and(intFlt(prop+".cars.tires.bolts.size", 10), textFlt(prop+".cars.tires.caps.color", "red"))
+			},
+		},
+		{
+			// Plan: single group, groupRunIdxLoop, lcaPath="cars".
+			// nested  doc7: make in cars[0], tires in cars[1] within root=1.
+			// nestedArray doc7: make in nestedArray[0].cars[0] (root=1), tires in nestedArray[1].cars[0] (root=2).
+			// nestedArray doc9: nestedArray[0] has cars[0]={make} and cars[1]={tires}
+			//   → same root, different cars → runIdxLoop: no car element has both → no match.
+			name: "cars make + tires.width — groupRunIdxLoop lcaPath cars",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E1(1, doc5), E1(1, doc7)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E1(1, doc5), E1(2, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(1, doc5)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(1, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{E1(2, doc7)}))
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				// doc5: cars[0]={make,tires} — make inherits tires leaf=1; both at Encode(1,1)
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E1(1, doc5)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E1(1, doc5)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(1, doc5)}))
+				// doc7 cross-root
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E(1, 1, doc7)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(2, 1, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 1, doc7), E(2, 1, doc7)}))
+				// doc9 same-root intermediate: nestedArray[0].cars[0]={make}, cars[1]={tires}
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E(1, 1, doc9)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(1, 2, doc9)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 1, doc9)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{E(1, 2, doc9)}))
+			},
+			filter: func(prop string) *filters.Clause {
+				return and(textFlt(prop+".cars.make", "bmw"), intFlt(prop+".cars.tires.width", 205))
+			},
+		},
+		{
+			// Plan: two separate groupAndAll groups (addresses, cars).
+			// nested  doc7: city="paris" — addresses group empty.
+			// nestedArray doc7: city in nestedArray[0] (root=1), make in nestedArray[1] (root=2).
+			// nestedArray doc9: nestedArray[0] has correct city and make, but addresses[0] and
+			//   cars[0] are the only elements, so there's no meaningful intermediate split here.
+			//   doc9 uses a second nestedArray element with city only (no make) to verify that
+			//   the cross-element case is handled (already covered by doc7); instead we verify
+			//   a wrong-city scenario in the same root for completeness.
+			name: "addresses.city + cars.make — two separate groupAndAll groups",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "addresses.city", "paris", []uint64{E1(1, doc7)})
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E1(2, doc5), E1(2, doc7)})
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E1(2, doc5)})
+				// doc7 cross-root: city in nestedArray[0] (root=1), make in nestedArray[1] (root=2)
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E(1, 1, doc7)})
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E(2, 1, doc7)})
+				// doc9 same root with wrong city value
+				writeNestedValue(t, vb, "addresses.city", "paris", []uint64{E(1, 1, doc9)})
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E(1, 2, doc9)})
+			},
+			filter: func(prop string) *filters.Clause {
+				return and(textFlt(prop+".addresses.city", "berlin"), textFlt(prop+".cars.make", "bmw"))
+			},
+		},
+		{
+			// Plan: groupAndAll(addresses) + groupRunIdxLoop(cars).
+			// nested  doc7: correct addresses, tires in cars[0] and accessories in cars[1].
+			// nestedArray doc7: addresses in nestedArray[0] (root=1), cars in nestedArray[1] (root=2).
+			// nestedArray doc9: nestedArray[0] has correct addresses AND cars[0]={tires}, cars[1]={accessories}
+			//   → same root, different cars → groupRunIdxLoop finds no car with both → no match.
+			name: "addresses city+postcode + cars tires+accessories — groupAndAll + groupRunIdxLoop",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E1(1, doc5), E1(1, doc7)})
+				writeNestedValue(t, vb, "addresses.postcode", "10115", []uint64{E1(1, doc5), E1(1, doc7)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E1(2, doc5), E1(2, doc7)}))
+				writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{E1(3, doc5), E1(3, doc7)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(2, doc5), E1(3, doc5)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(2, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{E1(3, doc7)}))
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				// doc5: nestedArray[0] has addresses(leaf=1) + cars[0]={tires(leaf=2),acc(leaf=3)}
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "addresses.postcode", "10115", []uint64{E1(1, doc5)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E1(2, doc5)}))
+				writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{E1(3, doc5)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(2, doc5), E1(3, doc5)}))
+				// doc7 cross-root: addresses in nestedArray[0] (root=1), cars in nestedArray[1] (root=2)
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E(1, 1, doc7)})
+				writeNestedValue(t, vb, "addresses.postcode", "10115", []uint64{E(1, 1, doc7)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(2, 1, doc7)}))
+				writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{E(2, 2, doc7)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(2, 1, doc7), E(2, 2, doc7)}))
+				// doc9 same-root intermediate: nestedArray[0] has correct addresses, but cars split
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E(1, 1, doc9)})
+				writeNestedValue(t, vb, "addresses.postcode", "10115", []uint64{E(1, 1, doc9)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(1, 2, doc9)}))
+				writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{E(1, 3, doc9)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 2, doc9)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{E(1, 3, doc9)}))
+			},
+			filter: func(prop string) *filters.Clause {
+				return and(
+					textFlt(prop+".addresses.city", "berlin"),
+					textFlt(prop+".addresses.postcode", "10115"),
+					intFlt(prop+".cars.tires.width", 205),
+					textFlt(prop+".cars.accessories.type", "spoiler"),
+				)
+			},
+		},
+		{
+			// Plan: groupAndAllMaskLeaf(tags, lcaPath="") + groupAndAll(addresses, lcaPath="addresses").
+			// nested  doc7: same tags but city="paris".
+			// nestedArray doc7: tags in nestedArray[0] (root=1), city in nestedArray[1] (root=2).
+			// nestedArray doc9: nestedArray[0] has tags x+y and city, but tags[0]="x" in a
+			//   different nestedArray element from city — not applicable here since tags and
+			//   addresses are separate sub-properties (different sub-trees), not the same array.
+			//   Instead doc9 verifies: nestedArray[0]={tags:["x","y"]}, nestedArray[1]={city:paris}
+			//   — same as doc7 but different wrong city to exercise a distinct wrong-value path.
+			//   The key nestedArray-specific test (cross-root) is covered by doc7.
+			name: "groupAndAllMaskLeaf + groupAndAll — tags multi + addresses.city",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "tags", "x", []uint64{E1(1, doc5), E1(1, doc7)})
+				writeNestedValue(t, vb, "tags", "y", []uint64{E1(2, doc5), E1(2, doc7)})
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E1(3, doc5)})
+				writeNestedValue(t, vb, "addresses.city", "paris", []uint64{E1(3, doc7)})
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "tags", "x", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "tags", "y", []uint64{E1(2, doc5)})
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E1(3, doc5)})
+				// doc7 cross-root: tags in nestedArray[0] (root=1), city in nestedArray[1] (root=2)
+				writeNestedValue(t, vb, "tags", "x", []uint64{E(1, 1, doc7)})
+				writeNestedValue(t, vb, "tags", "y", []uint64{E(1, 2, doc7)})
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E(2, 1, doc7)})
+				// doc9: nestedArray[0]={tags:["x","y"]} + wrong city in same element
+				writeNestedValue(t, vb, "tags", "x", []uint64{E(1, 1, doc9)})
+				writeNestedValue(t, vb, "tags", "y", []uint64{E(1, 2, doc9)})
+				writeNestedValue(t, vb, "addresses.city", "paris", []uint64{E(1, 3, doc9)})
+			},
+			filter: func(prop string) *filters.Clause {
+				return and(textFlt(prop+".tags", "x"), textFlt(prop+".tags", "y"), textFlt(prop+".addresses.city", "berlin"))
+			},
+		},
+		{
+			// Plan: three separate groupAndAll groups.
+			// nested  doc7: correct addresses+make but firstname="jane".
+			// nestedArray doc7: correct values but each in a different root element.
+			// nestedArray doc9: nestedArray[0] has owner+addresses but wrong make.
+			name: "three groupAndAll groups — owner.firstname + addresses.city + cars.make",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "owner.firstname", "john", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "owner.firstname", "jane", []uint64{E1(1, doc7)})
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E1(2, doc5), E1(2, doc7)})
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E1(3, doc5), E1(3, doc7)})
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "owner.firstname", "john", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E1(2, doc5)})
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E1(3, doc5)})
+				// doc7 cross-root: each condition in a different nestedArray element
+				writeNestedValue(t, vb, "owner.firstname", "john", []uint64{E(1, 1, doc7)})
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E(2, 1, doc7)})
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E(3, 1, doc7)})
+				// doc9 same nestedArray[0]: correct firstname+city but wrong make
+				writeNestedValue(t, vb, "owner.firstname", "john", []uint64{E(1, 1, doc9)})
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E(1, 2, doc9)})
+				writeNestedValue(t, vb, "cars.make", "honda", []uint64{E(1, 3, doc9)})
+			},
+			filter: func(prop string) *filters.Clause {
+				return and(
+					textFlt(prop+".owner.firstname", "john"),
+					textFlt(prop+".addresses.city", "berlin"),
+					textFlt(prop+".cars.make", "bmw"),
+				)
+			},
+		},
+		{
+			// Plan: single group, groupRunIdxLoop, lcaPath="cars.tires".
+			// nested  doc7: width in tires[0], bolts in tires[1].
+			// nestedArray doc7: width in nestedArray[0].tires[0] (root=1), bolts in nestedArray[1].tires[0] (root=2).
+			// nestedArray doc9: nestedArray[0].cars[0].tires[0]={width}, tires[1]={bolts}
+			//   → same root, same car, different tires → no tires element has both → no match.
+			name: "groupRunIdxLoop(cars.tires) — tires.width + tires.bolts.size",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E1(1, doc5), E1(1, doc7)}))
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E1(1, doc5), E1(2, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E1(1, doc5)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E1(1, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 1), []uint64{E1(2, doc7)}))
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				// doc5: tires[0]={width,bolts} — bolts[0]→leaf=1; width inherits leaf=1
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E1(1, doc5)}))
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E1(1, doc5)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E1(1, doc5)}))
+				// doc7 cross-root
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(1, 1, doc7)}))
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E(2, 1, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E(1, 1, doc7), E(2, 1, doc7)}))
+				// doc9 same-root, same-car, different-tires
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(1, 1, doc9)}))
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E(1, 2, doc9)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E(1, 1, doc9)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 1), []uint64{E(1, 2, doc9)}))
+			},
+			filter: func(prop string) *filters.Clause {
+				return and(intFlt(prop+".cars.tires.width", 205), intFlt(prop+".cars.tires.bolts.size", 10))
+			},
+		},
+		{
+			// Plan: single group, groupRunIdxLoop, lcaPath="cars" (LCA collapses from cars.tires).
+			// nested  doc7: bolts+caps in cars[0], accessories in cars[1].
+			// nestedArray doc7: bolts+caps in nestedArray[0].cars[0] (root=1), accessories in nestedArray[1].cars[0] (root=2).
+			// nestedArray doc9: nestedArray[0] has cars[0]={tires(bolts+caps)}, cars[1]={accessories}
+			//   → same root, different cars → idx loop finds no car with all three → no match.
+			name: "groupRunIdxLoop(cars) — tires.bolts + tires.caps + accessories, LCA collapses",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E1(1, doc5), E1(1, doc7)}))
+				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E1(2, doc5), E1(2, doc7)})
+				writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{E1(3, doc5), E1(3, doc7)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(1, doc5), E1(2, doc5), E1(3, doc5)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(1, doc7), E1(2, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{E1(3, doc7)}))
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				// doc5: nestedArray[0].cars[0]={tires(bolts:leaf=1,caps:leaf=2),acc:leaf=3}
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E1(1, doc5)}))
+				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E1(2, doc5)})
+				writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{E1(3, doc5)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(1, doc5), E1(2, doc5), E1(3, doc5)}))
+				// doc7 cross-root: bolts+caps in nestedArray[0].cars[0], accessories in nestedArray[1].cars[0]
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E(1, 1, doc7)}))
+				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E(1, 2, doc7)})
+				writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{E(2, 1, doc7)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 1, doc7), E(1, 2, doc7), E(2, 1, doc7)}))
+				// doc9 same-root: nestedArray[0].cars[0]={tires(bolts+caps)}, cars[1]={accessories}
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E(1, 1, doc9)}))
+				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E(1, 2, doc9)})
+				writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{E(1, 3, doc9)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 1, doc9), E(1, 2, doc9)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{E(1, 3, doc9)}))
+			},
+			filter: func(prop string) *filters.Clause {
+				return and(
+					intFlt(prop+".cars.tires.bolts.size", 10),
+					textFlt(prop+".cars.tires.caps.color", "red"),
+					textFlt(prop+".cars.accessories.type", "spoiler"),
+				)
+			},
+		},
+		{
+			// Plan: groupAndAllMaskLeaf(tags) + groupRunIdxLoop(cars).
+			// nested  doc7: correct tags + cars split (tires in cars[0], accessories in cars[1]).
+			// nestedArray doc7: tags in nestedArray[0] (root=1), cars in nestedArray[1] (root=2).
+			// nestedArray doc9: nestedArray[0]={tags:["x","y"]} + cars[0]={tires}, cars[1]={accessories}
+			//   → same root, cars conditions split across cars elements → runIdxLoop: no car with both.
+			name: "groupAndAllMaskLeaf + groupRunIdxLoop — tags multi + cars tires+accessories",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "tags", "x", []uint64{E1(1, doc5), E1(1, doc7)})
+				writeNestedValue(t, vb, "tags", "y", []uint64{E1(2, doc5), E1(2, doc7)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E1(3, doc5), E1(3, doc7)}))
+				writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{E1(4, doc5), E1(4, doc7)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(3, doc5), E1(4, doc5)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(3, doc7)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{E1(4, doc7)}))
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				// doc5: nestedArray[0]={tags(leaf=1,2),cars[0]={tires(leaf=3),acc(leaf=4)}}
+				writeNestedValue(t, vb, "tags", "x", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "tags", "y", []uint64{E1(2, doc5)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E1(3, doc5)}))
+				writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{E1(4, doc5)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(3, doc5), E1(4, doc5)}))
+				// doc7 cross-root: tags in nestedArray[0] (root=1), cars in nestedArray[1] (root=2)
+				writeNestedValue(t, vb, "tags", "x", []uint64{E(1, 1, doc7)})
+				writeNestedValue(t, vb, "tags", "y", []uint64{E(1, 2, doc7)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(2, 1, doc7)}))
+				writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{E(2, 2, doc7)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(2, 1, doc7), E(2, 2, doc7)}))
+				// doc9 same-root: nestedArray[0]={tags(leaf=1,2), cars[0]={tires(leaf=3)}, cars[1]={acc(leaf=4)}}
+				writeNestedValue(t, vb, "tags", "x", []uint64{E(1, 1, doc9)})
+				writeNestedValue(t, vb, "tags", "y", []uint64{E(1, 2, doc9)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(1, 3, doc9)}))
+				writeNestedValue(t, vb, "cars.accessories.type", "spoiler", []uint64{E(1, 4, doc9)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 3, doc9)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{E(1, 4, doc9)}))
+			},
+			filter: func(prop string) *filters.Clause {
+				return and(
+					textFlt(prop+".tags", "x"),
+					textFlt(prop+".tags", "y"),
+					intFlt(prop+".cars.tires.width", 205),
+					textFlt(prop+".cars.accessories.type", "spoiler"),
+				)
+			},
+		},
+
+		// -----------------------------------------------------------------------
+		// Single-condition cases — each produces one leaf pvp resolved via
+		// fetchNestedDocIDs (not resolveNestedCorrelated). These verify that the
+		// basic bucket read + MaskRootLeaf path works correctly at every nesting
+		// depth and for every leaf type.
+		//
+		// nestedArraySetup places doc5's value in nestedArray[1] (root=2) to
+		// verify that MaskRootLeaf strips root bits and returns the docID
+		// regardless of which array element holds the match.
+		// -----------------------------------------------------------------------
+		{
+			// Scalar text in DataTypeObject (no intermediate array).
+			// owner is plain object → wrapped at root=1; firstname inherits leaf=1.
+			// nestedArraySetup: value in nestedArray[1] (root=2) — MaskRootLeaf strips root bits → doc5 ✓
+			name: "single — owner.firstname (scalar in plain object)",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "owner.firstname", "john", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "owner.firstname", "jane", []uint64{E1(1, doc7)})
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "owner.firstname", "john", []uint64{E(2, 1, doc5)})
+				writeNestedValue(t, vb, "owner.firstname", "jane", []uint64{E(1, 1, doc7)})
+			},
+			filter: func(prop string) *filters.Clause {
+				c := textFlt(prop+".owner.firstname", "john")
+				return &c
+			},
+		},
+		{
+			// Scalar text through one object[] level.
+			// cars[0]={make:"bmw"}: no sub-arrays → leaf=1; make inherits leaf=1.
+			// nestedArraySetup: value in nestedArray[1] (root=2).
+			name: "single — cars.make (scalar through object[])",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "cars.make", "ford", []uint64{E1(1, doc7)})
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E(2, 1, doc5)})
+				writeNestedValue(t, vb, "cars.make", "ford", []uint64{E(1, 1, doc7)})
+			},
+			filter: func(prop string) *filters.Clause {
+				c := textFlt(prop+".cars.make", "bmw")
+				return &c
+			},
+		},
+		{
+			// Int through two object[] levels.
+			// cars[0].tires[0]={width:205}: no sub-arrays → leaf=1; width inherits leaf=1.
+			// nestedArraySetup: value in nestedArray[1] (root=2).
+			name: "single — cars.tires.width (int through two object[] levels)",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E1(1, doc5)}))
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", sortableInt(100)), []uint64{E1(1, doc7)}))
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(2, 1, doc5)}))
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", sortableInt(100)), []uint64{E(1, 1, doc7)}))
+			},
+			filter: func(prop string) *filters.Clause {
+				c := intFlt(prop+".cars.tires.width", 205)
+				return &c
+			},
+		},
+		{
+			// Text through three object[] levels (deepest path in schema).
+			// cars[0].tires[0].caps[0]={color:"red"}: leaf=1; color inherits leaf=1.
+			// nestedArraySetup: value in nestedArray[1] (root=2).
+			name: "single — cars.tires.caps.color (text through three object[] levels)",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "cars.tires.caps.color", "blue", []uint64{E1(1, doc7)})
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E(2, 1, doc5)})
+				writeNestedValue(t, vb, "cars.tires.caps.color", "blue", []uint64{E(1, 1, doc7)})
+			},
+			filter: func(prop string) *filters.Clause {
+				c := textFlt(prop+".cars.tires.caps.color", "red")
+				return &c
+			},
+		},
+		{
+			// Text array at root level (no intermediate object[]).
+			// tags[0]="x" → leaf=1.
+			// nestedArraySetup: value in nestedArray[1] (root=2).
+			name: "single — tags (text[] at root level)",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "tags", "x", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "tags", "z", []uint64{E1(1, doc7)})
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "tags", "x", []uint64{E(2, 1, doc5)})
+				writeNestedValue(t, vb, "tags", "z", []uint64{E(1, 1, doc7)})
+			},
+			filter: func(prop string) *filters.Clause {
+				c := textFlt(prop+".tags", "x")
+				return &c
+			},
+		},
+		{
+			// Scalar text through object[] (addresses).
+			// addresses[0]={city:"berlin"}: no sub-arrays → leaf=1; city inherits leaf=1.
+			// nestedArraySetup: value in nestedArray[1] (root=2).
+			name: "single — addresses.city (scalar through object[])",
+			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E1(1, doc5)})
+				writeNestedValue(t, vb, "addresses.city", "paris", []uint64{E1(1, doc7)})
+			},
+			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E(2, 1, doc5)})
+				writeNestedValue(t, vb, "addresses.city", "paris", []uint64{E(1, 1, doc7)})
+			},
+			filter: func(prop string) *filters.Clause {
+				c := textFlt(prop+".addresses.city", "berlin")
+				return &c
+			},
+		},
+	}
+
+	for _, prop := range []string{"nested", "nestedArray"} {
+		t.Run(prop, func(t *testing.T) {
+			valueBucketName := helpers.BucketNestedFromPropNameLSM(prop)
+			metaBucketName := helpers.BucketNestedMetaFromPropNameLSM(prop)
+
+			for _, tc := range cases {
+				t.Run(tc.name, func(t *testing.T) {
+					searcher, store := newSearcherForClass(t, class, valueBucketName, metaBucketName)
+
+					setup := tc.nestedSetup
+					if prop == "nestedArray" && tc.nestedArraySetup != nil {
+						setup = tc.nestedArraySetup
+					}
+					setup(t, store.Bucket(valueBucketName), store.Bucket(metaBucketName))
+
+					pv, err := searcher.extractPropValuePair(context.Background(), tc.filter(prop), "PlanTestClass")
+					require.NoError(t, err)
+
+					result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+					require.NoError(t, err)
+					assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+				})
+			}
+		})
+	}
+}
+
+// TestNestedFilteringComprehensive verifies correlated nested filtering across a
+// realistic document set for both DataTypeObject ("nested") and DataTypeObjectArray
+// ("nestedArray"). Running the same filter logic on both root types verifies that
+// intermediate-element enforcement (cars[], tires[]) works regardless of whether
+// the root property is a plain object or an array of objects.
+//
+// Four documents are used. Document d3 differs between properties:
+//
+//	DataTypeObject "nested" (root=1 always):
+//	  d3 = {cars:[{make:"bmw"}], addresses:[{city:"berlin",postcode:"10115"}]}
+//	  Exercises: bmw and berlin in the same root element; no tires/accessories.
+//
+//	DataTypeObjectArray "nestedArray" (root_idx = element index):
+//	  d3 = nestedArray[0]={cars:[{make:"bmw"}]}
+//	       nestedArray[1]={cars:[{tires:[{width:205}],accessories:[{type:"sunroof"}]}],
+//	                       addresses:[{city:"berlin",postcode:"10115"}]}
+//	  Exercises: bmw in root=1, tires/accessories/berlin in root=2 (cross-root split).
+//
+// Common documents (same positions for both properties):
+//
+//	d1 root=1: {addresses[0]→leaf=1, tags[0]→leaf=2,
+//	            cars[0]{tires[0]→leaf=3, acc[0]→leaf=4, make:"bmw" inherits[3,4]}}
+//	d2 root=1: {cars[0]{make:"bmw"→leaf=1}, cars[1]{tires[0]→leaf=2,acc[0]→leaf=3}}
+//	d4 root=1: {addresses[0]→leaf=1, cars[0]{tires[0]→leaf=2,acc[0]→leaf=3,make:"honda" inherits[2,3]}}
+func TestNestedFilteringComprehensive(t *testing.T) {
+	const (
+		d1 = uint64(11)
+		d2 = uint64(12)
+		d3 = uint64(13)
+		d4 = uint64(14)
+	)
+
+	sortableInt := func(v int) []byte {
+		b, err := ent.LexicographicallySortableInt64(int64(v))
+		require.NoError(t, err)
+		return b
+	}
+	width205 := sortableInt(205)
+	size10 := sortableInt(10)
+
+	class := planTestClass()
+	E := func(root, leaf uint16, docID uint64) uint64 { return invnested.Encode(root, leaf, docID) }
+
+	textFlt := func(propPath, value string) filters.Clause {
+		return filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: value},
+			On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(propPath)},
+		}
+	}
+	intFlt := func(propPath string, v int) filters.Clause {
+		return filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeInt, Value: v},
+			On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(propPath)},
+		}
+	}
+	and := func(ops ...filters.Clause) *filters.Clause {
+		return &filters.Clause{Operator: filters.OperatorAnd, Operands: ops}
+	}
+	or := func(ops ...filters.Clause) *filters.Clause {
+		return &filters.Clause{Operator: filters.OperatorOr, Operands: ops}
+	}
+
+	for _, prop := range []string{"nested", "nestedArray"} {
+		t.Run(prop, func(t *testing.T) {
+			valueBucketName := helpers.BucketNestedFromPropNameLSM(prop)
+			metaBucketName := helpers.BucketNestedMetaFromPropNameLSM(prop)
+			searcher, store := newSearcherForClass(t, class, valueBucketName, metaBucketName)
+			vb := store.Bucket(valueBucketName)
+			mb := store.Bucket(metaBucketName)
+
+			// -----------------------------------------------------------------
+			// d1 (root=1): addresses[0]→leaf=1, tags[0]→leaf=2,
+			//              cars[0]{tires[0]→leaf=3, acc[0]→leaf=4, make:"bmw" inherits[3,4]}
+			// -----------------------------------------------------------------
+			writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E(1, 1, d1)})
+			writeNestedValue(t, vb, "addresses.postcode", "10115", []uint64{E(1, 1, d1)})
+			writeNestedValue(t, vb, "tags", "premium", []uint64{E(1, 2, d1)})
+			require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(1, 3, d1)}))
+			writeNestedValue(t, vb, "cars.accessories.type", "sunroof", []uint64{E(1, 4, d1)})
+			writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E(1, 3, d1), E(1, 4, d1)})
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("addresses", 0), []uint64{E(1, 1, d1)}))
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E(1, 3, d1)}))
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.accessories", 0), []uint64{E(1, 4, d1)}))
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 3, d1), E(1, 4, d1)}))
+
+			// -----------------------------------------------------------------
+			// d2 (root=1): cars[0]{make:"bmw"→leaf=1}, cars[1]{tires[0]→leaf=2, acc[0]→leaf=3}
+			// -----------------------------------------------------------------
+			writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E(1, 1, d2)})
+			require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(1, 2, d2)}))
+			writeNestedValue(t, vb, "cars.accessories.type", "sunroof", []uint64{E(1, 3, d2)})
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E(1, 2, d2)}))
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.accessories", 0), []uint64{E(1, 3, d2)}))
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 1, d2)}))
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{E(1, 2, d2), E(1, 3, d2)}))
+
+			// -----------------------------------------------------------------
+			// d3: property-specific — see function doc comment.
+			// -----------------------------------------------------------------
+			if prop == "nested" {
+				// nested d3 (root=1): {cars[0]{make:"bmw"→leaf=2}, addresses[0]→leaf=1}
+				// No tires or accessories; bmw and berlin in the same root=1 element.
+				// Tests: same-root intermediate split is NOT present here — instead d3
+				// verifies that a document with bmw+berlin (different sub-trees) matches
+				// cross-subtree AND filters, unlike nestedArray where they're in different roots.
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E(1, 1, d3)})
+				writeNestedValue(t, vb, "addresses.postcode", "10115", []uint64{E(1, 1, d3)})
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E(1, 2, d3)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("addresses", 0), []uint64{E(1, 1, d3)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 2, d3)}))
+			} else {
+				// nestedArray d3: root=1={cars[0]{make:"bmw"→leaf=1}}
+				//                 root=2={addresses[0]→leaf=1, cars[0]{tires[0]→leaf=2,acc[0]→leaf=3}}
+				// Tests: cross-root split; bmw in root=1, everything else in root=2.
+				writeNestedValue(t, vb, "cars.make", "bmw", []uint64{E(1, 1, d3)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 1, d3)}))
+				writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E(2, 1, d3)})
+				writeNestedValue(t, vb, "addresses.postcode", "10115", []uint64{E(2, 1, d3)})
+				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(2, 2, d3)}))
+				writeNestedValue(t, vb, "cars.accessories.type", "sunroof", []uint64{E(2, 3, d3)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("addresses", 0), []uint64{E(2, 1, d3)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E(2, 2, d3)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.accessories", 0), []uint64{E(2, 3, d3)}))
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(2, 2, d3), E(2, 3, d3)}))
+			}
+
+			// -----------------------------------------------------------------
+			// d4 (root=1): addresses[0]→leaf=1, cars[0]{tires[0]→leaf=2,acc[0]→leaf=3,make:"honda" inherits[2,3]}
+			// -----------------------------------------------------------------
+			writeNestedValue(t, vb, "addresses.city", "berlin", []uint64{E(1, 1, d4)})
+			writeNestedValue(t, vb, "addresses.postcode", "10115", []uint64{E(1, 1, d4)})
+			require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.width", width205), []uint64{E(1, 2, d4)}))
+			writeNestedValue(t, vb, "cars.accessories.type", "sunroof", []uint64{E(1, 3, d4)})
+			writeNestedValue(t, vb, "cars.make", "honda", []uint64{E(1, 2, d4), E(1, 3, d4)})
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("addresses", 0), []uint64{E(1, 1, d4)}))
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E(1, 2, d4)}))
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.accessories", 0), []uint64{E(1, 3, d4)}))
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 2, d4), E(1, 3, d4)}))
+
+			// want returns the expected docIDs. For sub-tests where results differ
+			// between "nested" and "nestedArray", both slices are supplied;
+			// otherwise both slices should be identical.
+			want := func(forNested, forArray []uint64) []uint64 {
+				if prop == "nested" {
+					return forNested
+				}
+				return forArray
+			}
+
+			run := func(t *testing.T, f *filters.Clause, expected []uint64) {
+				t.Helper()
+				pv, err := searcher.extractPropValuePair(context.Background(), f, "PlanTestClass")
+				require.NoError(t, err)
+				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+				require.NoError(t, err)
+				assert.Equal(t, expected, result.docIDs.ToArray())
+			}
+
+			// -----------------------------------------------------------------
+			// Basic single-condition filters
+			// -----------------------------------------------------------------
+
+			t.Run("basic — cars.make = bmw", func(t *testing.T) {
+				// d1✓ d2✓ d3✓ d4✗
+				run(t, &filters.Clause{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeText, Value: "bmw"},
+					On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + ".cars.make")},
+				}, []uint64{d1, d2, d3})
+			})
+
+			t.Run("basic — cars.make = honda", func(t *testing.T) {
+				// d4✓ only
+				run(t, &filters.Clause{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeText, Value: "honda"},
+					On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + ".cars.make")},
+				}, []uint64{d4})
+			})
+
+			t.Run("basic — cars.tires.width = 205", func(t *testing.T) {
+				// nested:      d3 has no tires → [d1,d2,d4]
+				// nestedArray: d3 has tires in root=2 → [d1,d2,d3,d4]
+				run(t, &filters.Clause{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeInt, Value: 205},
+					On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + ".cars.tires.width")},
+				}, want([]uint64{d1, d2, d4}, []uint64{d1, d2, d3, d4}))
+			})
+
+			t.Run("basic — addresses.city = berlin", func(t *testing.T) {
+				// d1✓ d2✗(no addresses) d3✓ d4✓
+				run(t, &filters.Clause{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeText, Value: "berlin"},
+					On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + ".addresses.city")},
+				}, []uint64{d1, d3, d4})
+			})
+
+			t.Run("basic — tags = premium", func(t *testing.T) {
+				// d1✓ only
+				run(t, &filters.Clause{
+					Operator: filters.OperatorEqual,
+					Value:    &filters.Value{Type: schema.DataTypeText, Value: "premium"},
+					On:       &filters.Path{Class: "PlanTestClass", Property: schema.PropertyName(prop + ".tags")},
+				}, []uint64{d1})
+			})
+
+			// -----------------------------------------------------------------
+			// Simple AND — same-element enforcement
+			// -----------------------------------------------------------------
+
+			t.Run("AND — cars.make=bmw + cars.tires.width=205 same car", func(t *testing.T) {
+				// d1✓(same car) d2✗(diff cars) d3:nested✗(no tires),array✗(cross-root) d4✗(wrong make)
+				run(t, and(textFlt(prop+".cars.make", "bmw"), intFlt(prop+".cars.tires.width", 205)),
+					[]uint64{d1})
+			})
+
+			t.Run("AND — cars.make=bmw + cars.accessories.type=sunroof same car", func(t *testing.T) {
+				// d1✓  d2✗(diff cars)  d3✗  d4✗(wrong make)
+				run(t, and(textFlt(prop+".cars.make", "bmw"), textFlt(prop+".cars.accessories.type", "sunroof")),
+					[]uint64{d1})
+			})
+
+			t.Run("AND — cars.tires.width=205 + cars.accessories.type=sunroof same car", func(t *testing.T) {
+				// d1✓(same car)  d2✓(both in cars[1])
+				// nested:      d3 has no tires/acc → ✗  → [d1,d2,d4]
+				// nestedArray: d3 root=2 has both in same car → ✓ → [d1,d2,d3,d4]
+				// d4✓(same car)
+				run(t, and(intFlt(prop+".cars.tires.width", 205), textFlt(prop+".cars.accessories.type", "sunroof")),
+					want([]uint64{d1, d2, d4}, []uint64{d1, d2, d3, d4}))
+			})
+
+			t.Run("AND — cars.make=bmw + tires.width=205 + accessories.type=sunroof all same car", func(t *testing.T) {
+				// d1✓  d2✗(bmw in cars[0], rest in cars[1])  d3✗  d4✗(wrong make)
+				run(t, and(
+					textFlt(prop+".cars.make", "bmw"),
+					intFlt(prop+".cars.tires.width", 205),
+					textFlt(prop+".cars.accessories.type", "sunroof"),
+				), []uint64{d1})
+			})
+
+			t.Run("AND — cars.make=bmw + addresses.city=berlin same nestedArray element", func(t *testing.T) {
+				// d1✓(both in root=1)
+				// d2✗(no addresses)
+				// nested:      d3 has bmw+berlin in same root=1 → ✓ → [d1,d3]
+				// nestedArray: d3 has bmw in root=1, berlin in root=2 → ✗ → [d1]
+				// d4✗(wrong make)
+				run(t, and(textFlt(prop+".cars.make", "bmw"), textFlt(prop+".addresses.city", "berlin")),
+					want([]uint64{d1, d3}, []uint64{d1}))
+			})
+
+			t.Run("AND — addresses.city=berlin + addresses.postcode=10115 same address element", func(t *testing.T) {
+				// d1✓  d2✗(no addresses)  d3✓(both in same addresses[0])  d4✓
+				run(t, and(textFlt(prop+".addresses.city", "berlin"), textFlt(prop+".addresses.postcode", "10115")),
+					[]uint64{d1, d3, d4})
+			})
+
+			t.Run("AND — cars.make=bmw + addresses.city=berlin + addresses.postcode=10115", func(t *testing.T) {
+				// nested:      d3✓(bmw+berlin+10115 all in root=1) → [d1,d3]
+				// nestedArray: d3✗(cross-root) → [d1]
+				// d2✗(no addresses)  d4✗(wrong make)
+				run(t, and(
+					textFlt(prop+".cars.make", "bmw"),
+					textFlt(prop+".addresses.city", "berlin"),
+					textFlt(prop+".addresses.postcode", "10115"),
+				), want([]uint64{d1, d3}, []uint64{d1}))
+			})
+
+			t.Run("AND — tags=premium + cars.make=bmw same nestedArray element", func(t *testing.T) {
+				// d1✓(tags+bmw in root=1)  others: no tags or wrong make
+				run(t, and(textFlt(prop+".tags", "premium"), textFlt(prop+".cars.make", "bmw")), []uint64{d1})
+			})
+
+			t.Run("AND — tires.width=205 + accessories.type=sunroof + addresses.city=berlin + postcode=10115", func(t *testing.T) {
+				// d1✓(all in root=1)
+				// d2✗(no addresses)
+				// nested:      d3 has no tires/acc → ✗ → [d1,d4]
+				// nestedArray: d3 root=2 has all → ✓ → [d1,d3,d4]
+				// d4✓
+				run(t, and(
+					intFlt(prop+".cars.tires.width", 205),
+					textFlt(prop+".cars.accessories.type", "sunroof"),
+					textFlt(prop+".addresses.city", "berlin"),
+					textFlt(prop+".addresses.postcode", "10115"),
+				), want([]uint64{d1, d4}, []uint64{d1, d3, d4}))
+			})
+
+			// -----------------------------------------------------------------
+			// Simple OR — union, no same-element enforcement
+			// -----------------------------------------------------------------
+
+			t.Run("OR — cars.make=bmw OR cars.make=honda", func(t *testing.T) {
+				// All docs have either bmw or honda
+				run(t, or(textFlt(prop+".cars.make", "bmw"), textFlt(prop+".cars.make", "honda")),
+					[]uint64{d1, d2, d3, d4})
+			})
+
+			t.Run("OR — cars.make=bmw OR cars.tires.width=205", func(t *testing.T) {
+				// d1✓(both)  d2✓(both)  d3✓(bmw)  d4✓(tires+honda)
+				run(t, or(textFlt(prop+".cars.make", "bmw"), intFlt(prop+".cars.tires.width", 205)),
+					[]uint64{d1, d2, d3, d4})
+			})
+
+			t.Run("OR — tags=premium OR addresses.city=berlin", func(t *testing.T) {
+				// d1✓(both)  d2✗  d3✓(berlin)  d4✓(berlin)
+				run(t, or(textFlt(prop+".tags", "premium"), textFlt(prop+".addresses.city", "berlin")),
+					[]uint64{d1, d3, d4})
+			})
+
+			t.Run("OR — cars.make=bmw OR addresses.city=paris (paris absent)", func(t *testing.T) {
+				// d1✓(bmw)  d2✓(bmw)  d3✓(bmw)  d4✗(honda, no paris)
+				run(t, or(textFlt(prop+".cars.make", "bmw"), textFlt(prop+".addresses.city", "paris")),
+					[]uint64{d1, d2, d3})
+			})
+
+			// -----------------------------------------------------------------
+			// Complex multi-condition filters
+			// -----------------------------------------------------------------
+
+			t.Run("complex — (cars.make=bmw AND cars.tires.width=205) OR cars.make=honda", func(t *testing.T) {
+				// AND part requires same car: d1✓ only (d2: diff cars, d3: no tires or cross-root)
+				// OR with honda: d4✓
+				run(t, or(
+					*and(textFlt(prop+".cars.make", "bmw"), intFlt(prop+".cars.tires.width", 205)),
+					textFlt(prop+".cars.make", "honda"),
+				), []uint64{d1, d4})
+			})
+
+			t.Run("complex — cars.make=bmw AND (cars.tires.width=205 OR cars.accessories.type=sunroof)", func(t *testing.T) {
+				// Outer AND groups all into one correlated node. OR children resolve to docIDs independently.
+				// bmw: [d1,d2,d3]. OR(tires,acc): [d1,d2,d3(nestedArray)/d1,d2,d4(nested)].
+				// nested: OR(tires,acc)=[d1,d2,d4]; ∩ bmw=[d1,d2,d3] → [d1,d2]
+				// nestedArray: OR(tires,acc)=[d1,d2,d3,d4]; ∩ bmw=[d1,d2,d3] → [d1,d2,d3]
+				run(t, and(
+					textFlt(prop+".cars.make", "bmw"),
+					*or(intFlt(prop+".cars.tires.width", 205), textFlt(prop+".cars.accessories.type", "sunroof")),
+				), want([]uint64{d1, d2}, []uint64{d1, d2, d3}))
+			})
+
+			t.Run("complex — cars.make=bmw AND cars.tires.width=205 AND addresses.city=berlin", func(t *testing.T) {
+				// All must be in same nestedArray element.
+				// d1✓  d2✗(no addresses)  d3✗(no tires for nested; cross-root for nestedArray)  d4✗(wrong make)
+				run(t, and(
+					textFlt(prop+".cars.make", "bmw"),
+					intFlt(prop+".cars.tires.width", 205),
+					textFlt(prop+".addresses.city", "berlin"),
+				), []uint64{d1})
+			})
+
+			t.Run("complex — (cars.make=bmw OR cars.make=honda) AND addresses.city=berlin", func(t *testing.T) {
+				// OR(bmw,honda)=[d1,d2,d3,d4]; berlin=[d1,d3,d4]. Intersection=[d1,d3,d4].
+				run(t, and(
+					*or(textFlt(prop+".cars.make", "bmw"), textFlt(prop+".cars.make", "honda")),
+					textFlt(prop+".addresses.city", "berlin"),
+				), []uint64{d1, d3, d4})
+			})
+
+			t.Run("complex — tags=premium AND cars.make=bmw AND cars.tires.width=205 AND cars.accessories.type=sunroof", func(t *testing.T) {
+				// d1 has all: premium tags + bmw+tires+acc in same car ✓. Others missing tags or wrong make.
+				run(t, and(
+					textFlt(prop+".tags", "premium"),
+					textFlt(prop+".cars.make", "bmw"),
+					intFlt(prop+".cars.tires.width", 205),
+					textFlt(prop+".cars.accessories.type", "sunroof"),
+				), []uint64{d1})
+			})
+
+			// -----------------------------------------------------------------
+			// Extra: bolts data added to d1 for deep nesting test
+			// -----------------------------------------------------------------
+
+			t.Run("deep nesting — cars.tires.bolts.size=10 AND cars.tires.width=205 same tires", func(t *testing.T) {
+				// No bolts data written yet — expect empty result.
+				run(t, and(intFlt(prop+".cars.tires.bolts.size", 10), intFlt(prop+".cars.tires.width", 205)),
+					[]uint64{})
+			})
+
+			// Add bolts to d1 tires[0] (same element as tires.width, both at leaf=3 for d1 root=1).
+			require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E(1, 3, d1)}))
+			require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E(1, 3, d1)}))
+
+			t.Run("deep nesting — after adding bolts to d1: bolts.size=10 AND tires.width=205 same tires", func(t *testing.T) {
+				// Only d1 has bolts in the same tires element as width=205.
+				run(t, and(intFlt(prop+".cars.tires.bolts.size", 10), intFlt(prop+".cars.tires.width", 205)),
+					[]uint64{d1})
+			})
+
+			t.Run("deep nesting — bolts.size=10 AND tires.width=205 AND cars.make=bmw all same context", func(t *testing.T) {
+				// d1✓  d2 has no bolts  d3 has no bolts  d4 has no bolts
+				run(t, and(
+					intFlt(prop+".cars.tires.bolts.size", 10),
+					intFlt(prop+".cars.tires.width", 205),
+					textFlt(prop+".cars.make", "bmw"),
+				), []uint64{d1})
+			})
+		})
+	}
 }

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -33,7 +33,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/sorter"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/filters"
-	"github.com/weaviate/weaviate/entities/filters/nested"
+	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/inverted"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -369,7 +369,7 @@ func (s *Searcher) extractPropValuePair(
 	// correctly resolves to the "addresses" property in the schema.
 	// Only the first segment is cleaned here; extractNestedProp receives the
 	// original props[0] so that [N] indices on sub-paths are preserved.
-	propName := nested.RootPropName(props[0])
+	propName := filnested.RootPropName(props[0])
 
 	if s.onInternalProp(propName) {
 		return s.extractInternalProp(propName, filter.Value.Type, filter.Value.Value, filter.Operator, class)

--- a/adapters/repos/db/inverted/searcher_doc_bitmap.go
+++ b/adapters/repos/db/inverted/searcher_doc_bitmap.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/filters"
@@ -100,7 +100,7 @@ func (s *Searcher) docBitmapInvertedRoaringSet(ctx context.Context, b *lsmkv.Buc
 
 	var rr *RowReaderRoaringSet
 	if pv.nested.isNested {
-		rr = NewRowReaderRoaringSetWithPrefix(b, pv.value, pv.operator, false, nested.PathPrefix(pv.nested.relPath))
+		rr = NewRowReaderRoaringSetWithPrefix(b, pv.value, pv.operator, false, invnested.PathPrefix(pv.nested.relPath))
 	} else {
 		rr = NewRowReaderRoaringSet(b, pv.value, pv.operator, false)
 	}

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -132,13 +132,14 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, propName, f
 		})
 	}
 
-	if len(pvps) == 0 {
+	switch len(pvps) {
+	case 0:
 		return nil, ErrOnlyStopwords
-	}
-	if len(pvps) == 1 {
+	case 1:
 		return pvps[0], nil
+	default:
+		return &propValuePair{operator: filters.OperatorAnd, children: pvps, nested: nestedInfo{isCorrelated: true, childrenFromTokenization: true}, prop: propName, Class: class}, nil
 	}
-	return &propValuePair{operator: filters.OperatorAnd, children: pvps, nested: nestedInfo{isCorrelated: true, childrenFromTokenization: true}, prop: propName, Class: class}, nil
 }
 
 // buildNestedPrimitiveFilterPair handles non-text primitive types (int,

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -15,7 +15,7 @@ import (
 	"fmt"
 
 	"github.com/weaviate/weaviate/entities/filters"
-	"github.com/weaviate/weaviate/entities/filters/nested"
+	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/tokenizer"
@@ -29,7 +29,7 @@ import (
 func (s *Searcher) extractNestedProp(filter *filters.Clause, path string,
 	prop *models.Property, class *models.Class,
 ) (*propValuePair, error) {
-	cleanRelPath, cleanRelSegs, arrayIndices := nested.ParseIndexedPath(path)
+	cleanRelPath, cleanRelSegs, arrayIndices := filnested.ParseIndexedPath(path)
 
 	if filter.Operator == filters.OperatorIsNull {
 		return s.buildNestedIsNullPair(filter, prop.Name, cleanRelPath, arrayIndices, class)
@@ -57,7 +57,7 @@ func (s *Searcher) extractNestedProp(filter *filters.Clause, path string,
 // NestedProperty. Returns an error if any segment is not found.
 func findNestedLeaf(segments []string, props []*models.NestedProperty) (*models.NestedProperty, error) {
 	for i, seg := range segments {
-		found := nested.FindNestedProp(props, seg)
+		found := filnested.FindNestedProp(props, seg)
 		if found == nil {
 			return nil, fmt.Errorf("sub-property %q not found", seg)
 		}
@@ -72,7 +72,7 @@ func findNestedLeaf(segments []string, props []*models.NestedProperty) (*models.
 // buildNestedFilterPair encodes the filter value for the given leaf type and
 // returns the corresponding propValuePair(s).
 func (s *Searcher) buildNestedFilterPair(filter *filters.Clause, propName, fullPath, relPath string,
-	arrayIndices []nested.ArrayIndex, leaf *models.NestedProperty, class *models.Class,
+	arrayIndices []filnested.ArrayIndex, leaf *models.NestedProperty, class *models.Class,
 ) (*propValuePair, error) {
 	dt := schema.DataType(leaf.DataType[0])
 	switch dt {
@@ -91,7 +91,7 @@ func (s *Searcher) buildNestedFilterPair(filter *filters.Clause, propName, fullP
 // ASCII folding, wildcard handling) was aligned with extractTokenizableProp
 // manually. Consider extracting a shared helper to avoid future divergence.
 func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, propName, fullPath, relPath string,
-	leaf *models.NestedProperty, arrayIndices []nested.ArrayIndex, class *models.Class,
+	leaf *models.NestedProperty, arrayIndices []filnested.ArrayIndex, class *models.Class,
 ) (*propValuePair, error) {
 	valueStr, ok := filter.Value.Value.(string)
 	if !ok {
@@ -144,7 +144,7 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, propName, f
 // buildNestedPrimitiveFilterPair handles non-text primitive types (int,
 // number, bool, date and their array variants).
 func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, propName, fullPath, relPath string,
-	dt schema.DataType, arrayIndices []nested.ArrayIndex, class *models.Class,
+	dt schema.DataType, arrayIndices []filnested.ArrayIndex, class *models.Class,
 ) (*propValuePair, error) {
 	// Map array types to their scalar equivalent — each array element is stored
 	// individually in the nested bucket, so filtering works the same way.
@@ -187,7 +187,7 @@ func (s *Searcher) buildNestedPrimitiveFilterPair(filter *filters.Clause, propNa
 // nested property. relPath is "" for root-level existence (e.g. "addresses IsNull")
 // or the dot-notation sub-path (e.g. "city" for "addresses.city IsNull").
 // arrayIndices carries any arr[N] constraints from the filter path.
-func (s *Searcher) buildNestedIsNullPair(filter *filters.Clause, propName, relPath string, arrayIndices []nested.ArrayIndex, class *models.Class) (*propValuePair, error) {
+func (s *Searcher) buildNestedIsNullPair(filter *filters.Clause, propName, relPath string, arrayIndices []filnested.ArrayIndex, class *models.Class) (*propValuePair, error) {
 	value, err := s.extractBoolValue(filter.Value.Value)
 	if err != nil {
 		return nil, fmt.Errorf("nested IsNull %q: encode bool: %w", propName, err)

--- a/adapters/repos/db/inverted/searcher_nested_executor.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor.go
@@ -19,9 +19,100 @@ import (
 	"sort"
 
 	"github.com/weaviate/sroar"
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 )
+
+// planExecutor executes an executionPlan for a correlated nested AND filter.
+//
+// TODO aliszka:nested_filtering positionBitmaps bitmaps have no associated release
+// functions. Bitmaps fetched via fetchRawPositions may be backed by pooled
+// buffers that must be returned to the pool after use. Add a releases []func()
+// field and defer-call all of them at the end of execute() so pooled buffers
+// are correctly returned. See Option A in notes.
+type planExecutor struct {
+	plan            executionPlan
+	positionsByPath map[string]*positionBitmaps
+	metaBucket      *lsmkv.Bucket
+}
+
+func newPlanExecutor(
+	plan executionPlan,
+	positionsByPath map[string]*positionBitmaps,
+	metaBucket *lsmkv.Bucket,
+) *planExecutor {
+	return &planExecutor{
+		plan:            plan,
+		positionsByPath: positionsByPath,
+		metaBucket:      metaBucket,
+	}
+}
+
+// execute runs every condition group and strips position bits to return plain docIDs.
+//
+// groupAndAllMaskLeaf raw bitmaps are folded directly into the final AndAllMaskLeaf
+// call — no intermediate bitmap is produced for those groups. groupAndAll results
+// (full-position bitmaps from AndAll) and groupRunIdxLoop results (already
+// leaf-masked) are each added as single entries and leaf-masked in the final step.
+func (e *planExecutor) execute(ctx context.Context) (*sroar.Bitmap, error) {
+	// finalBitmaps collects one entry per groupAndAll/groupRunIdxLoop result, and
+	// the raw bitmaps from each groupAndAllMaskLeaf group directly — avoiding the
+	// intermediate AndAllMaskLeaf allocation for those groups.
+	finalBitmaps := make([]*sroar.Bitmap, 0, len(e.plan))
+	for _, g := range e.plan {
+		raw, err := e.collectRaw(g.paths)
+		if err != nil {
+			return nil, err
+		}
+		switch g.op {
+		case groupAndAll:
+			finalBitmaps = append(finalBitmaps, invnested.AndAll(raw))
+		case groupAndAllMaskLeaf:
+			// Fold raw bitmaps directly into the final AndAllMaskLeaf step.
+			// The final step masks each bitmap's leaf bits before ANDing, which
+			// is identical to running AndAllMaskLeaf here and then re-masking
+			// the result (a no-op) in the final step.
+			finalBitmaps = append(finalBitmaps, raw...)
+		case groupRunIdxLoop:
+			if e.metaBucket == nil {
+				return nil, fmt.Errorf("execute: meta bucket is nil for idxLoop on %q", g.lcaPath)
+			}
+			result, err := e.runIdxLoop(ctx, g.lcaPath, raw)
+			if err != nil {
+				return nil, err
+			}
+			finalBitmaps = append(finalBitmaps, result)
+		default:
+			return nil, fmt.Errorf("execute: unhandled group op %d", g.op)
+		}
+	}
+	return invnested.MaskRootLeaf(invnested.AndAllMaskLeaf(finalBitmaps)), nil
+}
+
+// collectRaw returns individual raw position bitmaps for all conditions across
+// the given paths: tokens for a path are pre-combined with AndAll (they must
+// share the exact same leaf position), each independent contributes its own
+// raw bitmap.
+func (e *planExecutor) collectRaw(paths []string) ([]*sroar.Bitmap, error) {
+	var bitmaps []*sroar.Bitmap
+	for _, path := range paths {
+		positions, ok := e.positionsByPath[path]
+		if !ok {
+			return nil, fmt.Errorf("collectRaw: no positions for path %q", path)
+		}
+		if len(positions.tokens) > 0 {
+			// Tokens must share the exact same leaf position — combine first.
+			bitmaps = append(bitmaps, invnested.AndAll(positions.tokens))
+		}
+		bitmaps = append(bitmaps, positions.independent...)
+	}
+	return bitmaps, nil
+}
+
+// ---------------------------------------------------------------------------
+// runIdxLoop — verifies that all condition bitmaps land in the same element
+// of the intermediate object[] identified by lcaPath.
+// ---------------------------------------------------------------------------
 
 // bitmapsByCard implements sort.Interface to sort a bitmap slice and its
 // precomputed cardinality slice together in a single pass, avoiding repeated
@@ -54,18 +145,7 @@ func (s bitmapsByCard) Swap(i, j int) {
 //     individual condition overlaps the element — no per-condition skip is
 //     needed inside the inner loop.
 //  4. Early termination when result already contains all documents in preFilter.
-//
-// Algorithm:
-//
-//	preFilter = AndAllMaskLeaf(sorted)
-//	if preFilter empty → return empty
-//	for each _idx.{lcaPath}[N] entry:
-//	    if preFilter AND MaskLeaf(elem[N]) empty → skip element cheaply
-//	    partial = MaskLeafAnd(bm[0], elem[N]) AND MaskLeafAnd(bm[1], elem[N]) AND ...
-//	    result = result OR partial
-//	    if result covers all docs in preFilter → stop early
-//	return result  (root+docID; caller applies MaskRootLeaf if needed)
-func (e *resolutionPlanExecutor) runIdxLoop(
+func (e *planExecutor) runIdxLoop(
 	ctx context.Context,
 	lcaPath string,
 	positionBitmaps []*sroar.Bitmap,
@@ -74,14 +154,9 @@ func (e *resolutionPlanExecutor) runIdxLoop(
 		return nil, fmt.Errorf("runIdxLoop: no position bitmaps provided for path %q", lcaPath)
 	}
 	if len(positionBitmaps) == 1 {
-		return nested.MaskLeaf(positionBitmaps[0]), nil
+		return invnested.MaskLeaf(positionBitmaps[0]), nil
 	}
 
-	// Optimisation 1: sort conditions by cardinality ascending so the most
-	// selective condition is checked first and triggers early exit sooner.
-	// Cardinalities are precomputed into a parallel slice so GetCardinality
-	// (O(containers)) is called exactly once per bitmap rather than O(n log n)
-	// times during sorting. Both slices are kept in sync via bitmapsByCard.
 	sorted := slices.Clone(positionBitmaps)
 	cards := make([]int, len(sorted))
 	for i, bm := range sorted {
@@ -89,10 +164,7 @@ func (e *resolutionPlanExecutor) runIdxLoop(
 	}
 	sort.Sort(bitmapsByCard{sorted, cards})
 
-	// Optimisation 2: build global pre-filter as the AND of all leaf-masked
-	// conditions. Using the sorted order means the most selective bitmap is
-	// ANDed first, shrinking the result fastest and reducing subsequent work.
-	preFilter := nested.AndAllMaskLeaf(sorted)
+	preFilter := invnested.AndAllMaskLeaf(sorted)
 	preFilterCard := preFilter.GetCardinality()
 	if preFilterCard == 0 {
 		return sroar.NewBitmap(), nil
@@ -102,13 +174,13 @@ func (e *resolutionPlanExecutor) runIdxLoop(
 		return nil, err
 	}
 
-	idxPrefix := nested.PathPrefix("_idx." + lcaPath)
+	idxPrefix := invnested.PathPrefix("_idx." + lcaPath)
 	result := sroar.NewBitmap()
 
 	c := e.metaBucket.CursorRoaringSet()
 	defer c.Close()
 
-	for k, elemBitmap := c.Seek(nested.IdxKey(lcaPath, 0)); k != nil; k, elemBitmap = c.Next() {
+	for k, elemBitmap := c.Seek(invnested.IdxKey(lcaPath, 0)); k != nil; k, elemBitmap = c.Next() {
 		if err := ctxExpired(ctx); err != nil {
 			return nil, err
 		}
@@ -119,31 +191,22 @@ func (e *resolutionPlanExecutor) runIdxLoop(
 			continue
 		}
 
-		// Optimisation 3: per-element pre-check using the precomputed masked
-		// element. One allocation to skip the entire K-condition processing when
-		// no document has all conditions satisfied within this element.
-		if nested.AndWithMaskLeaf(preFilter, elemBitmap).IsEmpty() {
+		if invnested.AndWithMaskLeaf(preFilter, elemBitmap).IsEmpty() {
 			continue
 		}
 
-		// Full K-condition processing: intersect each condition with element N.
-		// No per-condition pre-check is needed: the global pre-check above
-		// guarantees every condition overlaps this element, because
-		// preFilter ⊆ MaskLeaf(sorted[i]) for all i.
-		partial := nested.MaskLeafAnd(sorted[0], elemBitmap)
+		partial := invnested.MaskLeafAnd(sorted[0], elemBitmap)
 		empty := partial.IsEmpty()
 		for _, bm := range sorted[1:] {
 			if empty {
 				break
 			}
-			partial.And(nested.MaskLeafAnd(bm, elemBitmap))
+			partial.And(invnested.MaskLeafAnd(bm, elemBitmap))
 			empty = partial.IsEmpty()
 		}
 
 		if !empty {
 			result.Or(partial)
-			// Optimisation 4: stop early if result already covers all docs that
-			// preFilter could yield — further elements can only add duplicates.
 			if result.GetCardinality() >= preFilterCard {
 				break
 			}
@@ -151,161 +214,4 @@ func (e *resolutionPlanExecutor) runIdxLoop(
 	}
 
 	return result, nil
-}
-
-// resolutionPlanExecutor executes a resolutionPlan for a correlated nested AND.
-// positionsByPath maps each relative nested path to its pre-computed raw position
-// bitmap. metaBucket is the _idx meta bucket for the root nested property; it
-// may be nil when no idxLoopAnd node is in the plan.
-//
-// TODO aliszka:nested_filtering positionBitmaps bitmaps have no associated release
-// functions. Bitmaps fetched via fetchRawPositions may be backed by pooled
-// buffers that must be returned to the pool after use. Add a releases []func()
-// field and defer-call all of them at the end of execute() so pooled buffers
-// are correctly returned. See Option A in notes.
-type resolutionPlanExecutor struct {
-	plan            *resolutionPlan
-	positionsByPath map[string]*positionBitmaps
-	metaBucket      *lsmkv.Bucket
-}
-
-// newResolutionPlanExecutor returns an executor ready to run a resolutionPlan.
-func newResolutionPlanExecutor(
-	plan *resolutionPlan,
-	positionsByPath map[string]*positionBitmaps,
-	metaBucket *lsmkv.Bucket,
-) *resolutionPlanExecutor {
-	return &resolutionPlanExecutor{plan: plan, positionsByPath: positionsByPath, metaBucket: metaBucket}
-}
-
-// execute runs the plan and returns a docID-only bitmap.
-// MaskRootLeaf is applied once at the top; all recursive calls work with
-// partially-preserved position bits.
-func (e *resolutionPlanExecutor) execute(ctx context.Context) (*sroar.Bitmap, error) {
-	bm, err := e.executeNode(ctx, e.plan)
-	if err != nil {
-		return nil, err
-	}
-	return nested.MaskRootLeaf(bm), nil
-}
-
-// executeNode dispatches to the appropriate handler based on plan.op.
-// Each handler owns both the interior-groups and leaf-paths cases for its op.
-func (e *resolutionPlanExecutor) executeNode(ctx context.Context, plan *resolutionPlan) (*sroar.Bitmap, error) {
-	switch plan.op {
-	case directAnd:
-		return e.executeDirectAnd(plan)
-	case maskLeafAnd:
-		return e.executeMaskLeafAnd(ctx, plan)
-	case idxLoopAnd:
-		return e.executeIdxLoopAnd(ctx, plan)
-	}
-	return nil, fmt.Errorf("executeNode: unhandled op %d", plan.op)
-}
-
-// executeDirectAnd handles directAnd nodes. Positions are naturally aligned
-// (scalar siblings or ancestor/descendant), so a plain AND suffices.
-// directAnd is always a leaf node — no groups.
-func (e *resolutionPlanExecutor) executeDirectAnd(plan *resolutionPlan) (*sroar.Bitmap, error) {
-	bitmaps, err := e.fetchBitmaps(plan.paths)
-	if err != nil {
-		return nil, err
-	}
-	return nested.AndAll(bitmaps), nil
-}
-
-// executeMaskLeafAnd handles maskLeafAnd nodes. Zeros the leaf bits of each
-// input bitmap and ANDs them, aligning on root+docID. Handles both interior
-// nodes (sub-groups are recursively executed) and leaf nodes (paths fetched).
-func (e *resolutionPlanExecutor) executeMaskLeafAnd(ctx context.Context, plan *resolutionPlan) (*sroar.Bitmap, error) {
-	bitmaps, err := e.collectBitmaps(ctx, plan)
-	if err != nil {
-		return nil, err
-	}
-	return nested.AndAllMaskLeaf(bitmaps), nil
-}
-
-// executeIdxLoopAnd handles idxLoopAnd nodes. Verifies that all conditions land
-// within the same array element by iterating _idx.{lcaPath}[N] meta entries.
-// Handles both interior nodes (sub-groups executed first) and leaf nodes
-// (paths fetched directly). Returns root+docID.
-func (e *resolutionPlanExecutor) executeIdxLoopAnd(ctx context.Context, plan *resolutionPlan) (*sroar.Bitmap, error) {
-	if e.metaBucket == nil {
-		return nil, fmt.Errorf("executeIdxLoopAnd: meta bucket is nil for path %q", plan.lcaPath)
-	}
-	bitmaps, err := e.collectBitmaps(ctx, plan)
-	if err != nil {
-		return nil, err
-	}
-	return e.runIdxLoop(ctx, plan.lcaPath, bitmaps)
-}
-
-// collectBitmaps executes each sub-group of an interior maskLeafAnd or
-// idxLoopAnd node and returns the resulting bitmaps. maskLeafAnd and
-// idxLoopAnd nodes always have groups — flat paths are only used by directAnd,
-// which never calls this method.
-func (e *resolutionPlanExecutor) collectBitmaps(ctx context.Context, plan *resolutionPlan) ([]*sroar.Bitmap, error) {
-	if len(plan.groups) == 0 {
-		return nil, fmt.Errorf("collectBitmaps: %d node has no groups", plan.op)
-	}
-	bitmaps := make([]*sroar.Bitmap, 0, len(plan.groups))
-	for _, group := range plan.groups {
-		bm, err := e.executeNode(ctx, group)
-		if err != nil {
-			return nil, err
-		}
-		bitmaps = append(bitmaps, bm)
-	}
-	return bitmaps, nil
-}
-
-// fetchBitmaps returns one combined position bitmap per path by calling
-// combinePositionBitmaps. All merging logic is encapsulated here in the executor.
-func (e *resolutionPlanExecutor) fetchBitmaps(paths []string) ([]*sroar.Bitmap, error) {
-	bitmaps := make([]*sroar.Bitmap, 0, len(paths))
-	for _, path := range paths {
-		positions, ok := e.positionsByPath[path]
-		if !ok {
-			return nil, fmt.Errorf("fetchBitmaps: no positions for path %q", path)
-		}
-		bitmaps = append(bitmaps, combinePositionBitmaps(positions))
-	}
-	return bitmaps, nil
-}
-
-// combinePositionBitmaps merges the pre-fetched bitmaps in a positionBitmaps into one bitmap:
-//   - tokens are combined with AndAll — all tokens must share the same leaf
-//     position (multi-token text values like "New York" → ["new", "york"]).
-//   - A single independent bitmap is returned raw — no combining needed.
-//   - Multiple independent bitmaps are combined with MaskLeafAndAll — the
-//     values may be at different leaf positions (scalar array elements) but
-//     must belong to the same parent element (same root_idx).
-//   - When both tokens and independent bitmaps are present, the two partial
-//     results are aligned at root+docID level via MaskLeafAndAll.
-func combinePositionBitmaps(positions *positionBitmaps) *sroar.Bitmap {
-	var tokensResult *sroar.Bitmap
-	if len(positions.tokens) > 0 {
-		tokensResult = nested.AndAll(positions.tokens)
-	}
-
-	var independentResult *sroar.Bitmap
-	switch len(positions.independent) {
-	case 0:
-		// nothing
-	case 1:
-		independentResult = positions.independent[0] // single value: keep raw
-	default:
-		independentResult = nested.AndAllMaskLeaf(positions.independent)
-	}
-
-	switch {
-	case tokensResult == nil:
-		return independentResult
-	case independentResult == nil:
-		return tokensResult
-	default:
-		// Both present: align at root+docID so they can be in different
-		// leaf positions within the same parent element.
-		return nested.AndAllMaskLeaf([]*sroar.Bitmap{tokensResult, independentResult})
-	}
 }

--- a/adapters/repos/db/inverted/searcher_nested_executor_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_integration_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
@@ -47,7 +47,7 @@ func newIdxBucket(t *testing.T) *lsmkv.Bucket {
 // positions should already have the real docID encoded (not docID=0 templates).
 func writeIdx(t *testing.T, bucket *lsmkv.Bucket, path string, elemIdx int, positions []uint64) {
 	t.Helper()
-	require.NoError(t, bucket.RoaringSetAddList(nested.IdxKey(path, elemIdx), positions))
+	require.NoError(t, bucket.RoaringSetAddList(invnested.IdxKey(path, elemIdx), positions))
 }
 
 // ---- executeResolutionPlan with idxLoopAnd integration tests ----------------
@@ -66,10 +66,10 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 	t.Run("one bitmap returns MaskRootLeaf fast-path without cursor scan", func(t *testing.T) {
 		bucket := newIdxBucket(t)
 		// Write an idx entry that would produce a different result if scanned.
-		writeIdx(t, bucket, "cars", 0, []uint64{nested.Encode(1, 1, doc5), nested.Encode(1, 2, doc5)})
+		writeIdx(t, bucket, "cars", 0, []uint64{invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5)})
 
-		plan, bitmapsByPath := idxLoopAndPlan("cars", roaringset.NewBitmap(nested.Encode(1, 1, doc5)))
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		plan, bitmapsByPath := idxLoopPlan("cars", roaringset.NewBitmap(invnested.Encode(1, 1, doc5)))
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		// Fast-path: returns MaskRootLeaf(bitmap[0]), ignoring the bucket entirely.
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
@@ -77,16 +77,16 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 
 	t.Run("context already cancelled returns error", func(t *testing.T) {
 		bucket := newIdxBucket(t)
-		writeIdx(t, bucket, "cars", 0, []uint64{nested.Encode(1, 1, doc5)})
+		writeIdx(t, bucket, "cars", 0, []uint64{invnested.Encode(1, 1, doc5)})
 
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		plan, bitmapsByPath := idxLoopAndPlan("cars",
-			roaringset.NewBitmap(nested.Encode(1, 1, doc5)),
-			roaringset.NewBitmap(nested.Encode(1, 2, doc5)),
+		plan, bitmapsByPath := idxLoopPlan("cars",
+			roaringset.NewBitmap(invnested.Encode(1, 1, doc5)),
+			roaringset.NewBitmap(invnested.Encode(1, 2, doc5)),
 		)
-		_, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(ctx)
+		_, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(ctx)
 		require.Error(t, err)
 	})
 
@@ -101,14 +101,14 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		// Both are within cars[0] → should return doc5.
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
-			nested.Encode(1, 1, doc5), // leaf=1 (tires[0].width)
-			nested.Encode(1, 2, doc5), // leaf=2 (accessories[0].type)
+			invnested.Encode(1, 1, doc5), // leaf=1 (tires[0].width)
+			invnested.Encode(1, 2, doc5), // leaf=2 (accessories[0].type)
 		})
 
-		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5))
-		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5))
-		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5))
+		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5))
+		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
@@ -116,13 +116,13 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 	t.Run("two conditions in different elements — empty result", func(t *testing.T) {
 		// condA matches cars[0], condB matches cars[1] — different elements.
 		bucket := newIdxBucket(t)
-		writeIdx(t, bucket, "cars", 0, []uint64{nested.Encode(1, 1, doc5)})
-		writeIdx(t, bucket, "cars", 1, []uint64{nested.Encode(2, 1, doc5)})
+		writeIdx(t, bucket, "cars", 0, []uint64{invnested.Encode(1, 1, doc5)})
+		writeIdx(t, bucket, "cars", 1, []uint64{invnested.Encode(2, 1, doc5)})
 
-		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5)) // in cars[0]
-		condB := roaringset.NewBitmap(nested.Encode(2, 1, doc5)) // in cars[1]
-		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5)) // in cars[0]
+		condB := roaringset.NewBitmap(invnested.Encode(2, 1, doc5)) // in cars[1]
+		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -130,16 +130,16 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 	t.Run("two conditions both in element 1 (not element 0) — doc returned", func(t *testing.T) {
 		// Verifies that the cursor scans past element 0 to find the match in element 1.
 		bucket := newIdxBucket(t)
-		writeIdx(t, bucket, "cars", 0, []uint64{nested.Encode(1, 1, doc5)}) // condA only
+		writeIdx(t, bucket, "cars", 0, []uint64{invnested.Encode(1, 1, doc5)}) // condA only
 		writeIdx(t, bucket, "cars", 1, []uint64{
-			nested.Encode(2, 1, doc5),
-			nested.Encode(2, 2, doc5),
+			invnested.Encode(2, 1, doc5),
+			invnested.Encode(2, 2, doc5),
 		})
 
-		condA := roaringset.NewBitmap(nested.Encode(2, 1, doc5)) // in cars[1]
-		condB := roaringset.NewBitmap(nested.Encode(2, 2, doc5)) // in cars[1]
-		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		condA := roaringset.NewBitmap(invnested.Encode(2, 1, doc5)) // in cars[1]
+		condB := roaringset.NewBitmap(invnested.Encode(2, 2, doc5)) // in cars[1]
+		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
@@ -147,16 +147,16 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 	t.Run("three conditions all in same element — doc returned", func(t *testing.T) {
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
-			nested.Encode(1, 1, doc5),
-			nested.Encode(1, 2, doc5),
-			nested.Encode(1, 3, doc5),
+			invnested.Encode(1, 1, doc5),
+			invnested.Encode(1, 2, doc5),
+			invnested.Encode(1, 3, doc5),
 		})
 
-		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5))
-		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5))
-		condC := roaringset.NewBitmap(nested.Encode(1, 3, doc5))
-		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB, condC)
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5))
+		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5))
+		condC := roaringset.NewBitmap(invnested.Encode(1, 3, doc5))
+		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB, condC)
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
@@ -164,16 +164,16 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 	t.Run("three conditions — two in element 0, third only in element 1 — empty", func(t *testing.T) {
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
-			nested.Encode(1, 1, doc5),
-			nested.Encode(1, 2, doc5),
+			invnested.Encode(1, 1, doc5),
+			invnested.Encode(1, 2, doc5),
 		})
-		writeIdx(t, bucket, "cars", 1, []uint64{nested.Encode(2, 1, doc5)})
+		writeIdx(t, bucket, "cars", 1, []uint64{invnested.Encode(2, 1, doc5)})
 
-		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5)) // cars[0]
-		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5)) // cars[0]
-		condC := roaringset.NewBitmap(nested.Encode(2, 1, doc5)) // cars[1] only
-		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB, condC)
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5)) // cars[0]
+		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5)) // cars[0]
+		condC := roaringset.NewBitmap(invnested.Encode(2, 1, doc5)) // cars[1] only
+		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB, condC)
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -187,18 +187,18 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		// doc7: condA in cars[0], condB in cars[1] → no match
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
-			nested.Encode(1, 1, doc5),
-			nested.Encode(1, 2, doc5),
-			nested.Encode(1, 1, doc7), // doc7's condA
+			invnested.Encode(1, 1, doc5),
+			invnested.Encode(1, 2, doc5),
+			invnested.Encode(1, 1, doc7), // doc7's condA
 		})
 		writeIdx(t, bucket, "cars", 1, []uint64{
-			nested.Encode(2, 1, doc7), // doc7's condB (wrong element)
+			invnested.Encode(2, 1, doc7), // doc7's condB (wrong element)
 		})
 
-		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7))
-		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5), nested.Encode(2, 1, doc7))
-		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5), invnested.Encode(1, 1, doc7))
+		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5), invnested.Encode(2, 1, doc7))
+		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
@@ -206,16 +206,16 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 	t.Run("two docs both satisfy conditions in their respective elements", func(t *testing.T) {
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
-			nested.Encode(1, 1, doc5),
-			nested.Encode(1, 2, doc5),
-			nested.Encode(1, 1, doc7),
-			nested.Encode(1, 2, doc7),
+			invnested.Encode(1, 1, doc5),
+			invnested.Encode(1, 2, doc5),
+			invnested.Encode(1, 1, doc7),
+			invnested.Encode(1, 2, doc7),
 		})
 
-		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7))
-		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5), nested.Encode(1, 2, doc7))
-		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5), invnested.Encode(1, 1, doc7))
+		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5), invnested.Encode(1, 2, doc7))
+		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5, doc7}, result.ToArray())
 	})
@@ -226,20 +226,20 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		// doc9: condA in cars[0], condB in cars[1] → no match
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
-			nested.Encode(1, 1, doc5),
-			nested.Encode(1, 1, doc7),
-			nested.Encode(1, 2, doc7),
-			nested.Encode(1, 1, doc9),
+			invnested.Encode(1, 1, doc5),
+			invnested.Encode(1, 1, doc7),
+			invnested.Encode(1, 2, doc7),
+			invnested.Encode(1, 1, doc9),
 		})
 		writeIdx(t, bucket, "cars", 1, []uint64{
-			nested.Encode(2, 1, doc5),
-			nested.Encode(2, 1, doc9),
+			invnested.Encode(2, 1, doc5),
+			invnested.Encode(2, 1, doc9),
 		})
 
-		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5), nested.Encode(1, 1, doc7), nested.Encode(1, 1, doc9))
-		condB := roaringset.NewBitmap(nested.Encode(2, 1, doc5), nested.Encode(1, 2, doc7), nested.Encode(2, 1, doc9))
-		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5), invnested.Encode(1, 1, doc7), invnested.Encode(1, 1, doc9))
+		condB := roaringset.NewBitmap(invnested.Encode(2, 1, doc5), invnested.Encode(1, 2, doc7), invnested.Encode(2, 1, doc9))
+		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc7}, result.ToArray())
 	})
@@ -253,14 +253,14 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		// so preFilter is empty and the function returns early.
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
-			nested.Encode(1, 1, doc5),
-			nested.Encode(1, 2, doc7),
+			invnested.Encode(1, 1, doc5),
+			invnested.Encode(1, 2, doc7),
 		})
 
-		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5)) // only doc5
-		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc7)) // only doc7
-		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5)) // only doc5
+		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc7)) // only doc7
+		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -269,10 +269,10 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		// Bucket exists but has no _idx.cars entries.
 		bucket := newIdxBucket(t)
 
-		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5))
-		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5))
-		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5))
+		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5))
+		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -281,12 +281,12 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		// Both conditions match doc5, but the idx entry for element 0 only covers
 		// condA's position — condB's position is absent from that element.
 		bucket := newIdxBucket(t)
-		writeIdx(t, bucket, "cars", 0, []uint64{nested.Encode(1, 1, doc5)}) // only leaf=1
+		writeIdx(t, bucket, "cars", 0, []uint64{invnested.Encode(1, 1, doc5)}) // only leaf=1
 
-		condA := roaringset.NewBitmap(nested.Encode(1, 1, doc5))
-		condB := roaringset.NewBitmap(nested.Encode(1, 2, doc5)) // leaf=2 not in element 0
-		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5))
+		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5)) // leaf=2 not in element 0
+		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -298,18 +298,18 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 			root := uint16(i + 1)
 			if i == 3 {
 				writeIdx(t, bucket, "cars", i, []uint64{
-					nested.Encode(root, 1, doc5),
-					nested.Encode(root, 2, doc5),
+					invnested.Encode(root, 1, doc5),
+					invnested.Encode(root, 2, doc5),
 				})
 			} else {
-				writeIdx(t, bucket, "cars", i, []uint64{nested.Encode(root, 1, doc5)})
+				writeIdx(t, bucket, "cars", i, []uint64{invnested.Encode(root, 1, doc5)})
 			}
 		}
 
-		condA := roaringset.NewBitmap(nested.Encode(4, 1, doc5)) // only in element 3 (root=4)
-		condB := roaringset.NewBitmap(nested.Encode(4, 2, doc5)) // only in element 3 (root=4)
-		plan, bitmapsByPath := idxLoopAndPlan("cars", condA, condB)
-		result, err := newResolutionPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		condA := roaringset.NewBitmap(invnested.Encode(4, 1, doc5)) // only in element 3 (root=4)
+		condB := roaringset.NewBitmap(invnested.Encode(4, 2, doc5)) // only in element 3 (root=4)
+		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
+		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})

--- a/adapters/repos/db/inverted/searcher_nested_executor_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
-	"github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 )
 
@@ -27,9 +27,9 @@ import (
 // Plan-building helpers
 // ---------------------------------------------------------------------------
 
-// directAndPlan builds a directAnd plan and bitmapsByPath from the given
-// bitmaps. Paths are auto-generated as "p1", "p2", …
-func directAndPlan(bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*positionBitmaps) {
+// andAllPlan builds a groupAndAll plan from the given bitmaps.
+// Paths are auto-generated as "p1", "p2", …
+func andAllPlan(bitmaps ...*sroar.Bitmap) (executionPlan, map[string]*positionBitmaps) {
 	paths := make([]string, len(bitmaps))
 	positionsByPath := make(map[string]*positionBitmaps, len(bitmaps))
 	for i, bm := range bitmaps {
@@ -37,39 +37,37 @@ func directAndPlan(bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*posit
 		paths[i] = path
 		positionsByPath[path] = &positionBitmaps{independent: []*sroar.Bitmap{bm}}
 	}
-	return &resolutionPlan{op: directAnd, paths: paths}, positionsByPath
+	return executionPlan{{op: groupAndAll, paths: paths}}, positionsByPath
 }
 
-// maskLeafAndPlan builds a maskLeafAnd interior plan where each bitmap becomes
-// one directAnd sub-group.
-func maskLeafAndPlan(bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*positionBitmaps) {
-	groups := make([]*resolutionPlan, len(bitmaps))
+// andAllMaskLeafPlan builds a groupAndAllMaskLeaf plan from the given bitmaps.
+func andAllMaskLeafPlan(bitmaps ...*sroar.Bitmap) (executionPlan, map[string]*positionBitmaps) {
+	paths := make([]string, len(bitmaps))
 	positionsByPath := make(map[string]*positionBitmaps, len(bitmaps))
 	for i, bm := range bitmaps {
 		path := fmt.Sprintf("p%d", i+1)
-		groups[i] = &resolutionPlan{op: directAnd, paths: []string{path}}
+		paths[i] = path
 		positionsByPath[path] = &positionBitmaps{independent: []*sroar.Bitmap{bm}}
 	}
-	return &resolutionPlan{op: maskLeafAnd, groups: groups}, positionsByPath
+	return executionPlan{{op: groupAndAllMaskLeaf, paths: paths}}, positionsByPath
 }
 
-// idxLoopAndPlan builds an idxLoopAnd plan where each bitmap becomes one
-// directAnd sub-group.
-func idxLoopAndPlan(lcaPath string, bitmaps ...*sroar.Bitmap) (*resolutionPlan, map[string]*positionBitmaps) {
-	groups := make([]*resolutionPlan, len(bitmaps))
+// idxLoopPlan builds a groupRunIdxLoop plan from the given bitmaps.
+func idxLoopPlan(lcaPath string, bitmaps ...*sroar.Bitmap) (executionPlan, map[string]*positionBitmaps) {
+	paths := make([]string, len(bitmaps))
 	positionsByPath := make(map[string]*positionBitmaps, len(bitmaps))
 	for i, bm := range bitmaps {
 		path := fmt.Sprintf("p%d", i+1)
-		groups[i] = &resolutionPlan{op: directAnd, paths: []string{path}}
+		paths[i] = path
 		positionsByPath[path] = &positionBitmaps{independent: []*sroar.Bitmap{bm}}
 	}
-	return &resolutionPlan{op: idxLoopAnd, lcaPath: lcaPath, groups: groups}, positionsByPath
+	return executionPlan{{op: groupRunIdxLoop, lcaPath: lcaPath, paths: paths}}, positionsByPath
 }
 
-// exec is a shorthand for executeResolutionPlan with no meta bucket.
-func exec(t *testing.T, plan *resolutionPlan, bitmapsByPath map[string]*positionBitmaps) *sroar.Bitmap {
+// exec is a shorthand for executing a plan with no meta bucket.
+func exec(t *testing.T, plan executionPlan, bitmapsByPath map[string]*positionBitmaps) *sroar.Bitmap {
 	t.Helper()
-	result, err := newResolutionPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+	result, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
 	require.NoError(t, err)
 	return result
 }
@@ -83,43 +81,47 @@ func TestExecuteResolutionPlanDirectAnd(t *testing.T) {
 		doc5 = uint64(5)
 		doc7 = uint64(7)
 	)
-	pos511 := nested.Encode(1, 1, doc5) // root=1 leaf=1 docID=5
-	pos512 := nested.Encode(1, 2, doc5) // same root+docID, different leaf
-	pos521 := nested.Encode(2, 1, doc5) // different root
-	pos711 := nested.Encode(1, 1, doc7) // different doc
+	pos511 := invnested.Encode(1, 1, doc5) // root=1 leaf=1 docID=5
+	pos512 := invnested.Encode(1, 2, doc5) // same root+docID, different leaf
+	pos521 := invnested.Encode(2, 1, doc5) // different root
+	pos711 := invnested.Encode(1, 1, doc7) // different doc
 
 	t.Run("empty input returns empty", func(t *testing.T) {
-		plan, bitmapsByPath := directAndPlan()
+		plan, bitmapsByPath := andAllPlan()
 		assert.True(t, exec(t, plan, bitmapsByPath).IsEmpty())
 	})
 
 	t.Run("single bitmap returns docIDs", func(t *testing.T) {
-		plan, bitmapsByPath := directAndPlan(roaringset.NewBitmap(pos511))
+		plan, bitmapsByPath := andAllPlan(roaringset.NewBitmap(pos511))
 		assert.Equal(t, []uint64{doc5}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("exact same raw position in both bitmaps — match", func(t *testing.T) {
-		plan, bitmapsByPath := directAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos511))
+		plan, bitmapsByPath := andAllPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos511))
 		assert.Equal(t, []uint64{doc5}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
-	t.Run("same root+docID different leaf — no match (requires exact position)", func(t *testing.T) {
-		plan, bitmapsByPath := directAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512))
+	t.Run("same root+docID different leaf — no match (leaf distinguishes sub-elements)", func(t *testing.T) {
+		// directAnd uses AndAll (exact raw positions). Two conditions at different
+		// leaf positions represent different sub-elements of the same parent
+		// (e.g. make in cars[0] vs model in cars[1]). Raw AND correctly excludes
+		// them; masking leaves would lose this distinction and produce a false match.
+		plan, bitmapsByPath := andAllPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512))
 		assert.True(t, exec(t, plan, bitmapsByPath).IsEmpty())
 	})
 
 	t.Run("different root — no match", func(t *testing.T) {
-		plan, bitmapsByPath := directAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos521))
+		plan, bitmapsByPath := andAllPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos521))
 		assert.True(t, exec(t, plan, bitmapsByPath).IsEmpty())
 	})
 
 	t.Run("different docID — no match", func(t *testing.T) {
-		plan, bitmapsByPath := directAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos711))
+		plan, bitmapsByPath := andAllPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos711))
 		assert.True(t, exec(t, plan, bitmapsByPath).IsEmpty())
 	})
 
 	t.Run("three bitmaps — intersection of all", func(t *testing.T) {
-		plan, bitmapsByPath := directAndPlan(
+		plan, bitmapsByPath := andAllPlan(
 			roaringset.NewBitmap(pos511, pos521),
 			roaringset.NewBitmap(pos511, pos711),
 			roaringset.NewBitmap(pos511),
@@ -128,7 +130,7 @@ func TestExecuteResolutionPlanDirectAnd(t *testing.T) {
 	})
 
 	t.Run("multiple matching docs", func(t *testing.T) {
-		plan, bitmapsByPath := directAndPlan(
+		plan, bitmapsByPath := andAllPlan(
 			roaringset.NewBitmap(pos511, pos711),
 			roaringset.NewBitmap(pos511, pos711),
 		)
@@ -138,7 +140,7 @@ func TestExecuteResolutionPlanDirectAnd(t *testing.T) {
 	t.Run("inputs not modified", func(t *testing.T) {
 		a := roaringset.NewBitmap(pos511)
 		b := roaringset.NewBitmap(pos511)
-		plan, bitmapsByPath := directAndPlan(a, b)
+		plan, bitmapsByPath := andAllPlan(a, b)
 		exec(t, plan, bitmapsByPath)
 		assert.Equal(t, []uint64{pos511}, a.ToArray())
 		assert.Equal(t, []uint64{pos511}, b.ToArray())
@@ -154,29 +156,29 @@ func TestExecuteResolutionPlanMaskLeafAnd(t *testing.T) {
 		doc5 = uint64(5)
 		doc7 = uint64(7)
 	)
-	pos511 := nested.Encode(1, 1, doc5)
-	pos512 := nested.Encode(1, 2, doc5) // same root+docID, different leaf
-	pos513 := nested.Encode(1, 3, doc5) // same root+docID, yet another leaf
-	pos521 := nested.Encode(2, 1, doc5) // different root, same docID
-	pos711 := nested.Encode(1, 1, doc7) // same root+leaf, different docID
+	pos511 := invnested.Encode(1, 1, doc5)
+	pos512 := invnested.Encode(1, 2, doc5) // same root+docID, different leaf
+	pos513 := invnested.Encode(1, 3, doc5) // same root+docID, yet another leaf
+	pos521 := invnested.Encode(2, 1, doc5) // different root, same docID
+	pos711 := invnested.Encode(1, 1, doc7) // same root+leaf, different docID
 
 	t.Run("single bitmap returns docIDs", func(t *testing.T) {
-		plan, bitmapsByPath := maskLeafAndPlan(roaringset.NewBitmap(pos511))
+		plan, bitmapsByPath := andAllMaskLeafPlan(roaringset.NewBitmap(pos511))
 		assert.Equal(t, []uint64{doc5}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("same raw position — match", func(t *testing.T) {
-		plan, bitmapsByPath := maskLeafAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos511))
+		plan, bitmapsByPath := andAllMaskLeafPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos511))
 		assert.Equal(t, []uint64{doc5}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("same root+docID different leaf — match (leaf is zeroed before AND)", func(t *testing.T) {
-		plan, bitmapsByPath := maskLeafAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512))
+		plan, bitmapsByPath := andAllMaskLeafPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512))
 		assert.Equal(t, []uint64{doc5}, exec(t, plan, bitmapsByPath).ToArray())
 	})
 
 	t.Run("three bitmaps same root+docID different leaves — match", func(t *testing.T) {
-		plan, bitmapsByPath := maskLeafAndPlan(
+		plan, bitmapsByPath := andAllMaskLeafPlan(
 			roaringset.NewBitmap(pos511),
 			roaringset.NewBitmap(pos512),
 			roaringset.NewBitmap(pos513),
@@ -185,18 +187,18 @@ func TestExecuteResolutionPlanMaskLeafAnd(t *testing.T) {
 	})
 
 	t.Run("different root same docID — no match (root encodes element identity)", func(t *testing.T) {
-		plan, bitmapsByPath := maskLeafAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos521))
+		plan, bitmapsByPath := andAllMaskLeafPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos521))
 		assert.True(t, exec(t, plan, bitmapsByPath).IsEmpty())
 	})
 
 	t.Run("different docID — no match", func(t *testing.T) {
-		plan, bitmapsByPath := maskLeafAndPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos711))
+		plan, bitmapsByPath := andAllMaskLeafPlan(roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos711))
 		assert.True(t, exec(t, plan, bitmapsByPath).IsEmpty())
 	})
 
 	t.Run("multiple matching docs", func(t *testing.T) {
-		pos712 := nested.Encode(1, 2, doc7)
-		plan, bitmapsByPath := maskLeafAndPlan(
+		pos712 := invnested.Encode(1, 2, doc7)
+		plan, bitmapsByPath := andAllMaskLeafPlan(
 			roaringset.NewBitmap(pos511, pos711),
 			roaringset.NewBitmap(pos512, pos712),
 		)
@@ -206,7 +208,7 @@ func TestExecuteResolutionPlanMaskLeafAnd(t *testing.T) {
 	t.Run("inputs not modified", func(t *testing.T) {
 		a := roaringset.NewBitmap(pos511)
 		b := roaringset.NewBitmap(pos512)
-		plan, bitmapsByPath := maskLeafAndPlan(a, b)
+		plan, bitmapsByPath := andAllMaskLeafPlan(a, b)
 		exec(t, plan, bitmapsByPath)
 		assert.Equal(t, []uint64{pos511}, a.ToArray())
 		assert.Equal(t, []uint64{pos512}, b.ToArray())
@@ -214,21 +216,118 @@ func TestExecuteResolutionPlanMaskLeafAnd(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// idxLoopAnd preconditions (no lsmkv required)
+// preconditions (no lsmkv required)
 // ---------------------------------------------------------------------------
 
-func TestExecuteResolutionPlanIdxLoopPreconditions(t *testing.T) {
-	pos511 := nested.Encode(1, 1, 5)
-	pos512 := nested.Encode(1, 2, 5)
+func TestExecuteResolutionPlanPreconditions(t *testing.T) {
+	pos511 := invnested.Encode(1, 1, 5)
+	pos512 := invnested.Encode(1, 2, 5)
 
-	t.Run("nil metaBucket returns error", func(t *testing.T) {
-		plan, bitmapsByPath := idxLoopAndPlan("cars",
+	t.Run("groupAndAll: two independents at different leaves — no match (raw AndAll, leaf-aware)", func(t *testing.T) {
+		// groupAndAll uses raw AndAll. Two bitmaps at DIFFERENT leaf positions
+		// represent conditions in DIFFERENT sub-elements — they should NOT match.
+		plan := executionPlan{{op: groupAndAll, paths: []string{"p1"}}}
+		bitmapsByPath := map[string]*positionBitmaps{
+			"p1": {independent: []*sroar.Bitmap{
+				roaringset.NewBitmap(pos511),
+				roaringset.NewBitmap(pos512),
+			}},
+		}
+		result, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+		require.NoError(t, err)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("groupRunIdxLoop: nil metaBucket returns error", func(t *testing.T) {
+		plan, bitmapsByPath := idxLoopPlan("cars",
 			roaringset.NewBitmap(pos511),
 			roaringset.NewBitmap(pos512),
 		)
-		_, err := newResolutionPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+		_, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "meta bucket is nil")
-		assert.Contains(t, err.Error(), "cars")
+	})
+
+	t.Run("collectRaw: missing path in positionsByPath returns error", func(t *testing.T) {
+		plan := executionPlan{{op: groupAndAll, paths: []string{"p1", "p_missing"}}}
+		bitmapsByPath := map[string]*positionBitmaps{
+			"p1": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos511)}},
+			// "p_missing" intentionally absent
+		}
+		_, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "p_missing")
+	})
+}
+
+// ---------------------------------------------------------------------------
+// Multi-group execution
+// ---------------------------------------------------------------------------
+
+func TestExecuteMultiGroupPlan(t *testing.T) {
+	const (
+		doc5 = uint64(5)
+		doc7 = uint64(7)
+	)
+	pos511 := invnested.Encode(1, 1, doc5) // root=1, leaf=1, doc=5
+	pos521 := invnested.Encode(2, 1, doc5) // root=2, leaf=1, doc=5
+	pos711 := invnested.Encode(1, 1, doc7) // root=1, leaf=1, doc=7
+	pos721 := invnested.Encode(2, 1, doc7) // root=2, leaf=1, doc=7
+
+	t.Run("two groupAndAll groups — cross-group AndAllMaskLeaf aligns on root+docID", func(t *testing.T) {
+		// Group 1 (addresses): city bitmap at pos511 (root=1, doc=5) and pos711 (root=1, doc=7)
+		// Group 2 (cars):      make bitmap at pos521 (root=2, doc=5) and pos721 (root=2, doc=7)
+		// After execute: group1→AndAll([city])=cityBm; group2→AndAll([make])=makeBm
+		// Final: AndAllMaskLeaf([cityBm,makeBm]) masks both to root+docID level, then AND.
+		// city: root=1 for both docs; make: root=2 for both docs
+		// → {E(1,0,doc5),E(1,0,doc7)} ∩ {E(2,0,doc5),E(2,0,doc7)} = {} — no matching root.
+		// If city and make were in the SAME root element they would match.
+		plan := executionPlan{
+			{op: groupAndAll, paths: []string{"city"}},
+			{op: groupAndAll, paths: []string{"make"}},
+		}
+		bitmapsByPath := map[string]*positionBitmaps{
+			"city": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos511, pos711)}},
+			"make": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos521, pos721)}},
+		}
+		result, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+		require.NoError(t, err)
+		assert.True(t, result.IsEmpty()) // different root → cross-group AND gives empty
+	})
+
+	t.Run("two groupAndAll groups — same root matches across groups", func(t *testing.T) {
+		// city and make are both in root=1 for doc5.
+		// Group1→AndAll([city])={E(1,1,doc5)}; Group2→AndAll([make])={E(1,1,doc5)}
+		// AndAllMaskLeaf → both mask to E(1,0,doc5) → match → MaskRootLeaf → {doc5}
+		plan := executionPlan{
+			{op: groupAndAll, paths: []string{"city"}},
+			{op: groupAndAll, paths: []string{"make"}},
+		}
+		bitmapsByPath := map[string]*positionBitmaps{
+			"city": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos511)}},
+			"make": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos511)}},
+		}
+		result, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
+	})
+
+	t.Run("groupAndAll + groupAndAllMaskLeaf — masked result aligned at root+docID", func(t *testing.T) {
+		// Group1 (scalar, raw): city at root=1, leaf=1 for doc5
+		// Group2 (masked, multi-ind): tags at root=1 leaf=1 AND leaf=2 for doc5
+		// Group2→AndAllMaskLeaf([tag1,tag2])={E(1,0,doc5)}
+		// Final: AndAllMaskLeaf([{E(1,1,doc5)},{E(1,0,doc5)}]) = both mask to E(1,0,doc5) → doc5
+		pos512 := invnested.Encode(1, 2, doc5)
+		plan := executionPlan{
+			{op: groupAndAll, paths: []string{"city"}},
+			{op: groupAndAllMaskLeaf, paths: []string{"tags"}},
+		}
+		bitmapsByPath := map[string]*positionBitmaps{
+			"city": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos511)}},
+			"tags": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512)}},
+		}
+		result, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+		require.NoError(t, err)
+		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
 }

--- a/adapters/repos/db/inverted/searcher_nested_plan.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan.go
@@ -13,306 +13,218 @@ package inverted
 
 import (
 	"fmt"
-	"strings"
 
-	"github.com/weaviate/weaviate/entities/filters/nested"
+	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
 
-// nestedCorrelation describes which bitmap operation should combine two nested
-// filter conditions to achieve correct same-element semantics.
-type nestedCorrelation int
+// groupOp describes how the condition bitmaps within a conditionGroup are combined.
+type groupOp int
 
 const (
-	// directAnd: positions are naturally aligned (scalar siblings at the same
-	// element level, or ancestor/descendant). Standard bitmap AND on full 64-bit
-	// values gives correct results.
-	directAnd nestedCorrelation = iota
+	// groupAndAll: all conditions are single and positions are naturally aligned
+	// (no masked results, no further object[] in any path rem beyond the group
+	// LCA). Raw AndAll on full 64-bit positions gives correct results because
+	// leaf bits encode same-element identity — e.g. two scalars in the same car
+	// share the same leaf, two scalars in different cars do not.
+	groupAndAll groupOp = iota
 
-	// maskLeafAnd: paths are in different subtrees of a single object node with
-	// no shared intermediate object[] array. Zero the leaf bits (keep root+docID)
-	// then AND to align on document identity.
-	maskLeafAnd
+	// groupAndAllMaskLeaf: the group LCA is the root object[] itself (lcaPath=="")
+	// and at least one path has masked combinePositions output (multiple
+	// independents or tokens+independent). root_idx already encodes element
+	// identity so AndAllMaskLeaf gives correct same-root-element semantics
+	// without an idx loop.
+	groupAndAllMaskLeaf
 
-	// idxLoopAnd: paths are in different subtrees of a shared object[] array.
-	// Must iterate _idx.{lcaPath}[N] to verify both conditions fall under the
-	// same array element.
-	idxLoopAnd
+	// groupRunIdxLoop: the group LCA is an intermediate object[] (lcaPath!="").
+	// Must iterate _idx.{lcaPath}[N] entries to verify all conditions land in
+	// the same array element.
+	groupRunIdxLoop
 )
 
-// ---------------------------------------------------------------------------
-// Resolution plan
-// ---------------------------------------------------------------------------
-
-// resolutionPlan is a recursive tree that describes how to combine a set of
-// nested filter conditions to achieve correct same-element semantics.
-//
-// Leaf nodes (groups == nil) hold a flat list of relative paths that share a
-// common LCA and are combined with op. Interior maskLeafAnd nodes hold
-// sub-plans for each first-level sub-tree group.
-//
-// Examples:
-//
-//	addresses.city + addresses.postcode + cars.make + cars.colors
-//	→ maskLeafAnd
-//	    ├── directAnd  [addresses.city, addresses.postcode]
-//	    └── directAnd  [cars.make, cars.colors]
-//
-//	addresses.city + addresses.postcode + cars.tires.width + cars.accessories.type
-//	→ maskLeafAnd
-//	    ├── directAnd           [addresses.city, addresses.postcode]
-//	    └── idxLoopAnd("cars")
-//	            ├── directAnd   [cars.tires.width]
-//	            └── directAnd   [cars.accessories.type]
-//
-//	cars.tires.width + cars.accessories.type + cars.accessories.color
-//	→ idxLoopAnd("cars")
-//	    ├── directAnd   [cars.tires.width]
-//	    └── directAnd   [cars.accessories.type, cars.accessories.color]
-type resolutionPlan struct {
-	op      nestedCorrelation // operation to apply at this node
-	lcaPath string            // set for idxLoopAnd: LCA array path (relative)
-	groups  []*resolutionPlan // set for maskLeafAnd interior OR idxLoopAnd interior:
-	//                           one sub-plan per pathRem sub-tree beneath the LCA
-	paths []string // set for leaf nodes (no sub-groups): full relative paths
+// conditionGroup is one set of relPaths that share a common ObjectArray LCA
+// and are combined with a single operation.
+type conditionGroup struct {
+	op      groupOp
+	lcaPath string   // non-empty for groupRunIdxLoop: the intermediate object[] LCA
+	paths   []string // relPaths whose condition bitmaps participate in this group
 }
 
-// resolutionPlanBuilder constructs a resolutionPlan for a set of relative
-// nested filter paths. dt and props describe the root property's schema.
-//
-// Paths are split to segments exactly once and all internal work is done in
-// segment space. The schema context is threaded downward so each recursive
-// level starts from its LCA's schema rather than re-walking from the root.
-//
-// Algorithm:
-//  1. Group paths by first segment, preserving order.
-//  2. Multiple groups → interior maskLeafAnd; classify each group.
-//  3. Single group → classifyLeaf:
-//     a. Strip ancestor paths (pathRem == empty): their bitmaps are supersets of
-//     all siblings and are no-ops in any AND — exclude from further logic.
-//     b. Binary pair where one remainder is a direct scalar at the LCA level
-//     (inherits all parent positions, superset of siblings) → directAnd
-//     c. No remainder passes through a sub-array → directAnd
-//     d/e. At least one remainder has a sub-array → recurse with stripped segs
-//     and LCA-level schema:
-//     · LCA is intermediate object[] → idxLoopAnd(lcaPath) with groups
-//     · LCA is plain object or root object[] → maskLeafAnd with groups
-type resolutionPlanBuilder struct {
-	dt    schema.DataType
+// executionPlan is a flat list of condition groups. The executor combines all
+// group results with AndAllMaskLeaf and strips position bits with MaskRootLeaf.
+type executionPlan []conditionGroup
+
+// executionPlanBuilder groups relPaths by their common ObjectArray LCA and
+// assigns each group the appropriate combining operation.
+// Only the root property schema (props) is stored on the struct — it is
+// invariant for the lifetime of the builder. conditionCounts (per-path token
+// and independent counts) is query-specific and passed to build() directly.
+type executionPlanBuilder struct {
 	props []*models.NestedProperty
 }
 
-// newResolutionPlanBuilder returns a resolutionPlanBuilder for the given root
-// property schema. Call build on the result to produce a resolutionPlan.
-func newResolutionPlanBuilder(dt schema.DataType, props []*models.NestedProperty) *resolutionPlanBuilder {
-	return &resolutionPlanBuilder{dt: dt, props: props}
+// newExecutionPlanBuilder returns a builder for the given root property schema.
+func newExecutionPlanBuilder(props []*models.NestedProperty) *executionPlanBuilder {
+	return &executionPlanBuilder{props: props}
 }
 
-// build is the entry point. Returns an error if paths is empty.
-func (b *resolutionPlanBuilder) build(paths []string) (*resolutionPlan, error) {
-	if len(paths) == 0 {
-		return nil, fmt.Errorf("resolutionPlanBuilder: no paths provided")
+// build is the entry point. counts maps each relPath to [tokens, independents]
+// so the builder can determine which paths produce leaf-masked results.
+// Returns an error if paths is empty.
+func (b *executionPlanBuilder) build(paths []string, counts conditionCounts) (executionPlan, error) {
+	switch len(paths) {
+	case 0:
+		return nil, fmt.Errorf("buildExecutionPlan: no paths provided")
+	case 1:
+		return executionPlan{b.singlePathGroup(paths[0], counts)}, nil
+	default:
+		return b.groupPaths(paths, counts), nil
 	}
-	if len(paths) == 1 {
-		return &resolutionPlan{op: directAnd, paths: paths}, nil
-	}
-	pathsSegs := make([][]string, len(paths))
-	for i, p := range paths {
-		pathsSegs[i] = strings.Split(p, ".")
-	}
-	return b.planFromSegs(pathsSegs, paths, b.dt, b.props)
 }
 
-// planFromSegs groups paths by first segment and dispatches to classifyLeaf.
-// pathsSegs[i] is the pre-split form of paths[i]; dt/props is the schema at
-// the current nesting level.
-func (b *resolutionPlanBuilder) planFromSegs(
-	pathsSegs [][]string,
-	paths []string,
-	dt schema.DataType,
-	props []*models.NestedProperty,
-) (*resolutionPlan, error) {
-	if len(pathsSegs) <= 1 {
-		return &resolutionPlan{op: directAnd, paths: paths}, nil
+// groupPaths groups paths by their first segment, computes the common
+// ObjectArray LCA for each first-segment group, and assigns the combining op.
+func (b *executionPlanBuilder) groupPaths(paths []string, counts conditionCounts) executionPlan {
+	type rawGroup struct {
+		segs  [][]string
+		paths []string
 	}
-
 	seen := map[string]bool{}
 	order := []string{}
-	byFirst := map[string][]int{}
-	for i, pathSegs := range pathsSegs {
-		first := pathSegs[0]
+	byFirst := map[string]*rawGroup{}
+
+	for _, p := range paths {
+		segs := invnested.SplitRelPath(p)
+		first := segs[0]
 		if !seen[first] {
 			seen[first] = true
 			order = append(order, first)
+			byFirst[first] = &rawGroup{}
 		}
-		byFirst[first] = append(byFirst[first], i)
+		byFirst[first].segs = append(byFirst[first].segs, segs)
+		byFirst[first].paths = append(byFirst[first].paths, p)
 	}
 
-	if len(order) > 1 {
-		subPlans := make([]*resolutionPlan, 0, len(order))
-		for _, first := range order {
-			idxs := byFirst[first]
-			groupPathSegs := make([][]string, len(idxs))
-			groupPaths := make([]string, len(idxs))
-			for j, idx := range idxs {
-				groupPathSegs[j] = pathsSegs[idx]
-				groupPaths[j] = paths[idx]
-			}
-			subPlan, err := b.classifyLeaf(groupPathSegs, groupPaths, dt, props)
-			if err != nil {
-				return nil, err
-			}
-			subPlans = append(subPlans, subPlan)
-		}
-		return &resolutionPlan{op: maskLeafAnd, groups: subPlans}, nil
+	plan := make(executionPlan, 0, len(order))
+	for _, first := range order {
+		g := byFirst[first]
+		lcaPath := b.commonObjectArrayLCA(g.segs, g.paths)
+		op := b.determineGroupOp(g.paths, lcaPath, counts)
+		plan = append(plan, conditionGroup{op: op, lcaPath: lcaPath, paths: g.paths})
 	}
-
-	return b.classifyLeaf(pathsSegs, paths, dt, props)
+	return plan
 }
 
-// classifyLeaf classifies a set of pre-split paths that all share a common
-// first segment by computing their LCA and applying the decision rules.
-func (b *resolutionPlanBuilder) classifyLeaf(
-	pathsSegs [][]string,
-	paths []string,
-	dt schema.DataType,
-	props []*models.NestedProperty,
-) (*resolutionPlan, error) {
-	if len(pathsSegs) == 0 {
-		return nil, fmt.Errorf("resolutionPlanBuilder: no paths provided")
-	}
-	if len(pathsSegs) == 1 {
-		return &resolutionPlan{op: directAnd, paths: paths}, nil
-	}
+// singlePathGroup builds a conditionGroup for a single relPath.
+func (b *executionPlanBuilder) singlePathGroup(path string, counts conditionCounts) conditionGroup {
+	lcaPath := b.lastIntermediateObjectArray(path)
+	op := b.determineGroupOp([]string{path}, lcaPath, counts)
+	return conditionGroup{op: op, lcaPath: lcaPath, paths: []string{path}}
+}
 
-	lcaLen := len(pathsSegs[0])
-	for _, ps := range pathsSegs[1:] {
+// commonObjectArrayLCA returns the deepest ObjectArray in the common prefix of
+// all segs. For a single path it delegates to lastIntermediateObjectArray.
+func (b *executionPlanBuilder) commonObjectArrayLCA(segs [][]string, paths []string) string {
+	if len(paths) == 1 {
+		return b.lastIntermediateObjectArray(paths[0])
+	}
+	// Find the common prefix length across all segs.
+	lcaLen := len(segs[0])
+	for _, s := range segs[1:] {
 		i := 0
-		for i < lcaLen && i < len(ps) && pathsSegs[0][i] == ps[i] {
+		for i < lcaLen && i < len(s) && segs[0][i] == s[i] {
 			i++
 		}
 		lcaLen = i
 	}
-
-	// 3a: exclude ancestor paths — they are supersets of all siblings (no-ops).
-	var activePathSegs [][]string
-	var activePaths []string
-	for i, pathSegs := range pathsSegs {
-		if len(pathSegs) > lcaLen {
-			activePathSegs = append(activePathSegs, pathSegs)
-			activePaths = append(activePaths, paths[i])
-		}
+	if lcaLen == 0 {
+		return ""
 	}
-	if len(activePaths) <= 1 {
-		return &resolutionPlan{op: directAnd, paths: activePaths}, nil
-	}
-
-	lcaPathSegs := pathsSegs[0][:lcaLen]
-	lcaDT, lcaProps := b.nodeTypeAndProps(lcaPathSegs, dt, props)
-	if !schema.IsNested(lcaDT) {
-		return nil, fmt.Errorf("resolutionPlanBuilder: LCA node %q is not object or object[], got %q",
-			strings.Join(lcaPathSegs, "."), lcaDT)
-	}
-
-	activePathRems := make([][]string, len(activePathSegs))
-	for i, pathSegs := range activePathSegs {
-		activePathRems[i] = pathSegs[lcaLen:]
-	}
-
-	// 3b/3c: directAnd suffices when positions are naturally aligned.
-	if b.isDirectAndEligible(activePathRems, lcaProps) {
-		return &resolutionPlan{op: directAnd, paths: activePaths}, nil
-	}
-
-	// 3d/3e: element-level correlation required.
-	innerPlan, err := b.planFromSegs(activePathRems, activePaths, lcaDT, lcaProps)
-	if err != nil {
-		return nil, err
-	}
-
-	if lcaDT == schema.DataTypeObjectArray {
-		if lcaPath := strings.Join(lcaPathSegs, "."); lcaPath != "" {
-			return &resolutionPlan{op: idxLoopAnd, lcaPath: lcaPath, groups: b.extractGroups(innerPlan)}, nil
-		}
-	}
-	return &resolutionPlan{op: maskLeafAnd, groups: b.extractGroups(innerPlan)}, nil
+	return b.lastIntermediateObjectArray(invnested.JoinRelPath(segs[0][:lcaLen]))
 }
 
-// isDirectAndEligible returns true when a plain bitmap AND gives correct
-// same-element results without an idx loop:
-//   - 3b: binary pair where one remainder is a direct scalar at the LCA level
-//   - 3c: no remainder passes through a sub-array
-func (b *resolutionPlanBuilder) isDirectAndEligible(pathRems [][]string, lcaProps []*models.NestedProperty) bool {
-	if len(pathRems) == 2 {
-		if b.isScalarAtLevel(pathRems[0], lcaProps) || b.isScalarAtLevel(pathRems[1], lcaProps) {
-			return true
+// determineGroupOp picks the combining operation for a group:
+//
+//  1. Any masked path (tokens+independent or multiple independents) → leaf bits
+//     cannot be used for same-element detection via raw AndAll.
+//     - lcaPath!="" → groupRunIdxLoop (idx entries verify same intermediate element)
+//     - lcaPath==""  → groupAndAllMaskLeaf (root_idx encodes element identity)
+//
+//  2. All single conditions but some path passes through a further object[]
+//     beyond the group LCA → leaf positions are not naturally aligned.
+//     Same routing as above.
+//
+//  3. All single conditions, no further object[] in any rem → positions are
+//     naturally aligned; raw AndAll on leaf-precise positions is sufficient.
+//
+// Why groupAndAllMaskLeaf is never safe when lcaPath!="":
+//
+// root_idx always encodes the ROOT property's element index; leaf_idx is a
+// depth-first counter within that root element. Masking leaf bits collapses
+// all positions within the same root element to {root_idx, leaf=0, docID},
+// regardless of which intermediate array element they came from.
+//
+// Example — garages (root object[]), cars (intermediate object[]):
+//
+//	garages[0].cars[0].tags[0] = "german" → {root=1, leaf=1, doc=D}
+//	garages[0].cars[1].tags[0] = "electric" → {root=1, leaf=2, doc=D}
+//	MaskLeaf both → {root=1, leaf=0, doc=D} for each
+//	AndAllMaskLeaf → {root=1, leaf=0, doc=D}  ← false positive
+//
+// The two tags are in different cars, but the same garages element. Masking
+// the leaf loses the cars-level distinction entirely. Only the idx loop can
+// verify that all conditions land within the same intermediate element, so
+// groupRunIdxLoop is required for any lcaPath!="".
+func (b *executionPlanBuilder) determineGroupOp(paths []string, lcaPath string, counts conditionCounts) groupOp {
+	for _, p := range paths {
+		if counts.isMasked(p) || b.lastIntermediateObjectArray(p) != lcaPath {
+			if lcaPath != "" {
+				return groupRunIdxLoop
+			}
+			return groupAndAllMaskLeaf
 		}
 	}
-	for _, pathRem := range pathRems {
-		if b.containsObjectArray(pathRem, lcaProps) {
-			return false
-		}
-	}
-	return true
+	return groupAndAll
 }
 
-// extractGroups lifts the sub-groups of an interior maskLeafAnd node so they
-// can be used directly as groups of the outer operation, or wraps a single
-// plan as a one-element slice.
-func (b *resolutionPlanBuilder) extractGroups(plan *resolutionPlan) []*resolutionPlan {
-	if plan.op == maskLeafAnd && len(plan.groups) > 0 {
-		return plan.groups
-	}
-	return []*resolutionPlan{plan}
-}
-
-// nodeTypeAndProps walks pathSegs through the nested schema and returns the
-// DataType and NestedProperties at that node. An empty slice returns (dt, props).
-func (b *resolutionPlanBuilder) nodeTypeAndProps(
-	pathSegs []string,
-	dt schema.DataType,
-	props []*models.NestedProperty,
-) (schema.DataType, []*models.NestedProperty) {
-	for _, pathSeg := range pathSegs {
-		np := nested.FindNestedProp(props, pathSeg)
+// lastIntermediateObjectArray walks the nested property schema along path and
+// returns the dot-notation prefix up to and including the LAST (deepest)
+// segment whose DataType is DataTypeObjectArray, or "" if none exists.
+//
+// Examples:
+//
+//	"cars.tags"         (cars=object[], tags=text[])                   → "cars"
+//	"garages.cars.tags" (garages=object[], cars=object[], tags=text[]) → "garages.cars"
+//	"make"              (text, no intermediate array)                  → ""
+func (b *executionPlanBuilder) lastIntermediateObjectArray(path string) string {
+	segs := invnested.SplitRelPath(path)
+	props := b.props
+	last := ""
+	for i, seg := range segs {
+		np := filnested.FindNestedProp(props, seg)
 		if np == nil {
-			return dt, props
+			return last
 		}
-		dt = schema.DataType(np.DataType[0])
-		props = np.NestedProperties
-	}
-	return dt, props
-}
-
-// isScalarAtLevel returns true if pathSegs is a single segment resolving to a
-// non-array, non-nested scalar property. Such a property inherits ALL leaf
-// positions of its parent element and is a superset of any sibling's positions.
-func (b *resolutionPlanBuilder) isScalarAtLevel(pathSegs []string, props []*models.NestedProperty) bool {
-	if len(pathSegs) != 1 {
-		return false
-	}
-	np := nested.FindNestedProp(props, pathSegs[0])
-	if np == nil {
-		return false
-	}
-	dt := schema.DataType(np.DataType[0])
-	return !schema.IsNested(dt) && !schema.IsScalarArrayType(dt)
-}
-
-// containsObjectArray returns true if any segment in pathSegs resolves to a
-// DataTypeObjectArray property — the path passes through a nested array that
-// introduces element-level positions.
-func (b *resolutionPlanBuilder) containsObjectArray(pathSegs []string, props []*models.NestedProperty) bool {
-	for _, pathSeg := range pathSegs {
-		np := nested.FindNestedProp(props, pathSeg)
-		if np == nil {
-			return false
+		dt := schema.DataType(np.DataType[0])
+		if dt == schema.DataTypeObjectArray {
+			last = invnested.JoinRelPath(segs[:i+1])
 		}
-		if schema.DataType(np.DataType[0]) == schema.DataTypeObjectArray {
-			return true
+		if !schema.IsNested(dt) {
+			return last
 		}
 		props = np.NestedProperties
 	}
-	return false
+	return last
+}
+
+// conditionCounts maps each relPath to its [tokens, independents] condition counts.
+type conditionCounts map[string][2]int
+
+// isMasked reports whether the conditions for path will produce a leaf-masked
+// bitmap from the combining step: independents>1 OR (tokens>0 AND independents>0).
+func (c conditionCounts) isMasked(path string) bool {
+	tok, ind := c[path][0], c[path][1]
+	return ind > 1 || (tok > 0 && ind > 0)
 }

--- a/adapters/repos/db/inverted/searcher_nested_plan_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_test.go
@@ -12,7 +12,6 @@
 package inverted
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -100,642 +99,539 @@ func correlationTestProps() []*models.NestedProperty {
 	}
 }
 
-func TestBuildResolutionPlanLeafOps(t *testing.T) {
-	props := correlationTestProps()
-	objDT := schema.DataTypeObject
-	arrDT := schema.DataTypeObjectArray
-
-	// These cases all verify the top-level op (and lcaPath where relevant).
-	// Cross-subtree pairs produce an interior maskLeafAnd; same-subtree pairs
-	// produce a leaf or an idxLoopAnd.  The comments show the logical plan.
-	tests := []struct {
-		name    string
-		pathA   string
-		pathB   string
-		rootDT  schema.DataType
-		wantOp  nestedCorrelation
-		wantLCA string
+func TestConditionCountsIsMasked(t *testing.T) {
+	// isMasked returns true when: independents>1 OR (tokens>0 AND independents>0)
+	for _, tt := range []struct {
+		name         string
+		tokens       int
+		independents int
+		want         bool
 	}{
-		// ancestor / descendant
-		// → directAnd [addresses.city]  (identical paths: deduplicated to one)
-		{
-			name:  "identical paths",
-			pathA: "addresses.city", pathB: "addresses.city", rootDT: objDT,
-			wantOp: directAnd,
-		},
-		// → directAnd [cars.make]  ("cars" ancestor excluded as superset)
-		{
-			name:  "one is prefix of other",
-			pathA: "cars", pathB: "cars.make", rootDT: objDT,
-			wantOp: directAnd,
-		},
-
-		// scalar siblings (inherit all parent-element positions) → directAnd
-		// → directAnd [addresses.city, addresses.postcode]
-		{
-			name:  "addresses.city and addresses.postcode (scalar siblings in object[])",
-			pathA: "addresses.city", pathB: "addresses.postcode", rootDT: objDT,
-			wantOp: directAnd,
-		},
-		// → directAnd [owner.firstname, owner.lastname]
-		{
-			name:  "owner.firstname and owner.lastname (scalar siblings in object)",
-			pathA: "owner.firstname", pathB: "owner.lastname", rootDT: objDT,
-			wantOp: directAnd,
-		},
-		// → directAnd [cars.make, cars.colors]
-		{
-			name:  "cars.make and cars.colors (scalar siblings in cars object[])",
-			pathA: "cars.make", pathB: "cars.colors", rootDT: objDT,
-			wantOp: directAnd,
-		},
-		// → directAnd [cars.tires.width, cars.tires.radiuses]
-		{
-			name:  "tires.width and tires.radiuses (scalar siblings in tires object[])",
-			pathA: "cars.tires.width", pathB: "cars.tires.radiuses", rootDT: objDT,
-			wantOp: directAnd,
-		},
-
-		// different sub-arrays under intermediate object[] → idxLoopAnd
-		// → idxLoopAnd("cars")
-		//       ├── directAnd [cars.tires.width]
-		//       └── directAnd [cars.colors]
-		{
-			name:  "cars.tires.width and cars.colors (tires is sub-array of cars)",
-			pathA: "cars.tires.width", pathB: "cars.colors", rootDT: objDT,
-			wantOp: idxLoopAnd, wantLCA: "cars",
-		},
-		// make is scalar at cars level → superset of tires.width positions → directAnd
-		// → directAnd [cars.tires.width, cars.make]
-		{
-			name:  "cars.tires.width and cars.make (tires sub-array, make scalar superset)",
-			pathA: "cars.tires.width", pathB: "cars.make", rootDT: objDT,
-			wantOp: directAnd,
-		},
-		// → directAnd [cars.tires.radiuses, cars.tires.width]
-		{
-			name:  "cars.tires.radiuses and cars.tires.width (both scalar at tires level)",
-			pathA: "cars.tires.radiuses", pathB: "cars.tires.width", rootDT: objDT,
-			wantOp: directAnd,
-		},
-
-		// diverge at root of object[] → maskLeafAnd (root_idx aligns elements)
-		// → maskLeafAnd
-		//       ├── directAnd [addresses.city]
-		//       └── directAnd [cars.make]
-		{
-			name:  "diverge at root of object[] property",
-			pathA: "addresses.city", pathB: "cars.make", rootDT: arrDT,
-			wantOp: maskLeafAnd,
-		},
-
-		// diverge at root of single object → maskLeafAnd
-		// → maskLeafAnd
-		//       ├── directAnd [addresses.city]
-		//       └── directAnd [cars.make]
-		{
-			name:  "addresses.city and cars.make under single object",
-			pathA: "addresses.city", pathB: "cars.make", rootDT: objDT,
-			wantOp: maskLeafAnd,
-		},
-		// → maskLeafAnd
-		//       ├── directAnd [owner.firstname]
-		//       └── directAnd [addresses.city]
-		{
-			name:  "owner.firstname and addresses.city under single object",
-			pathA: "owner.firstname", pathB: "addresses.city", rootDT: objDT,
-			wantOp: maskLeafAnd,
-		},
-
-		// firstname is scalar at owner level → superset of nicknames (text[]) → directAnd
-		// → directAnd [owner.firstname, owner.nicknames]
-		{
-			name:  "owner.firstname and owner.nicknames (scalar vs text[])",
-			pathA: "owner.firstname", pathB: "owner.nicknames", rootDT: objDT,
-			wantOp: directAnd,
-		},
-	}
-
-	for _, tt := range tests {
+		// not masked
+		{"zero counts", 0, 0, false},
+		{"tokens only, no independent", 2, 0, false},
+		{"single independent, no tokens", 0, 1, false},
+		// masked: multiple independents
+		{"two independents", 0, 2, true},
+		{"three independents", 0, 3, true},
+		// masked: tokens + any independent
+		{"one token + one independent", 1, 1, true},
+		{"two tokens + one independent", 2, 1, true},
+		{"one token + two independents", 1, 2, true},
+	} {
 		t.Run(tt.name, func(t *testing.T) {
-			// Use buildResolutionPlan with the pair; cross-subtree pairs produce a
-			// maskLeafAnd interior node — check only the top-level op.
-			plan, err := newResolutionPlanBuilder(tt.rootDT, props).build([]string{tt.pathA, tt.pathB})
-			require.NoError(t, err)
-			// For cross-subtree pairs the plan is an interior maskLeafAnd with groups;
-			// for same-subtree pairs it is a leaf. Either way the top-level op matches.
-			assert.Equal(t, tt.wantOp, plan.op)
-			if tt.wantOp == idxLoopAnd {
-				assert.Equal(t, tt.wantLCA, plan.lcaPath)
-			}
+			c := conditionCounts{"p": {tt.tokens, tt.independents}}
+			assert.Equal(t, tt.want, c.isMasked("p"))
 		})
 	}
 }
 
-func TestBuildResolutionPlanNoPaths(t *testing.T) {
+func TestBuildExecutionPlanNoPaths(t *testing.T) {
 	props := correlationTestProps()
-	_, err := newResolutionPlanBuilder(schema.DataTypeObject, props).build(nil)
+	_, err := newExecutionPlanBuilder(props).build(nil, nil)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "no paths")
 }
 
-func TestBuildResolutionPlanInvalidDT(t *testing.T) {
+func TestBuildExecutionPlan(t *testing.T) {
 	props := correlationTestProps()
-	// cars.make is DataTypeText (non-nested); paths that go deeper share the
-	// same first-segment group, reaching the LCA check with a scalar LCA node.
-	_, err := newResolutionPlanBuilder(schema.DataTypeObject, props).
-		build([]string{"cars.make.foo", "cars.make.bar"})
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "object or object[]")
-}
 
-func TestBuildResolutionPlanMultiPath(t *testing.T) {
-	props := correlationTestProps()
-	objDT := schema.DataTypeObject
+	// counts helper: all single conditions (no masked results)
+	single := func(paths ...string) map[string][2]int {
+		m := make(map[string][2]int, len(paths))
+		for _, p := range paths {
+			m[p] = [2]int{0, 1}
+		}
+		return m
+	}
+	// masked: tokens+1 independent
+	tokenInd := func(paths ...string) map[string][2]int {
+		m := make(map[string][2]int, len(paths))
+		for _, p := range paths {
+			m[p] = [2]int{1, 1}
+		}
+		return m
+	}
+	// masked: 2 independents
+	multiInd := func(paths ...string) map[string][2]int {
+		m := make(map[string][2]int, len(paths))
+		for _, p := range paths {
+			m[p] = [2]int{0, 2}
+		}
+		return m
+	}
 
-	tests := []struct {
-		name    string
-		paths   []string
-		wantOp  nestedCorrelation
-		wantLCA string
+	for _, tt := range []struct {
+		name   string
+		paths  []string
+		counts map[string][2]int
+		// expected: one check per group in the plan
+		wantGroups []conditionGroup
 	}{
-		// empty paths is a programming error → expect error, not a plan
-		// → directAnd [addresses.city]
-		{name: "single path", paths: []string{"addresses.city"}, wantOp: directAnd},
+		// ---------------------------------------------------------------
+		// Single path
+		// ---------------------------------------------------------------
+		{
+			name:   "single scalar — groupAndAll, no meta needed",
+			paths:  []string{"cars.make"},
+			counts: single("cars.make"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "cars", paths: []string{"cars.make"}},
+			},
+		},
+		{
+			name:   "single multi-condition text[] through intermediate array — groupRunIdxLoop",
+			paths:  []string{"cars.colors"},
+			counts: multiInd("cars.colors"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.colors"}},
+			},
+		},
+		{
+			name:   "single multi-condition at root array (no intermediate) — groupAndAllMaskLeaf",
+			paths:  []string{"tags"},
+			counts: multiInd("tags"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAllMaskLeaf, lcaPath: "", paths: []string{"tags"}},
+			},
+		},
+		{
+			name:   "single token+ind path through intermediate array — groupRunIdxLoop",
+			paths:  []string{"cars.colors"},
+			counts: tokenInd("cars.colors"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.colors"}},
+			},
+		},
 
-		// N=3: scalar-superset rule (3b) only applies for N=2 → idxLoopAnd
-		// → idxLoopAnd("cars")
-		//       ├── directAnd [cars.make]
-		//       ├── directAnd [cars.colors]
-		//       └── directAnd [cars.accessories.type]
+		// ---------------------------------------------------------------
+		// Regression: single-segment lcaPath must always use groupRunIdxLoop,
+		// never groupAndAllMaskLeaf — root_idx encodes the ROOT element, not the
+		// intermediate array element, so MaskLeaf cannot distinguish conditions
+		// landing in different intermediate elements of the same root element.
+		// ---------------------------------------------------------------
 		{
-			name:   "cars.make + cars.colors + cars.accessories.type (N=3, scalar rule N=2 only)",
-			paths:  []string{"cars.make", "cars.colors", "cars.accessories.type"},
-			wantOp: idxLoopAnd, wantLCA: "cars",
+			// cars (depth-1 intermediate object[]) — multi-condition on same path.
+			// Even though lcaPath="cars" is a single segment, root_idx encodes the
+			// parent (root) element, not the cars element. Two tags in different
+			// cars of the same root element share root_idx → AndAllMaskLeaf would
+			// produce a false positive. Only groupRunIdxLoop is correct.
+			name:   "[regression] depth-1 intermediate, multi-condition same path — must be groupRunIdxLoop not groupAndAllMaskLeaf",
+			paths:  []string{"cars.colors"},
+			counts: multiInd("cars.colors"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.colors"}},
+			},
 		},
-		// → idxLoopAnd("cars")
-		//       ├── directAnd [cars.make]
-		//       ├── directAnd [cars.tires.width]
-		//       └── directAnd [cars.accessories.type]
 		{
-			name:   "cars.make + cars.tires.width + cars.accessories.type (N=3)",
-			paths:  []string{"cars.make", "cars.tires.width", "cars.accessories.type"},
-			wantOp: idxLoopAnd, wantLCA: "cars",
+			// addresses (depth-1 intermediate object[]) — multi-condition same path.
+			name:   "[regression] depth-1 intermediate addresses, multi-condition — must be groupRunIdxLoop",
+			paths:  []string{"addresses.numbers"},
+			counts: multiInd("addresses.numbers"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "addresses", paths: []string{"addresses.numbers"}},
+			},
 		},
-		// → idxLoopAnd("cars")
-		//       ├── directAnd [cars.colors]
-		//       └── directAnd [cars.accessories.type]
 		{
-			name:   "cars.colors + cars.accessories.type (no scalar, accessories is sub-array)",
-			paths:  []string{"cars.colors", "cars.accessories.type"},
-			wantOp: idxLoopAnd, wantLCA: "cars",
+			// Depth-2 intermediate (cars.tires) — multi-condition same path.
+			// Same reasoning applies at any depth.
+			name:   "[regression] depth-2 intermediate, multi-condition same path — must be groupRunIdxLoop",
+			paths:  []string{"cars.tires.radiuses"},
+			counts: multiInd("cars.tires.radiuses"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars.tires", paths: []string{"cars.tires.radiuses"}},
+			},
 		},
-		// → idxLoopAnd("cars")
-		//       ├── directAnd [cars.tires.width]
-		//       └── directAnd [cars.accessories.type]
 		{
-			name:   "cars.tires.width + cars.accessories.type (two sub-arrays under cars)",
+			// Single path, single condition through intermediate array — still needs
+			// groupAndAll because positions are naturally aligned (no masking needed).
+			// Contrast: this is groupAndAll, not groupRunIdxLoop, because isMasked=false
+			// and lastIntermediateObjectArray("cars.make")="cars"=lcaPath.
+			// Kept here to anchor the boundary between the two ops.
+			name:   "[regression] depth-1 intermediate, single condition — groupAndAll (not idxLoop, positions aligned)",
+			paths:  []string{"cars.make"},
+			counts: single("cars.make"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "cars", paths: []string{"cars.make"}},
+			},
+		},
+
+		// ---------------------------------------------------------------
+		// Two paths — same first segment (grouped together)
+		// ---------------------------------------------------------------
+		{
+			name:   "scalar siblings in cars[] — groupAndAll (no further object[])",
+			paths:  []string{"cars.make", "cars.colors"},
+			counts: single("cars.make", "cars.colors"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "cars", paths: []string{"cars.make", "cars.colors"}},
+			},
+		},
+		{
+			name:   "tires + accessories (both through object[]) — groupRunIdxLoop(cars)",
 			paths:  []string{"cars.tires.width", "cars.accessories.type"},
-			wantOp: idxLoopAnd, wantLCA: "cars",
+			counts: single("cars.tires.width", "cars.accessories.type"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.tires.width", "cars.accessories.type"}},
+			},
 		},
-		// → idxLoopAnd("cars")
-		//       ├── directAnd [cars.tires.width]
-		//       ├── directAnd [cars.colors]
-		//       └── directAnd [cars.accessories.type]
 		{
-			name:   "cars.tires.width + cars.colors + cars.accessories.type (no scalar)",
-			paths:  []string{"cars.tires.width", "cars.colors", "cars.accessories.type"},
-			wantOp: idxLoopAnd, wantLCA: "cars",
+			name:   "make + tires.width (one through object[]) — groupRunIdxLoop(cars)",
+			paths:  []string{"cars.make", "cars.tires.width"},
+			counts: single("cars.make", "cars.tires.width"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.make", "cars.tires.width"}},
+			},
 		},
-		// tires.width and tires.radiuses are scalar siblings → merged into one group
-		// → idxLoopAnd("cars")
-		//       ├── directAnd [cars.tires.width, cars.tires.radiuses]
-		//       ├── directAnd [cars.colors]
-		//       └── directAnd [cars.accessories.type]
 		{
-			name:   "cars.tires.width + cars.tires.radiuses + cars.colors + cars.accessories.type",
-			paths:  []string{"cars.tires.width", "cars.tires.radiuses", "cars.colors", "cars.accessories.type"},
-			wantOp: idxLoopAnd, wantLCA: "cars",
-		},
-
-		// tires.width is scalar at tires level → superset of radiuses → directAnd
-		// → directAnd [cars.tires.width, cars.tires.radiuses]
-		{
-			name:   "cars.tires.width + cars.tires.radiuses (scalar at tires level)",
+			name:   "tires.width + tires.radiuses (scalar siblings in tires[]) — groupAndAll",
 			paths:  []string{"cars.tires.width", "cars.tires.radiuses"},
-			wantOp: directAnd,
+			counts: single("cars.tires.width", "cars.tires.radiuses"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "cars.tires", paths: []string{"cars.tires.width", "cars.tires.radiuses"}},
+			},
 		},
-		// tires pair is scalar-rescued; accessories diverges under cars → idxLoopAnd
-		// → idxLoopAnd("cars")
-		//       ├── directAnd [cars.tires.width, cars.tires.radiuses]
-		//       └── directAnd [cars.accessories.type]
 		{
-			name:   "cars.tires.width + cars.tires.radiuses + cars.accessories.type (LCA still cars)",
-			paths:  []string{"cars.tires.width", "cars.tires.radiuses", "cars.accessories.type"},
-			wantOp: idxLoopAnd, wantLCA: "cars",
+			name:   "tires.bolts.size + tires.width (common LCA cars.tires) — groupRunIdxLoop(cars.tires)",
+			paths:  []string{"cars.tires.bolts.size", "cars.tires.width"},
+			counts: single("cars.tires.bolts.size", "cars.tires.width"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars.tires", paths: []string{"cars.tires.bolts.size", "cars.tires.width"}},
+			},
+		},
+		{
+			name:  "multi-condition colors + single make — groupRunIdxLoop(cars)",
+			paths: []string{"cars.colors", "cars.make"},
+			counts: func() map[string][2]int {
+				m := single("cars.make")
+				m["cars.colors"] = [2]int{0, 2}
+				return m
+			}(),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.colors", "cars.make"}},
+			},
 		},
 
-		// city is scalar at addresses level → superset of postcode and numbers → directAnd
-		// → directAnd [addresses.city, addresses.postcode, addresses.numbers]
+		// ---------------------------------------------------------------
+		// Two paths — different first segments (separate groups)
+		// ---------------------------------------------------------------
 		{
-			name:   "addresses.city + addresses.postcode + addresses.numbers (city is scalar)",
-			paths:  []string{"addresses.city", "addresses.postcode", "addresses.numbers"},
-			wantOp: directAnd,
+			name:   "addresses.city + cars.make — two groupAndAll groups",
+			paths:  []string{"addresses.city", "cars.make"},
+			counts: single("addresses.city", "cars.make"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "addresses", paths: []string{"addresses.city"}},
+				{op: groupAndAll, lcaPath: "cars", paths: []string{"cars.make"}},
+			},
 		},
-		// → directAnd [addresses.postcode, addresses.numbers]
 		{
-			name:   "addresses.postcode + addresses.numbers (postcode is scalar)",
-			paths:  []string{"addresses.postcode", "addresses.numbers"},
-			wantOp: directAnd,
+			name:   "owner.firstname + addresses.city — two groupAndAll groups",
+			paths:  []string{"owner.firstname", "addresses.city"},
+			counts: single("owner.firstname", "addresses.city"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "", paths: []string{"owner.firstname"}},
+				{op: groupAndAll, lcaPath: "addresses", paths: []string{"addresses.city"}},
+			},
 		},
 
-		// "cars" ancestor excluded as superset; descendants need idxLoopAnd
-		// → idxLoopAnd("cars")
-		//       ├── directAnd [cars.tires.width]
-		//       └── directAnd [cars.accessories.type]
+		// ---------------------------------------------------------------
+		// Defensive edge cases — CANNOT occur in real filters.
+		//
+		// (1) Identical paths: resolveNestedCorrelated deduplicates paths into
+		//     positionsByPath, so pathOrder never contains a path twice. The
+		//     second occurrence of the same condition becomes an extra bitmap in
+		//     independent[], not a separate path entry.
+		//
+		// (2) Ancestor paths like "cars" alongside "cars.make": value filters
+		//     target leaf scalar/array properties only — you cannot filter an
+		//     object[] property by value. IsNull filters on intermediate arrays
+		//     go through fetchNestedIsNull, not resolveNestedCorrelated.
+		//
+		// Kept for defensive robustness: if a bug ever produces unexpected paths
+		// the plan degrades gracefully rather than panicking.
+		// ---------------------------------------------------------------
 		{
-			name:   "cars + cars.tires.width + cars.accessories.type — ancestor excluded",
-			paths:  []string{"cars", "cars.tires.width", "cars.accessories.type"},
-			wantOp: idxLoopAnd, wantLCA: "cars",
+			name:   "[defensive] identical paths (addresses.city twice) — cannot happen in production",
+			paths:  []string{"addresses.city", "addresses.city"},
+			counts: single("addresses.city", "addresses.city"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "addresses", paths: []string{"addresses.city", "addresses.city"}},
+			},
 		},
-		// "cars" ancestor excluded; only cars.make remains → directAnd
-		// → directAnd [cars.make]
 		{
-			name:   "cars + cars.make (ancestor path only)",
+			name:   "[defensive] ancestor + descendant (cars + cars.make) — cannot happen in production",
 			paths:  []string{"cars", "cars.make"},
-			wantOp: directAnd,
+			counts: single("cars", "cars.make"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "cars", paths: []string{"cars", "cars.make"}},
+			},
+		},
+		{
+			name:   "[defensive] ancestor among multiple (cars + cars.tires.width + cars.accessories.type) — cannot happen in production",
+			paths:  []string{"cars", "cars.tires.width", "cars.accessories.type"},
+			counts: single("cars", "cars.tires.width", "cars.accessories.type"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars", "cars.tires.width", "cars.accessories.type"}},
+			},
 		},
 
-		// accessories.type and accessories.color must be in the same accessories element,
-		// not just the same car → rem sub-grouping puts them in one directAnd sub-plan
-		// → idxLoopAnd("cars")
-		//       ├── directAnd [cars.tires.width]
-		//       └── directAnd [cars.accessories.type, cars.accessories.color]
+		// ---------------------------------------------------------------
+		// Scalar siblings in various containers
+		// ---------------------------------------------------------------
 		{
-			name:   "cars.tires.width + cars.accessories.type + cars.accessories.color",
+			name:   "scalar siblings in addresses[] (city + postcode)",
+			paths:  []string{"addresses.city", "addresses.postcode"},
+			counts: single("addresses.city", "addresses.postcode"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "addresses", paths: []string{"addresses.city", "addresses.postcode"}},
+			},
+		},
+		{
+			name:   "scalar siblings in owner object (firstname + lastname)",
+			paths:  []string{"owner.firstname", "owner.lastname"},
+			counts: single("owner.firstname", "owner.lastname"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "", paths: []string{"owner.firstname", "owner.lastname"}},
+			},
+		},
+		{
+			name:   "scalar vs text[] in owner object (firstname + nicknames)",
+			paths:  []string{"owner.firstname", "owner.nicknames"},
+			counts: single("owner.firstname", "owner.nicknames"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "", paths: []string{"owner.firstname", "owner.nicknames"}},
+			},
+		},
+		{
+			name:   "three scalars in addresses[] (city + postcode + numbers)",
+			paths:  []string{"addresses.city", "addresses.postcode", "addresses.numbers"},
+			counts: single("addresses.city", "addresses.postcode", "addresses.numbers"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "addresses", paths: []string{"addresses.city", "addresses.postcode", "addresses.numbers"}},
+			},
+		},
+		{
+			name:   "scalar + scalar-array in addresses[] (postcode + numbers)",
+			paths:  []string{"addresses.postcode", "addresses.numbers"},
+			counts: single("addresses.postcode", "addresses.numbers"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "addresses", paths: []string{"addresses.postcode", "addresses.numbers"}},
+			},
+		},
+		{
+			name:   "tires.width + tires.radiuses + tires.caps.color (tires LCA, bolts is further)",
+			paths:  []string{"cars.tires.width", "cars.tires.radiuses"},
+			counts: single("cars.tires.width", "cars.tires.radiuses"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "cars.tires", paths: []string{"cars.tires.width", "cars.tires.radiuses"}},
+			},
+		},
+
+		// ---------------------------------------------------------------
+		// Paths through sub-arrays within same group
+		// ---------------------------------------------------------------
+		{
+			name:   "colors + accessories.type (no scalar sibling) — groupRunIdxLoop(cars)",
+			paths:  []string{"cars.colors", "cars.accessories.type"},
+			counts: single("cars.colors", "cars.accessories.type"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.colors", "cars.accessories.type"}},
+			},
+		},
+		{
+			name:   "tires.width + colors + accessories.type — groupRunIdxLoop(cars)",
+			paths:  []string{"cars.tires.width", "cars.colors", "cars.accessories.type"},
+			counts: single("cars.tires.width", "cars.colors", "cars.accessories.type"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.tires.width", "cars.colors", "cars.accessories.type"}},
+			},
+		},
+		{
+			name:   "tires.width + tires.radiuses + colors + accessories.type — groupRunIdxLoop(cars)",
+			paths:  []string{"cars.tires.width", "cars.tires.radiuses", "cars.colors", "cars.accessories.type"},
+			counts: single("cars.tires.width", "cars.tires.radiuses", "cars.colors", "cars.accessories.type"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.tires.width", "cars.tires.radiuses", "cars.colors", "cars.accessories.type"}},
+			},
+		},
+		{
+			name:   "tires.width + tires.radiuses + accessories.type (LCA still cars)",
+			paths:  []string{"cars.tires.width", "cars.tires.radiuses", "cars.accessories.type"},
+			counts: single("cars.tires.width", "cars.tires.radiuses", "cars.accessories.type"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.tires.width", "cars.tires.radiuses", "cars.accessories.type"}},
+			},
+		},
+		{
+			name:   "tires.width + accessories.type + accessories.color — groupRunIdxLoop(cars)",
 			paths:  []string{"cars.tires.width", "cars.accessories.type", "cars.accessories.color"},
-			wantOp: idxLoopAnd, wantLCA: "cars",
+			counts: single("cars.tires.width", "cars.accessories.type", "cars.accessories.color"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.tires.width", "cars.accessories.type", "cars.accessories.color"}},
+			},
 		},
 
-		// bolts and caps both live under cars.tires → LCA is "cars.tires" directly,
-		// so a single (non-nested) idxLoopAnd at that combined path is produced
-		// → idxLoopAnd("cars.tires")
-		//       ├── directAnd [cars.tires.bolts.size]
-		//       └── directAnd [cars.tires.caps.color]
+		// ---------------------------------------------------------------
+		// Deep nesting: LCA within tires
+		// ---------------------------------------------------------------
 		{
-			name:   "cars.tires.bolts.size + cars.tires.caps.color — idxLoopAnd at cars.tires",
+			name:   "tires.bolts.size + tires.caps.color — groupRunIdxLoop(cars.tires)",
 			paths:  []string{"cars.tires.bolts.size", "cars.tires.caps.color"},
-			wantOp: idxLoopAnd, wantLCA: "cars.tires",
+			counts: single("cars.tires.bolts.size", "cars.tires.caps.color"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars.tires", paths: []string{"cars.tires.bolts.size", "cars.tires.caps.color"}},
+			},
 		},
-		// adding accessories.type forces divergence at the cars level: tires and
-		// accessories are different subtrees → LCA = "cars". The tires sub-group
-		// itself diverges under tires (bolts vs caps) → nested idxLoopAnd("tires")
-		// → idxLoopAnd("cars")
-		//       ├── idxLoopAnd("tires")
-		//       │       ├── directAnd [cars.tires.bolts.size]
-		//       │       └── directAnd [cars.tires.caps.color]
-		//       └── directAnd [cars.accessories.type]
 		{
-			name:   "cars.tires.bolts.size + cars.tires.caps.color + cars.accessories.type — nested idxLoopAnd",
+			name:   "tires.bolts.size + tires.caps.color + accessories.type — LCA collapses to cars",
 			paths:  []string{"cars.tires.bolts.size", "cars.tires.caps.color", "cars.accessories.type"},
-			wantOp: idxLoopAnd, wantLCA: "cars",
+			counts: single("cars.tires.bolts.size", "cars.tires.caps.color", "cars.accessories.type"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.tires.bolts.size", "cars.tires.caps.color", "cars.accessories.type"}},
+			},
 		},
 
-		// cross-subtree at root → maskLeafAnd
-		// → maskLeafAnd
-		//       ├── directAnd [owner.firstname]
-		//       ├── directAnd [addresses.city]
-		//       └── directAnd [cars.make]
+		// ---------------------------------------------------------------
+		// Three paths
+		// ---------------------------------------------------------------
 		{
-			name:   "owner.firstname + addresses.city + cars.make (diverge at root)",
-			paths:  []string{"owner.firstname", "addresses.city", "cars.make"},
-			wantOp: maskLeafAnd,
+			name:   "three paths in cars — single group",
+			paths:  []string{"cars.make", "cars.tires.width", "cars.accessories.type"},
+			counts: single("cars.make", "cars.tires.width", "cars.accessories.type"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.make", "cars.tires.width", "cars.accessories.type"}},
+			},
 		},
-		// → maskLeafAnd
-		//       ├── directAnd [name]
-		//       ├── directAnd [owner.firstname]
-		//       ├── directAnd [addresses.city]
-		//       └── directAnd [cars.make]
+
+		// ---------------------------------------------------------------
+		// Cross-subtree paths (different first segments → separate groups)
+		// ---------------------------------------------------------------
+		{
+			name:   "owner.firstname + addresses.city + cars.make (three subtrees)",
+			paths:  []string{"owner.firstname", "addresses.city", "cars.make"},
+			counts: single("owner.firstname", "addresses.city", "cars.make"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "", paths: []string{"owner.firstname"}},
+				{op: groupAndAll, lcaPath: "addresses", paths: []string{"addresses.city"}},
+				{op: groupAndAll, lcaPath: "cars", paths: []string{"cars.make"}},
+			},
+		},
 		{
 			name:   "name + owner.firstname + addresses.city + cars.make (four subtrees)",
 			paths:  []string{"name", "owner.firstname", "addresses.city", "cars.make"},
-			wantOp: maskLeafAnd,
+			counts: single("name", "owner.firstname", "addresses.city", "cars.make"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "", paths: []string{"name"}},
+				{op: groupAndAll, lcaPath: "", paths: []string{"owner.firstname"}},
+				{op: groupAndAll, lcaPath: "addresses", paths: []string{"addresses.city"}},
+				{op: groupAndAll, lcaPath: "cars", paths: []string{"cars.make"}},
+			},
 		},
-		// → maskLeafAnd
-		//       ├── directAnd [addresses.city, addresses.postcode]
-		//       └── directAnd [cars.make, cars.colors]
 		{
-			name:   "addresses.city + addresses.postcode + cars.make + cars.colors (mixed subtrees)",
+			name:   "addresses.city + addresses.postcode + cars.make + cars.colors (two subtrees, two groups)",
 			paths:  []string{"addresses.city", "addresses.postcode", "cars.make", "cars.colors"},
-			wantOp: maskLeafAnd,
+			counts: single("addresses.city", "addresses.postcode", "cars.make", "cars.colors"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "addresses", paths: []string{"addresses.city", "addresses.postcode"}},
+				{op: groupAndAll, lcaPath: "cars", paths: []string{"cars.make", "cars.colors"}},
+			},
 		},
-	}
+		{
+			name:   "addresses.city + addresses.postcode + cars.tires.width + cars.accessories.type",
+			paths:  []string{"addresses.city", "addresses.postcode", "cars.tires.width", "cars.accessories.type"},
+			counts: single("addresses.city", "addresses.postcode", "cars.tires.width", "cars.accessories.type"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "addresses", paths: []string{"addresses.city", "addresses.postcode"}},
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.tires.width", "cars.accessories.type"}},
+			},
+		},
+		{
+			name:   "addresses + tires.bolts.size + tires.caps.color (deep tires LCA)",
+			paths:  []string{"addresses.city", "cars.tires.bolts.size", "cars.tires.caps.color"},
+			counts: single("addresses.city", "cars.tires.bolts.size", "cars.tires.caps.color"),
+			wantGroups: []conditionGroup{
+				{op: groupAndAll, lcaPath: "addresses", paths: []string{"addresses.city"}},
+				{op: groupRunIdxLoop, lcaPath: "cars.tires", paths: []string{"cars.tires.bolts.size", "cars.tires.caps.color"}},
+			},
+		},
 
-	for _, tt := range tests {
+		// ---------------------------------------------------------------
+		// Input order preserved within each group
+		// ---------------------------------------------------------------
+		{
+			name:   "interleaved paths — groups preserve insertion order",
+			paths:  []string{"cars.tires.width", "addresses.city", "cars.accessories.type", "addresses.postcode"},
+			counts: single("cars.tires.width", "addresses.city", "cars.accessories.type", "addresses.postcode"),
+			wantGroups: []conditionGroup{
+				{op: groupRunIdxLoop, lcaPath: "cars", paths: []string{"cars.tires.width", "cars.accessories.type"}},
+				{op: groupAndAll, lcaPath: "addresses", paths: []string{"addresses.city", "addresses.postcode"}},
+			},
+		},
+	} {
 		t.Run(tt.name, func(t *testing.T) {
-			plan, err := newResolutionPlanBuilder(objDT, props).build(tt.paths)
+			plan, err := newExecutionPlanBuilder(props).build(tt.paths, tt.counts)
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantOp, plan.op)
-			if tt.wantOp == idxLoopAnd {
-				assert.Equal(t, tt.wantLCA, plan.lcaPath)
+			require.Len(t, plan, len(tt.wantGroups), "number of groups")
+			for i, want := range tt.wantGroups {
+				got := plan[i]
+				assert.Equal(t, want.op, got.op, "group %d op", i)
+				assert.Equal(t, want.lcaPath, got.lcaPath, "group %d lcaPath", i)
+				assert.Equal(t, want.paths, got.paths, "group %d paths", i)
 			}
 		})
 	}
 }
 
-func TestBuildResolutionPlan(t *testing.T) {
+func TestLastIntermediateObjectArray(t *testing.T) {
 	props := correlationTestProps()
-	objDT := schema.DataTypeObject
 
-	tests := []struct {
-		name  string
-		paths []string
-		check func(t *testing.T, plan *resolutionPlan)
+	// Schema (from correlationTestProps, rooted at nestedObject: object):
+	//   name:      text
+	//   owner:     object  { firstname text; nicknames text[] }
+	//   addresses: object[] { city text; numbers number[] }
+	//   tags:      text[]
+	//   cars:      object[] {
+	//     make:        text
+	//     colors:      text[]
+	//     tires:       object[] { width int; radiuses int[]; bolts object[]{size int} }
+	//     accessories: object[] { type text }
+	//   }
+
+	for _, tt := range []struct {
+		path string
+		want string
 	}{
-		{
-			// → directAnd [addresses.city]
-			name:  "single path",
-			paths: []string{"addresses.city"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, directAnd, p.op)
-				assert.Equal(t, []string{"addresses.city"}, p.paths)
-				assert.Nil(t, p.groups)
-			},
-		},
-		{
-			// → directAnd [addresses.city, addresses.postcode]
-			name:  "scalar siblings in addresses → directAnd leaf",
-			paths: []string{"addresses.city", "addresses.postcode"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, directAnd, p.op)
-				assert.ElementsMatch(t, []string{"addresses.city", "addresses.postcode"}, p.paths)
-				assert.Nil(t, p.groups)
-			},
-		},
-		{
-			// → idxLoopAnd("cars")
-			//       ├── directAnd [cars.tires.width]
-			//       └── directAnd [cars.accessories.type]
-			name:  "cars.tires.width + cars.accessories.type → idxLoopAnd on cars",
-			paths: []string{"cars.tires.width", "cars.accessories.type"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, idxLoopAnd, p.op)
-				assert.Equal(t, "cars", p.lcaPath)
-			},
-		},
-		{
-			// → maskLeafAnd
-			//       ├── directAnd [addresses.city, addresses.postcode]
-			//       └── directAnd [cars.make, cars.colors]
-			name:  "addresses.city + addresses.postcode + cars.make + cars.colors → maskLeafAnd with two directAnd groups",
-			paths: []string{"addresses.city", "addresses.postcode", "cars.make", "cars.colors"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, maskLeafAnd, p.op)
-				require.Len(t, p.groups, 2)
+		// No ObjectArray anywhere in the path
+		{"name", ""},
+		{"tags", ""},            // text[] at root — no intermediate object[]
+		{"owner.firstname", ""}, // owner is DataTypeObject (not array)
+		{"owner.nicknames", ""}, // object → text[] — still no object[]
 
-				// find each group by paths content
-				var addrGroup, carsGroup *resolutionPlan
-				for _, g := range p.groups {
-					for _, path := range g.paths {
-						if path != "" && path[:4] == "addr" {
-							addrGroup = g
-						} else if path != "" && path[:4] == "cars" {
-							carsGroup = g
-						}
-					}
-				}
-				require.NotNil(t, addrGroup)
-				require.NotNil(t, carsGroup)
-				assert.Equal(t, directAnd, addrGroup.op)
-				assert.ElementsMatch(t, []string{"addresses.city", "addresses.postcode"}, addrGroup.paths)
-				assert.Equal(t, directAnd, carsGroup.op)
-				assert.ElementsMatch(t, []string{"cars.make", "cars.colors"}, carsGroup.paths)
-			},
-		},
-		{
-			// → maskLeafAnd
-			//       ├── directAnd           [addresses.city, addresses.postcode]
-			//       └── idxLoopAnd("cars")
-			//               ├── directAnd   [cars.tires.width]
-			//               └── directAnd   [cars.accessories.type]
-			name:  "addresses.city + addresses.postcode + cars.tires.width + cars.accessories.type → maskLeafAnd: directAnd + idxLoopAnd",
-			paths: []string{"addresses.city", "addresses.postcode", "cars.tires.width", "cars.accessories.type"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, maskLeafAnd, p.op)
-				require.Len(t, p.groups, 2)
+		// Path IS an ObjectArray segment itself
+		{"addresses", "addresses"},
+		{"cars", "cars"},
 
-				var addrGroup, carsGroup *resolutionPlan
-				for _, g := range p.groups {
-					if g.op == idxLoopAnd && g.lcaPath == "cars" {
-						carsGroup = g
-					} else if g.op == directAnd {
-						addrGroup = g
-					}
-				}
-				require.NotNil(t, addrGroup, "addresses group not found")
-				require.NotNil(t, carsGroup, "cars group not found")
-				assert.Equal(t, directAnd, addrGroup.op)
-				assert.ElementsMatch(t, []string{"addresses.city", "addresses.postcode"}, addrGroup.paths)
-				assert.Equal(t, idxLoopAnd, carsGroup.op)
-				assert.Equal(t, "cars", carsGroup.lcaPath)
-			},
-		},
-		{
-			// → idxLoopAnd("cars")
-			//       ├── directAnd [cars.tires.width]
-			//       ├── directAnd [cars.colors]
-			//       └── directAnd [cars.accessories.type]
-			name:  "cars.tires.width + cars.colors + cars.accessories.type → idxLoopAnd on cars with groups",
-			paths: []string{"cars.tires.width", "cars.colors", "cars.accessories.type"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, idxLoopAnd, p.op)
-				assert.Equal(t, "cars", p.lcaPath)
-				// Three distinct rem first-segments → three sub-plans.
-				require.Len(t, p.groups, 3)
-				assert.Nil(t, p.paths)
-				for _, g := range p.groups {
-					assert.Equal(t, directAnd, g.op)
-					assert.Len(t, g.paths, 1)
-				}
-			},
-		},
-		{
-			// accessories.type and accessories.color must be in the same accessories
-			// element — rem sub-grouping puts them in one directAnd plan.
-			// Sub-plans carry the original full paths.
-			// → idxLoopAnd("cars")
-			//       ├── directAnd [cars.tires.width]
-			//       └── directAnd [cars.accessories.type, cars.accessories.color]
-			name:  "cars.tires.width + cars.accessories.type + cars.accessories.color → idxLoopAnd with two groups",
-			paths: []string{"cars.tires.width", "cars.accessories.type", "cars.accessories.color"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, idxLoopAnd, p.op)
-				assert.Equal(t, "cars", p.lcaPath)
-				require.Len(t, p.groups, 2)
-				assert.Nil(t, p.paths)
+		// Path through a single ObjectArray
+		{"addresses.city", "addresses"},    // scalar leaf
+		{"addresses.numbers", "addresses"}, // scalar-array leaf
+		{"cars.make", "cars"},              // scalar leaf
+		{"cars.colors", "cars"},            // scalar-array leaf
 
-				// Identify groups by their path contents (not first-segment cut,
-				// since full paths all start with "cars.").
-				var tiresGroup, accGroup *resolutionPlan
-				for _, g := range p.groups {
-					if assert.Equal(t, directAnd, g.op) {
-						if len(g.paths) == 1 {
-							tiresGroup = g
-						} else {
-							accGroup = g
-						}
-					}
-				}
-				require.NotNil(t, tiresGroup, "tires group missing")
-				require.NotNil(t, accGroup, "accessories group missing")
-				assert.ElementsMatch(t, []string{"cars.tires.width"}, tiresGroup.paths)
-				assert.ElementsMatch(t, []string{"cars.accessories.type", "cars.accessories.color"}, accGroup.paths)
-			},
-		},
-		{
-			// Both paths share LCA "cars.tires" → single idxLoopAnd at that path.
-			// No nesting: the loop iterates _idx.cars.tires[N] entries directly.
-			// → idxLoopAnd("cars.tires")
-			//       ├── directAnd [cars.tires.bolts.size]
-			//       └── directAnd [cars.tires.caps.color]
-			name:  "cars.tires.bolts.size + cars.tires.caps.color → idxLoopAnd at cars.tires",
-			paths: []string{"cars.tires.bolts.size", "cars.tires.caps.color"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, idxLoopAnd, p.op)
-				assert.Equal(t, "cars.tires", p.lcaPath)
-				require.Len(t, p.groups, 2)
-				for _, g := range p.groups {
-					assert.Equal(t, directAnd, g.op)
-					assert.Len(t, g.paths, 1)
-				}
-			},
-		},
-		{
-			// accessories.type forces divergence at the cars level; the tires sub-group
-			// diverges further under tires (bolts vs caps) → nested idxLoopAnd("tires")
-			// inside idxLoopAnd("cars"). Sub-plans carry original full paths.
-			// → idxLoopAnd("cars")
-			//       ├── idxLoopAnd("tires")
-			//       │       ├── directAnd [cars.tires.bolts.size]
-			//       │       └── directAnd [cars.tires.caps.color]
-			//       └── directAnd [cars.accessories.type]
-			name:  "cars.tires.bolts.size + cars.tires.caps.color + cars.accessories.type → nested idxLoopAnd",
-			paths: []string{"cars.tires.bolts.size", "cars.tires.caps.color", "cars.accessories.type"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, idxLoopAnd, p.op)
-				assert.Equal(t, "cars", p.lcaPath)
-				require.Len(t, p.groups, 2)
+		// Deeper: two ObjectArray levels — returns the deepest one
+		{"cars.tires", "cars.tires"},                  // tires is itself object[]
+		{"cars.tires.width", "cars.tires"},            // int leaf
+		{"cars.tires.radiuses", "cars.tires"},         // int[] leaf
+		{"cars.accessories.type", "cars.accessories"}, // scalar leaf
 
-				var tiresLoop, accGroup *resolutionPlan
-				for _, g := range p.groups {
-					if g.op == idxLoopAnd {
-						tiresLoop = g
-					} else {
-						accGroup = g
-					}
-				}
-				require.NotNil(t, tiresLoop, "tires idxLoopAnd missing")
-				require.NotNil(t, accGroup, "accessories directAnd missing")
+		// Three ObjectArray levels
+		{"cars.tires.bolts.size", "cars.tires.bolts"},
 
-				assert.Equal(t, "tires", tiresLoop.lcaPath)
-				require.Len(t, tiresLoop.groups, 2)
-				for _, g := range tiresLoop.groups {
-					assert.Equal(t, directAnd, g.op)
-				}
-				assert.Equal(t, directAnd, accGroup.op)
-				assert.ElementsMatch(t, []string{"cars.accessories.type"}, accGroup.paths)
-			},
-		},
-		{
-			// → directAnd [owner.firstname, owner.lastname]
-			name:  "owner.firstname + owner.lastname → directAnd (scalar siblings in object)",
-			paths: []string{"owner.firstname", "owner.lastname"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, directAnd, p.op)
-				assert.ElementsMatch(t, []string{"owner.firstname", "owner.lastname"}, p.paths)
-			},
-		},
-		{
-			// → maskLeafAnd
-			//       ├── directAnd [owner.firstname]
-			//       └── directAnd [addresses.city]
-			name:  "owner.firstname + addresses.city → maskLeafAnd with two groups",
-			paths: []string{"owner.firstname", "addresses.city"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, maskLeafAnd, p.op)
-				assert.Len(t, p.groups, 2)
-			},
-		},
-		{
-			// Paths are interleaved but grouping is order-independent.
-			// → maskLeafAnd
-			//       ├── directAnd [cars.make, cars.colors]
-			//       └── directAnd [addresses.city, addresses.postcode]
-			name:  "interleaved cars and addresses paths → same grouping as sorted order",
-			paths: []string{"cars.make", "addresses.city", "cars.colors", "addresses.postcode"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, maskLeafAnd, p.op)
-				require.Len(t, p.groups, 2)
-
-				byFirst := map[string]*resolutionPlan{}
-				for _, g := range p.groups {
-					for _, path := range g.paths {
-						first, _, _ := strings.Cut(path, ".")
-						byFirst[first] = g
-						break
-					}
-				}
-
-				carsGroup := byFirst["cars"]
-				addrGroup := byFirst["addresses"]
-				require.NotNil(t, carsGroup, "cars group missing")
-				require.NotNil(t, addrGroup, "addresses group missing")
-
-				assert.Equal(t, directAnd, carsGroup.op)
-				assert.ElementsMatch(t, []string{"cars.make", "cars.colors"}, carsGroup.paths)
-				assert.Equal(t, directAnd, addrGroup.op)
-				assert.ElementsMatch(t, []string{"addresses.city", "addresses.postcode"}, addrGroup.paths)
-			},
-		},
-		{
-			// Paths are interleaved but grouping is order-independent.
-			// → maskLeafAnd
-			//       ├── directAnd           [addresses.city, addresses.postcode]
-			//       └── idxLoopAnd("cars")
-			//               ├── directAnd   [cars.tires.width]
-			//               └── directAnd   [cars.accessories.type]
-			name:  "interleaved deep cars and addresses paths",
-			paths: []string{"cars.tires.width", "addresses.city", "cars.accessories.type", "addresses.postcode"},
-			check: func(t *testing.T, p *resolutionPlan) {
-				assert.Equal(t, maskLeafAnd, p.op)
-				require.Len(t, p.groups, 2)
-
-				// Identify groups by op+lcaPath rather than path prefix, since
-				// sub-plans now carry LCA-stripped paths (e.g. "tires.width").
-				var carsGroup, addrGroup *resolutionPlan
-				for _, g := range p.groups {
-					if g.op == idxLoopAnd && g.lcaPath == "cars" {
-						carsGroup = g
-					} else if g.op == directAnd {
-						addrGroup = g
-					}
-				}
-				require.NotNil(t, carsGroup, "cars group missing")
-				require.NotNil(t, addrGroup, "addresses group missing")
-
-				assert.Equal(t, idxLoopAnd, carsGroup.op)
-				assert.Equal(t, "cars", carsGroup.lcaPath)
-				assert.Equal(t, directAnd, addrGroup.op)
-				assert.ElementsMatch(t, []string{"addresses.city", "addresses.postcode"}, addrGroup.paths)
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			plan, err := newResolutionPlanBuilder(objDT, props).build(tt.paths)
-			require.NoError(t, err)
-			tt.check(t, plan)
+		// Unknown segment — returns last found ObjectArray before the miss
+		{"cars.unknown", "cars"},
+		{"nonexistent", ""},
+	} {
+		t.Run(tt.path, func(t *testing.T) {
+			assert.Equal(t, tt.want, newExecutionPlanBuilder(props).lastIntermediateObjectArray(tt.path))
 		})
 	}
 }

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/filters"
-	"github.com/weaviate/weaviate/entities/filters/nested"
+	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -220,7 +220,7 @@ func TestExtractNestedProp(t *testing.T) {
 				assert.Equal(t, "city", pv.nested.relPath)
 				assert.True(t, pv.nested.isNested)
 				require.Len(t, pv.nested.arrayIndices, 1)
-				assert.Equal(t, nested.ArrayIndex{RelPath: "", Index: 0}, pv.nested.arrayIndices[0])
+				assert.Equal(t, filnested.ArrayIndex{RelPath: "", Index: 0}, pv.nested.arrayIndices[0])
 			},
 		},
 		{
@@ -232,7 +232,7 @@ func TestExtractNestedProp(t *testing.T) {
 				assert.Equal(t, "numbers", pv.nested.relPath)
 				assert.True(t, pv.nested.isNested)
 				require.Len(t, pv.nested.arrayIndices, 1)
-				assert.Equal(t, nested.ArrayIndex{RelPath: "numbers", Index: 1}, pv.nested.arrayIndices[0])
+				assert.Equal(t, filnested.ArrayIndex{RelPath: "numbers", Index: 1}, pv.nested.arrayIndices[0])
 			},
 		},
 		{
@@ -244,7 +244,7 @@ func TestExtractNestedProp(t *testing.T) {
 				assert.Equal(t, "owner.firstname", pv.nested.relPath)
 				assert.True(t, pv.nested.isNested)
 				require.Len(t, pv.nested.arrayIndices, 1)
-				assert.Equal(t, nested.ArrayIndex{RelPath: "", Index: 0}, pv.nested.arrayIndices[0])
+				assert.Equal(t, filnested.ArrayIndex{RelPath: "", Index: 0}, pv.nested.arrayIndices[0])
 			},
 		},
 		{
@@ -256,8 +256,8 @@ func TestExtractNestedProp(t *testing.T) {
 				assert.Equal(t, "numbers", pv.nested.relPath)
 				assert.True(t, pv.nested.isNested)
 				require.Len(t, pv.nested.arrayIndices, 2)
-				assert.Equal(t, nested.ArrayIndex{RelPath: "", Index: 0}, pv.nested.arrayIndices[0])
-				assert.Equal(t, nested.ArrayIndex{RelPath: "numbers", Index: 2}, pv.nested.arrayIndices[1])
+				assert.Equal(t, filnested.ArrayIndex{RelPath: "", Index: 0}, pv.nested.arrayIndices[0])
+				assert.Equal(t, filnested.ArrayIndex{RelPath: "numbers", Index: 2}, pv.nested.arrayIndices[1])
 			},
 		},
 		{


### PR DESCRIPTION
## Nested Object Filtering — Part 9

  This pull request refactors the correlated AND resolver from a recursive plan tree to a flat execution plan, fixes a correctness bug in arr[N] cross-index AND filters, and adds comprehensive integration tests covering all plan cases, arr[N] combinations, and IsNull+arr[N] interactions.

  ## Flat Execution Plan

  Replaces the previous recursive `resolutionPlan` tree with a flat `executionPlan` (`[]conditionGroup`). Each group carries one of three ops determined by the common ObjectArray LCA of its paths:

  - **`groupAndAll`** — positions are naturally aligned; raw `AndAll` on full 64-bit positions is sufficient
  - **`groupAndAllMaskLeaf`** — root-level array; `root_idx` already encodes element identity, no idx loop needed
  - **`groupRunIdxLoop`** — intermediate array; must iterate `_idx.{lcaPath}[N]` entries to verify same-element semantics

  `groupAndAllMaskLeaf` raw bitmaps fold directly into the final `AndAllMaskLeaf` step, eliminating one intermediate bitmap allocation per group. `runIdxLoop` sorts conditions by cardinality, builds a preFilter, and uses `MaskLeafAnd` per element with early exit when the result reaches preFilter cardinality.

  ## Bug Fix: arr[N] Cross-Index AND

  Conditions sharing a `relPath` but carrying different arr[N] constraints (e.g. `cars[1].colors="red" AND cars[0].colors="blue"`) were incorrectly merged into a single correlated AND requiring same-element semantics, always returning empty even when the document satisfied both conditions.

  `groupChildrenByArrayIndicesKey` now partitions children by their `arrayIndices.groupKey()`. Groups with the same key use the existing same-element executor; groups with different keys are resolved independently and ANDed at docID level.

  ## Type Improvements

  - `nestedInfo`, `arrayIndices`, and `arrayIndices.groupKey()` consolidated into `prop_value_pairs_nested.go`
  - `arrayIndices` is a named type (`[]filnested.ArrayIndex`) with a `groupKey()` method replacing a standalone free function

  ## Testing

  The PR includes unit tests for the plan builder (35+ cases) and executor, with regression cases pinning that depth-1 intermediate arrays always require `groupRunIdxLoop`. Integration tests cover all plan op combinations across both `DataTypeObject` and `DataTypeObjectArray` root properties, with negative cases for cross-root and same-root intermediate-split scenarios. Additional tests verify the full `extractPropValuePair` → `resolveDocIDs` pipeline for IsNull+arr[N], scalar and multi-level arr[N], mixed constrained/unconstrained AND filters, and the cross-index AND fix.