### PR TITLE
Ignore none for default quantization

### DIFF
--- a/entities/vectorindex/flat/config.go
+++ b/entities/vectorindex/flat/config.go
@@ -276,6 +276,8 @@ func ParseDefaultQuantization(vectorIndexConfig schemaConfig.VectorIndexConfig, 
 		return flatConfig, nil
 	}
 	switch compression {
+	case "", "none":
+		return flatConfig, nil
 	case "rq-1":
 		flatConfig.RQ.Enabled = true
 		flatConfig.RQ.Bits = 1

--- a/entities/vectorindex/flat/config_test.go
+++ b/entities/vectorindex/flat/config_test.go
@@ -358,6 +358,38 @@ func Test_FlatUserConfig(t *testing.T) {
 	}
 }
 
+func Test_ParseDefaultQuantization(t *testing.T) {
+	tests := []struct {
+		name        string
+		compression string
+		expectErr   bool
+		expectBQ    bool
+		expectRQ    bool
+	}{
+		{name: "empty string is no-op", compression: "", expectErr: false},
+		{name: "none is no-op", compression: "none", expectErr: false},
+		{name: "bq enables BQ", compression: "bq", expectBQ: true},
+		{name: "rq-1 enables RQ", compression: "rq-1", expectRQ: true},
+		{name: "rq-8 enables RQ", compression: "rq-8", expectRQ: true},
+		{name: "invalid compression", compression: "invalid", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uc := NewDefaultUserConfig()
+			result, err := ParseDefaultQuantization(uc, tt.compression)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			cfg := result.(UserConfig)
+			assert.Equal(t, tt.expectBQ, cfg.BQ.Enabled, "BQ.Enabled")
+			assert.Equal(t, tt.expectRQ, cfg.RQ.Enabled, "RQ.Enabled")
+		})
+	}
+}
+
 func Test_RQUserConfigDefaults(t *testing.T) {
 	t.Run("UserConfig SetDefaults includes RQ", func(t *testing.T) {
 		config := UserConfig{}

--- a/entities/vectorindex/hnsw/config.go
+++ b/entities/vectorindex/hnsw/config.go
@@ -347,6 +347,8 @@ func ParseDefaultQuantization(vectorIndexConfig config.VectorIndexConfig, compre
 		return hnswConfig, nil
 	}
 	switch compression {
+	case "", "none":
+		return hnswConfig, nil
 	case "pq":
 		hnswConfig.PQ.Enabled = true
 	case "sq":

--- a/entities/vectorindex/hnsw/config_test.go
+++ b/entities/vectorindex/hnsw/config_test.go
@@ -1143,6 +1143,44 @@ func Test_UserConfig(t *testing.T) {
 	}
 }
 
+func Test_ParseDefaultQuantization(t *testing.T) {
+	tests := []struct {
+		name        string
+		compression string
+		expectErr   bool
+		expectPQ    bool
+		expectSQ    bool
+		expectBQ    bool
+		expectRQ    bool
+	}{
+		{name: "empty string is no-op", compression: "", expectErr: false},
+		{name: "none is no-op", compression: "none", expectErr: false},
+		{name: "pq enables PQ", compression: "pq", expectPQ: true},
+		{name: "sq enables SQ", compression: "sq", expectSQ: true},
+		{name: "bq enables BQ", compression: "bq", expectBQ: true},
+		{name: "rq-1 enables RQ", compression: "rq-1", expectRQ: true},
+		{name: "rq-8 enables RQ", compression: "rq-8", expectRQ: true},
+		{name: "invalid compression", compression: "invalid", expectErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uc := NewDefaultUserConfig()
+			result, err := ParseDefaultQuantization(uc, tt.compression)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			cfg := result.(UserConfig)
+			assert.Equal(t, tt.expectPQ, cfg.PQ.Enabled, "PQ.Enabled")
+			assert.Equal(t, tt.expectSQ, cfg.SQ.Enabled, "SQ.Enabled")
+			assert.Equal(t, tt.expectBQ, cfg.BQ.Enabled, "BQ.Enabled")
+			assert.Equal(t, tt.expectRQ, cfg.RQ.Enabled, "RQ.Enabled")
+		})
+	}
+}
+
 func Test_UserConfigFilterStrategy(t *testing.T) {
 	t.Run("default filter strategy is sweeping", func(t *testing.T) {
 		cfg := UserConfig{}


### PR DESCRIPTION
### What's being changed:
Allow for `DEFAULT_QUANTIZATION=none` as option. Removes unnecessary `invalid default quantization for hnsw index: none` error messages.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
