### PR TITLE
Improve compressed vector index cache

### DIFF
--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -448,6 +448,8 @@ type shardedMultipleLockCache[T float32 | uint64 | byte] struct {
 	deletionInterval       time.Duration
 	allocChecker           memwatch.AllocChecker
 	vectorDocID            []CacheKeys
+	// Only used by multi vector caches
+	fetchByNodeID bool
 
 	// The maintenanceLock makes sure that only one maintenance operation, such
 	// as growing the cache or clearing the cache happens at the same time.
@@ -521,6 +523,7 @@ func NewShardedMultiUInt64LockCache(multipleVecForID common.VectorForID[uint64],
 		deletionInterval:    deletionInterval,
 		allocChecker:        allocChecker,
 		vectorDocID:         make([]CacheKeys, InitialSize),
+		fetchByNodeID:       true,
 	}
 
 	vc.ctx, vc.cancelFn = context.WithCancel(context.Background())
@@ -554,6 +557,7 @@ func NewShardedMultiByteLockCache(multipleVecForID common.VectorForID[byte], max
 		deletionInterval:    deletionInterval,
 		allocChecker:        allocChecker,
 		vectorDocID:         make([]CacheKeys, InitialSize),
+		fetchByNodeID:       true,
 	}
 
 	vc.ctx, vc.cancelFn = context.WithCancel(context.Background())
@@ -667,7 +671,11 @@ func (s *shardedMultipleLockCache[T]) handleMultipleCacheMiss(ctx context.Contex
 		}
 	}
 
-	vec, err := s.multipleVectorForID(ctx, docID, relativeID)
+	fetchID := docID
+	if s.fetchByNodeID {
+		fetchID = id
+	}
+	vec, err := s.multipleVectorForID(ctx, fetchID, relativeID)
 	if err != nil {
 		return nil, err
 	}

--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -138,7 +138,8 @@ func (s *shardedLockCache[T]) Get(ctx context.Context, id uint64) ([]T, error) {
 	s.shardedLocks.RLock(id)
 	if int(id) >= len(s.cache) {
 		s.shardedLocks.RUnlock(id)
-		return nil, errors.Errorf("id %d is out of bounds", id)
+		s.Grow(id)
+		return s.handleCacheMiss(ctx, id)
 	}
 	vec := s.cache[id]
 	s.shardedLocks.RUnlock(id)
@@ -588,7 +589,9 @@ func (s *shardedMultipleLockCache[T]) Get(ctx context.Context, id uint64) ([]T, 
 	s.shardedLocks.RLock(id)
 	if int(id) >= len(s.cache) {
 		s.shardedLocks.RUnlock(id)
-		return nil, errors.Errorf("id %d is out of bounds", id)
+		s.Grow(id)
+		docID, relativeID := s.GetKeys(id)
+		return s.handleMultipleCacheMiss(ctx, id, docID, relativeID)
 	}
 	vec := s.cache[id]
 	s.shardedLocks.RUnlock(id)

--- a/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 func TestVectorCacheGrowth(t *testing.T) {
@@ -349,26 +350,36 @@ func TestMultiCacheCleanup(t *testing.T) {
 func TestGet_OutOfBounds(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 
-	t.Run("shardedLockCache returns error for out-of-bounds id", func(t *testing.T) {
-		vectorCache := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+	notFoundVecForID := func(ctx context.Context, id uint64) ([]float32, error) {
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+	notFoundMultiVecForID := func(ctx context.Context, id uint64) ([][]float32, error) {
+		return nil, storobj.NewErrNotFoundf(id, "not found")
+	}
+
+	t.Run("shardedLockCache grows and handles miss for out-of-bounds id", func(t *testing.T) {
+		vectorCache := NewShardedFloat32LockCache(notFoundVecForID, nil, 1_000_000, 1, logger, false, 0, nil)
 		cache := vectorCache.(*shardedLockCache[float32])
 
 		outOfBoundsID := uint64(len(cache.cache) + 1)
 		vec, err := cache.Get(context.Background(), outOfBoundsID)
 
 		assert.Nil(t, vec)
-		assert.ErrorContains(t, err, "out of bounds")
+		assert.Error(t, err)
+		// Cache should have grown to accommodate the ID.
+		assert.Greater(t, len(cache.cache), int(outOfBoundsID))
 	})
 
-	t.Run("shardedLockCache returns error for id exactly at cache length", func(t *testing.T) {
-		vectorCache := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+	t.Run("shardedLockCache grows and handles miss for id exactly at cache length", func(t *testing.T) {
+		vectorCache := NewShardedFloat32LockCache(notFoundVecForID, nil, 1_000_000, 1, logger, false, 0, nil)
 		cache := vectorCache.(*shardedLockCache[float32])
 
 		atBoundID := uint64(len(cache.cache))
 		vec, err := cache.Get(context.Background(), atBoundID)
 
 		assert.Nil(t, vec)
-		assert.ErrorContains(t, err, "out of bounds")
+		assert.Error(t, err)
+		assert.Greater(t, len(cache.cache), int(atBoundID))
 	})
 
 	t.Run("shardedLockCache returns vector for valid id", func(t *testing.T) {
@@ -383,28 +394,28 @@ func TestGet_OutOfBounds(t *testing.T) {
 		assert.Equal(t, expected, vec)
 	})
 
-	t.Run("shardedMultipleLockCache returns error for out-of-bounds id", func(t *testing.T) {
-		var multivecForId common.VectorForID[[]float32] = nil
-		vectorCache := NewShardedMultiFloat32LockCache(multivecForId, 1_000_000, logger, false, 0, nil)
+	t.Run("shardedMultipleLockCache grows and handles miss for out-of-bounds id", func(t *testing.T) {
+		vectorCache := NewShardedMultiFloat32LockCache(notFoundMultiVecForID, 1_000_000, logger, false, 0, nil)
 		cache := vectorCache.(*shardedMultipleLockCache[float32])
 
 		outOfBoundsID := uint64(len(cache.cache) + 1)
 		vec, err := cache.Get(context.Background(), outOfBoundsID)
 
 		assert.Nil(t, vec)
-		assert.ErrorContains(t, err, "out of bounds")
+		assert.Error(t, err)
+		assert.Greater(t, len(cache.cache), int(outOfBoundsID))
 	})
 
-	t.Run("shardedMultipleLockCache returns error for id exactly at cache length", func(t *testing.T) {
-		var multivecForId common.VectorForID[[]float32] = nil
-		vectorCache := NewShardedMultiFloat32LockCache(multivecForId, 1_000_000, logger, false, 0, nil)
+	t.Run("shardedMultipleLockCache grows and handles miss for id exactly at cache length", func(t *testing.T) {
+		vectorCache := NewShardedMultiFloat32LockCache(notFoundMultiVecForID, 1_000_000, logger, false, 0, nil)
 		cache := vectorCache.(*shardedMultipleLockCache[float32])
 
 		atBoundID := uint64(len(cache.cache))
 		vec, err := cache.Get(context.Background(), atBoundID)
 
 		assert.Nil(t, vec)
-		assert.ErrorContains(t, err, "out of bounds")
+		assert.Error(t, err)
+		assert.Greater(t, len(cache.cache), int(atBoundID))
 	})
 
 	t.Run("shardedMultipleLockCache returns vector for valid id", func(t *testing.T) {

--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/cache"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
@@ -93,6 +94,7 @@ type quantizedVectorsCompressor[T byte | uint64] struct {
 	minMMapSize     int64
 	maxWalReuseSize int64
 	allocChecker    memwatch.AllocChecker
+	vectorForID     common.VectorForID[float32]
 }
 
 func (compressor *quantizedVectorsCompressor[T]) Drop() error {
@@ -218,15 +220,36 @@ func (compressor *quantizedVectorsCompressor[T]) DistanceBetweenCompressedVector
 func (compressor *quantizedVectorsCompressor[T]) getCompressedVectorForID(ctx context.Context, id uint64) ([]T, error) {
 	idBytes := make([]byte, 8)
 	compressor.storeId(idBytes, id)
-	compressedVector, err := compressor.compressedStore.Bucket(helpers.GetCompressedBucketName(compressor.targetVector)).Get(idBytes)
+	bucket := compressor.compressedStore.Bucket(helpers.GetCompressedBucketName(compressor.targetVector))
+	compressedVector, err := bucket.Get(idBytes)
 	if err != nil {
 		return nil, errors.Wrap(err, "Getting vector for id")
 	}
 	if len(compressedVector) == 0 {
+		if compressor.vectorForID != nil {
+			return compressor.recoverCompressedVector(ctx, id, idBytes, bucket)
+		}
 		return nil, storobj.NewErrNotFoundf(id, "getCompressedVectorForID")
 	}
 
 	return compressor.quantizer.FromCompressedBytes(compressedVector), nil
+}
+
+// recoverCompressedVector fetches the raw vector, encodes it, and persists
+// it to the compressed bucket so future reads don't need recovery.
+func (compressor *quantizedVectorsCompressor[T]) recoverCompressedVector(
+	ctx context.Context, id uint64, idBytes []byte, bucket *lsmkv.Bucket,
+) ([]T, error) {
+	rawVec, err := compressor.vectorForID(ctx, id)
+	if err != nil {
+		return nil, err
+	}
+	if len(rawVec) == 0 {
+		return nil, storobj.NewErrNotFoundf(id, "recoverCompressedVector: empty raw vector")
+	}
+	compressed := compressor.quantizer.Encode(rawVec)
+	bucket.Put(idBytes, compressor.quantizer.CompressedBytes(compressed))
+	return compressed, nil
 }
 
 func (compressor *quantizedVectorsCompressor[T]) NewDistancer(vector []float32) (CompressorDistancer, ReturnDistancerFn) {
@@ -432,6 +455,7 @@ func NewHNSWPQCompressor(
 	maxWalReuseSize int64,
 	allocChecker memwatch.AllocChecker,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := NewProductQuantizer(cfg, distance, dimensions, logger)
 	if err != nil {
@@ -447,6 +471,7 @@ func NewHNSWPQCompressor(
 		minMMapSize:     minMMapSize,
 		maxWalReuseSize: maxWalReuseSize,
 		allocChecker:    allocChecker,
+		vectorForID:     vectorForID,
 	}
 	if err := pqVectorsCompressor.initCompressedStore(); err != nil {
 		return nil, err
@@ -474,6 +499,7 @@ func RestoreHNSWPQCompressor(
 	maxWalReuseSize int64,
 	allocChecker memwatch.AllocChecker,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := NewProductQuantizerWithEncoders(cfg, distance, dimensions, encoders, logger)
 	if err != nil {
@@ -489,6 +515,7 @@ func RestoreHNSWPQCompressor(
 		minMMapSize:     minMMapSize,
 		maxWalReuseSize: maxWalReuseSize,
 		allocChecker:    allocChecker,
+		vectorForID:     vectorForID,
 	}
 	if err := pqVectorsCompressor.initCompressedStore(); err != nil {
 		return nil, err
@@ -511,6 +538,7 @@ func NewHNSWPQMultiCompressor(
 	maxWalReuseSize int64,
 	allocChecker memwatch.AllocChecker,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := NewProductQuantizer(cfg, distance, dimensions, logger)
 	if err != nil {
@@ -526,6 +554,7 @@ func NewHNSWPQMultiCompressor(
 		minMMapSize:     minMMapSize,
 		maxWalReuseSize: maxWalReuseSize,
 		allocChecker:    allocChecker,
+		vectorForID:     vectorForID,
 	}
 	if err := pqVectorsCompressor.initCompressedStore(); err != nil {
 		return nil, err
@@ -553,6 +582,7 @@ func RestoreHNSWPQMultiCompressor(
 	maxWalReuseSize int64,
 	allocChecker memwatch.AllocChecker,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := NewProductQuantizerWithEncoders(cfg, distance, dimensions, encoders, logger)
 	if err != nil {
@@ -568,6 +598,7 @@ func RestoreHNSWPQMultiCompressor(
 		minMMapSize:     minMMapSize,
 		maxWalReuseSize: maxWalReuseSize,
 		allocChecker:    allocChecker,
+		vectorForID:     vectorForID,
 	}
 	if err := pqVectorsCompressor.initCompressedStore(); err != nil {
 		return nil, err
@@ -587,6 +618,7 @@ func NewBQCompressor(
 	maxWalReuseSize int64,
 	allocChecker memwatch.AllocChecker,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer := NewBinaryQuantizer(distance)
 	bqVectorsCompressor := &quantizedVectorsCompressor[uint64]{
@@ -599,6 +631,7 @@ func NewBQCompressor(
 		minMMapSize:     minMMapSize,
 		maxWalReuseSize: maxWalReuseSize,
 		allocChecker:    allocChecker,
+		vectorForID:     vectorForID,
 	}
 	if err := bqVectorsCompressor.initCompressedStore(); err != nil {
 		return nil, err
@@ -618,6 +651,7 @@ func NewBQMultiCompressor(
 	maxWalReuseSize int64,
 	allocChecker memwatch.AllocChecker,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer := NewBinaryQuantizer(distance)
 	bqVectorsCompressor := &quantizedVectorsCompressor[uint64]{
@@ -630,6 +664,7 @@ func NewBQMultiCompressor(
 		minMMapSize:     minMMapSize,
 		maxWalReuseSize: maxWalReuseSize,
 		allocChecker:    allocChecker,
+		vectorForID:     vectorForID,
 	}
 	if err := bqVectorsCompressor.initCompressedStore(); err != nil {
 		return nil, err
@@ -650,6 +685,7 @@ func NewHNSWSQCompressor(
 	maxWalReuseSize int64,
 	allocChecker memwatch.AllocChecker,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer := NewScalarQuantizer(data, distance)
 	sqVectorsCompressor := &quantizedVectorsCompressor[byte]{
@@ -662,6 +698,7 @@ func NewHNSWSQCompressor(
 		minMMapSize:     minMMapSize,
 		maxWalReuseSize: maxWalReuseSize,
 		allocChecker:    allocChecker,
+		vectorForID:     vectorForID,
 	}
 	if err := sqVectorsCompressor.initCompressedStore(); err != nil {
 		return nil, err
@@ -684,6 +721,7 @@ func RestoreHNSWSQCompressor(
 	maxWalReuseSize int64,
 	allocChecker memwatch.AllocChecker,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := RestoreScalarQuantizer(a, b, dimensions, distance)
 	if err != nil {
@@ -699,6 +737,7 @@ func RestoreHNSWSQCompressor(
 		minMMapSize:     minMMapSize,
 		maxWalReuseSize: maxWalReuseSize,
 		allocChecker:    allocChecker,
+		vectorForID:     vectorForID,
 	}
 	if err := sqVectorsCompressor.initCompressedStore(); err != nil {
 		return nil, err
@@ -719,6 +758,7 @@ func NewHNSWSQMultiCompressor(
 	maxWalReuseSize int64,
 	allocChecker memwatch.AllocChecker,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer := NewScalarQuantizer(data, distance)
 	sqVectorsCompressor := &quantizedVectorsCompressor[byte]{
@@ -731,6 +771,7 @@ func NewHNSWSQMultiCompressor(
 		minMMapSize:     minMMapSize,
 		maxWalReuseSize: maxWalReuseSize,
 		allocChecker:    allocChecker,
+		vectorForID:     vectorForID,
 	}
 	if err := sqVectorsCompressor.initCompressedStore(); err != nil {
 		return nil, err
@@ -753,6 +794,7 @@ func RestoreHNSWSQMultiCompressor(
 	maxWalReuseSize int64,
 	allocChecker memwatch.AllocChecker,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	quantizer, err := RestoreScalarQuantizer(a, b, dimensions, distance)
 	if err != nil {
@@ -768,6 +810,7 @@ func RestoreHNSWSQMultiCompressor(
 		minMMapSize:     minMMapSize,
 		maxWalReuseSize: maxWalReuseSize,
 		allocChecker:    allocChecker,
+		vectorForID:     vectorForID,
 	}
 	if err := sqVectorsCompressor.initCompressedStore(); err != nil {
 		return nil, err
@@ -787,6 +830,7 @@ func NewRQCompressor(
 	bits int,
 	dim int,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	var rqVectorsCompressor VectorCompressor
 	switch bits {
@@ -799,6 +843,7 @@ func NewRQCompressor(
 			loadId:          binary.BigEndian.Uint64,
 			targetVector:    targetVector,
 			logger:          logger,
+			vectorForID:     vectorForID,
 		}
 		if err := rqVectorsCompressor.(*quantizedVectorsCompressor[uint64]).initCompressedStore(); err != nil {
 			return nil, err
@@ -815,6 +860,7 @@ func NewRQCompressor(
 			loadId:          binary.BigEndian.Uint64,
 			targetVector:    targetVector,
 			logger:          logger,
+			vectorForID:     vectorForID,
 		}
 		if err := rqVectorsCompressor.(*quantizedVectorsCompressor[byte]).initCompressedStore(); err != nil {
 			return nil, err
@@ -842,6 +888,7 @@ func RestoreRQCompressor(
 	store *lsmkv.Store,
 	allocChecker memwatch.AllocChecker,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	var rqVectorsCompressor VectorCompressor
 	switch bits {
@@ -857,6 +904,7 @@ func RestoreRQCompressor(
 			loadId:          binary.BigEndian.Uint64,
 			targetVector:    targetVector,
 			logger:          logger,
+			vectorForID:     vectorForID,
 		}
 		if err := rqVectorsCompressor.(*quantizedVectorsCompressor[uint64]).initCompressedStore(); err != nil {
 			return nil, err
@@ -876,6 +924,7 @@ func RestoreRQCompressor(
 			loadId:          binary.BigEndian.Uint64,
 			targetVector:    targetVector,
 			logger:          logger,
+			vectorForID:     vectorForID,
 		}
 		if err := rqVectorsCompressor.(*quantizedVectorsCompressor[byte]).initCompressedStore(); err != nil {
 			return nil, err
@@ -898,6 +947,7 @@ func NewRQMultiCompressor(
 	bits int,
 	dim int,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	var rqVectorsCompressor VectorCompressor
 	switch bits {
@@ -910,6 +960,7 @@ func NewRQMultiCompressor(
 			loadId:          binary.BigEndian.Uint64,
 			targetVector:    targetVector,
 			logger:          logger,
+			vectorForID:     vectorForID,
 		}
 		if err := rqVectorsCompressor.(*quantizedVectorsCompressor[uint64]).initCompressedStore(); err != nil {
 			return nil, err
@@ -926,6 +977,7 @@ func NewRQMultiCompressor(
 			loadId:          binary.BigEndian.Uint64,
 			targetVector:    targetVector,
 			logger:          logger,
+			vectorForID:     vectorForID,
 		}
 		if err := rqVectorsCompressor.(*quantizedVectorsCompressor[byte]).initCompressedStore(); err != nil {
 			return nil, err
@@ -953,6 +1005,7 @@ func RestoreRQMultiCompressor(
 	store *lsmkv.Store,
 	allocChecker memwatch.AllocChecker,
 	targetVector string,
+	vectorForID common.VectorForID[float32],
 ) (VectorCompressor, error) {
 	var rqVectorsCompressor VectorCompressor
 	switch bits {
@@ -968,6 +1021,7 @@ func RestoreRQMultiCompressor(
 			loadId:          binary.BigEndian.Uint64,
 			targetVector:    targetVector,
 			logger:          logger,
+			vectorForID:     vectorForID,
 		}
 		if err := rqVectorsCompressor.(*quantizedVectorsCompressor[uint64]).initCompressedStore(); err != nil {
 			return nil, err
@@ -987,6 +1041,7 @@ func RestoreRQMultiCompressor(
 			loadId:          binary.BigEndian.Uint64,
 			targetVector:    targetVector,
 			logger:          logger,
+			vectorForID:     vectorForID,
 		}
 		if err := rqVectorsCompressor.(*quantizedVectorsCompressor[byte]).initCompressedStore(); err != nil {
 			return nil, err

--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -248,7 +248,9 @@ func (compressor *quantizedVectorsCompressor[T]) recoverCompressedVector(
 		return nil, storobj.NewErrNotFoundf(id, "recoverCompressedVector: empty raw vector")
 	}
 	compressed := compressor.quantizer.Encode(rawVec)
-	bucket.Put(idBytes, compressor.quantizer.CompressedBytes(compressed))
+	if err := bucket.Put(idBytes, compressor.quantizer.CompressedBytes(compressed)); err != nil {
+		return nil, errors.Wrap(err, "recoverCompressedVector: persisting recovered vector")
+	}
 	return compressed, nil
 }
 

--- a/adapters/repos/db/vector/compressionhelpers/compression_distance_bag_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression_distance_bag_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func Test_NoRaceQuantizedDistanceBag(t *testing.T) {
-	compressor, err := compressionhelpers.NewBQCompressor(distancer.NewCosineDistanceProvider(), 1e12, nil, testinghelpers.NewDummyStore(t), 0, 0, nil, "name")
+	compressor, err := compressionhelpers.NewBQCompressor(distancer.NewCosineDistanceProvider(), 1e12, nil, testinghelpers.NewDummyStore(t), 0, 0, nil, "name", nil)
 	assert.Nil(t, err)
 	compressor.Preload(1, []float32{-0.5, 0.5})
 	compressor.Preload(2, []float32{0.25, 0.7})

--- a/adapters/repos/db/vector/compressionhelpers/compression_test.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression_test.go
@@ -22,13 +22,14 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
+	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/entities/vectorindex/hnsw"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 )
 
 func Test_NoRaceQuantizedVectorCompressor(t *testing.T) {
 	t.Run("loading and deleting data works", func(t *testing.T) {
-		compressor, err := compressionhelpers.NewBQCompressor(distancer.NewCosineDistanceProvider(), 1e12, nil, testinghelpers.NewDummyStore(t), 0, 0, nil, "name")
+		compressor, err := compressionhelpers.NewBQCompressor(distancer.NewCosineDistanceProvider(), 1e12, nil, testinghelpers.NewDummyStore(t), 0, 0, nil, "name", nil)
 		assert.Nil(t, err)
 		compressor.Preload(1, []float32{-0.5, 0.5})
 		vec, err := compressor.DistanceBetweenCompressedVectorsFromIDs(context.Background(), 1, 2)
@@ -44,7 +45,7 @@ func Test_NoRaceQuantizedVectorCompressor(t *testing.T) {
 	})
 
 	t.Run("distance are right when using BQ", func(t *testing.T) {
-		compressor, err := compressionhelpers.NewBQCompressor(distancer.NewCosineDistanceProvider(), 1e12, nil, testinghelpers.NewDummyStore(t), 0, 0, nil, "name")
+		compressor, err := compressionhelpers.NewBQCompressor(distancer.NewCosineDistanceProvider(), 1e12, nil, testinghelpers.NewDummyStore(t), 0, 0, nil, "name", nil)
 		assert.Nil(t, err)
 		compressor.Preload(1, []float32{-0.5, 0.5})
 		compressor.Preload(2, []float32{0.25, 0.7})
@@ -64,7 +65,7 @@ func Test_NoRaceQuantizedVectorCompressor(t *testing.T) {
 	})
 
 	t.Run("distance are right when using BQDistancer", func(t *testing.T) {
-		compressor, err := compressionhelpers.NewBQCompressor(distancer.NewCosineDistanceProvider(), 1e12, nil, testinghelpers.NewDummyStore(t), 0, 0, nil, "name")
+		compressor, err := compressionhelpers.NewBQCompressor(distancer.NewCosineDistanceProvider(), 1e12, nil, testinghelpers.NewDummyStore(t), 0, 0, nil, "name", nil)
 		assert.Nil(t, err)
 		compressor.Preload(1, []float32{-0.5, 0.5})
 		compressor.Preload(2, []float32{0.25, 0.7})
@@ -90,7 +91,7 @@ func Test_NoRaceQuantizedVectorCompressor(t *testing.T) {
 	})
 
 	t.Run("distance are right when using BQDistancer to compressed node", func(t *testing.T) {
-		compressor, err := compressionhelpers.NewBQCompressor(distancer.NewCosineDistanceProvider(), 1e12, nil, testinghelpers.NewDummyStore(t), 0, 0, nil, "name")
+		compressor, err := compressionhelpers.NewBQCompressor(distancer.NewCosineDistanceProvider(), 1e12, nil, testinghelpers.NewDummyStore(t), 0, 0, nil, "name", nil)
 		assert.Nil(t, err)
 		compressor.Preload(1, []float32{-0.5, 0.5})
 		compressor.Preload(2, []float32{0.25, 0.7})
@@ -114,6 +115,57 @@ func Test_NoRaceQuantizedVectorCompressor(t *testing.T) {
 		d, err = distancer.DistanceToFloat([]float32{0.8, -0.2})
 		assert.Nil(t, err)
 		assert.Equal(t, float32(2), d)
+	})
+
+	t.Run("recover missing compressed vector from raw vectorForID", func(t *testing.T) {
+		vectors := map[uint64][]float32{
+			1: {-0.5, 0.5},
+			2: {0.25, 0.7},
+			3: {0.5, 0.5},
+		}
+		vectorForID := func(ctx context.Context, id uint64) ([]float32, error) {
+			v, ok := vectors[id]
+			if !ok {
+				return nil, storobj.NewErrNotFoundf(id, "not found")
+			}
+			return v, nil
+		}
+
+		compressor, err := compressionhelpers.NewBQCompressor(
+			distancer.NewCosineDistanceProvider(), 1e12, nil,
+			testinghelpers.NewDummyStore(t), 0, 0, nil, "name", vectorForID)
+		require.NoError(t, err)
+
+		// Only preload vectors 1 and 2; leave 3 missing from the compressed bucket.
+		compressor.Preload(1, vectors[1])
+		compressor.Preload(2, vectors[2])
+
+		// Accessing vector 3 should recover it from vectorForID.
+		d, err := compressor.DistanceBetweenCompressedVectorsFromIDs(context.Background(), 2, 3)
+		assert.NoError(t, err)
+		assert.Equal(t, float32(0), d)
+
+		// DistanceToNode should also recover.
+		dist, returnFn := compressor.NewDistancer([]float32{0.1, -0.2})
+		defer returnFn()
+		_, err = dist.DistanceToNode(3)
+		assert.NoError(t, err)
+	})
+
+	t.Run("recovery returns ErrNotFound for deleted vectors", func(t *testing.T) {
+		vectorForID := func(ctx context.Context, id uint64) ([]float32, error) {
+			return nil, storobj.NewErrNotFoundf(id, "deleted")
+		}
+
+		compressor, err := compressionhelpers.NewBQCompressor(
+			distancer.NewCosineDistanceProvider(), 1e12, nil,
+			testinghelpers.NewDummyStore(t), 0, 0, nil, "name", vectorForID)
+		require.NoError(t, err)
+
+		// Vector 1 was never preloaded and vectorForID returns not-found.
+		_, err = compressor.DistanceBetweenCompressedVectorsFromIDs(context.Background(), 1, 2)
+		var e storobj.ErrNotFound
+		assert.ErrorAs(t, err, &e)
 	})
 
 	t.Run("don't panic when vector dimensions are mismatched", func(t *testing.T) {
@@ -147,6 +199,7 @@ func Test_NoRaceQuantizedVectorCompressor(t *testing.T) {
 			0,
 			memwatch.NewDummyMonitor(),
 			"name",
+			nil,
 		)
 		require.Nil(t, err)
 		d, _ := compressor.NewDistancer(storedVec)

--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -83,11 +83,11 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 			if singleVector {
 				h.compressor, err = compressionhelpers.NewHNSWPQCompressor(
 					cfg.PQ, h.distancerProvider, dims, 1e12, h.logger, cleanData, h.store,
-					h.MinMMapSize, h.MaxWalReuseSize, h.allocChecker, h.getTargetVector())
+					h.MinMMapSize, h.MaxWalReuseSize, h.allocChecker, h.getTargetVector(), h.vectorForID)
 			} else {
 				h.compressor, err = compressionhelpers.NewHNSWPQMultiCompressor(
 					cfg.PQ, h.distancerProvider, dims, 1e12, h.logger, cleanData, h.store,
-					h.MinMMapSize, h.MaxWalReuseSize, h.allocChecker, h.getTargetVector())
+					h.MinMMapSize, h.MaxWalReuseSize, h.allocChecker, h.getTargetVector(), h.vectorForID)
 			}
 			if err != nil {
 				h.pqConfig.Enabled = false
@@ -98,11 +98,11 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 			if singleVector {
 				h.compressor, err = compressionhelpers.NewHNSWSQCompressor(
 					h.distancerProvider, 1e12, h.logger, cleanData, h.store,
-					h.MinMMapSize, h.MaxWalReuseSize, h.allocChecker, h.getTargetVector())
+					h.MinMMapSize, h.MaxWalReuseSize, h.allocChecker, h.getTargetVector(), h.vectorForID)
 			} else {
 				h.compressor, err = compressionhelpers.NewHNSWSQMultiCompressor(
 					h.distancerProvider, 1e12, h.logger, cleanData, h.store,
-					h.MinMMapSize, h.MaxWalReuseSize, h.allocChecker, h.getTargetVector())
+					h.MinMMapSize, h.MaxWalReuseSize, h.allocChecker, h.getTargetVector(), h.vectorForID)
 			}
 			if err != nil {
 				h.sqConfig.Enabled = false
@@ -115,11 +115,11 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 		if singleVector {
 			h.compressor, err = compressionhelpers.NewBQCompressor(
 				h.distancerProvider, 1e12, h.logger, h.store, h.MinMMapSize,
-				h.MaxWalReuseSize, h.allocChecker, h.getTargetVector())
+				h.MaxWalReuseSize, h.allocChecker, h.getTargetVector(), h.vectorForID)
 		} else {
 			h.compressor, err = compressionhelpers.NewBQMultiCompressor(
 				h.distancerProvider, 1e12, h.logger, h.store, h.MinMMapSize,
-				h.MaxWalReuseSize, h.allocChecker, h.getTargetVector())
+				h.MaxWalReuseSize, h.allocChecker, h.getTargetVector(), h.vectorForID)
 		}
 		if err != nil {
 			return err

--- a/adapters/repos/db/vector/hnsw/compress.go
+++ b/adapters/repos/db/vector/hnsw/compress.go
@@ -87,7 +87,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 			} else {
 				h.compressor, err = compressionhelpers.NewHNSWPQMultiCompressor(
 					cfg.PQ, h.distancerProvider, dims, 1e12, h.logger, cleanData, h.store,
-					h.MinMMapSize, h.MaxWalReuseSize, h.allocChecker, h.getTargetVector(), h.vectorForID)
+					h.MinMMapSize, h.MaxWalReuseSize, h.allocChecker, h.getTargetVector(), h.multiVectorForNodeID)
 			}
 			if err != nil {
 				h.pqConfig.Enabled = false
@@ -102,7 +102,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 			} else {
 				h.compressor, err = compressionhelpers.NewHNSWSQMultiCompressor(
 					h.distancerProvider, 1e12, h.logger, cleanData, h.store,
-					h.MinMMapSize, h.MaxWalReuseSize, h.allocChecker, h.getTargetVector(), h.vectorForID)
+					h.MinMMapSize, h.MaxWalReuseSize, h.allocChecker, h.getTargetVector(), h.multiVectorForNodeID)
 			}
 			if err != nil {
 				h.sqConfig.Enabled = false
@@ -119,7 +119,7 @@ func (h *hnsw) compress(cfg ent.UserConfig) error {
 		} else {
 			h.compressor, err = compressionhelpers.NewBQMultiCompressor(
 				h.distancerProvider, 1e12, h.logger, h.store, h.MinMMapSize,
-				h.MaxWalReuseSize, h.allocChecker, h.getTargetVector(), h.vectorForID)
+				h.MaxWalReuseSize, h.allocChecker, h.getTargetVector(), h.multiVectorForNodeID)
 		}
 		if err != nil {
 			return err

--- a/adapters/repos/db/vector/hnsw/compress_test.go
+++ b/adapters/repos/db/vector/hnsw/compress_test.go
@@ -13,6 +13,7 @@ package hnsw
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"sync"
 	"testing"
@@ -23,6 +24,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/compressionhelpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
@@ -96,6 +98,65 @@ func Test_NoRaceCompressReturnsErrorWhenNotEnoughData(t *testing.T) {
 	uc.PQ = cfg
 	err := index.compress(uc)
 	assert.NotNil(t, err)
+}
+
+func Test_CompressedEntrypointRecoveryOnRestart(t *testing.T) {
+	dimensions := 20
+	vectorsSize := 10
+	vectors, queries := testinghelpers.RandomVecs(vectorsSize, 1, dimensions)
+	dist := distancer.NewL2SquaredProvider()
+	logger, _ := test.NewNullLogger()
+	ctx := context.Background()
+	tempDir := t.TempDir()
+	dummyStore := testinghelpers.NewDummyStoreFromFolder(tempDir, t)
+
+	uc := userConfig(dimensions/10, 5, 32, 64, 32, vectorsSize)
+	cfg := indexConfig("recovery_test", tempDir, logger, vectors, dist)
+
+	// Phase 1: build index and compress.
+	index, err := New(cfg, uc, cyclemanager.NewCallbackGroupNoop(), dummyStore)
+	require.NoError(t, err)
+
+	require.NoError(t, compressionhelpers.ConcurrentlyWithError(logger, uint64(vectorsSize), func(id uint64) error {
+		return index.Add(ctx, uint64(id), vectors[id])
+	}))
+	require.NoError(t, index.compress(uc))
+
+	// Record the entrypoint and search results before shutdown.
+	entrypoint := index.entryPointID
+	control, _, err := index.SearchByVector(ctx, queries[0], vectorsSize, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, index.Flush())
+	require.NoError(t, index.Shutdown(ctx))
+	dummyStore.FlushMemtables(ctx)
+
+	// Delete the entrypoint's compressed vector from the bucket to simulate
+	// an interrupted compression preload.
+	bucket := dummyStore.Bucket(helpers.GetCompressedBucketName("recovery_test"))
+	require.NotNil(t, bucket)
+	idBytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(idBytes, entrypoint)
+	require.NoError(t, bucket.Delete(idBytes))
+	dummyStore.FlushMemtables(ctx)
+
+	// Phase 2: restart — the entrypoint's compressed vector is missing.
+	restartCfg := indexConfig("recovery_test", tempDir, logger, vectors, dist)
+	restartCfg.WaitForCachePrefill = true
+
+	index, err = New(restartCfg, uc, cyclemanager.NewCallbackGroupNoop(), dummyStore)
+	require.NoError(t, err)
+	defer index.Shutdown(ctx)
+
+	index.PostStartup(ctx)
+
+	require.True(t, index.compressed.Load(), "index should be compressed")
+
+	// Search should succeed — the entrypoint's compressed vector is recovered
+	// on first access via the vectorForID fallback.
+	results, _, err := index.SearchByVector(ctx, queries[0], vectorsSize, nil)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, control, results, "search results should match after entrypoint recovery")
 }
 
 func Test_CompressAndInsertDoNotRace(t *testing.T) {

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -386,11 +386,11 @@ func New(cfg Config, uc ent.UserConfig,
 		if uc.Multivector.Enabled && !uc.Multivector.MuveraConfig.Enabled {
 			index.compressor, err = compressionhelpers.NewBQMultiCompressor(
 				index.distancerProvider, uc.VectorCacheMaxObjects, cfg.Logger, store,
-				cfg.MinMMapSize, cfg.MaxWalReuseSize, cfg.AllocChecker, index.getTargetVector())
+				cfg.MinMMapSize, cfg.MaxWalReuseSize, cfg.AllocChecker, index.getTargetVector(), index.vectorForID)
 		} else {
 			index.compressor, err = compressionhelpers.NewBQCompressor(
 				index.distancerProvider, uc.VectorCacheMaxObjects, cfg.Logger, store,
-				cfg.MinMMapSize, cfg.MaxWalReuseSize, cfg.AllocChecker, index.getTargetVector())
+				cfg.MinMMapSize, cfg.MaxWalReuseSize, cfg.AllocChecker, index.getTargetVector(), index.vectorForID)
 		}
 		if err != nil {
 			return nil, err

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -109,11 +109,11 @@ func (h *hnsw) checkAndCompress() error {
 			if singleVector {
 				h.compressor, err = compressionhelpers.NewRQCompressor(
 					h.distancerProvider, 1e12, h.logger, h.store,
-					h.allocChecker, int(h.rqConfig.Bits), int(h.dims.Load()), h.getTargetVector())
+					h.allocChecker, int(h.rqConfig.Bits), int(h.dims.Load()), h.getTargetVector(), h.vectorForID)
 			} else {
 				h.compressor, err = compressionhelpers.NewRQMultiCompressor(
 					h.distancerProvider, 1e12, h.logger, h.store,
-					h.allocChecker, int(h.rqConfig.Bits), int(h.dims.Load()), h.getTargetVector())
+					h.allocChecker, int(h.rqConfig.Bits), int(h.dims.Load()), h.getTargetVector(), h.vectorForID)
 			}
 
 			if err == nil {

--- a/adapters/repos/db/vector/hnsw/insert.go
+++ b/adapters/repos/db/vector/hnsw/insert.go
@@ -113,7 +113,7 @@ func (h *hnsw) checkAndCompress() error {
 			} else {
 				h.compressor, err = compressionhelpers.NewRQMultiCompressor(
 					h.distancerProvider, 1e12, h.logger, h.store,
-					h.allocChecker, int(h.rqConfig.Bits), int(h.dims.Load()), h.getTargetVector(), h.vectorForID)
+					h.allocChecker, int(h.rqConfig.Bits), int(h.dims.Load()), h.getTargetVector(), h.multiVectorForNodeID)
 			}
 
 			if err == nil {

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -162,6 +162,7 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 						h.MaxWalReuseSize,
 						h.allocChecker,
 						h.getTargetVector(),
+						h.vectorForID,
 					)
 				} else {
 					h.compressor, err = compressionhelpers.RestoreHNSWPQMultiCompressor(
@@ -176,6 +177,7 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 						h.MaxWalReuseSize,
 						h.allocChecker,
 						h.getTargetVector(),
+						h.vectorForID,
 					)
 				}
 				if err != nil {
@@ -198,6 +200,7 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 					h.MaxWalReuseSize,
 					h.allocChecker,
 					h.getTargetVector(),
+					h.vectorForID,
 				)
 			} else {
 				h.compressor, err = compressionhelpers.RestoreHNSWSQMultiCompressor(
@@ -212,6 +215,7 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 					h.MaxWalReuseSize,
 					h.allocChecker,
 					h.getTargetVector(),
+					h.vectorForID,
 				)
 			}
 			if err != nil {
@@ -285,6 +289,7 @@ func (h *hnsw) restoreRotationalQuantization(data *compressionhelpers.RQData) er
 				h.store,
 				h.allocChecker,
 				h.getTargetVector(),
+				h.vectorForID,
 			)
 		})
 	} else {
@@ -303,6 +308,7 @@ func (h *hnsw) restoreRotationalQuantization(data *compressionhelpers.RQData) er
 				h.store,
 				h.allocChecker,
 				h.getTargetVector(),
+				h.vectorForID,
 			)
 		})
 	}
@@ -329,6 +335,7 @@ func (h *hnsw) restoreBinaryRotationalQuantization(data *compressionhelpers.BRQD
 				h.store,
 				h.allocChecker,
 				h.getTargetVector(),
+				h.vectorForID,
 			)
 		})
 	} else {
@@ -347,6 +354,7 @@ func (h *hnsw) restoreBinaryRotationalQuantization(data *compressionhelpers.BRQD
 				h.store,
 				h.allocChecker,
 				h.getTargetVector(),
+				h.vectorForID,
 			)
 		})
 	}

--- a/adapters/repos/db/vector/hnsw/startup.go
+++ b/adapters/repos/db/vector/hnsw/startup.go
@@ -177,7 +177,7 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 						h.MaxWalReuseSize,
 						h.allocChecker,
 						h.getTargetVector(),
-						h.vectorForID,
+						h.multiVectorForNodeID,
 					)
 				}
 				if err != nil {
@@ -215,7 +215,7 @@ func (h *hnsw) restoreFromDisk(cl CommitLogger) error {
 					h.MaxWalReuseSize,
 					h.allocChecker,
 					h.getTargetVector(),
-					h.vectorForID,
+					h.multiVectorForNodeID,
 				)
 			}
 			if err != nil {
@@ -308,7 +308,7 @@ func (h *hnsw) restoreRotationalQuantization(data *compressionhelpers.RQData) er
 				h.store,
 				h.allocChecker,
 				h.getTargetVector(),
-				h.vectorForID,
+				h.multiVectorForNodeID,
 			)
 		})
 	}
@@ -354,7 +354,7 @@ func (h *hnsw) restoreBinaryRotationalQuantization(data *compressionhelpers.BRQD
 				h.store,
 				h.allocChecker,
 				h.getTargetVector(),
-				h.vectorForID,
+				h.multiVectorForNodeID,
 			)
 		})
 	}
@@ -439,6 +439,23 @@ func (h *hnsw) populateKeys() {
 			}
 		}
 	}
+}
+
+// multiVectorForNodeID resolves a nodeID to its raw float32 vector by looking
+// up the (docID, relativeID) mapping from the compressor's cache, then fetching
+// from the object store. Used as the recovery callback for compressed multi-vector
+// indexes instead of h.vectorForID, which points to the dropped float32 cache.
+func (h *hnsw) multiVectorForNodeID(ctx context.Context, nodeID uint64) ([]float32, error) {
+	docID, relativeID := h.compressor.GetKeys(nodeID)
+	vecs, err := h.MultiVectorForIDThunk(ctx, docID)
+	if err != nil {
+		return nil, errors.Wrapf(err, "multi-vector recovery for nodeID %d (docID %d)", nodeID, docID)
+	}
+	if int(relativeID) >= len(vecs) {
+		return nil, errors.Errorf("multi-vector recovery: relativeID %d out of bounds for docID %d (nodeID %d, got %d vecs)",
+			relativeID, docID, nodeID, len(vecs))
+	}
+	return vecs[relativeID], nil
 }
 
 func (h *hnsw) tombstoneCleanup(shouldAbort cyclemanager.ShouldAbortCallback) bool {


### PR DESCRIPTION
### What's being changed:
- The compressed vector index cache is now aware of the original vector
- On a cache miss of quantized vector from disk it will attempt to recover from original vector
- This fixes https://github.com/weaviate/weaviate/pull/10653 but without the need for expensive recompress at startup

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
