### PR TITLE
hfresh: retry transient errors during reassign

### DIFF
--- a/adapters/repos/db/vector/hfresh/reassign.go
+++ b/adapters/repos/db/vector/hfresh/reassign.go
@@ -58,11 +58,13 @@ func (h *HFresh) doReassign(ctx context.Context, op reassignOperation) error {
 	// increment the vector version. this will invalidate all the existing copies
 	// of the vector in other postings.
 	version, err = h.VersionMap.Increment(ctx, op.VectorID, version)
-	if err != nil {
+	if errors.Is(err, ErrVersionIncrementFailed) {
 		h.logger.WithField("vectorID", op.VectorID).
-			WithError(err).
-			Error("failed to increment version map for vector, skipping reassign operation")
+			Debug("version changed concurrently, skipping reassign operation")
 		return nil
+	}
+	if err != nil {
+		return errors.Wrapf(err, "failed to increment version map for vector %d", op.VectorID)
 	}
 
 	// create a new vector with the updated version

--- a/adapters/repos/db/vector/hfresh/reassign_test.go
+++ b/adapters/repos/db/vector/hfresh/reassign_test.go
@@ -125,6 +125,37 @@ func TestReassignDeduplicatorFlush(t *testing.T) {
 	require.Equal(t, uint64(3), newDedup.getLastKnownPostingID(302))
 }
 
+// Reassign a vector whose version was concurrently changed should be skipped
+func TestReassignConcurrentVersionChange(t *testing.T) {
+	tf := createHFreshIndex(t)
+
+	vector := []float32{1.0, 0.0, 0.0, 0.0}
+	vectorID := uint64(1000)
+	addVectorToIndex(t, &tf, vectorID, vector)
+
+	// Override VectorForIDThunk to increment the version as a side effect,
+	// simulating a concurrent reassign between Get and Increment.
+	tf.Index.config.VectorForIDThunk = func(ctx context.Context, id uint64) ([]float32, error) {
+		v, err := tf.Index.VersionMap.Get(ctx, id)
+		if err != nil {
+			return nil, err
+		}
+		_, err = tf.Index.VersionMap.Increment(ctx, id, v)
+		if err != nil {
+			return nil, err
+		}
+		return vector, nil
+	}
+
+	op := reassignOperation{
+		PostingID: 1,
+		VectorID:  vectorID,
+	}
+
+	err := tf.Index.doReassign(t.Context(), op)
+	require.NoError(t, err)
+}
+
 // Reassign properly manages task queue
 func TestReassignTaskQueueOperations(t *testing.T) {
 	tf := createHFreshIndex(t)


### PR DESCRIPTION
### What's being changed:

During reassign ops, some operations may fail because the shard is temporarily read-only for example.
This fixes a bug where we would ignore those errors when trying to increment the version of the reassigned vector.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
