### PR TITLE
Fix/hnsw findnewentrypoint panic

### DIFF
--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -664,47 +664,50 @@ func (h *hnsw) findNewGlobalEntrypoint(denyList helpers.AllowList, targetLevel i
 
 	h.metrics.TombstoneFindGlobalEntrypoint()
 
-	for l := targetLevel; l >= 0; l-- {
-		// ideally we can find a new entrypoint at the same level of the
-		// to-be-deleted node. However, there is a chance it was the only node on
-		// that level, in that case we need to look at the next lower level for a
-		// better candidate
+	// First pass: find the node with the highest level that is not in the denyList.
+	// This handles cases where nodes may have higher levels than both targetLevel
+	// and currentMaximumLayer (e.g., due to corrupt commit log replay or
+	// deserialization bugs).
+	h.RLock()
+	maxNodes := len(h.nodes)
+	h.RUnlock()
 
-		h.RLock()
-		maxNodes := len(h.nodes)
-		h.RUnlock()
+	bestCandidate := uint64(0)
+	bestLevel := -1
+	foundCandidate := false
 
-		for i := 0; i < maxNodes; i++ {
-			if h.getEntrypoint() != oldEntrypoint {
-				// entrypoint has already been changed (this could be due to a new import
-				// for example, nothing to do for us
-				return 0, 0, false
-			}
-
-			if denyList.Contains(uint64(i)) {
-				continue
-			}
-
-			h.shardedNodeLocks.RLock(uint64(i))
-			candidate := h.nodes[i]
-			h.shardedNodeLocks.RUnlock(uint64(i))
-
-			if candidate == nil {
-				continue
-			}
-
-			candidate.Lock()
-			candidateLevel := candidate.level
-			candidate.Unlock()
-
-			if candidateLevel != l {
-				// not reaching up to the current level, skip in hope of finding another candidate
-				continue
-			}
-
-			// we have a node that matches
-			return uint64(i), l, true
+	for i := 0; i < maxNodes; i++ {
+		if h.getEntrypoint() != oldEntrypoint {
+			// entrypoint has already been changed (this could be due to a new import
+			// for example, nothing to do for us
+			return 0, 0, false
 		}
+
+		if denyList.Contains(uint64(i)) {
+			continue
+		}
+
+		h.shardedNodeLocks.RLock(uint64(i))
+		candidate := h.nodes[i]
+		h.shardedNodeLocks.RUnlock(uint64(i))
+
+		if candidate == nil {
+			continue
+		}
+
+		candidate.Lock()
+		candidateLevel := candidate.level
+		candidate.Unlock()
+
+		if candidateLevel > bestLevel {
+			bestCandidate = uint64(i)
+			bestLevel = candidateLevel
+			foundCandidate = true
+		}
+	}
+
+	if foundCandidate {
+		return bestCandidate, bestLevel, true
 	}
 
 	if h.isEmpty() {

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -2228,7 +2228,8 @@ func TestDelete_EntrypointWithLowerLevelThanOtherNodes(t *testing.T) {
 	// - PANIC
 
 	t.Run("delete entrypoint should not panic when other nodes have higher levels", func(t *testing.T) {
-		// This test currently fails with panic. Once the fix is applied, it should pass.
+		// Guard against a regression where deleting the entrypoint panicked when the
+		// replacement node existed only on higher levels.
 		err := index.Delete(0)
 		require.Nil(t, err)
 

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -2135,3 +2135,107 @@ func Test_DeleteTombstoneMetrics(t *testing.T) {
 		require.Nil(t, vectorIndex.Drop(context.Background(), false))
 	})
 }
+
+// TestDelete_EntrypointWithLowerLevelThanOtherNodes tests a regression where
+// deleting an entrypoint with a lower level than other nodes in the graph
+// causes a panic. This can happen when:
+// 1. The entrypoint has level = 0
+// 2. Another node has level > 0 (e.g., level = 3)
+// 3. findNewGlobalEntrypoint searches from entrypoint.level (0) down to 0
+// 4. The other node with level = 3 is not found because candidateLevel != l
+// 5. But isOnlyNode considers the other node valid (connections.Layers() > 0)
+// 6. This causes the panic "findNewEntrypoint called on an empty hnsw graph"
+//
+// See: https://github.com/weaviate/weaviate/issues/XXXX
+func TestDelete_EntrypointWithLowerLevelThanOtherNodes(t *testing.T) {
+	ctx := context.Background()
+
+	// Create index with minimal config
+	index, err := New(Config{
+		RootPath:              "doesnt-matter-as-committlogger-is-mocked-out",
+		ID:                    "delete-entrypoint-level-mismatch-test",
+		MakeCommitLoggerThunk: MakeNoopCommitLogger,
+		DistanceProvider:      distancer.NewCosineDistanceProvider(),
+		VectorForIDThunk:      testVectorForID,
+		GetViewThunk:          GetViewThunk,
+		TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk([][]float32{
+			{0.1, 0.2},
+			{0.3, 0.4},
+		}),
+	}, ent.UserConfig{
+		MaxConnections:        30,
+		EFConstruction:        128,
+		EF:                    36,
+		VectorCacheMaxObjects: 100000,
+	}, cyclemanager.NewCallbackGroupNoop(), testinghelpers.NewDummyStore(t))
+	require.Nil(t, err)
+	defer index.Drop(ctx, false)
+
+	// Manually build an index with an inconsistent state:
+	// - Entrypoint (node 0) has level = 0
+	// - Node 1 has level = 3 (higher than entrypoint)
+	// - currentMaximumLayer = 0 (doesn't reflect the true max level)
+	//
+	// This simulates a state that could occur after:
+	// - Corrupt commit log replay
+	// - Deserialization bugs where node.level is not set correctly
+	// - Race conditions during recovery
+
+	index.Lock()
+	index.entryPointID = 0
+	index.currentMaximumLayer = 0 // Inconsistent: should be 3 to match node 1's level
+	index.nodes = make([]*vertex, 10)
+
+	// Node 0: entrypoint with level 0
+	conns0, _ := packedconn.NewWithElements([][]uint64{
+		{1}, // connections at level 0
+	})
+	index.nodes[0] = &vertex{
+		id:          0,
+		level:       0,
+		connections: conns0,
+	}
+
+	// Node 1: has level 3 (higher than entrypoint's level 0)
+	// This node has connections at levels 0, 1, 2, 3
+	conns1, _ := packedconn.NewWithElements([][]uint64{
+		{0}, // level 0
+		{},  // level 1
+		{},  // level 2
+		{},  // level 3
+	})
+	index.nodes[1] = &vertex{
+		id:          1,
+		level:       3, // Higher than entrypoint
+		connections: conns1,
+	}
+	index.Unlock()
+
+	// Verify the setup is correct
+	require.Equal(t, uint64(0), index.entryPointID)
+	require.Equal(t, 0, index.currentMaximumLayer)
+	require.Equal(t, 0, index.nodes[0].level)
+	require.Equal(t, 3, index.nodes[1].level)
+	require.Equal(t, uint8(1), index.nodes[0].connections.Layers())
+	require.Equal(t, uint8(4), index.nodes[1].connections.Layers())
+
+	// Now delete the entrypoint (node 0)
+	// This should NOT panic, but currently it does because:
+	// - isOnlyNode sees node 1 as valid (connections.Layers() > 0)
+	// - findNewGlobalEntrypoint searches from level 0 to 0
+	// - Node 1 has level = 3, so candidateLevel (3) != l (0)
+	// - No candidate is found
+	// - isEmpty() returns false (node 0 still exists)
+	// - isOnlyNode() returns false (node 1 is valid)
+	// - PANIC
+
+	t.Run("delete entrypoint should not panic when other nodes have higher levels", func(t *testing.T) {
+		// This test currently fails with panic. Once the fix is applied, it should pass.
+		err := index.Delete(0)
+		require.Nil(t, err)
+
+		// After deletion, node 1 should become the new entrypoint
+		require.Equal(t, uint64(1), index.entryPointID)
+		require.Equal(t, 3, index.currentMaximumLayer)
+	})
+}

--- a/adapters/repos/db/vector/hnsw/delete_test.go
+++ b/adapters/repos/db/vector/hnsw/delete_test.go
@@ -2145,8 +2145,6 @@ func Test_DeleteTombstoneMetrics(t *testing.T) {
 // 4. The other node with level = 3 is not found because candidateLevel != l
 // 5. But isOnlyNode considers the other node valid (connections.Layers() > 0)
 // 6. This causes the panic "findNewEntrypoint called on an empty hnsw graph"
-//
-// See: https://github.com/weaviate/weaviate/issues/XXXX
 func TestDelete_EntrypointWithLowerLevelThanOtherNodes(t *testing.T) {
 	ctx := context.Background()
 


### PR DESCRIPTION
### What's being changed:

## Summary                                                                                                                                  
                                                                                                                                              
  Fix panic `findNewEntrypoint called on an empty hnsw graph` that can occur when deleting an entrypoint node.
                                                                                                                                              
  **Root cause:** `findNewGlobalEntrypoint` searched for a replacement entrypoint starting from the deleted node's level down to 0. However,
  `isOnlyNode` (which determines if there are other valid nodes) uses a different criterion—it checks `connections.Layers() > 0`. This      
  mismatch causes a panic when nodes exist with levels higher than the deleted entrypoint's level, since the search never reaches those
  levels.

  **Scenario:** This can occur after corrupt commit log replay, deserialization bugs, or race conditions during recovery where `node.level`
  becomes inconsistent with `currentMaximumLayer`.

  **Fix:** Changed `findNewGlobalEntrypoint` to scan all nodes once and select the one with the highest level, rather than iterating
  level-by-level from `targetLevel` downward. This ensures we find a valid candidate regardless of inconsistencies between `targetLevel`,
  `currentMaximumLayer`, and actual node levels.

 ### Test plan

  - [x] Added regression test `TestDelete_EntrypointWithLowerLevelThanOtherNodes` that reproduces the panic
  - [x] All existing delete tests pass
  - [x] Race detector passes

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [X] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
