### PR TITLE
fix(cluster): prevent shutdown hangs by buffering close signal channels

### DIFF
--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -449,6 +449,32 @@ func TestRaftClose(t *testing.T) {
 	assert.Less(t, after.Sub(now), 2*time.Second)
 }
 
+func TestServiceCloseChannelsAreBuffered(t *testing.T) {
+	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
+	cfg := m.cfg
+	cfg.BindAddr = cfg.Host
+	cfg.RPCPort = utils.MustGetFreeTCPPort()
+
+	svc := New(cfg, nil, nil, nil)
+
+	assert.Equal(t, 1, cap(svc.closeBootstrapper))
+	assert.Equal(t, 1, cap(svc.closeOnFSMCaughtUp))
+	assert.Equal(t, 1, cap(svc.closeWaitForDB))
+
+	assertNonBlockingSend(t, svc.closeBootstrapper)
+	assertNonBlockingSend(t, svc.closeOnFSMCaughtUp)
+	assertNonBlockingSend(t, svc.closeWaitForDB)
+}
+
+func assertNonBlockingSend(t *testing.T, ch chan struct{}) {
+	t.Helper()
+	select {
+	case ch <- struct{}{}:
+	default:
+		t.Fatal("channel send should not block")
+	}
+}
+
 func TestRaftPanics(t *testing.T) {
 	m := NewMockStore(t, "Node-1", 9091)
 

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -110,9 +110,9 @@ func New(cfg Config, authZController authorization.Controller, snapshotter fsm.S
 		rpcClient:          client,
 		rpcServer:          svr,
 		logger:             cfg.Logger,
-		closeBootstrapper:  make(chan struct{}),
-		closeOnFSMCaughtUp: make(chan struct{}),
-		closeWaitForDB:     make(chan struct{}),
+		closeBootstrapper:  make(chan struct{}, 1),
+		closeOnFSMCaughtUp: make(chan struct{}, 1),
+		closeWaitForDB:     make(chan struct{}, 1),
 	}
 }
 


### PR DESCRIPTION
### What's being changed:
[Close()](https://github.com/weaviate/weaviate/blob/moogacs-6717d83b/cluster/service.go#L213) sends stop signals sequentially to bootstrap, DB restore, and FSM-catchup loops. When those channels are unbuffered, shutdown can block on the first send if the receiver already exited, preventing the remaining signals and causing `WaitToRestoreDB()` to keep polling indefinitely. Make the close channels buffered so shutdown signaling is non-blocking, and add a regression test to verify buffered/non-blocking close semantics.

```
  The goroutine in Close() sends all three sequentially:
  c.closeBootstrapper <- struct{}{}   // must succeed first, but we never read from this because we already bootstraped 
  c.closeWaitForDB <- struct{}{}      // only runs if above succeeds
  c.closeOnFSMCaughtUp <- struct{}{} // only runs if above succeeds
```

e.g. from server logs 
<img width="3386" height="1486" alt="Screenshot 2026-04-22 at 17 23 47" src="https://github.com/user-attachments/assets/635779d6-c554-4f18-ae7b-42a78d1615b0" />

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [x] Chaos pipeline run or not necessary. Link to pipeline: https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/24829421656
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
