### PR TITLE
chore(test): add WV_TEST_* host/port overrides for Python acceptance tests

### DIFF
--- a/test/acceptance_with_python/_wvhost.py
+++ b/test/acceptance_with_python/_wvhost.py
@@ -1,0 +1,55 @@
+#                           _       _
+# __      _____  __ ___   ___  __ _| |_ ___
+# \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+#  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+#   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+#
+#  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+#
+#  CONTACT: hello@weaviate.io
+#
+
+"""Resolve Weaviate REST and gRPC endpoints for acceptance tests.
+
+Defaults are localhost:8080 / localhost:50051. WV_TEST_HOST,
+WV_TEST_REST_PORT, and WV_TEST_GRPC_PORT override the non-RBAC instance.
+WV_TEST_RBAC_HOST, WV_TEST_RBAC_REST_PORT, and WV_TEST_RBAC_GRPC_PORT
+override the RBAC/auth instance (defaults localhost:8081 / 50052).
+
+Mirrors test/acceptance_with_go_client/internal/wvhost/wvhost.go so the
+Go and Python suites share a single configuration convention.
+"""
+
+import os
+
+
+def host() -> str:
+    return os.environ.get("WV_TEST_HOST") or "localhost"
+
+
+def rest_port() -> int:
+    return int(os.environ.get("WV_TEST_REST_PORT") or "8080")
+
+
+def grpc_port() -> int:
+    return int(os.environ.get("WV_TEST_GRPC_PORT") or "50051")
+
+
+def rest_url() -> str:
+    return f"http://{host()}:{rest_port()}"
+
+
+def rbac_host() -> str:
+    return os.environ.get("WV_TEST_RBAC_HOST") or "localhost"
+
+
+def rbac_rest_port() -> int:
+    return int(os.environ.get("WV_TEST_RBAC_REST_PORT") or "8081")
+
+
+def rbac_grpc_port() -> int:
+    return int(os.environ.get("WV_TEST_RBAC_GRPC_PORT") or "50052")
+
+
+def rbac_rest_url() -> str:
+    return f"http://{rbac_host()}:{rbac_rest_port()}"

--- a/test/acceptance_with_python/conftest.py
+++ b/test/acceptance_with_python/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from _pytest.fixtures import SubRequest
 
 import weaviate
+from ._wvhost import grpc_port, rest_port
 from weaviate.collections import Collection
 from weaviate.collections.classes.config import (
     Property,
@@ -58,10 +59,13 @@ class CollectionFactory(Protocol):
 
 @pytest.fixture
 def weaviate_client() -> Callable[[int, int], weaviate.WeaviateClient]:
-    def connect(http_port: int = 8080, grpc_port: int = 50051) -> weaviate.WeaviateClient:
+    def connect(
+        http_port: int = rest_port(),
+        grpc_port_: int = grpc_port(),
+    ) -> weaviate.WeaviateClient:
         return weaviate.connect_to_local(
             port=http_port,
-            grpc_port=grpc_port,
+            grpc_port=grpc_port_,
             additional_config=AdditionalConfig(timeout=(60, 120)),  # for image tests
         )
 
@@ -88,7 +92,7 @@ def collection_factory(request: SubRequest) -> Generator[CollectionFactory, None
         object_ttl: Optional[_ObjectTTLConfigCreate] = None,
         generative_config: Optional[_GenerativeProvider] = None,
         headers: Optional[Dict[str, str]] = None,
-        ports: Tuple[int, int] = (8080, 50051),
+        ports: Tuple[int, int] = (rest_port(), grpc_port()),
         data_model_properties: Optional[Type[Properties]] = None,
         data_model_refs: Optional[Type[Properties]] = None,
         replication_config: Optional[_ReplicationConfigCreate] = None,

--- a/test/acceptance_with_python/rbac/conftest.py
+++ b/test/acceptance_with_python/rbac/conftest.py
@@ -1,18 +1,12 @@
-from typing import (
-    Union,
-    Sequence,
-    Any,
-    ContextManager,
-    Protocol,
-    Iterator,
-)
+from contextlib import contextmanager
+from typing import Any, ContextManager, Iterator, Protocol, Sequence, Union
 
 import pytest
 import weaviate
 import weaviate.classes as wvc
 from _pytest.fixtures import SubRequest
-from contextlib import contextmanager
 
+from .._wvhost import rbac_grpc_port, rbac_rest_port
 from weaviate import WeaviateClient
 from weaviate.rbac.models import PermissionsCreateType
 
@@ -56,15 +50,23 @@ def role_wrapper() -> RoleWrapperProtocol:
     ) -> Iterator[None]:
         name = _sanitize_role_name(request.node.name) + "role"
         admin_client.roles.delete(name)
-        if not isinstance(permissions, list) or len(permissions) > 0:
+        has_permissions = not isinstance(permissions, list) or len(permissions) > 0
+        if has_permissions:
             admin_client.roles.create(role_name=name, permissions=permissions)
             admin_client.users.assign_roles(user_id=user, role_names=name)
 
-        yield
-
-        if not isinstance(permissions, list) or len(permissions) > 0:
-            admin_client.users.revoke_roles(user_id=user, role_names=name)
-            admin_client.roles.delete(name)
+        try:
+            yield
+        finally:
+            if has_permissions:
+                try:
+                    admin_client.users.revoke_roles(user_id=user, role_names=name)
+                except Exception:
+                    pass
+                try:
+                    admin_client.roles.delete(name)
+                except Exception:
+                    pass
 
     return contextmanager(wrapper)
 
@@ -72,7 +74,9 @@ def role_wrapper() -> RoleWrapperProtocol:
 @pytest.fixture
 def admin_client():
     with weaviate.connect_to_local(
-        port=8081, grpc_port=50052, auth_credentials=wvc.init.Auth.api_key("admin-key")
+        port=rbac_rest_port(),
+        grpc_port=rbac_grpc_port(),
+        auth_credentials=wvc.init.Auth.api_key("admin-key"),
     ) as client:
         yield client
 
@@ -80,7 +84,9 @@ def admin_client():
 @pytest.fixture
 def custom_client():
     with weaviate.connect_to_local(
-        port=8081, grpc_port=50052, auth_credentials=wvc.init.Auth.api_key("custom-key")
+        port=rbac_rest_port(),
+        grpc_port=rbac_grpc_port(),
+        auth_credentials=wvc.init.Auth.api_key("custom-key"),
     ) as client:
         yield client
 
@@ -88,6 +94,8 @@ def custom_client():
 @pytest.fixture
 def viewer_client():
     with weaviate.connect_to_local(
-        port=8081, grpc_port=50052, auth_credentials=wvc.init.Auth.api_key("viewer-key")
+        port=rbac_rest_port(),
+        grpc_port=rbac_grpc_port(),
+        auth_credentials=wvc.init.Auth.api_key("viewer-key"),
     ) as client:
         yield client

--- a/test/acceptance_with_python/rbac/test_db_users.py
+++ b/test/acceptance_with_python/rbac/test_db_users.py
@@ -1,12 +1,19 @@
 import pytest
 import weaviate
 import weaviate.classes as wvc
+from _pytest.fixtures import SubRequest
 from weaviate.exceptions import UnexpectedStatusCodeError
 from weaviate.rbac.models import Permissions
-from _pytest.fixtures import SubRequest
+
+from .._wvhost import rbac_grpc_port, rbac_rest_port
 from .conftest import _sanitize_role_name
 
 pytestmark = pytest.mark.xdist_group(name="rbac")
+
+
+def _get_auth_ports():
+    """Get auth instance ports from environment variables."""
+    return rbac_rest_port(), rbac_grpc_port()
 
 
 def test_db_user_create_collection(request: SubRequest, admin_client):
@@ -18,8 +25,9 @@ def test_db_user_create_collection(request: SubRequest, admin_client):
     collection_name = _sanitize_role_name(request.node.name) + "col"
 
     # normal collection
+    http_port, grpc_port = _get_auth_ports()
     with weaviate.connect_to_local(
-        port=8081, grpc_port=50052, auth_credentials=wvc.init.Auth.api_key(api_key)
+        port=http_port, grpc_port=grpc_port, auth_credentials=wvc.init.Auth.api_key(api_key)
     ) as custom_client:
         admin_client.collections.delete(collection_name)
 
@@ -47,8 +55,9 @@ def test_db_user_multi_tenant(request: SubRequest, admin_client):
     admin_client.users.db.assign_roles(user_id="test-user", role_names="admin")
 
     collection_name = _sanitize_role_name(request.node.name) + "col"
+    http_port, grpc_port = _get_auth_ports()
     with weaviate.connect_to_local(
-        port=8081, grpc_port=50052, auth_credentials=wvc.init.Auth.api_key(api_key)
+        port=http_port, grpc_port=grpc_port, auth_credentials=wvc.init.Auth.api_key(api_key)
     ) as custom_client:
         admin_client.collections.delete(collection_name)
 
@@ -93,8 +102,9 @@ def test_db_user_role_and_users(request: SubRequest, admin_client):
 
     collection_name = _sanitize_role_name(request.node.name) + "col"
     role_name = _sanitize_role_name(request.node.name) + "role"
+    http_port, grpc_port = _get_auth_ports()
     with weaviate.connect_to_local(
-        port=8081, grpc_port=50052, auth_credentials=wvc.init.Auth.api_key(api_key)
+        port=http_port, grpc_port=grpc_port, auth_credentials=wvc.init.Auth.api_key(api_key)
     ) as custom_client:
         admin_client.collections.delete(collection_name)
         admin_client.roles.delete(role_name)
@@ -107,8 +117,9 @@ def test_db_user_role_and_users(request: SubRequest, admin_client):
         )
 
         second_api_key = custom_client.users.db.create(user_id="second-user")
+        http_port2, grpc_port2 = _get_auth_ports()
         with weaviate.connect_to_local(
-            port=8081, grpc_port=50052, auth_credentials=wvc.init.Auth.api_key(second_api_key)
+            port=http_port2, grpc_port=grpc_port2, auth_credentials=wvc.init.Auth.api_key(second_api_key)
         ) as second_client:
             # cannot create collection without permissions
             with pytest.raises(UnexpectedStatusCodeError):
@@ -128,8 +139,9 @@ def test_db_user_batch_import(request: SubRequest, admin_client):
     admin_client.users.db.assign_roles(user_id="test-user", role_names="admin")
 
     collection_name = _sanitize_role_name(request.node.name) + "col"
+    http_port, grpc_port = _get_auth_ports()
     with weaviate.connect_to_local(
-        port=8081, grpc_port=50052, auth_credentials=wvc.init.Auth.api_key(api_key)
+        port=http_port, grpc_port=grpc_port, auth_credentials=wvc.init.Auth.api_key(api_key)
     ) as custom_client:
         admin_client.collections.delete(collection_name)
         collection = custom_client.collections.create(

--- a/test/acceptance_with_python/test_ascii_fold_ignore.py
+++ b/test/acceptance_with_python/test_ascii_fold_ignore.py
@@ -9,12 +9,13 @@ import urllib.error
 import urllib.request
 from typing import Generator
 
-import os
 import pytest
 import weaviate.classes as wvc
 
+from ._wvhost import rest_url
 
-BASE_URL = os.environ.get("WEAVIATE_URL", "http://localhost:8080")
+
+BASE_URL = rest_url()
 
 
 def _sanitize_collection_name(name: str) -> str:

--- a/test/acceptance_with_python/test_backup.py
+++ b/test/acceptance_with_python/test_backup.py
@@ -5,6 +5,7 @@ import weaviate
 import weaviate.classes as wvc
 from weaviate.backup.backup import BackupStatus
 
+from ._wvhost import grpc_port, rest_port
 from .conftest import _sanitize_collection_name
 from _pytest.fixtures import SubRequest
 
@@ -22,7 +23,10 @@ pytestmark = pytest.mark.xdist_group(name="backup")
 def test_backup_and_restore(request: SubRequest, compression: wvc.backup.BackupCompressionLevel):
     name = _sanitize_collection_name(request.node.name)
 
-    with weaviate.connect_to_local() as client:
+    with weaviate.connect_to_local(
+        port=rest_port(),
+        grpc_port=grpc_port(),
+    ) as client:
         client.collections.delete(name)
         collection = client.collections.create(
             name=name,

--- a/test/acceptance_with_python/test_collection.py
+++ b/test/acceptance_with_python/test_collection.py
@@ -1,9 +1,14 @@
 import weaviate
 import weaviate.classes as wvc
 
+from ._wvhost import grpc_port, rest_port
+
 
 def test_collection_casing() -> None:
-    with weaviate.connect_to_local() as client:
+    with weaviate.connect_to_local(
+        port=rest_port(),
+        grpc_port=grpc_port(),
+    ) as client:
         # Goal: Collection create/get/delete should automatically transform class name to GQL (first letter caps).
 
         # create collection with all "lower" case -> GQL ("Testcollectioncase")

--- a/test/acceptance_with_python/test_groupby.py
+++ b/test/acceptance_with_python/test_groupby.py
@@ -3,6 +3,8 @@ from typing import Optional
 import pytest
 import weaviate
 import weaviate.classes as wvc
+
+from ._wvhost import grpc_port, rest_port
 from .conftest import CollectionFactory
 
 
@@ -51,7 +53,10 @@ def test_groupby_with_refs(
                 assert len(obj.properties.get("text")) == 2
 
     # repeat with GQL - slightly different code path in
-    client = weaviate.connect_to_local()
+    client = weaviate.connect_to_local(
+        port=rest_port(),
+        grpc_port=grpc_port(),
+    )
     ref = "_additional{id distance}"
     if return_refs is None:
         ref = f"text {ref}"

--- a/test/acceptance_with_python/test_index_compression.py
+++ b/test/acceptance_with_python/test_index_compression.py
@@ -7,9 +7,14 @@ from weaviate.classes.config import Property, DataType
 from weaviate.classes.config import Reconfigure
 from weaviate.util import generate_uuid5
 
+from ._wvhost import grpc_port, rest_port
+
 
 def test_index_compression() -> None:
-    with weaviate.connect_to_local() as client:
+    with weaviate.connect_to_local(
+        port=rest_port(),
+        grpc_port=grpc_port(),
+    ) as client:
         COLLECTION_NAME = "Compressed"
 
         target_vector_dimensions = {

--- a/test/acceptance_with_python/test_multi_target_search_gql.py
+++ b/test/acceptance_with_python/test_multi_target_search_gql.py
@@ -1,8 +1,9 @@
-import weaviate
-import weaviate.classes as wvc
 import math
 
+import weaviate
+import weaviate.classes as wvc
 
+from ._wvhost import grpc_port, rest_port
 from .conftest import CollectionFactory, NamedCollection
 
 GQL_RETURNS = "{_additional {distance id score}"
@@ -12,12 +13,17 @@ APPLE_DISTANCE = 0.5168729424476624
 KALE_DISTANCE = 0.5732871294021606
 
 
+def _get_gql_client():
+    """Get a Weaviate client for GraphQL queries using environment-configured ports."""
+    return weaviate.connect_to_local(port=rest_port(), grpc_port=grpc_port())
+
+
 def test_gql_near_text(named_collection: NamedCollection):
     collection = named_collection()
     collection.data.insert(properties={"title1": "apple", "title2": "car", "title3": "kale"})
 
     # use collection for auto cleanup etc, but we need the client to use gql directly
-    client = weaviate.connect_to_local()
+    client = _get_gql_client()
     gql = client.graphql_raw_query(
         """{
       Get {
@@ -57,7 +63,7 @@ def test_gql_near_vector(named_collection: NamedCollection):
     )
 
     # use collection for auto cleanup etc, but we need the client to use gql directly
-    client = weaviate.connect_to_local()
+    client = _get_gql_client()
     gql = client.graphql_raw_query(
         """{
       Get {
@@ -102,7 +108,7 @@ def test_gql_near_object(named_collection: NamedCollection):
 
     uuid_str = '"' + str(uuid1) + '"'
     # use collection for auto cleanup etc, but we need the client to use gql directly
-    with weaviate.connect_to_local() as client:
+    with _get_gql_client() as client:
         gql = client.graphql_raw_query(
             """{
             Get {
@@ -146,7 +152,7 @@ def test_test_multi_target_near_vector_gql(collection_factory: CollectionFactory
         properties={}, vector={"title1": [0, 1], "title2": [0, 1, 0], "title3": [0, 0, 1, 0]}
     )
 
-    client = weaviate.connect_to_local()
+    client = _get_gql_client()
     gql = client.graphql_raw_query(
         """{
       Get {
@@ -191,7 +197,7 @@ def test_test_multi_target_hybrid_gql(collection_factory: CollectionFactory):
         properties={}, vector={"title1": [1, 0], "title2": [1, 0, 0], "title3": [0, 1, 0, 0]}
     )
 
-    client = weaviate.connect_to_local()
+    client = _get_gql_client()
 
     gql_query = (
         """{

--- a/test/acceptance_with_python/test_reranker.py
+++ b/test/acceptance_with_python/test_reranker.py
@@ -1,10 +1,15 @@
 import weaviate
 import weaviate.classes as wvc
 
+from ._wvhost import grpc_port, rest_port
+
 
 # the dummy reranker is not supported in the python client => create collection from dict
 def test_reranker() -> None:
-    client = weaviate.connect_to_local()
+    client = weaviate.connect_to_local(
+        port=rest_port(),
+        grpc_port=grpc_port(),
+    )
     collection_name = "TestRerankerDummy"
     client.collections.delete(name=collection_name)
     collection = client.collections.create_from_dict(

--- a/test/acceptance_with_python/test_stats_hnsw.py
+++ b/test/acceptance_with_python/test_stats_hnsw.py
@@ -1,10 +1,16 @@
 import json
+
 import httpx
-from weaviate.classes.config import Configure, VectorDistances
 import weaviate
+from weaviate.classes.config import Configure, VectorDistances
+
+from ._wvhost import grpc_port, rest_port
 
 
 def test_stats_hnsw() -> None:
+    http_port = rest_port()
+    grpc_port_ = grpc_port()
+
     short_url = "http://localhost:6060/debug/stats/collection/collection_name/shards"
     response = httpx.post(short_url)
     assert response.status_code == 404
@@ -18,7 +24,7 @@ def test_stats_hnsw() -> None:
     assert response.status_code == 404
     assert "invalid path" in response.text
     # HNSW index
-    client = weaviate.connect_to_local()
+    client = weaviate.connect_to_local(port=http_port, grpc_port=grpc_port_)
     client.collections.delete(name="vector")
     collection = client.collections.create_from_dict(
         {
@@ -62,6 +68,7 @@ def test_stats_hnsw() -> None:
     ] == keywords
 
     # Flat index
+    client.collections.delete(name="flatIndex")
     flat_index = client.collections.create(
         name="flatIndex",
         vector_index_config=Configure.VectorIndex.flat(

--- a/test/acceptance_with_python/test_tokenize.py
+++ b/test/acceptance_with_python/test_tokenize.py
@@ -2,12 +2,13 @@ import json
 import urllib.request
 import urllib.error
 from typing import Any, Generator
-import os
 
 import pytest
 
+from ._wvhost import rest_url
 
-WEAVIATE_URL = os.environ.get("WEAVIATE_URL", "http://localhost:8080")
+
+WEAVIATE_URL = rest_url()
 
 
 REQUEST_TIMEOUT = 10.0


### PR DESCRIPTION
## Summary

- Adds the same \`WV_TEST_HOST\` / \`WV_TEST_REST_PORT\` / \`WV_TEST_GRPC_PORT\` (and \`WV_TEST_RBAC_*\`) convention already used by the Go acceptance suite (\`test/acceptance_with_go_client/internal/wvhost\`) and the SDK clients to the Python acceptance suite, so the same env vars steer every test surface.
- New \`test/acceptance_with_python/_wvhost.py\` helper mirrors \`wvhost.go\` 1:1. Test files stop calling \`weaviate.connect_to_local()\` with hardcoded literals and instead pull defaults from the helper. Defaults remain \`localhost:8080 / 50051\` (RBAC \`localhost:8081 / 50052\`), so existing runners are unaffected.
- Two small drive-by improvements made while touching files:
  - \`rbac/conftest.py\` \`role_wrapper\` now revokes/deletes inside \`try/finally\`, so a failing test no longer leaves stale roles assigned.
  - \`test_stats_hnsw\` now deletes the \`flatIndex\` collection before recreating it (was the only test in the file without the delete-before-create idiom).

## Test plan

- [ ] \`cd test/acceptance_with_python && pytest -xvs test_collection.py\` — passes with no env vars set (default 8080/50051)
- [ ] \`WV_TEST_REST_PORT=9080 WV_TEST_GRPC_PORT=50052 pytest -xvs test_collection.py\` — passes against an alternate port
- [ ] \`WV_TEST_RBAC_REST_PORT=7080 WV_TEST_RBAC_GRPC_PORT=49052 pytest -xvs rbac/\` — passes against an alternate RBAC port

## Companion PRs

This is the server-side counterpart to the same convention being adopted across the SDK clients (already opened):
- weaviate/weaviate-python-client#2023
- weaviate/weaviate-go-client#388
- weaviate/java-client#567
- weaviate/typescript-client#428
- weaviate/csharp-client#333