### PR TITLE
hnsw: fix off-by-one in isEmptyUnlocked causing panic on zero-length nodes

### DIFF
--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -703,7 +703,7 @@ func (h *hnsw) isEmpty() bool {
 }
 
 func (h *hnsw) isEmptyUnlocked() bool {
-	return h.entryPointID > uint64(len(h.nodes)) || h.nodes[h.entryPointID] == nil
+	return h.entryPointID >= uint64(len(h.nodes)) || h.nodes[h.entryPointID] == nil
 }
 
 func (h *hnsw) nodeByID(id uint64) *vertex {

--- a/adapters/repos/db/vector/hnsw/index_test.go
+++ b/adapters/repos/db/vector/hnsw/index_test.go
@@ -259,6 +259,50 @@ func createVectorHnswIndexTestConfig() Config {
 	}
 }
 
+func TestIsEmptyUnlocked_ZeroLengthNodes(t *testing.T) {
+	// Regression test: when h.nodes has length 0 and h.entryPointID is 0,
+	// isEmptyUnlocked must return true without panicking. Before the fix,
+	// the check used ">" instead of ">=" which caused an out-of-bounds
+	// access: h.nodes[0] on a zero-length slice.
+	t.Run("zero-length nodes slice must not panic", func(t *testing.T) {
+		index := createEmptyHnswIndexForTests(t, testVectorForID)
+		// Simulate state loaded from a snapshot with zero nodes
+		index.shardedNodeLocks.LockAll()
+		index.nodes = make([]*vertex, 0)
+		index.shardedNodeLocks.UnlockAll()
+		index.entryPointID = 0
+
+		assert.NotPanics(t, func() {
+			assert.True(t, index.isEmpty())
+		})
+	})
+
+	t.Run("entryPointID beyond nodes length must not panic", func(t *testing.T) {
+		index := createEmptyHnswIndexForTests(t, testVectorForID)
+		index.shardedNodeLocks.LockAll()
+		index.nodes = make([]*vertex, 5)
+		index.shardedNodeLocks.UnlockAll()
+		index.entryPointID = 5
+
+		assert.NotPanics(t, func() {
+			assert.True(t, index.isEmpty())
+		})
+	})
+
+	t.Run("search on empty nodes returns nil without panic", func(t *testing.T) {
+		index := createEmptyHnswIndexForTests(t, testVectorForID)
+		index.shardedNodeLocks.LockAll()
+		index.nodes = make([]*vertex, 0)
+		index.shardedNodeLocks.UnlockAll()
+		index.entryPointID = 0
+
+		res, dists, err := index.SearchByVector(context.Background(), []float32{0.1, 0.2, 0.3}, 10, nil)
+		assert.NoError(t, err)
+		assert.Nil(t, res)
+		assert.Nil(t, dists)
+	})
+}
+
 func TestHnswIndexContainsDoc(t *testing.T) {
 	testHnswIndexContainsDoc(t, genericVecTestHelperSingle())
 }


### PR DESCRIPTION
## Summary

- Fix off-by-one bounds check in `isEmptyUnlocked()`: `>` → `>=`. When `h.nodes` has length 0 and `h.entryPointID` is 0, the old check `0 > 0` evaluated to false, falling through to `h.nodes[0]` which panics.
- Add regression test `TestIsEmptyUnlocked_ZeroLengthNodes` covering three scenarios: zero-length nodes, entryPointID at boundary, and `SearchByVector` on empty nodes.

## Context

Found via CI triage of [this e2e failure](https://github.com/weaviate/weaviate-e2e-tests/actions/runs/24989964106/job/73172895182). During an upgrade/downgrade cycle, a snapshot with zero nodes is loaded, producing `h.nodes = make([]*vertex, 0)`. A subsequent search hits `knnSearchByVector` → `isEmpty()` → `isEmptyUnlocked()`, which skips the empty check and panics on the zero-length slice access.

Fixes https://github.com/weaviate/0-weaviate-issues/issues/200.

## Test plan

- [x] `TestIsEmptyUnlocked_ZeroLengthNodes` passes locally
- [ ] e2e `test_post_upgrade_mixedvector` no longer panics


🤖 Generated with [Claude Code](https://claude.com/claude-code)