### PR TITLE
fix: support old stopword index config on endpoint

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -9631,17 +9631,20 @@ func init() {
           "description": "Optional text analyzer configuration (e.g. ASCII folding).",
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
-        "invertedIndexConfig": {
-          "description": "Optional collection-style inverted-index configuration. Used to supply a fallback ` + "`" + `stopwords` + "`" + ` config and/or user-defined ` + "`" + `stopwordPresets` + "`" + ` that ` + "`" + `analyzerConfig.stopwordPreset` + "`" + ` can reference. Mirrors the shape accepted on a collection, so the same config can be reused to preview tokenization behavior before creating a collection.",
-          "$ref": "#/definitions/InvertedIndexConfig"
-        },
         "stopwordPresets": {
-          "description": "Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals). This is a richer, tokenize-only alternative to invertedIndexConfig.stopwordPresets (which takes plain word lists); on name conflict, this field wins.",
+          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in, matching collection-level override semantics.",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/StopwordConfig"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "x-omitempty": true
+        },
+        "stopwords": {
+          "description": "Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection, so the same config can be reused to preview tokenization behavior before creating a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'.",
+          "$ref": "#/definitions/StopwordConfig"
         },
         "text": {
           "description": "The text to tokenize.",
@@ -20196,17 +20199,20 @@ func init() {
           "description": "Optional text analyzer configuration (e.g. ASCII folding).",
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
-        "invertedIndexConfig": {
-          "description": "Optional collection-style inverted-index configuration. Used to supply a fallback ` + "`" + `stopwords` + "`" + ` config and/or user-defined ` + "`" + `stopwordPresets` + "`" + ` that ` + "`" + `analyzerConfig.stopwordPreset` + "`" + ` can reference. Mirrors the shape accepted on a collection, so the same config can be reused to preview tokenization behavior before creating a collection.",
-          "$ref": "#/definitions/InvertedIndexConfig"
-        },
         "stopwordPresets": {
-          "description": "Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals). This is a richer, tokenize-only alternative to invertedIndexConfig.stopwordPresets (which takes plain word lists); on name conflict, this field wins.",
+          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in, matching collection-level override semantics.",
           "type": "object",
           "additionalProperties": {
-            "$ref": "#/definitions/StopwordConfig"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "x-omitempty": true
+        },
+        "stopwords": {
+          "description": "Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection, so the same config can be reused to preview tokenization behavior before creating a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'.",
+          "$ref": "#/definitions/StopwordConfig"
         },
         "text": {
           "description": "The text to tokenize.",

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -7901,7 +7901,7 @@ func init() {
           "type": "boolean"
         },
         "stopwordPresets": {
-          "description": "User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings.",
+          "description": "User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings. Preset names must not be empty or whitespace-only; each list must contain at least one word; individual words must not be empty or whitespace-only.",
           "type": "object",
           "additionalProperties": {
             "type": "array",
@@ -9632,7 +9632,7 @@ func init() {
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
         "stopwordPresets": {
-          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Mutually exclusive with stopwords — pass one or the other, not both.",
+          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Preset names must not be empty or whitespace-only; each word list must contain at least one word; individual words must not be empty or whitespace-only. Mutually exclusive with stopwords — pass one or the other, not both.",
           "type": "object",
           "additionalProperties": {
             "type": "array",
@@ -18277,7 +18277,7 @@ func init() {
           "type": "boolean"
         },
         "stopwordPresets": {
-          "description": "User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings.",
+          "description": "User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings. Preset names must not be empty or whitespace-only; each list must contain at least one word; individual words must not be empty or whitespace-only.",
           "type": "object",
           "additionalProperties": {
             "type": "array",
@@ -20184,7 +20184,7 @@ func init() {
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
         "stopwordPresets": {
-          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Mutually exclusive with stopwords — pass one or the other, not both.",
+          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Preset names must not be empty or whitespace-only; each word list must contain at least one word; individual words must not be empty or whitespace-only. Mutually exclusive with stopwords — pass one or the other, not both.",
           "type": "object",
           "additionalProperties": {
             "type": "array",

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -9668,7 +9668,7 @@ func init() {
       }
     },
     "TokenizeResponse": {
-      "description": "Response from the tokenize endpoints. The generic /v1/tokenize returns only ` + "`" + `indexed` + "`" + ` and ` + "`" + `query` + "`" + ` — it does not echo fields the caller already sent (tokenization, analyzerConfig, stopwords, stopwordPresets). The property endpoint additionally populates ` + "`" + `tokenization` + "`" + `, since that value is resolved server-side from the property's schema rather than passed by the caller.",
+      "description": "Response from the tokenize endpoints. Returns ` + "`" + `indexed` + "`" + ` text and text used at ` + "`" + `query` + "`" + ` time",
       "type": "object",
       "properties": {
         "indexed": {
@@ -9684,10 +9684,6 @@ func init() {
           "items": {
             "type": "string"
           }
-        },
-        "tokenization": {
-          "description": "The tokenization method that was applied. Populated only by the property-level endpoint.",
-          "type": "string"
         }
       }
     },
@@ -20224,7 +20220,7 @@ func init() {
       }
     },
     "TokenizeResponse": {
-      "description": "Response from the tokenize endpoints. The generic /v1/tokenize returns only ` + "`" + `indexed` + "`" + ` and ` + "`" + `query` + "`" + ` — it does not echo fields the caller already sent (tokenization, analyzerConfig, stopwords, stopwordPresets). The property endpoint additionally populates ` + "`" + `tokenization` + "`" + `, since that value is resolved server-side from the property's schema rather than passed by the caller.",
+      "description": "Response from the tokenize endpoints. Returns ` + "`" + `indexed` + "`" + ` text and text used at ` + "`" + `query` + "`" + ` time",
       "type": "object",
       "properties": {
         "indexed": {
@@ -20240,10 +20236,6 @@ func init() {
           "items": {
             "type": "string"
           }
-        },
-        "tokenization": {
-          "description": "The tokenization method that was applied. Populated only by the property-level endpoint.",
-          "type": "string"
         }
       }
     },

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -9631,8 +9631,12 @@ func init() {
           "description": "Optional text analyzer configuration (e.g. ASCII folding).",
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
+        "invertedIndexConfig": {
+          "description": "Optional collection-style inverted-index configuration. Used to supply a fallback ` + "`" + `stopwords` + "`" + ` config and/or user-defined ` + "`" + `stopwordPresets` + "`" + ` that ` + "`" + `analyzerConfig.stopwordPreset` + "`" + ` can reference. Mirrors the shape accepted on a collection, so the same config can be reused to preview tokenization behavior before creating a collection.",
+          "$ref": "#/definitions/InvertedIndexConfig"
+        },
         "stopwordPresets": {
-          "description": "Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals).",
+          "description": "Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals). This is a richer, tokenize-only alternative to invertedIndexConfig.stopwordPresets (which takes plain word lists); on name conflict, this field wins.",
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/StopwordConfig"
@@ -9674,6 +9678,10 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "invertedIndexConfig": {
+          "description": "The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the stopword preset that was used (defaulting to 'en' when none was explicitly supplied), matching the property-level endpoint which inherits the collection's InvertedIndexConfig.",
+          "$ref": "#/definitions/InvertedIndexConfig"
         },
         "query": {
           "description": "The tokens as they would be used for query matching (e.g., after stopword removal).",
@@ -20188,8 +20196,12 @@ func init() {
           "description": "Optional text analyzer configuration (e.g. ASCII folding).",
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
+        "invertedIndexConfig": {
+          "description": "Optional collection-style inverted-index configuration. Used to supply a fallback ` + "`" + `stopwords` + "`" + ` config and/or user-defined ` + "`" + `stopwordPresets` + "`" + ` that ` + "`" + `analyzerConfig.stopwordPreset` + "`" + ` can reference. Mirrors the shape accepted on a collection, so the same config can be reused to preview tokenization behavior before creating a collection.",
+          "$ref": "#/definitions/InvertedIndexConfig"
+        },
         "stopwordPresets": {
-          "description": "Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals).",
+          "description": "Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals). This is a richer, tokenize-only alternative to invertedIndexConfig.stopwordPresets (which takes plain word lists); on name conflict, this field wins.",
           "type": "object",
           "additionalProperties": {
             "$ref": "#/definitions/StopwordConfig"
@@ -20231,6 +20243,10 @@ func init() {
           "items": {
             "type": "string"
           }
+        },
+        "invertedIndexConfig": {
+          "description": "The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the stopword preset that was used (defaulting to 'en' when none was explicitly supplied), matching the property-level endpoint which inherits the collection's InvertedIndexConfig.",
+          "$ref": "#/definitions/InvertedIndexConfig"
         },
         "query": {
           "description": "The tokens as they would be used for query matching (e.g., after stopword removal).",

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -9668,23 +9668,15 @@ func init() {
       }
     },
     "TokenizeResponse": {
-      "description": "Response from the tokenize endpoint.",
+      "description": "Response from the tokenize endpoints. The generic /v1/tokenize returns only ` + "`" + `indexed` + "`" + ` and ` + "`" + `query` + "`" + ` — it does not echo fields the caller already sent (tokenization, analyzerConfig, stopwords, stopwordPresets). The property endpoint additionally populates ` + "`" + `tokenization` + "`" + `, since that value is resolved server-side from the property's schema rather than passed by the caller.",
       "type": "object",
       "properties": {
-        "analyzerConfig": {
-          "description": "The text analyzer configuration that was used, if any.",
-          "$ref": "#/definitions/TextAnalyzerConfig"
-        },
         "indexed": {
           "description": "The tokens as they would be stored in the inverted index.",
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "invertedIndexConfig": {
-          "description": "The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the effective ` + "`" + `stopwords.preset` + "`" + ` that was used (defaulting to 'en' when none was explicitly supplied). The returned preset name may be a user-defined preset resolved via ` + "`" + `stopwordPresets` + "`" + ` / ` + "`" + `invertedIndexConfig.stopwordPresets` + "`" + `, not only a built-in stopword list such as ` + "`" + `en` + "`" + ` or ` + "`" + `none` + "`" + `, matching the property-level endpoint which inherits the collection's InvertedIndexConfig.",
-          "$ref": "#/definitions/InvertedIndexConfig"
         },
         "query": {
           "description": "The tokens as they would be used for query matching (e.g., after stopword removal).",
@@ -9693,12 +9685,8 @@ func init() {
             "type": "string"
           }
         },
-        "stopwordConfig": {
-          "description": "The stopword configuration that was used, if any.",
-          "$ref": "#/definitions/StopwordConfig"
-        },
         "tokenization": {
-          "description": "The tokenization method that was applied.",
+          "description": "The tokenization method that was applied. Populated only by the property-level endpoint.",
           "type": "string"
         }
       }
@@ -20236,23 +20224,15 @@ func init() {
       }
     },
     "TokenizeResponse": {
-      "description": "Response from the tokenize endpoint.",
+      "description": "Response from the tokenize endpoints. The generic /v1/tokenize returns only ` + "`" + `indexed` + "`" + ` and ` + "`" + `query` + "`" + ` — it does not echo fields the caller already sent (tokenization, analyzerConfig, stopwords, stopwordPresets). The property endpoint additionally populates ` + "`" + `tokenization` + "`" + `, since that value is resolved server-side from the property's schema rather than passed by the caller.",
       "type": "object",
       "properties": {
-        "analyzerConfig": {
-          "description": "The text analyzer configuration that was used, if any.",
-          "$ref": "#/definitions/TextAnalyzerConfig"
-        },
         "indexed": {
           "description": "The tokens as they would be stored in the inverted index.",
           "type": "array",
           "items": {
             "type": "string"
           }
-        },
-        "invertedIndexConfig": {
-          "description": "The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the effective ` + "`" + `stopwords.preset` + "`" + ` that was used (defaulting to 'en' when none was explicitly supplied). The returned preset name may be a user-defined preset resolved via ` + "`" + `stopwordPresets` + "`" + ` / ` + "`" + `invertedIndexConfig.stopwordPresets` + "`" + `, not only a built-in stopword list such as ` + "`" + `en` + "`" + ` or ` + "`" + `none` + "`" + `, matching the property-level endpoint which inherits the collection's InvertedIndexConfig.",
-          "$ref": "#/definitions/InvertedIndexConfig"
         },
         "query": {
           "description": "The tokens as they would be used for query matching (e.g., after stopword removal).",
@@ -20261,12 +20241,8 @@ func init() {
             "type": "string"
           }
         },
-        "stopwordConfig": {
-          "description": "The stopword configuration that was used, if any.",
-          "$ref": "#/definitions/StopwordConfig"
-        },
         "tokenization": {
-          "description": "The tokenization method that was applied.",
+          "description": "The tokenization method that was applied. Populated only by the property-level endpoint.",
           "type": "string"
         }
       }

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -9632,7 +9632,7 @@ func init() {
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
         "stopwordPresets": {
-          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in, matching collection-level override semantics.",
+          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Mutually exclusive with stopwords — pass one or the other, not both.",
           "type": "object",
           "additionalProperties": {
             "type": "array",
@@ -9643,7 +9643,7 @@ func init() {
           "x-omitempty": true
         },
         "stopwords": {
-          "description": "Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection, so the same config can be reused to preview tokenization behavior before creating a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'.",
+          "description": "Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'. Mutually exclusive with stopwordPresets — pass one or the other, not both.",
           "$ref": "#/definitions/StopwordConfig"
         },
         "text": {
@@ -20188,7 +20188,7 @@ func init() {
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
         "stopwordPresets": {
-          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in, matching collection-level override semantics.",
+          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Mutually exclusive with stopwords — pass one or the other, not both.",
           "type": "object",
           "additionalProperties": {
             "type": "array",
@@ -20199,7 +20199,7 @@ func init() {
           "x-omitempty": true
         },
         "stopwords": {
-          "description": "Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection, so the same config can be reused to preview tokenization behavior before creating a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'.",
+          "description": "Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'. Mutually exclusive with stopwordPresets — pass one or the other, not both.",
           "$ref": "#/definitions/StopwordConfig"
         },
         "text": {

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -9680,7 +9680,7 @@ func init() {
           }
         },
         "invertedIndexConfig": {
-          "description": "The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the stopword preset that was used (defaulting to 'en' when none was explicitly supplied), matching the property-level endpoint which inherits the collection's InvertedIndexConfig.",
+          "description": "The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the effective ` + "`" + `stopwords.preset` + "`" + ` that was used (defaulting to 'en' when none was explicitly supplied). The returned preset name may be a user-defined preset resolved via ` + "`" + `stopwordPresets` + "`" + ` / ` + "`" + `invertedIndexConfig.stopwordPresets` + "`" + `, not only a built-in stopword list such as ` + "`" + `en` + "`" + ` or ` + "`" + `none` + "`" + `, matching the property-level endpoint which inherits the collection's InvertedIndexConfig.",
           "$ref": "#/definitions/InvertedIndexConfig"
         },
         "query": {
@@ -20245,7 +20245,7 @@ func init() {
           }
         },
         "invertedIndexConfig": {
-          "description": "The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the stopword preset that was used (defaulting to 'en' when none was explicitly supplied), matching the property-level endpoint which inherits the collection's InvertedIndexConfig.",
+          "description": "The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the effective ` + "`" + `stopwords.preset` + "`" + ` that was used (defaulting to 'en' when none was explicitly supplied). The returned preset name may be a user-defined preset resolved via ` + "`" + `stopwordPresets` + "`" + ` / ` + "`" + `invertedIndexConfig.stopwordPresets` + "`" + `, not only a built-in stopword list such as ` + "`" + `en` + "`" + ` or ` + "`" + `none` + "`" + `, matching the property-level endpoint which inherits the collection's InvertedIndexConfig.",
           "$ref": "#/definitions/InvertedIndexConfig"
         },
         "query": {

--- a/adapters/handlers/rest/handlers_tokenize.go
+++ b/adapters/handlers/rest/handlers_tokenize.go
@@ -66,54 +66,119 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 		})
 	}
 
-	prepared := tokenizer.NewPreparedAnalyzer(params.Body.AnalyzerConfig)
-
-	var detector tokenizer.StopwordDetector
-	if params.Body.AnalyzerConfig != nil && params.Body.AnalyzerConfig.StopwordPreset != "" {
-		preset := params.Body.AnalyzerConfig.StopwordPreset
-		_, isBuiltIn := stopwords.Presets[preset]
-		cfg, hasUserCfg := params.Body.StopwordPresets[preset]
-
-		switch {
-		case hasUserCfg:
-			// Request-level entry exists. It fully overrides any built-in
-			// preset of the same name (matches collection-level semantics
-			// in invertedIndexConfig.stopwordPresets, where a user-defined
-			// "en" replaces the built-in "en" entirely). If the user did
-			// not specify their own base preset, default to "none" so
-			// additions/removals are evaluated against an empty list.
-			if cfg.Preset == "" {
-				cfg.Preset = "none"
-			}
-			d, err := stopwords.NewDetectorFromConfig(cfg)
-			if err != nil {
-				return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-					Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("invalid stopwordPresets[%q]: %s", preset, err.Error())}},
-				})
-			}
-			detector = d
-		case isBuiltIn:
-			d, err := stopwords.NewDetectorFromPreset(preset)
-			if err != nil {
-				return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-					Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("invalid stopword preset %q: %s", preset, err.Error())}},
-				})
-			}
-			detector = d
-		default:
+	// Build the stopword Provider, mirroring the collection-level configuration
+	// the property-level endpoint inherits. Two optional request fields feed it:
+	//   - invertedIndexConfig.stopwordPresets (map[string][]string, collection-shape)
+	//   - stopwordPresets                      (map[string]StopwordConfig, richer tokenize-only form)
+	// Top-level stopwordPresets wins on name conflict, matching the
+	// "user-defined preset replaces built-in of same name" semantics we already
+	// document at the collection level.
+	var iicPresets map[string][]string
+	if params.Body.InvertedIndexConfig != nil {
+		iicPresets = params.Body.InvertedIndexConfig.StopwordPresets
+	}
+	presetDetectors, err := stopwords.BuildPresetDetectors(iicPresets)
+	if err != nil {
+		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
+			Error: []*models.ErrorResponseErrorItems0{{Message: err.Error()}},
+		})
+	}
+	if len(params.Body.StopwordPresets) > 0 && presetDetectors == nil {
+		presetDetectors = map[string]*stopwords.Detector{}
+	}
+	for name, cfg := range params.Body.StopwordPresets {
+		// No explicit base → treat like "none" so additions/removals are
+		// evaluated against an empty list (the same override semantics used
+		// at the collection level).
+		if cfg.Preset == "" {
+			cfg.Preset = "none"
+		}
+		d, err := stopwords.NewDetectorFromConfig(cfg)
+		if err != nil {
 			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("unknown stopword preset %q; provide it in stopwordPresets or use a built-in preset ('en', 'none')", preset)}},
+				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("invalid stopwordPresets[%q]: %s", name, err.Error())}},
 			})
 		}
+		presetDetectors[name] = d
 	}
 
+	// Collection-level fallback: invertedIndexConfig.stopwords is applied when
+	// analyzerConfig.stopwordPreset is not set, matching the property endpoint
+	// (which falls back to class.InvertedIndexConfig.Stopwords).
+	var fallback stopwords.StopwordDetector
+	var fallbackConfig *models.StopwordConfig
+	if params.Body.InvertedIndexConfig != nil && params.Body.InvertedIndexConfig.Stopwords != nil {
+		d, err := stopwords.NewDetectorFromConfig(*params.Body.InvertedIndexConfig.Stopwords)
+		if err != nil {
+			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
+				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("invalid invertedIndexConfig.stopwords: %s", err.Error())}},
+			})
+		}
+		fallback = d
+		fallbackConfig = params.Body.InvertedIndexConfig.Stopwords
+	}
+
+	provider := stopwords.NewProvider(fallback, presetDetectors)
+
+	// Resolve the detector using the same Provider semantics the property
+	// endpoint uses: analyzerConfig.stopwordPreset plays the role of a
+	// property-level preset override.
+	var detector tokenizer.StopwordDetector
+	var effectiveStopwords *models.StopwordConfig
+
+	callerPreset := ""
+	if params.Body.AnalyzerConfig != nil {
+		callerPreset = params.Body.AnalyzerConfig.StopwordPreset
+	}
+
+	switch {
+	case callerPreset != "":
+		d, perr := provider.Get(&models.Property{TextAnalyzer: params.Body.AnalyzerConfig})
+		if perr != nil {
+			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
+				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("unknown stopword preset %q; define it in invertedIndexConfig.stopwordPresets / stopwordPresets or use a built-in preset ('en', 'none')", callerPreset)}},
+			})
+		}
+		detector = d
+		effectiveStopwords = &models.StopwordConfig{Preset: callerPreset}
+	case fallback != nil:
+		detector = fallback
+		effectiveStopwords = fallbackConfig
+	case *params.Body.Tokenization == "word":
+		// Default to "en" for word tokenization so the endpoint matches the
+		// property-level endpoint's behavior when the collection's default
+		// inverted index config is in effect. Route through the Provider so
+		// a user override for "en" (in stopwordPresets or
+		// invertedIndexConfig.stopwordPresets) is respected even when the
+		// caller did not explicitly set analyzerConfig.stopwordPreset.
+		d, perr := provider.Get(&models.Property{
+			TextAnalyzer: &models.TextAnalyzerConfig{StopwordPreset: stopwords.EnglishPreset},
+		})
+		if perr != nil {
+			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
+				Error: []*models.ErrorResponseErrorItems0{{Message: perr.Error()}},
+			})
+		}
+		detector = d
+		effectiveStopwords = &models.StopwordConfig{Preset: stopwords.EnglishPreset}
+	}
+
+	prepared := tokenizer.NewPreparedAnalyzer(params.Body.AnalyzerConfig)
 	result := tokenizer.Analyze(*params.Body.Text, *params.Body.Tokenization, "", prepared, detector)
 
+	// Surface the effective inverted-index configuration that produced the
+	// query output, so callers can see which stopwords were applied.
+	var invertedIndexConfig *models.InvertedIndexConfig
+	if effectiveStopwords != nil {
+		invertedIndexConfig = &models.InvertedIndexConfig{Stopwords: effectiveStopwords}
+	}
+
 	return tokenizeops.NewTokenizeOK().WithPayload(&models.TokenizeResponse{
-		Tokenization:   *params.Body.Tokenization,
-		AnalyzerConfig: params.Body.AnalyzerConfig,
-		Indexed:        result.Indexed,
-		Query:          result.Query,
+		Tokenization:        *params.Body.Tokenization,
+		AnalyzerConfig:      params.Body.AnalyzerConfig,
+		InvertedIndexConfig: invertedIndexConfig,
+		Indexed:             result.Indexed,
+		Query:               result.Query,
 	})
 }
 

--- a/adapters/handlers/rest/handlers_tokenize.go
+++ b/adapters/handlers/rest/handlers_tokenize.go
@@ -67,6 +67,19 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 		})
 	}
 
+	// `stopwords` and `stopwordPresets` are mutually exclusive on this
+	// endpoint. `stopwords` is for the simple "apply one base preset
+	// optionally tweaked with additions/removals" case. `stopwordPresets`
+	// is for the "define named presets and select one via analyzerConfig"
+	// case. Allowing both on the same request creates subtle resolution
+	// corner cases (e.g. stopwords.preset="en" vs stopwordPresets.en=[...]);
+	// forcing callers to pick one keeps the mental model simple.
+	if params.Body.Stopwords != nil && len(params.Body.StopwordPresets) > 0 {
+		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
+			Error: []*models.ErrorResponseErrorItems0{{Message: "stopwords and stopwordPresets are mutually exclusive; pass only one"}},
+		})
+	}
+
 	// Validate stopwords/stopwordPresets with the same rules collection
 	// creation applies, so the shape accepted here genuinely "matches the
 	// shape accepted on a collection" (per the OpenAPI description). This

--- a/adapters/handlers/rest/handlers_tokenize.go
+++ b/adapters/handlers/rest/handlers_tokenize.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sirupsen/logrus"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -64,6 +65,20 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
 			Error: []*models.ErrorResponseErrorItems0{{Message: err.Error()}},
 		})
+	}
+
+	// Validate invertedIndexConfig with the same rules collection creation
+	// applies, so the shape accepted here genuinely "mirrors the shape
+	// accepted on a collection" (per the OpenAPI description). This also
+	// defaults Stopwords.Preset to "en" when the caller sent an empty preset,
+	// and rejects unknown presets, empty/whitespace preset names and empty
+	// word lists the same way a collection create/update would.
+	if params.Body.InvertedIndexConfig != nil {
+		if err := inverted.ValidateConfig(params.Body.InvertedIndexConfig); err != nil {
+			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
+				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("invalid invertedIndexConfig: %s", err.Error())}},
+			})
+		}
 	}
 
 	// Build the stopword Provider, mirroring the collection-level configuration

--- a/adapters/handlers/rest/handlers_tokenize.go
+++ b/adapters/handlers/rest/handlers_tokenize.go
@@ -67,70 +67,44 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 		})
 	}
 
-	// Validate invertedIndexConfig with the same rules collection creation
-	// applies, so the shape accepted here genuinely "mirrors the shape
-	// accepted on a collection" (per the OpenAPI description). This also
-	// defaults Stopwords.Preset to "en" when the caller sent an empty preset,
-	// and rejects unknown presets, empty/whitespace preset names and empty
-	// word lists the same way a collection create/update would.
-	if params.Body.InvertedIndexConfig != nil {
-		if err := inverted.ValidateConfig(params.Body.InvertedIndexConfig); err != nil {
-			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("invalid invertedIndexConfig: %s", err.Error())}},
-			})
-		}
+	// Validate stopwords/stopwordPresets with the same rules collection
+	// creation applies, so the shape accepted here genuinely "matches the
+	// shape accepted on a collection" (per the OpenAPI description). This
+	// also defaults Stopwords.Preset to "en" when the caller sent an empty
+	// preset. We run validation through inverted.ValidateConfig by wrapping
+	// the two request fields in a synthetic InvertedIndexConfig; other
+	// fields stay zero-valued and pass trivially.
+	synthConfig := &models.InvertedIndexConfig{
+		Stopwords:       params.Body.Stopwords,
+		StopwordPresets: params.Body.StopwordPresets,
+	}
+	if err := inverted.ValidateConfig(synthConfig); err != nil {
+		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
+			Error: []*models.ErrorResponseErrorItems0{{Message: err.Error()}},
+		})
 	}
 
 	// Build the stopword Provider, mirroring the collection-level configuration
-	// the property-level endpoint inherits. Two optional request fields feed it:
-	//   - invertedIndexConfig.stopwordPresets (map[string][]string, collection-shape)
-	//   - stopwordPresets                      (map[string]StopwordConfig, richer tokenize-only form)
-	// Top-level stopwordPresets wins on name conflict, matching the
-	// "user-defined preset replaces built-in of same name" semantics we already
-	// document at the collection level.
-	var iicPresets map[string][]string
-	if params.Body.InvertedIndexConfig != nil {
-		iicPresets = params.Body.InvertedIndexConfig.StopwordPresets
-	}
-	presetDetectors, err := stopwords.BuildPresetDetectors(iicPresets)
+	// the property-level endpoint inherits.
+	presetDetectors, err := stopwords.BuildPresetDetectors(params.Body.StopwordPresets)
 	if err != nil {
 		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
 			Error: []*models.ErrorResponseErrorItems0{{Message: err.Error()}},
 		})
 	}
-	if len(params.Body.StopwordPresets) > 0 && presetDetectors == nil {
-		presetDetectors = map[string]*stopwords.Detector{}
-	}
-	for name, cfg := range params.Body.StopwordPresets {
-		// No explicit base → treat like "none" so additions/removals are
-		// evaluated against an empty list (the same override semantics used
-		// at the collection level).
-		if cfg.Preset == "" {
-			cfg.Preset = "none"
-		}
-		d, err := stopwords.NewDetectorFromConfig(cfg)
-		if err != nil {
-			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("invalid stopwordPresets[%q]: %s", name, err.Error())}},
-			})
-		}
-		presetDetectors[name] = d
-	}
 
-	// Collection-level fallback: invertedIndexConfig.stopwords is applied when
+	// Collection-level fallback: stopwords is applied when
 	// analyzerConfig.stopwordPreset is not set, matching the property endpoint
 	// (which falls back to class.InvertedIndexConfig.Stopwords).
 	var fallback stopwords.StopwordDetector
-	var fallbackConfig *models.StopwordConfig
-	if params.Body.InvertedIndexConfig != nil && params.Body.InvertedIndexConfig.Stopwords != nil {
-		d, err := stopwords.NewDetectorFromConfig(*params.Body.InvertedIndexConfig.Stopwords)
-		if err != nil {
+	if params.Body.Stopwords != nil {
+		d, derr := stopwords.NewDetectorFromConfig(*params.Body.Stopwords)
+		if derr != nil {
 			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("invalid invertedIndexConfig.stopwords: %s", err.Error())}},
+				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("invalid stopwords: %s", derr.Error())}},
 			})
 		}
 		fallback = d
-		fallbackConfig = params.Body.InvertedIndexConfig.Stopwords
 	}
 
 	provider := stopwords.NewProvider(fallback, presetDetectors)
@@ -139,7 +113,6 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 	// endpoint uses: analyzerConfig.stopwordPreset plays the role of a
 	// property-level preset override.
 	var detector tokenizer.StopwordDetector
-	var effectiveStopwords *models.StopwordConfig
 
 	callerPreset := ""
 	if params.Body.AnalyzerConfig != nil {
@@ -151,21 +124,18 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 		d, perr := provider.Get(&models.Property{TextAnalyzer: params.Body.AnalyzerConfig})
 		if perr != nil {
 			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("unknown stopword preset %q; define it in invertedIndexConfig.stopwordPresets / stopwordPresets or use a built-in preset ('en', 'none')", callerPreset)}},
+				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("unknown stopword preset %q; define it in stopwordPresets or use a built-in preset ('en', 'none')", callerPreset)}},
 			})
 		}
 		detector = d
-		effectiveStopwords = &models.StopwordConfig{Preset: callerPreset}
 	case fallback != nil:
 		detector = fallback
-		effectiveStopwords = fallbackConfig
 	case *params.Body.Tokenization == "word":
 		// Default to "en" for word tokenization so the endpoint matches the
 		// property-level endpoint's behavior when the collection's default
 		// inverted index config is in effect. Route through the Provider so
-		// a user override for "en" (in stopwordPresets or
-		// invertedIndexConfig.stopwordPresets) is respected even when the
-		// caller did not explicitly set analyzerConfig.stopwordPreset.
+		// a user override for "en" in stopwordPresets is respected even when
+		// the caller did not explicitly set analyzerConfig.stopwordPreset.
 		d, perr := provider.Get(&models.Property{
 			TextAnalyzer: &models.TextAnalyzerConfig{StopwordPreset: stopwords.EnglishPreset},
 		})
@@ -175,25 +145,14 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 			})
 		}
 		detector = d
-		effectiveStopwords = &models.StopwordConfig{Preset: stopwords.EnglishPreset}
 	}
 
 	prepared := tokenizer.NewPreparedAnalyzer(params.Body.AnalyzerConfig)
 	result := tokenizer.Analyze(*params.Body.Text, *params.Body.Tokenization, "", prepared, detector)
 
-	// Surface the effective inverted-index configuration that produced the
-	// query output, so callers can see which stopwords were applied.
-	var invertedIndexConfig *models.InvertedIndexConfig
-	if effectiveStopwords != nil {
-		invertedIndexConfig = &models.InvertedIndexConfig{Stopwords: effectiveStopwords}
-	}
-
 	return tokenizeops.NewTokenizeOK().WithPayload(&models.TokenizeResponse{
-		Tokenization:        *params.Body.Tokenization,
-		AnalyzerConfig:      params.Body.AnalyzerConfig,
-		InvertedIndexConfig: invertedIndexConfig,
-		Indexed:             result.Indexed,
-		Query:               result.Query,
+		Indexed: result.Indexed,
+		Query:   result.Query,
 	})
 }
 

--- a/adapters/handlers/rest/handlers_tokenize.go
+++ b/adapters/handlers/rest/handlers_tokenize.go
@@ -255,9 +255,8 @@ func propertyTokenize(params schemaops.SchemaObjectsPropertiesTokenizeParams,
 	result := tokenizer.Analyze(*params.Body.Text, prop.Tokenization, className, prepared, detector)
 
 	return schemaops.NewSchemaObjectsPropertiesTokenizeOK().WithPayload(&models.TokenizeResponse{
-		Tokenization: prop.Tokenization,
-		Indexed:      result.Indexed,
-		Query:        result.Query,
+		Indexed: result.Indexed,
+		Query:   result.Query,
 	})
 }
 

--- a/adapters/handlers/rest/handlers_tokenize_test.go
+++ b/adapters/handlers/rest/handlers_tokenize_test.go
@@ -32,9 +32,6 @@ func TestHandleGenericTokenize(t *testing.T) {
 		wantOK      bool
 		wantIndexed []string
 		wantQuery   []string
-		// Expected InvertedIndexConfig.Stopwords.Preset in the response,
-		// or empty string if InvertedIndexConfig should be nil.
-		wantInvertedIndexPreset string
 	}{
 		{
 			// Word tokenization defaults to the "en" stopword preset when
@@ -45,13 +42,14 @@ func TestHandleGenericTokenize(t *testing.T) {
 				Text:         strPtr("The quick brown fox"),
 				Tokenization: strPtr("word"),
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"the", "quick", "brown", "fox"},
-			wantQuery:               []string{"quick", "brown", "fox"},
-			wantInvertedIndexPreset: "en",
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick", "brown", "fox"},
+			wantQuery:   []string{"quick", "brown", "fox"},
 		},
 		{
 			// Callers can opt out of the default by passing "none".
+			// Analyzer-preset path wins → response.Stopwords is not
+			// populated; the preset is visible via AnalyzerConfig echo.
 			name: "word tokenization with explicit stopwordPreset none disables default",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("The quick brown fox"),
@@ -60,10 +58,9 @@ func TestHandleGenericTokenize(t *testing.T) {
 					StopwordPreset: "none",
 				},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"the", "quick", "brown", "fox"},
-			wantQuery:               []string{"the", "quick", "brown", "fox"},
-			wantInvertedIndexPreset: "none",
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick", "brown", "fox"},
+			wantQuery:   []string{"the", "quick", "brown", "fox"},
 		},
 		{
 			name: "lowercase tokenization",
@@ -122,10 +119,9 @@ func TestHandleGenericTokenize(t *testing.T) {
 					ASCIIFold: true,
 				},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"l", "ecole", "est", "fermee"},
-			wantQuery:               []string{"l", "ecole", "est", "fermee"},
-			wantInvertedIndexPreset: "en",
+			wantOK:      true,
+			wantIndexed: []string{"l", "ecole", "est", "fermee"},
+			wantQuery:   []string{"l", "ecole", "est", "fermee"},
 		},
 		{
 			name: "ascii fold with ignore",
@@ -137,10 +133,9 @@ func TestHandleGenericTokenize(t *testing.T) {
 					ASCIIFoldIgnore: []string{"é"},
 				},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"l", "école", "est", "fermée"},
-			wantQuery:               []string{"l", "école", "est", "fermée"},
-			wantInvertedIndexPreset: "en",
+			wantOK:      true,
+			wantIndexed: []string{"l", "école", "est", "fermée"},
+			wantQuery:   []string{"l", "école", "est", "fermée"},
 		},
 		{
 			name: "stopword preset en",
@@ -151,44 +146,43 @@ func TestHandleGenericTokenize(t *testing.T) {
 					StopwordPreset: "en",
 				},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"the", "quick", "brown", "fox"},
-			wantQuery:               []string{"quick", "brown", "fox"},
-			wantInvertedIndexPreset: "en",
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick", "brown", "fox"},
+			wantQuery:   []string{"quick", "brown", "fox"},
 		},
 		{
-			name: "stopword custom additions only via request-level preset",
+			// Define a custom preset with a plain word list (collection shape)
+			// and reference it via analyzerConfig.stopwordPreset.
+			name: "custom stopword preset resolved by analyzerConfig",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("hello world test"),
 				Tokenization: strPtr("word"),
 				AnalyzerConfig: &models.TextAnalyzerConfig{
 					StopwordPreset: "custom",
 				},
-				StopwordPresets: map[string]models.StopwordConfig{
-					"custom": {Additions: []string{"test"}},
+				StopwordPresets: map[string][]string{
+					"custom": {"test"},
 				},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"hello", "world", "test"},
-			wantQuery:               []string{"hello", "world"},
-			wantInvertedIndexPreset: "custom",
+			wantOK:      true,
+			wantIndexed: []string{"hello", "world", "test"},
+			wantQuery:   []string{"hello", "world"},
 		},
 		{
-			name: "stopword preset with removals via request-level preset",
+			// "en minus the" via the stopwords fallback field: the caller sets
+			// preset=en with a removal rather than composing a named preset.
+			name: "stopwords fallback composes removals on top of en",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("the quick"),
 				Tokenization: strPtr("word"),
-				AnalyzerConfig: &models.TextAnalyzerConfig{
-					StopwordPreset: "en-no-the",
-				},
-				StopwordPresets: map[string]models.StopwordConfig{
-					"en-no-the": {Preset: "en", Removals: []string{"the"}},
+				Stopwords: &models.StopwordConfig{
+					Preset:   "en",
+					Removals: []string{"the"},
 				},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"the", "quick"},
-			wantQuery:               []string{"the", "quick"},
-			wantInvertedIndexPreset: "en-no-the",
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick"},
+			wantQuery:   []string{"the", "quick"},
 		},
 		{
 			name: "ascii fold combined with stopwords",
@@ -200,10 +194,9 @@ func TestHandleGenericTokenize(t *testing.T) {
 					StopwordPreset: "en",
 				},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"the", "ecole", "est", "fermee"},
-			wantQuery:               []string{"ecole", "est", "fermee"},
-			wantInvertedIndexPreset: "en",
+			wantOK:      true,
+			wantIndexed: []string{"the", "ecole", "est", "fermee"},
+			wantQuery:   []string{"ecole", "est", "fermee"},
 		},
 		{
 			name: "unknown stopword preset is rejected",
@@ -225,10 +218,9 @@ func TestHandleGenericTokenize(t *testing.T) {
 				Text:         strPtr("hello world"),
 				Tokenization: strPtr("word"),
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"hello", "world"},
-			wantQuery:               []string{"hello", "world"},
-			wantInvertedIndexPreset: "en",
+			wantOK:      true,
+			wantIndexed: []string{"hello", "world"},
+			wantQuery:   []string{"hello", "world"},
 		},
 		{
 			name: "ascii fold ignore without fold enabled is rejected",
@@ -255,195 +247,290 @@ func TestHandleGenericTokenize(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name: "request-level preset fully overrides built-in of same name",
+			// A user-defined preset with the same name as a built-in ("en")
+			// fully replaces the built-in, matching collection-level
+			// override semantics.
+			name: "user-defined preset replaces built-in of same name",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("the quick hello world"),
 				Tokenization: strPtr("word"),
 				AnalyzerConfig: &models.TextAnalyzerConfig{
 					StopwordPreset: "en",
 				},
-				StopwordPresets: map[string]models.StopwordConfig{
-					// No explicit Preset → defaults to "none". The
-					// user-defined "en" replaces the built-in entirely:
-					// only "hello" is filtered, "the" stays in the query
+				StopwordPresets: map[string][]string{
+					// Only "hello" is an "en" stopword; "the" passes through
 					// because the built-in en list is no longer applied.
-					"en": {Additions: []string{"hello"}},
+					"en": {"hello"},
 				},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"the", "quick", "hello", "world"},
-			wantQuery:               []string{"the", "quick", "world"},
-			wantInvertedIndexPreset: "en",
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick", "hello", "world"},
+			wantQuery:   []string{"the", "quick", "world"},
 		},
 		{
-			// invertedIndexConfig.stopwords is used as a fallback when
+			// Top-level stopwords is used as the fallback when
 			// analyzerConfig.stopwordPreset is not set, matching the
 			// property endpoint's inheritance from collection config.
-			name: "invertedIndexConfig.stopwords used as fallback",
+			name: "stopwords used as fallback",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("the quick brown fox"),
 				Tokenization: strPtr("word"),
-				InvertedIndexConfig: &models.InvertedIndexConfig{
-					Stopwords: &models.StopwordConfig{
-						Preset:    "en",
-						Additions: []string{"quick"},
-					},
+				Stopwords: &models.StopwordConfig{
+					Preset:    "en",
+					Additions: []string{"quick"},
 				},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"the", "quick", "brown", "fox"},
-			wantQuery:               []string{"brown", "fox"},
-			wantInvertedIndexPreset: "en",
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick", "brown", "fox"},
+			wantQuery:   []string{"brown", "fox"},
 		},
 		{
 			// analyzerConfig.stopwordPreset can reference a user-defined
-			// preset declared in invertedIndexConfig.stopwordPresets
-			// (plain word list, collection-shape).
-			name: "invertedIndexConfig.stopwordPresets resolved by analyzerConfig preset",
+			// preset declared in top-level stopwordPresets (plain word list,
+			// collection-shape).
+			name: "stopwordPresets resolved by analyzerConfig preset",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("le chat et la souris"),
 				Tokenization: strPtr("word"),
 				AnalyzerConfig: &models.TextAnalyzerConfig{
 					StopwordPreset: "fr",
 				},
-				InvertedIndexConfig: &models.InvertedIndexConfig{
-					StopwordPresets: map[string][]string{
-						"fr": {"le", "la", "et"},
-					},
+				StopwordPresets: map[string][]string{
+					"fr": {"le", "la", "et"},
 				},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"le", "chat", "et", "la", "souris"},
-			wantQuery:               []string{"chat", "souris"},
-			wantInvertedIndexPreset: "fr",
+			wantOK:      true,
+			wantIndexed: []string{"le", "chat", "et", "la", "souris"},
+			wantQuery:   []string{"chat", "souris"},
 		},
 		{
-			// analyzerConfig.stopwordPreset overrides the
-			// invertedIndexConfig.stopwords fallback, same as a
-			// property-level preset override at the collection level.
-			name: "analyzerConfig preset overrides invertedIndexConfig.stopwords fallback",
+			// analyzerConfig.stopwordPreset overrides the stopwords
+			// fallback, same as a property-level preset override at the
+			// collection level.
+			name: "analyzerConfig preset overrides stopwords fallback",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("the quick"),
 				Tokenization: strPtr("word"),
 				AnalyzerConfig: &models.TextAnalyzerConfig{
 					StopwordPreset: "none",
 				},
-				InvertedIndexConfig: &models.InvertedIndexConfig{
-					Stopwords: &models.StopwordConfig{Preset: "en"},
-				},
+				Stopwords: &models.StopwordConfig{Preset: "en"},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"the", "quick"},
-			wantQuery:               []string{"the", "quick"},
-			wantInvertedIndexPreset: "none",
-		},
-		{
-			// Top-level stopwordPresets (richer StopwordConfig form) wins
-			// over invertedIndexConfig.stopwordPresets on name conflict.
-			name: "top-level stopwordPresets overrides invertedIndexConfig.stopwordPresets on conflict",
-			body: &models.TokenizeRequest{
-				Text:         strPtr("hello world test"),
-				Tokenization: strPtr("word"),
-				AnalyzerConfig: &models.TextAnalyzerConfig{
-					StopwordPreset: "custom",
-				},
-				InvertedIndexConfig: &models.InvertedIndexConfig{
-					StopwordPresets: map[string][]string{
-						"custom": {"hello"}, // would filter "hello"
-					},
-				},
-				StopwordPresets: map[string]models.StopwordConfig{
-					"custom": {Additions: []string{"test"}}, // wins → filters "test"
-				},
-			},
-			wantOK:                  true,
-			wantIndexed:             []string{"hello", "world", "test"},
-			wantQuery:               []string{"hello", "world"},
-			wantInvertedIndexPreset: "custom",
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick"},
+			wantQuery:   []string{"the", "quick"},
 		},
 		{
 			// Unknown preset referenced by analyzerConfig is rejected.
-			name: "unknown preset against invertedIndexConfig is rejected",
+			name: "unknown preset against stopwordPresets is rejected",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("hello"),
 				Tokenization: strPtr("word"),
 				AnalyzerConfig: &models.TextAnalyzerConfig{
 					StopwordPreset: "missing",
 				},
-				InvertedIndexConfig: &models.InvertedIndexConfig{
-					StopwordPresets: map[string][]string{
-						"other": {"hello"},
-					},
+				StopwordPresets: map[string][]string{
+					"other": {"hello"},
 				},
 			},
 			wantOK: false,
 		},
 		{
-			// A user override for "en" via invertedIndexConfig.stopwordPresets
-			// is respected even when the caller did not explicitly reference
-			// it via analyzerConfig. This matches collection-level semantics
-			// where a user-defined "en" replaces the built-in entirely.
-			name: "user override for built-in en via invertedIndexConfig applies to default",
+			// A user override for "en" is respected even when the caller did
+			// not explicitly reference it via analyzerConfig. This matches
+			// collection-level semantics where a user-defined "en" replaces
+			// the built-in entirely.
+			name: "user override for built-in en applies to default",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("the quick hello world"),
 				Tokenization: strPtr("word"),
-				InvertedIndexConfig: &models.InvertedIndexConfig{
-					StopwordPresets: map[string][]string{
-						// Replaces the built-in "en" entirely — only "hello"
-						// is now an "en" stopword; "the" passes through.
-						"en": {"hello"},
-					},
+				StopwordPresets: map[string][]string{
+					// Replaces the built-in "en" entirely — only "hello" is
+					// now an "en" stopword; "the" passes through.
+					"en": {"hello"},
 				},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"the", "quick", "hello", "world"},
-			wantQuery:               []string{"the", "quick", "world"},
-			wantInvertedIndexPreset: "en",
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick", "hello", "world"},
+			wantQuery:   []string{"the", "quick", "world"},
 		},
 		{
-			// Same for the richer top-level stopwordPresets form.
-			name: "user override for built-in en via stopwordPresets applies to default",
-			body: &models.TokenizeRequest{
-				Text:         strPtr("the quick hello world"),
-				Tokenization: strPtr("word"),
-				StopwordPresets: map[string]models.StopwordConfig{
-					"en": {Additions: []string{"hello"}},
-				},
-			},
-			wantOK:                  true,
-			wantIndexed:             []string{"the", "quick", "hello", "world"},
-			wantQuery:               []string{"the", "quick", "world"},
-			wantInvertedIndexPreset: "en",
-		},
-		{
-			// invertedIndexConfig.stopwords with an empty Preset must be
-			// defaulted to "en", matching collection-level validation
+			// stopwords with an empty Preset must be defaulted to "en",
+			// matching collection-level validation
 			// (adapters/repos/db/inverted/config.go: validateStopwordConfig).
 			// Without that defaulting, NewDetectorFromConfig would build an
 			// empty detector and no stopwords would be filtered.
-			name: "invertedIndexConfig.stopwords empty preset defaults to en",
+			name: "stopwords empty preset defaults to en",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("the quick"),
 				Tokenization: strPtr("word"),
-				InvertedIndexConfig: &models.InvertedIndexConfig{
-					Stopwords: &models.StopwordConfig{},
-				},
+				Stopwords:    &models.StopwordConfig{},
 			},
-			wantOK:                  true,
-			wantIndexed:             []string{"the", "quick"},
-			wantQuery:               []string{"quick"},
-			wantInvertedIndexPreset: "en",
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick"},
+			wantQuery:   []string{"quick"},
 		},
 		{
-			// Unknown preset name in invertedIndexConfig.stopwords must be
-			// rejected the same way collection creation would reject it.
-			name: "invertedIndexConfig.stopwords unknown preset is rejected",
+			// Default "en" + additions: caller omits preset, passes only
+			// additions. Validation defaults preset to "en" and the
+			// detector is built from en + additions.
+			name: "stopwords additions without preset default to en plus additions",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("the quick hello world"),
+				Tokenization: strPtr("word"),
+				Stopwords:    &models.StopwordConfig{Additions: []string{"hello"}},
+			},
+			wantOK: true,
+			// "the" filtered by default en, "hello" filtered by caller's addition.
+			wantIndexed: []string{"the", "quick", "hello", "world"},
+			wantQuery:   []string{"quick", "world"},
+		},
+		{
+			// Default "en" - removals: caller omits preset, passes only
+			// removals. "the" is removed from the en list so it passes
+			// through the query.
+			name: "stopwords removals without preset default to en minus removals",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("the quick is fast"),
+				Tokenization: strPtr("word"),
+				Stopwords:    &models.StopwordConfig{Removals: []string{"the"}},
+			},
+			wantOK: true,
+			// "is" is still an en stopword, "the" was removed.
+			wantIndexed: []string{"the", "quick", "is", "fast"},
+			wantQuery:   []string{"the", "quick", "fast"},
+		},
+		{
+			// Both stopwords and stopwordPresets supplied, with an explicit
+			// analyzerConfig.stopwordPreset. Mirrors the property endpoint's
+			// override order: analyzerConfig.stopwordPreset (property-level)
+			// beats the stopwords fallback (collection-level default), so
+			// the "fr" user preset wins over the en-based fallback.
+			name: "analyzerConfig preset wins over stopwords fallback when both are set",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("the quick frword hello"),
+				Tokenization: strPtr("word"),
+				AnalyzerConfig: &models.TextAnalyzerConfig{
+					StopwordPreset: "fr",
+				},
+				Stopwords: &models.StopwordConfig{
+					Preset:    "en",
+					Additions: []string{"hello"},
+				},
+				StopwordPresets: map[string][]string{
+					"fr": {"frword"},
+				},
+			},
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick", "frword", "hello"},
+			// Only "frword" is filtered (from fr preset).
+			// "the" (en) and "hello" (addition) stay because the fallback is
+			// ignored when an analyzerConfig preset is set.
+			wantQuery: []string{"the", "quick", "hello"},
+			// Analyzer-preset path wins → response.Stopwords omitted; the
+			// caller's Stopwords fallback was ignored, and echoing "fr"
+			// under Stopwords would conflate the analyzer preset with the
+			// stopwords input the caller sent.
+		},
+		{
+			// "en" is set both as the stopwords fallback base AND as a
+			// user-defined preset in stopwordPresets. Mirrors a collection
+			// where invertedIndexConfig.stopwords.preset="en" and
+			// invertedIndexConfig.stopwordPresets["en"]=[...].
+			//
+			// Property-endpoint parallel: when a property has no
+			// stopwordPreset configured, the collection's stopwords fallback
+			// is used, and that fallback is built from the BUILT-IN "en"
+			// list — the user's stopwordPresets["en"] override is NOT
+			// consulted for the fallback. Here analyzerConfig.stopwordPreset
+			// is absent, so "the" (built-in en) is filtered and
+			// "customword" (user's en) passes through.
+			name: "fallback uses built-in en even when stopwordPresets overrides en",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("the quick customword"),
+				Tokenization: strPtr("word"),
+				Stopwords:    &models.StopwordConfig{Preset: "en"},
+				StopwordPresets: map[string][]string{
+					"en": {"customword"},
+				},
+			},
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick", "customword"},
+			wantQuery:   []string{"quick", "customword"},
+		},
+		{
+			// Same shape as the previous case, but now the caller explicitly
+			// references "en" via analyzerConfig.stopwordPreset. The
+			// Provider resolves "en" in the user-defined presets map first,
+			// so the user's override wins — "the" now passes through (it
+			// was dropped from the user's en list) and "customword" is
+			// filtered. Property-endpoint parallel: a property with
+			// textAnalyzer.stopwordPreset="en" against a collection that
+			// defines its own "en" preset will use the collection's version,
+			// not the built-in.
+			name: "analyzerConfig=en picks user's stopwordPresets override over built-in",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("the quick customword"),
+				Tokenization: strPtr("word"),
+				AnalyzerConfig: &models.TextAnalyzerConfig{
+					StopwordPreset: "en",
+				},
+				Stopwords: &models.StopwordConfig{Preset: "en"},
+				StopwordPresets: map[string][]string{
+					"en": {"customword"},
+				},
+			},
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick", "customword"},
+			wantQuery:   []string{"the", "quick"},
+		},
+		{
+			// Same inputs as above but WITHOUT analyzerConfig.stopwordPreset.
+			// Now the stopwords fallback wins (matches property endpoint
+			// behavior when the property has no stopwordPreset configured).
+			// The fr user preset is defined but not referenced, so it's
+			// inert.
+			name: "stopwords fallback wins when analyzerConfig preset is absent",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("the quick frword hello"),
+				Tokenization: strPtr("word"),
+				Stopwords: &models.StopwordConfig{
+					Preset:    "en",
+					Additions: []string{"hello"},
+				},
+				StopwordPresets: map[string][]string{
+					"fr": {"frword"},
+				},
+			},
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick", "frword", "hello"},
+			// "the" (en) and "hello" (addition) filtered; "frword"
+			// stays because fr preset was not selected.
+			wantQuery: []string{"quick", "frword"},
+		},
+		{
+			// Default "en" + additions + removals applied together.
+			name: "stopwords additions and removals without preset compose on en",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("the quick hello"),
+				Tokenization: strPtr("word"),
+				Stopwords: &models.StopwordConfig{
+					Additions: []string{"hello"},
+					Removals:  []string{"the"},
+				},
+			},
+			wantOK:      true,
+			wantIndexed: []string{"the", "quick", "hello"},
+			wantQuery:   []string{"the", "quick"},
+		},
+		{
+			// Unknown preset name in stopwords must be rejected the same
+			// way collection creation would reject it.
+			name: "stopwords unknown preset is rejected",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("hello"),
 				Tokenization: strPtr("word"),
-				InvertedIndexConfig: &models.InvertedIndexConfig{
-					Stopwords: &models.StopwordConfig{Preset: "nonexistent"},
-				},
+				Stopwords:    &models.StopwordConfig{Preset: "nonexistent"},
 			},
 			wantOK: false,
 		},
@@ -451,31 +538,27 @@ func TestHandleGenericTokenize(t *testing.T) {
 			// An empty word list for a user-defined preset is rejected by
 			// collection-level validateStopwordPresets, and the tokenize
 			// endpoint must reject it the same way.
-			name: "invertedIndexConfig.stopwordPresets empty list is rejected",
+			name: "stopwordPresets empty list is rejected",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("hello"),
 				Tokenization: strPtr("word"),
-				InvertedIndexConfig: &models.InvertedIndexConfig{
-					StopwordPresets: map[string][]string{
-						"custom": {},
-					},
+				StopwordPresets: map[string][]string{
+					"custom": {},
 				},
 			},
 			wantOK: false,
 		},
 		{
 			// Same as collection-level: the same word cannot appear in both
-			// additions and removals of invertedIndexConfig.stopwords.
-			name: "invertedIndexConfig.stopwords conflicting addition and removal is rejected",
+			// additions and removals of stopwords.
+			name: "stopwords conflicting addition and removal is rejected",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("hello"),
 				Tokenization: strPtr("word"),
-				InvertedIndexConfig: &models.InvertedIndexConfig{
-					Stopwords: &models.StopwordConfig{
-						Preset:    "en",
-						Additions: []string{"foo"},
-						Removals:  []string{"foo"},
-					},
+				Stopwords: &models.StopwordConfig{
+					Preset:    "en",
+					Additions: []string{"foo"},
+					Removals:  []string{"foo"},
 				},
 			},
 			wantOK: false,
@@ -490,18 +573,11 @@ func TestHandleGenericTokenize(t *testing.T) {
 			if tt.wantOK {
 				okResp, ok := resp.(*tokenizeops.TokenizeOK)
 				require.True(t, ok, "expected TokenizeOK response")
-				assert.Equal(t, *tt.body.Tokenization, okResp.Payload.Tokenization)
 				assert.Equal(t, tt.wantIndexed, okResp.Payload.Indexed)
 				assert.Equal(t, tt.wantQuery, okResp.Payload.Query)
-				if tt.wantInvertedIndexPreset == "" {
-					assert.Nil(t, okResp.Payload.InvertedIndexConfig,
-						"expected no invertedIndexConfig when preset was not applied")
-				} else {
-					require.NotNil(t, okResp.Payload.InvertedIndexConfig)
-					require.NotNil(t, okResp.Payload.InvertedIndexConfig.Stopwords)
-					assert.Equal(t, tt.wantInvertedIndexPreset,
-						okResp.Payload.InvertedIndexConfig.Stopwords.Preset)
-				}
+				// Generic endpoint does not echo tokenization; callers
+				// already know what they sent.
+				assert.Empty(t, okResp.Payload.Tokenization)
 			} else {
 				_, ok := resp.(*tokenizeops.TokenizeUnprocessableEntity)
 				assert.True(t, ok, "expected TokenizeUnprocessableEntity response")
@@ -696,7 +772,6 @@ func TestHandleGenericTokenizeGSE(t *testing.T) {
 
 			okResp, ok := resp.(*tokenizeops.TokenizeOK)
 			require.True(t, ok, "expected TokenizeOK response")
-			assert.Equal(t, *tt.body.Tokenization, okResp.Payload.Tokenization)
 			assert.Equal(t, tt.wantIndexed, okResp.Payload.Indexed)
 		})
 	}
@@ -753,7 +828,6 @@ func TestHandleGenericTokenizeKagome(t *testing.T) {
 
 			okResp, ok := resp.(*tokenizeops.TokenizeOK)
 			require.True(t, ok, "expected TokenizeOK response")
-			assert.Equal(t, *tt.body.Tokenization, okResp.Payload.Tokenization)
 			assert.Equal(t, tt.wantIndexed, okResp.Payload.Indexed)
 		})
 	}

--- a/adapters/handlers/rest/handlers_tokenize_test.go
+++ b/adapters/handlers/rest/handlers_tokenize_test.go
@@ -482,9 +482,6 @@ func TestHandleGenericTokenize(t *testing.T) {
 				require.True(t, ok, "expected TokenizeOK response")
 				assert.Equal(t, tt.wantIndexed, okResp.Payload.Indexed)
 				assert.Equal(t, tt.wantQuery, okResp.Payload.Query)
-				// Generic endpoint does not echo tokenization; callers
-				// already know what they sent.
-				assert.Empty(t, okResp.Payload.Tokenization)
 			} else {
 				_, ok := resp.(*tokenizeops.TokenizeUnprocessableEntity)
 				assert.True(t, ok, "expected TokenizeUnprocessableEntity response")

--- a/adapters/handlers/rest/handlers_tokenize_test.go
+++ b/adapters/handlers/rest/handlers_tokenize_test.go
@@ -401,112 +401,19 @@ func TestHandleGenericTokenize(t *testing.T) {
 			wantQuery:   []string{"the", "quick", "fast"},
 		},
 		{
-			// Both stopwords and stopwordPresets supplied, with an explicit
-			// analyzerConfig.stopwordPreset. Mirrors the property endpoint's
-			// override order: analyzerConfig.stopwordPreset (property-level)
-			// beats the stopwords fallback (collection-level default), so
-			// the "fr" user preset wins over the en-based fallback.
-			name: "analyzerConfig preset wins over stopwords fallback when both are set",
+			// Passing both stopwords and stopwordPresets is rejected:
+			// the two input shapes are mutually exclusive to keep the
+			// mental model simple. Callers must pick one.
+			name: "both stopwords and stopwordPresets is rejected",
 			body: &models.TokenizeRequest{
-				Text:         strPtr("the quick frword hello"),
-				Tokenization: strPtr("word"),
-				AnalyzerConfig: &models.TextAnalyzerConfig{
-					StopwordPreset: "fr",
-				},
-				Stopwords: &models.StopwordConfig{
-					Preset:    "en",
-					Additions: []string{"hello"},
-				},
-				StopwordPresets: map[string][]string{
-					"fr": {"frword"},
-				},
-			},
-			wantOK:      true,
-			wantIndexed: []string{"the", "quick", "frword", "hello"},
-			// Only "frword" is filtered (from fr preset).
-			// "the" (en) and "hello" (addition) stay because the fallback is
-			// ignored when an analyzerConfig preset is set.
-			wantQuery: []string{"the", "quick", "hello"},
-			// Analyzer-preset path wins → response.Stopwords omitted; the
-			// caller's Stopwords fallback was ignored, and echoing "fr"
-			// under Stopwords would conflate the analyzer preset with the
-			// stopwords input the caller sent.
-		},
-		{
-			// "en" is set both as the stopwords fallback base AND as a
-			// user-defined preset in stopwordPresets. Mirrors a collection
-			// where invertedIndexConfig.stopwords.preset="en" and
-			// invertedIndexConfig.stopwordPresets["en"]=[...].
-			//
-			// Property-endpoint parallel: when a property has no
-			// stopwordPreset configured, the collection's stopwords fallback
-			// is used, and that fallback is built from the BUILT-IN "en"
-			// list — the user's stopwordPresets["en"] override is NOT
-			// consulted for the fallback. Here analyzerConfig.stopwordPreset
-			// is absent, so "the" (built-in en) is filtered and
-			// "customword" (user's en) passes through.
-			name: "fallback uses built-in en even when stopwordPresets overrides en",
-			body: &models.TokenizeRequest{
-				Text:         strPtr("the quick customword"),
+				Text:         strPtr("hello"),
 				Tokenization: strPtr("word"),
 				Stopwords:    &models.StopwordConfig{Preset: "en"},
 				StopwordPresets: map[string][]string{
-					"en": {"customword"},
+					"custom": {"hello"},
 				},
 			},
-			wantOK:      true,
-			wantIndexed: []string{"the", "quick", "customword"},
-			wantQuery:   []string{"quick", "customword"},
-		},
-		{
-			// Same shape as the previous case, but now the caller explicitly
-			// references "en" via analyzerConfig.stopwordPreset. The
-			// Provider resolves "en" in the user-defined presets map first,
-			// so the user's override wins — "the" now passes through (it
-			// was dropped from the user's en list) and "customword" is
-			// filtered. Property-endpoint parallel: a property with
-			// textAnalyzer.stopwordPreset="en" against a collection that
-			// defines its own "en" preset will use the collection's version,
-			// not the built-in.
-			name: "analyzerConfig=en picks user's stopwordPresets override over built-in",
-			body: &models.TokenizeRequest{
-				Text:         strPtr("the quick customword"),
-				Tokenization: strPtr("word"),
-				AnalyzerConfig: &models.TextAnalyzerConfig{
-					StopwordPreset: "en",
-				},
-				Stopwords: &models.StopwordConfig{Preset: "en"},
-				StopwordPresets: map[string][]string{
-					"en": {"customword"},
-				},
-			},
-			wantOK:      true,
-			wantIndexed: []string{"the", "quick", "customword"},
-			wantQuery:   []string{"the", "quick"},
-		},
-		{
-			// Same inputs as above but WITHOUT analyzerConfig.stopwordPreset.
-			// Now the stopwords fallback wins (matches property endpoint
-			// behavior when the property has no stopwordPreset configured).
-			// The fr user preset is defined but not referenced, so it's
-			// inert.
-			name: "stopwords fallback wins when analyzerConfig preset is absent",
-			body: &models.TokenizeRequest{
-				Text:         strPtr("the quick frword hello"),
-				Tokenization: strPtr("word"),
-				Stopwords: &models.StopwordConfig{
-					Preset:    "en",
-					Additions: []string{"hello"},
-				},
-				StopwordPresets: map[string][]string{
-					"fr": {"frword"},
-				},
-			},
-			wantOK:      true,
-			wantIndexed: []string{"the", "quick", "frword", "hello"},
-			// "the" (en) and "hello" (addition) filtered; "frword"
-			// stays because fr preset was not selected.
-			wantQuery: []string{"quick", "frword"},
+			wantOK: false,
 		},
 		{
 			// Default "en" + additions + removals applied together.

--- a/adapters/handlers/rest/handlers_tokenize_test.go
+++ b/adapters/handlers/rest/handlers_tokenize_test.go
@@ -415,6 +415,71 @@ func TestHandleGenericTokenize(t *testing.T) {
 			wantQuery:               []string{"the", "quick", "world"},
 			wantInvertedIndexPreset: "en",
 		},
+		{
+			// invertedIndexConfig.stopwords with an empty Preset must be
+			// defaulted to "en", matching collection-level validation
+			// (adapters/repos/db/inverted/config.go: validateStopwordConfig).
+			// Without that defaulting, NewDetectorFromConfig would build an
+			// empty detector and no stopwords would be filtered.
+			name: "invertedIndexConfig.stopwords empty preset defaults to en",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("the quick"),
+				Tokenization: strPtr("word"),
+				InvertedIndexConfig: &models.InvertedIndexConfig{
+					Stopwords: &models.StopwordConfig{},
+				},
+			},
+			wantOK:                  true,
+			wantIndexed:             []string{"the", "quick"},
+			wantQuery:               []string{"quick"},
+			wantInvertedIndexPreset: "en",
+		},
+		{
+			// Unknown preset name in invertedIndexConfig.stopwords must be
+			// rejected the same way collection creation would reject it.
+			name: "invertedIndexConfig.stopwords unknown preset is rejected",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("hello"),
+				Tokenization: strPtr("word"),
+				InvertedIndexConfig: &models.InvertedIndexConfig{
+					Stopwords: &models.StopwordConfig{Preset: "nonexistent"},
+				},
+			},
+			wantOK: false,
+		},
+		{
+			// An empty word list for a user-defined preset is rejected by
+			// collection-level validateStopwordPresets, and the tokenize
+			// endpoint must reject it the same way.
+			name: "invertedIndexConfig.stopwordPresets empty list is rejected",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("hello"),
+				Tokenization: strPtr("word"),
+				InvertedIndexConfig: &models.InvertedIndexConfig{
+					StopwordPresets: map[string][]string{
+						"custom": {},
+					},
+				},
+			},
+			wantOK: false,
+		},
+		{
+			// Same as collection-level: the same word cannot appear in both
+			// additions and removals of invertedIndexConfig.stopwords.
+			name: "invertedIndexConfig.stopwords conflicting addition and removal is rejected",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("hello"),
+				Tokenization: strPtr("word"),
+				InvertedIndexConfig: &models.InvertedIndexConfig{
+					Stopwords: &models.StopwordConfig{
+						Preset:    "en",
+						Additions: []string{"foo"},
+						Removals:  []string{"foo"},
+					},
+				},
+			},
+			wantOK: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/adapters/handlers/rest/handlers_tokenize_test.go
+++ b/adapters/handlers/rest/handlers_tokenize_test.go
@@ -48,8 +48,6 @@ func TestHandleGenericTokenize(t *testing.T) {
 		},
 		{
 			// Callers can opt out of the default by passing "none".
-			// Analyzer-preset path wins → response.Stopwords is not
-			// populated; the preset is visible via AnalyzerConfig echo.
 			name: "word tokenization with explicit stopwordPreset none disables default",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("The quick brown fox"),
@@ -211,8 +209,7 @@ func TestHandleGenericTokenize(t *testing.T) {
 		},
 		{
 			// Word tokenization with no config still gets the default "en"
-			// preset reflected in invertedIndexConfig, even when no tokens
-			// happen to be English stopwords.
+			// preset, even when no tokens happen to be English stopwords.
 			name: "nil configs defaults to en",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("hello world"),

--- a/adapters/handlers/rest/handlers_tokenize_test.go
+++ b/adapters/handlers/rest/handlers_tokenize_test.go
@@ -32,16 +32,38 @@ func TestHandleGenericTokenize(t *testing.T) {
 		wantOK      bool
 		wantIndexed []string
 		wantQuery   []string
+		// Expected InvertedIndexConfig.Stopwords.Preset in the response,
+		// or empty string if InvertedIndexConfig should be nil.
+		wantInvertedIndexPreset string
 	}{
 		{
-			name: "word tokenization without stopwords",
+			// Word tokenization defaults to the "en" stopword preset when
+			// no analyzerConfig is supplied, matching the property-level
+			// endpoint (which inherits the collection's default, also "en").
+			name: "word tokenization defaults to en stopwords",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("The quick brown fox"),
 				Tokenization: strPtr("word"),
 			},
-			wantOK:      true,
-			wantIndexed: []string{"the", "quick", "brown", "fox"},
-			wantQuery:   []string{"the", "quick", "brown", "fox"},
+			wantOK:                  true,
+			wantIndexed:             []string{"the", "quick", "brown", "fox"},
+			wantQuery:               []string{"quick", "brown", "fox"},
+			wantInvertedIndexPreset: "en",
+		},
+		{
+			// Callers can opt out of the default by passing "none".
+			name: "word tokenization with explicit stopwordPreset none disables default",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("The quick brown fox"),
+				Tokenization: strPtr("word"),
+				AnalyzerConfig: &models.TextAnalyzerConfig{
+					StopwordPreset: "none",
+				},
+			},
+			wantOK:                  true,
+			wantIndexed:             []string{"the", "quick", "brown", "fox"},
+			wantQuery:               []string{"the", "quick", "brown", "fox"},
+			wantInvertedIndexPreset: "none",
 		},
 		{
 			name: "lowercase tokenization",
@@ -100,9 +122,10 @@ func TestHandleGenericTokenize(t *testing.T) {
 					ASCIIFold: true,
 				},
 			},
-			wantOK:      true,
-			wantIndexed: []string{"l", "ecole", "est", "fermee"},
-			wantQuery:   []string{"l", "ecole", "est", "fermee"},
+			wantOK:                  true,
+			wantIndexed:             []string{"l", "ecole", "est", "fermee"},
+			wantQuery:               []string{"l", "ecole", "est", "fermee"},
+			wantInvertedIndexPreset: "en",
 		},
 		{
 			name: "ascii fold with ignore",
@@ -114,9 +137,10 @@ func TestHandleGenericTokenize(t *testing.T) {
 					ASCIIFoldIgnore: []string{"é"},
 				},
 			},
-			wantOK:      true,
-			wantIndexed: []string{"l", "école", "est", "fermée"},
-			wantQuery:   []string{"l", "école", "est", "fermée"},
+			wantOK:                  true,
+			wantIndexed:             []string{"l", "école", "est", "fermée"},
+			wantQuery:               []string{"l", "école", "est", "fermée"},
+			wantInvertedIndexPreset: "en",
 		},
 		{
 			name: "stopword preset en",
@@ -127,9 +151,10 @@ func TestHandleGenericTokenize(t *testing.T) {
 					StopwordPreset: "en",
 				},
 			},
-			wantOK:      true,
-			wantIndexed: []string{"the", "quick", "brown", "fox"},
-			wantQuery:   []string{"quick", "brown", "fox"},
+			wantOK:                  true,
+			wantIndexed:             []string{"the", "quick", "brown", "fox"},
+			wantQuery:               []string{"quick", "brown", "fox"},
+			wantInvertedIndexPreset: "en",
 		},
 		{
 			name: "stopword custom additions only via request-level preset",
@@ -143,9 +168,10 @@ func TestHandleGenericTokenize(t *testing.T) {
 					"custom": {Additions: []string{"test"}},
 				},
 			},
-			wantOK:      true,
-			wantIndexed: []string{"hello", "world", "test"},
-			wantQuery:   []string{"hello", "world"},
+			wantOK:                  true,
+			wantIndexed:             []string{"hello", "world", "test"},
+			wantQuery:               []string{"hello", "world"},
+			wantInvertedIndexPreset: "custom",
 		},
 		{
 			name: "stopword preset with removals via request-level preset",
@@ -159,9 +185,10 @@ func TestHandleGenericTokenize(t *testing.T) {
 					"en-no-the": {Preset: "en", Removals: []string{"the"}},
 				},
 			},
-			wantOK:      true,
-			wantIndexed: []string{"the", "quick"},
-			wantQuery:   []string{"the", "quick"},
+			wantOK:                  true,
+			wantIndexed:             []string{"the", "quick"},
+			wantQuery:               []string{"the", "quick"},
+			wantInvertedIndexPreset: "en-no-the",
 		},
 		{
 			name: "ascii fold combined with stopwords",
@@ -173,9 +200,10 @@ func TestHandleGenericTokenize(t *testing.T) {
 					StopwordPreset: "en",
 				},
 			},
-			wantOK:      true,
-			wantIndexed: []string{"the", "ecole", "est", "fermee"},
-			wantQuery:   []string{"ecole", "est", "fermee"},
+			wantOK:                  true,
+			wantIndexed:             []string{"the", "ecole", "est", "fermee"},
+			wantQuery:               []string{"ecole", "est", "fermee"},
+			wantInvertedIndexPreset: "en",
 		},
 		{
 			name: "unknown stopword preset is rejected",
@@ -189,14 +217,18 @@ func TestHandleGenericTokenize(t *testing.T) {
 			wantOK: false,
 		},
 		{
-			name: "nil configs is backward compatible",
+			// Word tokenization with no config still gets the default "en"
+			// preset reflected in invertedIndexConfig, even when no tokens
+			// happen to be English stopwords.
+			name: "nil configs defaults to en",
 			body: &models.TokenizeRequest{
 				Text:         strPtr("hello world"),
 				Tokenization: strPtr("word"),
 			},
-			wantOK:      true,
-			wantIndexed: []string{"hello", "world"},
-			wantQuery:   []string{"hello", "world"},
+			wantOK:                  true,
+			wantIndexed:             []string{"hello", "world"},
+			wantQuery:               []string{"hello", "world"},
+			wantInvertedIndexPreset: "en",
 		},
 		{
 			name: "ascii fold ignore without fold enabled is rejected",
@@ -238,9 +270,150 @@ func TestHandleGenericTokenize(t *testing.T) {
 					"en": {Additions: []string{"hello"}},
 				},
 			},
-			wantOK:      true,
-			wantIndexed: []string{"the", "quick", "hello", "world"},
-			wantQuery:   []string{"the", "quick", "world"},
+			wantOK:                  true,
+			wantIndexed:             []string{"the", "quick", "hello", "world"},
+			wantQuery:               []string{"the", "quick", "world"},
+			wantInvertedIndexPreset: "en",
+		},
+		{
+			// invertedIndexConfig.stopwords is used as a fallback when
+			// analyzerConfig.stopwordPreset is not set, matching the
+			// property endpoint's inheritance from collection config.
+			name: "invertedIndexConfig.stopwords used as fallback",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("the quick brown fox"),
+				Tokenization: strPtr("word"),
+				InvertedIndexConfig: &models.InvertedIndexConfig{
+					Stopwords: &models.StopwordConfig{
+						Preset:    "en",
+						Additions: []string{"quick"},
+					},
+				},
+			},
+			wantOK:                  true,
+			wantIndexed:             []string{"the", "quick", "brown", "fox"},
+			wantQuery:               []string{"brown", "fox"},
+			wantInvertedIndexPreset: "en",
+		},
+		{
+			// analyzerConfig.stopwordPreset can reference a user-defined
+			// preset declared in invertedIndexConfig.stopwordPresets
+			// (plain word list, collection-shape).
+			name: "invertedIndexConfig.stopwordPresets resolved by analyzerConfig preset",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("le chat et la souris"),
+				Tokenization: strPtr("word"),
+				AnalyzerConfig: &models.TextAnalyzerConfig{
+					StopwordPreset: "fr",
+				},
+				InvertedIndexConfig: &models.InvertedIndexConfig{
+					StopwordPresets: map[string][]string{
+						"fr": {"le", "la", "et"},
+					},
+				},
+			},
+			wantOK:                  true,
+			wantIndexed:             []string{"le", "chat", "et", "la", "souris"},
+			wantQuery:               []string{"chat", "souris"},
+			wantInvertedIndexPreset: "fr",
+		},
+		{
+			// analyzerConfig.stopwordPreset overrides the
+			// invertedIndexConfig.stopwords fallback, same as a
+			// property-level preset override at the collection level.
+			name: "analyzerConfig preset overrides invertedIndexConfig.stopwords fallback",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("the quick"),
+				Tokenization: strPtr("word"),
+				AnalyzerConfig: &models.TextAnalyzerConfig{
+					StopwordPreset: "none",
+				},
+				InvertedIndexConfig: &models.InvertedIndexConfig{
+					Stopwords: &models.StopwordConfig{Preset: "en"},
+				},
+			},
+			wantOK:                  true,
+			wantIndexed:             []string{"the", "quick"},
+			wantQuery:               []string{"the", "quick"},
+			wantInvertedIndexPreset: "none",
+		},
+		{
+			// Top-level stopwordPresets (richer StopwordConfig form) wins
+			// over invertedIndexConfig.stopwordPresets on name conflict.
+			name: "top-level stopwordPresets overrides invertedIndexConfig.stopwordPresets on conflict",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("hello world test"),
+				Tokenization: strPtr("word"),
+				AnalyzerConfig: &models.TextAnalyzerConfig{
+					StopwordPreset: "custom",
+				},
+				InvertedIndexConfig: &models.InvertedIndexConfig{
+					StopwordPresets: map[string][]string{
+						"custom": {"hello"}, // would filter "hello"
+					},
+				},
+				StopwordPresets: map[string]models.StopwordConfig{
+					"custom": {Additions: []string{"test"}}, // wins → filters "test"
+				},
+			},
+			wantOK:                  true,
+			wantIndexed:             []string{"hello", "world", "test"},
+			wantQuery:               []string{"hello", "world"},
+			wantInvertedIndexPreset: "custom",
+		},
+		{
+			// Unknown preset referenced by analyzerConfig is rejected.
+			name: "unknown preset against invertedIndexConfig is rejected",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("hello"),
+				Tokenization: strPtr("word"),
+				AnalyzerConfig: &models.TextAnalyzerConfig{
+					StopwordPreset: "missing",
+				},
+				InvertedIndexConfig: &models.InvertedIndexConfig{
+					StopwordPresets: map[string][]string{
+						"other": {"hello"},
+					},
+				},
+			},
+			wantOK: false,
+		},
+		{
+			// A user override for "en" via invertedIndexConfig.stopwordPresets
+			// is respected even when the caller did not explicitly reference
+			// it via analyzerConfig. This matches collection-level semantics
+			// where a user-defined "en" replaces the built-in entirely.
+			name: "user override for built-in en via invertedIndexConfig applies to default",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("the quick hello world"),
+				Tokenization: strPtr("word"),
+				InvertedIndexConfig: &models.InvertedIndexConfig{
+					StopwordPresets: map[string][]string{
+						// Replaces the built-in "en" entirely — only "hello"
+						// is now an "en" stopword; "the" passes through.
+						"en": {"hello"},
+					},
+				},
+			},
+			wantOK:                  true,
+			wantIndexed:             []string{"the", "quick", "hello", "world"},
+			wantQuery:               []string{"the", "quick", "world"},
+			wantInvertedIndexPreset: "en",
+		},
+		{
+			// Same for the richer top-level stopwordPresets form.
+			name: "user override for built-in en via stopwordPresets applies to default",
+			body: &models.TokenizeRequest{
+				Text:         strPtr("the quick hello world"),
+				Tokenization: strPtr("word"),
+				StopwordPresets: map[string]models.StopwordConfig{
+					"en": {Additions: []string{"hello"}},
+				},
+			},
+			wantOK:                  true,
+			wantIndexed:             []string{"the", "quick", "hello", "world"},
+			wantQuery:               []string{"the", "quick", "world"},
+			wantInvertedIndexPreset: "en",
 		},
 	}
 
@@ -255,6 +428,15 @@ func TestHandleGenericTokenize(t *testing.T) {
 				assert.Equal(t, *tt.body.Tokenization, okResp.Payload.Tokenization)
 				assert.Equal(t, tt.wantIndexed, okResp.Payload.Indexed)
 				assert.Equal(t, tt.wantQuery, okResp.Payload.Query)
+				if tt.wantInvertedIndexPreset == "" {
+					assert.Nil(t, okResp.Payload.InvertedIndexConfig,
+						"expected no invertedIndexConfig when preset was not applied")
+				} else {
+					require.NotNil(t, okResp.Payload.InvertedIndexConfig)
+					require.NotNil(t, okResp.Payload.InvertedIndexConfig.Stopwords)
+					assert.Equal(t, tt.wantInvertedIndexPreset,
+						okResp.Payload.InvertedIndexConfig.Stopwords.Preset)
+				}
 			} else {
 				_, ok := resp.(*tokenizeops.TokenizeUnprocessableEntity)
 				assert.True(t, ok, "expected TokenizeUnprocessableEntity response")

--- a/entities/models/inverted_index_config.go
+++ b/entities/models/inverted_index_config.go
@@ -45,7 +45,7 @@ type InvertedIndexConfig struct {
 	// Index each object by its internal timestamps (default: `false`).
 	IndexTimestamps bool `json:"indexTimestamps,omitempty"`
 
-	// User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings.
+	// User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings. Preset names must not be empty or whitespace-only; each list must contain at least one word; individual words must not be empty or whitespace-only.
 	StopwordPresets map[string][]string `json:"stopwordPresets,omitempty"`
 
 	// stopwords

--- a/entities/models/tokenize_request.go
+++ b/entities/models/tokenize_request.go
@@ -34,7 +34,10 @@ type TokenizeRequest struct {
 	// Optional text analyzer configuration (e.g. ASCII folding).
 	AnalyzerConfig *TextAnalyzerConfig `json:"analyzerConfig,omitempty"`
 
-	// Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals).
+	// Optional collection-style inverted-index configuration. Used to supply a fallback `stopwords` config and/or user-defined `stopwordPresets` that `analyzerConfig.stopwordPreset` can reference. Mirrors the shape accepted on a collection, so the same config can be reused to preview tokenization behavior before creating a collection.
+	InvertedIndexConfig *InvertedIndexConfig `json:"invertedIndexConfig,omitempty"`
+
+	// Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals). This is a richer, tokenize-only alternative to invertedIndexConfig.stopwordPresets (which takes plain word lists); on name conflict, this field wins.
 	StopwordPresets map[string]StopwordConfig `json:"stopwordPresets,omitempty"`
 
 	// The text to tokenize.
@@ -52,6 +55,10 @@ func (m *TokenizeRequest) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateAnalyzerConfig(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateInvertedIndexConfig(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -84,6 +91,25 @@ func (m *TokenizeRequest) validateAnalyzerConfig(formats strfmt.Registry) error 
 				return ve.ValidateName("analyzerConfig")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("analyzerConfig")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *TokenizeRequest) validateInvertedIndexConfig(formats strfmt.Registry) error {
+	if swag.IsZero(m.InvertedIndexConfig) { // not required
+		return nil
+	}
+
+	if m.InvertedIndexConfig != nil {
+		if err := m.InvertedIndexConfig.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("invertedIndexConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("invertedIndexConfig")
 			}
 			return err
 		}
@@ -199,6 +225,10 @@ func (m *TokenizeRequest) ContextValidate(ctx context.Context, formats strfmt.Re
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateInvertedIndexConfig(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateStopwordPresets(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -217,6 +247,22 @@ func (m *TokenizeRequest) contextValidateAnalyzerConfig(ctx context.Context, for
 				return ve.ValidateName("analyzerConfig")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("analyzerConfig")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *TokenizeRequest) contextValidateInvertedIndexConfig(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.InvertedIndexConfig != nil {
+		if err := m.InvertedIndexConfig.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("invertedIndexConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("invertedIndexConfig")
 			}
 			return err
 		}

--- a/entities/models/tokenize_request.go
+++ b/entities/models/tokenize_request.go
@@ -34,10 +34,10 @@ type TokenizeRequest struct {
 	// Optional text analyzer configuration (e.g. ASCII folding).
 	AnalyzerConfig *TextAnalyzerConfig `json:"analyzerConfig,omitempty"`
 
-	// Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in, matching collection-level override semantics.
+	// Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Mutually exclusive with stopwords — pass one or the other, not both.
 	StopwordPresets map[string][]string `json:"stopwordPresets,omitempty"`
 
-	// Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection, so the same config can be reused to preview tokenization behavior before creating a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'.
+	// Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'. Mutually exclusive with stopwordPresets — pass one or the other, not both.
 	Stopwords *StopwordConfig `json:"stopwords,omitempty"`
 
 	// The text to tokenize.

--- a/entities/models/tokenize_request.go
+++ b/entities/models/tokenize_request.go
@@ -34,11 +34,11 @@ type TokenizeRequest struct {
 	// Optional text analyzer configuration (e.g. ASCII folding).
 	AnalyzerConfig *TextAnalyzerConfig `json:"analyzerConfig,omitempty"`
 
-	// Optional collection-style inverted-index configuration. Used to supply a fallback `stopwords` config and/or user-defined `stopwordPresets` that `analyzerConfig.stopwordPreset` can reference. Mirrors the shape accepted on a collection, so the same config can be reused to preview tokenization behavior before creating a collection.
-	InvertedIndexConfig *InvertedIndexConfig `json:"invertedIndexConfig,omitempty"`
+	// Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in, matching collection-level override semantics.
+	StopwordPresets map[string][]string `json:"stopwordPresets,omitempty"`
 
-	// Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals). This is a richer, tokenize-only alternative to invertedIndexConfig.stopwordPresets (which takes plain word lists); on name conflict, this field wins.
-	StopwordPresets map[string]StopwordConfig `json:"stopwordPresets,omitempty"`
+	// Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection, so the same config can be reused to preview tokenization behavior before creating a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'.
+	Stopwords *StopwordConfig `json:"stopwords,omitempty"`
 
 	// The text to tokenize.
 	// Required: true
@@ -58,11 +58,7 @@ func (m *TokenizeRequest) Validate(formats strfmt.Registry) error {
 		res = append(res, err)
 	}
 
-	if err := m.validateInvertedIndexConfig(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateStopwordPresets(formats); err != nil {
+	if err := m.validateStopwords(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -99,46 +95,20 @@ func (m *TokenizeRequest) validateAnalyzerConfig(formats strfmt.Registry) error 
 	return nil
 }
 
-func (m *TokenizeRequest) validateInvertedIndexConfig(formats strfmt.Registry) error {
-	if swag.IsZero(m.InvertedIndexConfig) { // not required
+func (m *TokenizeRequest) validateStopwords(formats strfmt.Registry) error {
+	if swag.IsZero(m.Stopwords) { // not required
 		return nil
 	}
 
-	if m.InvertedIndexConfig != nil {
-		if err := m.InvertedIndexConfig.Validate(formats); err != nil {
+	if m.Stopwords != nil {
+		if err := m.Stopwords.Validate(formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("invertedIndexConfig")
+				return ve.ValidateName("stopwords")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("invertedIndexConfig")
+				return ce.ValidateName("stopwords")
 			}
 			return err
 		}
-	}
-
-	return nil
-}
-
-func (m *TokenizeRequest) validateStopwordPresets(formats strfmt.Registry) error {
-	if swag.IsZero(m.StopwordPresets) { // not required
-		return nil
-	}
-
-	for k := range m.StopwordPresets {
-
-		if err := validate.Required("stopwordPresets"+"."+k, "body", m.StopwordPresets[k]); err != nil {
-			return err
-		}
-		if val, ok := m.StopwordPresets[k]; ok {
-			if err := val.Validate(formats); err != nil {
-				if ve, ok := err.(*errors.Validation); ok {
-					return ve.ValidateName("stopwordPresets" + "." + k)
-				} else if ce, ok := err.(*errors.CompositeError); ok {
-					return ce.ValidateName("stopwordPresets" + "." + k)
-				}
-				return err
-			}
-		}
-
 	}
 
 	return nil
@@ -225,11 +195,7 @@ func (m *TokenizeRequest) ContextValidate(ctx context.Context, formats strfmt.Re
 		res = append(res, err)
 	}
 
-	if err := m.contextValidateInvertedIndexConfig(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateStopwordPresets(ctx, formats); err != nil {
+	if err := m.contextValidateStopwords(ctx, formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -255,32 +221,17 @@ func (m *TokenizeRequest) contextValidateAnalyzerConfig(ctx context.Context, for
 	return nil
 }
 
-func (m *TokenizeRequest) contextValidateInvertedIndexConfig(ctx context.Context, formats strfmt.Registry) error {
+func (m *TokenizeRequest) contextValidateStopwords(ctx context.Context, formats strfmt.Registry) error {
 
-	if m.InvertedIndexConfig != nil {
-		if err := m.InvertedIndexConfig.ContextValidate(ctx, formats); err != nil {
+	if m.Stopwords != nil {
+		if err := m.Stopwords.ContextValidate(ctx, formats); err != nil {
 			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("invertedIndexConfig")
+				return ve.ValidateName("stopwords")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("invertedIndexConfig")
+				return ce.ValidateName("stopwords")
 			}
 			return err
 		}
-	}
-
-	return nil
-}
-
-func (m *TokenizeRequest) contextValidateStopwordPresets(ctx context.Context, formats strfmt.Registry) error {
-
-	for k := range m.StopwordPresets {
-
-		if val, ok := m.StopwordPresets[k]; ok {
-			if err := val.ContextValidate(ctx, formats); err != nil {
-				return err
-			}
-		}
-
 	}
 
 	return nil

--- a/entities/models/tokenize_request.go
+++ b/entities/models/tokenize_request.go
@@ -34,7 +34,7 @@ type TokenizeRequest struct {
 	// Optional text analyzer configuration (e.g. ASCII folding).
 	AnalyzerConfig *TextAnalyzerConfig `json:"analyzerConfig,omitempty"`
 
-	// Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Mutually exclusive with stopwords — pass one or the other, not both.
+	// Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Preset names must not be empty or whitespace-only; each word list must contain at least one word; individual words must not be empty or whitespace-only. Mutually exclusive with stopwords — pass one or the other, not both.
 	StopwordPresets map[string][]string `json:"stopwordPresets,omitempty"`
 
 	// Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'. Mutually exclusive with stopwordPresets — pass one or the other, not both.

--- a/entities/models/tokenize_response.go
+++ b/entities/models/tokenize_response.go
@@ -19,181 +19,32 @@ package models
 import (
 	"context"
 
-	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
 )
 
-// TokenizeResponse Response from the tokenize endpoint.
+// TokenizeResponse Response from the tokenize endpoints. The generic /v1/tokenize returns only indexed and query — it does not echo fields the caller already sent. The property endpoint additionally populates tokenization, since that value is resolved server-side from the property's schema and is not part of the request.
 //
 // swagger:model TokenizeResponse
 type TokenizeResponse struct {
 
-	// The text analyzer configuration that was used, if any.
-	AnalyzerConfig *TextAnalyzerConfig `json:"analyzerConfig,omitempty"`
-
 	// The tokens as they would be stored in the inverted index.
 	Indexed []string `json:"indexed"`
-
-	// The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the effective `stopwords.preset` that was used (defaulting to 'en' when none was explicitly supplied). The returned preset name may be a user-defined preset resolved via `stopwordPresets` / `invertedIndexConfig.stopwordPresets`, not only a built-in stopword list such as `en` or `none`, matching the property-level endpoint which inherits the collection's InvertedIndexConfig.
-	InvertedIndexConfig *InvertedIndexConfig `json:"invertedIndexConfig,omitempty"`
 
 	// The tokens as they would be used for query matching (e.g., after stopword removal).
 	Query []string `json:"query"`
 
-	// The stopword configuration that was used, if any.
-	StopwordConfig *StopwordConfig `json:"stopwordConfig,omitempty"`
-
-	// The tokenization method that was applied.
+	// The tokenization method that was applied. Populated only by the property-level endpoint, where the tokenization is resolved from the property's schema rather than passed by the caller.
 	Tokenization string `json:"tokenization,omitempty"`
 }
 
 // Validate validates this tokenize response
 func (m *TokenizeResponse) Validate(formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.validateAnalyzerConfig(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateInvertedIndexConfig(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.validateStopwordConfig(formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *TokenizeResponse) validateAnalyzerConfig(formats strfmt.Registry) error {
-	if swag.IsZero(m.AnalyzerConfig) { // not required
-		return nil
-	}
-
-	if m.AnalyzerConfig != nil {
-		if err := m.AnalyzerConfig.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("analyzerConfig")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("analyzerConfig")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *TokenizeResponse) validateInvertedIndexConfig(formats strfmt.Registry) error {
-	if swag.IsZero(m.InvertedIndexConfig) { // not required
-		return nil
-	}
-
-	if m.InvertedIndexConfig != nil {
-		if err := m.InvertedIndexConfig.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("invertedIndexConfig")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("invertedIndexConfig")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *TokenizeResponse) validateStopwordConfig(formats strfmt.Registry) error {
-	if swag.IsZero(m.StopwordConfig) { // not required
-		return nil
-	}
-
-	if m.StopwordConfig != nil {
-		if err := m.StopwordConfig.Validate(formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("stopwordConfig")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("stopwordConfig")
-			}
-			return err
-		}
-	}
-
 	return nil
 }
 
 // ContextValidate validate this tokenize response based on the context it is used
 func (m *TokenizeResponse) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
-	var res []error
-
-	if err := m.contextValidateAnalyzerConfig(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateInvertedIndexConfig(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if err := m.contextValidateStopwordConfig(ctx, formats); err != nil {
-		res = append(res, err)
-	}
-
-	if len(res) > 0 {
-		return errors.CompositeValidationError(res...)
-	}
-	return nil
-}
-
-func (m *TokenizeResponse) contextValidateAnalyzerConfig(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.AnalyzerConfig != nil {
-		if err := m.AnalyzerConfig.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("analyzerConfig")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("analyzerConfig")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *TokenizeResponse) contextValidateInvertedIndexConfig(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.InvertedIndexConfig != nil {
-		if err := m.InvertedIndexConfig.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("invertedIndexConfig")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("invertedIndexConfig")
-			}
-			return err
-		}
-	}
-
-	return nil
-}
-
-func (m *TokenizeResponse) contextValidateStopwordConfig(ctx context.Context, formats strfmt.Registry) error {
-
-	if m.StopwordConfig != nil {
-		if err := m.StopwordConfig.ContextValidate(ctx, formats); err != nil {
-			if ve, ok := err.(*errors.Validation); ok {
-				return ve.ValidateName("stopwordConfig")
-			} else if ce, ok := err.(*errors.CompositeError); ok {
-				return ce.ValidateName("stopwordConfig")
-			}
-			return err
-		}
-	}
-
 	return nil
 }
 

--- a/entities/models/tokenize_response.go
+++ b/entities/models/tokenize_response.go
@@ -35,6 +35,9 @@ type TokenizeResponse struct {
 	// The tokens as they would be stored in the inverted index.
 	Indexed []string `json:"indexed"`
 
+	// The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the stopword preset that was used (defaulting to 'en' when none was explicitly supplied), matching the property-level endpoint which inherits the collection's InvertedIndexConfig.
+	InvertedIndexConfig *InvertedIndexConfig `json:"invertedIndexConfig,omitempty"`
+
 	// The tokens as they would be used for query matching (e.g., after stopword removal).
 	Query []string `json:"query"`
 
@@ -50,6 +53,10 @@ func (m *TokenizeResponse) Validate(formats strfmt.Registry) error {
 	var res []error
 
 	if err := m.validateAnalyzerConfig(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if err := m.validateInvertedIndexConfig(formats); err != nil {
 		res = append(res, err)
 	}
 
@@ -74,6 +81,25 @@ func (m *TokenizeResponse) validateAnalyzerConfig(formats strfmt.Registry) error
 				return ve.ValidateName("analyzerConfig")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("analyzerConfig")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *TokenizeResponse) validateInvertedIndexConfig(formats strfmt.Registry) error {
+	if swag.IsZero(m.InvertedIndexConfig) { // not required
+		return nil
+	}
+
+	if m.InvertedIndexConfig != nil {
+		if err := m.InvertedIndexConfig.Validate(formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("invertedIndexConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("invertedIndexConfig")
 			}
 			return err
 		}
@@ -109,6 +135,10 @@ func (m *TokenizeResponse) ContextValidate(ctx context.Context, formats strfmt.R
 		res = append(res, err)
 	}
 
+	if err := m.contextValidateInvertedIndexConfig(ctx, formats); err != nil {
+		res = append(res, err)
+	}
+
 	if err := m.contextValidateStopwordConfig(ctx, formats); err != nil {
 		res = append(res, err)
 	}
@@ -127,6 +157,22 @@ func (m *TokenizeResponse) contextValidateAnalyzerConfig(ctx context.Context, fo
 				return ve.ValidateName("analyzerConfig")
 			} else if ce, ok := err.(*errors.CompositeError); ok {
 				return ce.ValidateName("analyzerConfig")
+			}
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (m *TokenizeResponse) contextValidateInvertedIndexConfig(ctx context.Context, formats strfmt.Registry) error {
+
+	if m.InvertedIndexConfig != nil {
+		if err := m.InvertedIndexConfig.ContextValidate(ctx, formats); err != nil {
+			if ve, ok := err.(*errors.Validation); ok {
+				return ve.ValidateName("invertedIndexConfig")
+			} else if ce, ok := err.(*errors.CompositeError); ok {
+				return ce.ValidateName("invertedIndexConfig")
 			}
 			return err
 		}

--- a/entities/models/tokenize_response.go
+++ b/entities/models/tokenize_response.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// TokenizeResponse Response from the tokenize endpoints. The generic /v1/tokenize returns only `indexed` and `query` — it does not echo fields the caller already sent (tokenization, analyzerConfig, stopwords, stopwordPresets). The property endpoint additionally populates `tokenization`, since that value is resolved server-side from the property's schema rather than passed by the caller.
+// TokenizeResponse Response from the tokenize endpoints. Returns `indexed` text and text used at `query` time
 //
 // swagger:model TokenizeResponse
 type TokenizeResponse struct {
@@ -33,9 +33,6 @@ type TokenizeResponse struct {
 
 	// The tokens as they would be used for query matching (e.g., after stopword removal).
 	Query []string `json:"query"`
-
-	// The tokenization method that was applied. Populated only by the property-level endpoint.
-	Tokenization string `json:"tokenization,omitempty"`
 }
 
 // Validate validates this tokenize response

--- a/entities/models/tokenize_response.go
+++ b/entities/models/tokenize_response.go
@@ -35,7 +35,7 @@ type TokenizeResponse struct {
 	// The tokens as they would be stored in the inverted index.
 	Indexed []string `json:"indexed"`
 
-	// The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the stopword preset that was used (defaulting to 'en' when none was explicitly supplied), matching the property-level endpoint which inherits the collection's InvertedIndexConfig.
+	// The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the effective `stopwords.preset` that was used (defaulting to 'en' when none was explicitly supplied). The returned preset name may be a user-defined preset resolved via `stopwordPresets` / `invertedIndexConfig.stopwordPresets`, not only a built-in stopword list such as `en` or `none`, matching the property-level endpoint which inherits the collection's InvertedIndexConfig.
 	InvertedIndexConfig *InvertedIndexConfig `json:"invertedIndexConfig,omitempty"`
 
 	// The tokens as they would be used for query matching (e.g., after stopword removal).

--- a/entities/models/tokenize_response.go
+++ b/entities/models/tokenize_response.go
@@ -23,7 +23,7 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-// TokenizeResponse Response from the tokenize endpoints. The generic /v1/tokenize returns only indexed and query — it does not echo fields the caller already sent. The property endpoint additionally populates tokenization, since that value is resolved server-side from the property's schema and is not part of the request.
+// TokenizeResponse Response from the tokenize endpoints. The generic /v1/tokenize returns only `indexed` and `query` — it does not echo fields the caller already sent (tokenization, analyzerConfig, stopwords, stopwordPresets). The property endpoint additionally populates `tokenization`, since that value is resolved server-side from the property's schema rather than passed by the caller.
 //
 // swagger:model TokenizeResponse
 type TokenizeResponse struct {
@@ -34,7 +34,7 @@ type TokenizeResponse struct {
 	// The tokens as they would be used for query matching (e.g., after stopword removal).
 	Query []string `json:"query"`
 
-	// The tokenization method that was applied. Populated only by the property-level endpoint, where the tokenization is resolved from the property's schema rather than passed by the caller.
+	// The tokenization method that was applied. Populated only by the property-level endpoint.
 	Tokenization string `json:"tokenization,omitempty"`
 }
 
@@ -43,7 +43,7 @@ func (m *TokenizeResponse) Validate(formats strfmt.Registry) error {
 	return nil
 }
 
-// ContextValidate validate this tokenize response based on the context it is used
+// ContextValidate validates this tokenize response based on context it is used
 func (m *TokenizeResponse) ContextValidate(ctx context.Context, formats strfmt.Registry) error {
 	return nil
 }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1021,7 +1021,7 @@
           "$ref": "#/definitions/StopwordConfig"
         },
         "invertedIndexConfig": {
-          "description": "The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the stopword preset that was used (defaulting to 'en' when none was explicitly supplied), matching the property-level endpoint which inherits the collection's InvertedIndexConfig.",
+          "description": "The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the effective `stopwords.preset` that was used (defaulting to 'en' when none was explicitly supplied). The returned preset name may be a user-defined preset resolved via `stopwordPresets` / `invertedIndexConfig.stopwordPresets`, not only a built-in stopword list such as `en` or `none`, matching the property-level endpoint which inherits the collection's InvertedIndexConfig.",
           "$ref": "#/definitions/InvertedIndexConfig"
         },
         "indexed": {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -991,11 +991,11 @@
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
         "stopwords": {
-          "description": "Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection, so the same config can be reused to preview tokenization behavior before creating a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'.",
+          "description": "Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'. Mutually exclusive with stopwordPresets — pass one or the other, not both.",
           "$ref": "#/definitions/StopwordConfig"
         },
         "stopwordPresets": {
-          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in, matching collection-level override semantics.",
+          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Mutually exclusive with stopwords — pass one or the other, not both.",
           "type": "object",
           "x-omitempty": true,
           "additionalProperties": {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -990,40 +990,25 @@
           "description": "Optional text analyzer configuration (e.g. ASCII folding).",
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
-        "invertedIndexConfig": {
-          "description": "Optional collection-style inverted-index configuration. Used to supply a fallback `stopwords` config and/or user-defined `stopwordPresets` that `analyzerConfig.stopwordPreset` can reference. Mirrors the shape accepted on a collection, so the same config can be reused to preview tokenization behavior before creating a collection.",
-          "$ref": "#/definitions/InvertedIndexConfig"
+        "stopwords": {
+          "description": "Optional fallback stopword configuration. Used when analyzerConfig.stopwordPreset is not set. Shape matches InvertedIndexConfig.stopwords on a collection, so the same config can be reused to preview tokenization behavior before creating a collection. When analyzerConfig.stopwordPreset is not set and this field is omitted, word tokenization defaults to preset 'en'.",
+          "$ref": "#/definitions/StopwordConfig"
         },
         "stopwordPresets": {
-          "description": "Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals). This is a richer, tokenize-only alternative to invertedIndexConfig.stopwordPresets (which takes plain word lists); on name conflict, this field wins.",
+          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in, matching collection-level override semantics.",
           "type": "object",
           "x-omitempty": true,
           "additionalProperties": {
-            "$ref": "#/definitions/StopwordConfig"
+            "type": "array",
+            "items": {"type": "string"}
           }
         }
       }
     },
     "TokenizeResponse": {
-      "description": "Response from the tokenize endpoint.",
+      "description": "Response from the tokenize endpoints. The generic /v1/tokenize returns only `indexed` and `query` — it does not echo fields the caller already sent (tokenization, analyzerConfig, stopwords, stopwordPresets). The property endpoint additionally populates `tokenization`, since that value is resolved server-side from the property's schema rather than passed by the caller.",
       "type": "object",
       "properties": {
-        "tokenization": {
-          "description": "The tokenization method that was applied.",
-          "type": "string"
-        },
-        "analyzerConfig": {
-          "description": "The text analyzer configuration that was used, if any.",
-          "$ref": "#/definitions/TextAnalyzerConfig"
-        },
-        "stopwordConfig": {
-          "description": "The stopword configuration that was used, if any.",
-          "$ref": "#/definitions/StopwordConfig"
-        },
-        "invertedIndexConfig": {
-          "description": "The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the effective `stopwords.preset` that was used (defaulting to 'en' when none was explicitly supplied). The returned preset name may be a user-defined preset resolved via `stopwordPresets` / `invertedIndexConfig.stopwordPresets`, not only a built-in stopword list such as `en` or `none`, matching the property-level endpoint which inherits the collection's InvertedIndexConfig.",
-          "$ref": "#/definitions/InvertedIndexConfig"
-        },
         "indexed": {
           "description": "The tokens as they would be stored in the inverted index.",
           "type": "array",
@@ -1037,6 +1022,10 @@
           "items": {
             "type": "string"
           }
+        },
+        "tokenization": {
+          "description": "The tokenization method that was applied. Populated only by the property-level endpoint.",
+          "type": "string"
         }
       }
     },

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -849,7 +849,7 @@
           }
         },
         "stopwordPresets": {
-          "description": "User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings.",
+          "description": "User-defined named stopword lists. Each key is a preset name that can be referenced by a property's textAnalyzer.stopwordPreset field. The value is an array of stopword strings. Preset names must not be empty or whitespace-only; each list must contain at least one word; individual words must not be empty or whitespace-only.",
           "type": "object",
           "x-omitempty": true,
           "additionalProperties": {
@@ -995,7 +995,7 @@
           "$ref": "#/definitions/StopwordConfig"
         },
         "stopwordPresets": {
-          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Mutually exclusive with stopwords — pass one or the other, not both.",
+          "description": "Optional user-defined named stopword presets. Shape matches InvertedIndexConfig.stopwordPresets on a collection: each key is a preset name, each value is a plain list of stopwords. A preset name that matches a built-in ('en', 'none') fully replaces the built-in. Preset names must not be empty or whitespace-only; each word list must contain at least one word; individual words must not be empty or whitespace-only. Mutually exclusive with stopwords — pass one or the other, not both.",
           "type": "object",
           "x-omitempty": true,
           "additionalProperties": {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -990,8 +990,12 @@
           "description": "Optional text analyzer configuration (e.g. ASCII folding).",
           "$ref": "#/definitions/TextAnalyzerConfig"
         },
+        "invertedIndexConfig": {
+          "description": "Optional collection-style inverted-index configuration. Used to supply a fallback `stopwords` config and/or user-defined `stopwordPresets` that `analyzerConfig.stopwordPreset` can reference. Mirrors the shape accepted on a collection, so the same config can be reused to preview tokenization behavior before creating a collection.",
+          "$ref": "#/definitions/InvertedIndexConfig"
+        },
         "stopwordPresets": {
-          "description": "Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals).",
+          "description": "Optional named stopword configurations. Each key is a preset name that can be referenced by analyzerConfig.stopwordPreset. Each value is a StopwordConfig (with optional preset, additions, and removals). This is a richer, tokenize-only alternative to invertedIndexConfig.stopwordPresets (which takes plain word lists); on name conflict, this field wins.",
           "type": "object",
           "x-omitempty": true,
           "additionalProperties": {
@@ -1015,6 +1019,10 @@
         "stopwordConfig": {
           "description": "The stopword configuration that was used, if any.",
           "$ref": "#/definitions/StopwordConfig"
+        },
+        "invertedIndexConfig": {
+          "description": "The effective inverted-index configuration that was applied to produce the query output. For word tokenization this includes the stopword preset that was used (defaulting to 'en' when none was explicitly supplied), matching the property-level endpoint which inherits the collection's InvertedIndexConfig.",
+          "$ref": "#/definitions/InvertedIndexConfig"
         },
         "indexed": {
           "description": "The tokens as they would be stored in the inverted index.",

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1006,7 +1006,7 @@
       }
     },
     "TokenizeResponse": {
-      "description": "Response from the tokenize endpoints. The generic /v1/tokenize returns only `indexed` and `query` — it does not echo fields the caller already sent (tokenization, analyzerConfig, stopwords, stopwordPresets). The property endpoint additionally populates `tokenization`, since that value is resolved server-side from the property's schema rather than passed by the caller.",
+      "description": "Response from the tokenize endpoints. Returns `indexed` text and text used at `query` time",
       "type": "object",
       "properties": {
         "indexed": {
@@ -1022,10 +1022,6 @@
           "items": {
             "type": "string"
           }
-        },
-        "tokenization": {
-          "description": "The tokenization method that was applied. Populated only by the property-level endpoint.",
-          "type": "string"
         }
       }
     },

--- a/test/acceptance_with_python/test_tokenize.py
+++ b/test/acceptance_with_python/test_tokenize.py
@@ -135,7 +135,7 @@ class TestGenericTokenize:
         # The response must not invent an analyzerConfig the caller did not send.
         assert body.get("analyzerConfig") in (None, {})
         # The effective stopword preset is reported under invertedIndexConfig.
-        assert body["invertedIndexConfig"] == {"stopwords": {"preset": "en"}}
+        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "en"
 
     def test_default_stopword_preset_can_be_opted_out(self) -> None:
         """Passing stopwordPreset='none' explicitly disables the default 'en' filtering."""
@@ -151,7 +151,7 @@ class TestGenericTokenize:
         assert body is not None
         assert body["indexed"] == ["the", "quick", "brown", "fox"]
         assert body["query"] == ["the", "quick", "brown", "fox"]
-        assert body["invertedIndexConfig"] == {"stopwords": {"preset": "none"}}
+        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "none"
 
     def test_default_stopword_preset_applied_when_only_ascii_fold_passed(self) -> None:
         """asciiFold without an explicit stopwordPreset should still default
@@ -168,7 +168,7 @@ class TestGenericTokenize:
         assert body is not None
         assert body["indexed"] == ["the", "ecole", "est", "fermee"]
         assert "the" not in body["query"]
-        assert body["invertedIndexConfig"] == {"stopwords": {"preset": "en"}}
+        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "en"
 
     @pytest.mark.parametrize(
         "tokenization,text,expected_tokens",
@@ -213,9 +213,9 @@ class TestGenericTokenize:
         assert body["indexed"] == ["the", "quick", "brown", "fox"]
         assert body["query"] == ["brown", "fox"]
         # The response echoes back the effective fallback config.
-        assert body["invertedIndexConfig"] == {
-            "stopwords": {"preset": "en", "additions": ["quick"]}
-        }
+        stopwords = body["invertedIndexConfig"]["stopwords"]
+        assert stopwords["preset"] == "en"
+        assert stopwords["additions"] == ["quick"]
 
     def test_invertedIndexConfig_stopwordPresets_resolved_by_analyzer_preset(self) -> None:
         """analyzerConfig.stopwordPreset can reference a named preset
@@ -235,7 +235,7 @@ class TestGenericTokenize:
         assert body is not None
         assert body["indexed"] == ["le", "chat", "et", "la", "souris"]
         assert body["query"] == ["chat", "souris"]
-        assert body["invertedIndexConfig"] == {"stopwords": {"preset": "fr"}}
+        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "fr"
 
     def test_analyzer_preset_overrides_invertedIndexConfig_stopwords(self) -> None:
         """An explicit analyzerConfig.stopwordPreset overrides the
@@ -256,7 +256,7 @@ class TestGenericTokenize:
         assert body is not None
         assert body["indexed"] == ["the", "quick"]
         assert body["query"] == ["the", "quick"]
-        assert body["invertedIndexConfig"] == {"stopwords": {"preset": "none"}}
+        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "none"
 
     def test_user_override_for_builtin_en_applies_to_default(self) -> None:
         """A user-defined 'en' preset replaces the built-in entirely and is
@@ -279,7 +279,7 @@ class TestGenericTokenize:
         assert body["indexed"] == ["the", "quick", "hello", "world"]
         # "the" no longer filtered (built-in en replaced), "hello" is.
         assert body["query"] == ["the", "quick", "world"]
-        assert body["invertedIndexConfig"] == {"stopwords": {"preset": "en"}}
+        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "en"
 
     def test_unknown_preset_against_invertedIndexConfig_is_rejected(self) -> None:
         status, _ = post_json(
@@ -291,6 +291,48 @@ class TestGenericTokenize:
                 "invertedIndexConfig": {
                     "stopwordPresets": {"other": ["hello"]},
                 },
+            },
+        )
+        assert status == 422
+
+    def test_invertedIndexConfig_stopwords_empty_preset_defaults_to_en(self) -> None:
+        """invertedIndexConfig.stopwords with an empty preset must default to
+        'en', matching collection-level validation semantics. Without this,
+        an empty stopwords config would silently filter nothing."""
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "the quick",
+                "tokenization": "word",
+                "invertedIndexConfig": {"stopwords": {}},
+            },
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "quick"]
+        assert body["query"] == ["quick"]
+        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "en"
+
+    def test_invertedIndexConfig_stopwords_unknown_preset_is_rejected(self) -> None:
+        """Same rejection as collection creation for an unknown preset."""
+        status, _ = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "hello",
+                "tokenization": "word",
+                "invertedIndexConfig": {"stopwords": {"preset": "nonexistent"}},
+            },
+        )
+        assert status == 422
+
+    def test_invertedIndexConfig_stopwordPresets_empty_list_is_rejected(self) -> None:
+        """Same rejection as collection creation for an empty preset word list."""
+        status, _ = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "hello",
+                "tokenization": "word",
+                "invertedIndexConfig": {"stopwordPresets": {"custom": []}},
             },
         )
         assert status == 422

--- a/test/acceptance_with_python/test_tokenize.py
+++ b/test/acceptance_with_python/test_tokenize.py
@@ -201,12 +201,11 @@ class TestGenericTokenize:
         assert body is not None
         assert body["indexed"] == ["the", "quick", "brown", "fox"]
         assert body["query"] == ["brown", "fox"]
-        # The response echoes back the effective fallback config.
 
     def test_stopwords_additions_without_preset_default_to_en(self) -> None:
         """Caller omits `preset`, supplies only `additions`. Validation
         defaults the preset to 'en' and the detector is built from en +
-        additions. The full effective config is echoed back."""
+        additions."""
         status, body = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {
@@ -653,7 +652,6 @@ class TestPropertyTokenize:
             {"text": "The quick brown fox"},
         )
         assert status == 200
-        assert body["tokenization"] == "word"
         assert body["indexed"] == ["the", "quick", "brown", "fox"]
 
     def test_field_property(self) -> None:
@@ -662,7 +660,6 @@ class TestPropertyTokenize:
             {"text": "  Hello World  "},
         )
         assert status == 200
-        assert body["tokenization"] == "field"
         assert body["indexed"] == ["Hello World"]
 
     def test_lowercase_first_letter_class_name(self) -> None:
@@ -737,7 +734,6 @@ class TestPropertyTokenize:
                 {"text": "the quick brown fox"},
             )
             assert status == 200
-            assert body["tokenization"] == "word"
             assert body["indexed"] == ["the", "quick", "brown", "fox"]
             # title has stopwordPreset='en' so 'the' should be filtered from the query
             assert "the" not in body["query"]

--- a/test/acceptance_with_python/test_tokenize.py
+++ b/test/acceptance_with_python/test_tokenize.py
@@ -238,90 +238,22 @@ class TestGenericTokenize:
         # "is" is still an en stopword, "the" was removed.
         assert body["query"] == ["the", "quick", "fast"]
 
-    def test_analyzer_preset_wins_over_stopwords_fallback_when_both_set(self) -> None:
-        """Both stopwords and stopwordPresets supplied, with an explicit
-        analyzerConfig.stopwordPreset. Mirrors the property endpoint's
-        override order: the analyzerConfig preset (property-level override)
-        wins over the stopwords fallback (collection-level default)."""
-        status, body = post_json(
+    def test_stopwords_and_stopwordPresets_are_mutually_exclusive(self) -> None:
+        """The two input shapes are mutually exclusive on the generic
+        endpoint. `stopwords` is for the simple "apply one base preset
+        (optionally tweaked)" case; `stopwordPresets` is for the
+        "define named presets, select via analyzerConfig" case. Passing
+        both is rejected to keep the mental model simple."""
+        status, _ = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {
-                "text": "the quick frword hello",
+                "text": "hello",
                 "tokenization": "word",
-                "analyzerConfig": {"stopwordPreset": "fr"},
-                "stopwords": {"preset": "en", "additions": ["hello"]},
-                "stopwordPresets": {"fr": ["frword"]},
+                "stopwords": {"preset": "en"},
+                "stopwordPresets": {"custom": ["hello"]},
             },
         )
-        assert status == 200
-        assert body is not None
-        assert body["indexed"] == ["the", "quick", "frword", "hello"]
-        # Only "frword" is filtered (from fr preset). The en-based fallback
-        # is ignored because an analyzerConfig preset was set, so "the" and
-        # "hello" pass through.
-        assert body["query"] == ["the", "quick", "hello"]
-
-    def test_en_on_both_stopwords_and_stopwordPresets_behaves_like_property(
-        self,
-    ) -> None:
-        """Mirrors a collection that sets both
-        invertedIndexConfig.stopwords.preset='en' AND
-        invertedIndexConfig.stopwordPresets['en']=[...].
-
-        Property-endpoint parallel: the collection's stopwords fallback is
-        built from the BUILT-IN 'en' list, not from the user's en override.
-        The override only applies when a property (here: analyzerConfig)
-        explicitly references 'en' via stopwordPreset.
-        """
-        body_base = {
-            "text": "the quick customword",
-            "tokenization": "word",
-            "stopwords": {"preset": "en"},
-            "stopwordPresets": {"en": ["customword"]},
-        }
-
-        # No analyzerConfig.stopwordPreset → fallback path uses built-in en.
-        # "the" is filtered (built-in en), "customword" passes (user en is
-        # NOT consulted for the fallback).
-        status, body = post_json(f"{WEAVIATE_URL}/v1/tokenize", body_base)
-        assert status == 200
-        assert body is not None
-        assert body["indexed"] == ["the", "quick", "customword"]
-        assert body["query"] == ["quick", "customword"]
-
-        # analyzerConfig.stopwordPreset='en' → resolved via the user-defined
-        # presets map first, so the user's en override wins. "the" now
-        # passes (not in user's en list) and "customword" is filtered.
-        status, body = post_json(
-            f"{WEAVIATE_URL}/v1/tokenize",
-            {**body_base, "analyzerConfig": {"stopwordPreset": "en"}},
-        )
-        assert status == 200
-        assert body is not None
-        assert body["indexed"] == ["the", "quick", "customword"]
-        assert body["query"] == ["the", "quick"]
-
-    def test_stopwords_fallback_wins_when_analyzer_preset_absent(self) -> None:
-        """Same inputs as the previous test but WITHOUT
-        analyzerConfig.stopwordPreset. Now the stopwords fallback wins
-        (matches property-endpoint behavior when the property has no
-        stopwordPreset configured). The 'fr' user preset is defined but
-        not referenced, so it's inert."""
-        status, body = post_json(
-            f"{WEAVIATE_URL}/v1/tokenize",
-            {
-                "text": "the quick frword hello",
-                "tokenization": "word",
-                "stopwords": {"preset": "en", "additions": ["hello"]},
-                "stopwordPresets": {"fr": ["frword"]},
-            },
-        )
-        assert status == 200
-        assert body is not None
-        assert body["indexed"] == ["the", "quick", "frword", "hello"]
-        # "the" (en) and "hello" (addition) filtered; "frword" stays because
-        # the fr preset was not selected.
-        assert body["query"] == ["quick", "frword"]
+        assert status == 422
 
     def test_stopwordPresets_resolved_by_analyzer_preset(self) -> None:
         """analyzerConfig.stopwordPreset can reference a named preset

--- a/test/acceptance_with_python/test_tokenize.py
+++ b/test/acceptance_with_python/test_tokenize.py
@@ -114,7 +114,6 @@ class TestGenericTokenize:
             {"text": text, "tokenization": tokenization},
         )
         assert status == 200
-        assert body["tokenization"] == tokenization
         assert body["indexed"] == expected_indexed
         assert body["query"] == expected_query
 
@@ -122,8 +121,7 @@ class TestGenericTokenize:
         """For word tokenization, when no stopwordPreset is supplied the
         endpoint defaults to the 'en' preset so the query output matches the
         property-level endpoint (which inherits the collection's default,
-        also 'en'). The defaulted preset is surfaced in invertedIndexConfig,
-        not echoed on analyzerConfig."""
+        also 'en')."""
         status, body = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {"text": "The quick brown fox", "tokenization": "word"},
@@ -132,10 +130,6 @@ class TestGenericTokenize:
         assert body is not None
         assert body["indexed"] == ["the", "quick", "brown", "fox"]
         assert body["query"] == ["quick", "brown", "fox"]
-        # The response must not invent an analyzerConfig the caller did not send.
-        assert body.get("analyzerConfig") in (None, {})
-        # The effective stopword preset is reported under invertedIndexConfig.
-        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "en"
 
     def test_default_stopword_preset_can_be_opted_out(self) -> None:
         """Passing stopwordPreset='none' explicitly disables the default 'en' filtering."""
@@ -151,7 +145,6 @@ class TestGenericTokenize:
         assert body is not None
         assert body["indexed"] == ["the", "quick", "brown", "fox"]
         assert body["query"] == ["the", "quick", "brown", "fox"]
-        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "none"
 
     def test_default_stopword_preset_applied_when_only_ascii_fold_passed(self) -> None:
         """asciiFold without an explicit stopwordPreset should still default
@@ -168,14 +161,13 @@ class TestGenericTokenize:
         assert body is not None
         assert body["indexed"] == ["the", "ecole", "est", "fermee"]
         assert "the" not in body["query"]
-        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "en"
 
     @pytest.mark.parametrize(
         "tokenization,text,expected_tokens",
         [
             # Non-word tokenizations do not apply the default "en" preset, so
             # "the" stays in the query output even though it is an English
-            # stopword, and invertedIndexConfig is omitted from the response.
+            # stopword, and stopwords is omitted from the response.
             ("lowercase", "the quick", ["the", "quick"]),
             ("whitespace", "the quick", ["the", "quick"]),
             ("field", "the quick", ["the quick"]),
@@ -192,20 +184,17 @@ class TestGenericTokenize:
         assert body is not None
         assert body["indexed"] == expected_tokens
         assert body["query"] == expected_tokens
-        assert body.get("invertedIndexConfig") in (None, {})
 
-    def test_invertedIndexConfig_stopwords_fallback(self) -> None:
-        """invertedIndexConfig.stopwords is used as the fallback detector
-        when analyzerConfig.stopwordPreset is not set, mirroring the
-        property endpoint's inheritance from collection config."""
+    def test_stopwords_fallback(self) -> None:
+        """Top-level stopwords is used as the fallback detector when
+        analyzerConfig.stopwordPreset is not set, mirroring the property
+        endpoint's inheritance from collection config."""
         status, body = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {
                 "text": "the quick brown fox",
                 "tokenization": "word",
-                "invertedIndexConfig": {
-                    "stopwords": {"preset": "en", "additions": ["quick"]},
-                },
+                "stopwords": {"preset": "en", "additions": ["quick"]},
             },
         )
         assert status == 200
@@ -213,50 +202,161 @@ class TestGenericTokenize:
         assert body["indexed"] == ["the", "quick", "brown", "fox"]
         assert body["query"] == ["brown", "fox"]
         # The response echoes back the effective fallback config.
-        stopwords = body["invertedIndexConfig"]["stopwords"]
-        assert stopwords["preset"] == "en"
-        assert stopwords["additions"] == ["quick"]
 
-    def test_invertedIndexConfig_stopwordPresets_resolved_by_analyzer_preset(self) -> None:
+    def test_stopwords_additions_without_preset_default_to_en(self) -> None:
+        """Caller omits `preset`, supplies only `additions`. Validation
+        defaults the preset to 'en' and the detector is built from en +
+        additions. The full effective config is echoed back."""
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "the quick hello world",
+                "tokenization": "word",
+                "stopwords": {"additions": ["hello"]},
+            },
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "quick", "hello", "world"]
+        # "the" filtered by default en, "hello" filtered by the addition.
+        assert body["query"] == ["quick", "world"]
+
+    def test_stopwords_removals_without_preset_default_to_en(self) -> None:
+        """Caller omits `preset`, supplies only `removals`. 'the' is removed
+        from the en list so it passes through the query."""
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "the quick is fast",
+                "tokenization": "word",
+                "stopwords": {"removals": ["the"]},
+            },
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "quick", "is", "fast"]
+        # "is" is still an en stopword, "the" was removed.
+        assert body["query"] == ["the", "quick", "fast"]
+
+    def test_analyzer_preset_wins_over_stopwords_fallback_when_both_set(self) -> None:
+        """Both stopwords and stopwordPresets supplied, with an explicit
+        analyzerConfig.stopwordPreset. Mirrors the property endpoint's
+        override order: the analyzerConfig preset (property-level override)
+        wins over the stopwords fallback (collection-level default)."""
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "the quick frword hello",
+                "tokenization": "word",
+                "analyzerConfig": {"stopwordPreset": "fr"},
+                "stopwords": {"preset": "en", "additions": ["hello"]},
+                "stopwordPresets": {"fr": ["frword"]},
+            },
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "quick", "frword", "hello"]
+        # Only "frword" is filtered (from fr preset). The en-based fallback
+        # is ignored because an analyzerConfig preset was set, so "the" and
+        # "hello" pass through.
+        assert body["query"] == ["the", "quick", "hello"]
+
+    def test_en_on_both_stopwords_and_stopwordPresets_behaves_like_property(
+        self,
+    ) -> None:
+        """Mirrors a collection that sets both
+        invertedIndexConfig.stopwords.preset='en' AND
+        invertedIndexConfig.stopwordPresets['en']=[...].
+
+        Property-endpoint parallel: the collection's stopwords fallback is
+        built from the BUILT-IN 'en' list, not from the user's en override.
+        The override only applies when a property (here: analyzerConfig)
+        explicitly references 'en' via stopwordPreset.
+        """
+        body_base = {
+            "text": "the quick customword",
+            "tokenization": "word",
+            "stopwords": {"preset": "en"},
+            "stopwordPresets": {"en": ["customword"]},
+        }
+
+        # No analyzerConfig.stopwordPreset → fallback path uses built-in en.
+        # "the" is filtered (built-in en), "customword" passes (user en is
+        # NOT consulted for the fallback).
+        status, body = post_json(f"{WEAVIATE_URL}/v1/tokenize", body_base)
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "quick", "customword"]
+        assert body["query"] == ["quick", "customword"]
+
+        # analyzerConfig.stopwordPreset='en' → resolved via the user-defined
+        # presets map first, so the user's en override wins. "the" now
+        # passes (not in user's en list) and "customword" is filtered.
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {**body_base, "analyzerConfig": {"stopwordPreset": "en"}},
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "quick", "customword"]
+        assert body["query"] == ["the", "quick"]
+
+    def test_stopwords_fallback_wins_when_analyzer_preset_absent(self) -> None:
+        """Same inputs as the previous test but WITHOUT
+        analyzerConfig.stopwordPreset. Now the stopwords fallback wins
+        (matches property-endpoint behavior when the property has no
+        stopwordPreset configured). The 'fr' user preset is defined but
+        not referenced, so it's inert."""
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "the quick frword hello",
+                "tokenization": "word",
+                "stopwords": {"preset": "en", "additions": ["hello"]},
+                "stopwordPresets": {"fr": ["frword"]},
+            },
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "quick", "frword", "hello"]
+        # "the" (en) and "hello" (addition) filtered; "frword" stays because
+        # the fr preset was not selected.
+        assert body["query"] == ["quick", "frword"]
+
+    def test_stopwordPresets_resolved_by_analyzer_preset(self) -> None:
         """analyzerConfig.stopwordPreset can reference a named preset
-        defined in invertedIndexConfig.stopwordPresets."""
+        defined in top-level stopwordPresets."""
         status, body = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {
                 "text": "le chat et la souris",
                 "tokenization": "word",
                 "analyzerConfig": {"stopwordPreset": "fr"},
-                "invertedIndexConfig": {
-                    "stopwordPresets": {"fr": ["le", "la", "et"]},
-                },
+                "stopwordPresets": {"fr": ["le", "la", "et"]},
             },
         )
         assert status == 200
         assert body is not None
         assert body["indexed"] == ["le", "chat", "et", "la", "souris"]
         assert body["query"] == ["chat", "souris"]
-        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "fr"
 
-    def test_analyzer_preset_overrides_invertedIndexConfig_stopwords(self) -> None:
-        """An explicit analyzerConfig.stopwordPreset overrides the
-        invertedIndexConfig.stopwords fallback, matching property-level
-        override semantics at the collection level."""
+    def test_analyzer_preset_overrides_stopwords_fallback(self) -> None:
+        """An explicit analyzerConfig.stopwordPreset overrides the stopwords
+        fallback, matching property-level override semantics at the
+        collection level."""
         status, body = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {
                 "text": "the quick",
                 "tokenization": "word",
                 "analyzerConfig": {"stopwordPreset": "none"},
-                "invertedIndexConfig": {
-                    "stopwords": {"preset": "en"},
-                },
+                "stopwords": {"preset": "en"},
             },
         )
         assert status == 200
         assert body is not None
         assert body["indexed"] == ["the", "quick"]
         assert body["query"] == ["the", "quick"]
-        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "none"
 
     def test_user_override_for_builtin_en_applies_to_default(self) -> None:
         """A user-defined 'en' preset replaces the built-in entirely and is
@@ -268,10 +368,8 @@ class TestGenericTokenize:
             {
                 "text": "the quick hello world",
                 "tokenization": "word",
-                "invertedIndexConfig": {
-                    # Replaces the built-in "en" entirely.
-                    "stopwordPresets": {"en": ["hello"]},
-                },
+                # Replaces the built-in "en" entirely.
+                "stopwordPresets": {"en": ["hello"]},
             },
         )
         assert status == 200
@@ -279,60 +377,56 @@ class TestGenericTokenize:
         assert body["indexed"] == ["the", "quick", "hello", "world"]
         # "the" no longer filtered (built-in en replaced), "hello" is.
         assert body["query"] == ["the", "quick", "world"]
-        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "en"
 
-    def test_unknown_preset_against_invertedIndexConfig_is_rejected(self) -> None:
+    def test_unknown_preset_against_stopwordPresets_is_rejected(self) -> None:
         status, _ = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {
                 "text": "hello",
                 "tokenization": "word",
                 "analyzerConfig": {"stopwordPreset": "missing"},
-                "invertedIndexConfig": {
-                    "stopwordPresets": {"other": ["hello"]},
-                },
+                "stopwordPresets": {"other": ["hello"]},
             },
         )
         assert status == 422
 
-    def test_invertedIndexConfig_stopwords_empty_preset_defaults_to_en(self) -> None:
-        """invertedIndexConfig.stopwords with an empty preset must default to
-        'en', matching collection-level validation semantics. Without this,
-        an empty stopwords config would silently filter nothing."""
+    def test_stopwords_empty_preset_defaults_to_en(self) -> None:
+        """stopwords with an empty preset must default to 'en', matching
+        collection-level validation semantics. Without this, an empty
+        stopwords config would silently filter nothing."""
         status, body = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {
                 "text": "the quick",
                 "tokenization": "word",
-                "invertedIndexConfig": {"stopwords": {}},
+                "stopwords": {},
             },
         )
         assert status == 200
         assert body is not None
         assert body["indexed"] == ["the", "quick"]
         assert body["query"] == ["quick"]
-        assert body["invertedIndexConfig"]["stopwords"]["preset"] == "en"
 
-    def test_invertedIndexConfig_stopwords_unknown_preset_is_rejected(self) -> None:
+    def test_stopwords_unknown_preset_is_rejected(self) -> None:
         """Same rejection as collection creation for an unknown preset."""
         status, _ = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {
                 "text": "hello",
                 "tokenization": "word",
-                "invertedIndexConfig": {"stopwords": {"preset": "nonexistent"}},
+                "stopwords": {"preset": "nonexistent"},
             },
         )
         assert status == 422
 
-    def test_invertedIndexConfig_stopwordPresets_empty_list_is_rejected(self) -> None:
+    def test_stopwordPresets_empty_list_is_rejected(self) -> None:
         """Same rejection as collection creation for an empty preset word list."""
         status, _ = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {
                 "text": "hello",
                 "tokenization": "word",
-                "invertedIndexConfig": {"stopwordPresets": {"custom": []}},
+                "stopwordPresets": {"custom": []},
             },
         )
         assert status == 422
@@ -398,31 +492,29 @@ class TestGenericTokenize:
         assert "quick" in body["query"]
 
     def test_stopword_custom_additions(self) -> None:
+        """A user-defined preset is a plain word list (collection shape)."""
         status, body = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {
                 "text": "hello world test",
                 "tokenization": "word",
                 "analyzerConfig": {"stopwordPreset": "custom"},
-                "stopwordPresets": {
-                    "custom": {"additions": ["test"]},
-                },
+                "stopwordPresets": {"custom": ["test"]},
             },
         )
         assert status == 200
         assert body["indexed"] == ["hello", "world", "test"]
         assert body["query"] == ["hello", "world"]
 
-    def test_stopword_preset_with_removals(self) -> None:
+    def test_stopwords_removals_preserve_words(self) -> None:
+        """Removing words from the 'en' base via the stopwords fallback
+        field: 'the' is removed from the en list, so it stays in query."""
         status, body = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {
                 "text": "the quick",
                 "tokenization": "word",
-                "analyzerConfig": {"stopwordPreset": "en-no-the"},
-                "stopwordPresets": {
-                    "en-no-the": {"preset": "en", "removals": ["the"]},
-                },
+                "stopwords": {"preset": "en", "removals": ["the"]},
             },
         )
         assert status == 200
@@ -493,9 +585,7 @@ class TestGenericTokenize:
                 "text": "le chat et la souris",
                 "tokenization": "word",
                 "analyzerConfig": {"stopwordPreset": "fr"},
-                "stopwordPresets": {
-                    "fr": {"additions": ["le", "la", "les"]},
-                },
+                "stopwordPresets": {"fr": ["le", "la", "les"]},
             },
         )
         assert status == 200
@@ -504,26 +594,6 @@ class TestGenericTokenize:
         assert "la" not in body["query"]
         assert "chat" in body["query"]
         assert "et" in body["query"]
-
-    def test_custom_preset_with_base_and_removals(self) -> None:
-        """Custom preset using 'en' as base with removals."""
-        status, body = post_json(
-            f"{WEAVIATE_URL}/v1/tokenize",
-            {
-                "text": "the quick and the fox",
-                "tokenization": "word",
-                "analyzerConfig": {"stopwordPreset": "custom"},
-                "stopwordPresets": {
-                    "custom": {"preset": "en", "removals": ["the"]},
-                },
-            },
-        )
-        assert status == 200
-        assert body["indexed"] == ["the", "quick", "and", "the", "fox"]
-        # 'the' was removed from en stopwords, so it stays in query
-        assert "the" in body["query"]
-        # 'and' is still an en stopword
-        assert "and" not in body["query"]
 
     def test_request_preset_overrides_builtin_of_same_name(self) -> None:
         """A request-level stopwordPreset sharing a name with a built-in
@@ -536,11 +606,8 @@ class TestGenericTokenize:
                 "text": "the quick hello world",
                 "tokenization": "word",
                 "analyzerConfig": {"stopwordPreset": "en"},
-                "stopwordPresets": {
-                    # No explicit base → defaults to "none". The user-defined
-                    # "en" is used as-is, so the built-in en list is ignored.
-                    "en": {"additions": ["hello"]},
-                },
+                # The user-defined "en" replaces the built-in entirely.
+                "stopwordPresets": {"en": ["hello"]},
             },
         )
         assert status == 200
@@ -555,15 +622,13 @@ class TestGenericTokenize:
 
     def test_custom_preset_not_found(self) -> None:
         """Referencing a preset not in stopwordPresets returns 422."""
-        status, body = post_json(
+        status, _ = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
             {
                 "text": "hello",
                 "tokenization": "word",
                 "analyzerConfig": {"stopwordPreset": "missing"},
-                "stopwordPresets": {
-                    "other": {"additions": ["hello"]},
-                },
+                "stopwordPresets": {"other": ["hello"]},
             },
         )
         assert status == 422

--- a/test/acceptance_with_python/test_tokenize.py
+++ b/test/acceptance_with_python/test_tokenize.py
@@ -92,17 +92,22 @@ class TestGenericTokenize:
     """Tests for POST /v1/tokenize."""
 
     @pytest.mark.parametrize(
-        "tokenization,text,expected_tokens",
+        "tokenization,text,expected_indexed,expected_query",
         [
-            ("word", "The quick brown fox", ["the", "quick", "brown", "fox"]),
-            ("lowercase", "Hello World Test", ["hello", "world", "test"]),
-            ("whitespace", "Hello World Test", ["Hello", "World", "Test"]),
-            ("field", "  Hello World  ", ["Hello World"]),
-            ("trigram", "Hello", ["hel", "ell", "llo"]),
+            # "the" is an English stopword, filtered from query by the default "en" preset
+            ("word", "The quick brown fox", ["the", "quick", "brown", "fox"], ["quick", "brown", "fox"]),
+            ("lowercase", "Hello World Test", ["hello", "world", "test"], ["hello", "world", "test"]),
+            ("whitespace", "Hello World Test", ["Hello", "World", "Test"], ["Hello", "World", "Test"]),
+            ("field", "  Hello World  ", ["Hello World"], ["Hello World"]),
+            ("trigram", "Hello", ["hel", "ell", "llo"], ["hel", "ell", "llo"]),
         ],
     )
     def test_tokenization_methods(
-        self, tokenization: str, text: str, expected_tokens: list[str]
+        self,
+        tokenization: str,
+        text: str,
+        expected_indexed: list[str],
+        expected_query: list[str],
     ) -> None:
         status, body = post_json(
             f"{WEAVIATE_URL}/v1/tokenize",
@@ -110,8 +115,185 @@ class TestGenericTokenize:
         )
         assert status == 200
         assert body["tokenization"] == tokenization
+        assert body["indexed"] == expected_indexed
+        assert body["query"] == expected_query
+
+    def test_default_stopword_preset_is_en_for_word_tokenization(self) -> None:
+        """For word tokenization, when no stopwordPreset is supplied the
+        endpoint defaults to the 'en' preset so the query output matches the
+        property-level endpoint (which inherits the collection's default,
+        also 'en'). The defaulted preset is surfaced in invertedIndexConfig,
+        not echoed on analyzerConfig."""
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {"text": "The quick brown fox", "tokenization": "word"},
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "quick", "brown", "fox"]
+        assert body["query"] == ["quick", "brown", "fox"]
+        # The response must not invent an analyzerConfig the caller did not send.
+        assert body.get("analyzerConfig") in (None, {})
+        # The effective stopword preset is reported under invertedIndexConfig.
+        assert body["invertedIndexConfig"] == {"stopwords": {"preset": "en"}}
+
+    def test_default_stopword_preset_can_be_opted_out(self) -> None:
+        """Passing stopwordPreset='none' explicitly disables the default 'en' filtering."""
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "The quick brown fox",
+                "tokenization": "word",
+                "analyzerConfig": {"stopwordPreset": "none"},
+            },
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "quick", "brown", "fox"]
+        assert body["query"] == ["the", "quick", "brown", "fox"]
+        assert body["invertedIndexConfig"] == {"stopwords": {"preset": "none"}}
+
+    def test_default_stopword_preset_applied_when_only_ascii_fold_passed(self) -> None:
+        """asciiFold without an explicit stopwordPreset should still default
+        to 'en' for word tokenization."""
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "The école est fermée",
+                "tokenization": "word",
+                "analyzerConfig": {"asciiFold": True},
+            },
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "ecole", "est", "fermee"]
+        assert "the" not in body["query"]
+        assert body["invertedIndexConfig"] == {"stopwords": {"preset": "en"}}
+
+    @pytest.mark.parametrize(
+        "tokenization,text,expected_tokens",
+        [
+            # Non-word tokenizations do not apply the default "en" preset, so
+            # "the" stays in the query output even though it is an English
+            # stopword, and invertedIndexConfig is omitted from the response.
+            ("lowercase", "the quick", ["the", "quick"]),
+            ("whitespace", "the quick", ["the", "quick"]),
+            ("field", "the quick", ["the quick"]),
+        ],
+    )
+    def test_default_stopword_preset_not_applied_for_non_word_tokenization(
+        self, tokenization: str, text: str, expected_tokens: list[str]
+    ) -> None:
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {"text": text, "tokenization": tokenization},
+        )
+        assert status == 200
+        assert body is not None
         assert body["indexed"] == expected_tokens
         assert body["query"] == expected_tokens
+        assert body.get("invertedIndexConfig") in (None, {})
+
+    def test_invertedIndexConfig_stopwords_fallback(self) -> None:
+        """invertedIndexConfig.stopwords is used as the fallback detector
+        when analyzerConfig.stopwordPreset is not set, mirroring the
+        property endpoint's inheritance from collection config."""
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "the quick brown fox",
+                "tokenization": "word",
+                "invertedIndexConfig": {
+                    "stopwords": {"preset": "en", "additions": ["quick"]},
+                },
+            },
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "quick", "brown", "fox"]
+        assert body["query"] == ["brown", "fox"]
+        # The response echoes back the effective fallback config.
+        assert body["invertedIndexConfig"] == {
+            "stopwords": {"preset": "en", "additions": ["quick"]}
+        }
+
+    def test_invertedIndexConfig_stopwordPresets_resolved_by_analyzer_preset(self) -> None:
+        """analyzerConfig.stopwordPreset can reference a named preset
+        defined in invertedIndexConfig.stopwordPresets."""
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "le chat et la souris",
+                "tokenization": "word",
+                "analyzerConfig": {"stopwordPreset": "fr"},
+                "invertedIndexConfig": {
+                    "stopwordPresets": {"fr": ["le", "la", "et"]},
+                },
+            },
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["le", "chat", "et", "la", "souris"]
+        assert body["query"] == ["chat", "souris"]
+        assert body["invertedIndexConfig"] == {"stopwords": {"preset": "fr"}}
+
+    def test_analyzer_preset_overrides_invertedIndexConfig_stopwords(self) -> None:
+        """An explicit analyzerConfig.stopwordPreset overrides the
+        invertedIndexConfig.stopwords fallback, matching property-level
+        override semantics at the collection level."""
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "the quick",
+                "tokenization": "word",
+                "analyzerConfig": {"stopwordPreset": "none"},
+                "invertedIndexConfig": {
+                    "stopwords": {"preset": "en"},
+                },
+            },
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "quick"]
+        assert body["query"] == ["the", "quick"]
+        assert body["invertedIndexConfig"] == {"stopwords": {"preset": "none"}}
+
+    def test_user_override_for_builtin_en_applies_to_default(self) -> None:
+        """A user-defined 'en' preset replaces the built-in entirely and is
+        applied to the default-en path for word tokenization, even when the
+        caller did not explicitly reference it via analyzerConfig. Matches
+        collection-level override semantics."""
+        status, body = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "the quick hello world",
+                "tokenization": "word",
+                "invertedIndexConfig": {
+                    # Replaces the built-in "en" entirely.
+                    "stopwordPresets": {"en": ["hello"]},
+                },
+            },
+        )
+        assert status == 200
+        assert body is not None
+        assert body["indexed"] == ["the", "quick", "hello", "world"]
+        # "the" no longer filtered (built-in en replaced), "hello" is.
+        assert body["query"] == ["the", "quick", "world"]
+        assert body["invertedIndexConfig"] == {"stopwords": {"preset": "en"}}
+
+    def test_unknown_preset_against_invertedIndexConfig_is_rejected(self) -> None:
+        status, _ = post_json(
+            f"{WEAVIATE_URL}/v1/tokenize",
+            {
+                "text": "hello",
+                "tokenization": "word",
+                "analyzerConfig": {"stopwordPreset": "missing"},
+                "invertedIndexConfig": {
+                    "stopwordPresets": {"other": ["hello"]},
+                },
+            },
+        )
+        assert status == 422
 
     def test_missing_text(self) -> None:
         status, _ = post_json(f"{WEAVIATE_URL}/v1/tokenize", {"tokenization": "word"})


### PR DESCRIPTION
### What's being changed:

- add extra stopword config to input
- remove input parameters from output

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
