### PR TITLE
Improve robustness and count accuracy in vector caches

### DIFF
--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -289,7 +289,10 @@ func (s *shardedLockCache[T]) Preload(id uint64, vec []T) {
 	s.shardedLocks.Lock(id)
 	defer s.shardedLocks.Unlock(id)
 
-	atomic.AddInt64(&s.count, 1)
+	// Only increment count if slot was previously empty
+	if s.cache[id] == nil {
+		atomic.AddInt64(&s.count, 1)
+	}
 	s.cache[id] = vec
 }
 
@@ -567,6 +570,10 @@ func (s *shardedMultipleLockCache[T]) All() [][]T {
 
 func (s *shardedMultipleLockCache[T]) GetKeys(id uint64) (uint64, uint64) {
 	s.shardedLocks.RLock(id)
+	if int(id) >= len(s.vectorDocID) {
+		s.shardedLocks.RUnlock(id)
+		return 0, 0
+	}
 	keys := s.vectorDocID[id]
 	s.shardedLocks.RUnlock(id)
 	return keys.DocID, keys.RelativeID
@@ -576,10 +583,16 @@ func (s *shardedMultipleLockCache[T]) SetKeys(id uint64, docID uint64, relativeI
 	s.shardedLocks.Lock(id)
 	defer s.shardedLocks.Unlock(id)
 
+	if int(id) >= len(s.vectorDocID) {
+		return
+	}
 	s.vectorDocID[id] = CacheKeys{DocID: docID, RelativeID: relativeID}
 }
 
 func (s *shardedMultipleLockCache[T]) GetKeysNoLock(id uint64) (uint64, uint64) {
+	if int(id) >= len(s.vectorDocID) {
+		return 0, 0
+	}
 	keys := s.vectorDocID[id]
 	return keys.DocID, keys.RelativeID
 }
@@ -591,11 +604,12 @@ func (s *shardedMultipleLockCache[T]) Get(ctx context.Context, id uint64) ([]T, 
 		return nil, errors.Errorf("id %d is out of bounds", id)
 	}
 	vec := s.cache[id]
+	// Read keys under the same lock to avoid race between cache check and keys read
+	keys := s.vectorDocID[id]
 	s.shardedLocks.RUnlock(id)
 
-	if len(vec) == 0 {
-		docID, relativeID := s.GetKeys(id)
-		return s.handleMultipleCacheMiss(ctx, id, docID, relativeID)
+	if vec == nil {
+		return s.handleMultipleCacheMiss(ctx, id, keys.DocID, keys.RelativeID)
 	}
 
 	return vec, nil
@@ -606,21 +620,40 @@ func (s *shardedLockCache[T]) GetDoc(ctx context.Context, docID uint64) ([][]flo
 }
 
 func (s *shardedMultipleLockCache[T]) GetDoc(ctx context.Context, docID uint64) ([][]float32, error) {
+	if s.multipleVectorForDocID == nil {
+		return nil, errors.New("GetDoc is not supported for this cache type")
+	}
 	return s.multipleVectorForDocID(ctx, docID)
 }
 
 func (s *shardedMultipleLockCache[T]) MultiGet(ctx context.Context, ids []uint64) ([][]T, []error) {
 	out := make([][]T, len(ids))
-	errs := make([]error, len(ids))
+	var errs []error // lazy allocation
 
 	for i, id := range ids {
-
 		s.shardedLocks.RLock(id)
+		if int(id) >= len(s.cache) {
+			s.shardedLocks.RUnlock(id)
+			if errs == nil {
+				errs = make([]error, len(ids))
+			}
+			errs[i] = errors.Errorf("id %d is out of bounds", id)
+			continue
+		}
 		vec := s.cache[id]
+		// Read keys under the same lock to avoid race
+		keys := s.vectorDocID[id]
 		s.shardedLocks.RUnlock(id)
-		if len(vec) == 0 {
-			docID, relativeID := s.GetKeys(id)
-			vec, errs[i] = s.handleMultipleCacheMiss(ctx, id, docID, relativeID)
+
+		if vec == nil {
+			var err error
+			vec, err = s.handleMultipleCacheMiss(ctx, id, keys.DocID, keys.RelativeID)
+			if err != nil {
+				if errs == nil {
+					errs = make([]error, len(ids))
+				}
+				errs[i] = err
+			}
 		}
 
 		out[i] = vec
@@ -633,7 +666,7 @@ func (s *shardedMultipleLockCache[T]) Delete(ctx context.Context, id uint64) {
 	s.shardedLocks.Lock(id)
 	defer s.shardedLocks.Unlock(id)
 
-	if int(id) >= len(s.cache) || len(s.cache[id]) == 0 {
+	if int(id) >= len(s.cache) || s.cache[id] == nil {
 		return
 	}
 
@@ -669,10 +702,13 @@ func (s *shardedMultipleLockCache[T]) handleMultipleCacheMiss(ctx context.Contex
 		return nil, err
 	}
 
-	atomic.AddInt64(&s.count, 1)
-	if len(vec) != 0 {
+	if vec != nil {
 		s.shardedLocks.Lock(id)
-		s.cache[id] = vec
+		// Double-check: only store and increment count if not already cached
+		if s.cache[id] == nil {
+			s.cache[id] = vec
+			atomic.AddInt64(&s.count, 1)
+		}
 		s.shardedLocks.Unlock(id)
 	}
 
@@ -691,16 +727,28 @@ func (s *shardedMultipleLockCache[T]) Prefetch(id uint64) {
 	s.shardedLocks.RLock(id)
 	defer s.shardedLocks.RUnlock(id)
 
+	if int(id) >= len(s.cache) {
+		return
+	}
 	prefetchFunc(uintptr(unsafe.Pointer(&s.cache[id])))
 }
 
 func (s *shardedMultipleLockCache[T]) PreloadMulti(docID uint64, ids []uint64, vecs [][]T) {
-	atomic.AddInt64(&s.count, int64(len(ids)))
+	newEntries := int64(0)
 	for i, id := range ids {
 		s.shardedLocks.Lock(id)
-		s.cache[id] = vecs[i]
-		s.vectorDocID[id] = CacheKeys{DocID: docID, RelativeID: uint64(i)}
+		if int(id) < len(s.cache) && i < len(vecs) {
+			// Only count as new entry if slot was previously empty
+			if s.cache[id] == nil {
+				newEntries++
+			}
+			s.cache[id] = vecs[i]
+			s.vectorDocID[id] = CacheKeys{DocID: docID, RelativeID: uint64(i)}
+		}
 		s.shardedLocks.Unlock(id)
+	}
+	if newEntries > 0 {
+		atomic.AddInt64(&s.count, newEntries)
 	}
 }
 
@@ -708,9 +756,16 @@ func (s *shardedMultipleLockCache[T]) PreloadPassage(id uint64, docID uint64, re
 	s.shardedLocks.Lock(id)
 	defer s.shardedLocks.Unlock(id)
 
+	if int(id) >= len(s.cache) {
+		return
+	}
+	// Only increment count if slot was previously empty
+	wasEmpty := s.cache[id] == nil
 	s.cache[id] = vec
 	s.vectorDocID[id] = CacheKeys{DocID: docID, RelativeID: relativeID}
-	atomic.AddInt64(&s.count, int64(1))
+	if wasEmpty {
+		atomic.AddInt64(&s.count, 1)
+	}
 }
 
 func (s *shardedMultipleLockCache[T]) Preload(docID uint64, vec []T) {

--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -188,11 +188,13 @@ func (s *shardedLockCache[T]) handleCacheMiss(ctx context.Context, id uint64) ([
 		return nil, err
 	}
 
-	atomic.AddInt64(&s.count, 1)
-
 	if vec != nil {
 		s.shardedLocks.Lock(id)
-		s.cache[id] = vec
+		// Double-check: only store and increment count if not already cached
+		if s.cache[id] == nil {
+			s.cache[id] = vec
+			atomic.AddInt64(&s.count, 1)
+		}
 		s.shardedLocks.Unlock(id)
 	}
 

--- a/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
@@ -762,3 +762,109 @@ func TestPreloadCountAccuracy(t *testing.T) {
 		assert.Equal(t, 6, countMultiCached(smlc))
 	})
 }
+
+func TestShardedLockCache_HandleCacheMissCountAccuracy(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	t.Run("count not incremented when vectorForID returns nil", func(t *testing.T) {
+		var vecForID common.VectorForID[float32] = func(ctx context.Context, id uint64) ([]float32, error) {
+			return nil, nil // returns nil vector, no error
+		}
+		cache := NewShardedFloat32LockCache(vecForID, nil, 1000, 1, logger, false, 0, nil)
+		slc := cache.(*shardedLockCache[float32])
+
+		initialCount := cache.CountVectors()
+
+		// Get triggers cache miss, vectorForID returns nil
+		vec, err := cache.Get(context.Background(), 0)
+		assert.NoError(t, err)
+		assert.Nil(t, vec)
+
+		// Count should NOT have increased since nothing was cached
+		assert.Equal(t, initialCount, cache.CountVectors())
+		assert.Equal(t, 0, countCached(slc))
+	})
+
+	t.Run("count not incremented when vectorForID returns error", func(t *testing.T) {
+		var vecForID common.VectorForID[float32] = func(ctx context.Context, id uint64) ([]float32, error) {
+			return nil, errors.New("storage error")
+		}
+		cache := NewShardedFloat32LockCache(vecForID, nil, 1000, 1, logger, false, 0, nil)
+		slc := cache.(*shardedLockCache[float32])
+
+		initialCount := cache.CountVectors()
+
+		vec, err := cache.Get(context.Background(), 0)
+		assert.Error(t, err)
+		assert.Nil(t, vec)
+
+		// Count should NOT have increased
+		assert.Equal(t, initialCount, cache.CountVectors())
+		assert.Equal(t, 0, countCached(slc))
+	})
+
+	t.Run("count incremented only once for concurrent misses on same id", func(t *testing.T) {
+		var vecForID common.VectorForID[float32] = func(ctx context.Context, id uint64) ([]float32, error) {
+			// Simulate some delay to allow concurrent calls
+			time.Sleep(10 * time.Millisecond)
+			return []float32{float32(id)}, nil
+		}
+		cache := NewShardedFloat32LockCache(vecForID, nil, 1000, 1, logger, false, 0, nil)
+		slc := cache.(*shardedLockCache[float32])
+
+		// Launch multiple concurrent gets for the same ID
+		var wg sync.WaitGroup
+		concurrentGets := 10
+		wg.Add(concurrentGets)
+
+		for i := 0; i < concurrentGets; i++ {
+			go func() {
+				defer wg.Done()
+				_, _ = cache.Get(context.Background(), 0)
+			}()
+		}
+
+		wg.Wait()
+
+		// Count should be exactly 1, not 10
+		assert.Equal(t, int64(1), cache.CountVectors())
+		assert.Equal(t, 1, countCached(slc))
+
+		// Subsequent gets should not increment count
+		_, _ = cache.Get(context.Background(), 0)
+		assert.Equal(t, int64(1), cache.CountVectors())
+	})
+
+	t.Run("count matches actual cached vectors after concurrent operations", func(t *testing.T) {
+		var vecForID common.VectorForID[float32] = func(ctx context.Context, id uint64) ([]float32, error) {
+			return []float32{float32(id)}, nil
+		}
+		cache := NewShardedFloat32LockCache(vecForID, nil, 1000, 1, logger, false, 0, nil)
+		slc := cache.(*shardedLockCache[float32])
+
+		// Concurrent gets for multiple IDs, with multiple goroutines per ID
+		numIDs := 50
+		goroutinesPerID := 5
+
+		var wg sync.WaitGroup
+		for id := 0; id < numIDs; id++ {
+			for g := 0; g < goroutinesPerID; g++ {
+				wg.Add(1)
+				go func(id uint64) {
+					defer wg.Done()
+					_, _ = cache.Get(context.Background(), id)
+				}(uint64(id))
+			}
+		}
+
+		wg.Wait()
+
+		// Count should equal number of unique IDs, not total goroutines
+		assert.Equal(t, int64(numIDs), cache.CountVectors())
+
+		// Verify by actually counting cached vectors
+		actualCached := countCached(slc)
+		assert.Equal(t, numIDs, actualCached)
+		assert.Equal(t, int64(actualCached), cache.CountVectors())
+	})
+}

--- a/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
@@ -433,3 +433,332 @@ func countMultiCached(c *shardedMultipleLockCache[float32]) int {
 	}
 	return count
 }
+
+func TestMultiCache_GetDocUnsupported(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	t.Run("UInt64 cache returns error instead of panic", func(t *testing.T) {
+		var vecForID common.VectorForID[uint64] = func(ctx context.Context, id uint64) ([]uint64, error) {
+			return []uint64{1, 2, 3}, nil
+		}
+		cache := NewShardedMultiUInt64LockCache(vecForID, 1000, logger, 0, nil)
+
+		// GetDoc should return error, not panic
+		_, err := cache.GetDoc(context.Background(), 0)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+	})
+
+	t.Run("Byte cache returns error instead of panic", func(t *testing.T) {
+		var vecForID common.VectorForID[byte] = func(ctx context.Context, id uint64) ([]byte, error) {
+			return []byte{1, 2, 3}, nil
+		}
+		cache := NewShardedMultiByteLockCache(vecForID, 1000, logger, 0, nil)
+
+		// GetDoc should return error, not panic
+		_, err := cache.GetDoc(context.Background(), 0)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "not supported")
+	})
+
+	t.Run("Float32 cache with multipleVectorForDocID works", func(t *testing.T) {
+		expectedVecs := [][]float32{{1.0, 2.0}, {3.0, 4.0}}
+		var multiVecForID common.VectorForID[[]float32] = func(ctx context.Context, id uint64) ([][]float32, error) {
+			return expectedVecs, nil
+		}
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+
+		vecs, err := cache.GetDoc(context.Background(), 0)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedVecs, vecs)
+	})
+}
+
+func TestMultiCache_BoundsChecks(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	t.Run("GetKeys returns zero values for out-of-bounds id", func(t *testing.T) {
+		var multiVecForID common.VectorForID[[]float32] = nil
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+		multiCache := cache.(*shardedMultipleLockCache[float32])
+
+		outOfBoundsID := uint64(len(multiCache.cache) + 100)
+
+		// Should not panic, should return 0, 0
+		docID, relativeID := cache.GetKeys(outOfBoundsID)
+		assert.Equal(t, uint64(0), docID)
+		assert.Equal(t, uint64(0), relativeID)
+	})
+
+	t.Run("SetKeys silently ignores out-of-bounds id", func(t *testing.T) {
+		var multiVecForID common.VectorForID[[]float32] = nil
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+		multiCache := cache.(*shardedMultipleLockCache[float32])
+
+		outOfBoundsID := uint64(len(multiCache.cache) + 100)
+
+		// Should not panic
+		cache.SetKeys(outOfBoundsID, 42, 7)
+
+		// Verify nothing changed (can't really verify for out-of-bounds, just ensure no panic)
+	})
+
+	t.Run("Prefetch does not panic for out-of-bounds id", func(t *testing.T) {
+		var multiVecForID common.VectorForID[[]float32] = nil
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+		multiCache := cache.(*shardedMultipleLockCache[float32])
+
+		outOfBoundsID := uint64(len(multiCache.cache) + 100)
+
+		// Should not panic
+		cache.Prefetch(outOfBoundsID)
+	})
+
+	t.Run("MultiGet returns error for out-of-bounds ids", func(t *testing.T) {
+		var multiVecForID common.VectorForID[[]float32] = func(ctx context.Context, id uint64) ([][]float32, error) {
+			return [][]float32{{1.0}}, nil
+		}
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+		multiCache := cache.(*shardedMultipleLockCache[float32])
+
+		// Pre-populate keys for valid IDs so cache miss doesn't fail
+		multiCache.vectorDocID[0] = CacheKeys{DocID: 0, RelativeID: 0}
+		multiCache.vectorDocID[1] = CacheKeys{DocID: 1, RelativeID: 0}
+
+		outOfBoundsID := uint64(len(multiCache.cache) + 100)
+		ids := []uint64{0, outOfBoundsID, 1}
+
+		vecs, errs := cache.MultiGet(context.Background(), ids)
+
+		assert.Len(t, vecs, 3)
+		assert.NotNil(t, errs)
+		assert.Nil(t, errs[0])
+		assert.ErrorContains(t, errs[1], "out of bounds")
+		assert.Nil(t, errs[2])
+	})
+
+	t.Run("PreloadPassage silently ignores out-of-bounds id", func(t *testing.T) {
+		var multiVecForID common.VectorForID[[]float32] = nil
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+		multiCache := cache.(*shardedMultipleLockCache[float32])
+
+		outOfBoundsID := uint64(len(multiCache.cache) + 100)
+		initialCount := cache.CountVectors()
+
+		// Should not panic
+		multiCache.PreloadPassage(outOfBoundsID, 1, 0, []float32{1.0, 2.0})
+
+		// Count should not increase
+		assert.Equal(t, initialCount, cache.CountVectors())
+	})
+
+	t.Run("PreloadMulti only counts successfully stored vectors", func(t *testing.T) {
+		var multiVecForID common.VectorForID[[]float32] = nil
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+		multiCache := cache.(*shardedMultipleLockCache[float32])
+
+		validID := uint64(0)
+		outOfBoundsID := uint64(len(multiCache.cache) + 100)
+		ids := []uint64{validID, outOfBoundsID}
+		vecs := [][]float32{{1.0, 2.0}, {3.0, 4.0}}
+
+		initialCount := cache.CountVectors()
+
+		// Should not panic
+		multiCache.PreloadMulti(1, ids, vecs)
+
+		// Only one vector should be stored (the valid one)
+		assert.Equal(t, initialCount+1, cache.CountVectors())
+	})
+}
+
+func TestMultiCache_CountAccuracy(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	t.Run("count not incremented when handleCacheMiss returns error", func(t *testing.T) {
+		// Simulates a vectorForID that returns an error
+		var multiVecForID common.VectorForID[[]float32] = func(ctx context.Context, id uint64) ([][]float32, error) {
+			return nil, errors.New("storage error")
+		}
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+		multiCache := cache.(*shardedMultipleLockCache[float32])
+
+		// Setup keys for ID 0
+		multiCache.vectorDocID[0] = CacheKeys{DocID: 0, RelativeID: 0}
+
+		initialCount := cache.CountVectors()
+
+		// Get should trigger cache miss with error
+		vec, err := cache.Get(context.Background(), 0)
+		assert.Error(t, err)
+		assert.Nil(t, vec)
+
+		// Count should NOT have increased since nothing was cached
+		assert.Equal(t, initialCount, cache.CountVectors())
+	})
+
+	t.Run("count incremented only once for concurrent misses on same id", func(t *testing.T) {
+		callCount := 0
+		var mu sync.Mutex
+		var multiVecForID common.VectorForID[[]float32] = func(ctx context.Context, id uint64) ([][]float32, error) {
+			mu.Lock()
+			callCount++
+			mu.Unlock()
+			// Simulate some delay to allow concurrent calls
+			time.Sleep(10 * time.Millisecond)
+			return [][]float32{{1.0, 2.0}}, nil
+		}
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+		multiCache := cache.(*shardedMultipleLockCache[float32])
+
+		// Setup keys for ID 0
+		multiCache.vectorDocID[0] = CacheKeys{DocID: 0, RelativeID: 0}
+
+		// Launch multiple concurrent gets for the same ID
+		var wg sync.WaitGroup
+		concurrentGets := 10
+		wg.Add(concurrentGets)
+
+		for i := 0; i < concurrentGets; i++ {
+			go func() {
+				defer wg.Done()
+				_, _ = cache.Get(context.Background(), 0)
+			}()
+		}
+
+		wg.Wait()
+
+		// Count should be exactly 1, not 10
+		assert.Equal(t, int64(1), cache.CountVectors())
+
+		// Verify the vector was cached (subsequent calls shouldn't increment)
+		_, _ = cache.Get(context.Background(), 0)
+		assert.Equal(t, int64(1), cache.CountVectors())
+	})
+
+	t.Run("count matches actual cached vectors after concurrent operations", func(t *testing.T) {
+		var multiVecForID common.VectorForID[[]float32] = func(ctx context.Context, id uint64) ([][]float32, error) {
+			return [][]float32{{float32(id)}}, nil
+		}
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+		multiCache := cache.(*shardedMultipleLockCache[float32])
+
+		// Setup keys for multiple IDs
+		numIDs := 100
+		for i := 0; i < numIDs; i++ {
+			multiCache.vectorDocID[i] = CacheKeys{DocID: uint64(i), RelativeID: 0}
+		}
+
+		// Concurrent gets for all IDs, with multiple goroutines per ID
+		var wg sync.WaitGroup
+		goroutinesPerID := 5
+
+		for id := 0; id < numIDs; id++ {
+			for g := 0; g < goroutinesPerID; g++ {
+				wg.Add(1)
+				go func(id uint64) {
+					defer wg.Done()
+					_, _ = cache.Get(context.Background(), id)
+				}(uint64(id))
+			}
+		}
+
+		wg.Wait()
+
+		// Count should equal number of unique IDs, not total goroutines
+		assert.Equal(t, int64(numIDs), cache.CountVectors())
+
+		// Verify by actually counting cached vectors
+		actualCached := countMultiCached(multiCache)
+		assert.Equal(t, numIDs, actualCached)
+		assert.Equal(t, int64(actualCached), cache.CountVectors())
+	})
+}
+
+func TestPreloadCountAccuracy(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+
+	t.Run("shardedLockCache Preload does not increment count on overwrite", func(t *testing.T) {
+		cache := NewShardedFloat32LockCache(nil, nil, 1000, 1, logger, false, 0, nil)
+		slc := cache.(*shardedLockCache[float32])
+
+		// First preload - should increment count
+		slc.Preload(0, []float32{1.0, 2.0})
+		assert.Equal(t, int64(1), cache.CountVectors())
+
+		// Second preload to same slot - should NOT increment count
+		slc.Preload(0, []float32{3.0, 4.0})
+		assert.Equal(t, int64(1), cache.CountVectors())
+
+		// Preload to new slot - should increment
+		slc.Preload(1, []float32{5.0, 6.0})
+		assert.Equal(t, int64(2), cache.CountVectors())
+
+		// Verify actual cache content
+		assert.Equal(t, 2, countCached(slc))
+	})
+
+	t.Run("shardedMultipleLockCache PreloadPassage does not increment count on overwrite", func(t *testing.T) {
+		var multiVecForID common.VectorForID[[]float32] = nil
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+		smlc := cache.(*shardedMultipleLockCache[float32])
+
+		// First preload - should increment count
+		smlc.PreloadPassage(0, 100, 0, []float32{1.0, 2.0})
+		assert.Equal(t, int64(1), cache.CountVectors())
+
+		// Second preload to same slot - should NOT increment count
+		smlc.PreloadPassage(0, 100, 0, []float32{3.0, 4.0})
+		assert.Equal(t, int64(1), cache.CountVectors())
+
+		// Preload to new slot - should increment
+		smlc.PreloadPassage(1, 100, 1, []float32{5.0, 6.0})
+		assert.Equal(t, int64(2), cache.CountVectors())
+
+		// Verify actual cache content
+		assert.Equal(t, 2, countMultiCached(smlc))
+	})
+
+	t.Run("shardedMultipleLockCache PreloadMulti does not increment count on overwrite", func(t *testing.T) {
+		var multiVecForID common.VectorForID[[]float32] = nil
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+		smlc := cache.(*shardedMultipleLockCache[float32])
+
+		// First batch preload - should count all 3
+		ids1 := []uint64{0, 1, 2}
+		vecs1 := [][]float32{{1.0}, {2.0}, {3.0}}
+		smlc.PreloadMulti(100, ids1, vecs1)
+		assert.Equal(t, int64(3), cache.CountVectors())
+
+		// Second batch with overlap - only new entries should be counted
+		// ids 1, 2 are overwrites, id 3 is new
+		ids2 := []uint64{1, 2, 3}
+		vecs2 := [][]float32{{10.0}, {20.0}, {30.0}}
+		smlc.PreloadMulti(100, ids2, vecs2)
+		assert.Equal(t, int64(4), cache.CountVectors()) // 3 original + 1 new
+
+		// Verify actual cache content
+		assert.Equal(t, 4, countMultiCached(smlc))
+	})
+
+	t.Run("shardedMultipleLockCache PreloadMulti mixed new and existing ids", func(t *testing.T) {
+		var multiVecForID common.VectorForID[[]float32] = nil
+		cache := NewShardedMultiFloat32LockCache(multiVecForID, 1000, logger, false, 0, nil)
+		smlc := cache.(*shardedMultipleLockCache[float32])
+
+		// Pre-populate some slots
+		smlc.PreloadPassage(0, 100, 0, []float32{1.0})
+		smlc.PreloadPassage(2, 100, 2, []float32{2.0})
+		smlc.PreloadPassage(4, 100, 4, []float32{3.0})
+		assert.Equal(t, int64(3), cache.CountVectors())
+
+		// Batch with mix: 0, 2, 4 exist; 1, 3, 5 are new
+		ids := []uint64{0, 1, 2, 3, 4, 5}
+		vecs := [][]float32{{10.0}, {20.0}, {30.0}, {40.0}, {50.0}, {60.0}}
+		smlc.PreloadMulti(200, ids, vecs)
+
+		// Should only add 3 new entries (ids 1, 3, 5)
+		assert.Equal(t, int64(6), cache.CountVectors())
+		assert.Equal(t, 6, countMultiCached(smlc))
+	})
+}


### PR DESCRIPTION
### What's being changed:

This PR hardens the behavior of both shardedLockCache and shardedMultipleLockCache, focusing on correctness, robustness, and consistency—especially around bounds safety and count tracking.

**Key improvements**

1. Count accuracy across all paths

count is now incremented only when a new cache entry is actually inserted.

This fixes multiple issues:

inflated counts when overwriting existing entries (Preload, PreloadPassage, PreloadMulti)
inflated counts on concurrent cache misses
incorrect increments when no vector is cached (e.g. nil result)

The fix is applied consistently across:

- handleCacheMiss (single-vector)
- handleMultipleCacheMiss (multi-vector)
- Preload (single-vector)
- PreloadPassage and PreloadMulti (multi-vector)

2. Concurrency safety in cache miss paths

Both cache implementations now use a double-check under lock before inserting:

- avoids duplicate work on concurrent misses
- ensures count reflects actual occupied slots

3. Bounds safety in multi-vector cache

Added bounds checks to prevent panics in:

- GetKeys, SetKeys, GetKeysNoLock
- Prefetch, MultiGet
- PreloadPassage, PreloadMulti

Out-of-bounds access is now handled safely instead of panicking.

4. Safer GetDoc behavior

GetDoc() now returns an explicit error when multipleVectorForDocID is not configured (e.g. UInt64/Byte multi caches), instead of panicking.

5. Improved internal consistency

- Get / MultiGet now read cache entries and keys under the same lock
- unified miss detection (vec == nil) with single-vector cache semantics

**Testing**

Added targeted tests covering:

- count accuracy under overwrite and concurrent access
- safe handling of out-of-bounds IDs
- GetDoc behavior for unsupported cache types
- correctness under race conditions (-race verified)

All relevant test suites pass, including:

- cache package
- compressionhelpers
- race detector

**Performance impact**

No degradation in hot paths:

- changes are limited to cache miss and preload (write) paths
- no additional locks or checks in cache hit paths (Get, MultiGet)

**Follow-ups (out of scope)**

- semantics of relativeID in UInt64/Byte multi caches
- methods still marked as panic("not implemented") in interfaces
- potential API improvements for out-of-bounds handling

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
