### PR TITLE
Namespaces: Make RBAC casbin aware

### DIFF
--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -47,14 +47,15 @@ const (
 var validateRoleNameRegex = regexp.MustCompile(`^` + roleNameRegexCore + `$`)
 
 type authZHandlers struct {
-	authorizer     authorization.Authorizer
-	controller     ControllerAndGetUsers
-	schemaReader   schemaUC.SchemaGetter
-	logger         logrus.FieldLogger
-	metrics        *monitoring.PrometheusMetrics
-	apiKeysConfigs config.StaticAPIKey
-	oidcConfigs    config.OIDC
-	rbacconfig     rbacconf.Config
+	authorizer        authorization.Authorizer
+	controller        ControllerAndGetUsers
+	schemaReader      schemaUC.SchemaGetter
+	logger            logrus.FieldLogger
+	metrics           *monitoring.PrometheusMetrics
+	apiKeysConfigs    config.StaticAPIKey
+	oidcConfigs       config.OIDC
+	rbacconfig        rbacconf.Config
+	namespacesEnabled bool
 }
 
 type ControllerAndGetUsers interface {
@@ -63,17 +64,18 @@ type ControllerAndGetUsers interface {
 }
 
 func SetupHandlers(api *operations.WeaviateAPI, controller ControllerAndGetUsers, schemaReader schemaUC.SchemaGetter,
-	apiKeysConfigs config.StaticAPIKey, oidcConfigs config.OIDC, rconfig rbacconf.Config, metrics *monitoring.PrometheusMetrics, authorizer authorization.Authorizer, logger logrus.FieldLogger,
+	apiKeysConfigs config.StaticAPIKey, oidcConfigs config.OIDC, rconfig rbacconf.Config, namespacesEnabled bool, metrics *monitoring.PrometheusMetrics, authorizer authorization.Authorizer, logger logrus.FieldLogger,
 ) {
 	h := &authZHandlers{
-		controller:     controller,
-		authorizer:     authorizer,
-		schemaReader:   schemaReader,
-		rbacconfig:     rconfig,
-		oidcConfigs:    oidcConfigs,
-		apiKeysConfigs: apiKeysConfigs,
-		logger:         logger,
-		metrics:        metrics,
+		controller:        controller,
+		authorizer:        authorizer,
+		schemaReader:      schemaReader,
+		rbacconfig:        rconfig,
+		oidcConfigs:       oidcConfigs,
+		apiKeysConfigs:    apiKeysConfigs,
+		namespacesEnabled: namespacesEnabled,
+		logger:            logger,
+		metrics:           metrics,
 	}
 
 	// rbac role handlers
@@ -149,6 +151,10 @@ func (h *authZHandlers) createRole(params authz.CreateRoleParams, principal *mod
 		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("you cannot create role with the same name as built-in role %s", *params.Body.Name)))
 	}
 
+	if err := h.validateNoQualifiedNamespaceInPolicies(policies[*params.Body.Name]); err != nil {
+		return authz.NewCreateRoleUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+	}
+
 	if err := h.authorizeRoleScopes(ctx, principal, authorization.CREATE, policies[*params.Body.Name], *params.Body.Name); err != nil {
 		return authz.NewCreateRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
@@ -194,6 +200,10 @@ func (h *authZHandlers) addPermissions(params authz.AddPermissionsParams, princi
 	})
 	if err != nil {
 		return authz.NewAddPermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("invalid permissions %w", err)))
+	}
+
+	if err := h.validateNoQualifiedNamespaceInPolicies(policies[params.ID]); err != nil {
+		return authz.NewAddPermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
 	if err := h.authorizeRoleScopes(ctx, principal, authorization.UPDATE, policies[params.ID], params.ID); err != nil {
@@ -484,6 +494,18 @@ func (h *authZHandlers) assignRoleToUser(params authz.AssignRoleToUserParams, pr
 	if userTypes == nil {
 		return authz.NewAssignRoleToUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("username to assign role to doesn't exist")))
 	}
+
+	if h.namespacesEnabled && !h.isStaticAPIKeyUser(params.ID) {
+		for _, role := range params.Body.Roles {
+			if slices.Contains(authorization.BuiltInRoles, role) {
+				return authz.NewAssignRoleToUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf(
+					"role %q is reserved for global/operator principals and cannot be assigned to namespaced dynamic DB user %q",
+					role, params.ID,
+				)))
+			}
+		}
+	}
+
 	for _, userType := range userTypes {
 		if err := h.controller.AddRolesForUser(conv.UserNameWithTypeFromId(params.ID, userType), params.Body.Roles); err != nil {
 			return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("AddRolesForUser: %w", err)))
@@ -1057,6 +1079,16 @@ func (h *authZHandlers) getRolesForGroup(params authz.GetRolesForGroupParams, pr
 	return authz.NewGetRolesForGroupOK().WithPayload(roles)
 }
 
+// isStaticAPIKeyUser reports whether userID is configured as a static API-key
+// user (env-var managed). Static API-key users are always global principals
+// and remain eligible for built-in roles even on namespace-enabled clusters.
+func (h *authZHandlers) isStaticAPIKeyUser(userID string) bool {
+	if !h.apiKeysConfigs.Enabled {
+		return false
+	}
+	return slices.Contains(h.apiKeysConfigs.Users, userID)
+}
+
 func (h *authZHandlers) userExists(user string, userType authentication.AuthType) (bool, error) {
 	switch userType {
 	case authentication.AuthTypeOIDC:
@@ -1150,6 +1182,22 @@ func (h *authZHandlers) getUserTypesAndValidateExistence(id string, userTypePara
 func validateEnvVarRoles(name string) error {
 	if slices.Contains(authorization.EnvVarRoles, name) {
 		return fmt.Errorf("modifying '%s' role or changing its assignments is not allowed", name)
+	}
+	return nil
+}
+
+// validateNoQualifiedNamespaceInPolicies rejects role-definition policies
+// whose resource paths contain the namespace separator. On namespace-enabled
+// clusters role definitions must remain namespace-relative templates; the
+// matcher specializes them at enforce time. No-op when namespaces are disabled.
+func (h *authZHandlers) validateNoQualifiedNamespaceInPolicies(policies []authorization.Policy) error {
+	if !h.namespacesEnabled {
+		return nil
+	}
+	for _, p := range policies {
+		if conv.ContainsNamespaceSeparator(p.Resource) {
+			return fmt.Errorf("role permissions must not contain namespace-qualified resource paths; got %q", p.Resource)
+		}
 	}
 	return nil
 }

--- a/adapters/handlers/rest/authz/handlers_authz_add_permission_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_add_permission_test.go
@@ -380,3 +380,57 @@ func TestAddPermissionsInternalServerError(t *testing.T) {
 		})
 	}
 }
+
+func TestValidateNoQualifiedNamespaceInPolicies(t *testing.T) {
+	tests := []struct {
+		name              string
+		namespacesEnabled bool
+		policies          []authorization.Policy
+		wantErr           bool
+	}{
+		{
+			name:              "namespaces disabled: qualified resource accepted",
+			namespacesEnabled: false,
+			policies:          []authorization.Policy{{Resource: "schema/collections/customer1:Movies/shards/#"}},
+		},
+		{
+			name:              "namespaces enabled: ns-relative resource accepted",
+			namespacesEnabled: true,
+			policies:          []authorization.Policy{{Resource: "schema/collections/Movies/shards/#"}},
+		},
+		{
+			name:              "namespaces enabled: qualified collection segment rejected",
+			namespacesEnabled: true,
+			policies:          []authorization.Policy{{Resource: "schema/collections/customer1:Movies/shards/#"}},
+			wantErr:           true,
+		},
+		{
+			name:              "namespaces enabled: qualified alias segment rejected",
+			namespacesEnabled: true,
+			policies:          []authorization.Policy{{Resource: "aliases/collections/Movies/aliases/customer1:Films"}},
+			wantErr:           true,
+		},
+		{
+			name:              "namespaces enabled: rejection scans every policy",
+			namespacesEnabled: true,
+			policies: []authorization.Policy{
+				{Resource: "schema/collections/Movies/shards/#"},
+				{Resource: "data/collections/customer1:Movies/shards/.*/objects/.*"},
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := &authZHandlers{namespacesEnabled: tt.namespacesEnabled}
+			err := h.validateNoQualifiedNamespaceInPolicies(tt.policies)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "namespace-qualified")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
+++ b/adapters/handlers/rest/authz/handlers_authz_assign_roles_test.go
@@ -13,6 +13,7 @@ package authz
 
 import (
 	"fmt"
+	"slices"
 	"testing"
 
 	"github.com/weaviate/weaviate/usecases/auth/authentication"
@@ -530,6 +531,100 @@ func TestAssignRoleToUserInternalServerError(t *testing.T) {
 
 			if tt.expectedError != "" {
 				assert.Contains(t, parsed.Payload.Error[0].Message, tt.expectedError)
+			}
+		})
+	}
+}
+
+func TestAssignRoleToUserBuiltInRoleNamespacesEnabled(t *testing.T) {
+	type testCase struct {
+		name              string
+		role              string
+		userID            string
+		namespacesEnabled bool
+		staticAPIKeyUsers []string
+		wantForbidden     bool
+	}
+
+	tests := []testCase{
+		{
+			name:              "namespaces enabled, dynamic DB user, admin role rejected",
+			role:              authorization.Admin,
+			userID:            "namespaced-user",
+			namespacesEnabled: true,
+			wantForbidden:     true,
+		},
+		{
+			name:              "namespaces enabled, dynamic DB user, viewer role rejected",
+			role:              authorization.Viewer,
+			userID:            "namespaced-user",
+			namespacesEnabled: true,
+			wantForbidden:     true,
+		},
+		{
+			name:              "namespaces enabled, dynamic DB user, custom role allowed",
+			role:              "customRole",
+			userID:            "namespaced-user",
+			namespacesEnabled: true,
+		},
+		{
+			name:              "namespaces enabled, static API-key user, admin role allowed",
+			role:              authorization.Admin,
+			userID:            "static-user",
+			namespacesEnabled: true,
+			staticAPIKeyUsers: []string{"static-user"},
+		},
+		{
+			name:              "namespaces disabled, dynamic DB user, admin role allowed",
+			role:              authorization.Admin,
+			userID:            "namespaced-user",
+			namespacesEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			authorizer := authorization.NewMockAuthorizer(t)
+			controller := NewMockControllerAndGetUsers(t)
+			logger, _ := test.NewNullLogger()
+
+			principal := &models.Principal{Username: "admin-user"}
+			params := authz.AssignRoleToUserParams{
+				ID:          tt.userID,
+				HTTPRequest: req,
+				Body: authz.AssignRoleToUserBody{
+					Roles:    []string{tt.role},
+					UserType: models.UserTypeInputDb,
+				},
+			}
+
+			authorizer.On("Authorize", mock.Anything, principal, authorization.USER_AND_GROUP_ASSIGN_AND_REVOKE, authorization.Users(tt.userID)[0]).Return(nil)
+			controller.On("GetRoles", tt.role).Return(map[string][]authorization.Policy{tt.role: {}}, nil)
+			isStatic := slices.Contains(tt.staticAPIKeyUsers, tt.userID)
+			if !isStatic {
+				controller.On("GetUsers", tt.userID).Return(map[string]*apikey.User{tt.userID: {}}, nil)
+			}
+			if !tt.wantForbidden {
+				controller.On("AddRolesForUser", conv.UserNameWithTypeFromId(tt.userID, authentication.AuthTypeDb), params.Body.Roles).Return(nil)
+			}
+
+			h := &authZHandlers{
+				authorizer:        authorizer,
+				controller:        controller,
+				apiKeysConfigs:    config.StaticAPIKey{Enabled: true, Users: tt.staticAPIKeyUsers},
+				namespacesEnabled: tt.namespacesEnabled,
+				logger:            logger,
+			}
+			res := h.assignRoleToUser(params, principal)
+			if tt.wantForbidden {
+				parsed, ok := res.(*authz.AssignRoleToUserForbidden)
+				assert.True(t, ok, "expected Forbidden, got %T", res)
+				if ok {
+					assert.Contains(t, parsed.Payload.Error[0].Message, "reserved for global/operator principals")
+				}
+			} else {
+				_, ok := res.(*authz.AssignRoleToUserOK)
+				assert.True(t, ok, "expected OK, got %T", res)
 			}
 		})
 	}

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1080,6 +1080,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		appState.ServerConfig.Config.Authentication.APIKey,
 		appState.ServerConfig.Config.Authentication.OIDC,
 		appState.ServerConfig.Config.Authorization.Rbac,
+		appState.ServerConfig.Config.Namespaces.Enabled,
 		appState.Metrics,
 		appState.Authorizer,
 		appState.Logger)

--- a/test/acceptance/authz/alter_schema_operations_test.go
+++ b/test/acceptance/authz/alter_schema_operations_test.go
@@ -37,6 +37,8 @@ func TestAuthzDeleteClassPropertyIndex(t *testing.T) {
 		nil,
 		false,
 		map[string]string{"ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT": "true"},
+		false,
+		false,
 	)
 	defer down()
 

--- a/test/acceptance/authz/namespaces_test.go
+++ b/test/acceptance/authz/namespaces_test.go
@@ -222,6 +222,23 @@ func TestAuthzNamespaces(t *testing.T) {
 	user2Key := helper.CreateUserWithNamespace(t, "u2", ns2, adminKey)
 	defer helper.DeleteUser(t, ns2+":u2", adminKey)
 
+	// Namespaced DB users start with no permissions. Grant both a single
+	// namespace-relative create_collections role; the matcher specializes the
+	// unqualified `*` template per caller, so each user can only create within
+	// their own namespace.
+	const bootstrapRole = "ns-bootstrap-create"
+	helper.CreateRole(t, adminKey, &models.Role{
+		Name: String(bootstrapRole),
+		Permissions: []*models.Permission{
+			helper.NewCollectionsPermission().WithAction(authorization.CreateCollections).WithCollection("*").Permission(),
+		},
+	})
+	defer helper.DeleteRole(t, adminKey, bootstrapRole)
+	helper.AssignRoleToUser(t, adminKey, bootstrapRole, ns1+":u1")
+	defer helper.RevokeRoleFromUser(t, adminKey, bootstrapRole, ns1+":u1")
+	helper.AssignRoleToUser(t, adminKey, bootstrapRole, ns2+":u2")
+	defer helper.RevokeRoleFromUser(t, adminKey, bootstrapRole, ns2+":u2")
+
 	helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user1Key)
 	defer helper.DeleteClassAuth(t, ns1+":Movies", adminKey)
 	helper.CreateClassAuth(t, &models.Class{Class: "MoviesArchive"}, user1Key)

--- a/test/acceptance/authz/namespaces_test.go
+++ b/test/acceptance/authz/namespaces_test.go
@@ -271,7 +271,7 @@ func TestAuthzNamespaces(t *testing.T) {
 		helper.CreateRole(t, adminKey, &models.Role{
 			Name: String(role),
 			Permissions: []*models.Permission{
-				helper.NewCollectionsPermission().WithAction(authorization.ReadCollections).WithCollection("Movies.*").Permission(),
+				helper.NewCollectionsPermission().WithAction(authorization.ReadCollections).WithCollection("Movies*").Permission(),
 			},
 		})
 		defer helper.DeleteRole(t, adminKey, role)

--- a/test/acceptance/authz/namespaces_test.go
+++ b/test/acceptance/authz/namespaces_test.go
@@ -18,7 +18,9 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/client/authz"
 	"github.com/weaviate/weaviate/client/namespaces"
+	"github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/helper"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -45,10 +47,9 @@ func TestAuthzNamespaces(t *testing.T) {
 		},
 		map[string]string{viewerUser: viewerKey},
 		false,
-		map[string]string{
-			"NAMESPACES_ENABLED": "true",
-			"DISABLE_GRAPHQL":    "true",
-		},
+		nil,
+		true, // withDbUsers — needed for the namespace-scoping subtests below.
+		true, // withNamespaces
 	)
 	defer down()
 
@@ -204,6 +205,169 @@ func TestAuthzNamespaces(t *testing.T) {
 
 		assert.Empty(t, helper.ListNamespaces(t, noPermsKey))
 	})
+
+	// Namespace-scoping subtests (WS5 matcher + role-safety guards). Reuses
+	// the same compose to avoid a second cluster boot.
+	const (
+		ns1 = "customer1"
+		ns2 = "customer2"
+	)
+	helper.CreateNamespace(t, ns1, adminKey)
+	defer helper.DeleteNamespace(t, ns1, adminKey)
+	helper.CreateNamespace(t, ns2, adminKey)
+	defer helper.DeleteNamespace(t, ns2, adminKey)
+
+	user1Key := helper.CreateUserWithNamespace(t, "u1", ns1, adminKey)
+	defer helper.DeleteUser(t, ns1+":u1", adminKey)
+	user2Key := helper.CreateUserWithNamespace(t, "u2", ns2, adminKey)
+	defer helper.DeleteUser(t, ns2+":u2", adminKey)
+
+	helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user1Key)
+	defer helper.DeleteClassAuth(t, ns1+":Movies", adminKey)
+	helper.CreateClassAuth(t, &models.Class{Class: "MoviesArchive"}, user1Key)
+	defer helper.DeleteClassAuth(t, ns1+":MoviesArchive", adminKey)
+	helper.CreateClassAuth(t, &models.Class{Class: "Music"}, user1Key)
+	defer helper.DeleteClassAuth(t, ns1+":Music", adminKey)
+
+	helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user2Key)
+	defer helper.DeleteClassAuth(t, ns2+":Movies", adminKey)
+	helper.CreateClassAuth(t, &models.Class{Class: "Music"}, user2Key)
+	defer helper.DeleteClassAuth(t, ns2+":Music", adminKey)
+
+	t.Run("read_collections wildcard scope: namespaced caller can read own-NS collection by unqualified name", func(t *testing.T) {
+		const role = "read-all"
+		helper.CreateRole(t, adminKey, &models.Role{
+			Name: String(role),
+			Permissions: []*models.Permission{
+				helper.NewCollectionsPermission().WithAction(authorization.ReadCollections).WithCollection("*").Permission(),
+			},
+		})
+		defer helper.DeleteRole(t, adminKey, role)
+		helper.AssignRoleToUser(t, adminKey, role, ns1+":u1")
+		defer helper.RevokeRoleFromUser(t, adminKey, role, ns1+":u1")
+
+		assert.Equal(t, ns1+":Movies", helper.GetClassAuth(t, "Movies", user1Key).Class)
+	})
+
+	t.Run("read_collections regex scope (Movies*): matches in own namespace only", func(t *testing.T) {
+		const role = "read-movies-prefix"
+		helper.CreateRole(t, adminKey, &models.Role{
+			Name: String(role),
+			Permissions: []*models.Permission{
+				helper.NewCollectionsPermission().WithAction(authorization.ReadCollections).WithCollection("Movies.*").Permission(),
+			},
+		})
+		defer helper.DeleteRole(t, adminKey, role)
+		helper.AssignRoleToUser(t, adminKey, role, ns1+":u1")
+		defer helper.RevokeRoleFromUser(t, adminKey, role, ns1+":u1")
+
+		assert.Equal(t, ns1+":Movies", helper.GetClassAuth(t, "Movies", user1Key).Class)
+		assert.Equal(t, ns1+":MoviesArchive", helper.GetClassAuth(t, "MoviesArchive", user1Key).Class)
+
+		_, err := helper.Client(t).Schema.SchemaObjectsGet(
+			schema.NewSchemaObjectsGetParams().WithClassName("Music"),
+			helper.CreateAuth(user1Key),
+		)
+		require.Error(t, err, "Music should not match Movies.*")
+	})
+
+	t.Run("read_collections exact scope (Movies): allows only Movies in own namespace", func(t *testing.T) {
+		const role = "read-movies-exact"
+		helper.CreateRole(t, adminKey, &models.Role{
+			Name: String(role),
+			Permissions: []*models.Permission{
+				helper.NewCollectionsPermission().WithAction(authorization.ReadCollections).WithCollection("Movies").Permission(),
+			},
+		})
+		defer helper.DeleteRole(t, adminKey, role)
+		helper.AssignRoleToUser(t, adminKey, role, ns1+":u1")
+		defer helper.RevokeRoleFromUser(t, adminKey, role, ns1+":u1")
+
+		assert.Equal(t, ns1+":Movies", helper.GetClassAuth(t, "Movies", user1Key).Class)
+
+		_, err := helper.Client(t).Schema.SchemaObjectsGet(
+			schema.NewSchemaObjectsGetParams().WithClassName("MoviesArchive"),
+			helper.CreateAuth(user1Key),
+		)
+		require.Error(t, err, "exact-scope role must not match MoviesArchive")
+	})
+
+	t.Run("schema dump filters to own namespace for namespaced caller", func(t *testing.T) {
+		const role = "read-all-for-dump"
+		helper.CreateRole(t, adminKey, &models.Role{
+			Name: String(role),
+			Permissions: []*models.Permission{
+				helper.NewCollectionsPermission().WithAction(authorization.ReadCollections).WithCollection("*").Permission(),
+			},
+		})
+		defer helper.DeleteRole(t, adminKey, role)
+		helper.AssignRoleToUser(t, adminKey, role, ns1+":u1")
+		defer helper.RevokeRoleFromUser(t, adminKey, role, ns1+":u1")
+
+		resp, err := helper.Client(t).Schema.SchemaDump(schema.NewSchemaDumpParams(), helper.CreateAuth(user1Key))
+		require.NoError(t, err)
+		got := classNames(resp.Payload.Classes)
+		assert.ElementsMatch(t, []string{ns1 + ":Movies", ns1 + ":MoviesArchive", ns1 + ":Music"}, got,
+			"namespaced caller must only see own-namespace classes in schema dump")
+	})
+
+	t.Run("global operator sees both namespaces in schema dump by qualified name", func(t *testing.T) {
+		resp, err := helper.Client(t).Schema.SchemaDump(schema.NewSchemaDumpParams(), helper.CreateAuth(adminKey))
+		require.NoError(t, err)
+		got := classNames(resp.Payload.Classes)
+		assert.ElementsMatch(t, []string{
+			ns1 + ":Movies", ns1 + ":MoviesArchive", ns1 + ":Music",
+			ns2 + ":Movies", ns2 + ":Music",
+		}, got)
+	})
+
+	t.Run("built-in admin role cannot be assigned to namespaced DB user", func(t *testing.T) {
+		_, err := helper.Client(t).Authz.AssignRoleToUser(
+			authz.NewAssignRoleToUserParams().WithID(ns1+":u1").WithBody(authz.AssignRoleToUserBody{
+				Roles:    []string{authorization.Admin},
+				UserType: models.UserTypeInputDb,
+			}),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var forbidden *authz.AssignRoleToUserForbidden
+		require.True(t, errors.As(err, &forbidden), "expected AssignRoleToUserForbidden, got %T: %v", err, err)
+	})
+
+	t.Run("built-in viewer role cannot be assigned to namespaced DB user", func(t *testing.T) {
+		_, err := helper.Client(t).Authz.AssignRoleToUser(
+			authz.NewAssignRoleToUserParams().WithID(ns1+":u1").WithBody(authz.AssignRoleToUserBody{
+				Roles:    []string{authorization.Viewer},
+				UserType: models.UserTypeInputDb,
+			}),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var forbidden *authz.AssignRoleToUserForbidden
+		require.True(t, errors.As(err, &forbidden), "expected AssignRoleToUserForbidden, got %T: %v", err, err)
+	})
+
+	t.Run("role with namespace-qualified resource path is rejected at create time", func(t *testing.T) {
+		const role = "qualified-path-role"
+		_, err := helper.Client(t).Authz.CreateRole(
+			authz.NewCreateRoleParams().WithBody(&models.Role{
+				Name: String(role),
+				Permissions: []*models.Permission{
+					helper.NewCollectionsPermission().WithAction(authorization.ReadCollections).WithCollection(ns1 + ":Movies").Permission(),
+				},
+			}),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err, "create role must reject namespace-qualified collection name")
+	})
+}
+
+func classNames(classes []*models.Class) []string {
+	out := make([]string, len(classes))
+	for i, c := range classes {
+		out[i] = c.Class
+	}
+	return out
 }
 
 func authzNamespaceNames(list []*models.Namespace) []string {

--- a/test/acceptance/authz/setup.go
+++ b/test/acceptance/authz/setup.go
@@ -22,19 +22,26 @@ import (
 )
 
 func composeUp(t *testing.T, admins map[string]string, users map[string]string, viewers map[string]string) (*docker.DockerCompose, func()) {
-	return composeUpWithSettings(t, admins, users, viewers, false, nil)
+	return composeUpWithSettings(t, admins, users, viewers, false, nil, false, false)
 }
 
 func composeUpWithMCP(t *testing.T, admins map[string]string, users map[string]string, viewers map[string]string, enableMCP bool) (*docker.DockerCompose, func()) {
-	return composeUpWithSettings(t, admins, users, viewers, enableMCP, nil)
+	return composeUpWithSettings(t, admins, users, viewers, enableMCP, nil, false, false)
 }
 
-func composeUpWithSettings(t *testing.T, admins map[string]string, users map[string]string, viewers map[string]string, enableMCP bool, weaviateEnvs map[string]string) (*docker.DockerCompose, func()) {
+func composeUpWithSettings(t *testing.T, admins map[string]string, users map[string]string, viewers map[string]string, enableMCP bool, weaviateEnvs map[string]string, withDbUsers, withNamespaces bool) (*docker.DockerCompose, func()) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 
 	builder := docker.New().WithWeaviateEnv("AUTOSCHEMA_ENABLED", "false").WithWeaviateWithGRPC().WithRBAC().WithApiKey()
 	for key, val := range weaviateEnvs {
 		builder = builder.WithWeaviateEnv(key, val)
+	}
+
+	if withDbUsers {
+		builder = builder.WithDbUsers()
+	}
+	if withNamespaces {
+		builder = builder.WithNamespaces()
 	}
 
 	// Enable MCP server if requested

--- a/test/helper/rbac.go
+++ b/test/helper/rbac.go
@@ -131,6 +131,20 @@ func CreateUser(t *testing.T, userId, key string) string {
 	return *resp.Payload.Apikey
 }
 
+func CreateUserWithNamespace(t *testing.T, userId, namespace, adminKey string) string {
+	t.Helper()
+	resp, err := Client(t).Users.CreateUser(
+		users.NewCreateUserParams().WithUserID(userId).WithBody(users.CreateUserBody{Namespace: namespace}),
+		CreateAuth(adminKey),
+	)
+	AssertRequestOk(t, resp, err, nil)
+	require.Nil(t, err)
+	require.NotNil(t, resp)
+	require.NotNil(t, resp.Payload)
+	require.NotNil(t, resp.Payload.Apikey)
+	return *resp.Payload.Apikey
+}
+
 func CreateUserWithApiKey(t *testing.T, userId, key string, createdAt *time.Time) string {
 	t.Helper()
 	tp := true

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -215,6 +215,15 @@ func CasbinNamespaces(name string) string {
 	return fmt.Sprintf("%s/%s", authorization.NamespacesDomain, name)
 }
 
+// ContainsNamespaceSeparator reports whether a casbin resource path contains
+// the namespace separator. The separator never appears in any other valid
+// resource path segment (collection, shard, tenant, role, and user names all
+// forbid it), so a plain byte scan unambiguously detects namespace
+// qualification regardless of the path shape.
+func ContainsNamespaceSeparator(resource string) bool {
+	return strings.IndexByte(resource, schema.NamespaceSeparator[0]) >= 0
+}
+
 func extractFromExtAction(inputAction string) (string, string, error) {
 	splits := strings.Split(inputAction, "_")
 	if len(splits) < 2 {

--- a/usecases/auth/authorization/rbac/authorizer_test.go
+++ b/usecases/auth/authorization/rbac/authorizer_test.go
@@ -175,6 +175,84 @@ func TestAuthorize(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name: "namespaced principal allowed in own namespace",
+			principal: &models.Principal{
+				Username:  "ns-user",
+				UserType:  models.UserTypeInputDb,
+				Namespace: "customer1",
+			},
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("customer1:Movies"),
+			setupPolicies: func(m *Manager) error {
+				if _, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("ns-role"),
+					authorization.CollectionsMetadata("Movies")[0], authorization.READ, authorization.SchemaDomain); err != nil {
+					return err
+				}
+				ok, err := m.casbin.AddRoleForUser(conv.UserNameWithTypeFromId("ns-user", authentication.AuthTypeDb),
+					conv.PrefixRoleName("ns-role"))
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("failed to add role for user")
+				}
+				return nil
+			},
+		},
+		{
+			name: "namespaced principal denied for matching name in another namespace",
+			principal: &models.Principal{
+				Username:  "ns-user-2",
+				UserType:  models.UserTypeInputDb,
+				Namespace: "customer1",
+			},
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("customer2:Movies"),
+			setupPolicies: func(m *Manager) error {
+				if _, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("ns-role-2"),
+					authorization.CollectionsMetadata("Movies")[0], authorization.READ, authorization.SchemaDomain); err != nil {
+					return err
+				}
+				ok, err := m.casbin.AddRoleForUser(conv.UserNameWithTypeFromId("ns-user-2", authentication.AuthTypeDb),
+					conv.PrefixRoleName("ns-role-2"))
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("failed to add role for user")
+				}
+				return nil
+			},
+			wantErr:     true,
+			errContains: "forbidden",
+		},
+		{
+			name: "namespaced group inherits role and is scoped to its namespace",
+			principal: &models.Principal{
+				Username:  "ns-group-user",
+				Groups:    []string{"customer1-group"},
+				UserType:  models.UserTypeInputDb,
+				Namespace: "customer1",
+			},
+			verb:      authorization.READ,
+			resources: authorization.CollectionsMetadata("customer1:Movies"),
+			setupPolicies: func(m *Manager) error {
+				if _, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("ns-group-role"),
+					authorization.CollectionsMetadata("Movies")[0], authorization.READ, authorization.SchemaDomain); err != nil {
+					return err
+				}
+				ok, err := m.casbin.AddRoleForUser(conv.PrefixGroupName("customer1-group"),
+					conv.PrefixRoleName("ns-group-role"))
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("failed to add role for group")
+				}
+				return nil
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -375,6 +453,36 @@ func TestFilterAuthorizedResources(t *testing.T) {
 				return nil
 			},
 			wantResources: authorization.CollectionsMetadata("Test1", "Test2"),
+		},
+		{
+			name: "namespaced principal filters by both namespace and collection scope",
+			principal: &models.Principal{
+				Username:  "ns-filter-user",
+				UserType:  models.UserTypeInputDb,
+				Namespace: "customer1",
+			},
+			verb: authorization.READ,
+			resources: append(append(append(
+				authorization.CollectionsMetadata("customer1:Movies1"),
+				authorization.CollectionsMetadata("customer1:Movies2")...),
+				authorization.CollectionsMetadata("customer1:Films")...),
+				authorization.CollectionsMetadata("customer2:Movies1")...),
+			setupPolicies: func(m *Manager) error {
+				if _, err := m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("ns-filter-role"),
+					authorization.CollectionsMetadata("Movies.*")[0], authorization.READ, authorization.SchemaDomain); err != nil {
+					return err
+				}
+				ok, err := m.casbin.AddRoleForUser(conv.UserNameWithTypeFromId("ns-filter-user", authentication.AuthTypeDb),
+					conv.PrefixRoleName("ns-filter-role"))
+				if err != nil {
+					return err
+				}
+				if !ok {
+					return fmt.Errorf("failed to add role for user")
+				}
+				return nil
+			},
+			wantResources: authorization.CollectionsMetadata("customer1:Movies1", "customer1:Movies2"),
 		},
 	}
 

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -465,9 +465,11 @@ func (m *Manager) checkPermissions(principal *models.Principal, resource, verb s
 	m.restoreLock.RLock()
 	defer m.restoreLock.RUnlock()
 
+	ns := principal.Namespace
+
 	// first check group permissions
 	for _, group := range principal.Groups {
-		allowed, err := m.casbin.Enforce(conv.PrefixGroupName(group), resource, verb)
+		allowed, err := m.casbin.Enforce(conv.PrefixGroupName(group), resource, verb, ns)
 		if err != nil {
 			return false, err
 		}
@@ -477,7 +479,7 @@ func (m *Manager) checkPermissions(principal *models.Principal, resource, verb s
 	}
 
 	// If no group permissions, check user permissions
-	return m.casbin.Enforce(conv.UserNameWithTypeFromPrincipal(principal), resource, verb)
+	return m.casbin.Enforce(conv.UserNameWithTypeFromPrincipal(principal), resource, verb, ns)
 }
 
 func prettyPermissionsActions(perm *models.Permission) string {

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -393,6 +393,15 @@ func namespaceAwareMatcher(reqObj, polObj, ns string) bool {
 		return weaviateKeyMatch(reqObj, polObj)
 	}
 
+	// Normalize `/*` to `/.*` before rewriting. KeyMatch5 applies this
+	// transform itself, but only at slash boundaries; once the rewrite
+	// prepends `<ns>:` to a bare `*` segment the `*` is no longer
+	// slash-bounded and KeyMatch5's transform stops firing. Producers like
+	// CollectionsMetadata, ShardsMetadata, and Objects emit literal `*`
+	// segments — without this normalization they would never match a
+	// qualified request after the rewrite.
+	polObj = strings.ReplaceAll(polObj, "/*", "/.*")
+
 	// Reaching this point means a rewrite is needed: either ns != "" (the
 	// caller is namespaced) or ns == "" with a qualified request (a global
 	// caller addressing a namespace-qualified resource).

--- a/usecases/auth/authorization/rbac/model.go
+++ b/usecases/auth/authorization/rbac/model.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/auth/authentication"
 
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -40,11 +41,11 @@ import (
 const DEFAULT_POLICY_VERSION = "1.29.0"
 
 const (
-	// MODEL is the used model for casbin to store roles, permissions, users and comparisons patterns
+	// MODEL is the used model for casbin to store roles, permissions, users and comparisons patterns.
 	// docs: https://casbin.org/docs/syntax-for-models
 	MODEL = `
 	[request_definition]
-	r = sub, obj, act
+	r = sub, obj, act, ns
 
 	[policy_definition]
 	p = sub, obj, act, dom
@@ -56,7 +57,7 @@ const (
 	e = some(where (p.eft == allow))
 
 	[matchers]
-	m = g(r.sub, p.sub) && weaviateMatcher(r.obj, p.obj) && regexMatch(r.act, p.act)
+	m = g(r.sub, p.sub) && namespaceAwareMatcher(r.obj, p.obj, r.ns) && regexMatch(r.act, p.act)
 `
 )
 
@@ -136,7 +137,7 @@ func Init(conf rbacconf.Config, policyPath string, authNconf config.Authenticati
 		}
 	}
 	// docs: https://casbin.org/docs/function/
-	enforcer.AddFunction("weaviateMatcher", WeaviateMatcherFunc)
+	enforcer.AddFunction("namespaceAwareMatcher", namespaceAwareMatcherFunc)
 
 	if err := applyPredefinedRoles(enforcer, conf, authNconf); err != nil {
 		return nil, errors.Wrapf(err, "apply env config")
@@ -262,23 +263,196 @@ func applyPredefinedRoles(enforcer *casbin.SyncedCachedEnforcer, conf rbacconf.C
 	return nil
 }
 
-func WeaviateMatcher(key1 string, key2 string) bool {
-	// If we're dealing with a tenant-specific path (matches /shards/#$)
-	if strings.HasSuffix(key1, "/shards/#") {
-		// Don't allow matching with wildcard patterns
-		if strings.HasSuffix(key2, "/shards/.*") {
-			return false
+var (
+	schemaCollectionsPrefix  = authorization.SchemaDomain + "/collections/"
+	dataCollectionsPrefix    = authorization.DataDomain + "/collections/"
+	aliasesCollectionsPrefix = authorization.AliasesDomain + "/collections/"
+)
+
+const (
+	shardsMidSeg  = "/shards/"
+	aliasesMidSeg = "/aliases/"
+)
+
+// anyNamespacePattern matches exactly one `<ns>:` prefix.
+var anyNamespacePattern = "[^/" + schema.NamespaceSeparator + "]+" + schema.NamespaceSeparator
+
+// findNamespaceSegments returns the [start, end) bounds of the collection-name
+// segment in path for the known shapes (schema/data/aliases). end == 0 means
+// path is not namespaceable. hasAlias reports whether path also has a 2nd
+// namespace-bearing alias segment, located at
+// [end + len(aliasesMidSeg), len(path)).
+func findNamespaceSegments(path string) (start, end int, hasAlias bool) {
+	if rest, ok := strings.CutPrefix(path, schemaCollectionsPrefix); ok {
+		idx := strings.Index(rest, shardsMidSeg)
+		if idx == -1 {
+			return 0, 0, false
 		}
+		s := len(schemaCollectionsPrefix)
+		return s, s + idx, false
 	}
-	// For all other cases, use standard KeyMatch5
-	return casbinutil.KeyMatch5(key1, key2)
+	if rest, ok := strings.CutPrefix(path, dataCollectionsPrefix); ok {
+		idx := strings.Index(rest, shardsMidSeg)
+		if idx == -1 {
+			return 0, 0, false
+		}
+		s := len(dataCollectionsPrefix)
+		return s, s + idx, false
+	}
+	if rest, ok := strings.CutPrefix(path, aliasesCollectionsPrefix); ok {
+		idx := strings.Index(rest, aliasesMidSeg)
+		if idx == -1 {
+			return 0, 0, false
+		}
+		s := len(aliasesCollectionsPrefix)
+		return s, s + idx, true
+	}
+	return 0, 0, false
 }
 
-func WeaviateMatcherFunc(args ...interface{}) (interface{}, error) {
-	name1 := args[0].(string)
-	name2 := args[1].(string)
+// segmentHasSeparator reports whether path[start:end] contains the namespace separator.
+func segmentHasSeparator(path string, start, end int) bool {
+	return strings.IndexByte(path[start:end], schema.NamespaceSeparator[0]) >= 0
+}
 
-	return (bool)(WeaviateMatcher(name1, name2)), nil
+// rewriteSegment appends prefix+seg to b (unqualified policy segment) or seg
+// verbatim (already-qualified). In fixedNs mode an already-qualified segment
+// must start with prefix exactly, otherwise ok=false.
+func rewriteSegment(b *strings.Builder, policy string, start, end int, prefix string, fixedNs bool) (ok bool) {
+	if segmentHasSeparator(policy, start, end) {
+		if fixedNs && !strings.HasPrefix(policy[start:end], prefix) {
+			return false
+		}
+		b.WriteString(policy[start:end])
+		return true
+	}
+	b.WriteString(prefix)
+	b.WriteString(policy[start:end])
+	return true
+}
+
+// rewritePolicy specializes (fixedNs=true, prefix=`<ns>:`) or widens
+// (fixedNs=false, prefix=anyNamespacePattern) the namespace-bearing segments
+// of policy. Returns ok=false in fixedNs mode if any already-qualified
+// segment names a different namespace.
+func rewritePolicy(policy string, colStart, colEnd int, hasAlias bool, prefix string, fixedNs bool) (string, bool) {
+	segCount := 1
+	if hasAlias {
+		segCount = 2
+	}
+	var b strings.Builder
+	b.Grow(len(policy) + segCount*len(prefix))
+
+	b.WriteString(policy[:colStart])
+	if !rewriteSegment(&b, policy, colStart, colEnd, prefix, fixedNs) {
+		return "", false
+	}
+	if !hasAlias {
+		b.WriteString(policy[colEnd:])
+		return b.String(), true
+	}
+
+	aliasStart := colEnd + len(aliasesMidSeg)
+	aliasEnd := len(policy)
+	b.WriteString(policy[colEnd:aliasStart])
+	if !rewriteSegment(&b, policy, aliasStart, aliasEnd, prefix, fixedNs) {
+		return "", false
+	}
+	return b.String(), true
+}
+
+// weaviateKeyMatch runs the `/shards/#` vs `/shards/.*` carve-out then
+// KeyMatch5: a collection-level request must not match a per-tenant policy.
+func weaviateKeyMatch(reqObj, polObj string) bool {
+	if strings.HasSuffix(reqObj, "/shards/#") && strings.HasSuffix(polObj, "/shards/.*") {
+		return false
+	}
+	return casbinutil.KeyMatch5(reqObj, polObj)
+}
+
+// namespaceAwareMatcher reports whether policy resource pattern polObj
+// authorizes a request for reqObj issued in namespace ns ("" for
+// global/operator callers).
+//
+//   - ns != "": unqualified policy segments specialize to `<ns>:<segment>`;
+//     already-qualified segments must start with `<ns>:` exactly.
+//   - ns == "" with a qualified request segment: unqualified policy segments
+//     widen with anyNamespacePattern; qualified segments stay fixed.
+//   - ns == "" with an unqualified request segment, or a non-namespaceable
+//     path shape: no rewrite.
+func namespaceAwareMatcher(reqObj, polObj, ns string) bool {
+	// Trivial passthrough: no rewrite is needed when the caller carries no
+	// namespace and the request resource is unqualified. This is the only
+	// path on namespace-disabled clusters (validation forbids `:` in any resource
+	// path) and also covers operator calls against unqualified resources
+	// on namespace-enabled clusters. The namespace separator never appears
+	// in any other part of a valid resource path
+	// (class/shard/tenant/role names all forbid `:`), so a single byte
+	// scan classifies the request.
+	if ns == "" && strings.IndexByte(reqObj, schema.NamespaceSeparator[0]) < 0 {
+		return weaviateKeyMatch(reqObj, polObj)
+	}
+
+	// Reaching this point means a rewrite is needed: either ns != "" (the
+	// caller is namespaced) or ns == "" with a qualified request (a global
+	// caller addressing a namespace-qualified resource).
+	//
+	// Casbin's KeyMatch5 has no notion of namespaces — it runs a plain regex
+	// match. The strategy is to rewrite the *policy* so its namespace-bearing
+	// segments speak in the same shape as the request, then hand the
+	// rewritten string to KeyMatch5. The request itself is never rewritten.
+	//
+	// Worked example, policy "schema/collections/Movies.*/shards/#" (operator
+	// template) vs request "schema/collections/customer1:Movies/shards/#":
+	//   - ns="customer1" → policy becomes "schema/collections/customer1:Movies.*/shards/#"
+	//     (specialize); KeyMatch5 matches.
+	//   - ns=""          → policy becomes "schema/collections/[^/:]+:Movies.*/shards/#"
+	//     (widen);       KeyMatch5 matches any namespace prefix.
+
+	// 1. Locate the collection segment in each path. findNamespaceSegments
+	//    returns its [start, end) bounds and a flag set on aliases paths,
+	//    which carry a *second* namespace-bearing segment after "/aliases/".
+	//    The request side only needs end+hasAlias (for the shape check
+	//    below); we don't rewrite the request, so its start is discarded.
+	polColStart, polColEnd, polHasAlias := findNamespaceSegments(polObj)
+	_, reqColEnd, reqHasAlias := findNamespaceSegments(reqObj)
+
+	// 2. Shape check. If either path isn't a namespaceable shape (end==0),
+	//    or the two disagree on alias-ness (one is schema/data, the other
+	//    aliases), there's nothing meaningful to rewrite — defer to plain
+	//    KeyMatch5 (which returns false on a shape mismatch anyway).
+	if reqColEnd == 0 || polColEnd == 0 || reqHasAlias != polHasAlias {
+		return weaviateKeyMatch(reqObj, polObj)
+	}
+
+	// 3a. Fixed-ns specialization. Unqualified policy segments become
+	//     "<ns>:<seg>". An already-qualified policy segment must start with
+	//     "<ns>:" exactly; otherwise the policy names a *different*
+	//     namespace and rewritePolicy returns ok=false → cross-namespace
+	//     deny.
+	if ns != "" {
+		rewritten, ok := rewritePolicy(polObj, polColStart, polColEnd, polHasAlias, ns+schema.NamespaceSeparator, true)
+		if !ok {
+			return false
+		}
+		return weaviateKeyMatch(reqObj, rewritten)
+	}
+
+	// 3b. Any-ns widening. Unqualified policy segments become
+	//     "anyNamespacePattern + <seg>" so they regex-match any single
+	//     namespace prefix; already-qualified segments stay fixed.
+	//
+	// 4.  Final KeyMatch5, with the /shards/# carve-out so a
+	//     collection-level request doesn't satisfy a per-tenant policy.
+	rewritten, _ := rewritePolicy(polObj, polColStart, polColEnd, polHasAlias, anyNamespacePattern, false)
+	return weaviateKeyMatch(reqObj, rewritten)
+}
+
+func namespaceAwareMatcherFunc(args ...any) (any, error) {
+	reqObj := args[0].(string)
+	polObj := args[1].(string)
+	ns := args[2].(string)
+	return namespaceAwareMatcher(reqObj, polObj, ns), nil
 }
 
 func getVersion(path string) (string, error) {

--- a/usecases/auth/authorization/rbac/model_alloc_test.go
+++ b/usecases/auth/authorization/rbac/model_alloc_test.go
@@ -11,10 +11,36 @@
 
 package rbac
 
-import "testing"
+import (
+	"strings"
+	"testing"
 
-func BenchmarkNamespaceAwareMatcher_TrivialPassthrough(b *testing.B) {
-	reqObj := "schema/collections/Movies/shards/#"
+	casbinutil "github.com/casbin/casbin/v2/util"
+)
+
+// legacyWeaviateMatcher is the pre-namespaces matcher kept here for benchmark
+// comparison only. Production code uses namespaceAwareMatcher.
+func legacyWeaviateMatcher(reqObj, polObj string) bool {
+	if strings.HasSuffix(reqObj, "/shards/#") && strings.HasSuffix(polObj, "/shards/.*") {
+		return false
+	}
+	return casbinutil.KeyMatch5(reqObj, polObj)
+}
+
+// Case 1: legacy/unqualified pass-through. namespaceAwareMatcher's fast path
+// must be no slower than the legacy matcher when neither side is qualified.
+
+func BenchmarkLegacyWeaviateMatcher_UnqualifiedPassthrough(b *testing.B) {
+	reqObj := "schema/collections/MoviesArchive/shards/#"
+	polObj := "schema/collections/Movies.*/shards/#"
+	b.ReportAllocs()
+	for b.Loop() {
+		legacyWeaviateMatcher(reqObj, polObj)
+	}
+}
+
+func BenchmarkNamespaceAwareMatcher_UnqualifiedPassthrough(b *testing.B) {
+	reqObj := "schema/collections/MoviesArchive/shards/#"
 	polObj := "schema/collections/Movies.*/shards/#"
 	b.ReportAllocs()
 	for b.Loop() {
@@ -22,17 +48,11 @@ func BenchmarkNamespaceAwareMatcher_TrivialPassthrough(b *testing.B) {
 	}
 }
 
-func BenchmarkNamespaceAwareMatcher_ShapeMismatch(b *testing.B) {
-	reqObj := "schema/collections/customer1:Movies/shards/#"
-	polObj := "aliases/collections/Movies.*/aliases/.*"
-	b.ReportAllocs()
-	for b.Loop() {
-		namespaceAwareMatcher(reqObj, polObj, "customer1")
-	}
-}
+// Case 2: empty-namespace any-namespace widening. ns="" against a qualified
+// request — the new matcher rewrites the policy with anyNamespacePattern.
 
 func BenchmarkNamespaceAwareMatcher_AnyNsWiden(b *testing.B) {
-	reqObj := "schema/collections/customer1:Movies/shards/#"
+	reqObj := "schema/collections/customer2:MoviesArchive/shards/#"
 	polObj := "schema/collections/Movies.*/shards/#"
 	b.ReportAllocs()
 	for b.Loop() {
@@ -40,18 +60,35 @@ func BenchmarkNamespaceAwareMatcher_AnyNsWiden(b *testing.B) {
 	}
 }
 
+// Case 3: fixed-namespace specialization. ns="customer1" — the new matcher
+// rewrites the policy with the caller's namespace prefix.
+
 func BenchmarkNamespaceAwareMatcher_FixedNsSpecialize(b *testing.B) {
-	reqObj := "schema/collections/customer1:Movies/shards/#"
+	reqObj := "schema/collections/customer1:MoviesArchive/shards/#"
 	polObj := "schema/collections/Movies.*/shards/#"
 	b.ReportAllocs()
 	for b.Loop() {
 		namespaceAwareMatcher(reqObj, polObj, "customer1")
 	}
 }
+
+// Case 4: already-qualified fixed path. Both sides already carry the same
+// namespace prefix — segment-prefix check passes without rewriting body text.
 
 func BenchmarkNamespaceAwareMatcher_FixedNsAlreadyQualified(b *testing.B) {
 	reqObj := "schema/collections/customer1:Movies/shards/#"
 	polObj := "schema/collections/customer1:Movies/shards/#"
+	b.ReportAllocs()
+	for b.Loop() {
+		namespaceAwareMatcher(reqObj, polObj, "customer1")
+	}
+}
+
+// Auxiliary cases covering branches the 4 primary cases don't exercise.
+
+func BenchmarkNamespaceAwareMatcher_ShapeMismatch(b *testing.B) {
+	reqObj := "schema/collections/customer1:Movies/shards/#"
+	polObj := "aliases/collections/Movies.*/aliases/.*"
 	b.ReportAllocs()
 	for b.Loop() {
 		namespaceAwareMatcher(reqObj, polObj, "customer1")

--- a/usecases/auth/authorization/rbac/model_alloc_test.go
+++ b/usecases/auth/authorization/rbac/model_alloc_test.go
@@ -1,0 +1,68 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rbac
+
+import "testing"
+
+func BenchmarkNamespaceAwareMatcher_TrivialPassthrough(b *testing.B) {
+	reqObj := "schema/collections/Movies/shards/#"
+	polObj := "schema/collections/Movies.*/shards/#"
+	b.ReportAllocs()
+	for b.Loop() {
+		namespaceAwareMatcher(reqObj, polObj, "")
+	}
+}
+
+func BenchmarkNamespaceAwareMatcher_ShapeMismatch(b *testing.B) {
+	reqObj := "schema/collections/customer1:Movies/shards/#"
+	polObj := "aliases/collections/Movies.*/aliases/.*"
+	b.ReportAllocs()
+	for b.Loop() {
+		namespaceAwareMatcher(reqObj, polObj, "customer1")
+	}
+}
+
+func BenchmarkNamespaceAwareMatcher_AnyNsWiden(b *testing.B) {
+	reqObj := "schema/collections/customer1:Movies/shards/#"
+	polObj := "schema/collections/Movies.*/shards/#"
+	b.ReportAllocs()
+	for b.Loop() {
+		namespaceAwareMatcher(reqObj, polObj, "")
+	}
+}
+
+func BenchmarkNamespaceAwareMatcher_FixedNsSpecialize(b *testing.B) {
+	reqObj := "schema/collections/customer1:Movies/shards/#"
+	polObj := "schema/collections/Movies.*/shards/#"
+	b.ReportAllocs()
+	for b.Loop() {
+		namespaceAwareMatcher(reqObj, polObj, "customer1")
+	}
+}
+
+func BenchmarkNamespaceAwareMatcher_FixedNsAlreadyQualified(b *testing.B) {
+	reqObj := "schema/collections/customer1:Movies/shards/#"
+	polObj := "schema/collections/customer1:Movies/shards/#"
+	b.ReportAllocs()
+	for b.Loop() {
+		namespaceAwareMatcher(reqObj, polObj, "customer1")
+	}
+}
+
+func BenchmarkNamespaceAwareMatcher_AliasesPath(b *testing.B) {
+	reqObj := "aliases/collections/customer1:Movies/aliases/customer1:Films"
+	polObj := "aliases/collections/Movies.*/aliases/.*"
+	b.ReportAllocs()
+	for b.Loop() {
+		namespaceAwareMatcher(reqObj, polObj, "customer1")
+	}
+}

--- a/usecases/auth/authorization/rbac/model_test.go
+++ b/usecases/auth/authorization/rbac/model_test.go
@@ -12,6 +12,7 @@
 package rbac
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -20,8 +21,8 @@ import (
 
 func testKeyMatch5(t *testing.T, key1, key2 string, expected bool) {
 	t.Helper()
-	if result := WeaviateMatcher(key1, key2); result != expected {
-		t.Errorf("WeaviateMatcher(%q, %q) = %v; want %v", key1, key2, result, expected)
+	if result := namespaceAwareMatcher(key1, key2, ""); result != expected {
+		t.Errorf("namespaceAwareMatcher(%q, %q, %q) = %v; want %v", key1, key2, "", result, expected)
 	}
 }
 
@@ -161,9 +162,314 @@ func TestKeyMatchTenant(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := WeaviateMatcher(tt.key1, tt.key2)
+			result := namespaceAwareMatcher(tt.key1, tt.key2, "")
 			if result != tt.expected {
-				t.Errorf("WeaviateMatcher(%s, %s) = %v; want %v", tt.key1, tt.key2, result, tt.expected)
+				t.Errorf("namespaceAwareMatcher(%s, %s, %q) = %v; want %v", tt.key1, tt.key2, "", result, tt.expected)
+			}
+		})
+	}
+}
+
+func testNamespaceAwareMatcher(t *testing.T, reqObj, polObj, ns string, expected bool) {
+	t.Helper()
+	if got := namespaceAwareMatcher(reqObj, polObj, ns); got != expected {
+		t.Errorf("namespaceAwareMatcher(%q, %q, %q) = %v; want %v", reqObj, polObj, ns, got, expected)
+	}
+}
+
+func TestNamespaceAwareMatcher(t *testing.T) {
+	tests := []struct {
+		name     string
+		reqObj   string
+		polObj   string
+		ns       string
+		expected bool
+	}{
+		{
+			"empty ns, qualified request, unqualified Movies* policy → match (any-ns widen)",
+			"schema/collections/customer2:MoviesArchive/shards/#",
+			conv.CasbinSchema("Movies*", "#"),
+			"",
+			true,
+		},
+		{
+			"ns=customer1, in-ns request, unqualified Movies* policy → match (fixed-ns specialize)",
+			"schema/collections/customer1:MoviesArchive/shards/#",
+			conv.CasbinSchema("Movies*", "#"),
+			"customer1",
+			true,
+		},
+		{
+			"ns=customer1, cross-ns request, unqualified Movies* policy → mismatch (cross-ns deny)",
+			"schema/collections/customer2:MoviesArchive/shards/#",
+			conv.CasbinSchema("Movies*", "#"),
+			"customer1",
+			false,
+		},
+		{
+			"empty ns, qualified request, wildcard policy → match (any-ns widen)",
+			"schema/collections/customer1:Movies/shards/#",
+			conv.CasbinSchema("*", "#"),
+			"",
+			true,
+		},
+		{
+			"ns=customer1, in-ns request, wildcard policy → match (fixed-ns specialize)",
+			"schema/collections/customer1:Movies/shards/#",
+			conv.CasbinSchema("*", "#"),
+			"customer1",
+			true,
+		},
+		{
+			"ns=customer1, cross-ns request, wildcard policy → mismatch",
+			"schema/collections/customer2:Movies/shards/#",
+			conv.CasbinSchema("*", "#"),
+			"customer1",
+			false,
+		},
+		{
+			"ns=customer1, in-ns request, exact-name unqualified policy → match",
+			"schema/collections/customer1:Movies/shards/#",
+			conv.CasbinSchema("Movies", "#"),
+			"customer1",
+			true,
+		},
+		{
+			"ns=customer1, in-ns Films request, exact-name Movies policy → mismatch",
+			"schema/collections/customer1:Films/shards/#",
+			conv.CasbinSchema("Movies", "#"),
+			"customer1",
+			false,
+		},
+		{
+			"ns=customer1, qualified policy customer1:Movies → match",
+			"schema/collections/customer1:Movies/shards/#",
+			conv.CasbinSchema("customer1:Movies", "#"),
+			"customer1",
+			true,
+		},
+		{
+			"ns=customer1, qualified policy customer2:Movies → mismatch (cross-ns guard)",
+			"schema/collections/customer1:Movies/shards/#",
+			conv.CasbinSchema("customer2:Movies", "#"),
+			"customer1",
+			false,
+		},
+		{
+			"ns=customer1, data path, unqualified Movies* policy → match",
+			"data/collections/customer1:Movies/shards/Tenant1/objects/obj-1",
+			conv.CasbinData("Movies*", "*", "*"),
+			"customer1",
+			true,
+		},
+		{
+			"ns=customer1, alias path with qualified col+alias, unqualified Movies/Films policy → match (both segments specialize)",
+			"aliases/collections/customer1:Movies/aliases/customer1:Films",
+			conv.CasbinAliases("Movies", "Films"),
+			"customer1",
+			true,
+		},
+		{
+			"ns=customer1, /shards/# request, /shards/.* policy → mismatch (carve-out)",
+			"schema/collections/customer1:Movies/shards/#",
+			conv.CasbinSchema("Movies", ""),
+			"customer1",
+			false,
+		},
+		{
+			"empty ns, unqualified request, unqualified policy → passthrough match",
+			"schema/collections/Movies/shards/#",
+			conv.CasbinSchema("Movies", "#"),
+			"",
+			true,
+		},
+		{
+			"empty ns, qualified request, exact unqualified policy → match (any-ns widen exact)",
+			"schema/collections/customer1:Movies/shards/#",
+			conv.CasbinSchema("Movies", "#"),
+			"",
+			true,
+		},
+		{
+			"empty ns, qualified customer2 request, qualified customer1 policy → mismatch (qualified policy stays fixed)",
+			"schema/collections/customer2:Movies/shards/#",
+			conv.CasbinSchema("customer1:Movies", "#"),
+			"",
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testNamespaceAwareMatcher(t, tt.reqObj, tt.polObj, tt.ns, tt.expected)
+		})
+	}
+}
+
+// TestRewriteSegment locks the contract of the per-segment rewriter directly,
+// so a regression in segment handling (e.g. double-prefixing, wrong cross-NS
+// behavior) shows up here rather than being masked by KeyMatch5 still
+// matching a malformed pattern.
+func TestRewriteSegment(t *testing.T) {
+	tests := []struct {
+		name     string
+		seg      string
+		prefix   string
+		fixedNs  bool
+		wantOK   bool
+		wantText string // builder contents on ok=true
+	}{
+		{
+			name:     "unqualified seg, fixed-ns: prefix is prepended",
+			seg:      "Movies.*",
+			prefix:   "customer1:",
+			fixedNs:  true,
+			wantOK:   true,
+			wantText: "customer1:Movies.*",
+		},
+		{
+			name:     "unqualified seg, any-ns: regex prefix is prepended",
+			seg:      "Movies.*",
+			prefix:   "[^/:]+:",
+			fixedNs:  false,
+			wantOK:   true,
+			wantText: "[^/:]+:Movies.*",
+		},
+		{
+			name:     "qualified seg matching prefix, fixed-ns: seg verbatim",
+			seg:      "customer1:Movies",
+			prefix:   "customer1:",
+			fixedNs:  true,
+			wantOK:   true,
+			wantText: "customer1:Movies",
+		},
+		{
+			name:    "qualified seg with different namespace, fixed-ns: ok=false (cross-NS deny)",
+			seg:     "customer2:Movies",
+			prefix:  "customer1:",
+			fixedNs: true,
+			wantOK:  false,
+		},
+		{
+			name:     "qualified seg, any-ns: seg verbatim (qualified stays fixed)",
+			seg:      "customer1:Movies",
+			prefix:   "[^/:]+:",
+			fixedNs:  false,
+			wantOK:   true,
+			wantText: "customer1:Movies",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b strings.Builder
+			ok := rewriteSegment(&b, tt.seg, 0, len(tt.seg), tt.prefix, tt.fixedNs)
+			if ok != tt.wantOK {
+				t.Fatalf("rewriteSegment ok = %v; want %v", ok, tt.wantOK)
+			}
+			if ok && b.String() != tt.wantText {
+				t.Errorf("rewriteSegment wrote %q; want %q", b.String(), tt.wantText)
+			}
+		})
+	}
+}
+
+// TestRewritePolicy asserts the exact rewritten string for representative
+// schema/data/aliases shapes and the cross-namespace deny path on both the
+// collection and alias segment.
+func TestRewritePolicy(t *testing.T) {
+	tests := []struct {
+		name     string
+		policy   string
+		prefix   string
+		fixedNs  bool
+		wantOK   bool
+		wantText string
+	}{
+		{
+			name:     "schema path, fixed-ns specialize, unqualified col",
+			policy:   "schema/collections/Movies.*/shards/#",
+			prefix:   "customer1:",
+			fixedNs:  true,
+			wantOK:   true,
+			wantText: "schema/collections/customer1:Movies.*/shards/#",
+		},
+		{
+			name:     "data path, fixed-ns specialize, unqualified col",
+			policy:   "data/collections/Movies.*/shards/.*/objects/.*",
+			prefix:   "customer1:",
+			fixedNs:  true,
+			wantOK:   true,
+			wantText: "data/collections/customer1:Movies.*/shards/.*/objects/.*",
+		},
+		{
+			name:     "data path, any-ns widen, unqualified col",
+			policy:   "data/collections/Movies.*/shards/.*/objects/.*",
+			prefix:   anyNamespacePattern,
+			fixedNs:  false,
+			wantOK:   true,
+			wantText: "data/collections/[^/:]+:Movies.*/shards/.*/objects/.*",
+		},
+		{
+			name:     "schema path, any-ns widen, unqualified col",
+			policy:   "schema/collections/Movies.*/shards/#",
+			prefix:   anyNamespacePattern,
+			fixedNs:  false,
+			wantOK:   true,
+			wantText: "schema/collections/[^/:]+:Movies.*/shards/#",
+		},
+		{
+			name:     "schema path, fixed-ns, already-qualified matching col → policy unchanged",
+			policy:   "schema/collections/customer1:Movies/shards/#",
+			prefix:   "customer1:",
+			fixedNs:  true,
+			wantOK:   true,
+			wantText: "schema/collections/customer1:Movies/shards/#",
+		},
+		{
+			name:    "schema path, fixed-ns, already-qualified mismatching col → cross-NS deny",
+			policy:  "schema/collections/customer2:Movies/shards/#",
+			prefix:  "customer1:",
+			fixedNs: true,
+			wantOK:  false,
+		},
+		{
+			name:     "aliases path, fixed-ns specialize, both segs unqualified",
+			policy:   "aliases/collections/Movies/aliases/Films",
+			prefix:   "customer1:",
+			fixedNs:  true,
+			wantOK:   true,
+			wantText: "aliases/collections/customer1:Movies/aliases/customer1:Films",
+		},
+		{
+			name:     "aliases path, any-ns widen, both segs unqualified",
+			policy:   "aliases/collections/Movies/aliases/Films",
+			prefix:   anyNamespacePattern,
+			fixedNs:  false,
+			wantOK:   true,
+			wantText: "aliases/collections/[^/:]+:Movies/aliases/[^/:]+:Films",
+		},
+		{
+			name:    "aliases path, fixed-ns, qualified alias names different NS → cross-NS deny on second segment",
+			policy:  "aliases/collections/customer1:Movies/aliases/customer2:Films",
+			prefix:  "customer1:",
+			fixedNs: true,
+			wantOK:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			colStart, colEnd, hasAlias := findNamespaceSegments(tt.policy)
+			if colEnd == 0 {
+				t.Fatalf("test setup: %q is not namespaceable", tt.policy)
+			}
+			got, ok := rewritePolicy(tt.policy, colStart, colEnd, hasAlias, tt.prefix, tt.fixedNs)
+			if ok != tt.wantOK {
+				t.Fatalf("rewritePolicy ok = %v; want %v (got=%q)", ok, tt.wantOK, got)
+			}
+			if ok && got != tt.wantText {
+				t.Errorf("rewritePolicy = %q; want %q", got, tt.wantText)
 			}
 		})
 	}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -67,9 +67,8 @@ func (h *Handler) GetConsistentClass(ctx context.Context, principal *models.Prin
 	// Also we resolve before doing `Authorize` so that Authorizer will work
 	// with correct `collectionName` for permissions and errors UX
 	name = schema.UppercaseClassName(name)
-	if rname := h.schemaReader.ResolveAlias(name); rname != "" {
-		name = rname
-	}
+	resolved, _ := namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, name)
+	name = resolved
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.READ, authorization.CollectionsMetadata(name)...); err != nil {
 		return nil, 0, err


### PR DESCRIPTION
### What's being changed:

This adds namespace-awareness to casbin for collection/data/alias (backup etc will come later), to support global roles (== a role such as collection=Movies*) which apply to each namespace individually.

Note that OIDC is out-of-scope and will come in a follow-up PR

The casbin changes:
- are a no-op for existing operations (non-namespaced cluster)
- have a slight overhead (~20%) for namespaced clusters in casbin (NOT the full request)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
