### PR TITLE
hnsw: fix snapshotFileName for compactv2 .sorted commit logs

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -428,8 +428,23 @@ func (l *hnswCommitLogger) calcCommitlogsSize(commitLogPaths ...string) int64 {
 }
 
 func (l *hnswCommitLogger) snapshotFileName(commitLogFileName string) string {
-	path := strings.TrimSuffix(commitLogFileName, ".condensed") + ".snapshot"
-	return strings.Replace(path, ".hnsw.commitlog.d", snapshotDirSuffix, 1)
+	dir := strings.Replace(filepath.Dir(commitLogFileName), ".hnsw.commitlog.d", snapshotDirSuffix, 1)
+	base := filepath.Base(commitLogFileName)
+
+	// Strip known commit log suffixes so the snapshot name is built from
+	// the bare timestamp(s). ".sorted" is produced by compact v2.
+	for _, suffix := range []string{".condensed", ".sorted"} {
+		base = strings.TrimSuffix(base, suffix)
+	}
+
+	// Compact v2 produces range-format files (e.g. "1000_1500"). Use the
+	// end timestamp so the resulting snapshot filename is a single integer
+	// that cleanupSnapshots and the rest of the snapshot machinery can parse.
+	if _, end, ok := strings.Cut(base, "_"); ok {
+		base = end
+	}
+
+	return filepath.Join(dir, base+".snapshot")
 }
 
 // read the directory and find the latest snapshot file

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
@@ -1790,3 +1790,47 @@ func TestMigrateCompactV2Snapshot(t *testing.T) {
 		require.NoError(t, cl.migrateCompactV2Snapshot())
 	})
 }
+
+func TestSnapshotFileName(t *testing.T) {
+	cl := &hnswCommitLogger{
+		rootPath: "/data",
+		id:       "main",
+	}
+
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "condensed file",
+			input: "/data/main.hnsw.commitlog.d/1500.condensed",
+			want:  "/data/main.hnsw.snapshot.d/1500.snapshot",
+		},
+		{
+			name:  "raw timestamp file",
+			input: "/data/main.hnsw.commitlog.d/1500",
+			want:  "/data/main.hnsw.snapshot.d/1500.snapshot",
+		},
+		{
+			// Compact v2 leftover: produced range-format .sorted files in
+			// the commit log dir. Without the fix the result was
+			// "1000_1500.sorted.snapshot", which cleanupSnapshots could
+			// not parse — this is the bug from issue #197.
+			name:  "compactv2 sorted range file",
+			input: "/data/main.hnsw.commitlog.d/1000_1500.sorted",
+			want:  "/data/main.hnsw.snapshot.d/1500.snapshot",
+		},
+		{
+			name:  "compactv2 sorted single timestamp",
+			input: "/data/main.hnsw.commitlog.d/1500.sorted",
+			want:  "/data/main.hnsw.snapshot.d/1500.snapshot",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, cl.snapshotFileName(tt.input))
+		})
+	}
+}


### PR DESCRIPTION
PR #10992 added compactv2 downgrade support but missed snapshotFileName, which builds the new snapshot path from the last commit log file. When fed a compactv2 ".sorted" or "{start}_{end}.sorted" name, it produced invalid paths like "1000_1500.sorted.snapshot" that later broke cleanupSnapshots:

  strconv.ParseInt: parsing "1000_1500.sorted": invalid syntax

Strip ".sorted" alongside ".condensed" and collapse range names to the end timestamp so the result is always "{ts}.snapshot".

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
