### PR TITLE
fix: normalize negative zero in LexicographicallySortableFloat64 to fix inverted index filters

### DIFF
--- a/entities/inverted/serialization.go
+++ b/entities/inverted/serialization.go
@@ -26,6 +26,14 @@ import (
 // flipped in any case, but additionally each remaining byte also needs to be
 // flipped if the number is negative
 func LexicographicallySortableFloat64(in float64) ([]byte, error) {
+	// Normalize negative zero (-0.0) to positive zero (0.0). IEEE 754 defines
+	// -0.0 == 0.0, but their bit representations differ. Without this
+	// normalization -0.0 would encode to a byte sequence that sorts before all
+	// negative numbers, breaking equality and range filters.
+	if in == 0 && math.Signbit(in) {
+		in = 0
+	}
+
 	buf := bytes.NewBuffer(nil)
 
 	err := binary.Write(buf, binary.BigEndian, in)

--- a/entities/inverted/serialization_test.go
+++ b/entities/inverted/serialization_test.go
@@ -20,6 +20,29 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestLexicographicallySortableFloat64NegativeZero verifies that -0.0 and 0.0
+// produce identical byte representations, satisfying IEEE 754 equality.
+func TestLexicographicallySortableFloat64NegativeZero(t *testing.T) {
+	negZeroBytes, err := LexicographicallySortableFloat64(math.Copysign(0, -1))
+	require.Nil(t, err)
+
+	posZeroBytes, err := LexicographicallySortableFloat64(0.0)
+	require.Nil(t, err)
+
+	assert.Equal(t, posZeroBytes, negZeroBytes, "-0.0 and 0.0 must encode identically")
+
+	// Also verify ordering: -1000000.0 must sort below 0.0
+	negBigBytes, err := LexicographicallySortableFloat64(-1000000.0)
+	require.Nil(t, err)
+
+	// negBigBytes < posZeroBytes lexicographically
+	assert.True(t, string(negBigBytes) < string(posZeroBytes),
+		"-1000000.0 must sort before 0.0")
+	// negZeroBytes must not sort before negBigBytes
+	assert.False(t, string(negZeroBytes) < string(negBigBytes),
+		"-0.0 must not sort before -1000000.0")
+}
+
 // TestSerialization makes sure that writing and reading into the
 // lexicographically sortable types byte slices ends up with the same values as
 // original. There is no focus on the sortability itself, as that is already


### PR DESCRIPTION
**What's being changed:**

In `entities/inverted/serialization.go`, `LexicographicallySortableFloat64` did not normalize IEEE 754 negative zero (-0.0) before encoding. The raw bit pattern of -0.0 is `0x8000000000000000`, which the positive-number branch transforms to `[0x00, 0x00, ...]`, placing it before all negative numbers in lexicographic order. Positive zero (0.0) correctly encodes to `[0x80, 0x00, ...]`. This caused two failures in the standard inverted index (used when `index_range_filterable=False`): `equal(0.0)` missed the -0.0 row, and range queries like `c1 <= -1000000.0` incorrectly returned the -0.0 row.

The fix adds a single guard at the top of `LexicographicallySortableFloat64` that detects -0.0 via `math.Signbit` and normalizes it to 0.0 before encoding, matching IEEE 754 semantics where -0.0 == 0.0.

A regression test `TestLexicographicallySortableFloat64NegativeZero` in `entities/inverted/serialization_test.go` verifies that -0.0 and 0.0 produce identical byte encodings and that -1000000.0 still sorts correctly below zero.

**Review checklist:**
- [x] Documentation has been updated, if necessary. Link to changed documentation: N/A
- [x] Chaos pipeline run or not necessary. Link to pipeline: not necessary
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary. Not necessary (no hot path change).

Fixes #10917
