### PR TITLE
Set export default path to empty by default

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -2206,9 +2206,6 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		registered.ExportDefaultBucket = appState.ServerConfig.Config.Export.DefaultBucket
 		registered.ExportDefaultPath = appState.ServerConfig.Config.Export.DefaultPath
 		registered.ExportParallelism = appState.ServerConfig.Config.ExportParallelism
-		// Note: Export.IsDefaultPathSet is intentionally not exposed as a runtime
-		// override — it is a derived internal flag, flipped via the
-		// "ExportDefaultPath" hook registered in postInitRuntimeOverrides.
 
 		if appState.ServerConfig.Config.Authentication.OIDC.Enabled {
 			registered.OIDCIssuer = appState.ServerConfig.Config.Authentication.OIDC.Issuer
@@ -2262,17 +2259,6 @@ func postInitRuntimeOverrides(appState *state.State, cm *configRuntime.ConfigMan
 		if appState.ServerConfig.Config.Authentication.OIDC.Enabled {
 			hooks["OIDC"] = appState.OIDC.Init
 		}
-		// Flip Export.IsDefaultPathSet whenever ExportDefaultPath is updated via
-		// a runtime override. IsDefaultPathSet is a derived internal flag (not
-		// exposed in WeaviateRuntimeConfig) but it must track "has the path
-		// been explicitly configured?" across runtime reloads too, not just at
-		// startup. Without this, an operator configuring exports for the
-		// first time via the runtime config file would update DefaultPath but
-		// the path-set check in the scheduler would still reject requests.
-		hooks["ExportDefaultPath"] = func() error {
-			appState.ServerConfig.Config.Export.IsDefaultPathSet.Store(true)
-			return nil
-		}
 		maps.Copy(hooks, appState.Crons.RuntimeConfigHooks())
 
 		appState.Logger.Log(logrus.InfoLevel, "registereing OIDC runtime overrides hooks")
@@ -2280,18 +2266,6 @@ func postInitRuntimeOverrides(appState *state.State, cm *configRuntime.ConfigMan
 		// reload current overrides file to take into account additional settings
 		if err := cm.ReloadConfig(); err != nil {
 			appState.Logger.WithField("action", "startup").Errorf("could not reload config: %v", err)
-		}
-		// Manual sync for Export.IsDefaultPathSet: the initial loadConfig inside
-		// NewConfigManager runs before hooks are registered, and the forced
-		// ReloadConfig above sees oldV == newV (it's re-applying the same
-		// values), so the "ExportDefaultPath" hook cannot have fired yet for
-		// the startup runtime config. If the runtime config did set a
-		// non-empty export_default_path, sync the flag now so the scheduler
-		// accepts requests. The empty-string-via-runtime-config case at
-		// startup is a documented limitation — operators who want the empty
-		// prefix should set EXPORT_DEFAULT_PATH="" at startup instead.
-		if appState.ServerConfig.Config.Export.DefaultPath.Get() != "" {
-			appState.ServerConfig.Config.Export.IsDefaultPathSet.Store(true)
 		}
 		// start runtime config background check
 		enterrors.GoWrapper(func() {

--- a/modules/backup-azure/backup_test.go
+++ b/modules/backup-azure/backup_test.go
@@ -155,6 +155,55 @@ func TestUploadParams(t *testing.T) {
 	})
 }
 
+func TestResolveContainer(t *testing.T) {
+	tests := []struct {
+		name            string
+		configContainer string
+		override        string
+		wantContainer   string
+		wantErr         string
+	}{
+		{
+			name:            "uses config container when no override",
+			configContainer: "my-container",
+			override:        "",
+			wantContainer:   "my-container",
+		},
+		{
+			name:            "override replaces config container",
+			configContainer: "my-container",
+			override:        "other-container",
+			wantContainer:   "other-container",
+		},
+		{
+			name:            "empty config container without override returns error",
+			configContainer: "",
+			override:        "",
+			wantErr:         "container must not be empty",
+		},
+		{
+			name:            "empty config container with override succeeds",
+			configContainer: "",
+			override:        "override-container",
+			wantContainer:   "override-container",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &azureClient{config: clientConfig{Container: tt.configContainer}}
+			container, err := client.resolveContainer(tt.override)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantContainer, container)
+			}
+		})
+	}
+}
+
 type fakeStorageProvider struct {
 	dataPath string
 }

--- a/modules/backup-azure/client.go
+++ b/modules/backup-azure/client.go
@@ -119,6 +119,17 @@ func (a *azureClient) HomeDir(backupID, overrideBucket, overridePath string) str
 	return a.serviceURL + path.Join(overrideBucket, a.makeObjectName(overridePath, []string{backupID}))
 }
 
+func (a *azureClient) resolveContainer(overrideBucket string) (string, error) {
+	container := a.config.Container
+	if overrideBucket != "" {
+		container = overrideBucket
+	}
+	if container == "" {
+		return "", fmt.Errorf("container must not be empty")
+	}
+	return container, nil
+}
+
 func (g *azureClient) makeObjectName(overridePath string, parts []string) string {
 	if overridePath != "" {
 		base := path.Join(parts...)
@@ -161,13 +172,11 @@ func (a *azureClient) AllBackups(ctx context.Context) ([]*backup.DistributedBack
 }
 
 func (a *azureClient) GetObject(ctx context.Context, backupID, key, overrideBucket, overridePath string) ([]byte, error) {
-	objectName := a.makeObjectName(overridePath, []string{backupID, key})
-
-	containerName := a.config.Container
-	if overrideBucket != "" {
-		containerName = overrideBucket
+	containerName, err := a.resolveContainer(overrideBucket)
+	if err != nil {
+		return nil, err
 	}
-
+	objectName := a.makeObjectName(overridePath, []string{backupID, key})
 	return a.getObject(ctx, containerName, objectName)
 }
 
@@ -194,15 +203,14 @@ func (a *azureClient) getObject(ctx context.Context, containerName, objectName s
 }
 
 func (a *azureClient) PutObject(ctx context.Context, backupID, key, overrideBucket, overridePath string, data []byte) error {
+	containerName, err := a.resolveContainer(overrideBucket)
+	if err != nil {
+		return err
+	}
 	objectName := a.makeObjectName(overridePath, []string{backupID, key})
 
-	containerName := a.config.Container
-	if overrideBucket != "" {
-		containerName = overrideBucket
-	}
-
 	reader := bytes.NewReader(data)
-	_, err := a.client.UploadStream(ctx,
+	if _, err = a.client.UploadStream(ctx,
 		containerName,
 		objectName,
 		reader,
@@ -211,8 +219,7 @@ func (a *azureClient) PutObject(ctx context.Context, backupID, key, overrideBuck
 			Tags:        map[string]string{"backupid": backupID},
 			BlockSize:   a.getBlockSize(ctx),
 			Concurrency: a.getConcurrency(ctx),
-		})
-	if err != nil {
+		}); err != nil {
 		return backup.NewErrInternal(errors.Wrapf(err, "upload stream for object %s", objectName))
 	}
 
@@ -220,15 +227,15 @@ func (a *azureClient) PutObject(ctx context.Context, backupID, key, overrideBuck
 }
 
 func (a *azureClient) Initialize(ctx context.Context, backupID, overrideBucket, overridePath string) error {
+	containerName, err := a.resolveContainer(overrideBucket)
+	if err != nil {
+		return err
+	}
+
 	key := "access-check"
 
 	if err := a.PutObject(ctx, backupID, key, overrideBucket, overridePath, []byte("")); err != nil {
 		return errors.Wrap(err, "failed to access-check Azure backup module")
-	}
-
-	containerName := a.config.Container
-	if overrideBucket != "" {
-		containerName = overrideBucket
 	}
 
 	objectName := a.makeObjectName(overridePath, []string{backupID, key})
@@ -240,6 +247,11 @@ func (a *azureClient) Initialize(ctx context.Context, backupID, overrideBucket, 
 }
 
 func (a *azureClient) WriteToFile(ctx context.Context, backupID, key, destPath, overrideBucket, overridePath string) error {
+	containerName, err := a.resolveContainer(overrideBucket)
+	if err != nil {
+		return err
+	}
+
 	dir := path.Dir(destPath)
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		return errors.Wrapf(err, "make dir %s", dir)
@@ -250,11 +262,6 @@ func (a *azureClient) WriteToFile(ctx context.Context, backupID, key, destPath, 
 		return backup.NewErrInternal(errors.Wrapf(err, "create file: %q", destPath))
 	}
 	defer file.Close()
-
-	containerName := a.config.Container
-	if overrideBucket != "" {
-		containerName = overrideBucket
-	}
 
 	objectName := a.makeObjectName(overridePath, []string{backupID, key})
 	_, err = a.client.DownloadFile(ctx, containerName, objectName, file, nil)
@@ -305,6 +312,11 @@ func (a *azureClient) getConcurrency(ctx context.Context) int {
 }
 
 func (a *azureClient) Write(ctx context.Context, backupID, key, overrideBucket, overridePath string, r backup.ReadCloserWithError) (written int64, err error) {
+	containerName, err := a.resolveContainer(overrideBucket)
+	if err != nil {
+		return 0, err
+	}
+
 	path := a.makeObjectName(overridePath, []string{backupID, key})
 	reader := &reader{src: r}
 	// Close the reader when done. Use CloseWithError to signal any error to the
@@ -313,11 +325,6 @@ func (a *azureClient) Write(ctx context.Context, backupID, key, overrideBucket, 
 		r.CloseWithError(err)
 		written = int64(reader.count)
 	}()
-
-	containerName := a.config.Container
-	if overrideBucket != "" {
-		containerName = overrideBucket
-	}
 
 	if _, err = a.client.UploadStream(ctx,
 		containerName,
@@ -338,9 +345,9 @@ func (a *azureClient) Write(ctx context.Context, backupID, key, overrideBucket, 
 func (a *azureClient) Read(ctx context.Context, backupID, key, overrideBucket, overridePath string, w io.WriteCloser) (int64, error) {
 	defer w.Close()
 
-	containerName := a.config.Container
-	if overrideBucket != "" {
-		containerName = overrideBucket
+	containerName, err := a.resolveContainer(overrideBucket)
+	if err != nil {
+		return -1, err
 	}
 
 	path := a.makeObjectName(overridePath, []string{backupID, key})

--- a/modules/backup-azure/module.go
+++ b/modules/backup-azure/module.go
@@ -46,9 +46,10 @@ type clientConfig struct {
 }
 
 type Module struct {
-	logger logrus.FieldLogger
-	*azureClient
-	dataPath string
+	logger       logrus.FieldLogger
+	*azureClient              // backup client
+	exportClient *azureClient // export client (BackupPath="")
+	dataPath     string
 }
 
 func New() *Module {
@@ -90,6 +91,16 @@ func (m *Module) Init(ctx context.Context,
 		return errors.Wrap(err, "init Azure client")
 	}
 	m.azureClient = client
+
+	exportConfig := &clientConfig{
+		Container:  os.Getenv(azureContainer),
+		BackupPath: "", // exports default to container root
+	}
+	exportClient, err := newClient(ctx, exportConfig, m.dataPath, m.logger)
+	if err != nil {
+		return errors.Wrap(err, "init Azure export client")
+	}
+	m.exportClient = exportClient
 	return nil
 }
 
@@ -102,9 +113,24 @@ func (m *Module) MetaInfo() (map[string]interface{}, error) {
 	return metaInfo, nil
 }
 
+// ExportBackend returns the export-specific backend whose BackupPath is
+// always empty, so exports default to the container root rather than
+// inheriting the backup module's BACKUP_AZURE_PATH.
+func (m *Module) ExportBackend() modulecapabilities.BackupBackend {
+	return &exportAzureBackend{m.exportClient}
+}
+
+type exportAzureBackend struct {
+	*azureClient
+}
+
+func (e *exportAzureBackend) IsExternal() bool { return true }
+func (e *exportAzureBackend) Name() string     { return Name }
+
 // verify we implement the modules.Module interface
 var (
 	_ = modulecapabilities.Module(New())
 	_ = modulecapabilities.BackupBackend(New())
 	_ = modulecapabilities.MetaProvider(New())
+	_ = modulecapabilities.ExportBackendProvider(New())
 )

--- a/modules/backup-azure/module.go
+++ b/modules/backup-azure/module.go
@@ -48,7 +48,7 @@ type clientConfig struct {
 type Module struct {
 	logger       logrus.FieldLogger
 	*azureClient              // backup client
-	exportClient *azureClient // export client (BackupPath="")
+	exportClient *azureClient // export-only client: no default container or path; the scheduler supplies both
 	dataPath     string
 }
 
@@ -93,8 +93,8 @@ func (m *Module) Init(ctx context.Context,
 	m.azureClient = client
 
 	exportConfig := &clientConfig{
-		Container:  os.Getenv(azureContainer),
-		BackupPath: "", // exports default to container root
+		Container:  "", // export scheduler provides bucket via EXPORT_DEFAULT_BUCKET
+		BackupPath: "", // export scheduler provides path via EXPORT_DEFAULT_PATH
 	}
 	exportClient, err := newClient(ctx, exportConfig, m.dataPath, m.logger)
 	if err != nil {
@@ -113,9 +113,9 @@ func (m *Module) MetaInfo() (map[string]interface{}, error) {
 	return metaInfo, nil
 }
 
-// ExportBackend returns the export-specific backend whose BackupPath is
-// always empty, so exports default to the container root rather than
-// inheriting the backup module's BACKUP_AZURE_PATH.
+// ExportBackend returns the export-specific backend. It has no default
+// container or path; the export scheduler supplies both via
+// EXPORT_DEFAULT_BUCKET and EXPORT_DEFAULT_PATH.
 func (m *Module) ExportBackend() modulecapabilities.BackupBackend {
 	return &exportAzureBackend{m.exportClient}
 }

--- a/modules/backup-filesystem/backup.go
+++ b/modules/backup-filesystem/backup.go
@@ -24,15 +24,23 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
-func (m *Module) GetObject(ctx context.Context, backupID, key, overrideBucket, overridePath string) ([]byte, error) {
-	var metaPath string
-	var err error
+func (m *Module) resolvePath(overridePath string) (string, error) {
+	p := m.backupsPath
 	if overridePath != "" {
-		metaPath, err = m.getObjectPath(ctx, overridePath, backupID, key)
-	} else {
-		metaPath, err = m.getObjectPath(ctx, m.backupsPath, backupID, key)
+		p = overridePath
 	}
+	if p == "" {
+		return "", fmt.Errorf("backup path must not be empty")
+	}
+	return p, nil
+}
 
+func (m *Module) GetObject(ctx context.Context, backupID, key, overrideBucket, overridePath string) ([]byte, error) {
+	basePath, err := m.resolvePath(overridePath)
+	if err != nil {
+		return nil, err
+	}
+	metaPath, err := m.getObjectPath(ctx, basePath, backupID, key)
 	if err != nil {
 		return nil, err
 	}
@@ -102,10 +110,11 @@ func (m *Module) PutObject(ctx context.Context, backupID, key, bucket, overrideP
 		m.logger.Info("bucket parameter not supported for filesystem backup module!")
 	}
 
-	backupPath := path.Join(m.makeBackupDirPath(m.backupsPath, backupID), key)
-	if overridePath != "" {
-		backupPath = path.Join(overridePath, backupID, key)
+	basePath, err := m.resolvePath(overridePath)
+	if err != nil {
+		return err
 	}
+	backupPath := path.Join(basePath, backupID, key)
 
 	dir := path.Dir(backupPath)
 
@@ -131,13 +140,11 @@ func (m *Module) Initialize(ctx context.Context, backupID, overrideBucket, overr
 }
 
 func (m *Module) WriteToFile(ctx context.Context, backupID, key, destPath, overrideBucket, overridePath string) error {
-	var objectPath string
-	var err error
-	if overridePath != "" {
-		objectPath = filepath.Join(overridePath, backupID, key)
-	} else {
-		objectPath = filepath.Join(m.backupsPath, backupID, key)
+	basePath, err := m.resolvePath(overridePath)
+	if err != nil {
+		return err
 	}
+	objectPath := filepath.Join(basePath, backupID, key)
 
 	bytesWritten, err := m.copyFile(objectPath, destPath)
 	if err != nil {
@@ -159,12 +166,11 @@ func (m *Module) Write(ctx context.Context, backupID, key, overrideBucket, overr
 		r.CloseWithError(err)
 	}()
 
-	var backupPath string
-	if overridePath != "" {
-		backupPath = filepath.Join(overridePath, backupID, key)
-	} else {
-		backupPath = filepath.Join(m.backupsPath, backupID, key)
+	basePath, err := m.resolvePath(overridePath)
+	if err != nil {
+		return 0, err
 	}
+	backupPath := filepath.Join(basePath, backupID, key)
 	dir := path.Dir(backupPath)
 	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
 		return 0, fmt.Errorf("make dir %q: %w", dir, err)
@@ -190,13 +196,11 @@ func (m *Module) Write(ctx context.Context, backupID, key, overrideBucket, overr
 func (m *Module) Read(ctx context.Context, backupID, key, overrideBucket, overridePath string, w io.WriteCloser) (int64, error) {
 	defer w.Close()
 
-	var sourcePath string
-	var err error
-	if overridePath != "" {
-		sourcePath, err = m.getObjectPath(ctx, overridePath, backupID, key)
-	} else {
-		sourcePath, err = m.getObjectPath(ctx, m.backupsPath, backupID, key)
+	basePath, err := m.resolvePath(overridePath)
+	if err != nil {
+		return -1, err
 	}
+	sourcePath, err := m.getObjectPath(ctx, basePath, backupID, key)
 	if err != nil {
 		return 0, fmt.Errorf("source path %s/%s: %w", backupID, key, err)
 	}

--- a/modules/backup-filesystem/backup_test.go
+++ b/modules/backup-filesystem/backup_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBackend_StoreBackup(t *testing.T) {
@@ -51,4 +52,49 @@ func TestBackend_StoreBackup(t *testing.T) {
 		_, err = os.Stat(backupAbsolutePath)
 		assert.Nil(t, err)
 	})
+}
+
+func TestResolvePath(t *testing.T) {
+	tests := []struct {
+		name         string
+		backupsPath  string
+		overridePath string
+		wantPath     string
+		wantErr      string
+	}{
+		{
+			name:        "uses config path when no override",
+			backupsPath: "/var/backups",
+			wantPath:    "/var/backups",
+		},
+		{
+			name:         "override replaces config path",
+			backupsPath:  "/var/backups",
+			overridePath: "/tmp/exports",
+			wantPath:     "/tmp/exports",
+		},
+		{
+			name:    "empty config path without override returns error",
+			wantErr: "backup path must not be empty",
+		},
+		{
+			name:         "empty config path with override succeeds",
+			overridePath: "/tmp/exports",
+			wantPath:     "/tmp/exports",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Module{backupsPath: tt.backupsPath}
+			p, err := m.resolvePath(tt.overridePath)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantPath, p)
+			}
+		})
+	}
 }

--- a/modules/backup-filesystem/module.go
+++ b/modules/backup-filesystem/module.go
@@ -33,9 +33,10 @@ const (
 )
 
 type Module struct {
-	logger      logrus.FieldLogger
-	dataPath    string // path to the current (operational) data
-	backupsPath string // complete(?) path to the directory that holds all the backups
+	logger        logrus.FieldLogger
+	dataPath      string  // path to the current (operational) data
+	backupsPath   string  // complete(?) path to the directory that holds all the backups
+	exportBackend *Module // export backend (backupsPath="")
 }
 
 func New() *Module {
@@ -66,6 +67,14 @@ func (m *Module) Init(ctx context.Context,
 	backupsPath := os.Getenv(backupsPathName)
 	if err := m.initBackupBackend(ctx, backupsPath); err != nil {
 		return fmt.Errorf("init backup backend: %w", err)
+	}
+
+	// Export backend with backupsPath="" so that exports use the
+	// overridePath from EXPORT_DEFAULT_PATH rather than falling back
+	// to BACKUP_FILESYSTEM_PATH.
+	m.exportBackend = &Module{
+		logger:   m.logger,
+		dataPath: m.dataPath,
 	}
 
 	return nil
@@ -115,9 +124,17 @@ func (m *Module) makeBackupDirPath(path, id string) string {
 	return filepath.Join(path, id)
 }
 
+// ExportBackend returns the export-specific backend whose backupsPath is
+// empty, so exports use only the overridePath from EXPORT_DEFAULT_PATH
+// rather than falling back to BACKUP_FILESYSTEM_PATH.
+func (m *Module) ExportBackend() modulecapabilities.BackupBackend {
+	return m.exportBackend
+}
+
 // verify we implement the modules.Module interface
 var (
 	_ = modulecapabilities.Module(New())
 	_ = modulecapabilities.BackupBackend(New())
 	_ = modulecapabilities.MetaProvider(New())
+	_ = modulecapabilities.ExportBackendProvider(New())
 )

--- a/modules/backup-filesystem/module.go
+++ b/modules/backup-filesystem/module.go
@@ -36,7 +36,7 @@ type Module struct {
 	logger        logrus.FieldLogger
 	dataPath      string  // path to the current (operational) data
 	backupsPath   string  // complete(?) path to the directory that holds all the backups
-	exportBackend *Module // export backend (backupsPath="")
+	exportBackend *Module // export-only backend: no default bucket or path; the scheduler supplies both
 }
 
 func New() *Module {
@@ -69,9 +69,9 @@ func (m *Module) Init(ctx context.Context,
 		return fmt.Errorf("init backup backend: %w", err)
 	}
 
-	// Export backend with backupsPath="" so that exports use the
-	// overridePath from EXPORT_DEFAULT_PATH rather than falling back
-	// to BACKUP_FILESYSTEM_PATH.
+	// Create a separate export backend with no default bucket or path.
+	// The export scheduler supplies both via EXPORT_DEFAULT_BUCKET
+	// and EXPORT_DEFAULT_PATH.
 	m.exportBackend = &Module{
 		logger:   m.logger,
 		dataPath: m.dataPath,
@@ -124,9 +124,9 @@ func (m *Module) makeBackupDirPath(path, id string) string {
 	return filepath.Join(path, id)
 }
 
-// ExportBackend returns the export-specific backend whose backupsPath is
-// empty, so exports use only the overridePath from EXPORT_DEFAULT_PATH
-// rather than falling back to BACKUP_FILESYSTEM_PATH.
+// ExportBackend returns the export-specific backend. It has no default
+// bucket or path; the export scheduler supplies both via
+// EXPORT_DEFAULT_BUCKET and EXPORT_DEFAULT_PATH.
 func (m *Module) ExportBackend() modulecapabilities.BackupBackend {
 	return m.exportBackend
 }

--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -188,6 +188,9 @@ func (g *gcsClient) findBucket(ctx context.Context, bucketOverride string) (*sto
 	if bucketOverride != "" {
 		b = bucketOverride
 	}
+	if b == "" {
+		return nil, fmt.Errorf("bucket must not be empty")
+	}
 	bucket := g.client.Bucket(b)
 
 	if _, err := bucket.Attrs(ctx); err != nil {

--- a/modules/backup-gcs/client_test.go
+++ b/modules/backup-gcs/client_test.go
@@ -1,0 +1,69 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modstggcs
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFindBucket_EmptyBucket(t *testing.T) {
+	// Note: cases where the resolved bucket is non-empty cannot be tested
+	// without a real GCS connection (client.Bucket panics on a nil client),
+	// so we only test the early-return guard here.
+	tests := []struct {
+		name         string
+		configBucket string
+		override     string
+		wantErr      string
+	}{
+		{
+			name:         "empty config bucket without override returns error",
+			configBucket: "",
+			override:     "",
+			wantErr:      "bucket must not be empty",
+		},
+		{
+			name:         "non-empty config bucket without override passes guard",
+			configBucket: "my-bucket",
+			override:     "",
+		},
+		{
+			name:         "empty config bucket with non-empty override passes guard",
+			configBucket: "",
+			override:     "override-bucket",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &gcsClient{config: clientConfig{Bucket: tt.configBucket}}
+
+			if tt.wantErr != "" {
+				_, err := client.findBucket(context.Background(), tt.override)
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				// Verify the guard logic: resolve the bucket the same way
+				// findBucket does and confirm it is non-empty.
+				b := tt.configBucket
+				if tt.override != "" {
+					b = tt.override
+				}
+				assert.NotEmpty(t, b)
+			}
+		})
+	}
+}

--- a/modules/backup-gcs/module.go
+++ b/modules/backup-gcs/module.go
@@ -48,7 +48,7 @@ type clientConfig struct {
 type Module struct {
 	logger       logrus.FieldLogger
 	*gcsClient              // backup client
-	exportClient *gcsClient // export client (BackupPath="")
+	exportClient *gcsClient // export-only client: no default bucket or path; the scheduler supplies both
 	dataPath     string
 }
 
@@ -93,8 +93,8 @@ func (m *Module) Init(ctx context.Context,
 	m.gcsClient = client
 
 	exportConfig := &clientConfig{
-		Bucket:     os.Getenv(gcsBucket),
-		BackupPath: "", // exports default to bucket root
+		Bucket:     "", // export scheduler provides bucket via EXPORT_DEFAULT_BUCKET
+		BackupPath: "", // export scheduler provides path via EXPORT_DEFAULT_PATH
 	}
 	exportClient, err := newClient(ctx, exportConfig, m.dataPath, m.logger)
 	if err != nil {
@@ -113,9 +113,9 @@ func (m *Module) MetaInfo() (map[string]interface{}, error) {
 	return metaInfo, nil
 }
 
-// ExportBackend returns the export-specific backend whose BackupPath is
-// always empty, so exports default to the bucket root rather than
-// inheriting the backup module's BACKUP_GCS_PATH.
+// ExportBackend returns the export-specific backend. It has no default
+// bucket or path; the export scheduler supplies both via
+// EXPORT_DEFAULT_BUCKET and EXPORT_DEFAULT_PATH.
 func (m *Module) ExportBackend() modulecapabilities.BackupBackend {
 	return &exportGCSBackend{m.exportClient}
 }

--- a/modules/backup-gcs/module.go
+++ b/modules/backup-gcs/module.go
@@ -46,9 +46,10 @@ type clientConfig struct {
 }
 
 type Module struct {
-	logger logrus.FieldLogger
-	*gcsClient
-	dataPath string
+	logger       logrus.FieldLogger
+	*gcsClient              // backup client
+	exportClient *gcsClient // export client (BackupPath="")
+	dataPath     string
 }
 
 func New() *Module {
@@ -90,6 +91,16 @@ func (m *Module) Init(ctx context.Context,
 		return errors.Wrap(err, "init gcs client")
 	}
 	m.gcsClient = client
+
+	exportConfig := &clientConfig{
+		Bucket:     os.Getenv(gcsBucket),
+		BackupPath: "", // exports default to bucket root
+	}
+	exportClient, err := newClient(ctx, exportConfig, m.dataPath, m.logger)
+	if err != nil {
+		return errors.Wrap(err, "init gcs export client")
+	}
+	m.exportClient = exportClient
 	return nil
 }
 
@@ -102,9 +113,24 @@ func (m *Module) MetaInfo() (map[string]interface{}, error) {
 	return metaInfo, nil
 }
 
+// ExportBackend returns the export-specific backend whose BackupPath is
+// always empty, so exports default to the bucket root rather than
+// inheriting the backup module's BACKUP_GCS_PATH.
+func (m *Module) ExportBackend() modulecapabilities.BackupBackend {
+	return &exportGCSBackend{m.exportClient}
+}
+
+type exportGCSBackend struct {
+	*gcsClient
+}
+
+func (e *exportGCSBackend) IsExternal() bool { return true }
+func (e *exportGCSBackend) Name() string     { return Name }
+
 // verify we implement the modules.Module interface
 var (
 	_ = modulecapabilities.Module(New())
 	_ = modulecapabilities.BackupBackend(New())
 	_ = modulecapabilities.MetaProvider(New())
+	_ = modulecapabilities.ExportBackendProvider(New())
 )

--- a/modules/backup-s3/client.go
+++ b/modules/backup-s3/client.go
@@ -210,13 +210,16 @@ func (s *s3Client) makeObjectName(overridePath string, parts ...string) string {
 
 // bucketAndPath resolves the effective bucket and object path,
 // applying overrides when set (e.g. for export to a different S3 location).
-func (s *s3Client) bucketAndPath(backupID, key, overrideBucket, overridePath string) (bucket, objectName string) {
+func (s *s3Client) bucketAndPath(backupID, key, overrideBucket, overridePath string) (bucket, objectName string, err error) {
 	bucket = s.config.Bucket
 	if overrideBucket != "" {
 		bucket = overrideBucket
 	}
+	if bucket == "" {
+		return "", "", fmt.Errorf("bucket must not be empty")
+	}
 	objectName = s.makeObjectName(overridePath, backupID, key)
-	return bucket, objectName
+	return bucket, objectName, nil
 }
 
 func (s *s3Client) HomeDir(backupID, overrideBucket, overridePath string) string {
@@ -284,7 +287,10 @@ func (s *s3Client) GetObject(ctx context.Context, backupID, key, overrideBucket,
 	if err != nil {
 		return nil, errors.Wrap(err, "get object: failed to get client")
 	}
-	bucket, remotePath := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	bucket, remotePath, err := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := ctx.Err(); err != nil {
 		return nil, backup.NewErrContextExpired(errors.Wrapf(err, "context expired in get object %s", remotePath))
@@ -324,7 +330,10 @@ func (s *s3Client) PutObject(ctx context.Context, backupID, key, overrideBucket,
 		return errors.Wrap(err, "put object: failed to get client")
 	}
 
-	bucket, remotePath := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	bucket, remotePath, err := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	if err != nil {
+		return err
+	}
 	opt := minio.PutObjectOptions{
 		ContentType:    "application/octet-stream",
 		PartSize:       MINIO_MIN_PART_SIZE,
@@ -358,7 +367,10 @@ func (s *s3Client) Initialize(ctx context.Context, backupID, overrideBucket, ove
 		return errors.Wrap(err, "failed to access-check s3 backup module")
 	}
 
-	bucket, objectName := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	bucket, objectName, err := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	if err != nil {
+		return err
+	}
 	opt := minio.RemoveObjectOptions{}
 	if err := client.RemoveObject(ctx, bucket, objectName, opt); err != nil {
 		return errors.Wrap(err, "failed to remove access-check s3 backup module")
@@ -373,7 +385,10 @@ func (s *s3Client) WriteToFile(ctx context.Context, backupID, key, destPath, ove
 	if err != nil {
 		return errors.Wrap(err, "write to file: cannot get client")
 	}
-	bucket, remotePath := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	bucket, remotePath, err := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	if err != nil {
+		return err
+	}
 
 	err = client.FGetObject(ctx, bucket, remotePath, destPath, minio.GetObjectOptions{})
 	if err != nil {
@@ -400,7 +415,10 @@ func (s *s3Client) Write(ctx context.Context, backupID, key, overrideBucket, ove
 	if err != nil {
 		return -1, errors.Wrap(err, "write: cannot get client")
 	}
-	bucket, remotePath := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	bucket, remotePath, err := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	if err != nil {
+		return -1, err
+	}
 	opt := minio.PutObjectOptions{
 		ContentType:      "application/octet-stream",
 		DisableMultipart: false,
@@ -426,7 +444,10 @@ func (s *s3Client) Read(ctx context.Context, backupID, key, overrideBucket, over
 	if err != nil {
 		return -1, errors.Wrap(err, "read: cannot get client")
 	}
-	bucket, remotePath := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	bucket, remotePath, err := s.bucketAndPath(backupID, key, overrideBucket, overridePath)
+	if err != nil {
+		return -1, err
+	}
 
 	obj, err := client.GetObject(ctx, bucket, remotePath, minio.GetObjectOptions{})
 	if err != nil {

--- a/modules/backup-s3/client_test.go
+++ b/modules/backup-s3/client_test.go
@@ -329,66 +329,78 @@ func TestExportBackend_AlwaysReturnsExportClient(t *testing.T) {
 }
 
 func TestBucketAndPath(t *testing.T) {
-	client := &s3Client{config: &clientConfig{Bucket: "default-bucket", BackupPath: "default-path"}}
-
 	tests := []struct {
 		name           string
-		backupID       string
-		key            string
+		configBucket   string
+		configPath     string
 		overrideBucket string
 		overridePath   string
 		wantBucket     string
 		wantObject     string
+		wantErr        string
 	}{
 		{
-			name:       "no overrides",
-			backupID:   "backup-1",
-			key:        "file.db",
-			wantBucket: "default-bucket",
-			wantObject: "default-path/backup-1/file.db",
+			name:         "no overrides",
+			configBucket: "default-bucket",
+			configPath:   "default-path",
+			wantBucket:   "default-bucket",
+			wantObject:   "default-path/backup-1/file.db",
 		},
 		{
 			name:           "override bucket only",
-			backupID:       "backup-1",
-			key:            "file.db",
+			configBucket:   "default-bucket",
+			configPath:     "default-path",
 			overrideBucket: "export-bucket",
 			wantBucket:     "export-bucket",
 			wantObject:     "default-path/backup-1/file.db",
 		},
 		{
 			name:         "override path only",
-			backupID:     "backup-1",
-			key:          "file.db",
+			configBucket: "default-bucket",
+			configPath:   "default-path",
 			overridePath: "export-path",
 			wantBucket:   "default-bucket",
 			wantObject:   "export-path/backup-1/file.db",
 		},
 		{
 			name:           "override both",
-			backupID:       "backup-1",
-			key:            "file.db",
+			configBucket:   "default-bucket",
+			configPath:     "default-path",
 			overrideBucket: "export-bucket",
 			overridePath:   "export-path",
 			wantBucket:     "export-bucket",
 			wantObject:     "export-path/backup-1/file.db",
 		},
+		{
+			name:         "empty config bucket without override returns error",
+			configBucket: "",
+			configPath:   "path",
+			wantErr:      "bucket must not be empty",
+		},
+		{
+			name:           "empty config bucket with override succeeds",
+			configBucket:   "",
+			configPath:     "path",
+			overrideBucket: "override-bucket",
+			wantBucket:     "override-bucket",
+			wantObject:     "path/backup-1/file.db",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bucket, objectName, err := client.bucketAndPath(tt.backupID, tt.key, tt.overrideBucket, tt.overridePath)
-			require.NoError(t, err)
-			assert.Equal(t, tt.wantBucket, bucket)
-			assert.Equal(t, tt.wantObject, objectName)
+			client := &s3Client{config: &clientConfig{Bucket: tt.configBucket, BackupPath: tt.configPath}}
+			bucket, objectName, err := client.bucketAndPath("backup-1", "file.db", tt.overrideBucket, tt.overridePath)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantBucket, bucket)
+				assert.Equal(t, tt.wantObject, objectName)
+			}
 		})
 	}
-
-	t.Run("empty bucket returns error", func(t *testing.T) {
-		emptyBucketClient := &s3Client{config: &clientConfig{Bucket: "", BackupPath: "path"}}
-		_, _, err := emptyBucketClient.bucketAndPath("backup-1", "file.db", "", "")
-		require.Error(t, err)
-		assert.Contains(t, err.Error(), "bucket must not be empty")
-	})
 }
 
 func TestRefreshableAssumeRole_IsProvider(t *testing.T) {

--- a/modules/backup-s3/client_test.go
+++ b/modules/backup-s3/client_test.go
@@ -298,23 +298,34 @@ func TestExportBackend_WithExportClient(t *testing.T) {
 	assert.True(t, eb.IsExternal())
 }
 
-func TestExportBackend_WithoutExportClient(t *testing.T) {
+func TestExportBackend_AlwaysReturnsExportClient(t *testing.T) {
 	setEnvVars(t, map[string]string{
 		"AWS_ACCESS_KEY_ID":     "test-key",
 		"AWS_SECRET_ACCESS_KEY": "test-secret",
 	})
 
-	backupCfg := newConfig("s3.amazonaws.com", "my-bucket", "", true)
+	backupCfg := newConfig("s3.amazonaws.com", "my-bucket", "backup-path", true)
 	backupClient, err := newClient(backupCfg, nil, "/tmp")
 	require.NoError(t, err)
 
+	exportCfg := newConfig("s3.amazonaws.com", "my-bucket", "", true)
+	exportClient, err := newClient(exportCfg, nil, "/tmp")
+	require.NoError(t, err)
+
 	m := &Module{
-		s3Client: backupClient,
+		s3Client:     backupClient,
+		exportClient: exportClient,
 	}
 
 	eb := m.ExportBackend()
-	// Should return the module itself when no export client is configured
-	assert.Equal(t, m, eb)
+	// Should return the export client, not the module itself
+	assert.NotEqual(t, m, eb)
+	assert.Equal(t, Name, eb.Name())
+	assert.True(t, eb.IsExternal())
+
+	// Export backend must NOT inherit the backup path
+	exportBackend := eb.(*exportS3Backend)
+	assert.Empty(t, exportBackend.config.BackupPath, "export backend should have empty BackupPath")
 }
 
 func TestBucketAndPath(t *testing.T) {

--- a/modules/backup-s3/client_test.go
+++ b/modules/backup-s3/client_test.go
@@ -376,11 +376,19 @@ func TestBucketAndPath(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			bucket, objectName := client.bucketAndPath(tt.backupID, tt.key, tt.overrideBucket, tt.overridePath)
+			bucket, objectName, err := client.bucketAndPath(tt.backupID, tt.key, tt.overrideBucket, tt.overridePath)
+			require.NoError(t, err)
 			assert.Equal(t, tt.wantBucket, bucket)
 			assert.Equal(t, tt.wantObject, objectName)
 		})
 	}
+
+	t.Run("empty bucket returns error", func(t *testing.T) {
+		emptyBucketClient := &s3Client{config: &clientConfig{Bucket: "", BackupPath: "path"}}
+		_, _, err := emptyBucketClient.bucketAndPath("backup-1", "file.db", "", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bucket must not be empty")
+	})
 }
 
 func TestRefreshableAssumeRole_IsProvider(t *testing.T) {

--- a/modules/backup-s3/module.go
+++ b/modules/backup-s3/module.go
@@ -50,7 +50,7 @@ const (
 
 type Module struct {
 	*s3Client              // embedded — handles backup (all BackupBackend methods auto-promoted)
-	exportClient *s3Client // only set when EXPORT_S3_ROLE_ARN is configured
+	exportClient *s3Client // export-only client: no default bucket or path; the scheduler supplies both
 	logger       logrus.FieldLogger
 	dataPath     string
 }
@@ -94,11 +94,11 @@ func (m *Module) Init(ctx context.Context,
 	}
 	m.s3Client = client
 
-	// Always create a separate export client with BackupPath="" so that
-	// exports default to the bucket root instead of inheriting BACKUP_S3_PATH.
-	// When EXPORT_S3_ROLE_ARN is set, the export client additionally uses
-	// STS AssumeRole for cross-account access.
-	exportCfg := newConfig(os.Getenv(s3Endpoint), bucket, "", useSSL)
+	// Create a separate export client with no default bucket or path.
+	// The export scheduler supplies both via EXPORT_DEFAULT_BUCKET and
+	// EXPORT_DEFAULT_PATH. When EXPORT_S3_ROLE_ARN is set the export
+	// client additionally uses STS AssumeRole for cross-account access.
+	exportCfg := newConfig(os.Getenv(s3Endpoint), "", "", useSSL)
 	if exportRoleARN := os.Getenv(exportS3RoleARN); exportRoleARN != "" {
 		exportCfg.RoleARN = exportRoleARN
 		exportCfg.ExternalID = os.Getenv(exportS3ExternalID)
@@ -117,9 +117,9 @@ func (m *Module) Init(ctx context.Context,
 	return nil
 }
 
-// ExportBackend returns the export-specific backend whose BackupPath is
-// always empty, so exports default to the bucket root rather than
-// inheriting the backup module's BACKUP_S3_PATH.
+// ExportBackend returns the export-specific backend. It has no default
+// bucket or path; the export scheduler supplies both via
+// EXPORT_DEFAULT_BUCKET and EXPORT_DEFAULT_PATH.
 func (m *Module) ExportBackend() modulecapabilities.BackupBackend {
 	return &exportS3Backend{m.exportClient}
 }

--- a/modules/backup-s3/module.go
+++ b/modules/backup-s3/module.go
@@ -94,9 +94,12 @@ func (m *Module) Init(ctx context.Context,
 	}
 	m.s3Client = client
 
-	// Create a separate export client with STS AssumeRole if configured.
+	// Always create a separate export client with BackupPath="" so that
+	// exports default to the bucket root instead of inheriting BACKUP_S3_PATH.
+	// When EXPORT_S3_ROLE_ARN is set, the export client additionally uses
+	// STS AssumeRole for cross-account access.
+	exportCfg := newConfig(os.Getenv(s3Endpoint), bucket, "", useSSL)
 	if exportRoleARN := os.Getenv(exportS3RoleARN); exportRoleARN != "" {
-		exportCfg := newConfig(os.Getenv(s3Endpoint), bucket, os.Getenv(s3Path), useSSL)
 		exportCfg.RoleARN = exportRoleARN
 		exportCfg.ExternalID = os.Getenv(exportS3ExternalID)
 		exportCfg.STSEndpoint = os.Getenv(exportS3STSEndpoint)
@@ -104,23 +107,21 @@ func (m *Module) Init(ctx context.Context,
 		if exportCfg.RoleSessionName == "" {
 			exportCfg.RoleSessionName = "weaviate-export-s3"
 		}
-		exportClient, err := newClient(exportCfg, m.logger, m.dataPath)
-		if err != nil {
-			return errors.Wrap(err, "initialize S3 export client")
-		}
-		m.exportClient = exportClient
 	}
+	exportClient, err := newClient(exportCfg, m.logger, m.dataPath)
+	if err != nil {
+		return errors.Wrap(err, "initialize S3 export client")
+	}
+	m.exportClient = exportClient
 
 	return nil
 }
 
-// ExportBackend returns the export-specific backend when configured,
-// otherwise falls back to the default backup backend.
+// ExportBackend returns the export-specific backend whose BackupPath is
+// always empty, so exports default to the bucket root rather than
+// inheriting the backup module's BACKUP_S3_PATH.
 func (m *Module) ExportBackend() modulecapabilities.BackupBackend {
-	if m.exportClient != nil {
-		return &exportS3Backend{m.exportClient}
-	}
-	return m
+	return &exportS3Backend{m.exportClient}
 }
 
 // exportS3Backend wraps an s3Client to satisfy the full BackupBackend

--- a/test/acceptance/authz/export_test.go
+++ b/test/acceptance/authz/export_test.go
@@ -46,7 +46,6 @@ func TestExportRBAC(t *testing.T) {
 		WithBackendS3(s3Bucket, "eu-west-1").
 		WithWeaviateEnv("EXPORT_ENABLED", "true").
 		WithWeaviateEnv("EXPORT_DEFAULT_BUCKET", s3Bucket).
-		WithWeaviateEnv("EXPORT_DEFAULT_PATH", "").
 		Start(ctx)
 	require.NoError(t, err)
 	defer func() {

--- a/test/modules/export-filesystem/setup_test.go
+++ b/test/modules/export-filesystem/setup_test.go
@@ -52,6 +52,7 @@ func setupSharedCluster(ctx context.Context) (*docker.DockerCompose, error) {
 	compose, err := docker.New().
 		WithBackendFilesystem().
 		WithWeaviateEnv("EXPORT_ENABLED", "true").
+		WithWeaviateEnv("EXPORT_DEFAULT_PATH", "/tmp/export").
 		With1NodeCluster().
 		Start(ctx)
 	if err != nil {

--- a/test/modules/export-filesystem/setup_test.go
+++ b/test/modules/export-filesystem/setup_test.go
@@ -52,7 +52,6 @@ func setupSharedCluster(ctx context.Context) (*docker.DockerCompose, error) {
 	compose, err := docker.New().
 		WithBackendFilesystem().
 		WithWeaviateEnv("EXPORT_ENABLED", "true").
-		WithWeaviateEnv("EXPORT_DEFAULT_PATH", "").
 		With1NodeCluster().
 		Start(ctx)
 	if err != nil {

--- a/test/modules/export-s3/setup_test.go
+++ b/test/modules/export-s3/setup_test.go
@@ -71,7 +71,6 @@ func setupSharedCluster(ctx context.Context) (*docker.DockerCompose, error) {
 		WithWeaviateEnv("AWS_REGION", defaultS3Region).
 		WithWeaviateEnv("EXPORT_ENABLED", "true").
 		WithWeaviateEnv("EXPORT_DEFAULT_BUCKET", s3Bucket).
-		WithWeaviateEnv("EXPORT_DEFAULT_PATH", "").
 		WithWeaviateCluster(3).
 		Start(ctx)
 	if err != nil {

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -607,7 +607,9 @@ type Export struct {
 	DefaultBucket *runtime.DynamicValue[string] `json:"default_bucket" yaml:"default_bucket"`
 
 	// DefaultPath is the default path prefix within the bucket or filesystem for exports.
-	// Defaults to empty string (no prefix).
+	// Defaults to empty string (no prefix). Each backup module provides a separate
+	// export backend that does not inherit the backup path (e.g. BACKUP_S3_PATH),
+	// so this value is used directly.
 	// Env: EXPORT_DEFAULT_PATH, runtime config: export_default_path.
 	DefaultPath *runtime.DynamicValue[string] `json:"default_path" yaml:"default_path"`
 }

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"regexp"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/go-openapi/swag"
@@ -608,37 +607,9 @@ type Export struct {
 	DefaultBucket *runtime.DynamicValue[string] `json:"default_bucket" yaml:"default_bucket"`
 
 	// DefaultPath is the default path prefix within the bucket or filesystem for exports.
+	// Defaults to empty string (no prefix).
 	// Env: EXPORT_DEFAULT_PATH, runtime config: export_default_path.
 	DefaultPath *runtime.DynamicValue[string] `json:"default_path" yaml:"default_path"`
-
-	// IsDefaultPathSet tracks whether DefaultPath was explicitly configured by the
-	// operator (vs. implicitly defaulted to the empty string). It is used to
-	// require an explicit path decision at export time — where an empty string
-	// is a valid, conscious choice (no prefix), but a missing value is not.
-	//
-	// This is a derived internal flag, not a user-facing knob: it is set
-	// automatically when DefaultPath is provided via EXPORT_DEFAULT_PATH, via
-	// the startup config file, or via a runtime override. It is intentionally
-	// a plain *atomic.Bool rather than a DynamicValue and is absent from
-	// WeaviateRuntimeConfig, so an operator cannot flip it independently of
-	// DefaultPath.
-	//
-	// Sources that flip it:
-	//  - parseExportConfig (environment.go): sets true if EXPORT_DEFAULT_PATH is
-	//    present or if the startup YAML/JSON config pre-populated DefaultPath.
-	//  - postInitRuntimeOverrides (configure_api.go): after runtime config
-	//    hook registration, syncs the flag if runtime config loaded a
-	//    non-empty DefaultPath (the initial load inside NewConfigManager
-	//    runs before hooks are registered — see the manual sync there).
-	//  - "ExportDefaultPath" hook (configure_api.go): flips it on subsequent
-	//    runtime config reloads when DefaultPath actually changes.
-	//
-	// Known limitation: an operator with no env/YAML config who sets
-	// `export_default_path: ""` only via the runtime config file at startup
-	// will not flip the flag, because the hook fires only on value changes
-	// and "" equals the startup default. Any non-empty value works, or set
-	// EXPORT_DEFAULT_PATH="" at startup.
-	IsDefaultPathSet *atomic.Bool `json:"-" yaml:"-"`
 }
 
 const (

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -20,7 +20,6 @@ import (
 	"slices"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -1960,18 +1959,9 @@ func (c *Config) parseExportConfig() {
 		c.Export.DefaultBucket = configRuntime.NewDynamicValue("")
 	}
 
-	c.Export.IsDefaultPathSet = new(atomic.Bool)
 	if v, ok := os.LookupEnv("EXPORT_DEFAULT_PATH"); ok {
 		c.Export.DefaultPath = configRuntime.NewDynamicValue(strings.TrimSpace(v))
-		c.Export.IsDefaultPathSet.Store(true)
-	} else if c.Export.DefaultPath != nil {
-		// Came from the startup config file — an explicit decision by the
-		// operator, even if the value is empty. IsDefaultPathSet is not
-		// user-settable (see config.Export), so we derive it here. It may
-		// also be flipped to true at runtime by the "ExportDefaultPath" hook
-		// registered against the runtime config manager.
-		c.Export.IsDefaultPathSet.Store(true)
-	} else {
+	} else if c.Export.DefaultPath == nil {
 		c.Export.DefaultPath = configRuntime.NewDynamicValue("")
 	}
 }

--- a/usecases/config/environment_test.go
+++ b/usecases/config/environment_test.go
@@ -1538,54 +1538,46 @@ func TestEnvironmentExportDefaultPath(t *testing.T) {
 		envValue []string
 		// preset simulates a value coming from the startup config file
 		// (YAML/JSON), which is parsed into Config before FromEnv runs.
-		preset    *string
-		expected  string
-		expectSet bool
+		preset   *string
+		expected string
 	}{
 		{
-			name:      "env set",
-			envValue:  []string{"custom/prefix"},
-			expected:  "custom/prefix",
-			expectSet: true,
+			name:     "env set",
+			envValue: []string{"custom/prefix"},
+			expected: "custom/prefix",
 		},
 		{
-			name:      "env set with whitespace trimmed",
-			envValue:  []string{"  some/path  "},
-			expected:  "some/path",
-			expectSet: true,
+			name:     "env set with whitespace trimmed",
+			envValue: []string{"  some/path  "},
+			expected: "some/path",
 		},
 		{
-			name:      "env set to empty string is still considered set",
-			envValue:  []string{""},
-			expected:  "",
-			expectSet: true,
+			name:     "env set to empty string",
+			envValue: []string{""},
+			expected: "",
 		},
 		{
-			name:      "not set defaults to empty and unset",
-			envValue:  []string{},
-			expected:  "",
-			expectSet: false,
+			name:     "not set defaults to empty",
+			envValue: []string{},
+			expected: "",
 		},
 		{
-			name:      "preset via startup config is considered set",
-			envValue:  []string{},
-			preset:    stringPtr("from/config/file"),
-			expected:  "from/config/file",
-			expectSet: true,
+			name:     "preset via startup config is preserved",
+			envValue: []string{},
+			preset:   stringPtr("from/config/file"),
+			expected: "from/config/file",
 		},
 		{
-			name:      "preset via startup config with empty string is considered set",
-			envValue:  []string{},
-			preset:    stringPtr(""),
-			expected:  "",
-			expectSet: true,
+			name:     "preset via startup config with empty string is preserved",
+			envValue: []string{},
+			preset:   stringPtr(""),
+			expected: "",
 		},
 		{
-			name:      "env overrides preset from startup config",
-			envValue:  []string{"from/env"},
-			preset:    stringPtr("from/config/file"),
-			expected:  "from/env",
-			expectSet: true,
+			name:     "env overrides preset from startup config",
+			envValue: []string{"from/env"},
+			preset:   stringPtr("from/config/file"),
+			expected: "from/env",
 		},
 	}
 	for _, tt := range tests {
@@ -1600,7 +1592,6 @@ func TestEnvironmentExportDefaultPath(t *testing.T) {
 			err := FromEnv(&conf)
 			require.Nil(t, err)
 			require.Equal(t, tt.expected, conf.Export.DefaultPath.Get())
-			require.Equal(t, tt.expectSet, conf.Export.IsDefaultPathSet.Load())
 		})
 	}
 }

--- a/usecases/config/runtimeconfig_test.go
+++ b/usecases/config/runtimeconfig_test.go
@@ -15,14 +15,11 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"os"
 	"regexp"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/go-jose/go-jose/v4/json"
-	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -592,222 +589,50 @@ replica_movement_minimum_async_wait: 10s`)
 	})
 }
 
-// TestExportDefaultPathRuntimeOverride verifies the end-to-end wiring that
-// lets an operator configure exports for the first time via the runtime
-// config file (no env var, no startup YAML).
-//
-// Because Export.IsDefaultPathSet is intentionally not exposed in
-// WeaviateRuntimeConfig (it would be a footgun — operators could toggle the
-// "set" flag independently of DefaultPath and bypass the path-required
-// check), we rely on a hook registered against the "ExportDefaultPath" field
-// to flip IsDefaultPathSet whenever DefaultPath is updated via runtime
-// overrides. This test asserts that flipping behavior.
-//
-// Known limitation: the runtime config hook system only fires on value
-// *changes* (see updateRuntimeConfig in runtimeconfig.go, which records a
-// log entry only when old != new). An operator who runs without any startup
-// export config (DefaultPath="") and then writes literally
-// `export_default_path: ""` into the runtime config will NOT flip
-// IsDefaultPathSet, because the value is the same as the startup default and
-// the hook never fires. In practice this is a non-issue: any non-empty
-// value works, and operators who genuinely want the empty-prefix case can
-// set EXPORT_DEFAULT_PATH="" at startup instead.
+// TestExportDefaultPathRuntimeOverride verifies that runtime config overrides
+// correctly update Export.DefaultPath.
 func TestExportDefaultPathRuntimeOverride(t *testing.T) {
 	log := logrus.New()
 	log.SetOutput(io.Discard)
 
 	tests := []struct {
-		name             string
-		initialPath      string // startup value for source.ExportDefaultPath
-		initialPathSet   bool   // startup value for IsDefaultPathSet
-		runtimeConfig    string // YAML applied via UpdateRuntimeConfig
-		expectedPath     string
-		expectedPathSet  bool
-		assertionMessage string
+		name          string
+		initialPath   string // startup value for source.ExportDefaultPath
+		runtimeConfig string // YAML applied via UpdateRuntimeConfig
+		expectedPath  string
 	}{
 		{
-			name:             "override with non-empty path flips IsDefaultPathSet from false to true",
-			initialPath:      "",
-			initialPathSet:   false,
-			runtimeConfig:    `export_default_path: "from/runtime"`,
-			expectedPath:     "from/runtime",
-			expectedPathSet:  true,
-			assertionMessage: "hook should have flipped IsDefaultPathSet to true when ExportDefaultPath was updated",
+			name:          "override from empty to non-empty path",
+			initialPath:   "",
+			runtimeConfig: `export_default_path: "from/runtime"`,
+			expectedPath:  "from/runtime",
 		},
 		{
-			name:            "override switching non-empty path to another non-empty path keeps it set",
-			initialPath:     "initial/path",
-			initialPathSet:  true,
-			runtimeConfig:   `export_default_path: "new/path"`,
-			expectedPath:    "new/path",
-			expectedPathSet: true,
+			name:          "override switching non-empty path to another non-empty path",
+			initialPath:   "initial/path",
+			runtimeConfig: `export_default_path: "new/path"`,
+			expectedPath:  "new/path",
 		},
 		{
-			name:             "override from non-empty to empty string keeps it set (empty is a valid explicit choice)",
-			initialPath:      "initial/path",
-			initialPathSet:   true,
-			runtimeConfig:    `export_default_path: ""`,
-			expectedPath:     "",
-			expectedPathSet:  true,
-			assertionMessage: "empty string is a valid explicit choice; hook must fire on any change",
+			name:          "override from non-empty to empty string",
+			initialPath:   "initial/path",
+			runtimeConfig: `export_default_path: ""`,
+			expectedPath:  "",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			defaultPath := runtime.NewDynamicValue(tt.initialPath)
-			defaultPathSet := new(atomic.Bool)
-			defaultPathSet.Store(tt.initialPathSet)
 			source := &WeaviateRuntimeConfig{
 				ExportDefaultPath: defaultPath,
-			}
-			// this is the hook that configure_api.go registers in production
-			hooks := map[string]func() error{
-				"ExportDefaultPath": func() error {
-					defaultPathSet.Store(true)
-					return nil
-				},
 			}
 
 			parsed, err := ParseRuntimeConfig([]byte(tt.runtimeConfig))
 			require.NoError(t, err)
-			require.NoError(t, UpdateRuntimeConfig(log, source, parsed, hooks))
+			require.NoError(t, UpdateRuntimeConfig(log, source, parsed, nil))
 
 			assert.Equal(t, tt.expectedPath, defaultPath.Get())
-			assert.Equal(t, tt.expectedPathSet, defaultPathSet.Load(), tt.assertionMessage)
-		})
-	}
-
-	t.Run("ExportIsDefaultPathSet is not a user-facing runtime config knob", func(t *testing.T) {
-		// Regression: if someone ever re-adds ExportIsDefaultPathSet to
-		// WeaviateRuntimeConfig, operators could bypass the path-required
-		// check. This test ensures the field stays absent.
-		parsed, err := ParseRuntimeConfig([]byte(`export_default_path_set: true`))
-		require.NoError(t, err) // parser tolerates unknown keys
-
-		// The struct must not carry a field corresponding to the key. We
-		// round-trip via YAML marshaling to observe the exposed fields.
-		yd, err := yaml.Marshal(parsed)
-		require.NoError(t, err)
-		var roundTripped map[string]any
-		require.NoError(t, yaml.Unmarshal(yd, &roundTripped))
-		_, present := roundTripped["export_default_path_set"]
-		assert.False(t, present,
-			"export_default_path_set must not be a runtime config field; it is a derived internal flag")
-	})
-}
-
-// TestExportDefaultPathRuntimeOverrideFullFlow exercises the real
-// NewConfigManager startup sequence to catch the "initial load runs without
-// hooks" bug. The bug: NewConfigManager calls cm.loadConfig() internally
-// *before* hooks are registered, so if the runtime config file sets
-// export_default_path, SetValue is called on source.ExportDefaultPath but
-// the ExportDefaultPath hook never fires. A subsequent forced ReloadConfig
-// (to apply hooks) then sees no value change and still doesn't fire the
-// hook. Without the explicit post-registration sync in postInitRuntimeOverrides,
-// IsDefaultPathSet would stay false and the scheduler would reject exports.
-func TestExportDefaultPathRuntimeOverrideFullFlow(t *testing.T) {
-	log := logrus.New()
-	log.SetOutput(io.Discard)
-
-	// newHooks returns the hook that configure_api.go registers in production.
-	newHooks := func(defaultPathSet *atomic.Bool) map[string]func() error {
-		return map[string]func() error{
-			"ExportDefaultPath": func() error {
-				defaultPathSet.Store(true)
-				return nil
-			},
-		}
-	}
-
-	// syncIsDefaultPathSet implements the post-registration manual sync.
-	// configure_api.go's postInitRuntimeOverrides does the same after
-	// cm.RegisterHooks to handle the initial-load case (where hooks weren't
-	// registered yet).
-	syncIsDefaultPathSet := func(source *WeaviateRuntimeConfig, defaultPathSet *atomic.Bool) {
-		if source.ExportDefaultPath != nil && source.ExportDefaultPath.Get() != "" {
-			defaultPathSet.Store(true)
-		}
-	}
-
-	writeRuntimeConfig := func(t *testing.T, content string) string {
-		t.Helper()
-		f, err := os.CreateTemp(t.TempDir(), "runtime_config_*.yaml")
-		require.NoError(t, err)
-		_, err = f.WriteString(content)
-		require.NoError(t, err)
-		require.NoError(t, f.Close())
-		return f.Name()
-	}
-
-	tests := []struct {
-		name             string
-		runtimeConfig    string
-		expectedPath     string
-		expectedPathSet  bool
-		assertionMessage string
-	}{
-		{
-			name:             "non-empty path in runtime config → scheduler accepts exports",
-			runtimeConfig:    `export_default_path: "from/runtime"`,
-			expectedPath:     "from/runtime",
-			expectedPathSet:  true,
-			assertionMessage: "manual post-registration sync must flip IsDefaultPathSet when runtime config set a non-empty path",
-		},
-		{
-			name:             "no export_default_path line → IsDefaultPathSet stays false",
-			runtimeConfig:    `# no export config here`,
-			expectedPath:     "",
-			expectedPathSet:  false,
-			assertionMessage: "no runtime config entry → nothing should flip IsDefaultPathSet",
-		},
-		{
-			// Documented edge case: an operator with no env/YAML config
-			// writing `export_default_path: ""` only via runtime config at
-			// startup. The manual sync uses Get() != "" as its heuristic
-			// and cannot distinguish "operator set empty" from "nothing
-			// set", so IsDefaultPathSet stays false.
-			name:             "empty path only via runtime config at startup is a documented limitation",
-			runtimeConfig:    `export_default_path: ""`,
-			expectedPath:     "",
-			expectedPathSet:  false,
-			assertionMessage: "documented edge case: empty-string-only via runtime config at startup does not flip the flag",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// parseExportConfig at startup with no env and no YAML:
-			//   DefaultPath = NewDynamicValue("") [def="", val=nil]
-			//   IsDefaultPathSet = new(atomic.Bool) [false]
-			source := &WeaviateRuntimeConfig{
-				ExportDefaultPath: runtime.NewDynamicValue(""),
-			}
-			defaultPathSet := new(atomic.Bool)
-
-			path := writeRuntimeConfig(t, tt.runtimeConfig)
-
-			// NewConfigManager runs the initial loadConfig internally with
-			// hooks=nil, silently updating source.ExportDefaultPath.
-			cm, err := runtime.NewConfigManager(
-				path, ParseRuntimeConfig, UpdateRuntimeConfig, source,
-				100*time.Millisecond, log, prometheus.NewPedanticRegistry(),
-			)
-			require.NoError(t, err)
-
-			// Register hooks and force a reload. The forced reload sees
-			// oldV == newV, so change-based hooks cannot fire here either.
-			// This is the gap that postInitRuntimeOverrides' manual sync
-			// exists to close.
-			cm.RegisterHooks(newHooks(defaultPathSet))
-			require.NoError(t, cm.ReloadConfig())
-
-			// The explicit manual sync in postInitRuntimeOverrides catches
-			// the case by observing that DefaultPath is non-empty.
-			syncIsDefaultPathSet(source, defaultPathSet)
-
-			assert.Equal(t, tt.expectedPath, source.ExportDefaultPath.Get())
-			assert.Equal(t, tt.expectedPathSet, defaultPathSet.Load(), tt.assertionMessage)
 		})
 	}
 }

--- a/usecases/export/helpers_for_test.go
+++ b/usecases/export/helpers_for_test.go
@@ -17,7 +17,6 @@ import (
 	"io"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -397,12 +396,9 @@ func (b *writeBlockingBackend) waitForParquetWrite(t *testing.T) {
 // testExportConfig returns an Export config with export enabled and a test bucket,
 // suitable for unit tests that need a non-nil exportConfig.
 func testExportConfig() config.Export {
-	pathSet := new(atomic.Bool)
-	pathSet.Store(true)
 	return config.Export{
-		Enabled:          configRuntime.NewDynamicValue(true),
-		DefaultBucket:    configRuntime.NewDynamicValue("test-bucket"),
-		DefaultPath:      configRuntime.NewDynamicValue(""),
-		IsDefaultPathSet: pathSet,
+		Enabled:       configRuntime.NewDynamicValue(true),
+		DefaultBucket: configRuntime.NewDynamicValue("test-bucket"),
+		DefaultPath:   configRuntime.NewDynamicValue(""),
 	}
 }

--- a/usecases/export/scheduler.go
+++ b/usecases/export/scheduler.go
@@ -934,19 +934,15 @@ func requiresBucket(backend string) bool {
 	}
 }
 
-// validateStorageConfig returns the configured bucket and path after verifying
-// that the operator has made both explicit. It is shared by Export, Status and
-// Cancel because all three need to address the same storage location: using
-// implicit defaults would silently point them at the wrong prefix and surface
-// as confusing "not found" errors for Status/Cancel.
+// validateStorageConfig returns the configured bucket and path. It is shared
+// by Export, Status and Cancel because all three need to address the same
+// storage location. The bucket is required for bucket-backed backends, but
+// the path defaults to empty (no prefix) if not configured.
 func (s *Scheduler) validateStorageConfig(backend string) (bucket, path string, err error) {
 	bucket = s.exportConfig.DefaultBucket.Get()
 	path = s.exportConfig.DefaultPath.Get()
 	if bucket == "" && requiresBucket(backend) {
 		return "", "", fmt.Errorf("%w: EXPORT_DEFAULT_BUCKET is required for backend %q", ErrExportValidation, backend)
-	}
-	if !s.exportConfig.IsDefaultPathSet.Load() {
-		return "", "", fmt.Errorf("%w: EXPORT_DEFAULT_PATH must be explicitly set (an empty value is allowed for no prefix)", ErrExportValidation)
 	}
 	return bucket, path, nil
 }

--- a/usecases/export/scheduler.go
+++ b/usecases/export/scheduler.go
@@ -936,8 +936,9 @@ func requiresBucket(backend string) bool {
 
 // validateStorageConfig returns the configured bucket and path. It is shared
 // by Export, Status and Cancel because all three need to address the same
-// storage location. The bucket is required for bucket-backed backends, but
-// the path defaults to empty (no prefix) if not configured.
+// storage location. The bucket is required for bucket-backed backends.
+// The path defaults to empty if not configured; each backend module provides
+// a dedicated export client that does not fall back to the backup path.
 func (s *Scheduler) validateStorageConfig(backend string) (bucket, path string, err error) {
 	bucket = s.exportConfig.DefaultBucket.Get()
 	path = s.exportConfig.DefaultPath.Get()

--- a/usecases/export/scheduler_test.go
+++ b/usecases/export/scheduler_test.go
@@ -16,7 +16,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -201,17 +200,6 @@ func TestScheduler_StorageConfigValidation(t *testing.T) {
 		}
 	}
 
-	t.Run("fails on all endpoints when EXPORT_DEFAULT_PATH was not set", func(t *testing.T) {
-		s := newScheduler()
-		// Simulate EXPORT_DEFAULT_PATH never having been set.
-		s.exportConfig.IsDefaultPathSet = new(atomic.Bool)
-		for name, err := range callAll(s) {
-			require.Errorf(t, err, "%s should error", name)
-			assert.ErrorIsf(t, err, ErrExportValidation, "%s should wrap ErrExportValidation", name)
-			assert.Containsf(t, err.Error(), "EXPORT_DEFAULT_PATH", "%s error should mention EXPORT_DEFAULT_PATH", name)
-		}
-	})
-
 	t.Run("fails on all endpoints when bucket is missing for bucket-backed backend", func(t *testing.T) {
 		s := newScheduler()
 		s.exportConfig.DefaultBucket = configRuntime.NewDynamicValue("")
@@ -222,13 +210,12 @@ func TestScheduler_StorageConfigValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("passes path validation when set to empty string", func(t *testing.T) {
+	t.Run("passes validation when path is empty (no prefix)", func(t *testing.T) {
 		s := newScheduler()
 		s.exportConfig.DefaultPath = configRuntime.NewDynamicValue("")
-		s.exportConfig.IsDefaultPathSet = new(atomic.Bool)
-		s.exportConfig.IsDefaultPathSet.Store(true)
-		// The path-set check must not fire; downstream errors are fine because
-		// this scheduler is stubbed and may fail later for unrelated reasons.
+		// Empty path is a valid default (no prefix). Downstream errors are
+		// fine because this scheduler is stubbed and may fail later for
+		// unrelated reasons.
 		for name, err := range callAll(s) {
 			if err != nil {
 				assert.NotContainsf(t, err.Error(), "EXPORT_DEFAULT_PATH", "%s should not fail on path validation", name)

--- a/usecases/export/scheduler_test.go
+++ b/usecases/export/scheduler_test.go
@@ -210,12 +210,11 @@ func TestScheduler_StorageConfigValidation(t *testing.T) {
 		}
 	})
 
-	t.Run("passes validation when path is empty (no prefix)", func(t *testing.T) {
+	t.Run("passes validation when path is empty", func(t *testing.T) {
 		s := newScheduler()
 		s.exportConfig.DefaultPath = configRuntime.NewDynamicValue("")
-		// Empty path is a valid default (no prefix). Downstream errors are
-		// fine because this scheduler is stubbed and may fail later for
-		// unrelated reasons.
+		// Empty path is a valid default. Downstream errors are fine because
+		// this scheduler is stubbed and may fail later for unrelated reasons.
 		for name, err := range callAll(s) {
 			if err != nil {
 				assert.NotContainsf(t, err.Error(), "EXPORT_DEFAULT_PATH", "%s should not fail on path validation", name)


### PR DESCRIPTION
### What's being changed:

- Export default path is "" by default and NOT required anymore
- All backup module get an extra exportClient with its own config so backup and export defaults are not mixed

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
