### PR TITLE
compact: deterministic WAL file sort to fix multivector relativeID out of bounds

### DIFF
--- a/adapters/repos/db/vector/hnsw/compact/file_discovery.go
+++ b/adapters/repos/db/vector/hnsw/compact/file_discovery.go
@@ -132,16 +132,25 @@ func (d *FileDiscovery) Scan() (*DirectoryState, error) {
 		allFiles = append(allFiles, info)
 	}
 
-	// Sort all files by StartTS to identify the live file
-	sort.Slice(allFiles, func(i, j int) bool {
-		return allFiles[i].StartTS < allFiles[j].StartTS
+	// Sort all files by StartTS to identify the live file.
+	// Use SliceStable with Path as secondary key so that files with the same
+	// second-precision timestamp are always ordered deterministically,
+	// regardless of filesystem readdir order.
+	sort.SliceStable(allFiles, func(i, j int) bool {
+		if allFiles[i].StartTS != allFiles[j].StartTS {
+			return allFiles[i].StartTS < allFiles[j].StartTS
+		}
+		return allFiles[i].Path < allFiles[j].Path
 	})
 
-	// Find the live file: highest timestamp raw file
+	// Find the live file: highest timestamp raw file.
+	// When two raw files share the same timestamp, the stable sort + Path
+	// tiebreaker above guarantees the last one in the slice is the one with
+	// the lexicographically highest path — use >= so we always pick that one.
 	var highestRawTS int64 = -1
 	highestRawIdx := -1
 	for i, f := range allFiles {
-		if f.Type == FileTypeRaw && f.StartTS > highestRawTS {
+		if f.Type == FileTypeRaw && f.StartTS >= highestRawTS {
 			highestRawTS = f.StartTS
 			highestRawIdx = i
 		}
@@ -170,9 +179,12 @@ func (d *FileDiscovery) Scan() (*DirectoryState, error) {
 		}
 	}
 
-	// Sort sorted files by StartTS (oldest first)
-	sort.Slice(state.SortedFiles, func(i, j int) bool {
-		return state.SortedFiles[i].StartTS < state.SortedFiles[j].StartTS
+	// Sort sorted files by StartTS (oldest first), with Path as tiebreaker.
+	sort.SliceStable(state.SortedFiles, func(i, j int) bool {
+		if state.SortedFiles[i].StartTS != state.SortedFiles[j].StartTS {
+			return state.SortedFiles[i].StartTS < state.SortedFiles[j].StartTS
+		}
+		return state.SortedFiles[i].Path < state.SortedFiles[j].Path
 	})
 
 	// Detect overlaps

--- a/adapters/repos/db/vector/hnsw/compact/loader.go
+++ b/adapters/repos/db/vector/hnsw/compact/loader.go
@@ -125,9 +125,15 @@ func (l *Loader) Load() (*LoadResult, error) {
 	// 4. Filter out overlapped files
 	walFiles = l.filterOverlappedFiles(walFiles, state.Overlaps)
 
-	// 5. Sort by timestamp (oldest first)
-	sort.Slice(walFiles, func(i, j int) bool {
-		return walFiles[i].StartTS < walFiles[j].StartTS
+	// 5. Sort by timestamp (oldest first), with Path as tiebreaker for
+	// files created in the same second. Deterministic order is critical
+	// because ReplaceLinksAtLevel overwrites neighbor lists — different
+	// replay order produces a different graph.
+	sort.SliceStable(walFiles, func(i, j int) bool {
+		if walFiles[i].StartTS != walFiles[j].StartTS {
+			return walFiles[i].StartTS < walFiles[j].StartTS
+		}
+		return walFiles[i].Path < walFiles[j].Path
 	})
 
 	// 6. Load snapshot if exists (starting point)


### PR DESCRIPTION
## Summary

- Use `sort.SliceStable` with `Path` as secondary key at all three WAL file sort sites (`file_discovery.go` x2, `loader.go` x1).
- Use `>=` in live file selection so same-timestamp raw files are deterministically resolved.

## Context

WAL filenames are second-precision Unix timestamps. Under heavy multivector load, `switchCommitLogs` can fire twice in the same second, producing two files with identical `StartTS`. `sort.Slice` is unstable, so their relative order depends on Go's internal algorithm and the initial arrangement from `os.ReadDir` — which can vary across restarts and replicas.

Since `ReplaceLinksAtLevel` **overwrites** neighbor lists, the order in which files are replayed determines the final graph state. Non-deterministic order after restart produces a graph where `docIDVectors[docID]` has a different number of entries than the actual vectors in the object store, causing:

```
relativeID 20 is out of bounds for docID 15364
```

The triage also showed different node counts across replicas for the same shard (398K vs 391K vs 390K), confirming non-deterministic replay.

Fixes https://github.com/weaviate/0-weaviate-issues/issues/202.

## Test plan

- [x] `go test -race ./adapters/repos/db/vector/hnsw/compact/...` passes
- [ ] Re-run the e2e multivector recall test that produced the `relativeID out of bounds` error


🤖 Generated with [Claude Code](https://claude.com/claude-code)