### PR TITLE
feat: hashtree optimizations

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -208,7 +208,22 @@ func readDigestsInRangeBinaryStream(r io.Reader, contentLength int64) ([]types.R
 func (c *replicationClient) HashTreeLevel(ctx context.Context,
 	host, index, shard string, level int, discriminant *hashtree.Bitset,
 ) ([]hashtree.Digest, error) {
-	body, err := discriminant.Marshal()
+	if level < 0 {
+		return nil, fmt.Errorf("invalid hash tree level: %d", level)
+	}
+	if discriminant == nil {
+		return nil, fmt.Errorf("discriminant must not be nil")
+	}
+	// Extract only the bits relevant to this level (level-local encoding).
+	// This reduces per-call payload from NodesCount(height) bits to
+	// nodesAtLevel(level) = LeavesCount(level) bits.
+	required := hashtree.InnerNodesCount(level) + hashtree.LeavesCount(level)
+	if discriminant.Size() < required {
+		return nil, fmt.Errorf("discriminant size %d too small for level %d: need at least %d bits",
+			discriminant.Size(), level, required)
+	}
+	levelLocalDisc := discriminant.ExtractSlice(hashtree.InnerNodesCount(level), hashtree.LeavesCount(level))
+	body, err := levelLocalDisc.Marshal()
 	if err != nil {
 		return nil, fmt.Errorf("marshal hashtree level input: %w", err)
 	}

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -448,7 +448,22 @@ func (c *grpcReplicationClient) HashTreeLevel(ctx context.Context, host, index, 
 		return nil, err
 	}
 
-	discData, err := discriminant.Marshal()
+	if level < 0 {
+		return nil, fmt.Errorf("invalid hash tree level: %d", level)
+	}
+	if discriminant == nil {
+		return nil, fmt.Errorf("discriminant must not be nil")
+	}
+	// Extract only the bits relevant to this level (level-local encoding).
+	// The server expects a discriminant of size LeavesCount(level); sending the
+	// full global bitset (NodesCount(height)) would fail the server-side size check.
+	required := hashtree.InnerNodesCount(level) + hashtree.LeavesCount(level)
+	if discriminant.Size() < required {
+		return nil, fmt.Errorf("discriminant size %d too small for level %d: need at least %d bits",
+			discriminant.Size(), level, required)
+	}
+	levelLocalDisc := discriminant.ExtractSlice(hashtree.InnerNodesCount(level), hashtree.LeavesCount(level))
+	discData, err := levelLocalDisc.Marshal()
 	if err != nil {
 		return nil, fmt.Errorf("marshal discriminant: %w", err)
 	}

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -606,9 +606,9 @@ func TestReplicationHashTreeLevel(t *testing.T) {
 		{0xdeadbeefcafebabe, 0x0123456789abcdef},
 	}
 
-	discriminant := hashtree.NewBitset(4)
-	discriminant.Set(0)
-	discriminant.Set(2)
+	discriminant := hashtree.NewBitset(15)
+	discriminant.Set(7)
+	discriminant.Set(9)
 
 	t.Run("BinaryResponse", func(t *testing.T) {
 		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"sync"
 	"time"
@@ -61,6 +62,12 @@ const (
 	defaultPropagationDelay            = 30 * time.Second
 	defaultPropagationConcurrency      = 1
 	defaultPropagationBatchSize        = 100
+
+	// initShieldCPUEveryN is the number of objects processed between
+	// runtime.Gosched() calls during hashtree initialization. Yielding
+	// periodically lets query goroutines make forward progress and prevents the
+	// init scan from monopolising CPU during a full-shard scan.
+	initShieldCPUEveryN = 10_000
 
 	minMaxWorkers = 1
 	maxMaxWorkers = 10
@@ -273,17 +280,22 @@ func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig,
 			prevProgressLogging = time.Now()
 		}
 
-		s.asyncReplicationRWMux.RLock()
-		defer s.asyncReplicationRWMux.RUnlock()
-
 		obj := &storobj.Object{}
 		obj.Object.LastUpdateTimeUnix = updateTime
+		s.asyncReplicationRWMux.RLock()
 		err := s.mayUpsertObjectHashTree(obj, uuidBytes, objectInsertStatus{})
+		s.asyncReplicationRWMux.RUnlock()
 		if err != nil {
 			return err
 		}
 
 		objCount++
+
+		// Yield to the Go scheduler periodically: on-disk scans can run for
+		// minutes on large shards and starve query goroutines on the same thread.
+		if objCount%initShieldCPUEveryN == 0 {
+			runtime.Gosched()
+		}
 
 		return nil
 	})
@@ -292,9 +304,9 @@ func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig,
 	}
 
 	s.asyncReplicationRWMux.Lock()
-	defer s.asyncReplicationRWMux.Unlock()
 
 	if s.hashtree == nil {
+		s.asyncReplicationRWMux.Unlock()
 		s.index.logger.
 			WithField("action", "async_replication").
 			WithField("class_name", s.class.Class).
@@ -304,6 +316,7 @@ func (s *Shard) initHashtree(ctx context.Context, config AsyncReplicationConfig,
 	}
 
 	s.hashtreeFullyInitialized = true
+	s.asyncReplicationRWMux.Unlock()
 
 	s.index.logger.
 		WithField("action", "async_replication").
@@ -508,6 +521,23 @@ func (s *Shard) dumpHashTree() error {
 }
 
 func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error) {
+	if level < 0 {
+		return nil, fmt.Errorf("hashtree level must be non-negative: %d", level)
+	}
+	if discriminant == nil {
+		return nil, fmt.Errorf("hashtree level %d: discriminant must not be nil", level)
+	}
+	// Validate and pre-allocate outside the lock: both are pure functions of
+	// level and discriminant, requiring no shard state. Keeping the critical
+	// section to the hashtreeFullyInitialized check and LevelLocal read reduces
+	// contention on the hot hashbeat path.
+	expectedSize := hashtree.LeavesCount(level)
+	if discriminant.Size() != expectedSize {
+		return nil, fmt.Errorf("hashtree level %d: discriminant size %d, expected %d (possible height mismatch)",
+			level, discriminant.Size(), expectedSize)
+	}
+	digests = make([]hashtree.Digest, expectedSize)
+
 	s.asyncReplicationRWMux.RLock()
 	defer s.asyncReplicationRWMux.RUnlock()
 
@@ -515,10 +545,7 @@ func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hash
 		return nil, fmt.Errorf("hashtree not initialized on shard %q", s.ID())
 	}
 
-	// TODO (jeroiraz): reusable pool of digests slices
-	digests = make([]hashtree.Digest, hashtree.LeavesCount(level+1))
-
-	n, err := s.hashtree.Level(level, discriminant, digests)
+	n, err := s.hashtree.LevelLocal(level, discriminant, digests)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/replica/hashtree/aggregated_hashtree.go
+++ b/usecases/replica/hashtree/aggregated_hashtree.go
@@ -19,6 +19,10 @@ type AggregatedHashTree interface {
 	Sync()
 	Root() Digest
 	Level(level int, discriminant *Bitset, digests []Digest) (n int, err error)
+	// LevelLocal works like Level but interprets the discriminant as level-local:
+	// bit i corresponds to the i-th node at the given level (global index
+	// InnerNodesCount(level)+i). discriminant.Size() must equal LeavesCount(level).
+	LevelLocal(level int, discriminant *Bitset, digests []Digest) (n int, err error)
 	Reset()
 	Clone() AggregatedHashTree
 

--- a/usecases/replica/hashtree/bitset.go
+++ b/usecases/replica/hashtree/bitset.go
@@ -14,6 +14,7 @@ package hashtree
 import (
 	"encoding/binary"
 	"fmt"
+	"math/bits"
 )
 
 type Bitset struct {
@@ -129,6 +130,48 @@ func (bset *Bitset) Unmarshal(b []byte) error {
 	}
 
 	return nil
+}
+
+// ExtractSlice returns a new Bitset of size count containing the bits at
+// positions [offset, offset+count) from this bitset. Used to produce a
+// level-local discriminant (size = nodesAtLevel(level)) from the full-tree
+// discriminant (size = NodesCount(height)) before sending it over the wire,
+// reducing per-call payload by a factor of (height+1) across a full traversal.
+// It panics if offset or count is negative, or if offset+count exceeds the bitset size.
+func (bset *Bitset) ExtractSlice(offset, count int) *Bitset {
+	if offset < 0 || count < 0 || offset+count > bset.size {
+		panic(fmt.Sprintf("ExtractSlice out of range [%d, %d) for bitset of size %d", offset, offset+count, bset.size))
+	}
+	result := NewBitset(count)
+	if count == 0 {
+		return result
+	}
+
+	srcWordStart := offset / 64
+	srcBitOff := uint(offset % 64)
+	dstWords := len(result.bits)
+
+	if srcBitOff == 0 {
+		copy(result.bits, bset.bits[srcWordStart:srcWordStart+dstWords])
+	} else {
+		for i := 0; i < dstWords; i++ {
+			result.bits[i] = int64(uint64(bset.bits[srcWordStart+i]) >> srcBitOff)
+			if srcWordStart+i+1 < len(bset.bits) {
+				result.bits[i] |= bset.bits[srcWordStart+i+1] << (64 - srcBitOff)
+			}
+		}
+	}
+
+	// Clear any bits beyond count in the last word.
+	if tail := uint(count % 64); tail != 0 {
+		result.bits[dstWords-1] &= int64((uint64(1) << tail) - 1)
+	}
+
+	for _, w := range result.bits {
+		result.setCount += bits.OnesCount64(uint64(w))
+	}
+
+	return result
 }
 
 func (bset *Bitset) Clone() *Bitset {

--- a/usecases/replica/hashtree/bitset_bench_test.go
+++ b/usecases/replica/hashtree/bitset_bench_test.go
@@ -1,0 +1,58 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hashtree
+
+import "testing"
+
+// BenchmarkExtractSlice* measure the cost of producing a level-local discriminant
+// from the full-tree discriminant before each HashTreeLevel RPC. The height-16
+// leaf-level case is the most expensive call in a hashbeat iteration; lower levels
+// are included to show how cost scales with slice size.
+//
+// InnerNodesCount(l) = 2^l - 1 is never word-aligned for l >= 1, so all real
+// call-site extractions exercise the shift path. BenchmarkExtractSliceWordAligned
+// provides a synthetic aligned baseline for comparison.
+func BenchmarkExtractSliceLevel16(b *testing.B) {
+	// Largest slice in a default single-tenant hashbeat: leaf level of height-16.
+	// offset=65535 (not word-aligned), count=65536.
+	src := NewBitset(NodesCount(16)).SetAll()
+	offset := InnerNodesCount(16) // 65535
+	count := LeavesCount(16)      // 65536
+	b.SetBytes(int64(count / 8))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = src.ExtractSlice(offset, count)
+	}
+}
+
+func BenchmarkExtractSliceLevel8(b *testing.B) {
+	// Mid-tree level: offset=255 (not word-aligned), count=256.
+	src := NewBitset(NodesCount(16)).SetAll()
+	offset := InnerNodesCount(8) // 255
+	count := LeavesCount(8)      // 256
+	b.SetBytes(int64(count / 8))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = src.ExtractSlice(offset, count)
+	}
+}
+
+func BenchmarkExtractSliceWordAligned(b *testing.B) {
+	// Synthetic word-aligned baseline (offset divisible by 64).
+	// Uses the copy path instead of the shift loop.
+	src := NewBitset(256).SetAll()
+	b.SetBytes(128 / 8)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = src.ExtractSlice(64, 128)
+	}
+}

--- a/usecases/replica/hashtree/bitset_test.go
+++ b/usecases/replica/hashtree/bitset_test.go
@@ -17,6 +17,148 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestBitsetExtractSlice(t *testing.T) {
+	t.Run("BasicExtraction", func(t *testing.T) {
+		bset := NewBitset(10)
+		bset.Set(3)
+		bset.Set(5)
+		bset.Set(7)
+
+		// Extract bits [3, 8) → local indices 0,2,4 should be set
+		result := bset.ExtractSlice(3, 5)
+
+		require.Equal(t, 5, result.Size())
+		require.True(t, result.IsSet(0))  // global 3
+		require.False(t, result.IsSet(1)) // global 4
+		require.True(t, result.IsSet(2))  // global 5
+		require.False(t, result.IsSet(3)) // global 6
+		require.True(t, result.IsSet(4))  // global 7
+		require.Equal(t, 3, result.SetCount())
+	})
+
+	t.Run("CrossWordBoundary", func(t *testing.T) {
+		// Bits straddle the 64-bit word boundary at position 63/64
+		bset := NewBitset(128)
+		bset.Set(62)
+		bset.Set(63)
+		bset.Set(64)
+		bset.Set(65)
+
+		result := bset.ExtractSlice(60, 10)
+
+		require.Equal(t, 10, result.Size())
+		require.True(t, result.IsSet(2)) // global 62
+		require.True(t, result.IsSet(3)) // global 63
+		require.True(t, result.IsSet(4)) // global 64
+		require.True(t, result.IsSet(5)) // global 65
+		require.Equal(t, 4, result.SetCount())
+	})
+
+	t.Run("FullRange", func(t *testing.T) {
+		bset := NewBitset(8)
+		bset.Set(1)
+		bset.Set(4)
+		bset.Set(7)
+
+		result := bset.ExtractSlice(0, 8)
+
+		require.Equal(t, 8, result.Size())
+		require.Equal(t, 3, result.SetCount())
+		require.True(t, result.IsSet(1))
+		require.True(t, result.IsSet(4))
+		require.True(t, result.IsSet(7))
+	})
+
+	t.Run("EmptySlice", func(t *testing.T) {
+		bset := NewBitset(16)
+		bset.Set(5)
+
+		result := bset.ExtractSlice(0, 4) // does not include bit 5
+		require.Equal(t, 4, result.Size())
+		require.Equal(t, 0, result.SetCount())
+	})
+
+	t.Run("WordAlignedMultiWord", func(t *testing.T) {
+		// offset is word-aligned and count spans more than one 64-bit word,
+		// exercising the copy path with dstWords > 1.
+		bset := NewBitset(256)
+		bset.Set(64)
+		bset.Set(65)
+		bset.Set(127)
+		bset.Set(128)
+
+		result := bset.ExtractSlice(64, 128)
+
+		require.Equal(t, 128, result.Size())
+		require.True(t, result.IsSet(0))  // global 64
+		require.True(t, result.IsSet(1))  // global 65
+		require.True(t, result.IsSet(63)) // global 127
+		require.True(t, result.IsSet(64)) // global 128
+		require.Equal(t, 4, result.SetCount())
+	})
+
+	t.Run("NonAlignedMultiWord", func(t *testing.T) {
+		// Non-aligned offset where count spans multiple destination words,
+		// exercising the shift loop for dstWords > 1.
+		// Range extracted: [5, 200); bit 200 is outside and must not appear.
+		bset := NewBitset(256)
+		bset.Set(5)
+		bset.Set(68)  // 5 + 63
+		bset.Set(133) // 5 + 128
+		bset.Set(200) // outside [5, 200) — must not be included
+
+		result := bset.ExtractSlice(5, 195)
+
+		require.Equal(t, 195, result.Size())
+		require.True(t, result.IsSet(0))   // global 5
+		require.True(t, result.IsSet(63))  // global 68
+		require.True(t, result.IsSet(128)) // global 133
+		require.False(t, result.IsSet(1))
+		require.Equal(t, 3, result.SetCount())
+	})
+
+	t.Run("NonAlignedSourceEndBoundary", func(t *testing.T) {
+		// Non-aligned extraction where the last destination word would require
+		// reading past the end of the source's backing slice. The boundary check
+		// must fire on the last loop iteration without panicking or producing
+		// spurious set bits.
+		bset := NewBitset(70) // 2 source words: bits [0,63] and [64,69]
+		bset.Set(66)
+		bset.Set(69)
+
+		// Extract [5, 70): srcBitOff=5, dstWords=2; on i=1 srcWordStart+i+1=2 == len(bits)=2
+		result := bset.ExtractSlice(5, 65)
+
+		require.Equal(t, 65, result.Size())
+		require.True(t, result.IsSet(61)) // global 66
+		require.True(t, result.IsSet(64)) // global 69
+		require.Equal(t, 2, result.SetCount())
+	})
+
+	t.Run("LevelLocalEquivalence", func(t *testing.T) {
+		// ExtractSlice(InnerNodesCount(l), LeavesCount(l)) must produce the
+		// same digest selection as a full-tree discriminant for level l.
+		height := 4
+		for level := 0; level <= height; level++ {
+			global := NewBitset(NodesCount(height))
+			// Set every other node at this level in the global discriminant
+			offset := InnerNodesCount(level)
+			count := LeavesCount(level) // nodesAtLevel(level)
+			for i := 0; i < count; i += 2 {
+				global.Set(offset + i)
+			}
+
+			local := global.ExtractSlice(offset, count)
+			require.Equal(t, count, local.Size())
+			require.Equal(t, (count+1)/2, local.SetCount()) // ceil(count/2)
+			for i := 0; i < count; i++ {
+				require.Equal(t, global.IsSet(offset+i), local.IsSet(i),
+					"level %d, node %d", level, i)
+			}
+		}
+	})
+}
+
 func TestBitSet(t *testing.T) {
 	bsetSize := 2 << 15
 

--- a/usecases/replica/hashtree/compact_hashtree.go
+++ b/usecases/replica/hashtree/compact_hashtree.go
@@ -121,6 +121,10 @@ func (ht *CompactHashTree) Level(level int, discriminant *Bitset, digests []Dige
 	return ht.hashtree.Level(level, discriminant, digests)
 }
 
+func (ht *CompactHashTree) LevelLocal(level int, discriminant *Bitset, digests []Digest) (n int, err error) {
+	return ht.hashtree.LevelLocal(level, discriminant, digests)
+}
+
 func (ht *CompactHashTree) Reset() {
 	ht.hashtree.Reset()
 }

--- a/usecases/replica/hashtree/hashtree.go
+++ b/usecases/replica/hashtree/hashtree.go
@@ -224,6 +224,51 @@ func (ht *HashTree) Level(level int, discriminant *Bitset, digests []Digest) (n 
 	return n, nil
 }
 
+// LevelLocal is like Level but the discriminant is level-local: its size must
+// be exactly nodesAtLevel(level) = LeavesCount(level), and bit i selects the
+// i-th node at the given level (global index InnerNodesCount(level)+i).
+// This avoids sending the full NodesCount(height)-sized discriminant over the
+// wire; callers use Bitset.ExtractSlice to produce the level-local view.
+func (ht *HashTree) LevelLocal(level int, discriminant *Bitset, digests []Digest) (n int, err error) {
+	ht.mux.Lock()
+	defer ht.mux.Unlock()
+
+	if level < 0 {
+		return 0, fmt.Errorf("%w: invalid level(%d)", ErrIllegalArguments, level)
+	}
+
+	if level > ht.height {
+		return 0, fmt.Errorf("%w: level(%d) is too high for current height(%d)", ErrIllegalState, level, ht.height)
+	}
+
+	if discriminant == nil {
+		return 0, fmt.Errorf("%w: nil discriminant provided", ErrIllegalArguments)
+	}
+
+	expectedSize := nodesAtLevel(level)
+	if discriminant.Size() != expectedSize {
+		return 0, fmt.Errorf("%w: discriminant size %d does not match expected %d for level %d",
+			ErrIllegalArguments, discriminant.Size(), expectedSize, level)
+	}
+
+	if len(digests) < expectedSize {
+		return 0, fmt.Errorf("%w: output buffer has not enough capacity", ErrIllegalArguments)
+	}
+
+	ht.sync()
+
+	offset := InnerNodesCount(level)
+
+	for i := 0; i < expectedSize; i++ {
+		if discriminant.IsSet(i) {
+			digests[n] = ht.nodes[offset+i]
+			n++
+		}
+	}
+
+	return n, nil
+}
+
 func (ht *HashTree) Clone() AggregatedHashTree {
 	ht.mux.Lock()
 	defer ht.mux.Unlock()

--- a/usecases/replica/hashtree/hashtree_bench_test.go
+++ b/usecases/replica/hashtree/hashtree_bench_test.go
@@ -1,0 +1,112 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hashtree
+
+import (
+	"fmt"
+	"testing"
+)
+
+// BenchmarkLevel and BenchmarkLevelLocal measure the per-call cost of retrieving
+// digests at the leaf level (height=16, all nodes selected). Both functions do
+// the same O(n) inner loop; the comparison establishes that LevelLocal does not
+// introduce overhead relative to Level for the same workload.
+func BenchmarkLevel(b *testing.B) {
+	ht := buildBenchTree(b, 16)
+	disc := NewBitset(NodesCount(16)).SetAll()
+	digests := make([]Digest, LeavesCount(16))
+	b.SetBytes(int64(LeavesCount(16)) * 16) // 16 bytes per Digest
+	b.ResetTimer()
+	var n int
+	for i := 0; i < b.N; i++ {
+		var err error
+		n, err = ht.Level(16, disc, digests)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	_ = n
+}
+
+func BenchmarkLevelLocal(b *testing.B) {
+	ht := buildBenchTree(b, 16)
+	disc := NewBitset(LeavesCount(16)).SetAll()
+	digests := make([]Digest, LeavesCount(16))
+	b.SetBytes(int64(LeavesCount(16)) * 16)
+	b.ResetTimer()
+	var n int
+	for i := 0; i < b.N; i++ {
+		var err error
+		n, err = ht.LevelLocal(16, disc, digests)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+	_ = n
+}
+
+// BenchmarkFullTraversal* benchmarks a complete height+1 level traversal — the
+// actual hashbeat call pattern. BenchmarkFullTraversalLevelLocal includes the
+// ExtractSlice cost that ships the level-local discriminant, so this pair
+// represents the end-to-end per-hashbeat CPU cost for the two approaches.
+func BenchmarkFullTraversalLevel(b *testing.B) {
+	height := 16
+	ht := buildBenchTree(b, height)
+	fullDisc := NewBitset(NodesCount(height)).SetAll()
+	digests := make([]Digest, LeavesCount(height))
+	b.ResetTimer()
+	var n int
+	for i := 0; i < b.N; i++ {
+		for level := 0; level <= height; level++ {
+			var err error
+			n, err = ht.Level(level, fullDisc, digests)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	_ = n
+}
+
+func BenchmarkFullTraversalLevelLocal(b *testing.B) {
+	height := 16
+	ht := buildBenchTree(b, height)
+	fullDisc := NewBitset(NodesCount(height)).SetAll()
+	digests := make([]Digest, LeavesCount(height))
+	b.ResetTimer()
+	var n int
+	for i := 0; i < b.N; i++ {
+		for level := 0; level <= height; level++ {
+			local := fullDisc.ExtractSlice(InnerNodesCount(level), LeavesCount(level))
+			var err error
+			n, err = ht.LevelLocal(level, local, digests)
+			if err != nil {
+				b.Fatal(err)
+			}
+		}
+	}
+	_ = n
+}
+
+func buildBenchTree(b *testing.B, height int) *HashTree {
+	b.Helper()
+	ht, err := NewHashTree(height)
+	if err != nil {
+		b.Fatal(err)
+	}
+	for i := 0; i < LeavesCount(height); i++ {
+		if err := ht.AggregateLeafWith(uint64(i), fmt.Appendf(nil, "v%d", i)); err != nil {
+			b.Fatal(err)
+		}
+	}
+	return ht
+}

--- a/usecases/replica/hashtree/hashtree_test.go
+++ b/usecases/replica/hashtree/hashtree_test.go
@@ -129,6 +129,63 @@ func TestBigHashTree(t *testing.T) {
 	require.Equal(t, 1, n)
 }
 
+func TestLevelLocal(t *testing.T) {
+	height := 4
+
+	ht, err := NewHashTree(height)
+	require.NoError(t, err)
+
+	leavesCount := LeavesCount(height)
+	for i := 0; i < leavesCount; i++ {
+		err = ht.AggregateLeafWith(uint64(i), []byte(fmt.Sprintf("val%d", i)))
+		require.NoError(t, err)
+	}
+
+	digests1 := make([]Digest, leavesCount)
+	digests2 := make([]Digest, leavesCount)
+
+	for level := 0; level <= height; level++ {
+		t.Run(fmt.Sprintf("level%d", level), func(t *testing.T) {
+			// Build a global discriminant with every other node set at this level
+			global := NewBitset(NodesCount(height))
+			offset := InnerNodesCount(level)
+			count := LeavesCount(level) // nodesAtLevel(level)
+			for i := 0; i < count; i += 2 {
+				global.Set(offset + i)
+			}
+
+			// Level() with global discriminant
+			n1, err := ht.Level(level, global, digests1)
+			require.NoError(t, err)
+
+			// LevelLocal() with extracted level-local discriminant
+			local := global.ExtractSlice(offset, count)
+			n2, err := ht.LevelLocal(level, local, digests2)
+			require.NoError(t, err)
+
+			require.Equal(t, n1, n2)
+			require.Equal(t, digests1[:n1], digests2[:n2])
+		})
+	}
+
+	t.Run("SizeMismatch", func(t *testing.T) {
+		wrongSize := NewBitset(99)
+		_, err := ht.LevelLocal(1, wrongSize, digests1)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	t.Run("NilDiscriminant", func(t *testing.T) {
+		_, err := ht.LevelLocal(1, nil, digests1)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	t.Run("LevelTooHigh", func(t *testing.T) {
+		local := NewBitset(LeavesCount(height + 1))
+		_, err := ht.LevelLocal(height+1, local, digests1)
+		require.ErrorIs(t, err, ErrIllegalState)
+	})
+}
+
 func TestHashTreeComparisonOneLeafAtATime(t *testing.T) {
 	height := 0
 
@@ -437,6 +494,39 @@ func TestHashTreeRandomAggregationOrder(t *testing.T) {
 		}
 
 	}
+}
+
+// TestPayloadSizeReduction quantifies the network-payload benefit of the
+// level-local discriminant encoding introduced by ExtractSlice + LevelLocal.
+// It asserts that across a full height-16 traversal the total bytes sent are
+// reduced by more than a factor of height (≈17× in practice).
+func TestPayloadSizeReduction(t *testing.T) {
+	height := 16
+	fullDisc := NewBitset(NodesCount(height)).SetAll()
+
+	var totalFull, totalLocal int
+	for level := 0; level <= height; level++ {
+		fullBytes, err := fullDisc.Marshal()
+		require.NoError(t, err)
+
+		localDisc := fullDisc.ExtractSlice(InnerNodesCount(level), LeavesCount(level))
+		localBytes, err := localDisc.Marshal()
+		require.NoError(t, err)
+
+		totalFull += len(fullBytes)
+		totalLocal += len(localBytes)
+
+		t.Logf("level=%2d  full=%6d B  local=%5d B  reduction=%.1fx",
+			level, len(fullBytes), len(localBytes),
+			float64(len(fullBytes))/float64(len(localBytes)))
+	}
+
+	reduction := float64(totalFull) / float64(totalLocal)
+	t.Logf("total traversal: %d B → %d B (%.1fx reduction)", totalFull, totalLocal, reduction)
+
+	// Must reduce total payload by more than a factor of height across the traversal.
+	require.Greater(t, reduction, float64(height),
+		"expected >%dx payload reduction for height=%d, got %.1fx", height, height, reduction)
 }
 
 func TestHashTreeConcurrentInsertions(t *testing.T) {

--- a/usecases/replica/hashtree/payload_compression_test.go
+++ b/usecases/replica/hashtree/payload_compression_test.go
@@ -1,0 +1,139 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hashtree
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPayloadCompressionReduction measures how much of the 16.8x raw-byte savings
+// from the level-local encoding survives zstd compression (the same compressor used
+// in adapters/clients/replication.go HashTreeLevel).
+//
+// Three discriminant patterns are tested for each of two heights:
+//
+//	AllSet    – every node selected; this is the first hashbeat after startup
+//	           or after a large divergence.  Highly compressible (runs of 0xFF).
+//	Sparse1pc – 1% of nodes selected; typical steady-state with few diffs.
+//	           Mostly-zero words, good zstd run-length compression.
+//	Random50  – 50% fill, independent uniform bits; worst case for compression
+//	           (near-maximum entropy, compressor gains nothing).
+func TestPayloadCompressionReduction(t *testing.T) {
+	enc, err := zstd.NewWriter(nil)
+	require.NoError(t, err)
+	defer enc.Close()
+
+	compress := func(b []byte) []byte {
+		return enc.EncodeAll(b, make([]byte, 0, len(b)))
+	}
+
+	type pattern struct {
+		name    string
+		fill    func(bset *Bitset)
+		comment string
+	}
+
+	heights := []int{10, 16}
+
+	for _, height := range heights {
+		t.Run(fmt.Sprintf("height%d", height), func(t *testing.T) {
+			nodesCount := NodesCount(height)
+			fullDisc := NewBitset(nodesCount)
+
+			patterns := []pattern{
+				{
+					name:    "AllSet",
+					fill:    func(bset *Bitset) { bset.SetAll() },
+					comment: "first hashbeat / full divergence — runs of 0xFF, excellent compression",
+				},
+				{
+					name: "Sparse1pct",
+					fill: func(bset *Bitset) {
+						rng := rand.New(rand.NewSource(42))
+						target := nodesCount / 100
+						for i := 0; i < target; i++ {
+							bset.Set(rng.Intn(nodesCount))
+						}
+					},
+					comment: "steady state with ~1% nodes differing — typical async replication",
+				},
+				{
+					name: "Random50pct",
+					fill: func(bset *Bitset) {
+						rng := rand.New(rand.NewSource(42))
+						for i := 0; i < nodesCount; i++ {
+							if rng.Intn(2) == 0 {
+								bset.Set(i)
+							}
+						}
+					},
+					comment: "50% random fill — worst case for compression (max entropy)",
+				},
+			}
+
+			for _, p := range patterns {
+				t.Run(p.name, func(t *testing.T) {
+					fullDisc.Reset()
+					p.fill(fullDisc)
+
+					rawFull, err := fullDisc.Marshal()
+					require.NoError(t, err)
+					compFull := compress(rawFull)
+
+					var totalRawFull, totalRawLocal int
+					var totalCompFull, totalCompLocal int
+
+					t.Logf("  %-12s  height=%d  (%s)", p.name, height, p.comment)
+					t.Logf("  %5s  %8s  %8s  %8s  %8s  %8s  %8s",
+						"level", "rawFull", "rawLocal", "cmpFull", "cmpLocal", "rawRed", "cmpRed")
+
+					for level := 0; level <= height; level++ {
+						localDisc := fullDisc.ExtractSlice(InnerNodesCount(level), LeavesCount(level))
+						rawLocal, err := localDisc.Marshal()
+						require.NoError(t, err)
+						compLocal := compress(rawLocal)
+
+						totalRawFull += len(rawFull)
+						totalRawLocal += len(rawLocal)
+						totalCompFull += len(compFull)
+						totalCompLocal += len(compLocal)
+
+						rawRed := float64(len(rawFull)) / float64(len(rawLocal))
+						cmpRed := float64(len(compFull)) / float64(len(compLocal))
+
+						t.Logf("  %5d  %8d  %8d  %8d  %8d  %7.1fx  %7.1fx",
+							level,
+							len(rawFull), len(rawLocal),
+							len(compFull), len(compLocal),
+							rawRed, cmpRed)
+					}
+
+					totalRawRed := float64(totalRawFull) / float64(totalRawLocal)
+					totalCmpRed := float64(totalCompFull) / float64(totalCompLocal)
+
+					t.Logf("  TOTAL (traversal)  raw: %dB→%dB (%.1fx)  compressed: %dB→%dB (%.1fx)",
+						totalRawFull, totalRawLocal, totalRawRed,
+						totalCompFull, totalCompLocal, totalCmpRed)
+					t.Logf("")
+
+					require.Less(t, totalRawLocal, totalRawFull,
+						"level-local raw bytes must be strictly smaller than full discriminant bytes across a traversal")
+				})
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

This pull request introduces a new "level-local" discriminant encoding for hash tree replication, optimizing network payload and CPU usage during hashbeat operations. The main improvement is the addition of `Bitset.ExtractSlice` and related logic, which allows only the relevant bits for a given hash tree level to be sent over the wire, rather than the full-tree discriminant. This change is implemented consistently across the client, server, and test code, and is thoroughly benchmarked and tested.

The most important changes are:

### Hash Tree API and Bitset Enhancements

* Added `LevelLocal` to the `AggregatedHashTree` interface and implemented it in both `HashTree` and `CompactHashTree`, allowing hash tree level queries to use a level-local discriminant for efficiency. [[1]](diffhunk://#diff-c53b34fd3b316f87250845bed5aca89619391c288ff0662af359ccb6d612be30R22-R25) [[2]](diffhunk://#diff-5a188f45d6baf57bd85a747eb64436df565992d65ffe671137fac881f093e54eR227-R271) [[3]](diffhunk://#diff-89868c48ec95df1faa0ff2ada2080a735fb8661a20d9b880c493876d988ccc54R124-R127)
* Introduced `Bitset.ExtractSlice`, which extracts a slice of bits for the level-local encoding, with comprehensive unit tests and benchmarks to ensure correctness and performance. [[1]](diffhunk://#diff-444da869b249055cf1ccbf9acda82c3d10a4f7698df903e9822297e3ef3786b8R135-R175) [[2]](diffhunk://#diff-c5440f9e042721403585748269b2420d6e680a4f9507d56016332233ea24cccfR20-R161) [[3]](diffhunk://#diff-b0886dc9fe03a2fe29be37aaddd4311d988d926eafdcc4e13232aece2bec8db9R1-R58)

### Replication Client and Server Refactoring

* Updated both HTTP and gRPC replication clients (`replication.go`, `replication_grpc.go`) to use the level-local discriminant, reducing per-call payload and validating input sizes. [[1]](diffhunk://#diff-9c6b07b40ed868288b28472fd7e8e41e994cfdaad151ca02a8442e772453a922L211-R226) [[2]](diffhunk://#diff-3af541807d92ad4d64c7ee228e439205c6d0a314f163652b26f3771404ebb9bcL451-R466)
* Changed the shard server-side implementation to validate and require level-local discriminants, and to use the new `LevelLocal` method for hash tree queries.

### Performance and Concurrency Improvements

* Added periodic `runtime.Gosched()` calls during hashtree initialization to yield CPU and prevent long-running scans from starving query goroutines. [[1]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210R66-R71) [[2]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210L276-R309) [[3]](diffhunk://#diff-9d2de57ecbf268ba95c556c7d63fa41defee384d9c3e6b118e991492717de210R319)

### Testing and Benchmarking

* Added comprehensive benchmarks for both the new `ExtractSlice` method and the `LevelLocal` API, including end-to-end hashbeat traversal scenarios. [[1]](diffhunk://#diff-b0886dc9fe03a2fe29be37aaddd4311d988d926eafdcc4e13232aece2bec8db9R1-R58) [[2]](diffhunk://#diff-7e4d482e18dd3e6770504229efd2823849791e3ce842488ff4dbddcbfd678be3R1-R112)
* Updated and expanded tests to cover the new level-local discriminant logic and ensure equivalence to the previous global discriminant approach. [[1]](diffhunk://#diff-c5440f9e042721403585748269b2420d6e680a4f9507d56016332233ea24cccfR20-R161) [[2]](diffhunk://#diff-4679ca5fef1e58a34c731d699ba35e69afe99b24a17f6ece435737dd85840f67L609-R611)

These changes significantly reduce network and CPU overhead during hashbeat operations, improve server responsiveness under load, and are well covered by tests and benchmarks.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
