### PR TITLE
chore(test): fix flakey tests TestRaftEndpoints TestSnapshotRestoreSchemaOnly

### DIFF
--- a/cluster/raft_snapshot_test.go
+++ b/cluster/raft_snapshot_test.go
@@ -45,7 +45,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	// Ensure Raft starts and a leader is elected
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
-	assert.True(t, tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader))
+	assert.True(t, tryNTimesWithWait(20, time.Millisecond*200, srv.store.IsLeader))
 	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
 
 	// DeleteClass

--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -85,7 +85,7 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
-	assert.True(t, tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader))
+	assert.True(t, tryNTimesWithWait(20, time.Millisecond*200, srv.store.IsLeader))
 	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
 	schemaReader := srv.SchemaReader()
 	assert.Equal(t, schemaReader.Len(), 0)
@@ -385,7 +385,7 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.Nil(t, srv.Open(ctx, m.indexer))
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
-	assert.True(t, tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader))
+	assert.True(t, tryNTimesWithWait(20, time.Millisecond*200, srv.store.IsLeader))
 	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
 	schemaReader = srv.SchemaReader()
 	assert.Equal(t, info, schemaReader.ClassInfo("C"))


### PR DESCRIPTION
### What's being changed:
pass proper wait time to avoid flakiness 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
