### PR TITLE
queue: promote partial chunk in PrepareForBackup to prevent S3 BadDigest

### DIFF
--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -478,8 +478,15 @@ func (q *DiskQueue) Wait(ctx context.Context) error {
 	return q.scheduler.Wait(ctx, q.id)
 }
 
-// PrepareForBackup pauses the queue and flushes all tasks to disk to prepare for backup.
-// It also enables maintenance mode, which prevents processed chunk files from being deleted until the backup is complete.
+// PrepareForBackup pauses the queue and flushes all tasks to disk to prepare
+// for backup. It also promotes the current partial chunk into a sealed file
+// and enables maintenance mode, which prevents processed chunk files from
+// being deleted until the backup is complete.
+//
+// Promoting the partial chunk ensures that no open writer can modify files in
+// the queue directory while they are being uploaded. Without this, the resumed
+// queue writer could modify chunk files mid-upload, causing checksum mismatches
+// (e.g. S3 BadDigest errors).
 func (q *DiskQueue) PrepareForBackup(ctx context.Context) error {
 	err := q.Pause(ctx)
 	if err != nil {
@@ -490,6 +497,18 @@ func (q *DiskQueue) PrepareForBackup(ctx context.Context) error {
 	err = q.Flush()
 	if err != nil {
 		return err
+	}
+
+	// Seal the current partial chunk so the writer starts a fresh file on
+	// Resume. This guarantees all existing chunk files are immutable during
+	// the upload.
+	q.m.Lock()
+	if q.w != nil {
+		err = q.w.Promote()
+	}
+	q.m.Unlock()
+	if err != nil {
+		return errors.Wrap(err, "promote partial chunk for backup")
 	}
 
 	q.EnableMaintenanceMode()


### PR DESCRIPTION
## Summary

- After `Flush()`, call `w.Promote()` to seal the current partial chunk into an immutable file before enabling maintenance mode. The writer starts a fresh file on `Resume()`, so all existing chunk files are stable during the upload.

## Context

This is an alternative to #11156 (option 1: keep queue paused). Both fix the same bug but with different trade-offs:

| | Option 1 (#11156) | Option 2 (this PR) |
|---|---|---|
| Approach | Remove `defer q.Resume()` — queue stays paused | Keep `Resume()` but `Promote()` the partial chunk first |
| Writer state after call | Paused — no writes possible | Resumed — writes go to a new file |
| Existing files | Partial chunk may still be open (but writer is paused) | All chunks are sealed and immutable |
| Risk | If something else expects the queue to be resumed, it won't be | None — `Promote` + `Resume` is the same pattern `ForceSwitch` uses |

Option 2 is defense-in-depth: even if the queue is resumed, all pre-existing files are immutable because `Promote()` sealed the partial chunk and the writer opened a fresh file.

Fixes https://github.com/weaviate/0-weaviate-issues/issues/201.

## Test plan

- [x] `go test -race ./adapters/repos/db/queue/...` passes
- [ ] Re-run the e2e offload test that produced the BadDigest error


🤖 Generated with [Claude Code](https://claude.com/claude-code)