### PR TITLE
 Nested object filtering — Part 10: pool-backed BitmapOps and lifecycle testing

### DIFF
--- a/adapters/repos/db/inverted/nested/bitmap.go
+++ b/adapters/repos/db/inverted/nested/bitmap.go
@@ -12,9 +12,8 @@
 package nested
 
 import (
-	"fmt"
-
 	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 )
 
 // Position encoding layout (64 bits total):
@@ -79,18 +78,6 @@ func DecodeDocID(pos uint64) uint64 {
 	return pos & docMask
 }
 
-// EncodePositions creates position values for a given root/leaf pair across
-// multiple documents. Useful for building bitmaps from position templates
-// (where docID=0) by ORing in the real docID.
-func EncodePositions(rootIdx, leafIdx uint16, docIDs []uint64) []uint64 {
-	base := (uint64(rootIdx) << rootShift) | (uint64(leafIdx) << leafShift)
-	out := make([]uint64, len(docIDs))
-	for i, d := range docIDs {
-		out[i] = base | (d & docMask)
-	}
-	return out
-}
-
 // OrDocID ORs a real docID into position templates that have docID=0.
 // Returns a new slice; does not modify the input.
 func OrDocID(positions []uint64, docID uint64) []uint64 {
@@ -102,84 +89,112 @@ func OrDocID(positions []uint64, docID uint64) []uint64 {
 	return out
 }
 
-// ValidateRootIdx checks that a root index fits within the 14-bit field.
-func ValidateRootIdx(rootIdx int) error {
-	if rootIdx < 1 || rootIdx >= MaxRoots {
-		return fmt.Errorf("root index %d out of range [1, %d)", rootIdx, MaxRoots)
+// BitmapOps provides pool-backed versions of every bitmap merge operation used
+// by the nested filter executor. Each method returns the result bitmap and a
+// release function; callers must invoke release() when the bitmap is no longer
+// needed so the underlying buffer is returned to the pool.
+//
+// Using pool-backed allocations on the hot resolution path reduces GC pressure
+// because intermediate bitmaps do not escape to the heap.
+type BitmapOps struct {
+	pool roaringset.BitmapBufPool
+}
+
+// NewBitmapOps constructs a BitmapOps that allocates result bitmaps from pool.
+// Pass roaringset.NewBitmapBufPoolNoop() in tests or the real pool in production.
+func NewBitmapOps(pool roaringset.BitmapBufPool) *BitmapOps {
+	return &BitmapOps{pool: pool}
+}
+
+// NewEmpty returns an empty bitmap backed by a pool buffer sized to minCap
+// bytes. As values are added the bitmap may outgrow the initial buffer and
+// allocate internally, but for typical use (result ⊆ some known upper bound)
+// the hint avoids that reallocation.
+func (o *BitmapOps) NewEmpty(minCap int) (result *sroar.Bitmap, release func()) {
+	buf, put := o.pool.Get(minCap)
+	// TODO aliszka:nested_filtering see MaskLeaf — same sroar buf len vs cap issue.
+	return sroar.NewBitmapToBuf(buf[:cap(buf)]), put
+}
+
+// MaskLeaf zeroes the leaf bits of raw and returns the rootDoc bitmap in a
+// pool buffer. The caller must invoke release() when the result is no longer
+// needed.
+func (o *BitmapOps) MaskLeaf(raw *sroar.Bitmap) (rootDoc *sroar.Bitmap, release func()) {
+	buf, put := o.pool.Get(raw.LenInBytes())
+	// TODO aliszka:nested_filtering buf[:cap(buf)] works around a sroar bug:
+	// MaskedToBuf checks len(buf) instead of cap(buf). Fix in sroar so that
+	// pool-provided slices with len=0,cap=n are accepted without reslicing.
+	return raw.MaskedToBuf(zeroLeafBits, buf[:cap(buf)]), put
+}
+
+// MaskRootLeaf zeroes both root and leaf bits of positions, returning only
+// docIDs in a pool buffer. Use as the final step to extract plain document
+// IDs. positions may be raw or rootDoc.
+func (o *BitmapOps) MaskRootLeaf(positions *sroar.Bitmap) (doc *sroar.Bitmap, release func()) {
+	buf, put := o.pool.Get(positions.LenInBytes())
+	// TODO aliszka:nested_filtering see MaskLeaf — same sroar buf len vs cap issue.
+	return positions.MaskedToBuf(zeroRootBits&zeroLeafBits, buf[:cap(buf)]), put
+}
+
+// AndAll returns the intersection of all raw position bitmaps in a pool
+// buffer. Returns an empty (non-pooled) bitmap when raws is empty. The loop
+// exits early when the running intersection becomes empty — further ANDs
+// cannot change the result.
+func (o *BitmapOps) AndAll(raws []*sroar.Bitmap, maxConcurrency int) (raw *sroar.Bitmap, release func()) {
+	if len(raws) == 0 {
+		return sroar.NewBitmap(), func() {}
 	}
-	return nil
-}
-
-// ValidateLeafIdx checks that a leaf index fits within the 14-bit field.
-func ValidateLeafIdx(leafIdx int) error {
-	if leafIdx < 1 || leafIdx >= MaxLeavesPerRoot {
-		return fmt.Errorf("leaf index %d out of range [1, %d)", leafIdx, MaxLeavesPerRoot)
-	}
-	return nil
-}
-
-// MaskLeaf zeroes the leaf bits of every value in bm, collapsing positions
-// to root+docID granularity. Values that differed only in leaf_idx become
-// identical after masking, allowing element-level alignment across sub-trees.
-func MaskLeaf(bm *sroar.Bitmap) *sroar.Bitmap {
-	return bm.Masked(zeroLeafBits)
-}
-
-// MaskRootLeaf zeroes both root and leaf bits of every value in bm, keeping
-// only the docID. Use this as the final step to extract plain document IDs
-// from a position bitmap.
-func MaskRootLeaf(bm *sroar.Bitmap) *sroar.Bitmap {
-	return bm.Masked(zeroRootBits & zeroLeafBits)
-}
-
-// AndAll returns the intersection of all bitmaps on raw positions. Inputs are
-// not modified. Returns an empty bitmap if bitmaps is empty or if the running
-// intersection becomes empty mid-loop (further ANDs cannot change the result).
-func AndAll(bitmaps []*sroar.Bitmap) *sroar.Bitmap {
-	if len(bitmaps) == 0 {
-		return sroar.NewBitmap()
-	}
-	result := bitmaps[0].Clone()
-	for _, bm := range bitmaps[1:] {
-		result.And(bm)
-		if result.IsEmpty() {
-			return result
+	raw, release = o.pool.CloneToBuf(raws[0])
+	for _, bm := range raws[1:] {
+		raw.AndConc(bm, maxConcurrency)
+		if raw.IsEmpty() {
+			return raw, release
 		}
 	}
-	return result
+	return raw, release
 }
 
-// AndAllMaskLeaf zeroes the leaf bits of each bitmap and ANDs them all,
-// returning root+docID values present across every input. Use this to find
-// which document-element pairs satisfy all conditions simultaneously.
-// Returns an empty bitmap if bitmaps is empty or if the running intersection
-// becomes empty mid-loop (further ANDs cannot change the result).
-func AndAllMaskLeaf(bitmaps []*sroar.Bitmap) *sroar.Bitmap {
-	if len(bitmaps) == 0 {
-		return sroar.NewBitmap()
+// AndAllMaskLeaf zeroes the leaf bits of each raw bitmap, ANDs them all, and
+// returns the rootDoc bitmap in a pool buffer. Returns an empty (non-pooled)
+// bitmap when raws is empty. The loop exits early when the running
+// intersection becomes empty — further ANDs cannot change the result.
+func (o *BitmapOps) AndAllMaskLeaf(raws []*sroar.Bitmap, maxConcurrency int) (rootDoc *sroar.Bitmap, release func()) {
+	if len(raws) == 0 {
+		return sroar.NewBitmap(), func() {}
 	}
-	result := MaskLeaf(bitmaps[0])
-	for _, bm := range bitmaps[1:] {
-		result.AndMasked(bm, zeroLeafBits)
-		if result.IsEmpty() {
-			return result
+	buf, put := o.pool.Get(raws[0].LenInBytes())
+	// TODO aliszka:nested_filtering see MaskLeaf — same sroar buf len vs cap issue.
+	rootDoc = raws[0].MaskedToBuf(zeroLeafBits, buf[:cap(buf)])
+	for _, bm := range raws[1:] {
+		rootDoc.AndMaskedConc(bm, zeroLeafBits, maxConcurrency)
+		if rootDoc.IsEmpty() {
+			return rootDoc, put
 		}
 	}
-	return result
+	return rootDoc, put
 }
 
-// MaskLeafAnd intersects a and b on raw positions and zeroes the leaf bits of
-// the result, returning root+docID values. Both a and b must be raw position
-// bitmaps. Equivalent to MaskLeaf(sroar.And(a, b)) but avoids allocating the
-// intermediate AND bitmap.
-func MaskLeafAnd(a, b *sroar.Bitmap) *sroar.Bitmap {
-	return sroar.MaskedAnd(a, b, zeroLeafBits)
+// MaskLeafAnd intersects rawA and rawB on raw positions, zeroes the leaf bits
+// of the result, and returns the rootDoc bitmap in a pool buffer. Equivalent
+// to MaskLeaf(sroar.And(rawA, rawB)) but uses a single fused operation.
+//
+// Both inputs must be raw position bitmaps (non-zero leaf bits). When one
+// input is already leaf-masked, use AndMaskLeaf instead to avoid re-masking.
+func (o *BitmapOps) MaskLeafAnd(rawA, rawB *sroar.Bitmap) (rootDoc *sroar.Bitmap, release func()) {
+	buf, put := o.pool.Get(min(rawA.LenInBytes(), rawB.LenInBytes()))
+	// TODO aliszka:nested_filtering see MaskLeaf — same sroar buf len vs cap issue.
+	return sroar.MaskedAndToBuf(rawA, rawB, zeroLeafBits, buf[:cap(buf)]), put
 }
 
-// AndWithMaskLeaf intersects a with b after zeroing b's leaf bits, returning
-// root+docID values. a must already be leaf-masked (e.g. from MaskLeaf or
-// AndAllMaskLeaf); only b is leaf-masked before the AND. Avoids allocating an
-// intermediate masked copy of b.
-func AndWithMaskLeaf(a, b *sroar.Bitmap) *sroar.Bitmap {
-	return a.Clone().AndMasked(b, zeroLeafBits)
+// AndMaskLeaf intersects rootDoc with raw after masking raw's leaf bits, and
+// returns the result in a pool buffer. rootDoc must already be leaf-masked
+// (e.g. from AndAllMaskLeaf); only raw's leaf bits are zeroed.
+//
+// Prefer this over AndAllMaskLeaf([rootDoc, raw]) when rootDoc is pre-masked:
+// CloneToBuf is a bulk memcopy while MaskedToBuf iterates containers — the
+// difference matters when rootDoc is large.
+func (o *BitmapOps) AndMaskLeaf(rootDoc, raw *sroar.Bitmap, maxConcurrency int) (result *sroar.Bitmap, release func()) {
+	result, release = o.pool.CloneToBuf(rootDoc)
+	result.AndMaskedConc(raw, zeroLeafBits, maxConcurrency)
+	return result, release
 }

--- a/adapters/repos/db/inverted/nested/bitmap.go
+++ b/adapters/repos/db/inverted/nested/bitmap.go
@@ -112,8 +112,7 @@ func NewBitmapOps(pool roaringset.BitmapBufPool) *BitmapOps {
 // the hint avoids that reallocation.
 func (o *BitmapOps) NewEmpty(minCap int) (result *sroar.Bitmap, release func()) {
 	buf, put := o.pool.Get(minCap)
-	// TODO aliszka:nested_filtering see MaskLeaf — same sroar buf len vs cap issue.
-	return sroar.NewBitmapToBuf(buf[:cap(buf)]), put
+	return sroar.NewBitmapToBuf(buf), put
 }
 
 // MaskLeaf zeroes the leaf bits of raw and returns the rootDoc bitmap in a
@@ -121,10 +120,7 @@ func (o *BitmapOps) NewEmpty(minCap int) (result *sroar.Bitmap, release func()) 
 // needed.
 func (o *BitmapOps) MaskLeaf(raw *sroar.Bitmap) (rootDoc *sroar.Bitmap, release func()) {
 	buf, put := o.pool.Get(raw.LenInBytes())
-	// TODO aliszka:nested_filtering buf[:cap(buf)] works around a sroar bug:
-	// MaskedToBuf checks len(buf) instead of cap(buf). Fix in sroar so that
-	// pool-provided slices with len=0,cap=n are accepted without reslicing.
-	return raw.MaskedToBuf(zeroLeafBits, buf[:cap(buf)]), put
+	return raw.MaskedToBuf(zeroLeafBits, buf), put
 }
 
 // MaskRootLeaf zeroes both root and leaf bits of positions, returning only
@@ -132,8 +128,7 @@ func (o *BitmapOps) MaskLeaf(raw *sroar.Bitmap) (rootDoc *sroar.Bitmap, release 
 // IDs. positions may be raw or rootDoc.
 func (o *BitmapOps) MaskRootLeaf(positions *sroar.Bitmap) (doc *sroar.Bitmap, release func()) {
 	buf, put := o.pool.Get(positions.LenInBytes())
-	// TODO aliszka:nested_filtering see MaskLeaf — same sroar buf len vs cap issue.
-	return positions.MaskedToBuf(zeroRootBits&zeroLeafBits, buf[:cap(buf)]), put
+	return positions.MaskedToBuf(zeroRootBits&zeroLeafBits, buf), put
 }
 
 // AndAll returns the intersection of all raw position bitmaps in a pool
@@ -163,8 +158,7 @@ func (o *BitmapOps) AndAllMaskLeaf(raws []*sroar.Bitmap, maxConcurrency int) (ro
 		return sroar.NewBitmap(), func() {}
 	}
 	buf, put := o.pool.Get(raws[0].LenInBytes())
-	// TODO aliszka:nested_filtering see MaskLeaf — same sroar buf len vs cap issue.
-	rootDoc = raws[0].MaskedToBuf(zeroLeafBits, buf[:cap(buf)])
+	rootDoc = raws[0].MaskedToBuf(zeroLeafBits, buf)
 	for _, bm := range raws[1:] {
 		rootDoc.AndMaskedConc(bm, zeroLeafBits, maxConcurrency)
 		if rootDoc.IsEmpty() {
@@ -178,23 +172,16 @@ func (o *BitmapOps) AndAllMaskLeaf(raws []*sroar.Bitmap, maxConcurrency int) (ro
 // of the result, and returns the rootDoc bitmap in a pool buffer. Equivalent
 // to MaskLeaf(sroar.And(rawA, rawB)) but uses a single fused operation.
 //
-// Both inputs must be raw position bitmaps (non-zero leaf bits). When one
-// input is already leaf-masked, use AndMaskLeaf instead to avoid re-masking.
+// Both inputs must be raw position bitmaps (non-zero leaf bits).
 func (o *BitmapOps) MaskLeafAnd(rawA, rawB *sroar.Bitmap) (rootDoc *sroar.Bitmap, release func()) {
 	buf, put := o.pool.Get(min(rawA.LenInBytes(), rawB.LenInBytes()))
-	// TODO aliszka:nested_filtering see MaskLeaf — same sroar buf len vs cap issue.
-	return sroar.MaskedAndToBuf(rawA, rawB, zeroLeafBits, buf[:cap(buf)]), put
+	return sroar.MaskedAndToBuf(rawA, rawB, zeroLeafBits, buf), put
 }
 
-// AndMaskLeaf intersects rootDoc with raw after masking raw's leaf bits, and
-// returns the result in a pool buffer. rootDoc must already be leaf-masked
-// (e.g. from AndAllMaskLeaf); only raw's leaf bits are zeroed.
-//
-// Prefer this over AndAllMaskLeaf([rootDoc, raw]) when rootDoc is pre-masked:
-// CloneToBuf is a bulk memcopy while MaskedToBuf iterates containers — the
-// difference matters when rootDoc is large.
-func (o *BitmapOps) AndMaskLeaf(rootDoc, raw *sroar.Bitmap, maxConcurrency int) (result *sroar.Bitmap, release func()) {
-	result, release = o.pool.CloneToBuf(rootDoc)
-	result.AndMaskedConc(raw, zeroLeafBits, maxConcurrency)
-	return result, release
+// IntersectsMaskedLeaf reports whether rootDoc and raw share at least one
+// position after zeroing raw's leaf bits. rootDoc must already be leaf-masked.
+// No allocation is performed — use this for cheap element pre-checks before
+// running the full per-element intersection.
+func (o *BitmapOps) IntersectsMaskedLeaf(rootDoc, raw *sroar.Bitmap) bool {
+	return rootDoc.IntersectsMasked(raw, zeroLeafBits)
 }

--- a/adapters/repos/db/inverted/nested/bitmap_test.go
+++ b/adapters/repos/db/inverted/nested/bitmap_test.go
@@ -17,7 +17,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 )
+
+func newTestOps() *BitmapOps {
+	return NewBitmapOps(roaringset.NewBitmapBufPoolNoop())
+}
 
 func TestEncodeDecodeRoundtrip(t *testing.T) {
 	tests := []struct {
@@ -99,18 +104,6 @@ func TestEncodeBitLayout(t *testing.T) {
 	// root=2, leaf=3, docID=42
 	pos2 := Encode(2, 3, 42)
 	assert.Equal(t, uint64(2)<<50|uint64(3)<<36|42, pos2)
-}
-
-func TestEncodePositions(t *testing.T) {
-	docIDs := []uint64{10, 20, 30}
-	positions := EncodePositions(1, 5, docIDs)
-
-	require.Len(t, positions, 3)
-	for i, pos := range positions {
-		assert.Equal(t, uint16(1), DecodeRootIdx(pos))
-		assert.Equal(t, uint16(5), DecodeLeafIdx(pos))
-		assert.Equal(t, docIDs[i], DecodeDocID(pos))
-	}
 }
 
 func TestOrDocID(t *testing.T) {
@@ -256,46 +249,143 @@ func TestDirectAND_DifferentElements(t *testing.T) {
 	assert.Equal(t, 0, result.GetCardinality())
 }
 
-func TestMaskPosThenAND_CrossSubtree(t *testing.T) {
-	// addresses.city="Berlin" AND cars.make="BMW" (sibling subtrees under root)
-	// Different leaf positions but same root+docID
-	cityBm := sroar.NewBitmap()
-	cityBm.Set(Encode(1, 3, 123))
-	cityBm.Set(Encode(1, 4, 123))
-
-	makeBm := sroar.NewBitmap()
-	makeBm.Set(Encode(1, 7, 123))
-	makeBm.Set(Encode(1, 8, 123))
-
-	// MaskLeaf to erase leaf differences
-	maskedCity := MaskLeaf(cityBm)
-	maskedMake := MaskLeaf(makeBm)
-
-	result := maskedCity.And(maskedMake)
-	arr := result.ToArray()
-	require.Len(t, arr, 1)
-	assert.Equal(t, uint16(1), DecodeRootIdx(arr[0]))
-	assert.Equal(t, uint64(123), DecodeDocID(arr[0]))
-}
-
 func TestConstants(t *testing.T) {
 	assert.Equal(t, 1<<14, MaxRoots)
 	assert.Equal(t, 1<<14, MaxLeavesPerRoot)
 	assert.Equal(t, uint64(0x0000000FFFFFFFFF), uint64(MaxDocID))
 }
 
-func TestAndAll(t *testing.T) {
+func TestBitmapOps_NewEmpty(t *testing.T) {
+	ops := newTestOps()
+
+	result, release := ops.NewEmpty(1024)
+	defer release()
+
+	assert.NotNil(t, result)
+	assert.True(t, result.IsEmpty())
+
+	result.Set(Encode(1, 2, 42))
+	assert.False(t, result.IsEmpty())
+}
+
+func TestBitmapOps_MaskLeaf(t *testing.T) {
+	ops := newTestOps()
+
+	t.Run("leaf bits zeroed, root and docID preserved", func(t *testing.T) {
+		bm := sroar.NewBitmap()
+		// addresses[0].city="Berlin" in doc 123 with positions l3, l4
+		bm.Set(Encode(1, 3, 123))
+		bm.Set(Encode(1, 4, 123))
+		// addresses[1].city="Hamburg" in doc 123 with position l5
+		bm.Set(Encode(1, 5, 123))
+		// Same in doc 456
+		bm.Set(Encode(1, 3, 456))
+
+		masked, release := ops.MaskLeaf(bm)
+		defer release()
+
+		// After masking leaf bits, all positions with same root+docID collapse
+		arr := masked.ToArray()
+		assert.Len(t, arr, 2) // r1|d123 and r1|d456
+		for _, v := range arr {
+			assert.Equal(t, uint16(0), DecodeLeafIdx(v))
+			assert.Equal(t, uint16(1), DecodeRootIdx(v))
+		}
+	})
+
+	t.Run("input not modified", func(t *testing.T) {
+		bm := sroar.NewBitmap()
+		bm.Set(Encode(1, 3, 123))
+		original := bm.ToArray()
+
+		_, release := ops.MaskLeaf(bm)
+		defer release()
+
+		assert.Equal(t, original, bm.ToArray())
+	})
+
+	t.Run("cross-subtree masking enables AND", func(t *testing.T) {
+		// addresses.city="Berlin" AND cars.make="BMW" (sibling subtrees under root)
+		// Different leaf positions but same root+docID
+		cityBm := sroar.NewBitmap()
+		cityBm.Set(Encode(1, 3, 123))
+		cityBm.Set(Encode(1, 4, 123))
+
+		makeBm := sroar.NewBitmap()
+		makeBm.Set(Encode(1, 7, 123))
+		makeBm.Set(Encode(1, 8, 123))
+
+		maskedCity, relCity := ops.MaskLeaf(cityBm)
+		defer relCity()
+		maskedMake, relMake := ops.MaskLeaf(makeBm)
+		defer relMake()
+
+		result := maskedCity.And(maskedMake)
+		arr := result.ToArray()
+		require.Len(t, arr, 1)
+		assert.Equal(t, uint16(1), DecodeRootIdx(arr[0]))
+		assert.Equal(t, uint64(123), DecodeDocID(arr[0]))
+	})
+}
+
+func TestBitmapOps_MaskRootLeaf(t *testing.T) {
+	ops := newTestOps()
+
+	t.Run("root and leaf bits zeroed, only docID remains", func(t *testing.T) {
+		bm := sroar.NewBitmap()
+		// Object array: root=1 in doc 999, root=2 in doc 999
+		bm.Set(Encode(1, 3, 999))
+		bm.Set(Encode(1, 4, 999))
+		bm.Set(Encode(2, 1, 999))
+		// Different doc
+		bm.Set(Encode(1, 1, 888))
+
+		stripped, release := ops.MaskRootLeaf(bm)
+		defer release()
+
+		arr := stripped.ToArray()
+		assert.Len(t, arr, 2) // d999 and d888
+		for _, v := range arr {
+			assert.Equal(t, uint16(0), DecodeRootIdx(v))
+			assert.Equal(t, uint16(0), DecodeLeafIdx(v))
+		}
+
+		docIDs := make([]uint64, len(arr))
+		for i, v := range arr {
+			docIDs[i] = DecodeDocID(v)
+		}
+		assert.ElementsMatch(t, []uint64{888, 999}, docIDs)
+	})
+
+	t.Run("input not modified", func(t *testing.T) {
+		bm := sroar.NewBitmap()
+		bm.Set(Encode(2, 5, 100))
+		original := bm.ToArray()
+
+		_, release := ops.MaskRootLeaf(bm)
+		defer release()
+
+		assert.Equal(t, original, bm.ToArray())
+	})
+}
+
+func TestBitmapOps_AndAll(t *testing.T) {
+	ops := newTestOps()
+
 	t.Run("empty input returns empty bitmap", func(t *testing.T) {
-		result := AndAll(nil)
+		result, release := ops.AndAll(nil, 1)
+		defer release()
 		assert.True(t, result.IsEmpty())
 	})
 
-	t.Run("single bitmap returned as clone", func(t *testing.T) {
+	t.Run("single bitmap cloned", func(t *testing.T) {
 		bm := sroar.NewBitmap()
 		bm.SetMany([]uint64{1, 2, 3})
-		result := AndAll([]*sroar.Bitmap{bm})
+		result, release := ops.AndAll([]*sroar.Bitmap{bm}, 1)
+		defer release()
 		assert.Equal(t, bm.ToArray(), result.ToArray())
-		// original unmodified
+		// result is a clone — mutating it must not affect the original
+		result.Remove(2)
 		assert.Equal(t, []uint64{1, 2, 3}, bm.ToArray())
 	})
 
@@ -304,7 +394,8 @@ func TestAndAll(t *testing.T) {
 		a.SetMany([]uint64{1, 2, 3, 4})
 		b := sroar.NewBitmap()
 		b.SetMany([]uint64{2, 4, 6})
-		result := AndAll([]*sroar.Bitmap{a, b})
+		result, release := ops.AndAll([]*sroar.Bitmap{a, b}, 1)
+		defer release()
 		assert.Equal(t, []uint64{2, 4}, result.ToArray())
 		// inputs unmodified
 		assert.Equal(t, []uint64{1, 2, 3, 4}, a.ToArray())
@@ -317,25 +408,33 @@ func TestAndAll(t *testing.T) {
 		b.SetMany([]uint64{2, 3, 4})
 		c := sroar.NewBitmap()
 		c.SetMany([]uint64{3, 4, 5})
-		result := AndAll([]*sroar.Bitmap{a, b, c})
+		result, release := ops.AndAll([]*sroar.Bitmap{a, b, c}, 1)
+		defer release()
 		assert.Equal(t, []uint64{3, 4}, result.ToArray())
 	})
 }
 
-func TestAndAllMaskLeaf(t *testing.T) {
-	// Use two positions from the same doc but different leaf indices.
-	// After MaskLeaf, both become root+docID and should AND together.
+func TestBitmapOps_AndAllMaskLeaf(t *testing.T) {
+	ops := newTestOps()
+
 	doc := uint64(42)
 	posA := Encode(1, 3, doc) // root=1 leaf=3 doc=42
 	posB := Encode(1, 7, doc) // root=1 leaf=7 doc=42 (different leaf)
 	posC := Encode(2, 3, doc) // root=2 leaf=3 doc=42 (different root)
+
+	t.Run("empty input returns empty bitmap", func(t *testing.T) {
+		result, release := ops.AndAllMaskLeaf(nil, 1)
+		defer release()
+		assert.True(t, result.IsEmpty())
+	})
 
 	t.Run("same root different leaf — AND succeeds after masking", func(t *testing.T) {
 		bmA := sroar.NewBitmap()
 		bmA.Set(posA)
 		bmB := sroar.NewBitmap()
 		bmB.Set(posB)
-		result := AndAllMaskLeaf([]*sroar.Bitmap{bmA, bmB})
+		result, release := ops.AndAllMaskLeaf([]*sroar.Bitmap{bmA, bmB}, 1)
+		defer release()
 		// After masking leaf bits: both become Encode(1, 0, 42) → AND non-empty
 		require.False(t, result.IsEmpty())
 		// Result contains root+docID only (leaf zeroed)
@@ -348,7 +447,8 @@ func TestAndAllMaskLeaf(t *testing.T) {
 		bmA.Set(posA) // root=1
 		bmC := sroar.NewBitmap()
 		bmC.Set(posC) // root=2
-		result := AndAllMaskLeaf([]*sroar.Bitmap{bmA, bmC})
+		result, release := ops.AndAllMaskLeaf([]*sroar.Bitmap{bmA, bmC}, 1)
+		defer release()
 		// After masking: root=1|doc=42 vs root=2|doc=42 → no overlap
 		assert.True(t, result.IsEmpty())
 	})
@@ -356,7 +456,129 @@ func TestAndAllMaskLeaf(t *testing.T) {
 	t.Run("inputs not modified", func(t *testing.T) {
 		bmA := sroar.NewBitmap()
 		bmA.Set(posA)
-		AndAllMaskLeaf([]*sroar.Bitmap{bmA})
+		_, release := ops.AndAllMaskLeaf([]*sroar.Bitmap{bmA}, 1)
+		defer release()
 		assert.Equal(t, []uint64{posA}, bmA.ToArray())
+	})
+}
+
+func TestBitmapOps_MaskLeafAnd(t *testing.T) {
+	ops := newTestOps()
+
+	t.Run("intersection of same-element positions, leaf zeroed", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 3, 10))
+		a.Set(Encode(1, 3, 20))
+		b := sroar.NewBitmap()
+		b.Set(Encode(1, 3, 20))
+		b.Set(Encode(1, 3, 30))
+
+		result, release := ops.MaskLeafAnd(a, b)
+		defer release()
+
+		arr := result.ToArray()
+		require.Len(t, arr, 1)
+		assert.Equal(t, uint16(0), DecodeLeafIdx(arr[0]))
+		assert.Equal(t, uint64(20), DecodeDocID(arr[0]))
+	})
+
+	t.Run("no intersection returns empty", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 1, 10))
+		b := sroar.NewBitmap()
+		b.Set(Encode(1, 2, 20))
+
+		result, release := ops.MaskLeafAnd(a, b)
+		defer release()
+
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("inputs not modified", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 3, 10))
+		b := sroar.NewBitmap()
+		b.Set(Encode(1, 3, 10))
+		origA := a.ToArray()
+		origB := b.ToArray()
+
+		_, release := ops.MaskLeafAnd(a, b)
+		defer release()
+
+		assert.Equal(t, origA, a.ToArray())
+		assert.Equal(t, origB, b.ToArray())
+	})
+}
+
+func TestBitmapOps_AndMaskLeaf(t *testing.T) {
+	ops := newTestOps()
+
+	// a is leaf-masked (e.g. preFilter from AndAllMaskLeaf), b has raw positions
+	// (e.g. elemBitmap). Result keeps values from a whose (root, docID) appear
+	// in b at any leaf. CloneToBuf(a) + AndMaskedConc(b) avoids re-masking a.
+	t.Run("matches on root+docID regardless of leaf in b", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 0, 10)) // doc 10, leaf=0 (pre-masked)
+		a.Set(Encode(1, 0, 20)) // doc 20, leaf=0 (pre-masked)
+
+		b := sroar.NewBitmap()
+		b.Set(Encode(1, 3, 10)) // doc 10 at leaf=3 (raw position)
+		b.Set(Encode(1, 5, 30)) // doc 30 at leaf=5 (not in a)
+
+		result, release := ops.AndMaskLeaf(a, b, 1)
+		defer release()
+
+		arr := result.ToArray()
+		require.Len(t, arr, 1)
+		assert.Equal(t, uint16(1), DecodeRootIdx(arr[0]))
+		assert.Equal(t, uint16(0), DecodeLeafIdx(arr[0])) // retains a's leaf=0
+		assert.Equal(t, uint64(10), DecodeDocID(arr[0]))
+	})
+
+	t.Run("MaskLeafAnd gives empty when a is pre-masked, AndMaskLeaf does not", func(t *testing.T) {
+		// MaskLeafAnd = MaskLeaf(a ∩ b): requires exact key match, so pre-masked
+		// a (leaf=0) never matches raw b (leaf≠0) → always empty.
+		// AndMaskLeaf = a AND MaskLeaf(b): correct for pre-masked a.
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 0, 42)) // leaf=0 (pre-masked)
+
+		b := sroar.NewBitmap()
+		b.Set(Encode(1, 7, 42)) // leaf=7 (raw position)
+
+		wrong, rel1 := ops.MaskLeafAnd(a, b)
+		defer rel1()
+		assert.True(t, wrong.IsEmpty())
+
+		correct, rel2 := ops.AndMaskLeaf(a, b, 1)
+		defer rel2()
+		assert.False(t, correct.IsEmpty())
+	})
+
+	t.Run("no match when root differs", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 0, 10))
+
+		b := sroar.NewBitmap()
+		b.Set(Encode(2, 3, 10)) // same docID, different root
+
+		result, release := ops.AndMaskLeaf(a, b, 1)
+		defer release()
+
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("inputs not modified", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 0, 10))
+		b := sroar.NewBitmap()
+		b.Set(Encode(1, 3, 10))
+		origA := a.ToArray()
+		origB := b.ToArray()
+
+		_, release := ops.AndMaskLeaf(a, b, 1)
+		defer release()
+
+		assert.Equal(t, origA, a.ToArray())
+		assert.Equal(t, origB, b.ToArray())
 	})
 }

--- a/adapters/repos/db/inverted/nested/bitmap_test.go
+++ b/adapters/repos/db/inverted/nested/bitmap_test.go
@@ -13,6 +13,7 @@ package nested
 
 import (
 	"testing"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,8 +21,34 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 )
 
-func newTestOps() *BitmapOps {
-	return NewBitmapOps(roaringset.NewBitmapBufPoolNoop())
+// requireBitmapValid asserts that bm's backing buffer has not been zeroed by
+// the tracking pool's release function. It reads n[indexNumKeys] — the second
+// uint64 in bm.data — which sroar always initialises to 1 (sentinel key=0x00
+// container). A zeroed buffer has 0, indicating premature release.
+//
+// TODO aliszka:nested_filtering replace unsafe read with bm.NumKeys() once
+// that method is exposed by the sroar library.
+func requireBitmapValid(t *testing.T, bm *sroar.Bitmap) {
+	t.Helper()
+	require.NotNil(t, bm)
+	// TODO aliszka:nested_filtering remove unsafe once sroar exposes NumKeys().
+	// bm.data []uint16 is the first field of sroar.Bitmap. Its backing array
+	// pointer is at offset 0 of the struct. n[indexNumKeys] is at byte offset 8
+	// (second uint64) within that array.
+	dataPtr := *(*unsafe.Pointer)(unsafe.Pointer(bm))
+	numKeys := *(*uint64)(unsafe.Pointer(uintptr(dataPtr) + 8))
+	require.Positive(t, numKeys, "bitmap backing buffer is zeroed — premature release?")
+}
+
+func newTrackingOps(t *testing.T) *BitmapOps {
+	t.Helper()
+	pool := roaringset.NewBitmapBufPoolTracking()
+	t.Cleanup(func() {
+		if n := pool.Outstanding(); n != 0 {
+			t.Errorf("pool: %d bitmap buffer(s) not released", n)
+		}
+	})
+	return NewBitmapOps(pool)
 }
 
 func TestEncodeDecodeRoundtrip(t *testing.T) {
@@ -158,68 +185,6 @@ func TestEncodeOutOfRangeClipped(t *testing.T) {
 	assert.Equal(t, uint16(5), DecodeLeafIdx(encoded3), "oversized leafIdx lower bits are preserved")
 }
 
-func TestValidateRootIdx(t *testing.T) {
-	assert.NoError(t, ValidateRootIdx(1))
-	assert.NoError(t, ValidateRootIdx(MaxRoots-1))
-	assert.Error(t, ValidateRootIdx(0))
-	assert.Error(t, ValidateRootIdx(MaxRoots))
-	assert.Error(t, ValidateRootIdx(-1))
-}
-
-func TestValidateLeafIdx(t *testing.T) {
-	assert.NoError(t, ValidateLeafIdx(1))
-	assert.NoError(t, ValidateLeafIdx(MaxLeavesPerRoot-1))
-	assert.Error(t, ValidateLeafIdx(0))
-	assert.Error(t, ValidateLeafIdx(MaxLeavesPerRoot))
-	assert.Error(t, ValidateLeafIdx(-1))
-}
-
-func TestMaskLeaf(t *testing.T) {
-	bm := sroar.NewBitmap()
-	// addresses[0].city="Berlin" in doc 123 with positions l3, l4
-	bm.Set(Encode(1, 3, 123))
-	bm.Set(Encode(1, 4, 123))
-	// addresses[1].city="Hamburg" in doc 123 with position l5
-	bm.Set(Encode(1, 5, 123))
-	// Same in doc 456
-	bm.Set(Encode(1, 3, 456))
-
-	masked := MaskLeaf(bm)
-
-	// After masking leaf bits, all positions with same root+docID collapse
-	arr := masked.ToArray()
-	assert.Len(t, arr, 2) // r1|d123 and r1|d456
-	for _, v := range arr {
-		assert.Equal(t, uint16(0), DecodeLeafIdx(v))
-		assert.Equal(t, uint16(1), DecodeRootIdx(v))
-	}
-}
-
-func TestMaskRootLeaf(t *testing.T) {
-	bm := sroar.NewBitmap()
-	// Object array: root=1 in doc 999, root=2 in doc 999
-	bm.Set(Encode(1, 3, 999))
-	bm.Set(Encode(1, 4, 999))
-	bm.Set(Encode(2, 1, 999))
-	// Different doc
-	bm.Set(Encode(1, 1, 888))
-
-	stripped := MaskRootLeaf(bm)
-
-	arr := stripped.ToArray()
-	assert.Len(t, arr, 2) // d999 and d888
-	for _, v := range arr {
-		assert.Equal(t, uint16(0), DecodeRootIdx(v))
-		assert.Equal(t, uint16(0), DecodeLeafIdx(v))
-	}
-
-	docIDs := make([]uint64, len(arr))
-	for i, v := range arr {
-		docIDs[i] = DecodeDocID(v)
-	}
-	assert.ElementsMatch(t, []uint64{888, 999}, docIDs)
-}
-
 func TestDirectAND(t *testing.T) {
 	// addresses.city="Madrid" AND addresses.postcode="28001" (same element)
 	// Both have positions {r1|l2|d124}
@@ -256,11 +221,12 @@ func TestConstants(t *testing.T) {
 }
 
 func TestBitmapOps_NewEmpty(t *testing.T) {
-	ops := newTestOps()
+	ops := newTrackingOps(t)
 
 	result, release := ops.NewEmpty(1024)
 	defer release()
 
+	requireBitmapValid(t, result)
 	assert.NotNil(t, result)
 	assert.True(t, result.IsEmpty())
 
@@ -269,7 +235,7 @@ func TestBitmapOps_NewEmpty(t *testing.T) {
 }
 
 func TestBitmapOps_MaskLeaf(t *testing.T) {
-	ops := newTestOps()
+	ops := newTrackingOps(t)
 
 	t.Run("leaf bits zeroed, root and docID preserved", func(t *testing.T) {
 		bm := sroar.NewBitmap()
@@ -284,6 +250,7 @@ func TestBitmapOps_MaskLeaf(t *testing.T) {
 		masked, release := ops.MaskLeaf(bm)
 		defer release()
 
+		requireBitmapValid(t, masked)
 		// After masking leaf bits, all positions with same root+docID collapse
 		arr := masked.ToArray()
 		assert.Len(t, arr, 2) // r1|d123 and r1|d456
@@ -320,6 +287,8 @@ func TestBitmapOps_MaskLeaf(t *testing.T) {
 		maskedMake, relMake := ops.MaskLeaf(makeBm)
 		defer relMake()
 
+		requireBitmapValid(t, maskedCity)
+		requireBitmapValid(t, maskedMake)
 		result := maskedCity.And(maskedMake)
 		arr := result.ToArray()
 		require.Len(t, arr, 1)
@@ -329,7 +298,7 @@ func TestBitmapOps_MaskLeaf(t *testing.T) {
 }
 
 func TestBitmapOps_MaskRootLeaf(t *testing.T) {
-	ops := newTestOps()
+	ops := newTrackingOps(t)
 
 	t.Run("root and leaf bits zeroed, only docID remains", func(t *testing.T) {
 		bm := sroar.NewBitmap()
@@ -343,6 +312,7 @@ func TestBitmapOps_MaskRootLeaf(t *testing.T) {
 		stripped, release := ops.MaskRootLeaf(bm)
 		defer release()
 
+		requireBitmapValid(t, stripped)
 		arr := stripped.ToArray()
 		assert.Len(t, arr, 2) // d999 and d888
 		for _, v := range arr {
@@ -370,11 +340,12 @@ func TestBitmapOps_MaskRootLeaf(t *testing.T) {
 }
 
 func TestBitmapOps_AndAll(t *testing.T) {
-	ops := newTestOps()
+	ops := newTrackingOps(t)
 
 	t.Run("empty input returns empty bitmap", func(t *testing.T) {
 		result, release := ops.AndAll(nil, 1)
 		defer release()
+		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
 	})
 
@@ -383,6 +354,7 @@ func TestBitmapOps_AndAll(t *testing.T) {
 		bm.SetMany([]uint64{1, 2, 3})
 		result, release := ops.AndAll([]*sroar.Bitmap{bm}, 1)
 		defer release()
+		requireBitmapValid(t, result)
 		assert.Equal(t, bm.ToArray(), result.ToArray())
 		// result is a clone — mutating it must not affect the original
 		result.Remove(2)
@@ -396,6 +368,7 @@ func TestBitmapOps_AndAll(t *testing.T) {
 		b.SetMany([]uint64{2, 4, 6})
 		result, release := ops.AndAll([]*sroar.Bitmap{a, b}, 1)
 		defer release()
+		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{2, 4}, result.ToArray())
 		// inputs unmodified
 		assert.Equal(t, []uint64{1, 2, 3, 4}, a.ToArray())
@@ -410,12 +383,13 @@ func TestBitmapOps_AndAll(t *testing.T) {
 		c.SetMany([]uint64{3, 4, 5})
 		result, release := ops.AndAll([]*sroar.Bitmap{a, b, c}, 1)
 		defer release()
+		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{3, 4}, result.ToArray())
 	})
 }
 
 func TestBitmapOps_AndAllMaskLeaf(t *testing.T) {
-	ops := newTestOps()
+	ops := newTrackingOps(t)
 
 	doc := uint64(42)
 	posA := Encode(1, 3, doc) // root=1 leaf=3 doc=42
@@ -425,6 +399,7 @@ func TestBitmapOps_AndAllMaskLeaf(t *testing.T) {
 	t.Run("empty input returns empty bitmap", func(t *testing.T) {
 		result, release := ops.AndAllMaskLeaf(nil, 1)
 		defer release()
+		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
 	})
 
@@ -435,6 +410,7 @@ func TestBitmapOps_AndAllMaskLeaf(t *testing.T) {
 		bmB.Set(posB)
 		result, release := ops.AndAllMaskLeaf([]*sroar.Bitmap{bmA, bmB}, 1)
 		defer release()
+		requireBitmapValid(t, result)
 		// After masking leaf bits: both become Encode(1, 0, 42) → AND non-empty
 		require.False(t, result.IsEmpty())
 		// Result contains root+docID only (leaf zeroed)
@@ -449,6 +425,7 @@ func TestBitmapOps_AndAllMaskLeaf(t *testing.T) {
 		bmC.Set(posC) // root=2
 		result, release := ops.AndAllMaskLeaf([]*sroar.Bitmap{bmA, bmC}, 1)
 		defer release()
+		requireBitmapValid(t, result)
 		// After masking: root=1|doc=42 vs root=2|doc=42 → no overlap
 		assert.True(t, result.IsEmpty())
 	})
@@ -463,7 +440,7 @@ func TestBitmapOps_AndAllMaskLeaf(t *testing.T) {
 }
 
 func TestBitmapOps_MaskLeafAnd(t *testing.T) {
-	ops := newTestOps()
+	ops := newTrackingOps(t)
 
 	t.Run("intersection of same-element positions, leaf zeroed", func(t *testing.T) {
 		a := sroar.NewBitmap()
@@ -476,6 +453,7 @@ func TestBitmapOps_MaskLeafAnd(t *testing.T) {
 		result, release := ops.MaskLeafAnd(a, b)
 		defer release()
 
+		requireBitmapValid(t, result)
 		arr := result.ToArray()
 		require.Len(t, arr, 1)
 		assert.Equal(t, uint16(0), DecodeLeafIdx(arr[0]))
@@ -491,6 +469,7 @@ func TestBitmapOps_MaskLeafAnd(t *testing.T) {
 		result, release := ops.MaskLeafAnd(a, b)
 		defer release()
 
+		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
 	})
 
@@ -511,7 +490,7 @@ func TestBitmapOps_MaskLeafAnd(t *testing.T) {
 }
 
 func TestBitmapOps_AndMaskLeaf(t *testing.T) {
-	ops := newTestOps()
+	ops := newTrackingOps(t)
 
 	// a is leaf-masked (e.g. preFilter from AndAllMaskLeaf), b has raw positions
 	// (e.g. elemBitmap). Result keeps values from a whose (root, docID) appear
@@ -528,6 +507,7 @@ func TestBitmapOps_AndMaskLeaf(t *testing.T) {
 		result, release := ops.AndMaskLeaf(a, b, 1)
 		defer release()
 
+		requireBitmapValid(t, result)
 		arr := result.ToArray()
 		require.Len(t, arr, 1)
 		assert.Equal(t, uint16(1), DecodeRootIdx(arr[0]))
@@ -547,10 +527,12 @@ func TestBitmapOps_AndMaskLeaf(t *testing.T) {
 
 		wrong, rel1 := ops.MaskLeafAnd(a, b)
 		defer rel1()
+		requireBitmapValid(t, wrong)
 		assert.True(t, wrong.IsEmpty())
 
 		correct, rel2 := ops.AndMaskLeaf(a, b, 1)
 		defer rel2()
+		requireBitmapValid(t, correct)
 		assert.False(t, correct.IsEmpty())
 	})
 
@@ -564,6 +546,7 @@ func TestBitmapOps_AndMaskLeaf(t *testing.T) {
 		result, release := ops.AndMaskLeaf(a, b, 1)
 		defer release()
 
+		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
 	})
 

--- a/adapters/repos/db/inverted/nested/bitmap_test.go
+++ b/adapters/repos/db/inverted/nested/bitmap_test.go
@@ -13,7 +13,6 @@ package nested
 
 import (
 	"testing"
-	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -22,22 +21,13 @@ import (
 )
 
 // requireBitmapValid asserts that bm's backing buffer has not been zeroed by
-// the tracking pool's release function. It reads n[indexNumKeys] — the second
-// uint64 in bm.data — which sroar always initialises to 1 (sentinel key=0x00
-// container). A zeroed buffer has 0, indicating premature release.
-//
-// TODO aliszka:nested_filtering replace unsafe read with bm.NumKeys() once
-// that method is exposed by the sroar library.
+// the tracking pool's release function. sroar always initialises the bitmap
+// with one sentinel container (key=0x00), so NumContainers() >= 1 indicates a
+// live buffer; a zeroed buffer reports 0.
 func requireBitmapValid(t *testing.T, bm *sroar.Bitmap) {
 	t.Helper()
 	require.NotNil(t, bm)
-	// TODO aliszka:nested_filtering remove unsafe once sroar exposes NumKeys().
-	// bm.data []uint16 is the first field of sroar.Bitmap. Its backing array
-	// pointer is at offset 0 of the struct. n[indexNumKeys] is at byte offset 8
-	// (second uint64) within that array.
-	dataPtr := *(*unsafe.Pointer)(unsafe.Pointer(bm))
-	numKeys := *(*uint64)(unsafe.Pointer(uintptr(dataPtr) + 8))
-	require.Positive(t, numKeys, "bitmap backing buffer is zeroed — premature release?")
+	require.Positive(t, bm.NumContainers(), "bitmap backing buffer is zeroed — premature release?")
 }
 
 func newTrackingOps(t *testing.T) *BitmapOps {
@@ -489,79 +479,45 @@ func TestBitmapOps_MaskLeafAnd(t *testing.T) {
 	})
 }
 
-func TestBitmapOps_AndMaskLeaf(t *testing.T) {
+func TestBitmapOps_IntersectsMaskedLeaf(t *testing.T) {
 	ops := newTrackingOps(t)
 
-	// a is leaf-masked (e.g. preFilter from AndAllMaskLeaf), b has raw positions
-	// (e.g. elemBitmap). Result keeps values from a whose (root, docID) appear
-	// in b at any leaf. CloneToBuf(a) + AndMaskedConc(b) avoids re-masking a.
-	t.Run("matches on root+docID regardless of leaf in b", func(t *testing.T) {
-		a := sroar.NewBitmap()
-		a.Set(Encode(1, 0, 10)) // doc 10, leaf=0 (pre-masked)
-		a.Set(Encode(1, 0, 20)) // doc 20, leaf=0 (pre-masked)
+	// rootDoc is leaf-masked (e.g. preFilter from AndAllMaskLeaf); raw has raw
+	// positions (e.g. elemBitmap). Returns true if they share at least one
+	// (root, docID) pair after zeroing raw's leaf bits. No allocation.
+	t.Run("true when root+docID overlap regardless of raw's leaf", func(t *testing.T) {
+		rootDoc := sroar.NewBitmap()
+		rootDoc.Set(Encode(1, 0, 10)) // doc 10, leaf=0 (pre-masked)
+		rootDoc.Set(Encode(1, 0, 20)) // doc 20, leaf=0 (pre-masked)
 
-		b := sroar.NewBitmap()
-		b.Set(Encode(1, 3, 10)) // doc 10 at leaf=3 (raw position)
-		b.Set(Encode(1, 5, 30)) // doc 30 at leaf=5 (not in a)
+		raw := sroar.NewBitmap()
+		raw.Set(Encode(1, 3, 10)) // doc 10 at leaf=3 (raw position)
+		raw.Set(Encode(1, 5, 30)) // doc 30 at leaf=5 (not in rootDoc)
 
-		result, release := ops.AndMaskLeaf(a, b, 1)
-		defer release()
-
-		requireBitmapValid(t, result)
-		arr := result.ToArray()
-		require.Len(t, arr, 1)
-		assert.Equal(t, uint16(1), DecodeRootIdx(arr[0]))
-		assert.Equal(t, uint16(0), DecodeLeafIdx(arr[0])) // retains a's leaf=0
-		assert.Equal(t, uint64(10), DecodeDocID(arr[0]))
+		assert.True(t, ops.IntersectsMaskedLeaf(rootDoc, raw))
 	})
 
-	t.Run("MaskLeafAnd gives empty when a is pre-masked, AndMaskLeaf does not", func(t *testing.T) {
-		// MaskLeafAnd = MaskLeaf(a ∩ b): requires exact key match, so pre-masked
-		// a (leaf=0) never matches raw b (leaf≠0) → always empty.
-		// AndMaskLeaf = a AND MaskLeaf(b): correct for pre-masked a.
-		a := sroar.NewBitmap()
-		a.Set(Encode(1, 0, 42)) // leaf=0 (pre-masked)
+	t.Run("false when root differs", func(t *testing.T) {
+		rootDoc := sroar.NewBitmap()
+		rootDoc.Set(Encode(1, 0, 10))
 
-		b := sroar.NewBitmap()
-		b.Set(Encode(1, 7, 42)) // leaf=7 (raw position)
+		raw := sroar.NewBitmap()
+		raw.Set(Encode(2, 3, 10)) // same docID, different root
 
-		wrong, rel1 := ops.MaskLeafAnd(a, b)
-		defer rel1()
-		requireBitmapValid(t, wrong)
-		assert.True(t, wrong.IsEmpty())
-
-		correct, rel2 := ops.AndMaskLeaf(a, b, 1)
-		defer rel2()
-		requireBitmapValid(t, correct)
-		assert.False(t, correct.IsEmpty())
-	})
-
-	t.Run("no match when root differs", func(t *testing.T) {
-		a := sroar.NewBitmap()
-		a.Set(Encode(1, 0, 10))
-
-		b := sroar.NewBitmap()
-		b.Set(Encode(2, 3, 10)) // same docID, different root
-
-		result, release := ops.AndMaskLeaf(a, b, 1)
-		defer release()
-
-		requireBitmapValid(t, result)
-		assert.True(t, result.IsEmpty())
+		assert.False(t, ops.IntersectsMaskedLeaf(rootDoc, raw))
 	})
 
 	t.Run("inputs not modified", func(t *testing.T) {
-		a := sroar.NewBitmap()
-		a.Set(Encode(1, 0, 10))
-		b := sroar.NewBitmap()
-		b.Set(Encode(1, 3, 10))
-		origA := a.ToArray()
-		origB := b.ToArray()
+		rootDoc := sroar.NewBitmap()
+		rootDoc.Set(Encode(1, 0, 10))
+		raw := sroar.NewBitmap()
+		raw.Set(Encode(1, 3, 10))
+		origRootDoc := rootDoc.ToArray()
+		origRaw := raw.ToArray()
 
-		_, release := ops.AndMaskLeaf(a, b, 1)
-		defer release()
+		ops.IntersectsMaskedLeaf(rootDoc, raw)
 
-		assert.Equal(t, origA, a.ToArray())
-		assert.Equal(t, origB, b.ToArray())
+		assert.Equal(t, origRootDoc, rootDoc.ToArray())
+		assert.Equal(t, origRaw, raw.ToArray())
 	})
 }

--- a/adapters/repos/db/inverted/nested/keys.go
+++ b/adapters/repos/db/inverted/nested/keys.go
@@ -17,7 +17,10 @@ import (
 	"github.com/cespare/xxhash/v2"
 )
 
-const hashSize = 8 // xxHash64 produces 8 bytes
+const (
+	hashSize   = 8            // xxHash64 produces 8 bytes
+	IdxKeySize = hashSize + 2 // hash8 + BE16(index)
+)
 
 // hashKey is the shared primitive: allocate a buffer, write
 // xxhash.Sum64String(input) as 8 big-endian bytes, then append suffix.
@@ -44,6 +47,17 @@ func ValueKey(path string, analyzedValue []byte) []byte {
 // hash8("_idx." + path) + BE16(index).
 func IdxKey(path string, index int) []byte {
 	return hashKey("_idx."+path, binary.BigEndian.AppendUint16(nil, uint16(index)))
+}
+
+// IdxKeyToBuf writes an _idx key into buf and returns the populated slice.
+// buf must be at least IdxKeySize bytes. Use this in loops to avoid
+// per-iteration allocation; declare a [IdxKeySize]byte on the stack and pass
+// a slice of it.
+func IdxKeyToBuf(path string, index int, buf []byte) []byte {
+	buf = buf[:IdxKeySize]
+	binary.BigEndian.PutUint64(buf, xxhash.Sum64String("_idx."+path))
+	binary.BigEndian.PutUint16(buf[hashSize:], uint16(index))
+	return buf
 }
 
 // ExistsKey builds the key for an _exists metadata entry:

--- a/adapters/repos/db/inverted/nested/keys_test.go
+++ b/adapters/repos/db/inverted/nested/keys_test.go
@@ -85,6 +85,28 @@ func TestIdxKey(t *testing.T) {
 	})
 }
 
+func TestIdxKeyToBuf(t *testing.T) {
+	t.Run("produces same result as IdxKey", func(t *testing.T) {
+		var buf [IdxKeySize]byte
+		assert.Equal(t, IdxKey("addresses", 0), IdxKeyToBuf("addresses", 0, buf[:]))
+		assert.Equal(t, IdxKey("addresses", 3), IdxKeyToBuf("addresses", 3, buf[:]))
+		assert.Equal(t, IdxKey("cars", 7), IdxKeyToBuf("cars", 7, buf[:]))
+	})
+
+	t.Run("buffer is reused across calls", func(t *testing.T) {
+		var buf [IdxKeySize]byte
+		k0 := IdxKeyToBuf("addresses", 0, buf[:])
+		k1 := IdxKeyToBuf("addresses", 1, buf[:])
+		// Both slices point into the same backing array — k0 reflects the last write.
+		assert.Equal(t, k0, k1)
+	})
+
+	t.Run("result length is always IdxKeySize", func(t *testing.T) {
+		var buf [IdxKeySize]byte
+		assert.Len(t, IdxKeyToBuf("some.nested.path", 42, buf[:]), IdxKeySize)
+	})
+}
+
 func TestExistsKey(t *testing.T) {
 	t.Run("named path hashes _exists prefix with path", func(t *testing.T) {
 		key := ExistsKey("owner.firstname")

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -37,7 +37,6 @@ type propValuePair struct {
 	// only set if operator=OperatorWithinGeoRange, as that cannot be served by a
 	// byte value from an inverted index
 	valueGeoRange      *filters.GeoRange
-	docIDs             docBitmap
 	children           []*propValuePair
 	hasFilterableIndex bool
 	hasSearchableIndex bool
@@ -50,11 +49,11 @@ func newPropValuePair(class *models.Class) (*propValuePair, error) {
 	if class == nil {
 		return nil, errors.Errorf("class must not be nil")
 	}
-	return &propValuePair{docIDs: newDocBitmap(), Class: class}, nil
+	return &propValuePair{Class: class}, nil
 }
 
 func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
-	if err := ctx.Err(); err != nil {
+	if err := ctxExpired(ctx); err != nil {
 		return nil, err
 	}
 

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -261,8 +261,8 @@ func mergeBitmapsAndOrWithDenyList(a, b *docBitmap, operator filters.Operator) *
 	// swapForEfficiency puts the larger bitmap in `a` for Or (fewer union ops),
 	// or the smaller bitmap in `a` for And (fewer intersection ops).
 	swapForEfficiency := func(op filters.Operator) {
-		if (op == filters.OperatorOr && a.docIDs.CompareNumKeys(b.docIDs) < 0) ||
-			(op == filters.OperatorAnd && a.docIDs.CompareNumKeys(b.docIDs) > 0) {
+		if (op == filters.OperatorOr && a.docIDs.NumContainers() < b.docIDs.NumContainers()) ||
+			(op == filters.OperatorAnd && a.docIDs.NumContainers() > b.docIDs.NumContainers()) {
 			a, b = b, a
 		}
 	}

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -20,6 +20,8 @@ import (
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
+	"github.com/weaviate/weaviate/entities/concurrency"
+	"github.com/weaviate/weaviate/entities/filters"
 	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/schema"
 )
@@ -73,11 +75,14 @@ func (a arrayIndices) groupKey() string {
 // docID-only results. It fetches raw positions, applies any arr[N] index
 // constraints, then strips position bits to extract plain docIDs.
 func (pv *propValuePair) fetchNestedDocIDs(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
-	dbm, err := pv.fetchNestedPositions(ctx, s, limit)
+	positions, err := pv.fetchNestedPositions(ctx, s, limit)
 	if err != nil {
 		return nil, err
 	}
-	dbm.docIDs = invnested.MaskRootLeaf(dbm.docIDs)
+	defer positions.release()
+
+	dbm := &docBitmap{isDenyList: positions.isDenyList}
+	dbm.docIDs, dbm.release = s.nestedBitmapOps.MaskRootLeaf(positions.docIDs)
 	return dbm, nil
 }
 
@@ -94,21 +99,20 @@ func (pv *propValuePair) fetchNestedIsNull(s *Searcher) (*docBitmap, error) {
 		return nil, errors.Errorf("nested IsNull: meta bucket for %q not found — is it indexed?", pv.prop)
 	}
 
-	positions, release, err := metaBucket.RoaringSetGet(invnested.ExistsKey(pv.nested.relPath))
+	positionsExists, release, err := metaBucket.RoaringSetGet(invnested.ExistsKey(pv.nested.relPath))
 	if err != nil {
 		return nil, fmt.Errorf("nested IsNull: read exists key for %q: %w", pv.prop, err)
 	}
-	defer release()
-
-	if err := pv.restrictByNestedIdx(s, positions); err != nil {
-		return nil, err
+	dbmExists, err := pv.restrictByNestedIdx(s, &docBitmap{docIDs: positionsExists, release: release})
+	if err != nil {
+		return nil, err // restrictByNestedIdx released the bitmap on error
 	}
+	defer dbmExists.release()
 
-	dbm := newDocBitmap()
-	dbm.docIDs = invnested.MaskRootLeaf(positions)
 	// pv.value is a little-endian bool: 0x01 = true (IsNull — property absent → denylist).
-	dbm.isDenyList = len(pv.value) > 0 && pv.value[0] == 0x01
-	return &dbm, nil
+	dbm := &docBitmap{isDenyList: len(pv.value) > 0 && pv.value[0] == 0x01}
+	dbm.docIDs, dbm.release = s.nestedBitmapOps.MaskRootLeaf(dbmExists.docIDs)
+	return dbm, nil
 }
 
 // fetchNestedPositions fetches the raw position bitmap for a nested value
@@ -116,37 +120,49 @@ func (pv *propValuePair) fetchNestedIsNull(s *Searcher) (*docBitmap, error) {
 // to docIDs — callers that need docIDs use fetchNestedDocIDs instead; the
 // correlated resolution path (resolveNestedCorrelated) uses this directly.
 func (pv *propValuePair) fetchNestedPositions(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
-	dbm, err := pv.readFromBucket(ctx, s, limit)
+	raw, err := pv.readFromBucket(ctx, s, limit)
 	if err != nil {
 		return nil, err
 	}
-	if err := pv.restrictByNestedIdx(s, dbm.docIDs); err != nil {
-		return nil, err
-	}
-	return dbm, nil
+	return pv.restrictByNestedIdx(s, raw)
 }
 
 // restrictByNestedIdx restricts a position bitmap to the specific array
 // elements recorded in pv.nested.arrayIndices. For each constraint it reads
 // IdxKey(relPath, index) from the nested metadata bucket and ANDs it into
-// the bitmap in place. No-op when arrayIndices is empty.
-func (pv *propValuePair) restrictByNestedIdx(s *Searcher, positions *sroar.Bitmap) error {
+// the accumulator using mergeBitmapsAndOrWithDenyList, which selects the more
+// efficient accumulator (smaller for AND) and releases the discarded buffer.
+// Returns the (potentially swapped) accumulator. On error the current
+// accumulator is returned unchanged — the caller is responsible for releasing it.
+// No-op when arrayIndices is empty.
+func (pv *propValuePair) restrictByNestedIdx(s *Searcher, positions *docBitmap) (*docBitmap, error) {
 	if len(pv.nested.arrayIndices) == 0 {
-		return nil
+		return positions, nil
 	}
+	// Release the current accumulator on any non-success exit (error or panic).
+	// The closure reads positions at call time, so it always releases the latest
+	// accumulator even after mergeBitmapsAndOrWithDenyList swaps it.
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			positions.release()
+		}
+	}()
+
 	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(pv.prop))
 	if metaBucket == nil {
-		return fmt.Errorf("nested [N] filter: meta bucket for %q not found — is it indexed?", pv.prop)
+		return nil, fmt.Errorf("nested [N] filter: meta bucket for %q not found — is it indexed?", pv.prop)
 	}
 	for _, ai := range pv.nested.arrayIndices {
-		idxPositions, release, err := metaBucket.RoaringSetGet(invnested.IdxKey(ai.RelPath, ai.Index))
+		positionsIdx, release, err := metaBucket.RoaringSetGet(invnested.IdxKey(ai.RelPath, ai.Index))
 		if err != nil {
-			return fmt.Errorf("nested [N] filter: read idx key for %q[%d]: %w", ai.RelPath, ai.Index, err)
+			return nil, fmt.Errorf("nested [N] filter: read idx key for %q[%d]: %w", ai.RelPath, ai.Index, err)
 		}
-		positions.And(idxPositions)
-		release()
+		dbmIdx := &docBitmap{docIDs: positionsIdx, release: release}
+		positions = mergeBitmapsAndOrWithDenyList(positions, dbmIdx, filters.OperatorAnd)
 	}
-	return nil
+	succeeded = true
+	return positions, nil
 }
 
 // positionBitmaps groups pre-fetched raw position bitmaps for a single nested path,
@@ -178,25 +194,37 @@ func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searche
 		return nil, fmt.Errorf("nested correlated AND: no condition groups for %q", pv.prop)
 	case 1:
 		return pv.resolveNestedCorrelatedGroup(ctx, s, groups[0])
-	default:
-		// Multiple groups with conflicting arr[N] constraints: resolve each group
-		// independently using same-element semantics, then AND the docID results.
-		first, err := pv.resolveNestedCorrelatedGroup(ctx, s, groups[0])
+	}
+
+	// Multiple groups with conflicting arr[N] constraints: resolve each group
+	// independently using same-element semantics, then AND the docID results.
+	dbm, err := pv.resolveNestedCorrelatedGroup(ctx, s, groups[0])
+	if err != nil {
+		return nil, err
+	}
+
+	// Release dbm's buffer on any non-success exit (error or panic).
+	// Cleared to a no-op once ownership is transferred to the caller.
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			dbm.release()
+		}
+	}()
+
+	for _, group := range groups[1:] {
+		groupDbm, err := pv.resolveNestedCorrelatedGroup(ctx, s, group)
 		if err != nil {
 			return nil, err
 		}
-		combined := first.docIDs
-		for _, group := range groups[1:] {
-			dbm, err := pv.resolveNestedCorrelatedGroup(ctx, s, group)
-			if err != nil {
-				return nil, err
-			}
-			combined.And(dbm.docIDs)
-		}
-		result := newDocBitmap()
-		result.docIDs = combined
-		return &result, nil
+		// mergeBitmapsAndOrWithDenyList selects the more efficient bitmap to
+		// accumulate into (smaller for AND), merges in-place, and defers
+		// release of the unused buffer — whether that is dbmGroup or the old
+		// dbm after an efficiency swap.
+		dbm = mergeBitmapsAndOrWithDenyList(dbm, groupDbm, filters.OperatorAnd)
 	}
+	succeeded = true
+	return dbm, nil
 }
 
 // resolveNestedCorrelatedGroup resolves a single set of children using
@@ -208,11 +236,23 @@ func (pv *propValuePair) resolveNestedCorrelatedGroup(ctx context.Context, s *Se
 	positionsByPath := make(map[string]*positionBitmaps, len(children))
 	paths := make([]string, 0, len(children))
 
+	// releases collects the pool-buffer release functions from every fetched
+	// position bitmap. They are deferred until after execute() returns, at
+	// which point the executor has finished reading all position bitmaps and
+	// it is safe to return the backing buffers to the pool.
+	var releases []func()
+	defer func() {
+		for _, rel := range releases {
+			rel()
+		}
+	}()
+
 	fetchAndRoute := func(leaf *propValuePair, isToken bool) error {
 		dbm, err := leaf.fetchNestedPositions(ctx, s, 0)
 		if err != nil {
 			return err
 		}
+		releases = append(releases, dbm.release)
 		path := leaf.nested.relPath
 		if _, exists := positionsByPath[path]; !exists {
 			positionsByPath[path] = &positionBitmaps{}
@@ -266,14 +306,14 @@ func (pv *propValuePair) resolveNestedCorrelatedGroup(ctx context.Context, s *Se
 		return nil, fmt.Errorf("nested correlated AND: build plan for %q: %w", pv.prop, err)
 	}
 
-	docIDs, err := newPlanExecutor(plan, positionsByPath, metaBucket).execute(ctx)
+	// TODO aliszka:nested_filtering concurrency.SROAR_MERGE is a fixed budget;
+	// consider deriving it from the request context or shard-level config.
+	docIDs, release, err := newPlanExecutor(plan, positionsByPath, metaBucket, s.nestedBitmapOps, concurrency.SROAR_MERGE).execute(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("nested correlated AND: execute for %q: %w", pv.prop, err)
 	}
 
-	dbm := newDocBitmap()
-	dbm.docIDs = docIDs
-	return &dbm, nil
+	return &docBitmap{docIDs: docIDs, release: release}, nil
 }
 
 // groupChildrenByArrayIndicesKey partitions the children of a correlated AND

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -153,8 +153,9 @@ func (pv *propValuePair) restrictByNestedIdx(s *Searcher, positions *docBitmap) 
 	if metaBucket == nil {
 		return nil, fmt.Errorf("nested [N] filter: meta bucket for %q not found — is it indexed?", pv.prop)
 	}
+	var keyBuf [invnested.IdxKeySize]byte
 	for _, ai := range pv.nested.arrayIndices {
-		positionsIdx, release, err := metaBucket.RoaringSetGet(invnested.IdxKey(ai.RelPath, ai.Index))
+		positionsIdx, release, err := metaBucket.RoaringSetGet(invnested.IdxKeyToBuf(ai.RelPath, ai.Index, keyBuf[:]))
 		if err != nil {
 			return nil, fmt.Errorf("nested [N] filter: read idx key for %q[%d]: %w", ai.RelPath, ai.Index, err)
 		}

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -102,7 +102,7 @@ func newNestedTestSearcher(t *testing.T, bucketNames ...string) (*Searcher, *lsm
 	}
 
 	bitmapFactory := roaringset.NewBitmapFactory(
-		roaringset.NewBitmapBufPoolNoop(), func() uint64 { return 1_000_000 })
+		newTrackingPool(t), func() uint64 { return 1_000_000 })
 
 	class := correlationTestClass()
 	searcher := NewSearcher(logger, store, func(string) *models.Class { return class },
@@ -186,6 +186,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -210,6 +212,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -250,6 +254,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -285,6 +291,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.True(t, result.docIDs.IsEmpty())
 	})
 
@@ -319,6 +327,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -352,6 +362,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -388,6 +400,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -476,6 +490,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -549,6 +565,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -610,6 +628,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -673,6 +693,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		pv := makeCorrelatedPvp(class, "cars", makePvp("make", "bmw"), widthPvp)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -771,6 +793,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -806,6 +830,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		}
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -829,6 +855,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.True(t, result.docIDs.IsEmpty())
 	})
 
@@ -937,6 +965,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -1019,6 +1049,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -1074,6 +1106,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -1111,6 +1145,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc3}, result.docIDs.ToArray())
 	})
 
@@ -1203,6 +1239,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -1280,6 +1318,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 	// -----------------------------------------------------------------------
@@ -1375,6 +1415,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -1444,6 +1486,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -1519,6 +1563,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -1601,6 +1647,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -1644,6 +1692,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
 
@@ -1720,6 +1770,8 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray(),
 			"doc7 must not match: tags in different cars collapse to same masked position "+
 				"but groupRunIdxLoop correctly requires them to be in the same car element")
@@ -1837,6 +1889,8 @@ func TestNestedIsNull(t *testing.T) {
 				pv := makeIsNullPvp(class, "addresses", "", tt.isNull)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.Equal(t, tt.wantIsDenyList, result.isDenyList)
 				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
 			})
@@ -1874,6 +1928,8 @@ func TestNestedIsNull(t *testing.T) {
 				pv := makeIsNullPvp(class, "addresses", "city", tt.isNull)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.Equal(t, tt.wantIsDenyList, result.isDenyList)
 				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
 			})
@@ -1911,6 +1967,8 @@ func TestNestedIsNull(t *testing.T) {
 				pv := makeIsNullPvp(class, "meta", "", tt.isNull)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.Equal(t, tt.wantIsDenyList, result.isDenyList)
 				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
 			})
@@ -1949,6 +2007,8 @@ func TestNestedIsNull(t *testing.T) {
 				pv := makeIsNullPvp(class, "meta", "isbn", tt.isNull)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.Equal(t, tt.wantIsDenyList, result.isDenyList)
 				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
 			})
@@ -1990,6 +2050,8 @@ func TestNestedIsNull(t *testing.T) {
 				pv := makeIsNullPvp(class, "container", "owner", tt.isNull)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.Equal(t, tt.wantIsDenyList, result.isDenyList)
 				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
 			})
@@ -2029,6 +2091,8 @@ func TestNestedIsNull(t *testing.T) {
 				pv := makeIsNullPvp(class, "container", "items", tt.isNull)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.Equal(t, tt.wantIsDenyList, result.isDenyList)
 				assert.Equal(t, tt.wantDocIDs, result.docIDs.ToArray())
 			})
@@ -2086,6 +2150,8 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc1}, result.docIDs.ToArray())
 	})
 
@@ -2107,6 +2173,8 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.True(t, result.docIDs.IsEmpty())
 	})
 
@@ -2130,6 +2198,8 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.False(t, result.isDenyList)
 		assert.Equal(t, []uint64{doc1}, result.docIDs.ToArray())
 	})
@@ -2160,6 +2230,8 @@ func TestNestedArrayIndexFilter(t *testing.T) {
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		// doc1 and doc3 both have addresses[1].city set; doc2 has no addresses[1]
 		assert.False(t, result.isDenyList)
 		assert.Equal(t, []uint64{doc1, doc3}, result.docIDs.ToArray())
@@ -2225,6 +2297,8 @@ func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc1}, result.docIDs.ToArray())
 	})
 
@@ -2265,6 +2339,8 @@ func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc1}, result.docIDs.ToArray())
 	})
 
@@ -2305,6 +2381,8 @@ func TestNestedArrayIndexFilterIntermediate(t *testing.T) {
 
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc1}, result.docIDs.ToArray())
 	})
 }
@@ -2427,7 +2505,7 @@ func newSearcherForClass(t *testing.T, class *models.Class, bucketNames ...strin
 			name, lsmkv.WithStrategy(lsmkv.StrategyRoaringSet)))
 	}
 	bitmapFactory := roaringset.NewBitmapFactory(
-		roaringset.NewBitmapBufPoolNoop(), func() uint64 { return 1_000_000 })
+		newTrackingPool(t), func() uint64 { return 1_000_000 })
 	searcher := NewSearcher(logger, store, func(string) *models.Class { return class },
 		nil, nil, stopwords.NewProvider(fakeStopwordDetector{}, nil), 2,
 		func() bool { return false }, nil, "",
@@ -3049,6 +3127,8 @@ func TestPlanCasesIntegration(t *testing.T) {
 
 					result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 					require.NoError(t, err)
+					defer result.release()
+					requireBitmapValid(t, result.docIDs)
 					assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 				})
 			}
@@ -3213,6 +3293,8 @@ func TestNestedFilteringComprehensive(t *testing.T) {
 				require.NoError(t, err)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.Equal(t, expected, result.docIDs.ToArray())
 			}
 
@@ -3522,6 +3604,8 @@ func TestNestedFilteringIsNull(t *testing.T) {
 				require.NoError(t, err)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.False(t, result.isDenyList)
 				assert.Equal(t, []uint64{doc5, doc7}, result.docIDs.ToArray())
 			})
@@ -3532,6 +3616,8 @@ func TestNestedFilteringIsNull(t *testing.T) {
 				require.NoError(t, err)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.True(t, result.isDenyList)
 				assert.Equal(t, []uint64{doc5, doc7}, result.docIDs.ToArray())
 			})
@@ -3543,6 +3629,8 @@ func TestNestedFilteringIsNull(t *testing.T) {
 				require.NoError(t, err)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.False(t, result.isDenyList)
 				assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 			})
@@ -3553,6 +3641,8 @@ func TestNestedFilteringIsNull(t *testing.T) {
 				require.NoError(t, err)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.True(t, result.isDenyList)
 				assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 			})
@@ -3570,6 +3660,8 @@ func TestNestedFilteringIsNull(t *testing.T) {
 					require.NoError(t, err)
 					result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 					require.NoError(t, err)
+					defer result.release()
+					requireBitmapValid(t, result.docIDs)
 					assert.False(t, result.isDenyList)
 					// doc5 (root=1) and doc8 (root=2) both have city → both returned
 					assert.Equal(t, []uint64{doc5, doc8}, result.docIDs.ToArray())
@@ -3641,6 +3733,8 @@ func TestNestedFilteringArrayIndex(t *testing.T) {
 				require.NoError(t, err)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 			})
 
@@ -3666,6 +3760,8 @@ func TestNestedFilteringArrayIndex(t *testing.T) {
 				require.NoError(t, err)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.True(t, result.docIDs.IsEmpty())
 			})
 
@@ -3718,6 +3814,8 @@ func TestNestedFilteringArrayIndex(t *testing.T) {
 				require.NoError(t, err)
 				result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 				require.NoError(t, err)
+				defer result.release()
+				requireBitmapValid(t, result.docIDs)
 				assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 			})
 
@@ -3755,6 +3853,8 @@ func TestNestedFilteringArrayIndex(t *testing.T) {
 					require.NoError(t, err)
 					result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 					require.NoError(t, err)
+					defer result.release()
+					requireBitmapValid(t, result.docIDs)
 					// Both doc5 (root=1, addresses[1]) and doc8 (root=2, addresses[1]) match
 					assert.Equal(t, []uint64{doc5, doc8}, result.docIDs.ToArray())
 				})
@@ -3844,6 +3944,8 @@ func TestNestedFilteringArrayIndexLevelsAndCombinations(t *testing.T) {
 		require.NoError(t, err)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, want, result.docIDs.ToArray())
 	}
 
@@ -4097,6 +4199,8 @@ func TestNestedFilteringIsNullAndMultiLevelArrayIndex(t *testing.T) {
 		require.NoError(t, err)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, want, result.docIDs.ToArray())
 	}
 	runDeny := func(t *testing.T, searcher *Searcher, f *filters.Clause, wantDeny bool, want []uint64) {
@@ -4105,6 +4209,8 @@ func TestNestedFilteringIsNullAndMultiLevelArrayIndex(t *testing.T) {
 		require.NoError(t, err)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, wantDeny, result.isDenyList)
 		assert.Equal(t, want, result.docIDs.ToArray())
 	}
@@ -4339,6 +4445,8 @@ func TestNestedFilteringMixedArrayIndexConstraints(t *testing.T) {
 		require.NoError(t, err)
 		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
 		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, want, result.docIDs.ToArray())
 	}
 

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/propertyspecific"
@@ -72,6 +73,7 @@ type Searcher struct {
 	// nestedCrossRefLimit limits the number of nested cross refs returned for a query
 	nestedCrossRefLimit int64
 	bitmapFactory       *roaringset.BitmapFactory
+	nestedBitmapOps     *invnested.BitmapOps
 	// tokResolver, when non-nil, overrides prop.Tokenization on query
 	// input analysis. Used by the per-shard tokenization overlay to
 	// keep query tokenization aligned with the bucket content during
@@ -137,6 +139,7 @@ func NewSearcher(logger logrus.FieldLogger, store *lsmkv.Store,
 		tenant:                  tenant,
 		nestedCrossRefLimit:     nestedCrossRefLimit,
 		bitmapFactory:           bitmapFactory,
+		nestedBitmapOps:         invnested.NewBitmapOps(bitmapFactory.BufPool()),
 	}
 }
 

--- a/adapters/repos/db/inverted/searcher_nested_executor.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor.go
@@ -24,27 +24,27 @@ import (
 )
 
 // planExecutor executes an executionPlan for a correlated nested AND filter.
-//
-// TODO aliszka:nested_filtering positionBitmaps bitmaps have no associated release
-// functions. Bitmaps fetched via fetchRawPositions may be backed by pooled
-// buffers that must be returned to the pool after use. Add a releases []func()
-// field and defer-call all of them at the end of execute() so pooled buffers
-// are correctly returned. See Option A in notes.
 type planExecutor struct {
 	plan            executionPlan
 	positionsByPath map[string]*positionBitmaps
 	metaBucket      *lsmkv.Bucket
+	bitmapOps       *invnested.BitmapOps
+	maxConcurrency  int
 }
 
 func newPlanExecutor(
 	plan executionPlan,
 	positionsByPath map[string]*positionBitmaps,
 	metaBucket *lsmkv.Bucket,
+	bitmapOps *invnested.BitmapOps,
+	maxConcurrency int,
 ) *planExecutor {
 	return &planExecutor{
 		plan:            plan,
 		positionsByPath: positionsByPath,
 		metaBucket:      metaBucket,
+		bitmapOps:       bitmapOps,
+		maxConcurrency:  maxConcurrency,
 	}
 }
 
@@ -54,19 +54,38 @@ func newPlanExecutor(
 // call — no intermediate bitmap is produced for those groups. groupAndAll results
 // (full-position bitmaps from AndAll) and groupRunIdxLoop results (already
 // leaf-masked) are each added as single entries and leaf-masked in the final step.
-func (e *planExecutor) execute(ctx context.Context) (*sroar.Bitmap, error) {
+func (e *planExecutor) execute(ctx context.Context) (*sroar.Bitmap, func(), error) {
+	// intermediateReleases collects pool-buffer releases for all bitmaps
+	// created within execute — token-combined bitmaps from collectRaw and
+	// groupAndAll results. They are all released after MaskRootLeaf produces
+	// the final result, at which point the executor no longer reads them.
+	var intermediateReleases []func()
+	defer func() {
+		for _, rel := range intermediateReleases {
+			rel()
+		}
+	}()
+
 	// finalBitmaps collects one entry per groupAndAll/groupRunIdxLoop result, and
 	// the raw bitmaps from each groupAndAllMaskLeaf group directly — avoiding the
 	// intermediate AndAllMaskLeaf allocation for those groups.
 	finalBitmaps := make([]*sroar.Bitmap, 0, len(e.plan))
 	for _, g := range e.plan {
-		raw, err := e.collectRaw(g.paths)
+		raw, rawReleases, err := e.collectRaw(g.paths)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
+		intermediateReleases = append(intermediateReleases, rawReleases...)
+
 		switch g.op {
 		case groupAndAll:
-			finalBitmaps = append(finalBitmaps, invnested.AndAll(raw))
+			if len(raw) == 1 {
+				finalBitmaps = append(finalBitmaps, raw[0])
+			} else {
+				result, release := e.bitmapOps.AndAll(raw, e.maxConcurrency)
+				intermediateReleases = append(intermediateReleases, release)
+				finalBitmaps = append(finalBitmaps, result)
+			}
 		case groupAndAllMaskLeaf:
 			// Fold raw bitmaps directly into the final AndAllMaskLeaf step.
 			// The final step masks each bitmap's leaf bits before ANDing, which
@@ -75,38 +94,55 @@ func (e *planExecutor) execute(ctx context.Context) (*sroar.Bitmap, error) {
 			finalBitmaps = append(finalBitmaps, raw...)
 		case groupRunIdxLoop:
 			if e.metaBucket == nil {
-				return nil, fmt.Errorf("execute: meta bucket is nil for idxLoop on %q", g.lcaPath)
+				return nil, nil, fmt.Errorf("execute: meta bucket is nil for idxLoop on %q", g.lcaPath)
 			}
-			result, err := e.runIdxLoop(ctx, g.lcaPath, raw)
+			result, release, err := e.runIdxLoop(ctx, g.lcaPath, raw)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
+			intermediateReleases = append(intermediateReleases, release)
 			finalBitmaps = append(finalBitmaps, result)
 		default:
-			return nil, fmt.Errorf("execute: unhandled group op %d", g.op)
+			return nil, nil, fmt.Errorf("execute: unhandled group op %d", g.op)
 		}
 	}
-	return invnested.MaskRootLeaf(invnested.AndAllMaskLeaf(finalBitmaps)), nil
+	masked, maskedRelease := e.bitmapOps.AndAllMaskLeaf(finalBitmaps, e.maxConcurrency)
+	intermediateReleases = append(intermediateReleases, maskedRelease)
+	final, finalRelease := e.bitmapOps.MaskRootLeaf(masked)
+	return final, finalRelease, nil
 }
 
 // collectRaw returns individual raw position bitmaps for all conditions across
 // the given paths: tokens for a path are pre-combined with AndAll (they must
 // share the exact same leaf position), each independent contributes its own
 // raw bitmap.
-func (e *planExecutor) collectRaw(paths []string) ([]*sroar.Bitmap, error) {
+//
+// The second return value contains release functions for the pool-backed
+// token-combined bitmaps created here. Independent bitmaps are direct
+// references to input bitmaps owned by the caller — no releases for those.
+func (e *planExecutor) collectRaw(paths []string) ([]*sroar.Bitmap, []func(), error) {
 	var bitmaps []*sroar.Bitmap
+	var releases []func()
 	for _, path := range paths {
 		positions, ok := e.positionsByPath[path]
 		if !ok {
-			return nil, fmt.Errorf("collectRaw: no positions for path %q", path)
+			return nil, nil, fmt.Errorf("collectRaw: no positions for path %q", path)
 		}
-		if len(positions.tokens) > 0 {
-			// Tokens must share the exact same leaf position — combine first.
-			bitmaps = append(bitmaps, invnested.AndAll(positions.tokens))
+		switch len(positions.tokens) {
+		case 0:
+			// nothing
+		case 1:
+			// Single token: no merge needed, reuse directly without cloning.
+			bitmaps = append(bitmaps, positions.tokens[0])
+		default:
+			// Multiple tokens must share the exact same leaf position — combine first.
+			combined, release := e.bitmapOps.AndAll(positions.tokens, e.maxConcurrency)
+			bitmaps = append(bitmaps, combined)
+			releases = append(releases, release)
 		}
 		bitmaps = append(bitmaps, positions.independent...)
 	}
-	return bitmaps, nil
+	return bitmaps, releases, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -149,12 +185,13 @@ func (e *planExecutor) runIdxLoop(
 	ctx context.Context,
 	lcaPath string,
 	positionBitmaps []*sroar.Bitmap,
-) (*sroar.Bitmap, error) {
+) (*sroar.Bitmap, func(), error) {
 	if len(positionBitmaps) == 0 {
-		return nil, fmt.Errorf("runIdxLoop: no position bitmaps provided for path %q", lcaPath)
+		return nil, nil, fmt.Errorf("runIdxLoop: no position bitmaps provided for path %q", lcaPath)
 	}
 	if len(positionBitmaps) == 1 {
-		return invnested.MaskLeaf(positionBitmaps[0]), nil
+		result, release := e.bitmapOps.MaskLeaf(positionBitmaps[0])
+		return result, release, nil
 	}
 
 	sorted := slices.Clone(positionBitmaps)
@@ -164,25 +201,35 @@ func (e *planExecutor) runIdxLoop(
 	}
 	sort.Sort(bitmapsByCard{sorted, cards})
 
-	preFilter := invnested.AndAllMaskLeaf(sorted)
+	preFilter, releasePreFilter := e.bitmapOps.AndAllMaskLeaf(sorted, e.maxConcurrency)
+	defer releasePreFilter()
+
 	preFilterCard := preFilter.GetCardinality()
 	if preFilterCard == 0 {
-		return sroar.NewBitmap(), nil
+		return sroar.NewBitmap(), func() {}, nil
 	}
 
 	if err := ctxExpired(ctx); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	idxPrefix := invnested.PathPrefix("_idx." + lcaPath)
-	result := sroar.NewBitmap()
+	// result accumulates via Or and is bounded by preFilter (result ⊆ preFilter),
+	// so preFilter's size is a reliable upper bound for the pool buffer.
+	result, releaseResult := e.bitmapOps.NewEmpty(preFilter.LenInBytes())
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			releaseResult()
+		}
+	}()
 
 	c := e.metaBucket.CursorRoaringSet()
 	defer c.Close()
 
 	for k, elemBitmap := c.Seek(invnested.IdxKey(lcaPath, 0)); k != nil; k, elemBitmap = c.Next() {
 		if err := ctxExpired(ctx); err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if !bytes.HasPrefix(k, idxPrefix) {
 			break
@@ -190,28 +237,52 @@ func (e *planExecutor) runIdxLoop(
 		if elemBitmap.IsEmpty() {
 			continue
 		}
-
-		if invnested.AndWithMaskLeaf(preFilter, elemBitmap).IsEmpty() {
+		if !e.matchElement(result, sorted, preFilter, elemBitmap) {
 			continue
 		}
-
-		partial := invnested.MaskLeafAnd(sorted[0], elemBitmap)
-		empty := partial.IsEmpty()
-		for _, bm := range sorted[1:] {
-			if empty {
-				break
-			}
-			partial.And(invnested.MaskLeafAnd(bm, elemBitmap))
-			empty = partial.IsEmpty()
-		}
-
-		if !empty {
-			result.Or(partial)
-			if result.GetCardinality() >= preFilterCard {
-				break
-			}
+		if result.GetCardinality() >= preFilterCard {
+			break
 		}
 	}
 
-	return result, nil
+	succeeded = true
+	return result, releaseResult, nil
+}
+
+// matchElement checks whether all conditions in sorted satisfy the same array
+// element (represented by elemBitmap) and, if so, ORs the per-element result
+// into acc. Returns true when at least one document matched.
+//
+// All intermediate pool buffers (pre-check, partial accumulator, per-condition
+// temporaries) are released before the method returns, including on panic.
+func (e *planExecutor) matchElement(acc *sroar.Bitmap, sorted []*sroar.Bitmap, preFilter, elemBitmap *sroar.Bitmap) bool {
+	// Pre-check: skip element if it cannot possibly satisfy all conditions.
+	// preFilter is already leaf-masked; AndMaskLeaf clones it cheaply and
+	// masks only elemBitmap's leaf bits so (root, docID) pairs are compared.
+	check, releaseCheck := e.bitmapOps.AndMaskLeaf(preFilter, elemBitmap, e.maxConcurrency)
+	defer releaseCheck()
+	if check.IsEmpty() {
+		return false
+	}
+
+	// Compute the intersection of all conditions within this element.
+	partial, releasePartial := e.bitmapOps.MaskLeafAnd(sorted[0], elemBitmap)
+	defer releasePartial()
+
+	for _, bm := range sorted[1:] {
+		if partial.IsEmpty() {
+			break
+		}
+		func() {
+			inner, releaseInner := e.bitmapOps.MaskLeafAnd(bm, elemBitmap)
+			defer releaseInner()
+			partial.AndConc(inner, e.maxConcurrency)
+		}()
+	}
+
+	if partial.IsEmpty() {
+		return false
+	}
+	acc.OrConc(partial, e.maxConcurrency)
+	return true
 }

--- a/adapters/repos/db/inverted/searcher_nested_executor.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor.go
@@ -257,11 +257,9 @@ func (e *planExecutor) runIdxLoop(
 // temporaries) are released before the method returns, including on panic.
 func (e *planExecutor) matchElement(acc *sroar.Bitmap, sorted []*sroar.Bitmap, preFilter, elemBitmap *sroar.Bitmap) bool {
 	// Pre-check: skip element if it cannot possibly satisfy all conditions.
-	// preFilter is already leaf-masked; AndMaskLeaf clones it cheaply and
-	// masks only elemBitmap's leaf bits so (root, docID) pairs are compared.
-	check, releaseCheck := e.bitmapOps.AndMaskLeaf(preFilter, elemBitmap, e.maxConcurrency)
-	defer releaseCheck()
-	if check.IsEmpty() {
+	// preFilter is already leaf-masked; IntersectsMaskedLeaf zeroes elemBitmap's
+	// leaf bits and checks for overlap without allocating — cheap fast-reject.
+	if !e.bitmapOps.IntersectsMaskedLeaf(preFilter, elemBitmap) {
 		return false
 	}
 

--- a/adapters/repos/db/inverted/searcher_nested_executor_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_integration_test.go
@@ -16,10 +16,12 @@ package inverted
 import (
 	"context"
 	"testing"
+	"unsafe"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
@@ -60,25 +62,26 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		doc9 = uint64(9)
 	)
 
-	noop := invnested.NewBitmapOps(roaringset.NewBitmapBufPoolNoop())
-
 	// -------------------------------------------------------------------------
 	// Preconditions requiring a real (non-nil) bucket
 	// -------------------------------------------------------------------------
 
 	t.Run("one bitmap returns MaskRootLeaf fast-path without cursor scan", func(t *testing.T) {
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		// Write an idx entry that would produce a different result if scanned.
 		writeIdx(t, bucket, "cars", 0, []uint64{invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5)})
 
 		plan, bitmapsByPath := idxLoopPlan("cars", roaringset.NewBitmap(invnested.Encode(1, 1, doc5)))
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
 		// Fast-path: returns MaskRootLeaf(bitmap[0]), ignoring the bucket entirely.
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
 
 	t.Run("context already cancelled returns error", func(t *testing.T) {
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{invnested.Encode(1, 1, doc5)})
 
@@ -89,7 +92,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 			roaringset.NewBitmap(invnested.Encode(1, 1, doc5)),
 			roaringset.NewBitmap(invnested.Encode(1, 2, doc5)),
 		)
-		_, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(ctx)
+		_, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(ctx)
 		require.Error(t, err)
 	})
 
@@ -102,6 +105,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		// condA = tires.width matches at root=1,leaf=1
 		// condB = accessories.type matches at root=1,leaf=2
 		// Both are within cars[0] → should return doc5.
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
 			invnested.Encode(1, 1, doc5), // leaf=1 (tires[0].width)
@@ -111,13 +115,16 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5))
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5))
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
 
 	t.Run("two conditions in different elements — empty result", func(t *testing.T) {
 		// condA matches cars[0], condB matches cars[1] — different elements.
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{invnested.Encode(1, 1, doc5)})
 		writeIdx(t, bucket, "cars", 1, []uint64{invnested.Encode(2, 1, doc5)})
@@ -125,13 +132,16 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5)) // in cars[0]
 		condB := roaringset.NewBitmap(invnested.Encode(2, 1, doc5)) // in cars[1]
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
 	})
 
 	t.Run("two conditions both in element 1 (not element 0) — doc returned", func(t *testing.T) {
 		// Verifies that the cursor scans past element 0 to find the match in element 1.
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{invnested.Encode(1, 1, doc5)}) // condA only
 		writeIdx(t, bucket, "cars", 1, []uint64{
@@ -142,12 +152,15 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(2, 1, doc5)) // in cars[1]
 		condB := roaringset.NewBitmap(invnested.Encode(2, 2, doc5)) // in cars[1]
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
 
 	t.Run("three conditions all in same element — doc returned", func(t *testing.T) {
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
 			invnested.Encode(1, 1, doc5),
@@ -159,12 +172,15 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5))
 		condC := roaringset.NewBitmap(invnested.Encode(1, 3, doc5))
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB, condC)
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
 
 	t.Run("three conditions — two in element 0, third only in element 1 — empty", func(t *testing.T) {
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
 			invnested.Encode(1, 1, doc5),
@@ -176,8 +192,10 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5)) // cars[0]
 		condC := roaringset.NewBitmap(invnested.Encode(2, 1, doc5)) // cars[1] only
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB, condC)
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
 	})
 
@@ -188,6 +206,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 	t.Run("two docs — one matches same element, one has split conditions", func(t *testing.T) {
 		// doc5: condA and condB both in cars[0] → match
 		// doc7: condA in cars[0], condB in cars[1] → no match
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
 			invnested.Encode(1, 1, doc5),
@@ -201,12 +220,15 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5), invnested.Encode(1, 1, doc7))
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5), invnested.Encode(2, 1, doc7))
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
 
 	t.Run("two docs both satisfy conditions in their respective elements", func(t *testing.T) {
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
 			invnested.Encode(1, 1, doc5),
@@ -218,8 +240,10 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5), invnested.Encode(1, 1, doc7))
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5), invnested.Encode(1, 2, doc7))
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{doc5, doc7}, result.ToArray())
 	})
 
@@ -227,6 +251,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		// doc5: condA in cars[0], condB in cars[1] → no match
 		// doc7: condA and condB both in cars[0]     → match
 		// doc9: condA in cars[0], condB in cars[1] → no match
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
 			invnested.Encode(1, 1, doc5),
@@ -242,8 +267,10 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5), invnested.Encode(1, 1, doc7), invnested.Encode(1, 1, doc9))
 		condB := roaringset.NewBitmap(invnested.Encode(2, 1, doc5), invnested.Encode(1, 2, doc7), invnested.Encode(2, 1, doc9))
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{doc7}, result.ToArray())
 	})
 
@@ -254,6 +281,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 	t.Run("preFilter empty — cursor never opened", func(t *testing.T) {
 		// condA matches doc5, condB matches doc7 — no overlap at root+docID level,
 		// so preFilter is empty and the function returns early.
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{
 			invnested.Encode(1, 1, doc5),
@@ -263,39 +291,48 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5)) // only doc5
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc7)) // only doc7
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
 	})
 
 	t.Run("no idx entries for path — empty result", func(t *testing.T) {
 		// Bucket exists but has no _idx.cars entries.
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5))
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5))
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
 	})
 
 	t.Run("conditions match but no idx entry covers both positions — empty", func(t *testing.T) {
 		// Both conditions match doc5, but the idx entry for element 0 only covers
 		// condA's position — condB's position is absent from that element.
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		writeIdx(t, bucket, "cars", 0, []uint64{invnested.Encode(1, 1, doc5)}) // only leaf=1
 
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5))
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5)) // leaf=2 not in element 0
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
 	})
 
 	t.Run("multiple elements only one contains both conditions", func(t *testing.T) {
 		// Five elements, conditions only co-occur in element 3.
+		ops := newLifecycleOps(t)
 		bucket := newIdxBucket(t)
 		for i := 0; i < 5; i++ {
 			root := uint16(i + 1)
@@ -312,8 +349,51 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(4, 1, doc5)) // only in element 3 (root=4)
 		condB := roaringset.NewBitmap(invnested.Encode(4, 2, doc5)) // only in element 3 (root=4)
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
+		result, release, err := newPlanExecutor(plan, bitmapsByPath, bucket, ops, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
+}
+
+// newTrackingPool creates a BitmapBufPoolTracking and registers a t.Cleanup
+// that fails the test if any buffer remains unreleased when the (sub)test
+// completes. The pool zeroes backing buffers on release so that any bitmap
+// read after its release returns zeros, making premature releases visible as
+// wrong values in assertions.
+func newTrackingPool(t *testing.T) *roaringset.BitmapBufPoolTracking {
+	t.Helper()
+	pool := roaringset.NewBitmapBufPoolTracking()
+	t.Cleanup(func() {
+		if n := pool.Outstanding(); n != 0 {
+			t.Errorf("pool: %d bitmap buffer(s) not released", n)
+		}
+	})
+	return pool
+}
+
+// requireBitmapValid asserts that bm's backing buffer has not been zeroed by
+// the tracking pool's release function. It reads n[indexNumKeys] — the second
+// uint64 in bm.data — which sroar always initialises to 1 (sentinel key=0x00
+// container). A zeroed buffer has 0, indicating premature release.
+//
+// TODO aliszka:nested_filtering replace unsafe read with bm.NumKeys() once
+// that method is exposed by the sroar library.
+func requireBitmapValid(t *testing.T, bm *sroar.Bitmap) {
+	t.Helper()
+	require.NotNil(t, bm)
+	// TODO aliszka:nested_filtering remove unsafe once sroar exposes NumKeys().
+	// bm.data []uint16 is the first field of sroar.Bitmap. Its backing array
+	// pointer is at offset 0 of the struct. n[indexNumKeys] is at byte offset 8
+	// (second uint64) within that array.
+	dataPtr := *(*unsafe.Pointer)(unsafe.Pointer(bm))
+	numKeys := *(*uint64)(unsafe.Pointer(uintptr(dataPtr) + 8))
+	require.Positive(t, numKeys, "bitmap backing buffer is zeroed — premature release?")
+}
+
+// newLifecycleOps returns a BitmapOps backed by a tracking pool.
+func newLifecycleOps(t *testing.T) *invnested.BitmapOps {
+	t.Helper()
+	return invnested.NewBitmapOps(newTrackingPool(t))
 }

--- a/adapters/repos/db/inverted/searcher_nested_executor_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_integration_test.go
@@ -23,6 +23,7 @@ import (
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/cyclemanager"
 )
 
@@ -59,6 +60,8 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		doc9 = uint64(9)
 	)
 
+	noop := invnested.NewBitmapOps(roaringset.NewBitmapBufPoolNoop())
+
 	// -------------------------------------------------------------------------
 	// Preconditions requiring a real (non-nil) bucket
 	// -------------------------------------------------------------------------
@@ -69,7 +72,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		writeIdx(t, bucket, "cars", 0, []uint64{invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5)})
 
 		plan, bitmapsByPath := idxLoopPlan("cars", roaringset.NewBitmap(invnested.Encode(1, 1, doc5)))
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		// Fast-path: returns MaskRootLeaf(bitmap[0]), ignoring the bucket entirely.
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
@@ -86,7 +89,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 			roaringset.NewBitmap(invnested.Encode(1, 1, doc5)),
 			roaringset.NewBitmap(invnested.Encode(1, 2, doc5)),
 		)
-		_, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(ctx)
+		_, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(ctx)
 		require.Error(t, err)
 	})
 
@@ -108,7 +111,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5))
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5))
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
@@ -122,7 +125,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5)) // in cars[0]
 		condB := roaringset.NewBitmap(invnested.Encode(2, 1, doc5)) // in cars[1]
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -139,7 +142,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(2, 1, doc5)) // in cars[1]
 		condB := roaringset.NewBitmap(invnested.Encode(2, 2, doc5)) // in cars[1]
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
@@ -156,7 +159,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5))
 		condC := roaringset.NewBitmap(invnested.Encode(1, 3, doc5))
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB, condC)
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
@@ -173,7 +176,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5)) // cars[0]
 		condC := roaringset.NewBitmap(invnested.Encode(2, 1, doc5)) // cars[1] only
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB, condC)
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -198,7 +201,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5), invnested.Encode(1, 1, doc7))
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5), invnested.Encode(2, 1, doc7))
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
@@ -215,7 +218,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5), invnested.Encode(1, 1, doc7))
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5), invnested.Encode(1, 2, doc7))
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5, doc7}, result.ToArray())
 	})
@@ -239,7 +242,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5), invnested.Encode(1, 1, doc7), invnested.Encode(1, 1, doc9))
 		condB := roaringset.NewBitmap(invnested.Encode(2, 1, doc5), invnested.Encode(1, 2, doc7), invnested.Encode(2, 1, doc9))
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc7}, result.ToArray())
 	})
@@ -260,7 +263,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5)) // only doc5
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc7)) // only doc7
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -272,7 +275,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5))
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5))
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -286,7 +289,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(1, 1, doc5))
 		condB := roaringset.NewBitmap(invnested.Encode(1, 2, doc5)) // leaf=2 not in element 0
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -309,7 +312,7 @@ func TestExecuteResolutionPlanIdxLoopIntegration(t *testing.T) {
 		condA := roaringset.NewBitmap(invnested.Encode(4, 1, doc5)) // only in element 3 (root=4)
 		condB := roaringset.NewBitmap(invnested.Encode(4, 2, doc5)) // only in element 3 (root=4)
 		plan, bitmapsByPath := idxLoopPlan("cars", condA, condB)
-		result, err := newPlanExecutor(plan, bitmapsByPath, bucket).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, bucket, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})

--- a/adapters/repos/db/inverted/searcher_nested_executor_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_integration_test.go
@@ -16,7 +16,6 @@ package inverted
 import (
 	"context"
 	"testing"
-	"unsafe"
 
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
@@ -374,22 +373,13 @@ func newTrackingPool(t *testing.T) *roaringset.BitmapBufPoolTracking {
 }
 
 // requireBitmapValid asserts that bm's backing buffer has not been zeroed by
-// the tracking pool's release function. It reads n[indexNumKeys] — the second
-// uint64 in bm.data — which sroar always initialises to 1 (sentinel key=0x00
-// container). A zeroed buffer has 0, indicating premature release.
-//
-// TODO aliszka:nested_filtering replace unsafe read with bm.NumKeys() once
-// that method is exposed by the sroar library.
+// the tracking pool's release function. sroar always initialises the bitmap
+// with one sentinel container (key=0x00), so NumContainers() >= 1 indicates a
+// live buffer; a zeroed buffer reports 0.
 func requireBitmapValid(t *testing.T, bm *sroar.Bitmap) {
 	t.Helper()
 	require.NotNil(t, bm)
-	// TODO aliszka:nested_filtering remove unsafe once sroar exposes NumKeys().
-	// bm.data []uint16 is the first field of sroar.Bitmap. Its backing array
-	// pointer is at offset 0 of the struct. n[indexNumKeys] is at byte offset 8
-	// (second uint64) within that array.
-	dataPtr := *(*unsafe.Pointer)(unsafe.Pointer(bm))
-	numKeys := *(*uint64)(unsafe.Pointer(uintptr(dataPtr) + 8))
-	require.Positive(t, numKeys, "bitmap backing buffer is zeroed — premature release?")
+	require.Positive(t, bm.NumContainers(), "bitmap backing buffer is zeroed — premature release?")
 }
 
 // newLifecycleOps returns a BitmapOps backed by a tracking pool.

--- a/adapters/repos/db/inverted/searcher_nested_executor_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/sroar"
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	"github.com/weaviate/weaviate/entities/concurrency"
 )
 
 // ---------------------------------------------------------------------------
@@ -67,7 +68,8 @@ func idxLoopPlan(lcaPath string, bitmaps ...*sroar.Bitmap) (executionPlan, map[s
 // exec is a shorthand for executing a plan with no meta bucket.
 func exec(t *testing.T, plan executionPlan, bitmapsByPath map[string]*positionBitmaps) *sroar.Bitmap {
 	t.Helper()
-	result, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+	noop := invnested.NewBitmapOps(roaringset.NewBitmapBufPoolNoop())
+	result, _, err := newPlanExecutor(plan, bitmapsByPath, nil, noop, concurrency.SROAR_MERGE).execute(context.Background())
 	require.NoError(t, err)
 	return result
 }
@@ -222,6 +224,7 @@ func TestExecuteResolutionPlanMaskLeafAnd(t *testing.T) {
 func TestExecuteResolutionPlanPreconditions(t *testing.T) {
 	pos511 := invnested.Encode(1, 1, 5)
 	pos512 := invnested.Encode(1, 2, 5)
+	noop := invnested.NewBitmapOps(roaringset.NewBitmapBufPoolNoop())
 
 	t.Run("groupAndAll: two independents at different leaves — no match (raw AndAll, leaf-aware)", func(t *testing.T) {
 		// groupAndAll uses raw AndAll. Two bitmaps at DIFFERENT leaf positions
@@ -233,7 +236,7 @@ func TestExecuteResolutionPlanPreconditions(t *testing.T) {
 				roaringset.NewBitmap(pos512),
 			}},
 		}
-		result, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, nil, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty())
 	})
@@ -243,7 +246,7 @@ func TestExecuteResolutionPlanPreconditions(t *testing.T) {
 			roaringset.NewBitmap(pos511),
 			roaringset.NewBitmap(pos512),
 		)
-		_, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+		_, _, err := newPlanExecutor(plan, bitmapsByPath, nil, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "meta bucket is nil")
 	})
@@ -254,7 +257,7 @@ func TestExecuteResolutionPlanPreconditions(t *testing.T) {
 			"p1": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos511)}},
 			// "p_missing" intentionally absent
 		}
-		_, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+		_, _, err := newPlanExecutor(plan, bitmapsByPath, nil, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "p_missing")
 	})
@@ -273,6 +276,7 @@ func TestExecuteMultiGroupPlan(t *testing.T) {
 	pos521 := invnested.Encode(2, 1, doc5) // root=2, leaf=1, doc=5
 	pos711 := invnested.Encode(1, 1, doc7) // root=1, leaf=1, doc=7
 	pos721 := invnested.Encode(2, 1, doc7) // root=2, leaf=1, doc=7
+	noop := invnested.NewBitmapOps(roaringset.NewBitmapBufPoolNoop())
 
 	t.Run("two groupAndAll groups — cross-group AndAllMaskLeaf aligns on root+docID", func(t *testing.T) {
 		// Group 1 (addresses): city bitmap at pos511 (root=1, doc=5) and pos711 (root=1, doc=7)
@@ -290,7 +294,7 @@ func TestExecuteMultiGroupPlan(t *testing.T) {
 			"city": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos511, pos711)}},
 			"make": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos521, pos721)}},
 		}
-		result, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, nil, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.True(t, result.IsEmpty()) // different root → cross-group AND gives empty
 	})
@@ -307,7 +311,7 @@ func TestExecuteMultiGroupPlan(t *testing.T) {
 			"city": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos511)}},
 			"make": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos511)}},
 		}
-		result, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, nil, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})
@@ -326,7 +330,7 @@ func TestExecuteMultiGroupPlan(t *testing.T) {
 			"city": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos511)}},
 			"tags": {independent: []*sroar.Bitmap{roaringset.NewBitmap(pos511), roaringset.NewBitmap(pos512)}},
 		}
-		result, err := newPlanExecutor(plan, bitmapsByPath, nil).execute(context.Background())
+		result, _, err := newPlanExecutor(plan, bitmapsByPath, nil, noop, concurrency.SROAR_MERGE).execute(context.Background())
 		require.NoError(t, err)
 		assert.Equal(t, []uint64{doc5}, result.ToArray())
 	})

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -18,7 +18,9 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
 	"github.com/weaviate/weaviate/entities/filters"
 	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
@@ -74,6 +76,7 @@ func newTestSearcher() *Searcher {
 		stopwordProvider:       stopwords.NewProvider(fakeStopwordDetector{}, nil),
 		isFallbackToSearchable: func() bool { return false },
 		logger:                 logger,
+		nestedBitmapOps:        invnested.NewBitmapOps(roaringset.NewBitmapBufPoolNoop()),
 	}
 }
 

--- a/adapters/repos/db/roaringset/buf_pool.go
+++ b/adapters/repos/db/roaringset/buf_pool.go
@@ -17,6 +17,7 @@ import (
 	"math/bits"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/dustin/go-humanize"
@@ -81,6 +82,45 @@ func (p *bitmapBufPoolNoop) Get(minCap int) (buf []byte, put func()) {
 
 func (p *bitmapBufPoolNoop) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
 	return cloneToBuf(p, bm)
+}
+
+// -----------------------------------------------------------------------------
+
+// BitmapBufPoolTracking is a pool for use in tests. It tracks outstanding
+// allocations and zeroes the backing buffer on release, so that any bitmap
+// read after its release returns zeros — making premature releases visible as
+// wrong values in test assertions. Double-release panics immediately.
+//
+// Call Outstanding() in a t.Cleanup to assert all buffers were released.
+type BitmapBufPoolTracking struct {
+	outstanding atomic.Int64
+}
+
+func NewBitmapBufPoolTracking() *BitmapBufPoolTracking {
+	return &BitmapBufPoolTracking{}
+}
+
+func (p *BitmapBufPoolTracking) Get(minCap int) (buf []byte, put func()) {
+	p.outstanding.Add(1)
+	buf = make([]byte, 0, max(minCap, 0))
+	var released atomic.Bool
+	return buf, func() {
+		if !released.CompareAndSwap(false, true) {
+			panic("bitmap buffer released twice")
+		}
+		clear(buf[:cap(buf)])
+		p.outstanding.Add(-1)
+	}
+}
+
+func (p *BitmapBufPoolTracking) CloneToBuf(bm *sroar.Bitmap) (cloned *sroar.Bitmap, put func()) {
+	return cloneToBuf(p, bm)
+}
+
+// Outstanding returns the number of buffers that have been allocated but not
+// yet released. A non-zero value at the end of a test indicates a leak.
+func (p *BitmapBufPoolTracking) Outstanding() int64 {
+	return p.outstanding.Load()
 }
 
 // -----------------------------------------------------------------------------

--- a/adapters/repos/db/roaringset/buf_pool_test.go
+++ b/adapters/repos/db/roaringset/buf_pool_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/sroar"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 )
 
@@ -847,4 +848,86 @@ func TestValidateBufferRanges(t *testing.T) {
 			require.Equal(t, tc.expectedRanges, ranges)
 		})
 	}
+}
+
+func TestBitmapBufPoolTracking_Get(t *testing.T) {
+	t.Run("outstanding increments on Get and decrements on release", func(t *testing.T) {
+		pool := NewBitmapBufPoolTracking()
+		assert.Equal(t, int64(0), pool.Outstanding())
+
+		_, rel1 := pool.Get(64)
+		assert.Equal(t, int64(1), pool.Outstanding())
+
+		_, rel2 := pool.Get(64)
+		assert.Equal(t, int64(2), pool.Outstanding())
+
+		rel1()
+		assert.Equal(t, int64(1), pool.Outstanding())
+
+		rel2()
+		assert.Equal(t, int64(0), pool.Outstanding())
+	})
+
+	t.Run("release zeroes backing buffer", func(t *testing.T) {
+		pool := NewBitmapBufPoolTracking()
+		buf, release := pool.Get(64)
+		// Write into the backing array through the cap slice.
+		full := buf[:cap(buf)]
+		full[0] = 0xFF
+		full[cap(buf)-1] = 0xFF
+
+		release()
+
+		// Backing array must be zeroed after release.
+		for i, b := range full {
+			if b != 0 {
+				t.Errorf("buf[%d] = %d after release, want 0", i, b)
+			}
+		}
+	})
+
+	t.Run("double release panics", func(t *testing.T) {
+		pool := NewBitmapBufPoolTracking()
+		_, release := pool.Get(64)
+		release()
+		assert.Panics(t, release)
+	})
+}
+
+func TestBitmapBufPoolTracking_CloneToBuf(t *testing.T) {
+	t.Run("outstanding increments on CloneToBuf and decrements on release", func(t *testing.T) {
+		pool := NewBitmapBufPoolTracking()
+
+		bm := sroar.NewBitmap()
+		bm.SetMany([]uint64{1, 2, 3})
+
+		cloned, release := pool.CloneToBuf(bm)
+		assert.Equal(t, int64(1), pool.Outstanding())
+		assert.Equal(t, bm.ToArray(), cloned.ToArray())
+
+		release()
+		assert.Equal(t, int64(0), pool.Outstanding())
+	})
+
+	t.Run("release zeroes cloned bitmap backing buffer", func(t *testing.T) {
+		pool := NewBitmapBufPoolTracking()
+
+		bm := sroar.NewBitmap()
+		bm.SetMany([]uint64{10, 20, 30})
+
+		cloned, release := pool.CloneToBuf(bm)
+		assert.False(t, cloned.IsEmpty())
+
+		// ToBuffer returns a view into the backing memory while the bitmap is
+		// non-empty. Capture it before release so we can inspect it afterward.
+		full := cloned.ToBuffer()
+		release()
+
+		// Backing array must be zeroed after release.
+		for i, b := range full {
+			if b != 0 {
+				t.Errorf("buf[%d] = %d after release, want 0", i, b)
+			}
+		}
+	})
 }

--- a/adapters/repos/db/roaringset/helpers.go
+++ b/adapters/repos/db/roaringset/helpers.go
@@ -72,6 +72,11 @@ func NewBitmapFactory(bufPool BitmapBufPool, maxIdGetter MaxIdGetterFunc) *Bitma
 	}
 }
 
+// BufPool returns the underlying buffer pool used by this factory.
+func (bmf *BitmapFactory) BufPool() BitmapBufPool {
+	return bmf.bufPool
+}
+
 // GetBitmap returns a prefilled bitmap, which is cloned from a shared internal.
 // This method is safe to call concurrently. The purpose behind sharing an
 // internal bitmap, is that a Clone() operation is cheaper than prefilling

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/weaviate/fgprof v0.0.1
 	github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2
 	github.com/weaviate/s5cmd/v2 v2.0.1
-	github.com/weaviate/sroar v0.0.14-0.20260407105840-f1351692405c
+	github.com/weaviate/sroar v0.0.14-0.20260425092300-c79995b0f0ba
 	github.com/weaviate/tiktoken-go v0.0.3
 	go.etcd.io/bbolt v1.4.3
 	go.opentelemetry.io/otel v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -687,8 +687,8 @@ github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2 h1:lJpPgu+7Vx9K2
 github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2/go.mod h1:6cErcTSXUX3sGQEY+FQlxBztdlzVPoArKdMRNq6XKlE=
 github.com/weaviate/s5cmd/v2 v2.0.1 h1:NLsBemDEeUa1pcqVAGl5Y2quKH8EFpkz/Z8n4s620hg=
 github.com/weaviate/s5cmd/v2 v2.0.1/go.mod h1:JEoBF8SXVwK8qoaRKi0fPA4qi4OFmr+iVgc4XO3l/Zs=
-github.com/weaviate/sroar v0.0.14-0.20260407105840-f1351692405c h1:g/D24on7qR0hxroUkvxtCnn9kQKl4FstM3rxlNYZ+Qg=
-github.com/weaviate/sroar v0.0.14-0.20260407105840-f1351692405c/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
+github.com/weaviate/sroar v0.0.14-0.20260425092300-c79995b0f0ba h1:ZVaa77mn6lSiMuHT3euZ/Xa7EinjJnB9iBi3CURyPC8=
+github.com/weaviate/sroar v0.0.14-0.20260425092300-c79995b0f0ba/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/tiktoken-go v0.0.3 h1:05QrZ0un7zoGyLYBWVK4HuxVHfpdbbdRfQokvxBNtXg=
 github.com/weaviate/tiktoken-go v0.0.3/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=


### PR DESCRIPTION
### Nested object filtering — Part 10

  Tenth PR in the nested object filtering series, building on Part 9 (flat execution plan and arr[N] cross-index fix). This PR   introduces pool-backed bitmap operations throughout the nested filter executor, fixes all buffer lifecycle issues, and adds test infrastructure for lifecycle correctness verification.

  **Pool-backed BitmapOps**

  New `BitmapOps` struct in `nested/bitmap.go` wraps all bitmap merge operations used by the nested filter executor. Each method returns `(result, release func())` so callers can return pool buffers as soon as they are no longer needed, reducing GC pressure on the hot resolution path. Input/output bitmap types use `raw`/`rootDoc`/`doc` naming to communicate operand semantics:
  `MaskLeaf(raw)→rootDoc`, `MaskRootLeaf(positions)→doc`, `AndAll/AndAllMaskLeaf(raws)→raw/rootDoc`, `MaskLeafAnd(rawA,rawB)→rootDoc` (fused AND+mask), `AndMaskLeaf(rootDoc,raw)→result` (clones rootDoc cheaply, masks only raw).

  **Executor lifecycle**

  `planExecutor` gains a `maxConcurrency` field; all merges use concurrent sroar operations. `execute()` defers all intermediate releases; `runIdxLoop()` is pool-backed with a `succeeded` flag; `matchElement()` is extracted from `runIdxLoop` and owns its intermediate buffers via `defer`. `prop_value_pairs_nested.go` lifecycle fixes cover `fetchNestedDocIDs`, `fetchNestedIsNull`, `restrictByNestedIdx`, `resolveNestedCorrelatedGroup`, and `resolveNestedCorrelated`.

  **BitmapBufPoolTracking and requireBitmapValid**

  Test-only pool that tracks outstanding allocations (`Outstanding() int64`, checked via `t.Cleanup`) and zeroes backing buffers on release — making premature releases visible as wrong values in assertions and double-releases an immediate panic.
  `requireBitmapValid` reads `n[indexNumKeys]` from the bitmap's backing buffer to distinguish a legitimately empty bitmap from a prematurely released (zeroed) one; called before every content assertion in unit and integration tests.

  **Test plan**
  - [ ] `go test ./adapters/repos/db/inverted/nested/...`
  - [ ] `go test ./adapters/repos/db/roaringset/...`
  - [ ] `go test -tags integrationTest ./adapters/repos/db/inverted/...`