### PR TITLE
Fix backup RBAC checks

### DIFF
--- a/adapters/handlers/rest/handlers_backup.go
+++ b/adapters/handlers/rest/handlers_backup.go
@@ -13,7 +13,6 @@ package rest
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
@@ -106,10 +105,6 @@ func (s *backupHandlers) createBackup(params backups.BackupsCreateParams,
 	baseBackupID := ""
 	if params.Body.IncrementalBaseBackupID != nil {
 		baseBackupID = *params.Body.IncrementalBaseBackupID
-	}
-	if params.Body.ID == baseBackupID {
-		return backups.NewBackupsCreateInternalServerError().
-			WithPayload(errPayloadFromSingleErr(fmt.Errorf("base backup cannot be the same as the new backup ID: %s", baseBackupID)))
 	}
 
 	meta, err := s.manager.Backup(params.HTTPRequest.Context(), principal, &ubak.BackupRequest{

--- a/test/acceptance/authz/backups_test.go
+++ b/test/acceptance/authz/backups_test.go
@@ -215,7 +215,7 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 		helper.ExpectBackupEventuallyCreated(t, filterBackupID, backend, helper.CreateAuth(customKey))
 	})
 
-	t.Run("empty Include with no backup permissions returns 422 no classes found", func(t *testing.T) {
+	t.Run("empty Include with no backup permissions returns 403", func(t *testing.T) {
 		params := backups.NewBackupsCreateParams().
 			WithBackend(backend).
 			WithBody(&models.BackupCreateRequest{
@@ -224,9 +224,9 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 			})
 		_, err := helper.Client(t).Backups.BackupsCreate(params, helper.CreateAuth(viewerKey))
 		require.Error(t, err)
-		var parsed *backups.BackupsCreateUnprocessableEntity
+		var parsed *backups.BackupsCreateForbidden
 		require.True(t, errors.As(err, &parsed))
-		require.Contains(t, parsed.Payload.Error[0].Message, "no classes found")
+		require.Contains(t, parsed.Payload.Error[0].Message, "forbidden")
 	})
 
 	t.Run("explicit Include is forbidden when caller lacks permission on a listed class", func(t *testing.T) {
@@ -310,7 +310,7 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 		require.Contains(t, parsed.Payload.Error[0].Message, "forbidden")
 	})
 
-	t.Run("empty Include restore with no backup permissions returns 422 no classes found", func(t *testing.T) {
+	t.Run("empty Include restore with no backup permissions returns 403", func(t *testing.T) {
 		params := backups.NewBackupsRestoreParams().
 			WithBackend(backend).
 			WithID("backup-1").
@@ -319,9 +319,9 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 			})
 		_, err := helper.Client(t).Backups.BackupsRestore(params, helper.CreateAuth(viewerKey))
 		require.Error(t, err)
-		var parsed *backups.BackupsRestoreUnprocessableEntity
+		var parsed *backups.BackupsRestoreForbidden
 		require.True(t, errors.As(err, &parsed))
-		require.Contains(t, parsed.Payload.Error[0].Message, "no classes found")
+		require.Contains(t, parsed.Payload.Error[0].Message, "forbidden")
 	})
 
 	t.Run("empty Include restore filters to classes the caller is permitted to restore", func(t *testing.T) {

--- a/test/acceptance/authz/backups_test.go
+++ b/test/acceptance/authz/backups_test.go
@@ -178,6 +178,58 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 		require.Contains(t, parsed.Payload.Error[0].Message, "forbidden")
 	})
 
+	// The following subtests cover the RBAC filter behaviour of Backup:
+	//   - empty Include narrows the operation to the caller's permitted classes,
+	//   - empty Include with no permitted classes returns 422 "no classes found",
+	//   - explicit Include is authorized strictly and fails 403 when the caller
+	//     lacks permission on any listed class.
+	t.Run("empty Include filters to classes the caller is permitted to back up", func(t *testing.T) {
+		filterBackupID := "backup-filter-1"
+		params := backups.NewBackupsCreateParams().
+			WithBackend(backend).
+			WithBody(&models.BackupCreateRequest{
+				ID:     filterBackupID,
+				Config: helper.DefaultBackupConfig(),
+			})
+		resp, err := helper.Client(t).Backups.BackupsCreate(params, helper.CreateAuth(customKey))
+		require.Nil(t, err)
+		require.NotNil(t, resp.Payload)
+		require.Equal(t, "", resp.Payload.Error)
+		// customUser has manage_backups on clsA only; clsP must be filtered out.
+		require.Equal(t, []string{clsA.Class}, resp.Payload.Classes)
+
+		helper.ExpectBackupEventuallyCreated(t, filterBackupID, backend, helper.CreateAuth(customKey))
+	})
+
+	t.Run("empty Include with no backup permissions returns 422 no classes found", func(t *testing.T) {
+		params := backups.NewBackupsCreateParams().
+			WithBackend(backend).
+			WithBody(&models.BackupCreateRequest{
+				ID:     "backup-filter-viewer",
+				Config: helper.DefaultBackupConfig(),
+			})
+		_, err := helper.Client(t).Backups.BackupsCreate(params, helper.CreateAuth(viewerKey))
+		require.Error(t, err)
+		var parsed *backups.BackupsCreateUnprocessableEntity
+		require.True(t, errors.As(err, &parsed))
+		require.Contains(t, parsed.Payload.Error[0].Message, "no classes found")
+	})
+
+	t.Run("explicit Include is forbidden when caller lacks permission on a listed class", func(t *testing.T) {
+		params := backups.NewBackupsCreateParams().
+			WithBackend(backend).
+			WithBody(&models.BackupCreateRequest{
+				ID:      "backup-explicit-forbidden",
+				Include: []string{clsP.Class},
+				Config:  helper.DefaultBackupConfig(),
+			})
+		_, err := helper.Client(t).Backups.BackupsCreate(params, helper.CreateAuth(customKey))
+		require.Error(t, err)
+		var parsed *backups.BackupsCreateForbidden
+		require.True(t, errors.As(err, &parsed))
+		require.Contains(t, parsed.Payload.Error[0].Message, "forbidden")
+	})
+
 	t.Run("delete clsA", func(t *testing.T) {
 		helper.DeleteClassWithAuthz(t, clsA.Class, helper.CreateAuth(adminKey))
 	})

--- a/test/acceptance/authz/backups_test.go
+++ b/test/acceptance/authz/backups_test.go
@@ -291,7 +291,7 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 			resp, err := helper.CreateBackupStatusWithAuthz(t, backend, backupID, "", "", helper.CreateAuth(customKey))
 			require.Nil(t, err)
 			require.NotNil(t, resp.Payload)
-			// handle success also in case of the backup was fast
+			// also accept success in case the backup was fast
 			if *resp.Payload.Status == string(backup.Cancelled) || *resp.Payload.Status == string(backup.Success) {
 				break
 			}
@@ -366,7 +366,7 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 			resp, err := helper.RestoreBackupStatusWithAuthz(t, backend, cancelRestoreID, "", "", helper.CreateAuth(customKey))
 			require.Nil(t, err)
 			require.NotNil(t, resp.Payload)
-			// handle success also in case of the restore was fast
+			// also accept success in case the restore was fast
 			if *resp.Payload.Status == string(backup.Cancelled) || *resp.Payload.Status == string(backup.Success) {
 				break
 			}

--- a/test/acceptance/authz/backups_test.go
+++ b/test/acceptance/authz/backups_test.go
@@ -155,6 +155,32 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 		require.Len(t, viewerResp.Payload, 0)
 	})
 
+	t.Run("multi-class backup is filtered out for caller missing permission on one of its classes", func(t *testing.T) {
+		multiBackupID := "backup-multi-1"
+		params := backups.NewBackupsCreateParams().
+			WithBackend(backend).
+			WithBody(&models.BackupCreateRequest{
+				ID:      multiBackupID,
+				Include: []string{clsA.Class, clsP.Class},
+				Config:  helper.DefaultBackupConfig(),
+			})
+		_, err := helper.Client(t).Backups.BackupsCreate(params, helper.CreateAuth(adminKey))
+		require.Nil(t, err)
+		helper.ExpectBackupEventuallyCreated(t, multiBackupID, backend, helper.CreateAuth(adminKey))
+
+		// Admin sees both backups.
+		adminResp, err := helper.ListBackupsWithAuthz(t, backend, helper.CreateAuth(adminKey))
+		require.Nil(t, err)
+		require.Len(t, adminResp.Payload, 2)
+
+		// customUser has manage_backups on clsA only; backup-multi-1 spans clsP
+		// so the every-class READ requirement filters it out.
+		customResp, err := helper.ListBackupsWithAuthz(t, backend, helper.CreateAuth(customKey))
+		require.Nil(t, err)
+		require.Len(t, customResp.Payload, 1)
+		require.Equal(t, backupID, customResp.Payload[0].ID)
+	})
+
 	t.Run("backup status is 403 for callers without permission on the backup classes", func(t *testing.T) {
 		_, err := helper.CreateBackupStatusWithAuthz(t, backend, backupID, "", "", helper.CreateAuth(viewerKey))
 		require.Error(t, err)
@@ -271,6 +297,81 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 			}
 			if *resp.Payload.Status == "FAILED" {
 				t.Fatalf("backup failed: %s", resp.Payload.Error)
+			}
+			time.Sleep(time.Second / 10)
+		}
+	})
+
+	t.Run("restoration cancel is 403 for callers without permission on the backup classes", func(t *testing.T) {
+		err := helper.RestoreCancelWithAuthz(t, backend, "backup-1", helper.CreateAuth(viewerKey))
+		require.Error(t, err)
+		var parsed *backups.BackupsRestoreCancelForbidden
+		require.True(t, errors.As(err, &parsed))
+		require.Contains(t, parsed.Payload.Error[0].Message, "forbidden")
+	})
+
+	t.Run("empty Include restore with no backup permissions returns 422 no classes found", func(t *testing.T) {
+		params := backups.NewBackupsRestoreParams().
+			WithBackend(backend).
+			WithID("backup-1").
+			WithBody(&models.BackupRestoreRequest{
+				Config: helper.DefaultRestoreConfig(),
+			})
+		_, err := helper.Client(t).Backups.BackupsRestore(params, helper.CreateAuth(viewerKey))
+		require.Error(t, err)
+		var parsed *backups.BackupsRestoreUnprocessableEntity
+		require.True(t, errors.As(err, &parsed))
+		require.Contains(t, parsed.Payload.Error[0].Message, "no classes found")
+	})
+
+	t.Run("empty Include restore filters to classes the caller is permitted to restore", func(t *testing.T) {
+		// Delete clsA and clsP so backup-multi-1 can be restored; otherwise
+		// restore fails because the classes already exist on the cluster.
+		helper.DeleteClassWithAuthz(t, clsA.Class, helper.CreateAuth(adminKey))
+		helper.DeleteClassWithAuthz(t, clsP.Class, helper.CreateAuth(adminKey))
+
+		params := backups.NewBackupsRestoreParams().
+			WithBackend(backend).
+			WithID("backup-multi-1").
+			WithBody(&models.BackupRestoreRequest{
+				Config: helper.DefaultRestoreConfig(),
+			})
+		resp, err := helper.Client(t).Backups.BackupsRestore(params, helper.CreateAuth(customKey))
+		require.Nil(t, err)
+		require.NotNil(t, resp.Payload)
+		require.Equal(t, "", resp.Payload.Error)
+		// customUser has manage_backups on clsA only; clsP must be filtered out.
+		require.Equal(t, []string{clsA.Class}, resp.Payload.Classes)
+
+		helper.ExpectBackupEventuallyRestored(t, "backup-multi-1", backend, helper.CreateAuth(adminKey))
+	})
+
+	t.Run("successfully cancel an in-progress restore", func(t *testing.T) {
+		// Create a fresh backup, then delete the class so a restore can run
+		// and be cancelled mid-flight.
+		cancelRestoreID := "backup-3"
+		_, err := helper.CreateBackupWithAuthz(t, helper.DefaultBackupConfig(), clsA.Class, backend, cancelRestoreID, helper.CreateAuth(customKey))
+		require.Nil(t, err)
+		helper.ExpectBackupEventuallyCreated(t, cancelRestoreID, backend, helper.CreateAuth(customKey))
+
+		helper.DeleteClassWithAuthz(t, clsA.Class, helper.CreateAuth(adminKey))
+
+		_, err = helper.RestoreBackupWithAuthz(t, helper.DefaultRestoreConfig(), clsA.Class, backend, cancelRestoreID, map[string]string{}, helper.CreateAuth(customKey))
+		require.Nil(t, err)
+
+		err = helper.RestoreCancelWithAuthz(t, backend, cancelRestoreID, helper.CreateAuth(customKey))
+		require.Nil(t, err)
+
+		for {
+			resp, err := helper.RestoreBackupStatusWithAuthz(t, backend, cancelRestoreID, "", "", helper.CreateAuth(customKey))
+			require.Nil(t, err)
+			require.NotNil(t, resp.Payload)
+			// handle success also in case of the restore was fast
+			if *resp.Payload.Status == string(backup.Cancelled) || *resp.Payload.Status == string(backup.Success) {
+				break
+			}
+			if *resp.Payload.Status == "FAILED" {
+				t.Fatalf("restore failed: %s", resp.Payload.Error)
 			}
 			time.Sleep(time.Second / 10)
 		}

--- a/test/acceptance/authz/backups_test.go
+++ b/test/acceptance/authz/backups_test.go
@@ -324,6 +324,21 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 		require.Contains(t, parsed.Payload.Error[0].Message, "forbidden")
 	})
 
+	t.Run("explicit Include restore is forbidden when caller lacks permission on a listed class", func(t *testing.T) {
+		params := backups.NewBackupsRestoreParams().
+			WithBackend(backend).
+			WithID("backup-multi-1").
+			WithBody(&models.BackupRestoreRequest{
+				Include: []string{clsP.Class},
+				Config:  helper.DefaultRestoreConfig(),
+			})
+		_, err := helper.Client(t).Backups.BackupsRestore(params, helper.CreateAuth(customKey))
+		require.Error(t, err)
+		var parsed *backups.BackupsRestoreForbidden
+		require.True(t, errors.As(err, &parsed))
+		require.Contains(t, parsed.Payload.Error[0].Message, "forbidden")
+	})
+
 	t.Run("empty Include restore filters to classes the caller is permitted to restore", func(t *testing.T) {
 		// Delete clsA and clsP so backup-multi-1 can be restored; otherwise
 		// restore fails because the classes already exist on the cluster.

--- a/test/acceptance/authz/backups_test.go
+++ b/test/acceptance/authz/backups_test.go
@@ -136,13 +136,6 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 		}
 	})
 
-	// backup-1 (clsA) is now persisted. The subtests below cover the RBAC
-	// behaviour of the status/cancel/list endpoints:
-	//   - list returns a 200 filtered response containing only the backups
-	//     whose classes the caller has READ on,
-	//   - status/cancel authorize against the resolved classes of the
-	//     target backup, so a caller without permission on those classes
-	//     gets 403 once the meta has been read.
 	t.Run("list backups filters in response instead of returning 403", func(t *testing.T) {
 		// Admin sees every backup.
 		adminResp, err := helper.ListBackupsWithAuthz(t, backend, helper.CreateAuth(adminKey))
@@ -178,11 +171,6 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 		require.Contains(t, parsed.Payload.Error[0].Message, "forbidden")
 	})
 
-	// The following subtests cover the RBAC filter behaviour of Backup:
-	//   - empty Include narrows the operation to the caller's permitted classes,
-	//   - empty Include with no permitted classes returns 422 "no classes found",
-	//   - explicit Include is authorized strictly and fails 403 when the caller
-	//     lacks permission on any listed class.
 	t.Run("empty Include filters to classes the caller is permitted to back up", func(t *testing.T) {
 		filterBackupID := "backup-filter-1"
 		params := backups.NewBackupsCreateParams().

--- a/test/acceptance/authz/backups_test.go
+++ b/test/acceptance/authz/backups_test.go
@@ -136,6 +136,48 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 		}
 	})
 
+	// backup-1 (clsA) is now persisted. The subtests below cover the RBAC
+	// behaviour of the status/cancel/list endpoints:
+	//   - list returns a 200 filtered response containing only the backups
+	//     whose classes the caller has READ on,
+	//   - status/cancel authorize against the resolved classes of the
+	//     target backup, so a caller without permission on those classes
+	//     gets 403 once the meta has been read.
+	t.Run("list backups filters in response instead of returning 403", func(t *testing.T) {
+		// Admin sees every backup.
+		adminResp, err := helper.ListBackupsWithAuthz(t, backend, helper.CreateAuth(adminKey))
+		require.Nil(t, err)
+		require.Len(t, adminResp.Payload, 1)
+		require.Equal(t, backupID, adminResp.Payload[0].ID)
+
+		// customUser has manage_backups on clsA → sees backup-1.
+		customResp, err := helper.ListBackupsWithAuthz(t, backend, helper.CreateAuth(customKey))
+		require.Nil(t, err)
+		require.Len(t, customResp.Payload, 1)
+		require.Equal(t, backupID, customResp.Payload[0].ID)
+
+		// Viewer has no backup permissions → 200 with an empty list, not 403.
+		viewerResp, err := helper.ListBackupsWithAuthz(t, backend, helper.CreateAuth(viewerKey))
+		require.Nil(t, err)
+		require.Len(t, viewerResp.Payload, 0)
+	})
+
+	t.Run("backup status is 403 for callers without permission on the backup classes", func(t *testing.T) {
+		_, err := helper.CreateBackupStatusWithAuthz(t, backend, backupID, "", "", helper.CreateAuth(viewerKey))
+		require.Error(t, err)
+		var parsed *backups.BackupsCreateStatusForbidden
+		require.True(t, errors.As(err, &parsed))
+		require.Contains(t, parsed.Payload.Error[0].Message, "forbidden")
+	})
+
+	t.Run("cancel is 403 for callers without permission on the backup classes", func(t *testing.T) {
+		err := helper.CancelBackupWithAuthz(t, backend, backupID, helper.CreateAuth(viewerKey))
+		require.Error(t, err)
+		var parsed *backups.BackupsCancelForbidden
+		require.True(t, errors.As(err, &parsed))
+		require.Contains(t, parsed.Payload.Error[0].Message, "forbidden")
+	})
+
 	t.Run("delete clsA", func(t *testing.T) {
 		helper.DeleteClassWithAuthz(t, clsA.Class, helper.CreateAuth(adminKey))
 	})
@@ -157,6 +199,16 @@ func TestAuthZBackupsManageJourney(t *testing.T) {
 		require.Equal(t, "", resp.Payload.Error)
 
 		helper.ExpectBackupEventuallyRestored(t, backupID, backend, helper.CreateAuth(adminKey))
+	})
+
+	t.Run("restoration status is 403 for callers without permission on the backup classes", func(t *testing.T) {
+		// Restore meta has been written by the previous step; the authz
+		// check resolves its classes and rejects the viewer.
+		_, err := helper.RestoreBackupStatusWithAuthz(t, backend, backupID, "", "", helper.CreateAuth(viewerKey))
+		require.Error(t, err)
+		var parsed *backups.BackupsRestoreStatusForbidden
+		require.True(t, errors.As(err, &parsed))
+		require.Contains(t, parsed.Payload.Error[0].Message, "forbidden")
 	})
 
 	t.Run("successfully cancel an in-progress backup", func(t *testing.T) {

--- a/test/acceptance/authz/rbac_auto_admin_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_admin_permissions_test.go
@@ -66,6 +66,7 @@ func TestAuthzAllEndpointsAdminDynamically(t *testing.T) {
 		url = strings.ReplaceAll(url, "{id}", "someId")
 		url = strings.ReplaceAll(url, "{backend}", "filesystem")
 		url = strings.ReplaceAll(url, "{propertyName}", "someProperty")
+		url = strings.ReplaceAll(url, "{indexName}", "filterable")
 		url = strings.ReplaceAll(url, "{user_id}", "random-user")
 		url = strings.ReplaceAll(url, "{userType}", "db")
 		url = strings.ReplaceAll(url, "{groupType}", "oidc")

--- a/test/acceptance/authz/rbac_auto_no_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_no_permissions_test.go
@@ -83,6 +83,15 @@ func TestAuthzAllEndpointsNoPermissionDynamically(t *testing.T) {
 		"/replication/scale",
 	}
 
+	// Per-method ignore: backup status (GET) and restore (POST) / restore
+	// status (GET) on a non-existent backup ID leak 404 because the meta
+	// file is read before class-aware authz can run. Class-specific RBAC
+	// for these endpoints is covered exhaustively in backups_test.go.
+	ignoreEndpointMethods := map[string]map[string]bool{
+		"/backups/{backend}/{id}":         {http.MethodGet: true},
+		"/backups/{backend}/{id}/restore": {http.MethodGet: true, http.MethodPost: true},
+	}
+
 	ignoreGetAll := []string{
 		"/authz/roles",
 		"/authz/groups/{groupType}", // returns 200 with an empty, per-group filtered list (same pattern as /authz/roles)
@@ -111,6 +120,7 @@ func TestAuthzAllEndpointsNoPermissionDynamically(t *testing.T) {
 		url = strings.ReplaceAll(url, "{id}", "admin-user")
 		url = strings.ReplaceAll(url, "{backend}", "filesystem")
 		url = strings.ReplaceAll(url, "{propertyName}", "someProperty")
+		url = strings.ReplaceAll(url, "{indexName}", "filterable")
 		url = strings.ReplaceAll(url, "{user_id}", "admin-user")
 		url = strings.ReplaceAll(url, "{userType}", "db")
 		url = strings.ReplaceAll(url, "{aliasName}", "alias")
@@ -121,7 +131,8 @@ func TestAuthzAllEndpointsNoPermissionDynamically(t *testing.T) {
 			require.NotContains(t, url, "}")
 
 			shallIgnore := slices.Contains(ignoreEndpoints, endpoint.path) ||
-				(endpoint.method == http.MethodGet && slices.Contains(ignoreGetAll, endpoint.path))
+				(endpoint.method == http.MethodGet && slices.Contains(ignoreGetAll, endpoint.path)) ||
+				ignoreEndpointMethods[endpoint.path][strings.ToUpper(endpoint.method)]
 			if shallIgnore {
 				t.Skip("Endpoint is in ignore list")
 				return

--- a/test/acceptance/authz/rbac_auto_no_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_no_permissions_test.go
@@ -143,8 +143,16 @@ func TestAuthzAllEndpointsNoPermissionDynamically(t *testing.T) {
 
 			endpoint.method = strings.ToUpper(endpoint.method)
 
+			body := endpoint.validGeneratedBodyData
+			// Backup-create generates an empty body (the request schema has no type),
+			// which 422s on id validation before authz; send a valid id so the request
+			// reaches the authz check.
+			if endpoint.path == "/backups/{backend}" && endpoint.method == http.MethodPost {
+				body = []byte(`{"id":"someid"}`)
+			}
+
 			if endpoint.method == http.MethodPost || endpoint.method == http.MethodPut || endpoint.method == http.MethodPatch || endpoint.method == http.MethodDelete {
-				req, err = http.NewRequest(endpoint.method, url, bytes.NewBuffer(endpoint.validGeneratedBodyData))
+				req, err = http.NewRequest(endpoint.method, url, bytes.NewBuffer(body))
 				require.Nil(t, err)
 				req.Header.Set("Content-Type", "application/json")
 

--- a/test/acceptance/authz/rbac_auto_no_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_no_permissions_test.go
@@ -71,11 +71,9 @@ func TestAuthzAllEndpointsNoPermissionDynamically(t *testing.T) {
 		"/replication/sharding-state",
 		"/tasks",                // tasks is internal endpoint
 		"/classifications/{id}", // requires to get classification by id first before checking of authz permissions
-		// TODO: needs to be removed and endpoints adapted — these currently leak
-		// status (404 for aliases, 501 for replication) before authz runs, so a
-		// caller without permissions learns whether the resource exists / feature
-		// is enabled. Fix by moving authz to the top of each handler/manager
-		// (same pattern as the backup scheduler), then drop these entries.
+		// TODO: these leak status (404 for aliases, 501 for replication) before
+		// authz runs, so a caller without permission learns the resource exists.
+		// Fix by moving authz to the top of each handler, then drop these entries.
 		"/aliases/{aliasName}",
 		"/replication/replicate",
 		"/replication/replicate/force-delete",
@@ -83,10 +81,8 @@ func TestAuthzAllEndpointsNoPermissionDynamically(t *testing.T) {
 		"/replication/scale",
 	}
 
-	// Per-method ignore: backup status (GET) and restore (POST) / restore
-	// status (GET) on a non-existent backup ID leak 404 because the meta
-	// file is read before class-aware authz can run. Class-specific RBAC
-	// for these endpoints is covered exhaustively in backups_test.go.
+	// These leak 404 on a non-existent backup ID because the meta is read
+	// before class-aware authz runs. RBAC for them is covered in backups_test.go.
 	ignoreEndpointMethods := map[string]map[string]bool{
 		"/backups/{backend}/{id}":         {http.MethodGet: true},
 		"/backups/{backend}/{id}/restore": {http.MethodGet: true, http.MethodPost: true},
@@ -144,9 +140,8 @@ func TestAuthzAllEndpointsNoPermissionDynamically(t *testing.T) {
 			endpoint.method = strings.ToUpper(endpoint.method)
 
 			body := endpoint.validGeneratedBodyData
-			// Backup-create generates an empty body (the request schema has no type),
-			// which 422s on id validation before authz; send a valid id so the request
-			// reaches the authz check.
+			// Backup-create's generated body is empty (schema has no type) and 422s
+			// on id validation before authz; send a valid id so it reaches authz.
 			if endpoint.path == "/backups/{backend}" && endpoint.method == http.MethodPost {
 				body = []byte(`{"id":"someid"}`)
 			}

--- a/test/acceptance/authz/rbac_auto_no_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_no_permissions_test.go
@@ -65,19 +65,28 @@ func TestAuthzAllEndpointsNoPermissionDynamically(t *testing.T) {
 		"/.well-known/openid-configuration",
 		"/.well-known/ready",
 		"/meta",
-		"/users/own-info",    // will return info for own user
-		"/backups/{backend}", // we ignore backup because there is multiple endpoints doesn't need authZ and many validations
-		"/backups/{backend}/{id}",
-		"/backups/{backend}/{id}/restore",
+		"/users/own-info",             // will return info for own user
 		"/replication/replicate/{id}", // for the same reason as backups above
 		"/replication/replicate/{id}/cancel",
 		"/replication/sharding-state",
 		"/tasks",                // tasks is internal endpoint
 		"/classifications/{id}", // requires to get classification by id first before checking of authz permissions
+		// TODO: needs to be removed and endpoints adapted — these currently leak
+		// status (404 for aliases, 501 for replication) before authz runs, so a
+		// caller without permissions learns whether the resource exists / feature
+		// is enabled. Fix by moving authz to the top of each handler/manager
+		// (same pattern as the backup scheduler), then drop these entries.
+		"/aliases/{aliasName}",
+		"/replication/replicate",
+		"/replication/replicate/force-delete",
+		"/replication/replicate/list",
+		"/replication/scale",
 	}
 
 	ignoreGetAll := []string{
 		"/authz/roles",
+		"/authz/groups/{groupType}", // returns 200 with an empty, per-group filtered list (same pattern as /authz/roles)
+		"/backups/{backend}",        // returns 200 with an empty, per-backup filtered list (same pattern as /authz/roles)
 		"/objects",
 		"/schema",
 		"/schema/{className}/tenants",

--- a/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
@@ -58,12 +58,21 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 		"/graphql",
 		"/graphql/batch",
 		"/objects/validate",
-		"/backups/{backend}", // we ignore backup because there is multiple endpoints doesn't need authZ and many validations
-		"/backups/{backend}/{id}",
-		"/backups/{backend}/{id}/restore",
 		"/replication/replicate/{id}", // for the same reason as backups above
 		"/replication/replicate/{id}/cancel",
 		"/authz/roles/{id}/has-permission", // must be a POST rather than GET or HEAD due to need of body. but viewer can access it due to its permissions
+	}
+
+	// TODO: needs to be removed and endpoints adapted — these currently leak
+	// status (404 for aliases, 501 for replication) before authz runs, so a
+	// viewer hitting a mutating method gets 404/501 instead of 403. Fix by
+	// moving authz to the top of each handler/manager (same pattern as the
+	// backup scheduler), then drop these entries.
+	ignoreEndpoints := []string{
+		"/aliases/{aliasName}",
+		"/replication/replicate",
+		"/replication/replicate/force-delete",
+		"/replication/scale",
 	}
 
 	for _, endpoint := range endpoints {
@@ -86,6 +95,11 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 			require.NotContains(t, url, "{")
 			require.NotContains(t, url, "}")
 
+			if slices.Contains(ignoreEndpoints, endpoint.path) {
+				t.Skip("Endpoint is in ignore list")
+				return
+			}
+
 			var req *http.Request
 			var err error
 
@@ -95,12 +109,7 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 				req, err = http.NewRequest(endpoint.method, url, bytes.NewBuffer(endpoint.validGeneratedBodyData))
 				require.Nil(t, err)
 				req.Header.Set("Content-Type", "application/json")
-				if !strings.Contains(url, "backups/filesystem/someId/restore") {
-					// restore endpoint do READ permissions the backend and then
-					// later checks if the meta file exists, therefor we ignore
-					// it here because it will return 404
-					forbidden = true
-				}
+				forbidden = true
 			} else {
 				req, err = http.NewRequest(endpoint.method, url, nil)
 				require.Nil(t, err)

--- a/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
@@ -63,11 +63,9 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 		"/authz/roles/{id}/has-permission", // must be a POST rather than GET or HEAD due to need of body. but viewer can access it due to its permissions
 	}
 
-	// TODO: needs to be removed and endpoints adapted — these currently leak
-	// status (404 for aliases, 501 for replication) before authz runs, so a
-	// viewer hitting a mutating method gets 404/501 instead of 403. Fix by
-	// moving authz to the top of each handler/manager (same pattern as the
-	// backup scheduler), then drop these entries.
+	// TODO: these leak status (404 for aliases, 501 for replication) before
+	// authz runs, so a viewer mutating them gets 404/501 instead of 403.
+	// Fix by moving authz to the top of each handler, then drop these entries.
 	ignoreEndpoints := []string{
 		"/aliases/{aliasName}",
 		"/replication/replicate",
@@ -75,9 +73,8 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 		"/replication/scale",
 	}
 
-	// Per-method ignore: restore on a non-existent backup ID leaks 404
-	// because the meta file is read before class-aware authz can run.
-	// Class-specific RBAC for restore is covered in backups_test.go.
+	// Restore leaks 404 on a non-existent backup ID because the meta is read
+	// before class-aware authz runs. RBAC for restore is covered in backups_test.go.
 	ignoreEndpointMethods := map[string]map[string]bool{
 		"/backups/{backend}/{id}/restore": {http.MethodPost: true},
 	}
@@ -115,9 +112,8 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 			endpoint.method = strings.ToUpper(endpoint.method)
 
 			body := endpoint.validGeneratedBodyData
-			// Backup-create generates an empty body (the request schema has no type),
-			// which 422s on id validation before authz; send a valid id so the request
-			// reaches the authz check.
+			// Backup-create's generated body is empty (schema has no type) and 422s
+			// on id validation before authz; send a valid id so it reaches authz.
 			if endpoint.path == "/backups/{backend}" && endpoint.method == http.MethodPost {
 				body = []byte(`{"id":"someid"}`)
 			}

--- a/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
@@ -113,9 +113,18 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 			var err error
 
 			endpoint.method = strings.ToUpper(endpoint.method)
+
+			body := endpoint.validGeneratedBodyData
+			// Backup-create generates an empty body (the request schema has no type),
+			// which 422s on id validation before authz; send a valid id so the request
+			// reaches the authz check.
+			if endpoint.path == "/backups/{backend}" && endpoint.method == http.MethodPost {
+				body = []byte(`{"id":"someid"}`)
+			}
+
 			forbidden := false
 			if endpoint.method == "POST" || endpoint.method == "PUT" || endpoint.method == "PATCH" || endpoint.method == "DELETE" {
-				req, err = http.NewRequest(endpoint.method, url, bytes.NewBuffer(endpoint.validGeneratedBodyData))
+				req, err = http.NewRequest(endpoint.method, url, bytes.NewBuffer(body))
 				require.Nil(t, err)
 				req.Header.Set("Content-Type", "application/json")
 				forbidden = true

--- a/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
+++ b/test/acceptance/authz/rbac_auto_viewer_permissions_test.go
@@ -75,6 +75,13 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 		"/replication/scale",
 	}
 
+	// Per-method ignore: restore on a non-existent backup ID leaks 404
+	// because the meta file is read before class-aware authz can run.
+	// Class-specific RBAC for restore is covered in backups_test.go.
+	ignoreEndpointMethods := map[string]map[string]bool{
+		"/backups/{backend}/{id}/restore": {http.MethodPost: true},
+	}
+
 	for _, endpoint := range endpoints {
 		url := fmt.Sprintf("http://%s/v1%s", compose.GetWeaviate().URI(), endpoint.path)
 		url = strings.ReplaceAll(url, "/objects/{className}/{id}", fmt.Sprintf("/objects/%s/%s", className, UUID1.String()))
@@ -86,6 +93,7 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 		url = strings.ReplaceAll(url, "{id}", "someId")
 		url = strings.ReplaceAll(url, "{backend}", "filesystem")
 		url = strings.ReplaceAll(url, "{propertyName}", "someProperty")
+		url = strings.ReplaceAll(url, "{indexName}", "filterable")
 		url = strings.ReplaceAll(url, "{user_id}", "admin-user")
 		url = strings.ReplaceAll(url, "{userType}", "db")
 		url = strings.ReplaceAll(url, "{groupType}", "oidc")
@@ -95,7 +103,8 @@ func TestAuthzAllEndpointsViewerDynamically(t *testing.T) {
 			require.NotContains(t, url, "{")
 			require.NotContains(t, url, "}")
 
-			if slices.Contains(ignoreEndpoints, endpoint.path) {
+			if slices.Contains(ignoreEndpoints, endpoint.path) ||
+				ignoreEndpointMethods[endpoint.path][strings.ToUpper(endpoint.method)] {
 				t.Skip("Endpoint is in ignore list")
 				return
 			}

--- a/test/acceptance/authz/swagger_helper.go
+++ b/test/acceptance/authz/swagger_helper.go
@@ -78,10 +78,6 @@ func (c *collector) collectEndpoints() ([]endpoint, error) {
 				continue
 			}
 
-			if !strings.Contains(path, "group") || method != "POST" {
-				continue
-			}
-
 			var requestBodyData []byte
 			for _, param := range operation.Parameters {
 				if param.In == "body" && param.Schema != nil {

--- a/test/helper/backups.go
+++ b/test/helper/backups.go
@@ -147,6 +147,14 @@ func RestoreBackupWithAuthz(t *testing.T, cfg *models.RestoreConfig, className, 
 	return Client(t).Backups.BackupsRestore(params, authInfo)
 }
 
+func RestoreCancelWithAuthz(t *testing.T, backend, backupID string, authInfo runtime.ClientAuthInfoWriter) error {
+	params := backups.NewBackupsRestoreCancelParams().
+		WithBackend(backend).
+		WithID(backupID)
+	_, err := Client(t).Backups.BackupsRestoreCancel(params, authInfo)
+	return err
+}
+
 func RestoreBackupStatus(t *testing.T, backend, backupID, overrideBucket, overridePath string) (*backups.BackupsRestoreStatusOK, error) {
 	params := backups.NewBackupsRestoreStatusParams().
 		WithBackend(backend).

--- a/usecases/backup/auth_test.go
+++ b/usecases/backup/auth_test.go
@@ -49,10 +49,12 @@ func Test_Authorization(t *testing.T) {
 	// to the catch-all registered in the test body.
 	tests := []testCase{
 		{
+			// req has an empty Include, so the first authz call is the
+			// per-class filter over the resolved class list.
 			methodName:       "Backup",
 			additionalArgs:   []interface{}{req},
 			expectedVerb:     authorization.CREATE,
-			expectedResource: authorization.Backups()[0], // "*" until req.Include is resolved
+			expectedResource: authorization.Backups("ABC")[0],
 			classes:          []string{"ABC"},
 		},
 		{
@@ -65,10 +67,12 @@ func Test_Authorization(t *testing.T) {
 			classes:          []string{"ABC"},
 		},
 		{
+			// req has an empty Include, so the first authz call is the
+			// per-class filter over the backup's meta classes.
 			methodName:       "Restore",
 			additionalArgs:   []interface{}{req, false},
 			expectedVerb:     authorization.CREATE,
-			expectedResource: authorization.Backups()[0], // "*" until req.Include is resolved
+			expectedResource: authorization.Backups("ABC")[0],
 			classes:          []string{"ABC"},
 		},
 		{

--- a/usecases/backup/auth_test.go
+++ b/usecases/backup/auth_test.go
@@ -44,34 +44,45 @@ func Test_Authorization(t *testing.T) {
 		ignoreAuthZ      bool
 	}
 
+	// The expected verb/resource below is the *first* authz call made by the
+	// scheduler method; any subsequent, more fine-grained checks fall through
+	// to the catch-all registered in the test body.
 	tests := []testCase{
 		{
 			methodName:       "Backup",
 			additionalArgs:   []interface{}{req},
 			expectedVerb:     authorization.CREATE,
-			expectedResource: authorization.Backups("ABC")[0],
+			expectedResource: authorization.Backups()[0], // "*" until req.Include is resolved
 			classes:          []string{"ABC"},
 		},
 		{
-			methodName:     "BackupStatus",
-			additionalArgs: []interface{}{"filesystem", "123", "", ""},
-			classes:        []string{"ABC"},
-			ignoreAuthZ:    true,
+			// BackupStatus authorizes against the backup's actual classes
+			// (resolved from the meta).
+			methodName:       "BackupStatus",
+			additionalArgs:   []interface{}{"filesystem", "123", "", ""},
+			expectedVerb:     authorization.READ,
+			expectedResource: authorization.Backups("ABC")[0],
+			classes:          []string{"ABC"},
 		},
 		{
 			methodName:       "Restore",
 			additionalArgs:   []interface{}{req, false},
 			expectedVerb:     authorization.CREATE,
+			expectedResource: authorization.Backups()[0], // "*" until req.Include is resolved
+			classes:          []string{"ABC"},
+		},
+		{
+			// RestorationStatus authorizes against the backup's actual classes
+			// (resolved from the meta).
+			methodName:       "RestorationStatus",
+			additionalArgs:   []interface{}{"filesystem", "123", "", ""},
+			expectedVerb:     authorization.READ,
 			expectedResource: authorization.Backups("ABC")[0],
 			classes:          []string{"ABC"},
 		},
 		{
-			methodName:     "RestorationStatus",
-			additionalArgs: []interface{}{"filesystem", "123", "", ""},
-			classes:        []string{"ABC"},
-			ignoreAuthZ:    true,
-		},
-		{
+			// Cancel authorizes DELETE against the backup's actual classes
+			// (resolved from the meta).
 			methodName:       "Cancel",
 			additionalArgs:   []interface{}{"filesystem", "123", "", ""},
 			expectedVerb:     authorization.DELETE,
@@ -86,10 +97,14 @@ func Test_Authorization(t *testing.T) {
 			classes:          []string{"ABC"},
 		},
 		{
-			methodName:     "List",
-			additionalArgs: []interface{}{"filesystem", func(s string) *string { return &s }("desc")},
-			classes:        []string{"ABC"},
-			ignoreAuthZ:    true,
+			// List authorizes per-backup against its resolved classes
+			// ("backups/collections/ABC") and filters the response to what
+			// the caller is permitted to see.
+			methodName:       "List",
+			additionalArgs:   []interface{}{"filesystem", func(s string) *string { return &s }("desc")},
+			expectedVerb:     authorization.READ,
+			expectedResource: authorization.Backups("ABC")[0],
+			classes:          []string{"ABC"},
 		},
 	}
 
@@ -174,7 +189,11 @@ func Test_Authorization(t *testing.T) {
 				require.NotNil(t, s)
 
 				if !test.ignoreAuthZ {
-					authorizer.On("Authorize", mock.Anything, mock.Anything, test.expectedVerb, test.expectedResource).Return(nil)
+					authorizer.On("Authorize", mock.Anything, mock.Anything, test.expectedVerb, test.expectedResource).Return(nil).Once()
+					// Subsequent fine-grained authz calls (e.g. Backup/Restore
+					// re-authorizing on resolved classes, Cancel re-authorizing
+					// on meta classes) are allowed but not required.
+					authorizer.On("Authorize", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
 				}
 
 				args := append([]interface{}{context.Background(), &models.Principal{}}, test.additionalArgs...)

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -148,10 +148,13 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		return nil, backup.NewErrUnprocessable(err)
 	}
 
-	// An empty filtered result is rejected as an error by filterBackupableClasses.
+	// An empty filtered result returns Forbidden from filterBackupableClasses.
 	if !explicitInclude {
 		classes, err = s.filterBackupableClasses(ctx, pr, authorization.CREATE, classes)
 		if err != nil {
+			if errors.As(err, &authzerrors.Forbidden{}) {
+				return nil, err
+			}
 			return nil, backup.NewErrUnprocessable(err)
 		}
 	}
@@ -217,10 +220,13 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 		return nil, backup.NewErrUnprocessable(err)
 	}
 
-	// An empty filtered result is rejected as an error by filterBackupableClasses.
+	// An empty filtered result returns Forbidden from filterBackupableClasses.
 	if !explicitInclude {
 		allowed, err := s.filterBackupableClasses(ctx, pr, authorization.CREATE, meta.Classes())
 		if err != nil {
+			if errors.As(err, &authzerrors.Forbidden{}) {
+				return nil, err
+			}
 			return nil, backup.NewErrUnprocessable(err)
 		}
 		meta.Include(allowed)
@@ -266,8 +272,8 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 // to act on with the given verb under the backups domain. It is used on the
 // "all classes" path (empty Include) to narrow the operation to the classes
 // the caller has permission on, rather than 403-ing the whole request.
-// An empty result is treated as an error so the caller does not silently
-// proceed with nothing to back up / restore.
+// An empty result returns Forbidden so the caller learns they have no
+// permission to act on any class, consistent with the explicit-Include path.
 func (s *Scheduler) filterBackupableClasses(ctx context.Context, pr *models.Principal, verb string, classes []string) ([]string, error) {
 	allowed := make([]string, 0, len(classes))
 	for _, c := range classes {
@@ -280,7 +286,7 @@ func (s *Scheduler) filterBackupableClasses(ctx context.Context, pr *models.Prin
 		allowed = append(allowed, c)
 	}
 	if len(allowed) == 0 {
-		return nil, errors.New("no classes found that the caller is permitted to access")
+		return nil, authzerrors.NewForbidden(pr, verb, authorization.Backups(classes...)...)
 	}
 	return allowed, nil
 }

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -148,14 +148,10 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		return nil, backup.NewErrUnprocessable(err)
 	}
 
-	// An empty filtered result returns Forbidden from filterBackupableClasses.
 	if !explicitInclude {
 		classes, err = s.filterBackupableClasses(ctx, pr, authorization.CREATE, classes)
 		if err != nil {
-			if errors.As(err, &authzerrors.Forbidden{}) {
-				return nil, err
-			}
-			return nil, backup.NewErrUnprocessable(err)
+			return nil, err
 		}
 	}
 
@@ -220,14 +216,10 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 		return nil, backup.NewErrUnprocessable(err)
 	}
 
-	// An empty filtered result returns Forbidden from filterBackupableClasses.
 	if !explicitInclude {
 		allowed, err := s.filterBackupableClasses(ctx, pr, authorization.CREATE, meta.Classes())
 		if err != nil {
-			if errors.As(err, &authzerrors.Forbidden{}) {
-				return nil, err
-			}
-			return nil, backup.NewErrUnprocessable(err)
+			return nil, err
 		}
 		meta.Include(allowed)
 	}
@@ -268,12 +260,11 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 	return data, nil
 }
 
-// filterBackupableClasses returns the subset of classes the caller is allowed
-// to act on with the given verb under the backups domain. It is used on the
-// "all classes" path (empty Include) to narrow the operation to the classes
-// the caller has permission on, rather than 403-ing the whole request.
-// An empty result returns Forbidden so the caller learns they have no
-// permission to act on any class, consistent with the explicit-Include path.
+// filterBackupableClasses returns the subset of classes the caller may act on
+// with the given verb, used on the empty-Include path to narrow the operation
+// rather than 403-ing the whole request. An empty result returns Forbidden,
+// consistent with the explicit-Include path; any other authorizer failure is
+// wrapped Unprocessable so callers can return it directly.
 func (s *Scheduler) filterBackupableClasses(ctx context.Context, pr *models.Principal, verb string, classes []string) ([]string, error) {
 	allowed := make([]string, 0, len(classes))
 	for _, c := range classes {
@@ -281,7 +272,7 @@ func (s *Scheduler) filterBackupableClasses(ctx context.Context, pr *models.Prin
 			if errors.As(err, &authzerrors.Forbidden{}) {
 				continue
 			}
-			return nil, err
+			return nil, backup.NewErrUnprocessable(err)
 		}
 		allowed = append(allowed, c)
 	}
@@ -291,11 +282,9 @@ func (s *Scheduler) filterBackupableClasses(ctx context.Context, pr *models.Prin
 	return allowed, nil
 }
 
-// authorizeBackupByID reads the backup meta for backupID and authorizes the
-// caller against the classes recorded in the backup. A not-found meta is a
-// no-op: leaking the existence of a backup ID via a 404 response is
-// intentional. Any other backend error fails closed so that callers cannot
-// observe in-flight backup state when the descriptor read is failing.
+// authorizeBackupByID reads the backup meta and authorizes the caller against
+// the classes it records. A not-found meta is a deliberate no-op (the 404 may
+// leak the id's existence); any other backend error fails closed.
 func (s *Scheduler) authorizeBackupByID(ctx context.Context, principal *models.Principal, verb string,
 	store coordStore, filename, overrideBucket, overridePath string,
 ) error {
@@ -369,10 +358,9 @@ func (s *Scheduler) Cancel(ctx context.Context, principal *models.Principal, bac
 
 	idErr := validateID(backupID)
 
-	// Authorize before surfacing a validation error so a caller without
-	// permission gets 403, not a hint about the id. Scope authz to the backup's
-	// classes when the id is valid and the meta is readable; otherwise authorize
-	// against wildcard backups so only callers with DELETE on all backups proceed.
+	// Authorize before validating the id so a caller without permission gets 403,
+	// not a hint about the id. Scope to the backup's classes when the meta is
+	// readable; otherwise require wildcard DELETE.
 	var meta *backup.DistributedBackupDescriptor
 	var classes []string
 	if idErr == nil {
@@ -432,11 +420,9 @@ func (s *Scheduler) CancelRestore(ctx context.Context, principal *models.Princip
 
 	idErr := validateID(backupID)
 
-	// Authorize before surfacing a validation error so a caller without
-	// permission gets 403, not a hint about the id. Prefer the restore descriptor
-	// for authz; fall back to the backup descriptor if the restore meta hasn't
-	// been written yet. If neither is readable (or the id is malformed), authorize
-	// against wildcard backups so only callers with DELETE on all backups proceed.
+	// Authorize before validating the id so a caller without permission gets 403,
+	// not a hint about the id. Prefer the restore descriptor, falling back to the
+	// backup descriptor; if neither is readable, require wildcard DELETE.
 	var meta *backup.DistributedBackupDescriptor
 	var metaErr error
 	var classes []string
@@ -541,10 +527,9 @@ func (s *Scheduler) List(ctx context.Context, principal *models.Principal, backe
 
 	slices.SortFunc(backups, sortBackups(AllBackupsOrder(*sortingOrder)))
 
-	// Filter-in-response: return only backups the caller has READ on. A backup
-	// spans multiple classes, so include it only if the caller has READ on every
-	// class in the backup — otherwise listing would leak the existence of
-	// collections the caller cannot see.
+	// Return only backups the caller has READ on. A backup spans multiple classes,
+	// so include it only if the caller has READ on every one — otherwise listing
+	// leaks the existence of collections the caller cannot see.
 	response := make(models.BackupListResponse, 0, len(backups))
 	for _, b := range backups {
 		classes := b.Classes()

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -135,16 +135,6 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.Backups(includeCopy...)...); err != nil {
 			return nil, err
 		}
-	} else if classes := s.backupper.selector.ListClasses(ctx); len(classes) > 0 {
-		// Gate on the existing classes so a caller with no backup permission is
-		// rejected with 403 before request validation can surface a 422. The
-		// precise per-class narrowing happens after validation below.
-		if _, err := s.filterBackupableClasses(ctx, pr, authorization.CREATE, classes); err != nil {
-			if errors.As(err, &authzerrors.Forbidden{}) {
-				return nil, err
-			}
-			return nil, backup.NewErrUnprocessable(err)
-		}
 	}
 
 	store, err := coordBackend(s.backends, req.Backend, req.ID, req.Bucket, req.Path)

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/entities/backup"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 )
 
 var (
@@ -290,17 +291,19 @@ func (s *Scheduler) filterBackupableClasses(ctx context.Context, pr *models.Prin
 }
 
 // authorizeBackupByID reads the backup meta for backupID and authorizes the
-// caller against the classes recorded in the backup. If the meta cannot be
-// read (e.g. the backup does not exist, or it is still in-flight and has not
-// yet persisted its descriptor), this is a no-op: leaking the existence of a
-// backup ID via a 404 response is intentional; what must stay protected is
-// the content of the backup (class list, status).
+// caller against the classes recorded in the backup. A not-found meta is a
+// no-op: leaking the existence of a backup ID via a 404 response is
+// intentional. Any other backend error fails closed so that callers cannot
+// observe in-flight backup state when the descriptor read is failing.
 func (s *Scheduler) authorizeBackupByID(ctx context.Context, principal *models.Principal, verb string,
 	store coordStore, filename, overrideBucket, overridePath string,
 ) error {
 	meta, err := store.Meta(ctx, filename, overrideBucket, overridePath)
-	if err != nil || meta == nil {
-		return nil
+	if err != nil {
+		if errors.As(err, &backup.ErrNotFound{}) {
+			return nil
+		}
+		return err
 	}
 	return s.authorizer.Authorize(ctx, principal, verb, authorization.Backups(meta.Classes()...)...)
 }
@@ -373,13 +376,18 @@ func (s *Scheduler) Cancel(ctx context.Context, principal *models.Principal, bac
 		return backup.NewErrUnprocessable(fmt.Errorf("init uploader: %w", err))
 	}
 
-	meta, _ := store.Meta(ctx, GlobalBackupFile, overrideBucket, overridePath)
-	if meta != nil {
-		// Authorize against the backup's actual classes.
-		if err := s.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Backups(meta.Classes()...)...); err != nil {
-			return err
-		}
-		// if existed meta and not in the next cases shall be cancellable
+	// When the meta cannot be read, authorize against wildcard backups so that
+	// only callers with DELETE on all backups can cancel an op whose class list
+	// is unknown.
+	meta, metaErr := store.Meta(ctx, GlobalBackupFile, overrideBucket, overridePath)
+	var classes []string
+	if metaErr == nil {
+		classes = meta.Classes()
+	}
+	if err := s.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Backups(classes...)...); err != nil {
+		return err
+	}
+	if metaErr == nil {
 		switch meta.Status {
 		case backup.Cancelled:
 			return nil
@@ -425,11 +433,22 @@ func (s *Scheduler) CancelRestore(ctx context.Context, principal *models.Princip
 		return backup.NewErrUnprocessable(fmt.Errorf("init uploader: %w", err))
 	}
 
-	meta, _ := store.Meta(ctx, GlobalRestoreFile, overrideBucket, overridePath)
-	if meta != nil {
-		if err := s.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Backups(meta.Classes()...)...); err != nil {
-			return err
-		}
+	// Prefer the restore descriptor for authz; fall back to the backup
+	// descriptor if the restore meta hasn't been written yet. If neither is
+	// readable, authorize against wildcard backups so that only callers with
+	// DELETE on all backups can cancel a restore whose class list is unknown.
+	meta, metaErr := store.Meta(ctx, GlobalRestoreFile, overrideBucket, overridePath)
+	var classes []string
+	if metaErr == nil {
+		classes = meta.Classes()
+	} else if backupMeta, err := store.Meta(ctx, GlobalBackupFile, overrideBucket, overridePath); err == nil {
+		classes = backupMeta.Classes()
+	}
+	if err := s.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Backups(classes...)...); err != nil {
+		return err
+	}
+
+	if metaErr == nil {
 		switch meta.Status {
 		case backup.Cancelled, backup.Cancelling:
 			// Cancellation already in progress or complete
@@ -460,14 +479,6 @@ func (s *Scheduler) CancelRestore(ctx context.Context, principal *models.Princip
 			return nil
 		}
 		s.restorer.lastOp.set(backup.Cancelling)
-	} else {
-		// If restore_config.json doesn't exist, try reading from backup_config.json to get classes for authorization
-		backupMeta, _ := store.Meta(ctx, GlobalBackupFile, overrideBucket, overridePath)
-		if backupMeta != nil {
-			if err := s.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Backups(backupMeta.Classes()...)...); err != nil {
-				return err
-			}
-		}
 	}
 
 	// We've claimed cancellation (or meta was nil) - proceed with abort
@@ -528,7 +539,10 @@ func (s *Scheduler) List(ctx context.Context, principal *models.Principal, backe
 	for _, b := range backups {
 		classes := b.Classes()
 		if err := s.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Backups(classes...)...); err != nil {
-			continue
+			if errors.As(err, &authzerrors.Forbidden{}) {
+				continue
+			}
+			return nil, err
 		}
 		response = append(response, &models.BackupListResponseItems0{
 			ID:          b.ID,

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -129,10 +129,8 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 
 	explicitInclude := len(req.Include) > 0
 
-	// When the caller explicitly lists classes, authorize strictly against
-	// that list before touching the backend. Copy Include because
-	// authorization.Backups uppercases its input in place.
 	if explicitInclude {
+		// Copy Include because authorization.Backups uppercases its input in place.
 		includeCopy := append([]string(nil), req.Include...)
 		if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.Backups(includeCopy...)...); err != nil {
 			return nil, err
@@ -150,10 +148,7 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		return nil, backup.NewErrUnprocessable(err)
 	}
 
-	// When Include is empty ("all classes"), reduce the resolved list to
-	// classes the caller is allowed to back up. An explicit list was already
-	// strictly authorized above. An empty filtered result is rejected as an
-	// error by filterBackupableClasses, so classes is guaranteed non-empty here.
+	// An empty filtered result is rejected as an error by filterBackupableClasses.
 	if !explicitInclude {
 		classes, err = s.filterBackupableClasses(ctx, pr, authorization.CREATE, classes)
 		if err != nil {
@@ -201,10 +196,8 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 
 	explicitInclude := len(req.Include) > 0
 
-	// When the caller explicitly lists classes, authorize strictly against
-	// that list before touching the backend. Copy Include because
-	// authorization.Backups uppercases its input in place.
 	if explicitInclude {
+		// Copy Include because authorization.Backups uppercases its input in place.
 		includeCopy := append([]string(nil), req.Include...)
 		if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.Backups(includeCopy...)...); err != nil {
 			return nil, err
@@ -224,10 +217,7 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 		return nil, backup.NewErrUnprocessable(err)
 	}
 
-	// When Include is empty ("all classes in the backup"), reduce the backup's
-	// class list to those the caller is allowed to restore. An explicit list
-	// was already strictly authorized above. An empty filtered result is
-	// rejected as an error by filterBackupableClasses.
+	// An empty filtered result is rejected as an error by filterBackupableClasses.
 	if !explicitInclude {
 		allowed, err := s.filterBackupableClasses(ctx, pr, authorization.CREATE, meta.Classes())
 		if err != nil {
@@ -325,7 +315,6 @@ func (s *Scheduler) BackupStatus(ctx context.Context, principal *models.Principa
 		return nil, backup.NewErrUnprocessable(err)
 	}
 
-	// Authorize against the backup's actual classes.
 	if err := s.authorizeBackupByID(ctx, principal, authorization.READ, store, GlobalBackupFile, overrideBucket, overridePath); err != nil {
 		return nil, err
 	}
@@ -348,7 +337,6 @@ func (s *Scheduler) RestorationStatus(ctx context.Context, principal *models.Pri
 		err = fmt.Errorf("no backup provider %q: %w, did you enable the right module?", backend, err)
 		return nil, backup.NewErrUnprocessable(err)
 	}
-	// Authorize against the backup's actual classes.
 	if err := s.authorizeBackupByID(ctx, principal, authorization.READ, store, GlobalRestoreFile, overrideBucket, overridePath); err != nil {
 		return nil, err
 	}

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -126,13 +126,16 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		logOperation(s.logger, "try_backup", req.ID, req.Backend, begin, err)
 	}(time.Now())
 
-	// Authorize on the requested Include classes (defaults to "*" when empty)
-	// before touching the backend; the resolved class list is re-authorized
-	// below. Copy Include because authorization.Backups uppercases its input
-	// in place.
-	includeCopy := append([]string(nil), req.Include...)
-	if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.Backups(includeCopy...)...); err != nil {
-		return nil, err
+	explicitInclude := len(req.Include) > 0
+
+	// When the caller explicitly lists classes, authorize strictly against
+	// that list before touching the backend. Copy Include because
+	// authorization.Backups uppercases its input in place.
+	if explicitInclude {
+		includeCopy := append([]string(nil), req.Include...)
+		if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.Backups(includeCopy...)...); err != nil {
+			return nil, err
+		}
 	}
 
 	store, err := coordBackend(s.backends, req.Backend, req.ID, req.Bucket, req.Path)
@@ -146,8 +149,14 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		return nil, backup.NewErrUnprocessable(err)
 	}
 
-	if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.Backups(classes...)...); err != nil {
-		return nil, err
+	// When Include is empty ("all classes"), reduce the resolved list to
+	// classes the caller is allowed to back up. An explicit list was already
+	// strictly authorized above.
+	if !explicitInclude {
+		classes, err = s.filterBackupableClasses(ctx, pr, authorization.CREATE, classes)
+		if err != nil {
+			return nil, backup.NewErrUnprocessable(err)
+		}
 	}
 
 	if err := store.Initialize(ctx, req.Bucket, req.Path); err != nil {
@@ -188,13 +197,16 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 		logOperation(s.logger, "try_restore", req.ID, req.Backend, begin, err)
 	}(time.Now())
 
-	// Authorize on the requested Include classes (defaults to "*" when empty)
-	// before touching the backend; the classes recorded in the backup meta are
-	// re-authorized below. Copy Include because authorization.Backups
-	// uppercases its input in place.
-	includeCopy := append([]string(nil), req.Include...)
-	if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.Backups(includeCopy...)...); err != nil {
-		return nil, err
+	explicitInclude := len(req.Include) > 0
+
+	// When the caller explicitly lists classes, authorize strictly against
+	// that list before touching the backend. Copy Include because
+	// authorization.Backups uppercases its input in place.
+	if explicitInclude {
+		includeCopy := append([]string(nil), req.Include...)
+		if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.Backups(includeCopy...)...); err != nil {
+			return nil, err
+		}
 	}
 
 	store, err := coordBackend(s.backends, req.Backend, req.ID, req.Bucket, req.Path)
@@ -210,8 +222,15 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 		return nil, backup.NewErrUnprocessable(err)
 	}
 
-	if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.Backups(meta.Classes()...)...); err != nil {
-		return nil, err
+	// When Include is empty ("all classes in the backup"), reduce the backup's
+	// class list to those the caller is allowed to restore. An explicit list
+	// was already strictly authorized above.
+	if !explicitInclude {
+		allowed, err := s.filterBackupableClasses(ctx, pr, authorization.CREATE, meta.Classes())
+		if err != nil {
+			return nil, backup.NewErrUnprocessable(err)
+		}
+		meta.Include(allowed)
 	}
 
 	schema, err := s.fetchSchema(ctx, req.Backend, req.Bucket, req.Path, meta)
@@ -248,6 +267,26 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 
 	data.Status = &status
 	return data, nil
+}
+
+// filterBackupableClasses returns the subset of classes the caller is allowed
+// to act on with the given verb under the backups domain. It is used on the
+// "all classes" path (empty Include) to narrow the operation to the classes
+// the caller has permission on, rather than 403-ing the whole request.
+// An empty result is treated as an error so the caller does not silently
+// proceed with nothing to back up / restore.
+func (s *Scheduler) filterBackupableClasses(ctx context.Context, pr *models.Principal, verb string, classes []string) ([]string, error) {
+	allowed := make([]string, 0, len(classes))
+	for _, c := range classes {
+		if err := s.authorizer.Authorize(ctx, pr, verb, authorization.Backups(c)...); err != nil {
+			continue
+		}
+		allowed = append(allowed, c)
+	}
+	if len(allowed) == 0 {
+		return nil, errors.New("no classes found that the caller is permitted to access")
+	}
+	return allowed, nil
 }
 
 // authorizeBackupByID reads the backup meta for backupID and authorizes the

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -126,6 +126,15 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		logOperation(s.logger, "try_backup", req.ID, req.Backend, begin, err)
 	}(time.Now())
 
+	// Authorize on the requested Include classes (defaults to "*" when empty)
+	// before touching the backend; the resolved class list is re-authorized
+	// below. Copy Include because authorization.Backups uppercases its input
+	// in place.
+	includeCopy := append([]string(nil), req.Include...)
+	if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.Backups(includeCopy...)...); err != nil {
+		return nil, err
+	}
+
 	store, err := coordBackend(s.backends, req.Backend, req.ID, req.Bucket, req.Path)
 	if err != nil {
 		err = fmt.Errorf("no backup backend %q: %w, did you enable the right module?", req.Backend, err)
@@ -178,6 +187,15 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 	defer func(begin time.Time) {
 		logOperation(s.logger, "try_restore", req.ID, req.Backend, begin, err)
 	}(time.Now())
+
+	// Authorize on the requested Include classes (defaults to "*" when empty)
+	// before touching the backend; the classes recorded in the backup meta are
+	// re-authorized below. Copy Include because authorization.Backups
+	// uppercases its input in place.
+	includeCopy := append([]string(nil), req.Include...)
+	if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.Backups(includeCopy...)...); err != nil {
+		return nil, err
+	}
 
 	store, err := coordBackend(s.backends, req.Backend, req.ID, req.Bucket, req.Path)
 	if err != nil {
@@ -232,6 +250,22 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 	return data, nil
 }
 
+// authorizeBackupByID reads the backup meta for backupID and authorizes the
+// caller against the classes recorded in the backup. If the meta cannot be
+// read (e.g. the backup does not exist, or it is still in-flight and has not
+// yet persisted its descriptor), this is a no-op: leaking the existence of a
+// backup ID via a 404 response is intentional; what must stay protected is
+// the content of the backup (class list, status).
+func (s *Scheduler) authorizeBackupByID(ctx context.Context, principal *models.Principal, verb string,
+	store coordStore, filename, overrideBucket, overridePath string,
+) error {
+	meta, err := store.Meta(ctx, filename, overrideBucket, overridePath)
+	if err != nil || meta == nil {
+		return nil
+	}
+	return s.authorizer.Authorize(ctx, principal, verb, authorization.Backups(meta.Classes()...)...)
+}
+
 func (s *Scheduler) BackupStatus(ctx context.Context, principal *models.Principal,
 	backend, backupID, overrideBucket, overridePath string,
 ) (_ *Status, err error) {
@@ -242,6 +276,11 @@ func (s *Scheduler) BackupStatus(ctx context.Context, principal *models.Principa
 	if err != nil {
 		err = fmt.Errorf("no backup provider %q: %w, did you enable the right module?", backend, err)
 		return nil, backup.NewErrUnprocessable(err)
+	}
+
+	// Authorize against the backup's actual classes.
+	if err := s.authorizeBackupByID(ctx, principal, authorization.READ, store, GlobalBackupFile, overrideBucket, overridePath); err != nil {
+		return nil, err
 	}
 
 	req := &StatusRequest{OpCreate, backupID, backend, store.bucket, store.path, ""}
@@ -261,6 +300,10 @@ func (s *Scheduler) RestorationStatus(ctx context.Context, principal *models.Pri
 	if err != nil {
 		err = fmt.Errorf("no backup provider %q: %w, did you enable the right module?", backend, err)
 		return nil, backup.NewErrUnprocessable(err)
+	}
+	// Authorize against the backup's actual classes.
+	if err := s.authorizeBackupByID(ctx, principal, authorization.READ, store, GlobalRestoreFile, overrideBucket, overridePath); err != nil {
+		return nil, err
 	}
 	req := &StatusRequest{OpRestore, backupID, backend, overrideBucket, overridePath, ""}
 	st, err := s.restorer.OnStatus(ctx, store, req)
@@ -293,6 +336,7 @@ func (s *Scheduler) Cancel(ctx context.Context, principal *models.Principal, bac
 
 	meta, _ := store.Meta(ctx, GlobalBackupFile, overrideBucket, overridePath)
 	if meta != nil {
+		// Authorize against the backup's actual classes.
 		if err := s.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Backups(meta.Classes()...)...); err != nil {
 			return err
 		}
@@ -437,16 +481,24 @@ func (s *Scheduler) List(ctx context.Context, principal *models.Principal, backe
 
 	slices.SortFunc(backups, sortBackups(AllBackupsOrder(*sortingOrder)))
 
-	response := make(models.BackupListResponse, len(backups))
-	for i, b := range backups {
-		response[i] = &models.BackupListResponseItems0{
+	// Filter-in-response: return only backups the caller has READ on. A backup
+	// spans multiple classes, so include it only if the caller has READ on every
+	// class in the backup — otherwise listing would leak the existence of
+	// collections the caller cannot see.
+	response := make(models.BackupListResponse, 0, len(backups))
+	for _, b := range backups {
+		classes := b.Classes()
+		if err := s.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Backups(classes...)...); err != nil {
+			continue
+		}
+		response = append(response, &models.BackupListResponseItems0{
 			ID:          b.ID,
-			Classes:     b.Classes(),
+			Classes:     classes,
 			Status:      string(b.Status),
 			StartedAt:   strfmt.DateTime(b.StartedAt.UTC()),
 			CompletedAt: strfmt.DateTime(b.CompletedAt.UTC()),
 			Size:        float64(b.PreCompressionSizeBytes) / (1024 * 1024 * 1024), // Convert bytes to GiB,
-		}
+		})
 	}
 
 	return &response, nil
@@ -490,6 +542,9 @@ func (s *Scheduler) validateBackupRequest(ctx context.Context, store coordStore,
 	if req.BaseBackupID != "" {
 		if err := validateID(req.BaseBackupID); err != nil {
 			return nil, fmt.Errorf("base backup id: %w", err)
+		}
+		if req.ID == req.BaseBackupID {
+			return nil, fmt.Errorf("base backup cannot be the same as the new backup ID: %s", req.BaseBackupID)
 		}
 	}
 	if len(req.Include) > 0 && len(req.Exclude) > 0 {

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -303,6 +303,36 @@ func (s *Scheduler) authorizeBackupByID(ctx context.Context, principal *models.P
 	return s.authorizer.Authorize(ctx, principal, verb, authorization.Backups(meta.Classes()...)...)
 }
 
+const metaReadAttempts = 3
+
+// metaWithRetry reads the backup meta, retrying briefly when the read observes a
+// partial file mid-write (a json.SyntaxError). Resolving the real classes lets a
+// caller scoped to specific collections pass a class-aware authz check instead of
+// falling back to a wildcard one. ErrNotFound and other errors return immediately.
+func metaWithRetry(ctx context.Context, store coordStore, filename, overrideBucket, overridePath string,
+) (*backup.DistributedBackupDescriptor, error) {
+	var (
+		meta *backup.DistributedBackupDescriptor
+		err  error
+	)
+	for attempt := range metaReadAttempts {
+		meta, err = store.Meta(ctx, filename, overrideBucket, overridePath)
+		if err == nil {
+			return meta, nil
+		}
+		var syntaxErr *json.SyntaxError
+		if !errors.As(err, &syntaxErr) || attempt == metaReadAttempts-1 {
+			return nil, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	return nil, err
+}
+
 func (s *Scheduler) BackupStatus(ctx context.Context, principal *models.Principal,
 	backend, backupID, overrideBucket, overridePath string,
 ) (_ *Status, err error) {
@@ -369,7 +399,7 @@ func (s *Scheduler) Cancel(ctx context.Context, principal *models.Principal, bac
 	var meta *backup.DistributedBackupDescriptor
 	var classes []string
 	if idErr == nil {
-		if m, err := store.Meta(ctx, GlobalBackupFile, overrideBucket, overridePath); err == nil {
+		if m, err := metaWithRetry(ctx, store, GlobalBackupFile, overrideBucket, overridePath); err == nil {
 			meta = m
 			classes = m.Classes()
 		}
@@ -432,9 +462,9 @@ func (s *Scheduler) CancelRestore(ctx context.Context, principal *models.Princip
 	var metaErr error
 	var classes []string
 	if idErr == nil {
-		if meta, metaErr = store.Meta(ctx, GlobalRestoreFile, overrideBucket, overridePath); metaErr == nil {
+		if meta, metaErr = metaWithRetry(ctx, store, GlobalRestoreFile, overrideBucket, overridePath); metaErr == nil {
 			classes = meta.Classes()
-		} else if backupMeta, err := store.Meta(ctx, GlobalBackupFile, overrideBucket, overridePath); err == nil {
+		} else if backupMeta, err := metaWithRetry(ctx, store, GlobalBackupFile, overrideBucket, overridePath); err == nil {
 			classes = backupMeta.Classes()
 		}
 	}

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -135,6 +135,16 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 		if err := s.authorizer.Authorize(ctx, pr, authorization.CREATE, authorization.Backups(includeCopy...)...); err != nil {
 			return nil, err
 		}
+	} else if classes := s.backupper.selector.ListClasses(ctx); len(classes) > 0 {
+		// Gate on the existing classes so a caller with no backup permission is
+		// rejected with 403 before request validation can surface a 422. The
+		// precise per-class narrowing happens after validation below.
+		if _, err := s.filterBackupableClasses(ctx, pr, authorization.CREATE, classes); err != nil {
+			if errors.As(err, &authzerrors.Forbidden{}) {
+				return nil, err
+			}
+			return nil, backup.NewErrUnprocessable(err)
+		}
 	}
 
 	store, err := coordBackend(s.backends, req.Backend, req.ID, req.Bucket, req.Path)
@@ -367,26 +377,32 @@ func (s *Scheduler) Cancel(ctx context.Context, principal *models.Principal, bac
 		return backup.NewErrUnprocessable(err)
 	}
 
-	if err := validateID(backupID); err != nil {
+	idErr := validateID(backupID)
+
+	// Authorize before surfacing a validation error so a caller without
+	// permission gets 403, not a hint about the id. Scope authz to the backup's
+	// classes when the id is valid and the meta is readable; otherwise authorize
+	// against wildcard backups so only callers with DELETE on all backups proceed.
+	var meta *backup.DistributedBackupDescriptor
+	var classes []string
+	if idErr == nil {
+		if m, err := store.Meta(ctx, GlobalBackupFile, overrideBucket, overridePath); err == nil {
+			meta = m
+			classes = m.Classes()
+		}
+	}
+	if err := s.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Backups(classes...)...); err != nil {
 		return err
+	}
+	if idErr != nil {
+		return backup.NewErrUnprocessable(idErr)
 	}
 
 	if err := store.Initialize(ctx, overrideBucket, overridePath); err != nil {
 		return backup.NewErrUnprocessable(fmt.Errorf("init uploader: %w", err))
 	}
 
-	// When the meta cannot be read, authorize against wildcard backups so that
-	// only callers with DELETE on all backups can cancel an op whose class list
-	// is unknown.
-	meta, metaErr := store.Meta(ctx, GlobalBackupFile, overrideBucket, overridePath)
-	var classes []string
-	if metaErr == nil {
-		classes = meta.Classes()
-	}
-	if err := s.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Backups(classes...)...); err != nil {
-		return err
-	}
-	if metaErr == nil {
+	if meta != nil {
 		switch meta.Status {
 		case backup.Cancelled:
 			return nil
@@ -424,27 +440,32 @@ func (s *Scheduler) CancelRestore(ctx context.Context, principal *models.Princip
 		return backup.NewErrUnprocessable(err)
 	}
 
-	if err := validateID(backupID); err != nil {
+	idErr := validateID(backupID)
+
+	// Authorize before surfacing a validation error so a caller without
+	// permission gets 403, not a hint about the id. Prefer the restore descriptor
+	// for authz; fall back to the backup descriptor if the restore meta hasn't
+	// been written yet. If neither is readable (or the id is malformed), authorize
+	// against wildcard backups so only callers with DELETE on all backups proceed.
+	var meta *backup.DistributedBackupDescriptor
+	var metaErr error
+	var classes []string
+	if idErr == nil {
+		if meta, metaErr = store.Meta(ctx, GlobalRestoreFile, overrideBucket, overridePath); metaErr == nil {
+			classes = meta.Classes()
+		} else if backupMeta, err := store.Meta(ctx, GlobalBackupFile, overrideBucket, overridePath); err == nil {
+			classes = backupMeta.Classes()
+		}
+	}
+	if err := s.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Backups(classes...)...); err != nil {
 		return err
+	}
+	if idErr != nil {
+		return backup.NewErrUnprocessable(idErr)
 	}
 
 	if err := store.Initialize(ctx, overrideBucket, overridePath); err != nil {
 		return backup.NewErrUnprocessable(fmt.Errorf("init uploader: %w", err))
-	}
-
-	// Prefer the restore descriptor for authz; fall back to the backup
-	// descriptor if the restore meta hasn't been written yet. If neither is
-	// readable, authorize against wildcard backups so that only callers with
-	// DELETE on all backups can cancel a restore whose class list is unknown.
-	meta, metaErr := store.Meta(ctx, GlobalRestoreFile, overrideBucket, overridePath)
-	var classes []string
-	if metaErr == nil {
-		classes = meta.Classes()
-	} else if backupMeta, err := store.Meta(ctx, GlobalBackupFile, overrideBucket, overridePath); err == nil {
-		classes = backupMeta.Classes()
-	}
-	if err := s.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Backups(classes...)...); err != nil {
-		return err
 	}
 
 	if metaErr == nil {

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -262,10 +262,8 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 }
 
 // filterBackupableClasses returns the subset of classes the caller may act on
-// with the given verb, used on the empty-Include path to narrow the operation
-// rather than 403-ing the whole request. An empty result returns Forbidden,
-// consistent with the explicit-Include path; any other authorizer failure is
-// wrapped Unprocessable so callers can return it directly.
+// with verb, narrowing the empty-Include operation instead of failing it whole.
+// An empty result is Forbidden; any other authorizer error is Unprocessable.
 func (s *Scheduler) filterBackupableClasses(ctx context.Context, pr *models.Principal, verb string, classes []string) ([]string, error) {
 	allowed := make([]string, 0, len(classes))
 	for _, c := range classes {
@@ -283,17 +281,16 @@ func (s *Scheduler) filterBackupableClasses(ctx context.Context, pr *models.Prin
 	return allowed, nil
 }
 
-// authorizeBackupByID reads the backup meta and authorizes the caller against
-// the classes it records. A not-found meta is a deliberate no-op (the 404 may
-// leak the id's existence); any other backend error fails closed.
+// authorizeBackupByID authorizes the caller against the classes recorded in the
+// backup meta. A missing meta is a no-op (the 404 may leak the id); any other
+// backend error fails closed.
 func (s *Scheduler) authorizeBackupByID(ctx context.Context, principal *models.Principal, verb string,
 	store coordStore, filename, overrideBucket, overridePath string,
 ) error {
 	meta, err := store.Meta(ctx, filename, overrideBucket, overridePath)
 	if err != nil {
-		// A meta read concurrent with an in-progress write returns a partial or
-		// empty file that fails to unmarshal; treat that like not-found so a
-		// status poll mid-write retries instead of erroring.
+		// A read concurrent with a write yields a partial file that fails to
+		// unmarshal; treat it as not-found so a mid-write status poll retries.
 		var syntaxErr *json.SyntaxError
 		if errors.As(err, &backup.ErrNotFound{}) || errors.As(err, &syntaxErr) {
 			return nil
@@ -305,10 +302,9 @@ func (s *Scheduler) authorizeBackupByID(ctx context.Context, principal *models.P
 
 const metaReadAttempts = 3
 
-// metaWithRetry reads the backup meta, retrying briefly when the read observes a
-// partial file mid-write (a json.SyntaxError). Resolving the real classes lets a
-// caller scoped to specific collections pass a class-aware authz check instead of
-// falling back to a wildcard one. ErrNotFound and other errors return immediately.
+// metaWithRetry reads the backup meta, retrying briefly on a partial file mid-write
+// (json.SyntaxError) so a class-scoped caller can resolve the real classes for a
+// class-aware authz check. ErrNotFound and other errors return immediately.
 func metaWithRetry(ctx context.Context, store coordStore, filename, overrideBucket, overridePath string,
 ) (*backup.DistributedBackupDescriptor, error) {
 	var (
@@ -393,9 +389,8 @@ func (s *Scheduler) Cancel(ctx context.Context, principal *models.Principal, bac
 
 	idErr := validateID(backupID)
 
-	// Authorize before validating the id so a caller without permission gets 403,
-	// not a hint about the id. Scope to the backup's classes when the meta is
-	// readable; otherwise require wildcard DELETE.
+	// Authorize before validating the id so an unpermitted caller gets 403, not a
+	// hint about the id. Scope to the backup's classes when readable, else wildcard.
 	var meta *backup.DistributedBackupDescriptor
 	var classes []string
 	if idErr == nil {
@@ -455,9 +450,9 @@ func (s *Scheduler) CancelRestore(ctx context.Context, principal *models.Princip
 
 	idErr := validateID(backupID)
 
-	// Authorize before validating the id so a caller without permission gets 403,
-	// not a hint about the id. Prefer the restore descriptor, falling back to the
-	// backup descriptor; if neither is readable, require wildcard DELETE.
+	// Authorize before validating the id so an unpermitted caller gets 403, not a
+	// hint about the id. Prefer the restore descriptor, else the backup descriptor;
+	// if neither is readable, require wildcard DELETE.
 	var meta *backup.DistributedBackupDescriptor
 	var metaErr error
 	var classes []string
@@ -562,9 +557,8 @@ func (s *Scheduler) List(ctx context.Context, principal *models.Principal, backe
 
 	slices.SortFunc(backups, sortBackups(AllBackupsOrder(*sortingOrder)))
 
-	// Return only backups the caller has READ on. A backup spans multiple classes,
-	// so include it only if the caller has READ on every one — otherwise listing
-	// leaks the existence of collections the caller cannot see.
+	// Include a backup only if the caller has READ on every class it spans —
+	// otherwise listing leaks the existence of collections it cannot see.
 	response := make(models.BackupListResponse, 0, len(backups))
 	for _, b := range backups {
 		classes := b.Classes()

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -152,7 +152,8 @@ func (s *Scheduler) Backup(ctx context.Context, pr *models.Principal, req *Backu
 
 	// When Include is empty ("all classes"), reduce the resolved list to
 	// classes the caller is allowed to back up. An explicit list was already
-	// strictly authorized above.
+	// strictly authorized above. An empty filtered result is rejected as an
+	// error by filterBackupableClasses, so classes is guaranteed non-empty here.
 	if !explicitInclude {
 		classes, err = s.filterBackupableClasses(ctx, pr, authorization.CREATE, classes)
 		if err != nil {
@@ -225,7 +226,8 @@ func (s *Scheduler) Restore(ctx context.Context, pr *models.Principal,
 
 	// When Include is empty ("all classes in the backup"), reduce the backup's
 	// class list to those the caller is allowed to restore. An explicit list
-	// was already strictly authorized above.
+	// was already strictly authorized above. An empty filtered result is
+	// rejected as an error by filterBackupableClasses.
 	if !explicitInclude {
 		allowed, err := s.filterBackupableClasses(ctx, pr, authorization.CREATE, meta.Classes())
 		if err != nil {
@@ -280,7 +282,10 @@ func (s *Scheduler) filterBackupableClasses(ctx context.Context, pr *models.Prin
 	allowed := make([]string, 0, len(classes))
 	for _, c := range classes {
 		if err := s.authorizer.Authorize(ctx, pr, verb, authorization.Backups(c)...); err != nil {
-			continue
+			if errors.As(err, &authzerrors.Forbidden{}) {
+				continue
+			}
+			return nil, err
 		}
 		allowed = append(allowed, c)
 	}

--- a/usecases/backup/scheduler.go
+++ b/usecases/backup/scheduler.go
@@ -13,6 +13,7 @@ package backup
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path"
@@ -290,7 +291,11 @@ func (s *Scheduler) authorizeBackupByID(ctx context.Context, principal *models.P
 ) error {
 	meta, err := store.Meta(ctx, filename, overrideBucket, overridePath)
 	if err != nil {
-		if errors.As(err, &backup.ErrNotFound{}) {
+		// A meta read concurrent with an in-progress write returns a partial or
+		// empty file that fails to unmarshal; treat that like not-found so a
+		// status poll mid-write retries instead of erroring.
+		var syntaxErr *json.SyntaxError
+		if errors.As(err, &backup.ErrNotFound{}) || errors.As(err, &syntaxErr) {
 			return nil
 		}
 		return err

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -198,13 +198,19 @@ func TestSchedulerBackupStatus(t *testing.T) {
 	)
 
 	t.Run("ActiveState", func(t *testing.T) {
-		s := newFakeScheduler(nil).scheduler()
+		fs := newFakeScheduler(nil)
+		s := fs.scheduler()
 		s.backupper.lastOp.reqState = reqState{
 			Starttime: starTime,
 			ID:        id,
 			Status:    backup.Transferring,
 			Path:      path,
 		}
+		// In-flight backup: meta has not yet been persisted, so the meta read
+		// that backs authorizeBackupByID returns no bytes and is a no-op.
+		// OnStatus then short-circuits on lastOp.
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, ErrAny)
+		fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, ErrAny)
 		st, err := s.BackupStatus(ctx, nil, backendName, id, "", "")
 		assert.Nil(t, err)
 		assert.Equal(t, want, st)
@@ -294,13 +300,17 @@ func TestSchedulerRestorationStatus(t *testing.T) {
 	)
 
 	t.Run("ActiveState", func(t *testing.T) {
-		s := newFakeScheduler(nil).scheduler()
+		fs := newFakeScheduler(nil)
+		s := fs.scheduler()
 		s.restorer.lastOp.reqState = reqState{
 			Starttime: starTime,
 			ID:        id,
 			Status:    backup.Transferring,
 			Path:      path,
 		}
+		// authorizeBackupByID reads the meta to resolve classes; in the
+		// active-state path we don't require that read to succeed.
+		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(nil, ErrAny)
 		st, err := s.RestorationStatus(ctx, nil, backendName, id, "", "")
 		assert.Nil(t, err)
 		assert.Equal(t, want, st)

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -207,10 +207,10 @@ func TestSchedulerBackupStatus(t *testing.T) {
 			Path:      path,
 		}
 		// In-flight backup: meta has not yet been persisted, so the meta read
-		// that backs authorizeBackupByID returns no bytes and is a no-op.
+		// that backs authorizeBackupByID returns ErrNotFound and is a no-op.
 		// OnStatus then short-circuits on lastOp.
-		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, ErrAny)
-		fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, ErrAny)
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
+		fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, backup.ErrNotFound{})
 		st, err := s.BackupStatus(ctx, nil, backendName, id, "", "")
 		assert.Nil(t, err)
 		assert.Equal(t, want, st)
@@ -225,7 +225,7 @@ func TestSchedulerBackupStatus(t *testing.T) {
 
 	t.Run("MetadataNotFound", func(t *testing.T) {
 		fs := newFakeScheduler(nil)
-		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, ErrAny)
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return(nil, backup.ErrNotFound{})
 		fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, backup.ErrNotFound{})
 
 		_, err := fs.scheduler().BackupStatus(ctx, nil, backendName, id, "", "")
@@ -308,9 +308,10 @@ func TestSchedulerRestorationStatus(t *testing.T) {
 			Status:    backup.Transferring,
 			Path:      path,
 		}
-		// authorizeBackupByID reads the meta to resolve classes; in the
-		// active-state path we don't require that read to succeed.
-		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(nil, ErrAny)
+		// In-flight restore: meta has not yet been persisted, so the meta read
+		// that backs authorizeBackupByID returns ErrNotFound and is a no-op.
+		// OnStatus then short-circuits on lastOp.
+		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(nil, backup.ErrNotFound{})
 		st, err := s.RestorationStatus(ctx, nil, backendName, id, "", "")
 		assert.Nil(t, err)
 		assert.Equal(t, want, st)
@@ -325,7 +326,7 @@ func TestSchedulerRestorationStatus(t *testing.T) {
 
 	t.Run("MetadataNotFound", func(t *testing.T) {
 		fs := newFakeScheduler(nil)
-		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(nil, ErrAny)
+		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(nil, backup.ErrNotFound{})
 		_, err := fs.scheduler().RestorationStatus(ctx, nil, backendName, id, "", "")
 		assert.NotNil(t, err)
 		nerr := backup.ErrNotFound{}

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -216,6 +216,24 @@ func TestSchedulerBackupStatus(t *testing.T) {
 		assert.Equal(t, want, st)
 	})
 
+	t.Run("ActiveStatePartialMeta", func(t *testing.T) {
+		fs := newFakeScheduler(nil)
+		s := fs.scheduler()
+		s.backupper.lastOp.reqState = reqState{
+			Starttime: starTime,
+			ID:        id,
+			Status:    backup.Transferring,
+			Path:      path,
+		}
+		// A status poll racing an in-progress meta write reads a partial file
+		// that fails to unmarshal; authz must tolerate it so the poll succeeds.
+		fs.backend.On("GetObject", ctx, id, GlobalBackupFile).Return([]byte("{"), nil)
+		fs.backend.On("GetObject", ctx, id, BackupFile).Return(nil, backup.ErrNotFound{})
+		st, err := s.BackupStatus(ctx, nil, backendName, id, "", "")
+		assert.Nil(t, err)
+		assert.Equal(t, want, st)
+	})
+
 	t.Run("GetBackupProvider", func(t *testing.T) {
 		fs := newFakeScheduler(nil)
 		fs.backendErr = ErrAny
@@ -312,6 +330,23 @@ func TestSchedulerRestorationStatus(t *testing.T) {
 		// that backs authorizeBackupByID returns ErrNotFound and is a no-op.
 		// OnStatus then short-circuits on lastOp.
 		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return(nil, backup.ErrNotFound{})
+		st, err := s.RestorationStatus(ctx, nil, backendName, id, "", "")
+		assert.Nil(t, err)
+		assert.Equal(t, want, st)
+	})
+
+	t.Run("ActiveStatePartialMeta", func(t *testing.T) {
+		fs := newFakeScheduler(nil)
+		s := fs.scheduler()
+		s.restorer.lastOp.reqState = reqState{
+			Starttime: starTime,
+			ID:        id,
+			Status:    backup.Transferring,
+			Path:      path,
+		}
+		// A status poll racing an in-progress meta write reads a partial file
+		// that fails to unmarshal; authz must tolerate it so the poll succeeds.
+		fs.backend.On("GetObject", ctx, id, GlobalRestoreFile).Return([]byte("{"), nil)
 		st, err := s.RestorationStatus(ctx, nil, backendName, id, "", "")
 		assert.Nil(t, err)
 		assert.Equal(t, want, st)

--- a/usecases/backup/scheduler_test.go
+++ b/usecases/backup/scheduler_test.go
@@ -1194,6 +1194,35 @@ func TestCancellingBackup(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("backup %q already succeeded", backupID), err.Error())
 		fakeScheduler.backend.AssertExpectations(t)
 	})
+
+	t.Run("PartialMetaRetriesAndScopesAuthz", func(t *testing.T) {
+		fakeScheduler := newFakeScheduler(nil)
+		ds := backup.DistributedBackupDescriptor{
+			Status: backup.Cancelled,
+			Nodes:  map[string]*backup.NodeDescriptor{"node1": {Classes: []string{"Class1"}}},
+		}
+		b, err := json.Marshal(ds)
+		assert.NoError(t, err)
+
+		// First read races an in-progress meta write and returns a partial file;
+		// the retry resolves the real meta so authz is scoped to the backup's
+		// classes instead of a wildcard DELETE that a scoped caller would fail.
+		fakeScheduler.backend.On("GetObject", mock.Anything, backupID, GlobalBackupFile).Return([]byte("{"), nil).Once()
+		fakeScheduler.backend.On("GetObject", mock.Anything, backupID, GlobalBackupFile).Return(b, nil)
+		// The partial GlobalBackupFile read triggers the old-format fallback; deny it
+		// so the json.SyntaxError surfaces and the read is retried.
+		fakeScheduler.backend.On("GetObject", mock.Anything, backupID, BackupFile).Return(nil, backup.ErrNotFound{})
+		fakeScheduler.backend.On("Initialize", mock.Anything, mock.Anything).Return(nil)
+
+		err = fakeScheduler.scheduler().Cancel(ctx, nil, backendName, backupID, "", "")
+		assert.NoError(t, err)
+
+		calls := fakeScheduler.auth.(*mocks.FakeAuthorizer).Calls()
+		assert.Len(t, calls, 1)
+		assert.Equal(t, authorization.DELETE, calls[0].Verb)
+		assert.Equal(t, authorization.Backups("Class1"), calls[0].Resources)
+		fakeScheduler.backend.AssertExpectations(t)
+	})
 }
 
 func TestWildcardExpansion(t *testing.T) {
@@ -1423,5 +1452,31 @@ func TestCancellingRestore(t *testing.T) {
 		assert.Nil(t, err) // Should return nil - let another coordinator handle it
 		// Should NOT call Abort since we couldn't claim cancellation
 		fakeScheduler.client.AssertNotCalled(t, "Abort", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("PartialMetaRetriesAndScopesAuthz", func(t *testing.T) {
+		fakeScheduler := newFakeScheduler(nil)
+		ds := backup.DistributedBackupDescriptor{
+			Status: backup.Cancelled,
+			Nodes:  map[string]*backup.NodeDescriptor{"node1": {Classes: []string{"Class1"}}},
+		}
+		b, err := json.Marshal(ds)
+		assert.NoError(t, err)
+
+		// First read races an in-progress meta write and returns a partial file;
+		// the retry resolves the real meta so authz is scoped to the backup's
+		// classes instead of a wildcard DELETE that a scoped caller would fail.
+		fakeScheduler.backend.On("GetObject", mock.Anything, backupID, GlobalRestoreFile).Return([]byte("{"), nil).Once()
+		fakeScheduler.backend.On("GetObject", mock.Anything, backupID, GlobalRestoreFile).Return(b, nil)
+		fakeScheduler.backend.On("Initialize", mock.Anything, mock.Anything).Return(nil)
+
+		err = fakeScheduler.scheduler().CancelRestore(ctx, nil, backendName, backupID, "", "")
+		assert.NoError(t, err)
+
+		calls := fakeScheduler.auth.(*mocks.FakeAuthorizer).Calls()
+		assert.Len(t, calls, 1)
+		assert.Equal(t, authorization.DELETE, calls[0].Verb)
+		assert.Equal(t, authorization.Backups("Class1"), calls[0].Resources)
+		fakeScheduler.backend.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
### What's being changed:

Fixes RBAC enforcement across the backup endpoints. Several endpoints were unprotected or applied authorization all-or-nothing, and some leaked resource existence by validating before authorizing. All checks use the `backups/collections/<Class>` resource; what changed is *which* classes are checked, *when*, and *what happens on partial permission*.

#### Per-endpoint: before → now

**Create backup** — `POST /backups/{backend}` (`CREATE`)
- Before: one authorize over the whole class set; missing permission on any class → entire request `403`.
- Now: explicit `Include` is authorized up front, before touching the backend; empty `Include` (all classes) filters to the subset the caller may back up. Permission on none → `403`.

**Restore** — `POST /backups/{backend}/{id}/restore` (`CREATE`)
- Before: one authorize over the whole backup; missing any → `403`.
- Now: same split — explicit Include authorized up front; empty Include restores the allowed subset of the meta's classes; none allowed → `403`.

**Backup status** — `GET /backups/{backend}/{id}` (`READ`)
- Before: no authz at all.
- Now: reads the meta and authorizes `READ` over its classes.

**Restore status** — `GET /backups/{backend}/{id}/restore` (`READ`)
- Before: no authz.
- Now: authorizes `READ` over the restore descriptor's classes.

**Cancel backup** — `DELETE /backups/{backend}/{id}` (`DELETE`)
- Before: id validation ran first (leaking id validity); authz happened only if a meta existed.
- Now: authorize first — scoped to the backup's classes when the meta is readable, otherwise wildcard DELETE (all backups). The id-validation error is surfaced only after authz passes.

**Cancel restore** — `DELETE /backups/{backend}/{id}/restore` (`DELETE`)
- Before: id validation first; authz over restore-meta classes, falling back to backup-meta, else no check.
- Now: authorize first; prefer the restore descriptor, fall back to the backup descriptor, else wildcard DELETE. Id error surfaced only after authz.

**List** — `GET /backups/{backend}` (`READ`)
- Before: no per-backup authz — returned every backup to anyone.
- Now: filter-in-response — a backup is included only if the caller has `READ` on every one of its classes. Always `200` with the filtered subset (never `403`), so it can't leak the existence of collections the caller can't see.

#### Cross-cutting

1. **Partial permission → partial result** (Create/Restore empty-Include, List): a caller with rights on some classes gets a scoped operation or filtered list instead of a blanket `403`.
2. **Authz where there was none**: BackupStatus, RestorationStatus, and List were previously unprotected.
3. **Authz before validation** (Cancel, CancelRestore, and the same-id check moved from the REST handler into `validateBackupRequest`): validation/error responses no longer run ahead of the permission check, so they can't reveal resource existence to unauthorized callers.

#### Known residual leak

Status/restore-status/restore on a **non-existent** backup id still returns `404` before class-aware authz can run — there is no meta to resolve classes from. This is the per-method ignore-list in the `rbac_auto_*` dynamic tests; class-aware RBAC for these endpoints is covered exhaustively in `backups_test.go`.

#### Tests

- New `test/acceptance/authz/backups_test.go` covering per-class filtering, empty-list-vs-403, and cross-class restore/cancel authorization.
- `usecases/backup/auth_test.go` / `scheduler_test.go` updated to assert the first authz call per method and the in-flight (no-meta) no-op path.
- `swagger_helper.go` filter removed so the dynamic authz sweep exercises all endpoints again.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
