### PR TITLE
Merge stable/v1.35 into stable/v1.36

### DIFF
--- a/cluster/raft_snapshot_test.go
+++ b/cluster/raft_snapshot_test.go
@@ -45,7 +45,7 @@ func TestSnapshotRestoreSchemaOnly(t *testing.T) {
 	// Ensure Raft starts and a leader is elected
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
-	assert.True(t, tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader))
+	assert.True(t, tryNTimesWithWait(20, time.Millisecond*200, srv.store.IsLeader))
 	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
 
 	// DeleteClass

--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -85,7 +85,7 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
-	assert.True(t, tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader))
+	assert.True(t, tryNTimesWithWait(20, time.Millisecond*200, srv.store.IsLeader))
 	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
 	schemaReader := srv.SchemaReader()
 	assert.Equal(t, schemaReader.Len(), 0)
@@ -385,7 +385,7 @@ func TestRaftEndpoints(t *testing.T) {
 	assert.Nil(t, srv.Open(ctx, m.indexer))
 	assert.Nil(t, srv.store.Notify(m.cfg.NodeID, addr))
 	assert.Nil(t, srv.WaitUntilDBRestored(ctx, time.Second*1, make(chan struct{})))
-	assert.True(t, tryNTimesWithWait(20, time.Millisecond*100, srv.store.IsLeader))
+	assert.True(t, tryNTimesWithWait(20, time.Millisecond*200, srv.store.IsLeader))
 	assert.True(t, tryNTimesWithWait(10, time.Millisecond*200, srv.Ready))
 	schemaReader = srv.SchemaReader()
 	assert.Equal(t, info, schemaReader.ClassInfo("C"))

--- a/cluster/raft_test.go
+++ b/cluster/raft_test.go
@@ -449,6 +449,32 @@ func TestRaftClose(t *testing.T) {
 	assert.Less(t, after.Sub(now), 2*time.Second)
 }
 
+func TestServiceCloseChannelsAreBuffered(t *testing.T) {
+	m := NewMockStore(t, "Node-1", utils.MustGetFreeTCPPort())
+	cfg := m.cfg
+	cfg.BindAddr = cfg.Host
+	cfg.RPCPort = utils.MustGetFreeTCPPort()
+
+	svc := New(cfg, nil, nil, nil)
+
+	assert.Equal(t, 1, cap(svc.closeBootstrapper))
+	assert.Equal(t, 1, cap(svc.closeOnFSMCaughtUp))
+	assert.Equal(t, 1, cap(svc.closeWaitForDB))
+
+	assertNonBlockingSend(t, svc.closeBootstrapper)
+	assertNonBlockingSend(t, svc.closeOnFSMCaughtUp)
+	assertNonBlockingSend(t, svc.closeWaitForDB)
+}
+
+func assertNonBlockingSend(t *testing.T, ch chan struct{}) {
+	t.Helper()
+	select {
+	case ch <- struct{}{}:
+	default:
+		t.Fatal("channel send should not block")
+	}
+}
+
 func TestRaftPanics(t *testing.T) {
 	m := NewMockStore(t, "Node-1", 9091)
 

--- a/cluster/service.go
+++ b/cluster/service.go
@@ -110,9 +110,9 @@ func New(cfg Config, authZController authorization.Controller, snapshotter fsm.S
 		rpcClient:          client,
 		rpcServer:          svr,
 		logger:             cfg.Logger,
-		closeBootstrapper:  make(chan struct{}),
-		closeOnFSMCaughtUp: make(chan struct{}),
-		closeWaitForDB:     make(chan struct{}),
+		closeBootstrapper:  make(chan struct{}, 1),
+		closeOnFSMCaughtUp: make(chan struct{}, 1),
+		closeWaitForDB:     make(chan struct{}, 1),
 	}
 }
 


### PR DESCRIPTION
Cascade merge-forward from `stable/v1.35` into `stable/v1.36` as a prerequisite for the v1.37.2 patch release. Both commits below are already on `stable/v1.35` but have not propagated to `stable/v1.36` or `stable/v1.37`.

## Commits brought forward

- `52100fc781` fix(cluster): prevent shutdown hangs by buffering close signal channels (#11114)
- `a48d4a0b18` chore: fix flakey tests TestRaftEndpoints TestSnapshotRestoreSchemaOnly (#11116)

## Diff scope

```
 cluster/raft_snapshot_test.go |  2 +-
 cluster/raft_test.go          | 30 ++++++++++++++++++++++++++++--
 cluster/service.go            |  6 +++---
 3 files changed, 32 insertions(+), 6 deletions(-)
```

Auto-merged by the `ort` strategy, no manual conflict resolution.

## Next step

Once this lands, a follow-up `merge-stable-v1.36-into-v1.37` PR will cascade these commits onto `stable/v1.37`, after which the v1.37.2 release prep can begin.