### PR TITLE
fix: prevent tar write-too-long during backup of growing HNSW commit logs

### DIFF
--- a/usecases/backup/zip.go
+++ b/usecases/backup/zip.go
@@ -356,8 +356,11 @@ func (z *zip) writeOne(ctx context.Context, info fs.FileInfo, relPath string, r 
 		}
 		return written, fmt.Errorf("write backup header in file %s: %s: %w", z.sourcePath, relPath, err)
 	}
-	// write bytes
-	written, err = io.Copy(z.w, r)
+	// Write bytes, limiting the read to the declared file size. This prevents
+	// "archive/tar: write too long" errors when a file grows between the stat
+	// (used for the tar header) and the copy. HNSW commit logs are append-only,
+	// so a size-limited prefix is always a consistent snapshot.
+	written, err = io.Copy(z.w, io.LimitReader(r, info.Size()))
 	if err != nil {
 		if errors.Is(ctx.Err(), context.Canceled) {
 			// we ignore in case the ctx was cancelled

--- a/usecases/backup/zip_test.go
+++ b/usecases/backup/zip_test.go
@@ -1919,3 +1919,52 @@ func newFileList(t *testing.T, sourceDir string, files []string) *backup.FileLis
 		FileSizes: fileSizes,
 	}
 }
+
+// TestWriteOne_FileGrowsDuringCopy verifies that writeOne does not produce an
+// "archive/tar: write too long" error when the underlying file grows between
+// the stat (used for the tar header) and the io.Copy. This simulates the race
+// condition seen with HNSW commit logs during concurrent imports and backups.
+func TestWriteOne_FileGrowsDuringCopy(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write initial content (size recorded in tar header).
+	filePath := filepath.Join(dir, "commitlog.wal")
+	initialData := bytes.Repeat([]byte("A"), 1000)
+	require.NoError(t, os.WriteFile(filePath, initialData, 0o644))
+
+	// Stat the file to capture the original size for the tar header.
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+	require.Equal(t, int64(1000), info.Size())
+
+	// Append extra data to simulate the file growing after stat.
+	f, err := os.OpenFile(filePath, os.O_APPEND|os.O_WRONLY, 0o644)
+	require.NoError(t, err)
+	_, err = f.Write(bytes.Repeat([]byte("B"), 500))
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	// Open the file for reading (sees full 1500 bytes).
+	reader, err := os.Open(filePath)
+	require.NoError(t, err)
+	defer reader.Close()
+
+	// Create a zip writer backed by a tar archive.
+	z, rc, err := NewZip(dir, int(GzipBestSpeed), 0, 0, 0)
+	require.NoError(t, err)
+
+	// writeOne should succeed despite the file being larger than info.Size().
+	var writeErr error
+	go func() {
+		_, writeErr = z.writeOne(context.Background(), info, "commitlog.wal", reader)
+		z.Close()
+	}()
+
+	// Drain the reader side.
+	_, err = io.Copy(io.Discard, rc)
+	require.NoError(t, err)
+	require.NoError(t, rc.Close())
+
+	// The write must not have failed with "write too long".
+	require.NoError(t, writeErr)
+}


### PR DESCRIPTION
## Summary

- Fixes `archive/tar: write too long` error when backing up HNSW commit log files that grow during concurrent imports
- Uses `io.LimitReader` in `writeOne` to cap bytes copied to the declared file size from the tar header
- Adds a regression test that simulates a file growing between stat and copy

## Context

Discovered via chaos engineering test `replication_importing_with_backup.sh` against the `compactv2` branch ([CI run](https://github.com/weaviate/weaviate-chaos-engineering/actions/runs/24983127208/job/73149813415)). The backup producer reads the file size for the tar header via `os.Stat`, then streams content via `io.Copy`. When a commit log file grows between these two operations (due to concurrent HNSW writes), the tar writer rejects the extra bytes.

Since HNSW commit logs are append-only, a size-limited prefix is always a consistent snapshot — truncating at the declared size produces a valid backup.

Fixes: weaviate/0-weaviate-issues#203

## Test plan

- [x] New unit test `TestWriteOne_FileGrowsDuringCopy` — simulates file growth after stat, verifies no tar error
- [x] Existing `usecases/backup` tests pass
- [ ] Re-run `replication_importing_with_backup.sh` chaos test against a build with this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)