### PR TITLE
hnsw: restore 32KB WAL write buffer

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -104,7 +104,7 @@ func NewCommitLogger(rootPath, name string, logger logrus.FieldLogger,
 
 	l.currentFile = fd
 	l.currentFileName = fileName
-	l.currentWriter = bufio.NewWriter(fd)
+	l.currentWriter = bufio.NewWriterSize(fd, 32*1024)
 	l.walWriter = compact.NewWALWriter(l.currentWriter)
 
 	// Create compactor for maintenance
@@ -524,7 +524,7 @@ func (l *hnswCommitLogger) switchCommitLogs(force bool) (bool, error) {
 
 	l.currentFile = fd
 	l.currentFileName = filePath
-	l.currentWriter = bufio.NewWriter(fd)
+	l.currentWriter = bufio.NewWriterSize(fd, 32*1024)
 	l.walWriter = compact.NewWALWriter(l.currentWriter)
 
 	return true, nil


### PR DESCRIPTION
## Summary

- Restore the 32KB `bufio.Writer` buffer that the previous commit logger used. The new code defaulted to `bufio.NewWriter` (4KB), causing ~8x more frequent flushes on the hottest write path during HNSW construction.

## Context

Analysis in https://github.com/weaviate/0-weaviate-issues/issues/199 identified this as the most likely contributor to the ~15% import time regression observed with `hnsw-compact-v2`, especially under RQ compression.

## Test plan

- [ ] Re-run the import benchmark (hundreds of thousands of objects with RQ compression) and compare total import time against `hnsw-compact-v2` without this fix


🤖 Generated with [Claude Code](https://claude.com/claude-code)