### PR TITLE
hfresh: guard distToNode against nil distancer during async init

### DIFF
--- a/adapters/repos/db/vector/hfresh/search_flat.go
+++ b/adapters/repos/db/vector/hfresh/search_flat.go
@@ -117,6 +117,17 @@ func (h *HFresh) distToNode(ctx context.Context, node uint64, vecB []float32) (f
 			"got a nil or zero-length vector as search vector")
 	}
 
+	// With ASYNC_INDEXING the HFRESH distancer is populated lazily as
+	// index init completes. A filtered near_vector issued in the brief
+	// window between the insert's ack and init finishing otherwise lands
+	// here with h.distancer still nil and dereferences through the inner
+	// .distancer field. Return a typed error so the caller surfaces
+	// "index not yet initialized" instead of the recovered runtime panic
+	// and the user can retry once the async pipeline catches up.
+	if h.distancer == nil {
+		return 0, fmt.Errorf("HFRESH distancer is not yet initialized")
+	}
+
 	return h.distancer.distancer.SingleDist(vecA, vecB)
 }
 


### PR DESCRIPTION
## What

`distToNode` in `adapters/repos/db/vector/hfresh/search_flat.go` dereferences `h.distancer.distancer.SingleDist(...)` without checking whether the outer `h.distancer` has been populated yet. With `ASYNC_INDEXING=true` a filtered `near_vector` query issued in the short window between `insert_many`'s ack and the HFRESH index finishing init reaches the small-allowlist flat-search path, hits a node, and crashes inside the deref:

```
panic occurred: runtime error: invalid memory address or nil pointer dereference
  .../hfresh/search_flat.go:120
```

Per #11086 this is reproducible with a minimal Python script: insert a batch with a self-provided vector and an HFRESH index, then query immediately. The waited-control branch (sleep briefly before the query) succeeds.

The gRPC handler recovers the panic but surfaces it as a generic `"vector search: panic occurred: runtime error: invalid memory address or nil pointer dereference"`, which gives the caller no path to retry intelligently.

## Fix

Add an explicit nil check on `h.distancer` immediately before the deref and return a typed error:

```go
if h.distancer == nil {
    return 0, fmt.Errorf("HFRESH distancer is not yet initialized")
}

return h.distancer.distancer.SingleDist(vecA, vecB)
```

Caller now sees an actionable "init still in progress" signal and can retry once `ASYNC_INDEXING` drains, instead of the post-recover stack. The waited-control path is unchanged (distancer is non-nil, check is free). Non-HFRESH paths aren't touched.

This PR is the minimal fix at the crash site. The underlying lifecycle question — whether queries against a not-yet-ready HFRESH index should queue for the init to finish, fail fast as this PR does, or be routed elsewhere — is a larger product decision best handled separately; this PR just stops the panic.

Fixes #11086