### PR TITLE
Extend namespace startup check to DB Users

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -941,12 +941,23 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 				classNames = append(classNames, c.Class)
 			}
 		}
+		var userNames []string
+		if appState.APIKey != nil && appState.APIKey.Dynamic != nil {
+			users, err := appState.APIKey.Dynamic.GetUsers()
+			if err != nil {
+				l.WithError(err).Fatal("could not list dynamic DB users for namespace startup invariant")
+			}
+			for name := range users {
+				userNames = append(userNames, name)
+			}
+		}
 		if err := enforceNamespaceStartupInvariants(
 			appState.ServerConfig.Config.Namespaces.Enabled,
 			appState.ServerConfig.Config.Persistence.LSMSkipWriteClassNameEnabled,
 			appState.ServerConfig.Config.Replication.MaximumFactor,
 			classNames,
 			appState.ClusterService.NamespaceCount(),
+			userNames,
 		); err != nil {
 			l.Fatal(err)
 		}
@@ -1212,10 +1223,10 @@ func configureReindexer(recovered []db.RecoveredReindex, logger logrus.FieldLogg
 // decision logic can be unit-tested without fighting os.Exit; the caller wires
 // a non-nil return to logrus.Fatal.
 //
-// A class name is considered namespace-qualified iff it contains
+// A class or DB user name is considered namespace-qualified iff it contains
 // entschema.NamespaceSeparator (":"), which is forbidden in plain class names
-// by ClassNameRegexCore and locked by TestValidateClassName_RejectsNamespaceSeparator.
-func enforceNamespaceStartupInvariants(enabled bool, lsmSkipWriteClassNameEnabled bool, maxReplicationFactor int, classNames []string, nsCount int) error {
+// by ClassNameRegexCore and in DB user names by UserNameRegexCore.
+func enforceNamespaceStartupInvariants(enabled bool, lsmSkipWriteClassNameEnabled bool, maxReplicationFactor int, classNames []string, nsCount int, userNames []string) error {
 	var nonNamespacedCount, namespacedCount int
 	var nonNamespacedExample, namespacedExample string
 	for _, name := range classNames {
@@ -1229,6 +1240,22 @@ func enforceNamespaceStartupInvariants(enabled bool, lsmSkipWriteClassNameEnable
 				nonNamespacedExample = name
 			}
 			nonNamespacedCount++
+		}
+	}
+
+	var unqualifiedUserCount, qualifiedUserCount int
+	var unqualifiedUserExample, qualifiedUserExample string
+	for _, name := range userNames {
+		if strings.Contains(name, entschema.NamespaceSeparator) {
+			if qualifiedUserCount == 0 {
+				qualifiedUserExample = name
+			}
+			qualifiedUserCount++
+		} else {
+			if unqualifiedUserCount == 0 {
+				unqualifiedUserExample = name
+			}
+			unqualifiedUserCount++
 		}
 	}
 
@@ -1246,6 +1273,10 @@ func enforceNamespaceStartupInvariants(enabled bool, lsmSkipWriteClassNameEnable
 	case !enabled && namespacedCount > 0:
 		// Guards against disabling namespaces on a namespaced cluster.
 		return fmt.Errorf("NAMESPACES_ENABLED=false but cluster has %d namespace-qualified collection(s) (e.g. %q); refusing to start with inconsistent state", namespacedCount, namespacedExample)
+	case !enabled && qualifiedUserCount > 0:
+		return fmt.Errorf("NAMESPACES_ENABLED=false but cluster has %d DB user name(s) containing the namespace separator %q (e.g. %q); refusing to start with inconsistent state", qualifiedUserCount, entschema.NamespaceSeparator, qualifiedUserExample)
+	case enabled && unqualifiedUserCount > 0:
+		return fmt.Errorf("NAMESPACES_ENABLED=true but cluster has %d non-namespaced DB user name(s) (e.g. %q); namespaces can only be enabled on clusters whose DB users are all already namespace-qualified", unqualifiedUserCount, unqualifiedUserExample)
 	}
 	return nil
 }

--- a/adapters/handlers/rest/configure_api_namespace_invariants_test.go
+++ b/adapters/handlers/rest/configure_api_namespace_invariants_test.go
@@ -32,6 +32,7 @@ func TestEnforceNamespaceStartupInvariants(t *testing.T) {
 		maxReplicationFac            int
 		classNames                   []string
 		nsCount                      int
+		userNames                    []string
 		wantErr                      bool
 		errSubstr                    string
 	}{
@@ -127,11 +128,67 @@ func TestEnforceNamespaceStartupInvariants(t *testing.T) {
 			wantErr:    true,
 			errSubstr:  "namespace-qualified collection",
 		},
+		{
+			name:       "disabled, qualified DB user (defense in depth)",
+			enabled:    false,
+			classNames: nil,
+			nsCount:    0,
+			userNames:  []string{qualified("tenant1", "alice")},
+			wantErr:    true,
+			errSubstr:  "DB user name",
+		},
+		{
+			name:       "disabled, clean DB user",
+			enabled:    false,
+			classNames: nil,
+			nsCount:    0,
+			userNames:  []string{"alice"},
+		},
+		{
+			name:                         "enabled, qualified DB user",
+			enabled:                      true,
+			lsmSkipWriteClassNameEnabled: true,
+			maxReplicationFac:            1,
+			classNames:                   []string{qualified("t1", "Movie")},
+			nsCount:                      1,
+			userNames:                    []string{qualified("t1", "alice")},
+		},
+		{
+			name:                         "enabled, unqualified DB user",
+			enabled:                      true,
+			lsmSkipWriteClassNameEnabled: true,
+			maxReplicationFac:            1,
+			classNames:                   []string{qualified("t1", "Movie")},
+			nsCount:                      1,
+			userNames:                    []string{"alice"},
+			wantErr:                      true,
+			errSubstr:                    "non-namespaced DB user",
+		},
+		{
+			name:                         "enabled, mixed DB users — unqualified branch wins",
+			enabled:                      true,
+			lsmSkipWriteClassNameEnabled: true,
+			maxReplicationFac:            1,
+			classNames:                   []string{qualified("t1", "Movie")},
+			nsCount:                      1,
+			userNames:                    []string{qualified("t1", "alice"), "bob"},
+			wantErr:                      true,
+			errSubstr:                    "non-namespaced DB user",
+		},
+		{
+			name:       "disabled, qualified class+user — class branch wins",
+			enabled:    false,
+			classNames: []string{qualified("t1", "Movie")},
+			nsCount:    0,
+			userNames:  []string{qualified("t1", "alice")},
+			wantErr:    true,
+			errSubstr:  "namespace-qualified collection",
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := enforceNamespaceStartupInvariants(tt.enabled, tt.lsmSkipWriteClassNameEnabled, tt.maxReplicationFac, tt.classNames, tt.nsCount)
+			err := enforceNamespaceStartupInvariants(tt.enabled, tt.lsmSkipWriteClassNameEnabled, tt.maxReplicationFac, tt.classNames, tt.nsCount, tt.userNames)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tt.errSubstr)

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"sync"
@@ -366,7 +367,8 @@ func (c *DBUser) GetUsers(userIds ...string) (map[string]*User, error) {
 	defer c.lock.RUnlock()
 
 	if len(userIds) == 0 {
-		return c.data.Users, nil
+		// Clone so callers can iterate without racing concurrent writers to c.data.Users.
+		return maps.Clone(c.data.Users), nil
 	}
 
 	users := make(map[string]*User, len(userIds))


### PR DESCRIPTION
### What's being changed:

This also validates that the users are compatible with the namespace-settings at startup

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
