### PR TITLE
feat: add LSM flush callbacks, disk-only views, and CompareDigests shard op

### DIFF
--- a/adapters/repos/db/lsmkv/bucket.go
+++ b/adapters/repos/db/lsmkv/bucket.go
@@ -210,6 +210,20 @@ type Bucket struct {
 	// sequentialAccess hints the kernel (via fadvise) that segment files will
 	// be read sequentially. Set via WithSequentialAccess for snapshot buckets.
 	sequentialAccess bool
+
+	// flushCallback is an optional function called synchronously in the flush
+	// goroutine after each successful memtable flush. It must return quickly
+	// and must not block. Protected by flushCallbackMu.
+	flushCallback   func()
+	flushCallbackMu sync.Mutex
+
+	// objectFlushCallback is called inside FlushAndSwitch after the flushing
+	// memtable has been written to disk but before the new segment is added to
+	// the segment group. It receives an iterator over the flushed entries and a
+	// function to look up existing on-disk values (pre-new-segment).
+	// Only invoked for StrategyReplace buckets.
+	objectFlushCallback   ObjectFlushCallback
+	objectFlushCallbackMu sync.Mutex
 }
 
 func NewBucketCreator() *Bucket { return &Bucket{} }
@@ -408,14 +422,6 @@ func (b *Bucket) IterateObjects(ctx context.Context, f func(object *storobj.Obje
 	return nil
 }
 
-func (b *Bucket) pauseCompaction(ctx context.Context) error {
-	return b.disk.pauseCompaction(ctx)
-}
-
-func (b *Bucket) resumeCompaction(ctx context.Context) error {
-	return b.disk.resumeCompaction(ctx)
-}
-
 // ApplyToObjectDigests iterates over all objects in the bucket, both in memtable
 // and on disk, and applies the given function to each object.
 // The afterInMemCallback is called after the in-memory memtable has been processed.
@@ -423,30 +429,12 @@ func (b *Bucket) resumeCompaction(ctx context.Context) error {
 // objects have been processed.
 // The function f is called for each object, and if it returns an error, the
 // processing is stopped and the error is returned.
-// Note: this function pauses compaction while it is running, to ensure a consistent view of the data.
+// Cursor stability is guaranteed by the consistent-view mechanism (ref-counted segment
+// snapshots); compaction may proceed concurrently and old segments are only dropped
+// once this function returns and the cursor is closed.
 func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 	afterInMemCallback func(), f func(uuidBytes []byte, updateTime int64) error,
 ) error {
-	err := b.pauseCompaction(ctx)
-	if err != nil {
-		afterInMemCallback()
-		return fmt.Errorf("pausing compaction: %w", err)
-	}
-	defer func() {
-		ec := errorcompounder.New()
-
-		if err != nil {
-			ec.AddWrapf(err, "during ApplyToObjectDigests")
-		}
-
-		err = b.resumeCompaction(ctx)
-		if err != nil {
-			ec.AddWrapf(err, "resuming compaction after ApplyToObjectDigests")
-		}
-
-		err = ec.ToError()
-	}()
-
 	// note: it's important to first create the on disk cursor so to avoid potential double scanning over flushing memtable
 	onDiskCursor := b.CursorOnDisk()
 	defer onDiskCursor.Close()
@@ -454,7 +442,7 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 	inmemProcessedDocIDs := make(map[uint64]struct{})
 
 	// note: read-write access to active and flushing memtable will be blocked only during the scope of this inner function
-	err = func() error {
+	err := func() error {
 		defer afterInMemCallback()
 
 		inMemCursor := b.CursorInMem()
@@ -499,6 +487,35 @@ func (b *Bucket) ApplyToObjectDigests(ctx context.Context,
 
 			if err := f(k, updateTime); err != nil {
 				return fmt.Errorf("callback on object '%d' failed: %w", docID, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// ApplyToOnDiskObjectDigests iterates over objects stored in on-disk segments
+// only (memtables are not scanned) and calls fn for each object. For keys that
+// appear in multiple segments the latest version is returned (segment group
+// deduplication). Tombstoned entries are skipped.
+//
+// This is the disk-only counterpart of ApplyToObjectDigests, intended for
+// initialising state that should reflect durable on-disk data exclusively.
+func (b *Bucket) ApplyToOnDiskObjectDigests(ctx context.Context, fn func(uuidBytes []byte, updateTime int64) error) error {
+	onDiskCursor := b.CursorOnDisk()
+	defer onDiskCursor.Close()
+
+	for k, v := onDiskCursor.First(); k != nil; k, v = onDiskCursor.Next() {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			_, updateTime, err := storobj.DocIDAndTimeFromBinary(v)
+			if err != nil || updateTime < 1 {
+				continue
+			}
+			if err := fn(k, updateTime); err != nil {
+				return err
 			}
 		}
 	}
@@ -592,6 +609,41 @@ func (b *Bucket) Get(key []byte) ([]byte, error) {
 
 func (b *Bucket) GetErrDeleted(key []byte) ([]byte, error) {
 	return b.get(key)
+}
+
+// GetDiskOnlyConsistentView returns a consistent snapshot of the on-disk
+// segments without acquiring flushLock or capturing memtable references.
+// Only maintenanceLock (briefly) and segmentRefCounterLock are taken to
+// ref-count the segments, preventing compaction from removing them while the
+// view is live.
+//
+// The caller must call view.ReleaseView() when all lookups are complete to
+// decrement the segment ref-counts and allow compaction to proceed.
+//
+// Use this together with GetErrDeletedOnDisk for batch operations that must
+// not touch memtables and want to amortise lock acquisition across many keys.
+func (b *Bucket) GetDiskOnlyConsistentView() BucketConsistentView {
+	diskSegments, releaseDiskSegments := b.disk.getConsistentViewOfSegments()
+	return BucketConsistentView{
+		Disk:    diskSegments,
+		release: releaseDiskSegments,
+		Bucket:  b,
+	}
+}
+
+// GetErrDeletedOnDisk looks up key in the on-disk segments of the pre-acquired
+// view, skipping both the active and flushing memtables entirely. The caller
+// must hold the view for the duration of all lookups and release it via
+// view.ReleaseView() when done.
+//
+// Returns lsmkv.ErrDeleted if the key has a tombstone in the segments (note:
+// disk tombstones do not carry a deletion timestamp), lsmkv.NotFound if absent
+// from disk, or nil error with the value if found.
+//
+// Use this for batch lookups where a single consistent view is shared across
+// many keys to amortise lock acquisition cost.
+func (b *Bucket) GetErrDeletedOnDisk(key []byte, view BucketConsistentView) ([]byte, error) {
+	return b.getFromSegmentGroup(key, view.Disk)
 }
 
 func (b *Bucket) get(key []byte) ([]byte, error) {
@@ -1533,10 +1585,10 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 		b.metrics.ObserveBucketShutdownDurationByStrategy(b.strategy, time.Since(start))
 	}()
 
-	if err := b.disk.shutdown(ctx); err != nil {
-		return err
-	}
-
+	// Unregister flush callbacks before anything else: this blocks until any
+	// in-progress auto-flush (flushAndSwitchIfThresholdsMet) completes and
+	// prevents new ones from starting.  b.disk is still fully accessible here,
+	// which is required by fireObjectFlushCallbackForActiveMem below.
 	if err := b.flushCallbackCtrl.Unregister(ctx); err != nil {
 		return fmt.Errorf("long-running flush in progress: %w", ctx.Err())
 	}
@@ -1563,7 +1615,17 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 		b.active.setAveragePropertyLength(avgPropLength, propLengthCount)
 	}
 
-	if b.shouldReuseWAL() {
+	reuseWAL := b.shouldReuseWAL()
+	if !reuseWAL {
+		// Fire objectFlushCallback for the active memtable before flushing it to
+		// disk.  b.disk is still accessible at this point (not yet shut down), so
+		// getConsistentViewOfSegments can snapshot the current on-disk segments
+		// and the callback receives the correct pre-flush disk state — matching
+		// the semantics used in FlushAndSwitch.
+		b.fireObjectFlushCallbackForActiveMem()
+	}
+
+	if reuseWAL {
 		if err := b.active.flushWAL(); err != nil {
 			b.flushLock.Unlock()
 			return err
@@ -1575,6 +1637,13 @@ func (b *Bucket) Shutdown(ctx context.Context) (err error) {
 		}
 	}
 	b.flushLock.Unlock()
+
+	// Shut down disk segments after the active memtable has been flushed and
+	// the objectFlushCallback has been fired, so that any hashtree saved by
+	// mayStopAsyncReplication reflects the fully up-to-date on-disk state.
+	if err := b.disk.shutdown(ctx); err != nil {
+		return err
+	}
 
 	if b.flushing == nil {
 		// active has flushing, no one else was currently flushing, it's safe to
@@ -1649,6 +1718,14 @@ func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAb
 				b.memtableThreshold = uint64(next)
 			}
 		}
+
+		b.flushCallbackMu.Lock()
+		cb := b.flushCallback
+		b.flushCallbackMu.Unlock()
+		if cb != nil {
+			cb()
+		}
+
 		return true
 	}
 	return false
@@ -1656,6 +1733,79 @@ func (b *Bucket) flushAndSwitchIfThresholdsMet(shouldAbort cyclemanager.ShouldAb
 
 func (b *Bucket) getAndUpdateWritesSinceLastSync() bool {
 	return b.active.getAndUpdateWritesSinceLastSync(b.logger)
+}
+
+// SetFlushCallback registers a function to be called after each successful
+// memtable flush. The callback is invoked synchronously in the flush goroutine,
+// so it must return quickly and must not block. Pass nil to clear a previously
+// set callback.
+func (b *Bucket) SetFlushCallback(fn func()) {
+	b.flushCallbackMu.Lock()
+	b.flushCallback = fn
+	b.flushCallbackMu.Unlock()
+}
+
+// ObjectFlushCallback is called inside FlushAndSwitch after the flushing
+// memtable has been written to disk but before the new segment is added to the
+// segment group. This allows the caller to observe exactly which objects were
+// durably persisted and update derived state (e.g. a hashtree) accordingly.
+//
+// forEachFlushedObject iterates all entries in the flushed memtable in key
+// order, providing raw key bytes, raw value bytes, and a tombstone flag.
+//
+// lookupOnDisk looks up a key in the existing segment group, which at this
+// point does NOT yet include the newly flushed segment. This lets callers
+// retrieve the previous on-disk value for a key before the flush overwrites it.
+//
+// The callback is invoked synchronously in the flush goroutine and must not
+// perform long-blocking I/O. Only invoked for StrategyReplace buckets.
+type ObjectFlushCallback func(
+	forEachFlushedObject func(fn func(key []byte, value []byte, tombstone bool)),
+	lookupOnDisk func(key []byte) ([]byte, bool),
+)
+
+// SetObjectFlushCallback registers a callback to be called inside FlushAndSwitch
+// after the flushing memtable has been written to disk but before the new segment
+// is added to the segment group. Pass nil to clear a previously set callback.
+func (b *Bucket) SetObjectFlushCallback(fn ObjectFlushCallback) {
+	b.objectFlushCallbackMu.Lock()
+	b.objectFlushCallback = fn
+	b.objectFlushCallbackMu.Unlock()
+}
+
+// fireObjectFlushCallbackForActiveMem fires the objectFlushCallback for the
+// current active memtable using the same semantics as FlushAndSwitch: each key
+// in the active memtable is paired with its pre-flush on-disk value so the
+// callback can correctly XOR-in/XOR-out the digest delta.
+//
+// Must be called while b.flushLock is held by the caller and before
+// b.disk.shutdown so that getConsistentViewOfSegments remains accessible.
+// Has no effect for non-StrategyReplace buckets or when no callback is registered.
+func (b *Bucket) fireObjectFlushCallbackForActiveMem() {
+	b.objectFlushCallbackMu.Lock()
+	objCb := b.objectFlushCallback
+	b.objectFlushCallbackMu.Unlock()
+
+	if objCb == nil || b.strategy != StrategyReplace {
+		return
+	}
+
+	// b.active is safe to access here: the caller holds b.flushLock, and
+	// flushCallbackCtrl has already been unregistered so no concurrent
+	// auto-flush can switch b.active underneath us.
+	diskSegments, releaseDiskSegments := b.disk.getConsistentViewOfSegments()
+	defer releaseDiskSegments()
+
+	forEachFlushed := func(fn func(key []byte, value []byte, tombstone bool)) {
+		if m, ok := b.active.(*Memtable); ok {
+			m.ForEachReplaceEntry(fn)
+		}
+	}
+	lookupOnDisk := func(key []byte) ([]byte, bool) {
+		v, err := b.disk.getWithSegmentList(key, diskSegments)
+		return v, err == nil && len(v) > 0
+	}
+	objCb(forEachFlushed, lookupOnDisk)
 }
 
 // UpdateStatus is used by the parent shard to communicate to the bucket
@@ -1800,6 +1950,33 @@ func (b *Bucket) FlushAndSwitch() error {
 	segment, err := b.disk.initAndPrecomputeNewSegment(segmentPath)
 	if err != nil {
 		return fmt.Errorf("precompute metadata: %w", err)
+	}
+
+	// Invoke the object-flush callback before adding the new segment to the
+	// segment group. At this point the flushing memtable is still accessible
+	// and b.disk does NOT yet contain the new segment, so lookupOnDisk returns
+	// the pre-flush on-disk value for any key.
+	b.objectFlushCallbackMu.Lock()
+	objCb := b.objectFlushCallback
+	b.objectFlushCallbackMu.Unlock()
+
+	if objCb != nil && b.strategy == StrategyReplace {
+		flushing := b.flushing
+		// Snapshot the current on-disk segments and hold the ref-count for the
+		// duration of the callback so that compaction cannot drop them underneath us.
+		diskSegments, releaseDiskSegments := b.disk.getConsistentViewOfSegments()
+
+		forEachFlushed := func(fn func(key []byte, value []byte, tombstone bool)) {
+			if m, ok := flushing.(*Memtable); ok {
+				m.ForEachReplaceEntry(fn)
+			}
+		}
+		lookupOnDisk := func(key []byte) ([]byte, bool) {
+			v, err := b.disk.getWithSegmentList(key, diskSegments)
+			return v, err == nil && len(v) > 0
+		}
+		objCb(forEachFlushed, lookupOnDisk)
+		releaseDiskSegments()
 	}
 
 	if err := b.atomicallyAddDiskSegmentAndRemoveFlushing(segment); err != nil {
@@ -2445,4 +2622,12 @@ func DetermineUnloadedBucketStrategyAmong(bucketPath string, prioritizedStrategi
 // for full semantics and preconditions.
 func (b *Bucket) PrependSegmentsFromBucket(ctx context.Context, srcDir string) error {
 	return b.disk.PrependSegmentsFromBucket(ctx, srcDir)
+}
+
+func (b *Bucket) pauseCompaction(ctx context.Context) error {
+	return b.disk.pauseCompaction(ctx)
+}
+
+func (b *Bucket) resumeCompaction(ctx context.Context) error {
+	return b.disk.resumeCompaction(ctx)
 }

--- a/adapters/repos/db/lsmkv/memtable.go
+++ b/adapters/repos/db/lsmkv/memtable.go
@@ -742,3 +742,16 @@ func (m *Memtable) extractRoaringSetRange() *roaringsetrange.Memtable {
 	result := m.roaringSetRange
 	return result
 }
+
+// ForEachReplaceEntry iterates over all key-value entries in a Replace-strategy
+// memtable, calling fn for each entry in ascending key order. fn receives the
+// raw key bytes, the raw value bytes, and a tombstone flag (true = deletion).
+// This is a no-op for non-Replace strategies or an empty memtable.
+func (m *Memtable) ForEachReplaceEntry(fn func(key []byte, value []byte, tombstone bool)) {
+	if m.strategy != StrategyReplace || m.key == nil {
+		return
+	}
+	for _, node := range m.key.flattenInOrder() {
+		fn(node.key, node.value, node.tombstone)
+	}
+}

--- a/adapters/repos/db/lsmkv/segment_group.go
+++ b/adapters/repos/db/lsmkv/segment_group.go
@@ -532,14 +532,6 @@ func newSegmentGroup(ctx context.Context, logger logrus.FieldLogger, metrics *Me
 	return sg, nil
 }
 
-func (sg *SegmentGroup) pauseCompaction(ctx context.Context) error {
-	return sg.compactionCallbackCtrl.Deactivate(ctx)
-}
-
-func (sg *SegmentGroup) resumeCompaction(_ context.Context) error {
-	return sg.compactionCallbackCtrl.Activate()
-}
-
 func (sg *SegmentGroup) makeExistsOn(segments []Segment) existsOnLowerSegmentsFn {
 	return func(key []byte) (bool, error) {
 		if len(segments) == 0 {
@@ -1027,4 +1019,12 @@ func (sg *SegmentGroup) GetAveragePropertyLength() (float64, uint64) {
 	}
 	sum := sg.averagePropSum.Load()
 	return float64(sum) / float64(count), count
+}
+
+func (sg *SegmentGroup) pauseCompaction(ctx context.Context) error {
+	return sg.compactionCallbackCtrl.Deactivate(ctx)
+}
+
+func (sg *SegmentGroup) resumeCompaction(_ context.Context) error {
+	return sg.compactionCallbackCtrl.Activate()
 }

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -382,6 +382,13 @@ func (l *LazyLoadShard) ObjectDigestsInRange(ctx context.Context,
 	return l.shard.ObjectDigestsInRange(ctx, initialUUID, finalUUID, limit)
 }
 
+func (l *LazyLoadShard) CompareDigests(ctx context.Context, sourceDigests []types.RepairResponse) ([]types.RepairResponse, error) {
+	if err := l.Load(ctx); err != nil {
+		return nil, err
+	}
+	return l.shard.CompareDigests(ctx, sourceDigests)
+}
+
 func (l *LazyLoadShard) ID() string {
 	return shardId(l.shardOpts.index.ID(), l.shardOpts.name)
 }

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -37,6 +37,7 @@ import (
 	selector "github.com/weaviate/weaviate/adapters/repos/db/vector/selection"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/filters"
+	entlsmkv "github.com/weaviate/weaviate/entities/lsmkv"
 	"github.com/weaviate/weaviate/entities/multi"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
@@ -47,8 +48,7 @@ import (
 )
 
 func (s *Shard) ObjectDigestErrDeleted(ctx context.Context, id strfmt.UUID) (types.RepairResponse, error) {
-	s.activityTrackerRead.Add(1)
-
+	// Replication-internal operation: do not count as user read activity.
 	idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
 	if err != nil {
 		return types.RepairResponse{}, err
@@ -67,8 +67,6 @@ func (s *Shard) ObjectDigestErrDeleted(ctx context.Context, id strfmt.UUID) (typ
 	replicaObj := types.RepairResponse{
 		ID:         id.String(),
 		UpdateTime: updateTime,
-		// TODO: use version when supported
-		Version: 0,
 	}
 
 	return replicaObj, nil
@@ -134,8 +132,7 @@ func (s *Shard) MultiObjectByID(ctx context.Context, query []multi.Identifier) (
 }
 
 func (s *Shard) ObjectDigests(ctx context.Context, query []multi.Identifier) ([]types.RepairResponse, error) {
-	s.activityTrackerRead.Add(1)
-
+	// Replication-internal operation: do not count as user read activity.
 	objects := make([]types.RepairResponse, len(query))
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
@@ -172,24 +169,23 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 	initialUUID, finalUUID strfmt.UUID, limit int) (
 	objs []types.RepairResponse, err error,
 ) {
-	initialUUIDBytes, err := uuid.MustParse(initialUUID.String()).MarshalBinary()
+	initialUUID16, err := uuid.Parse(initialUUID.String())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid initial UUID %q: %w", initialUUID, err)
 	}
-
-	finalUUIDBytes, err := uuid.MustParse(finalUUID.String()).MarshalBinary()
+	finalUUID16, err := uuid.Parse(finalUUID.String())
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("invalid final UUID %q: %w", finalUUID, err)
 	}
 
 	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
 
-	cursor := bucket.Cursor()
+	cursor := bucket.CursorOnDisk()
 	defer cursor.Close()
 
 	n := 0
 
-	for k, v := cursor.Seek(initialUUIDBytes); n < limit && k != nil && bytes.Compare(k, finalUUIDBytes) < 1; k, v = cursor.Next() {
+	for k, v := cursor.Seek(initialUUID16[:]); n < limit && k != nil && bytes.Compare(k, finalUUID16[:]) < 1; k, v = cursor.Next() {
 		if ctx.Err() != nil {
 			return objs, ctx.Err()
 		}
@@ -207,8 +203,6 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 		replicaObj := types.RepairResponse{
 			ID:         uuidParsed.String(),
 			UpdateTime: updateTime,
-			// TODO: use version when supported
-			Version: 0,
 		}
 
 		objs = append(objs, replicaObj)
@@ -217,6 +211,148 @@ func (s *Shard) ObjectDigestsInRange(ctx context.Context,
 	}
 
 	return objs, nil
+}
+
+// CompareDigests identifies which of the caller's sourceDigests require
+// action on the source side. It returns three categories:
+//   - Missing: object absent from this shard; returned with UpdateTime==0.
+//   - Stale: source has a strictly newer UpdateTime; returned with the local
+//     UpdateTime so the caller can use it as remoteStaleUpdateTime.
+//   - Tombstoned: object is deleted on this shard. The configured deletion
+//     strategy is applied here on the target side:
+//     NoAutomatedResolution → suppressed (not returned).
+//     DeleteOnConflict      → returned with Deleted=true.
+//     TimeBasedResolution   → returned with Deleted=true when deletion is
+//     same-or-newer; returned as a normal stale entry when source is strictly
+//     newer so the source propagates the live object to restore it.
+//     Note: tombstones flushed to on-disk segments lose their deletion
+//     timestamp. When deletionTime==0, TimeBasedResolution conservatively
+//     treats deletion as the winner regardless of the source's UpdateTime.
+//
+// Equal-timestamp objects (source and target hold the same UpdateTime) are NOT
+// returned: the hashtree digest for an object is hash(uuid, updateTime), so two
+// nodes holding the same object at the same time produce identical leaf digests.
+// The hashtree diff will not detect them as differing, meaning CompareDigests is
+// never called for such objects during a hashbeat that is already in sync.
+// Returning them would cause the source to re-propagate objects it just
+// successfully delivered (and already present on disk after the next flush),
+// exhausting the propagation limit and preventing genuinely stale objects
+// from being reached.
+//
+// Algorithm: one shared on-disk consistent view is acquired once; then one
+// GetErrDeletedOnDisk call per source UUID — O(N_source × log N_local) —
+// amortising the segment ref-count lock acquisition across the entire batch.
+// Only on-disk segments are consulted, consistent with ObjectDigestsInRange
+// using CursorOnDisk on the source side.
+func (s *Shard) CompareDigests(ctx context.Context, sourceDigests []types.RepairResponse) ([]types.RepairResponse, error) {
+	// Replication-internal operation: do not count as user read activity.
+	if len(sourceDigests) == 0 {
+		return nil, nil
+	}
+
+	bucket := s.store.Bucket(helpers.ObjectsBucketLSM)
+	view := bucket.GetDiskOnlyConsistentView()
+	defer view.ReleaseView()
+
+	result := make([]types.RepairResponse, 0, len(sourceDigests))
+	for _, d := range sourceDigests {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		u, err := uuid.Parse(d.ID)
+		if err != nil {
+			return nil, fmt.Errorf("parse source uuid %q: %w", d.ID, err)
+		}
+
+		v, err := bucket.GetErrDeletedOnDisk(u[:], view)
+		if err != nil {
+			if errors.Is(err, entlsmkv.Deleted) {
+				// Key is tombstoned on this shard.  Extract the deletion timestamp
+				// when available (written by recent deletes); older tombstones or
+				// those from compacted segments may carry no timestamp (zero).
+				var deletionTime int64
+				var errDeleted entlsmkv.ErrDeleted
+				if errors.As(err, &errDeleted) && !errDeleted.DeletionTime().IsZero() {
+					deletionTime = errDeleted.DeletionTime().UnixMilli()
+				}
+
+				// Apply the deletion conflict strategy on the target side so the
+				// source can act on the verdict without needing to re-read strategy.
+				switch s.index.DeletionStrategy() {
+				case models.ReplicationConfigDeletionStrategyNoAutomatedResolution:
+					// No automated resolution: suppress the tombstone so the source
+					// neither propagates nor deletes — leave the conflict for manual
+					// handling.
+					continue
+
+				case models.ReplicationConfigDeletionStrategyDeleteOnConflict:
+					// Deletion always wins: instruct source to delete its live copy.
+					result = append(result, types.RepairResponse{
+						ID:         d.ID,
+						Deleted:    true,
+						UpdateTime: deletionTime,
+					})
+
+				case models.ReplicationConfigDeletionStrategyTimeBasedResolution:
+					if deletionTime > 0 && d.UpdateTime > deletionTime {
+						// Source's live object is strictly newer than the local tombstone:
+						// return as a normal stale entry so the source propagates the live
+						// object to this shard (overwriting the tombstone).
+						result = append(result, types.RepairResponse{ID: d.ID, UpdateTime: deletionTime})
+					} else {
+						// Local deletion is same-or-newer, or deletion time is unknown:
+						// instruct source to delete its live copy.
+						result = append(result, types.RepairResponse{
+							ID:         d.ID,
+							Deleted:    true,
+							UpdateTime: deletionTime,
+						})
+					}
+
+				default:
+					// Unknown strategy: behave conservatively like NoAutomatedResolution.
+					continue
+				}
+				continue
+			}
+			if errors.Is(err, entlsmkv.NotFound) {
+				// Key is absent from this shard — source must propagate.
+				result = append(result, types.RepairResponse{ID: d.ID, UpdateTime: 0})
+				continue
+			}
+			return nil, fmt.Errorf("get object %q: %w", d.ID, err)
+		}
+
+		if v == nil {
+			// Safety guard: GetErrDeletedOnDisk returns NotFound for absent keys
+			// (handled above), but treat unexpected nil as absent to avoid a nil dereference.
+			result = append(result, types.RepairResponse{ID: d.ID, UpdateTime: 0})
+			continue
+		}
+
+		_, localTime, err := storobj.DocIDAndTimeFromBinary(v)
+		if err != nil {
+			return nil, fmt.Errorf("extract update time for %q: %w", d.ID, err)
+		}
+
+		if d.UpdateTime > localTime {
+			// Source has a strictly newer version — this shard is stale and the
+			// source must propagate.
+			//
+			// Equal-timestamp (d.UpdateTime == localTime) is intentionally NOT
+			// returned: objects with the same UpdateTime on both nodes have
+			// identical hashtree digests (hash(uuid, updateTime)), so the
+			// hashtree diff cannot detect them as differing in the first place.
+			// Returning them would only cause the source to re-propagate objects
+			// it just successfully delivered (same version already in target
+			// memtable or on disk), exhausting the propagation limit and
+			// preventing genuinely stale objects from being reached.
+			result = append(result, types.RepairResponse{ID: d.ID, UpdateTime: localTime})
+		}
+	}
+
+	return result, nil
 }
 
 // TODO: This does an actual read which is not really needed, if we see this
@@ -871,14 +1007,6 @@ func (s *Shard) uuidFromDocID(docID uint64) (strfmt.UUID, error) {
 }
 
 func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionTime time.Time) error {
-	s.asyncReplicationRWMux.RLock()
-	defer s.asyncReplicationRWMux.RUnlock()
-
-	err := s.waitForMinimalHashTreeInitialization(ctx)
-	if err != nil {
-		return err
-	}
-
 	idBytes, err := uuid.MustParse(id.String()).MarshalBinary()
 	if err != nil {
 		return err
@@ -904,7 +1032,7 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 
 	// we need the doc ID so we can clean up inverted indices currently
 	// pointing to this object
-	docID, updateTime, err := storobj.DocIDAndTimeFromBinary(existing)
+	docID, _, err := storobj.DocIDAndTimeFromBinary(existing)
 	if err != nil {
 		return errors.Wrap(err, "get existing doc id from object binary")
 	}
@@ -919,10 +1047,6 @@ func (s *Shard) batchDeleteObject(ctx context.Context, id strfmt.UUID, deletionT
 	}
 	if err != nil {
 		return errors.Wrap(err, "delete object from bucket")
-	}
-
-	if err = s.mayDeleteObjectHashTree(idBytes, updateTime); err != nil {
-		return errors.Wrap(err, "object deletion in hashtree")
 	}
 
 	err = s.cleanupInvertedIndexOnDelete(existing, docID)


### PR DESCRIPTION
### What's being changed:

This pull request introduces several enhancements and new features to the LSMKV bucket implementation, focusing on improved flush lifecycle extensibility, on-disk data access, and support for maintenance and replication operations. The most important changes are grouped below.

### Flush lifecycle extensibility

* Added `SetFlushCallback` and `SetObjectFlushCallback` methods to `Bucket`, enabling registration of synchronous callbacks after each memtable flush and after the memtable is written to disk but before the new segment is added to the segment group. This allows external code to react to flush events and update derived state efficiently. [[1]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28R213-R226) [[2]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28R1738-R1810) [[3]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28R1955-R1981)
* Introduced locking for flush and object flush callbacks to ensure thread safety when registering or invoking these hooks. [[1]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28R213-R226) [[2]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28R1738-R1810)

### On-disk data access improvements

* Added `ApplyToOnDiskObjectDigests`, `GetDiskOnlyConsistentView`, and `GetErrDeletedOnDisk` methods to `Bucket`, allowing iteration and batch lookups over only the on-disk segments (excluding memtables) with consistent snapshots for efficient and safe maintenance operations. [[1]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28R497-R525) [[2]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28R614-R648)
* Updated `ObjectDigestsInRange` and related shard methods to use on-disk cursors and handle UUID parsing more robustly, ensuring operations over large datasets are consistent and efficient.

### Maintenance and compaction controls

* Exposed `pauseCompaction` and `resumeCompaction` methods on `Bucket` and `SegmentGroup` to allow external callers to temporarily halt or resume compaction during critical operations. [[1]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28R2626-R2633) [[2]](diffhunk://#diff-a7dbc361d25c3552363566fb26607efa70f0a5c2abe790bb82ad0bf6aaa8cf3cR1023-R1030)

### Replication and repair support

* Added `CompareDigests` to `LazyLoadShard` and improved handling of repair/replication-internal operations in `Shard` to avoid counting them as user reads and to support efficient comparison of object digests. [[1]](diffhunk://#diff-da3785a57e3e2760e83c3f147c52db256b03105e52549b18f84f1a98c9a31e28R385-R391) [[2]](diffhunk://#diff-d08244a2bbe99960c516af6a929befc67a879b42950ca0dadbcde372fb7c8cfaL50-R51) [[3]](diffhunk://#diff-d08244a2bbe99960c516af6a929befc67a879b42950ca0dadbcde372fb7c8cfaL137-R135)

### Internal API and code improvements

* Added `ForEachReplaceEntry` to `Memtable` for efficient iteration over all entries in a Replace-strategy memtable.
* Refactored shutdown logic in `Bucket` to ensure flush callbacks are unregistered and invoked in the correct order, and to guarantee that the on-disk state is fully up-to-date before final shutdown. [[1]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28L1536-R1591) [[2]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28L1566-R1628) [[3]](diffhunk://#diff-9658bb68e1a9d3f3d4ae83104656f4dc7c6cf22d931592c53971acdda7225e28R1641-R1647)

These changes collectively improve the extensibility, maintainability, and reliability of the LSMKV storage engine, especially for advanced use cases like replication, repair, and custom maintenance workflows.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
