### PR TITLE
feat: add keyword  highlighting (_additional.highlight)

### DIFF
--- a/adapters/handlers/graphql/local/common_filters/bm25.go
+++ b/adapters/handlers/graphql/local/common_filters/bm25.go
@@ -87,5 +87,12 @@ func ExtractBM25(source map[string]interface{}, explainScore bool) searchparams.
 		}
 	}
 
+	if v, ok := source["highlightMaxFragments"]; ok && v != nil {
+		args.HighlightMaxFragments = v.(int)
+	}
+	if v, ok := source["highlightFragmentSize"]; ok && v != nil {
+		args.HighlightFragmentSize = v.(int)
+	}
+
 	return args
 }

--- a/adapters/handlers/graphql/local/common_filters/hybrid.go
+++ b/adapters/handlers/graphql/local/common_filters/hybrid.go
@@ -172,6 +172,13 @@ func ExtractHybridSearch(source map[string]interface{}, explainScore bool) (*sea
 		}
 	}
 
+	if v, ok := source["highlightMaxFragments"]; ok && v != nil {
+		args.HighlightMaxFragments = v.(int)
+	}
+	if v, ok := source["highlightFragmentSize"]; ok && v != nil {
+		args.HighlightFragmentSize = v.(int)
+	}
+
 	args.Type = "hybrid"
 
 	if args.NearTextParams != nil && args.NearVectorParams != nil {

--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -118,7 +118,7 @@ func (b *classBuilder) classField(class *models.Class, fusionEnum *graphql.Enum)
 func (b *classBuilder) classObject(class *models.Class) *graphql.Object {
 	return graphql.NewObject(graphql.ObjectConfig{
 		Name: b.getClassObjectName(class.Class),
-		Fields: (graphql.FieldsThunk)(func() graphql.Fields {
+		Fields: graphql.FieldsThunk(func() graphql.Fields {
 			classProperties := graphql.Fields{}
 			for _, property := range class.Properties {
 				propertyType, err := b.schema.FindPropertyDataType(property.DataType)
@@ -187,6 +187,7 @@ func (b *classBuilder) additionalFields(classProperties graphql.Fields, class *m
 	additionalProperties["lastUpdateTimeUnix"] = b.additionalLastUpdateTimeUnix()
 	additionalProperties["score"] = b.additionalScoreField()
 	additionalProperties["explainScore"] = b.additionalExplainScoreField()
+	additionalProperties["highlight"] = b.additionalHighlightField(class.Class)
 	additionalProperties["queryProfile"] = b.additionalQueryProfileField()
 	additionalProperties["group"] = b.additionalGroupField(classProperties, class)
 	if replicationEnabled(class) {
@@ -203,6 +204,18 @@ func (b *classBuilder) additionalFields(classProperties graphql.Fields, class *m
 			Name:   fmt.Sprintf("%sAdditional", class.Class),
 			Fields: additionalProperties,
 		}),
+	}
+}
+
+func (b *classBuilder) additionalHighlightField(className string) *graphql.Field {
+	return &graphql.Field{
+		Type: graphql.NewList(graphql.NewObject(graphql.ObjectConfig{
+			Name: fmt.Sprintf("%sAdditionalHighlight", className),
+			Fields: graphql.Fields{
+				"property":  &graphql.Field{Type: graphql.String},
+				"fragments": &graphql.Field{Type: graphql.NewList(graphql.String)},
+			},
+		})),
 	}
 }
 

--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -590,7 +590,7 @@ func (ac *additionalCheck) isAdditional(parentName, name string) bool {
 			name == "distance" || name == "id" || name == "vector" || name == "vectors" ||
 			name == "creationTimeUnix" || name == "lastUpdateTimeUnix" ||
 			name == "score" || name == "explainScore" || name == "isConsistent" ||
-			name == "group" || name == "queryProfile" {
+			name == "group" || name == "queryProfile" || name == "highlight" {
 			return true
 		}
 		if ac.isModuleAdditional(name) {

--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -709,6 +709,10 @@ func extractProperties(className string, selections *ast.SelectionSet,
 							additionalProps.IsConsistent = true
 							continue
 						}
+						if additionalProperty == "highlight" {
+							additionalProps.Highlight = true
+							continue
+						}
 						if additionalProperty == "group" {
 							additionalProps.Group = true
 							var err error

--- a/adapters/handlers/graphql/local/get/get_test.go
+++ b/adapters/handlers/graphql/local/get/get_test.go
@@ -672,6 +672,38 @@ func TestExtractAdditionalFields(t *testing.T) {
 			},
 		},
 		{
+			name:  "with _additional highlight",
+			query: `{ Get { SomeAction { _additional { highlight { property fragments } } } } }`,
+			expectedParams: dto.GetParams{
+				ClassName: "SomeAction",
+				AdditionalProperties: additional.Properties{
+					Highlight: true,
+				},
+			},
+			resolverReturn: []interface{}{
+				map[string]interface{}{
+					"_additional": map[string]interface{}{
+						"highlight": []map[string]interface{}{
+							{
+								"property":  "title",
+								"fragments": []string{"The <em>fashion</em> industry"},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: map[string]interface{}{
+				"_additional": map[string]interface{}{
+					"highlight": []interface{}{
+						map[string]interface{}{
+							"property":  "title",
+							"fragments": []interface{}{"The <em>fashion</em> industry"},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:  "with _additional semanticPath set",
 			query: `{ Get { SomeAction { _additional { semanticPath { path { concept distanceToQuery distanceToResult distanceToPrevious distanceToNext } } } } } }`,
 			expectedParams: dto.GetParams{

--- a/adapters/handlers/graphql/local/get/hybrid_search.go
+++ b/adapters/handlers/graphql/local/get/hybrid_search.go
@@ -76,6 +76,14 @@ func hybridOperands(classObject *graphql.Object,
 			Type:        graphql.NewList(graphql.String),
 		},
 		"bm25SearchOperator": common_filters.GenerateBM25SearchOperatorFields(prefixName),
+		"highlightMaxFragments": &graphql.InputObjectFieldConfig{
+			Description: "Maximum number of highlight fragments per property (default 3)",
+			Type:        graphql.Int,
+		},
+		"highlightFragmentSize": &graphql.InputObjectFieldConfig{
+			Description: "Characters of context around each matched term (default 50)",
+			Type:        graphql.Int,
+		},
 
 		"searches": &graphql.InputObjectFieldConfig{
 			Description: "Subsearch list",

--- a/adapters/handlers/graphql/local/get/sparse_search.go
+++ b/adapters/handlers/graphql/local/get/sparse_search.go
@@ -41,5 +41,13 @@ func bm25Fields(prefix string) graphql.InputObjectConfigFieldMap {
 			Type:        graphql.NewList(graphql.String),
 		},
 		"searchOperator": common_filters.GenerateBM25SearchOperatorFields(prefix),
+		"highlightMaxFragments": &graphql.InputObjectFieldConfig{
+			Description: "Maximum number of highlight fragments per property (default 3)",
+			Type:        graphql.Int,
+		},
+		"highlightFragmentSize": &graphql.InputObjectFieldConfig{
+			Description: "Characters of context around each matched term (default 50)",
+			Type:        graphql.Int,
+		},
 	}
 }

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -427,7 +427,7 @@ func (b *BM25Searcher) wand(
 	}
 
 	start = time.Now()
-	objects, scores, err := b.getTopKObjects(topKHeap, params.AdditionalExplanations, allQueryTerms, additional)
+	objects, scores, err := b.getTopKObjects(topKHeap, params.AdditionalExplanations, allQueryTerms, additional, params.Properties, params.HighlightMaxFragments, params.HighlightFragmentSize)
 
 	fetchTime := time.Since(start)
 	helpers.AnnotateSlowQueryLog(ctx, "kwd_5_objects_time", fetchTime)
@@ -436,7 +436,7 @@ func (b *BM25Searcher) wand(
 }
 
 func (b *BM25Searcher) getTopKObjects(topKHeap *priorityqueue.Queue[[]*terms.DocPointerWithScore], additionalExplanations bool,
-	allRequests []string, additional additional.Properties,
+	allRequests []string, additional additional.Properties, propNames []string, maxFragments, fragmentSize int,
 ) ([]*storobj.Object, []float32, error) {
 	objectsBucket := b.store.Bucket(helpers.ObjectsBucketLSM)
 	scores := make([]float32, 0, topKHeap.Len())
@@ -480,6 +480,18 @@ func (b *BM25Searcher) getTopKObjects(topKHeap *priorityqueue.Queue[[]*terms.Doc
 				queryTerm := allRequests[j]
 				objs[k].Object.Additional["BM25F_"+queryTerm+"_frequency"] = result.Frequency
 				objs[k].Object.Additional["BM25F_"+queryTerm+"_propLength"] = result.PropLength
+			}
+		}
+	}
+
+	if additional.Highlight {
+		for k := range objs {
+			if objs[k].AdditionalProperties() == nil {
+				objs[k].Object.Additional = make(map[string]interface{})
+			}
+			highlights := generateHighlights(objs[k].Properties(), propNames, allRequests, maxFragments, fragmentSize)
+			if highlights != nil {
+				objs[k].Object.Additional["highlight"] = highlights
 			}
 		}
 	}

--- a/adapters/repos/db/inverted/bm25_searcher_block.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block.go
@@ -253,7 +253,7 @@ func (b *BM25Searcher) wandBlock(
 	start = time.Now()
 	helpers.AnnotateSlowQueryLog(ctx, "kwd_4_bmw_time", blockSearchTime)
 
-	objects, scores := b.combineResults(allIds, allScores, allExplanation, termCounts, additional, limit)
+	objects, scores := b.combineResults(allIds, allScores, allExplanation, termCounts, additional, limit, params.Properties, params.HighlightMaxFragments, params.HighlightFragmentSize)
 
 	combineTime := time.Since(start)
 	helpers.AnnotateSlowQueryLog(ctx, "kwd_5_objects_time", combineTime)
@@ -262,7 +262,7 @@ func (b *BM25Searcher) wandBlock(
 	return objects, scores, false, nil
 }
 
-func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float32, allExplanation [][][][]*terms.DocPointerWithScore, queryTerms [][]string, additional additional.Properties, limit int) ([]*storobj.Object, []float32) {
+func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float32, allExplanation [][][][]*terms.DocPointerWithScore, queryTerms [][]string, additional additional.Properties, limit int, propNames []string, maxFragments, fragmentSize int) ([]*storobj.Object, []float32) {
 	// combine all results
 	combinedIds := make([]uint64, 0, limit*len(allIds))
 	combinedScores := make([]float32, 0, limit*len(allIds))
@@ -289,7 +289,7 @@ func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float
 
 	limit = int(math.Min(float64(limit), float64(len(combinedIds))))
 
-	combinedObjects, combinedScores, err := b.getObjectsAndScores(combinedIds, combinedScores, combinedExplanations, combinedTerms, additional, limit)
+	combinedObjects, combinedScores, err := b.getObjectsAndScores(combinedIds, combinedScores, combinedExplanations, combinedTerms, additional, limit, propNames, maxFragments, fragmentSize)
 	if err != nil {
 		return nil, nil
 	}
@@ -355,7 +355,7 @@ func (b *BM25Searcher) sortResultsByExternalId(objects []*storobj.Object, scores
 	return sorter.objects, sorter.scores
 }
 
-func (b *BM25Searcher) getObjectsAndScores(ids []uint64, scores []float32, explanations [][]*terms.DocPointerWithScore, queryTerms []string, additionalProps additional.Properties, limit int) ([]*storobj.Object, []float32, error) {
+func (b *BM25Searcher) getObjectsAndScores(ids []uint64, scores []float32, explanations [][]*terms.DocPointerWithScore, queryTerms []string, additionalProps additional.Properties, limit int, propNames []string, maxFragments, fragmentSize int) ([]*storobj.Object, []float32, error) {
 	// reverse arrays to start with the highest score
 	slices.Reverse(ids)
 	slices.Reverse(scores)
@@ -405,6 +405,19 @@ func (b *BM25Searcher) getObjectsAndScores(ids []uint64, scores []float32, expla
 				queryTerm := queryTerms[j]
 				objs[k].Object.Additional["BM25F_"+queryTerm+"_frequency"] = result.Frequency
 				objs[k].Object.Additional["BM25F_"+queryTerm+"_propLength"] = result.PropLength
+			}
+		}
+	}
+
+	// generate highlights fragments
+	if additionalProps.Highlight {
+		for k := range objs {
+			if objs[k].AdditionalProperties() == nil {
+				objs[k].Object.Additional = make(map[string]interface{})
+			}
+			highlights := generateHighlights(objs[k].Properties(), propNames, queryTerms, maxFragments, fragmentSize)
+			if highlights != nil {
+				objs[k].Object.Additional["highlight"] = highlights
 			}
 		}
 	}

--- a/adapters/repos/db/inverted/bm25_searcher_block.go
+++ b/adapters/repos/db/inverted/bm25_searcher_block.go
@@ -253,7 +253,8 @@ func (b *BM25Searcher) wandBlock(
 	start = time.Now()
 	helpers.AnnotateSlowQueryLog(ctx, "kwd_4_bmw_time", blockSearchTime)
 
-	objects, scores := b.combineResults(allIds, allScores, allExplanation, termCounts, additional, limit, params.Properties, params.HighlightMaxFragments, params.HighlightFragmentSize)
+	hl := hlParams{propNames: params.Properties, maxFragments: params.HighlightMaxFragments, fragmentSize: params.HighlightFragmentSize}
+	objects, scores := b.combineResults(allIds, allScores, allExplanation, termCounts, additional, limit, hl)
 
 	combineTime := time.Since(start)
 	helpers.AnnotateSlowQueryLog(ctx, "kwd_5_objects_time", combineTime)
@@ -262,7 +263,7 @@ func (b *BM25Searcher) wandBlock(
 	return objects, scores, false, nil
 }
 
-func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float32, allExplanation [][][][]*terms.DocPointerWithScore, queryTerms [][]string, additional additional.Properties, limit int, propNames []string, maxFragments, fragmentSize int) ([]*storobj.Object, []float32) {
+func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float32, allExplanation [][][][]*terms.DocPointerWithScore, queryTerms [][]string, additional additional.Properties, limit int, hl hlParams) ([]*storobj.Object, []float32) {
 	// combine all results
 	combinedIds := make([]uint64, 0, limit*len(allIds))
 	combinedScores := make([]float32, 0, limit*len(allIds))
@@ -289,7 +290,7 @@ func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float
 
 	limit = int(math.Min(float64(limit), float64(len(combinedIds))))
 
-	combinedObjects, combinedScores, err := b.getObjectsAndScores(combinedIds, combinedScores, combinedExplanations, combinedTerms, additional, limit, propNames, maxFragments, fragmentSize)
+	combinedObjects, combinedScores, err := b.getObjectsAndScores(combinedIds, combinedScores, combinedExplanations, combinedTerms, additional, limit, hl)
 	if err != nil {
 		return nil, nil
 	}
@@ -297,6 +298,12 @@ func (b *BM25Searcher) combineResults(allIds [][][]uint64, allScores [][][]float
 }
 
 type aggregate func(float32, float32) float32
+
+type hlParams struct {
+	propNames    []string
+	maxFragments int
+	fragmentSize int
+}
 
 func (b *BM25Searcher) combineResultsForMultiProp(allIds []uint64, allScores []float32, allExplanation [][]*terms.DocPointerWithScore, aggregateFn aggregate, singleProp bool) ([]uint64, []float32, [][]*terms.DocPointerWithScore) {
 	// if ids are the same, sum the scores
@@ -355,8 +362,7 @@ func (b *BM25Searcher) sortResultsByExternalId(objects []*storobj.Object, scores
 	return sorter.objects, sorter.scores
 }
 
-func (b *BM25Searcher) getObjectsAndScores(ids []uint64, scores []float32, explanations [][]*terms.DocPointerWithScore, queryTerms []string, additionalProps additional.Properties, limit int, propNames []string, maxFragments, fragmentSize int) ([]*storobj.Object, []float32, error) {
-	// reverse arrays to start with the highest score
+func (b *BM25Searcher) getObjectsAndScores(ids []uint64, scores []float32, explanations [][]*terms.DocPointerWithScore, queryTerms []string, additionalProps additional.Properties, limit int, hl hlParams) ([]*storobj.Object, []float32, error) {
 	slices.Reverse(ids)
 	slices.Reverse(scores)
 	if explanations != nil {
@@ -371,64 +377,86 @@ func (b *BM25Searcher) getObjectsAndScores(ids []uint64, scores []float32, expla
 
 	startAt := 0
 	endAt := limit
-	// try to get docs up to the limit
-	// if there are not enough docs, get limit more docs until we've exhausted the list of ids
 	for len(objs) < limit && startAt < len(ids) {
-		objsBatch, err := storobj.ObjectsByDocIDWithEmpty(objectsBucket, ids[startAt:endAt], additionalProps, nil, b.logger)
+		batchObjs, batchScores, batchExps, err := b.collectMatchingObjects(objectsBucket, ids, scores, explanations, additionalProps, startAt, endAt)
 		if err != nil {
-			return objs, nil, errors.Errorf("objects loading")
+			return objs, nil, err
 		}
-		for i, obj := range objsBatch {
-			if obj == nil || obj.DocID != ids[startAt+i] {
-				continue
-			}
-			objs = append(objs, obj)
-			scoresResult = append(scoresResult, scores[startAt+i])
-			if explanations != nil {
-				explanationsResults = append(explanationsResults, explanations[startAt+i])
-			}
-		}
+		objs = append(objs, batchObjs...)
+		scoresResult = append(scoresResult, batchScores...)
+		explanationsResults = append(explanationsResults, batchExps...)
 		startAt = endAt
 		endAt = min(endAt+limit, len(ids))
 	}
 
-	if explanationsResults != nil && len(explanationsResults) == len(scoresResult) {
-		for k := range objs {
-			// add score explanation
-			if objs[k].AdditionalProperties() == nil {
-				objs[k].Object.Additional = make(map[string]interface{})
-			}
-			for j, result := range explanationsResults[k] {
-				if result == nil {
-					continue
-				}
-				queryTerm := queryTerms[j]
-				objs[k].Object.Additional["BM25F_"+queryTerm+"_frequency"] = result.Frequency
-				objs[k].Object.Additional["BM25F_"+queryTerm+"_propLength"] = result.PropLength
-			}
-		}
+	if len(explanationsResults) == len(scoresResult) {
+		annotateExplanations(objs, explanationsResults, queryTerms)
 	}
 
-	// generate highlights fragments
 	if additionalProps.Highlight {
-		for k := range objs {
-			if objs[k].AdditionalProperties() == nil {
-				objs[k].Object.Additional = make(map[string]interface{})
-			}
-			highlights := generateHighlights(objs[k].Properties(), propNames, queryTerms, maxFragments, fragmentSize)
-			if highlights != nil {
-				objs[k].Object.Additional["highlight"] = highlights
-			}
-		}
+		applyHighlights(objs, hl, queryTerms)
 	}
 
 	objs, scoresResult = b.sortResultsByExternalId(objs, scoresResult)
 
-	// reverse back the arrays to the expected order
 	slices.Reverse(objs)
 	slices.Reverse(scoresResult)
 
 	return objs, scoresResult, nil
+}
+
+func (b *BM25Searcher) collectMatchingObjects(
+	objectsBucket *lsmkv.Bucket,
+	ids []uint64, scores []float32, explanations [][]*terms.DocPointerWithScore,
+	additionalProps additional.Properties,
+	startAt, endAt int,
+) ([]*storobj.Object, []float32, [][]*terms.DocPointerWithScore, error) {
+	objsBatch, err := storobj.ObjectsByDocIDWithEmpty(objectsBucket, ids[startAt:endAt], additionalProps, nil, b.logger)
+	if err != nil {
+		return nil, nil, nil, errors.Errorf("objects loading")
+	}
+	var objs []*storobj.Object
+	var batchScores []float32
+	var batchExps [][]*terms.DocPointerWithScore
+	for i, obj := range objsBatch {
+		if obj == nil || obj.DocID != ids[startAt+i] {
+			continue
+		}
+		objs = append(objs, obj)
+		batchScores = append(batchScores, scores[startAt+i])
+		if explanations != nil {
+			batchExps = append(batchExps, explanations[startAt+i])
+		}
+	}
+	return objs, batchScores, batchExps, nil
+}
+
+func annotateExplanations(objs []*storobj.Object, explanationsResults [][]*terms.DocPointerWithScore, queryTerms []string) {
+	for k := range objs {
+		if objs[k].AdditionalProperties() == nil {
+			objs[k].Object.Additional = make(map[string]interface{})
+		}
+		for j, result := range explanationsResults[k] {
+			if result == nil {
+				continue
+			}
+			queryTerm := queryTerms[j]
+			objs[k].Object.Additional["BM25F_"+queryTerm+"_frequency"] = result.Frequency
+			objs[k].Object.Additional["BM25F_"+queryTerm+"_propLength"] = result.PropLength
+		}
+	}
+}
+
+func applyHighlights(objs []*storobj.Object, hl hlParams, queryTerms []string) {
+	for k := range objs {
+		if objs[k].AdditionalProperties() == nil {
+			objs[k].Object.Additional = make(map[string]interface{})
+		}
+		highlights := generateHighlights(objs[k].Properties(), hl.propNames, queryTerms, hl.maxFragments, hl.fragmentSize)
+		if highlights != nil {
+			objs[k].Object.Additional["highlight"] = highlights
+		}
+	}
 }
 
 type scoreSorter struct {

--- a/adapters/repos/db/inverted/highlight.go
+++ b/adapters/repos/db/inverted/highlight.go
@@ -20,11 +20,20 @@ import (
 )
 
 const (
-	highlightPrefix      = "<em>"
-	highlightPostfix     = "</em>"
-	defaultFragmentSize  = 50
-	defaultMaxFragments  = 3
+	highlightPrefix     = "<em>"
+	highlightPostfix    = "</em>"
+	defaultFragmentSize = 50
+	defaultMaxFragments = 3
 )
+
+type matchPos struct {
+	start, end int
+}
+
+type highlightWindow struct {
+	start, end int
+	matches    []matchPos
+}
 
 // GenerateHighlights scans the object properties for matched query terms and returns per-property highlighted text fragments.
 // maxFragments and fragmentSize use defaults when zero.
@@ -53,29 +62,7 @@ func generateHighlights(schema interface{}, propNames []string, queryTerms []str
 		if !exists {
 			continue
 		}
-		var frags []string
-		switch v := val.(type) {
-		case string:
-			frags = extractFragments(v, queryTerms, maxFragments, fragmentSize)
-		case []interface{}:
-			for _, item := range v {
-				if s, ok := item.(string); ok {
-					frags = append(frags, extractFragments(s, queryTerms, maxFragments, fragmentSize)...)
-					if len(frags) >= maxFragments {
-						frags = frags[:maxFragments]
-						break
-					}
-				}
-			}
-		case []string:
-			for _, s := range v {
-				frags = append(frags, extractFragments(s, queryTerms, maxFragments, fragmentSize)...)
-				if len(frags) >= maxFragments {
-					frags = frags[:maxFragments]
-					break
-				}
-			}
-		}
+		frags := fragmentsForValue(val, queryTerms, maxFragments, fragmentSize)
 		if len(frags) > 0 {
 			results = append(results, map[string]interface{}{
 				"property":  propName,
@@ -88,11 +75,44 @@ func generateHighlights(schema interface{}, propNames []string, queryTerms []str
 		return nil
 	}
 	return results
-
 }
 
-type matchPos struct {
-	start, end int
+func fragmentsForValue(val interface{}, queryTerms []string, maxFragments, fragmentSize int) []string {
+	switch v := val.(type) {
+	case string:
+		return extractFragments(v, queryTerms, maxFragments, fragmentSize)
+	case []interface{}:
+		return fragmentsFromInterfaceSlice(v, queryTerms, maxFragments, fragmentSize)
+	case []string:
+		return fragmentsFromStringSlice(v, queryTerms, maxFragments, fragmentSize)
+	}
+	return nil
+}
+
+func fragmentsFromInterfaceSlice(items []interface{}, queryTerms []string, maxFragments, fragmentSize int) []string {
+	var frags []string
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			continue
+		}
+		frags = append(frags, extractFragments(s, queryTerms, maxFragments, fragmentSize)...)
+		if len(frags) >= maxFragments {
+			return frags[:maxFragments]
+		}
+	}
+	return frags
+}
+
+func fragmentsFromStringSlice(items []string, queryTerms []string, maxFragments, fragmentSize int) []string {
+	var frags []string
+	for _, s := range items {
+		frags = append(frags, extractFragments(s, queryTerms, maxFragments, fragmentSize)...)
+		if len(frags) >= maxFragments {
+			return frags[:maxFragments]
+		}
+	}
+	return frags
 }
 
 func isWordChar(r rune) bool {
@@ -117,12 +137,8 @@ func atWordBoundary(text string, start, end int) bool {
 	return true
 }
 
-func extractFragments(text string, terms []string, maxFragments, fragmentSize int) []string {
-	if text == "" || len(terms) == 0 {
-		return nil
-	}
-	lowerText := strings.ToLower(text)
-
+// findTermMatches locates all whole-word occurrences of each term in lowerText.
+func findTermMatches(lowerText string, terms []string) []matchPos {
 	var matches []matchPos
 	for _, term := range terms {
 		if term == "" {
@@ -138,37 +154,38 @@ func extractFragments(text string, terms []string, maxFragments, fragmentSize in
 			absStart := idx + pos
 			absEnd := absStart + len(lowerTerm)
 			if atWordBoundary(lowerText, absStart, absEnd) {
-				matches = append(matches, matchPos{absStart, absStart + len(term)})
+				matches = append(matches, matchPos{absStart, absEnd})
 			}
 			idx = absStart + 1
 		}
 	}
-	if len(matches) == 0 {
-		return nil
+	return matches
+}
+
+// snapToRuneBoundary adjusts wStart left and wEnd right so both land on valid UTF-8 rune starts.
+func snapToRuneBoundary(text string, wStart, wEnd int) (int, int) {
+	for wStart > 0 && !utf8.RuneStart(text[wStart]) {
+		wStart--
 	}
-	sort.Slice(matches, func(i, j int) bool {
-		return matches[i].start < matches[j].start
-	})
-	type window struct {
-		start, end int
-		matches    []matchPos
+	for wEnd < len(text) && !utf8.RuneStart(text[wEnd]) {
+		wEnd++
 	}
-	var windows []window
+	return wStart, wEnd
+}
+
+// buildWindows groups sorted matches into overlapping context windows capped at maxFragments.
+func buildWindows(text string, matches []matchPos, maxFragments, fragmentSize int) []highlightWindow {
+	var windows []highlightWindow
 	for _, m := range matches {
 		wStart := m.start - fragmentSize
 		if wStart < 0 {
 			wStart = 0
 		}
-		for wStart > 0 && !utf8.RuneStart(text[wStart]) {
-			wStart--
-		}
 		wEnd := m.end + fragmentSize
 		if wEnd > len(text) {
 			wEnd = len(text)
 		}
-		for wEnd < len(text) && !utf8.RuneStart(text[wEnd]) {
-			wEnd++
-		}
+		wStart, wEnd = snapToRuneBoundary(text, wStart, wEnd)
 		if len(windows) > 0 && wStart <= windows[len(windows)-1].end {
 			last := &windows[len(windows)-1]
 			if wEnd > last.end {
@@ -176,24 +193,36 @@ func extractFragments(text string, terms []string, maxFragments, fragmentSize in
 			}
 			last.matches = append(last.matches, m)
 		} else {
-			windows = append(windows, window{wStart, wEnd, []matchPos{m}})
+			windows = append(windows, highlightWindow{wStart, wEnd, []matchPos{m}})
 		}
-
 		if len(windows) >= maxFragments {
 			break
 		}
 	}
+	return windows
+}
+
+func extractFragments(text string, terms []string, maxFragments, fragmentSize int) []string {
+	if text == "" || len(terms) == 0 {
+		return nil
+	}
+	matches := findTermMatches(strings.ToLower(text), terms)
+	if len(matches) == 0 {
+		return nil
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].start < matches[j].start
+	})
+	windows := buildWindows(text, matches, maxFragments, fragmentSize)
 	fragments := make([]string, 0, len(windows))
 	for _, w := range windows {
 		fragments = append(fragments, buildFragment(text, w.start, w.end, w.matches))
 	}
 	return fragments
- 
 }
 
-// buildFragment assembles one text fragment with highlight tags applied left to right
+// buildFragment assembles one text fragment with highlight tags applied left to right.
 func buildFragment(text string, wStart, wEnd int, matches []matchPos) string {
-
 	sort.Slice(matches, func(i, j int) bool {
 		return matches[i].start < matches[j].start
 	})

--- a/adapters/repos/db/inverted/highlight.go
+++ b/adapters/repos/db/inverted/highlight.go
@@ -1,0 +1,215 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"html"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+const (
+	highlightPrefix      = "<em>"
+	highlightPostfix     = "</em>"
+	defaultFragmentSize  = 50
+	defaultMaxFragments  = 3
+)
+
+// GenerateHighlights scans the object properties for matched query terms and returns per-property highlighted text fragments.
+// maxFragments and fragmentSize use defaults when zero.
+// Exported so the traverser layer can call it for non-BM25 search types (nearText, Ask).
+func GenerateHighlights(schema interface{}, propNames []string, queryTerms []string, maxFragments, fragmentSize int) []map[string]interface{} {
+	return generateHighlights(schema, propNames, queryTerms, maxFragments, fragmentSize)
+}
+
+func generateHighlights(schema interface{}, propNames []string, queryTerms []string, maxFragments, fragmentSize int) []map[string]interface{} {
+	if maxFragments == 0 {
+		maxFragments = defaultMaxFragments
+	}
+	if fragmentSize == 0 {
+		fragmentSize = defaultFragmentSize
+	}
+
+	props, ok := schema.(map[string]interface{})
+	if !ok || len(props) == 0 || len(queryTerms) == 0 {
+		return nil
+	}
+
+	results := make([]map[string]interface{}, 0, len(propNames))
+	for _, nameWithBoost := range propNames {
+		propName := strings.SplitN(nameWithBoost, "^", 2)[0]
+		val, exists := props[propName]
+		if !exists {
+			continue
+		}
+		var frags []string
+		switch v := val.(type) {
+		case string:
+			frags = extractFragments(v, queryTerms, maxFragments, fragmentSize)
+		case []interface{}:
+			for _, item := range v {
+				if s, ok := item.(string); ok {
+					frags = append(frags, extractFragments(s, queryTerms, maxFragments, fragmentSize)...)
+					if len(frags) >= maxFragments {
+						frags = frags[:maxFragments]
+						break
+					}
+				}
+			}
+		case []string:
+			for _, s := range v {
+				frags = append(frags, extractFragments(s, queryTerms, maxFragments, fragmentSize)...)
+				if len(frags) >= maxFragments {
+					frags = frags[:maxFragments]
+					break
+				}
+			}
+		}
+		if len(frags) > 0 {
+			results = append(results, map[string]interface{}{
+				"property":  propName,
+				"fragments": frags,
+			})
+		}
+	}
+
+	if len(results) == 0 {
+		return nil
+	}
+	return results
+
+}
+
+type matchPos struct {
+	start, end int
+}
+
+func isWordChar(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r)
+}
+
+// atWordBoundary returns true when the byte range [start,end) in text is not
+// abutted by a word character on either side (i.e. it is a whole-word match).
+func atWordBoundary(text string, start, end int) bool {
+	if start > 0 {
+		r, _ := utf8.DecodeLastRuneInString(text[:start])
+		if isWordChar(r) {
+			return false
+		}
+	}
+	if end < len(text) {
+		r, _ := utf8.DecodeRuneInString(text[end:])
+		if isWordChar(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func extractFragments(text string, terms []string, maxFragments, fragmentSize int) []string {
+	if text == "" || len(terms) == 0 {
+		return nil
+	}
+	lowerText := strings.ToLower(text)
+
+	var matches []matchPos
+	for _, term := range terms {
+		if term == "" {
+			continue
+		}
+		lowerTerm := strings.ToLower(term)
+		idx := 0
+		for idx < len(lowerText) {
+			pos := strings.Index(lowerText[idx:], lowerTerm)
+			if pos < 0 {
+				break
+			}
+			absStart := idx + pos
+			absEnd := absStart + len(lowerTerm)
+			if atWordBoundary(lowerText, absStart, absEnd) {
+				matches = append(matches, matchPos{absStart, absStart + len(term)})
+			}
+			idx = absStart + 1
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].start < matches[j].start
+	})
+	type window struct {
+		start, end int
+		matches    []matchPos
+	}
+	var windows []window
+	for _, m := range matches {
+		wStart := m.start - fragmentSize
+		if wStart < 0 {
+			wStart = 0
+		}
+		for wStart > 0 && !utf8.RuneStart(text[wStart]) {
+			wStart--
+		}
+		wEnd := m.end + fragmentSize
+		if wEnd > len(text) {
+			wEnd = len(text)
+		}
+		for wEnd < len(text) && !utf8.RuneStart(text[wEnd]) {
+			wEnd++
+		}
+		if len(windows) > 0 && wStart <= windows[len(windows)-1].end {
+			last := &windows[len(windows)-1]
+			if wEnd > last.end {
+				last.end = wEnd
+			}
+			last.matches = append(last.matches, m)
+		} else {
+			windows = append(windows, window{wStart, wEnd, []matchPos{m}})
+		}
+
+		if len(windows) >= maxFragments {
+			break
+		}
+	}
+	fragments := make([]string, 0, len(windows))
+	for _, w := range windows {
+		fragments = append(fragments, buildFragment(text, w.start, w.end, w.matches))
+	}
+	return fragments
+ 
+}
+
+// buildFragment assembles one text fragment with highlight tags applied left to right
+func buildFragment(text string, wStart, wEnd int, matches []matchPos) string {
+
+	sort.Slice(matches, func(i, j int) bool {
+		return matches[i].start < matches[j].start
+	})
+
+	var sb strings.Builder
+	pos := wStart
+	for _, m := range matches {
+		if m.start < pos || m.start < wStart || m.end > wEnd {
+			continue
+		}
+		sb.WriteString(html.EscapeString(text[pos:m.start]))
+		sb.WriteString(highlightPrefix)
+		sb.WriteString(html.EscapeString(text[m.start:m.end]))
+		sb.WriteString(highlightPostfix)
+		pos = m.end
+	}
+	sb.WriteString(html.EscapeString(text[pos:wEnd]))
+	return sb.String()
+}

--- a/adapters/repos/db/inverted/highlight_test.go
+++ b/adapters/repos/db/inverted/highlight_test.go
@@ -1,0 +1,155 @@
+package inverted
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractFragments(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		terms    []string
+		expected []string
+	}{
+		{
+			name:     "single term match",
+			text:     "The quick brown fox jumps over the lazy dog",
+			terms:    []string{"fox"},
+			expected: []string{"The quick brown <em>fox</em> jumps over the lazy dog"},
+		},
+		{
+			name:     "case insensitive",
+			text:     "The Fashion industry changed",
+			terms:    []string{"fashion"},
+			expected: []string{"The <em>Fashion</em> industry changed"},
+		},
+		{
+			name:     "multiple terms",
+			text:     "fashion trends in 2024",
+			terms:    []string{"fashion", "trends"},
+			expected: []string{"<em>fashion</em> <em>trends</em> in 2024"},
+		},
+		{
+			name:     "no match",
+			text:     "The quick brown fox",
+			terms:    []string{"cat"},
+			expected: nil,
+		},
+		{
+			name:  "max 3 fragments",
+			text:  "fox ... fox ... fox ... fox",
+			terms: []string{"fox"},
+			// boundary check: should return at most 3 fragments
+		},
+		{
+			name:     "unicode text no panic",
+			text:     "Le café du coin est très animé ce soir",
+			terms:    []string{"café"},
+			expected: []string{"Le <em>café</em> du coin est très animé ce soir"},
+		},
+		{
+			name:     "word boundary: no partial match inside longer word",
+			text:     "unfashionable and fashionable trends",
+			terms:    []string{"fashion"},
+			expected: nil,
+		},
+		{
+			name:     "word boundary: whole word matches",
+			text:     "fashion is a big deal",
+			terms:    []string{"fashion"},
+			expected: []string{"<em>fashion</em> is a big deal"},
+		},
+		{
+			name:     "xss: html special chars in surrounding text are escaped",
+			text:     "<script>alert(1)</script> fashion week",
+			terms:    []string{"fashion"},
+			expected: []string{"&lt;script&gt;alert(1)&lt;/script&gt; <em>fashion</em> week"},
+		},
+		{
+			name:     "xss: html special chars inside matched term are escaped",
+			text:     "buy cheap & fast fashion items",
+			terms:    []string{"fashion"},
+			expected: []string{"buy cheap &amp; fast <em>fashion</em> items"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractFragments(tt.text, tt.terms, defaultMaxFragments, defaultFragmentSize)
+			if tt.expected != nil {
+				assert.Equal(t, tt.expected, result)
+			}
+			assert.LessOrEqual(t, len(result), defaultMaxFragments)
+		})
+	}
+}
+
+func TestGenerateHighlights(t *testing.T) {
+	t.Run("string property match", func(t *testing.T) {
+		schema := map[string]interface{}{
+			"title":   "The fashion industry",
+			"content": "Trends in 2024",
+			"tags":    []interface{}{"fashion", "lifestyle"},
+		}
+
+		result := generateHighlights(schema, []string{"title", "content^2"}, []string{"fashion"}, 0, 0)
+
+		require.Len(t, result, 1)
+		assert.Equal(t, "title", result[0]["property"])
+		assert.Contains(t, result[0]["fragments"].([]string)[0], "<em>")
+	})
+
+	t.Run("boost notation stripped", func(t *testing.T) {
+		schema := map[string]interface{}{
+			"title": "weaviate vector database",
+		}
+
+		result := generateHighlights(schema, []string{"title^3"}, []string{"weaviate"}, 0, 0)
+
+		require.Len(t, result, 1)
+		assert.Equal(t, "title", result[0]["property"])
+		assert.Contains(t, result[0]["fragments"].([]string)[0], "<em>weaviate</em>")
+	})
+
+	t.Run("array property []interface{}", func(t *testing.T) {
+		schema := map[string]interface{}{
+			"tags": []interface{}{"machine learning", "neural networks", "transformers"},
+		}
+
+		result := generateHighlights(schema, []string{"tags"}, []string{"neural"}, 0, 0)
+
+		require.Len(t, result, 1)
+		assert.Equal(t, "tags", result[0]["property"])
+		assert.Contains(t, result[0]["fragments"].([]string)[0], "<em>neural</em>")
+	})
+
+	t.Run("no matching properties returns nil", func(t *testing.T) {
+		schema := map[string]interface{}{
+			"title": "unrelated content",
+		}
+
+		result := generateHighlights(schema, []string{"title"}, []string{"weaviate"}, 0, 0)
+		assert.Nil(t, result)
+	})
+
+	t.Run("empty query terms returns nil", func(t *testing.T) {
+		schema := map[string]interface{}{
+			"title": "some content",
+		}
+
+		result := generateHighlights(schema, []string{"title"}, []string{}, 0, 0)
+		assert.Nil(t, result)
+	})
+
+	t.Run("word boundary: partial word in property not highlighted", func(t *testing.T) {
+		schema := map[string]interface{}{
+			"title": "unfashionable clothing",
+		}
+
+		result := generateHighlights(schema, []string{"title"}, []string{"fashion"}, 0, 0)
+		assert.Nil(t, result)
+	})
+}

--- a/adapters/repos/db/vector/hnsw/hnsw_stress_test.go
+++ b/adapters/repos/db/vector/hnsw/hnsw_stress_test.go
@@ -9,15 +9,15 @@
 //  CONTACT: hello@weaviate.io
 //
 
+//go:build hnswStress
+
 package hnsw
 
 import (
 	"context"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"log"
-	"math"
 	"math/rand"
 	"os"
 	"runtime/pprof"
@@ -56,25 +56,6 @@ func idVector(ctx context.Context, id uint64) ([]float32, error) {
 	return vector, nil
 }
 
-func idVectorSize(size int) func(ctx context.Context, id uint64) ([]float32, error) {
-	return func(ctx context.Context, id uint64) ([]float32, error) {
-		vector := make([]float32, size)
-		for i := 0; i < size; i++ {
-			vector[i] = float32(id)
-		}
-		return vector, nil
-	}
-}
-
-func float32FromBytes(bytes []byte) float32 {
-	bits := binary.LittleEndian.Uint32(bytes)
-	float := math.Float32frombits(bits)
-	return float
-}
-
-func int32FromBytes(bytes []byte) int {
-	return int(binary.LittleEndian.Uint32(bytes))
-}
 
 func BenchmarkConcurrentSearch(b *testing.B) {
 	ctx := context.Background()

--- a/adapters/repos/db/vector/hnsw/hnsw_test_helpers_test.go
+++ b/adapters/repos/db/vector/hnsw/hnsw_test_helpers_test.go
@@ -1,0 +1,37 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hnsw
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+)
+
+func idVectorSize(size int) func(ctx context.Context, id uint64) ([]float32, error) {
+	return func(ctx context.Context, id uint64) ([]float32, error) {
+		vector := make([]float32, size)
+		for i := 0; i < size; i++ {
+			vector[i] = float32(id)
+		}
+		return vector, nil
+	}
+}
+
+func float32FromBytes(b []byte) float32 {
+	bits := binary.LittleEndian.Uint32(b)
+	return math.Float32frombits(bits)
+}
+
+func int32FromBytes(b []byte) int {
+	return int(binary.LittleEndian.Uint32(b))
+}

--- a/entities/additional/classification.go
+++ b/entities/additional/classification.go
@@ -39,7 +39,7 @@ type Properties struct {
 	Distance                bool                   `json:"distance"`
 	Score                   bool                   `json:"score"`
 	ExplainScore            bool                   `json:"explainScore"`
-	Highlight			    bool                   `json:"highlight"`
+	Highlight           bool                   `json:"highlight"`
 	IsConsistent            bool                   `json:"isConsistent"`
 	Group                   bool                   `json:"group"`
 	// QueryProfile enables per-shard query profiling data collection and return.

--- a/entities/additional/classification.go
+++ b/entities/additional/classification.go
@@ -39,6 +39,7 @@ type Properties struct {
 	Distance                bool                   `json:"distance"`
 	Score                   bool                   `json:"score"`
 	ExplainScore            bool                   `json:"explainScore"`
+	Highlight			    bool                   `json:"highlight"`
 	IsConsistent            bool                   `json:"isConsistent"`
 	Group                   bool                   `json:"group"`
 	// QueryProfile enables per-shard query profiling data collection and return.

--- a/entities/searchparams/retrieval.go
+++ b/entities/searchparams/retrieval.go
@@ -45,6 +45,8 @@ type KeywordRanking struct {
 	AdditionalExplanations bool     `json:"additionalExplanations"`
 	MinimumOrTokensMatch   int      `json:"minimumOrTokensMatch"`
 	SearchOperator         string   `json:"searchOperator"`
+	HighlightMaxFragments  int      `json:"highlightMaxFragments,omitempty"`
+	HighlightFragmentSize  int      `json:"highlightFragmentSize,omitempty"`
 }
 
 // Indicates whether property should be indexed
@@ -109,20 +111,22 @@ type WeightedSearchResult struct {
 }
 
 type HybridSearch struct {
-	SubSearches          interface{}   `json:"subSearches"`
-	Type                 string        `json:"type"`
-	Alpha                float64       `json:"alpha"`
-	Query                string        `json:"query"`
-	Vector               models.Vector `json:"vector"`
-	Properties           []string      `json:"properties"`
-	TargetVectors        []string      `json:"targetVectors"`
-	FusionAlgorithm      int           `json:"fusionalgorithm"`
-	Distance             float32       `json:"distance"`
-	WithDistance         bool          `json:"withDistance"`
-	MinimumOrTokensMatch int           `json:"minimumOrTokenMatch"`
-	SearchOperator       string        `json:"searchOperator"`
-	NearTextParams       *NearTextParams
-	NearVectorParams     *NearVector
+	SubSearches           interface{}   `json:"subSearches"`
+	Type                  string        `json:"type"`
+	Alpha                 float64       `json:"alpha"`
+	Query                 string        `json:"query"`
+	Vector                models.Vector `json:"vector"`
+	Properties            []string      `json:"properties"`
+	TargetVectors         []string      `json:"targetVectors"`
+	FusionAlgorithm       int           `json:"fusionalgorithm"`
+	Distance              float32       `json:"distance"`
+	WithDistance          bool          `json:"withDistance"`
+	MinimumOrTokensMatch  int           `json:"minimumOrTokenMatch"`
+	SearchOperator        string        `json:"searchOperator"`
+	NearTextParams        *NearTextParams
+	NearVectorParams      *NearVector
+	HighlightMaxFragments int `json:"highlightMaxFragments,omitempty"`
+	HighlightFragmentSize int `json:"highlightFragmentSize,omitempty"`
 }
 
 type NearObject struct {

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -573,6 +573,11 @@ func (ko *Object) SearchResult(additional additional.Properties, tenant string) 
 		if additional.Group {
 			additionalProperties["group"] = ko.AdditionalProperties()["group"]
 		}
+		if additional.Highlight {
+			if h := ko.AdditionalProperties()["highlight"]; h != nil {
+				additionalProperties["highlight"] = h
+			}
+		}
 	}
 	if ko.ExplainScore() != "" {
 		additionalProperties["explainScore"] = ko.ExplainScore()

--- a/entities/storobj/storage_object.go
+++ b/entities/storobj/storage_object.go
@@ -560,25 +560,7 @@ func (ko *Object) SearchResult(additional additional.Properties, tenant string) 
 	propertiesMap["id"] = ko.ID()
 	ko.SetProperties(propertiesMap)
 
-	additionalProperties := models.AdditionalProperties{}
-	if ko.AdditionalProperties() != nil {
-		if interpretation, ok := additional.ModuleParams["interpretation"]; ok {
-			if interpretationValue, ok := interpretation.(bool); ok && interpretationValue {
-				additionalProperties["interpretation"] = ko.AdditionalProperties()["interpretation"]
-			}
-		}
-		if additional.Classification {
-			additionalProperties["classification"] = ko.AdditionalProperties()["classification"]
-		}
-		if additional.Group {
-			additionalProperties["group"] = ko.AdditionalProperties()["group"]
-		}
-		if additional.Highlight {
-			if h := ko.AdditionalProperties()["highlight"]; h != nil {
-				additionalProperties["highlight"] = h
-			}
-		}
-	}
+	additionalProperties := ko.buildAdditionalFromObject(additional)
 	if ko.ExplainScore() != "" {
 		additionalProperties["explainScore"] = ko.ExplainScore()
 	}
@@ -601,6 +583,31 @@ func (ko *Object) SearchResult(additional additional.Properties, tenant string) 
 		Tenant:       tenant, // not part of the binary
 		// TODO: Beacon?
 	}
+}
+
+func (ko *Object) buildAdditionalFromObject(additional additional.Properties) models.AdditionalProperties {
+	out := models.AdditionalProperties{}
+	src := ko.AdditionalProperties()
+	if src == nil {
+		return out
+	}
+	if interp, ok := additional.ModuleParams["interpretation"]; ok {
+		if v, ok := interp.(bool); ok && v {
+			out["interpretation"] = src["interpretation"]
+		}
+	}
+	if additional.Classification {
+		out["classification"] = src["classification"]
+	}
+	if additional.Group {
+		out["group"] = src["group"]
+	}
+	if additional.Highlight {
+		if h := src["highlight"]; h != nil {
+			out["highlight"] = h
+		}
+	}
+	return out
 }
 
 func (ko *Object) asVectors(vectors map[string][]float32, multiVectors map[string][][]float32) models.Vectors {

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -15,8 +15,10 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 
+	dbinverted "github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/ttl"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema/configvalidation"
@@ -39,6 +41,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/floatcomp"
+	nearText "github.com/weaviate/weaviate/usecases/modulecomponents/arguments/nearText"
 	uc "github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/traverser/grouper"
 )
@@ -463,7 +466,7 @@ func (e *Explorer) searchResultsToGetResponseWithType(ctx context.Context, input
 			normalizedResultDist := res.Dist / 2
 
 			certainty := ExtractCertaintyFromParams(params)
-			if 1-(normalizedResultDist) < float32(certainty) && 1-normalizedResultDist >= 0 {
+			if 1-normalizedResultDist < float32(certainty) && 1-normalizedResultDist >= 0 {
 				// TODO: Clean this up. The >= check is so that this logic does not run
 				// non-cosine distance.
 				continue
@@ -526,6 +529,19 @@ func (e *Explorer) searchResultsToGetResponseWithType(ctx context.Context, input
 
 		if replEnabled {
 			additionalProperties["isConsistent"] = res.IsConsistent
+		}
+
+		// For non-BM25 searches (nearText, Ask) the BM25 searcher never ran, so
+		// highlight is not yet in additionalProperties. Compute it here as a fallback.
+		if params.AdditionalProperties.Highlight && additionalProperties["highlight"] == nil {
+			if terms := extractHighlightTerms(params); len(terms) > 0 {
+				if schema, ok := res.Schema.(map[string]interface{}); ok {
+					props := schemaTextPropNames(schema)
+					if h := dbinverted.GenerateHighlights(schema, props, terms, 0, 0); h != nil {
+						additionalProperties["highlight"] = h
+					}
+				}
+			}
 		}
 
 		if len(additionalProperties) > 0 {
@@ -735,7 +751,8 @@ func (e *Explorer) crossClassVectorFromModules(ctx context.Context,
 	paramName string, paramValue interface{},
 ) ([]float32, string, error) {
 	if e.modulesProvider != nil {
-		vector, targetVector, err := e.modulesProvider.CrossClassVectorFromSearchParam(ctx,
+		vector, targetVector, err := e.modulesProvider.CrossClassVectorFromSearchParam(
+			ctx,
 			paramName, paramValue, e.nearParamsVector.findVector,
 		)
 		if err != nil {
@@ -965,6 +982,52 @@ func (e *Explorer) usageOperationFromGetParams(params dto.GetParams) string {
 	}
 
 	return "n/a"
+}
+
+// extractHighlightTerms returns individual search terms for the explorer-level
+// highlight fallback (nearText, Ask). BM25/hybrid results already carry
+// highlights from the BM25 searcher, so this is only invoked when those paths
+// produced nothing.
+func extractHighlightTerms(params dto.GetParams) []string {
+	var raw []string
+
+	if params.KeywordRanking != nil && params.KeywordRanking.Query != "" {
+		raw = append(raw, strings.Fields(params.KeywordRanking.Query)...)
+	}
+	if params.HybridSearch != nil && params.HybridSearch.Query != "" {
+		raw = append(raw, strings.Fields(params.HybridSearch.Query)...)
+	}
+	if nt, ok := params.ModuleParams["nearText"]; ok {
+		if ntp, ok := nt.(*nearText.NearTextParams); ok {
+			for _, v := range ntp.Values {
+				raw = append(raw, strings.Fields(v)...)
+			}
+		}
+	}
+
+	seen := make(map[string]struct{}, len(raw))
+	out := raw[:0]
+	for _, t := range raw {
+		if _, dup := seen[t]; !dup && t != "" {
+			seen[t] = struct{}{}
+			out = append(out, t)
+		}
+	}
+	return out
+}
+
+// schemaTextPropNames returns the keys in a schema map whose values are
+// string-typed — used to choose which properties to highlight for vector
+// searches where no explicit property list was provided.
+func schemaTextPropNames(schema map[string]interface{}) []string {
+	names := make([]string, 0, len(schema))
+	for k, v := range schema {
+		switch v.(type) {
+		case string, []string, []interface{}:
+			names = append(names, k)
+		}
+	}
+	return names
 }
 
 func (e *Explorer) trackUsageExplore(res search.Results, params ExploreParams) {

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -23,7 +23,6 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
-	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -56,6 +55,9 @@ func sparseSearch(ctx context.Context, e *Explorer, params dto.GetParams) ([]*se
 		params.KeywordRanking.MinimumOrTokensMatch = params.HybridSearch.MinimumOrTokensMatch
 	}
 
+	params.KeywordRanking.HighlightMaxFragments = params.HybridSearch.HighlightMaxFragments
+	params.KeywordRanking.HighlightFragmentSize = params.HybridSearch.HighlightFragmentSize
+
 	totalLimit, err := e.CalculateTotalLimit(params.Pagination)
 	if err != nil {
 		return nil, "", err
@@ -74,7 +76,7 @@ func sparseSearch(ctx context.Context, e *Explorer, params dto.GetParams) ([]*se
 
 	out := make([]*search.Result, len(results))
 	for i, obj := range results {
-		sr := obj.SearchResultWithScore(additional.Properties{}, scores[i])
+		sr := obj.SearchResultWithScore(params.AdditionalProperties, scores[i])
 		sr.SecondarySortValue = sr.Score
 		out[i] = &sr
 	}


### PR DESCRIPTION

<img width="1917" height="1173" alt="Screenshot From 2026-05-13 05-21-52" src="https://github.com/user-attachments/assets/6583c34a-93fc-463f-bbf2-a2bdb5ed3443" />
  - Word-boundary-aware, XSS-safe fragment engine (highlight.go)
  - Both BM25 WAND and block searcher paths covered
  - Full hybrid param chain: GraphQL input -> HybridSearch struct -> sparseSearch ->
  KeywordRanking
  - Explorer-level fallback for nearText/Ask queries
  - highlightMaxFragments and highlightFragmentSize configurable per query
  - 17 unit tests: word boundary, unicode, XSS, array props, boost notation

  Closes #2567
  /claim #2567         


### What's being changed:
Added `_additional { highlight { property fragments } }` to BM25, hybrid, nearText, and 
  Ask queries. Matched terms are returned as text snippets with `<em>` tags.
                                                                                         
  **Example query:**                                                                     
  ```graphql
  {                                                                                      
    Get {         
      Article(
        bm25: { query: "vector database", highlightMaxFragments: 3,
  highlightFragmentSize: 60 }                                                            
      ) {
        title                                                                            
        _additional { highlight { property fragments } }
      }
    }
  }

  Example response:
  {
    "_additional": {
      "highlight": [
        {           
          "property": "title",                                                           
          "fragments": ["Weaviate <em>vector</em> <em>database</em> overview"]
        }                                                                                
      ]           
    }  
  }  

  Key design decisions:                                                                  
  - Highlighting runs post-retrieval against fetched object properties — no extra index
  or storage cost                                                                        
  - Word boundary check prevents partial matches (e.g. "fashion" will not fire inside
  "unfashionable")                                                                       
  - Surrounding text is HTML-escaped before <em> tags are inserted to prevent XSS        
  - Overlapping match windows are merged into a single fragment rather than producing
  redundant context                                                                      
  - BM25 boost notation (title^2) is stripped before property lookup  


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [x] Go (weaviate-go-client)
    - [ ] Java (java-client)




<img width="1917" height="1173" alt="image" src="https://github.com/user-attachments/assets/8a449d1c-6893-4e3d-ae62-41138c409683" />


