### PR TITLE
fix(ttl): guarantee tenant re-deactivation when TTL context is canceled mid-deletion

### DIFF
--- a/adapters/repos/db/index_objects_ttl.go
+++ b/adapters/repos/db/index_objects_ttl.go
@@ -405,9 +405,8 @@ func (l *tenantTTLLoop) ensureDeactivation(ec errorcompounder.ErrorCompounder, d
 		return
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), ttlDeactivateTimeout)
-	err := l.mgr.DeactivateTenants(ctx, l.class, l.tenant)
-	cancel() // release timer resources after the call completes
-	if err != nil {
+	defer cancel()
+	if err := l.mgr.DeactivateTenants(ctx, l.class, l.tenant); err != nil {
 		ec.AddGroups(fmt.Errorf("deactivate tenant: %w", err), l.class, l.tenant)
 	}
 }

--- a/adapters/repos/db/index_objects_ttl.go
+++ b/adapters/repos/db/index_objects_ttl.go
@@ -99,6 +99,8 @@ func (i *Index) incomingDeleteObjectsExpired(ctx context.Context, eg *enterrors.
 
 		for _, tenant := range tenants {
 			eg.Go(func() error {
+				// processedBatches is intentionally shared between the findUUIDs and processBatch
+				// closures below — both run within this single goroutine, so there is no race.
 				processedBatches := 0
 
 				loop := tenantTTLLoop{

--- a/adapters/repos/db/index_objects_ttl.go
+++ b/adapters/repos/db/index_objects_ttl.go
@@ -29,6 +29,12 @@ import (
 	"github.com/weaviate/weaviate/usecases/multitenancy"
 )
 
+// ttlTenantsManager is the subset of schemaUC.TenantsActivityManager used by processTenantTTLLoop.
+type ttlTenantsManager interface {
+	TenantsStatus(class string, tenants ...string) (map[string]string, error)
+	DeactivateTenants(ctx context.Context, class string, tenants ...string) error
+}
+
 func (i *Index) IncomingDeleteObjectsExpired(ctx context.Context, eg *enterrors.ErrorGroupWrapper, ec errorcompounder.ErrorCompounder,
 	deleteOnPropName string, ttlThreshold, deletionTime time.Time, countDeleted func(int32), schemaVersion uint64,
 ) {
@@ -75,62 +81,32 @@ func (i *Index) incomingDeleteObjectsExpired(ctx context.Context, eg *enterrors.
 
 		for _, tenant := range tenants {
 			eg.Go(func() error {
-				deactivate := false
-				activityChecked := false
 				processedBatches := 0
-				// find uuids up to limit -> delete -> find uuids up to limit -> delete -> ... until no uuids left
-				for {
-					if err := context.Cause(ctx); err != nil {
-						ec.AddGroups(err, class.Class, tenant)
-						return nil
-					}
 
-					// if autoActivationEnabled, findUUIDsForExpiredObjects/findUUIDs call will implicitly activate tenant.
-					// activated tenant should be deactivated back after finished deletions
-					if autoActivationEnabled && !activityChecked {
-						tenants2status, err := i.tenantsManager.TenantsStatus(class.Class, tenant)
-						if err != nil {
-							ec.AddGroups(fmt.Errorf("check activity status: %w", err), class.Class, tenant)
-							return nil
-						}
-						deactivate = tenants2status[tenant] == models.TenantActivityStatusCOLD
-						activityChecked = true
-					}
-
+				// findUUIDs and processBatch are closures that bind the Index's storage
+				// operations so that processTenantTTLLoop can be unit-tested without storage.
+				findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) {
 					perShardLimit := i.Config.ObjectsTTLBatchSize.Get()
 					tenants2uuids, err := i.findUUIDsForExpiredObjects(ctx, filter, tenant, replProps, perShardLimit)
 					if err != nil {
-						// skip inactive tenants
-						if !errors.Is(err, enterrors.ErrTenantNotActive) {
-							ec.AddGroups(fmt.Errorf("find uuids: %w", err), class.Class, tenant)
-						}
-						return nil
+						return nil, err
 					}
+					return tenants2uuids[tenant], nil
+				}
 
-					uuids := tenants2uuids[tenant]
-					if len(uuids) == 0 {
-						if deactivate {
-							if err := i.tenantsManager.DeactivateTenants(ctx, class.Class, tenant); err != nil {
-								ec.AddGroups(fmt.Errorf("deactivate tenant: %w", err), class.Class, tenant)
-							}
-						}
-						return nil
-					}
-
+				processBatch := func(ctx context.Context, uuids []strfmt.UUID) error {
 					if err := i.incomingDeleteObjectsExpiredUuids(ctx, deletionTime, "", tenant,
 						uuids, countDeleted, replProps, schemaVersion); err != nil {
 						ec.AddGroups(fmt.Errorf("batch delete: %w", err), class.Class, tenant)
 					}
 					processedBatches++
-
-					pauseEveryNoBatches := i.Config.ObjectsTTLPauseEveryNoBatches.Get()
-					pauseDuration := i.Config.ObjectsTTLPauseDuration.Get()
-					if pauseDuration > 0 && pauseEveryNoBatches > 0 && processedBatches >= pauseEveryNoBatches {
+					pauseEvery := i.Config.ObjectsTTLPauseEveryNoBatches.Get()
+					pauseDur := i.Config.ObjectsTTLPauseDuration.Get()
+					if pauseDur > 0 && pauseEvery > 0 && processedBatches >= pauseEvery {
 						t1 := time.Now()
-						t2, err := sleepWithCtx(ctx, pauseDuration)
-						if err != nil {
-							ec.AddGroups(err, class.Class, tenant)
-							return nil
+						t2, sleepErr := sleepWithCtx(ctx, pauseDur)
+						if sleepErr != nil {
+							return sleepErr // caller adds to ec and stops the loop
 						}
 						i.logger.WithFields(logrus.Fields{
 							"action":     "objects_ttl_deletion",
@@ -139,7 +115,12 @@ func (i *Index) incomingDeleteObjectsExpired(ctx context.Context, eg *enterrors.
 						}).Debugf("paused for %s after processing %d batches", t2.Sub(t1), processedBatches)
 						processedBatches = 0
 					}
+					return nil
 				}
+
+				processTenantTTLLoop(ctx, ec, class.Class, tenant, autoActivationEnabled,
+					i.tenantsManager, findUUIDs, processBatch)
+				return nil
 			})
 			if ctx.Err() != nil {
 				break
@@ -330,6 +311,80 @@ func (i *Index) findUUIDsForExpiredObjects(ctx context.Context,
 	}()
 
 	return i.findUUIDs(ctx, filters, tenant, repl, perShardLimit)
+}
+
+// processTenantTTLLoop runs the TTL deletion loop for a single multi-tenant shard.
+//
+// findUUIDs is called each iteration to obtain the next batch of expired UUIDs for the
+// tenant. Returning (nil, nil) signals completion. Returning enterrors.ErrTenantNotActive
+// silently skips the tenant (it was never activated).
+//
+// processBatch is called for each non-empty batch. It should accumulate batch-level
+// errors in ec itself and return nil; return non-nil only when the loop must stop
+// (e.g. context cancellation during a configured pause sleep).
+//
+// When autoActivationEnabled is true and TenantsStatus reports the tenant is COLD,
+// DeactivateTenants is guaranteed to be called on exit — even if ctx is canceled — via
+// a deferred call with context.Background(). This prevents a previously-COLD tenant from
+// being left permanently HOT when a concurrent RAFT operation (e.g. another TTL round's
+// own DeactivateTenants propagation) cancels the TTL context mid-deletion.
+func processTenantTTLLoop(
+	ctx context.Context,
+	ec errorcompounder.ErrorCompounder,
+	class, tenant string,
+	autoActivationEnabled bool,
+	mgr ttlTenantsManager,
+	findUUIDs func(ctx context.Context) ([]strfmt.UUID, error),
+	processBatch func(ctx context.Context, uuids []strfmt.UUID) error,
+) {
+	deactivate := false
+	activityChecked := false
+
+	// Ensure the tenant is re-deactivated even if ctx is canceled mid-deletion.
+	// Uses context.Background() so the RAFT call completes regardless of TTL context state.
+	defer func() {
+		if deactivate {
+			if deactErr := mgr.DeactivateTenants(context.Background(), class, tenant); deactErr != nil {
+				ec.AddGroups(fmt.Errorf("deactivate tenant: %w", deactErr), class, tenant)
+			}
+		}
+	}()
+
+	for {
+		if err := context.Cause(ctx); err != nil {
+			ec.AddGroups(err, class, tenant)
+			return // deferred call above handles re-deactivation
+		}
+
+		// If autoActivationEnabled, the findUUIDs call will implicitly activate the tenant via
+		// RAFT. Record whether it was COLD so we can re-deactivate it when done.
+		if autoActivationEnabled && !activityChecked {
+			tenants2status, err := mgr.TenantsStatus(class, tenant)
+			if err != nil {
+				ec.AddGroups(fmt.Errorf("check activity status: %w", err), class, tenant)
+				return
+			}
+			deactivate = tenants2status[tenant] == models.TenantActivityStatusCOLD
+			activityChecked = true
+		}
+
+		uuids, err := findUUIDs(ctx)
+		if err != nil {
+			if !errors.Is(err, enterrors.ErrTenantNotActive) {
+				ec.AddGroups(fmt.Errorf("find uuids: %w", err), class, tenant)
+			}
+			return // deferred call above handles re-deactivation
+		}
+
+		if len(uuids) == 0 {
+			return // deferred call above handles re-deactivation
+		}
+
+		if err := processBatch(ctx, uuids); err != nil {
+			ec.AddGroups(err, class, tenant)
+			return
+		}
+	}
 }
 
 func sleepWithCtx(ctx context.Context, d time.Duration) (val time.Time, err error) {

--- a/adapters/repos/db/index_objects_ttl.go
+++ b/adapters/repos/db/index_objects_ttl.go
@@ -29,10 +29,28 @@ import (
 	"github.com/weaviate/weaviate/usecases/multitenancy"
 )
 
-// ttlTenantsManager is the subset of schemaUC.TenantsActivityManager used by processTenantTTLLoop.
+// ttlTenantsManager is the subset of schemaUC.TenantsActivityManager used by tenantTTLLoop.
 type ttlTenantsManager interface {
 	TenantsStatus(class string, tenants ...string) (map[string]string, error)
 	DeactivateTenants(ctx context.Context, class string, tenants ...string) error
+}
+
+// ttlDeactivateTimeout bounds the deferred DeactivateTenants RAFT call so that a stuck or
+// partitioned leader cannot block the goroutine indefinitely.
+const ttlDeactivateTimeout = 30 * time.Second
+
+// tenantTTLLoop manages the TTL deletion loop for a single multi-tenant shard.
+//
+// When autoActivationEnabled is true and the tenant was COLD at the start of the loop, the
+// loop guarantees that DeactivateTenants is called on exit — even if ctx is canceled — via a
+// deferred call with a bounded timeout. This prevents a previously-COLD tenant from being
+// left permanently HOT when a concurrent RAFT operation cancels the TTL context mid-deletion.
+type tenantTTLLoop struct {
+	class, tenant         string
+	autoActivationEnabled bool
+	mgr                   ttlTenantsManager
+	findUUIDs             func(ctx context.Context) ([]strfmt.UUID, error)
+	processBatch          func(ctx context.Context, uuids []strfmt.UUID) error
 }
 
 func (i *Index) IncomingDeleteObjectsExpired(ctx context.Context, eg *enterrors.ErrorGroupWrapper, ec errorcompounder.ErrorCompounder,
@@ -83,43 +101,44 @@ func (i *Index) incomingDeleteObjectsExpired(ctx context.Context, eg *enterrors.
 			eg.Go(func() error {
 				processedBatches := 0
 
-				// findUUIDs and processBatch are closures that bind the Index's storage
-				// operations so that processTenantTTLLoop can be unit-tested without storage.
-				findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) {
-					perShardLimit := i.Config.ObjectsTTLBatchSize.Get()
-					tenants2uuids, err := i.findUUIDsForExpiredObjects(ctx, filter, tenant, replProps, perShardLimit)
-					if err != nil {
-						return nil, err
-					}
-					return tenants2uuids[tenant], nil
-				}
-
-				processBatch := func(ctx context.Context, uuids []strfmt.UUID) error {
-					if err := i.incomingDeleteObjectsExpiredUuids(ctx, deletionTime, "", tenant,
-						uuids, countDeleted, replProps, schemaVersion); err != nil {
-						ec.AddGroups(fmt.Errorf("batch delete: %w", err), class.Class, tenant)
-					}
-					processedBatches++
-					pauseEvery := i.Config.ObjectsTTLPauseEveryNoBatches.Get()
-					pauseDur := i.Config.ObjectsTTLPauseDuration.Get()
-					if pauseDur > 0 && pauseEvery > 0 && processedBatches >= pauseEvery {
-						t1 := time.Now()
-						t2, sleepErr := sleepWithCtx(ctx, pauseDur)
-						if sleepErr != nil {
-							return sleepErr // caller adds to ec and stops the loop
+				loop := tenantTTLLoop{
+					class:                 class.Class,
+					tenant:                tenant,
+					autoActivationEnabled: autoActivationEnabled,
+					mgr:                   i.tenantsManager,
+					findUUIDs: func(ctx context.Context) ([]strfmt.UUID, error) {
+						perShardLimit := i.Config.ObjectsTTLBatchSize.Get()
+						tenants2uuids, err := i.findUUIDsForExpiredObjects(ctx, filter, tenant, replProps, perShardLimit)
+						if err != nil {
+							return nil, err
 						}
-						i.logger.WithFields(logrus.Fields{
-							"action":     "objects_ttl_deletion",
-							"collection": class.Class,
-							"shard":      tenant,
-						}).Debugf("paused for %s after processing %d batches", t2.Sub(t1), processedBatches)
-						processedBatches = 0
-					}
-					return nil
+						return tenants2uuids[tenant], nil
+					},
+					processBatch: func(ctx context.Context, uuids []strfmt.UUID) error {
+						if err := i.incomingDeleteObjectsExpiredUuids(ctx, deletionTime, "", tenant,
+							uuids, countDeleted, replProps, schemaVersion); err != nil {
+							ec.AddGroups(fmt.Errorf("batch delete: %w", err), class.Class, tenant)
+						}
+						processedBatches++
+						pauseEvery := i.Config.ObjectsTTLPauseEveryNoBatches.Get()
+						pauseDur := i.Config.ObjectsTTLPauseDuration.Get()
+						if pauseDur > 0 && pauseEvery > 0 && processedBatches >= pauseEvery {
+							t1 := time.Now()
+							t2, sleepErr := sleepWithCtx(ctx, pauseDur)
+							if sleepErr != nil {
+								return sleepErr // caller adds to ec and stops the loop
+							}
+							i.logger.WithFields(logrus.Fields{
+								"action":     "objects_ttl_deletion",
+								"collection": class.Class,
+								"shard":      tenant,
+							}).Debugf("paused for %s after processing %d batches", t2.Sub(t1), processedBatches)
+							processedBatches = 0
+						}
+						return nil
+					},
 				}
-
-				processTenantTTLLoop(ctx, ec, class.Class, tenant, autoActivationEnabled,
-					i.tenantsManager, findUUIDs, processBatch)
+				loop.run(ctx, ec)
 				return nil
 			})
 			if ctx.Err() != nil {
@@ -313,77 +332,81 @@ func (i *Index) findUUIDsForExpiredObjects(ctx context.Context,
 	return i.findUUIDs(ctx, filters, tenant, repl, perShardLimit)
 }
 
-// processTenantTTLLoop runs the TTL deletion loop for a single multi-tenant shard.
-//
-// findUUIDs is called each iteration to obtain the next batch of expired UUIDs for the
-// tenant. Returning (nil, nil) signals completion. Returning enterrors.ErrTenantNotActive
-// silently skips the tenant (it was never activated).
-//
-// processBatch is called for each non-empty batch. It should accumulate batch-level
-// errors in ec itself and return nil; return non-nil only when the loop must stop
-// (e.g. context cancellation during a configured pause sleep).
-//
-// When autoActivationEnabled is true and TenantsStatus reports the tenant is COLD,
-// DeactivateTenants is guaranteed to be called on exit — even if ctx is canceled — via
-// a deferred call with context.Background(). This prevents a previously-COLD tenant from
-// being left permanently HOT when a concurrent RAFT operation (e.g. another TTL round's
-// own DeactivateTenants propagation) cancels the TTL context mid-deletion.
-func processTenantTTLLoop(
-	ctx context.Context,
-	ec errorcompounder.ErrorCompounder,
-	class, tenant string,
-	autoActivationEnabled bool,
-	mgr ttlTenantsManager,
-	findUUIDs func(ctx context.Context) ([]strfmt.UUID, error),
-	processBatch func(ctx context.Context, uuids []strfmt.UUID) error,
-) {
+// run executes the TTL deletion loop for this tenant.
+func (l *tenantTTLLoop) run(ctx context.Context, ec errorcompounder.ErrorCompounder) {
 	deactivate := false
 	activityChecked := false
 
-	// Ensure the tenant is re-deactivated even if ctx is canceled mid-deletion.
-	// Uses context.Background() so the RAFT call completes regardless of TTL context state.
-	defer func() {
-		if deactivate {
-			if deactErr := mgr.DeactivateTenants(context.Background(), class, tenant); deactErr != nil {
-				ec.AddGroups(fmt.Errorf("deactivate tenant: %w", deactErr), class, tenant)
-			}
-		}
-	}()
+	defer l.ensureDeactivation(ec, &deactivate)
 
 	for {
 		if err := context.Cause(ctx); err != nil {
-			ec.AddGroups(err, class, tenant)
-			return // deferred call above handles re-deactivation
+			ec.AddGroups(err, l.class, l.tenant)
+			return
 		}
 
-		// If autoActivationEnabled, the findUUIDs call will implicitly activate the tenant via
-		// RAFT. Record whether it was COLD so we can re-deactivate it when done.
-		if autoActivationEnabled && !activityChecked {
-			tenants2status, err := mgr.TenantsStatus(class, tenant)
+		if l.autoActivationEnabled && !activityChecked {
+			shouldDeactivate, err := l.checkActivity()
 			if err != nil {
-				ec.AddGroups(fmt.Errorf("check activity status: %w", err), class, tenant)
+				ec.AddGroups(err, l.class, l.tenant)
 				return
 			}
-			deactivate = tenants2status[tenant] == models.TenantActivityStatusCOLD
+			deactivate = shouldDeactivate
 			activityChecked = true
 		}
 
-		uuids, err := findUUIDs(ctx)
-		if err != nil {
-			if !errors.Is(err, enterrors.ErrTenantNotActive) {
-				ec.AddGroups(fmt.Errorf("find uuids: %w", err), class, tenant)
-			}
-			return // deferred call above handles re-deactivation
-		}
-
-		if len(uuids) == 0 {
-			return // deferred call above handles re-deactivation
-		}
-
-		if err := processBatch(ctx, uuids); err != nil {
-			ec.AddGroups(err, class, tenant)
+		if l.findAndDelete(ctx, ec, &deactivate) {
 			return
 		}
+	}
+}
+
+// checkActivity queries the tenant's current activity status.
+// Returns true when the tenant is COLD and should be re-deactivated after TTL processing.
+func (l *tenantTTLLoop) checkActivity() (shouldDeactivate bool, err error) {
+	tenants2status, err := l.mgr.TenantsStatus(l.class, l.tenant)
+	if err != nil {
+		return false, fmt.Errorf("check activity status: %w", err)
+	}
+	return tenants2status[l.tenant] == models.TenantActivityStatusCOLD, nil
+}
+
+// findAndDelete fetches the next batch of expired UUIDs and deletes them.
+// Returns true when the loop should stop (no more work, or an error occurred).
+func (l *tenantTTLLoop) findAndDelete(ctx context.Context, ec errorcompounder.ErrorCompounder, deactivate *bool) (done bool) {
+	uuids, err := l.findUUIDs(ctx)
+	if err != nil {
+		if errors.Is(err, enterrors.ErrTenantNotActive) {
+			// The tenant was never successfully activated — no RAFT deactivation needed.
+			*deactivate = false
+		} else {
+			ec.AddGroups(fmt.Errorf("find uuids: %w", err), l.class, l.tenant)
+		}
+		return true
+	}
+
+	if len(uuids) == 0 {
+		return true
+	}
+
+	if err := l.processBatch(ctx, uuids); err != nil {
+		ec.AddGroups(err, l.class, l.tenant)
+		return true
+	}
+	return false
+}
+
+// ensureDeactivation re-deactivates the tenant if it was auto-activated for TTL processing.
+// Uses a bounded timeout so a stuck RAFT call cannot block the goroutine indefinitely.
+func (l *tenantTTLLoop) ensureDeactivation(ec errorcompounder.ErrorCompounder, deactivate *bool) {
+	if !*deactivate {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), ttlDeactivateTimeout)
+	err := l.mgr.DeactivateTenants(ctx, l.class, l.tenant)
+	cancel() // release timer resources after the call completes
+	if err != nil {
+		ec.AddGroups(fmt.Errorf("deactivate tenant: %w", err), l.class, l.tenant)
 	}
 }
 

--- a/adapters/repos/db/index_objects_ttl_test.go
+++ b/adapters/repos/db/index_objects_ttl_test.go
@@ -1,0 +1,261 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync/atomic"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/errorcompounder"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// fakeTTLTenantsManager implements the ttlTenantsManager interface for testing.
+type fakeTTLTenantsManager struct {
+	// statusMap controls what TenantsStatus returns: tenant name → activity status string.
+	statusMap map[string]string
+	// statusErr, if non-nil, is returned by TenantsStatus.
+	statusErr error
+
+	// deactivateCalled records each call to DeactivateTenants.
+	deactivateCalled []deactivateCall
+	// deactivateErr, if non-nil, is returned by DeactivateTenants.
+	deactivateErr error
+}
+
+type deactivateCall struct {
+	ctx    context.Context
+	class  string
+	tenant string
+}
+
+func (f *fakeTTLTenantsManager) TenantsStatus(class string, tenants ...string) (map[string]string, error) {
+	if f.statusErr != nil {
+		return nil, f.statusErr
+	}
+	result := make(map[string]string, len(tenants))
+	for _, t := range tenants {
+		if s, ok := f.statusMap[t]; ok {
+			result[t] = s
+		}
+	}
+	return result, nil
+}
+
+func (f *fakeTTLTenantsManager) DeactivateTenants(ctx context.Context, class string, tenants ...string) error {
+	for _, t := range tenants {
+		f.deactivateCalled = append(f.deactivateCalled, deactivateCall{ctx: ctx, class: class, tenant: t})
+	}
+	return f.deactivateErr
+}
+
+// TestProcessTenantTTLLoop_ContextCancelAfterActivation is the primary regression test for
+// the server bug reported in:
+//
+//	test_tenant_auto_activation_during_ttl_deletion (weaviate-e2e-tests CI failure, 2026-04-13)
+//
+// Root cause: when a previously-COLD (inactive) tenant was auto-activated by the TTL loop
+// and a concurrent RAFT DeactivateTenants propagation from another node canceled the TTL
+// context mid-deletion, the goroutine exited without calling DeactivateTenants. The tenant
+// remained permanently HOT/ACTIVE.
+//
+// Fix: deferred DeactivateTenants call using context.Background() in processTenantTTLLoop.
+func TestProcessTenantTTLLoop_ContextCancelAfterActivation(t *testing.T) {
+	const (
+		class  = "MyClass"
+		tenant = "tenant_0"
+	)
+
+	// The tenant was COLD (inactive) before the TTL run — it should be re-deactivated on exit.
+	mgr := &fakeTTLTenantsManager{
+		statusMap: map[string]string{
+			tenant: models.TenantActivityStatusCOLD,
+		},
+	}
+
+	// cancelCtx simulates the TTL context being canceled mid-deletion (e.g. by a concurrent
+	// RAFT DeactivateTenants propagation from another node completing its own TTL round).
+	cancelCtx, cancel := context.WithCancelCause(context.Background())
+
+	batchesProcessed := 0
+	uuids := []strfmt.UUID{"uuid-1", "uuid-2", "uuid-3"}
+
+	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) {
+		if batchesProcessed == 0 {
+			// First call: return a non-empty batch so the loop makes progress.
+			return uuids, nil
+		}
+		// Second call: context is already canceled; processTenantTTLLoop detects this at
+		// the top of the loop and exits before reaching findUUIDs again. This path is
+		// reached only if the loop doesn't check ctx.Err() between batches (a regression).
+		return nil, nil
+	}
+
+	processBatch := func(ctx context.Context, got []strfmt.UUID) error {
+		batchesProcessed++
+		// Simulate a concurrent RAFT event canceling the TTL context after the first batch.
+		cancel(fmt.Errorf("concurrent raft deactivation canceled ttl context"))
+		return nil
+	}
+
+	ec := errorcompounder.New()
+	processTenantTTLLoop(cancelCtx, ec, class, tenant,
+		true /*autoActivationEnabled*/, mgr, findUUIDs, processBatch)
+
+	// The loop must have exited (at the second ctx check after the first batch).
+	require.Equal(t, 1, batchesProcessed, "expected exactly one batch before context cancel")
+
+	// KEY ASSERTION: DeactivateTenants must be called even though the context was canceled.
+	require.Len(t, mgr.deactivateCalled, 1, "DeactivateTenants must be called exactly once")
+	call := mgr.deactivateCalled[0]
+	assert.Equal(t, class, call.class)
+	assert.Equal(t, tenant, call.tenant)
+
+	// The deactivation call must use context.Background() — not the canceled TTL context —
+	// so it completes even after the TTL round's context is done.
+	assert.NoError(t, call.ctx.Err(),
+		"DeactivateTenants must be called with a non-canceled context (context.Background())")
+}
+
+func TestProcessTenantTTLLoop_NormalCompletion_Deactivates(t *testing.T) {
+	const (
+		class  = "MyClass"
+		tenant = "tenant_0"
+	)
+
+	mgr := &fakeTTLTenantsManager{
+		statusMap: map[string]string{tenant: models.TenantActivityStatusCOLD},
+	}
+
+	calls := atomic.Int32{}
+	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) {
+		n := calls.Add(1)
+		if n == 1 {
+			return []strfmt.UUID{"uuid-1"}, nil
+		}
+		return nil, nil // second call: empty → signals completion
+	}
+	processBatch := func(ctx context.Context, uuids []strfmt.UUID) error { return nil }
+
+	ec := errorcompounder.New()
+	processTenantTTLLoop(context.Background(), ec, class, tenant,
+		true, mgr, findUUIDs, processBatch)
+
+	assert.NoError(t, ec.ToError())
+	require.Len(t, mgr.deactivateCalled, 1)
+	assert.Equal(t, tenant, mgr.deactivateCalled[0].tenant)
+}
+
+func TestProcessTenantTTLLoop_ActiveTenant_NoDeactivation(t *testing.T) {
+	// A tenant that was already HOT (active) must not be deactivated.
+	mgr := &fakeTTLTenantsManager{
+		statusMap: map[string]string{"tenant_hot": models.TenantActivityStatusHOT},
+	}
+
+	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) { return nil, nil }
+	processBatch := func(ctx context.Context, uuids []strfmt.UUID) error { return nil }
+
+	ec := errorcompounder.New()
+	processTenantTTLLoop(context.Background(), ec, "MyClass", "tenant_hot",
+		true, mgr, findUUIDs, processBatch)
+
+	assert.Empty(t, mgr.deactivateCalled, "active tenant must not be deactivated")
+}
+
+func TestProcessTenantTTLLoop_AutoActivationDisabled_NoDeactivation(t *testing.T) {
+	// When autoActivationEnabled is false, TenantsStatus is never checked and
+	// deactivation must never happen.
+	mgr := &fakeTTLTenantsManager{
+		statusMap: map[string]string{"tenant_0": models.TenantActivityStatusCOLD},
+	}
+
+	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) { return nil, nil }
+	processBatch := func(ctx context.Context, uuids []strfmt.UUID) error { return nil }
+
+	ec := errorcompounder.New()
+	processTenantTTLLoop(context.Background(), ec, "MyClass", "tenant_0",
+		false /*autoActivationEnabled=false*/, mgr, findUUIDs, processBatch)
+
+	assert.Empty(t, mgr.deactivateCalled)
+}
+
+func TestProcessTenantTTLLoop_TenantNotActive_Skipped(t *testing.T) {
+	// findUUIDs returning ErrTenantNotActive should be silently skipped and must not
+	// add anything to ec.
+	mgr := &fakeTTLTenantsManager{
+		statusMap: map[string]string{"tenant_0": models.TenantActivityStatusCOLD},
+	}
+
+	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) {
+		return nil, enterrors.ErrTenantNotActive
+	}
+	processBatch := func(ctx context.Context, uuids []strfmt.UUID) error { return nil }
+
+	ec := errorcompounder.New()
+	processTenantTTLLoop(context.Background(), ec, "MyClass", "tenant_0",
+		true, mgr, findUUIDs, processBatch)
+
+	assert.NoError(t, ec.ToError(), "ErrTenantNotActive must be silently ignored")
+}
+
+func TestProcessTenantTTLLoop_ContextAlreadyCanceled(t *testing.T) {
+	// If the context is already canceled on entry the loop must exit immediately without
+	// calling TenantsStatus, findUUIDs, or processBatch.
+	mgr := &fakeTTLTenantsManager{
+		statusMap: map[string]string{"tenant_0": models.TenantActivityStatusCOLD},
+	}
+
+	ctx, cancel := context.WithCancelCause(context.Background())
+	cancel(errors.New("pre-canceled"))
+
+	called := false
+	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) {
+		called = true
+		return nil, nil
+	}
+	processBatch := func(ctx context.Context, uuids []strfmt.UUID) error { return nil }
+
+	ec := errorcompounder.New()
+	processTenantTTLLoop(ctx, ec, "MyClass", "tenant_0", true, mgr, findUUIDs, processBatch)
+
+	assert.False(t, called, "findUUIDs must not be called when context is already canceled")
+	// deactivate was never set (TenantsStatus was never called), so no deactivation.
+	assert.Empty(t, mgr.deactivateCalled)
+}
+
+func TestProcessTenantTTLLoop_DeactivateError_ReportedInEc(t *testing.T) {
+	// A failure in DeactivateTenants must be surfaced via ec, not silently swallowed.
+	deactivateErr := errors.New("raft timeout")
+	mgr := &fakeTTLTenantsManager{
+		statusMap:     map[string]string{"tenant_0": models.TenantActivityStatusCOLD},
+		deactivateErr: deactivateErr,
+	}
+
+	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) { return nil, nil }
+	processBatch := func(ctx context.Context, uuids []strfmt.UUID) error { return nil }
+
+	ec := errorcompounder.New()
+	processTenantTTLLoop(context.Background(), ec, "MyClass", "tenant_0",
+		true, mgr, findUUIDs, processBatch)
+
+	err := ec.ToError()
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "deactivate tenant")
+	assert.ErrorContains(t, err, "raft timeout")
+}

--- a/adapters/repos/db/index_objects_ttl_test.go
+++ b/adapters/repos/db/index_objects_ttl_test.go
@@ -28,21 +28,18 @@ import (
 
 // fakeTTLTenantsManager implements the ttlTenantsManager interface for testing.
 type fakeTTLTenantsManager struct {
-	// statusMap controls what TenantsStatus returns: tenant name → activity status string.
-	statusMap map[string]string
-	// statusErr, if non-nil, is returned by TenantsStatus.
-	statusErr error
+	statusMap map[string]string // tenant name → activity status
+	statusErr error             // if non-nil, returned by TenantsStatus
 
-	// deactivateCalled records each call to DeactivateTenants.
-	deactivateCalled []deactivateCall
-	// deactivateErr, if non-nil, is returned by DeactivateTenants.
-	deactivateErr error
+	deactivateCalled []deactivateCall // records each DeactivateTenants call
+	deactivateErr    error            // if non-nil, returned by DeactivateTenants
 }
 
 type deactivateCall struct {
-	ctx    context.Context
-	class  string
-	tenant string
+	ctxWasLive  bool // ctx.Err() == nil at the time of the call
+	hasDeadline bool // context had a deadline (from WithTimeout)
+	class       string
+	tenant      string
 }
 
 func (f *fakeTTLTenantsManager) TenantsStatus(class string, tenants ...string) (map[string]string, error) {
@@ -59,13 +56,37 @@ func (f *fakeTTLTenantsManager) TenantsStatus(class string, tenants ...string) (
 }
 
 func (f *fakeTTLTenantsManager) DeactivateTenants(ctx context.Context, class string, tenants ...string) error {
+	_, hasDeadline := ctx.Deadline()
 	for _, t := range tenants {
-		f.deactivateCalled = append(f.deactivateCalled, deactivateCall{ctx: ctx, class: class, tenant: t})
+		f.deactivateCalled = append(f.deactivateCalled, deactivateCall{
+			ctxWasLive:  ctx.Err() == nil,
+			hasDeadline: hasDeadline,
+			class:       class,
+			tenant:      t,
+		})
 	}
 	return f.deactivateErr
 }
 
-// TestProcessTenantTTLLoop_ContextCancelAfterActivation is the primary regression test for
+func newTestLoop(t *testing.T, mgr *fakeTTLTenantsManager, autoActivation bool,
+	findFn func(ctx context.Context) ([]strfmt.UUID, error),
+	batchFn func(ctx context.Context, uuids []strfmt.UUID) error,
+) tenantTTLLoop {
+	t.Helper()
+	if batchFn == nil {
+		batchFn = func(context.Context, []strfmt.UUID) error { return nil }
+	}
+	return tenantTTLLoop{
+		class:                 "MyClass",
+		tenant:                "tenant_0",
+		autoActivationEnabled: autoActivation,
+		mgr:                   mgr,
+		findUUIDs:             findFn,
+		processBatch:          batchFn,
+	}
+}
+
+// TestTenantTTLLoop_ContextCancelAfterActivation is the primary regression test for
 // the server bug reported in:
 //
 //	test_tenant_auto_activation_during_ttl_deletion (weaviate-e2e-tests CI failure, 2026-04-13)
@@ -75,18 +96,10 @@ func (f *fakeTTLTenantsManager) DeactivateTenants(ctx context.Context, class str
 // context mid-deletion, the goroutine exited without calling DeactivateTenants. The tenant
 // remained permanently HOT/ACTIVE.
 //
-// Fix: deferred DeactivateTenants call using context.Background() in processTenantTTLLoop.
-func TestProcessTenantTTLLoop_ContextCancelAfterActivation(t *testing.T) {
-	const (
-		class  = "MyClass"
-		tenant = "tenant_0"
-	)
-
-	// The tenant was COLD (inactive) before the TTL run — it should be re-deactivated on exit.
+// Fix: deferred DeactivateTenants with bounded timeout in tenantTTLLoop.ensureDeactivation.
+func TestTenantTTLLoop_ContextCancelAfterActivation(t *testing.T) {
 	mgr := &fakeTTLTenantsManager{
-		statusMap: map[string]string{
-			tenant: models.TenantActivityStatusCOLD,
-		},
+		statusMap: map[string]string{"tenant_0": models.TenantActivityStatusCOLD},
 	}
 
 	// cancelCtx simulates the TTL context being canceled mid-deletion (e.g. by a concurrent
@@ -94,129 +107,120 @@ func TestProcessTenantTTLLoop_ContextCancelAfterActivation(t *testing.T) {
 	cancelCtx, cancel := context.WithCancelCause(context.Background())
 
 	batchesProcessed := 0
-	uuids := []strfmt.UUID{"uuid-1", "uuid-2", "uuid-3"}
-
-	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) {
-		if batchesProcessed == 0 {
-			// First call: return a non-empty batch so the loop makes progress.
-			return uuids, nil
-		}
-		// Second call: context is already canceled; processTenantTTLLoop detects this at
-		// the top of the loop and exits before reaching findUUIDs again. This path is
-		// reached only if the loop doesn't check ctx.Err() between batches (a regression).
-		return nil, nil
-	}
-
-	processBatch := func(ctx context.Context, got []strfmt.UUID) error {
-		batchesProcessed++
-		// Simulate a concurrent RAFT event canceling the TTL context after the first batch.
-		cancel(fmt.Errorf("concurrent raft deactivation canceled ttl context"))
-		return nil
-	}
+	loop := newTestLoop(t, mgr, true,
+		func(ctx context.Context) ([]strfmt.UUID, error) {
+			if batchesProcessed == 0 {
+				return []strfmt.UUID{"uuid-1", "uuid-2", "uuid-3"}, nil
+			}
+			// If we reach this point, the loop failed to detect context cancellation.
+			return nil, nil
+		},
+		func(ctx context.Context, _ []strfmt.UUID) error {
+			batchesProcessed++
+			// Simulate a concurrent RAFT event canceling the TTL context after the first batch.
+			cancel(fmt.Errorf("concurrent raft deactivation canceled ttl context"))
+			return nil
+		},
+	)
 
 	ec := errorcompounder.New()
-	processTenantTTLLoop(cancelCtx, ec, class, tenant,
-		true /*autoActivationEnabled*/, mgr, findUUIDs, processBatch)
+	loop.run(cancelCtx, ec)
 
-	// The loop must have exited (at the second ctx check after the first batch).
 	require.Equal(t, 1, batchesProcessed, "expected exactly one batch before context cancel")
 
 	// KEY ASSERTION: DeactivateTenants must be called even though the context was canceled.
 	require.Len(t, mgr.deactivateCalled, 1, "DeactivateTenants must be called exactly once")
 	call := mgr.deactivateCalled[0]
-	assert.Equal(t, class, call.class)
-	assert.Equal(t, tenant, call.tenant)
+	assert.Equal(t, "MyClass", call.class)
+	assert.Equal(t, "tenant_0", call.tenant)
 
-	// The deactivation call must use context.Background() — not the canceled TTL context —
-	// so it completes even after the TTL round's context is done.
-	assert.NoError(t, call.ctx.Err(),
-		"DeactivateTenants must be called with a non-canceled context (context.Background())")
+	// The deactivation call must use a live context (not the canceled TTL context)
+	// so the RAFT call can complete.
+	assert.True(t, call.ctxWasLive,
+		"DeactivateTenants must be called with a non-canceled context")
+	assert.True(t, call.hasDeadline,
+		"DeactivateTenants must be called with a timeout-bounded context")
 }
 
-func TestProcessTenantTTLLoop_NormalCompletion_Deactivates(t *testing.T) {
-	const (
-		class  = "MyClass"
-		tenant = "tenant_0"
-	)
-
+func TestTenantTTLLoop_NormalCompletion_Deactivates(t *testing.T) {
 	mgr := &fakeTTLTenantsManager{
-		statusMap: map[string]string{tenant: models.TenantActivityStatusCOLD},
+		statusMap: map[string]string{"tenant_0": models.TenantActivityStatusCOLD},
 	}
 
 	calls := atomic.Int32{}
-	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) {
-		n := calls.Add(1)
-		if n == 1 {
-			return []strfmt.UUID{"uuid-1"}, nil
-		}
-		return nil, nil // second call: empty → signals completion
-	}
-	processBatch := func(ctx context.Context, uuids []strfmt.UUID) error { return nil }
+	loop := newTestLoop(t, mgr, true,
+		func(ctx context.Context) ([]strfmt.UUID, error) {
+			if calls.Add(1) == 1 {
+				return []strfmt.UUID{"uuid-1"}, nil
+			}
+			return nil, nil
+		},
+		nil,
+	)
 
 	ec := errorcompounder.New()
-	processTenantTTLLoop(context.Background(), ec, class, tenant,
-		true, mgr, findUUIDs, processBatch)
+	loop.run(context.Background(), ec)
 
 	assert.NoError(t, ec.ToError())
 	require.Len(t, mgr.deactivateCalled, 1)
-	assert.Equal(t, tenant, mgr.deactivateCalled[0].tenant)
+	assert.Equal(t, "tenant_0", mgr.deactivateCalled[0].tenant)
 }
 
-func TestProcessTenantTTLLoop_ActiveTenant_NoDeactivation(t *testing.T) {
-	// A tenant that was already HOT (active) must not be deactivated.
+func TestTenantTTLLoop_ActiveTenant_NoDeactivation(t *testing.T) {
 	mgr := &fakeTTLTenantsManager{
-		statusMap: map[string]string{"tenant_hot": models.TenantActivityStatusHOT},
+		statusMap: map[string]string{"tenant_0": models.TenantActivityStatusHOT},
 	}
 
-	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) { return nil, nil }
-	processBatch := func(ctx context.Context, uuids []strfmt.UUID) error { return nil }
+	loop := newTestLoop(t, mgr, true,
+		func(ctx context.Context) ([]strfmt.UUID, error) { return nil, nil },
+		nil,
+	)
 
 	ec := errorcompounder.New()
-	processTenantTTLLoop(context.Background(), ec, "MyClass", "tenant_hot",
-		true, mgr, findUUIDs, processBatch)
+	loop.run(context.Background(), ec)
 
 	assert.Empty(t, mgr.deactivateCalled, "active tenant must not be deactivated")
 }
 
-func TestProcessTenantTTLLoop_AutoActivationDisabled_NoDeactivation(t *testing.T) {
-	// When autoActivationEnabled is false, TenantsStatus is never checked and
-	// deactivation must never happen.
+func TestTenantTTLLoop_AutoActivationDisabled_NoDeactivation(t *testing.T) {
 	mgr := &fakeTTLTenantsManager{
 		statusMap: map[string]string{"tenant_0": models.TenantActivityStatusCOLD},
 	}
 
-	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) { return nil, nil }
-	processBatch := func(ctx context.Context, uuids []strfmt.UUID) error { return nil }
+	loop := newTestLoop(t, mgr, false, // autoActivation disabled
+		func(ctx context.Context) ([]strfmt.UUID, error) { return nil, nil },
+		nil,
+	)
 
 	ec := errorcompounder.New()
-	processTenantTTLLoop(context.Background(), ec, "MyClass", "tenant_0",
-		false /*autoActivationEnabled=false*/, mgr, findUUIDs, processBatch)
+	loop.run(context.Background(), ec)
 
 	assert.Empty(t, mgr.deactivateCalled)
 }
 
-func TestProcessTenantTTLLoop_TenantNotActive_Skipped(t *testing.T) {
-	// findUUIDs returning ErrTenantNotActive should be silently skipped and must not
-	// add anything to ec.
+func TestTenantTTLLoop_TenantNotActive_NoDeactivation(t *testing.T) {
+	// findUUIDs returning ErrTenantNotActive means the tenant was never successfully
+	// activated. The loop should silently skip it AND must NOT trigger a RAFT
+	// DeactivateTenants call (the tenant is already COLD).
 	mgr := &fakeTTLTenantsManager{
 		statusMap: map[string]string{"tenant_0": models.TenantActivityStatusCOLD},
 	}
 
-	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) {
-		return nil, enterrors.ErrTenantNotActive
-	}
-	processBatch := func(ctx context.Context, uuids []strfmt.UUID) error { return nil }
+	loop := newTestLoop(t, mgr, true,
+		func(ctx context.Context) ([]strfmt.UUID, error) {
+			return nil, enterrors.ErrTenantNotActive
+		},
+		nil,
+	)
 
 	ec := errorcompounder.New()
-	processTenantTTLLoop(context.Background(), ec, "MyClass", "tenant_0",
-		true, mgr, findUUIDs, processBatch)
+	loop.run(context.Background(), ec)
 
 	assert.NoError(t, ec.ToError(), "ErrTenantNotActive must be silently ignored")
+	assert.Empty(t, mgr.deactivateCalled, "ErrTenantNotActive must not trigger deactivation")
 }
 
-func TestProcessTenantTTLLoop_ContextAlreadyCanceled(t *testing.T) {
-	// If the context is already canceled on entry the loop must exit immediately without
-	// calling TenantsStatus, findUUIDs, or processBatch.
+func TestTenantTTLLoop_ContextAlreadyCanceled(t *testing.T) {
 	mgr := &fakeTTLTenantsManager{
 		statusMap: map[string]string{"tenant_0": models.TenantActivityStatusCOLD},
 	}
@@ -224,38 +228,61 @@ func TestProcessTenantTTLLoop_ContextAlreadyCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancelCause(context.Background())
 	cancel(errors.New("pre-canceled"))
 
-	called := false
-	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) {
-		called = true
-		return nil, nil
-	}
-	processBatch := func(ctx context.Context, uuids []strfmt.UUID) error { return nil }
+	findCalled := false
+	loop := newTestLoop(t, mgr, true,
+		func(ctx context.Context) ([]strfmt.UUID, error) {
+			findCalled = true
+			return nil, nil
+		},
+		nil,
+	)
 
 	ec := errorcompounder.New()
-	processTenantTTLLoop(ctx, ec, "MyClass", "tenant_0", true, mgr, findUUIDs, processBatch)
+	loop.run(ctx, ec)
 
-	assert.False(t, called, "findUUIDs must not be called when context is already canceled")
+	assert.False(t, findCalled, "findUUIDs must not be called when context is already canceled")
 	// deactivate was never set (TenantsStatus was never called), so no deactivation.
 	assert.Empty(t, mgr.deactivateCalled)
 }
 
-func TestProcessTenantTTLLoop_DeactivateError_ReportedInEc(t *testing.T) {
-	// A failure in DeactivateTenants must be surfaced via ec, not silently swallowed.
-	deactivateErr := errors.New("raft timeout")
+func TestTenantTTLLoop_DeactivateError_ReportedInEc(t *testing.T) {
 	mgr := &fakeTTLTenantsManager{
 		statusMap:     map[string]string{"tenant_0": models.TenantActivityStatusCOLD},
-		deactivateErr: deactivateErr,
+		deactivateErr: errors.New("raft timeout"),
 	}
 
-	findUUIDs := func(ctx context.Context) ([]strfmt.UUID, error) { return nil, nil }
-	processBatch := func(ctx context.Context, uuids []strfmt.UUID) error { return nil }
+	loop := newTestLoop(t, mgr, true,
+		func(ctx context.Context) ([]strfmt.UUID, error) { return nil, nil },
+		nil,
+	)
 
 	ec := errorcompounder.New()
-	processTenantTTLLoop(context.Background(), ec, "MyClass", "tenant_0",
-		true, mgr, findUUIDs, processBatch)
+	loop.run(context.Background(), ec)
 
 	err := ec.ToError()
 	require.Error(t, err)
 	assert.ErrorContains(t, err, "deactivate tenant")
 	assert.ErrorContains(t, err, "raft timeout")
+}
+
+func TestTenantTTLLoop_DeactivateUsesTimeout(t *testing.T) {
+	// Verify the deferred DeactivateTenants call uses a bounded-timeout context,
+	// not a bare context.Background().
+	mgr := &fakeTTLTenantsManager{
+		statusMap: map[string]string{"tenant_0": models.TenantActivityStatusCOLD},
+	}
+
+	loop := newTestLoop(t, mgr, true,
+		func(ctx context.Context) ([]strfmt.UUID, error) { return nil, nil },
+		nil,
+	)
+
+	ec := errorcompounder.New()
+	loop.run(context.Background(), ec)
+
+	require.Len(t, mgr.deactivateCalled, 1)
+	call := mgr.deactivateCalled[0]
+
+	assert.True(t, call.ctxWasLive, "deactivation context must not be expired at call time")
+	assert.True(t, call.hasDeadline, "deactivation context must have a deadline (from WithTimeout)")
 }


### PR DESCRIPTION
## Summary

- Fixes weaviate/weaviate#11055
- Auto-activated (previously-COLD) tenants were being left permanently HOT when a concurrent RAFT event canceled the TTL context mid-deletion
- Root cause: the goroutine's context-canceled early-return path skipped the `DeactivateTenants` call
- Fix: deferred `DeactivateTenants` with bounded timeout in `tenantTTLLoop.ensureDeactivation`, so re-deactivation fires on every exit path

## Changes

**`adapters/repos/db/index_objects_ttl.go`**
- New `tenantTTLLoop` struct with four focused methods (`run`, `checkActivity`, `findAndDelete`, `ensureDeactivation`), replacing the inline goroutine body
- New `ttlTenantsManager` local interface (subset of `schemaUC.TenantsActivityManager` — only `TenantsStatus` and `DeactivateTenants`)
- The key fix: `ensureDeactivation` calls `mgr.DeactivateTenants(ctx, ...)` where `ctx` is `context.WithTimeout(context.Background(), 30s)`, ensuring the RAFT call completes even when the TTL context is canceled, with a bounded timeout to prevent indefinite goroutine hang
- `findAndDelete` clears `deactivate` on `ErrTenantNotActive` — the tenant was never activated, so RAFT deactivation is unnecessary

**`adapters/repos/db/index_objects_ttl_test.go`** (new file)
- 8 unit tests for `tenantTTLLoop`, no storage required, run with standard `go test`
- Primary regression test: `TestTenantTTLLoop_ContextCancelAfterActivation` — simulates context cancellation after the first batch and verifies `DeactivateTenants` is still called with a live, deadline-bounded context
- Test fake snapshots context state at call time (`ctxWasLive`, `hasDeadline`) for stable assertions regardless of post-call cleanup

## Test plan

- [x] `go test ./adapters/repos/db/ -run TestTenantTTLLoop` — all 8 pass
- [x] `go test ./adapters/repos/db/` — all existing package tests pass (no regression)
- [x] Red/green verified: removing the defer causes `ContextCancelAfterActivation` and `NormalCompletion_Deactivates` to fail
- [ ] CI e2e: `test_tenant_auto_activation_during_ttl_deletion` on multi-node cluster

## Related

- e2e timing fix PR: weaviate/weaviate-e2e-tests#288
- CI failure: https://github.com/weaviate/weaviate-e2e-tests/actions/runs/24344028938/job/71080878486

🤖 Generated with [Claude Code](https://claude.com/claude-code)