### PR TITLE
fix: optimize zstd encoder usage in replication client

### DIFF
--- a/adapters/clients/remote_index_test.go
+++ b/adapters/clients/remote_index_test.go
@@ -229,7 +229,12 @@ func TestRemoteIndexPutFile(t *testing.T) {
 func newRemoteIndex(httpClient *http.Client) *RemoteIndex {
 	ri := NewRemoteIndex(httpClient)
 	ri.minBackOff = time.Millisecond * 1
-	ri.maxBackOff = time.Millisecond * 10
+	// maxBackOff drives MaxElapsedTime = n*maxBackOff in the retryer.
+	// A small value like 10ms makes MaxElapsedTime=90ms, which a single
+	// slow CI round-trip can exhaust before retries complete. 500ms gives
+	// MaxElapsedTime=4.5s — still fast in practice (actual backoff starts
+	// at minBackOff=1ms) but resilient to CI scheduling jitter.
+	ri.maxBackOff = time.Millisecond * 500
 	ri.timeoutUnit = time.Millisecond * 20
 	return ri
 }

--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -24,6 +24,7 @@ import (
 	"math/rand"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
@@ -57,15 +58,39 @@ const (
 
 type replicationClient struct {
 	retryClient
+	zstdEncoderPool sync.Pool
 }
 
-func NewReplicationClient(httpClient *http.Client) *replicationClient {
-	return &replicationClient{
+var _ replica.Client = (*replicationClient)(nil)
+
+func NewReplicationClient(httpClient *http.Client) (*replicationClient, error) {
+	// Verify encoder creation works at startup before returning the client.
+	enc, err := zstd.NewWriter(nil)
+	if err != nil {
+		return nil, fmt.Errorf("create zstd encoder: %w", err)
+	}
+	c := &replicationClient{
 		retryClient: retryClient{
 			client:  httpClient,
 			retryer: newRetryer(),
 		},
 	}
+	// zstdEncoderPool reuses *zstd.Encoder instances across goroutines.
+	// A pool is required because zstd.Encoder is not safe for concurrent use:
+	// each caller acquires an exclusive encoder via Get, runs EncodeAll, then
+	// returns it with Put. New returns nil on failure; call sites guard with
+	// an ok+nil check and fall back to creating a fresh encoder.
+	c.zstdEncoderPool = sync.Pool{
+		New: func() any {
+			e, err := zstd.NewWriter(nil)
+			if err != nil {
+				return nil
+			}
+			return e
+		},
+	}
+	c.zstdEncoderPool.Put(enc)
+	return c, nil
 }
 
 // FetchObject fetches one object it exits
@@ -188,12 +213,15 @@ func (c *replicationClient) HashTreeLevel(ctx context.Context,
 		return nil, fmt.Errorf("marshal hashtree level input: %w", err)
 	}
 
-	enc, err := zstd.NewWriter(nil)
-	if err != nil {
-		return nil, fmt.Errorf("create zstd encoder: %w", err)
+	enc, ok := c.zstdEncoderPool.Get().(*zstd.Encoder)
+	if !ok || enc == nil {
+		enc, err = zstd.NewWriter(nil)
+		if err != nil {
+			return nil, fmt.Errorf("create zstd encoder: %w", err)
+		}
 	}
-	defer enc.Close()
 	bodyBytes := enc.EncodeAll(body, make([]byte, 0, len(body)))
+	c.zstdEncoderPool.Put(enc)
 
 	ctx, cancel := context.WithTimeout(ctx, c.timeoutUnit*20)
 	defer cancel()
@@ -237,12 +265,15 @@ func (c *replicationClient) OverwriteObjects(ctx context.Context,
 		return nil, fmt.Errorf("encode request: %w", err)
 	}
 
-	enc, err := zstd.NewWriter(nil)
-	if err != nil {
-		return nil, fmt.Errorf("create zstd encoder: %w", err)
+	enc, ok := c.zstdEncoderPool.Get().(*zstd.Encoder)
+	if !ok || enc == nil {
+		enc, err = zstd.NewWriter(nil)
+		if err != nil {
+			return nil, fmt.Errorf("create zstd encoder: %w", err)
+		}
 	}
-	defer enc.Close()
 	bodyCompressed := enc.EncodeAll(body, make([]byte, 0, len(body)))
+	c.zstdEncoderPool.Put(enc)
 
 	req, err := newHttpReplicaRequest(
 		ctx, http.MethodPut, host, index, shard,

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -848,6 +849,63 @@ func TestReplicationOverwriteObjectsCompression(t *testing.T) {
 	})
 }
 
+func TestReplicationOverwriteObjectsConcurrent(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	input := []*objects.VObject{
+		{
+			LatestObject: &models.Object{
+				ID:                 UUID1,
+				Class:              "C1",
+				LastUpdateTimeUnix: now.UnixMilli(),
+			},
+			StaleUpdateTime: now.UnixMilli(),
+		},
+	}
+	expected := []types.RepairResponse{
+		{ID: UUID1.String(), UpdateTime: now.UnixMilli()},
+	}
+
+	// Each request handler decompresses the body independently to verify the
+	// pooled encoder produces correct output under concurrent use.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		dec, err := zstd.NewReader(r.Body)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer dec.Close()
+		if _, err := io.ReadAll(dec); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		b, _ := json.Marshal(expected)
+		w.Write(b)
+	}))
+	defer server.Close()
+
+	// A single client is shared across all goroutines to exercise the encoder
+	// pool under concurrent use. Run with -race to detect data races.
+	c := newReplicationClient(t, server.Client())
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	errs := make([]error, goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(idx int) {
+			defer wg.Done()
+			_, errs[idx] = c.OverwriteObjects(context.Background(), server.URL[7:], "C1", "S1", input)
+		}(i)
+	}
+	wg.Wait()
+
+	for i, err := range errs {
+		require.NoErrorf(t, err, "goroutine %d failed", i)
+	}
+}
+
 func TestExpBackOff(t *testing.T) {
 	N := 200
 	av := time.Duration(0)
@@ -863,7 +921,8 @@ func TestExpBackOff(t *testing.T) {
 
 func newReplicationClient(t *testing.T, httpClient *http.Client) *replicationClient {
 	t.Helper()
-	c := NewReplicationClient(httpClient)
+	c, err := NewReplicationClient(httpClient)
+	require.NoError(t, err)
 	c.minBackOff = time.Millisecond * 1
 	c.maxBackOff = time.Millisecond * 8
 	c.timeoutUnit = time.Millisecond * 20

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -386,7 +386,11 @@ func TestReplicationAbort(t *testing.T) {
 		assert.NotNil(t, err)
 		assert.Contains(t, err.Error(), "decode response")
 	})
-	client.timeoutUnit = client.maxBackOff * 3
+	// timeoutUnit * 5 drives the per-request context deadline. Setting it to
+	// maxBackOff*100 (800ms) makes the deadline >> MaxElapsedTime (72ms), so
+	// the retry loop always exhausts retries rather than the context, even under
+	// CI scheduling pressure.
+	client.timeoutUnit = client.maxBackOff * 100
 	t.Run("ServerInternalError", func(t *testing.T) {
 		_, err := client.Abort(ctx, fs.host, "C1", "S1", RequestInternalError)
 		assert.NotNil(t, err)
@@ -709,6 +713,9 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
+		// timeoutUnit*20 is the per-request deadline; set it large enough to
+		// survive CI scheduling jitter without relying on retry.
+		c.timeoutUnit = time.Second
 		got, err := c.DigestObjectsInRange(context.Background(), server.URL[7:], "C1", "S1", UUID1, UUID2, 10)
 		require.NoError(t, err)
 		require.Len(t, got, 2)
@@ -727,6 +734,7 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
+		c.timeoutUnit = time.Second
 		got, err := c.DigestObjectsInRange(context.Background(), server.URL[7:], "C1", "S1", UUID1, UUID2, 10)
 		require.NoError(t, err)
 		require.Len(t, got, 2)
@@ -745,6 +753,7 @@ func TestReplicationDigestObjectsInRange(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
+		c.timeoutUnit = time.Second
 		got, err := c.DigestObjectsInRange(context.Background(), server.URL[7:], "C1", "S1", UUID1, UUID2, 10)
 		require.NoError(t, err)
 		assert.Empty(t, got)

--- a/adapters/handlers/rest/clusterapi/indices_replicas.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas.go
@@ -74,6 +74,24 @@ const (
 	responseQueueFull    = "too many buffered requests"
 )
 
+// zstdDecoderPool pools *zstd.Decoder instances to avoid the allocation cost
+// of zstd.NewReader on every compressed request. New returns nil only when
+// zstd.NewReader fails during construction; the call site detects this and
+// falls back to newZstdDecoder() to surface the error explicitly.
+var zstdDecoderPool = sync.Pool{
+	New: func() any {
+		dec, err := zstd.NewReader(nil)
+		if err != nil {
+			return nil
+		}
+		return dec
+	},
+}
+
+func newZstdDecoder() (*zstd.Decoder, error) {
+	return zstd.NewReader(nil)
+}
+
 var (
 	regxObject = regexp.MustCompile(`\/replicas\/indices\/(` + cl + `)` +
 		`\/shards\/(` + sh + `)\/objects\/(` + ob + `)(\/[0-9]{1,64})?`)
@@ -661,11 +679,27 @@ func readRequestBodyWithOptionalCompression(
 		return nil, fmt.Errorf("compression algorithm unsupported: %s", compressionHeader)
 	}
 
-	zstdr, err := zstd.NewReader(body)
-	if err != nil {
-		return nil, fmt.Errorf("create zstd reader: %w", err)
+	zstdr, ok := zstdDecoderPool.Get().(*zstd.Decoder)
+	if !ok || zstdr == nil {
+		// pool.New failed; call directly to surface the underlying error
+		var err error
+		zstdr, err = newZstdDecoder()
+		if err != nil {
+			return nil, fmt.Errorf("create zstd decoder: %w", err)
+		}
 	}
-	defer zstdr.Close()
+	if err := zstdr.Reset(body); err != nil {
+		zstdr.Close()
+		return nil, fmt.Errorf("reset zstd decoder: %w", err)
+	}
+	defer func() {
+		if err := zstdr.Reset(nil); err == nil {
+			zstdDecoderPool.Put(zstdr)
+		} else {
+			// decoder is closed/broken; close it before discarding
+			zstdr.Close()
+		}
+	}()
 
 	b, err := io.ReadAll(zstdr)
 	if err != nil {

--- a/adapters/handlers/rest/clusterapi/indices_replicas_test.go
+++ b/adapters/handlers/rest/clusterapi/indices_replicas_test.go
@@ -722,3 +722,70 @@ func TestPutOverwriteObjectsCompression(t *testing.T) {
 		})
 	}
 }
+
+func TestPutOverwriteObjectsCorruptedZstdBody(t *testing.T) {
+	t.Parallel()
+
+	_, url := newOverwriteServer(t)
+
+	// Send a body that has the zstd compression header but is not valid zstd data.
+	// This exercises the error path in readRequestBodyWithOptionalCompression where
+	// io.ReadAll fails on an invalid stream, and ensures the decoder is properly
+	// closed/returned before the error is returned.
+	body := []byte("this is not valid zstd data")
+	req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("X-Request-Compression", "zstd")
+	req.Header.Set("X-Request-Encoding", "binary")
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}
+
+func TestPutOverwriteObjectsZstdConcurrent(t *testing.T) {
+	t.Parallel()
+
+	_, url := newOverwriteServer(t)
+
+	body := vobjectPayload(t)
+	enc, err := zstd.NewWriter(nil)
+	require.NoError(t, err)
+	compressed := enc.EncodeAll(body, make([]byte, 0, len(body)))
+	enc.Close()
+
+	const goroutines = 50
+	errs := make(chan error, goroutines)
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequest(http.MethodPut, url, bytes.NewReader(compressed))
+			if err != nil {
+				errs <- fmt.Errorf("create request: %w", err)
+				return
+			}
+			req.Header.Set("X-Request-Compression", "zstd")
+			req.Header.Set("X-Request-Encoding", "binary")
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				errs <- fmt.Errorf("do request: %w", err)
+				return
+			}
+			defer resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				errs <- fmt.Errorf("unexpected status: got %d want %d", resp.StatusCode, http.StatusOK)
+				return
+			}
+			errs <- nil
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+}

--- a/adapters/handlers/rest/clusterapi/overwrite_objects_integration_test.go
+++ b/adapters/handlers/rest/clusterapi/overwrite_objects_integration_test.go
@@ -130,7 +130,8 @@ func TestOverwriteObjectsClientServerIntegration(t *testing.T) {
 
 	// Use the real replication client with the test server's HTTP client so
 	// requests are routed to the in-process server without TLS.
-	c := clients.NewReplicationClient(server.Client())
+	c, err := clients.NewReplicationClient(server.Client())
+	require.NoError(t, err)
 
 	// server.URL is "http://host:port"; strip the scheme for the client which
 	// constructs the URL itself.

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -379,7 +379,10 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	// TODO: configure http transport for efficient intra-cluster comm
 	remoteIndexClient := clients.NewRemoteIndex(appState.ClusterHttpClient)
 	remoteNodesClient := clients.NewRemoteNode(appState.ClusterHttpClient)
-	replicationClient := clients.NewReplicationClient(appState.ClusterHttpClient)
+	replicationClient, err := clients.NewReplicationClient(appState.ClusterHttpClient)
+	if err != nil {
+		appState.Logger.WithField("action", "startup").Fatalf("failed to create replication client: %v", err)
+	}
 	repo, err := db.New(appState.Logger, appState.Cluster.LocalName(), db.Config{
 		ServerVersion:                       config.ServerVersion,
 		GitHash:                             build.Revision,

--- a/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
+++ b/adapters/repos/db/clusterintegrationtest/fakes_for_test.go
@@ -93,7 +93,10 @@ func (n *node) init(t *testing.T, dirName string, allNodes *[]*node, shardingSta
 
 	client := clients.NewRemoteIndex(&http.Client{})
 	nodesClient := clients.NewRemoteNode(&http.Client{})
-	replicaClient := clients.NewReplicationClient(&http.Client{})
+	replicaClient, err := clients.NewReplicationClient(&http.Client{})
+	if err != nil {
+		t.Fatalf("failed to create replication client: %v", err)
+	}
 
 	// Create schema manager first so the mock can reference it
 	n.schemaManager = &fakeSchemaManager{

--- a/usecases/replica/coordinator_test.go
+++ b/usecases/replica/coordinator_test.go
@@ -264,7 +264,8 @@ func Test_coordinatorPush(t *testing.T) {
 				replicas[i], replicas[j] = replicas[j], replicas[i]
 			}
 
-			client := clients.NewReplicationClient(&http.Client{})
+			client, err := clients.NewReplicationClient(&http.Client{})
+			require.NoError(t, err)
 			coordinator := replica.NewWriteCoordinator[replica.SimpleResponse, error](
 				client,
 				setupRouter(cl, replicas),
@@ -458,7 +459,8 @@ func Test_coordinatorPull(t *testing.T) {
 				{NodeName: "node3", ShardName: shard, HostAddr: tt.node3.URL[7:]},
 			}
 
-			client := clients.NewReplicationClient(&http.Client{})
+			client, err := clients.NewReplicationClient(&http.Client{})
+			require.NoError(t, err)
 			coordinator := replica.NewReadCoordinator[types.RepairResponse](
 				setupRouter(cl, replicas),
 				metrics,


### PR DESCRIPTION
### What's being changed:

This pull request introduces zstd encoder and decoder pooling to improve performance and resource efficiency for compression and decompression operations in replication and REST handlers. It also adds comprehensive concurrent and error-path tests to ensure thread safety and robustness, and updates all affected code and tests to handle the new initialization and error handling patterns.

**Compression/Decompression Pooling Improvements:**

* Added a `sync.Pool` for `*zstd.Encoder` instances in `replicationClient` to reuse encoders, reducing allocation overhead during compression. (`replication.go`) [[1]](diffhunk://#diff-9c6b07b40ed868288b28472fd7e8e41e994cfdaad151ca02a8442e772453a922R27) [[2]](diffhunk://#diff-9c6b07b40ed868288b28472fd7e8e41e994cfdaad151ca02a8442e772453a922R61-R88)
* Added a `sync.Pool` for `*zstd.Decoder` instances in the REST handler to efficiently reuse decoders for incoming compressed requests. (`indices_replicas.go`) [[1]](diffhunk://#diff-edda0c88ff94e97f6c3ac75f5476b8e85ae1d1f388fc2a8282e31d3790c8232fR77-R94) [[2]](diffhunk://#diff-edda0c88ff94e97f6c3ac75f5476b8e85ae1d1f388fc2a8282e31d3790c8232fL664-R702)

**Concurrency and Robustness Enhancements:**

* Updated the encoder/decoder usage to safely get and put instances from their respective pools, including proper error handling and fallback creation when pool acquisition fails. (`replication.go`, `indices_replicas.go`) [[1]](diffhunk://#diff-9c6b07b40ed868288b28472fd7e8e41e994cfdaad151ca02a8442e772453a922L191-R219) [[2]](diffhunk://#diff-9c6b07b40ed868288b28472fd7e8e41e994cfdaad151ca02a8442e772453a922L240-R271) [[3]](diffhunk://#diff-edda0c88ff94e97f6c3ac75f5476b8e85ae1d1f388fc2a8282e31d3790c8232fL664-R702)
* Ensured that pooled resources are safely returned or closed, even on error paths, to prevent leaks or inconsistent state. (`indices_replicas.go`)

**Testing Improvements:**

* Added concurrent tests for both client and server sides to verify thread safety and correctness of the encoder and decoder pools under high concurrency, including race detection. (`replication_test.go`, `indices_replicas_test.go`) [[1]](diffhunk://#diff-4679ca5fef1e58a34c731d699ba35e69afe99b24a17f6ece435737dd85840f67R852-R908) [[2]](diffhunk://#diff-58fbff669f58982f32d3c23e449466ead5029fbcb632aacc7f032dda37e5a155R725-R791)
* Added tests for corrupted zstd input to ensure error paths are handled gracefully and resources are managed correctly. (`indices_replicas_test.go`)

**API and Initialization Changes:**

* Changed `NewReplicationClient` to return an error, updating all call sites and tests to handle possible initialization failure of the encoder. (`replication.go`, `replication_test.go`, `overwrite_objects_integration_test.go`, `configure_api.go`, `fakes_for_test.go`, `coordinator_test.go`) [[1]](diffhunk://#diff-9c6b07b40ed868288b28472fd7e8e41e994cfdaad151ca02a8442e772453a922R61-R88) [[2]](diffhunk://#diff-4679ca5fef1e58a34c731d699ba35e69afe99b24a17f6ece435737dd85840f67L866-R925) [[3]](diffhunk://#diff-c84cda55d5fc29ce09403183aa4a80c0d3be4dc27d543b0da6b5862fe6d974deL133-R134) [[4]](diffhunk://#diff-cd7296822b65611c2881895279e1cf008b414befc7a4fc723e16e15fdc46b7b2L382-R385) [[5]](diffhunk://#diff-1c12b866f15f4a786c58ad8b904b7e7f127339311a3ffe08755d86ba525ac6afL96-R99) [[6]](diffhunk://#diff-7a841c16bdf107cbfa4a02e6cb5f1380ba9f50ce50ee6dc5a3ca0c14b595d0a2L267-R268) [[7]](diffhunk://#diff-7a841c16bdf107cbfa4a02e6cb5f1380ba9f50ce50ee6dc5a3ca0c14b595d0a2L461-R463)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
