### PR TITLE
hfresh: normalize query vector before rescoring

### DIFF
--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -357,11 +357,13 @@ func (h *HFresh) Iterate(fn func(id uint64) bool) {
 }
 
 func (h *HFresh) QueryVectorDistancer(queryVector []float32) common.QueryVectorDistancer {
+	queryVector = h.normalizeVec(queryVector)
 	distFunc := func(id uint64) (float32, error) {
 		vector, err := h.vectorForId(h.ctx, id)
 		if err != nil {
 			return 0, err
 		}
+		vector = h.normalizeVec(vector)
 		dist, err := h.config.DistanceProvider.SingleDist(queryVector, vector)
 		if err != nil {
 			return 0, err

--- a/adapters/repos/db/vector/hfresh/search.go
+++ b/adapters/repos/db/vector/hfresh/search.go
@@ -29,12 +29,13 @@ const (
 )
 
 func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, allowList helpers.AllowList) ([]uint64, []float32, error) {
+	vector = h.normalizeVec(vector)
+
 	if allowList != nil && allowList.Len() < flatSearchCutoff {
 		return h.flatSearch(ctx, vector, k, allowList)
 	}
 
 	rescoreLimit := int(h.rescoreLimit)
-	vector = h.normalizeVec(vector)
 	if h.quantizer == nil {
 		if atomic.LoadUint32(&h.dims) == 0 {
 			return nil, nil, nil
@@ -148,6 +149,7 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 		if err != nil {
 			return nil, nil, err
 		}
+		vec = h.normalizeVec(vec)
 		dist, err := h.distancer.distancer.SingleDist(vector, vec)
 		if err != nil {
 			return nil, nil, err

--- a/adapters/repos/db/vector/hfresh/search_flat.go
+++ b/adapters/repos/db/vector/hfresh/search_flat.go
@@ -117,6 +117,7 @@ func (h *HFresh) distToNode(ctx context.Context, node uint64, vecB []float32) (f
 			"got a nil or zero-length vector as search vector")
 	}
 
+	vecA = h.normalizeVec(vecA)
 	return h.distancer.distancer.SingleDist(vecA, vecB)
 }
 

--- a/adapters/repos/db/vector/hfresh/search_test.go
+++ b/adapters/repos/db/vector/hfresh/search_test.go
@@ -14,10 +14,14 @@ package hfresh
 import (
 	"context"
 	"fmt"
+	"math"
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw/distancer"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/testinghelpers"
 )
 
@@ -58,4 +62,108 @@ func TestSearchWithEmptyIndex(t *testing.T) {
 	require.NoError(t, err)
 	require.Empty(t, ids)
 	require.Empty(t, dists)
+}
+
+// TestSearchCosineDistanceRescore verifies that HFresh correctly computes and
+// reports distances when using cosine distance. The VectorForIDThunk returns
+// raw (unnormalized) vectors to simulate the real object store, where vectors
+// are stored as provided by the user.
+//
+// The bug: HFresh normalizes the query vector internally for quantized search
+// but the rescore step fetches raw vectors from vectorForId. The cosine-dot
+// distance function computes 1-dot(a,b) and clamps negative values to 0.
+// Since dot(normalized_query, unnormalized_stored) > 1 for vectors with
+// magnitude > 1, all rescored distances get clamped to 0.
+func TestSearchCosineDistanceRescore(t *testing.T) {
+	store := testinghelpers.NewDummyStore(t)
+	cfg, uc := makeHFreshConfig(t)
+
+	// Use cosine distance for both the main index and centroids,
+	// matching how shard_init_vector.go configures HFresh in production.
+	cfg.DistanceProvider = distancer.NewCosineDistanceProvider()
+	cfg.Centroids.HNSWConfig.DistanceProvider = distancer.NewCosineDistanceProvider()
+
+	vectorsSize := 500
+	dimensions := 32
+	k := 10
+
+	vectors, _ := testinghelpers.RandomVecsFixedSeed(vectorsSize, 0, dimensions)
+
+	// Verify that our test vectors have magnitude > 1, which is
+	// required to trigger the bug.
+	var norm float32
+	for _, v := range vectors[0] {
+		norm += v * v
+	}
+	norm = float32(math.Sqrt(float64(norm)))
+	require.Greater(t, norm, float32(1.0),
+		"test vectors should have magnitude > 1 to exercise the bug")
+
+	// VectorForIDThunk returns RAW (unnormalized) vectors, simulating
+	// the real object store. In production, the shard stores the user's
+	// original vector, not the normalized version that HFresh uses internally.
+	cfg.VectorForIDThunk = hnsw.NewVectorForIDThunk(cfg.TargetVector, func(ctx context.Context, indexID uint64, targetVector string) ([]float32, error) {
+		if int(indexID) < len(vectors) {
+			return vectors[indexID], nil
+		}
+		return nil, fmt.Errorf("vector not found for ID %d", indexID)
+	})
+
+	index := makeHFreshWithConfig(t, store, cfg, uc)
+
+	for i := 0; i < vectorsSize; i++ {
+		err := index.Add(t.Context(), uint64(i), vectors[i])
+		require.NoError(t, err)
+	}
+
+	// Wait for background tasks (splits, merges) to complete.
+	for index.taskQueue.Size() > 0 {
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	// Search for a vector that was indexed. The self-match must be the
+	// top result with distance ≈ 0, and the remaining results must have
+	// non-zero distances in ascending order.
+	queryID := uint64(42)
+	ids, dists, err := index.SearchByVector(t.Context(), vectors[queryID], k, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, ids)
+
+	// Self-match must be rank 1.
+	assert.Equal(t, queryID, ids[0],
+		"self-match should be the first result")
+
+	// Self-match distance must be approximately 0.
+	assert.InDelta(t, 0, dists[0], 0.01,
+		"self-match distance should be near zero")
+
+	// Not all distances should be zero — if they are, the rescore is broken.
+	allZero := true
+	for _, d := range dists {
+		if d > 0 {
+			allZero = false
+			break
+		}
+	}
+	assert.False(t, allZero,
+		"all distances are zero: rescore is not producing correct distances")
+
+	// Distances must be monotonically non-decreasing (correctly ordered).
+	for i := 1; i < len(dists); i++ {
+		assert.LessOrEqual(t, dists[i-1], dists[i],
+			"distances should be non-decreasing: dists[%d]=%f > dists[%d]=%f",
+			i-1, dists[i-1], i, dists[i])
+	}
+
+	// Verify returned distances match independently computed cosine distances.
+	cosine := distancer.NewCosineDistanceProvider()
+	for i, id := range ids {
+		normalizedQuery := distancer.Normalize(vectors[queryID])
+		normalizedStored := distancer.Normalize(vectors[id])
+		expected, err := cosine.SingleDist(normalizedQuery, normalizedStored)
+		require.NoError(t, err)
+		assert.InDelta(t, expected, dists[i], 0.01,
+			"result %d (id=%d): returned distance %f != expected cosine distance %f",
+			i, id, dists[i], expected)
+	}
 }


### PR DESCRIPTION
### What's being changed:

During rescoring, HFresh was fetching raw vectors from the objects bucket but wasn't normalizing them properly before computing distance.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
