### PR TITLE
chore: reduce startup time for single node

### DIFF
--- a/cluster/raft.go
+++ b/cluster/raft.go
@@ -67,8 +67,8 @@ func (s *Raft) SchemaReader() schema.SchemaReader {
 	return s.store.SchemaReader()
 }
 
-func (s *Raft) WaitUntilDBRestored(ctx context.Context, period time.Duration, close chan struct{}) error {
-	return s.store.WaitToRestoreDB(ctx, period, close)
+func (s *Raft) WaitUntilDBRestored(ctx context.Context, close chan struct{}) error {
+	return s.store.WaitToRestoreDB(ctx, close)
 }
 
 func (s *Raft) WaitForUpdate(ctx context.Context, schemaVersion uint64) error {

--- a/cluster/raft_snapshot_test.go
+++ b/cluster/raft_snapshot_test.go
@@ -44,7 +44,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 
 	// Ensure Raft starts and a leader is elected
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
-	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
+	assert.Nil(t, srv.WaitUntilDBRestored(ctx, make(chan struct{})))
 	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
 	tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader)
 	assert.True(t, srv.store.IsLeader())
@@ -108,7 +108,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	m.indexer.On("TriggerSchemaUpdateCallbacks").Return().Once()
 	assert.Nil(t, srv.Open(ctx, m.indexer))
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
-	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
+	assert.Nil(t, srv.WaitUntilDBRestored(ctx, make(chan struct{})))
 	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
 	tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader)
 

--- a/cluster/raft_snapshot_test.go
+++ b/cluster/raft_snapshot_test.go
@@ -45,8 +45,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	// Ensure Raft starts and a leader is elected
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, make(chan struct{})))
-	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
-	tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader)
+	assert.True(t, tryNTimesWithWait(30, time.Millisecond*200, srv.Ready))
 	assert.True(t, srv.store.IsLeader())
 
 	// DeleteClass
@@ -109,8 +108,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	assert.Nil(t, srv.Open(ctx, m.indexer))
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, make(chan struct{})))
-	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
-	tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader)
+	assert.True(t, tryNTimesWithWait(30, time.Millisecond*200, srv.Ready))
 
 	// Ensure that the class has been restored and that the tenant is present with the right state
 	schemaReader = srv.SchemaReader()

--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -70,7 +70,7 @@ func TestRaftEndpoints(t *testing.T) {
 	func() {
 		ctx, cancel := context.WithTimeout(ctx, time.Millisecond*30)
 		defer cancel()
-		assert.ErrorIs(t, srv.WaitUntilDBRestored(ctx, 5*time.Millisecond, make(chan struct{})), context.DeadlineExceeded)
+		assert.ErrorIs(t, srv.WaitUntilDBRestored(ctx, make(chan struct{})), context.DeadlineExceeded)
 	}()
 
 	// Open
@@ -84,7 +84,7 @@ func TestRaftEndpoints(t *testing.T) {
 	// Connect
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 
-	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
+	assert.Nil(t, srv.WaitUntilDBRestored(ctx, make(chan struct{})))
 	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
 	tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader)
 	assert.True(t, srv.store.IsLeader())
@@ -385,7 +385,7 @@ func TestRaftEndpoints(t *testing.T) {
 	srv = NewRaft(mocks.NewMockNodeSelector(), m.store, nil)
 	assert.Nil(t, srv.Open(ctx, m.indexer))
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
-	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
+	assert.Nil(t, srv.WaitUntilDBRestored(ctx, make(chan struct{})))
 	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
 	tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader)
 	schemaReader = srv.SchemaReader()
@@ -445,7 +445,7 @@ func TestRaftClose(t *testing.T) {
 		close <- struct{}{}
 	}()
 	now := time.Now()
-	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*10, close))
+	assert.Nil(t, srv.WaitUntilDBRestored(ctx, close))
 	after := time.Now()
 	assert.Less(t, after.Sub(now), 2*time.Second)
 }

--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -85,8 +85,7 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, make(chan struct{})))
-	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
-	tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader)
+	assert.True(t, tryNTimesWithWait(30, time.Millisecond*200, srv.Ready))
 	assert.True(t, srv.store.IsLeader())
 	schemaReader := srv.SchemaReader()
 	assert.Equal(t, schemaReader.Len(), 0)
@@ -386,8 +385,7 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.Nil(t, srv.Open(ctx, m.indexer))
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, make(chan struct{})))
-	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
-	tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader)
+	assert.True(t, tryNTimesWithWait(30, time.Millisecond*200, srv.Ready))
 	schemaReader = srv.SchemaReader()
 	assert.Equal(t, info, schemaReader.ClassInfo("C"))
 }

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -170,7 +170,8 @@ func (c *Service) Open(ctx context.Context, db schema.Indexer) error {
 	// peers that we are ready to form a new cluster.
 	bootstrapCtx, bCancel := context.WithTimeout(ctx, c.config.BootstrapTimeout)
 	defer bCancel()
-	if hasState {
+	if hasState && c.config.BootstrapExpect > 1 {
+		// Multi-node cluster: re-join to update configuration with our current IP.
 		joiner := bootstrap.NewJoiner(c.rpcClient, c.config.NodeID, c.raftAddr, c.config.Voter)
 		err = backoff.Retry(func() error {
 			joinNodes := bootstrap.ResolveRemoteNodes(c.config.NodeSelector, c.config.NodeNameToPortMap)
@@ -180,6 +181,8 @@ func (c *Service) Open(ctx context.Context, db schema.Indexer) error {
 		if err != nil {
 			return fmt.Errorf("could not join raft join list: %w. Weaviate detected this node to have state stored. If the DB is still loading up we will hit this timeout. You can try increasing/setting RAFT_BOOTSTRAP_TIMEOUT env variable to a higher value", err)
 		}
+	} else if hasState {
+		// Single-node cluster: skip joiner, node will elect itself leader.
 	} else {
 		bs := bootstrap.NewBootstrapper(
 			c.rpcClient,
@@ -198,7 +201,7 @@ func (c *Service) Open(ctx context.Context, db schema.Indexer) error {
 		}
 	}
 
-	if err := c.WaitUntilDBRestored(ctx, 1*time.Second, c.closeWaitForDB); err != nil {
+	if err := c.WaitUntilDBRestored(ctx, c.closeWaitForDB); err != nil {
 		return fmt.Errorf("restore database: %w", err)
 	}
 

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -18,6 +18,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -199,8 +200,10 @@ type Store struct {
 
 	// open is set on opening the store
 	open atomic.Bool
-	// dbLoaded is set when the DB is loaded at startup
-	dbLoaded atomic.Bool
+	// dbLoadedCh is closed when the DB is loaded at startup
+	dbLoadedCh chan struct{}
+	// dbLoadedOnce ensures dbLoadedCh is closed exactly once
+	dbLoadedOnce sync.Once
 
 	// raft implementation from external library
 	raft          *raft.Raft
@@ -334,7 +337,8 @@ func NewFSM(cfg Config, authZController authorization.Controller, snapshotter fs
 			Clock:            clockwork.NewRealClock(),
 			CompletedTaskTTL: cfg.DistributedTasks.CompletedTaskTTL,
 		}),
-		metrics: newStoreMetrics(cfg.NodeID, reg),
+		metrics:    newStoreMetrics(cfg.NodeID, reg),
+		dbLoadedCh: make(chan struct{}),
 	}
 }
 
@@ -397,7 +401,7 @@ func (st *Store) Open(ctx context.Context) (err error) {
 	snapIndex := lastSnapshotIndex(st.snapshotStore)
 	if st.lastAppliedIndexToDB.Load() == 0 && snapIndex == 0 {
 		// if empty node report ready
-		st.dbLoaded.Store(true)
+		st.setDBLoaded()
 	}
 
 	st.lastAppliedIndex.Store(st.raft.AppliedIndex())
@@ -570,31 +574,35 @@ func (st *Store) Close(ctx context.Context) error {
 func (st *Store) SetDB(db schema.Indexer) { st.schemaManager.SetIndexer(db) }
 
 func (st *Store) Ready() bool {
-	return st.open.Load() && st.dbLoaded.Load() && st.Leader() != ""
+	return st.open.Load() && st.isDBLoaded() && st.Leader() != ""
 }
 
 // WaitToLoadDB waits for the DB to be loaded. The DB might be first loaded
 // after RAFT is in a healthy state, which is when the leader has been elected and there
 // is consensus on the log.
-func (st *Store) WaitToRestoreDB(ctx context.Context, period time.Duration, close chan struct{}) error {
-	if st.dbLoaded.Load() {
-		return nil
+func (st *Store) isDBLoaded() bool {
+	select {
+	case <-st.dbLoadedCh:
+		return true
+	default:
+		return false
 	}
-	t := time.NewTicker(period)
-	defer t.Stop()
-	for {
-		select {
-		case <-close:
-			return nil
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-t.C:
-			if st.dbLoaded.Load() {
-				return nil
-			} else {
-				st.log.Info("waiting for database to be restored")
-			}
-		}
+}
+
+func (st *Store) setDBLoaded() {
+	st.dbLoadedOnce.Do(func() {
+		close(st.dbLoadedCh)
+	})
+}
+
+func (st *Store) WaitToRestoreDB(ctx context.Context, closeCh chan struct{}) error {
+	select {
+	case <-st.dbLoadedCh:
+		return nil
+	case <-closeCh:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 }
 
@@ -687,7 +695,7 @@ func (st *Store) Stats() map[string]any {
 	stats["candidates"] = st.candidates
 	stats["last_store_log_applied_index"] = st.lastAppliedIndexToDB.Load()
 	stats["last_applied_index"] = st.lastIndex()
-	stats["db_loaded"] = st.dbLoaded.Load()
+	stats["db_loaded"] = st.isDBLoaded()
 
 	// If the raft stats exist, add them as a nested map
 	if st.raft != nil {
@@ -737,15 +745,14 @@ func (st *Store) assertFuture(fut raft.IndexFuture) error {
 
 func (st *Store) raftConfig() *raft.Config {
 	cfg := raft.DefaultConfig()
-	// If the TimeoutsMultiplier is set, use it to multiply the timeout values
-	// This is used to speed up the raft election, heartbeat, and leader lease
-	// in a multi-node cluster.
-	// the default value is 1
-	// for production requirement,it's recommended to set it to 5
-	// this in order to tolerate the network delay and avoid extensive leader election triggered more frequently
-	// example : https://developer.hashicorp.com/consul/docs/reference/architecture/server#production-server-requirements
+	// TimeoutsMultiplier scales raft heartbeat, election, and leader lease timeouts
+	// to tolerate network delays in multi-node clusters and reduce unnecessary
+	// leader elections under heavy load. The default is 5 (via RAFT_TIMEOUTS_MULTIPLIER).
+	// For single-node clusters the multiplier is not applied since there are no
+	// network peers to tolerate delays from.
+	// See: https://developer.hashicorp.com/consul/docs/reference/architecture/server#production-server-requirements
 	timeOutMultiplier := 1
-	if st.cfg.TimeoutsMultiplier > 1 {
+	if st.cfg.BootstrapExpect > 1 && st.cfg.TimeoutsMultiplier > 1 {
 		timeOutMultiplier = st.cfg.TimeoutsMultiplier
 	}
 	if st.cfg.HeartbeatTimeout > 0 {
@@ -788,7 +795,7 @@ func (st *Store) raftConfig() *raft.Config {
 }
 
 func (st *Store) openDatabase(ctx context.Context) {
-	if st.dbLoaded.Load() {
+	if st.isDBLoaded() {
 		return
 	}
 
@@ -816,7 +823,7 @@ func (st *Store) reloadDBFromSchema() {
 	} else {
 		st.log.Info("skipping reload DB from schema as the node is metadata only")
 	}
-	st.dbLoaded.Store(true)
+	st.setDBLoaded()
 
 	// in this path it means it was called from Apply()
 	// or forced Restore()

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -111,7 +111,7 @@ func (st *Store) Apply(l *raft.Log) any {
 		// we do this at the beginning to handle situation were schema was catching up
 		// and to make sure no matter is the error status we are going to open the db on startup
 		// we reload the db only if we have a previous state and the db is not loaded
-		dbReloadRequired := st.lastAppliedIndexToDB.Load() != 0 && !st.dbLoaded.Load()
+		dbReloadRequired := st.lastAppliedIndexToDB.Load() != 0 && !st.isDBLoaded()
 		if dbReloadRequired && l.Index != 0 && l.Index >= st.lastAppliedIndexToDB.Load() {
 			st.log.WithFields(logrus.Fields{
 				"log_type":                     l.Type,

--- a/cluster/store_raft_config_test.go
+++ b/cluster/store_raft_config_test.go
@@ -55,7 +55,34 @@ func TestRaftConfig(t *testing.T) {
 			},
 		},
 		{
-			name: "custom timeouts with multiplier",
+			name: "custom timeouts with multiplier (multi-node)",
+			config: Config{
+				NodeID:             "node1",
+				Logger:             logrus.New(),
+				Voter:              true,
+				WorkDir:            t.TempDir(),
+				Host:               "localhost",
+				RaftPort:           9090,
+				RPCPort:            9091,
+				BootstrapExpect:    3,
+				HeartbeatTimeout:   2 * time.Second,
+				ElectionTimeout:    3 * time.Second,
+				LeaderLeaseTimeout: 4 * time.Second,
+				TimeoutsMultiplier: 2,
+			},
+			expectedConfig: func(cfg *raft.Config) {
+				assert.Equal(t, raft.ServerID("node1"), cfg.LocalID)
+				assert.Equal(t, "info", cfg.LogLevel)
+				assert.True(t, cfg.NoLegacyTelemetry)
+				assert.NotNil(t, cfg.Logger)
+				// Timeouts should be multiplied by 2 for multi-node clusters
+				assert.Equal(t, 4*time.Second, cfg.HeartbeatTimeout)
+				assert.Equal(t, 6*time.Second, cfg.ElectionTimeout)
+				assert.Equal(t, 8*time.Second, cfg.LeaderLeaseTimeout)
+			},
+		},
+		{
+			name: "custom timeouts with multiplier ignored for single-node",
 			config: Config{
 				NodeID:             "node1",
 				Logger:             logrus.New(),
@@ -72,13 +99,10 @@ func TestRaftConfig(t *testing.T) {
 			},
 			expectedConfig: func(cfg *raft.Config) {
 				assert.Equal(t, raft.ServerID("node1"), cfg.LocalID)
-				assert.Equal(t, "info", cfg.LogLevel)
-				assert.True(t, cfg.NoLegacyTelemetry)
-				assert.NotNil(t, cfg.Logger)
-				// Timeouts should be multiplied by 2
-				assert.Equal(t, 4*time.Second, cfg.HeartbeatTimeout)
-				assert.Equal(t, 6*time.Second, cfg.ElectionTimeout)
-				assert.Equal(t, 8*time.Second, cfg.LeaderLeaseTimeout)
+				// Multiplier not applied for single-node clusters
+				assert.Equal(t, 2*time.Second, cfg.HeartbeatTimeout)
+				assert.Equal(t, 3*time.Second, cfg.ElectionTimeout)
+				assert.Equal(t, 4*time.Second, cfg.LeaderLeaseTimeout)
 			},
 		},
 		{


### PR DESCRIPTION
### What's being changed:

This change is a continuation of https://github.com/weaviate/weaviate/pull/11064.

It sets the TimeoutsMultiplier to 1 for single node setups, as they are not using RAFT. It also changes the logic of `WaitUntilDBRestored` to be notified instantly when the DB is loaded, instead of polling.

This reduces startup time drastically for single node setups.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
