### PR TITLE
compactv2: migrate all compactv2 files during startup

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -426,25 +426,31 @@ func (l *hnswCommitLogger) cleanupCompactV2TempFiles() error {
 	return nil
 }
 
-func (l *hnswCommitLogger) initSnapshotData() error {
-	// Migrate compact v2 snapshots from the commitlog directory to the
-	// snapshot directory. This enables downgrade compatibility: compact v2
-	// stores snapshots alongside commit logs, but the current version
-	// expects them in a separate directory.
+// migrateFromCompactV2 normalizes any compact v2 on-disk artifacts so the
+// rest of the commit logger only sees v1.37 native formats. Runs once at
+// startup and is a no-op when no compact v2 artifacts are present.
+// Failures are logged but non-fatal: a partial migration leaves some
+// artifacts in place rather than blocking startup.
+func (l *hnswCommitLogger) migrateFromCompactV2() {
+	// .snapshot files in the commitlog dir → snapshot dir.
 	if err := l.migrateCompactV2Snapshot(); err != nil {
 		l.logger.Warnf("failed to migrate compact v2 snapshot: %v", err)
 	}
 
-	// Rename compact v2 .sorted commit log files to .condensed so the rest
-	// of the commit logger doesn't have to know about the .sorted format.
+	// .sorted commit log files → .condensed (a .sorted file is just a
+	// re-ordered WAL, so renaming is enough).
 	if err := l.migrateCompactV2SortedFiles(); err != nil {
 		l.logger.Warnf("failed to migrate compact v2 sorted files: %v", err)
 	}
 
-	// Remove orphan .tmp files left behind by a crashed compact v2 write.
+	// Orphan .tmp leftovers from a crashed compact v2 write.
 	if err := l.cleanupCompactV2TempFiles(); err != nil {
 		l.logger.Warnf("failed to cleanup compact v2 temp files: %v", err)
 	}
+}
+
+func (l *hnswCommitLogger) initSnapshotData() error {
+	l.migrateFromCompactV2()
 
 	dirs := strings.Split(filepath.Clean(l.rootPath), string(os.PathSeparator))
 	if ln := len(dirs); ln > 2 {

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -322,6 +322,78 @@ func (l *hnswCommitLogger) migrateCompactV2Snapshot() error {
 	return nil
 }
 
+// migrateCompactV2SortedFiles renames any compact v2 ".sorted" commit log
+// files (and ".sorted.condensed" leftovers from earlier botched downgrades)
+// to plain "{endTS}.condensed". A .sorted file is just a re-ordered WAL, so
+// renaming is enough — the rest of the commit logger (condensor, combiner,
+// snapshotFileName, ...) only knows about ".condensed" and would otherwise
+// produce chained suffixes like ".sorted.condensed" or ".sorted.snapshot".
+// The method is idempotent: once renamed, there is nothing left to migrate.
+func (l *hnswCommitLogger) migrateCompactV2SortedFiles() error {
+	commitlogDir := commitLogDirectory(l.rootPath, l.id)
+	entries, err := l.fs.ReadDir(commitlogDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrap(err, "read commitlog directory")
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+
+		var inner string
+		switch {
+		case strings.HasSuffix(name, ".sorted.condensed"):
+			inner = strings.TrimSuffix(name, ".sorted.condensed")
+		case strings.HasSuffix(name, ".sorted"):
+			inner = strings.TrimSuffix(name, ".sorted")
+		default:
+			continue
+		}
+
+		// Parse end timestamp (handles both "{ts}" and "{start}_{end}")
+		var endTS int64
+		if _, end, ok := strings.Cut(inner, "_"); ok {
+			endTS, err = strconv.ParseInt(end, 10, 64)
+		} else {
+			endTS, err = strconv.ParseInt(inner, 10, 64)
+		}
+		if err != nil {
+			continue // skip files we can't parse
+		}
+
+		oldPath := filepath.Join(commitlogDir, name)
+		newName := fmt.Sprintf("%d.condensed", endTS)
+		newPath := filepath.Join(commitlogDir, newName)
+
+		// Don't clobber an existing condensed file with the same end timestamp.
+		if _, err := l.fs.Stat(newPath); err == nil {
+			l.logger.WithFields(logrus.Fields{
+				"action":   "migrate_compact_v2_sorted",
+				"old_path": oldPath,
+				"new_path": newPath,
+			}).Warn("destination already exists, skipping migration")
+			continue
+		}
+
+		if err := l.fs.Rename(oldPath, newPath); err != nil {
+			return errors.Wrapf(err, "migrate sorted file %s to %s", oldPath, newPath)
+		}
+
+		l.logger.WithFields(logrus.Fields{
+			"action":   "migrate_compact_v2_sorted",
+			"old_path": oldPath,
+			"new_path": newPath,
+		}).Info("migrated compact v2 sorted file to condensed")
+	}
+
+	return nil
+}
+
 func (l *hnswCommitLogger) initSnapshotData() error {
 	// Migrate compact v2 snapshots from the commitlog directory to the
 	// snapshot directory. This enables downgrade compatibility: compact v2
@@ -329,6 +401,12 @@ func (l *hnswCommitLogger) initSnapshotData() error {
 	// expects them in a separate directory.
 	if err := l.migrateCompactV2Snapshot(); err != nil {
 		l.logger.Warnf("failed to migrate compact v2 snapshot: %v", err)
+	}
+
+	// Rename compact v2 .sorted commit log files to .condensed so the rest
+	// of the commit logger doesn't have to know about the .sorted format.
+	if err := l.migrateCompactV2SortedFiles(); err != nil {
+		l.logger.Warnf("failed to migrate compact v2 sorted files: %v", err)
 	}
 
 	dirs := strings.Split(filepath.Clean(l.rootPath), string(os.PathSeparator))

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -394,6 +394,48 @@ func (l *hnswCommitLogger) migrateCompactV2SortedFiles() error {
 	return nil
 }
 
+// cleanupCompactV2TempFiles removes orphan ".tmp" files left in the commitlog
+// directory by a crashed compact v2 write. Compact v2's SafeFileWriter writes
+// to "{finalPath}.tmp" and atomically renames on commit; if the process died
+// before the rename, the .tmp file persists. v1.37 only handles ".scratch.tmp"
+// and ".combined.tmp" — anything else (e.g. "1500.sorted.tmp") would slip
+// through and break getCommitFiles' timestamp parsing.
+//
+// v1.37 itself never writes ".sorted.tmp" or ".snapshot.tmp" in this directory,
+// so deleting them is safe.
+func (l *hnswCommitLogger) cleanupCompactV2TempFiles() error {
+	commitlogDir := commitLogDirectory(l.rootPath, l.id)
+	entries, err := l.fs.ReadDir(commitlogDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrap(err, "read commitlog directory")
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".sorted.tmp") && !strings.HasSuffix(name, ".snapshot.tmp") {
+			continue
+		}
+
+		path := filepath.Join(commitlogDir, name)
+		if err := l.fs.Remove(path); err != nil && !os.IsNotExist(err) {
+			return errors.Wrapf(err, "remove orphan temp file %s", path)
+		}
+
+		l.logger.WithFields(logrus.Fields{
+			"action": "cleanup_compact_v2_tmp",
+			"path":   path,
+		}).Info("removed orphan compact v2 temp file")
+	}
+
+	return nil
+}
+
 func (l *hnswCommitLogger) initSnapshotData() error {
 	// Migrate compact v2 snapshots from the commitlog directory to the
 	// snapshot directory. This enables downgrade compatibility: compact v2
@@ -407,6 +449,11 @@ func (l *hnswCommitLogger) initSnapshotData() error {
 	// of the commit logger doesn't have to know about the .sorted format.
 	if err := l.migrateCompactV2SortedFiles(); err != nil {
 		l.logger.Warnf("failed to migrate compact v2 sorted files: %v", err)
+	}
+
+	// Remove orphan .tmp files left behind by a crashed compact v2 write.
+	if err := l.cleanupCompactV2TempFiles(); err != nil {
+		l.logger.Warnf("failed to cleanup compact v2 temp files: %v", err)
 	}
 
 	dirs := strings.Split(filepath.Clean(l.rootPath), string(os.PathSeparator))

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot.go
@@ -323,11 +323,10 @@ func (l *hnswCommitLogger) migrateCompactV2Snapshot() error {
 }
 
 // migrateCompactV2SortedFiles renames any compact v2 ".sorted" commit log
-// files (and ".sorted.condensed" leftovers from earlier botched downgrades)
-// to plain "{endTS}.condensed". A .sorted file is just a re-ordered WAL, so
-// renaming is enough — the rest of the commit logger (condensor, combiner,
-// snapshotFileName, ...) only knows about ".condensed" and would otherwise
-// produce chained suffixes like ".sorted.condensed" or ".sorted.snapshot".
+// files to plain "{endTS}.condensed". A .sorted file is just a re-ordered
+// WAL, so renaming is enough — the rest of the commit logger (condensor,
+// combiner, snapshotFileName, ...) only knows about ".condensed" and would
+// otherwise produce chained suffixes like ".sorted.snapshot".
 // The method is idempotent: once renamed, there is nothing left to migrate.
 func (l *hnswCommitLogger) migrateCompactV2SortedFiles() error {
 	commitlogDir := commitLogDirectory(l.rootPath, l.id)
@@ -340,20 +339,11 @@ func (l *hnswCommitLogger) migrateCompactV2SortedFiles() error {
 	}
 
 	for _, entry := range entries {
-		if entry.IsDir() {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".sorted") {
 			continue
 		}
 		name := entry.Name()
-
-		var inner string
-		switch {
-		case strings.HasSuffix(name, ".sorted.condensed"):
-			inner = strings.TrimSuffix(name, ".sorted.condensed")
-		case strings.HasSuffix(name, ".sorted"):
-			inner = strings.TrimSuffix(name, ".sorted")
-		default:
-			continue
-		}
+		inner := strings.TrimSuffix(name, ".sorted")
 
 		// Parse end timestamp (handles both "{ts}" and "{start}_{end}")
 		var endTS int64

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
@@ -1935,3 +1935,64 @@ func TestMigrateCompactV2SortedFiles(t *testing.T) {
 		require.Equal(t, "1500.condensed", entries[0].Name())
 	})
 }
+
+func TestCleanupCompactV2TempFiles(t *testing.T) {
+	newLogger := func(rootDir, id string) *hnswCommitLogger {
+		return &hnswCommitLogger{
+			rootPath: rootDir,
+			id:       id,
+			logger:   logrus.New(),
+			fs:       common.NewOSFS(),
+		}
+	}
+
+	t.Run("removes compactv2 .sorted.tmp and .snapshot.tmp leftovers", func(t *testing.T) {
+		rootDir := t.TempDir()
+		commitlogDir := commitLogDirectory(rootDir, "main")
+		require.NoError(t, os.MkdirAll(commitlogDir, 0o755))
+
+		// Compactv2 SafeFileWriter leftovers from a crashed write.
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1500.sorted.tmp"), []byte("a"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1000_1500.sorted.tmp"), []byte("b"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1500.snapshot.tmp"), []byte("c"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1000_1500.snapshot.tmp"), []byte("d"), 0o644))
+
+		require.NoError(t, newLogger(rootDir, "main").cleanupCompactV2TempFiles())
+
+		entries, err := os.ReadDir(commitlogDir)
+		require.NoError(t, err)
+		require.Empty(t, entries)
+	})
+
+	t.Run("preserves v1.37 native files and other tmp formats", func(t *testing.T) {
+		rootDir := t.TempDir()
+		commitlogDir := commitLogDirectory(rootDir, "main")
+		require.NoError(t, os.MkdirAll(commitlogDir, 0o755))
+
+		// Mix: compactv2 leftover (must remove), v1.37 natives, and v1.37 tmp
+		// formats handled elsewhere (must NOT remove).
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1500.sorted.tmp"), []byte("a"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1000.condensed"), []byte("b"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "2000"), []byte("c"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "2500.scratch.tmp"), []byte("d"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "3000.combined.tmp"), []byte("e"), 0o644))
+
+		require.NoError(t, newLogger(rootDir, "main").cleanupCompactV2TempFiles())
+
+		entries, err := os.ReadDir(commitlogDir)
+		require.NoError(t, err)
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		require.ElementsMatch(t,
+			[]string{"1000.condensed", "2000", "2500.scratch.tmp", "3000.combined.tmp"},
+			names)
+	})
+
+	t.Run("noop when commitlog directory is missing", func(t *testing.T) {
+		rootDir := t.TempDir()
+		// don't create commitlog dir
+		require.NoError(t, newLogger(rootDir, "main").cleanupCompactV2TempFiles())
+	})
+}

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
@@ -1790,3 +1790,148 @@ func TestMigrateCompactV2Snapshot(t *testing.T) {
 		require.NoError(t, cl.migrateCompactV2Snapshot())
 	})
 }
+
+func TestMigrateCompactV2SortedFiles(t *testing.T) {
+	newLogger := func(rootDir, id string) *hnswCommitLogger {
+		return &hnswCommitLogger{
+			rootPath: rootDir,
+			id:       id,
+			logger:   logrus.New(),
+			fs:       common.NewOSFS(),
+		}
+	}
+
+	t.Run("renames single-timestamp .sorted to .condensed", func(t *testing.T) {
+		rootDir := t.TempDir()
+		commitlogDir := commitLogDirectory(rootDir, "main")
+		require.NoError(t, os.MkdirAll(commitlogDir, 0o755))
+
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1500.sorted"), []byte("a"), 0o644))
+
+		require.NoError(t, newLogger(rootDir, "main").migrateCompactV2SortedFiles())
+
+		entries, err := os.ReadDir(commitlogDir)
+		require.NoError(t, err)
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		require.ElementsMatch(t, []string{"1500.condensed"}, names)
+	})
+
+	t.Run("renames range .sorted to {endTS}.condensed", func(t *testing.T) {
+		rootDir := t.TempDir()
+		commitlogDir := commitLogDirectory(rootDir, "main")
+		require.NoError(t, os.MkdirAll(commitlogDir, 0o755))
+
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1000_1500.sorted"), []byte("a"), 0o644))
+
+		require.NoError(t, newLogger(rootDir, "main").migrateCompactV2SortedFiles())
+
+		entries, err := os.ReadDir(commitlogDir)
+		require.NoError(t, err)
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		require.ElementsMatch(t, []string{"1500.condensed"}, names)
+	})
+
+	t.Run("cleans up legacy .sorted.condensed leftovers", func(t *testing.T) {
+		rootDir := t.TempDir()
+		commitlogDir := commitLogDirectory(rootDir, "main")
+		require.NoError(t, os.MkdirAll(commitlogDir, 0o755))
+
+		// Pre-fix botched downgrade: condensor ran on a .sorted file and produced
+		// a chained name. Migration should normalize it back to {endTS}.condensed.
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1000_1500.sorted.condensed"), []byte("a"), 0o644))
+
+		require.NoError(t, newLogger(rootDir, "main").migrateCompactV2SortedFiles())
+
+		entries, err := os.ReadDir(commitlogDir)
+		require.NoError(t, err)
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		require.ElementsMatch(t, []string{"1500.condensed"}, names)
+	})
+
+	t.Run("preserves non-compactv2 files", func(t *testing.T) {
+		rootDir := t.TempDir()
+		commitlogDir := commitLogDirectory(rootDir, "main")
+		require.NoError(t, os.MkdirAll(commitlogDir, 0o755))
+
+		// Mix: a sorted file to migrate, a native condensed file to preserve,
+		// and a raw active log to preserve.
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1500.sorted"), []byte("a"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "2000.condensed"), []byte("b"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "2500"), []byte("c"), 0o644))
+
+		require.NoError(t, newLogger(rootDir, "main").migrateCompactV2SortedFiles())
+
+		entries, err := os.ReadDir(commitlogDir)
+		require.NoError(t, err)
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		require.ElementsMatch(t, []string{"1500.condensed", "2000.condensed", "2500"}, names)
+	})
+
+	t.Run("skips when destination already exists", func(t *testing.T) {
+		rootDir := t.TempDir()
+		commitlogDir := commitLogDirectory(rootDir, "main")
+		require.NoError(t, os.MkdirAll(commitlogDir, 0o755))
+
+		// Both forms map to "1500.condensed" — collision case.
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1500.sorted"), []byte("a"), 0o644))
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1500.condensed"), []byte("b"), 0o644))
+
+		require.NoError(t, newLogger(rootDir, "main").migrateCompactV2SortedFiles())
+
+		// Both files preserved, no overwrite.
+		entries, err := os.ReadDir(commitlogDir)
+		require.NoError(t, err)
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		require.ElementsMatch(t, []string{"1500.sorted", "1500.condensed"}, names)
+	})
+
+	t.Run("idempotent", func(t *testing.T) {
+		rootDir := t.TempDir()
+		commitlogDir := commitLogDirectory(rootDir, "main")
+		require.NoError(t, os.MkdirAll(commitlogDir, 0o755))
+
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1500.sorted"), []byte("a"), 0o644))
+
+		cl := newLogger(rootDir, "main")
+		require.NoError(t, cl.migrateCompactV2SortedFiles())
+		require.NoError(t, cl.migrateCompactV2SortedFiles())
+
+		entries, err := os.ReadDir(commitlogDir)
+		require.NoError(t, err)
+		names := make([]string, len(entries))
+		for i, e := range entries {
+			names[i] = e.Name()
+		}
+		require.ElementsMatch(t, []string{"1500.condensed"}, names)
+	})
+
+	t.Run("noop when no sorted files exist", func(t *testing.T) {
+		rootDir := t.TempDir()
+		commitlogDir := commitLogDirectory(rootDir, "main")
+		require.NoError(t, os.MkdirAll(commitlogDir, 0o755))
+
+		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1500.condensed"), []byte("a"), 0o644))
+
+		require.NoError(t, newLogger(rootDir, "main").migrateCompactV2SortedFiles())
+
+		entries, err := os.ReadDir(commitlogDir)
+		require.NoError(t, err)
+		require.Len(t, entries, 1)
+		require.Equal(t, "1500.condensed", entries[0].Name())
+	})
+}

--- a/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger_snapshot_test.go
@@ -1837,26 +1837,6 @@ func TestMigrateCompactV2SortedFiles(t *testing.T) {
 		require.ElementsMatch(t, []string{"1500.condensed"}, names)
 	})
 
-	t.Run("cleans up legacy .sorted.condensed leftovers", func(t *testing.T) {
-		rootDir := t.TempDir()
-		commitlogDir := commitLogDirectory(rootDir, "main")
-		require.NoError(t, os.MkdirAll(commitlogDir, 0o755))
-
-		// Pre-fix botched downgrade: condensor ran on a .sorted file and produced
-		// a chained name. Migration should normalize it back to {endTS}.condensed.
-		require.NoError(t, os.WriteFile(filepath.Join(commitlogDir, "1000_1500.sorted.condensed"), []byte("a"), 0o644))
-
-		require.NoError(t, newLogger(rootDir, "main").migrateCompactV2SortedFiles())
-
-		entries, err := os.ReadDir(commitlogDir)
-		require.NoError(t, err)
-		names := make([]string, len(entries))
-		for i, e := range entries {
-			names[i] = e.Name()
-		}
-		require.ElementsMatch(t, []string{"1500.condensed"}, names)
-	})
-
 	t.Run("preserves non-compactv2 files", func(t *testing.T) {
 		rootDir := t.TempDir()
 		commitlogDir := commitLogDirectory(rootDir, "main")


### PR DESCRIPTION
### What's being changed:

This forces the migration of all the compactv2 files during startup to pre-compactv2 format.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
