### PR TITLE
fix: reject unrecognized fields in JSON and YAML config files

### DIFF
--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -814,13 +814,15 @@ func (f *WeaviateConfig) parseConfigFile(file []byte, name string) (Config, erro
 
 	switch m[1] {
 	case "json":
-		err := json.Unmarshal(file, &config)
-		if err != nil {
+		dec := json.NewDecoder(strings.NewReader(string(file)))
+		dec.DisallowUnknownFields()
+		if err := dec.Decode(&config); err != nil {
 			return config, fmt.Errorf("error unmarshalling the json config file: %w", err)
 		}
 	case "yaml":
-		err := yaml.Unmarshal(file, &config)
-		if err != nil {
+		dec := yaml.NewDecoder(strings.NewReader(string(file)))
+		dec.KnownFields(true)
+		if err := dec.Decode(&config); err != nil {
 			return config, fmt.Errorf("error unmarshalling the yaml config file: %w", err)
 		}
 	default:

--- a/usecases/config/config_handler_test.go
+++ b/usecases/config/config_handler_test.go
@@ -351,3 +351,33 @@ func TestConfigValidation_Namespaces(t *testing.T) {
 		})
 	}
 }
+
+func TestParseConfigFileUnknownFields(t *testing.T) {
+	weaviateConfig := &WeaviateConfig{}
+
+	t.Run("json config with unknown field returns error", func(t *testing.T) {
+		configJSON := `{"bogus_option": true}`
+		_, err := weaviateConfig.parseConfigFile([]byte(configJSON), "config.json")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bogus_option")
+	})
+
+	t.Run("yaml config with unknown field returns error", func(t *testing.T) {
+		configYAML := "bogus_option: true\n"
+		_, err := weaviateConfig.parseConfigFile([]byte(configYAML), "config.yaml")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "bogus_option")
+	})
+
+	t.Run("json config with valid fields does not error", func(t *testing.T) {
+		configJSON := `{"debug": true}`
+		_, err := weaviateConfig.parseConfigFile([]byte(configJSON), "config.json")
+		require.NoError(t, err)
+	})
+
+	t.Run("yaml config with valid fields does not error", func(t *testing.T) {
+		configYAML := "debug: true\n"
+		_, err := weaviateConfig.parseConfigFile([]byte(configYAML), "config.yaml")
+		require.NoError(t, err)
+	})
+}


### PR DESCRIPTION
## What's being changed:

In `usecases/config/config_handler.go`, the `parseConfigFile` function used `json.Unmarshal` and `yaml.Unmarshal` which both silently ignore unrecognized fields. This meant a config file like `{"bogus_option": true}` would be accepted without any warning or error, letting typos and deprecated keys go unnoticed.

The fix switches both parsers to use strict decoding: `json.NewDecoder` with `DisallowUnknownFields()` for JSON, and `yaml.NewDecoder` with `KnownFields(true)` for YAML. When an unrecognized field is encountered, the error message includes the field name so users can quickly identify and fix the typo or remove the stale key.

A regression test in `config_handler_test.go` covers both JSON and YAML unknown-field rejection, as well as confirming that valid fields still parse without error.

## Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

Fixes #5080
