### PR TITLE
Namespaces: Add support for creating collections and many endpoints

### DIFF
--- a/adapters/handlers/grpc/v1/batch/handler.go
+++ b/adapters/handlers/grpc/v1/batch/handler.go
@@ -36,15 +36,17 @@ type Handler struct {
 	batchManager  *objects.BatchManager
 	logger        logrus.FieldLogger
 	schemaManager *schema.Manager
+	nsEnabled     bool
 }
 
-func NewHandler(authorizer authorization.Authorizer, batchManager *objects.BatchManager, logger logrus.FieldLogger, authenticator *auth.Handler, schemaManager *schema.Manager) *Handler {
+func NewHandler(authorizer authorization.Authorizer, batchManager *objects.BatchManager, logger logrus.FieldLogger, authenticator *auth.Handler, schemaManager *schema.Manager, nsEnabled bool) *Handler {
 	return &Handler{
 		authorizer:    authorizer,
 		authenticator: authenticator,
 		batchManager:  batchManager,
 		logger:        logger,
 		schemaManager: schemaManager,
+		nsEnabled:     nsEnabled,
 	}
 }
 
@@ -64,7 +66,7 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 	knownClasses := map[string]versioned.Class{}
 	knownClassesAuthCheck := map[string]*models.Class{}
 	classGetter := func(classname, shard string) (*models.Class, error) {
-		resolved, _, err := namespacing.Resolve(principal, h.schemaManager, classname)
+		resolved, _, err := namespacing.Resolve(principal, h.schemaManager, h.nsEnabled, classname)
 		if err != nil {
 			return nil, err
 		}

--- a/adapters/handlers/grpc/v1/batch/handler.go
+++ b/adapters/handlers/grpc/v1/batch/handler.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 type Handler struct {
@@ -63,10 +64,11 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 	knownClasses := map[string]versioned.Class{}
 	knownClassesAuthCheck := map[string]*models.Class{}
 	classGetter := func(classname, shard string) (*models.Class, error) {
-		// classname might be an alias
-		if cls := h.schemaManager.ResolveAlias(classname); cls != "" {
-			classname = cls
+		resolved, _, err := namespacing.Resolve(principal, h.schemaManager, classname)
+		if err != nil {
+			return nil, err
 		}
+		classname = resolved
 		// use a letter that cannot be in class/shard name to not allow different combinations leading to the same combined name
 		classTenantName := classname + "#" + shard
 		class, ok := knownClassesAuthCheck[classTenantName]

--- a/adapters/handlers/grpc/v1/batch/handler.go
+++ b/adapters/handlers/grpc/v1/batch/handler.go
@@ -66,11 +66,7 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 	knownClasses := map[string]versioned.Class{}
 	knownClassesAuthCheck := map[string]*models.Class{}
 	classGetter := func(classname, shard string) (*models.Class, error) {
-		resolved, _, err := namespacing.Resolve(principal, h.schemaManager, h.nsEnabled, classname)
-		if err != nil {
-			return nil, err
-		}
-		classname = resolved
+		classname, _ = namespacing.Resolve(principal, h.schemaManager, h.nsEnabled, classname)
 		// use a letter that cannot be in class/shard name to not allow different combinations leading to the same combined name
 		classTenantName := classname + "#" + shard
 		class, ok := knownClassesAuthCheck[classTenantName]

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -288,11 +288,7 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	}
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
-	resolved, _, err := namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection)
-	if err != nil {
-		return nil, err
-	}
-	req.Collection = resolved
+	req.Collection, _ = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection)
 
 	parser := NewParser(
 		req.Uses_127Api,

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -21,6 +21,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/adapters/handlers/grpc/v1/auth"
@@ -269,10 +270,6 @@ func (s *Service) Search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	var result *pb.SearchReply
 	var errInner error
 
-	if class := s.schemaManager.ResolveAlias(req.Collection); class != "" {
-		req.Collection = class
-	}
-
 	if err := enterrors.GoWrapperWithBlock(func() {
 		result, errInner = s.search(ctx, req)
 	}, s.logger); err != nil {
@@ -290,6 +287,12 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
+
+	resolved, _, err := namespacing.Resolve(principal, s.schemaManager, req.Collection)
+	if err != nil {
+		return nil, err
+	}
+	req.Collection = resolved
 
 	parser := NewParser(
 		req.Uses_127Api,

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -62,7 +62,7 @@ type Service struct {
 
 func NewService(allowAnonymous bool, authComposer composer.TokenFunc, state *state.State) (*Service, batch.Drain) {
 	authenticator := auth.NewHandler(allowAnonymous, authComposer)
-	batchHandler := batch.NewHandler(state.Authorizer, state.BatchManager, state.Logger, authenticator, state.SchemaManager)
+	batchHandler := batch.NewHandler(state.Authorizer, state.BatchManager, state.Logger, authenticator, state.SchemaManager, state.ServerConfig.Config.Namespaces.Enabled)
 	batchStreamHandler, batchDrain := batch.Start(authenticator, state.Authorizer, batchHandler, state.SchemaManager, prometheus.DefaultRegisterer, NUMCPU, state.Logger)
 	return &Service{
 		traverser:            state.Traverser,
@@ -288,7 +288,7 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	}
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
-	resolved, _, err := namespacing.Resolve(principal, s.schemaManager, req.Collection)
+	resolved, _, err := namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection)
 	if err != nil {
 		return nil, err
 	}

--- a/entities/schema/schema.go
+++ b/entities/schema/schema.go
@@ -64,6 +64,21 @@ func UppercaseClassName(name string) string {
 		return name
 	}
 
+	// If the name is already namespace-qualified ("<namespace>:<ClassName>"),
+	// only uppercase the class portion. The namespace prefix is lowercase by
+	// contract and must be preserved verbatim so resolved names remain stable.
+	if ns, cls, ok := strings.Cut(name, NamespaceSeparator); ok {
+		return ns + NamespaceSeparator + uppercaseFirst(cls)
+	}
+
+	return uppercaseFirst(name)
+}
+
+func uppercaseFirst(name string) string {
+	if len(name) < 1 {
+		return name
+	}
+
 	if len(name) == 1 {
 		return strings.ToUpper(name)
 	}

--- a/entities/schema/schema.go
+++ b/entities/schema/schema.go
@@ -67,6 +67,12 @@ func UppercaseClassName(name string) string {
 	// If the name is already namespace-qualified ("<namespace>:<ClassName>"),
 	// only uppercase the class portion. The namespace prefix is lowercase by
 	// contract and must be preserved verbatim so resolved names remain stable.
+	//
+	// strings.Cut (first-separator split) is correct here because qualified
+	// names always have exactly one separator: a namespace name is validated
+	// to be lowercase ASCII letters/digits only (see usecases/namespaces
+	// ValidateName), so it cannot itself contain ":", and qualification
+	// happens at most once per request at the resolver boundary.
 	if ns, cls, ok := strings.Cut(name, NamespaceSeparator); ok {
 		return ns + NamespaceSeparator + uppercaseFirst(cls)
 	}

--- a/entities/schema/schema_test.go
+++ b/entities/schema/schema_test.go
@@ -1,0 +1,49 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUppercaseClassName(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		out  string
+	}{
+		{name: "empty", in: "", out: ""},
+		{name: "single lowercase", in: "a", out: "A"},
+		{name: "single uppercase", in: "A", out: "A"},
+		{name: "already uppercased", in: "Movies", out: "Movies"},
+		{name: "lowercase first letter", in: "movies", out: "Movies"},
+		{name: "namespaced lowercase class", in: "customer1:movies", out: "customer1:Movies"},
+		{name: "namespaced uppercase class", in: "customer1:Movies", out: "customer1:Movies"},
+		{name: "namespaced single-char class", in: "customer1:m", out: "customer1:M"},
+		{name: "namespaced empty class", in: "customer1:", out: "customer1:"},
+		{name: "empty namespace", in: ":Movies", out: ":Movies"},
+		{name: "namespace with uppercase prefix preserved verbatim", in: "Customer1:movies", out: "Customer1:Movies"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.out, UppercaseClassName(tt.in))
+		})
+	}
+}
+
+func TestUppercaseClassesNames(t *testing.T) {
+	in := []string{"movies", "customer1:movies", "Books"}
+	out := UppercaseClassesNames(in...)
+	assert.Equal(t, []string{"Movies", "customer1:Movies", "Books"}, out)
+}

--- a/entities/schema/validation.go
+++ b/entities/schema/validation.go
@@ -27,7 +27,7 @@ var (
 const (
 	// Restricted by max length allowed for dir name (255 chars)
 	// As dir containing class data is named after class, 255 chars are allowed
-	classNameMaxLength = 255
+	ClassNameMaxLength = 255
 	ClassNameRegexCore = `[A-Z][_0-9A-Za-z]{0,254}`
 	// ClassNameRegexAllowRegex allowed chars in class name including regex patterns, 255 chars are allowed
 	ClassNameRegexAllowRegex = `^(\*|[A-Z][_0-9A-Za-z\-.*+?^$()|{}\[\]\\]{0,254})$`
@@ -81,9 +81,9 @@ func ValidateAliasName(name string) (string, error) {
 // ValidateClassNameIncludesRegex validates that this string is a valid class name (format wise)
 // can include regex pattern
 func ValidateClassNameIncludesRegex(name string) (ClassName, error) {
-	if len(name) > classNameMaxLength {
+	if len(name) > ClassNameMaxLength {
 		return "", fmt.Errorf("'%s' is not a valid class name. Name should not be longer than %d characters",
-			name, classNameMaxLength)
+			name, ClassNameMaxLength)
 	}
 	if !regexp.MustCompile(ClassNameRegexAllowRegex).MatchString(name) {
 		return "", fmt.Errorf("'%s' is not a valid class name", name)
@@ -97,9 +97,9 @@ func validateClassOrAliasName(name string, isAlias bool) (string, error) {
 		typ = "alias"
 	}
 
-	if len(name) > classNameMaxLength {
+	if len(name) > ClassNameMaxLength {
 		return "", fmt.Errorf("'%s' is not a valid %s name. Name should not be longer than %d characters",
-			name, typ, classNameMaxLength)
+			name, typ, ClassNameMaxLength)
 	}
 	if !validateClassNameRegex.MatchString(name) {
 		return "", fmt.Errorf("'%s' is not a valid %s name", name, typ)

--- a/entities/schema/validation.go
+++ b/entities/schema/validation.go
@@ -63,6 +63,23 @@ const (
 	// audit all consumers of NamespaceSeparator and update them atomically.
 	// TestValidateClassName_RejectsNamespaceSeparator locks the contract.
 	NamespaceSeparator = ":"
+
+	// Namespace name validation contract (kept tight so the operator API gives
+	// predictable results and so name-in-URL round-tripping is unambiguous):
+	//
+	//   - Must start with a lowercase ASCII letter.
+	//   - Subsequent characters are lowercase letters or digits.
+	//   - Length in [NamespaceMinLength, NamespaceMaxLength].
+	//   - Must not collide with a reserved name.
+	//
+	// The regex and reserved-name list live in usecases/namespaces alongside
+	// ValidateName; only the length bounds are shared here so both the
+	// namespace controller and the syntactic qualification helpers
+	// (usecases/schema/namespacing) read from a single source of truth.
+	// Reserved names are held back for platform/system use (e.g. a future
+	// "default" namespace or routing sentinels) and are refused at Create time.
+	NamespaceMinLength = 3
+	NamespaceMaxLength = 36
 )
 
 // ValidateClassName validates that this string is a valid class name (format wise)

--- a/entities/schema/validation.go
+++ b/entities/schema/validation.go
@@ -25,8 +25,9 @@ var (
 )
 
 const (
-	// Restricted by max length allowed for dir name (255 chars)
-	// As dir containing class data is named after class, 255 chars are allowed
+	// ClassNameMaxLength is restricted by the max length allowed for a
+	// directory name (255 chars). As the dir containing class data is named
+	// after the class, 255 chars are allowed.
 	ClassNameMaxLength = 255
 	ClassNameRegexCore = `[A-Z][_0-9A-Za-z]{0,254}`
 	// ClassNameRegexAllowRegex allowed chars in class name including regex patterns, 255 chars are allowed

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -15,7 +15,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -115,64 +114,6 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		)
 	})
 
-	t.Run("end-to-end: insert and get object with short, lowercase class name", func(t *testing.T) {
-		// Submit the class name lowercased on every hop. This exercises
-		// UppercaseClassName end-to-end through namespacing.Resolve: the bare
-		// short input is uppercased *before* the namespace prefix is glued on,
-		// so the qualified name stored on disk is "<namespace>:E2emovies".
-		for _, key := range []string{user1Key, user2Key} {
-			_, err := helper.Client(t).Schema.SchemaObjectsCreate(
-				schema.NewSchemaObjectsCreateParams().WithObjectClass(&models.Class{Class: "e2emovies"}),
-				helper.CreateAuth(key),
-			)
-			require.NoError(t, err)
-		}
-		defer helper.DeleteClassAuth(t, "customer1:E2emovies", adminKey)
-		defer helper.DeleteClassAuth(t, "customer2:E2emovies", adminKey)
-
-		// Same UUID, same short class name, different props in each namespace.
-		// The two writes must land on independent shards; reads must come back
-		// with the writer's own props, not the other namespace's.
-		sharedID := strfmt.UUID("11111111-2222-3333-4444-555555555555")
-		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
-			ID:         sharedID,
-			Class:      "e2emovies",
-			Properties: map[string]any{"title": "The Matrix"},
-		}, user1Key)
-		require.NoError(t, err)
-		_, err = helper.CreateObjectWithResponseAuth(t, &models.Object{
-			ID:         sharedID,
-			Class:      "e2emovies",
-			Properties: map[string]any{"title": "Inception"},
-		}, user2Key)
-		require.NoError(t, err)
-
-		// Each namespaced user reads back their own row.
-		got1, err := helper.GetObjectAuth(t, "e2emovies", sharedID, user1Key)
-		require.NoError(t, err)
-		assert.Equal(t, "customer1:E2emovies", got1.Class)
-		assert.Equal(t, sharedID, got1.ID)
-		props1, ok := got1.Properties.(map[string]any)
-		require.True(t, ok)
-		assert.Equal(t, "The Matrix", props1["title"])
-
-		got2, err := helper.GetObjectAuth(t, "e2emovies", sharedID, user2Key)
-		require.NoError(t, err)
-		assert.Equal(t, "customer2:E2emovies", got2.Class)
-		assert.Equal(t, sharedID, got2.ID)
-		props2, ok := got2.Properties.(map[string]any)
-		require.True(t, ok)
-		assert.Equal(t, "Inception", props2["title"])
-
-		// Admin verification: raw schema view shows both qualified collection names.
-		gotClass1 := helper.GetClassAuth(t, "customer1:E2emovies", adminKey)
-		require.NotNil(t, gotClass1)
-		assert.Equal(t, "customer1:E2emovies", gotClass1.Class)
-		gotClass2 := helper.GetClassAuth(t, "customer2:E2emovies", adminKey)
-		require.NotNil(t, gotClass2)
-		assert.Equal(t, "customer2:E2emovies", gotClass2.Class)
-	})
-
 	t.Run("end-to-end: insert and get object via alias, with cross-namespace isolation", func(t *testing.T) {
 		// Create the same class name in both namespaces so the only thing
 		// keeping user2 from reading user1's object is the resolver.
@@ -231,78 +172,6 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		require.Error(t, err)
 		var nfAlias *objectsCli.ObjectsClassGetNotFound
 		require.True(t, errors.As(err, &nfAlias), "expected ObjectsClassGetNotFound, got %T: %v", err, err)
-	})
-
-	t.Run("namespaced caller submitting :-qualified class on read double-prefixes to 404", func(t *testing.T) {
-		_, err := helper.Client(t).Schema.SchemaObjectsCreate(
-			schema.NewSchemaObjectsCreateParams().WithObjectClass(&models.Class{Class: "E2EDoublePrefix"}),
-			helper.CreateAuth(user1Key),
-		)
-		require.NoError(t, err)
-		defer helper.DeleteClassAuth(t, "customer1:E2EDoublePrefix", adminKey)
-
-		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
-			Class:      "E2EDoublePrefix",
-			Properties: map[string]any{"title": "Memento"},
-		}, user1Key)
-		require.NoError(t, err)
-		require.NotEmpty(t, obj.ID)
-
-		// user1 supplying the already-qualified name double-prefixes to
-		// "customer1:customer1:E2EDoublePrefix" — no such class, 404.
-		_, err = helper.GetObjectAuth(t, "customer1:E2EDoublePrefix", obj.ID, user1Key)
-		require.Error(t, err)
-		var nf *objectsCli.ObjectsClassGetNotFound
-		require.True(t, errors.As(err, &nf), "expected ObjectsClassGetNotFound, got %T: %v", err, err)
-	})
-
-	t.Run("global admin reads object via qualified class name", func(t *testing.T) {
-		_, err := helper.Client(t).Schema.SchemaObjectsCreate(
-			schema.NewSchemaObjectsCreateParams().WithObjectClass(&models.Class{Class: "E2EAdminRead"}),
-			helper.CreateAuth(user1Key),
-		)
-		require.NoError(t, err)
-		defer helper.DeleteClassAuth(t, "customer1:E2EAdminRead", adminKey)
-
-		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
-			Class:      "E2EAdminRead",
-			Properties: map[string]any{"title": "Tenet"},
-		}, user1Key)
-		require.NoError(t, err)
-		require.NotEmpty(t, obj.ID)
-
-		// Admin has no namespace, so Resolve is a no-op and the qualified
-		// name flows through untouched.
-		got, err := helper.GetObjectAuth(t, "customer1:E2EAdminRead", obj.ID, adminKey)
-		require.NoError(t, err)
-		assert.Equal(t, "customer1:E2EAdminRead", got.Class)
-		assert.Equal(t, obj.ID, got.ID)
-		props, ok := got.Properties.(map[string]any)
-		require.True(t, ok)
-		assert.Equal(t, "Tenet", props["title"])
-	})
-
-	t.Run("global admin reading object via short name returns 404", func(t *testing.T) {
-		_, err := helper.Client(t).Schema.SchemaObjectsCreate(
-			schema.NewSchemaObjectsCreateParams().WithObjectClass(&models.Class{Class: "E2EAdminShort"}),
-			helper.CreateAuth(user1Key),
-		)
-		require.NoError(t, err)
-		defer helper.DeleteClassAuth(t, "customer1:E2EAdminShort", adminKey)
-
-		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
-			Class:      "E2EAdminShort",
-			Properties: map[string]any{"title": "Dunkirk"},
-		}, user1Key)
-		require.NoError(t, err)
-		require.NotEmpty(t, obj.ID)
-
-		// Admin → no namespace → Resolve leaves "E2EAdminShort" as-is. There is
-		// no class by that bare name, only "customer1:E2EAdminShort" → 404.
-		_, err = helper.GetObjectAuth(t, "E2EAdminShort", obj.ID, adminKey)
-		require.Error(t, err)
-		var nf *objectsCli.ObjectsClassGetNotFound
-		require.True(t, errors.As(err, &nf), "expected ObjectsClassGetNotFound, got %T: %v", err, err)
 	})
 
 	t.Run("global admin rejected with 403 on NS-enabled cluster", func(t *testing.T) {

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -12,97 +12,73 @@
 package namespace
 
 import (
-	"context"
 	"errors"
 	"testing"
-	"time"
 
+	"github.com/go-openapi/strfmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	objectsCli "github.com/weaviate/weaviate/client/objects"
 	"github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/client/users"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
 
+func createMovies(t *testing.T, key string) {
+	t.Helper()
+	class := &models.Class{Class: "Movies"}
+	params := schema.NewSchemaObjectsCreateParams().WithObjectClass(class)
+	_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, helper.CreateAuth(key))
+	require.NoError(t, err)
+}
+
+func createNamespacedUser(t *testing.T, userID, ns, adminKey string) string {
+	t.Helper()
+	resp, err := helper.Client(t).Users.CreateUser(
+		users.NewCreateUserParams().WithUserID(userID).WithBody(users.CreateUserBody{Namespace: ns}),
+		helper.CreateAuth(adminKey),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Payload.Apikey)
+	return *resp.Payload.Apikey
+}
+
 // TestNamespaces_CollectionAndAliasCreate exercises the inline qualification
-// added to AddClass / AddAlias. RBAC is off so namespaced DB users reach the
-// handler unconditionally; the only gating in play is the handler-level
-// IsGlobalOperator/Namespace check plus the entity-name validators.
-func TestNamespaces_CollectionAndAliasCreate(t *testing.T) {
+// added to AddClass / AddAlias, as well as the read path with namespace resolution.
+// RBAC is off so namespaced DB users reach the handler unconditionally; the only
+// gating in play is the handler-level IsGlobalOperator/Namespace check plus the
+// entity-name validators.
+func TestNamespaces_CollectionAndAlias(t *testing.T) {
 	const (
-		testAdminUser = "admin-user"
-		testAdminKey  = "admin-key"
-		ns1           = "customer1"
-		ns2           = "customer2"
+		ns1 = "customer1"
+		ns2 = "customer2"
 	)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-	compose, err := docker.New().WithWeaviate().
-		WithApiKey().WithUserApiKey(testAdminUser, testAdminKey).
-		WithDbUsers().
-		WithNamespaces().
-		Start(ctx)
-	require.NoError(t, err)
-	helper.SetupClient(compose.GetWeaviate().URI())
-	defer func() {
-		helper.ResetClient()
-		require.NoError(t, compose.Terminate(ctx))
-		cancel()
-	}()
+	helper.CreateNamespace(t, ns1, adminKey)
+	helper.CreateNamespace(t, ns2, adminKey)
+	defer helper.DeleteNamespace(t, ns1, adminKey)
+	defer helper.DeleteNamespace(t, ns2, adminKey)
 
-	helper.CreateNamespace(t, ns1, testAdminKey)
-	helper.CreateNamespace(t, ns2, testAdminKey)
-	defer helper.DeleteNamespace(t, ns1, testAdminKey)
-	defer helper.DeleteNamespace(t, ns2, testAdminKey)
-
-	user1Key := createNamespacedUser(t, "u1", ns1, testAdminKey)
-	user2Key := createNamespacedUser(t, "u2", ns2, testAdminKey)
+	user1Key := createNamespacedUser(t, "u1", ns1, adminKey)
+	user2Key := createNamespacedUser(t, "u2", ns2, adminKey)
 	t.Cleanup(func() {
-		helper.DeleteUser(t, ns1+":u1", testAdminKey)
-		helper.DeleteUser(t, ns2+":u2", testAdminKey)
-	})
-
-	t.Run("each namespaced user creates Movies; raw view shows qualified names", func(t *testing.T) {
-		defer helper.DeleteClassAuth(t, "customer1:Movies", testAdminKey)
-		defer helper.DeleteClassAuth(t, "customer2:Movies", testAdminKey)
-
-		createMovies(t, user1Key)
-		createMovies(t, user2Key)
-
-		// Admin (global) sees both qualified collections.
-		got1 := helper.GetClassAuth(t, "customer1:Movies", testAdminKey)
-		require.Equal(t, "customer1:Movies", got1.Class)
-		got2 := helper.GetClassAuth(t, "customer2:Movies", testAdminKey)
-		require.Equal(t, "customer2:Movies", got2.Class)
-	})
-
-	t.Run("global admin rejected with 403 on NS-enabled cluster", func(t *testing.T) {
-		class := &models.Class{Class: "Movies"}
-		params := schema.NewSchemaObjectsCreateParams().WithObjectClass(class)
-		_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, helper.CreateAuth(testAdminKey))
-		require.Error(t, err)
-		var forbidden *schema.SchemaObjectsCreateForbidden
-		require.True(t, errors.As(err, &forbidden), "expected SchemaObjectsCreateForbidden, got %T: %v", err, err)
-	})
-
-	t.Run("namespaced caller submitting class name with ':' rejected", func(t *testing.T) {
-		class := &models.Class{Class: "Customer2:Movies"}
-		params := schema.NewSchemaObjectsCreateParams().WithObjectClass(class)
-		_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, helper.CreateAuth(user1Key))
-		require.Error(t, err)
-		var unproc *schema.SchemaObjectsCreateUnprocessableEntity
-		require.True(t, errors.As(err, &unproc), "expected SchemaObjectsCreateUnprocessableEntity, got %T: %v", err, err)
-		assert.Contains(t, unproc.Payload.Error[0].Message, "is not a valid class name")
+		helper.DeleteUser(t, ns1+":u1", adminKey)
+		helper.DeleteUser(t, ns2+":u2", adminKey)
 	})
 
 	t.Run("namespace-local alias create succeeds and is independent across namespaces", func(t *testing.T) {
 		createMovies(t, user1Key)
 		createMovies(t, user2Key)
-		defer helper.DeleteClassAuth(t, "customer1:Movies", testAdminKey)
-		defer helper.DeleteClassAuth(t, "customer2:Movies", testAdminKey)
+		defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+		defer helper.DeleteClassAuth(t, "customer2:Movies", adminKey)
+
+		// Admin (global) sees both qualified collections.
+		gotClass1 := helper.GetClassAuth(t, "customer1:Movies", adminKey)
+		require.Equal(t, "customer1:Movies", gotClass1.Class)
+		gotClass2 := helper.GetClassAuth(t, "customer2:Movies", adminKey)
+		require.Equal(t, "customer2:Movies", gotClass2.Class)
 
 		// user1: Films -> Movies. The handler qualifies both to customer1:.
 		alias1 := &models.Alias{Alias: "Films", Class: "Movies"}
@@ -121,22 +97,231 @@ func TestNamespaces_CollectionAndAliasCreate(t *testing.T) {
 		require.NoError(t, err)
 
 		// Admin can see both qualified aliases exist.
-		got1 := helper.GetAliasWithAuthz(t, "customer1:Films", helper.CreateAuth(testAdminKey))
+		got1 := helper.GetAliasWithAuthz(t, "customer1:Films", helper.CreateAuth(adminKey))
 		require.Equal(t, "customer1:Films", got1.Alias)
 		require.Equal(t, "customer1:Movies", got1.Class)
-		got2 := helper.GetAliasWithAuthz(t, "customer2:Films", helper.CreateAuth(testAdminKey))
+		got2 := helper.GetAliasWithAuthz(t, "customer2:Films", helper.CreateAuth(adminKey))
 		require.Equal(t, "customer2:Films", got2.Alias)
 		require.Equal(t, "customer2:Movies", got2.Class)
 
 		// Cleanup is best-effort; the compose teardown also wipes state.
 		_, _ = helper.Client(t).Schema.AliasesDelete(
 			schema.NewAliasesDeleteParams().WithAliasName("customer1:Films"),
-			helper.CreateAuth(testAdminKey),
+			helper.CreateAuth(adminKey),
 		)
 		_, _ = helper.Client(t).Schema.AliasesDelete(
 			schema.NewAliasesDeleteParams().WithAliasName("customer2:Films"),
-			helper.CreateAuth(testAdminKey),
+			helper.CreateAuth(adminKey),
 		)
+	})
+
+	t.Run("end-to-end: insert and get object with short, lowercase class name", func(t *testing.T) {
+		// Submit the class name lowercased on every hop. This exercises
+		// UppercaseClassName end-to-end through namespacing.Resolve: the bare
+		// short input is uppercased *before* the namespace prefix is glued on,
+		// so the qualified name stored on disk is "<namespace>:E2emovies".
+		for _, key := range []string{user1Key, user2Key} {
+			_, err := helper.Client(t).Schema.SchemaObjectsCreate(
+				schema.NewSchemaObjectsCreateParams().WithObjectClass(&models.Class{Class: "e2emovies"}),
+				helper.CreateAuth(key),
+			)
+			require.NoError(t, err)
+		}
+		defer helper.DeleteClassAuth(t, "customer1:E2emovies", adminKey)
+		defer helper.DeleteClassAuth(t, "customer2:E2emovies", adminKey)
+
+		// Same UUID, same short class name, different props in each namespace.
+		// The two writes must land on independent shards; reads must come back
+		// with the writer's own props, not the other namespace's.
+		sharedID := strfmt.UUID("11111111-2222-3333-4444-555555555555")
+		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			ID:         sharedID,
+			Class:      "e2emovies",
+			Properties: map[string]any{"title": "The Matrix"},
+		}, user1Key)
+		require.NoError(t, err)
+		_, err = helper.CreateObjectWithResponseAuth(t, &models.Object{
+			ID:         sharedID,
+			Class:      "e2emovies",
+			Properties: map[string]any{"title": "Inception"},
+		}, user2Key)
+		require.NoError(t, err)
+
+		// Each namespaced user reads back their own row.
+		got1, err := helper.GetObjectAuth(t, "e2emovies", sharedID, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "customer1:E2emovies", got1.Class)
+		assert.Equal(t, sharedID, got1.ID)
+		props1, ok := got1.Properties.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "The Matrix", props1["title"])
+
+		got2, err := helper.GetObjectAuth(t, "e2emovies", sharedID, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, "customer2:E2emovies", got2.Class)
+		assert.Equal(t, sharedID, got2.ID)
+		props2, ok := got2.Properties.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "Inception", props2["title"])
+
+		// Admin verification: raw schema view shows both qualified collection names.
+		gotClass1 := helper.GetClassAuth(t, "customer1:E2emovies", adminKey)
+		require.NotNil(t, gotClass1)
+		assert.Equal(t, "customer1:E2emovies", gotClass1.Class)
+		gotClass2 := helper.GetClassAuth(t, "customer2:E2emovies", adminKey)
+		require.NotNil(t, gotClass2)
+		assert.Equal(t, "customer2:E2emovies", gotClass2.Class)
+	})
+
+	t.Run("end-to-end: insert and get object via alias, with cross-namespace isolation", func(t *testing.T) {
+		// Create the same class name in both namespaces so the only thing
+		// keeping user2 from reading user1's object is the resolver.
+		for _, key := range []string{user1Key, user2Key} {
+			_, err := helper.Client(t).Schema.SchemaObjectsCreate(
+				schema.NewSchemaObjectsCreateParams().WithObjectClass(&models.Class{Class: "E2EFilmsTarget"}),
+				helper.CreateAuth(key),
+			)
+			require.NoError(t, err)
+		}
+		defer helper.DeleteClassAuth(t, "customer1:E2EFilmsTarget", adminKey)
+		defer helper.DeleteClassAuth(t, "customer2:E2EFilmsTarget", adminKey)
+
+		// Both namespaces get the same short alias name pointing at their own copy.
+		for _, key := range []string{user1Key, user2Key} {
+			_, err := helper.Client(t).Schema.AliasesCreate(
+				schema.NewAliasesCreateParams().WithBody(&models.Alias{Alias: "E2EFilmsAlias", Class: "E2EFilmsTarget"}),
+				helper.CreateAuth(key),
+			)
+			require.NoError(t, err)
+		}
+		defer helper.Client(t).Schema.AliasesDelete(
+			schema.NewAliasesDeleteParams().WithAliasName("customer1:E2EFilmsAlias"),
+			helper.CreateAuth(adminKey),
+		)
+		defer helper.Client(t).Schema.AliasesDelete(
+			schema.NewAliasesDeleteParams().WithAliasName("customer2:E2EFilmsAlias"),
+			helper.CreateAuth(adminKey),
+		)
+
+		// user1 inserts via the alias name; on disk it lands as customer1:E2EFilmsTarget.
+		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			Class:      "E2EFilmsAlias",
+			Properties: map[string]any{"title": "Inception"},
+		}, user1Key)
+		require.NoError(t, err)
+		require.NotEmpty(t, obj.ID)
+
+		// user1 reads it back via the alias — Resolve qualifies + maps alias → target.
+		got, err := helper.GetObjectAuth(t, "E2EFilmsAlias", obj.ID, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "customer1:E2EFilmsTarget", got.Class)
+		assert.Equal(t, obj.ID, got.ID)
+		propsGot, ok := got.Properties.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "Inception", propsGot["title"])
+
+		// Cross-namespace isolation: user2 asks for the same id under the same
+		// short class name and the same short alias name. Both qualify to
+		// customer2:* — different shard, no such object → 404.
+		_, err = helper.GetObjectAuth(t, "E2EFilmsTarget", obj.ID, user2Key)
+		require.Error(t, err)
+		var nfClass *objectsCli.ObjectsClassGetNotFound
+		require.True(t, errors.As(err, &nfClass), "expected ObjectsClassGetNotFound, got %T: %v", err, err)
+		_, err = helper.GetObjectAuth(t, "E2EFilmsAlias", obj.ID, user2Key)
+		require.Error(t, err)
+		var nfAlias *objectsCli.ObjectsClassGetNotFound
+		require.True(t, errors.As(err, &nfAlias), "expected ObjectsClassGetNotFound, got %T: %v", err, err)
+	})
+
+	t.Run("namespaced caller submitting :-qualified class on read double-prefixes to 404", func(t *testing.T) {
+		_, err := helper.Client(t).Schema.SchemaObjectsCreate(
+			schema.NewSchemaObjectsCreateParams().WithObjectClass(&models.Class{Class: "E2EDoublePrefix"}),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		defer helper.DeleteClassAuth(t, "customer1:E2EDoublePrefix", adminKey)
+
+		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			Class:      "E2EDoublePrefix",
+			Properties: map[string]any{"title": "Memento"},
+		}, user1Key)
+		require.NoError(t, err)
+		require.NotEmpty(t, obj.ID)
+
+		// user1 supplying the already-qualified name double-prefixes to
+		// "customer1:customer1:E2EDoublePrefix" — no such class, 404.
+		_, err = helper.GetObjectAuth(t, "customer1:E2EDoublePrefix", obj.ID, user1Key)
+		require.Error(t, err)
+		var nf *objectsCli.ObjectsClassGetNotFound
+		require.True(t, errors.As(err, &nf), "expected ObjectsClassGetNotFound, got %T: %v", err, err)
+	})
+
+	t.Run("global admin reads object via qualified class name", func(t *testing.T) {
+		_, err := helper.Client(t).Schema.SchemaObjectsCreate(
+			schema.NewSchemaObjectsCreateParams().WithObjectClass(&models.Class{Class: "E2EAdminRead"}),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		defer helper.DeleteClassAuth(t, "customer1:E2EAdminRead", adminKey)
+
+		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			Class:      "E2EAdminRead",
+			Properties: map[string]any{"title": "Tenet"},
+		}, user1Key)
+		require.NoError(t, err)
+		require.NotEmpty(t, obj.ID)
+
+		// Admin has no namespace, so Resolve is a no-op and the qualified
+		// name flows through untouched.
+		got, err := helper.GetObjectAuth(t, "customer1:E2EAdminRead", obj.ID, adminKey)
+		require.NoError(t, err)
+		assert.Equal(t, "customer1:E2EAdminRead", got.Class)
+		assert.Equal(t, obj.ID, got.ID)
+		props, ok := got.Properties.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "Tenet", props["title"])
+	})
+
+	t.Run("global admin reading object via short name returns 404", func(t *testing.T) {
+		_, err := helper.Client(t).Schema.SchemaObjectsCreate(
+			schema.NewSchemaObjectsCreateParams().WithObjectClass(&models.Class{Class: "E2EAdminShort"}),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		defer helper.DeleteClassAuth(t, "customer1:E2EAdminShort", adminKey)
+
+		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			Class:      "E2EAdminShort",
+			Properties: map[string]any{"title": "Dunkirk"},
+		}, user1Key)
+		require.NoError(t, err)
+		require.NotEmpty(t, obj.ID)
+
+		// Admin → no namespace → Resolve leaves "E2EAdminShort" as-is. There is
+		// no class by that bare name, only "customer1:E2EAdminShort" → 404.
+		_, err = helper.GetObjectAuth(t, "E2EAdminShort", obj.ID, adminKey)
+		require.Error(t, err)
+		var nf *objectsCli.ObjectsClassGetNotFound
+		require.True(t, errors.As(err, &nf), "expected ObjectsClassGetNotFound, got %T: %v", err, err)
+	})
+
+	t.Run("global admin rejected with 403 on NS-enabled cluster", func(t *testing.T) {
+		class := &models.Class{Class: "Movies"}
+		params := schema.NewSchemaObjectsCreateParams().WithObjectClass(class)
+		_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, helper.CreateAuth(adminKey))
+		require.Error(t, err)
+		var forbidden *schema.SchemaObjectsCreateForbidden
+		require.True(t, errors.As(err, &forbidden), "expected SchemaObjectsCreateForbidden, got %T: %v", err, err)
+	})
+
+	t.Run("namespaced caller submitting class name with ':' rejected", func(t *testing.T) {
+		class := &models.Class{Class: "Customer2:Movies"}
+		params := schema.NewSchemaObjectsCreateParams().WithObjectClass(class)
+		_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, helper.CreateAuth(user1Key))
+		require.Error(t, err)
+		var unproc *schema.SchemaObjectsCreateUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected SchemaObjectsCreateUnprocessableEntity, got %T: %v", err, err)
+		assert.Contains(t, unproc.Payload.Error[0].Message, "is not a valid class name")
 	})
 
 	t.Run("namespaced caller submitting alias with ':' in target rejected", func(t *testing.T) {
@@ -165,29 +350,10 @@ func TestNamespaces_CollectionAndAliasCreate(t *testing.T) {
 		alias := &models.Alias{Alias: "Films", Class: "Movies"}
 		_, err := helper.Client(t).Schema.AliasesCreate(
 			schema.NewAliasesCreateParams().WithBody(alias),
-			helper.CreateAuth(testAdminKey),
+			helper.CreateAuth(adminKey),
 		)
 		require.Error(t, err)
 		var forbidden *schema.AliasesCreateForbidden
 		require.True(t, errors.As(err, &forbidden), "expected AliasesCreateForbidden, got %T: %v", err, err)
 	})
-}
-
-func createMovies(t *testing.T, key string) {
-	t.Helper()
-	class := &models.Class{Class: "Movies", Vectorizer: "none"}
-	params := schema.NewSchemaObjectsCreateParams().WithObjectClass(class)
-	_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, helper.CreateAuth(key))
-	require.NoError(t, err)
-}
-
-func createNamespacedUser(t *testing.T, userID, ns, adminKey string) string {
-	t.Helper()
-	resp, err := helper.Client(t).Users.CreateUser(
-		users.NewCreateUserParams().WithUserID(userID).WithBody(users.CreateUserBody{Namespace: ns}),
-		helper.CreateAuth(adminKey),
-	)
-	require.NoError(t, err)
-	require.NotNil(t, resp.Payload.Apikey)
-	return *resp.Payload.Apikey
 }

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -1,0 +1,193 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespace
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/client/users"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// TestNamespaces_CollectionAndAliasCreate exercises the inline qualification
+// added to AddClass / AddAlias. RBAC is off so namespaced DB users reach the
+// handler unconditionally; the only gating in play is the handler-level
+// IsGlobalOperator/Namespace check plus the entity-name validators.
+func TestNamespaces_CollectionAndAliasCreate(t *testing.T) {
+	const (
+		testAdminUser = "admin-user"
+		testAdminKey  = "admin-key"
+		ns1           = "customer1"
+		ns2           = "customer2"
+	)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	compose, err := docker.New().WithWeaviate().
+		WithApiKey().WithUserApiKey(testAdminUser, testAdminKey).
+		WithDbUsers().
+		WithNamespaces().
+		Start(ctx)
+	require.NoError(t, err)
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer func() {
+		helper.ResetClient()
+		require.NoError(t, compose.Terminate(ctx))
+		cancel()
+	}()
+
+	helper.CreateNamespace(t, ns1, testAdminKey)
+	helper.CreateNamespace(t, ns2, testAdminKey)
+	defer helper.DeleteNamespace(t, ns1, testAdminKey)
+	defer helper.DeleteNamespace(t, ns2, testAdminKey)
+
+	user1Key := createNamespacedUser(t, "u1", ns1, testAdminKey)
+	user2Key := createNamespacedUser(t, "u2", ns2, testAdminKey)
+	t.Cleanup(func() {
+		helper.DeleteUser(t, ns1+":u1", testAdminKey)
+		helper.DeleteUser(t, ns2+":u2", testAdminKey)
+	})
+
+	t.Run("each namespaced user creates Movies; raw view shows qualified names", func(t *testing.T) {
+		defer helper.DeleteClassAuth(t, "customer1:Movies", testAdminKey)
+		defer helper.DeleteClassAuth(t, "customer2:Movies", testAdminKey)
+
+		createMovies(t, user1Key)
+		createMovies(t, user2Key)
+
+		// Admin (global) sees both qualified collections.
+		got1 := helper.GetClassAuth(t, "customer1:Movies", testAdminKey)
+		require.Equal(t, "customer1:Movies", got1.Class)
+		got2 := helper.GetClassAuth(t, "customer2:Movies", testAdminKey)
+		require.Equal(t, "customer2:Movies", got2.Class)
+	})
+
+	t.Run("global admin rejected with 403 on NS-enabled cluster", func(t *testing.T) {
+		class := &models.Class{Class: "Movies"}
+		params := schema.NewSchemaObjectsCreateParams().WithObjectClass(class)
+		_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, helper.CreateAuth(testAdminKey))
+		require.Error(t, err)
+		var forbidden *schema.SchemaObjectsCreateForbidden
+		require.True(t, errors.As(err, &forbidden), "expected SchemaObjectsCreateForbidden, got %T: %v", err, err)
+	})
+
+	t.Run("namespaced caller submitting class name with ':' rejected", func(t *testing.T) {
+		class := &models.Class{Class: "Customer2:Movies"}
+		params := schema.NewSchemaObjectsCreateParams().WithObjectClass(class)
+		_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, helper.CreateAuth(user1Key))
+		require.Error(t, err)
+		var unproc *schema.SchemaObjectsCreateUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected SchemaObjectsCreateUnprocessableEntity, got %T: %v", err, err)
+		assert.Contains(t, unproc.Payload.Error[0].Message, "is not a valid class name")
+	})
+
+	t.Run("namespace-local alias create succeeds and is independent across namespaces", func(t *testing.T) {
+		createMovies(t, user1Key)
+		createMovies(t, user2Key)
+		defer helper.DeleteClassAuth(t, "customer1:Movies", testAdminKey)
+		defer helper.DeleteClassAuth(t, "customer2:Movies", testAdminKey)
+
+		// user1: Films -> Movies. The handler qualifies both to customer1:.
+		alias1 := &models.Alias{Alias: "Films", Class: "Movies"}
+		_, err := helper.Client(t).Schema.AliasesCreate(
+			schema.NewAliasesCreateParams().WithBody(alias1),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+
+		// user2 can independently create the same short alias name.
+		alias2 := &models.Alias{Alias: "Films", Class: "Movies"}
+		_, err = helper.Client(t).Schema.AliasesCreate(
+			schema.NewAliasesCreateParams().WithBody(alias2),
+			helper.CreateAuth(user2Key),
+		)
+		require.NoError(t, err)
+
+		// Admin can see both qualified aliases exist.
+		got1 := helper.GetAliasWithAuthz(t, "customer1:Films", helper.CreateAuth(testAdminKey))
+		require.Equal(t, "customer1:Films", got1.Alias)
+		require.Equal(t, "customer1:Movies", got1.Class)
+		got2 := helper.GetAliasWithAuthz(t, "customer2:Films", helper.CreateAuth(testAdminKey))
+		require.Equal(t, "customer2:Films", got2.Alias)
+		require.Equal(t, "customer2:Movies", got2.Class)
+
+		// Cleanup is best-effort; the compose teardown also wipes state.
+		_, _ = helper.Client(t).Schema.AliasesDelete(
+			schema.NewAliasesDeleteParams().WithAliasName("customer1:Films"),
+			helper.CreateAuth(testAdminKey),
+		)
+		_, _ = helper.Client(t).Schema.AliasesDelete(
+			schema.NewAliasesDeleteParams().WithAliasName("customer2:Films"),
+			helper.CreateAuth(testAdminKey),
+		)
+	})
+
+	t.Run("namespaced caller submitting alias with ':' in target rejected", func(t *testing.T) {
+		alias := &models.Alias{Alias: "Films", Class: "Customer2:Movies"}
+		_, err := helper.Client(t).Schema.AliasesCreate(
+			schema.NewAliasesCreateParams().WithBody(alias),
+			helper.CreateAuth(user1Key),
+		)
+		require.Error(t, err)
+		var unproc *schema.AliasesCreateUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected AliasesCreateUnprocessableEntity, got %T: %v", err, err)
+	})
+
+	t.Run("namespaced caller submitting alias with ':' in alias name rejected", func(t *testing.T) {
+		alias := &models.Alias{Alias: "Customer2:Films", Class: "Movies"}
+		_, err := helper.Client(t).Schema.AliasesCreate(
+			schema.NewAliasesCreateParams().WithBody(alias),
+			helper.CreateAuth(user1Key),
+		)
+		require.Error(t, err)
+		var unproc *schema.AliasesCreateUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected AliasesCreateUnprocessableEntity, got %T: %v", err, err)
+	})
+
+	t.Run("global admin rejected on alias create with NS-enabled", func(t *testing.T) {
+		alias := &models.Alias{Alias: "Films", Class: "Movies"}
+		_, err := helper.Client(t).Schema.AliasesCreate(
+			schema.NewAliasesCreateParams().WithBody(alias),
+			helper.CreateAuth(testAdminKey),
+		)
+		require.Error(t, err)
+		var forbidden *schema.AliasesCreateForbidden
+		require.True(t, errors.As(err, &forbidden), "expected AliasesCreateForbidden, got %T: %v", err, err)
+	})
+}
+
+func createMovies(t *testing.T, key string) {
+	t.Helper()
+	class := &models.Class{Class: "Movies", Vectorizer: "none"}
+	params := schema.NewSchemaObjectsCreateParams().WithObjectClass(class)
+	_, err := helper.Client(t).Schema.SchemaObjectsCreate(params, helper.CreateAuth(key))
+	require.NoError(t, err)
+}
+
+func createNamespacedUser(t *testing.T, userID, ns, adminKey string) string {
+	t.Helper()
+	resp, err := helper.Client(t).Users.CreateUser(
+		users.NewCreateUserParams().WithUserID(userID).WithBody(users.CreateUserBody{Namespace: ns}),
+		helper.CreateAuth(adminKey),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, resp.Payload.Apikey)
+	return *resp.Payload.Apikey
+}

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -1,0 +1,260 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespace
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	schemaCli "github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/test/helper"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+func newGrpcClient(t *testing.T) (pb.WeaviateClient, *grpc.ClientConn) {
+	t.Helper()
+	conn, err := helper.CreateGrpcConnectionClient(sharedCompose.GetWeaviate().GrpcURI())
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	return helper.CreateGrpcWeaviateClient(conn), conn
+}
+
+func authCtx(key string) context.Context {
+	return metadata.AppendToOutgoingContext(context.Background(), "authorization", fmt.Sprintf("Bearer %s", key))
+}
+
+// searchReq builds a SearchRequest with the API-version flags every gRPC
+// caller in this suite needs. Tests can mutate the returned struct (e.g. to
+// add Properties/Metadata) before sending.
+func searchReq(collection string, limit uint32) *pb.SearchRequest {
+	return &pb.SearchRequest{
+		Collection:  collection,
+		Limit:       limit,
+		Uses_123Api: true,
+		Uses_125Api: true,
+		Uses_127Api: true,
+	}
+}
+
+// TestNamespaces_GRPC exercises namespace fan-out for the gRPC endpoints
+// (BatchObjects, Search, Aggregate). Each namespaced caller submits the
+// short collection name; the handler must qualify it via namespacing.Resolve
+// so the request only ever touches the caller's namespace shard.
+func TestNamespaces_GRPC(t *testing.T) {
+	user1Key, user2Key := twoNamespaces(t)
+
+	grpcClient, conn := newGrpcClient(t)
+	defer conn.Close()
+
+	const class = "MoviesGRPC"
+	setupClassInBothNamespaces(t, class, user1Key, user2Key)
+
+	id1 := strfmt.UUID("aaaaaaaa-1111-1111-1111-111111111111")
+	id2 := strfmt.UUID("bbbbbbbb-2222-2222-2222-222222222222")
+
+	makeBatchObj := func(id strfmt.UUID, collection, title string) *pb.BatchObject {
+		return &pb.BatchObject{
+			Uuid:       id.String(),
+			Collection: collection,
+			Properties: &pb.BatchObject_Properties{
+				NonRefProperties: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"title": structpb.NewStringValue(title),
+					},
+				},
+			},
+		}
+	}
+
+	t.Run("BatchObjects fans out per namespace", func(t *testing.T) {
+		// user1 inserts under the short class name; the handler qualifies
+		// to customer1:MoviesGRPC.
+		resp, err := grpcClient.BatchObjects(authCtx(user1Key), &pb.BatchObjectsRequest{
+			Objects: []*pb.BatchObject{
+				makeBatchObj(id1, class, "ns1-The Matrix"),
+				makeBatchObj(id2, class, "ns1-Inception"),
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Empty(t, resp.Errors)
+
+		// user2 inserts the same UUIDs under the same short class name;
+		// the handler qualifies to customer2:MoviesGRPC, so there is no
+		// id collision between the two namespaces.
+		resp, err = grpcClient.BatchObjects(authCtx(user2Key), &pb.BatchObjectsRequest{
+			Objects: []*pb.BatchObject{
+				makeBatchObj(id1, class, "ns2-Memento"),
+				makeBatchObj(id2, class, "ns2-Tenet"),
+			},
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+		require.Empty(t, resp.Errors)
+
+		// Cross-check via the REST get path that the rows landed under their
+		// respective qualified class names.
+		got1, err := helper.GetObjectAuth(t, class, id1, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "customer1:"+class, got1.Class)
+		assert.Equal(t, "ns1-The Matrix", got1.Properties.(map[string]any)["title"])
+
+		got2, err := helper.GetObjectAuth(t, class, id1, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, "customer2:"+class, got2.Class)
+		assert.Equal(t, "ns2-Memento", got2.Properties.(map[string]any)["title"])
+	})
+
+	t.Run("Search is namespace-scoped", func(t *testing.T) {
+		req := func(key string) (*pb.SearchReply, error) {
+			r := searchReq(class, 10)
+			r.Properties = &pb.PropertiesRequest{NonRefProperties: []string{"title"}}
+			r.Metadata = &pb.MetadataRequest{Uuid: true}
+			return grpcClient.Search(authCtx(key), r)
+		}
+
+		resp1, err := req(user1Key)
+		require.NoError(t, err)
+		require.Len(t, resp1.Results, 2)
+		titles1 := []string{
+			resp1.Results[0].Properties.NonRefProps.Fields["title"].GetTextValue(),
+			resp1.Results[1].Properties.NonRefProps.Fields["title"].GetTextValue(),
+		}
+		assert.ElementsMatch(t, []string{"ns1-The Matrix", "ns1-Inception"}, titles1)
+
+		resp2, err := req(user2Key)
+		require.NoError(t, err)
+		require.Len(t, resp2.Results, 2)
+		titles2 := []string{
+			resp2.Results[0].Properties.NonRefProps.Fields["title"].GetTextValue(),
+			resp2.Results[1].Properties.NonRefProps.Fields["title"].GetTextValue(),
+		}
+		assert.ElementsMatch(t, []string{"ns2-Memento", "ns2-Tenet"}, titles2)
+	})
+
+	t.Run("Aggregate count is namespace-scoped", func(t *testing.T) {
+		// gRPC Aggregate is not yet namespace-aware. Two gaps stand in the
+		// way: the handler doesn't qualify the class via namespacing.Resolve,
+		// and count(*) fan-out goes through a cluster-API HTTP route whose
+		// URL regex is built from ClassNameRegexCore — that regex excludes
+		// ":", so namespace-qualified index names never match the route.
+		t.Skip("aggregate on namespaced classes not yet wired; tracked separately")
+
+		for _, key := range []string{user1Key, user2Key} {
+			resp, err := grpcClient.Aggregate(authCtx(key), &pb.AggregateRequest{
+				Collection:   class,
+				ObjectsCount: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, resp.GetSingleResult())
+			assert.Equal(t, int64(2), resp.GetSingleResult().GetObjectsCount())
+		}
+	})
+
+	t.Run("Search via alias resolves per namespace", func(t *testing.T) {
+		// Both namespaces register the same short alias name pointing at
+		// their own copy of MoviesGRPC. The handler must qualify the alias
+		// to "<ns>:MoviesGRPCAlias" before alias→target lookup, otherwise
+		// user1's request would land on user2's data (or vice versa).
+		// Aggregate-via-alias is intentionally not exercised — gRPC Aggregate
+		// is not yet namespace-aware (see Aggregate subtest above).
+		const aliasName = "MoviesGRPCAlias"
+		for _, key := range []string{user1Key, user2Key} {
+			_, err := helper.Client(t).Schema.AliasesCreate(
+				schemaCli.NewAliasesCreateParams().WithBody(&models.Alias{Alias: aliasName, Class: class}),
+				helper.CreateAuth(key),
+			)
+			require.NoError(t, err)
+		}
+		defer helper.Client(t).Schema.AliasesDelete(
+			schemaCli.NewAliasesDeleteParams().WithAliasName("customer1:"+aliasName),
+			helper.CreateAuth(adminKey),
+		)
+		defer helper.Client(t).Schema.AliasesDelete(
+			schemaCli.NewAliasesDeleteParams().WithAliasName("customer2:"+aliasName),
+			helper.CreateAuth(adminKey),
+		)
+
+		for _, key := range []string{user1Key, user2Key} {
+			searchResp, err := grpcClient.Search(authCtx(key), searchReq(aliasName, 10))
+			require.NoError(t, err)
+			assert.Len(t, searchResp.Results, 2)
+		}
+	})
+
+	t.Run("namespaced caller submitting :-qualified collection double-prefixes", func(t *testing.T) {
+		// user1 supplying "customer1:MoviesGRPC" gets qualified again to
+		// "customer1:customer1:MoviesGRPC" — no such class on disk.
+		// Aggregate is not exercised here — gRPC Aggregate is not yet
+		// namespace-aware (see Aggregate subtest above).
+		qualified := "customer1:" + class
+
+		_, err := grpcClient.Search(authCtx(user1Key), searchReq(qualified, 1))
+		require.Error(t, err)
+
+		batchResp, err := grpcClient.BatchObjects(authCtx(user1Key), &pb.BatchObjectsRequest{
+			Objects: []*pb.BatchObject{
+				makeBatchObj(strfmt.UUID("dddddddd-4444-4444-4444-444444444444"), qualified, "double"),
+			},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, batchResp.Errors)
+	})
+
+	t.Run("global admin succeeds with qualified name and fails with short name", func(t *testing.T) {
+		// Admin has no namespace, so qualify is a no-op and the supplied
+		// name flows through. Short name → no class on disk → error.
+		// Qualified name → matches storage → success.
+		// Aggregate is not exercised — gRPC Aggregate is not yet
+		// namespace-aware (see Aggregate subtest above).
+		shortReq := func() (*pb.SearchReply, error) {
+			return grpcClient.Search(authCtx(adminKey), searchReq(class, 10))
+		}
+		qualifiedReq := func() (*pb.SearchReply, error) {
+			return grpcClient.Search(authCtx(adminKey), searchReq("customer1:"+class, 10))
+		}
+
+		_, err := shortReq()
+		require.Error(t, err)
+		searchResp, err := qualifiedReq()
+		require.NoError(t, err)
+		assert.Len(t, searchResp.Results, 2)
+
+		// BatchObjects: short → per-object error; qualified → success and
+		// the row shows up via REST.
+		shortBatch, err := grpcClient.BatchObjects(authCtx(adminKey), &pb.BatchObjectsRequest{
+			Objects: []*pb.BatchObject{makeBatchObj(strfmt.UUID("eeeeeeee-5555-5555-5555-555555555555"), class, "admin-short")},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, shortBatch.Errors)
+
+		adminID := strfmt.UUID("ffffffff-6666-6666-6666-666666666666")
+		qualifiedBatch, err := grpcClient.BatchObjects(authCtx(adminKey), &pb.BatchObjectsRequest{
+			Objects: []*pb.BatchObject{makeBatchObj(adminID, "customer1:"+class, "admin-qualified")},
+		})
+		require.NoError(t, err)
+		require.Empty(t, qualifiedBatch.Errors)
+
+		got, err := helper.GetObjectAuth(t, "customer1:"+class, adminID, adminKey)
+		require.NoError(t, err)
+		assert.Equal(t, "customer1:"+class, got.Class)
+		assert.Equal(t, "admin-qualified", got.Properties.(map[string]any)["title"])
+	})
+}

--- a/test/acceptance/namespace/objects_test.go
+++ b/test/acceptance/namespace/objects_test.go
@@ -1,0 +1,403 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespace
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/client/batch"
+	"github.com/weaviate/weaviate/client/objects"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// twoNamespaces brings up customer1+customer2 plus a single namespaced
+// DB user per namespace and returns their API keys. Cleanup is registered.
+func twoNamespaces(t *testing.T) (string, string) {
+	t.Helper()
+	const (
+		ns1 = "customer1"
+		ns2 = "customer2"
+	)
+	helper.CreateNamespace(t, ns1, adminKey)
+	helper.CreateNamespace(t, ns2, adminKey)
+	t.Cleanup(func() {
+		helper.DeleteNamespace(t, ns1, adminKey)
+		helper.DeleteNamespace(t, ns2, adminKey)
+	})
+	user1Key := createNamespacedUser(t, "u1", ns1, adminKey)
+	user2Key := createNamespacedUser(t, "u2", ns2, adminKey)
+	t.Cleanup(func() {
+		helper.DeleteUser(t, ns1+":u1", adminKey)
+		helper.DeleteUser(t, ns2+":u2", adminKey)
+	})
+	return user1Key, user2Key
+}
+
+// setupClassInBothNamespaces creates a class with a single text "title"
+// property under each user's namespace and registers cleanup of the
+// qualified names.
+func setupClassInBothNamespaces(t *testing.T, name, k1, k2 string) {
+	t.Helper()
+	for _, key := range []string{k1, k2} {
+		helper.CreateClassAuth(t, &models.Class{
+			Class: name,
+			Properties: []*models.Property{
+				{Name: "title", DataType: []string{"text"}},
+			},
+		}, key)
+	}
+	t.Cleanup(func() {
+		helper.DeleteClassAuth(t, "customer1:"+name, adminKey)
+		helper.DeleteClassAuth(t, "customer2:"+name, adminKey)
+	})
+}
+
+// setupClassInNs1 creates a class with a single text "title" property under
+// user1Key only and registers cleanup of the qualified name.
+func setupClassInNs1(t *testing.T, name, key string) {
+	t.Helper()
+	helper.CreateClassAuth(t, &models.Class{
+		Class: name,
+		Properties: []*models.Property{
+			{Name: "title", DataType: []string{"text"}},
+		},
+	}, key)
+	t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+name, adminKey) })
+}
+
+// seedTwo writes the same UUID under the same short class name in both
+// namespaces with different "title" content.
+func seedTwo(t *testing.T, class string, id strfmt.UUID, ns1Title, ns2Title, k1, k2 string) {
+	t.Helper()
+	_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+		ID: id, Class: class, Properties: map[string]any{"title": ns1Title},
+	}, k1)
+	require.NoError(t, err)
+	_, err = helper.CreateObjectWithResponseAuth(t, &models.Object{
+		ID: id, Class: class, Properties: map[string]any{"title": ns2Title},
+	}, k2)
+	require.NoError(t, err)
+}
+
+// TestNamespaces_ObjectLifecycle exercises namespacing.Resolve fan-out across
+// the object REST endpoints (add/get/update/merge/delete/head/list/validate)
+// plus the WS4 contract for double-prefix and global-principal access.
+func TestNamespaces_ObjectLifecycle(t *testing.T) {
+	user1Key, user2Key := twoNamespaces(t)
+
+	t.Run("add and get with short, lowercase class name", func(t *testing.T) {
+		// Submit lowercased on every hop. UppercaseClassName runs before the
+		// namespace prefix is glued on, so the qualified name on disk is
+		// "<namespace>:E2emovies".
+		const (
+			short      = "e2emovies"
+			qualified1 = "customer1:E2emovies"
+			qualified2 = "customer2:E2emovies"
+		)
+		setupClassInBothNamespaces(t, short, user1Key, user2Key)
+
+		id := strfmt.UUID("11111111-2222-3333-4444-555555555555")
+		seedTwo(t, short, id, "The Matrix", "Inception", user1Key, user2Key)
+
+		got1, err := helper.GetObjectAuth(t, short, id, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, qualified1, got1.Class)
+		assert.Equal(t, "The Matrix", got1.Properties.(map[string]any)["title"])
+
+		got2, err := helper.GetObjectAuth(t, short, id, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, qualified2, got2.Class)
+		assert.Equal(t, "Inception", got2.Properties.(map[string]any)["title"])
+
+		// Admin's raw schema view shows both qualified names exist.
+		assert.Equal(t, qualified1, helper.GetClassAuth(t, qualified1, adminKey).Class)
+		assert.Equal(t, qualified2, helper.GetClassAuth(t, qualified2, adminKey).Class)
+	})
+
+	t.Run("update / merge / delete on ns1 leave ns2 untouched", func(t *testing.T) {
+		const class = "MutationTarget"
+		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+
+		id := strfmt.UUID("aaaaaaaa-1111-1111-1111-111111111111")
+		seedTwo(t, class, id, "v1-ns1", "v1-ns2", user1Key, user2Key)
+
+		// PUT in ns1.
+		_, err := helper.Client(t).Objects.ObjectsClassPut(
+			objects.NewObjectsClassPutParams().WithClassName(class).WithID(id).
+				WithBody(&models.Object{ID: id, Class: class, Properties: map[string]any{"title": "v2-ns1"}}),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		got1, err := helper.GetObjectAuth(t, class, id, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "v2-ns1", got1.Properties.(map[string]any)["title"])
+
+		// PATCH in ns1.
+		_, err = helper.Client(t).Objects.ObjectsClassPatch(
+			objects.NewObjectsClassPatchParams().WithClassName(class).WithID(id).
+				WithBody(&models.Object{Class: class, Properties: map[string]any{"title": "v3-ns1"}}),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		got1, err = helper.GetObjectAuth(t, class, id, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "v3-ns1", got1.Properties.(map[string]any)["title"])
+
+		// DELETE in ns1.
+		_, err = helper.Client(t).Objects.ObjectsClassDelete(
+			objects.NewObjectsClassDeleteParams().WithClassName(class).WithID(id),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		_, err = helper.GetObjectAuth(t, class, id, user1Key)
+		require.Error(t, err)
+		var nfGet *objects.ObjectsClassGetNotFound
+		require.True(t, errors.As(err, &nfGet), "expected ObjectsClassGetNotFound, got %T: %v", err, err)
+
+		// ns2 row never moved.
+		got2, err := helper.GetObjectAuth(t, class, id, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, "v1-ns2", got2.Properties.(map[string]any)["title"])
+	})
+
+	t.Run("head is namespace-scoped", func(t *testing.T) {
+		const class = "HeadTarget"
+		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+
+		// Insert only in ns1; ns2 has the class but no row.
+		id := strfmt.UUID("cccccccc-3333-3333-3333-333333333333")
+		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			ID: id, Class: class, Properties: map[string]any{"title": "head-ns1"},
+		}, user1Key)
+		require.NoError(t, err)
+
+		_, err = helper.Client(t).Objects.ObjectsClassHead(
+			objects.NewObjectsClassHeadParams().WithClassName(class).WithID(id),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+
+		_, err = helper.Client(t).Objects.ObjectsClassHead(
+			objects.NewObjectsClassHeadParams().WithClassName(class).WithID(id),
+			helper.CreateAuth(user2Key),
+		)
+		require.Error(t, err)
+		var nf *objects.ObjectsClassHeadNotFound
+		require.True(t, errors.As(err, &nf), "expected ObjectsClassHeadNotFound, got %T: %v", err, err)
+	})
+
+	t.Run("query (GET /objects?class=) is namespace-scoped", func(t *testing.T) {
+		const class = "ListTarget"
+		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+
+		id := strfmt.UUID("eeeeeeee-5555-5555-5555-555555555555")
+		seedTwo(t, class, id, "list-ns1", "list-ns2", user1Key, user2Key)
+
+		shortClass := class
+		listResp1, err := helper.Client(t).Objects.ObjectsList(
+			objects.NewObjectsListParams().WithClass(&shortClass),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		require.Len(t, listResp1.Payload.Objects, 1)
+		assert.Equal(t, "customer1:"+class, listResp1.Payload.Objects[0].Class)
+		assert.Equal(t, "list-ns1", listResp1.Payload.Objects[0].Properties.(map[string]any)["title"])
+
+		listResp2, err := helper.Client(t).Objects.ObjectsList(
+			objects.NewObjectsListParams().WithClass(&shortClass),
+			helper.CreateAuth(user2Key),
+		)
+		require.NoError(t, err)
+		require.Len(t, listResp2.Payload.Objects, 1)
+		assert.Equal(t, "customer2:"+class, listResp2.Payload.Objects[0].Class)
+		assert.Equal(t, "list-ns2", listResp2.Payload.Objects[0].Properties.(map[string]any)["title"])
+	})
+
+	t.Run("validate resolves the class per namespace", func(t *testing.T) {
+		// Class only in ns1. user1 validates → ok. user2 validates same short
+		// class → unresolved → error.
+		const class = "ValidateTarget"
+		setupClassInNs1(t, class, user1Key)
+
+		id := strfmt.UUID("ffffffff-6666-6666-6666-666666666666")
+		_, err := helper.Client(t).Objects.ObjectsValidate(
+			objects.NewObjectsValidateParams().WithBody(&models.Object{
+				ID: id, Class: class, Properties: map[string]any{"title": "ok"},
+			}),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+
+		_, err = helper.Client(t).Objects.ObjectsValidate(
+			objects.NewObjectsValidateParams().WithBody(&models.Object{
+				ID: id, Class: class, Properties: map[string]any{"title": "ok"},
+			}),
+			helper.CreateAuth(user2Key),
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("namespaced caller submitting :-qualified class on read double-prefixes to 404", func(t *testing.T) {
+		const class = "DoublePrefix"
+		setupClassInNs1(t, class, user1Key)
+
+		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			Class:      class,
+			Properties: map[string]any{"title": "Memento"},
+		}, user1Key)
+		require.NoError(t, err)
+		require.NotEmpty(t, obj.ID)
+
+		// user1 supplying the already-qualified name double-prefixes to
+		// "customer1:customer1:DoublePrefix" — no such class, 404.
+		_, err = helper.GetObjectAuth(t, "customer1:"+class, obj.ID, user1Key)
+		require.Error(t, err)
+		var nf *objects.ObjectsClassGetNotFound
+		require.True(t, errors.As(err, &nf), "expected ObjectsClassGetNotFound, got %T: %v", err, err)
+	})
+
+	t.Run("global admin reads object via qualified class name", func(t *testing.T) {
+		const class = "AdminQualified"
+		setupClassInNs1(t, class, user1Key)
+
+		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			Class:      class,
+			Properties: map[string]any{"title": "Tenet"},
+		}, user1Key)
+		require.NoError(t, err)
+		require.NotEmpty(t, obj.ID)
+
+		// Admin has no namespace, so Resolve is a no-op and the qualified
+		// name flows through untouched.
+		got, err := helper.GetObjectAuth(t, "customer1:"+class, obj.ID, adminKey)
+		require.NoError(t, err)
+		assert.Equal(t, "customer1:"+class, got.Class)
+		assert.Equal(t, "Tenet", got.Properties.(map[string]any)["title"])
+	})
+
+	t.Run("global admin reading object via short name returns 404", func(t *testing.T) {
+		const class = "AdminShort"
+		setupClassInNs1(t, class, user1Key)
+
+		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			Class:      class,
+			Properties: map[string]any{"title": "Dunkirk"},
+		}, user1Key)
+		require.NoError(t, err)
+		require.NotEmpty(t, obj.ID)
+
+		// Admin → no namespace → Resolve leaves the short name as-is. Storage
+		// only has "customer1:AdminShort" → 404.
+		_, err = helper.GetObjectAuth(t, class, obj.ID, adminKey)
+		require.Error(t, err)
+		var nf *objects.ObjectsClassGetNotFound
+		require.True(t, errors.As(err, &nf), "expected ObjectsClassGetNotFound, got %T: %v", err, err)
+	})
+}
+
+// TestNamespaces_BatchOperations exercises BatchManager fan-out under
+// namespace resolution.
+func TestNamespaces_BatchOperations(t *testing.T) {
+	user1Key, user2Key := twoNamespaces(t)
+
+	t.Run("batch insert is namespace-scoped", func(t *testing.T) {
+		const class = "BatchInsert"
+		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+
+		id1 := strfmt.UUID("11111111-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+		id2 := strfmt.UUID("22222222-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+		helper.CreateObjectsBatchAuth(t, []*models.Object{
+			{ID: id1, Class: class, Properties: map[string]any{"title": "ns1-a"}},
+			{ID: id2, Class: class, Properties: map[string]any{"title": "ns1-b"}},
+		}, user1Key)
+		helper.CreateObjectsBatchAuth(t, []*models.Object{
+			{ID: id1, Class: class, Properties: map[string]any{"title": "ns2-a"}},
+			{ID: id2, Class: class, Properties: map[string]any{"title": "ns2-b"}},
+		}, user2Key)
+
+		got1a, err := helper.GetObjectAuth(t, class, id1, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "customer1:"+class, got1a.Class)
+		assert.Equal(t, "ns1-a", got1a.Properties.(map[string]any)["title"])
+
+		got2b, err := helper.GetObjectAuth(t, class, id2, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, "customer2:"+class, got2b.Class)
+		assert.Equal(t, "ns2-b", got2b.Properties.(map[string]any)["title"])
+	})
+
+	t.Run("batch delete by filter is namespace-scoped", func(t *testing.T) {
+		// Filter validation rejects namespace-qualified class names: the path
+		// validator in entities/filters/path.go runs each path element through
+		// schema.ValidateClassName, whose regex disallows the `:` separator.
+		// Until filter parsing is taught to accept qualified names,
+		// namespace-aware batch delete cannot succeed.
+		t.Skip("blocked: filter parser rejects namespace-qualified class names; tracked as a separate WS item")
+
+		const class = "BatchDelete"
+		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+
+		id1 := strfmt.UUID("33333333-cccc-cccc-cccc-cccccccccccc")
+		id2 := strfmt.UUID("44444444-dddd-dddd-dddd-dddddddddddd")
+		helper.CreateObjectsBatchAuth(t, []*models.Object{
+			{ID: id1, Class: class, Properties: map[string]any{"title": "kill"}},
+			{ID: id2, Class: class, Properties: map[string]any{"title": "keep"}},
+		}, user1Key)
+		helper.CreateObjectsBatchAuth(t, []*models.Object{
+			{ID: id1, Class: class, Properties: map[string]any{"title": "kill"}},
+			{ID: id2, Class: class, Properties: map[string]any{"title": "keep"}},
+		}, user2Key)
+
+		killText := "kill"
+		body := &models.BatchDelete{
+			Match: &models.BatchDeleteMatch{
+				Class: class,
+				Where: &models.WhereFilter{
+					Operator:  "Equal",
+					Path:      []string{"title"},
+					ValueText: &killText,
+				},
+			},
+		}
+		resp, err := helper.Client(t).Batch.BatchObjectsDelete(
+			batch.NewBatchObjectsDeleteParams().WithBody(body),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload.Results)
+		assert.EqualValues(t, 1, resp.Payload.Results.Successful)
+
+		// ns1's "kill" gone; "keep" survives.
+		_, err = helper.GetObjectAuth(t, class, id1, user1Key)
+		require.Error(t, err)
+		var nfGet *objects.ObjectsClassGetNotFound
+		require.True(t, errors.As(err, &nfGet), "expected ObjectsClassGetNotFound, got %T: %v", err, err)
+		got, err := helper.GetObjectAuth(t, class, id2, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "keep", got.Properties.(map[string]any)["title"])
+
+		// ns2 untouched.
+		got21, err := helper.GetObjectAuth(t, class, id1, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, "kill", got21.Properties.(map[string]any)["title"])
+		got22, err := helper.GetObjectAuth(t, class, id2, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, "keep", got22.Properties.(map[string]any)["title"])
+	})
+}

--- a/test/acceptance/namespace/objects_test.go
+++ b/test/acceptance/namespace/objects_test.go
@@ -96,7 +96,7 @@ func seedTwo(t *testing.T, class string, id strfmt.UUID, ns1Title, ns2Title, k1,
 
 // TestNamespaces_ObjectLifecycle exercises namespacing.Resolve fan-out across
 // the object REST endpoints (add/get/update/merge/delete/head/list/validate)
-// plus the WS4 contract for double-prefix and global-principal access.
+// plus the contract for double-prefix and global-principal access.
 func TestNamespaces_ObjectLifecycle(t *testing.T) {
 	user1Key, user2Key := twoNamespaces(t)
 

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -47,8 +47,7 @@ func TestMain(m *testing.M) {
 		WithUserApiKey(scopedManageUser, scopedManageKey).
 		WithUserApiKey(viewerUser, viewerKey).
 		WithUserApiKey(noPermsUser, noPermsKey).
-		WithRBAC().
-		WithRbacRoots(adminUser).
+		WithDbUsers().
 		WithNamespaces().
 		WithWeaviate().
 		Start(ctx)

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -49,7 +49,7 @@ func TestMain(m *testing.M) {
 		WithUserApiKey(noPermsUser, noPermsKey).
 		WithDbUsers().
 		WithNamespaces().
-		WithWeaviate().
+		WithWeaviateWithGRPC().
 		Start(ctx)
 	if err != nil {
 		panic(errors.Wrap(err, "failed to start shared compose"))

--- a/usecases/auth/authorization/errors/errors.go
+++ b/usecases/auth/authorization/errors/errors.go
@@ -18,11 +18,12 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
-// Forbidden indicates a failed authorization
+// Forbidden indicates a failed authorization or namespace requirement.
 type Forbidden struct {
-	principal *models.Principal
-	verb      string
-	resources []string
+	principal   *models.Principal
+	verb        string
+	resources   []string
+	isNamespace bool // true for namespace-required errors
 }
 
 type Unauthenticated struct{}
@@ -36,17 +37,35 @@ func NewUnauthenticated() Unauthenticated {
 	return Unauthenticated{}
 }
 
-// NewForbidden creates an explicit Forbidden error with details about the
-// principal and the attempted access on a specific resource
+// NewForbidden creates an explicit Forbidden error for RBAC failures with details about the
+// principal and the attempted access on a specific resource.
 func NewForbidden(principal *models.Principal, verb string, resources ...string) Forbidden {
 	return Forbidden{
-		principal: principal,
-		verb:      verb,
-		resources: resources,
+		principal:   principal,
+		verb:        verb,
+		resources:   resources,
+		isNamespace: false,
+	}
+}
+
+// NewNamespaceForbidden creates a Forbidden error for namespace requirement failures.
+func NewNamespaceForbidden(principal *models.Principal) Forbidden {
+	return Forbidden{
+		principal:   principal,
+		verb:        "",
+		resources:   nil,
+		isNamespace: true,
 	}
 }
 
 func (f Forbidden) Error() string {
+	if f.isNamespace {
+		username := "unknown"
+		if f.principal != nil {
+			username = f.principal.Username
+		}
+		return fmt.Sprintf("user '%s' must be namespaced on a namespaces-enabled cluster", username)
+	}
 	optionalGroups := ""
 	if len(f.principal.Groups) == 1 {
 		optionalGroups = fmt.Sprintf(" (of group '%s')", f.principal.Groups[0])

--- a/usecases/namespaces/controller.go
+++ b/usecases/namespaces/controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	entschema "github.com/weaviate/weaviate/entities/schema"
 )
 
 var (
@@ -44,21 +45,9 @@ var (
 	ErrNotFound = errors.New("namespace not found")
 )
 
-// Name validation contract (kept tight so the operator API gives
-// predictable results and so name-in-URL round-tripping is unambiguous):
-//
-//   - Must start with a lowercase ASCII letter.
-//   - Subsequent characters are lowercase letters or digits.
-//   - Length in [NameMinLength, NameMaxLength].
-//   - Must not collide with a reserved name (see reservedNames).
-//
-// Reserved names are held back for platform/system use (e.g. a future
-// "default" namespace or routing sentinels) and are refused at Create time.
-const (
-	NameMinLength = 3
-	NameMaxLength = 36
-)
-
+// See entschema.NamespaceMinLength for the full namespace name validation
+// contract. The regex and reserved-name list below are the non-length parts
+// that live in this package.
 var namespaceNameRegex = regexp.MustCompile(`^[a-z][a-z0-9]*$`)
 
 // reservedNames are refused at Create time. Kept as a package variable (not a
@@ -217,8 +206,8 @@ func (c *Controller) Restore(snapshot []byte) error {
 // REST handler (for fast 422 rejection without a RAFT round-trip) and from
 // the apply path (as a defense-in-depth check).
 func ValidateName(name string) error {
-	if l := len(name); l < NameMinLength || l > NameMaxLength {
-		return fmt.Errorf("namespace name %q must be %d-%d characters", name, NameMinLength, NameMaxLength)
+	if l := len(name); l < entschema.NamespaceMinLength || l > entschema.NamespaceMaxLength {
+		return fmt.Errorf("namespace name %q must be %d-%d characters", name, entschema.NamespaceMinLength, entschema.NamespaceMaxLength)
 	}
 	if !namespaceNameRegex.MatchString(name) {
 		return fmt.Errorf("namespace name %q must start with a lowercase letter and contain only lowercase letters and digits", name)

--- a/usecases/namespaces/controller_test.go
+++ b/usecases/namespaces/controller_test.go
@@ -40,11 +40,11 @@ func TestValidateName(t *testing.T) {
 		// valid
 		{name: "short valid", input: "foo", wantErr: false},
 		{name: "letters and digits", input: "customer1", wantErr: false},
-		{name: "max length", input: strings.Repeat("a", NameMaxLength), wantErr: false},
+		{name: "max length", input: strings.Repeat("a", entschema.NamespaceMaxLength), wantErr: false},
 		// length
 		{name: "too short", input: "ab", wantErr: true},
 		{name: "empty", input: "", wantErr: true},
-		{name: "too long", input: strings.Repeat("a", NameMaxLength+1), wantErr: true},
+		{name: "too long", input: strings.Repeat("a", entschema.NamespaceMaxLength+1), wantErr: true},
 		// format
 		{name: "uppercase leading", input: "Foo", wantErr: true},
 		{name: "uppercase middle", input: "fooBar", wantErr: true},

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -31,6 +31,7 @@ import (
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/objects/validation"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // AddObject Class Instance to the connected DB.
@@ -38,7 +39,10 @@ func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, ob
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
 	className := schema.UppercaseClassName(object.Class)
-	className, _ = m.resolveAlias(className)
+	className, _, err := namespacing.Resolve(principal, m.schemaManager, className)
+	if err != nil {
+		return nil, err
+	}
 	object.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.ShardsData(className, object.Tenant)...); err != nil {

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -39,7 +39,7 @@ func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, ob
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
 	className := schema.UppercaseClassName(object.Class)
-	className, _, err := namespacing.Resolve(principal, m.schemaManager, className)
+	className, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -31,7 +31,6 @@ import (
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/objects/validation"
-	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // AddObject Class Instance to the connected DB.
@@ -39,7 +38,7 @@ func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, ob
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
 	className := schema.UppercaseClassName(object.Class)
-	className, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
+	className, _ = m.resolveNS(principal, className)
 	object.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.ShardsData(className, object.Tenant)...); err != nil {

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -39,10 +39,7 @@ func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, ob
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
 	className := schema.UppercaseClassName(object.Class)
-	className, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
-	if err != nil {
-		return nil, err
-	}
+	className, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
 	object.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.ShardsData(className, object.Tenant)...); err != nil {

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/entities/versioned"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/objects/validation"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 var errEmptyObjects = NewErrInvalidUserInput("invalid param 'objects': cannot be empty, need at least one object for batching")
@@ -40,7 +41,10 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 	classesShards := make(map[string][]string)
 	for _, obj := range objects {
 		obj.Class = schema.UppercaseClassName(obj.Class)
-		cls, _ := b.resolveAlias(obj.Class)
+		cls, _, err := namespacing.Resolve(principal, b.schemaManager, obj.Class)
+		if err != nil {
+			return nil, err
+		}
 		obj.Class = cls
 		classesShards[obj.Class] = append(classesShards[obj.Class], obj.Tenant)
 	}

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -41,7 +41,7 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 	classesShards := make(map[string][]string)
 	for _, obj := range objects {
 		obj.Class = schema.UppercaseClassName(obj.Class)
-		cls, _, err := namespacing.Resolve(principal, b.schemaManager, obj.Class)
+		cls, _, err := namespacing.Resolve(principal, b.schemaManager, b.config.Config.Namespaces.Enabled, obj.Class)
 		if err != nil {
 			return nil, err
 		}

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -41,10 +41,7 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 	classesShards := make(map[string][]string)
 	for _, obj := range objects {
 		obj.Class = schema.UppercaseClassName(obj.Class)
-		cls, _, err := namespacing.Resolve(principal, b.schemaManager, b.config.Config.Namespaces.Enabled, obj.Class)
-		if err != nil {
-			return nil, err
-		}
+		cls, _ := namespacing.Resolve(principal, b.schemaManager, b.config.Config.Namespaces.Enabled, obj.Class)
 		obj.Class = cls
 		classesShards[obj.Class] = append(classesShards[obj.Class], obj.Tenant)
 	}

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -27,7 +27,6 @@ import (
 	"github.com/weaviate/weaviate/entities/versioned"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/objects/validation"
-	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 var errEmptyObjects = NewErrInvalidUserInput("invalid param 'objects': cannot be empty, need at least one object for batching")
@@ -41,7 +40,7 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 	classesShards := make(map[string][]string)
 	for _, obj := range objects {
 		obj.Class = schema.UppercaseClassName(obj.Class)
-		cls, _ := namespacing.Resolve(principal, b.schemaManager, b.config.Config.Namespaces.Enabled, obj.Class)
+		cls, _ := b.resolveNS(principal, obj.Class)
 		obj.Class = cls
 		classesShards[obj.Class] = append(classesShards[obj.Class], obj.Tenant)
 	}

--- a/usecases/objects/batch_manager.go
+++ b/usecases/objects/batch_manager.go
@@ -18,10 +18,12 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/entities/additional"
+	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects/alias"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // BatchManager manages kind changes in batch at a use-case level , i.e.
@@ -74,4 +76,10 @@ func NewBatchManager(vectorRepo BatchVectorRepo, modulesProvider ModulesProvider
 // Alias support
 func (m *BatchManager) resolveAlias(class string) (className, aliasName string) {
 	return alias.ResolveAlias(m.schemaManager, class)
+}
+
+// resolveNS qualifies name with the principal's namespace (if enabled)
+// and resolves any alias to its underlying class.
+func (b *BatchManager) resolveNS(principal *models.Principal, name string) (class, originalAlias string) {
+	return namespacing.Resolve(principal, b.schemaManager, b.config.Config.Namespaces.Enabled, name)
 }

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/memwatch"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // DeleteObject Class Instance from the connected DB
@@ -37,10 +38,12 @@ func (m *Manager) DeleteObject(ctx context.Context,
 	repl *additional.ReplicationProperties, tenant string,
 ) error {
 	className = schema.UppercaseClassName(className)
-	className, _ = m.resolveAlias(className)
-
-	err := m.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Objects(className, tenant, id))
+	className, _, err := namespacing.Resolve(principal, m.schemaManager, className)
 	if err != nil {
+		return err
+	}
+
+	if err := m.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Objects(className, tenant, id)); err != nil {
 		return err
 	}
 	ctx = classcache.ContextWithClassCache(ctx)

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -38,10 +38,7 @@ func (m *Manager) DeleteObject(ctx context.Context,
 	repl *additional.ReplicationProperties, tenant string,
 ) error {
 	className = schema.UppercaseClassName(className)
-	className, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
-	if err != nil {
-		return err
-	}
+	className, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Objects(className, tenant, id)); err != nil {
 		return err

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -26,7 +26,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/memwatch"
-	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // DeleteObject Class Instance from the connected DB
@@ -38,7 +37,7 @@ func (m *Manager) DeleteObject(ctx context.Context,
 	repl *additional.ReplicationProperties, tenant string,
 ) error {
 	className = schema.UppercaseClassName(className)
-	className, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
+	className, _ = m.resolveNS(principal, className)
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Objects(className, tenant, id)); err != nil {
 		return err

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -38,7 +38,7 @@ func (m *Manager) DeleteObject(ctx context.Context,
 	repl *additional.ReplicationProperties, tenant string,
 ) error {
 	className = schema.UppercaseClassName(className)
-	className, _, err := namespacing.Resolve(principal, m.schemaManager, className)
+	className, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
 	if err != nil {
 		return err
 	}

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -27,6 +27,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // GetObject Class from the connected DB
@@ -35,9 +36,13 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal,
 	replProps *additional.ReplicationProperties, tenant string,
 ) (*models.Object, error) {
 	class = schema.UppercaseClassName(class)
-	class, _ = m.resolveAlias(class)
+	resolvedClass, _, err := namespacing.Resolve(principal, m.schemaManager, class)
+	if err != nil {
+		return nil, err
+	}
+	class = resolvedClass
 
-	err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(class, tenant, id))
+	err = m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(class, tenant, id))
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -36,7 +36,7 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal,
 	replProps *additional.ReplicationProperties, tenant string,
 ) (*models.Object, error) {
 	class = schema.UppercaseClassName(class)
-	resolvedClass, _, err := namespacing.Resolve(principal, m.schemaManager, class)
+	resolvedClass, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, class)
 	if err != nil {
 		return nil, err
 	}
@@ -128,9 +128,6 @@ func (m *Manager) getObjectFromRepo(ctx context.Context, class string, id strfmt
 	adds additional.Properties, repl *additional.ReplicationProperties, tenant string,
 ) (res *search.Result, err error) {
 	if class != "" {
-		if cls := m.schemaManager.ResolveAlias(class); cls != "" {
-			class = cls
-		}
 		res, err = m.vectorRepo.Object(ctx, class, id, search.SelectProperties{}, adds, repl, tenant)
 	} else {
 		res, err = m.vectorRepo.ObjectByID(ctx, id, search.SelectProperties{}, adds, tenant)

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -36,14 +36,9 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal,
 	replProps *additional.ReplicationProperties, tenant string,
 ) (*models.Object, error) {
 	class = schema.UppercaseClassName(class)
-	resolvedClass, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, class)
-	if err != nil {
-		return nil, err
-	}
-	class = resolvedClass
+	class, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, class)
 
-	err = m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(class, tenant, id))
-	if err != nil {
+	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(class, tenant, id)); err != nil {
 		return nil, err
 	}
 

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -27,7 +27,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
-	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // GetObject Class from the connected DB
@@ -36,7 +35,7 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal,
 	replProps *additional.ReplicationProperties, tenant string,
 ) (*models.Object, error) {
 	class = schema.UppercaseClassName(class)
-	class, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, class)
+	class, _ = m.resolveNS(principal, class)
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(class, tenant, id)); err != nil {
 		return nil, err

--- a/usecases/objects/head.go
+++ b/usecases/objects/head.go
@@ -20,23 +20,23 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // HeadObject check object's existence in the connected DB
 func (m *Manager) HeadObject(ctx context.Context, principal *models.Principal, className string,
 	id strfmt.UUID, repl *additional.ReplicationProperties, tenant string,
 ) (bool, *Error) {
-	className, _ = m.resolveAlias(className)
+	className, _, err := namespacing.Resolve(principal, m.schemaManager, className)
+	if err != nil {
+		return false, &Error{err.Error(), StatusInternalServerError, err}
+	}
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(className, tenant, id)); err != nil {
 		return false, &Error{err.Error(), StatusForbidden, err}
 	}
 
 	m.metrics.HeadObjectInc()
 	defer m.metrics.HeadObjectDec()
-
-	if cls := m.schemaManager.ResolveAlias(className); cls != "" {
-		className = cls
-	}
 
 	ok, err := m.vectorRepo.Exists(ctx, className, id, repl, tenant)
 	if err != nil {

--- a/usecases/objects/head.go
+++ b/usecases/objects/head.go
@@ -27,10 +27,7 @@ import (
 func (m *Manager) HeadObject(ctx context.Context, principal *models.Principal, className string,
 	id strfmt.UUID, repl *additional.ReplicationProperties, tenant string,
 ) (bool, *Error) {
-	className, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
-	if err != nil {
-		return false, &Error{err.Error(), StatusInternalServerError, err}
-	}
+	className, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(className, tenant, id)); err != nil {
 		return false, &Error{err.Error(), StatusForbidden, err}
 	}

--- a/usecases/objects/head.go
+++ b/usecases/objects/head.go
@@ -20,14 +20,13 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
-	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // HeadObject check object's existence in the connected DB
 func (m *Manager) HeadObject(ctx context.Context, principal *models.Principal, className string,
 	id strfmt.UUID, repl *additional.ReplicationProperties, tenant string,
 ) (bool, *Error) {
-	className, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
+	className, _ = m.resolveNS(principal, className)
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(className, tenant, id)); err != nil {
 		return false, &Error{err.Error(), StatusForbidden, err}
 	}

--- a/usecases/objects/head.go
+++ b/usecases/objects/head.go
@@ -27,7 +27,7 @@ import (
 func (m *Manager) HeadObject(ctx context.Context, principal *models.Principal, className string,
 	id strfmt.UUID, repl *additional.ReplicationProperties, tenant string,
 ) (bool, *Error) {
-	className, _, err := namespacing.Resolve(principal, m.schemaManager, className)
+	className, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
 	if err != nil {
 		return false, &Error{err.Error(), StatusInternalServerError, err}
 	}

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -186,7 +186,10 @@ func NewManager(schemaManager schemaManager,
 	}
 }
 
-// Alias
+// resolveAlias is the pre-WS4 alias-only resolver, kept here for the
+// reference endpoints (AddObjectReference / UpdateObjectReferences /
+// DeleteObjectReference) which are out of WS4 scope. Namespace-aware
+// reference resolution lands in WS7.
 func (m *Manager) resolveAlias(class string) (className, aliasName string) {
 	return alias.ResolveAlias(m.schemaManager, class)
 }

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -186,10 +186,11 @@ func NewManager(schemaManager schemaManager,
 	}
 }
 
-// resolveAlias is the pre-WS4 alias-only resolver, kept here for the
-// reference endpoints (AddObjectReference / UpdateObjectReferences /
-// DeleteObjectReference) which are out of WS4 scope. Namespace-aware
-// reference resolution lands in WS7.
+// resolveAlias is the alias-only resolver still used by the reference
+// endpoints (AddObjectReference / UpdateObjectReferences /
+// DeleteObjectReference). It is namespace-unaware on purpose; the
+// reference path will move to namespacing.Resolve once beacon resolution
+// is namespace-aware end to end.
 func (m *Manager) resolveAlias(class string) (className, aliasName string) {
 	return alias.ResolveAlias(m.schemaManager, class)
 }

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -36,6 +36,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/objects/alias"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 type schemaManager interface {
@@ -193,6 +194,12 @@ func NewManager(schemaManager schemaManager,
 // is namespace-aware end to end.
 func (m *Manager) resolveAlias(class string) (className, aliasName string) {
 	return alias.ResolveAlias(m.schemaManager, class)
+}
+
+// resolveNS qualifies name with the principal's namespace (if enabled)
+// and resolves any alias to its underlying class.
+func (m *Manager) resolveNS(principal *models.Principal, name string) (class, originalAlias string) {
+	return namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, name)
 }
 
 func generateUUID() (strfmt.UUID, error) {

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -29,6 +29,7 @@ import (
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 type MergeDocument struct {
@@ -49,7 +50,10 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	if err := m.validateInputs(updates); err != nil {
 		return &Error{"bad request", StatusBadRequest, err}
 	}
-	className, aliasName := m.resolveAlias(schema.UppercaseClassName(updates.Class))
+	className, aliasName, err := namespacing.Resolve(principal, m.schemaManager, schema.UppercaseClassName(updates.Class))
+	if err != nil {
+		return &Error{err.Error(), StatusInternalServerError, err}
+	}
 	updates.Class = className
 	cls, id := updates.Class, updates.ID
 	if err := m.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Objects(cls, updates.Tenant, id)); err != nil {

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -50,7 +50,7 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	if err := m.validateInputs(updates); err != nil {
 		return &Error{"bad request", StatusBadRequest, err}
 	}
-	className, aliasName, err := namespacing.Resolve(principal, m.schemaManager, schema.UppercaseClassName(updates.Class))
+	className, aliasName, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, schema.UppercaseClassName(updates.Class))
 	if err != nil {
 		return &Error{err.Error(), StatusInternalServerError, err}
 	}

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -29,7 +29,6 @@ import (
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/memwatch"
-	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 type MergeDocument struct {
@@ -50,7 +49,7 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	if err := m.validateInputs(updates); err != nil {
 		return &Error{"bad request", StatusBadRequest, err}
 	}
-	className, aliasName := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, schema.UppercaseClassName(updates.Class))
+	className, aliasName := m.resolveNS(principal, schema.UppercaseClassName(updates.Class))
 	updates.Class = className
 	cls, id := updates.Class, updates.ID
 	if err := m.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Objects(cls, updates.Tenant, id)); err != nil {

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -50,10 +50,7 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	if err := m.validateInputs(updates); err != nil {
 		return &Error{"bad request", StatusBadRequest, err}
 	}
-	className, aliasName, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, schema.UppercaseClassName(updates.Class))
-	if err != nil {
-		return &Error{err.Error(), StatusInternalServerError, err}
-	}
+	className, aliasName := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, schema.UppercaseClassName(updates.Class))
 	updates.Class = className
 	cls, id := updates.Class, updates.ID
 	if err := m.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Objects(cls, updates.Tenant, id)); err != nil {

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -20,6 +20,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 type QueryInput struct {
@@ -71,7 +72,11 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 	class := "*"
 
 	if params != nil && params.Class != "" {
-		params.Class, _ = m.resolveAlias(params.Class)
+		resolved, _, err := namespacing.Resolve(principal, m.schemaManager, params.Class)
+		if err != nil {
+			return nil, &Error{err.Error(), StatusInternalServerError, err}
+		}
+		params.Class = resolved
 		class = params.Class
 	}
 

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -20,7 +20,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
-	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 type QueryInput struct {
@@ -72,7 +71,7 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 	class := "*"
 
 	if params != nil && params.Class != "" {
-		params.Class, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, params.Class)
+		params.Class, _ = m.resolveNS(principal, params.Class)
 		class = params.Class
 	}
 

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -72,11 +72,7 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 	class := "*"
 
 	if params != nil && params.Class != "" {
-		resolved, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, params.Class)
-		if err != nil {
-			return nil, &Error{err.Error(), StatusInternalServerError, err}
-		}
-		params.Class = resolved
+		params.Class, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, params.Class)
 		class = params.Class
 	}
 

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -72,7 +72,7 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 	class := "*"
 
 	if params != nil && params.Class != "" {
-		resolved, _, err := namespacing.Resolve(principal, m.schemaManager, params.Class)
+		resolved, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, params.Class)
 		if err != nil {
 			return nil, &Error{err.Error(), StatusInternalServerError, err}
 		}

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/entities/versioned"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/memwatch"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // UpdateObject updates object of class.
@@ -35,7 +36,10 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
 	className := schema.UppercaseClassName(updates.Class)
-	className, _ = m.resolveAlias(className)
+	className, _, err := namespacing.Resolve(principal, m.schemaManager, className)
+	if err != nil {
+		return nil, err
+	}
 	updates.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Objects(updates.Class, updates.Tenant, updates.ID)); err != nil {
@@ -57,17 +61,13 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 		return nil, fmt.Errorf("cannot process update object: %w", err)
 	}
 
-	return m.updateObjectToConnectorAndSchema(ctx, principal, class, id, updates, repl, fetchedClasses)
+	return m.updateObjectToConnectorAndSchema(ctx, principal, className, id, updates, repl, fetchedClasses)
 }
 
 func (m *Manager) updateObjectToConnectorAndSchema(ctx context.Context,
 	principal *models.Principal, className string, id strfmt.UUID, updates *models.Object,
 	repl *additional.ReplicationProperties, fetchedClasses map[string]versioned.Class,
 ) (*models.Object, error) {
-	if cls := m.schemaManager.ResolveAlias(className); cls != "" {
-		className = cls
-	}
-
 	if id != updates.ID {
 		return nil, NewErrInvalidUserInput("invalid update: field 'id' is immutable")
 	}

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -36,10 +36,7 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
 	className := schema.UppercaseClassName(updates.Class)
-	className, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
-	if err != nil {
-		return nil, err
-	}
+	className, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
 	updates.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Objects(updates.Class, updates.Tenant, updates.ID)); err != nil {

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -36,7 +36,7 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
 	className := schema.UppercaseClassName(updates.Class)
-	className, _, err := namespacing.Resolve(principal, m.schemaManager, className)
+	className, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
 	if err != nil {
 		return nil, err
 	}

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -25,7 +25,6 @@ import (
 	"github.com/weaviate/weaviate/entities/versioned"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/memwatch"
-	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // UpdateObject updates object of class.
@@ -36,7 +35,7 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
 	className := schema.UppercaseClassName(updates.Class)
-	className, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
+	className, _ = m.resolveNS(principal, className)
 	updates.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Objects(updates.Class, updates.Tenant, updates.ID)); err != nil {

--- a/usecases/objects/update_test.go
+++ b/usecases/objects/update_test.go
@@ -91,7 +91,7 @@ func Test_UpdateAction(t *testing.T) {
 			Created:   beforeUpdate,
 			Updated:   beforeUpdate,
 		}
-		db.On("ObjectByID", id, mock.Anything, mock.Anything).Return(result, nil).Once()
+		db.On("Object", "ActionClass", id, mock.Anything, mock.Anything, "").Return(result, nil).Once()
 		modulesProvider.On("UpdateVector", mock.Anything, mock.AnythingOfType(FindObjectFn)).
 			Return(vec, nil)
 		db.On("PutObject", mock.Anything, mock.Anything).Return(nil).Once()

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	autherrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // ValidateObject without adding it to the database. Can be used in UIs for
@@ -31,11 +32,13 @@ func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principa
 	obj *models.Object, repl *additional.ReplicationProperties,
 ) error {
 	className := schema.UppercaseClassName(obj.Class)
-	className, _ = m.resolveAlias(className)
+	className, _, err := namespacing.Resolve(principal, m.schemaManager, className)
+	if err != nil {
+		return err
+	}
 	obj.Class = className
 
-	err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(className, obj.Tenant, obj.ID))
-	if err != nil {
+	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(className, obj.Tenant, obj.ID)); err != nil {
 		return err
 	}
 

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -32,10 +32,7 @@ func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principa
 	obj *models.Object, repl *additional.ReplicationProperties,
 ) error {
 	className := schema.UppercaseClassName(obj.Class)
-	className, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
-	if err != nil {
-		return err
-	}
+	className, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
 	obj.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(className, obj.Tenant, obj.ID)); err != nil {

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -32,7 +32,7 @@ func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principa
 	obj *models.Object, repl *additional.ReplicationProperties,
 ) error {
 	className := schema.UppercaseClassName(obj.Class)
-	className, _, err := namespacing.Resolve(principal, m.schemaManager, className)
+	className, _, err := namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
 	if err != nil {
 		return err
 	}

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -23,7 +23,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	autherrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
-	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // ValidateObject without adding it to the database. Can be used in UIs for
@@ -32,7 +31,7 @@ func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principa
 	obj *models.Object, repl *additional.ReplicationProperties,
 ) error {
 	className := schema.UppercaseClassName(obj.Class)
-	className, _ = namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, className)
+	className, _ = m.resolveNS(principal, className)
 	obj.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(className, obj.Tenant, obj.ID)); err != nil {

--- a/usecases/schema/alias.go
+++ b/usecases/schema/alias.go
@@ -20,7 +20,9 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 func (h *Handler) GetAliases(ctx context.Context, principal *models.Principal, alias, className string) ([]*models.Alias, error) {
@@ -79,17 +81,34 @@ func (h *Handler) AddAlias(ctx context.Context, principal *models.Principal,
 	alias.Class = schema.UppercaseClassName(alias.Class)
 	alias.Alias = schema.UppercaseClassName(alias.Alias)
 
-	err := h.Authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.Aliases(alias.Class, alias.Alias)...)
+	// Captured for the entity-name validators, which forbid ":".
+	originalAliasName := alias.Alias
+	originalTargetName := alias.Class
+	qAlias, err := namespacing.QualifyForCreate(principal, h.config.Namespaces.Enabled, alias.Alias)
+	if errors.Is(err, namespacing.ErrCreateRequiresNamespace) {
+		return nil, 0, authzerrors.NewNamespaceForbidden(principal)
+	}
 	if err != nil {
+		return nil, 0, err
+	}
+	qTarget, err := namespacing.QualifyForCreate(principal, h.config.Namespaces.Enabled, alias.Class)
+	if err != nil {
+		return nil, 0, err
+	}
+	alias.Alias = qAlias
+	alias.Class = qTarget
+
+	if err := h.Authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.Aliases(alias.Class, alias.Alias)...); err != nil {
 		return nil, 0, err
 	}
 
 	// alias should have same validation as collection.
-	al, err := schema.ValidateAliasName(alias.Alias)
-	if err != nil {
+	if _, err := schema.ValidateAliasName(originalAliasName); err != nil {
 		return nil, 0, err
 	}
-	alias.Alias = al
+	if _, err := schema.ValidateClassName(originalTargetName); err != nil {
+		return nil, 0, err
+	}
 
 	class := h.schemaReader.ReadOnlyClass(alias.Class)
 	version, err := h.schemaManager.CreateAlias(ctx, alias.Alias, class)

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -40,10 +40,12 @@ import (
 	"github.com/weaviate/weaviate/entities/vectorindex"
 	"github.com/weaviate/weaviate/entities/versioned"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/config"
 	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/replica"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 	"github.com/weaviate/weaviate/usecases/sharding"
 	shardingcfg "github.com/weaviate/weaviate/usecases/sharding/config"
 )
@@ -112,8 +114,18 @@ func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 	cls.Class = schema.UppercaseClassName(cls.Class)
 	cls.Properties = schema.LowercaseAllPropertyNames(cls.Properties)
 
-	err := h.Authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.CollectionsMetadata(cls.Class)...)
+	// Captured for the entity-name validator, which forbids ":".
+	originalClassName := cls.Class
+	qualified, err := namespacing.QualifyForCreate(principal, h.config.Namespaces.Enabled, cls.Class)
+	if errors.Is(err, namespacing.ErrCreateRequiresNamespace) {
+		return nil, 0, authzerrors.NewNamespaceForbidden(principal)
+	}
 	if err != nil {
+		return nil, 0, err
+	}
+	cls.Class = qualified
+
+	if err := h.Authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.CollectionsMetadata(cls.Class)...); err != nil {
 		return nil, 0, err
 	}
 
@@ -134,7 +146,7 @@ func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 		return nil, 0, err
 	}
 
-	if err := h.validateCanAddClass(ctx, cls, classGetterWithAuth, true); err != nil {
+	if err := h.validateCanAddClass(ctx, cls, originalClassName, classGetterWithAuth, true); err != nil {
 		return nil, 0, err
 	}
 	// migrate only after validation in completed
@@ -254,7 +266,7 @@ func (h *Handler) RestoreClass(ctx context.Context, d *backup.ClassDescriptor, m
 		return h.schemaReader.ReadOnlyClass(name), nil
 	}
 
-	err = h.validateClassInvariants(ctx, class, classGetterWrapper, true)
+	err = h.validateClassInvariants(ctx, class, class.Class, classGetterWrapper, true)
 	if err != nil {
 		return err
 	}
@@ -771,7 +783,10 @@ func setInvertedConfigDefaults(class *models.Class) {
 	}
 }
 
-func (h *Handler) validateCanAddClass(ctx context.Context, class *models.Class, classGetterWithAuth func(string) (*models.Class, error),
+// validateCanAddClass runs heavy creation-time validation. originalName is
+// the raw user-supplied short class name; ValidateClassName must see it
+// rather than the qualified form because ClassNameRegexCore forbids ":".
+func (h *Handler) validateCanAddClass(ctx context.Context, class *models.Class, originalName string, classGetterWithAuth func(string) (*models.Class, error),
 	relaxCrossRefValidation bool,
 ) error {
 	if modelsext.ClassHasLegacyVectorIndex(class) && len(class.VectorConfig) > 0 {
@@ -788,14 +803,14 @@ func (h *Handler) validateCanAddClass(ctx context.Context, class *models.Class, 
 		}
 	}
 
-	return h.validateClassInvariants(ctx, class, classGetterWithAuth, relaxCrossRefValidation)
+	return h.validateClassInvariants(ctx, class, originalName, classGetterWithAuth, relaxCrossRefValidation)
 }
 
 func (h *Handler) validateClassInvariants(
-	ctx context.Context, class *models.Class, classGetterWithAuth func(string) (*models.Class, error),
+	ctx context.Context, class *models.Class, originalName string, classGetterWithAuth func(string) (*models.Class, error),
 	relaxCrossRefValidation bool,
 ) error {
-	if _, err := schema.ValidateClassName(class.Class); err != nil {
+	if _, err := schema.ValidateClassName(originalName); err != nil {
 		return err
 	}
 

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -114,7 +114,12 @@ func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 	cls.Class = schema.UppercaseClassName(cls.Class)
 	cls.Properties = schema.LowercaseAllPropertyNames(cls.Properties)
 
-	// Captured for the entity-name validator, which forbids ":".
+	// originalClassName must be passed to validateCanAddClass below: the
+	// qualified form ("<ns>:<Class>") fails ValidateClassName because
+	// ClassNameRegexCore forbids ":". Removing this capture would reject
+	// every legitimate namespaced create. Both the rejection of
+	// caller-supplied ":" and the success of the namespaced-create flow are
+	// covered by test/acceptance/namespace/collection_alias_test.go.
 	originalClassName := cls.Class
 	qualified, err := namespacing.QualifyForCreate(principal, h.config.Namespaces.Enabled, cls.Class)
 	if errors.Is(err, namespacing.ErrCreateRequiresNamespace) {

--- a/usecases/schema/namespace_create_test.go
+++ b/usecases/schema/namespace_create_test.go
@@ -1,0 +1,225 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization/mocks"
+	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
+	"github.com/weaviate/weaviate/usecases/fakes"
+)
+
+// newTestHandlerWithNamespaces returns a Handler that has the cluster-wide
+// NAMESPACES_ENABLED flag flipped on. It is otherwise identical to the helper
+// at helpers_test.go:newTestHandler so existing fakes keep working.
+func newTestHandlerWithNamespaces(t *testing.T, enabled bool) (*Handler, *fakeSchemaManager) {
+	t.Helper()
+	schemaManager := &fakeSchemaManager{}
+	logger, _ := test.NewNullLogger()
+	vectorizerValidator := &fakeVectorizerValidator{
+		valid: []string{"text2vec-contextionary", "model1", "model2"},
+	}
+	cfg := config.Config{
+		DefaultVectorizerModule:     config.VectorizerModuleNone,
+		DefaultVectorDistanceMetric: "cosine",
+	}
+	cfg.Namespaces.Enabled = enabled
+	fakeClusterState := fakes.NewFakeClusterState()
+	fakeValidator := &fakeValidator{}
+	schemaParser := NewParser(fakeClusterState, dummyParseVectorConfig, fakeValidator, fakeModulesProvider{}, nil, nil)
+	handler, err := NewHandler(
+		schemaManager, schemaManager, fakeValidator, logger, mocks.NewMockAuthorizer(),
+		&cfg.SchemaHandlerConfig, cfg, dummyParseVectorConfig, vectorizerValidator, dummyValidateInvertedConfig,
+		&fakeModuleConfig{}, fakeClusterState, nil, *schemaParser, nil)
+	require.NoError(t, err)
+	handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
+	return &handler, schemaManager
+}
+
+func namespacedPrincipal(ns string) *models.Principal {
+	return &models.Principal{Username: "u1", Namespace: ns}
+}
+
+func globalPrincipal() *models.Principal {
+	return &models.Principal{Username: "admin", IsGlobalOperator: true}
+}
+
+func TestAddClass(t *testing.T) {
+	t.Parallel()
+	casts := []struct {
+		name       string
+		enabled    bool
+		principal  *models.Principal
+		class      string
+		wantClass  string
+		wantErrMsg string
+	}{
+		{
+			name:      "namespaced principal qualifies and persists prefixed class",
+			enabled:   true,
+			principal: namespacedPrincipal("customer1"),
+			class:     "Movies",
+			wantClass: "customer1:Movies",
+		},
+		{
+			name:       "global principal rejected on namespaces enabled",
+			enabled:    true,
+			principal:  globalPrincipal(),
+			class:      "Movies",
+			wantErrMsg: "must be namespaced",
+		},
+		{
+			name:       "nil principal rejected on namespaces enabled",
+			enabled:    true,
+			principal:  nil,
+			class:      "Movies",
+			wantErrMsg: "must be namespaced",
+		},
+		{
+			name:      "global principal allowed on namespaces disabled",
+			enabled:   false,
+			principal: globalPrincipal(),
+			class:     "Movies",
+			wantClass: "Movies",
+		},
+		{
+			name:       "namespaced principal short name containing colon rejected",
+			enabled:    true,
+			principal:  namespacedPrincipal("customer1"),
+			class:      "Customer2:Movies",
+			wantErrMsg: "is not a valid class name",
+		},
+		{
+			name:       "namespaced principal over length rejected",
+			enabled:    true,
+			principal:  namespacedPrincipal("customer"),
+			class:      "C" + strings.Repeat("x", 254),
+			wantErrMsg: "namespaced names must be at most",
+		},
+	}
+
+	for _, tt := range casts {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler, sm := newTestHandlerWithNamespaces(t, tt.enabled)
+
+			class := &models.Class{
+				Class:             tt.class,
+				Vectorizer:        "model1",
+				VectorIndexConfig: map[string]interface{}{},
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+			}
+
+			if tt.wantClass != "" {
+				sm.On("AddClass", mock.MatchedBy(func(c *models.Class) bool {
+					return c.Class == tt.wantClass
+				}), mock.Anything).Return(nil)
+				sm.On("QueryCollectionsCount").Return(0, nil)
+			}
+
+			got, _, err := handler.AddClass(context.Background(), tt.principal, class)
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantClass, got.Class)
+		})
+	}
+}
+
+func TestAddAlias(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name       string
+		enabled    bool
+		principal  *models.Principal
+		alias      string
+		class      string
+		wantAlias  string
+		wantClass  string
+		wantErrMsg string
+		mockTarget string
+	}{
+		{
+			name:       "namespaced principal qualifies both",
+			enabled:    true,
+			principal:  namespacedPrincipal("customer1"),
+			alias:      "Films",
+			class:      "Movies",
+			wantAlias:  "customer1:Films",
+			wantClass:  "customer1:Movies",
+			mockTarget: "customer1:Movies",
+		},
+		{
+			name:       "global principal rejected on namespaces enabled",
+			enabled:    true,
+			principal:  globalPrincipal(),
+			alias:      "Films",
+			class:      "Movies",
+			wantErrMsg: "must be namespaced",
+		},
+		{
+			name:       "namespaced principal colon in target rejected",
+			enabled:    true,
+			principal:  namespacedPrincipal("customer1"),
+			alias:      "Films",
+			class:      "Customer2:Movies",
+			wantErrMsg: "is not a valid class name",
+		},
+		{
+			name:       "namespaced principal colon in alias rejected",
+			enabled:    true,
+			principal:  namespacedPrincipal("customer1"),
+			alias:      "Customer2:Films",
+			class:      "Movies",
+			wantErrMsg: "is not a valid alias name",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler, sm := newTestHandlerWithNamespaces(t, tt.enabled)
+
+			if tt.mockTarget != "" {
+				target := &models.Class{Class: tt.mockTarget}
+				sm.On("ReadOnlyClass", tt.mockTarget).Return(target)
+				sm.On("CreateAlias", mock.Anything, tt.wantAlias, mock.MatchedBy(func(c *models.Class) bool {
+					return c != nil && c.Class == tt.wantClass
+				})).Return(nil)
+			}
+
+			alias := &models.Alias{Alias: tt.alias, Class: tt.class}
+			got, _, err := handler.AddAlias(context.Background(), tt.principal, alias)
+			if tt.wantErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrMsg)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantAlias, got.Alias)
+			require.Equal(t, tt.wantClass, got.Class)
+		})
+	}
+}

--- a/usecases/schema/namespacing/namespacing.go
+++ b/usecases/schema/namespacing/namespacing.go
@@ -1,0 +1,56 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package namespacing provides the syntax-only helpers used to qualify
+// collection and alias names with their owning namespace. The helpers are
+// pure functions: no I/O, no validation beyond a length check on the
+// pre-qualification short name.
+package namespacing
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/namespaces"
+)
+
+// ErrCreateRequiresNamespace is returned by QualifyForCreate when a global
+// (or anonymous) principal attempts a create on an NS-enabled cluster.
+// Call sites translate this into authzerrors.NewNamespaceForbidden — the namespacing
+// package stays free of auth vocabulary.
+var ErrCreateRequiresNamespace = errors.New("create requires a namespaced principal on a namespaces-enabled cluster")
+
+// ShortNameMaxLength caps the raw (pre-qualification) name length for
+// namespaced principals. The cap is computed from the maximum namespace
+// length and the maximum class name length so it stays constant regardless
+// of which namespace the caller is bound to — a `customer` user and a `c` user
+// get the same limit.
+const ShortNameMaxLength = schema.ClassNameMaxLength - namespaces.NameMaxLength - 1
+
+// QualifyForCreate is the create-path entry point: it enforces the NS-enabled
+// policy, length-checks the raw short name, and returns the qualified form.
+// On NS-enabled clusters, callers without a namespace are rejected with
+// ErrCreateRequiresNamespace; the call site is responsible for translating
+// that into a 403 with the appropriate verb and resources.
+func QualifyForCreate(principal *models.Principal, nsEnabled bool, raw string) (string, error) {
+	if !nsEnabled {
+		return raw, nil
+	}
+	if principal == nil || principal.Namespace == "" {
+		return "", ErrCreateRequiresNamespace
+	}
+	if len(raw) > ShortNameMaxLength {
+		return "", fmt.Errorf("'%s' is too long: namespaced names must be at most %d characters before qualification", raw, ShortNameMaxLength)
+	}
+	return principal.Namespace + schema.NamespaceSeparator + raw, nil
+}

--- a/usecases/schema/namespacing/namespacing.go
+++ b/usecases/schema/namespacing/namespacing.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
-	"github.com/weaviate/weaviate/usecases/namespaces"
 )
 
 // ErrCreateRequiresNamespace is returned by QualifyForCreate when a global
@@ -30,12 +29,16 @@ import (
 // package stays free of auth vocabulary.
 var ErrCreateRequiresNamespace = errors.New("create requires a namespaced principal on a namespaces-enabled cluster")
 
+// NamespaceMaxLength is the maximum length of a namespace name.
+// This is duplicated from usecases/namespaces to avoid import cycles.
+const NamespaceMaxLength = 36
+
 // ShortNameMaxLength caps the raw (pre-qualification) name length for
 // namespaced principals. The cap is computed from the maximum namespace
 // length and the maximum class name length so it stays constant regardless
 // of which namespace the caller is bound to — a `customer` user and a `c` user
 // get the same limit.
-const ShortNameMaxLength = schema.ClassNameMaxLength - namespaces.NameMaxLength - 1
+const ShortNameMaxLength = schema.ClassNameMaxLength - NamespaceMaxLength - 1
 
 // QualifyForCreate is the create-path entry point: it enforces the NS-enabled
 // policy, length-checks the raw short name, and returns the qualified form.
@@ -52,5 +55,5 @@ func QualifyForCreate(principal *models.Principal, nsEnabled bool, raw string) (
 	if len(raw) > ShortNameMaxLength {
 		return "", fmt.Errorf("'%s' is too long: namespaced names must be at most %d characters before qualification", raw, ShortNameMaxLength)
 	}
-	return principal.Namespace + schema.NamespaceSeparator + raw, nil
+	return qualify(principal, raw), nil
 }

--- a/usecases/schema/namespacing/namespacing.go
+++ b/usecases/schema/namespacing/namespacing.go
@@ -29,16 +29,12 @@ import (
 // package stays free of auth vocabulary.
 var ErrCreateRequiresNamespace = errors.New("create requires a namespaced principal on a namespaces-enabled cluster")
 
-// NamespaceMaxLength is the maximum length of a namespace name.
-// This is duplicated from usecases/namespaces to avoid import cycles.
-const NamespaceMaxLength = 36
-
 // ShortNameMaxLength caps the raw (pre-qualification) name length for
 // namespaced principals. The cap is computed from the maximum namespace
 // length and the maximum class name length so it stays constant regardless
 // of which namespace the caller is bound to — a `customer` user and a `c` user
 // get the same limit.
-const ShortNameMaxLength = schema.ClassNameMaxLength - NamespaceMaxLength - 1
+const ShortNameMaxLength = schema.ClassNameMaxLength - schema.NamespaceMaxLength - len(schema.NamespaceSeparator)
 
 // QualifyForCreate is the create-path entry point: it enforces the NS-enabled
 // policy, length-checks the raw short name, and returns the qualified form.

--- a/usecases/schema/namespacing/namespacing_test.go
+++ b/usecases/schema/namespacing/namespacing_test.go
@@ -1,0 +1,114 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespacing
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func TestQualifyForCreate(t *testing.T) {
+	cases := []struct {
+		name         string
+		principal    *models.Principal
+		nsEnabled    bool
+		raw          string
+		want         string
+		wantSentinel bool
+		wantOtherErr bool
+	}{
+		{
+			name:      "namespaced principal qualifies",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			nsEnabled: true,
+			raw:       "Movies",
+			want:      "customer1:Movies",
+		},
+		{
+			name:         "global principal rejected with sentinel on NS-enabled",
+			principal:    &models.Principal{Username: "admin", IsGlobalOperator: true},
+			nsEnabled:    true,
+			raw:          "Movies",
+			wantSentinel: true,
+		},
+		{
+			name:         "nil principal rejected with sentinel on NS-enabled",
+			principal:    nil,
+			nsEnabled:    true,
+			raw:          "Movies",
+			wantSentinel: true,
+		},
+		{
+			name:      "global principal allowed on NS-disabled (raw passthrough)",
+			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
+			nsEnabled: false,
+			raw:       "Movies",
+			want:      "Movies",
+		},
+		{
+			name:      "NS-disabled passthrough does not enforce length cap",
+			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
+			nsEnabled: false,
+			raw:       "C" + strings.Repeat("x", ShortNameMaxLength+50),
+			want:      "C" + strings.Repeat("x", ShortNameMaxLength+50),
+		},
+		{
+			name:      "nil principal on NS-disabled returns raw unchanged",
+			principal: nil,
+			nsEnabled: false,
+			raw:       "Movies",
+			want:      "Movies",
+		},
+		{
+			name:      "namespaced principal at the cap accepted",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			nsEnabled: true,
+			raw:       "C" + strings.Repeat("x", ShortNameMaxLength-1),
+			want:      "customer1:" + "C" + strings.Repeat("x", ShortNameMaxLength-1),
+		},
+		{
+			name:         "namespaced principal one over the cap rejected with non-sentinel error",
+			principal:    &models.Principal{Username: "u", Namespace: "customer1"},
+			nsEnabled:    true,
+			raw:          "C" + strings.Repeat("x", ShortNameMaxLength),
+			wantOtherErr: true,
+		},
+		{
+			name:         "namespaced principal far over the cap rejected with non-sentinel error",
+			principal:    &models.Principal{Username: "u", Namespace: "customer1"},
+			nsEnabled:    true,
+			raw:          strings.Repeat("x", ShortNameMaxLength*2),
+			wantOtherErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := QualifyForCreate(tc.principal, tc.nsEnabled, tc.raw)
+			switch {
+			case tc.wantSentinel:
+				require.ErrorIs(t, err, ErrCreateRequiresNamespace)
+			case tc.wantOtherErr:
+				require.Error(t, err)
+				require.False(t, errors.Is(err, ErrCreateRequiresNamespace), "expected non-sentinel error, got sentinel")
+			default:
+				require.NoError(t, err)
+				assert.Equal(t, tc.want, got)
+			}
+		})
+	}
+}

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -1,0 +1,55 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespacing
+
+import (
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+)
+
+// SchemaManager is a single-method interface exposing alias resolution.
+// It allows the resolver to look up aliases without depending on the full
+// schema reader.
+type SchemaManager interface {
+	ResolveAlias(alias string) string
+}
+
+// qualify prepends principal.Namespace to name.
+func qualify(principal *models.Principal, name string) string {
+	if principal == nil || principal.Namespace == "" {
+		return name
+	}
+	return principal.Namespace + schema.NamespaceSeparator + name
+}
+
+// Resolve is the read-side entry point used everywhere a user-supplied
+// class/alias name needs to become an internal class name:
+//
+//  1. Qualify the input with the principal's namespace.
+//  2. Look the qualified name up as an alias via the existing in-memory
+//     resolver; if it matches an alias, return the alias target.
+//
+// Returns (class, originalAlias, err). originalAlias is the caller-supplied
+// short name when an alias was hit, "" otherwise — used by the objects
+// layer to preserve existing alias-aware flows. Sites that do not need
+// this can ignore the second return value.
+func Resolve(principal *models.Principal, sm SchemaManager, name string) (class, originalAlias string, err error) {
+	qualified := qualify(principal, name)
+
+	// Check if the qualified name is an alias
+	if resolvedClass := sm.ResolveAlias(qualified); resolvedClass != "" {
+		return resolvedClass, qualified, nil
+	}
+
+	// Not an alias, return the qualified name
+	return qualified, "", nil
+}

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -12,9 +12,20 @@
 package namespacing
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
+
+// ErrNamespaceOnDisabledCluster is returned when a principal carries a
+// non-empty Namespace while the cluster has namespaces disabled. This state
+// should be unreachable — WS1 startup invariants, WS3 DB-user create
+// validation, and WS6 OIDC classification all reject it upstream — so a
+// principal reaching the resolver in this shape indicates a bug or a
+// mis-issued token. Fail closed rather than silently ignoring the namespace.
+var ErrNamespaceOnDisabledCluster = errors.New("principal carries a namespace but namespaces are disabled on this cluster")
 
 // SchemaManager is a single-method interface exposing alias resolution.
 // It allows the resolver to look up aliases without depending on the full
@@ -34,16 +45,29 @@ func qualify(principal *models.Principal, name string) string {
 // Resolve is the read-side entry point used everywhere a user-supplied
 // class/alias name needs to become an internal class name:
 //
-//  1. Qualify the input with the principal's namespace.
-//  2. Look the qualified name up as an alias via the existing in-memory
-//     resolver; if it matches an alias, return the alias target.
+//  1. If namespaces are disabled but the principal carries a namespace,
+//     fail closed with ErrNamespaceOnDisabledCluster. The state should be
+//     unreachable; surfacing it as an error rather than silently ignoring
+//     the namespace prevents a stray principal.Namespace (carryover from a
+//     JWT, mis-issued token, etc.) from going undetected.
+//  2. If namespaces are enabled cluster-wide, qualify the input with the
+//     principal's namespace.
+//  3. Look the (possibly qualified) name up as an alias via the existing
+//     in-memory resolver; if it matches an alias, return the alias target.
 //
 // Returns (class, originalAlias, err). originalAlias is the caller-supplied
 // short name when an alias was hit, "" otherwise — used by the objects
 // layer to preserve existing alias-aware flows. Sites that do not need
 // this can ignore the second return value.
-func Resolve(principal *models.Principal, sm SchemaManager, name string) (class, originalAlias string, err error) {
-	qualified := qualify(principal, name)
+func Resolve(principal *models.Principal, sm SchemaManager, nsEnabled bool, name string) (class, originalAlias string, err error) {
+	if !nsEnabled && principal != nil && principal.Namespace != "" {
+		return "", "", fmt.Errorf("%w: principal=%q namespace=%q", ErrNamespaceOnDisabledCluster, principal.Username, principal.Namespace)
+	}
+
+	qualified := name
+	if nsEnabled {
+		qualified = qualify(principal, name)
+	}
 
 	// Check if the qualified name is an alias
 	if resolvedClass := sm.ResolveAlias(qualified); resolvedClass != "" {

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -12,20 +12,9 @@
 package namespacing
 
 import (
-	"errors"
-	"fmt"
-
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
 )
-
-// ErrNamespaceOnDisabledCluster is returned when a principal carries a
-// non-empty Namespace while the cluster has namespaces disabled. This state
-// should be unreachable — WS1 startup invariants, WS3 DB-user create
-// validation, and WS6 OIDC classification all reject it upstream — so a
-// principal reaching the resolver in this shape indicates a bug or a
-// mis-issued token. Fail closed rather than silently ignoring the namespace.
-var ErrNamespaceOnDisabledCluster = errors.New("principal carries a namespace but namespaces are disabled on this cluster")
 
 // SchemaManager is a single-method interface exposing alias resolution.
 // It allows the resolver to look up aliases without depending on the full
@@ -45,25 +34,20 @@ func qualify(principal *models.Principal, name string) string {
 // Resolve is the read-side entry point used everywhere a user-supplied
 // class/alias name needs to become an internal class name:
 //
-//  1. If namespaces are disabled but the principal carries a namespace,
-//     fail closed with ErrNamespaceOnDisabledCluster. The state should be
-//     unreachable; surfacing it as an error rather than silently ignoring
-//     the namespace prevents a stray principal.Namespace (carryover from a
-//     JWT, mis-issued token, etc.) from going undetected.
-//  2. If namespaces are enabled cluster-wide, qualify the input with the
-//     principal's namespace.
-//  3. Look the (possibly qualified) name up as an alias via the existing
+//  1. If namespaces are enabled cluster-wide, qualify the input with the
+//     principal's namespace. When NS is disabled the qualification step is
+//     skipped — a stray principal.Namespace on an NS-disabled cluster is
+//     silently ignored here; rejecting that state is an upstream invariant
+//     enforced by startup gating, DB-user create, and OIDC classification.
+//  2. Look the (possibly qualified) name up as an alias via the existing
 //     in-memory resolver; if it matches an alias, return the alias target.
 //
-// Returns (class, originalAlias, err). originalAlias is the caller-supplied
-// short name when an alias was hit, "" otherwise — used by the objects
-// layer to preserve existing alias-aware flows. Sites that do not need
-// this can ignore the second return value.
-func Resolve(principal *models.Principal, sm SchemaManager, nsEnabled bool, name string) (class, originalAlias string, err error) {
-	if !nsEnabled && principal != nil && principal.Namespace != "" {
-		return "", "", fmt.Errorf("%w: principal=%q namespace=%q", ErrNamespaceOnDisabledCluster, principal.Username, principal.Namespace)
-	}
-
+// Returns (class, originalAlias). originalAlias is the qualified alias name
+// used for lookup when an alias was hit (i.e. namespace-prefixed for
+// namespaced principals, raw for global principals), "" otherwise — used by
+// the objects layer to preserve existing alias-aware flows. Sites that do
+// not need this can ignore the second return value.
+func Resolve(principal *models.Principal, sm SchemaManager, nsEnabled bool, name string) (class, originalAlias string) {
 	qualified := name
 	if nsEnabled {
 		qualified = qualify(principal, name)
@@ -71,9 +55,9 @@ func Resolve(principal *models.Principal, sm SchemaManager, nsEnabled bool, name
 
 	// Check if the qualified name is an alias
 	if resolvedClass := sm.ResolveAlias(qualified); resolvedClass != "" {
-		return resolvedClass, qualified, nil
+		return resolvedClass, qualified
 	}
 
 	// Not an alias, return the qualified name
-	return qualified, "", nil
+	return qualified, ""
 }

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -1,0 +1,164 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespacing
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+// fakeSchemaManager implements SchemaManager for testing
+type fakeSchemaManager struct {
+	aliases map[string]string
+}
+
+func (f *fakeSchemaManager) ResolveAlias(alias string) string {
+	return f.aliases[alias]
+}
+
+func TestQualify(t *testing.T) {
+	cases := []struct {
+		testName  string
+		principal *models.Principal
+		input     string
+		want      string
+	}{
+		{
+			testName:  "namespaced principal qualifies",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			input:     "Movies",
+			want:      "customer1:Movies",
+		},
+		{
+			testName:  "global principal short input passthrough",
+			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
+			input:     "Movies",
+			want:      "Movies",
+		},
+		{
+			testName:  "global principal qualified input passthrough",
+			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
+			input:     "customer1:Movies",
+			want:      "customer1:Movies",
+		},
+		{
+			testName:  "nil principal passthrough",
+			principal: nil,
+			input:     "Movies",
+			want:      "Movies",
+		},
+		{
+			testName:  "empty namespace passthrough",
+			principal: &models.Principal{Username: "u", Namespace: ""},
+			input:     "Movies",
+			want:      "Movies",
+		},
+		{
+			testName:  "namespaced principal with empty name",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			input:     "",
+			want:      "customer1:",
+		},
+		{
+			testName:  "namespaced principal with qualified name gets double prefixed",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			input:     "customer2:Movies",
+			want:      "customer1:customer2:Movies",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.testName, func(t *testing.T) {
+			got := qualify(tc.principal, tc.input)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestResolve(t *testing.T) {
+	cases := []struct {
+		testName  string
+		principal *models.Principal
+		sm        SchemaManager
+		input     string
+		wantClass string
+		wantAlias string
+	}{
+		{
+			testName:  "namespaced principal resolves to qualified name",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			sm:        &fakeSchemaManager{aliases: map[string]string{}},
+			input:     "Movies",
+			wantClass: "customer1:Movies",
+			wantAlias: "",
+		},
+		{
+			testName:  "namespaced principal with alias",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			sm:        &fakeSchemaManager{aliases: map[string]string{"customer1:Films": "customer1:Movies"}},
+			input:     "Films",
+			wantClass: "customer1:Movies",
+			wantAlias: "customer1:Films",
+		},
+		{
+			testName:  "global principal passthrough",
+			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
+			sm:        &fakeSchemaManager{aliases: map[string]string{}},
+			input:     "Movies",
+			wantClass: "Movies",
+			wantAlias: "",
+		},
+		{
+			testName:  "global principal qualified input with alias hit resolves normally",
+			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
+			sm:        &fakeSchemaManager{aliases: map[string]string{"customer1:Movies": "customer1:ActualMovies"}},
+			input:     "customer1:Movies",
+			wantClass: "customer1:ActualMovies",
+			wantAlias: "customer1:Movies",
+		},
+		{
+			testName:  "nil principal passthrough",
+			principal: nil,
+			sm:        &fakeSchemaManager{aliases: map[string]string{}},
+			input:     "Movies",
+			wantClass: "Movies",
+			wantAlias: "",
+		},
+		{
+			testName:  "namespaced principal qualified input gets double prefixed",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			sm:        &fakeSchemaManager{aliases: map[string]string{}},
+			input:     "customer2:Movies",
+			wantClass: "customer1:customer2:Movies",
+			wantAlias: "",
+		},
+		{
+			testName:  "namespaced principal with alias that resolves to target",
+			principal: &models.Principal{Username: "u", Namespace: "ns1"},
+			sm:        &fakeSchemaManager{aliases: map[string]string{"ns1:MyAlias": "ns1:MyClass"}},
+			input:     "MyAlias",
+			wantClass: "ns1:MyClass",
+			wantAlias: "ns1:MyAlias",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.testName, func(t *testing.T) {
+			gotClass, gotAlias, err := Resolve(tc.principal, tc.sm, tc.input)
+			require.NoError(t, err)
+			assert.Equal(t, tc.wantClass, gotClass)
+			assert.Equal(t, tc.wantAlias, gotAlias)
+		})
+	}
+}

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -15,7 +15,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -96,7 +95,6 @@ func TestResolve(t *testing.T) {
 		input     string
 		wantClass string
 		wantAlias string
-		wantErr   error
 	}{
 		{
 			testName:  "namespaced principal resolves to qualified name",
@@ -162,16 +160,13 @@ func TestResolve(t *testing.T) {
 			wantAlias: "ns1:MyAlias",
 		},
 		{
-			// Fail-closed: a stray principal.Namespace on an NS-disabled
-			// cluster should never reach the resolver. Surfacing it as an
-			// error catches upstream bugs (mis-issued tokens, missed startup
-			// gating) instead of silently ignoring the namespace.
-			testName:  "ns disabled rejects principal with namespace",
+			testName:  "ns disabled ignores principal namespace",
 			principal: &models.Principal{Username: "u", Namespace: "customer1"},
 			sm:        &fakeSchemaManager{aliases: map[string]string{}},
 			nsEnabled: false,
 			input:     "Movies",
-			wantErr:   ErrNamespaceOnDisabledCluster,
+			wantClass: "Movies",
+			wantAlias: "",
 		},
 		{
 			testName:  "ns disabled resolves alias on raw input for non-namespaced principal",
@@ -185,12 +180,7 @@ func TestResolve(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			gotClass, gotAlias, err := Resolve(tc.principal, tc.sm, tc.nsEnabled, tc.input)
-			if tc.wantErr != nil {
-				require.ErrorIs(t, err, tc.wantErr)
-				return
-			}
-			require.NoError(t, err)
+			gotClass, gotAlias := Resolve(tc.principal, tc.sm, tc.nsEnabled, tc.input)
 			assert.Equal(t, tc.wantClass, gotClass)
 			assert.Equal(t, tc.wantAlias, gotAlias)
 		})

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -92,14 +92,17 @@ func TestResolve(t *testing.T) {
 		testName  string
 		principal *models.Principal
 		sm        SchemaManager
+		nsEnabled bool
 		input     string
 		wantClass string
 		wantAlias string
+		wantErr   error
 	}{
 		{
 			testName:  "namespaced principal resolves to qualified name",
 			principal: &models.Principal{Username: "u", Namespace: "customer1"},
 			sm:        &fakeSchemaManager{aliases: map[string]string{}},
+			nsEnabled: true,
 			input:     "Movies",
 			wantClass: "customer1:Movies",
 			wantAlias: "",
@@ -108,6 +111,7 @@ func TestResolve(t *testing.T) {
 			testName:  "namespaced principal with alias",
 			principal: &models.Principal{Username: "u", Namespace: "customer1"},
 			sm:        &fakeSchemaManager{aliases: map[string]string{"customer1:Films": "customer1:Movies"}},
+			nsEnabled: true,
 			input:     "Films",
 			wantClass: "customer1:Movies",
 			wantAlias: "customer1:Films",
@@ -116,6 +120,7 @@ func TestResolve(t *testing.T) {
 			testName:  "global principal passthrough",
 			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
 			sm:        &fakeSchemaManager{aliases: map[string]string{}},
+			nsEnabled: true,
 			input:     "Movies",
 			wantClass: "Movies",
 			wantAlias: "",
@@ -124,6 +129,7 @@ func TestResolve(t *testing.T) {
 			testName:  "global principal qualified input with alias hit resolves normally",
 			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
 			sm:        &fakeSchemaManager{aliases: map[string]string{"customer1:Movies": "customer1:ActualMovies"}},
+			nsEnabled: true,
 			input:     "customer1:Movies",
 			wantClass: "customer1:ActualMovies",
 			wantAlias: "customer1:Movies",
@@ -132,6 +138,7 @@ func TestResolve(t *testing.T) {
 			testName:  "nil principal passthrough",
 			principal: nil,
 			sm:        &fakeSchemaManager{aliases: map[string]string{}},
+			nsEnabled: true,
 			input:     "Movies",
 			wantClass: "Movies",
 			wantAlias: "",
@@ -140,6 +147,7 @@ func TestResolve(t *testing.T) {
 			testName:  "namespaced principal qualified input gets double prefixed",
 			principal: &models.Principal{Username: "u", Namespace: "customer1"},
 			sm:        &fakeSchemaManager{aliases: map[string]string{}},
+			nsEnabled: true,
 			input:     "customer2:Movies",
 			wantClass: "customer1:customer2:Movies",
 			wantAlias: "",
@@ -148,14 +156,40 @@ func TestResolve(t *testing.T) {
 			testName:  "namespaced principal with alias that resolves to target",
 			principal: &models.Principal{Username: "u", Namespace: "ns1"},
 			sm:        &fakeSchemaManager{aliases: map[string]string{"ns1:MyAlias": "ns1:MyClass"}},
+			nsEnabled: true,
 			input:     "MyAlias",
 			wantClass: "ns1:MyClass",
 			wantAlias: "ns1:MyAlias",
 		},
+		{
+			// Fail-closed: a stray principal.Namespace on an NS-disabled
+			// cluster should never reach the resolver. Surfacing it as an
+			// error catches upstream bugs (mis-issued tokens, missed startup
+			// gating) instead of silently ignoring the namespace.
+			testName:  "ns disabled rejects principal with namespace",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			sm:        &fakeSchemaManager{aliases: map[string]string{}},
+			nsEnabled: false,
+			input:     "Movies",
+			wantErr:   ErrNamespaceOnDisabledCluster,
+		},
+		{
+			testName:  "ns disabled resolves alias on raw input for non-namespaced principal",
+			principal: &models.Principal{Username: "u"},
+			sm:        &fakeSchemaManager{aliases: map[string]string{"Films": "Movies"}},
+			nsEnabled: false,
+			input:     "Films",
+			wantClass: "Movies",
+			wantAlias: "Films",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			gotClass, gotAlias, err := Resolve(tc.principal, tc.sm, tc.input)
+			gotClass, gotAlias, err := Resolve(tc.principal, tc.sm, tc.nsEnabled, tc.input)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
 			require.NoError(t, err)
 			assert.Equal(t, tc.wantClass, gotClass)
 			assert.Equal(t, tc.wantAlias, gotAlias)


### PR DESCRIPTION
### What's being changed:

This PR adds:
- create for namespaced collections/alias
  - only from namespaced users, global operators cannot create them
- support for namespaces in read-schema path
- support for namespaces in many other REST/GRPC endpoints (the rest is deferred to later. We first want a working POC, before migrating+testing all the nieche endpoints)
- tests for everything

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
