### PR TITLE
fix: skip stale doc IDs in HFRESH rescore and flat search after deletion

### DIFF
--- a/adapters/repos/db/vector/hfresh/search.go
+++ b/adapters/repos/db/vector/hfresh/search.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/vector/common"
+	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/floatcomp"
 )
 
@@ -150,6 +151,12 @@ func (h *HFresh) SearchByVector(ctx context.Context, vector []float32, k int, al
 	for id := range q.Iter() {
 		vec, err := h.vectorForId(ctx, id)
 		if err != nil {
+			// The object may have been deleted between the posting scan and the
+			// rescore step (race condition). Skip stale entries gracefully.
+			var notFound storobj.ErrNotFound
+			if errors.As(err, &notFound) {
+				continue
+			}
 			return nil, nil, err
 		}
 		vec = h.normalizeVec(vec)

--- a/adapters/repos/db/vector/hfresh/search_flat.go
+++ b/adapters/repos/db/vector/hfresh/search_flat.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/priorityqueue"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/storobj"
 )
 
 const (
@@ -55,6 +56,12 @@ func (h *HFresh) flatSearch(ctx context.Context, queryVector []float32, k int,
 
 				dist, err := h.distToNode(ctx, candidate, queryVector)
 				if err != nil {
+					// The object may have been deleted between allowList iteration
+					// and vector fetch. Skip stale entries gracefully.
+					var notFound storobj.ErrNotFound
+					if errors.As(err, &notFound) {
+						continue
+					}
 					return err
 				}
 


### PR DESCRIPTION
**What's being changed:**

When a `near_vector` query runs immediately after deleting an object, HFRESH can fail with `no object found for doc id <N>: no object for doc id, it could have been deleted`. The root cause is a race in the two-phase search: the posting scan checks `IsDeleted` and marks the candidate as live, but by the time the rescore step calls `vectorForId`, the object has been removed from the object store. The same window exists in the flat search path via `distToNode`.

The fix adds a `storobj.ErrNotFound` check in both the rescore loop (`SearchByVector` in `search.go`) and the flat search worker (`flatSearch` in `search_flat.go`). When `vectorForId` returns a not-found error for a candidate, the entry is silently skipped rather than failing the entire query, matching the behaviour HNSW already uses in `searchLayerByVectorWithDistancer`.

**Review checklist:**
- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

Fixes #11085
