### PR TITLE
test: set timeout unit for replication client in HashTreeLevel tests

### DIFF
--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -626,6 +626,7 @@ func TestReplicationHashTreeLevel(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
+		c.timeoutUnit = time.Second
 		got, err := c.HashTreeLevel(context.Background(), server.URL[7:], "C1", "S1", 3, discriminant)
 		require.NoError(t, err)
 		require.Equal(t, expected, got)
@@ -640,6 +641,7 @@ func TestReplicationHashTreeLevel(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
+		c.timeoutUnit = time.Second
 		got, err := c.HashTreeLevel(context.Background(), server.URL[7:], "C1", "S1", 3, discriminant)
 		require.NoError(t, err)
 		require.Equal(t, expected, got)
@@ -659,6 +661,7 @@ func TestReplicationHashTreeLevel(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
+		c.timeoutUnit = time.Second
 		_, err := c.HashTreeLevel(context.Background(), server.URL[7:], "C1", "S1", 3, discriminant)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "status code")
@@ -672,6 +675,7 @@ func TestReplicationHashTreeLevel(t *testing.T) {
 		defer server.Close()
 
 		c := newReplicationClient(t, server.Client())
+		c.timeoutUnit = time.Second
 		_, err := c.HashTreeLevel(context.Background(), server.URL[7:], "C1", "S1", 3, discriminant)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "read digest")


### PR DESCRIPTION
### What's being changed:

This pull request makes a minor but important update to the `TestReplicationHashTreeLevel` test function. The change sets the `timeoutUnit` field of the replication client to `time.Second` in several test cases, ensuring consistent timeout behavior during testing.

Testing improvements:

* Set `c.timeoutUnit = time.Second` in all relevant test cases within `TestReplicationHashTreeLevel` in `replication_test.go` to standardize the timeout duration used by the replication client during these tests. [[1]](diffhunk://#diff-4679ca5fef1e58a34c731d699ba35e69afe99b24a17f6ece435737dd85840f67R629) [[2]](diffhunk://#diff-4679ca5fef1e58a34c731d699ba35e69afe99b24a17f6ece435737dd85840f67R644) [[3]](diffhunk://#diff-4679ca5fef1e58a34c731d699ba35e69afe99b24a17f6ece435737dd85840f67R664) [[4]](diffhunk://#diff-4679ca5fef1e58a34c731d699ba35e69afe99b24a17f6ece435737dd85840f67R678)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
