### PR TITLE
Add Boost API for soft-ranking

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -378,7 +378,7 @@ func (p *Parser) Search(req *pb.SearchRequest, config *config.Config) (dto.GetPa
 	}
 
 	if req.Boost != nil {
-		boost, err := p.extractBoost(req.Boost, req.Collection, req.Tenant)
+		boost, err := p.extractBoost(req.Boost, req.Collection, req.Tenant, config.Namespaces.Enabled)
 		if err != nil {
 			return dto.GetParams{}, err
 		}
@@ -648,7 +648,7 @@ func extractRerank(req *pb.SearchRequest) *rank.Params {
 	return &rerank
 }
 
-func (p *Parser) extractBoost(boost *pb.Boost, className, tenant string) (*filters.Boost, error) {
+func (p *Parser) extractBoost(boost *pb.Boost, className, tenant string, namespacesEnabled bool) (*filters.Boost, error) {
 	if boost == nil {
 		return nil, nil
 	}
@@ -660,7 +660,7 @@ func (p *Parser) extractBoost(boost *pb.Boost, className, tenant string) (*filte
 
 	conditions := make([]filters.BoostCondition, 0, len(boost.GetConditions()))
 	for i, cond := range boost.GetConditions() {
-		pc, err := p.extractBoostCondition(cond, className, tenant, i)
+		pc, err := p.extractBoostCondition(cond, className, tenant, i, namespacesEnabled)
 		if err != nil {
 			return nil, err
 		}
@@ -685,7 +685,7 @@ func (p *Parser) extractBoost(boost *pb.Boost, className, tenant string) (*filte
 	return result, nil
 }
 
-func (p *Parser) extractBoostCondition(cond *pb.Boost_Condition, className, tenant string, idx int) (filters.BoostCondition, error) {
+func (p *Parser) extractBoostCondition(cond *pb.Boost_Condition, className, tenant string, idx int, namespacesEnabled bool) (filters.BoostCondition, error) {
 	weight := float32(1.0)
 	if cond.Weight != nil {
 		weight = cond.GetWeight()
@@ -697,7 +697,7 @@ func (p *Parser) extractBoostCondition(cond *pb.Boost_Condition, className, tena
 
 	switch c := cond.GetCondition().(type) {
 	case *pb.Boost_Condition_Filter:
-		clause, err := ExtractFilters(c.Filter, p.authorizedGetClass, className, tenant)
+		clause, err := ExtractFilters(c.Filter, p.authorizedGetClass, className, tenant, namespacesEnabled)
 		if err != nil {
 			return filters.BoostCondition{}, fmt.Errorf("boost condition[%d] filter: %w", idx, err)
 		}

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -14,7 +14,6 @@ package v1
 import (
 	"fmt"
 	"slices"
-	"strconv"
 
 	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/schema/configvalidation"
@@ -813,18 +812,19 @@ func extractNumericDecayFunction(d *pb.Boost_NumericDecayFunction, condIdx int) 
 		decayValue = d.GetDecayValue()
 	}
 
-	offset := "0"
+	var offset float64
 	if d.Offset != nil {
-		offset = strconv.FormatFloat(d.GetOffset(), 'f', -1, 64)
+		offset = d.GetOffset()
 	}
 
 	return &filters.Decay{
-		Path:       &filters.Path{Property: schema.PropertyName(prop)},
-		Origin:     strconv.FormatFloat(d.GetOrigin(), 'f', -1, 64),
-		Scale:      strconv.FormatFloat(d.GetScale(), 'f', -1, 64),
-		Offset:     offset,
-		Curve:      extractDecayCurve(d.GetCurve()),
-		DecayValue: decayValue,
+		Path:          &filters.Path{Property: schema.PropertyName(prop)},
+		IsNumeric:     true,
+		OriginNumeric: d.GetOrigin(),
+		ScaleNumeric:  d.GetScale(),
+		OffsetNumeric: offset,
+		Curve:         extractDecayCurve(d.GetCurve()),
+		DecayValue:    decayValue,
 	}, nil
 }
 

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -14,6 +14,7 @@ package v1
 import (
 	"fmt"
 	"slices"
+	"strconv"
 
 	"github.com/weaviate/weaviate/entities/modelsext"
 	"github.com/weaviate/weaviate/entities/schema/configvalidation"
@@ -376,6 +377,14 @@ func (p *Parser) Search(req *pb.SearchRequest, config *config.Config) (dto.GetPa
 		out.AdditionalProperties.ModuleParams["rerank"] = extractRerank(req)
 	}
 
+	if req.Boost != nil {
+		boost, err := p.extractBoost(req.Boost, req.Collection, req.Tenant)
+		if err != nil {
+			return dto.GetParams{}, err
+		}
+		out.Boost = boost
+	}
+
 	if len(req.After) > 0 {
 		out.Cursor = &filters.Cursor{After: req.After, Limit: out.Pagination.Limit}
 	}
@@ -637,6 +646,186 @@ func extractRerank(req *pb.SearchRequest) *rank.Params {
 		rerank.Query = req.Rerank.Query
 	}
 	return &rerank
+}
+
+func (p *Parser) extractBoost(boost *pb.Boost, className, tenant string) (*filters.Boost, error) {
+	if boost == nil {
+		return nil, nil
+	}
+
+	weight := float32(0.5)
+	if boost.Weight != nil {
+		weight = boost.GetWeight()
+	}
+
+	conditions := make([]filters.BoostCondition, 0, len(boost.GetConditions()))
+	for i, cond := range boost.GetConditions() {
+		pc, err := p.extractBoostCondition(cond, className, tenant, i)
+		if err != nil {
+			return nil, err
+		}
+		conditions = append(conditions, pc)
+	}
+
+	var depth int
+	if boost.Depth != nil {
+		depth = int(boost.GetDepth())
+	}
+
+	result := &filters.Boost{
+		Conditions: conditions,
+		Weight:     weight,
+		Depth:      depth,
+	}
+
+	if err := filters.ValidateBoost(result); err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func (p *Parser) extractBoostCondition(cond *pb.Boost_Condition, className, tenant string, idx int) (filters.BoostCondition, error) {
+	weight := float32(1.0)
+	if cond.Weight != nil {
+		weight = cond.GetWeight()
+	}
+
+	pc := filters.BoostCondition{
+		Weight: weight,
+	}
+
+	switch c := cond.GetCondition().(type) {
+	case *pb.Boost_Condition_Filter:
+		clause, err := ExtractFilters(c.Filter, p.authorizedGetClass, className, tenant)
+		if err != nil {
+			return filters.BoostCondition{}, fmt.Errorf("boost condition[%d] filter: %w", idx, err)
+		}
+		pc.Filter = &filters.LocalFilter{Root: &clause}
+	case *pb.Boost_Condition_TimeDecay:
+		decay, err := extractTimeDecayFunction(c.TimeDecay, idx)
+		if err != nil {
+			return filters.BoostCondition{}, err
+		}
+		pc.Decay = decay
+	case *pb.Boost_Condition_NumericDecay:
+		decay, err := extractNumericDecayFunction(c.NumericDecay, idx)
+		if err != nil {
+			return filters.BoostCondition{}, err
+		}
+		pc.Decay = decay
+	case *pb.Boost_Condition_PropertyValue:
+		fv, err := extractPropertyValueFunction(c.PropertyValue, idx)
+		if err != nil {
+			return filters.BoostCondition{}, err
+		}
+		pc.PropertyValue = fv
+	default:
+		return filters.BoostCondition{}, fmt.Errorf("boost condition[%d]: exactly one of 'filter', 'decay', or 'property_value' must be set", idx)
+	}
+
+	return pc, nil
+}
+
+func extractPropertyValueFunction(fv *pb.Boost_PropertyValueFunction, condIdx int) (*filters.PropertyValue, error) {
+	if fv == nil {
+		return nil, nil
+	}
+
+	prop := fv.GetProperty()
+	if prop == "" {
+		return nil, fmt.Errorf("boost condition[%d] property_value: property is required", condIdx)
+	}
+
+	modifier := filters.PropertyValueModifierNone
+	switch fv.GetModifier() {
+	case pb.Boost_PROPERTY_VALUE_MODIFIER_LOG1P:
+		modifier = filters.PropertyValueModifierLog1p
+	case pb.Boost_PROPERTY_VALUE_MODIFIER_SQRT:
+		modifier = filters.PropertyValueModifierSqrt
+	case pb.Boost_PROPERTY_VALUE_MODIFIER_UNSPECIFIED:
+		modifier = filters.PropertyValueModifierNone
+	}
+
+	return &filters.PropertyValue{
+		Path:     &filters.Path{Property: schema.PropertyName(prop)},
+		Modifier: modifier,
+	}, nil
+}
+
+func extractDecayCurve(curve pb.Boost_DecayCurve) filters.DecayCurveType {
+	switch curve {
+	case pb.Boost_DECAY_CURVE_GAUSS:
+		return filters.DecayCurveGauss
+	case pb.Boost_DECAY_CURVE_LINEAR:
+		return filters.DecayCurveLinear
+	default:
+		return filters.DecayCurveExp
+	}
+}
+
+func extractTimeDecayFunction(d *pb.Boost_TimeDecayFunction, condIdx int) (*filters.Decay, error) {
+	if d == nil {
+		return nil, nil
+	}
+
+	prop := d.GetProperty()
+	if prop == "" {
+		return nil, fmt.Errorf("boost condition[%d] time_decay: property is required", condIdx)
+	}
+
+	decayValue := float32(0.5)
+	if d.DecayValue != nil {
+		decayValue = d.GetDecayValue()
+	}
+
+	offset := "0"
+	if d.Offset != nil {
+		offset = d.GetOffset()
+	}
+
+	return &filters.Decay{
+		Path:       &filters.Path{Property: schema.PropertyName(prop)},
+		Origin:     d.GetOrigin(),
+		Scale:      d.GetScale(),
+		Offset:     offset,
+		Curve:      extractDecayCurve(d.GetCurve()),
+		DecayValue: decayValue,
+	}, nil
+}
+
+func extractNumericDecayFunction(d *pb.Boost_NumericDecayFunction, condIdx int) (*filters.Decay, error) {
+	if d == nil {
+		return nil, nil
+	}
+
+	prop := d.GetProperty()
+	if prop == "" {
+		return nil, fmt.Errorf("boost condition[%d] numeric_decay: property is required", condIdx)
+	}
+
+	if d.GetScale() <= 0 {
+		return nil, fmt.Errorf("boost condition[%d] numeric_decay: scale must be > 0", condIdx)
+	}
+
+	decayValue := float32(0.5)
+	if d.DecayValue != nil {
+		decayValue = d.GetDecayValue()
+	}
+
+	offset := "0"
+	if d.Offset != nil {
+		offset = strconv.FormatFloat(d.GetOffset(), 'f', -1, 64)
+	}
+
+	return &filters.Decay{
+		Path:       &filters.Path{Property: schema.PropertyName(prop)},
+		Origin:     strconv.FormatFloat(d.GetOrigin(), 'f', -1, 64),
+		Scale:      strconv.FormatFloat(d.GetScale(), 'f', -1, 64),
+		Offset:     offset,
+		Curve:      extractDecayCurve(d.GetCurve()),
+		DecayValue: decayValue,
+	}, nil
 }
 
 func extractNearText(classname string, limit int, nearTextIn *pb.NearTextSearch, targetVectors []string) (*nearText2.NearTextParams, error) {

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -783,9 +783,14 @@ func extractTimeDecayFunction(d *pb.Boost_TimeDecayFunction, condIdx int) (*filt
 		offset = d.GetOffset()
 	}
 
+	origin := d.GetOrigin()
+	if origin == "" {
+		origin = "now"
+	}
+
 	return &filters.Decay{
 		Path:       &filters.Path{Property: schema.PropertyName(prop)},
-		Origin:     d.GetOrigin(),
+		Origin:     origin,
 		Scale:      d.GetScale(),
 		Offset:     offset,
 		Curve:      extractDecayCurve(d.GetCurve()),

--- a/entities/dto/dto.go
+++ b/entities/dto/dto.go
@@ -59,6 +59,7 @@ type GetParams struct {
 	HybridSearch            *searchparams.HybridSearch
 	GroupBy                 *searchparams.GroupBy
 	Selection               *searchparams.Selection
+	Boost                   *filters.Boost
 	TargetVectorCombination *TargetCombination
 	Group                   *GroupParams
 	ModuleParams            map[string]interface{}

--- a/entities/filters/boost.go
+++ b/entities/filters/boost.go
@@ -67,11 +67,23 @@ type PropertyValue struct {
 
 // Decay defines a distance-based scoring function that produces a continuous
 // score in [0,1] based on how far a property value is from an origin point.
+//
+// For time-based decay, Origin/Scale/Offset are strings ("now", "7d", ISO date).
+// For numeric decay, set IsNumeric=true and use OriginNumeric/ScaleNumeric/OffsetNumeric
+// directly to avoid lossy float64→string→float64 round-trips.
 type Decay struct {
-	Path       *Path
-	Origin     string // "now", ISO date, or numeric string
-	Scale      string // "7d", "20" — required
-	Offset     string // default "0"
+	Path   *Path
+	Origin string // "now", ISO date, or numeric string (time decay)
+	Scale  string // "7d", "20" — required (time decay)
+	Offset string // default "0" (time decay)
+
+	// Pre-parsed numeric values. When IsNumeric is true, these are used
+	// directly by the scorer instead of parsing Origin/Scale/Offset strings.
+	IsNumeric     bool
+	OriginNumeric float64
+	ScaleNumeric  float64
+	OffsetNumeric float64
+
 	Curve      DecayCurveType
 	DecayValue float32 // score at scale distance, default 0.5
 }
@@ -178,7 +190,11 @@ func validateDecay(d *Decay, condIdx int) error {
 	}
 	// Origin is optional — defaults to "now" for date properties at scoring time.
 	// For numeric properties, a missing origin will produce a parse error at scoring time.
-	if d.Scale == "" {
+	if d.IsNumeric {
+		if d.ScaleNumeric <= 0 {
+			return fmt.Errorf("boost condition[%d] decay: scale must be > 0", condIdx)
+		}
+	} else if d.Scale == "" {
 		return fmt.Errorf("boost condition[%d] decay: scale is required", condIdx)
 	}
 

--- a/entities/filters/boost.go
+++ b/entities/filters/boost.go
@@ -170,8 +170,7 @@ func validateBoostFilterOps(clause *Clause, condIdx int) error {
 	case OperatorEqual, OperatorNotEqual,
 		OperatorGreaterThan, OperatorGreaterThanEqual,
 		OperatorLessThan, OperatorLessThanEqual,
-		OperatorAnd, OperatorOr, OperatorNot,
-		OperatorLike, OperatorIsNull:
+		OperatorAnd, OperatorOr, OperatorNot:
 		// supported
 	default:
 		return fmt.Errorf("boost condition[%d] filter: operator %s is not supported in boost conditions", condIdx, clause.Operator.Name())

--- a/entities/filters/boost.go
+++ b/entities/filters/boost.go
@@ -1,0 +1,214 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package filters
+
+import (
+	"fmt"
+)
+
+// Boost represents a set of soft ranking conditions that promote or demote
+// matching documents without excluding non-matching ones. Boost rescores the
+// primary search results using a weighted combination of primary and boost scores.
+type Boost struct {
+	Conditions []BoostCondition
+	Weight     float32 // blending weight [0,1]: final = (1-w)*primary + w*boost, default 0.5
+	Depth      int     // candidate pool size for reranking; 0 means use default (100)
+
+	// OriginalOffset and OriginalLimit are set internally by the explorer
+	// when overfetching for boost. They record the user's requested pagination
+	// so it can be applied after boost re-sorts.
+	OriginalOffset int
+	OriginalLimit  int
+}
+
+// PropertyValueModifierType is the modifier applied to a property value before normalization.
+type PropertyValueModifierType string
+
+const (
+	PropertyValueModifierNone  PropertyValueModifierType = "none"
+	PropertyValueModifierLog1p PropertyValueModifierType = "log1p"
+	PropertyValueModifierSqrt  PropertyValueModifierType = "sqrt"
+)
+
+// DecayCurveType is the mathematical function used for distance-based decay scoring.
+type DecayCurveType string
+
+const (
+	DecayCurveExp    DecayCurveType = "exp"
+	DecayCurveGauss  DecayCurveType = "gauss"
+	DecayCurveLinear DecayCurveType = "linear"
+)
+
+// BoostCondition represents a single boost condition. Exactly one of
+// Filter, Decay, or PropertyValue must be set.
+type BoostCondition struct {
+	Filter        *LocalFilter   // binary: 1 if match, 0 if not
+	Decay         *Decay         // continuous: distance-based [0,1]
+	PropertyValue *PropertyValue // continuous: score proportional to property value
+	Weight        float32        // per-condition weight, default 1.0; negative values demote
+}
+
+// PropertyValue defines a scoring function that produces a score proportional to
+// a numeric property's value. The raw values are normalized to [0,1] across
+// the result set using min-max normalization after applying the modifier.
+type PropertyValue struct {
+	Path     *Path
+	Modifier PropertyValueModifierType
+}
+
+// Decay defines a distance-based scoring function that produces a continuous
+// score in [0,1] based on how far a property value is from an origin point.
+type Decay struct {
+	Path       *Path
+	Origin     string // "now", ISO date, or numeric string
+	Scale      string // "7d", "20" — required
+	Offset     string // default "0"
+	Curve      DecayCurveType
+	DecayValue float32 // score at scale distance, default 0.5
+}
+
+// MaxBoostConditions is the maximum number of conditions allowed in a single
+// boost clause. Each condition triggers index queries or per-document scoring,
+// so an unbounded count could cause resource exhaustion.
+const MaxBoostConditions = 20
+
+// ValidateBoost validates a Boost struct for correctness. Returns nil for
+// nil input.
+func ValidateBoost(boost *Boost) error {
+	if boost == nil {
+		return nil
+	}
+
+	if len(boost.Conditions) == 0 {
+		return fmt.Errorf("boost: at least one condition is required")
+	}
+
+	if len(boost.Conditions) > MaxBoostConditions {
+		return fmt.Errorf("boost: too many conditions (%d), maximum is %d",
+			len(boost.Conditions), MaxBoostConditions)
+	}
+
+	if boost.Weight < 0 || boost.Weight > 1 {
+		return fmt.Errorf("boost: weight must be between 0 and 1, got %f", boost.Weight)
+	}
+
+	if boost.Depth < 0 {
+		return fmt.Errorf("boost: depth must be >= 0, got %d", boost.Depth)
+	}
+
+	for i, cond := range boost.Conditions {
+		if err := validateBoostCondition(cond, i); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func validateBoostCondition(cond BoostCondition, idx int) error {
+	hasFilter := cond.Filter != nil
+	hasDecay := cond.Decay != nil
+	hasPropertyValue := cond.PropertyValue != nil
+
+	set := 0
+	if hasFilter {
+		set++
+	}
+	if hasDecay {
+		set++
+	}
+	if hasPropertyValue {
+		set++
+	}
+	if set != 1 {
+		return fmt.Errorf("boost condition[%d]: exactly one of 'filter', 'decay', or 'property_value' must be set", idx)
+	}
+
+	if hasFilter {
+		return validateBoostFilterOps(cond.Filter.Root, idx)
+	}
+
+	if hasDecay {
+		return validateDecay(cond.Decay, idx)
+	}
+
+	if hasPropertyValue {
+		return validatePropertyValue(cond.PropertyValue, idx)
+	}
+
+	return nil
+}
+
+// validateBoostFilterOps checks that the filter only uses operators supported
+// by in-memory evaluation. Unsupported operators would silently score 0.
+func validateBoostFilterOps(clause *Clause, condIdx int) error {
+	if clause == nil {
+		return nil
+	}
+	switch clause.Operator {
+	case OperatorEqual, OperatorNotEqual,
+		OperatorGreaterThan, OperatorGreaterThanEqual,
+		OperatorLessThan, OperatorLessThanEqual,
+		OperatorAnd, OperatorOr, OperatorNot,
+		OperatorLike, OperatorIsNull:
+		// supported
+	case OperatorWithinGeoRange:
+		return fmt.Errorf("boost condition[%d] filter: operator WithinGeoRange is not supported in boost conditions", condIdx)
+	case ContainsAny, ContainsAll, ContainsNone:
+		return fmt.Errorf("boost condition[%d] filter: operator %s is not supported in boost conditions", condIdx, clause.Operator.Name())
+	}
+	for i := range clause.Operands {
+		if err := validateBoostFilterOps(&clause.Operands[i], condIdx); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateDecay(d *Decay, condIdx int) error {
+	if d.Path == nil {
+		return fmt.Errorf("boost condition[%d] decay: path is required", condIdx)
+	}
+	// Origin is optional — defaults to "now" for date properties at scoring time.
+	// For numeric properties, a missing origin will produce a parse error at scoring time.
+	if d.Scale == "" {
+		return fmt.Errorf("boost condition[%d] decay: scale is required", condIdx)
+	}
+
+	switch d.Curve {
+	case DecayCurveExp, DecayCurveGauss, DecayCurveLinear, "":
+		// valid
+	default:
+		return fmt.Errorf("boost condition[%d] decay: curve must be one of 'exp', 'gauss', 'linear', got %q", condIdx, d.Curve)
+	}
+
+	// DecayValue == 0 is treated as unset (defaults to 0.5 at scoring time).
+	// Explicit values must be in (0, 1].
+	if d.DecayValue != 0 && (d.DecayValue < 0 || d.DecayValue > 1) {
+		return fmt.Errorf("boost condition[%d] decay: decay_value must be between 0 and 1, got %f", condIdx, d.DecayValue)
+	}
+
+	return nil
+}
+
+func validatePropertyValue(fv *PropertyValue, condIdx int) error {
+	if fv.Path == nil {
+		return fmt.Errorf("boost condition[%d] property_value: path is required", condIdx)
+	}
+	switch fv.Modifier {
+	case PropertyValueModifierNone, PropertyValueModifierLog1p, PropertyValueModifierSqrt, "":
+		// valid
+	default:
+		return fmt.Errorf("boost condition[%d] property_value: modifier must be one of 'none', 'log1p', 'sqrt', got %q", condIdx, fv.Modifier)
+	}
+	return nil
+}

--- a/entities/filters/boost.go
+++ b/entities/filters/boost.go
@@ -161,9 +161,7 @@ func validateBoostFilterOps(clause *Clause, condIdx int) error {
 		OperatorAnd, OperatorOr, OperatorNot,
 		OperatorLike, OperatorIsNull:
 		// supported
-	case OperatorWithinGeoRange:
-		return fmt.Errorf("boost condition[%d] filter: operator WithinGeoRange is not supported in boost conditions", condIdx)
-	case ContainsAny, ContainsAll, ContainsNone:
+	default:
 		return fmt.Errorf("boost condition[%d] filter: operator %s is not supported in boost conditions", condIdx, clause.Operator.Name())
 	}
 	for i := range clause.Operands {

--- a/entities/filters/boost_test.go
+++ b/entities/filters/boost_test.go
@@ -193,6 +193,42 @@ func TestValidateBoost(t *testing.T) {
 			errMsg:  "exactly one of",
 		},
 		{
+			name: "filter with WithinGeoRange returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{Filter: &LocalFilter{Root: &Clause{Operator: OperatorWithinGeoRange}}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "not supported in boost conditions",
+		},
+		{
+			name: "filter with ContainsAny returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{Filter: &LocalFilter{Root: &Clause{Operator: ContainsAny}}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "not supported in boost conditions",
+		},
+		{
+			name: "filter with nested unsupported operator returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{Filter: &LocalFilter{Root: &Clause{
+						Operator: OperatorAnd,
+						Operands: []Clause{
+							{Operator: OperatorEqual},
+							{Operator: ContainsAll},
+						},
+					}}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "not supported in boost conditions",
+		},
+		{
 			name: "valid filter condition returns no error",
 			boost: &Boost{
 				Weight: 0.5,

--- a/entities/filters/boost_test.go
+++ b/entities/filters/boost_test.go
@@ -1,0 +1,279 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package filters
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateBoost(t *testing.T) {
+	tests := []struct {
+		name    string
+		boost   *Boost
+		wantErr bool
+		errMsg  string
+	}{
+		{
+			name:    "nil boost returns no error",
+			boost:   nil,
+			wantErr: false,
+		},
+		{
+			name:    "empty conditions returns error",
+			boost:   &Boost{Conditions: []BoostCondition{}},
+			wantErr: true,
+			errMsg:  "at least one condition is required",
+		},
+		{
+			name: "negative weight returns error",
+			boost: &Boost{
+				Weight: -1.0,
+				Conditions: []BoostCondition{
+					{Filter: &LocalFilter{}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "weight must be between 0 and 1",
+		},
+		{
+			name: "condition with none set returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{Weight: 1.0},
+				},
+			},
+			wantErr: true,
+			errMsg:  "exactly one of 'filter', 'decay', or 'property_value' must be set",
+		},
+		{
+			name: "condition with both filter and decay returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{
+						Filter: &LocalFilter{},
+						Decay:  &Decay{Path: &Path{Property: "age"}, Origin: "30", Scale: "10"},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "exactly one of 'filter', 'decay', or 'property_value' must be set",
+		},
+		{
+			name: "condition with negative weight is valid",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{Filter: &LocalFilter{}, Weight: -0.5},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "decay with missing path returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{Decay: &Decay{Scale: "10"}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "path is required",
+		},
+		{
+			name: "decay with missing origin is valid (defaults to now for dates)",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{Decay: &Decay{Path: &Path{Property: "created_at"}, Scale: "7d"}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "decay with missing scale returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{Decay: &Decay{Path: &Path{Property: "age"}, Origin: "30"}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "scale is required",
+		},
+		{
+			name: "decay with invalid curve returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{Decay: &Decay{
+						Path:   &Path{Property: "age"},
+						Origin: "30",
+						Scale:  "10",
+						Curve:  "invalid",
+					}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "curve must be one of",
+		},
+		{
+			name: "negative depth returns error",
+			boost: &Boost{
+				Depth: -1,
+				Conditions: []BoostCondition{
+					{Filter: &LocalFilter{}, Weight: 1.0},
+				},
+			},
+			wantErr: true,
+			errMsg:  "depth must be >= 0",
+		},
+		{
+			name: "positive depth is valid",
+			boost: &Boost{
+				Depth: 500,
+				Conditions: []BoostCondition{
+					{Filter: &LocalFilter{}, Weight: 1.0},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "property_value with missing path returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{PropertyValue: &PropertyValue{Modifier: "log1p"}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "path is required",
+		},
+		{
+			name: "property_value with invalid modifier returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{PropertyValue: &PropertyValue{
+						Path:     &Path{Property: "likes"},
+						Modifier: "invalid",
+					}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "modifier must be one of",
+		},
+		{
+			name: "valid property_value condition",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{PropertyValue: &PropertyValue{
+						Path:     &Path{Property: "likes"},
+						Modifier: "log1p",
+					}},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "condition with filter and property_value returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{
+						Filter:        &LocalFilter{},
+						PropertyValue: &PropertyValue{Path: &Path{Property: "likes"}},
+					},
+				},
+			},
+			wantErr: true,
+			errMsg:  "exactly one of",
+		},
+		{
+			name: "valid filter condition returns no error",
+			boost: &Boost{
+				Weight: 0.5,
+				Conditions: []BoostCondition{
+					{Filter: &LocalFilter{}, Weight: 1.0},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid decay condition returns no error",
+			boost: &Boost{
+				Weight: 0.5,
+				Conditions: []BoostCondition{
+					{Decay: &Decay{
+						Path:   &Path{Property: "age"},
+						Origin: "30",
+						Scale:  "10",
+						Curve:  "exp",
+					}, Weight: 1.0},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "negative decay_value returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{Decay: &Decay{
+						Path:       &Path{Property: "age"},
+						Origin:     "30",
+						Scale:      "10",
+						DecayValue: -0.5,
+					}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "decay_value must be between 0 and 1",
+		},
+		{
+			name: "decay_value greater than 1 returns error",
+			boost: &Boost{
+				Conditions: []BoostCondition{
+					{Decay: &Decay{
+						Path:       &Path{Property: "age"},
+						Origin:     "30",
+						Scale:      "10",
+						DecayValue: 1.5,
+					}},
+				},
+			},
+			wantErr: true,
+			errMsg:  "decay_value must be between 0 and 1",
+		},
+		{
+			name: "multiple valid conditions returns no error",
+			boost: &Boost{
+				Weight: 0.8,
+				Conditions: []BoostCondition{
+					{Filter: &LocalFilter{}, Weight: 1.0},
+					{Decay: &Decay{
+						Path:   &Path{Property: "timestamp"},
+						Origin: "now",
+						Scale:  "7d",
+						Curve:  "gauss",
+					}, Weight: 2.0},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateBoost(tt.boost)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errMsg)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/grpc/generated/protocol/v1/search_get.pb.go
+++ b/grpc/generated/protocol/v1/search_get.pb.go
@@ -18,6 +18,107 @@ const (
 	_ = protoimpl.EnforceVersion(protoimpl.MaxVersion - 20)
 )
 
+type Boost_PropertyValueModifier int32
+
+const (
+	Boost_PROPERTY_VALUE_MODIFIER_UNSPECIFIED Boost_PropertyValueModifier = 0
+	Boost_PROPERTY_VALUE_MODIFIER_LOG1P       Boost_PropertyValueModifier = 1
+	Boost_PROPERTY_VALUE_MODIFIER_SQRT        Boost_PropertyValueModifier = 2
+)
+
+// Enum value maps for Boost_PropertyValueModifier.
+var (
+	Boost_PropertyValueModifier_name = map[int32]string{
+		0: "PROPERTY_VALUE_MODIFIER_UNSPECIFIED",
+		1: "PROPERTY_VALUE_MODIFIER_LOG1P",
+		2: "PROPERTY_VALUE_MODIFIER_SQRT",
+	}
+	Boost_PropertyValueModifier_value = map[string]int32{
+		"PROPERTY_VALUE_MODIFIER_UNSPECIFIED": 0,
+		"PROPERTY_VALUE_MODIFIER_LOG1P":       1,
+		"PROPERTY_VALUE_MODIFIER_SQRT":        2,
+	}
+)
+
+func (x Boost_PropertyValueModifier) Enum() *Boost_PropertyValueModifier {
+	p := new(Boost_PropertyValueModifier)
+	*p = x
+	return p
+}
+
+func (x Boost_PropertyValueModifier) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (Boost_PropertyValueModifier) Descriptor() protoreflect.EnumDescriptor {
+	return file_v1_search_get_proto_enumTypes[0].Descriptor()
+}
+
+func (Boost_PropertyValueModifier) Type() protoreflect.EnumType {
+	return &file_v1_search_get_proto_enumTypes[0]
+}
+
+func (x Boost_PropertyValueModifier) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use Boost_PropertyValueModifier.Descriptor instead.
+func (Boost_PropertyValueModifier) EnumDescriptor() ([]byte, []int) {
+	return file_v1_search_get_proto_rawDescGZIP(), []int{16, 0}
+}
+
+type Boost_DecayCurve int32
+
+const (
+	Boost_DECAY_CURVE_UNSPECIFIED Boost_DecayCurve = 0
+	Boost_DECAY_CURVE_GAUSS       Boost_DecayCurve = 1
+	Boost_DECAY_CURVE_LINEAR      Boost_DecayCurve = 2
+	Boost_DECAY_CURVE_EXPONENTIAL Boost_DecayCurve = 3
+)
+
+// Enum value maps for Boost_DecayCurve.
+var (
+	Boost_DecayCurve_name = map[int32]string{
+		0: "DECAY_CURVE_UNSPECIFIED",
+		1: "DECAY_CURVE_GAUSS",
+		2: "DECAY_CURVE_LINEAR",
+		3: "DECAY_CURVE_EXPONENTIAL",
+	}
+	Boost_DecayCurve_value = map[string]int32{
+		"DECAY_CURVE_UNSPECIFIED": 0,
+		"DECAY_CURVE_GAUSS":       1,
+		"DECAY_CURVE_LINEAR":      2,
+		"DECAY_CURVE_EXPONENTIAL": 3,
+	}
+)
+
+func (x Boost_DecayCurve) Enum() *Boost_DecayCurve {
+	p := new(Boost_DecayCurve)
+	*p = x
+	return p
+}
+
+func (x Boost_DecayCurve) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (Boost_DecayCurve) Descriptor() protoreflect.EnumDescriptor {
+	return file_v1_search_get_proto_enumTypes[1].Descriptor()
+}
+
+func (Boost_DecayCurve) Type() protoreflect.EnumType {
+	return &file_v1_search_get_proto_enumTypes[1]
+}
+
+func (x Boost_DecayCurve) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use Boost_DecayCurve.Descriptor instead.
+func (Boost_DecayCurve) EnumDescriptor() ([]byte, []int) {
+	return file_v1_search_get_proto_rawDescGZIP(), []int{16, 1}
+}
+
 type SearchRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// required
@@ -51,6 +152,7 @@ type SearchRequest struct {
 	NearImu      *NearIMUSearch     `protobuf:"bytes,51,opt,name=near_imu,json=nearImu,proto3,oneof" json:"near_imu,omitempty"`
 	Generative   *GenerativeSearch  `protobuf:"bytes,60,opt,name=generative,proto3,oneof" json:"generative,omitempty"`
 	Rerank       *Rerank            `protobuf:"bytes,61,opt,name=rerank,proto3,oneof" json:"rerank,omitempty"`
+	Boost        *Boost             `protobuf:"bytes,62,opt,name=boost,proto3,oneof" json:"boost,omitempty"`
 	// Deprecated: Marked as deprecated in v1/search_get.proto.
 	Uses_123Api bool `protobuf:"varint,100,opt,name=uses_123_api,json=uses123Api,proto3" json:"uses_123_api,omitempty"`
 	// Deprecated: Marked as deprecated in v1/search_get.proto.
@@ -261,6 +363,13 @@ func (x *SearchRequest) GetGenerative() *GenerativeSearch {
 func (x *SearchRequest) GetRerank() *Rerank {
 	if x != nil {
 		return x.Rerank
+	}
+	return nil
+}
+
+func (x *SearchRequest) GetBoost() *Boost {
+	if x != nil {
+		return x.Boost
 	}
 	return nil
 }
@@ -1475,6 +1584,66 @@ func (x *RefPropertiesResult) GetPropName() string {
 	return ""
 }
 
+type Boost struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Conditions    []*Boost_Condition     `protobuf:"bytes,1,rep,name=conditions,proto3" json:"conditions,omitempty"`
+	Weight        *float32               `protobuf:"fixed32,2,opt,name=weight,proto3,oneof" json:"weight,omitempty"`
+	Depth         *uint32                `protobuf:"varint,3,opt,name=depth,proto3,oneof" json:"depth,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Boost) Reset() {
+	*x = Boost{}
+	mi := &file_v1_search_get_proto_msgTypes[16]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Boost) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Boost) ProtoMessage() {}
+
+func (x *Boost) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_search_get_proto_msgTypes[16]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Boost.ProtoReflect.Descriptor instead.
+func (*Boost) Descriptor() ([]byte, []int) {
+	return file_v1_search_get_proto_rawDescGZIP(), []int{16}
+}
+
+func (x *Boost) GetConditions() []*Boost_Condition {
+	if x != nil {
+		return x.Conditions
+	}
+	return nil
+}
+
+func (x *Boost) GetWeight() float32 {
+	if x != nil && x.Weight != nil {
+		return *x.Weight
+	}
+	return 0
+}
+
+func (x *Boost) GetDepth() uint32 {
+	if x != nil && x.Depth != nil {
+		return *x.Depth
+	}
+	return 0
+}
+
 // SearchProfile holds the profiling details for a single search type within a shard.
 type QueryProfile_SearchProfile struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -1486,7 +1655,7 @@ type QueryProfile_SearchProfile struct {
 
 func (x *QueryProfile_SearchProfile) Reset() {
 	*x = QueryProfile_SearchProfile{}
-	mi := &file_v1_search_get_proto_msgTypes[16]
+	mi := &file_v1_search_get_proto_msgTypes[17]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1498,7 +1667,7 @@ func (x *QueryProfile_SearchProfile) String() string {
 func (*QueryProfile_SearchProfile) ProtoMessage() {}
 
 func (x *QueryProfile_SearchProfile) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_search_get_proto_msgTypes[16]
+	mi := &file_v1_search_get_proto_msgTypes[17]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1536,7 +1705,7 @@ type QueryProfile_ShardProfile struct {
 
 func (x *QueryProfile_ShardProfile) Reset() {
 	*x = QueryProfile_ShardProfile{}
-	mi := &file_v1_search_get_proto_msgTypes[17]
+	mi := &file_v1_search_get_proto_msgTypes[18]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -1548,7 +1717,7 @@ func (x *QueryProfile_ShardProfile) String() string {
 func (*QueryProfile_ShardProfile) ProtoMessage() {}
 
 func (x *QueryProfile_ShardProfile) ProtoReflect() protoreflect.Message {
-	mi := &file_v1_search_get_proto_msgTypes[17]
+	mi := &file_v1_search_get_proto_msgTypes[18]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -1585,11 +1754,353 @@ func (x *QueryProfile_ShardProfile) GetSearches() map[string]*QueryProfile_Searc
 	return nil
 }
 
+type Boost_PropertyValueFunction struct {
+	state         protoimpl.MessageState       `protogen:"open.v1"`
+	Property      string                       `protobuf:"bytes,1,opt,name=property,proto3" json:"property,omitempty"`
+	Modifier      *Boost_PropertyValueModifier `protobuf:"varint,2,opt,name=modifier,proto3,enum=weaviate.v1.Boost_PropertyValueModifier,oneof" json:"modifier,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Boost_PropertyValueFunction) Reset() {
+	*x = Boost_PropertyValueFunction{}
+	mi := &file_v1_search_get_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Boost_PropertyValueFunction) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Boost_PropertyValueFunction) ProtoMessage() {}
+
+func (x *Boost_PropertyValueFunction) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_search_get_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Boost_PropertyValueFunction.ProtoReflect.Descriptor instead.
+func (*Boost_PropertyValueFunction) Descriptor() ([]byte, []int) {
+	return file_v1_search_get_proto_rawDescGZIP(), []int{16, 0}
+}
+
+func (x *Boost_PropertyValueFunction) GetProperty() string {
+	if x != nil {
+		return x.Property
+	}
+	return ""
+}
+
+func (x *Boost_PropertyValueFunction) GetModifier() Boost_PropertyValueModifier {
+	if x != nil && x.Modifier != nil {
+		return *x.Modifier
+	}
+	return Boost_PROPERTY_VALUE_MODIFIER_UNSPECIFIED
+}
+
+type Boost_TimeDecayFunction struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Property      string                 `protobuf:"bytes,1,opt,name=property,proto3" json:"property,omitempty"`
+	Origin        string                 `protobuf:"bytes,2,opt,name=origin,proto3" json:"origin,omitempty"`
+	Scale         string                 `protobuf:"bytes,3,opt,name=scale,proto3" json:"scale,omitempty"`
+	Offset        *string                `protobuf:"bytes,4,opt,name=offset,proto3,oneof" json:"offset,omitempty"`
+	Curve         *Boost_DecayCurve      `protobuf:"varint,5,opt,name=curve,proto3,enum=weaviate.v1.Boost_DecayCurve,oneof" json:"curve,omitempty"`
+	DecayValue    *float32               `protobuf:"fixed32,6,opt,name=decay_value,json=decayValue,proto3,oneof" json:"decay_value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Boost_TimeDecayFunction) Reset() {
+	*x = Boost_TimeDecayFunction{}
+	mi := &file_v1_search_get_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Boost_TimeDecayFunction) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Boost_TimeDecayFunction) ProtoMessage() {}
+
+func (x *Boost_TimeDecayFunction) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_search_get_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Boost_TimeDecayFunction.ProtoReflect.Descriptor instead.
+func (*Boost_TimeDecayFunction) Descriptor() ([]byte, []int) {
+	return file_v1_search_get_proto_rawDescGZIP(), []int{16, 1}
+}
+
+func (x *Boost_TimeDecayFunction) GetProperty() string {
+	if x != nil {
+		return x.Property
+	}
+	return ""
+}
+
+func (x *Boost_TimeDecayFunction) GetOrigin() string {
+	if x != nil {
+		return x.Origin
+	}
+	return ""
+}
+
+func (x *Boost_TimeDecayFunction) GetScale() string {
+	if x != nil {
+		return x.Scale
+	}
+	return ""
+}
+
+func (x *Boost_TimeDecayFunction) GetOffset() string {
+	if x != nil && x.Offset != nil {
+		return *x.Offset
+	}
+	return ""
+}
+
+func (x *Boost_TimeDecayFunction) GetCurve() Boost_DecayCurve {
+	if x != nil && x.Curve != nil {
+		return *x.Curve
+	}
+	return Boost_DECAY_CURVE_UNSPECIFIED
+}
+
+func (x *Boost_TimeDecayFunction) GetDecayValue() float32 {
+	if x != nil && x.DecayValue != nil {
+		return *x.DecayValue
+	}
+	return 0
+}
+
+type Boost_NumericDecayFunction struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Property      string                 `protobuf:"bytes,1,opt,name=property,proto3" json:"property,omitempty"`
+	Origin        float64                `protobuf:"fixed64,2,opt,name=origin,proto3" json:"origin,omitempty"`
+	Scale         float64                `protobuf:"fixed64,3,opt,name=scale,proto3" json:"scale,omitempty"`
+	Offset        *float64               `protobuf:"fixed64,4,opt,name=offset,proto3,oneof" json:"offset,omitempty"`
+	Curve         *Boost_DecayCurve      `protobuf:"varint,5,opt,name=curve,proto3,enum=weaviate.v1.Boost_DecayCurve,oneof" json:"curve,omitempty"`
+	DecayValue    *float32               `protobuf:"fixed32,6,opt,name=decay_value,json=decayValue,proto3,oneof" json:"decay_value,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Boost_NumericDecayFunction) Reset() {
+	*x = Boost_NumericDecayFunction{}
+	mi := &file_v1_search_get_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Boost_NumericDecayFunction) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Boost_NumericDecayFunction) ProtoMessage() {}
+
+func (x *Boost_NumericDecayFunction) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_search_get_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Boost_NumericDecayFunction.ProtoReflect.Descriptor instead.
+func (*Boost_NumericDecayFunction) Descriptor() ([]byte, []int) {
+	return file_v1_search_get_proto_rawDescGZIP(), []int{16, 2}
+}
+
+func (x *Boost_NumericDecayFunction) GetProperty() string {
+	if x != nil {
+		return x.Property
+	}
+	return ""
+}
+
+func (x *Boost_NumericDecayFunction) GetOrigin() float64 {
+	if x != nil {
+		return x.Origin
+	}
+	return 0
+}
+
+func (x *Boost_NumericDecayFunction) GetScale() float64 {
+	if x != nil {
+		return x.Scale
+	}
+	return 0
+}
+
+func (x *Boost_NumericDecayFunction) GetOffset() float64 {
+	if x != nil && x.Offset != nil {
+		return *x.Offset
+	}
+	return 0
+}
+
+func (x *Boost_NumericDecayFunction) GetCurve() Boost_DecayCurve {
+	if x != nil && x.Curve != nil {
+		return *x.Curve
+	}
+	return Boost_DECAY_CURVE_UNSPECIFIED
+}
+
+func (x *Boost_NumericDecayFunction) GetDecayValue() float32 {
+	if x != nil && x.DecayValue != nil {
+		return *x.DecayValue
+	}
+	return 0
+}
+
+type Boost_Condition struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Types that are valid to be assigned to Condition:
+	//
+	//	*Boost_Condition_Filter
+	//	*Boost_Condition_TimeDecay
+	//	*Boost_Condition_PropertyValue
+	//	*Boost_Condition_NumericDecay
+	Condition     isBoost_Condition_Condition `protobuf_oneof:"condition"`
+	Weight        *float32                    `protobuf:"fixed32,5,opt,name=weight,proto3,oneof" json:"weight,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *Boost_Condition) Reset() {
+	*x = Boost_Condition{}
+	mi := &file_v1_search_get_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *Boost_Condition) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*Boost_Condition) ProtoMessage() {}
+
+func (x *Boost_Condition) ProtoReflect() protoreflect.Message {
+	mi := &file_v1_search_get_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use Boost_Condition.ProtoReflect.Descriptor instead.
+func (*Boost_Condition) Descriptor() ([]byte, []int) {
+	return file_v1_search_get_proto_rawDescGZIP(), []int{16, 3}
+}
+
+func (x *Boost_Condition) GetCondition() isBoost_Condition_Condition {
+	if x != nil {
+		return x.Condition
+	}
+	return nil
+}
+
+func (x *Boost_Condition) GetFilter() *Filters {
+	if x != nil {
+		if x, ok := x.Condition.(*Boost_Condition_Filter); ok {
+			return x.Filter
+		}
+	}
+	return nil
+}
+
+func (x *Boost_Condition) GetTimeDecay() *Boost_TimeDecayFunction {
+	if x != nil {
+		if x, ok := x.Condition.(*Boost_Condition_TimeDecay); ok {
+			return x.TimeDecay
+		}
+	}
+	return nil
+}
+
+func (x *Boost_Condition) GetPropertyValue() *Boost_PropertyValueFunction {
+	if x != nil {
+		if x, ok := x.Condition.(*Boost_Condition_PropertyValue); ok {
+			return x.PropertyValue
+		}
+	}
+	return nil
+}
+
+func (x *Boost_Condition) GetNumericDecay() *Boost_NumericDecayFunction {
+	if x != nil {
+		if x, ok := x.Condition.(*Boost_Condition_NumericDecay); ok {
+			return x.NumericDecay
+		}
+	}
+	return nil
+}
+
+func (x *Boost_Condition) GetWeight() float32 {
+	if x != nil && x.Weight != nil {
+		return *x.Weight
+	}
+	return 0
+}
+
+type isBoost_Condition_Condition interface {
+	isBoost_Condition_Condition()
+}
+
+type Boost_Condition_Filter struct {
+	Filter *Filters `protobuf:"bytes,1,opt,name=filter,proto3,oneof"`
+}
+
+type Boost_Condition_TimeDecay struct {
+	TimeDecay *Boost_TimeDecayFunction `protobuf:"bytes,2,opt,name=time_decay,json=timeDecay,proto3,oneof"`
+}
+
+type Boost_Condition_PropertyValue struct {
+	PropertyValue *Boost_PropertyValueFunction `protobuf:"bytes,3,opt,name=property_value,json=propertyValue,proto3,oneof"`
+}
+
+type Boost_Condition_NumericDecay struct {
+	NumericDecay *Boost_NumericDecayFunction `protobuf:"bytes,4,opt,name=numeric_decay,json=numericDecay,proto3,oneof"`
+}
+
+func (*Boost_Condition_Filter) isBoost_Condition_Condition() {}
+
+func (*Boost_Condition_TimeDecay) isBoost_Condition_Condition() {}
+
+func (*Boost_Condition_PropertyValue) isBoost_Condition_Condition() {}
+
+func (*Boost_Condition_NumericDecay) isBoost_Condition_Condition() {}
+
 var File_v1_search_get_proto protoreflect.FileDescriptor
 
 const file_v1_search_get_proto_rawDesc = "" +
 	"\n" +
-	"\x13v1/search_get.proto\x12\vweaviate.v1\x1a\rv1/base.proto\x1a\x14v1/base_search.proto\x1a\x13v1/generative.proto\x1a\x13v1/properties.proto\"\xc7\r\n" +
+	"\x13v1/search_get.proto\x12\vweaviate.v1\x1a\rv1/base.proto\x1a\x14v1/base_search.proto\x1a\x13v1/generative.proto\x1a\x13v1/properties.proto\"\x80\x0e\n" +
 	"\rSearchRequest\x12\x1e\n" +
 	"\n" +
 	"collection\x18\x01 \x01(\tR\n" +
@@ -1630,7 +2141,8 @@ const file_v1_search_get_proto_rawDesc = "" +
 	"\n" +
 	"generative\x18< \x01(\v2\x1d.weaviate.v1.GenerativeSearchH\x10R\n" +
 	"generative\x88\x01\x01\x120\n" +
-	"\x06rerank\x18= \x01(\v2\x13.weaviate.v1.RerankH\x11R\x06rerank\x88\x01\x01\x12$\n" +
+	"\x06rerank\x18= \x01(\v2\x13.weaviate.v1.RerankH\x11R\x06rerank\x88\x01\x01\x12-\n" +
+	"\x05boost\x18> \x01(\v2\x12.weaviate.v1.BoostH\x12R\x05boost\x88\x01\x01\x12$\n" +
 	"\fuses_123_api\x18d \x01(\bB\x02\x18\x01R\n" +
 	"uses123Api\x12$\n" +
 	"\fuses_125_api\x18e \x01(\bB\x02\x18\x01R\n" +
@@ -1656,7 +2168,8 @@ const file_v1_search_get_proto_rawDesc = "" +
 	"\r_near_thermalB\v\n" +
 	"\t_near_imuB\r\n" +
 	"\v_generativeB\t\n" +
-	"\a_rerank\"s\n" +
+	"\a_rerankB\b\n" +
+	"\x06_boost\"s\n" +
 	"\aGroupBy\x12\x12\n" +
 	"\x04path\x18\x01 \x03(\tR\x04path\x12(\n" +
 	"\x10number_of_groups\x18\x02 \x01(\x05R\x0enumberOfGroups\x12*\n" +
@@ -1786,7 +2299,60 @@ const file_v1_search_get_proto_rawDesc = "" +
 	"\n" +
 	"properties\x18\x01 \x03(\v2\x1d.weaviate.v1.PropertiesResultR\n" +
 	"properties\x12\x1b\n" +
-	"\tprop_name\x18\x02 \x01(\tR\bpropNameBs\n" +
+	"\tprop_name\x18\x02 \x01(\tR\bpropName\"\x83\v\n" +
+	"\x05Boost\x12<\n" +
+	"\n" +
+	"conditions\x18\x01 \x03(\v2\x1c.weaviate.v1.Boost.ConditionR\n" +
+	"conditions\x12\x1b\n" +
+	"\x06weight\x18\x02 \x01(\x02H\x00R\x06weight\x88\x01\x01\x12\x19\n" +
+	"\x05depth\x18\x03 \x01(\rH\x01R\x05depth\x88\x01\x01\x1a\x8b\x01\n" +
+	"\x15PropertyValueFunction\x12\x1a\n" +
+	"\bproperty\x18\x01 \x01(\tR\bproperty\x12I\n" +
+	"\bmodifier\x18\x02 \x01(\x0e2(.weaviate.v1.Boost.PropertyValueModifierH\x00R\bmodifier\x88\x01\x01B\v\n" +
+	"\t_modifier\x1a\xff\x01\n" +
+	"\x11TimeDecayFunction\x12\x1a\n" +
+	"\bproperty\x18\x01 \x01(\tR\bproperty\x12\x16\n" +
+	"\x06origin\x18\x02 \x01(\tR\x06origin\x12\x14\n" +
+	"\x05scale\x18\x03 \x01(\tR\x05scale\x12\x1b\n" +
+	"\x06offset\x18\x04 \x01(\tH\x00R\x06offset\x88\x01\x01\x128\n" +
+	"\x05curve\x18\x05 \x01(\x0e2\x1d.weaviate.v1.Boost.DecayCurveH\x01R\x05curve\x88\x01\x01\x12$\n" +
+	"\vdecay_value\x18\x06 \x01(\x02H\x02R\n" +
+	"decayValue\x88\x01\x01B\t\n" +
+	"\a_offsetB\b\n" +
+	"\x06_curveB\x0e\n" +
+	"\f_decay_value\x1a\x82\x02\n" +
+	"\x14NumericDecayFunction\x12\x1a\n" +
+	"\bproperty\x18\x01 \x01(\tR\bproperty\x12\x16\n" +
+	"\x06origin\x18\x02 \x01(\x01R\x06origin\x12\x14\n" +
+	"\x05scale\x18\x03 \x01(\x01R\x05scale\x12\x1b\n" +
+	"\x06offset\x18\x04 \x01(\x01H\x00R\x06offset\x88\x01\x01\x128\n" +
+	"\x05curve\x18\x05 \x01(\x0e2\x1d.weaviate.v1.Boost.DecayCurveH\x01R\x05curve\x88\x01\x01\x12$\n" +
+	"\vdecay_value\x18\x06 \x01(\x02H\x02R\n" +
+	"decayValue\x88\x01\x01B\t\n" +
+	"\a_offsetB\b\n" +
+	"\x06_curveB\x0e\n" +
+	"\f_decay_value\x1a\xda\x02\n" +
+	"\tCondition\x12.\n" +
+	"\x06filter\x18\x01 \x01(\v2\x14.weaviate.v1.FiltersH\x00R\x06filter\x12E\n" +
+	"\n" +
+	"time_decay\x18\x02 \x01(\v2$.weaviate.v1.Boost.TimeDecayFunctionH\x00R\ttimeDecay\x12Q\n" +
+	"\x0eproperty_value\x18\x03 \x01(\v2(.weaviate.v1.Boost.PropertyValueFunctionH\x00R\rpropertyValue\x12N\n" +
+	"\rnumeric_decay\x18\x04 \x01(\v2'.weaviate.v1.Boost.NumericDecayFunctionH\x00R\fnumericDecay\x12\x1b\n" +
+	"\x06weight\x18\x05 \x01(\x02H\x01R\x06weight\x88\x01\x01B\v\n" +
+	"\tconditionB\t\n" +
+	"\a_weight\"\x85\x01\n" +
+	"\x15PropertyValueModifier\x12'\n" +
+	"#PROPERTY_VALUE_MODIFIER_UNSPECIFIED\x10\x00\x12!\n" +
+	"\x1dPROPERTY_VALUE_MODIFIER_LOG1P\x10\x01\x12 \n" +
+	"\x1cPROPERTY_VALUE_MODIFIER_SQRT\x10\x02\"u\n" +
+	"\n" +
+	"DecayCurve\x12\x1b\n" +
+	"\x17DECAY_CURVE_UNSPECIFIED\x10\x00\x12\x15\n" +
+	"\x11DECAY_CURVE_GAUSS\x10\x01\x12\x16\n" +
+	"\x12DECAY_CURVE_LINEAR\x10\x02\x12\x1b\n" +
+	"\x17DECAY_CURVE_EXPONENTIAL\x10\x03B\t\n" +
+	"\a_weightB\b\n" +
+	"\x06_depthBs\n" +
 	"#io.weaviate.client.grpc.protocol.v1B\x16WeaviateProtoSearchGetZ4github.com/weaviate/weaviate/grpc/generated;protocolb\x06proto3"
 
 var (
@@ -1801,97 +2367,117 @@ func file_v1_search_get_proto_rawDescGZIP() []byte {
 	return file_v1_search_get_proto_rawDescData
 }
 
-var file_v1_search_get_proto_msgTypes = make([]protoimpl.MessageInfo, 20)
-var file_v1_search_get_proto_goTypes = []any{
-	(*SearchRequest)(nil),              // 0: weaviate.v1.SearchRequest
-	(*GroupBy)(nil),                    // 1: weaviate.v1.GroupBy
-	(*SortBy)(nil),                     // 2: weaviate.v1.SortBy
-	(*MetadataRequest)(nil),            // 3: weaviate.v1.MetadataRequest
-	(*PropertiesRequest)(nil),          // 4: weaviate.v1.PropertiesRequest
-	(*ObjectPropertiesRequest)(nil),    // 5: weaviate.v1.ObjectPropertiesRequest
-	(*RefPropertiesRequest)(nil),       // 6: weaviate.v1.RefPropertiesRequest
-	(*Rerank)(nil),                     // 7: weaviate.v1.Rerank
-	(*SearchReply)(nil),                // 8: weaviate.v1.SearchReply
-	(*QueryProfile)(nil),               // 9: weaviate.v1.QueryProfile
-	(*RerankReply)(nil),                // 10: weaviate.v1.RerankReply
-	(*GroupByResult)(nil),              // 11: weaviate.v1.GroupByResult
-	(*SearchResult)(nil),               // 12: weaviate.v1.SearchResult
-	(*MetadataResult)(nil),             // 13: weaviate.v1.MetadataResult
-	(*PropertiesResult)(nil),           // 14: weaviate.v1.PropertiesResult
-	(*RefPropertiesResult)(nil),        // 15: weaviate.v1.RefPropertiesResult
-	(*QueryProfile_SearchProfile)(nil), // 16: weaviate.v1.QueryProfile.SearchProfile
-	(*QueryProfile_ShardProfile)(nil),  // 17: weaviate.v1.QueryProfile.ShardProfile
-	nil,                                // 18: weaviate.v1.QueryProfile.SearchProfile.DetailsEntry
-	nil,                                // 19: weaviate.v1.QueryProfile.ShardProfile.SearchesEntry
-	(ConsistencyLevel)(0),              // 20: weaviate.v1.ConsistencyLevel
-	(*Filters)(nil),                    // 21: weaviate.v1.Filters
-	(*Hybrid)(nil),                     // 22: weaviate.v1.Hybrid
-	(*BM25)(nil),                       // 23: weaviate.v1.BM25
-	(*NearVector)(nil),                 // 24: weaviate.v1.NearVector
-	(*NearObject)(nil),                 // 25: weaviate.v1.NearObject
-	(*NearTextSearch)(nil),             // 26: weaviate.v1.NearTextSearch
-	(*NearImageSearch)(nil),            // 27: weaviate.v1.NearImageSearch
-	(*NearAudioSearch)(nil),            // 28: weaviate.v1.NearAudioSearch
-	(*NearVideoSearch)(nil),            // 29: weaviate.v1.NearVideoSearch
-	(*NearDepthSearch)(nil),            // 30: weaviate.v1.NearDepthSearch
-	(*NearThermalSearch)(nil),          // 31: weaviate.v1.NearThermalSearch
-	(*NearIMUSearch)(nil),              // 32: weaviate.v1.NearIMUSearch
-	(*GenerativeSearch)(nil),           // 33: weaviate.v1.GenerativeSearch
-	(*GenerativeResult)(nil),           // 34: weaviate.v1.GenerativeResult
-	(*GenerativeReply)(nil),            // 35: weaviate.v1.GenerativeReply
-	(*Vectors)(nil),                    // 36: weaviate.v1.Vectors
-	(*Properties)(nil),                 // 37: weaviate.v1.Properties
-}
+var (
+	file_v1_search_get_proto_enumTypes = make([]protoimpl.EnumInfo, 2)
+	file_v1_search_get_proto_msgTypes  = make([]protoimpl.MessageInfo, 25)
+	file_v1_search_get_proto_goTypes   = []any{
+		(Boost_PropertyValueModifier)(0),    // 0: weaviate.v1.Boost.PropertyValueModifier
+		(Boost_DecayCurve)(0),               // 1: weaviate.v1.Boost.DecayCurve
+		(*SearchRequest)(nil),               // 2: weaviate.v1.SearchRequest
+		(*GroupBy)(nil),                     // 3: weaviate.v1.GroupBy
+		(*SortBy)(nil),                      // 4: weaviate.v1.SortBy
+		(*MetadataRequest)(nil),             // 5: weaviate.v1.MetadataRequest
+		(*PropertiesRequest)(nil),           // 6: weaviate.v1.PropertiesRequest
+		(*ObjectPropertiesRequest)(nil),     // 7: weaviate.v1.ObjectPropertiesRequest
+		(*RefPropertiesRequest)(nil),        // 8: weaviate.v1.RefPropertiesRequest
+		(*Rerank)(nil),                      // 9: weaviate.v1.Rerank
+		(*SearchReply)(nil),                 // 10: weaviate.v1.SearchReply
+		(*QueryProfile)(nil),                // 11: weaviate.v1.QueryProfile
+		(*RerankReply)(nil),                 // 12: weaviate.v1.RerankReply
+		(*GroupByResult)(nil),               // 13: weaviate.v1.GroupByResult
+		(*SearchResult)(nil),                // 14: weaviate.v1.SearchResult
+		(*MetadataResult)(nil),              // 15: weaviate.v1.MetadataResult
+		(*PropertiesResult)(nil),            // 16: weaviate.v1.PropertiesResult
+		(*RefPropertiesResult)(nil),         // 17: weaviate.v1.RefPropertiesResult
+		(*Boost)(nil),                       // 18: weaviate.v1.Boost
+		(*QueryProfile_SearchProfile)(nil),  // 19: weaviate.v1.QueryProfile.SearchProfile
+		(*QueryProfile_ShardProfile)(nil),   // 20: weaviate.v1.QueryProfile.ShardProfile
+		nil,                                 // 21: weaviate.v1.QueryProfile.SearchProfile.DetailsEntry
+		nil,                                 // 22: weaviate.v1.QueryProfile.ShardProfile.SearchesEntry
+		(*Boost_PropertyValueFunction)(nil), // 23: weaviate.v1.Boost.PropertyValueFunction
+		(*Boost_TimeDecayFunction)(nil),     // 24: weaviate.v1.Boost.TimeDecayFunction
+		(*Boost_NumericDecayFunction)(nil),  // 25: weaviate.v1.Boost.NumericDecayFunction
+		(*Boost_Condition)(nil),             // 26: weaviate.v1.Boost.Condition
+		(ConsistencyLevel)(0),               // 27: weaviate.v1.ConsistencyLevel
+		(*Filters)(nil),                     // 28: weaviate.v1.Filters
+		(*Hybrid)(nil),                      // 29: weaviate.v1.Hybrid
+		(*BM25)(nil),                        // 30: weaviate.v1.BM25
+		(*NearVector)(nil),                  // 31: weaviate.v1.NearVector
+		(*NearObject)(nil),                  // 32: weaviate.v1.NearObject
+		(*NearTextSearch)(nil),              // 33: weaviate.v1.NearTextSearch
+		(*NearImageSearch)(nil),             // 34: weaviate.v1.NearImageSearch
+		(*NearAudioSearch)(nil),             // 35: weaviate.v1.NearAudioSearch
+		(*NearVideoSearch)(nil),             // 36: weaviate.v1.NearVideoSearch
+		(*NearDepthSearch)(nil),             // 37: weaviate.v1.NearDepthSearch
+		(*NearThermalSearch)(nil),           // 38: weaviate.v1.NearThermalSearch
+		(*NearIMUSearch)(nil),               // 39: weaviate.v1.NearIMUSearch
+		(*GenerativeSearch)(nil),            // 40: weaviate.v1.GenerativeSearch
+		(*GenerativeResult)(nil),            // 41: weaviate.v1.GenerativeResult
+		(*GenerativeReply)(nil),             // 42: weaviate.v1.GenerativeReply
+		(*Vectors)(nil),                     // 43: weaviate.v1.Vectors
+		(*Properties)(nil),                  // 44: weaviate.v1.Properties
+	}
+)
+
 var file_v1_search_get_proto_depIdxs = []int32{
-	20, // 0: weaviate.v1.SearchRequest.consistency_level:type_name -> weaviate.v1.ConsistencyLevel
-	4,  // 1: weaviate.v1.SearchRequest.properties:type_name -> weaviate.v1.PropertiesRequest
-	3,  // 2: weaviate.v1.SearchRequest.metadata:type_name -> weaviate.v1.MetadataRequest
-	1,  // 3: weaviate.v1.SearchRequest.group_by:type_name -> weaviate.v1.GroupBy
-	2,  // 4: weaviate.v1.SearchRequest.sort_by:type_name -> weaviate.v1.SortBy
-	21, // 5: weaviate.v1.SearchRequest.filters:type_name -> weaviate.v1.Filters
-	22, // 6: weaviate.v1.SearchRequest.hybrid_search:type_name -> weaviate.v1.Hybrid
-	23, // 7: weaviate.v1.SearchRequest.bm25_search:type_name -> weaviate.v1.BM25
-	24, // 8: weaviate.v1.SearchRequest.near_vector:type_name -> weaviate.v1.NearVector
-	25, // 9: weaviate.v1.SearchRequest.near_object:type_name -> weaviate.v1.NearObject
-	26, // 10: weaviate.v1.SearchRequest.near_text:type_name -> weaviate.v1.NearTextSearch
-	27, // 11: weaviate.v1.SearchRequest.near_image:type_name -> weaviate.v1.NearImageSearch
-	28, // 12: weaviate.v1.SearchRequest.near_audio:type_name -> weaviate.v1.NearAudioSearch
-	29, // 13: weaviate.v1.SearchRequest.near_video:type_name -> weaviate.v1.NearVideoSearch
-	30, // 14: weaviate.v1.SearchRequest.near_depth:type_name -> weaviate.v1.NearDepthSearch
-	31, // 15: weaviate.v1.SearchRequest.near_thermal:type_name -> weaviate.v1.NearThermalSearch
-	32, // 16: weaviate.v1.SearchRequest.near_imu:type_name -> weaviate.v1.NearIMUSearch
-	33, // 17: weaviate.v1.SearchRequest.generative:type_name -> weaviate.v1.GenerativeSearch
-	7,  // 18: weaviate.v1.SearchRequest.rerank:type_name -> weaviate.v1.Rerank
-	6,  // 19: weaviate.v1.PropertiesRequest.ref_properties:type_name -> weaviate.v1.RefPropertiesRequest
-	5,  // 20: weaviate.v1.PropertiesRequest.object_properties:type_name -> weaviate.v1.ObjectPropertiesRequest
-	5,  // 21: weaviate.v1.ObjectPropertiesRequest.object_properties:type_name -> weaviate.v1.ObjectPropertiesRequest
-	4,  // 22: weaviate.v1.RefPropertiesRequest.properties:type_name -> weaviate.v1.PropertiesRequest
-	3,  // 23: weaviate.v1.RefPropertiesRequest.metadata:type_name -> weaviate.v1.MetadataRequest
-	12, // 24: weaviate.v1.SearchReply.results:type_name -> weaviate.v1.SearchResult
-	11, // 25: weaviate.v1.SearchReply.group_by_results:type_name -> weaviate.v1.GroupByResult
-	34, // 26: weaviate.v1.SearchReply.generative_grouped_results:type_name -> weaviate.v1.GenerativeResult
-	9,  // 27: weaviate.v1.SearchReply.query_profile:type_name -> weaviate.v1.QueryProfile
-	17, // 28: weaviate.v1.QueryProfile.shards:type_name -> weaviate.v1.QueryProfile.ShardProfile
-	12, // 29: weaviate.v1.GroupByResult.objects:type_name -> weaviate.v1.SearchResult
-	10, // 30: weaviate.v1.GroupByResult.rerank:type_name -> weaviate.v1.RerankReply
-	35, // 31: weaviate.v1.GroupByResult.generative:type_name -> weaviate.v1.GenerativeReply
-	34, // 32: weaviate.v1.GroupByResult.generative_result:type_name -> weaviate.v1.GenerativeResult
-	14, // 33: weaviate.v1.SearchResult.properties:type_name -> weaviate.v1.PropertiesResult
-	13, // 34: weaviate.v1.SearchResult.metadata:type_name -> weaviate.v1.MetadataResult
-	34, // 35: weaviate.v1.SearchResult.generative:type_name -> weaviate.v1.GenerativeResult
-	36, // 36: weaviate.v1.MetadataResult.vectors:type_name -> weaviate.v1.Vectors
-	15, // 37: weaviate.v1.PropertiesResult.ref_props:type_name -> weaviate.v1.RefPropertiesResult
-	13, // 38: weaviate.v1.PropertiesResult.metadata:type_name -> weaviate.v1.MetadataResult
-	37, // 39: weaviate.v1.PropertiesResult.non_ref_props:type_name -> weaviate.v1.Properties
-	14, // 40: weaviate.v1.RefPropertiesResult.properties:type_name -> weaviate.v1.PropertiesResult
-	18, // 41: weaviate.v1.QueryProfile.SearchProfile.details:type_name -> weaviate.v1.QueryProfile.SearchProfile.DetailsEntry
-	19, // 42: weaviate.v1.QueryProfile.ShardProfile.searches:type_name -> weaviate.v1.QueryProfile.ShardProfile.SearchesEntry
-	16, // 43: weaviate.v1.QueryProfile.ShardProfile.SearchesEntry.value:type_name -> weaviate.v1.QueryProfile.SearchProfile
-	44, // [44:44] is the sub-list for method output_type
-	44, // [44:44] is the sub-list for method input_type
-	44, // [44:44] is the sub-list for extension type_name
-	44, // [44:44] is the sub-list for extension extendee
-	0,  // [0:44] is the sub-list for field type_name
+	27, // 0: weaviate.v1.SearchRequest.consistency_level:type_name -> weaviate.v1.ConsistencyLevel
+	6,  // 1: weaviate.v1.SearchRequest.properties:type_name -> weaviate.v1.PropertiesRequest
+	5,  // 2: weaviate.v1.SearchRequest.metadata:type_name -> weaviate.v1.MetadataRequest
+	3,  // 3: weaviate.v1.SearchRequest.group_by:type_name -> weaviate.v1.GroupBy
+	4,  // 4: weaviate.v1.SearchRequest.sort_by:type_name -> weaviate.v1.SortBy
+	28, // 5: weaviate.v1.SearchRequest.filters:type_name -> weaviate.v1.Filters
+	29, // 6: weaviate.v1.SearchRequest.hybrid_search:type_name -> weaviate.v1.Hybrid
+	30, // 7: weaviate.v1.SearchRequest.bm25_search:type_name -> weaviate.v1.BM25
+	31, // 8: weaviate.v1.SearchRequest.near_vector:type_name -> weaviate.v1.NearVector
+	32, // 9: weaviate.v1.SearchRequest.near_object:type_name -> weaviate.v1.NearObject
+	33, // 10: weaviate.v1.SearchRequest.near_text:type_name -> weaviate.v1.NearTextSearch
+	34, // 11: weaviate.v1.SearchRequest.near_image:type_name -> weaviate.v1.NearImageSearch
+	35, // 12: weaviate.v1.SearchRequest.near_audio:type_name -> weaviate.v1.NearAudioSearch
+	36, // 13: weaviate.v1.SearchRequest.near_video:type_name -> weaviate.v1.NearVideoSearch
+	37, // 14: weaviate.v1.SearchRequest.near_depth:type_name -> weaviate.v1.NearDepthSearch
+	38, // 15: weaviate.v1.SearchRequest.near_thermal:type_name -> weaviate.v1.NearThermalSearch
+	39, // 16: weaviate.v1.SearchRequest.near_imu:type_name -> weaviate.v1.NearIMUSearch
+	40, // 17: weaviate.v1.SearchRequest.generative:type_name -> weaviate.v1.GenerativeSearch
+	9,  // 18: weaviate.v1.SearchRequest.rerank:type_name -> weaviate.v1.Rerank
+	18, // 19: weaviate.v1.SearchRequest.boost:type_name -> weaviate.v1.Boost
+	8,  // 20: weaviate.v1.PropertiesRequest.ref_properties:type_name -> weaviate.v1.RefPropertiesRequest
+	7,  // 21: weaviate.v1.PropertiesRequest.object_properties:type_name -> weaviate.v1.ObjectPropertiesRequest
+	7,  // 22: weaviate.v1.ObjectPropertiesRequest.object_properties:type_name -> weaviate.v1.ObjectPropertiesRequest
+	6,  // 23: weaviate.v1.RefPropertiesRequest.properties:type_name -> weaviate.v1.PropertiesRequest
+	5,  // 24: weaviate.v1.RefPropertiesRequest.metadata:type_name -> weaviate.v1.MetadataRequest
+	14, // 25: weaviate.v1.SearchReply.results:type_name -> weaviate.v1.SearchResult
+	13, // 26: weaviate.v1.SearchReply.group_by_results:type_name -> weaviate.v1.GroupByResult
+	41, // 27: weaviate.v1.SearchReply.generative_grouped_results:type_name -> weaviate.v1.GenerativeResult
+	11, // 28: weaviate.v1.SearchReply.query_profile:type_name -> weaviate.v1.QueryProfile
+	20, // 29: weaviate.v1.QueryProfile.shards:type_name -> weaviate.v1.QueryProfile.ShardProfile
+	14, // 30: weaviate.v1.GroupByResult.objects:type_name -> weaviate.v1.SearchResult
+	12, // 31: weaviate.v1.GroupByResult.rerank:type_name -> weaviate.v1.RerankReply
+	42, // 32: weaviate.v1.GroupByResult.generative:type_name -> weaviate.v1.GenerativeReply
+	41, // 33: weaviate.v1.GroupByResult.generative_result:type_name -> weaviate.v1.GenerativeResult
+	16, // 34: weaviate.v1.SearchResult.properties:type_name -> weaviate.v1.PropertiesResult
+	15, // 35: weaviate.v1.SearchResult.metadata:type_name -> weaviate.v1.MetadataResult
+	41, // 36: weaviate.v1.SearchResult.generative:type_name -> weaviate.v1.GenerativeResult
+	43, // 37: weaviate.v1.MetadataResult.vectors:type_name -> weaviate.v1.Vectors
+	17, // 38: weaviate.v1.PropertiesResult.ref_props:type_name -> weaviate.v1.RefPropertiesResult
+	15, // 39: weaviate.v1.PropertiesResult.metadata:type_name -> weaviate.v1.MetadataResult
+	44, // 40: weaviate.v1.PropertiesResult.non_ref_props:type_name -> weaviate.v1.Properties
+	16, // 41: weaviate.v1.RefPropertiesResult.properties:type_name -> weaviate.v1.PropertiesResult
+	26, // 42: weaviate.v1.Boost.conditions:type_name -> weaviate.v1.Boost.Condition
+	21, // 43: weaviate.v1.QueryProfile.SearchProfile.details:type_name -> weaviate.v1.QueryProfile.SearchProfile.DetailsEntry
+	22, // 44: weaviate.v1.QueryProfile.ShardProfile.searches:type_name -> weaviate.v1.QueryProfile.ShardProfile.SearchesEntry
+	19, // 45: weaviate.v1.QueryProfile.ShardProfile.SearchesEntry.value:type_name -> weaviate.v1.QueryProfile.SearchProfile
+	0,  // 46: weaviate.v1.Boost.PropertyValueFunction.modifier:type_name -> weaviate.v1.Boost.PropertyValueModifier
+	1,  // 47: weaviate.v1.Boost.TimeDecayFunction.curve:type_name -> weaviate.v1.Boost.DecayCurve
+	1,  // 48: weaviate.v1.Boost.NumericDecayFunction.curve:type_name -> weaviate.v1.Boost.DecayCurve
+	28, // 49: weaviate.v1.Boost.Condition.filter:type_name -> weaviate.v1.Filters
+	24, // 50: weaviate.v1.Boost.Condition.time_decay:type_name -> weaviate.v1.Boost.TimeDecayFunction
+	23, // 51: weaviate.v1.Boost.Condition.property_value:type_name -> weaviate.v1.Boost.PropertyValueFunction
+	25, // 52: weaviate.v1.Boost.Condition.numeric_decay:type_name -> weaviate.v1.Boost.NumericDecayFunction
+	53, // [53:53] is the sub-list for method output_type
+	53, // [53:53] is the sub-list for method input_type
+	53, // [53:53] is the sub-list for extension type_name
+	53, // [53:53] is the sub-list for extension extendee
+	0,  // [0:53] is the sub-list for field type_name
 }
 
 func init() { file_v1_search_get_proto_init() }
@@ -1909,18 +2495,29 @@ func file_v1_search_get_proto_init() {
 	file_v1_search_get_proto_msgTypes[11].OneofWrappers = []any{}
 	file_v1_search_get_proto_msgTypes[12].OneofWrappers = []any{}
 	file_v1_search_get_proto_msgTypes[13].OneofWrappers = []any{}
+	file_v1_search_get_proto_msgTypes[16].OneofWrappers = []any{}
+	file_v1_search_get_proto_msgTypes[21].OneofWrappers = []any{}
+	file_v1_search_get_proto_msgTypes[22].OneofWrappers = []any{}
+	file_v1_search_get_proto_msgTypes[23].OneofWrappers = []any{}
+	file_v1_search_get_proto_msgTypes[24].OneofWrappers = []any{
+		(*Boost_Condition_Filter)(nil),
+		(*Boost_Condition_TimeDecay)(nil),
+		(*Boost_Condition_PropertyValue)(nil),
+		(*Boost_Condition_NumericDecay)(nil),
+	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_v1_search_get_proto_rawDesc), len(file_v1_search_get_proto_rawDesc)),
-			NumEnums:      0,
-			NumMessages:   20,
+			NumEnums:      2,
+			NumMessages:   25,
 			NumExtensions: 0,
 			NumServices:   0,
 		},
 		GoTypes:           file_v1_search_get_proto_goTypes,
 		DependencyIndexes: file_v1_search_get_proto_depIdxs,
+		EnumInfos:         file_v1_search_get_proto_enumTypes,
 		MessageInfos:      file_v1_search_get_proto_msgTypes,
 	}.Build()
 	File_v1_search_get_proto = out.File

--- a/grpc/proto/v1/search_get.proto
+++ b/grpc/proto/v1/search_get.proto
@@ -49,6 +49,8 @@ message SearchRequest {
   optional GenerativeSearch generative = 60;
   optional Rerank rerank = 61;
 
+  optional Boost boost = 62;
+
   bool uses_123_api = 100 [deprecated = true];
   bool uses_125_api = 101 [deprecated = true];
   bool uses_127_api = 102; 
@@ -211,4 +213,50 @@ message PropertiesResult {
 message RefPropertiesResult {
   repeated PropertiesResult properties = 1;
   string prop_name = 2;
+}
+
+message Boost {
+  enum PropertyValueModifier {
+    PROPERTY_VALUE_MODIFIER_UNSPECIFIED = 0;
+    PROPERTY_VALUE_MODIFIER_LOG1P = 1;
+    PROPERTY_VALUE_MODIFIER_SQRT = 2;
+  }
+  enum DecayCurve {
+    DECAY_CURVE_UNSPECIFIED = 0;
+    DECAY_CURVE_GAUSS = 1;
+    DECAY_CURVE_LINEAR = 2;
+    DECAY_CURVE_EXPONENTIAL = 3;
+  }
+  message PropertyValueFunction {
+    string property = 1;
+    optional PropertyValueModifier modifier = 2;
+  }
+  message TimeDecayFunction {
+    string property = 1;
+    string origin = 2;
+    string scale = 3;
+    optional string offset = 4;
+    optional DecayCurve curve = 5;
+    optional float decay_value = 6;
+  }
+  message NumericDecayFunction {
+    string property = 1;
+    double origin = 2;
+    double scale = 3;
+    optional double offset = 4;
+    optional DecayCurve curve = 5;
+    optional float decay_value = 6;
+  }
+  message Condition {
+    oneof condition {
+      Filters filter = 1;
+      TimeDecayFunction time_decay = 2;
+      PropertyValueFunction property_value = 3;
+      NumericDecayFunction numeric_decay = 4;
+    }
+    optional float weight = 5;
+  }
+  repeated Condition conditions = 1;
+  optional float weight = 2;
+  optional uint32 depth = 3;
 }

--- a/test/acceptance/boost/boost_test.go
+++ b/test/acceptance/boost/boost_test.go
@@ -1,0 +1,1306 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package boost_test
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/usecases/byteops"
+)
+
+const className = "Song"
+
+func float32Ptr(f float32) *float32 { return &f }
+func uint32Ptr(u uint32) *uint32    { return &u }
+
+// deterministicVector returns a unit-ish 4D vector seeded by index.
+func deterministicVector(i int) []float32 {
+	x := float32(math.Sin(float64(i)*0.7)) * 0.5
+	y := float32(math.Cos(float64(i)*1.3)) * 0.5
+	z := float32(math.Sin(float64(i)*2.1+1.0)) * 0.5
+	w := float32(math.Cos(float64(i)*0.3+2.0)) * 0.5
+	return []float32{x, y, z, w}
+}
+
+func setupTestData(t *testing.T) {
+	t.Helper()
+
+	class := &models.Class{
+		Class:      className,
+		Vectorizer: "none",
+		Properties: []*models.Property{
+			{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: models.PropertyTokenizationWord, IndexSearchable: boolPtr(true)},
+			{Name: "likes", DataType: schema.DataTypeNumber.PropString(), IndexFilterable: boolPtr(true)},
+			{Name: "date_published", DataType: schema.DataTypeDate.PropString(), IndexFilterable: boolPtr(true)},
+		},
+	}
+	helper.CreateClass(t, class)
+
+	baseTime := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	objects := make([]*models.Object, 100)
+	for i := range objects {
+		// likes: deterministic spread 0..990 (i*10 with some variation)
+		likes := float64((i*7 + 13) % 100 * 10) // 0..990, pseudo-shuffled
+		// date_published: spread over 200 days from baseTime
+		dayOffset := (i*3 + 5) % 200
+		published := baseTime.Add(-time.Duration(dayOffset) * 24 * time.Hour)
+
+		objects[i] = &models.Object{
+			Class:  className,
+			Vector: deterministicVector(i),
+			Properties: map[string]any{
+				"name":           fmt.Sprintf("Song %03d", i),
+				"likes":          likes,
+				"date_published": published.Format(time.RFC3339),
+			},
+		}
+	}
+	helper.CreateObjectsBatch(t, objects)
+}
+
+func boolPtr(b bool) *bool { return &b }
+
+// withDepth returns a copy of the boost with depth set.
+func withDepth(b *pb.Boost, depth uint32) *pb.Boost {
+	return &pb.Boost{
+		Conditions: b.Conditions,
+		Weight:     b.Weight,
+		Depth:      uint32Ptr(depth),
+	}
+}
+
+func resultIDs(results []*pb.SearchResult) []string {
+	ids := make([]string, len(results))
+	for i, r := range results {
+		ids[i] = r.Metadata.Id
+	}
+	return ids
+}
+
+func TestBoost(t *testing.T) {
+	ctx := context.Background()
+
+	compose, err := docker.New().
+		WithWeaviateWithGRPC().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, compose.Terminate(ctx))
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer helper.ResetClient()
+
+	grpcConn, err := helper.CreateGrpcConnectionClient(compose.GetWeaviate().GrpcURI())
+	require.NoError(t, err)
+	defer grpcConn.Close()
+	grpcClient := helper.CreateGrpcWeaviateClient(grpcConn)
+
+	setupTestData(t)
+	defer helper.DeleteClass(t, className)
+
+	// Wait for indexing.
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection:  className,
+			Limit:       1,
+			Metadata:    &pb.MetadataRequest{Uuid: true},
+			Uses_127Api: true,
+		})
+		assert.NoError(ct, err)
+		assert.NotEmpty(ct, resp.GetResults())
+	}, 15*time.Second, 500*time.Millisecond)
+
+	queryVec := byteops.Fp32SliceToBytes(deterministicVector(0))
+
+	baseNearVector := func() *pb.NearVector {
+		return &pb.NearVector{
+			Vectors: []*pb.Vectors{{
+				VectorBytes: queryVec,
+				Type:        pb.Vectors_VECTOR_TYPE_SINGLE_FP32,
+			}},
+		}
+	}
+
+	// Get first result ID for nearObject tests.
+	baseResp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+		Collection:  className,
+		Limit:       5,
+		Metadata:    &pb.MetadataRequest{Uuid: true, Distance: true, Score: true},
+		NearVector:  baseNearVector(),
+		Uses_127Api: true,
+	})
+	require.NoError(t, err)
+	require.NotEmpty(t, baseResp.Results)
+	firstID := baseResp.Results[0].Metadata.Id
+
+	// ── Baseline: no boost ──────────────────────────────────────
+
+	t.Run("nearVector no boost", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection:  className,
+			Limit:       10,
+			Metadata:    &pb.MetadataRequest{Uuid: true, Distance: true, Score: true},
+			NearVector:  baseNearVector(),
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	t.Run("nearObject no boost", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection:  className,
+			Limit:       10,
+			Metadata:    &pb.MetadataRequest{Uuid: true, Distance: true, Score: true},
+			NearObject:  &pb.NearObject{Id: firstID},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	// ── Filter boost on likes ───────────────────────────────────
+
+	t.Run("nearVector boost filter likes > 500", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.8),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_Filter{Filter: &pb.Filters{
+						Operator:  pb.Filters_OPERATOR_GREATER_THAN,
+						TestValue: &pb.Filters_ValueNumber{ValueNumber: 500},
+						Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "likes"}},
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+		// With weight=0.8 toward filter, high-likes items should dominate top results.
+		// Verify at least 7/10 top results have score > 0 (boosted).
+		highScoreCount := 0
+		for _, r := range resp.Results {
+			if r.Metadata.Score > 0.5 {
+				highScoreCount++
+			}
+		}
+		assert.GreaterOrEqual(t, highScoreCount, 5, "most top results should be boosted by likes filter")
+	})
+
+	t.Run("nearObject boost filter likes > 500", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearObject: &pb.NearObject{Id: firstID},
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.8),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_Filter{Filter: &pb.Filters{
+						Operator:  pb.Filters_OPERATOR_GREATER_THAN,
+						TestValue: &pb.Filters_ValueNumber{ValueNumber: 500},
+						Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "likes"}},
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	// ── Filter boost on likes AND date_published ────────────────
+
+	t.Run("nearVector boost filter likes AND recent date", func(t *testing.T) {
+		cutoff := time.Date(2024, 11, 1, 0, 0, 0, 0, time.UTC).Format(time.RFC3339)
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.9),
+				Conditions: []*pb.Boost_Condition{
+					{
+						Condition: &pb.Boost_Condition_Filter{Filter: &pb.Filters{
+							Operator:  pb.Filters_OPERATOR_GREATER_THAN,
+							TestValue: &pb.Filters_ValueNumber{ValueNumber: 500},
+							Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "likes"}},
+						}},
+						Weight: float32Ptr(2.0),
+					},
+					{
+						Condition: &pb.Boost_Condition_Filter{Filter: &pb.Filters{
+							Operator:  pb.Filters_OPERATOR_GREATER_THAN,
+							TestValue: &pb.Filters_ValueText{ValueText: cutoff},
+							Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "date_published"}},
+						}},
+						Weight: float32Ptr(1.0),
+					},
+				},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	// ── PropertyValue boost on likes ────────────────────────────
+
+	t.Run("nearVector property_value likes none", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.7),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_PropertyValue{PropertyValue: &pb.Boost_PropertyValueFunction{
+						Property: "likes",
+						Modifier: pb.Boost_PROPERTY_VALUE_MODIFIER_UNSPECIFIED.Enum(),
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	t.Run("nearVector property_value likes log1p", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.7),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_PropertyValue{PropertyValue: &pb.Boost_PropertyValueFunction{
+						Property: "likes",
+						Modifier: pb.Boost_PROPERTY_VALUE_MODIFIER_LOG1P.Enum(),
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	t.Run("nearVector property_value likes sqrt", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.7),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_PropertyValue{PropertyValue: &pb.Boost_PropertyValueFunction{
+						Property: "likes",
+						Modifier: pb.Boost_PROPERTY_VALUE_MODIFIER_SQRT.Enum(),
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	// Compare: log1p should compress the range relative to none.
+	// With log1p, the gap between the top-likes and mid-likes items should be smaller,
+	// meaning vector distance has more influence, so ordering is closer to the baseline.
+	t.Run("property_value log1p vs none ordering differs", func(t *testing.T) {
+		makeReq := func(modifier pb.Boost_PropertyValueModifier) *pb.SearchRequest {
+			return &pb.SearchRequest{
+				Collection: className,
+				Limit:      20,
+				Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+				NearVector: baseNearVector(),
+				Boost: &pb.Boost{
+					Weight: float32Ptr(0.5),
+					Conditions: []*pb.Boost_Condition{{
+						Condition: &pb.Boost_Condition_PropertyValue{PropertyValue: &pb.Boost_PropertyValueFunction{
+							Property: "likes",
+							Modifier: modifier.Enum(),
+						}},
+						Weight: float32Ptr(1.0),
+					}},
+				},
+				Uses_127Api: true,
+			}
+		}
+		noneResp, err := grpcClient.Search(ctx, makeReq(pb.Boost_PROPERTY_VALUE_MODIFIER_UNSPECIFIED))
+		require.NoError(t, err)
+		log1pResp, err := grpcClient.Search(ctx, makeReq(pb.Boost_PROPERTY_VALUE_MODIFIER_LOG1P))
+		require.NoError(t, err)
+
+		noneIDs := resultIDs(noneResp.Results)
+		log1pIDs := resultIDs(log1pResp.Results)
+		// They should not be identical since log1p compresses the score range differently.
+		assert.NotEqual(t, noneIDs, log1pIDs, "log1p and none should produce different orderings")
+	})
+
+	// ── Decay on date_published ─────────────────────────────────
+
+	t.Run("nearVector decay date_published exp curve", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.8),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+						Property: "date_published",
+						Origin:   "2025-01-01T00:00:00Z",
+						Scale:    "30d",
+						Curve:    pb.Boost_DECAY_CURVE_EXPONENTIAL.Enum(),
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	t.Run("nearVector decay date_published gauss curve", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.8),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+						Property: "date_published",
+						Origin:   "2025-01-01T00:00:00Z",
+						Scale:    "30d",
+						Curve:    pb.Boost_DECAY_CURVE_GAUSS.Enum(),
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	t.Run("nearVector decay date_published linear curve", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.8),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+						Property: "date_published",
+						Origin:   "2025-01-01T00:00:00Z",
+						Scale:    "30d",
+						Curve:    pb.Boost_DECAY_CURVE_LINEAR.Enum(),
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	// Decay with "now" origin — items published recently score higher.
+	t.Run("nearVector decay date_published origin now", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.8),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+						Property: "date_published",
+						Scale:    "60d",
+						Curve:    pb.Boost_DECAY_CURVE_EXPONENTIAL.Enum(),
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	// Tight scale (7d) should change ordering more aggressively than wide scale (180d).
+	t.Run("decay tight vs wide scale produces different ordering", func(t *testing.T) {
+		makeDecayReq := func(scale string) *pb.SearchRequest {
+			return &pb.SearchRequest{
+				Collection: className,
+				Limit:      20,
+				Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+				NearVector: baseNearVector(),
+				Boost: &pb.Boost{
+					Weight: float32Ptr(0.5),
+					Conditions: []*pb.Boost_Condition{{
+						Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+							Property: "date_published",
+							Origin:   "2025-01-01T00:00:00Z",
+							Scale:    scale,
+							Curve:    pb.Boost_DECAY_CURVE_EXPONENTIAL.Enum(),
+						}},
+						Weight: float32Ptr(1.0),
+					}},
+				},
+				Uses_127Api: true,
+			}
+		}
+		tightResp, err := grpcClient.Search(ctx, makeDecayReq("7d"))
+		require.NoError(t, err)
+		wideResp, err := grpcClient.Search(ctx, makeDecayReq("180d"))
+		require.NoError(t, err)
+
+		tightIDs := resultIDs(tightResp.Results)
+		wideIDs := resultIDs(wideResp.Results)
+		assert.NotEqual(t, tightIDs, wideIDs, "tight and wide scales should produce different orderings")
+	})
+
+	// Different decay_value should affect scoring.
+	t.Run("decay different decay_value", func(t *testing.T) {
+		makeDecayReq := func(dv float32) *pb.SearchRequest {
+			return &pb.SearchRequest{
+				Collection: className,
+				Limit:      20,
+				Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+				NearVector: baseNearVector(),
+				Boost: &pb.Boost{
+					Weight: float32Ptr(0.5),
+					Conditions: []*pb.Boost_Condition{{
+						Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+							Property:   "date_published",
+							Origin:     "2025-01-01T00:00:00Z",
+							Scale:      "30d",
+							Curve:      pb.Boost_DECAY_CURVE_EXPONENTIAL.Enum(),
+							DecayValue: float32Ptr(dv),
+						}},
+						Weight: float32Ptr(1.0),
+					}},
+				},
+				Uses_127Api: true,
+			}
+		}
+		resp01, err := grpcClient.Search(ctx, makeDecayReq(0.1))
+		require.NoError(t, err)
+		resp09, err := grpcClient.Search(ctx, makeDecayReq(0.9))
+		require.NoError(t, err)
+
+		ids01 := resultIDs(resp01.Results)
+		ids09 := resultIDs(resp09.Results)
+		assert.NotEqual(t, ids01, ids09, "decay_value 0.1 vs 0.9 should produce different orderings")
+	})
+
+	// Different curves should produce different orderings.
+	t.Run("decay different curves produce different orderings", func(t *testing.T) {
+		makeDecayReq := func(curve pb.Boost_DecayCurve) *pb.SearchRequest {
+			return &pb.SearchRequest{
+				Collection: className,
+				Limit:      20,
+				Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+				NearVector: baseNearVector(),
+				Boost: &pb.Boost{
+					Weight: float32Ptr(0.5),
+					Conditions: []*pb.Boost_Condition{{
+						Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+							Property: "date_published",
+							Origin:   "2025-01-01T00:00:00Z",
+							Scale:    "30d",
+							Curve:    curve.Enum(),
+						}},
+						Weight: float32Ptr(1.0),
+					}},
+				},
+				Uses_127Api: true,
+			}
+		}
+		expResp, err := grpcClient.Search(ctx, makeDecayReq(pb.Boost_DECAY_CURVE_EXPONENTIAL))
+		require.NoError(t, err)
+		linearResp, err := grpcClient.Search(ctx, makeDecayReq(pb.Boost_DECAY_CURVE_LINEAR))
+		require.NoError(t, err)
+
+		expIDs := resultIDs(expResp.Results)
+		linearIDs := resultIDs(linearResp.Results)
+		assert.NotEqual(t, expIDs, linearIDs, "exp vs linear curves should produce different orderings")
+	})
+
+	// ── Blend: multiple boost conditions ────────────────────────
+
+	t.Run("blend filter + decay with varying weights", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.7),
+				Conditions: []*pb.Boost_Condition{
+					{
+						Condition: &pb.Boost_Condition_Filter{Filter: &pb.Filters{
+							Operator:  pb.Filters_OPERATOR_GREATER_THAN,
+							TestValue: &pb.Filters_ValueNumber{ValueNumber: 500},
+							Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "likes"}},
+						}},
+						Weight: float32Ptr(3.0),
+					},
+					{
+						Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+							Property: "date_published",
+							Origin:   "2025-01-01T00:00:00Z",
+							Scale:    "30d",
+							Curve:    pb.Boost_DECAY_CURVE_EXPONENTIAL.Enum(),
+						}},
+						Weight: float32Ptr(1.0),
+					},
+				},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	t.Run("blend property_value + decay", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.6),
+				Conditions: []*pb.Boost_Condition{
+					{
+						Condition: &pb.Boost_Condition_PropertyValue{PropertyValue: &pb.Boost_PropertyValueFunction{
+							Property: "likes",
+							Modifier: pb.Boost_PROPERTY_VALUE_MODIFIER_LOG1P.Enum(),
+						}},
+						Weight: float32Ptr(2.0),
+					},
+					{
+						Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+							Property: "date_published",
+							Origin:   "2025-01-01T00:00:00Z",
+							Scale:    "14d",
+							Curve:    pb.Boost_DECAY_CURVE_GAUSS.Enum(),
+						}},
+						Weight: float32Ptr(1.5),
+					},
+				},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	t.Run("blend filter + property_value + decay", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.8),
+				Conditions: []*pb.Boost_Condition{
+					{
+						Condition: &pb.Boost_Condition_Filter{Filter: &pb.Filters{
+							Operator:  pb.Filters_OPERATOR_GREATER_THAN,
+							TestValue: &pb.Filters_ValueNumber{ValueNumber: 300},
+							Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "likes"}},
+						}},
+						Weight: float32Ptr(1.0),
+					},
+					{
+						Condition: &pb.Boost_Condition_PropertyValue{PropertyValue: &pb.Boost_PropertyValueFunction{
+							Property: "likes",
+							Modifier: pb.Boost_PROPERTY_VALUE_MODIFIER_SQRT.Enum(),
+						}},
+						Weight: float32Ptr(2.0),
+					},
+					{
+						Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+							Property: "date_published",
+							Origin:   "2025-01-01T00:00:00Z",
+							Scale:    "60d",
+							Curve:    pb.Boost_DECAY_CURVE_LINEAR.Enum(),
+						}},
+						Weight: float32Ptr(1.5),
+					},
+				},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	// Verify that changing boost weight changes the ordering.
+	t.Run("blend weight 0.3 vs 1.0 produces different ordering", func(t *testing.T) {
+		makeReq := func(w float32) *pb.SearchRequest {
+			return &pb.SearchRequest{
+				Collection: className,
+				Limit:      20,
+				Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+				NearVector: baseNearVector(),
+				Boost: &pb.Boost{
+					Weight: float32Ptr(w),
+					Conditions: []*pb.Boost_Condition{
+						{
+							Condition: &pb.Boost_Condition_PropertyValue{PropertyValue: &pb.Boost_PropertyValueFunction{
+								Property: "likes",
+								Modifier: pb.Boost_PROPERTY_VALUE_MODIFIER_UNSPECIFIED.Enum(),
+							}},
+							Weight: float32Ptr(1.0),
+						},
+						{
+							Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+								Property: "date_published",
+								Origin:   "2025-01-01T00:00:00Z",
+								Scale:    "30d",
+								Curve:    pb.Boost_DECAY_CURVE_EXPONENTIAL.Enum(),
+							}},
+							Weight: float32Ptr(1.0),
+						},
+					},
+				},
+				Uses_127Api: true,
+			}
+		}
+		resp03, err := grpcClient.Search(ctx, makeReq(0.3))
+		require.NoError(t, err)
+		resp10, err := grpcClient.Search(ctx, makeReq(1.0))
+		require.NoError(t, err)
+
+		ids03 := resultIDs(resp03.Results)
+		ids10 := resultIDs(resp10.Results)
+		assert.NotEqual(t, ids03, ids10,
+			"boost weight 0.3 vs 1.0 should produce different orderings")
+	})
+
+	// ── Depth controls candidate pool ───────────────────────────
+
+	// With limit=1, the single returned result should change as depth increases
+	// because boost can promote items from deeper in the vector search results.
+	// We use a strong filter boost (weight=1.0) to promote a specific item that
+	// is NOT the closest vector match.
+	t.Run("depth controls candidate pool", func(t *testing.T) {
+		// First, find what the top-1 result is WITHOUT boost (pure vector search).
+		baseResp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection:  className,
+			Limit:       1,
+			Metadata:    &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector:  baseNearVector(),
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, baseResp.Results, 1)
+		baseTopID := baseResp.Results[0].Metadata.Id
+
+		// Now find a high-likes item that is far in vector space (not top-1).
+		// Get top-100 vector results and find one with likes > 800 that isn't the top-1.
+		allResp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection:  className,
+			Limit:       100,
+			Metadata:    &pb.MetadataRequest{Uuid: true, Score: true},
+			Properties:  &pb.PropertiesRequest{ReturnAllNonrefProperties: true},
+			NearVector:  baseNearVector(),
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, allResp.Results)
+
+		// Find the position of the first high-likes item (likes > 800).
+		var highLikesPosition int
+		found := false
+		for i, r := range allResp.Results {
+			likesVal := r.Properties.NonRefProps.Fields["likes"].GetNumberValue()
+			if likesVal > 800 && r.Metadata.Id != baseTopID {
+				highLikesPosition = i
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "should find a high-likes item that isn't the top vector match")
+
+		// Boost that strongly promotes likes > 800.
+		boostLikes := &pb.Boost{
+			Weight: float32Ptr(1.0),
+			Conditions: []*pb.Boost_Condition{{
+				Condition: &pb.Boost_Condition_Filter{Filter: &pb.Filters{
+					Operator:  pb.Filters_OPERATOR_GREATER_THAN,
+					TestValue: &pb.Filters_ValueNumber{ValueNumber: 800},
+					Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "likes"}},
+				}},
+				Weight: float32Ptr(1.0),
+			}},
+		}
+
+		// depth=1: only 1 candidate, boost can't reorder.
+		resp1, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection:  className,
+			Limit:       1,
+			Metadata:    &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector:  baseNearVector(),
+			Boost:       withDepth(boostLikes, 1),
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp1.Results, 1)
+		depth1ID := resp1.Results[0].Metadata.Id
+
+		// depth large enough to include the high-likes item.
+		largeDepth := uint32(highLikesPosition + 5)
+		if largeDepth < 10 {
+			largeDepth = 10
+		}
+		respLarge, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection:  className,
+			Limit:       1,
+			Metadata:    &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector:  baseNearVector(),
+			Boost:       withDepth(boostLikes, largeDepth),
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, respLarge.Results, 1)
+		depthLargeID := respLarge.Results[0].Metadata.Id
+
+		// With depth=1, boost has no room to reorder — should match base.
+		assert.Equal(t, baseTopID, depth1ID,
+			"depth=1 should return same result as no-boost (only 1 candidate)")
+
+		// With large depth, boost should promote the high-likes item.
+		assert.NotEqual(t, baseTopID, depthLargeID,
+			"large depth should allow boost to promote a different item")
+	})
+
+	// Negative condition weight should demote matches.
+	t.Run("blend negative weight demotes", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector: baseNearVector(),
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.8),
+				Conditions: []*pb.Boost_Condition{
+					{
+						// Promote high likes.
+						Condition: &pb.Boost_Condition_PropertyValue{PropertyValue: &pb.Boost_PropertyValueFunction{
+							Property: "likes",
+							Modifier: pb.Boost_PROPERTY_VALUE_MODIFIER_UNSPECIFIED.Enum(),
+						}},
+						Weight: float32Ptr(2.0),
+					},
+					{
+						// Demote old items.
+						Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+							Property: "date_published",
+							Origin:   "2025-01-01T00:00:00Z",
+							Scale:    "30d",
+							Curve:    pb.Boost_DECAY_CURVE_EXPONENTIAL.Enum(),
+						}},
+						Weight: float32Ptr(-0.5),
+					},
+				},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	// ── Hybrid search + boost ───────────────────────────────────
+
+	// All song names are "Song 000" .. "Song 099", so BM25 on "Song" matches all.
+	// Hybrid combines BM25 + vector. Boost should reorder the fused results.
+
+	t.Run("hybrid no boost baseline", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			HybridSearch: &pb.Hybrid{
+				Query:      "Song",
+				Properties: []string{"name"},
+				NearVector: baseNearVector(),
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	t.Run("hybrid boost filter likes > 500", func(t *testing.T) {
+		// Without boost: hybrid returns results by fused BM25+vector score.
+		// With boost: high-likes items should be promoted.
+		noBoostResp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			HybridSearch: &pb.Hybrid{
+				Query:      "Song",
+				Properties: []string{"name"},
+				NearVector: baseNearVector(),
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+
+		boostResp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			HybridSearch: &pb.Hybrid{
+				Query:      "Song",
+				Properties: []string{"name"},
+				NearVector: baseNearVector(),
+			},
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.8),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_Filter{Filter: &pb.Filters{
+						Operator:  pb.Filters_OPERATOR_GREATER_THAN,
+						TestValue: &pb.Filters_ValueNumber{ValueNumber: 500},
+						Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "likes"}},
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, boostResp.Results, 10)
+
+		noBoostIDs := resultIDs(noBoostResp.Results)
+		boostIDs := resultIDs(boostResp.Results)
+		assert.NotEqual(t, noBoostIDs, boostIDs,
+			"hybrid + boost should produce different ordering than hybrid alone")
+	})
+
+	t.Run("hybrid boost property_value likes", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			HybridSearch: &pb.Hybrid{
+				Query:      "Song",
+				Properties: []string{"name"},
+				NearVector: baseNearVector(),
+			},
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.7),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_PropertyValue{PropertyValue: &pb.Boost_PropertyValueFunction{
+						Property: "likes",
+						Modifier: pb.Boost_PROPERTY_VALUE_MODIFIER_LOG1P.Enum(),
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	t.Run("hybrid boost decay date_published", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			HybridSearch: &pb.Hybrid{
+				Query:      "Song",
+				Properties: []string{"name"},
+				NearVector: baseNearVector(),
+			},
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.6),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+						Property: "date_published",
+						Origin:   "2025-01-01T00:00:00Z",
+						Scale:    "30d",
+						Curve:    pb.Boost_DECAY_CURVE_EXPONENTIAL.Enum(),
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	t.Run("hybrid boost blend multiple conditions", func(t *testing.T) {
+		resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			HybridSearch: &pb.Hybrid{
+				Query:      "Song",
+				Properties: []string{"name"},
+				NearVector: baseNearVector(),
+			},
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0.7),
+				Conditions: []*pb.Boost_Condition{
+					{
+						Condition: &pb.Boost_Condition_Filter{Filter: &pb.Filters{
+							Operator:  pb.Filters_OPERATOR_GREATER_THAN,
+							TestValue: &pb.Filters_ValueNumber{ValueNumber: 300},
+							Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "likes"}},
+						}},
+						Weight: float32Ptr(2.0),
+					},
+					{
+						Condition: &pb.Boost_Condition_TimeDecay{TimeDecay: &pb.Boost_TimeDecayFunction{
+							Property: "date_published",
+							Origin:   "2025-01-01T00:00:00Z",
+							Scale:    "60d",
+							Curve:    pb.Boost_DECAY_CURVE_GAUSS.Enum(),
+						}},
+						Weight: float32Ptr(1.0),
+					},
+				},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, resp.Results, 10)
+	})
+
+	t.Run("hybrid boost weight 0 has no effect", func(t *testing.T) {
+		noBoostResp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			HybridSearch: &pb.Hybrid{
+				Query:      "Song",
+				Properties: []string{"name"},
+				NearVector: baseNearVector(),
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+
+		zeroWeightResp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			HybridSearch: &pb.Hybrid{
+				Query:      "Song",
+				Properties: []string{"name"},
+				NearVector: baseNearVector(),
+			},
+			Boost: &pb.Boost{
+				Weight: float32Ptr(0),
+				Conditions: []*pb.Boost_Condition{{
+					Condition: &pb.Boost_Condition_Filter{Filter: &pb.Filters{
+						Operator:  pb.Filters_OPERATOR_GREATER_THAN,
+						TestValue: &pb.Filters_ValueNumber{ValueNumber: 500},
+						Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "likes"}},
+					}},
+					Weight: float32Ptr(1.0),
+				}},
+			},
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+
+		noBoostIDs := resultIDs(noBoostResp.Results)
+		zeroWeightIDs := resultIDs(zeroWeightResp.Results)
+		assert.Equal(t, noBoostIDs, zeroWeightIDs,
+			"hybrid + boost with weight=0 should produce same ordering as no boost")
+	})
+
+	// ── Pagination (offset) + boost ───────────────────────────────
+
+	likesBoost := &pb.Boost{
+		Weight: float32Ptr(0.8),
+		Conditions: []*pb.Boost_Condition{{
+			Condition: &pb.Boost_Condition_PropertyValue{PropertyValue: &pb.Boost_PropertyValueFunction{
+				Property: "likes",
+				Modifier: pb.Boost_PROPERTY_VALUE_MODIFIER_UNSPECIFIED.Enum(),
+			}},
+			Weight: float32Ptr(1.0),
+		}},
+	}
+
+	// Get all 20 results in one page as the reference ordering.
+	t.Run("pagination: page-through consistency nearVector", func(t *testing.T) {
+		allResp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection:  className,
+			Limit:       20,
+			Offset:      0,
+			Metadata:    &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector:  baseNearVector(),
+			Boost:       likesBoost,
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, allResp.Results, 20)
+		allIDs := resultIDs(allResp.Results)
+
+		// Page 1: offset=0, limit=10
+		p1Resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection:  className,
+			Limit:       10,
+			Offset:      0,
+			Metadata:    &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector:  baseNearVector(),
+			Boost:       likesBoost,
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, p1Resp.Results, 10)
+
+		// Page 2: offset=10, limit=10
+		p2Resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection:  className,
+			Limit:       10,
+			Offset:      10,
+			Metadata:    &pb.MetadataRequest{Uuid: true, Score: true},
+			NearVector:  baseNearVector(),
+			Boost:       likesBoost,
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, p2Resp.Results, 10)
+
+		p1IDs := resultIDs(p1Resp.Results)
+		p2IDs := resultIDs(p2Resp.Results)
+
+		// Page 1 + Page 2 should match the full 20 result IDs.
+		combined := append(p1IDs, p2IDs...)
+		assert.Equal(t, allIDs, combined,
+			"page 1 + page 2 should equal the full result set")
+
+		// No overlap between pages.
+		p1Set := make(map[string]bool)
+		for _, id := range p1IDs {
+			p1Set[id] = true
+		}
+		for _, id := range p2IDs {
+			assert.False(t, p1Set[id], "page 2 result %s should not appear in page 1", id)
+		}
+	})
+
+	t.Run("pagination: page-through consistency hybrid", func(t *testing.T) {
+		hybridBoost := &pb.Boost{
+			Weight: float32Ptr(0.7),
+			Conditions: []*pb.Boost_Condition{{
+				Condition: &pb.Boost_Condition_Filter{Filter: &pb.Filters{
+					Operator:  pb.Filters_OPERATOR_GREATER_THAN,
+					TestValue: &pb.Filters_ValueNumber{ValueNumber: 500},
+					Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "likes"}},
+				}},
+				Weight: float32Ptr(1.0),
+			}},
+		}
+
+		allResp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      20,
+			Offset:     0,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			HybridSearch: &pb.Hybrid{
+				Query:      "Song",
+				Properties: []string{"name"},
+				NearVector: baseNearVector(),
+			},
+			Boost:       hybridBoost,
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, allResp.Results, 20)
+		allIDs := resultIDs(allResp.Results)
+
+		p1Resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Offset:     0,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			HybridSearch: &pb.Hybrid{
+				Query:      "Song",
+				Properties: []string{"name"},
+				NearVector: baseNearVector(),
+			},
+			Boost:       hybridBoost,
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, p1Resp.Results, 10)
+
+		p2Resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Offset:     10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			HybridSearch: &pb.Hybrid{
+				Query:      "Song",
+				Properties: []string{"name"},
+				NearVector: baseNearVector(),
+			},
+			Boost:       hybridBoost,
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, p2Resp.Results, 10)
+
+		p1IDs := resultIDs(p1Resp.Results)
+		p2IDs := resultIDs(p2Resp.Results)
+
+		combined := append(p1IDs, p2IDs...)
+		assert.Equal(t, allIDs, combined,
+			"hybrid: page 1 + page 2 should equal the full result set")
+	})
+
+	t.Run("pagination: offset with BM25 + boost", func(t *testing.T) {
+		bm25Boost := &pb.Boost{
+			Weight: float32Ptr(0.8),
+			Conditions: []*pb.Boost_Condition{{
+				Condition: &pb.Boost_Condition_PropertyValue{PropertyValue: &pb.Boost_PropertyValueFunction{
+					Property: "likes",
+					Modifier: pb.Boost_PROPERTY_VALUE_MODIFIER_UNSPECIFIED.Enum(),
+				}},
+				Weight: float32Ptr(1.0),
+			}},
+		}
+
+		allResp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      20,
+			Offset:     0,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			Bm25Search: &pb.BM25{
+				Query:      "Song",
+				Properties: []string{"name"},
+			},
+			Boost:       bm25Boost,
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, allResp.Results, 20)
+		allIDs := resultIDs(allResp.Results)
+
+		p1Resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Offset:     0,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			Bm25Search: &pb.BM25{
+				Query:      "Song",
+				Properties: []string{"name"},
+			},
+			Boost:       bm25Boost,
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, p1Resp.Results, 10)
+
+		p2Resp, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection: className,
+			Limit:      10,
+			Offset:     10,
+			Metadata:   &pb.MetadataRequest{Uuid: true, Score: true},
+			Bm25Search: &pb.BM25{
+				Query:      "Song",
+				Properties: []string{"name"},
+			},
+			Boost:       bm25Boost,
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+		require.Len(t, p2Resp.Results, 10)
+
+		p1IDs := resultIDs(p1Resp.Results)
+		p2IDs := resultIDs(p2Resp.Results)
+
+		combined := append(p1IDs, p2IDs...)
+		assert.Equal(t, allIDs, combined,
+			"BM25: page 1 + page 2 should equal the full result set")
+	})
+
+	t.Run("pagination: boost reorders across offset boundary", func(t *testing.T) {
+		// Without boost, nearVector returns by distance. With a strong boost
+		// on likes, the ordering changes. Verify that offset into the boosted
+		// ordering returns different results than offset into the unboosted ordering.
+		unboostedP2, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection:  className,
+			Limit:       5,
+			Offset:      5,
+			Metadata:    &pb.MetadataRequest{Uuid: true},
+			NearVector:  baseNearVector(),
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+
+		boostedP2, err := grpcClient.Search(ctx, &pb.SearchRequest{
+			Collection:  className,
+			Limit:       5,
+			Offset:      5,
+			Metadata:    &pb.MetadataRequest{Uuid: true},
+			NearVector:  baseNearVector(),
+			Boost:       likesBoost,
+			Uses_127Api: true,
+		})
+		require.NoError(t, err)
+
+		unboostedIDs := resultIDs(unboostedP2.Results)
+		boostedIDs := resultIDs(boostedP2.Results)
+		assert.NotEqual(t, unboostedIDs, boostedIDs,
+			"offset=5 with boost should differ from offset=5 without boost")
+	})
+}

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -153,6 +153,7 @@ type Config struct {
 	QueryDefaults                    QueryDefaults            `json:"query_defaults" yaml:"query_defaults"`
 	QueryMaximumResults              int64                    `json:"query_maximum_results" yaml:"query_maximum_results"`
 	QueryHybridMaximumResults        int64                    `json:"query_hybrid_maximum_results" yaml:"query_hybrid_maximum_results"`
+	QueryBoostDefaultDepth           int                      `json:"query_boost_default_depth" yaml:"query_boost_default_depth"`
 	QueryNestedCrossReferenceLimit   int64                    `json:"query_nested_cross_reference_limit" yaml:"query_nested_cross_reference_limit"`
 	QueryCrossReferenceDepthLimit    int                      `json:"query_cross_reference_depth_limit" yaml:"query_cross_reference_depth_limit"`
 	Contextionary                    Contextionary            `json:"contextionary" yaml:"contextionary"`

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -787,6 +787,19 @@ func FromEnv(config *Config) error {
 		config.QueryHybridMaximumResults = DefaultQueryHybridMaximumResults
 	}
 
+	if v := os.Getenv("QUERY_BOOST_DEFAULT_DEPTH"); v != "" {
+		asInt, err := strconv.Atoi(v)
+		if err != nil {
+			return fmt.Errorf("parse QUERY_BOOST_DEFAULT_DEPTH as int: %w", err)
+		}
+		if asInt <= 0 {
+			return fmt.Errorf("QUERY_BOOST_DEFAULT_DEPTH must be a positive integer, got %d", asInt)
+		}
+		config.QueryBoostDefaultDepth = asInt
+	} else {
+		config.QueryBoostDefaultDepth = DefaultQueryBoostDepth
+	}
+
 	if v := os.Getenv("QUERY_NESTED_CROSS_REFERENCE_LIMIT"); v != "" {
 		limit, err := strconv.ParseInt(v, 10, 64)
 		if err != nil {
@@ -1777,6 +1790,7 @@ func parseFloatVerify(envName string, defaultValue float64, cb func(val float64)
 const (
 	DefaultQueryMaximumResults       = int64(10000)
 	DefaultQueryHybridMaximumResults = int64(100)
+	DefaultQueryBoostDepth           = 100
 	// DefaultQueryNestedCrossReferenceLimit describes the max number of nested crossrefs returned for a query
 	DefaultQueryNestedCrossReferenceLimit = int64(100000)
 	// DefaultQueryCrossReferenceDepthLimit describes the max depth of nested crossrefs in a query

--- a/usecases/traverser/boost_scorer.go
+++ b/usecases/traverser/boost_scorer.go
@@ -171,7 +171,7 @@ func scoreResult(r *search.Result, conditions []filters.BoostCondition,
 }
 
 // distToScore converts distance-based results (from vector search) to
-// score-based results that applyRankScoring can blend with. Distance is
+// score-based results that applyBoostScoring can blend with. Distance is
 // inverted so that closer objects get higher scores.
 func distToScore(results []search.Result) {
 	for i := range results {

--- a/usecases/traverser/boost_scorer.go
+++ b/usecases/traverser/boost_scorer.go
@@ -448,9 +448,19 @@ type parsedDecay struct {
 }
 
 func parseDecayParams(d *filters.Decay) parsedDecay {
-	offset, _ := parseNumericOrDuration(d.Offset)
-	scale, err := parseNumericOrDuration(d.Scale)
-	if err != nil || scale <= 0 {
+	var offset, scale float64
+	if d.IsNumeric {
+		offset = d.OffsetNumeric
+		scale = d.ScaleNumeric
+	} else {
+		var err error
+		offset, _ = parseNumericOrDuration(d.Offset)
+		scale, err = parseNumericOrDuration(d.Scale)
+		if err != nil {
+			return parsedDecay{}
+		}
+	}
+	if scale <= 0 {
 		return parsedDecay{}
 	}
 	decayValue := float64(d.DecayValue)
@@ -507,9 +517,14 @@ func computeDistance(decay *filters.Decay, propValue interface{}, nowTime time.T
 		return 0, err
 	}
 
-	originNum, err := strconv.ParseFloat(decay.Origin, 64)
-	if err != nil {
-		return 0, err
+	var originNum float64
+	if decay.IsNumeric {
+		originNum = decay.OriginNumeric
+	} else {
+		originNum, err = strconv.ParseFloat(decay.Origin, 64)
+		if err != nil {
+			return 0, err
+		}
 	}
 
 	return math.Abs(numVal - originNum), nil

--- a/usecases/traverser/boost_scorer.go
+++ b/usecases/traverser/boost_scorer.go
@@ -260,11 +260,11 @@ func applyPropertyValueModifier(val float64, modifier filters.PropertyValueModif
 }
 
 // extractProps gets the properties map from a search result.
-func extractProps(r *search.Result) map[string]interface{} {
+func extractProps(r *search.Result) map[string]any {
 	if r.Schema == nil {
 		return nil
 	}
-	props, ok := r.Schema.(map[string]interface{})
+	props, ok := r.Schema.(map[string]any)
 	if !ok {
 		return nil
 	}
@@ -273,14 +273,14 @@ func extractProps(r *search.Result) map[string]interface{} {
 
 // matchesFilter evaluates a LocalFilter against an object's properties in-memory.
 // This handles the common filter operators used in boost conditions.
-func matchesFilter(filter *filters.LocalFilter, props map[string]interface{}) bool {
+func matchesFilter(filter *filters.LocalFilter, props map[string]any) bool {
 	if filter == nil || filter.Root == nil || props == nil {
 		return false
 	}
 	return matchesClause(filter.Root, props)
 }
 
-func matchesClause(clause *filters.Clause, props map[string]interface{}) bool {
+func matchesClause(clause *filters.Clause, props map[string]any) bool {
 	switch clause.Operator {
 	case filters.OperatorAnd:
 		for i := range clause.Operands {
@@ -309,7 +309,7 @@ func matchesClause(clause *filters.Clause, props map[string]interface{}) bool {
 	}
 }
 
-func matchesValueClause(clause *filters.Clause, props map[string]interface{}) bool {
+func matchesValueClause(clause *filters.Clause, props map[string]any) bool {
 	if clause.On == nil || clause.Value == nil {
 		return false
 	}
@@ -323,7 +323,7 @@ func matchesValueClause(clause *filters.Clause, props map[string]interface{}) bo
 	return compareValues(clause.Operator, propVal, clause.Value.Value)
 }
 
-func compareValues(op filters.Operator, propVal, filterVal interface{}) bool {
+func compareValues(op filters.Operator, propVal, filterVal any) bool {
 	// Try boolean comparison.
 	if boolVal, ok := asBool(propVal); ok {
 		if filterBool, ok := asBool(filterVal); ok {
@@ -388,7 +388,7 @@ func compareValues(op filters.Operator, propVal, filterVal interface{}) bool {
 	return false
 }
 
-func asBool(v interface{}) (bool, bool) {
+func asBool(v any) (bool, bool) {
 	switch b := v.(type) {
 	case bool:
 		return b, true
@@ -397,7 +397,7 @@ func asBool(v interface{}) (bool, bool) {
 	}
 }
 
-func asFloat64(v interface{}) (float64, bool) {
+func asFloat64(v any) (float64, bool) {
 	switch n := v.(type) {
 	case float64:
 		return n, true
@@ -455,7 +455,7 @@ func parseDecayParams(d *filters.Decay) parsedDecay {
 	}
 }
 
-func computeDecayForResult(decay *filters.Decay, parsed parsedDecay, props map[string]interface{}, nowTime time.Time) float32 {
+func computeDecayForResult(decay *filters.Decay, parsed parsedDecay, props map[string]any, nowTime time.Time) float32 {
 	if !parsed.valid || props == nil || decay.Path == nil {
 		return 0
 	}
@@ -474,7 +474,7 @@ func computeDecayForResult(decay *filters.Decay, parsed parsedDecay, props map[s
 	return computeDecayFunction(parsed.curve, dist, parsed.offset, parsed.scale, parsed.decayValue)
 }
 
-func computeDistance(decay *filters.Decay, propValue interface{}, nowTime time.Time) (float64, error) {
+func computeDistance(decay *filters.Decay, propValue any, nowTime time.Time) (float64, error) {
 	if dateVal, ok := tryParseDate(propValue); ok {
 		origin := decay.Origin
 		if origin == "" {
@@ -530,7 +530,7 @@ func computeDecayFunction(curve filters.DecayCurveType, dist, offset, scale, dec
 
 // --- Time/duration parsing helpers ---
 
-func tryParseDate(val interface{}) (time.Time, bool) {
+func tryParseDate(val any) (time.Time, bool) {
 	switch v := val.(type) {
 	case time.Time:
 		return v, true
@@ -593,7 +593,7 @@ func parseNumericOrDuration(s string) (float64, error) {
 	return strconv.ParseFloat(s, 64)
 }
 
-func toFloat64(val interface{}) (float64, error) {
+func toFloat64(val any) (float64, error) {
 	switch v := val.(type) {
 	case float64:
 		return v, nil

--- a/usecases/traverser/boost_scorer.go
+++ b/usecases/traverser/boost_scorer.go
@@ -43,9 +43,6 @@ func applyBoostScoring(results []search.Result, boost *filters.Boost) []search.R
 	if weight <= 0 {
 		return results
 	}
-	if weight > 1 {
-		weight = 1
-	}
 
 	nowTime := time.Now()
 
@@ -101,6 +98,29 @@ func applyBoostScoring(results []search.Result, boost *filters.Boost) []search.R
 	// Combine scores.
 	for i := range results {
 		results[i].Score = (1-weight)*primaryScores[i] + weight*boostScores[i]
+	}
+
+	// Normalize combined scores to [0,1] for user-facing display.
+	// Negative per-condition weights can produce combined scores below 0.
+	var minCombined, maxCombined float32
+	minCombined = results[0].Score
+	maxCombined = results[0].Score
+	for _, r := range results[1:] {
+		if r.Score < minCombined {
+			minCombined = r.Score
+		}
+		if r.Score > maxCombined {
+			maxCombined = r.Score
+		}
+	}
+	if rangeCombined := maxCombined - minCombined; rangeCombined > 0 {
+		for i := range results {
+			results[i].Score = (results[i].Score - minCombined) / rangeCombined
+		}
+	} else {
+		for i := range results {
+			results[i].Score = 1.0
+		}
 	}
 
 	// Re-sort by combined score descending.

--- a/usecases/traverser/boost_scorer.go
+++ b/usecases/traverser/boost_scorer.go
@@ -1,0 +1,621 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// boost_scorer.go implements the boost post-scoring pipeline. It rescores
+// search results by evaluating each result against a set of boost
+// conditions (filter-based binary scoring and/or decay-based continuous
+// scoring), then blending the boost score with the normalized primary
+// search score using a configurable weight parameter.
+//
+// This file is intentionally self-contained: all scoring, filter matching,
+// and decay computation happens in-memory on already-fetched search results.
+// No index queries are issued from this code.
+
+package traverser
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/search"
+)
+
+func applyBoostScoring(results []search.Result, boost *filters.Boost) []search.Result {
+	if boost == nil || len(boost.Conditions) == 0 || len(results) == 0 {
+		return results
+	}
+
+	weight := boost.Weight
+	if weight <= 0 {
+		return results
+	}
+	if weight > 1 {
+		weight = 1
+	}
+
+	nowTime := time.Now()
+
+	// Pre-parse decay parameters and pre-compile Like patterns once.
+	decayParams := make([]parsedDecay, len(boost.Conditions))
+	likeCache := make(map[string]*regexp.Regexp)
+	for i, cond := range boost.Conditions {
+		if cond.Decay != nil {
+			decayParams[i] = parseDecayParams(cond.Decay)
+		}
+		if cond.Filter != nil {
+			precompileLikePatterns(cond.Filter.Root, likeCache)
+		}
+	}
+
+	// Pre-compute normalized property value scores for each property_value condition.
+	// These need the full result set for min-max normalization.
+	propertyValueScores := precomputePropertyValueScores(results, boost.Conditions)
+
+	// Compute boost score for each result.
+	boostScores := make([]float32, len(results))
+	for i := range results {
+		boostScores[i] = scoreResult(&results[i], boost.Conditions, decayParams, propertyValueScores, i, nowTime, likeCache)
+	}
+
+	// Normalize primary scores to [0,1] using min-max.
+	primaryScores := make([]float32, len(results))
+	var minPrimary, maxPrimary float32
+	minPrimary = math.MaxFloat32
+	maxPrimary = -math.MaxFloat32
+	for i := range results {
+		s := results[i].Score
+		primaryScores[i] = s
+		if s < minPrimary {
+			minPrimary = s
+		}
+		if s > maxPrimary {
+			maxPrimary = s
+		}
+	}
+	rangePrimary := maxPrimary - minPrimary
+	if rangePrimary > 0 {
+		for i := range primaryScores {
+			primaryScores[i] = (primaryScores[i] - minPrimary) / rangePrimary
+		}
+	} else {
+		// All same score — normalize to 1.0 so boost is the tiebreaker.
+		for i := range primaryScores {
+			primaryScores[i] = 1.0
+		}
+	}
+
+	// Combine scores.
+	for i := range results {
+		results[i].Score = (1-weight)*primaryScores[i] + weight*boostScores[i]
+	}
+
+	// Re-sort by combined score descending.
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Score != results[j].Score {
+			return results[i].Score > results[j].Score
+		}
+		return results[i].ID < results[j].ID
+	})
+
+	// Apply offset, then truncate to limit.
+	offset := boost.OriginalOffset
+	limit := boost.OriginalLimit
+	if offset > 0 {
+		if offset >= len(results) {
+			return nil
+		}
+		results = results[offset:]
+	}
+	if limit > 0 && len(results) > limit {
+		results = results[:limit]
+	}
+
+	return results
+}
+
+// scoreResult computes the weighted boost score for a single search result.
+// Negative per-condition weights demote matching documents. The denominator
+// uses abs(weight) so the score range is [-1, 1].
+func scoreResult(r *search.Result, conditions []filters.BoostCondition,
+	decayParams []parsedDecay, propertyValueScores [][]float32, resultIdx int,
+	nowTime time.Time, likeCache map[string]*regexp.Regexp,
+) float32 {
+	var weightedSum, weightSum float32
+
+	props := extractProps(r)
+
+	for i, cond := range conditions {
+		weight := cond.Weight
+		if weight == 0 {
+			weight = 1.0
+		}
+
+		var condScore float32
+
+		if cond.Filter != nil {
+			if matchesFilter(cond.Filter, props, likeCache) {
+				condScore = 1.0
+			}
+		} else if cond.Decay != nil {
+			condScore = computeDecayForResult(cond.Decay, decayParams[i], props, nowTime)
+		} else if cond.PropertyValue != nil {
+			condScore = propertyValueScores[i][resultIdx]
+		}
+
+		weightedSum += weight * condScore
+		absWeight := weight
+		if absWeight < 0 {
+			absWeight = -absWeight
+		}
+		weightSum += absWeight
+	}
+
+	if weightSum == 0 {
+		return 0
+	}
+	return weightedSum / weightSum
+}
+
+// distToScore converts distance-based results (from vector search) to
+// score-based results that applyRankScoring can blend with. Distance is
+// inverted so that closer objects get higher scores.
+func distToScore(results []search.Result) {
+	for i := range results {
+		results[i].Score = -results[i].Dist
+	}
+}
+
+// precomputePropertyValueScores computes normalized [0,1] scores for each
+// property_value condition across all results. Min-max normalization is applied
+// after the modifier so that the highest value in the result set scores 1.0.
+// Returns a slice indexed by [conditionIdx][resultIdx].
+func precomputePropertyValueScores(results []search.Result, conditions []filters.BoostCondition) [][]float32 {
+	scores := make([][]float32, len(conditions))
+	for i, cond := range conditions {
+		if cond.PropertyValue == nil {
+			continue
+		}
+
+		fv := cond.PropertyValue
+		propName := string(fv.Path.Property)
+		raw := make([]float64, len(results))
+
+		for j := range results {
+			props := extractProps(&results[j])
+			if props == nil {
+				continue
+			}
+			val, err := toFloat64(props[propName])
+			if err != nil {
+				continue
+			}
+			raw[j] = applyPropertyValueModifier(val, fv.Modifier)
+		}
+
+		// Min-max normalize to [0,1].
+		minVal, maxVal := raw[0], raw[0]
+		for _, v := range raw[1:] {
+			if v < minVal {
+				minVal = v
+			}
+			if v > maxVal {
+				maxVal = v
+			}
+		}
+
+		scores[i] = make([]float32, len(results))
+		rangeVal := maxVal - minVal
+		if rangeVal > 0 {
+			for j := range raw {
+				scores[i][j] = float32((raw[j] - minVal) / rangeVal)
+			}
+		} else {
+			// All same value — normalize to 1.0
+			for j := range scores[i] {
+				scores[i][j] = 1.0
+			}
+		}
+	}
+	return scores
+}
+
+func applyPropertyValueModifier(val float64, modifier filters.PropertyValueModifierType) float64 {
+	switch modifier {
+	case filters.PropertyValueModifierLog1p:
+		return math.Log1p(math.Max(0, val))
+	case filters.PropertyValueModifierSqrt:
+		return math.Sqrt(math.Max(0, val))
+	default:
+		return val
+	}
+}
+
+// extractProps gets the properties map from a search result.
+func extractProps(r *search.Result) map[string]interface{} {
+	if r.Schema == nil {
+		return nil
+	}
+	props, ok := r.Schema.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	return props
+}
+
+// matchesFilter evaluates a LocalFilter against an object's properties in-memory.
+// This handles the common filter operators used in prefer conditions.
+func matchesFilter(filter *filters.LocalFilter, props map[string]interface{}, likeCache map[string]*regexp.Regexp) bool {
+	if filter == nil || filter.Root == nil || props == nil {
+		return false
+	}
+	return matchesClause(filter.Root, props, likeCache)
+}
+
+func matchesClause(clause *filters.Clause, props map[string]interface{}, likeCache map[string]*regexp.Regexp) bool {
+	switch clause.Operator {
+	case filters.OperatorAnd:
+		for i := range clause.Operands {
+			if !matchesClause(&clause.Operands[i], props, likeCache) {
+				return false
+			}
+		}
+		return true
+
+	case filters.OperatorOr:
+		for i := range clause.Operands {
+			if matchesClause(&clause.Operands[i], props, likeCache) {
+				return true
+			}
+		}
+		return false
+
+	case filters.OperatorNot:
+		if len(clause.Operands) > 0 {
+			return !matchesClause(&clause.Operands[0], props, likeCache)
+		}
+		return false
+
+	default:
+		return matchesValueClause(clause, props, likeCache)
+	}
+}
+
+func matchesValueClause(clause *filters.Clause, props map[string]interface{}, likeCache map[string]*regexp.Regexp) bool {
+	if clause.On == nil || clause.Value == nil {
+		return false
+	}
+
+	propName := string(clause.On.Property)
+	propVal, exists := props[propName]
+	if !exists {
+		if clause.Operator == filters.OperatorIsNull {
+			return clause.Value.Value == true
+		}
+		return false
+	}
+
+	if clause.Operator == filters.OperatorIsNull {
+		isNull := propVal == nil
+		return isNull == (clause.Value.Value == true)
+	}
+
+	return compareValues(clause.Operator, propVal, clause.Value.Value, likeCache)
+}
+
+func compareValues(op filters.Operator, propVal, filterVal interface{}, likeCache map[string]*regexp.Regexp) bool {
+	// Try boolean comparison.
+	if boolVal, ok := asBool(propVal); ok {
+		if filterBool, ok := asBool(filterVal); ok {
+			switch op {
+			case filters.OperatorEqual:
+				return boolVal == filterBool
+			case filters.OperatorNotEqual:
+				return boolVal != filterBool
+			default:
+				return false
+			}
+		}
+		return false
+	}
+
+	// Try numeric comparison.
+	if numProp, ok := asFloat64(propVal); ok {
+		if numFilter, ok := asFloat64(filterVal); ok {
+			switch op {
+			case filters.OperatorEqual:
+				return numProp == numFilter
+			case filters.OperatorNotEqual:
+				return numProp != numFilter
+			case filters.OperatorGreaterThan:
+				return numProp > numFilter
+			case filters.OperatorGreaterThanEqual:
+				return numProp >= numFilter
+			case filters.OperatorLessThan:
+				return numProp < numFilter
+			case filters.OperatorLessThanEqual:
+				return numProp <= numFilter
+			default:
+				return false
+			}
+		}
+		return false
+	}
+
+	// Try string comparison.
+	if strProp, ok := propVal.(string); ok {
+		if strFilter, ok := filterVal.(string); ok {
+			switch op {
+			case filters.OperatorEqual:
+				return strProp == strFilter
+			case filters.OperatorNotEqual:
+				return strProp != strFilter
+			case filters.OperatorGreaterThan:
+				return strProp > strFilter
+			case filters.OperatorGreaterThanEqual:
+				return strProp >= strFilter
+			case filters.OperatorLessThan:
+				return strProp < strFilter
+			case filters.OperatorLessThanEqual:
+				return strProp <= strFilter
+			case filters.OperatorLike:
+				return matchLikeCached(strProp, strFilter, likeCache)
+			default:
+				return false
+			}
+		}
+		return false
+	}
+
+	return false
+}
+
+func asBool(v interface{}) (bool, bool) {
+	switch b := v.(type) {
+	case bool:
+		return b, true
+	default:
+		return false, false
+	}
+}
+
+func asFloat64(v interface{}) (float64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return n, true
+	case float32:
+		return float64(n), true
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	default:
+		return 0, false
+	}
+}
+
+// precompileLikePatterns walks a filter clause tree and pre-compiles any Like
+// operator patterns into the cache so they aren't recompiled per document.
+func precompileLikePatterns(clause *filters.Clause, cache map[string]*regexp.Regexp) {
+	if clause == nil {
+		return
+	}
+	if clause.Operator == filters.OperatorLike && clause.Value != nil {
+		if pattern, ok := clause.Value.Value.(string); ok {
+			if _, exists := cache[pattern]; !exists {
+				regexStr := "^" + regexp.QuoteMeta(pattern) + "$"
+				regexStr = strings.ReplaceAll(regexStr, `\*`, ".*")
+				regexStr = strings.ReplaceAll(regexStr, `\?`, ".")
+				if re, err := regexp.Compile(regexStr); err == nil {
+					cache[pattern] = re
+				}
+			}
+		}
+	}
+	for i := range clause.Operands {
+		precompileLikePatterns(&clause.Operands[i], cache)
+	}
+}
+
+func matchLikeCached(value, pattern string, cache map[string]*regexp.Regexp) bool {
+	if re, ok := cache[pattern]; ok {
+		return re.MatchString(value)
+	}
+	return false
+}
+
+// --- Decay scoring on search results ---
+
+type parsedDecay struct {
+	offset     float64
+	scale      float64
+	decayValue float64
+	curve      filters.DecayCurveType
+	valid      bool
+}
+
+func parseDecayParams(d *filters.Decay) parsedDecay {
+	offset, _ := parseNumericOrDuration(d.Offset)
+	scale, err := parseNumericOrDuration(d.Scale)
+	if err != nil || scale <= 0 {
+		return parsedDecay{}
+	}
+	decayValue := float64(d.DecayValue)
+	if decayValue == 0 {
+		decayValue = 0.5
+	}
+	curve := d.Curve
+	if curve == "" {
+		curve = filters.DecayCurveExp
+	}
+	return parsedDecay{
+		offset:     offset,
+		scale:      scale,
+		decayValue: decayValue,
+		curve:      curve,
+		valid:      true,
+	}
+}
+
+func computeDecayForResult(decay *filters.Decay, parsed parsedDecay, props map[string]interface{}, nowTime time.Time) float32 {
+	if !parsed.valid || props == nil || decay.Path == nil {
+		return 0
+	}
+
+	propName := string(decay.Path.Property)
+	propVal, exists := props[propName]
+	if !exists || propVal == nil {
+		return 0
+	}
+
+	dist, err := computeDistance(decay, propVal, nowTime)
+	if err != nil {
+		return 0
+	}
+
+	return computeDecayFunction(parsed.curve, dist, parsed.offset, parsed.scale, parsed.decayValue)
+}
+
+func computeDistance(decay *filters.Decay, propValue interface{}, nowTime time.Time) (float64, error) {
+	if dateVal, ok := tryParseDate(propValue); ok {
+		origin := decay.Origin
+		if origin == "" {
+			origin = "now"
+		}
+		originTime, err := parseOriginAsTime(origin, nowTime)
+		if err != nil {
+			return 0, err
+		}
+		return math.Abs(float64(dateVal.Sub(originTime))), nil
+	}
+
+	numVal, err := toFloat64(propValue)
+	if err != nil {
+		return 0, err
+	}
+
+	originNum, err := strconv.ParseFloat(decay.Origin, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	return math.Abs(numVal - originNum), nil
+}
+
+func computeDecayFunction(curve filters.DecayCurveType, dist, offset, scale, decayValue float64) float32 {
+	effectiveDist := math.Max(0, dist-offset)
+	if effectiveDist == 0 {
+		return 1.0
+	}
+
+	var score float64
+	switch curve {
+	case filters.DecayCurveExp:
+		score = math.Pow(decayValue, effectiveDist/scale)
+	case filters.DecayCurveGauss:
+		factor := -math.Log(decayValue)
+		ratio := effectiveDist / scale
+		score = math.Exp(-factor * ratio * ratio)
+	case filters.DecayCurveLinear:
+		score = math.Max(0, 1.0-(1.0-decayValue)*effectiveDist/scale)
+	default:
+		score = math.Pow(decayValue, effectiveDist/scale)
+	}
+
+	return float32(score)
+}
+
+// --- Time/duration parsing helpers ---
+
+func tryParseDate(val interface{}) (time.Time, bool) {
+	switch v := val.(type) {
+	case time.Time:
+		return v, true
+	case string:
+		for _, layout := range []string{
+			time.RFC3339Nano, time.RFC3339,
+			"2006-01-02T15:04:05", "2006-01-02",
+		} {
+			if t, err := time.Parse(layout, v); err == nil {
+				return t, true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+func parseOriginAsTime(origin string, nowTime time.Time) (time.Time, error) {
+	if origin == "now" {
+		return nowTime, nil
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano, time.RFC3339,
+		"2006-01-02T15:04:05", "2006-01-02",
+	} {
+		if t, err := time.Parse(layout, origin); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("cannot parse %q as time", origin)
+}
+
+var durationPattern = regexp.MustCompile(`^(\d+(?:\.\d+)?)(d|h|m|s|ms)$`)
+
+func parseNumericOrDuration(s string) (float64, error) {
+	if s == "" {
+		return 0, nil
+	}
+	matches := durationPattern.FindStringSubmatch(s)
+	if matches != nil {
+		num, err := strconv.ParseFloat(matches[1], 64)
+		if err != nil {
+			return 0, err
+		}
+		switch matches[2] {
+		case "d":
+			return num * float64(24*time.Hour), nil
+		case "h":
+			return num * float64(time.Hour), nil
+		case "m":
+			return num * float64(time.Minute), nil
+		case "s":
+			return num * float64(time.Second), nil
+		case "ms":
+			return num * float64(time.Millisecond), nil
+		}
+	}
+	if d, err := time.ParseDuration(s); err == nil {
+		return float64(d), nil
+	}
+	return strconv.ParseFloat(s, 64)
+}
+
+func toFloat64(val interface{}) (float64, error) {
+	switch v := val.(type) {
+	case float64:
+		return v, nil
+	case float32:
+		return float64(v), nil
+	case int:
+		return float64(v), nil
+	case int64:
+		return float64(v), nil
+	case string:
+		return strconv.ParseFloat(v, 64)
+	default:
+		return 0, fmt.Errorf("cannot convert %T to float64", val)
+	}
+}

--- a/usecases/traverser/boost_scorer.go
+++ b/usecases/traverser/boost_scorer.go
@@ -27,7 +27,6 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/weaviate/weaviate/entities/filters"
@@ -46,15 +45,11 @@ func applyBoostScoring(results []search.Result, boost *filters.Boost) []search.R
 
 	nowTime := time.Now()
 
-	// Pre-parse decay parameters and pre-compile Like patterns once.
+	// Pre-parse decay parameters once.
 	decayParams := make([]parsedDecay, len(boost.Conditions))
-	likeCache := make(map[string]*regexp.Regexp)
 	for i, cond := range boost.Conditions {
 		if cond.Decay != nil {
 			decayParams[i] = parseDecayParams(cond.Decay)
-		}
-		if cond.Filter != nil {
-			precompileLikePatterns(cond.Filter.Root, likeCache)
 		}
 	}
 
@@ -65,7 +60,7 @@ func applyBoostScoring(results []search.Result, boost *filters.Boost) []search.R
 	// Compute boost score for each result.
 	boostScores := make([]float32, len(results))
 	for i := range results {
-		boostScores[i] = scoreResult(&results[i], boost.Conditions, decayParams, propertyValueScores, i, nowTime, likeCache)
+		boostScores[i] = scoreResult(&results[i], boost.Conditions, decayParams, propertyValueScores, i, nowTime)
 	}
 
 	// Normalize primary scores to [0,1] using min-max.
@@ -152,7 +147,7 @@ func applyBoostScoring(results []search.Result, boost *filters.Boost) []search.R
 // uses abs(weight) so the score range is [-1, 1].
 func scoreResult(r *search.Result, conditions []filters.BoostCondition,
 	decayParams []parsedDecay, propertyValueScores [][]float32, resultIdx int,
-	nowTime time.Time, likeCache map[string]*regexp.Regexp,
+	nowTime time.Time,
 ) float32 {
 	var weightedSum, weightSum float32
 
@@ -167,7 +162,7 @@ func scoreResult(r *search.Result, conditions []filters.BoostCondition,
 		var condScore float32
 
 		if cond.Filter != nil {
-			if matchesFilter(cond.Filter, props, likeCache) {
+			if matchesFilter(cond.Filter, props) {
 				condScore = 1.0
 			}
 		} else if cond.Decay != nil {
@@ -277,19 +272,19 @@ func extractProps(r *search.Result) map[string]interface{} {
 }
 
 // matchesFilter evaluates a LocalFilter against an object's properties in-memory.
-// This handles the common filter operators used in prefer conditions.
-func matchesFilter(filter *filters.LocalFilter, props map[string]interface{}, likeCache map[string]*regexp.Regexp) bool {
+// This handles the common filter operators used in boost conditions.
+func matchesFilter(filter *filters.LocalFilter, props map[string]interface{}) bool {
 	if filter == nil || filter.Root == nil || props == nil {
 		return false
 	}
-	return matchesClause(filter.Root, props, likeCache)
+	return matchesClause(filter.Root, props)
 }
 
-func matchesClause(clause *filters.Clause, props map[string]interface{}, likeCache map[string]*regexp.Regexp) bool {
+func matchesClause(clause *filters.Clause, props map[string]interface{}) bool {
 	switch clause.Operator {
 	case filters.OperatorAnd:
 		for i := range clause.Operands {
-			if !matchesClause(&clause.Operands[i], props, likeCache) {
+			if !matchesClause(&clause.Operands[i], props) {
 				return false
 			}
 		}
@@ -297,7 +292,7 @@ func matchesClause(clause *filters.Clause, props map[string]interface{}, likeCac
 
 	case filters.OperatorOr:
 		for i := range clause.Operands {
-			if matchesClause(&clause.Operands[i], props, likeCache) {
+			if matchesClause(&clause.Operands[i], props) {
 				return true
 			}
 		}
@@ -305,16 +300,16 @@ func matchesClause(clause *filters.Clause, props map[string]interface{}, likeCac
 
 	case filters.OperatorNot:
 		if len(clause.Operands) > 0 {
-			return !matchesClause(&clause.Operands[0], props, likeCache)
+			return !matchesClause(&clause.Operands[0], props)
 		}
 		return false
 
 	default:
-		return matchesValueClause(clause, props, likeCache)
+		return matchesValueClause(clause, props)
 	}
 }
 
-func matchesValueClause(clause *filters.Clause, props map[string]interface{}, likeCache map[string]*regexp.Regexp) bool {
+func matchesValueClause(clause *filters.Clause, props map[string]interface{}) bool {
 	if clause.On == nil || clause.Value == nil {
 		return false
 	}
@@ -322,21 +317,13 @@ func matchesValueClause(clause *filters.Clause, props map[string]interface{}, li
 	propName := string(clause.On.Property)
 	propVal, exists := props[propName]
 	if !exists {
-		if clause.Operator == filters.OperatorIsNull {
-			return clause.Value.Value == true
-		}
 		return false
 	}
 
-	if clause.Operator == filters.OperatorIsNull {
-		isNull := propVal == nil
-		return isNull == (clause.Value.Value == true)
-	}
-
-	return compareValues(clause.Operator, propVal, clause.Value.Value, likeCache)
+	return compareValues(clause.Operator, propVal, clause.Value.Value)
 }
 
-func compareValues(op filters.Operator, propVal, filterVal interface{}, likeCache map[string]*regexp.Regexp) bool {
+func compareValues(op filters.Operator, propVal, filterVal interface{}) bool {
 	// Try boolean comparison.
 	if boolVal, ok := asBool(propVal); ok {
 		if filterBool, ok := asBool(filterVal); ok {
@@ -391,8 +378,6 @@ func compareValues(op filters.Operator, propVal, filterVal interface{}, likeCach
 				return strProp < strFilter
 			case filters.OperatorLessThanEqual:
 				return strProp <= strFilter
-			case filters.OperatorLike:
-				return matchLikeCached(strProp, strFilter, likeCache)
 			default:
 				return false
 			}
@@ -425,36 +410,6 @@ func asFloat64(v interface{}) (float64, bool) {
 	default:
 		return 0, false
 	}
-}
-
-// precompileLikePatterns walks a filter clause tree and pre-compiles any Like
-// operator patterns into the cache so they aren't recompiled per document.
-func precompileLikePatterns(clause *filters.Clause, cache map[string]*regexp.Regexp) {
-	if clause == nil {
-		return
-	}
-	if clause.Operator == filters.OperatorLike && clause.Value != nil {
-		if pattern, ok := clause.Value.Value.(string); ok {
-			if _, exists := cache[pattern]; !exists {
-				regexStr := "^" + regexp.QuoteMeta(pattern) + "$"
-				regexStr = strings.ReplaceAll(regexStr, `\*`, ".*")
-				regexStr = strings.ReplaceAll(regexStr, `\?`, ".")
-				if re, err := regexp.Compile(regexStr); err == nil {
-					cache[pattern] = re
-				}
-			}
-		}
-	}
-	for i := range clause.Operands {
-		precompileLikePatterns(&clause.Operands[i], cache)
-	}
-}
-
-func matchLikeCached(value, pattern string, cache map[string]*regexp.Regexp) bool {
-	if re, ok := cache[pattern]; ok {
-		return re.MatchString(value)
-	}
-	return false
 }
 
 // --- Decay scoring on search results ---

--- a/usecases/traverser/boost_scorer_test.go
+++ b/usecases/traverser/boost_scorer_test.go
@@ -1,0 +1,1293 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package traverser
+
+import (
+	"fmt"
+	"math"
+	"regexp"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/search"
+)
+
+func makeResult(id string, score float32, props map[string]interface{}) search.Result {
+	return search.Result{
+		ID:     strfmt.UUID(id),
+		Score:  score,
+		Schema: props,
+	}
+}
+
+func filterCondition(path string, op filters.Operator, val interface{}, dt schema.DataType) filters.BoostCondition {
+	return filters.BoostCondition{
+		Filter: &filters.LocalFilter{
+			Root: &filters.Clause{
+				On: &filters.Path{Property: schema.PropertyName(path)},
+				Value: &filters.Value{
+					Value: val,
+					Type:  dt,
+				},
+				Operator: op,
+			},
+		},
+		Weight: 1.0,
+	}
+}
+
+func decayCondition(path, origin, scale string, curve filters.DecayCurveType, decayValue float32) filters.BoostCondition {
+	return filters.BoostCondition{
+		Decay: &filters.Decay{
+			Path:       &filters.Path{Property: schema.PropertyName(path)},
+			Origin:     origin,
+			Scale:      scale,
+			Curve:      curve,
+			DecayValue: decayValue,
+		},
+		Weight: 1.0,
+	}
+}
+
+// withOriginalLimit returns a shallow copy of the boost with OriginalOffset and OriginalLimit set.
+func withOriginalLimit(b *filters.Boost, limit int) *filters.Boost {
+	cp := *b
+	cp.OriginalLimit = limit
+	return &cp
+}
+
+func withOriginalPagination(b *filters.Boost, offset, limit int) *filters.Boost {
+	cp := *b
+	cp.OriginalOffset = offset
+	cp.OriginalLimit = limit
+	return &cp
+}
+
+// --- applyBoostScoring tests ---
+
+func TestApplyBoostScoring_NilRank(t *testing.T) {
+	results := []search.Result{makeResult("a", 1.0, nil)}
+	got := applyBoostScoring(results, nil)
+	assert.Equal(t, results, got)
+}
+
+func TestApplyBoostScoring_EmptyConditions(t *testing.T) {
+	results := []search.Result{makeResult("a", 1.0, nil)}
+	got := applyBoostScoring(results, &filters.Boost{Conditions: nil, Weight: 0.5, OriginalLimit: 10})
+	assert.Equal(t, results, got)
+}
+
+func TestApplyBoostScoring_WeightZero(t *testing.T) {
+	results := []search.Result{
+		makeResult("a", 1.0, map[string]interface{}{"inStock": true}),
+		makeResult("b", 0.5, map[string]interface{}{"inStock": false}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("inStock", filters.OperatorEqual, true, schema.DataTypeBoolean),
+		},
+		Weight: 0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// weight=0 → no change, original order preserved
+	assert.Equal(t, strfmt.UUID("a"), got[0].ID)
+	assert.Equal(t, strfmt.UUID("b"), got[1].ID)
+}
+
+func TestApplyBoostScoring_FilterPromotesMatchingResults(t *testing.T) {
+	results := []search.Result{
+		makeResult("no-stock", 1.0, map[string]interface{}{"inStock": false}),
+		makeResult("in-stock", 0.5, map[string]interface{}{"inStock": true}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("inStock", filters.OperatorEqual, true, schema.DataTypeBoolean),
+		},
+		Weight: 1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// With weight=1.0, only boost score matters. in-stock should be first.
+	assert.Equal(t, strfmt.UUID("in-stock"), got[0].ID)
+	assert.Equal(t, strfmt.UUID("no-stock"), got[1].ID)
+}
+
+func TestApplyBoostScoring_Truncation(t *testing.T) {
+	results := []search.Result{
+		makeResult("a", 1.0, map[string]interface{}{"x": true}),
+		makeResult("b", 0.9, map[string]interface{}{"x": true}),
+		makeResult("c", 0.8, map[string]interface{}{"x": true}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("x", filters.OperatorEqual, true, schema.DataTypeBoolean),
+		},
+		Weight: 0.5,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 2))
+	assert.Len(t, got, 2)
+}
+
+func TestApplyBoostScoring_DepthPromotesDeepResult(t *testing.T) {
+	// Simulates depth overfetch: 10 results fetched (depth=10), original limit=3.
+	// The best boost match is at position 9 (last). With boost weight=1.0,
+	// it should be promoted to the top and the output truncated to 3.
+	results := make([]search.Result, 10)
+	for i := range results {
+		results[i] = makeResult(
+			fmt.Sprintf("item-%d", i),
+			float32(10-i)*0.1, // decreasing primary scores: 1.0, 0.9, ..., 0.1
+			map[string]interface{}{"promoted": i == 9},
+		)
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("promoted", filters.OperatorEqual, true, schema.DataTypeBoolean),
+		},
+		Weight: 1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 3))
+	require.Len(t, got, 3)
+	// item-9 (promoted=true, boost=1.0) should be first despite worst primary score.
+	assert.Equal(t, strfmt.UUID("item-9"), got[0].ID)
+}
+
+func TestApplyBoostScoring_SmallDepthMissesDeepResult(t *testing.T) {
+	// When depth is small (limit=3, only 3 results fetched), the promoted item
+	// at position 9 is never seen. Only the top-3 primary results are rescored.
+	results := make([]search.Result, 3)
+	for i := range results {
+		results[i] = makeResult(
+			fmt.Sprintf("item-%d", i),
+			float32(10-i)*0.1,
+			map[string]interface{}{"promoted": false},
+		)
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("promoted", filters.OperatorEqual, true, schema.DataTypeBoolean),
+		},
+		Weight: 1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 3))
+	require.Len(t, got, 3)
+	// No promoted items in the candidate pool, so order is unchanged.
+	assert.Equal(t, strfmt.UUID("item-0"), got[0].ID)
+}
+
+func TestApplyBoostScoring_DepthTruncatesToOriginalLimit(t *testing.T) {
+	// 20 results fetched (depth=20), original limit=5.
+	// Verify output is exactly 5 results.
+	results := make([]search.Result, 20)
+	for i := range results {
+		results[i] = makeResult(
+			fmt.Sprintf("item-%02d", i),
+			float32(20-i)*0.05,
+			map[string]interface{}{"inStock": i%3 == 0},
+		)
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("inStock", filters.OperatorEqual, true, schema.DataTypeBoolean),
+		},
+		Weight: 0.8,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 5))
+	require.Len(t, got, 5)
+	// With weight=0.8, inStock items should dominate the top-5.
+	inStockCount := 0
+	for _, r := range got {
+		props := r.Schema.(map[string]interface{})
+		if props["inStock"] == true {
+			inStockCount++
+		}
+	}
+	assert.GreaterOrEqual(t, inStockCount, 3, "most top-5 results should be in-stock after boost")
+}
+
+func TestApplyBoostScoring_AllSamePrimaryScore(t *testing.T) {
+	// When all primary scores are equal, they normalize to 1.0
+	// and boost becomes the tiebreaker.
+	results := []search.Result{
+		makeResult("no-match", 0.5, map[string]interface{}{"inStock": false}),
+		makeResult("match", 0.5, map[string]interface{}{"inStock": true}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("inStock", filters.OperatorEqual, true, schema.DataTypeBoolean),
+		},
+		Weight: 0.5,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// match has boost=1.0, no-match has boost=0.0
+	// final(match) = 0.5*1.0 + 0.5*1.0 = 1.0
+	// final(no-match) = 0.5*1.0 + 0.5*0.0 = 0.5
+	assert.Equal(t, strfmt.UUID("match"), got[0].ID)
+}
+
+func TestDistToScore(t *testing.T) {
+	// distToScore converts distance-based results to score-based by inverting.
+	results := []search.Result{
+		{ID: strfmt.UUID("close"), Dist: 0.01},
+		{ID: strfmt.UUID("medium"), Dist: 0.10},
+		{ID: strfmt.UUID("far"), Dist: 0.90},
+	}
+	distToScore(results)
+	assert.InDelta(t, -0.01, float64(results[0].Score), 0.001)
+	assert.InDelta(t, -0.10, float64(results[1].Score), 0.001)
+	assert.InDelta(t, -0.90, float64(results[2].Score), 0.001)
+}
+
+func TestApplyBoostScoring_WithDistConvertedScores(t *testing.T) {
+	// Simulates vector search: explorer calls distToScore before applyBoostScoring.
+	results := []search.Result{
+		{ID: strfmt.UUID("close"), Dist: 0.01, Schema: map[string]interface{}{"streaming": false}},
+		{ID: strfmt.UUID("medium"), Dist: 0.10, Schema: map[string]interface{}{"streaming": true}},
+		{ID: strfmt.UUID("far"), Dist: 0.90, Schema: map[string]interface{}{"streaming": true}},
+	}
+	distToScore(results)
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("streaming", filters.OperatorEqual, true, schema.DataTypeBoolean),
+		},
+		Weight: 0.5,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// "medium": decent distance (normalized ~0.9) + streaming (1.0) → best combined
+	// "close": best distance (normalized 1.0) but no streaming (0.0) → 0.5
+	// "far": worst distance (normalized 0.0) but streaming (1.0) → 0.5
+	assert.Equal(t, strfmt.UUID("medium"), got[0].ID)
+}
+
+func TestApplyBoostScoring_EmptyResults(t *testing.T) {
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("x", filters.OperatorEqual, true, schema.DataTypeBoolean),
+		},
+		Weight: 0.5,
+	}
+	got := applyBoostScoring(nil, withOriginalLimit(boost, 10))
+	assert.Nil(t, got)
+}
+
+// --- scoreResult tests ---
+
+func TestScoreResult_FilterMatch(t *testing.T) {
+	r := makeResult("a", 1.0, map[string]interface{}{"color": "red"})
+	conds := []filters.BoostCondition{
+		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
+	}
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	assert.InDelta(t, 1.0, float64(score), 0.001)
+}
+
+func TestScoreResult_FilterNoMatch(t *testing.T) {
+	r := makeResult("a", 1.0, map[string]interface{}{"color": "blue"})
+	conds := []filters.BoostCondition{
+		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
+	}
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	assert.InDelta(t, 0.0, float64(score), 0.001)
+}
+
+func TestScoreResult_FilterMissingProperty(t *testing.T) {
+	r := makeResult("a", 1.0, map[string]interface{}{})
+	conds := []filters.BoostCondition{
+		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
+	}
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	assert.InDelta(t, 0.0, float64(score), 0.001)
+}
+
+func TestScoreResult_NilSchema(t *testing.T) {
+	r := makeResult("a", 1.0, nil)
+	conds := []filters.BoostCondition{
+		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
+	}
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	assert.InDelta(t, 0.0, float64(score), 0.001)
+}
+
+func TestScoreResult_WeightedAverage(t *testing.T) {
+	r := makeResult("a", 1.0, map[string]interface{}{
+		"inStock":  true,
+		"category": "electronics",
+	})
+	conds := []filters.BoostCondition{
+		{
+			Filter: &filters.LocalFilter{Root: &filters.Clause{
+				On:       &filters.Path{Property: "inStock"},
+				Value:    &filters.Value{Value: true, Type: schema.DataTypeBoolean},
+				Operator: filters.OperatorEqual,
+			}},
+			Weight: 2.0, // matches → score 1.0
+		},
+		{
+			Filter: &filters.LocalFilter{Root: &filters.Clause{
+				On:       &filters.Path{Property: "category"},
+				Value:    &filters.Value{Value: "sports", Type: schema.DataTypeText},
+				Operator: filters.OperatorEqual,
+			}},
+			Weight: 1.0, // doesn't match → score 0.0
+		},
+	}
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	// (2*1.0 + 1*0.0) / (2+1) = 0.6667
+	assert.InDelta(t, 0.6667, float64(score), 0.01)
+}
+
+func TestScoreResult_ZeroWeight(t *testing.T) {
+	r := makeResult("a", 1.0, map[string]interface{}{"x": true})
+	conds := []filters.BoostCondition{
+		{
+			Filter: &filters.LocalFilter{Root: &filters.Clause{
+				On:       &filters.Path{Property: "x"},
+				Value:    &filters.Value{Value: true, Type: schema.DataTypeBoolean},
+				Operator: filters.OperatorEqual,
+			}},
+			Weight: 0, // zero weight defaults to 1.0
+		},
+	}
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	assert.InDelta(t, 1.0, float64(score), 0.001)
+}
+
+// --- matchesFilter / matchesClause tests ---
+
+func TestMatchesFilter_And(t *testing.T) {
+	props := map[string]interface{}{"a": true, "b": true}
+	filter := &filters.LocalFilter{Root: &filters.Clause{
+		Operator: filters.OperatorAnd,
+		Operands: []filters.Clause{
+			{On: &filters.Path{Property: "a"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorEqual},
+			{On: &filters.Path{Property: "b"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorEqual},
+		},
+	}}
+	assert.True(t, matchesFilter(filter, props, nil))
+
+	props["b"] = false
+	assert.False(t, matchesFilter(filter, props, nil))
+}
+
+func TestMatchesFilter_Or(t *testing.T) {
+	props := map[string]interface{}{"a": false, "b": true}
+	filter := &filters.LocalFilter{Root: &filters.Clause{
+		Operator: filters.OperatorOr,
+		Operands: []filters.Clause{
+			{On: &filters.Path{Property: "a"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorEqual},
+			{On: &filters.Path{Property: "b"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorEqual},
+		},
+	}}
+	assert.True(t, matchesFilter(filter, props, nil))
+
+	props["b"] = false
+	assert.False(t, matchesFilter(filter, props, nil))
+}
+
+func TestMatchesFilter_Not(t *testing.T) {
+	props := map[string]interface{}{"a": false}
+	filter := &filters.LocalFilter{Root: &filters.Clause{
+		Operator: filters.OperatorNot,
+		Operands: []filters.Clause{
+			{On: &filters.Path{Property: "a"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorEqual},
+		},
+	}}
+	assert.True(t, matchesFilter(filter, props, nil))
+}
+
+func TestMatchesFilter_IsNull(t *testing.T) {
+	// Property exists and is non-nil → isNull=false
+	props := map[string]interface{}{"a": "hello"}
+	assert.False(t, matchesFilter(&filters.LocalFilter{Root: &filters.Clause{
+		On: &filters.Path{Property: "a"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorIsNull,
+	}}, props, nil))
+
+	// Property missing → isNull=true
+	assert.True(t, matchesFilter(&filters.LocalFilter{Root: &filters.Clause{
+		On: &filters.Path{Property: "missing"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorIsNull,
+	}}, props, nil))
+}
+
+func TestMatchesFilter_NilInputs(t *testing.T) {
+	assert.False(t, matchesFilter(nil, map[string]interface{}{}, nil))
+	assert.False(t, matchesFilter(&filters.LocalFilter{}, map[string]interface{}{}, nil))
+	assert.False(t, matchesFilter(&filters.LocalFilter{Root: &filters.Clause{
+		On: &filters.Path{Property: "a"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorEqual,
+	}}, nil, nil))
+}
+
+// --- compareValues tests ---
+
+func TestCompareValues_Numeric(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       filters.Operator
+		propVal  interface{}
+		filterV  interface{}
+		expected bool
+	}{
+		{"equal float64", filters.OperatorEqual, float64(10), float64(10), true},
+		{"not equal", filters.OperatorNotEqual, float64(10), float64(5), true},
+		{"greater than", filters.OperatorGreaterThan, float64(10), float64(5), true},
+		{"greater than false", filters.OperatorGreaterThan, float64(5), float64(10), false},
+		{"greater or equal", filters.OperatorGreaterThanEqual, float64(10), float64(10), true},
+		{"less than", filters.OperatorLessThan, float64(5), float64(10), true},
+		{"less or equal", filters.OperatorLessThanEqual, float64(10), float64(10), true},
+		{"int prop", filters.OperatorEqual, int(42), float64(42), true},
+		{"int64 prop", filters.OperatorEqual, int64(42), float64(42), true},
+		{"float32 prop", filters.OperatorEqual, float32(42), float64(42), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, compareValues(tt.op, tt.propVal, tt.filterV, nil))
+		})
+	}
+}
+
+func TestCompareValues_String(t *testing.T) {
+	tests := []struct {
+		name     string
+		op       filters.Operator
+		prop     string
+		filter   string
+		expected bool
+	}{
+		{"equal", filters.OperatorEqual, "abc", "abc", true},
+		{"not equal", filters.OperatorNotEqual, "abc", "def", true},
+		{"gt", filters.OperatorGreaterThan, "b", "a", true},
+		{"lt", filters.OperatorLessThan, "a", "b", true},
+		{"gte", filters.OperatorGreaterThanEqual, "a", "a", true},
+		{"lte", filters.OperatorLessThanEqual, "a", "a", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, compareValues(tt.op, tt.prop, tt.filter, nil))
+		})
+	}
+}
+
+func TestCompareValues_Boolean(t *testing.T) {
+	assert.True(t, compareValues(filters.OperatorEqual, true, true, nil))
+	assert.False(t, compareValues(filters.OperatorEqual, true, false, nil))
+	assert.True(t, compareValues(filters.OperatorNotEqual, true, false, nil))
+}
+
+func TestCompareValues_Like(t *testing.T) {
+	cache := make(map[string]*regexp.Regexp)
+	precompileLikePatterns(&filters.Clause{
+		Operator: filters.OperatorLike,
+		Value:    &filters.Value{Value: "Lap*"},
+	}, cache)
+	assert.True(t, compareValues(filters.OperatorLike, "Laptop Pro", "Lap*", cache))
+	assert.False(t, compareValues(filters.OperatorLike, "Desktop", "Lap*", cache))
+}
+
+// --- Decay function tests ---
+
+func TestComputeDecayFunction_Exp(t *testing.T) {
+	// decay=0.5, dist=scale → score=0.5
+	score := computeDecayFunction(filters.DecayCurveExp, 100, 0, 100, 0.5)
+	assert.InDelta(t, 0.5, float64(score), 0.001)
+
+	// dist=0 → score=1.0
+	score = computeDecayFunction(filters.DecayCurveExp, 0, 0, 100, 0.5)
+	assert.InDelta(t, 1.0, float64(score), 0.001)
+
+	// dist=2*scale → score=0.25
+	score = computeDecayFunction(filters.DecayCurveExp, 200, 0, 100, 0.5)
+	assert.InDelta(t, 0.25, float64(score), 0.001)
+}
+
+func TestComputeDecayFunction_Gauss(t *testing.T) {
+	// dist=scale → score=decayValue
+	score := computeDecayFunction(filters.DecayCurveGauss, 100, 0, 100, 0.5)
+	assert.InDelta(t, 0.5, float64(score), 0.001)
+
+	// dist=0 → 1.0
+	score = computeDecayFunction(filters.DecayCurveGauss, 0, 0, 100, 0.5)
+	assert.InDelta(t, 1.0, float64(score), 0.001)
+}
+
+func TestComputeDecayFunction_Linear(t *testing.T) {
+	// dist=scale → decayValue
+	score := computeDecayFunction(filters.DecayCurveLinear, 100, 0, 100, 0.5)
+	assert.InDelta(t, 0.5, float64(score), 0.001)
+
+	// dist=0 → 1.0
+	score = computeDecayFunction(filters.DecayCurveLinear, 0, 0, 100, 0.5)
+	assert.InDelta(t, 1.0, float64(score), 0.001)
+
+	// dist > scale/(1-decay) → 0
+	score = computeDecayFunction(filters.DecayCurveLinear, 300, 0, 100, 0.5)
+	assert.InDelta(t, 0.0, float64(score), 0.001)
+}
+
+func TestComputeDecayFunction_WithOffset(t *testing.T) {
+	// dist within offset → score=1.0
+	score := computeDecayFunction(filters.DecayCurveExp, 50, 50, 100, 0.5)
+	assert.InDelta(t, 1.0, float64(score), 0.001)
+
+	// dist=offset+scale → decayValue
+	score = computeDecayFunction(filters.DecayCurveExp, 150, 50, 100, 0.5)
+	assert.InDelta(t, 0.5, float64(score), 0.001)
+}
+
+func TestComputeDecayFunction_DefaultCurve(t *testing.T) {
+	// Unknown curve falls back to exp behavior
+	score := computeDecayFunction("unknown", 100, 0, 100, 0.5)
+	scoreExp := computeDecayFunction(filters.DecayCurveExp, 100, 0, 100, 0.5)
+	assert.InDelta(t, float64(scoreExp), float64(score), 0.001)
+}
+
+// --- Decay on search result ---
+
+func TestComputeDecayForResult_NumericProperty(t *testing.T) {
+	decay := &filters.Decay{
+		Path:       &filters.Path{Property: "price"},
+		Origin:     "100",
+		Scale:      "200",
+		Curve:      filters.DecayCurveExp,
+		DecayValue: 0.5,
+	}
+	parsed := parseDecayParams(decay)
+	props := map[string]interface{}{"price": float64(300)} // dist=200=scale → 0.5
+	score := computeDecayForResult(decay, parsed, props, time.Now())
+	assert.InDelta(t, 0.5, float64(score), 0.001)
+}
+
+func TestComputeDecayForResult_MissingProperty(t *testing.T) {
+	decay := &filters.Decay{
+		Path:   &filters.Path{Property: "price"},
+		Origin: "100",
+		Scale:  "200",
+	}
+	parsed := parseDecayParams(decay)
+	props := map[string]interface{}{}
+	score := computeDecayForResult(decay, parsed, props, time.Now())
+	assert.InDelta(t, 0.0, float64(score), 0.001)
+}
+
+func TestComputeDecayForResult_DateProperty(t *testing.T) {
+	now := time.Now()
+	origin := "now"
+	scale := "7d"
+	decay := &filters.Decay{
+		Path:       &filters.Path{Property: "createdAt"},
+		Origin:     origin,
+		Scale:      scale,
+		Curve:      filters.DecayCurveExp,
+		DecayValue: 0.5,
+	}
+	parsed := parseDecayParams(decay)
+
+	// 7 days ago → dist=scale → 0.5
+	t7dAgo := now.Add(-7 * 24 * time.Hour).Format(time.RFC3339)
+	props := map[string]interface{}{"createdAt": t7dAgo}
+	score := computeDecayForResult(decay, parsed, props, now)
+	assert.InDelta(t, 0.5, float64(score), 0.05)
+
+	// Now → dist=0 → 1.0
+	props = map[string]interface{}{"createdAt": now.Format(time.RFC3339)}
+	score = computeDecayForResult(decay, parsed, props, now)
+	assert.InDelta(t, 1.0, float64(score), 0.05)
+}
+
+// --- parseNumericOrDuration ---
+
+func TestParseNumericOrDuration(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected float64
+	}{
+		{"", 0},
+		{"42", 42},
+		{"3.14", 3.14},
+		{"7d", 7 * float64(24*time.Hour)},
+		{"24h", 24 * float64(time.Hour)},
+		{"30m", 30 * float64(time.Minute)},
+		{"10s", 10 * float64(time.Second)},
+		{"500ms", 500 * float64(time.Millisecond)},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseNumericOrDuration(tt.input)
+			require.NoError(t, err)
+			assert.InDelta(t, tt.expected, got, 0.001)
+		})
+	}
+}
+
+// --- parseDecayParams ---
+
+func TestParseDecayParams_Valid(t *testing.T) {
+	d := &filters.Decay{
+		Origin:     "100",
+		Scale:      "200",
+		Offset:     "10",
+		Curve:      filters.DecayCurveGauss,
+		DecayValue: 0.3,
+	}
+	p := parseDecayParams(d)
+	assert.True(t, p.valid)
+	assert.InDelta(t, 10, p.offset, 0.001)
+	assert.InDelta(t, 200, p.scale, 0.001)
+	assert.InDelta(t, 0.3, p.decayValue, 0.001)
+	assert.Equal(t, filters.DecayCurveGauss, p.curve)
+}
+
+func TestParseDecayParams_Defaults(t *testing.T) {
+	d := &filters.Decay{
+		Scale: "100",
+	}
+	p := parseDecayParams(d)
+	assert.True(t, p.valid)
+	assert.InDelta(t, 0.5, p.decayValue, 0.001)     // default
+	assert.Equal(t, filters.DecayCurveExp, p.curve) // default
+}
+
+func TestParseDecayParams_InvalidScale(t *testing.T) {
+	d := &filters.Decay{Scale: ""}
+	p := parseDecayParams(d)
+	assert.False(t, p.valid)
+
+	d = &filters.Decay{Scale: "0"}
+	p = parseDecayParams(d)
+	assert.False(t, p.valid)
+
+	d = &filters.Decay{Scale: "-10"}
+	p = parseDecayParams(d)
+	assert.False(t, p.valid, "negative scale should produce invalid params")
+}
+
+// --- toFloat64 ---
+
+func TestToFloat64(t *testing.T) {
+	tests := []struct {
+		input    interface{}
+		expected float64
+		hasErr   bool
+	}{
+		{float64(1.5), 1.5, false},
+		{float32(2.5), 2.5, false},
+		{int(10), 10, false},
+		{int64(20), 20, false},
+		{"3.14", 3.14, false},
+		{[]int{1}, 0, true},
+	}
+	for _, tt := range tests {
+		got, err := toFloat64(tt.input)
+		if tt.hasErr {
+			assert.Error(t, err)
+		} else {
+			require.NoError(t, err)
+			assert.InDelta(t, tt.expected, got, 0.001)
+		}
+	}
+}
+
+// --- tryParseDate ---
+
+func TestTryParseDate(t *testing.T) {
+	now := time.Now()
+
+	// time.Time passthrough
+	parsed, ok := tryParseDate(now)
+	assert.True(t, ok)
+	assert.Equal(t, now, parsed)
+
+	// RFC3339
+	s := "2024-06-15T10:30:00Z"
+	parsed, ok = tryParseDate(s)
+	assert.True(t, ok)
+	assert.Equal(t, 2024, parsed.Year())
+
+	// Date only
+	parsed, ok = tryParseDate("2024-06-15")
+	assert.True(t, ok)
+	assert.Equal(t, 15, parsed.Day())
+
+	// Invalid
+	_, ok = tryParseDate("not-a-date")
+	assert.False(t, ok)
+
+	// Non-string, non-time
+	_, ok = tryParseDate(42)
+	assert.False(t, ok)
+}
+
+// --- precompileLikePatterns ---
+
+func TestPrecompileLikePatterns(t *testing.T) {
+	cache := make(map[string]*regexp.Regexp)
+	clause := &filters.Clause{
+		Operator: filters.OperatorLike,
+		Value:    &filters.Value{Value: "hello*"},
+	}
+	precompileLikePatterns(clause, cache)
+	require.Contains(t, cache, "hello*")
+	assert.True(t, cache["hello*"].MatchString("hello world"))
+	assert.False(t, cache["hello*"].MatchString("world hello"))
+}
+
+func TestPrecompileLikePatterns_QuestionMark(t *testing.T) {
+	cache := make(map[string]*regexp.Regexp)
+	clause := &filters.Clause{
+		Operator: filters.OperatorLike,
+		Value:    &filters.Value{Value: "h?llo"},
+	}
+	precompileLikePatterns(clause, cache)
+	assert.True(t, cache["h?llo"].MatchString("hello"))
+	assert.True(t, cache["h?llo"].MatchString("hallo"))
+	assert.False(t, cache["h?llo"].MatchString("heello"))
+}
+
+func TestPrecompileLikePatterns_Nested(t *testing.T) {
+	cache := make(map[string]*regexp.Regexp)
+	clause := &filters.Clause{
+		Operator: filters.OperatorAnd,
+		Operands: []filters.Clause{
+			{Operator: filters.OperatorLike, Value: &filters.Value{Value: "a*"}},
+			{Operator: filters.OperatorLike, Value: &filters.Value{Value: "b*"}},
+		},
+	}
+	precompileLikePatterns(clause, cache)
+	assert.Len(t, cache, 2)
+	assert.Contains(t, cache, "a*")
+	assert.Contains(t, cache, "b*")
+}
+
+func TestPrecompileLikePatterns_NilClause(t *testing.T) {
+	cache := make(map[string]*regexp.Regexp)
+	precompileLikePatterns(nil, cache) // should not panic
+	assert.Empty(t, cache)
+}
+
+// --- extractProps ---
+
+func TestExtractProps(t *testing.T) {
+	r := makeResult("a", 1.0, map[string]interface{}{"key": "val"})
+	props := extractProps(&r)
+	assert.Equal(t, "val", props["key"])
+
+	r2 := makeResult("b", 1.0, nil)
+	assert.Nil(t, extractProps(&r2))
+
+	r3 := search.Result{Schema: "not-a-map"}
+	assert.Nil(t, extractProps(&r3))
+}
+
+// --- Integration: applyBoostScoring with decay ---
+
+func TestApplyBoostScoring_DecayReorders(t *testing.T) {
+	results := []search.Result{
+		makeResult("far", 0.5, map[string]interface{}{"price": float64(1000)}),
+		makeResult("close", 0.5, map[string]interface{}{"price": float64(110)}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			decayCondition("price", "100", "200", filters.DecayCurveExp, 0.5),
+		},
+		Weight: 1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// close (dist=10) should rank first, far (dist=900) last
+	assert.Equal(t, strfmt.UUID("close"), got[0].ID)
+	assert.Equal(t, strfmt.UUID("far"), got[1].ID)
+}
+
+func TestApplyBoostScoring_MixedConditions(t *testing.T) {
+	results := []search.Result{
+		makeResult("a", 0.5, map[string]interface{}{"inStock": true, "price": float64(500)}),
+		makeResult("b", 0.5, map[string]interface{}{"inStock": false, "price": float64(100)}),
+		makeResult("c", 0.5, map[string]interface{}{"inStock": true, "price": float64(100)}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			{
+				Filter: &filters.LocalFilter{Root: &filters.Clause{
+					On:       &filters.Path{Property: "inStock"},
+					Value:    &filters.Value{Value: true},
+					Operator: filters.OperatorEqual,
+				}},
+				Weight: 2.0,
+			},
+			decayCondition("price", "100", "500", filters.DecayCurveLinear, 0.5),
+		},
+		Weight: 1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// c: inStock=true(w=2,s=1) + price=100(w=1,s=1.0) → (2*1+1*1)/3 = 1.0
+	// a: inStock=true(w=2,s=1) + price=500(w=1,s=0.5) → (2*1+1*0.5)/3 = 0.833
+	// b: inStock=false(w=2,s=0) + price=100(w=1,s=1.0) → (2*0+1*1.0)/3 = 0.333
+	assert.Equal(t, strfmt.UUID("c"), got[0].ID)
+	assert.Equal(t, strfmt.UUID("a"), got[1].ID)
+	assert.Equal(t, strfmt.UUID("b"), got[2].ID)
+}
+
+func TestScoreResult_NegativeWeightDemotes(t *testing.T) {
+	// A single negative weight: matching result gets demoted.
+	r := makeResult("a", 1.0, map[string]interface{}{"inStock": true})
+	conds := []filters.BoostCondition{
+		{
+			Filter: &filters.LocalFilter{Root: &filters.Clause{
+				On:       &filters.Path{Property: "inStock"},
+				Value:    &filters.Value{Value: true, Type: schema.DataTypeBoolean},
+				Operator: filters.OperatorEqual,
+			}},
+			Weight: -1.0,
+		},
+	}
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	// weight=-1, condScore=1 → weightedSum = -1*1 = -1, weightSum = 1 → -1/1 = -1
+	assert.InDelta(t, -1.0, float64(score), 0.001)
+}
+
+func TestScoreResult_MixedPositiveNegativeWeights(t *testing.T) {
+	// Positive weight=2 matches + negative weight=-1 matches → (2*1 + -1*1) / (2+1) = 1/3
+	r := makeResult("a", 1.0, map[string]interface{}{
+		"inStock":  true,
+		"category": "electronics",
+	})
+	conds := []filters.BoostCondition{
+		{
+			Filter: &filters.LocalFilter{Root: &filters.Clause{
+				On:       &filters.Path{Property: "inStock"},
+				Value:    &filters.Value{Value: true, Type: schema.DataTypeBoolean},
+				Operator: filters.OperatorEqual,
+			}},
+			Weight: 2.0,
+		},
+		{
+			Filter: &filters.LocalFilter{Root: &filters.Clause{
+				On:       &filters.Path{Property: "category"},
+				Value:    &filters.Value{Value: "electronics", Type: schema.DataTypeText},
+				Operator: filters.OperatorEqual,
+			}},
+			Weight: -1.0,
+		},
+	}
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	// (2*1 + -1*1) / (2+1) = 1/3 ≈ 0.333
+	assert.InDelta(t, 0.333, float64(score), 0.01)
+}
+
+func TestApplyBoostScoring_NegativeWeightDemotesMatchingResult(t *testing.T) {
+	results := []search.Result{
+		makeResult("match", 0.5, map[string]interface{}{"banned": true}),
+		makeResult("no-match", 0.5, map[string]interface{}{"banned": false}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			{
+				Filter: &filters.LocalFilter{Root: &filters.Clause{
+					On:       &filters.Path{Property: "banned"},
+					Value:    &filters.Value{Value: true, Type: schema.DataTypeBoolean},
+					Operator: filters.OperatorEqual,
+				}},
+				Weight: -1.0,
+			},
+		},
+		Weight: 0.5,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// no-match has boost=0 (doesn't match, so condScore=0, score=0)
+	// match has boost=-1 (matches negative weight)
+	// After blending with weight=0.5: no-match ranks higher
+	assert.Equal(t, strfmt.UUID("no-match"), got[0].ID)
+	assert.Equal(t, strfmt.UUID("match"), got[1].ID)
+}
+
+// --- asFloat64 / asBool ---
+
+func TestAsFloat64(t *testing.T) {
+	v, ok := asFloat64(float64(1.5))
+	assert.True(t, ok)
+	assert.InDelta(t, 1.5, v, 0.001)
+
+	v, ok = asFloat64(float32(2.5))
+	assert.True(t, ok)
+	assert.InDelta(t, 2.5, v, 0.001)
+
+	v, ok = asFloat64(int(10))
+	assert.True(t, ok)
+	assert.InDelta(t, 10, v, 0.001)
+
+	_, ok = asFloat64("string")
+	assert.False(t, ok)
+}
+
+func TestAsBool(t *testing.T) {
+	v, ok := asBool(true)
+	assert.True(t, ok)
+	assert.True(t, v)
+
+	_, ok = asBool("string")
+	assert.False(t, ok)
+}
+
+// --- parseOriginAsTime ---
+
+func TestParseOriginAsTime(t *testing.T) {
+	now := time.Now()
+	parsed, err := parseOriginAsTime("now", now)
+	require.NoError(t, err)
+	assert.Equal(t, now, parsed)
+
+	parsed, err = parseOriginAsTime("2024-06-15T10:00:00Z", now)
+	require.NoError(t, err)
+	assert.Equal(t, 2024, parsed.Year())
+
+	_, err = parseOriginAsTime("invalid", now)
+	assert.Error(t, err)
+}
+
+// --- computeDistance ---
+
+func TestComputeDistance_Numeric(t *testing.T) {
+	decay := &filters.Decay{Origin: "100"}
+	dist, err := computeDistance(decay, float64(150), time.Now())
+	require.NoError(t, err)
+	assert.InDelta(t, 50, dist, 0.001)
+}
+
+func TestComputeDistance_Date(t *testing.T) {
+	now := time.Now()
+	decay := &filters.Decay{Origin: "now"}
+	dateVal := now.Add(-48 * time.Hour).Format(time.RFC3339)
+	dist, err := computeDistance(decay, dateVal, now)
+	require.NoError(t, err)
+	expected := float64(48 * time.Hour)
+	assert.InDelta(t, expected, dist, float64(2*time.Second))
+}
+
+// Ensure decay curves score correctly at extreme distances.
+func TestComputeDecayFunction_ExtremeDistances(t *testing.T) {
+	// Very large distance → exp approaches 0
+	score := computeDecayFunction(filters.DecayCurveExp, 1e9, 0, 100, 0.5)
+	assert.True(t, float64(score) < 1e-10, "exp at huge distance should be near 0")
+
+	// Gauss at huge distance → 0
+	score = computeDecayFunction(filters.DecayCurveGauss, 1e6, 0, 100, 0.5)
+	assert.InDelta(t, 0, float64(score), 1e-10)
+
+	// Linear caps at 0
+	score = computeDecayFunction(filters.DecayCurveLinear, 1e6, 0, 100, 0.5)
+	assert.InDelta(t, 0, float64(score), 1e-10)
+}
+
+// Verify that NaN/Inf don't leak through decay calculations.
+func TestComputeDecayFunction_NoNaN(t *testing.T) {
+	score := computeDecayFunction(filters.DecayCurveExp, 0, 0, 100, 0.5)
+	assert.False(t, math.IsNaN(float64(score)))
+	assert.False(t, math.IsInf(float64(score), 0))
+
+	score = computeDecayFunction(filters.DecayCurveGauss, 0, 0, 100, 0.5)
+	assert.False(t, math.IsNaN(float64(score)))
+
+	score = computeDecayFunction(filters.DecayCurveLinear, 0, 0, 100, 0.5)
+	assert.False(t, math.IsNaN(float64(score)))
+}
+
+// --- PropertyValue tests ---
+
+func propertyValueCondition(path string, modifier filters.PropertyValueModifierType) filters.BoostCondition {
+	return filters.BoostCondition{
+		PropertyValue: &filters.PropertyValue{
+			Path:     &filters.Path{Property: schema.PropertyName(path)},
+			Modifier: modifier,
+		},
+		Weight: 1.0,
+	}
+}
+
+func TestApplyBoostScoring_PropertyValuePromotesHighValues(t *testing.T) {
+	results := []search.Result{
+		makeResult("low-likes", 1.0, map[string]interface{}{"likes": float64(10)}),
+		makeResult("high-likes", 0.5, map[string]interface{}{"likes": float64(1000)}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{propertyValueCondition("likes", filters.PropertyValueModifierNone)},
+		Weight:     1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// With weight=1.0, only boost score matters. high-likes (normalized to 1.0) should be first.
+	assert.Equal(t, strfmt.UUID("high-likes"), got[0].ID)
+	assert.Equal(t, strfmt.UUID("low-likes"), got[1].ID)
+}
+
+func TestApplyBoostScoring_PropertyValueLog1p(t *testing.T) {
+	results := []search.Result{
+		makeResult("a", 0.5, map[string]interface{}{"likes": float64(0)}),
+		makeResult("b", 0.5, map[string]interface{}{"likes": float64(100)}),
+		makeResult("c", 0.5, map[string]interface{}{"likes": float64(10000)}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{propertyValueCondition("likes", filters.PropertyValueModifierLog1p)},
+		Weight:     1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// log1p compresses the range: log1p(10000) >> log1p(100) > log1p(0)
+	assert.Equal(t, strfmt.UUID("c"), got[0].ID)
+	assert.Equal(t, strfmt.UUID("b"), got[1].ID)
+	assert.Equal(t, strfmt.UUID("a"), got[2].ID)
+	// With log1p, middle value should be closer to top than with "none"
+	assert.True(t, got[1].Score > 0.4, "log1p should compress range, middle score should be > 0.4")
+}
+
+func TestApplyBoostScoring_PropertyValueSqrt(t *testing.T) {
+	results := []search.Result{
+		makeResult("a", 0.5, map[string]interface{}{"likes": float64(0)}),
+		makeResult("b", 0.5, map[string]interface{}{"likes": float64(100)}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{propertyValueCondition("likes", filters.PropertyValueModifierSqrt)},
+		Weight:     1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	assert.Equal(t, strfmt.UUID("b"), got[0].ID)
+	assert.Equal(t, strfmt.UUID("a"), got[1].ID)
+}
+
+func TestApplyBoostScoring_PropertyValueAllSameValue(t *testing.T) {
+	results := []search.Result{
+		makeResult("a", 1.0, map[string]interface{}{"likes": float64(50)}),
+		makeResult("b", 0.5, map[string]interface{}{"likes": float64(50)}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{propertyValueCondition("likes", filters.PropertyValueModifierNone)},
+		Weight:     0.5,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// All same property value → all normalize to 1.0
+	// Primary score breaks the tie: a (1.0) > b (0.5)
+	assert.Equal(t, strfmt.UUID("a"), got[0].ID)
+}
+
+func TestApplyBoostScoring_PropertyValueMissingProperty(t *testing.T) {
+	results := []search.Result{
+		makeResult("has-likes", 0.5, map[string]interface{}{"likes": float64(100)}),
+		makeResult("no-likes", 0.5, map[string]interface{}{"title": "hello"}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{propertyValueCondition("likes", filters.PropertyValueModifierNone)},
+		Weight:     1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// Missing property → raw value 0. has-likes should rank first.
+	assert.Equal(t, strfmt.UUID("has-likes"), got[0].ID)
+}
+
+func TestApplyPropertyValueModifier(t *testing.T) {
+	tests := []struct {
+		name     string
+		val      float64
+		modifier filters.PropertyValueModifierType
+		expected float64
+	}{
+		{"none passes through", 100, filters.PropertyValueModifierNone, 100},
+		{"log1p of 0", 0, filters.PropertyValueModifierLog1p, 0},
+		{"log1p of 100", 100, filters.PropertyValueModifierLog1p, math.Log1p(100)},
+		{"log1p of negative clamps to 0", -5, filters.PropertyValueModifierLog1p, 0},
+		{"sqrt of 100", 100, filters.PropertyValueModifierSqrt, 10},
+		{"sqrt of 0", 0, filters.PropertyValueModifierSqrt, 0},
+		{"sqrt of negative clamps to 0", -5, filters.PropertyValueModifierSqrt, 0},
+		{"empty modifier is none", 42, "", 42},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := applyPropertyValueModifier(tt.val, tt.modifier)
+			assert.InDelta(t, tt.expected, got, 0.001)
+		})
+	}
+}
+
+func TestScoreResult_NegativeWeightNonMatch(t *testing.T) {
+	// Negative weight on a non-matching result should score 0 (not negative).
+	r := makeResult("a", 1.0, map[string]interface{}{"inStock": false})
+	conds := []filters.BoostCondition{
+		{
+			Filter: &filters.LocalFilter{Root: &filters.Clause{
+				On:       &filters.Path{Property: "inStock"},
+				Value:    &filters.Value{Value: true, Type: schema.DataTypeBoolean},
+				Operator: filters.OperatorEqual,
+			}},
+			Weight: -1.0,
+		},
+	}
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	// condScore=0 (no match), weight=-1 → weightedSum=-1*0=0, weightSum=1 → 0/1=0
+	assert.InDelta(t, 0.0, float64(score), 0.001)
+}
+
+func TestComputeDecayForResult_NonExistingField(t *testing.T) {
+	decay := &filters.Decay{
+		Path:   &filters.Path{Property: "nonExistent"},
+		Origin: "100",
+		Scale:  "200",
+	}
+	parsed := parseDecayParams(decay)
+	props := map[string]interface{}{"price": float64(50)}
+	score := computeDecayForResult(decay, parsed, props, time.Now())
+	assert.InDelta(t, 0.0, float64(score), 0.001, "decay on non-existing field should score 0")
+}
+
+func TestComputeDecayForResult_NilProps(t *testing.T) {
+	decay := &filters.Decay{
+		Path:   &filters.Path{Property: "price"},
+		Origin: "100",
+		Scale:  "200",
+	}
+	parsed := parseDecayParams(decay)
+	score := computeDecayForResult(decay, parsed, nil, time.Now())
+	assert.InDelta(t, 0.0, float64(score), 0.001, "decay on nil props should score 0")
+}
+
+func TestApplyBoostScoring_PropertyValueNonExistingField(t *testing.T) {
+	results := []search.Result{
+		makeResult("a", 1.0, map[string]interface{}{"title": "hello"}),
+		makeResult("b", 0.5, map[string]interface{}{"title": "world"}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{{
+			PropertyValue: &filters.PropertyValue{
+				Path:     &filters.Path{Property: "nonExistent"},
+				Modifier: filters.PropertyValueModifierNone,
+			},
+			Weight: 1.0,
+		}},
+		Weight: 1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// All property values are 0 → all normalize to 1.0 (same value).
+	// Primary scores break the tie: a (1.0) > b (0.5) after normalization.
+	require.Len(t, got, 2)
+	assert.Equal(t, strfmt.UUID("a"), got[0].ID)
+}
+
+func TestApplyBoostScoring_PropertyValueNilSchema(t *testing.T) {
+	results := []search.Result{
+		makeResult("a", 1.0, nil),
+		makeResult("b", 0.5, map[string]interface{}{"likes": float64(100)}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{{
+			PropertyValue: &filters.PropertyValue{
+				Path:     &filters.Path{Property: "likes"},
+				Modifier: filters.PropertyValueModifierNone,
+			},
+			Weight: 1.0,
+		}},
+		Weight: 1.0,
+	}
+	got := applyBoostScoring(results, withOriginalLimit(boost, 10))
+	// a has nil schema → likes=0, b has likes=100.
+	// With weight=1.0, only boost matters. b should rank first.
+	require.Len(t, got, 2)
+	assert.Equal(t, strfmt.UUID("b"), got[0].ID)
+}
+
+// --- Offset pagination tests ---
+
+func TestApplyBoostScoring_OffsetSkipsTopResults(t *testing.T) {
+	results := make([]search.Result, 10)
+	for i := range results {
+		results[i] = makeResult(
+			fmt.Sprintf("item-%d", i),
+			float32(10-i)*0.1,
+			map[string]interface{}{"promoted": i == 9},
+		)
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("promoted", filters.OperatorEqual, true, schema.DataTypeBoolean),
+		},
+		Weight: 1.0,
+	}
+	// offset=0, limit=3: should get [item-9, item-0, item-1]
+	page1 := applyBoostScoring(cloneResults(results), withOriginalPagination(boost, 0, 3))
+	require.Len(t, page1, 3)
+	assert.Equal(t, strfmt.UUID("item-9"), page1[0].ID)
+
+	// offset=3, limit=3: should skip the first 3 and return the next 3
+	page2 := applyBoostScoring(cloneResults(results), withOriginalPagination(boost, 3, 3))
+	require.Len(t, page2, 3)
+
+	// Pages should not overlap
+	page1IDs := make(map[strfmt.UUID]bool)
+	for _, r := range page1 {
+		page1IDs[r.ID] = true
+	}
+	for _, r := range page2 {
+		assert.False(t, page1IDs[r.ID], "page2 result %s should not appear in page1", r.ID)
+	}
+}
+
+func TestApplyBoostScoring_OffsetPlusLimitMatchesFullResults(t *testing.T) {
+	results := make([]search.Result, 10)
+	for i := range results {
+		results[i] = makeResult(
+			fmt.Sprintf("item-%d", i),
+			float32(10-i)*0.1,
+			map[string]interface{}{"likes": float64(i * 100)},
+		)
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{{
+			PropertyValue: &filters.PropertyValue{
+				Path:     &filters.Path{Property: "likes"},
+				Modifier: filters.PropertyValueModifierNone,
+			},
+			Weight: 1.0,
+		}},
+		Weight: 0.7,
+	}
+	// Get all 10 results in one go
+	all := applyBoostScoring(cloneResults(results), withOriginalPagination(boost, 0, 10))
+	require.Len(t, all, 10)
+
+	// Get page 1 (offset=0, limit=5) and page 2 (offset=5, limit=5)
+	p1 := applyBoostScoring(cloneResults(results), withOriginalPagination(boost, 0, 5))
+	p2 := applyBoostScoring(cloneResults(results), withOriginalPagination(boost, 5, 5))
+	require.Len(t, p1, 5)
+	require.Len(t, p2, 5)
+
+	// Concatenation of pages should match full result
+	combined := append(p1, p2...)
+	for i := range all {
+		assert.Equal(t, all[i].ID, combined[i].ID, "position %d mismatch", i)
+	}
+}
+
+func TestApplyBoostScoring_OffsetBeyondResults(t *testing.T) {
+	results := []search.Result{
+		makeResult("a", 1.0, map[string]interface{}{"x": true}),
+		makeResult("b", 0.5, map[string]interface{}{"x": false}),
+	}
+	boost := &filters.Boost{
+		Conditions: []filters.BoostCondition{
+			filterCondition("x", filters.OperatorEqual, true, schema.DataTypeBoolean),
+		},
+		Weight: 0.5,
+	}
+	got := applyBoostScoring(results, withOriginalPagination(boost, 10, 5))
+	assert.Nil(t, got, "offset beyond result count should return nil")
+}
+
+func cloneResults(results []search.Result) []search.Result {
+	out := make([]search.Result, len(results))
+	copy(out, results)
+	return out
+}

--- a/usecases/traverser/boost_scorer_test.go
+++ b/usecases/traverser/boost_scorer_test.go
@@ -14,7 +14,6 @@ package traverser
 import (
 	"fmt"
 	"math"
-	"regexp"
 	"testing"
 	"time"
 
@@ -290,7 +289,7 @@ func TestScoreResult_FilterMatch(t *testing.T) {
 	conds := []filters.BoostCondition{
 		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
 	assert.InDelta(t, 1.0, float64(score), 0.001)
 }
 
@@ -299,7 +298,7 @@ func TestScoreResult_FilterNoMatch(t *testing.T) {
 	conds := []filters.BoostCondition{
 		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
 	assert.InDelta(t, 0.0, float64(score), 0.001)
 }
 
@@ -308,7 +307,7 @@ func TestScoreResult_FilterMissingProperty(t *testing.T) {
 	conds := []filters.BoostCondition{
 		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
 	assert.InDelta(t, 0.0, float64(score), 0.001)
 }
 
@@ -317,7 +316,7 @@ func TestScoreResult_NilSchema(t *testing.T) {
 	conds := []filters.BoostCondition{
 		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
 	assert.InDelta(t, 0.0, float64(score), 0.001)
 }
 
@@ -344,7 +343,7 @@ func TestScoreResult_WeightedAverage(t *testing.T) {
 			Weight: 1.0, // doesn't match → score 0.0
 		},
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
 	// (2*1.0 + 1*0.0) / (2+1) = 0.6667
 	assert.InDelta(t, 0.6667, float64(score), 0.01)
 }
@@ -361,7 +360,7 @@ func TestScoreResult_ZeroWeight(t *testing.T) {
 			Weight: 0, // zero weight defaults to 1.0
 		},
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
 	assert.InDelta(t, 1.0, float64(score), 0.001)
 }
 
@@ -376,10 +375,10 @@ func TestMatchesFilter_And(t *testing.T) {
 			{On: &filters.Path{Property: "b"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorEqual},
 		},
 	}}
-	assert.True(t, matchesFilter(filter, props, nil))
+	assert.True(t, matchesFilter(filter, props))
 
 	props["b"] = false
-	assert.False(t, matchesFilter(filter, props, nil))
+	assert.False(t, matchesFilter(filter, props))
 }
 
 func TestMatchesFilter_Or(t *testing.T) {
@@ -391,10 +390,10 @@ func TestMatchesFilter_Or(t *testing.T) {
 			{On: &filters.Path{Property: "b"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorEqual},
 		},
 	}}
-	assert.True(t, matchesFilter(filter, props, nil))
+	assert.True(t, matchesFilter(filter, props))
 
 	props["b"] = false
-	assert.False(t, matchesFilter(filter, props, nil))
+	assert.False(t, matchesFilter(filter, props))
 }
 
 func TestMatchesFilter_Not(t *testing.T) {
@@ -405,28 +404,15 @@ func TestMatchesFilter_Not(t *testing.T) {
 			{On: &filters.Path{Property: "a"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorEqual},
 		},
 	}}
-	assert.True(t, matchesFilter(filter, props, nil))
-}
-
-func TestMatchesFilter_IsNull(t *testing.T) {
-	// Property exists and is non-nil → isNull=false
-	props := map[string]interface{}{"a": "hello"}
-	assert.False(t, matchesFilter(&filters.LocalFilter{Root: &filters.Clause{
-		On: &filters.Path{Property: "a"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorIsNull,
-	}}, props, nil))
-
-	// Property missing → isNull=true
-	assert.True(t, matchesFilter(&filters.LocalFilter{Root: &filters.Clause{
-		On: &filters.Path{Property: "missing"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorIsNull,
-	}}, props, nil))
+	assert.True(t, matchesFilter(filter, props))
 }
 
 func TestMatchesFilter_NilInputs(t *testing.T) {
-	assert.False(t, matchesFilter(nil, map[string]interface{}{}, nil))
-	assert.False(t, matchesFilter(&filters.LocalFilter{}, map[string]interface{}{}, nil))
+	assert.False(t, matchesFilter(nil, map[string]interface{}{}))
+	assert.False(t, matchesFilter(&filters.LocalFilter{}, map[string]interface{}{}))
 	assert.False(t, matchesFilter(&filters.LocalFilter{Root: &filters.Clause{
 		On: &filters.Path{Property: "a"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorEqual,
-	}}, nil, nil))
+	}}, nil))
 }
 
 // --- compareValues tests ---
@@ -452,7 +438,7 @@ func TestCompareValues_Numeric(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, compareValues(tt.op, tt.propVal, tt.filterV, nil))
+			assert.Equal(t, tt.expected, compareValues(tt.op, tt.propVal, tt.filterV))
 		})
 	}
 }
@@ -474,25 +460,15 @@ func TestCompareValues_String(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, compareValues(tt.op, tt.prop, tt.filter, nil))
+			assert.Equal(t, tt.expected, compareValues(tt.op, tt.prop, tt.filter))
 		})
 	}
 }
 
 func TestCompareValues_Boolean(t *testing.T) {
-	assert.True(t, compareValues(filters.OperatorEqual, true, true, nil))
-	assert.False(t, compareValues(filters.OperatorEqual, true, false, nil))
-	assert.True(t, compareValues(filters.OperatorNotEqual, true, false, nil))
-}
-
-func TestCompareValues_Like(t *testing.T) {
-	cache := make(map[string]*regexp.Regexp)
-	precompileLikePatterns(&filters.Clause{
-		Operator: filters.OperatorLike,
-		Value:    &filters.Value{Value: "Lap*"},
-	}, cache)
-	assert.True(t, compareValues(filters.OperatorLike, "Laptop Pro", "Lap*", cache))
-	assert.False(t, compareValues(filters.OperatorLike, "Desktop", "Lap*", cache))
+	assert.True(t, compareValues(filters.OperatorEqual, true, true))
+	assert.False(t, compareValues(filters.OperatorEqual, true, false))
+	assert.True(t, compareValues(filters.OperatorNotEqual, true, false))
 }
 
 // --- Decay function tests ---
@@ -728,53 +704,6 @@ func TestTryParseDate(t *testing.T) {
 	assert.False(t, ok)
 }
 
-// --- precompileLikePatterns ---
-
-func TestPrecompileLikePatterns(t *testing.T) {
-	cache := make(map[string]*regexp.Regexp)
-	clause := &filters.Clause{
-		Operator: filters.OperatorLike,
-		Value:    &filters.Value{Value: "hello*"},
-	}
-	precompileLikePatterns(clause, cache)
-	require.Contains(t, cache, "hello*")
-	assert.True(t, cache["hello*"].MatchString("hello world"))
-	assert.False(t, cache["hello*"].MatchString("world hello"))
-}
-
-func TestPrecompileLikePatterns_QuestionMark(t *testing.T) {
-	cache := make(map[string]*regexp.Regexp)
-	clause := &filters.Clause{
-		Operator: filters.OperatorLike,
-		Value:    &filters.Value{Value: "h?llo"},
-	}
-	precompileLikePatterns(clause, cache)
-	assert.True(t, cache["h?llo"].MatchString("hello"))
-	assert.True(t, cache["h?llo"].MatchString("hallo"))
-	assert.False(t, cache["h?llo"].MatchString("heello"))
-}
-
-func TestPrecompileLikePatterns_Nested(t *testing.T) {
-	cache := make(map[string]*regexp.Regexp)
-	clause := &filters.Clause{
-		Operator: filters.OperatorAnd,
-		Operands: []filters.Clause{
-			{Operator: filters.OperatorLike, Value: &filters.Value{Value: "a*"}},
-			{Operator: filters.OperatorLike, Value: &filters.Value{Value: "b*"}},
-		},
-	}
-	precompileLikePatterns(clause, cache)
-	assert.Len(t, cache, 2)
-	assert.Contains(t, cache, "a*")
-	assert.Contains(t, cache, "b*")
-}
-
-func TestPrecompileLikePatterns_NilClause(t *testing.T) {
-	cache := make(map[string]*regexp.Regexp)
-	precompileLikePatterns(nil, cache) // should not panic
-	assert.Empty(t, cache)
-}
-
 // --- extractProps ---
 
 func TestExtractProps(t *testing.T) {
@@ -850,7 +779,7 @@ func TestScoreResult_NegativeWeightDemotes(t *testing.T) {
 			Weight: -1.0,
 		},
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
 	// weight=-1, condScore=1 → weightedSum = -1*1 = -1, weightSum = 1 → -1/1 = -1
 	assert.InDelta(t, -1.0, float64(score), 0.001)
 }
@@ -879,7 +808,7 @@ func TestScoreResult_MixedPositiveNegativeWeights(t *testing.T) {
 			Weight: -1.0,
 		},
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
 	// (2*1 + -1*1) / (2+1) = 1/3 ≈ 0.333
 	assert.InDelta(t, 0.333, float64(score), 0.01)
 }
@@ -1127,7 +1056,7 @@ func TestScoreResult_NegativeWeightNonMatch(t *testing.T) {
 			Weight: -1.0,
 		},
 	}
-	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now(), nil)
+	score := scoreResult(&r, conds, make([]parsedDecay, len(conds)), nil, 0, time.Now())
 	// condScore=0 (no match), weight=-1 → weightedSum=-1*0=0, weightSum=1 → 0/1=0
 	assert.InDelta(t, 0.0, float64(score), 0.001)
 }

--- a/usecases/traverser/boost_scorer_test.go
+++ b/usecases/traverser/boost_scorer_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/search"
 )
 
-func makeResult(id string, score float32, props map[string]interface{}) search.Result {
+func makeResult(id string, score float32, props map[string]any) search.Result {
 	return search.Result{
 		ID:     strfmt.UUID(id),
 		Score:  score,
@@ -33,7 +33,7 @@ func makeResult(id string, score float32, props map[string]interface{}) search.R
 	}
 }
 
-func filterCondition(path string, op filters.Operator, val interface{}, dt schema.DataType) filters.BoostCondition {
+func filterCondition(path string, op filters.Operator, val any, dt schema.DataType) filters.BoostCondition {
 	return filters.BoostCondition{
 		Filter: &filters.LocalFilter{
 			Root: &filters.Clause{
@@ -92,8 +92,8 @@ func TestApplyBoostScoring_EmptyConditions(t *testing.T) {
 
 func TestApplyBoostScoring_WeightZero(t *testing.T) {
 	results := []search.Result{
-		makeResult("a", 1.0, map[string]interface{}{"inStock": true}),
-		makeResult("b", 0.5, map[string]interface{}{"inStock": false}),
+		makeResult("a", 1.0, map[string]any{"inStock": true}),
+		makeResult("b", 0.5, map[string]any{"inStock": false}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{
@@ -109,8 +109,8 @@ func TestApplyBoostScoring_WeightZero(t *testing.T) {
 
 func TestApplyBoostScoring_FilterPromotesMatchingResults(t *testing.T) {
 	results := []search.Result{
-		makeResult("no-stock", 1.0, map[string]interface{}{"inStock": false}),
-		makeResult("in-stock", 0.5, map[string]interface{}{"inStock": true}),
+		makeResult("no-stock", 1.0, map[string]any{"inStock": false}),
+		makeResult("in-stock", 0.5, map[string]any{"inStock": true}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{
@@ -126,9 +126,9 @@ func TestApplyBoostScoring_FilterPromotesMatchingResults(t *testing.T) {
 
 func TestApplyBoostScoring_Truncation(t *testing.T) {
 	results := []search.Result{
-		makeResult("a", 1.0, map[string]interface{}{"x": true}),
-		makeResult("b", 0.9, map[string]interface{}{"x": true}),
-		makeResult("c", 0.8, map[string]interface{}{"x": true}),
+		makeResult("a", 1.0, map[string]any{"x": true}),
+		makeResult("b", 0.9, map[string]any{"x": true}),
+		makeResult("c", 0.8, map[string]any{"x": true}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{
@@ -149,7 +149,7 @@ func TestApplyBoostScoring_DepthPromotesDeepResult(t *testing.T) {
 		results[i] = makeResult(
 			fmt.Sprintf("item-%d", i),
 			float32(10-i)*0.1, // decreasing primary scores: 1.0, 0.9, ..., 0.1
-			map[string]interface{}{"promoted": i == 9},
+			map[string]any{"promoted": i == 9},
 		)
 	}
 	boost := &filters.Boost{
@@ -172,7 +172,7 @@ func TestApplyBoostScoring_SmallDepthMissesDeepResult(t *testing.T) {
 		results[i] = makeResult(
 			fmt.Sprintf("item-%d", i),
 			float32(10-i)*0.1,
-			map[string]interface{}{"promoted": false},
+			map[string]any{"promoted": false},
 		)
 	}
 	boost := &filters.Boost{
@@ -195,7 +195,7 @@ func TestApplyBoostScoring_DepthTruncatesToOriginalLimit(t *testing.T) {
 		results[i] = makeResult(
 			fmt.Sprintf("item-%02d", i),
 			float32(20-i)*0.05,
-			map[string]interface{}{"inStock": i%3 == 0},
+			map[string]any{"inStock": i%3 == 0},
 		)
 	}
 	boost := &filters.Boost{
@@ -209,7 +209,7 @@ func TestApplyBoostScoring_DepthTruncatesToOriginalLimit(t *testing.T) {
 	// With weight=0.8, inStock items should dominate the top-5.
 	inStockCount := 0
 	for _, r := range got {
-		props := r.Schema.(map[string]interface{})
+		props := r.Schema.(map[string]any)
 		if props["inStock"] == true {
 			inStockCount++
 		}
@@ -221,8 +221,8 @@ func TestApplyBoostScoring_AllSamePrimaryScore(t *testing.T) {
 	// When all primary scores are equal, they normalize to 1.0
 	// and boost becomes the tiebreaker.
 	results := []search.Result{
-		makeResult("no-match", 0.5, map[string]interface{}{"inStock": false}),
-		makeResult("match", 0.5, map[string]interface{}{"inStock": true}),
+		makeResult("no-match", 0.5, map[string]any{"inStock": false}),
+		makeResult("match", 0.5, map[string]any{"inStock": true}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{
@@ -253,9 +253,9 @@ func TestDistToScore(t *testing.T) {
 func TestApplyBoostScoring_WithDistConvertedScores(t *testing.T) {
 	// Simulates vector search: explorer calls distToScore before applyBoostScoring.
 	results := []search.Result{
-		{ID: strfmt.UUID("close"), Dist: 0.01, Schema: map[string]interface{}{"streaming": false}},
-		{ID: strfmt.UUID("medium"), Dist: 0.10, Schema: map[string]interface{}{"streaming": true}},
-		{ID: strfmt.UUID("far"), Dist: 0.90, Schema: map[string]interface{}{"streaming": true}},
+		{ID: strfmt.UUID("close"), Dist: 0.01, Schema: map[string]any{"streaming": false}},
+		{ID: strfmt.UUID("medium"), Dist: 0.10, Schema: map[string]any{"streaming": true}},
+		{ID: strfmt.UUID("far"), Dist: 0.90, Schema: map[string]any{"streaming": true}},
 	}
 	distToScore(results)
 	boost := &filters.Boost{
@@ -285,7 +285,7 @@ func TestApplyBoostScoring_EmptyResults(t *testing.T) {
 // --- scoreResult tests ---
 
 func TestScoreResult_FilterMatch(t *testing.T) {
-	r := makeResult("a", 1.0, map[string]interface{}{"color": "red"})
+	r := makeResult("a", 1.0, map[string]any{"color": "red"})
 	conds := []filters.BoostCondition{
 		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
 	}
@@ -294,7 +294,7 @@ func TestScoreResult_FilterMatch(t *testing.T) {
 }
 
 func TestScoreResult_FilterNoMatch(t *testing.T) {
-	r := makeResult("a", 1.0, map[string]interface{}{"color": "blue"})
+	r := makeResult("a", 1.0, map[string]any{"color": "blue"})
 	conds := []filters.BoostCondition{
 		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
 	}
@@ -303,7 +303,7 @@ func TestScoreResult_FilterNoMatch(t *testing.T) {
 }
 
 func TestScoreResult_FilterMissingProperty(t *testing.T) {
-	r := makeResult("a", 1.0, map[string]interface{}{})
+	r := makeResult("a", 1.0, map[string]any{})
 	conds := []filters.BoostCondition{
 		filterCondition("color", filters.OperatorEqual, "red", schema.DataTypeText),
 	}
@@ -321,7 +321,7 @@ func TestScoreResult_NilSchema(t *testing.T) {
 }
 
 func TestScoreResult_WeightedAverage(t *testing.T) {
-	r := makeResult("a", 1.0, map[string]interface{}{
+	r := makeResult("a", 1.0, map[string]any{
 		"inStock":  true,
 		"category": "electronics",
 	})
@@ -349,7 +349,7 @@ func TestScoreResult_WeightedAverage(t *testing.T) {
 }
 
 func TestScoreResult_ZeroWeight(t *testing.T) {
-	r := makeResult("a", 1.0, map[string]interface{}{"x": true})
+	r := makeResult("a", 1.0, map[string]any{"x": true})
 	conds := []filters.BoostCondition{
 		{
 			Filter: &filters.LocalFilter{Root: &filters.Clause{
@@ -367,7 +367,7 @@ func TestScoreResult_ZeroWeight(t *testing.T) {
 // --- matchesFilter / matchesClause tests ---
 
 func TestMatchesFilter_And(t *testing.T) {
-	props := map[string]interface{}{"a": true, "b": true}
+	props := map[string]any{"a": true, "b": true}
 	filter := &filters.LocalFilter{Root: &filters.Clause{
 		Operator: filters.OperatorAnd,
 		Operands: []filters.Clause{
@@ -382,7 +382,7 @@ func TestMatchesFilter_And(t *testing.T) {
 }
 
 func TestMatchesFilter_Or(t *testing.T) {
-	props := map[string]interface{}{"a": false, "b": true}
+	props := map[string]any{"a": false, "b": true}
 	filter := &filters.LocalFilter{Root: &filters.Clause{
 		Operator: filters.OperatorOr,
 		Operands: []filters.Clause{
@@ -397,7 +397,7 @@ func TestMatchesFilter_Or(t *testing.T) {
 }
 
 func TestMatchesFilter_Not(t *testing.T) {
-	props := map[string]interface{}{"a": false}
+	props := map[string]any{"a": false}
 	filter := &filters.LocalFilter{Root: &filters.Clause{
 		Operator: filters.OperatorNot,
 		Operands: []filters.Clause{
@@ -408,8 +408,8 @@ func TestMatchesFilter_Not(t *testing.T) {
 }
 
 func TestMatchesFilter_NilInputs(t *testing.T) {
-	assert.False(t, matchesFilter(nil, map[string]interface{}{}))
-	assert.False(t, matchesFilter(&filters.LocalFilter{}, map[string]interface{}{}))
+	assert.False(t, matchesFilter(nil, map[string]any{}))
+	assert.False(t, matchesFilter(&filters.LocalFilter{}, map[string]any{}))
 	assert.False(t, matchesFilter(&filters.LocalFilter{Root: &filters.Clause{
 		On: &filters.Path{Property: "a"}, Value: &filters.Value{Value: true}, Operator: filters.OperatorEqual,
 	}}, nil))
@@ -421,8 +421,8 @@ func TestCompareValues_Numeric(t *testing.T) {
 	tests := []struct {
 		name     string
 		op       filters.Operator
-		propVal  interface{}
-		filterV  interface{}
+		propVal  any
+		filterV  any
 		expected bool
 	}{
 		{"equal float64", filters.OperatorEqual, float64(10), float64(10), true},
@@ -539,7 +539,7 @@ func TestComputeDecayForResult_NumericProperty(t *testing.T) {
 		DecayValue: 0.5,
 	}
 	parsed := parseDecayParams(decay)
-	props := map[string]interface{}{"price": float64(300)} // dist=200=scale → 0.5
+	props := map[string]any{"price": float64(300)} // dist=200=scale → 0.5
 	score := computeDecayForResult(decay, parsed, props, time.Now())
 	assert.InDelta(t, 0.5, float64(score), 0.001)
 }
@@ -551,7 +551,7 @@ func TestComputeDecayForResult_MissingProperty(t *testing.T) {
 		Scale:  "200",
 	}
 	parsed := parseDecayParams(decay)
-	props := map[string]interface{}{}
+	props := map[string]any{}
 	score := computeDecayForResult(decay, parsed, props, time.Now())
 	assert.InDelta(t, 0.0, float64(score), 0.001)
 }
@@ -571,12 +571,12 @@ func TestComputeDecayForResult_DateProperty(t *testing.T) {
 
 	// 7 days ago → dist=scale → 0.5
 	t7dAgo := now.Add(-7 * 24 * time.Hour).Format(time.RFC3339)
-	props := map[string]interface{}{"createdAt": t7dAgo}
+	props := map[string]any{"createdAt": t7dAgo}
 	score := computeDecayForResult(decay, parsed, props, now)
 	assert.InDelta(t, 0.5, float64(score), 0.05)
 
 	// Now → dist=0 → 1.0
-	props = map[string]interface{}{"createdAt": now.Format(time.RFC3339)}
+	props = map[string]any{"createdAt": now.Format(time.RFC3339)}
 	score = computeDecayForResult(decay, parsed, props, now)
 	assert.InDelta(t, 1.0, float64(score), 0.05)
 }
@@ -652,7 +652,7 @@ func TestParseDecayParams_InvalidScale(t *testing.T) {
 
 func TestToFloat64(t *testing.T) {
 	tests := []struct {
-		input    interface{}
+		input    any
 		expected float64
 		hasErr   bool
 	}{
@@ -707,7 +707,7 @@ func TestTryParseDate(t *testing.T) {
 // --- extractProps ---
 
 func TestExtractProps(t *testing.T) {
-	r := makeResult("a", 1.0, map[string]interface{}{"key": "val"})
+	r := makeResult("a", 1.0, map[string]any{"key": "val"})
 	props := extractProps(&r)
 	assert.Equal(t, "val", props["key"])
 
@@ -722,8 +722,8 @@ func TestExtractProps(t *testing.T) {
 
 func TestApplyBoostScoring_DecayReorders(t *testing.T) {
 	results := []search.Result{
-		makeResult("far", 0.5, map[string]interface{}{"price": float64(1000)}),
-		makeResult("close", 0.5, map[string]interface{}{"price": float64(110)}),
+		makeResult("far", 0.5, map[string]any{"price": float64(1000)}),
+		makeResult("close", 0.5, map[string]any{"price": float64(110)}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{
@@ -739,9 +739,9 @@ func TestApplyBoostScoring_DecayReorders(t *testing.T) {
 
 func TestApplyBoostScoring_MixedConditions(t *testing.T) {
 	results := []search.Result{
-		makeResult("a", 0.5, map[string]interface{}{"inStock": true, "price": float64(500)}),
-		makeResult("b", 0.5, map[string]interface{}{"inStock": false, "price": float64(100)}),
-		makeResult("c", 0.5, map[string]interface{}{"inStock": true, "price": float64(100)}),
+		makeResult("a", 0.5, map[string]any{"inStock": true, "price": float64(500)}),
+		makeResult("b", 0.5, map[string]any{"inStock": false, "price": float64(100)}),
+		makeResult("c", 0.5, map[string]any{"inStock": true, "price": float64(100)}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{
@@ -768,7 +768,7 @@ func TestApplyBoostScoring_MixedConditions(t *testing.T) {
 
 func TestScoreResult_NegativeWeightDemotes(t *testing.T) {
 	// A single negative weight: matching result gets demoted.
-	r := makeResult("a", 1.0, map[string]interface{}{"inStock": true})
+	r := makeResult("a", 1.0, map[string]any{"inStock": true})
 	conds := []filters.BoostCondition{
 		{
 			Filter: &filters.LocalFilter{Root: &filters.Clause{
@@ -786,7 +786,7 @@ func TestScoreResult_NegativeWeightDemotes(t *testing.T) {
 
 func TestScoreResult_MixedPositiveNegativeWeights(t *testing.T) {
 	// Positive weight=2 matches + negative weight=-1 matches → (2*1 + -1*1) / (2+1) = 1/3
-	r := makeResult("a", 1.0, map[string]interface{}{
+	r := makeResult("a", 1.0, map[string]any{
 		"inStock":  true,
 		"category": "electronics",
 	})
@@ -815,8 +815,8 @@ func TestScoreResult_MixedPositiveNegativeWeights(t *testing.T) {
 
 func TestApplyBoostScoring_NegativeWeightDemotesMatchingResult(t *testing.T) {
 	results := []search.Result{
-		makeResult("match", 0.5, map[string]interface{}{"banned": true}),
-		makeResult("no-match", 0.5, map[string]interface{}{"banned": false}),
+		makeResult("match", 0.5, map[string]any{"banned": true}),
+		makeResult("no-match", 0.5, map[string]any{"banned": false}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{
@@ -944,8 +944,8 @@ func propertyValueCondition(path string, modifier filters.PropertyValueModifierT
 
 func TestApplyBoostScoring_PropertyValuePromotesHighValues(t *testing.T) {
 	results := []search.Result{
-		makeResult("low-likes", 1.0, map[string]interface{}{"likes": float64(10)}),
-		makeResult("high-likes", 0.5, map[string]interface{}{"likes": float64(1000)}),
+		makeResult("low-likes", 1.0, map[string]any{"likes": float64(10)}),
+		makeResult("high-likes", 0.5, map[string]any{"likes": float64(1000)}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{propertyValueCondition("likes", filters.PropertyValueModifierNone)},
@@ -959,9 +959,9 @@ func TestApplyBoostScoring_PropertyValuePromotesHighValues(t *testing.T) {
 
 func TestApplyBoostScoring_PropertyValueLog1p(t *testing.T) {
 	results := []search.Result{
-		makeResult("a", 0.5, map[string]interface{}{"likes": float64(0)}),
-		makeResult("b", 0.5, map[string]interface{}{"likes": float64(100)}),
-		makeResult("c", 0.5, map[string]interface{}{"likes": float64(10000)}),
+		makeResult("a", 0.5, map[string]any{"likes": float64(0)}),
+		makeResult("b", 0.5, map[string]any{"likes": float64(100)}),
+		makeResult("c", 0.5, map[string]any{"likes": float64(10000)}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{propertyValueCondition("likes", filters.PropertyValueModifierLog1p)},
@@ -978,8 +978,8 @@ func TestApplyBoostScoring_PropertyValueLog1p(t *testing.T) {
 
 func TestApplyBoostScoring_PropertyValueSqrt(t *testing.T) {
 	results := []search.Result{
-		makeResult("a", 0.5, map[string]interface{}{"likes": float64(0)}),
-		makeResult("b", 0.5, map[string]interface{}{"likes": float64(100)}),
+		makeResult("a", 0.5, map[string]any{"likes": float64(0)}),
+		makeResult("b", 0.5, map[string]any{"likes": float64(100)}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{propertyValueCondition("likes", filters.PropertyValueModifierSqrt)},
@@ -992,8 +992,8 @@ func TestApplyBoostScoring_PropertyValueSqrt(t *testing.T) {
 
 func TestApplyBoostScoring_PropertyValueAllSameValue(t *testing.T) {
 	results := []search.Result{
-		makeResult("a", 1.0, map[string]interface{}{"likes": float64(50)}),
-		makeResult("b", 0.5, map[string]interface{}{"likes": float64(50)}),
+		makeResult("a", 1.0, map[string]any{"likes": float64(50)}),
+		makeResult("b", 0.5, map[string]any{"likes": float64(50)}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{propertyValueCondition("likes", filters.PropertyValueModifierNone)},
@@ -1007,8 +1007,8 @@ func TestApplyBoostScoring_PropertyValueAllSameValue(t *testing.T) {
 
 func TestApplyBoostScoring_PropertyValueMissingProperty(t *testing.T) {
 	results := []search.Result{
-		makeResult("has-likes", 0.5, map[string]interface{}{"likes": float64(100)}),
-		makeResult("no-likes", 0.5, map[string]interface{}{"title": "hello"}),
+		makeResult("has-likes", 0.5, map[string]any{"likes": float64(100)}),
+		makeResult("no-likes", 0.5, map[string]any{"title": "hello"}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{propertyValueCondition("likes", filters.PropertyValueModifierNone)},
@@ -1045,7 +1045,7 @@ func TestApplyPropertyValueModifier(t *testing.T) {
 
 func TestScoreResult_NegativeWeightNonMatch(t *testing.T) {
 	// Negative weight on a non-matching result should score 0 (not negative).
-	r := makeResult("a", 1.0, map[string]interface{}{"inStock": false})
+	r := makeResult("a", 1.0, map[string]any{"inStock": false})
 	conds := []filters.BoostCondition{
 		{
 			Filter: &filters.LocalFilter{Root: &filters.Clause{
@@ -1068,7 +1068,7 @@ func TestComputeDecayForResult_NonExistingField(t *testing.T) {
 		Scale:  "200",
 	}
 	parsed := parseDecayParams(decay)
-	props := map[string]interface{}{"price": float64(50)}
+	props := map[string]any{"price": float64(50)}
 	score := computeDecayForResult(decay, parsed, props, time.Now())
 	assert.InDelta(t, 0.0, float64(score), 0.001, "decay on non-existing field should score 0")
 }
@@ -1086,8 +1086,8 @@ func TestComputeDecayForResult_NilProps(t *testing.T) {
 
 func TestApplyBoostScoring_PropertyValueNonExistingField(t *testing.T) {
 	results := []search.Result{
-		makeResult("a", 1.0, map[string]interface{}{"title": "hello"}),
-		makeResult("b", 0.5, map[string]interface{}{"title": "world"}),
+		makeResult("a", 1.0, map[string]any{"title": "hello"}),
+		makeResult("b", 0.5, map[string]any{"title": "world"}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{{
@@ -1109,7 +1109,7 @@ func TestApplyBoostScoring_PropertyValueNonExistingField(t *testing.T) {
 func TestApplyBoostScoring_PropertyValueNilSchema(t *testing.T) {
 	results := []search.Result{
 		makeResult("a", 1.0, nil),
-		makeResult("b", 0.5, map[string]interface{}{"likes": float64(100)}),
+		makeResult("b", 0.5, map[string]any{"likes": float64(100)}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{{
@@ -1136,7 +1136,7 @@ func TestApplyBoostScoring_OffsetSkipsTopResults(t *testing.T) {
 		results[i] = makeResult(
 			fmt.Sprintf("item-%d", i),
 			float32(10-i)*0.1,
-			map[string]interface{}{"promoted": i == 9},
+			map[string]any{"promoted": i == 9},
 		)
 	}
 	boost := &filters.Boost{
@@ -1170,7 +1170,7 @@ func TestApplyBoostScoring_OffsetPlusLimitMatchesFullResults(t *testing.T) {
 		results[i] = makeResult(
 			fmt.Sprintf("item-%d", i),
 			float32(10-i)*0.1,
-			map[string]interface{}{"likes": float64(i * 100)},
+			map[string]any{"likes": float64(i * 100)},
 		)
 	}
 	boost := &filters.Boost{
@@ -1202,8 +1202,8 @@ func TestApplyBoostScoring_OffsetPlusLimitMatchesFullResults(t *testing.T) {
 
 func TestApplyBoostScoring_OffsetBeyondResults(t *testing.T) {
 	results := []search.Result{
-		makeResult("a", 1.0, map[string]interface{}{"x": true}),
-		makeResult("b", 0.5, map[string]interface{}{"x": false}),
+		makeResult("a", 1.0, map[string]any{"x": true}),
+		makeResult("b", 0.5, map[string]any{"x": false}),
 	}
 	boost := &filters.Boost{
 		Conditions: []filters.BoostCondition{

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -172,8 +172,10 @@ func (e *Explorer) GetClass(ctx context.Context,
 		if overfetch < minCandidates {
 			overfetch = minCandidates
 		}
-		params.Pagination.Limit = overfetch
-		params.Pagination.Offset = 0
+		pagination := *params.Pagination
+		pagination.Limit = overfetch
+		pagination.Offset = 0
+		params.Pagination = &pagination
 	}
 
 	if params.KeywordRanking != nil {

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -45,6 +45,8 @@ import (
 
 var _NUMCPU = runtime.GOMAXPROCS(0)
 
+const DefaultBoostDepth = 100
+
 // Explorer is a helper construct to perform vector-based searches. It does not
 // contain monitoring or authorization checks. It should thus never be directly
 // used by an API, but through a Traverser.
@@ -148,6 +150,32 @@ func (e *Explorer) GetClass(ctx context.Context,
 		return nil, errors.Wrap(err, "cursor api: invalid 'after' parameter")
 	}
 
+	// When boost is set, overfetch to give boost room to reorder results.
+	// The candidate pool size is controlled by boost.Depth (per-query) with
+	// a default of DefaultBoostDepth. Capped at QueryMaximumResults.
+	// We also zero the offset so boost sees all top candidates from position 0;
+	// the original offset/limit are stored on the Boost struct and applied
+	// after boost re-sorts.
+	if params.Boost != nil && params.Boost.Weight > 0 {
+		params.Boost.OriginalOffset = params.Pagination.Offset
+		params.Boost.OriginalLimit = params.Pagination.Limit
+
+		overfetch := params.Boost.Depth
+		if overfetch == 0 {
+			overfetch = DefaultBoostDepth
+		}
+		if overfetch > int(e.config.QueryMaximumResults) {
+			overfetch = int(e.config.QueryMaximumResults)
+		}
+		// Need at least offset+limit candidates so the original page is reachable.
+		minCandidates := params.Boost.OriginalOffset + params.Boost.OriginalLimit
+		if overfetch < minCandidates {
+			overfetch = minCandidates
+		}
+		params.Pagination.Limit = overfetch
+		params.Pagination.Offset = 0
+	}
+
 	if params.KeywordRanking != nil {
 		res, err := e.getClassKeywordBased(ctx, params)
 		if err != nil {
@@ -164,11 +192,27 @@ func (e *Explorer) GetClass(ctx context.Context,
 		return e.searchResultsToGetResponse(ctx, res, searchVector, params, searchStartTime)
 	}
 
+	// Hybrid and plain list searches go through getClassList, which handles
+	// Group workarounds, ListExploreAdditionalExtend, and usage tracking.
 	res, err := e.getClassList(ctx, params)
 	if err != nil {
 		return nil, err
 	}
 	return e.searchResultsToGetResponse(ctx, res, nil, params, searchStartTime)
+}
+
+// applyBoostIfNeeded applies boost post-scoring when boost conditions are
+// present and weight > 0. For vector searches, distances are converted to
+// scores first since vector search populates Dist but not Score.
+// The original pagination (offset/limit) is read from the Boost struct.
+func (e *Explorer) applyBoostIfNeeded(res []search.Result, boost *filters.Boost, isVectorSearch bool) []search.Result {
+	if boost == nil || boost.Weight <= 0 || len(res) == 0 {
+		return res
+	}
+	if isVectorSearch {
+		distToScore(res)
+	}
+	return applyBoostScoring(res, boost)
 }
 
 func (e *Explorer) getClassKeywordBased(ctx context.Context, params dto.GetParams) ([]search.Result, error) {
@@ -195,6 +239,8 @@ func (e *Explorer) getClassKeywordBased(ctx context.Context, params dto.GetParam
 		}
 		return nil, errors.Errorf("explorer: get class: vector search: %v", err)
 	}
+
+	res = e.applyBoostIfNeeded(res, params.Boost, false)
 
 	if e.modulesProvider != nil {
 		res, err = e.modulesProvider.GetExploreAdditionalExtend(ctx, res, params.AdditionalProperties.ModuleParams, nil, params.ModuleParams)
@@ -297,6 +343,12 @@ func (e *Explorer) searchForTargets(ctx context.Context, params dto.GetParams, t
 		res = grouped
 	}
 
+	// Apply boost before module extensions (rerankers) so the order is:
+	// vector search → boost → reranker. Only for non-hybrid paths.
+	if params.HybridSearch == nil {
+		res = e.applyBoostIfNeeded(res, params.Boost, true)
+	}
+
 	// This operation cannot be performed with hybrid search.
 	// In case of hybrid it needs to be done later with combined results from vector and keyword search
 	if e.modulesProvider != nil && params.HybridSearch == nil {
@@ -392,8 +444,9 @@ func (e *Explorer) getClassList(ctx context.Context,
 		res = grouped
 	}
 
-	if e.modulesProvider != nil {
+	res = e.applyBoostIfNeeded(res, params.Boost, false)
 
+	if e.modulesProvider != nil {
 		res, err = e.modulesProvider.ListExploreAdditionalExtend(ctx, res,
 			params.AdditionalProperties.ModuleParams, params.ModuleParams)
 		if err != nil {

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -45,8 +45,6 @@ import (
 
 var _NUMCPU = runtime.GOMAXPROCS(0)
 
-const DefaultBoostDepth = 100
-
 // Explorer is a helper construct to perform vector-based searches. It does not
 // contain monitoring or authorization checks. It should thus never be directly
 // used by an API, but through a Traverser.
@@ -152,7 +150,7 @@ func (e *Explorer) GetClass(ctx context.Context,
 
 	// When boost is set, overfetch to give boost room to reorder results.
 	// The candidate pool size is controlled by boost.Depth (per-query) with
-	// a default of DefaultBoostDepth. Capped at QueryMaximumResults.
+	// a default of QueryBoostDefaultDepth. Capped at QueryMaximumResults.
 	// We also zero the offset so boost sees all top candidates from position 0;
 	// the original offset/limit are stored on the Boost struct and applied
 	// after boost re-sorts.
@@ -162,7 +160,7 @@ func (e *Explorer) GetClass(ctx context.Context,
 
 		overfetch := params.Boost.Depth
 		if overfetch == 0 {
-			overfetch = DefaultBoostDepth
+			overfetch = e.config.QueryBoostDefaultDepth
 		}
 		if overfetch > int(e.config.QueryMaximumResults) {
 			overfetch = int(e.config.QueryMaximumResults)

--- a/usecases/traverser/explorer_boost_test.go
+++ b/usecases/traverser/explorer_boost_test.go
@@ -37,16 +37,16 @@ type spyModulesProvider struct {
 }
 
 func (s *spyModulesProvider) GetExploreAdditionalExtend(ctx context.Context, in []search.Result,
-	moduleParams map[string]interface{}, searchVector models.Vector,
-	argumentModuleParams map[string]interface{},
+	moduleParams map[string]any, searchVector models.Vector,
+	argumentModuleParams map[string]any,
 ) ([]search.Result, error) {
 	s.recordCall(in)
 	return in, nil
 }
 
 func (s *spyModulesProvider) ListExploreAdditionalExtend(ctx context.Context, in []search.Result,
-	moduleParams map[string]interface{},
-	argumentModuleParams map[string]interface{},
+	moduleParams map[string]any,
+	argumentModuleParams map[string]any,
 ) ([]search.Result, error) {
 	s.recordCall(in)
 	return in, nil
@@ -68,7 +68,7 @@ func makeBM25Results(n int) []search.Result {
 		results[i] = search.Result{
 			ID:    strfmt.UUID(fmt.Sprintf("id-%02d", i)),
 			Score: float32(n-i) * 0.1,
-			Schema: map[string]interface{}{
+			Schema: map[string]any{
 				"name":  fmt.Sprintf("Item %02d", i),
 				"likes": float64(i * 100),
 			},
@@ -85,7 +85,7 @@ func makeVectorResults(n int) []search.Result {
 		results[i] = search.Result{
 			ID:   strfmt.UUID(fmt.Sprintf("id-%02d", i)),
 			Dist: float32(i) * 0.05,
-			Schema: map[string]interface{}{
+			Schema: map[string]any{
 				"name":  fmt.Sprintf("Item %02d", i),
 				"likes": float64(i * 100),
 			},
@@ -122,13 +122,13 @@ func likesBoost(weight float32, depth int) *filters.Boost {
 	}
 }
 
-func idsFromResponse(res []interface{}) []string {
-	// GetClass returns []interface{} where each is the Schema map.
+func idsFromResponse(res []any) []string {
+	// GetClass returns []any where each is the Schema map.
 	// We can't read IDs from Schema unless we put _additional in.
 	// Instead, read the "name" field which encodes the index.
 	ids := make([]string, len(res))
 	for i, r := range res {
-		m := r.(map[string]interface{})
+		m := r.(map[string]any)
 		ids[i] = m["name"].(string)
 	}
 	return ids

--- a/usecases/traverser/explorer_boost_test.go
+++ b/usecases/traverser/explorer_boost_test.go
@@ -1,0 +1,321 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package traverser
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/dto"
+	"github.com/weaviate/weaviate/entities/filters"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/search"
+	"github.com/weaviate/weaviate/entities/searchparams"
+	"github.com/weaviate/weaviate/usecases/config"
+)
+
+// spyModulesProvider wraps the default fakeModulesProvider and records
+// what results the module extension (reranker) receives.
+type spyModulesProvider struct {
+	*fakeModulesProvider
+	extendCalls [][]strfmt.UUID
+}
+
+func (s *spyModulesProvider) GetExploreAdditionalExtend(ctx context.Context, in []search.Result,
+	moduleParams map[string]interface{}, searchVector models.Vector,
+	argumentModuleParams map[string]interface{},
+) ([]search.Result, error) {
+	s.recordCall(in)
+	return in, nil
+}
+
+func (s *spyModulesProvider) ListExploreAdditionalExtend(ctx context.Context, in []search.Result,
+	moduleParams map[string]interface{},
+	argumentModuleParams map[string]interface{},
+) ([]search.Result, error) {
+	s.recordCall(in)
+	return in, nil
+}
+
+func (s *spyModulesProvider) recordCall(in []search.Result) {
+	ids := make([]strfmt.UUID, len(in))
+	for i, r := range in {
+		ids[i] = r.ID
+	}
+	s.extendCalls = append(s.extendCalls, ids)
+}
+
+// makeBM25Results generates n results with deterministic BM25 scores and properties.
+// Score decreases, likes increases — so boost on likes reverses the order.
+func makeBM25Results(n int) []search.Result {
+	results := make([]search.Result, n)
+	for i := range results {
+		results[i] = search.Result{
+			ID:    strfmt.UUID(fmt.Sprintf("id-%02d", i)),
+			Score: float32(n-i) * 0.1,
+			Schema: map[string]interface{}{
+				"name":  fmt.Sprintf("Item %02d", i),
+				"likes": float64(i * 100),
+			},
+			Dims: 3,
+		}
+	}
+	return results
+}
+
+// makeVectorResults generates n results with deterministic distances and properties.
+func makeVectorResults(n int) []search.Result {
+	results := make([]search.Result, n)
+	for i := range results {
+		results[i] = search.Result{
+			ID:   strfmt.UUID(fmt.Sprintf("id-%02d", i)),
+			Dist: float32(i) * 0.05,
+			Schema: map[string]interface{}{
+				"name":  fmt.Sprintf("Item %02d", i),
+				"likes": float64(i * 100),
+			},
+			Dims: 3,
+		}
+	}
+	return results
+}
+
+func newTestExplorer(searcher *fakeVectorSearcher, modules ModulesProvider) *Explorer {
+	log, _ := test.NewNullLogger()
+	metrics := &fakeMetrics{}
+	metrics.On("AddUsageDimensions", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	conf := config.Config{
+		QueryDefaults:       config.QueryDefaults{Limit: 100},
+		QueryMaximumResults: 200,
+	}
+	explorer := NewExplorer(searcher, log, modules, metrics, conf)
+	explorer.SetSchemaGetter(newFakeSchemaGetter("TestClass"))
+	return explorer
+}
+
+func likesBoost(weight float32, depth int) *filters.Boost {
+	return &filters.Boost{
+		Weight: weight,
+		Depth:  depth,
+		Conditions: []filters.BoostCondition{{
+			PropertyValue: &filters.PropertyValue{
+				Path:     &filters.Path{Property: "likes"},
+				Modifier: filters.PropertyValueModifierNone,
+			},
+			Weight: 1.0,
+		}},
+	}
+}
+
+func idsFromResponse(res []interface{}) []string {
+	// GetClass returns []interface{} where each is the Schema map.
+	// We can't read IDs from Schema unless we put _additional in.
+	// Instead, read the "name" field which encodes the index.
+	ids := make([]string, len(res))
+	for i, r := range res {
+		m := r.(map[string]interface{})
+		ids[i] = m["name"].(string)
+	}
+	return ids
+}
+
+func Test_Explorer_BoostPipeline(t *testing.T) {
+	t.Run("BM25 + boost reorders by likes", func(t *testing.T) {
+		searcher := &fakeVectorSearcher{}
+		explorer := newTestExplorer(searcher, getFakeModulesProvider())
+
+		searcher.On("Search", mock.Anything).Return(makeBM25Results(20), nil)
+
+		params := dto.GetParams{
+			ClassName:  "TestClass",
+			Pagination: &filters.Pagination{Offset: 0, Limit: 5},
+			KeywordRanking: &searchparams.KeywordRanking{
+				Query: "test", Type: "bm25", Properties: []string{"name"},
+			},
+			Boost: likesBoost(1.0, 20),
+		}
+
+		res, err := explorer.GetClass(context.Background(), params)
+		require.NoError(t, err)
+		require.Len(t, res, 5)
+
+		// With weight=1.0 on likes, highest-likes items should be first.
+		// makeBM25Results gives likes = i*100, so id-19 has likes=1900, id-18=1800, etc.
+		names := idsFromResponse(res)
+		assert.Equal(t, "Item 19", names[0])
+		assert.Equal(t, "Item 18", names[1])
+	})
+
+	t.Run("BM25 + boost page-through consistency", func(t *testing.T) {
+		searcher := &fakeVectorSearcher{}
+		explorer := newTestExplorer(searcher, getFakeModulesProvider())
+
+		searcher.On("Search", mock.Anything).Return(makeBM25Results(20), nil)
+
+		makeParams := func(offset, limit int) dto.GetParams {
+			return dto.GetParams{
+				ClassName:  "TestClass",
+				Pagination: &filters.Pagination{Offset: offset, Limit: limit},
+				KeywordRanking: &searchparams.KeywordRanking{
+					Query: "test", Type: "bm25", Properties: []string{"name"},
+				},
+				Boost: likesBoost(0.8, 20),
+			}
+		}
+
+		allRes, err := explorer.GetClass(context.Background(), makeParams(0, 10))
+		require.NoError(t, err)
+		require.Len(t, allRes, 10)
+
+		p1Res, err := explorer.GetClass(context.Background(), makeParams(0, 5))
+		require.NoError(t, err)
+		require.Len(t, p1Res, 5)
+
+		p2Res, err := explorer.GetClass(context.Background(), makeParams(5, 5))
+		require.NoError(t, err)
+		require.Len(t, p2Res, 5)
+
+		allNames := idsFromResponse(allRes)
+		p1Names := idsFromResponse(p1Res)
+		p2Names := idsFromResponse(p2Res)
+
+		combined := append(p1Names, p2Names...)
+		assert.Equal(t, allNames, combined, "page 1 + page 2 should equal full result")
+	})
+
+	t.Run("nearVector + boost page-through consistency", func(t *testing.T) {
+		searcher := &fakeVectorSearcher{}
+		explorer := newTestExplorer(searcher, getFakeModulesProvider())
+
+		searcher.On("VectorSearch", mock.Anything, mock.Anything).Return(makeVectorResults(20), nil)
+
+		makeParams := func(offset, limit int) dto.GetParams {
+			return dto.GetParams{
+				ClassName:  "TestClass",
+				Pagination: &filters.Pagination{Offset: offset, Limit: limit},
+				NearVector: &searchparams.NearVector{
+					Vectors: []models.Vector{[]float32{0.1, 0.2, 0.3}},
+				},
+				Boost: likesBoost(0.8, 20),
+			}
+		}
+
+		allRes, err := explorer.GetClass(context.Background(), makeParams(0, 10))
+		require.NoError(t, err)
+		require.Len(t, allRes, 10)
+
+		p1Res, err := explorer.GetClass(context.Background(), makeParams(0, 5))
+		require.NoError(t, err)
+		require.Len(t, p1Res, 5)
+
+		p2Res, err := explorer.GetClass(context.Background(), makeParams(5, 5))
+		require.NoError(t, err)
+		require.Len(t, p2Res, 5)
+
+		allNames := idsFromResponse(allRes)
+		p1Names := idsFromResponse(p1Res)
+		p2Names := idsFromResponse(p2Res)
+
+		combined := append(p1Names, p2Names...)
+		assert.Equal(t, allNames, combined, "page 1 + page 2 should equal full result")
+	})
+
+	t.Run("module extension receives boost-paginated results for BM25", func(t *testing.T) {
+		searcher := &fakeVectorSearcher{}
+		spy := &spyModulesProvider{fakeModulesProvider: &fakeModulesProvider{}}
+		explorer := newTestExplorer(searcher, spy)
+
+		searcher.On("Search", mock.Anything).Return(makeBM25Results(20), nil)
+
+		params := dto.GetParams{
+			ClassName:  "TestClass",
+			Pagination: &filters.Pagination{Offset: 0, Limit: 5},
+			KeywordRanking: &searchparams.KeywordRanking{
+				Query: "test", Type: "bm25", Properties: []string{"name"},
+			},
+			Boost: likesBoost(1.0, 20),
+		}
+
+		_, err := explorer.GetClass(context.Background(), params)
+		require.NoError(t, err)
+
+		// Module extension should receive exactly 5 results (after boost pagination),
+		// not 20 (the full overfetched pool).
+		require.Len(t, spy.extendCalls, 1)
+		assert.Len(t, spy.extendCalls[0], 5,
+			"reranker should receive boost-paginated results, not the full pool")
+
+		// The IDs should be in boost order (highest likes first).
+		assert.Equal(t, strfmt.UUID("id-19"), spy.extendCalls[0][0])
+	})
+
+	t.Run("module extension receives boost-paginated results for nearVector", func(t *testing.T) {
+		searcher := &fakeVectorSearcher{}
+		spy := &spyModulesProvider{fakeModulesProvider: &fakeModulesProvider{}}
+		explorer := newTestExplorer(searcher, spy)
+
+		searcher.On("VectorSearch", mock.Anything, mock.Anything).Return(makeVectorResults(20), nil)
+
+		params := dto.GetParams{
+			ClassName:  "TestClass",
+			Pagination: &filters.Pagination{Offset: 0, Limit: 5},
+			NearVector: &searchparams.NearVector{
+				Vectors: []models.Vector{[]float32{0.1, 0.2, 0.3}},
+			},
+			Boost: likesBoost(1.0, 20),
+		}
+
+		_, err := explorer.GetClass(context.Background(), params)
+		require.NoError(t, err)
+
+		require.Len(t, spy.extendCalls, 1)
+		assert.Len(t, spy.extendCalls[0], 5,
+			"reranker should receive boost-paginated results, not the full pool")
+		assert.Equal(t, strfmt.UUID("id-19"), spy.extendCalls[0][0])
+	})
+
+	t.Run("module extension receives offset results for BM25 + boost", func(t *testing.T) {
+		searcher := &fakeVectorSearcher{}
+		spy := &spyModulesProvider{fakeModulesProvider: &fakeModulesProvider{}}
+		explorer := newTestExplorer(searcher, spy)
+
+		searcher.On("Search", mock.Anything).Return(makeBM25Results(20), nil)
+
+		params := dto.GetParams{
+			ClassName:  "TestClass",
+			Pagination: &filters.Pagination{Offset: 5, Limit: 3},
+			KeywordRanking: &searchparams.KeywordRanking{
+				Query: "test", Type: "bm25", Properties: []string{"name"},
+			},
+			Boost: likesBoost(1.0, 20),
+		}
+
+		_, err := explorer.GetClass(context.Background(), params)
+		require.NoError(t, err)
+
+		require.Len(t, spy.extendCalls, 1)
+		assert.Len(t, spy.extendCalls[0], 3,
+			"reranker should receive 3 results (offset=5, limit=3)")
+
+		// With weight=1.0, boost orders by likes desc: id-19, id-18, ..., id-00.
+		// Offset=5 skips the first 5, so reranker should see id-14, id-13, id-12.
+		assert.Equal(t, strfmt.UUID("id-14"), spy.extendCalls[0][0])
+		assert.Equal(t, strfmt.UUID("id-13"), spy.extendCalls[0][1])
+		assert.Equal(t, strfmt.UUID("id-12"), spy.extendCalls[0][2])
+	})
+}

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -43,6 +43,7 @@ func sparseSearch(ctx context.Context, e *Explorer, params dto.GetParams) ([]*se
 
 	params.Group = nil
 	params.GroupBy = nil
+	params.Boost = nil
 
 	if params.Pagination == nil {
 		return nil, "", fmt.Errorf("invalid params, pagination object is nil")
@@ -90,6 +91,7 @@ func denseSearch(ctx context.Context, e *Explorer, params dto.GetParams, searchn
 	}
 	params.Group = nil
 	params.GroupBy = nil
+	params.Boost = nil
 
 	partialResults, searchVectors, err := e.searchForTargets(ctx, params, targetVectors, searchVector)
 	if err != nil {
@@ -163,7 +165,7 @@ func nearTextSubSearch(ctx context.Context, e *Explorer, params dto.GetParams, t
 	subsearchWrap.ModuleParams["nearText"] = &subSearchParams
 
 	subsearchWrap.HybridSearch = nil
-	subsearchWrap.Boost = nil // boost is applied after hybrid fusion, not during sub-searches
+	subsearchWrap.Boost = nil
 	subsearchWrap.Group = nil
 	subsearchWrap.GroupBy = nil
 	partialResults, vectors, err := e.searchForTargets(ctx, subsearchWrap, targetVectors, nil)

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -163,6 +163,7 @@ func nearTextSubSearch(ctx context.Context, e *Explorer, params dto.GetParams, t
 	subsearchWrap.ModuleParams["nearText"] = &subSearchParams
 
 	subsearchWrap.HybridSearch = nil
+	subsearchWrap.Boost = nil // boost is applied after hybrid fusion, not during sub-searches
 	subsearchWrap.Group = nil
 	subsearchWrap.GroupBy = nil
 	partialResults, vectors, err := e.searchForTargets(ctx, subsearchWrap, targetVectors, nil)

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -217,17 +217,25 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		Autocut: params.Pagination.Autocut,
 	}
 
+	// Sub-search sizing should reflect the user's actual limit, not any
+	// boost-inflated overfetch. Boost overfetch only needs to affect how many
+	// fused results Hybrid returns (controlled by origParams.Pagination.Limit).
+	subSearchLimit := params.Pagination.Limit
+	if params.Boost != nil && params.Boost.OriginalLimit > 0 {
+		subSearchLimit = params.Boost.OriginalLimit
+	}
+
 	// pagination is handled after combining results
 	vectorParams := params
 	vectorParams.Pagination = &filters.Pagination{
-		Limit:   int(math.Max(float64(e.config.QueryHybridMaximumResults), float64(params.Pagination.Limit))),
+		Limit:   int(math.Max(float64(e.config.QueryHybridMaximumResults), float64(subSearchLimit))),
 		Offset:  0,
 		Autocut: -1,
 	}
 
 	keywordParams := params
 	keywordParams.Pagination = &filters.Pagination{
-		Limit:   int(math.Max(float64(e.config.QueryHybridMaximumResults), float64(params.Pagination.Limit))),
+		Limit:   int(math.Max(float64(e.config.QueryHybridMaximumResults), float64(subSearchLimit))),
 		Offset:  0,
 		Autocut: -1,
 	}


### PR DESCRIPTION
### What's being changed:

This PR introduces a Boost api that be used in vector, hybrid, and BM25 queries.

4 types of Boost conditions are supported:
- TimeDecay (canonically to boost more recent objects or objects close to a specified date, supports adjustable origin, offsets, and curves)
- NumericDecay
- PropertyValue (numeric properties such as likes, downloads, popularity)
- Filter (boosts where filter matches, supports a subset of filters)

Boosts are currently done post primary search (vector / hybrid / BM25) and merged in with min-max normalization (in the same way as relative score fusion in hybrid search).

Curves for time and numeric decay conditions include gaussian, linear, exponential.

<img width="2075" height="1618" alt="decay_timestamp" src="https://github.com/user-attachments/assets/dd0b8492-7baa-428d-8245-effa17d4a27a" />

<img width="2075" height="1618" alt="decay_numeric" src="https://github.com/user-attachments/assets/d04274ff-42c1-4f6f-b22a-740736785c4a" />

Curves for property values include none, log1p, and sqrt.

<img width="1175" height="842" alt="property_value_curves" src="https://github.com/user-attachments/assets/ca18585e-4867-41e8-b6f6-a86a92692aa6" />

A `depth` parameter allows for larger depth boosts and is limited by `QueryMaximumResults`. There are plans to allow great integration to the vector index (for more performant deeper boosts) in following releases.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] E2E tests https://github.com/weaviate/weaviate-e2e-tests/pull/306
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
