### PR TITLE
async indexing: retry forever when disk is full 

### DIFF
--- a/entities/errors/transient.go
+++ b/entities/errors/transient.go
@@ -14,6 +14,7 @@ package errors
 import (
 	"errors"
 	"fmt"
+	"syscall"
 )
 
 func IsTransient(err error) bool {
@@ -22,6 +23,13 @@ func IsTransient(err error) bool {
 	}
 
 	if errors.Is(err, ErrNotEnoughMappings) {
+		return true
+	}
+
+	// Disk-full errors are transient: an operator (or automated job) can free
+	// up or grow the disk, so retrying gives the recovery a chance to land
+	// before we discard the batch.
+	if errors.Is(err, syscall.ENOSPC) {
 		return true
 	}
 

--- a/entities/errors/transient_test.go
+++ b/entities/errors/transient_test.go
@@ -1,0 +1,82 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package errors
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+	"testing"
+
+	pkgerrors "github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsTransient(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "not enough memory",
+			err:  NewNotEnoughMemory("oom"),
+			want: true,
+		},
+		{
+			name: "not enough mappings",
+			err:  ErrNotEnoughMappings,
+			want: true,
+		},
+		{
+			name: "raw ENOSPC",
+			err:  syscall.ENOSPC,
+			want: true,
+		},
+		{
+			name: "ENOSPC wrapped in os.PathError (as returned by os.Write)",
+			err:  &os.PathError{Op: "write", Path: "/var/lib/weaviate/foo", Err: syscall.ENOSPC},
+			want: true,
+		},
+		{
+			name: "ENOSPC wrapped via fmt.Errorf %w",
+			err:  fmt.Errorf("add to hnsw: %w", &os.PathError{Op: "write", Path: "/var/lib/weaviate/foo", Err: syscall.ENOSPC}),
+			want: true,
+		},
+		{
+			name: "ENOSPC wrapped via pkg/errors.Wrapf (as used in hfresh)",
+			err:  pkgerrors.Wrapf(&os.PathError{Op: "write", Path: "/var/lib/weaviate/foo", Err: syscall.ENOSPC}, "failed to upsert new centroid %d after split operation", 8178),
+			want: true,
+		},
+		{
+			name: "unrelated permanent error",
+			err:  fmt.Errorf("some permanent error"),
+			want: false,
+		},
+		{
+			name: "other syscall errno (EACCES) is not transient",
+			err:  &os.PathError{Op: "write", Path: "/var/lib/weaviate/foo", Err: syscall.EACCES},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, IsTransient(tt.err))
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

This PR makes async indexing retry forever when the disk is full. This prevents the queue from discarding vectors just because the disk is temporarily full. This should prevent recall loss.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
