### PR TITLE
fix: initialize dateAggregator max sentinel to MinInt64 to handle pre-1970 dates

### DIFF
--- a/adapters/repos/db/aggregator/date.go
+++ b/adapters/repos/db/aggregator/date.go
@@ -85,6 +85,7 @@ type dateAggregator struct {
 func newDateAggregator() *dateAggregator {
 	return &dateAggregator{
 		min:          timestamp{epochNano: math.MaxInt64},
+		max:          timestamp{epochNano: math.MinInt64},
 		valueCounter: map[timestamp]uint64{},
 		pairs:        make([]timestampCountPair, 0),
 	}

--- a/adapters/repos/db/aggregator/date_test.go
+++ b/adapters/repos/db/aggregator/date_test.go
@@ -23,6 +23,23 @@ const (
 	DateNanoSecondsTimeZone    = ".451235Z"
 )
 
+func TestDateAggregatorPreEpoch(t *testing.T) {
+	// Regression test for https://github.com/weaviate/weaviate/issues/11125:
+	// maximum returned empty string for pre-1970 DATE values because the
+	// initial max sentinel was 0 (epoch), causing negative unix nanoseconds to
+	// never satisfy the > comparison.
+	earlier := "1969-12-31T23:59:58Z"
+	later := "1969-12-31T23:59:59Z"
+
+	agg := newDateAggregator()
+	assert.Nil(t, agg.AddTimestamp(earlier))
+	assert.Nil(t, agg.AddTimestamp(later))
+	agg.buildPairsFromCounts()
+
+	assert.Equal(t, later, agg.Max(), "maximum of two pre-1970 dates should be the later one")
+	assert.Equal(t, earlier, agg.Min(), "minimum of two pre-1970 dates should be the earlier one")
+}
+
 func TestDateAggregator(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
**What's being changed:**

In `adapters/repos/db/aggregator/date.go`, `newDateAggregator()` initialized `min.epochNano` to `math.MaxInt64` as a sentinel so the first real value always wins, but left `max` at the zero value (`epochNano: 0`). Pre-1970 timestamps have negative Unix nanoseconds, so the comparison `ts.epochNano > a.max.epochNano` (i.e. `negative > 0`) is never true—the `max` field is never updated, and `Max()` returns an empty string.

The fix is a one-line change: initialize `max.epochNano` to `math.MinInt64` so that any real timestamp, including negative ones, correctly replaces the sentinel on the first insertion. A regression test covering the exact two-value pre-1970 scenario from the issue is added to `date_test.go`.

**Review checklist**

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

Fixes #11125
