### PR TITLE
queue: don't resume queue in PrepareForBackup to prevent S3 BadDigest

### DIFF
--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -478,17 +478,24 @@ func (q *DiskQueue) Wait(ctx context.Context) error {
 	return q.scheduler.Wait(ctx, q.id)
 }
 
-// PrepareForBackup pauses the queue and flushes all tasks to disk to prepare for backup.
-// It also enables maintenance mode, which prevents processed chunk files from being deleted until the backup is complete.
+// PrepareForBackup pauses the queue and flushes all tasks to disk to prepare
+// for backup. It also enables maintenance mode, which prevents processed chunk
+// files from being deleted until the backup is complete.
+//
+// The queue remains paused after this call. The caller is responsible for
+// ensuring that the upload completes before the shard is dropped or the queue
+// is otherwise resumed. Resuming the queue here would allow the writer to
+// modify chunk files while they are being uploaded, causing checksum mismatches
+// (e.g. S3 BadDigest errors).
 func (q *DiskQueue) PrepareForBackup(ctx context.Context) error {
 	err := q.Pause(ctx)
 	if err != nil {
 		return err
 	}
-	defer q.Resume()
 
 	err = q.Flush()
 	if err != nil {
+		q.Resume()
 		return err
 	}
 


### PR DESCRIPTION
## Summary

- Remove `defer q.Resume()` from `DiskQueue.PrepareForBackup`. The queue now stays paused after preparation, preventing the writer from modifying chunk files while they are being uploaded to S3.
- On `Flush` error, explicitly `Resume()` to avoid leaving the queue permanently paused.

## Context

During tenant offload, `PrepareForBackup` paused the queue, flushed, enabled maintenance mode, then **resumed** the queue via `defer`. By the time `s5cmd cp` started uploading chunk files to S3, the writer was already active again and could modify files mid-read, causing `BadDigest: The Content-Md5 you specified did not match what we received`.

The queue does not need to resume here — the shard is dropped after a successful offload, and the regular backup path (`ResumeAfterBackup`) only calls `DisableMaintenanceMode`, not `Resume`.

Fixes https://github.com/weaviate/0-weaviate-issues/issues/201.

## Test plan

- [x] `go test -race ./adapters/repos/db/queue/...` passes
- [ ] Re-run the e2e offload test that produced the BadDigest error


🤖 Generated with [Claude Code](https://claude.com/claude-code)