### PR TITLE
Asynchronous replication automatically enabled unless it is globally disabled

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -8948,11 +8948,6 @@ func init() {
           "x-omitempty": true,
           "$ref": "#/definitions/ReplicationAsyncConfig"
         },
-        "asyncEnabled": {
-          "description": "Enable asynchronous replication (default: ` + "`" + `false` + "`" + `).",
-          "type": "boolean",
-          "x-omitempty": false
-        },
         "deletionStrategy": {
           "description": "Conflict resolution strategy for deleted objects.",
           "type": "string",
@@ -19496,11 +19491,6 @@ func init() {
           "description": "Configuration parameters for asynchronous replication.",
           "x-omitempty": true,
           "$ref": "#/definitions/ReplicationAsyncConfig"
-        },
-        "asyncEnabled": {
-          "description": "Enable asynchronous replication (default: ` + "`" + `false` + "`" + `).",
-          "type": "boolean",
-          "x-omitempty": false
         },
         "deletionStrategy": {
           "description": "Conflict resolution strategy for deleted objects.",

--- a/adapters/repos/db/export.go
+++ b/adapters/repos/db/export.go
@@ -128,26 +128,18 @@ func (db *DB) IsMultiTenant(_ context.Context, className string) bool {
 // IsAsyncReplicationEnabled returns true if async replication is either
 // enabled or not required for correctness. Classes with a replication
 // factor ≤ 1 have no replicas, so async replication is irrelevant and
-// the method returns true. For RF > 1 the class must have async
-// replication enabled and it must not be globally disabled at the
-// cluster level.
+// the method returns true. For RF > 1 async replication is enabled
+// automatically unless globally disabled at the cluster level.
 func (db *DB) IsAsyncReplicationEnabled(_ context.Context, className string) bool {
 	idx := db.GetIndex(schema.ClassName(className))
 	if idx == nil {
 		return false
 	}
-	class := idx.getClass()
-	if class == nil {
-		return false
-	}
 	// No replicas → async replication is not needed for correctness.
-	if class.ReplicationConfig == nil || class.ReplicationConfig.Factor <= 1 {
+	if idx.Config.ReplicationFactor <= 1 {
 		return true
 	}
-	if db.config.Replication.AsyncReplicationDisabled.Get() {
-		return false
-	}
-	return class.ReplicationConfig.AsyncEnabled
+	return idx.AsyncReplicationEnabled()
 }
 
 // SnapshotShards creates point-in-time snapshots of the objects buckets for

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -859,6 +859,9 @@ func (i *Index) getStopwordProvider() *stopwords.Provider {
 }
 
 func (i *Index) asyncReplicationGloballyDisabled() bool {
+	if i.globalreplicationConfig == nil {
+		return false
+	}
 	return i.globalreplicationConfig.AsyncReplicationDisabled.Get()
 }
 
@@ -868,7 +871,6 @@ func (i *Index) updateReplicationConfig(ctx context.Context, cfg *models.Replica
 
 	i.Config.ReplicationFactor = cfg.Factor
 	i.Config.DeletionStrategy = cfg.DeletionStrategy
-	i.Config.AsyncReplicationEnabled = cfg.AsyncEnabled
 
 	config, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(i.getClass().MultiTenancyConfig), cfg.AsyncConfig)
 	if err != nil {
@@ -878,13 +880,6 @@ func (i *Index) updateReplicationConfig(ctx context.Context, cfg *models.Replica
 
 	// unloaded shards will fetch the latest config when they are loaded
 	err = i.ForEachLoadedShard(func(name string, shard ShardLike) error {
-		if i.Config.AsyncReplicationEnabled && cfg.AsyncConfig != nil {
-			// if async replication is being enabled, first disable it to reset any previous config
-			if err := shard.SetAsyncReplicationState(ctx, AsyncReplicationConfig{}, false); err != nil {
-				return fmt.Errorf("updating async replication on shard %q: %w", name, err)
-			}
-		}
-
 		if err := shard.SetAsyncReplicationState(ctx, i.Config.AsyncReplicationConfig, i.asyncReplicationEnabled()); err != nil {
 			return fmt.Errorf("updating async replication on shard %q: %w", name, err)
 		}
@@ -935,7 +930,6 @@ type IndexConfig struct {
 	MaxSegmentSize                      int64
 	ReplicationFactor                   int64
 	DeletionStrategy                    string
-	AsyncReplicationEnabled             bool
 	AsyncReplicationConfig              AsyncReplicationConfig
 	AsyncReplicationWorkersLimiter      *dynsemaphore.DynamicWeighted
 	AvoidMMap                           bool
@@ -1244,7 +1238,7 @@ func (i *Index) AsyncReplicationEnabled() bool {
 }
 
 func (i *Index) asyncReplicationEnabled() bool {
-	return i.Config.ReplicationFactor > 1 && i.Config.AsyncReplicationEnabled && !i.asyncReplicationGloballyDisabled()
+	return i.Config.ReplicationFactor > 1 && !i.asyncReplicationGloballyDisabled()
 }
 
 func (i *Index) AsyncReplicationConfig() AsyncReplicationConfig {

--- a/adapters/repos/db/index_integration_test.go
+++ b/adapters/repos/db/index_integration_test.go
@@ -603,12 +603,11 @@ func TestIndex_DropLoadedShard(t *testing.T) {
 	}
 	shardResolver := resolver.NewShardResolver(class.Class, class.MultiTenancyConfig.Enabled, schemaGetter)
 	index, err := NewIndex(testCtx(), IndexConfig{
-		EnableLazyLoadShards:    true,
-		RootPath:                dirName,
-		ClassName:               schema.ClassName(class.Class),
-		ReplicationFactor:       1,
-		ShardLoadLimiter:        loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
-		AsyncReplicationEnabled: true,
+		EnableLazyLoadShards: true,
+		RootPath:             dirName,
+		ClassName:            schema.ClassName(class.Class),
+		ReplicationFactor:    1,
+		ShardLoadLimiter:     loadlimiter.NewLoadLimiter(monitoring.NoopRegisterer, "dummy", 1),
 	}, inverted.ConfigFromModel(class.InvertedIndexConfig),
 		hnsw.NewDefaultUserConfig(), nil, router, shardResolver, schemaGetter, mockSchemaReader, nil, logger, nil, nil, nil, &replication.GlobalConfig{}, nil, class, nil, scheduler, cpFile, memwatch.NewDummyMonitor(),
 		NewShardReindexerV3Noop(), roaringset.NewBitmapBufPoolNoop(), false, nil)

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -177,7 +177,6 @@ func (db *DB) init(ctx context.Context) error {
 				TransferInactivityTimeout:                    db.config.TransferInactivityTimeout,
 				LSMEnableSegmentsChecksumValidation:          db.config.LSMEnableSegmentsChecksumValidation,
 				ReplicationFactor:                            class.ReplicationConfig.Factor,
-				AsyncReplicationEnabled:                      class.ReplicationConfig.AsyncEnabled,
 				AsyncReplicationConfig:                       asyncConfig,
 				AsyncReplicationWorkersLimiter:               db.asyncReplicationWorkersLimiter,
 				DeletionStrategy:                             class.ReplicationConfig.DeletionStrategy,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -201,7 +201,6 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 			TransferInactivityTimeout:                    m.db.config.TransferInactivityTimeout,
 			LSMEnableSegmentsChecksumValidation:          m.db.config.LSMEnableSegmentsChecksumValidation,
 			ReplicationFactor:                            class.ReplicationConfig.Factor,
-			AsyncReplicationEnabled:                      class.ReplicationConfig.AsyncEnabled,
 			AsyncReplicationConfig:                       asyncConfig,
 			AsyncReplicationWorkersLimiter:               m.db.asyncReplicationWorkersLimiter,
 			DeletionStrategy:                             class.ReplicationConfig.DeletionStrategy,

--- a/entities/deepcopy/models_deepcopy.go
+++ b/entities/deepcopy/models_deepcopy.go
@@ -46,7 +46,6 @@ func Class(c *models.Class) *models.Class {
 		replicationConf = &models.ReplicationConfig{
 			Factor:           c.ReplicationConfig.Factor,
 			DeletionStrategy: c.ReplicationConfig.DeletionStrategy,
-			AsyncEnabled:     c.ReplicationConfig.AsyncEnabled,
 			AsyncConfig:      asyncConfig,
 		}
 	}

--- a/entities/models/replication_config.go
+++ b/entities/models/replication_config.go
@@ -34,9 +34,6 @@ type ReplicationConfig struct {
 	// Configuration parameters for asynchronous replication.
 	AsyncConfig *ReplicationAsyncConfig `json:"asyncConfig,omitempty"`
 
-	// Enable asynchronous replication (default: `false`).
-	AsyncEnabled bool `json:"asyncEnabled"`
-
 	// Conflict resolution strategy for deleted objects.
 	// Enum: [NoAutomatedResolution DeleteOnConflict TimeBasedResolution]
 	DeletionStrategy string `json:"deletionStrategy,omitempty"`

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -887,11 +887,6 @@
           "description": "Number of times a collection (class) is replicated (default: 1).",
           "type": "integer"
         },
-        "asyncEnabled": {
-          "description": "Enable asynchronous replication (default: `false`).",
-          "type": "boolean",
-          "x-omitempty": false
-        },
         "asyncConfig": {
           "description": "Configuration parameters for asynchronous replication.",
           "$ref": "#/definitions/ReplicationAsyncConfig",

--- a/test/acceptance/grpc/batching_test.go
+++ b/test/acceptance/grpc/batching_test.go
@@ -451,13 +451,11 @@ func TestGRPC_ClusterBatching(t *testing.T) {
 
 	clsA := articles.ArticlesClass()
 	clsA.ReplicationConfig = &models.ReplicationConfig{
-		Factor:       3,
-		AsyncEnabled: true,
+		Factor: 3,
 	}
 	clsP := articles.ParagraphsClass()
 	clsP.ReplicationConfig = &models.ReplicationConfig{
-		Factor:       3,
-		AsyncEnabled: true,
+		Factor: 3,
 	}
 
 	setupClasses := func() func() {

--- a/test/acceptance/recovery/scale_down_after_remove_node_test.go
+++ b/test/acceptance/recovery/scale_down_after_remove_node_test.go
@@ -61,8 +61,7 @@ func TestScaleDownAfterRemoveNode(t *testing.T) {
 	paragraphClass := articles.ParagraphsClass()
 	paragraphClass.ShardingConfig = map[string]interface{}{"desiredCount": 3}
 	paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-		Factor:       2,
-		AsyncEnabled: false,
+		Factor: 2,
 	}
 	paragraphClass.Vectorizer = "text2vec-contextionary"
 

--- a/test/acceptance/replication/async_replication/async_repair_deletes_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_deletes_test.go
@@ -55,7 +55,6 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectDeleteScenario() {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
 			Factor:           int64(clusterSize),
 			DeletionStrategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
-			AsyncEnabled:     true,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 

--- a/test/acceptance/replication/async_replication/async_repair_insertions_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_insertions_test.go
@@ -53,8 +53,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectInsertionScenario()
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       int64(clusterSize),
-			AsyncEnabled: true,
+			Factor: int64(clusterSize),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 

--- a/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
@@ -78,8 +78,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       int64(clusterSize),
-			AsyncEnabled: true,
+			Factor: int64(clusterSize),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
@@ -182,8 +181,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 
 	t.Run("create schema with async replication disabled", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       int64(clusterSize),
-			AsyncEnabled: false,
+			Factor: int64(clusterSize),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
@@ -209,7 +207,6 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 
 		// Update to enable async replication
 		class := res.Payload
-		class.ReplicationConfig.AsyncEnabled = true
 
 		// Update the class
 		helper.UpdateClass(t, class)

--- a/test/acceptance/replication/async_replication/async_repair_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_test.go
@@ -95,14 +95,12 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       3,
-			AsyncEnabled: true,
+			Factor: 3,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
 		articleClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       3,
-			AsyncEnabled: true,
+			Factor: 3,
 		}
 		helper.CreateClass(t, articleClass)
 	})

--- a/test/acceptance/replication/async_replication/async_repair_updates_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_updates_test.go
@@ -54,8 +54,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectUpdateScenario() {
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       int64(clusterSize),
-			AsyncEnabled: true,
+			Factor: int64(clusterSize),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 

--- a/test/acceptance/replication/replica_replication/fast/replica_replication_test.go
+++ b/test/acceptance/replication/replica_replication/fast/replica_replication_test.go
@@ -92,15 +92,13 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementHappyPath() {
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ShardingConfig = map[string]interface{}{"desiredCount": 1}
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
 		articleClass.ShardingConfig = map[string]interface{}{"desiredCount": 1}
 		articleClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		helper.CreateClass(t, articleClass)
 	})
@@ -273,8 +271,7 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementTenantHappyPath()
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
 			Enabled:              true,
@@ -284,8 +281,7 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementTenantHappyPath()
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
 		articleClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		articleClass.MultiTenancyConfig = &models.MultiTenancyConfig{
 			Enabled:              true,
@@ -469,8 +465,7 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementTenantHappyPath()
 // 	t.Run("create schema", func(t *testing.T) {
 // 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
 // 			Factor:       2,
-// 			AsyncEnabled: false,
-// 		}
+// 			// 		}
 // 		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
 // 			Enabled:              true,
 // 			AutoTenantActivation: true,
@@ -480,8 +475,7 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementTenantHappyPath()
 // 		helper.CreateClass(t, paragraphClass)
 // 		articleClass.ReplicationConfig = &models.ReplicationConfig{
 // 			Factor:       2,
-// 			AsyncEnabled: false,
-// 		}
+// 			// 		}
 // 		articleClass.MultiTenancyConfig = &models.MultiTenancyConfig{
 // 			Enabled:              true,
 // 			AutoTenantActivation: true,

--- a/test/acceptance/replication/replica_replication/scale/scale_test.go
+++ b/test/acceptance/replication/replica_replication/scale/scale_test.go
@@ -82,8 +82,7 @@ func (suite *ScaleTestSuite) TestScalingSingleTenant() {
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ShardingConfig = map[string]interface{}{"desiredCount": shardsCount}
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
@@ -275,8 +274,7 @@ func (suite *ScaleTestSuite) TestScalingMultiTenant() {
 
 	t.Run("create schema (multi-tenant)", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
 			Enabled:              true,

--- a/test/acceptance/replication/replica_replication/slow/slow_file_copy_test.go
+++ b/test/acceptance/replication/replica_replication/slow/slow_file_copy_test.go
@@ -79,8 +79,7 @@ func (suite *ReplicationTestSuite) TestReplicaMovementOneWriteExtraSlowFileCopy(
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ShardingConfig = map[string]interface{}{"desiredCount": 1}
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)

--- a/test/acceptance/schema/get_schema_without_client_test.go
+++ b/test/acceptance/schema/get_schema_without_client_test.go
@@ -100,7 +100,6 @@ func testGetSchemaWithoutClient(t *testing.T) {
 					"virtualPerPhysical":  float64(128),
 				},
 				"replicationConfig": map[string]interface{}{
-					"asyncEnabled":     false,
 					"factor":           float64(1),
 					"deletionStrategy": "TimeBasedResolution",
 				},

--- a/test/acceptance/schema/update_class_async_replication_test.go
+++ b/test/acceptance/schema/update_class_async_replication_test.go
@@ -33,12 +33,10 @@ func TestUpdateClassAsyncReplicationConfig(t *testing.T) {
 		require.Nil(t, err)
 	})
 
-	t.Run("create class with async replication disabled", func(t *testing.T) {
+	t.Run("create class", func(t *testing.T) {
 		c := &models.Class{
-			Class: className,
-			ReplicationConfig: &models.ReplicationConfig{
-				AsyncEnabled: false,
-			},
+			Class:             className,
+			ReplicationConfig: &models.ReplicationConfig{},
 		}
 
 		params := clschema.NewSchemaObjectsCreateParams().WithObjectClass(c)
@@ -101,7 +99,6 @@ func TestUpdateClassAsyncReplicationConfig(t *testing.T) {
 			require.Nil(t, err)
 
 			class := res.Payload
-			class.ReplicationConfig.AsyncEnabled = true
 			class.ReplicationConfig.AsyncConfig = tc.config
 
 			// update
@@ -118,7 +115,6 @@ func TestUpdateClassAsyncReplicationConfig(t *testing.T) {
 
 			rc := res.Payload.ReplicationConfig
 			require.NotNil(t, rc)
-			require.True(t, rc.AsyncEnabled)
 			require.NotNil(t, rc.AsyncConfig)
 
 			requireAsyncConfigEquals(t, tc.config, rc.AsyncConfig)

--- a/test/modules/export-s3/export_test.go
+++ b/test/modules/export-s3/export_test.go
@@ -51,8 +51,7 @@ func TestExport_SingleShard(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -153,8 +152,7 @@ func TestExport_MultiShard(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(3),
@@ -234,8 +232,7 @@ func TestExport_DeletedAndUpdatedObjects(t *testing.T) {
 			},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -436,8 +433,7 @@ func TestExport_EmptyCollection(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -468,8 +464,7 @@ func TestExport_MultipleClasses(t *testing.T) {
 				{Name: "text", DataType: []string{"text"}},
 			},
 			ReplicationConfig: &models.ReplicationConfig{
-				AsyncEnabled: true,
-				Factor:       3,
+				Factor: 3,
 			},
 			ShardingConfig: map[string]interface{}{
 				"desiredCount": float64(1),
@@ -507,7 +502,7 @@ func TestExport_MultiTenant_SingleShard(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: "text", DataType: []string{"text"}},
 		},
-		ReplicationConfig:  &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		ReplicationConfig:  &models.ReplicationConfig{Factor: 3},
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 	})
 	defer helper.DeleteClass(t, className)
@@ -565,7 +560,7 @@ func TestExport_MultiTenant_MultiShard(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: "text", DataType: []string{"text"}},
 		},
-		ReplicationConfig:  &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		ReplicationConfig:  &models.ReplicationConfig{Factor: 3},
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 	})
 	defer helper.DeleteClass(t, className)
@@ -616,8 +611,7 @@ func TestExport_NamedVectorAndMultiVector(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		VectorConfig: map[string]models.VectorConfig{
 			"regular": {
@@ -771,7 +765,7 @@ func TestExport_MultiTenant_ActiveAndInactive(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: "text", DataType: []string{"text"}},
 		},
-		ReplicationConfig: &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 3},
 		MultiTenancyConfig: &models.MultiTenancyConfig{
 			Enabled:              true,
 			AutoTenantActivation: false,
@@ -860,7 +854,7 @@ func TestExport_MultiTenant_AllCold(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: "text", DataType: []string{"text"}},
 		},
-		ReplicationConfig: &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 3},
 		MultiTenancyConfig: &models.MultiTenancyConfig{
 			Enabled:              true,
 			AutoTenantActivation: false,
@@ -952,7 +946,7 @@ func TestExport_MultiTenant_HotEmptyTenants(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: "text", DataType: []string{"text"}},
 		},
-		ReplicationConfig:  &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		ReplicationConfig:  &models.ReplicationConfig{Factor: 3},
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 	})
 	defer helper.DeleteClass(t, className)
@@ -1043,7 +1037,7 @@ func TestExport_ColdTenantReactivatedDuringExport(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: "text", DataType: []string{"text"}},
 		},
-		ReplicationConfig: &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 3},
 		MultiTenancyConfig: &models.MultiTenancyConfig{
 			Enabled:              true,
 			AutoTenantActivation: false,
@@ -1330,8 +1324,7 @@ func TestExport_Validation(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -1415,8 +1408,7 @@ func TestExport_ExcludeFilter(t *testing.T) {
 				{Name: "text", DataType: []string{"text"}},
 			},
 			ReplicationConfig: &models.ReplicationConfig{
-				AsyncEnabled: true,
-				Factor:       3,
+				Factor: 3,
 			},
 			ShardingConfig: map[string]interface{}{
 				"desiredCount": float64(1),
@@ -1479,8 +1471,7 @@ func TestExport_DuplicateID(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -1517,8 +1508,7 @@ func TestExport_ConcurrentExport(t *testing.T) {
 				{Name: "text", DataType: []string{"text"}},
 			},
 			ReplicationConfig: &models.ReplicationConfig{
-				AsyncEnabled: true,
-				Factor:       3,
+				Factor: 3,
 			},
 			ShardingConfig: map[string]interface{}{
 				"desiredCount": float64(1),
@@ -1565,8 +1555,7 @@ func TestExport_Cancel(t *testing.T) {
 				{Name: "text", DataType: []string{"text"}},
 			},
 			ReplicationConfig: &models.ReplicationConfig{
-				AsyncEnabled: true,
-				Factor:       3,
+				Factor: 3,
 			},
 			ShardingConfig: map[string]interface{}{
 				"desiredCount": float64(1),
@@ -1606,8 +1595,7 @@ func TestExport_Cancel(t *testing.T) {
 				{Name: "text", DataType: []string{"text"}},
 			},
 			ReplicationConfig: &models.ReplicationConfig{
-				AsyncEnabled: true,
-				Factor:       3,
+				Factor: 3,
 			},
 			ShardingConfig: map[string]interface{}{
 				"desiredCount": float64(1),
@@ -1654,8 +1642,7 @@ func TestExport_Cancel_AlreadyFinished(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -1689,8 +1676,7 @@ func TestExport_RejectsWithoutAsyncReplication(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			Factor:       3,
-			AsyncEnabled: false,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -1720,8 +1706,7 @@ func TestExport_SequentialSnapshots(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -437,7 +437,6 @@ func (m *Handler) setNewClassDefaults(class *models.Class, globalCfg replication
 		class.ReplicationConfig = &models.ReplicationConfig{
 			Factor:           int64(m.config.Replication.MinimumFactor),
 			DeletionStrategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
-			AsyncEnabled:     false,
 		}
 		return nil
 	}

--- a/usecases/schema/schema_comparison_test.go
+++ b/usecases/schema/schema_comparison_test.go
@@ -247,7 +247,7 @@ func Test_SchemaComparison_VariousMismatches(t *testing.T) {
 		"class Foo: module config mismatch: " +
 			"L has \"bar\", but R has null",
 		"class Foo: replication config mismatch: " +
-			"L has {\"asyncEnabled\":false,\"factor\":7}, but R has {\"asyncEnabled\":false,\"factor\":8}",
+			"L has {\"factor\":7}, but R has {\"factor\":8}",
 		"class Foo: sharding config mismatch: " +
 			"L has {\"desiredCount\":7}, but R has null",
 		"class Foo: vector index config mismatch: " +


### PR DESCRIPTION
### What's being changed:

This pull request removes the `asyncEnabled` field and related logic from the replication configuration throughout the codebase. Asynchronous replication is now automatically enabled for classes with a replication factor greater than one, unless it is globally disabled. The changes simplify the configuration and usage of asynchronous replication, and update relevant documentation, logic, and tests accordingly.

Key changes:

**Replication configuration and logic simplification:**
* Removed the `AsyncEnabled` field from the `ReplicationConfig` struct and all related logic, making async replication automatically enabled for replication factor > 1 unless globally disabled (`entities/models/replication_config.go`, `adapters/repos/db/index.go`, `adapters/repos/db/export.go`, `adapters/repos/db/init.go`, `adapters/repos/db/migrator.go`, `entities/deepcopy/models_deepcopy.go`) [[1]](diffhunk://#diff-f7a4b71559d4f34941ce802e62a477a7b2c0b43ac146dbdca12e5177ee070393L37-L39) [[2]](diffhunk://#diff-d080e5efa621477a1d974bced14c39a8912fcb7a649eb4a0fb219647728dbc3dL938) [[3]](diffhunk://#diff-d080e5efa621477a1d974bced14c39a8912fcb7a649eb4a0fb219647728dbc3dL1247-R1241) [[4]](diffhunk://#diff-4785303795f90f63d52ea0f1be5460cb4eb451a01faa72babc26ea4478c2a04cL131-R142) [[5]](diffhunk://#diff-781b381d5b43bd7163ae9e705641ff67efb27a7fd1910b4587a05c3ed49cefadL180) [[6]](diffhunk://#diff-0dc6dc729205ff405d67d356b2577d699eac6b2b9bb6c128a668a263e6db796bL204) [[7]](diffhunk://#diff-7bec264c04f9d0ea616fb294423dbc014315e4bbfa576e671d0b7dcc79effb87L49).
* Updated the async replication logic to rely solely on the replication factor and global config, removing checks and settings related to the now-removed `AsyncEnabled` field (`adapters/repos/db/index.go`, `adapters/repos/db/export.go`) [[1]](diffhunk://#diff-d080e5efa621477a1d974bced14c39a8912fcb7a649eb4a0fb219647728dbc3dL1247-R1241) [[2]](diffhunk://#diff-4785303795f90f63d52ea0f1be5460cb4eb451a01faa72babc26ea4478c2a04cL131-R142).

**API and documentation updates:**
* Removed the `asyncEnabled` property from OpenAPI specs and embedded swagger documentation, reflecting the new configuration approach (`openapi-specs/schema.json`, `adapters/handlers/rest/embedded_spec.go`) [[1]](diffhunk://#diff-6e46d1a078f97315e53e6f21a97a0d18ac955212f3272ad75cfe0db74a248398L890-L894) [[2]](diffhunk://#diff-e49c3ba8135ff9dccd5dbd02e994c19e5ecdea21a382cfd3455eb97e290cd939L8951-L8955) [[3]](diffhunk://#diff-e49c3ba8135ff9dccd5dbd02e994c19e5ecdea21a382cfd3455eb97e290cd939L19500-L19504).

**Test updates:**
* Removed all usage and references to `AsyncEnabled` in test setup and schema definitions, ensuring tests align with the new async replication behavior (`test/acceptance/replication/async_replication/*`, `test/acceptance/replication/replica_replication/*`, `test/acceptance/grpc/batching_test.go`, `test/acceptance/recovery/scale_down_after_remove_node_test.go`, `test/acceptance/replication/replica_replication/scale/scale_test.go`) [[1]](diffhunk://#diff-ff44e4436fe8e9d4c9e24c6d3cc784629cfb46076a484c19b73741f4f7f15708L455-L460) [[2]](diffhunk://#diff-738288ad51cd644cf2ad8c607a3eca2be01fdd5ca4e7a86f222640816601e576L65) [[3]](diffhunk://#diff-bd3b11dad676e305f8dbf43f3e74ba7991e09484d5cda8ecc24d069807a13ef3L58) [[4]](diffhunk://#diff-2d07e29dea7e56d6c0d3419a41b6c00862a9c923325042ae71013ef92600cc0aL57) [[5]](diffhunk://#diff-b04eb44aced6213fed61b25beb854b735453273955149b89accdd750b09c5585L82) [[6]](diffhunk://#diff-b04eb44aced6213fed61b25beb854b735453273955149b89accdd750b09c5585L186) [[7]](diffhunk://#diff-b04eb44aced6213fed61b25beb854b735453273955149b89accdd750b09c5585L212) [[8]](diffhunk://#diff-907549aaad1929e49947a54512fcf5c27505e47c178c364f91a28599208f39dbL99-L105) [[9]](diffhunk://#diff-513ab449abb83b81882d7b94808f5917fe0a0be0946ea25373a0cdf8e2e76437L58) [[10]](diffhunk://#diff-fc4dd5921c0e9bead2b9f3e3d248221d560aa8a653d82c2bf5588ac6cb2caf68L96-L103) [[11]](diffhunk://#diff-fc4dd5921c0e9bead2b9f3e3d248221d560aa8a653d82c2bf5588ac6cb2caf68L277) [[12]](diffhunk://#diff-fc4dd5921c0e9bead2b9f3e3d248221d560aa8a653d82c2bf5588ac6cb2caf68L288) [[13]](diffhunk://#diff-fc4dd5921c0e9bead2b9f3e3d248221d560aa8a653d82c2bf5588ac6cb2caf68L472-R468) [[14]](diffhunk://#diff-fc4dd5921c0e9bead2b9f3e3d248221d560aa8a653d82c2bf5588ac6cb2caf68L483-R478) [[15]](diffhunk://#diff-d3cc4e8c450225081bc1030c9e3808bc834db8bbe45da2671d844b067a4aef8dL86) [[16]](diffhunk://#diff-d3cc4e8c450225081bc1030c9e3808bc834db8bbe45da2671d844b067a4aef8dL279).

**Minor improvements:**
* Added a nil check for `globalreplicationConfig` in `asyncReplicationGloballyDisabled` for robustness (`adapters/repos/db/index.go`).

These changes collectively make the configuration and management of asynchronous replication more straightforward and less error-prone.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
