### PR TITLE
Fix concurrent sends and dropped reports in SSB

### DIFF
--- a/adapters/handlers/grpc/v1/batch/queues.go
+++ b/adapters/handlers/grpc/v1/batch/queues.go
@@ -12,6 +12,8 @@
 package batch
 
 import (
+	"context"
+	"fmt"
 	"math"
 	"sync"
 	"time"
@@ -99,7 +101,7 @@ func NewProcessingQueue() processingQueue {
 
 func NewReportingQueues() *reportingQueues {
 	return &reportingQueues{
-		queues: make(map[string]reportingQueue),
+		queues: make(map[string]reportingQueue, 256),
 		closed: make(map[string]struct{}),
 	}
 }
@@ -137,18 +139,18 @@ func (r *reportingQueues) delete(streamId string) {
 	delete(r.closed, streamId)
 }
 
-func (r *reportingQueues) send(streamId string, successes []*pb.BatchStreamReply_Results_Success, errors []*pb.BatchStreamReply_Results_Error, stats *workerStats) bool {
+func (r *reportingQueues) send(streamCtx context.Context, streamId string, successes []*pb.BatchStreamReply_Results_Success, errors []*pb.BatchStreamReply_Results_Error, stats *workerStats) error {
 	r.lock.RLock()
 	defer r.lock.RUnlock()
 	queue, ok := r.queues[streamId]
 	if !ok {
-		return false
+		return fmt.Errorf("reporting queue not found for stream ID: %s", streamId)
 	}
 	select {
 	case queue <- &report{Successes: successes, Errors: errors, Stats: stats}:
-		return true
-	case <-time.After(1 * time.Second):
-		return false
+		return nil
+	case <-streamCtx.Done():
+		return streamCtx.Err()
 	}
 }
 

--- a/adapters/handlers/grpc/v1/batch/queues.go
+++ b/adapters/handlers/grpc/v1/batch/queues.go
@@ -13,6 +13,7 @@ package batch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"sync"
@@ -20,6 +21,8 @@ import (
 
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
+
+var errReportingQueueClosed = errors.New("reporting queue closed")
 
 const OOM_WAIT_TIME = 300
 
@@ -100,67 +103,96 @@ func NewProcessingQueue() processingQueue {
 }
 
 func NewReportingQueues() *reportingQueues {
-	return &reportingQueues{
-		queues: make(map[string]reportingQueue, 256),
-		closed: make(map[string]struct{}),
-	}
+	return &reportingQueues{}
 }
 
+// reportingQueues is a registry of per-stream reporting channels. Each stream owns its
+// own lifecycle synchronization via streamQueue, so a slow consumer on one stream does
+// not block operations on any other.
 type reportingQueues struct {
-	lock   sync.RWMutex
-	queues map[string]reportingQueue
-	closed map[string]struct{}
+	queues sync.Map // map[string]*streamQueue
 }
 
-// Get retrieves the read queue for the given stream ID.
-func (r *reportingQueues) Get(streamId string) (reportingQueue, bool) {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
-	queue, ok := r.queues[streamId]
-	return queue, ok
+// streamQueue is a per-stream reporting channel with done-channel + sends-WG semantics
+// so that close can signal in-flight senders to abort, wait for them to release, and
+// then close the underlying channel — without holding any cross-stream lock.
+type streamQueue struct {
+	ch        reportingQueue
+	done      chan struct{}
+	sendsWg   sync.WaitGroup
+	mu        sync.Mutex
+	closed    bool
+	closeOnce sync.Once
 }
 
-func (r *reportingQueues) close(streamId string) {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	if queue, ok := r.queues[streamId]; ok {
-		if _, alreadyClosed := r.closed[streamId]; alreadyClosed {
-			return
-		}
-		close(queue)
-		r.closed[streamId] = struct{}{}
+func newStreamQueue() *streamQueue {
+	return &streamQueue{
+		ch:   make(reportingQueue),
+		done: make(chan struct{}),
 	}
 }
 
-func (r *reportingQueues) delete(streamId string) {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	delete(r.queues, streamId)
-	delete(r.closed, streamId)
-}
-
-func (r *reportingQueues) send(streamCtx context.Context, streamId string, successes []*pb.BatchStreamReply_Results_Success, errors []*pb.BatchStreamReply_Results_Error, stats *workerStats) error {
-	r.lock.RLock()
-	defer r.lock.RUnlock()
-	queue, ok := r.queues[streamId]
-	if !ok {
-		return fmt.Errorf("reporting queue not found for stream ID: %s", streamId)
+func (sq *streamQueue) send(streamCtx context.Context, r *report) error {
+	sq.mu.Lock()
+	if sq.closed {
+		sq.mu.Unlock()
+		return errReportingQueueClosed
 	}
+	sq.sendsWg.Add(1)
+	sq.mu.Unlock()
+	defer sq.sendsWg.Done()
+
 	select {
-	case queue <- &report{Successes: successes, Errors: errors, Stats: stats}:
+	case sq.ch <- r:
 		return nil
+	case <-sq.done:
+		return errReportingQueueClosed
 	case <-streamCtx.Done():
 		return streamCtx.Err()
 	}
 }
 
+func (sq *streamQueue) close() {
+	sq.closeOnce.Do(func() {
+		sq.mu.Lock()
+		sq.closed = true
+		sq.mu.Unlock()
+		close(sq.done)
+		sq.sendsWg.Wait()
+		close(sq.ch)
+	})
+}
+
+// Get returns the read end of the reporting channel for streamId.
+func (r *reportingQueues) Get(streamId string) (reportingQueue, bool) {
+	v, ok := r.queues.Load(streamId)
+	if !ok {
+		return nil, false
+	}
+	return v.(*streamQueue).ch, true
+}
+
+func (r *reportingQueues) close(streamId string) {
+	if v, ok := r.queues.Load(streamId); ok {
+		v.(*streamQueue).close()
+	}
+}
+
+func (r *reportingQueues) delete(streamId string) {
+	r.queues.Delete(streamId)
+}
+
+func (r *reportingQueues) send(streamCtx context.Context, streamId string, successes []*pb.BatchStreamReply_Results_Success, errs []*pb.BatchStreamReply_Results_Error, stats *workerStats) error {
+	v, ok := r.queues.Load(streamId)
+	if !ok {
+		return fmt.Errorf("reporting queue not found for stream ID: %s", streamId)
+	}
+	return v.(*streamQueue).send(streamCtx, &report{Successes: successes, Errors: errs, Stats: stats})
+}
+
 // Make initializes a reporting queue for the given stream ID if it does not already exist.
 func (r *reportingQueues) Make(streamId string) {
-	r.lock.Lock()
-	defer r.lock.Unlock()
-	if _, ok := r.queues[streamId]; !ok {
-		r.queues[streamId] = make(reportingQueue)
-	}
+	r.queues.LoadOrStore(streamId, newStreamQueue())
 }
 
 type workerStats struct {

--- a/adapters/handlers/grpc/v1/batch/queues_test.go
+++ b/adapters/handlers/grpc/v1/batch/queues_test.go
@@ -12,10 +12,12 @@
 package batch
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
 func Test_statsUpdateBatchSize(t *testing.T) {
@@ -57,4 +59,65 @@ func Test_statsUpdateBatchSize(t *testing.T) {
 		require.Equal(t, 1000, stats.getBatchSize())
 		// when it takes less than 1s to process, the batch size should increase, but not above 1000
 	})
+}
+
+func TestReportingQueueSendBlocksUntilDelivery(t *testing.T) {
+	streamId := "test-stream-blocks-until-delivery"
+	q := NewReportingQueues()
+	q.Make(streamId)
+
+	successes := []*pb.BatchStreamReply_Results_Success{
+		{Detail: &pb.BatchStreamReply_Results_Success_Uuid{Uuid: "uuid-1"}},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- q.send(t.Context(), streamId, successes, nil, &workerStats{processingTime: time.Second})
+	}()
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("send returned prematurely: %v", err)
+	case <-time.After(2 * time.Second):
+	}
+
+	rq, ok := q.Get(streamId)
+	require.True(t, ok)
+	report := <-rq
+	require.Len(t, report.Successes, 1)
+	require.Equal(t, "uuid-1", report.Successes[0].GetUuid())
+
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("send did not return after queue drained")
+	}
+}
+
+func TestReportingQueueSendCancelsOnStreamCtx(t *testing.T) {
+	streamId := "test-stream-cancels-on-streamctx"
+	q := NewReportingQueues()
+	q.Make(streamId)
+
+	streamCtx, cancel := context.WithCancel(t.Context())
+
+	successes := []*pb.BatchStreamReply_Results_Success{
+		{Detail: &pb.BatchStreamReply_Results_Success_Uuid{Uuid: "uuid-1"}},
+	}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- q.send(streamCtx, streamId, successes, nil, &workerStats{processingTime: time.Second})
+	}()
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("send did not return after streamCtx cancel")
+	}
 }

--- a/adapters/handlers/grpc/v1/batch/queues_test.go
+++ b/adapters/handlers/grpc/v1/batch/queues_test.go
@@ -95,6 +95,42 @@ func TestReportingQueueSendBlocksUntilDelivery(t *testing.T) {
 	}
 }
 
+func TestReportingQueueCloseUnblocksBlockedSend(t *testing.T) {
+	streamId := "test-stream-close-unblocks-send"
+	q := NewReportingQueues()
+	q.Make(streamId)
+
+	successes := []*pb.BatchStreamReply_Results_Success{
+		{Detail: &pb.BatchStreamReply_Results_Success_Uuid{Uuid: "uuid-1"}},
+	}
+
+	sendCh := make(chan error, 1)
+	go func() {
+		sendCh <- q.send(t.Context(), streamId, successes, nil, &workerStats{processingTime: time.Second})
+	}()
+
+	time.Sleep(10 * time.Millisecond) // let the send goroutine park in the select
+
+	closeCh := make(chan struct{})
+	go func() {
+		q.close(streamId)
+		close(closeCh)
+	}()
+
+	select {
+	case <-closeCh:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("close did not complete promptly with a blocked send")
+	}
+
+	select {
+	case err := <-sendCh:
+		require.ErrorIs(t, err, errReportingQueueClosed)
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("send did not return after close")
+	}
+}
+
 func TestReportingQueueSendCancelsOnStreamCtx(t *testing.T) {
 	streamId := "test-stream-cancels-on-streamctx"
 	q := NewReportingQueues()

--- a/adapters/handlers/grpc/v1/batch/stream.go
+++ b/adapters/handlers/grpc/v1/batch/stream.go
@@ -66,6 +66,7 @@ type StreamHandler struct {
 	allocChecker           memwatch.AllocChecker
 	memInFlight            atomic.Int64
 	schemaManager          schemaManager
+	streamMux              sync.Mutex
 }
 
 func NewStreamHandler(
@@ -96,6 +97,7 @@ func NewStreamHandler(
 		// this ensures that vectors can be stored in-memory before being processed downstream
 		allocChecker:  memwatch.NewMonitor(memwatch.LiveHeapReader, debug.SetMemoryLimit, 0.8),
 		schemaManager: schemaManager,
+		streamMux:     sync.Mutex{},
 	}
 	return h
 }
@@ -186,7 +188,7 @@ func (h *StreamHandler) drainReportingQueue(queue reportingQueue, batchResults *
 	for report := range queue {
 		h.handleWorkerResults(report, batchResults, stream, logger)
 	}
-	if err := batchResults.send(stream); err != nil {
+	if err := batchResults.send(h, stream); err != nil {
 		logger.Errorf("failed to send final results message while draining reporting queue: %s", err)
 		return
 	}
@@ -253,20 +255,35 @@ func (h *StreamHandler) handleWorkerResults(report *report, batchResults *batchR
 		h.metrics.OnStreamError(len(report.Errors))
 	}
 	batchResults.add(report.Successes, report.Errors)
-	if innerErr := batchResults.send(stream); innerErr != nil {
+	if innerErr := batchResults.send(h, stream); innerErr != nil {
 		logger.Errorf("failed to send results message: %s", innerErr)
 		return
 	}
 	batchResults.reset()
 }
 
+// send sends a message through the stream with proper locking to prevent concurrent sends which would cause the stream to error out.
+func (h *StreamHandler) send(stream pb.Weaviate_BatchStreamServer, msg *pb.BatchStreamReply) error {
+	h.streamMux.Lock()
+	defer h.streamMux.Unlock()
+	if err := stream.Send(msg); err != nil {
+		return fmt.Errorf("send message: %w", err)
+	}
+	return nil
+}
+
+// sender is the main loop for sending messages back to the client through the stream.
+//
+// It listens for reports from workers through the stream-specific reporting queue and for errors from the receiver goroutine through the recvErrCh channel.
+//
+// It also listens for shutdown signals to stop accepting new messages and to eventually close the stream gracefully.
 func (h *StreamHandler) sender(ctx context.Context, streamId string, stream pb.Weaviate_BatchStreamServer, recvErrCh chan error) error {
 	defer h.stoppingPerStream.Delete(streamId)
 	log := h.logger.WithField("streamId", streamId)
 	// shuttingDown acts as a soft cancel here so we can send the shutting down message to the client.
 	// Once the workers are drained then h.shutdownFinished will be closed and we will shutdown completely
 	shuttingDownDone := h.shuttingDownCtx.Done()
-	if err := stream.Send(newBatchStartedMessage()); err != nil {
+	if err := h.send(stream, newBatchStartedMessage()); err != nil {
 		log.Errorf("failed to send started message: %s", err)
 		return fmt.Errorf("send started message: %w", err)
 	}
@@ -307,7 +324,7 @@ func (h *StreamHandler) sender(ctx context.Context, streamId string, stream pb.W
 			}
 		case report, open := <-reportingQueue:
 			if !open {
-				if err := batchResults.send(stream); err != nil {
+				if err := batchResults.send(h, stream); err != nil {
 					log.Errorf("failed to send final results message after reporting queue closed: %s", err)
 				}
 				log.Debug("reportingQueue is closed, closing stream")
@@ -325,7 +342,7 @@ func (h *StreamHandler) sender(ctx context.Context, streamId string, stream pb.W
 			batchSize := h.workerStats(streamId).getBatchSize()
 			batchResults.updateBatchSize(batchSize)
 			log.WithField("batchSize", batchSize).Debug("sending backoff message to client")
-			if err := stream.Send(newBatchBackoffMessage(batchSize)); err != nil {
+			if err := h.send(stream, newBatchBackoffMessage(batchSize)); err != nil {
 				log.Errorf("failed to send backoff message: %s", err)
 				return fmt.Errorf("send backoff message: %w", err)
 			}
@@ -365,6 +382,11 @@ func (h *StreamHandler) recv(stream pb.Weaviate_BatchStreamServer) (chan *pb.Bat
 	return reqCh, errCh
 }
 
+// receiver is the main loop for receiving messages from the client through the stream.
+//
+// It receives messages from the stream and pushes them to the processing queue for downstream workers to pick up.
+//
+// It also listens for shutdown signals to stop accepting new messages and to eventually close the stream gracefully.
 func (h *StreamHandler) receiver(ctx context.Context, streamId string, consistencyLevel *pb.ConsistencyLevel, stream pb.Weaviate_BatchStreamServer) error {
 	log := h.logger.WithField("streamId", streamId)
 
@@ -488,7 +510,7 @@ func (h *StreamHandler) receiver(ctx context.Context, streamId string, consisten
 				beacons = append(beacons, toBeacon(ref))
 			}
 			// Acknowledge receipt of these objects and/or references from the message
-			if err := stream.Send(newBatchAcksMessage(uuids, beacons)); err != nil {
+			if err := h.send(stream, newBatchAcksMessage(uuids, beacons)); err != nil {
 				log.Errorf("failed to send acks message: %s", err)
 				return fmt.Errorf("send acks message: %w", err)
 			}
@@ -591,11 +613,11 @@ func (r *batchResults) reset() {
 	r.errors = r.errors[:0]
 }
 
-func (r *batchResults) send(stream pb.Weaviate_BatchStreamServer) error {
+func (r *batchResults) send(handler *StreamHandler, stream pb.Weaviate_BatchStreamServer) error {
 	if len(r.successes) == 0 && len(r.errors) == 0 {
 		return nil
 	}
-	if err := stream.Send(newBatchResultsMessage(r.successes, r.errors)); err != nil {
+	if err := handler.send(stream, newBatchResultsMessage(r.successes, r.errors)); err != nil {
 		return err
 	}
 	return nil

--- a/adapters/handlers/grpc/v1/batch/stream.go
+++ b/adapters/handlers/grpc/v1/batch/stream.go
@@ -97,7 +97,6 @@ func NewStreamHandler(
 		// this ensures that vectors can be stored in-memory before being processed downstream
 		allocChecker:  memwatch.NewMonitor(memwatch.LiveHeapReader, debug.SetMemoryLimit, 0.8),
 		schemaManager: schemaManager,
-		streamMux:     sync.Mutex{},
 	}
 	return h
 }
@@ -188,9 +187,11 @@ func (h *StreamHandler) drainReportingQueue(queue reportingQueue, batchResults *
 	for report := range queue {
 		h.handleWorkerResults(report, batchResults, stream, logger)
 	}
-	if err := batchResults.send(h, stream); err != nil {
-		logger.Errorf("failed to send final results message while draining reporting queue: %s", err)
-		return
+	if res := batchResults.build(); res != nil {
+		if err := h.send(stream, res); err != nil {
+			logger.Errorf("failed to send final results message while draining reporting queue: %s", err)
+			return
+		}
 	}
 	batchResults.reset()
 }
@@ -199,7 +200,7 @@ func (h *StreamHandler) handleRecvErr(recvErr error, stream pb.Weaviate_BatchStr
 	var oomErr *oom
 	if errors.As(recvErr, &oomErr) {
 		logger.Warnf("receive error due to memory pressure: %v", recvErr)
-		if err := stream.Send(newBatchOutOfMemoryMessage(oomErr.uuids, oomErr.beacons)); err != nil {
+		if err := h.send(stream, newBatchOutOfMemoryMessage(oomErr.uuids, oomErr.beacons)); err != nil {
 			logger.Errorf("failed to send out of memory message: %s", err)
 		}
 		// return nil to close the stream gracefully after sending the out of memory message
@@ -229,7 +230,7 @@ func (h *StreamHandler) handleServerShuttingDown(stream pb.Weaviate_BatchStreamS
 	logger.Debug("server is shutting down, will stop accepting new requests soon")
 	// If shutting down context has been set by shutdown.Drain then send the shutdown triggered message to the client
 	// so that it can backoff accordingly
-	if innerErr := stream.Send(newBatchShuttingDownMessage()); innerErr != nil {
+	if innerErr := h.send(stream, newBatchShuttingDownMessage()); innerErr != nil {
 		logger.Errorf("failed to send shutdown triggered message: %s", innerErr)
 		return innerErr
 	}
@@ -255,9 +256,11 @@ func (h *StreamHandler) handleWorkerResults(report *report, batchResults *batchR
 		h.metrics.OnStreamError(len(report.Errors))
 	}
 	batchResults.add(report.Successes, report.Errors)
-	if innerErr := batchResults.send(h, stream); innerErr != nil {
-		logger.Errorf("failed to send results message: %s", innerErr)
-		return
+	if res := batchResults.build(); res != nil {
+		if innerErr := h.send(stream, res); innerErr != nil {
+			logger.Errorf("failed to send results message: %s", innerErr)
+			return
+		}
 	}
 	batchResults.reset()
 }
@@ -324,8 +327,10 @@ func (h *StreamHandler) sender(ctx context.Context, streamId string, stream pb.W
 			}
 		case report, open := <-reportingQueue:
 			if !open {
-				if err := batchResults.send(h, stream); err != nil {
-					log.Errorf("failed to send final results message after reporting queue closed: %s", err)
+				if res := batchResults.build(); res != nil {
+					if err := h.send(stream, res); err != nil {
+						log.Errorf("failed to send final results message after reporting queue closed: %s", err)
+					}
 				}
 				log.Debug("reportingQueue is closed, closing stream")
 				recvErr := <-recvErrCh
@@ -613,14 +618,11 @@ func (r *batchResults) reset() {
 	r.errors = r.errors[:0]
 }
 
-func (r *batchResults) send(handler *StreamHandler, stream pb.Weaviate_BatchStreamServer) error {
+func (r *batchResults) build() *pb.BatchStreamReply {
 	if len(r.successes) == 0 && len(r.errors) == 0 {
 		return nil
 	}
-	if err := handler.send(stream, newBatchResultsMessage(r.successes, r.errors)); err != nil {
-		return err
-	}
-	return nil
+	return newBatchResultsMessage(r.successes, r.errors)
 }
 
 func (h *StreamHandler) workerStats(streamId string) *stats {

--- a/adapters/handlers/grpc/v1/batch/stream_test.go
+++ b/adapters/handlers/grpc/v1/batch/stream_test.go
@@ -15,9 +15,12 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -265,6 +268,146 @@ func TestStreamHandler(t *testing.T) {
 		err := handler.Handle(mockStream)
 		require.NoError(t, err, "Expected no error when handling stream")
 		require.Len(t, objsCh, numObjs, "Expected all objects to be processed into mock channel")
+	})
+
+	t.Run("receiver and sender Send calls are mutually exclusive", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		mockBatcher := mocks.NewMockbatcher(t)
+		mockSchemaManager := mocks.NewMockschemaManager(t)
+		mockStream := newMockStream(t)
+		mockStream.EXPECT().Context().Return(ctx).Maybe()
+		mockAuthenticator := mocks.NewMockauthenticator(t)
+		mockAuthenticator.EXPECT().PrincipalFromContext(ctx).Return(&models.Principal{}, nil).Once()
+
+		const numBatches = 100
+		collection := "TestClass"
+
+		var inFlight atomic.Int32
+		var maxObserved atomic.Int32
+		mockStream.EXPECT().Send(mock.Anything).RunAndReturn(func(msg *pb.BatchStreamReply) error {
+			n := inFlight.Add(1)
+			for {
+				prev := maxObserved.Load()
+				if n <= prev || maxObserved.CompareAndSwap(prev, n) {
+					break
+				}
+			}
+			if n > 1 {
+				t.Errorf("concurrent Send detected: %d goroutines in flight", n)
+			}
+			time.Sleep(time.Microsecond) // widen the race window
+			inFlight.Add(-1)
+			return nil
+		}).Maybe()
+
+		recvCount := 0
+		mockStream.EXPECT().Recv().RunAndReturn(func() (*pb.BatchStreamRequest, error) {
+			recvCount++
+			switch {
+			case recvCount == 1:
+				return newBatchStreamStartRequest(), nil
+			case recvCount <= numBatches+1:
+				return newBatchStreamObjsRequest([]*pb.BatchObject{
+					{Collection: collection, Uuid: uuid.New().String()},
+				}), nil
+			default:
+				return nil, io.EOF
+			}
+		}).Times(numBatches + 2)
+
+		mockBatcher.EXPECT().BatchObjects(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *pb.BatchObjectsRequest) (*pb.BatchObjectsReply, error) {
+			return &pb.BatchObjectsReply{Took: 1}, nil
+		}).Maybe()
+		mockSchemaManager.EXPECT().GetCachedClassNoAuth(mock.Anything, collection).
+			Return(map[string]versioned.Class{collection: {Class: &models.Class{Class: collection}}}, nil).Maybe()
+
+		// numWorkers > 1 so worker Results overlap with receiver Acks in time.
+		numWorkers := 4
+		handler, _ := batch.Start(mockAuthenticator, nil, mockBatcher, mockSchemaManager, nil, numWorkers, logger)
+		err := handler.Handle(mockStream)
+		require.NoError(t, err)
+
+		require.Equal(t, int32(0), inFlight.Load())
+		require.LessOrEqual(t, maxObserved.Load(), int32(1), "stream.Send must never have more than one goroutine in flight")
+	})
+
+	t.Run("results not lost when stream Send is slow", func(t *testing.T) {
+		ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		mockBatcher := mocks.NewMockbatcher(t)
+		mockSchemaManager := mocks.NewMockschemaManager(t)
+		mockStream := newMockStream(t)
+		mockStream.EXPECT().Context().Return(ctx).Maybe()
+		mockAuthenticator := mocks.NewMockauthenticator(t)
+		mockAuthenticator.EXPECT().PrincipalFromContext(ctx).Return(&models.Principal{}, nil).Once()
+
+		const numBatches = 20
+		collection := "TestClass"
+
+		expected := make([]string, 0, numBatches)
+		for range numBatches {
+			expected = append(expected, uuid.New().String())
+		}
+
+		var slowdownsRemaining atomic.Int32
+		slowdownsRemaining.Store(3)
+
+		// Mutex-guarded so the test holds even if the concurrent-Send guard regresses.
+		var seenMu sync.Mutex
+		seen := make(map[string]struct{}, numBatches)
+
+		mockStream.EXPECT().Send(mock.Anything).RunAndReturn(func(msg *pb.BatchStreamReply) error {
+			if results := msg.GetResults(); results != nil {
+				if slowdownsRemaining.Add(-1) >= 0 {
+					time.Sleep(1200 * time.Millisecond)
+				}
+				seenMu.Lock()
+				for _, s := range results.GetSuccesses() {
+					if u := s.GetUuid(); u != "" {
+						seen[u] = struct{}{}
+					}
+				}
+				seenMu.Unlock()
+			}
+			return nil
+		}).Maybe()
+
+		recvCount := 0
+		mockStream.EXPECT().Recv().RunAndReturn(func() (*pb.BatchStreamRequest, error) {
+			recvCount++
+			switch {
+			case recvCount == 1:
+				return newBatchStreamStartRequest(), nil
+			case recvCount <= numBatches+1:
+				return newBatchStreamObjsRequest([]*pb.BatchObject{
+					{Collection: collection, Uuid: expected[recvCount-2]},
+				}), nil
+			default:
+				return nil, io.EOF
+			}
+		}).Times(numBatches + 2)
+
+		mockBatcher.EXPECT().BatchObjects(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *pb.BatchObjectsRequest) (*pb.BatchObjectsReply, error) {
+			return &pb.BatchObjectsReply{Took: 1}, nil
+		}).Maybe()
+		mockSchemaManager.EXPECT().GetCachedClassNoAuth(mock.Anything, collection).
+			Return(map[string]versioned.Class{collection: {Class: &models.Class{Class: collection}}}, nil).Maybe()
+
+		numWorkers := 4
+		handler, _ := batch.Start(mockAuthenticator, nil, mockBatcher, mockSchemaManager, nil, numWorkers, logger)
+		err := handler.Handle(mockStream)
+		require.NoError(t, err)
+
+		seenMu.Lock()
+		got := make([]string, 0, len(seen))
+		for u := range seen {
+			got = append(got, u)
+		}
+		seenMu.Unlock()
+		require.ElementsMatch(t, expected, got)
 	})
 }
 

--- a/adapters/handlers/grpc/v1/batch/worker.go
+++ b/adapters/handlers/grpc/v1/batch/worker.go
@@ -371,7 +371,7 @@ func (w *worker) process(req *processRequest) {
 	}
 
 	stats := newWorkersStats(time.Since(start))
-	if ok := w.reportingQueues.send(req.streamId, successes, errors, stats); !ok {
-		w.logger.WithField("streamId", req.streamId).Warn("timed out sending a worker report to the reporting queue, maybe the client disconnected?")
+	if err := w.reportingQueues.send(req.streamCtx, req.streamId, successes, errors, stats); err != nil {
+		w.logger.WithField("streamId", req.streamId).Warnf("failed to send report to reporting queue: %s", err)
 	}
 }

--- a/adapters/handlers/grpc/v1/batch/worker_test.go
+++ b/adapters/handlers/grpc/v1/batch/worker_test.go
@@ -274,6 +274,91 @@ func TestWorkerLoop(t *testing.T) {
 		require.Empty(t, processingQueue, "Expected processing queue to be empty after processing")
 	})
 
+	t.Run("worker exits cleanly when streamCtx cancels mid-process and remains available", func(t *testing.T) {
+		mockBatcher := mocks.NewMockbatcher(t)
+
+		reportingQueues := NewReportingQueues()
+		reportingQueues.Make(StreamId)
+		processingQueue := NewProcessingQueue()
+
+		// Closed inside the mock so the test can cancel only after the worker is mid-call,
+		// not mid-setup (sendObjects short-circuits if ctx is already cancelled on entry).
+		batchObjectsAStarted := make(chan struct{})
+
+		mockBatcher.EXPECT().BatchObjects(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *pb.BatchObjectsRequest) (*pb.BatchObjectsReply, error) {
+			close(batchObjectsAStarted)
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(5 * time.Second):
+				return &pb.BatchObjectsReply{Took: 1}, nil
+			}
+		}).Once()
+		mockBatcher.EXPECT().BatchObjects(mock.Anything, mock.Anything).RunAndReturn(func(ctx context.Context, req *pb.BatchObjectsRequest) (*pb.BatchObjectsReply, error) {
+			return &pb.BatchObjectsReply{Took: 1}, nil
+		}).Once()
+
+		var wg sync.WaitGroup
+		StartBatchWorkers(&wg, 1, processingQueue, reportingQueues, mockBatcher, logger)
+
+		collection := "TestCollection"
+		uuidA := uuid.New().String()
+		uuidB := uuid.New().String()
+		objA := &pb.BatchObject{Collection: collection, Uuid: uuidA}
+		objB := &pb.BatchObject{Collection: collection, Uuid: uuidB}
+
+		streamCtxA, cancelA := context.WithCancel(t.Context())
+		completedA := make(chan struct{})
+
+		streamCtxB := t.Context()
+		completedB := make(chan struct{})
+
+		wg.Add(2)
+
+		go func() {
+			processingQueue <- &processRequest{
+				objects:                       []*pb.BatchObject{objA},
+				streamId:                      StreamId,
+				streamCtx:                     streamCtxA,
+				usesVectorisationByCollection: map[string]bool{collection: false},
+				onStart:                       func() {},
+				onComplete:                    func() { close(completedA); wg.Done() },
+			}
+		}()
+
+		<-batchObjectsAStarted
+		cancelA()
+
+		select {
+		case <-completedA:
+		case <-time.After(PER_PROCESS_TIMEOUT + time.Second):
+			t.Fatal("worker did not complete after streamCtx cancel")
+		}
+
+		go func() {
+			processingQueue <- &processRequest{
+				objects:                       []*pb.BatchObject{objB},
+				streamId:                      StreamId,
+				streamCtx:                     streamCtxB,
+				usesVectorisationByCollection: map[string]bool{collection: false},
+				onStart:                       func() {},
+				onComplete:                    func() { close(completedB); wg.Done() },
+			}
+		}()
+
+		rq, ok := reportingQueues.Get(StreamId)
+		require.True(t, ok)
+		report := <-rq
+		require.Len(t, report.Successes, 1)
+		require.Equal(t, uuidB, report.Successes[0].GetUuid())
+
+		<-completedB
+
+		close(processingQueue)
+		wg.Wait()
+		require.Empty(t, processingQueue)
+	})
+
 	t.Run("should fanout if request uses vectorisation returning errors correctly", func(t *testing.T) {
 		mockBatcher := mocks.NewMockbatcher(t)
 


### PR DESCRIPTION
### What's being changed:

This PR attempts to fix deadlock flakes seen in [py](https://github.com/weaviate/weaviate-python-client/actions/runs/24792391085/job/72553084688) & [ts](https://github.com/weaviate/typescript-client/actions/runs/24989953253/job/73173025727?pr=417) integration tests

In short:
1. due to `receiver` and `sender` both calling `stream.Send` without any synchronisation, concurrent sends over the stream are possible that can causing hanging/deadlocked behaviour during the batch import process
2. due to the short timeout when a worker pushes to `reportingQueue`, some reports can be lost under load leading to inconsistencies observed by the client, e.g. writes that were not reported as successful/erroring
3. because of the `RLock` within `reportingQueues` being held over the `stream.Send` call, slow clients can block workers from returning early

This PR avoids these issues by:
1. wrapping all `stream.Send` calls in a write lock
2. returning from a worker's blocked push to the `reportingQueue` only when the stream itself has been cancelled
3. refactoring `reportingQueue` to `streamQueue` that doesn't hold this lock for such a length of time

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
