### PR TITLE
Add missing nil checks for alias

### DIFF
--- a/usecases/schema/alias.go
+++ b/usecases/schema/alias.go
@@ -92,6 +92,9 @@ func (h *Handler) AddAlias(ctx context.Context, principal *models.Principal,
 	alias.Alias = al
 
 	class := h.schemaReader.ReadOnlyClass(alias.Class)
+	if class == nil {
+		return nil, 0, fmt.Errorf("class %s: %w", alias.Class, ErrNotFound)
+	}
 	version, err := h.schemaManager.CreateAlias(ctx, alias.Alias, class)
 	if err != nil {
 		return nil, 0, err
@@ -119,6 +122,9 @@ func (h *Handler) UpdateAlias(ctx context.Context, principal *models.Principal,
 
 	alias := aliases[0]
 	targetClass := h.schemaReader.ReadOnlyClass(targetClassName)
+	if targetClass == nil {
+		return nil, fmt.Errorf("class %s: %w", targetClassName, ErrNotFound)
+	}
 
 	_, err = h.schemaManager.ReplaceAlias(ctx, alias, targetClass)
 	if err != nil {


### PR DESCRIPTION
### What's being changed:

ReadOnlyClass returns nil when it cannot find the class. There is a nil check in RAFT in CreateAlias that catches this, but we should check right here so any further refactoring will not suddenly create panics

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
