### PR TITLE
hfresh: use asymmetric distance computation

### DIFF
--- a/adapters/repos/db/vector/hfresh/search.go
+++ b/adapters/repos/db/vector/hfresh/search.go
@@ -41,7 +41,7 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 		}
 		return nil, nil, errors.New("quantizer not initialized")
 	}
-	queryVector := NewAnonymousVector(h.quantizer.CompressedBytes(h.quantizer.Encode(vector)))
+	queryDistancer := h.quantizer.NewDistancer(vector)
 
 	var selectedCentroids []uint64
 	var postings []Posting
@@ -94,6 +94,8 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 	visited := h.visitedPool.Borrow()
 	defer h.visitedPool.Return(visited)
 
+	var decompressBuf []uint64
+
 	for i, p := range postings {
 		if p == nil { // posting nil if not found
 			continue
@@ -124,7 +126,8 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 				continue
 			}
 
-			dist, err := v.Distance(h.distancer, queryVector)
+			decompressBuf = h.quantizer.FromCompressedBytesInto(v.Data(), decompressBuf)
+			dist, err := queryDistancer.Distance(decompressBuf)
 			if err != nil {
 				return nil, nil, errors.Wrapf(err, "failed to compute distance for vector %d", id)
 			}


### PR DESCRIPTION
### What's being changed:

This changes HFresh's search logic to use asymmetric distance computation: we keep the query vector at a higher precision than the stored data and compute the distance.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
