### PR TITLE
hfresh: dequeue analyze after ressignments

### DIFF
--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -265,7 +265,7 @@ func (h *HFresh) PrepareForBackup(ctx context.Context) error {
 	}
 
 	for _, queue := range []*queue.DiskQueue{
-		h.taskQueue.analyzeQueue,
+		h.taskQueue.analyzeQueue.DiskQueue,
 		h.taskQueue.splitQueue,
 		h.taskQueue.reassignQueue.DiskQueue,
 		h.taskQueue.mergeQueue,
@@ -281,7 +281,7 @@ func (h *HFresh) PrepareForBackup(ctx context.Context) error {
 
 func (h *HFresh) ResumeAfterBackup(ctx context.Context) error {
 	for _, queue := range []*queue.DiskQueue{
-		h.taskQueue.analyzeQueue,
+		h.taskQueue.analyzeQueue.DiskQueue,
 		h.taskQueue.splitQueue,
 		h.taskQueue.reassignQueue.DiskQueue,
 		h.taskQueue.mergeQueue,
@@ -315,7 +315,7 @@ func (h *HFresh) ListQueues(ctx context.Context, basePath string) ([]string, err
 	var files []string
 
 	for _, queue := range []*queue.DiskQueue{
-		h.taskQueue.analyzeQueue,
+		h.taskQueue.analyzeQueue.DiskQueue,
 		h.taskQueue.splitQueue,
 		h.taskQueue.reassignQueue.DiskQueue,
 		h.taskQueue.mergeQueue,

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -267,7 +267,7 @@ func (h *HFresh) PrepareForBackup(ctx context.Context) error {
 	for _, queue := range []*queue.DiskQueue{
 		h.taskQueue.analyzeQueue.DiskQueue,
 		h.taskQueue.splitQueue,
-		h.taskQueue.reassignQueue.DiskQueue,
+		h.taskQueue.reassignQueue,
 		h.taskQueue.mergeQueue,
 	} {
 		err := queue.PrepareForBackup(ctx)
@@ -283,7 +283,7 @@ func (h *HFresh) ResumeAfterBackup(ctx context.Context) error {
 	for _, queue := range []*queue.DiskQueue{
 		h.taskQueue.analyzeQueue.DiskQueue,
 		h.taskQueue.splitQueue,
-		h.taskQueue.reassignQueue.DiskQueue,
+		h.taskQueue.reassignQueue,
 		h.taskQueue.mergeQueue,
 	} {
 		queue.DisableMaintenanceMode()
@@ -317,7 +317,7 @@ func (h *HFresh) ListQueues(ctx context.Context, basePath string) ([]string, err
 	for _, queue := range []*queue.DiskQueue{
 		h.taskQueue.analyzeQueue.DiskQueue,
 		h.taskQueue.splitQueue,
-		h.taskQueue.reassignQueue.DiskQueue,
+		h.taskQueue.reassignQueue,
 		h.taskQueue.mergeQueue,
 	} {
 		f, err := queue.ForceSwitch(ctx, basePath)

--- a/adapters/repos/db/vector/hfresh/hfresh.go
+++ b/adapters/repos/db/vector/hfresh/hfresh.go
@@ -267,7 +267,7 @@ func (h *HFresh) PrepareForBackup(ctx context.Context) error {
 	for _, queue := range []*queue.DiskQueue{
 		h.taskQueue.analyzeQueue,
 		h.taskQueue.splitQueue,
-		h.taskQueue.reassignQueue,
+		h.taskQueue.reassignQueue.DiskQueue,
 		h.taskQueue.mergeQueue,
 	} {
 		err := queue.PrepareForBackup(ctx)
@@ -283,7 +283,7 @@ func (h *HFresh) ResumeAfterBackup(ctx context.Context) error {
 	for _, queue := range []*queue.DiskQueue{
 		h.taskQueue.analyzeQueue,
 		h.taskQueue.splitQueue,
-		h.taskQueue.reassignQueue,
+		h.taskQueue.reassignQueue.DiskQueue,
 		h.taskQueue.mergeQueue,
 	} {
 		queue.DisableMaintenanceMode()
@@ -317,7 +317,7 @@ func (h *HFresh) ListQueues(ctx context.Context, basePath string) ([]string, err
 	for _, queue := range []*queue.DiskQueue{
 		h.taskQueue.analyzeQueue,
 		h.taskQueue.splitQueue,
-		h.taskQueue.reassignQueue,
+		h.taskQueue.reassignQueue.DiskQueue,
 		h.taskQueue.mergeQueue,
 	} {
 		f, err := queue.ForceSwitch(ctx, basePath)

--- a/adapters/repos/db/vector/hfresh/insert.go
+++ b/adapters/repos/db/vector/hfresh/insert.go
@@ -212,8 +212,8 @@ func (h *HFresh) append(ctx context.Context, vector Vector, centroidID uint64, r
 
 	if !reassigned {
 		// If the posting is way too big, we need to split it immediately.
-		if count > h.maxPostingSize*5 {
-			err = h.doSplit(ctx, centroidID, true)
+		if count > h.maxPostingSize {
+			err = h.taskQueue.EnqueueSplit(centroidID)
 			if err != nil {
 				return false, err
 			}

--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -362,6 +362,11 @@ type reassignQueue struct {
 }
 
 func (r *reassignQueue) DequeueBatch() (*queue.Batch, error) {
+	// hold off reassigns while there are pending splits,
+	// to prioritize splits and reduce the chance of cascade
+	if r.splitQueue.Size() > 0 {
+		return nil, nil
+	}
 	return r.DiskQueue.DequeueBatch()
 }
 

--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -40,13 +40,22 @@ const (
 	mergeTaskQueueChunkSize    = 16 * 1024 // 16KB
 )
 
+// reassignQueue wraps the underlying disk queue used for reassign operations.
+type reassignQueue struct {
+	*queue.DiskQueue
+}
+
+func (r *reassignQueue) DequeueBatch() (*queue.Batch, error) {
+	return r.DiskQueue.DequeueBatch()
+}
+
 type TaskQueue struct {
 	// queue for analyze operations
 	analyzeQueue *queue.DiskQueue
 	// queue for split operations
 	splitQueue *queue.DiskQueue
 	// queue for reassign operations
-	reassignQueue *queue.DiskQueue
+	reassignQueue *reassignQueue
 	// queue for merge operations, as these need to be run sequentially
 	mergeQueue *queue.DiskQueue
 
@@ -117,7 +126,7 @@ func NewTaskQueue(index *HFresh, bucket *lsmkv.Bucket) (*TaskQueue, error) {
 	}
 
 	// create queue for reassign operations
-	tq.reassignQueue, err = queue.NewDiskQueue(
+	rq, err := queue.NewDiskQueue(
 		queue.DiskQueueOptions{
 			ID:               fmt.Sprintf("hfresh_reassign_queue_%s_%s", index.config.ShardName, index.config.ID),
 			Logger:           index.logger,
@@ -131,6 +140,7 @@ func NewTaskQueue(index *HFresh, bucket *lsmkv.Bucket) (*TaskQueue, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create hfresh reassign queue")
 	}
+	tq.reassignQueue = &reassignQueue{DiskQueue: rq}
 	err = tq.reassignQueue.Init()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize hfresh reassign queue")

--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -46,7 +46,7 @@ type TaskQueue struct {
 	// queue for split operations
 	splitQueue *queue.DiskQueue
 	// queue for reassign operations
-	reassignQueue *reassignQueue
+	reassignQueue *queue.DiskQueue
 	// queue for merge operations, as these need to be run sequentially
 	mergeQueue *queue.DiskQueue
 
@@ -117,7 +117,7 @@ func NewTaskQueue(index *HFresh, bucket *lsmkv.Bucket) (*TaskQueue, error) {
 	}
 
 	// create queue for reassign operations
-	rq, err := queue.NewDiskQueue(
+	tq.reassignQueue, err = queue.NewDiskQueue(
 		queue.DiskQueueOptions{
 			ID:               fmt.Sprintf("hfresh_reassign_queue_%s_%s", index.config.ShardName, index.config.ID),
 			Logger:           index.logger,
@@ -131,7 +131,6 @@ func NewTaskQueue(index *HFresh, bucket *lsmkv.Bucket) (*TaskQueue, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create hfresh reassign queue")
 	}
-	tq.reassignQueue = &reassignQueue{DiskQueue: rq, splitQueue: tq.splitQueue}
 	err = tq.reassignQueue.Init()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize hfresh reassign queue")
@@ -357,25 +356,10 @@ func (tq *TaskQueue) DecodeTask(data []byte) (queue.Task, error) {
 	return nil, errors.Errorf("unknown operation: %d", op)
 }
 
-// reassignQueue wraps the underlying disk queue used for reassign operations.
-type reassignQueue struct {
-	*queue.DiskQueue
-	splitQueue *queue.DiskQueue
-}
-
-func (r *reassignQueue) DequeueBatch() (*queue.Batch, error) {
-	// hold off reassigns while there are pending splits,
-	// to prioritize splits and reduce the chance of cascade
-	if r.splitQueue.Size() > 0 {
-		return nil, nil
-	}
-	return r.DiskQueue.DequeueBatch()
-}
-
 // analyzeQueue wraps the underlying disk queue used for analyze operations.
 type analyzeQueue struct {
 	*queue.DiskQueue
-	reassignQueue *reassignQueue
+	reassignQueue *queue.DiskQueue
 }
 
 func (a *analyzeQueue) DequeueBatch() (*queue.Batch, error) {

--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -42,7 +42,7 @@ const (
 
 type TaskQueue struct {
 	// queue for analyze operations
-	analyzeQueue *queue.DiskQueue
+	analyzeQueue *analyzeQueue
 	// queue for split operations
 	splitQueue *queue.DiskQueue
 	// queue for reassign operations
@@ -77,7 +77,7 @@ func NewTaskQueue(index *HFresh, bucket *lsmkv.Bucket) (*TaskQueue, error) {
 	}
 
 	// create queue for analyze operations
-	tq.analyzeQueue, err = queue.NewDiskQueue(
+	aq, err := queue.NewDiskQueue(
 		queue.DiskQueueOptions{
 			ID:               fmt.Sprintf("hfresh_analyze_queue_%s_%s", index.config.ShardName, index.config.ID),
 			Logger:           index.logger,
@@ -91,7 +91,7 @@ func NewTaskQueue(index *HFresh, bucket *lsmkv.Bucket) (*TaskQueue, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create hfresh analyze queue")
 	}
-	err = tq.analyzeQueue.Init()
+	err = aq.Init()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize hfresh analyze queue")
 	}
@@ -136,6 +136,8 @@ func NewTaskQueue(index *HFresh, bucket *lsmkv.Bucket) (*TaskQueue, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize hfresh reassign queue")
 	}
+
+	tq.analyzeQueue = &analyzeQueue{DiskQueue: aq, reassignQueue: tq.reassignQueue}
 
 	// create queue for merge operations
 	tq.mergeQueue, err = queue.NewDiskQueue(
@@ -368,6 +370,21 @@ func (r *reassignQueue) DequeueBatch() (*queue.Batch, error) {
 		return nil, nil
 	}
 	return r.DiskQueue.DequeueBatch()
+}
+
+// analyzeQueue wraps the underlying disk queue used for analyze operations.
+type analyzeQueue struct {
+	*queue.DiskQueue
+	reassignQueue *reassignQueue
+}
+
+func (a *analyzeQueue) DequeueBatch() (*queue.Batch, error) {
+	// hold off analyzes while there are pending reassigns,
+	// to prioritize reassigns and reduce the chance of cascade
+	if a.reassignQueue.Size() > 0 {
+		return nil, nil
+	}
+	return a.DiskQueue.DequeueBatch()
 }
 
 type AnalyzeTask struct {

--- a/adapters/repos/db/vector/hfresh/task_queue.go
+++ b/adapters/repos/db/vector/hfresh/task_queue.go
@@ -40,15 +40,6 @@ const (
 	mergeTaskQueueChunkSize    = 16 * 1024 // 16KB
 )
 
-// reassignQueue wraps the underlying disk queue used for reassign operations.
-type reassignQueue struct {
-	*queue.DiskQueue
-}
-
-func (r *reassignQueue) DequeueBatch() (*queue.Batch, error) {
-	return r.DiskQueue.DequeueBatch()
-}
-
 type TaskQueue struct {
 	// queue for analyze operations
 	analyzeQueue *queue.DiskQueue
@@ -140,7 +131,7 @@ func NewTaskQueue(index *HFresh, bucket *lsmkv.Bucket) (*TaskQueue, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create hfresh reassign queue")
 	}
-	tq.reassignQueue = &reassignQueue{DiskQueue: rq}
+	tq.reassignQueue = &reassignQueue{DiskQueue: rq, splitQueue: tq.splitQueue}
 	err = tq.reassignQueue.Init()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize hfresh reassign queue")
@@ -362,6 +353,16 @@ func (tq *TaskQueue) DecodeTask(data []byte) (queue.Task, error) {
 	}
 
 	return nil, errors.Errorf("unknown operation: %d", op)
+}
+
+// reassignQueue wraps the underlying disk queue used for reassign operations.
+type reassignQueue struct {
+	*queue.DiskQueue
+	splitQueue *queue.DiskQueue
+}
+
+func (r *reassignQueue) DequeueBatch() (*queue.Batch, error) {
+	return r.DiskQueue.DequeueBatch()
 }
 
 type AnalyzeTask struct {


### PR DESCRIPTION
### What's being changed:

This prevents hfresh from dequeuing analyze tasks until all reassignments are processed.
Previously, reassignments would trigger analyze operations in cascade, slowing down everything.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
