### PR TITLE
feat: per-level discriminants for hashtree peer comparison

### DIFF
--- a/adapters/clients/replication.go
+++ b/adapters/clients/replication.go
@@ -207,10 +207,22 @@ func readDigestsInRangeBinaryStream(r io.Reader, contentLength int64) ([]types.R
 	}
 }
 
-// HashTreeLevel fetches hash tree level digests
+// HashTreeLevel fetches hash tree level digests. discriminant.Size() must
+// equal hashtree.LeavesCount(level).
 func (c *replicationClient) HashTreeLevel(ctx context.Context,
 	host, index, shard string, level int, discriminant *hashtree.Bitset,
 ) ([]hashtree.Digest, error) {
+	if level < 0 {
+		return nil, fmt.Errorf("invalid hashtree level: %d", level)
+	}
+	if discriminant == nil {
+		return nil, fmt.Errorf("nil discriminant")
+	}
+	expected := hashtree.LeavesCount(level)
+	if discriminant.Size() != expected {
+		return nil, fmt.Errorf("discriminant size %d, expected %d (level-local) for level %d",
+			discriminant.Size(), expected, level)
+	}
 	body, err := discriminant.Marshal()
 	if err != nil {
 		return nil, fmt.Errorf("marshal hashtree level input: %w", err)

--- a/adapters/clients/replication_grpc.go
+++ b/adapters/clients/replication_grpc.go
@@ -440,9 +440,23 @@ func (c *grpcReplicationClient) FindUUIDs(ctx context.Context, host, index, shar
 	return clusterapi.StringsToUUIDs(resp.GetUuids()), nil
 }
 
+// HashTreeLevel fetches hash tree level digests via gRPC. discriminant must
+// be a level-local bitset of size hashtree.LeavesCount(level).
 func (c *grpcReplicationClient) HashTreeLevel(ctx context.Context, host, index, shard string,
 	level int, discriminant *hashtree.Bitset,
 ) ([]hashtree.Digest, error) {
+	if level < 0 {
+		return nil, fmt.Errorf("invalid hashtree level: %d", level)
+	}
+	if discriminant == nil {
+		return nil, fmt.Errorf("nil discriminant")
+	}
+	expected := hashtree.LeavesCount(level)
+	if discriminant.Size() != expected {
+		return nil, fmt.Errorf("discriminant size %d, expected %d (level-local) for level %d",
+			discriminant.Size(), expected, level)
+	}
+
 	client, err := c.getClient(host)
 	if err != nil {
 		return nil, err

--- a/adapters/clients/replication_test.go
+++ b/adapters/clients/replication_test.go
@@ -606,7 +606,9 @@ func TestReplicationHashTreeLevel(t *testing.T) {
 		{0xdeadbeefcafebabe, 0x0123456789abcdef},
 	}
 
-	discriminant := hashtree.NewBitset(4)
+	// level-local discriminant: size must equal hashtree.LeavesCount(level)
+	// = 8 for level 3.
+	discriminant := hashtree.NewBitset(hashtree.LeavesCount(3))
 	discriminant.Set(0)
 	discriminant.Set(2)
 

--- a/adapters/handlers/rest/clusterapi/grpc/server_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/server_test.go
@@ -341,7 +341,8 @@ func Test_ServerReplicationService(t *testing.T) {
 				c := "C"
 				s := "S"
 				level := 1
-				discriminant := hashtree.NewBitset(8)
+				// level-local discriminant: size must equal hashtree.LeavesCount(level).
+				discriminant := hashtree.NewBitset(hashtree.LeavesCount(level))
 				discriminant.Set(0)
 				expectedDigests := []hashtree.Digest{
 					{1, 2},

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -1152,11 +1152,23 @@ func (s *Shard) dumpHashTreeWithTimeout(ht hashtree.AggregatedHashTree) {
 	}
 }
 
-// HashTreeLevel returns the digests at the given level of the shard's async-
-// replication hashtree, filtered by the provided discriminant bitset.
-// Returns an error if the hashtree is not yet fully initialised on this shard.
+// HashTreeLevel returns the digests at level of the shard's async-replication
+// hashtree, filtered by discriminant (Size() == hashtree.LeavesCount(level)).
+// Returns an error if the hashtree is not yet fully initialised.
 func (s *Shard) HashTreeLevel(ctx context.Context, level int, discriminant *hashtree.Bitset) (digests []hashtree.Digest, err error) {
-	digests = make([]hashtree.Digest, hashtree.LeavesCount(level))
+	if level < 0 {
+		return nil, fmt.Errorf("hashtree level must be non-negative: %d", level)
+	}
+	if discriminant == nil {
+		return nil, fmt.Errorf("hashtree level %d: nil discriminant", level)
+	}
+
+	expected := hashtree.LeavesCount(level)
+	if discriminant.Size() != expected {
+		return nil, fmt.Errorf("hashtree level %d: discriminant size %d, expected %d (height mismatch?)",
+			level, discriminant.Size(), expected)
+	}
+	digests = make([]hashtree.Digest, expected)
 
 	s.asyncReplicationRWMux.RLock()
 	defer s.asyncReplicationRWMux.RUnlock()

--- a/usecases/replica/finder.go
+++ b/usecases/replica/finder.go
@@ -340,45 +340,59 @@ func (f *Finder) CollectShardDifferences(ctx context.Context,
 		ctx, cancel := context.WithTimeout(ctx, diffTimeoutPerNode)
 		defer cancel()
 
-		diff := hashtree.NewBitset(hashtree.NodesCount(ht.Height()))
+		height := ht.Height()
+		digests := make([]hashtree.Digest, hashtree.LeavesCount(height))
 
-		digests := make([]hashtree.Digest, hashtree.LeavesCount(ht.Height()))
+		discriminant := hashtree.NewBitset(1) // nodesAtLevel(0) = 1
+		discriminant.Set(0)                   // seed at root
 
-		diff.Set(0) // init comparison at root level
+		var leaf *hashtree.Bitset
 
-		for l := 0; l <= ht.Height(); l++ {
-			_, err := ht.Level(l, diff, digests)
-			if err != nil {
+		for l := 0; l <= height; l++ {
+			if _, err := ht.Level(l, discriminant, digests); err != nil {
 				return nil, fmt.Errorf("%q: %w", targetNodeAddress, err)
 			}
 
-			levelDigests, err := f.client.HashTreeLevel(ctx, targetNodeAddress, f.class, shardName, l, diff)
+			levelDigests, err := f.client.HashTreeLevel(ctx, targetNodeAddress, f.class, shardName, l, discriminant)
 			if err != nil {
 				return nil, fmt.Errorf("%q: %w", targetNodeAddress, err)
 			}
 			if len(levelDigests) == 0 {
-				// no differences were found
+				// peer agrees at this level
 				break
 			}
 
-			levelDiffCount := hashtree.LevelDiff(l, diff, digests, levelDigests)
-			if levelDiffCount == 0 {
-				// no differences were found
+			nextDiscriminant, levelDiffCount, err := hashtree.LevelDiff(l, height, discriminant, digests, levelDigests)
+			if err != nil {
+				return nil, fmt.Errorf("%q: %w", targetNodeAddress, err)
+			}
+
+			if l == height {
+				leaf = discriminant
 				break
 			}
+			if levelDiffCount == 0 {
+				break
+			}
+			discriminant = nextDiscriminant
 		}
 
-		if diff.SetCount() == 0 {
+		if leaf == nil || leaf.SetCount() == 0 {
 			return &ShardDifferenceReader{
 				TargetNodeName:    targetNodeName,
 				TargetNodeAddress: targetNodeAddress,
 			}, ErrNoDiffFound
 		}
 
+		rangeReader, err := ht.NewRangeReader(leaf)
+		if err != nil {
+			return nil, fmt.Errorf("%q: %w", targetNodeAddress, err)
+		}
+
 		return &ShardDifferenceReader{
 			TargetNodeName:    targetNodeName,
 			TargetNodeAddress: targetNodeAddress,
-			RangeReader:       ht.NewRangeReader(diff),
+			RangeReader:       rangeReader,
 		}, nil
 	}
 

--- a/usecases/replica/hashtree/aggregated_hashtree.go
+++ b/usecases/replica/hashtree/aggregated_hashtree.go
@@ -11,7 +11,10 @@
 
 package hashtree
 
-import "io"
+import (
+	"fmt"
+	"io"
+)
 
 type AggregatedHashTree interface {
 	Height() int
@@ -23,9 +26,8 @@ type AggregatedHashTree interface {
 	Clone() AggregatedHashTree
 
 	Diff(ht AggregatedHashTree) (discriminant *Bitset, err error)
-	DiffUsing(ht AggregatedHashTree, discriminant *Bitset, digests1, digests2 []Digest) error
 
-	NewRangeReader(discriminant *Bitset) AggregatedHashTreeRangeReader
+	NewRangeReader(discriminant *Bitset) (AggregatedHashTreeRangeReader, error)
 
 	Serialize(w io.Writer) (n int64, err error)
 }
@@ -34,39 +36,56 @@ type AggregatedHashTreeRangeReader interface {
 	Next() (uint64, uint64, error)
 }
 
-func LevelDiff(l int, discriminant *Bitset, digests1, digests2 []Digest) (levelDiffCount int) {
-	offset := InnerNodesCount(l)
+// LevelDiff compares level-l digests1 and digests2, clearing matched bits in
+// discriminant. For l < height it returns a level-(l+1) discriminant with
+// the children of mismatched nodes set; at l == height it returns nil.
+func LevelDiff(l, height int, discriminant *Bitset, digests1, digests2 []Digest) (nextDiscriminant *Bitset, levelDiffCount int, err error) {
+	if l < 0 {
+		return nil, 0, fmt.Errorf("%w: invalid level(%d)", ErrIllegalArguments, l)
+	}
+	if l > height {
+		return nil, 0, fmt.Errorf("%w: level(%d) is too high for height(%d)", ErrIllegalState, l, height)
+	}
+	if discriminant == nil {
+		return nil, 0, fmt.Errorf("%w: nil discriminant provided", ErrIllegalArguments)
+	}
+
+	expected := nodesAtLevel(l)
+	if discriminant.Size() != expected {
+		return nil, 0, fmt.Errorf("%w: discriminant size %d, expected %d for level %d",
+			ErrIllegalArguments, discriminant.Size(), expected, l)
+	}
+
+	// digests1/digests2 hold one entry per set bit, not per Size().
+	setCount := discriminant.SetCount()
+	if len(digests1) < setCount || len(digests2) < setCount {
+		return nil, 0, fmt.Errorf("%w: digests slice too short for level %d (have %d/%d, need >= %d)",
+			ErrIllegalArguments, l, len(digests1), len(digests2), setCount)
+	}
+
+	if l < height {
+		nextDiscriminant = NewBitset(nodesAtLevel(l + 1))
+	}
 
 	n := 0
-
-	for j := 0; j < nodesAtLevel(l); j++ {
-		node := offset + j
-
-		if !discriminant.IsSet(node) {
+	for j := 0; j < discriminant.Size(); j++ {
+		if !discriminant.IsSet(j) {
 			continue
 		}
 
 		if digests1[n] == digests2[n] {
+			discriminant.Unset(j)
 			n++
-			discriminant.Unset(node)
 			continue
-		} else {
-			levelDiffCount++
 		}
-
+		levelDiffCount++
 		n++
 
-		leftChild := 2*node + 1
-		rightChild := 2*node + 2
-
-		if discriminant.Size() <= rightChild {
-			// node is a leaf
-			continue
+		if nextDiscriminant != nil {
+			nextDiscriminant.Set(2 * j)
+			nextDiscriminant.Set(2*j + 1)
 		}
-
-		discriminant.Set(leftChild)
-		discriminant.Set(rightChild)
 	}
 
-	return levelDiffCount
+	return nextDiscriminant, levelDiffCount, nil
 }

--- a/usecases/replica/hashtree/compact_hashtree_diff.go
+++ b/usecases/replica/hashtree/compact_hashtree_diff.go
@@ -11,22 +11,11 @@
 
 package hashtree
 
-func (ht *CompactHashTree) Diff(ht2 AggregatedHashTree) (discriminant *Bitset, err error) {
+func (ht *CompactHashTree) Diff(ht2 AggregatedHashTree) (*Bitset, error) {
 	cht2, isCompactHashTree := ht2.(*CompactHashTree)
-
 	if ht2 == nil || !isCompactHashTree {
 		return nil, ErrIllegalArguments
 	}
 
 	return ht.hashtree.Diff(cht2.hashtree)
-}
-
-func (ht *CompactHashTree) DiffUsing(ht2 AggregatedHashTree, discriminant *Bitset, digests1, digests2 []Digest) error {
-	cht2, isCompactHashTree := ht2.(*CompactHashTree)
-
-	if ht2 == nil || !isCompactHashTree {
-		return ErrIllegalArguments
-	}
-
-	return ht.hashtree.DiffUsing(cht2.hashtree, discriminant, digests1, digests2)
 }

--- a/usecases/replica/hashtree/compact_hashtree_range_reader.go
+++ b/usecases/replica/hashtree/compact_hashtree_range_reader.go
@@ -16,11 +16,15 @@ type CompactHashTreeDiffReader struct {
 	rangeReader AggregatedHashTreeRangeReader
 }
 
-func (ht *CompactHashTree) NewRangeReader(discriminant *Bitset) AggregatedHashTreeRangeReader {
+func (ht *CompactHashTree) NewRangeReader(discriminant *Bitset) (AggregatedHashTreeRangeReader, error) {
+	rr, err := ht.hashtree.NewRangeReader(discriminant)
+	if err != nil {
+		return nil, err
+	}
 	return &CompactHashTreeDiffReader{
 		ht:          ht,
-		rangeReader: ht.hashtree.NewRangeReader(discriminant),
-	}
+		rangeReader: rr,
+	}, nil
 }
 
 func (r *CompactHashTreeDiffReader) Next() (uint64, uint64, error) {

--- a/usecases/replica/hashtree/compact_hashtree_test.go
+++ b/usecases/replica/hashtree/compact_hashtree_test.go
@@ -39,7 +39,7 @@ func TestCompactHashTree(t *testing.T) {
 
 	var rootLevel [1]Digest
 
-	n, err := ht.Level(0, NewBitset(NodesCount(ht.Height())).Set(0), rootLevel[:])
+	n, err := ht.Level(0, NewBitset(nodesAtLevel(0)).Set(0), rootLevel[:])
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 
@@ -90,7 +90,7 @@ func TestCompactBigHashTree(t *testing.T) {
 
 	var rootLevel [1]Digest
 
-	n, err := ht.Level(0, NewBitset(ht.Height()).Set(0), rootLevel[:])
+	n, err := ht.Level(0, NewBitset(nodesAtLevel(0)).Set(0), rootLevel[:])
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 }
@@ -109,7 +109,8 @@ func TestCompactHashTreeComparisonHeight1(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, diff)
 
-	rangeReader := ht1.NewRangeReader(diff)
+	rangeReader, err := ht1.NewRangeReader(diff)
+	require.NoError(t, err)
 
 	_, _, err = rangeReader.Next()
 	require.ErrorIs(t, err, ErrNoMoreRanges)
@@ -120,7 +121,8 @@ func TestCompactHashTreeComparisonHeight1(t *testing.T) {
 	diff, err = ht1.Diff(ht2)
 	require.NoError(t, err)
 
-	rangeReader = ht1.NewRangeReader(diff)
+	rangeReader, err = ht1.NewRangeReader(diff)
+	require.NoError(t, err)
 
 	diff1, diff2, err := rangeReader.Next()
 	require.NoError(t, err)
@@ -136,7 +138,8 @@ func TestCompactHashTreeComparisonHeight1(t *testing.T) {
 	diff, err = ht1.Diff(ht2)
 	require.NoError(t, err)
 
-	rangeReader = ht1.NewRangeReader(diff)
+	rangeReader, err = ht1.NewRangeReader(diff)
+	require.NoError(t, err)
 
 	_, _, err = rangeReader.Next()
 	require.ErrorIs(t, err, ErrNoMoreRanges)
@@ -212,7 +215,8 @@ func TestCompactHashTreeComparisonIncrementalConciliation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, diff)
 
-	rangeReader := ht1.NewRangeReader(diff)
+	rangeReader, err := ht1.NewRangeReader(diff)
+	require.NoError(t, err)
 
 	_, _, err = rangeReader.Next()
 	require.ErrorIs(t, err, ErrNoMoreRanges) // no differences should be found
@@ -246,7 +250,8 @@ func TestCompactHashTreeComparisonIncrementalConciliation(t *testing.T) {
 		diff, err := ht1.Diff(ht2)
 		require.NoError(t, err)
 
-		rangeReader := ht1.NewRangeReader(diff)
+		rangeReader, err := ht1.NewRangeReader(diff)
+		require.NoError(t, err)
 
 		diffCount = 0
 

--- a/usecases/replica/hashtree/hashtree.go
+++ b/usecases/replica/hashtree/hashtree.go
@@ -189,6 +189,8 @@ func (ht *HashTree) root() Digest {
 	return ht.nodes[0]
 }
 
+// Level returns digests for nodes selected by discriminant, which is
+// level-local: Size() must equal nodesAtLevel(level), bit i selects node i.
 func (ht *HashTree) Level(level int, discriminant *Bitset, digests []Digest) (n int, err error) {
 	ht.mux.Lock()
 	defer ht.mux.Unlock()
@@ -205,7 +207,13 @@ func (ht *HashTree) Level(level int, discriminant *Bitset, digests []Digest) (n 
 		return 0, fmt.Errorf("%w: nil discriminant provided", ErrIllegalArguments)
 	}
 
-	if len(digests) < nodesAtLevel(level) {
+	expectedSize := nodesAtLevel(level)
+	if discriminant.Size() != expectedSize {
+		return 0, fmt.Errorf("%w: discriminant size %d, expected %d for level %d",
+			ErrIllegalArguments, discriminant.Size(), expectedSize, level)
+	}
+
+	if len(digests) < expectedSize {
 		return 0, fmt.Errorf("%w: output buffer has not enough capacity", ErrIllegalArguments)
 	}
 
@@ -213,9 +221,8 @@ func (ht *HashTree) Level(level int, discriminant *Bitset, digests []Digest) (n 
 
 	offset := InnerNodesCount(level)
 
-	// TODO(jeroiraz): it may be more performant to iterate over the set positions in the discriminant
-	for i := 0; i < nodesAtLevel(level); i++ {
-		if discriminant.IsSet(offset + i) {
+	for i := 0; i < expectedSize; i++ {
+		if discriminant.IsSet(i) {
 			digests[n] = ht.nodes[offset+i]
 			n++
 		}

--- a/usecases/replica/hashtree/hashtree_diff.go
+++ b/usecases/replica/hashtree/hashtree_diff.go
@@ -13,71 +13,46 @@ package hashtree
 
 import "fmt"
 
-func (ht *HashTree) Diff(ht2 AggregatedHashTree) (discriminant *Bitset, err error) {
+// Diff returns a leaf-level discriminant; bit i is set when leaf i differs.
+func (ht *HashTree) Diff(ht2 AggregatedHashTree) (*Bitset, error) {
 	_, isHashTree := ht2.(*HashTree)
-
 	if ht2 == nil || !isHashTree {
 		return nil, ErrIllegalArguments
 	}
 
-	if ht.Height() != ht2.Height() {
+	height := ht.Height()
+	if height != ht2.Height() {
 		return nil, fmt.Errorf("%w: hash trees of different heights are non-comparable", ErrIllegalArguments)
 	}
 
-	// init for comparison
-	discriminant = NewBitset(NodesCount(ht.Height()))
-
-	leavesCount := LeavesCount(ht.Height())
+	leavesCount := LeavesCount(height)
 	digests1 := make([]Digest, leavesCount)
 	digests2 := make([]Digest, leavesCount)
 
-	err = ht.DiffUsing(ht2, discriminant, digests1, digests2)
-	if err != nil {
-		return nil, err
-	}
+	walk := NewBitset(1)
+	walk.Set(0) // root
 
-	return discriminant, nil
-}
+	for l := 0; l <= height; l++ {
+		if _, err := ht.Level(l, walk, digests1); err != nil {
+			return nil, err
+		}
+		if _, err := ht2.Level(l, walk, digests2); err != nil {
+			return nil, err
+		}
 
-func (ht *HashTree) DiffUsing(ht2 AggregatedHashTree, discriminant *Bitset, digests1, digests2 []Digest) error {
-	_, isHashTree := ht2.(*HashTree)
-
-	if ht2 == nil || !isHashTree {
-		return ErrIllegalArguments
-	}
-
-	if discriminant == nil {
-		return ErrIllegalArguments
-	}
-
-	if ht.Height() != ht2.Height() {
-		return fmt.Errorf("%w: hash trees of different heights are non-comparable", ErrIllegalArguments)
-	}
-
-	if discriminant.Size() != NodesCount(ht.Height()) {
-		return fmt.Errorf("%w: diff bitset size should mismatch", ErrIllegalArguments)
-	}
-
-	discriminant.Reset().Set(0) // init comparison at root level
-
-	for l := 0; l <= ht.Height(); l++ {
-		_, err := ht.Level(l, discriminant, digests1)
+		nextWalk, levelDiffCount, err := LevelDiff(l, height, walk, digests1, digests2)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
-		_, err = ht2.Level(l, discriminant, digests2)
-		if err != nil {
-			return err
+		if l == height {
+			return walk, nil
 		}
-
-		LevelDiff(l, discriminant, digests1, digests2)
-
-		if discriminant.SetCount() == 0 {
-			// no difference found
-			break
+		if levelDiffCount == 0 {
+			return NewBitset(leavesCount), nil
 		}
+		walk = nextWalk
 	}
 
-	return nil
+	return NewBitset(leavesCount), nil
 }

--- a/usecases/replica/hashtree/hashtree_range_reader.go
+++ b/usecases/replica/hashtree/hashtree_range_reader.go
@@ -11,28 +11,34 @@
 
 package hashtree
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var ErrNoMoreRanges = errors.New("no more ranges")
 
 type HashTreeDiffReader struct {
 	discriminant *Bitset
-	firstLeafPos int
 	pos          int
 }
 
-func (ht *HashTree) NewRangeReader(discriminant *Bitset) AggregatedHashTreeRangeReader {
-	if discriminant == nil || discriminant.Size() != NodesCount(ht.Height()) {
-		panic("illegal discriminant")
+// NewRangeReader expects a leaf-level discriminant (Size() ==
+// LeavesCount(ht.Height())); bit i indicates leaf i differs.
+func (ht *HashTree) NewRangeReader(discriminant *Bitset) (AggregatedHashTreeRangeReader, error) {
+	if discriminant == nil {
+		return nil, fmt.Errorf("%w: nil discriminant provided", ErrIllegalArguments)
 	}
-
-	firstLeafPos := NodesCount(ht.Height() - 1)
+	expected := LeavesCount(ht.Height())
+	if discriminant.Size() != expected {
+		return nil, fmt.Errorf("%w: discriminant size %d, expected %d (leaf-level)",
+			ErrIllegalArguments, discriminant.Size(), expected)
+	}
 
 	return &HashTreeDiffReader{
 		discriminant: discriminant,
-		firstLeafPos: firstLeafPos,
-		pos:          firstLeafPos,
-	}
+		pos:          0,
+	}, nil
 }
 
 func (r *HashTreeDiffReader) Next() (uint64, uint64, error) {
@@ -48,5 +54,5 @@ func (r *HashTreeDiffReader) Next() (uint64, uint64, error) {
 	for ; r.pos < r.discriminant.Size() && r.discriminant.IsSet(r.pos); r.pos++ {
 	}
 
-	return uint64(pos0 - r.firstLeafPos), uint64(r.pos - 1 - r.firstLeafPos), nil
+	return uint64(pos0), uint64(r.pos - 1), nil
 }

--- a/usecases/replica/hashtree/hashtree_test.go
+++ b/usecases/replica/hashtree/hashtree_test.go
@@ -42,7 +42,7 @@ func TestSmallestHashTree(t *testing.T) {
 
 	var rootLevel [1]Digest
 
-	n, err := ht.Level(0, NewBitset(NodesCount(height)).SetAll(), rootLevel[:])
+	n, err := ht.Level(0, NewBitset(nodesAtLevel(0)).SetAll(), rootLevel[:])
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 
@@ -75,11 +75,9 @@ func TestHashTree(t *testing.T) {
 	err = ht.AggregateLeafWith(1, someValues[1])
 	require.NoError(t, err)
 
-	discriminant := NewBitset(NodesCount(height)).SetAll()
-
 	digests := make([]Digest, leavesCount)
 
-	n, err := ht.Level(1, discriminant, digests)
+	n, err := ht.Level(1, NewBitset(nodesAtLevel(1)).SetAll(), digests)
 	require.NoError(t, err)
 	require.Equal(t, 2, n)
 
@@ -98,9 +96,7 @@ func TestHashTree(t *testing.T) {
 	expectedRootH1, expectedRootH2 := h.Sum128()
 	expectedRoot := Digest{expectedRootH1, expectedRootH2}
 
-	discriminant.Reset().Set(0)
-
-	n, err = ht.Level(0, discriminant, digests)
+	n, err = ht.Level(0, NewBitset(nodesAtLevel(0)).SetAll(), digests)
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 	require.Equal(t, expectedRoot, digests[0])
@@ -124,7 +120,7 @@ func TestBigHashTree(t *testing.T) {
 
 	var rootDigests [1]Digest
 
-	n, err := ht.Level(0, NewBitset(NodesCount(height)).SetAll(), rootDigests[:])
+	n, err := ht.Level(0, NewBitset(nodesAtLevel(0)).SetAll(), rootDigests[:])
 	require.NoError(t, err)
 	require.Equal(t, 1, n)
 }
@@ -142,7 +138,8 @@ func TestHashTreeComparisonOneLeafAtATime(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, diff)
 
-	rangeReader := ht1.NewRangeReader(diff)
+	rangeReader, err := ht1.NewRangeReader(diff)
+	require.NoError(t, err)
 
 	_, _, err = rangeReader.Next()
 	require.ErrorIs(t, err, ErrNoMoreRanges) // no differences should be found
@@ -157,7 +154,8 @@ func TestHashTreeComparisonOneLeafAtATime(t *testing.T) {
 		diff, err = ht1.Diff(ht2)
 		require.NoError(t, err)
 
-		rangeReader := ht1.NewRangeReader(diff)
+		rangeReader, err := ht1.NewRangeReader(diff)
+		require.NoError(t, err)
 
 		diff0, diff1, err := rangeReader.Next()
 		require.NoError(t, err)
@@ -176,7 +174,8 @@ func TestHashTreeComparisonOneLeafAtATime(t *testing.T) {
 		diff, err = ht1.Diff(ht2)
 		require.NoError(t, err)
 
-		rangeReader = ht1.NewRangeReader(diff)
+		rangeReader, err = ht1.NewRangeReader(diff)
+		require.NoError(t, err)
 
 		_, _, err = rangeReader.Next()
 		require.ErrorIs(t, err, ErrNoMoreRanges) // no differences should be found
@@ -196,7 +195,8 @@ func TestHashTreeAllDiffInSingleIteration(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, diff)
 
-	rangeReader := ht1.NewRangeReader(diff)
+	rangeReader, err := ht1.NewRangeReader(diff)
+	require.NoError(t, err)
 
 	_, _, err = rangeReader.Next()
 	require.ErrorIs(t, err, ErrNoMoreRanges)
@@ -217,7 +217,8 @@ func TestHashTreeAllDiffInSingleIteration(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, diff)
 
-	rangeReader = ht1.NewRangeReader(diff)
+	rangeReader, err = ht1.NewRangeReader(diff)
+	require.NoError(t, err)
 
 	i, j, err := rangeReader.Next()
 	require.NoError(t, err)
@@ -242,7 +243,8 @@ func TestHashTreeComparisonIncrementalConciliation(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, diff)
 
-	rangeReader := ht1.NewRangeReader(diff)
+	rangeReader, err := ht1.NewRangeReader(diff)
+	require.NoError(t, err)
 
 	_, _, err = rangeReader.Next()
 	require.ErrorIs(t, err, ErrNoMoreRanges) // no differences should be found
@@ -275,7 +277,8 @@ func TestHashTreeComparisonIncrementalConciliation(t *testing.T) {
 		diff, err = ht1.Diff(ht2)
 		require.NoError(t, err)
 
-		rangeReader := ht1.NewRangeReader(diff)
+		rangeReader, err := ht1.NewRangeReader(diff)
+		require.NoError(t, err)
 
 		diffCount := 0
 
@@ -327,7 +330,8 @@ func TestHashTreeComparisonHeight2(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, diff)
 
-	rangeReader := ht1.NewRangeReader(diff)
+	rangeReader, err := ht1.NewRangeReader(diff)
+	require.NoError(t, err)
 
 	_, _, err = rangeReader.Next()
 	require.ErrorIs(t, err, ErrNoMoreRanges) // no differences should be found
@@ -347,7 +351,8 @@ func TestHashTreeComparisonHeight2(t *testing.T) {
 	diff, err = ht1.Diff(ht2)
 	require.NoError(t, err)
 
-	rangeReader = ht1.NewRangeReader(diff)
+	rangeReader, err = ht1.NewRangeReader(diff)
+	require.NoError(t, err)
 
 	diff0, diff1, err := rangeReader.Next()
 	require.NoError(t, err)
@@ -366,7 +371,8 @@ func TestHashTreeComparisonHeight2(t *testing.T) {
 	diff, err = ht1.Diff(ht2)
 	require.NoError(t, err)
 
-	rangeReader = ht1.NewRangeReader(diff)
+	rangeReader, err = ht1.NewRangeReader(diff)
+	require.NoError(t, err)
 
 	diff0, diff1, err = rangeReader.Next()
 	require.NoError(t, err)
@@ -385,7 +391,8 @@ func TestHashTreeComparisonHeight2(t *testing.T) {
 	diff, err = ht1.Diff(ht2)
 	require.NoError(t, err)
 
-	rangeReader = ht1.NewRangeReader(diff)
+	rangeReader, err = ht1.NewRangeReader(diff)
+	require.NoError(t, err)
 
 	_, _, err = rangeReader.Next()
 	require.ErrorIs(t, err, ErrNoMoreRanges) // no differences should be found
@@ -425,7 +432,7 @@ func TestHashTreeRandomAggregationOrder(t *testing.T) {
 
 			var rootDigests [1]Digest
 
-			n, err := ht.Level(0, NewBitset(NodesCount(h)).SetAll(), rootDigests[:])
+			n, err := ht.Level(0, NewBitset(nodesAtLevel(0)).SetAll(), rootDigests[:])
 			require.NoError(t, err)
 			require.Equal(t, 1, n)
 
@@ -478,7 +485,7 @@ func TestHashTreeConcurrentInsertions(t *testing.T) {
 
 		var rootDigests [1]Digest
 
-		n, err := ht.Level(0, NewBitset(height).SetAll(), rootDigests[:])
+		n, err := ht.Level(0, NewBitset(nodesAtLevel(0)).SetAll(), rootDigests[:])
 		require.NoError(t, err)
 		require.Equal(t, 1, n)
 

--- a/usecases/replica/hashtree/level_local_test.go
+++ b/usecases/replica/hashtree/level_local_test.go
@@ -1,0 +1,276 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package hashtree
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLevelValidation(t *testing.T) {
+	height := 4
+	ht, err := NewHashTree(height)
+	require.NoError(t, err)
+
+	digests := make([]Digest, LeavesCount(height))
+
+	t.Run("negative level", func(t *testing.T) {
+		_, err := ht.Level(-1, NewBitset(1), digests)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	t.Run("level too high", func(t *testing.T) {
+		_, err := ht.Level(height+1, NewBitset(1), digests)
+		require.ErrorIs(t, err, ErrIllegalState)
+	})
+
+	t.Run("nil discriminant", func(t *testing.T) {
+		_, err := ht.Level(0, nil, digests)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	t.Run("wrong size discriminant — too small", func(t *testing.T) {
+		_, err := ht.Level(2, NewBitset(2), digests)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	t.Run("wrong size discriminant — too large", func(t *testing.T) {
+		_, err := ht.Level(2, NewBitset(8), digests)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	t.Run("output buffer too small", func(t *testing.T) {
+		small := make([]Digest, 4)
+		_, err := ht.Level(3, NewBitset(8), small)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+}
+
+func TestLevelDiffAtLeafLevel(t *testing.T) {
+	d := func(a, b uint64) Digest { return Digest{a, b} }
+
+	t.Run("all match — discriminant cleared, next nil", func(t *testing.T) {
+		discriminant := NewBitset(4).SetAll()
+		digs1 := []Digest{d(1, 1), d(2, 2), d(3, 3), d(4, 4)}
+		digs2 := []Digest{d(1, 1), d(2, 2), d(3, 3), d(4, 4)}
+
+		next, count, err := LevelDiff(2, 2, discriminant, digs1, digs2)
+		require.NoError(t, err)
+		assert.Nil(t, next)
+		assert.Equal(t, 0, count)
+		assert.Equal(t, 0, discriminant.SetCount())
+	})
+
+	t.Run("all mismatch — discriminant preserved, next nil", func(t *testing.T) {
+		discriminant := NewBitset(4).SetAll()
+		digs1 := []Digest{d(1, 1), d(2, 2), d(3, 3), d(4, 4)}
+		digs2 := []Digest{d(9, 9), d(9, 9), d(9, 9), d(9, 9)}
+
+		next, count, err := LevelDiff(2, 2, discriminant, digs1, digs2)
+		require.NoError(t, err)
+		assert.Nil(t, next)
+		assert.Equal(t, 4, count)
+		assert.Equal(t, 4, discriminant.SetCount())
+	})
+
+	t.Run("mixed — only matched bits cleared", func(t *testing.T) {
+		discriminant := NewBitset(4).SetAll()
+		digs1 := []Digest{d(1, 1), d(2, 2), d(3, 3), d(4, 4)}
+		digs2 := []Digest{d(1, 1), d(9, 9), d(3, 3), d(8, 8)}
+
+		next, count, err := LevelDiff(2, 2, discriminant, digs1, digs2)
+		require.NoError(t, err)
+		assert.Nil(t, next)
+		assert.Equal(t, 2, count)
+		assert.False(t, discriminant.IsSet(0))
+		assert.True(t, discriminant.IsSet(1))
+		assert.False(t, discriminant.IsSet(2))
+		assert.True(t, discriminant.IsSet(3))
+	})
+}
+
+func TestLevelDiffInnerLevelSetsChildren(t *testing.T) {
+	d := func(a, b uint64) Digest { return Digest{a, b} }
+
+	t.Run("mismatched node sets both children in next", func(t *testing.T) {
+		discriminant := NewBitset(2)
+		discriminant.Set(0)
+		discriminant.Set(1)
+
+		digs1 := []Digest{d(1, 1), d(2, 2)}
+		digs2 := []Digest{d(1, 1), d(9, 9)}
+
+		next, count, err := LevelDiff(1, 3, discriminant, digs1, digs2)
+		require.NoError(t, err)
+		require.NotNil(t, next)
+		assert.Equal(t, 4, next.Size())
+		assert.Equal(t, 1, count)
+
+		assert.False(t, discriminant.IsSet(0))
+		assert.False(t, next.IsSet(0))
+		assert.False(t, next.IsSet(1))
+
+		assert.True(t, discriminant.IsSet(1))
+		assert.True(t, next.IsSet(2))
+		assert.True(t, next.IsSet(3))
+	})
+
+	t.Run("matched node does not set children", func(t *testing.T) {
+		discriminant := NewBitset(2).SetAll()
+		digs1 := []Digest{d(1, 1), d(2, 2)}
+		digs2 := []Digest{d(1, 1), d(2, 2)}
+
+		next, count, err := LevelDiff(1, 3, discriminant, digs1, digs2)
+		require.NoError(t, err)
+		require.NotNil(t, next)
+		assert.Equal(t, 0, count)
+		assert.Equal(t, 0, discriminant.SetCount())
+		assert.Equal(t, 0, next.SetCount())
+	})
+}
+
+func TestLevelDiffValidation(t *testing.T) {
+	d := func(a, b uint64) Digest { return Digest{a, b} }
+
+	t.Run("negative level", func(t *testing.T) {
+		_, _, err := LevelDiff(-1, 3, NewBitset(1), []Digest{d(1, 1)}, []Digest{d(1, 1)})
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	t.Run("level above height", func(t *testing.T) {
+		_, _, err := LevelDiff(4, 3, NewBitset(1), []Digest{d(1, 1)}, []Digest{d(1, 1)})
+		require.ErrorIs(t, err, ErrIllegalState)
+	})
+
+	t.Run("nil discriminant", func(t *testing.T) {
+		_, _, err := LevelDiff(0, 3, nil, []Digest{d(1, 1)}, []Digest{d(1, 1)})
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	t.Run("wrong-sized discriminant", func(t *testing.T) {
+		_, _, err := LevelDiff(2, 3, NewBitset(8), make([]Digest, 4), make([]Digest, 4))
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	t.Run("digests1 too short", func(t *testing.T) {
+		disc := NewBitset(4).SetAll()
+		_, _, err := LevelDiff(2, 3, disc, make([]Digest, 2), make([]Digest, 4))
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	t.Run("digests2 too short", func(t *testing.T) {
+		disc := NewBitset(4).SetAll()
+		_, _, err := LevelDiff(2, 3, disc, make([]Digest, 4), make([]Digest, 2))
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+
+	// At deeper levels the walk is partial: digests are sized to
+	// discriminant.SetCount(), not Size().
+	t.Run("partial walk — digests sized to SetCount, not Size", func(t *testing.T) {
+		d := func(a, b uint64) Digest { return Digest{a, b} }
+		disc := NewBitset(4)
+		disc.Set(0)
+		disc.Set(2)
+		digs1 := []Digest{d(1, 1), d(2, 2)}
+		digs2 := []Digest{d(1, 1), d(2, 2)}
+		_, _, err := LevelDiff(2, 3, disc, digs1, digs2)
+		require.NoError(t, err)
+	})
+}
+
+func TestNewRangeReaderRejectsWrongSize(t *testing.T) {
+	height := 3
+	ht, err := NewHashTree(height)
+	require.NoError(t, err)
+
+	t.Run("full-tree-sized bitset", func(t *testing.T) {
+		rr, err := ht.NewRangeReader(NewBitset(NodesCount(height)))
+		assert.Nil(t, rr)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+	t.Run("nil discriminant", func(t *testing.T) {
+		rr, err := ht.NewRangeReader(nil)
+		assert.Nil(t, rr)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+	t.Run("arbitrary wrong size", func(t *testing.T) {
+		rr, err := ht.NewRangeReader(NewBitset(7))
+		assert.Nil(t, rr)
+		require.ErrorIs(t, err, ErrIllegalArguments)
+	})
+}
+
+func TestNewRangeReaderLeafIndices(t *testing.T) {
+	height := 4
+	ht, err := NewHashTree(height)
+	require.NoError(t, err)
+
+	leaf := NewBitset(LeavesCount(height))
+	leaf.Set(2)
+	leaf.Set(3)
+	leaf.Set(4)
+	leaf.Set(7)
+
+	rr, err := ht.NewRangeReader(leaf)
+	require.NoError(t, err)
+
+	a, b, err := rr.Next()
+	require.NoError(t, err)
+	assert.EqualValues(t, 2, a)
+	assert.EqualValues(t, 4, b)
+
+	a, b, err = rr.Next()
+	require.NoError(t, err)
+	assert.EqualValues(t, 7, a)
+	assert.EqualValues(t, 7, b)
+
+	_, _, err = rr.Next()
+	require.True(t, errors.Is(err, ErrNoMoreRanges))
+}
+
+// TestHashTreeLevelMarshalSizeScalesWithLevel asserts the per-level wire size
+// is nodesAtLevel(level)/8 + header, and strictly smaller than the previous
+// full-tree encoding at every non-leaf level.
+func TestHashTreeLevelMarshalSizeScalesWithLevel(t *testing.T) {
+	height := 16
+
+	// Bitset.Marshal header: uint32 size + uint32 setCount.
+	const header = 8
+
+	fullBytes := (NodesCount(height) + 63) / 64 * 8
+	require.Equal(t, header+fullBytes, marshalledSize(t, NewBitset(NodesCount(height))))
+
+	for level := 0; level <= height; level++ {
+		want := header + (nodesAtLevel(level)+63)/64*8
+
+		buf, err := NewBitset(nodesAtLevel(level)).Marshal()
+		require.NoError(t, err)
+		assert.Equalf(t, want, len(buf),
+			"level %d: marshalled bitset = %d bytes, expected %d", level, len(buf), want)
+
+		if level < height {
+			assert.Lessf(t, len(buf), header+fullBytes,
+				"level %d: per-level payload (%d) should be < full-tree payload (%d)",
+				level, len(buf), header+fullBytes)
+		}
+	}
+}
+
+func marshalledSize(t *testing.T, b *Bitset) int {
+	t.Helper()
+	buf, err := b.Marshal()
+	require.NoError(t, err)
+	return len(buf)
+}


### PR DESCRIPTION
## Motivation

Async replication's shard-difference protocol walks the hashtree level-by-level. At each level the local node sends a discriminant bitset to the peer and the peer replies with the digests selected by that bitset. Before this change, the discriminant was sized for the **whole tree** (`NodesCount(height)` bits — 131,071 at the default height 16) at every level. At the root only 1 bit out of 131,071 is meaningful; even at the leaf level, 65,535 inner-node bits are dead weight. We sent and indexed that full bitset 17 times per shard, per peer, per cycle.

This PR converts the on-the-wire and in-memory discriminant to a **level-local** bitset (`nodesAtLevel(l)` bits), and rewrites the diff walk on both sides to allocate one small bitset per level instead of carrying one giant bitset across all levels.

## Approach

Three coordinated changes:

1. **`HashTree.Level` accepts a level-local discriminant.** ([hashtree.go:192](https://github.com/weaviate/weaviate/blob/09dc352de0d7747a36d0359a305b5d194470eab1/usecases/replica/hashtree/hashtree.go#L192)) `discriminant.Size() == nodesAtLevel(level)`; bit `i` directly selects node `i` at that level. The old global-bitset form (where bit `InnerNodesCount(level)+i` selected node `i`) is gone — there is only one `Level` method now. `CompactHashTree` forwards through.

2. **`LevelDiff` allocates and returns the next level's discriminant — except at the leaf.** ([aggregated_hashtree.go:53](https://github.com/weaviate/weaviate/blob/09dc352de0d7747a36d0359a305b5d194470eab1/usecases/replica/hashtree/aggregated_hashtree.go#L53)) Signature: `LevelDiff(l, height int, discriminant *Bitset, digests1, digests2 []Digest) (nextDiscriminant *Bitset, levelDiffCount int, err error)`. For inner levels (`l < height`) it allocates `nextDiscriminant = NewBitset(nodesAtLevel(l+1))` and, for each mismatched node `j`, sets bits `2j` and `2j+1`. Matched bits in `discriminant` are cleared in place. **At the leaf level (`l == height`) it returns `nil` for `nextDiscriminant` and does not allocate one** — there are no children to descend to; the caller uses the (now mutated) input `discriminant` itself as the leaf-level diff. Validation rejects `l < 0` (`ErrIllegalArguments`), `l > height` (`ErrIllegalState`, mirroring `Level`), nil discriminant, wrong-sized discriminant, and undersized digest slices.

3. **`Diff` is self-contained on both `HashTree` and `CompactHashTree`.** ([hashtree_diff.go:19](https://github.com/weaviate/weaviate/blob/09dc352de0d7747a36d0359a305b5d194470eab1/usecases/replica/hashtree/hashtree_diff.go#L19), [compact_hashtree_diff.go:14](https://github.com/weaviate/weaviate/blob/09dc352de0d7747a36d0359a305b5d194470eab1/usecases/replica/hashtree/compact_hashtree_diff.go#L14)) The `DiffUsing` hook (which existed for buffer-reuse but had no remaining callers passing pre-allocated bitsets) is removed. `Diff` walks levels with the new level-local `LevelDiff` and returns a leaf-level bitset of size `LeavesCount(height)`.

`NewRangeReader` ([hashtree_range_reader.go:29](https://github.com/weaviate/weaviate/blob/09dc352de0d7747a36d0359a305b5d194470eab1/usecases/replica/hashtree/hashtree_range_reader.go#L29)) now requires exactly a leaf-level bitset, drops the `firstLeafPos` offset arithmetic, and returns leaf indices directly. **It returns `(AggregatedHashTreeRangeReader, error)` rather than panicking on a wrong-sized discriminant**: nil, full-tree-sized, and other wrong sizes return a wrapped `ErrIllegalArguments`. The signature change applies to both `HashTree` and `CompactHashTree` and to the `AggregatedHashTree` interface.

The cross-node diff walk in `Finder.CollectShardDifferences` ([finder.go:329](https://github.com/weaviate/weaviate/blob/09dc352de0d7747a36d0359a305b5d194470eab1/usecases/replica/finder.go#L329)) is rewritten to seed the discriminant at the root (`NewBitset(1).Set(0)`) and step through levels with the new `LevelDiff` return value, capturing the leaf-level discriminant explicitly via `if l == height { leaf = discriminant; break }`. When the peer replies with zero digests we break early and return an empty `ShardDifferenceReader` (same observable behavior as before). The `NewRangeReader` error is wrapped with the target node address.

Both clients (`replicationClient.HashTreeLevel` over REST at [replication.go:212](https://github.com/weaviate/weaviate/blob/09dc352de0d7747a36d0359a305b5d194470eab1/adapters/clients/replication.go#L212), and `grpcReplicationClient.HashTreeLevel` at [replication_grpc.go:443](https://github.com/weaviate/weaviate/blob/09dc352de0d7747a36d0359a305b5d194470eab1/adapters/clients/replication_grpc.go#L443)) and the server-side `Shard.HashTreeLevel` ([shard_async_replication.go:1153](https://github.com/weaviate/weaviate/blob/09dc352de0d7747a36d0359a305b5d194470eab1/adapters/repos/db/shard_async_replication.go#L1153)) validate `discriminant.Size() == nodesAtLevel(level)` up front. Server-side validation is hoisted **outside** `asyncReplicationRWMux.RLock` since it depends only on `level` and the discriminant.

## Key areas for review

- `usecases/replica/hashtree/aggregated_hashtree.go:LevelDiff` — the new signature and contract. Verify the `l == height` short-circuit (no allocation, returns `nil` `nextDiscriminant`) and the `l > height` validation case (returns `ErrIllegalState`, matching `Level`).
- `usecases/replica/hashtree/hashtree_diff.go:Diff` — the new walk loop. The leaf-level branch returns `walk` directly (it has been mutated in place by `LevelDiff` to clear matched leaves), and the early-exit `levelDiffCount == 0` branch returns an empty leaf-level bitset. Confirm both paths compose correctly with `NewRangeReader`.
- `usecases/replica/finder.go:CollectShardDifferences` — the symmetric remote walk. Note the explicit `leaf` variable: it is only set on the leaf-level iteration; if the peer returns zero digests at any earlier level we break out with `leaf == nil` and return an empty reader. Verify `NewRangeReader`'s error is propagated wrapped with the target node address.
- `usecases/replica/hashtree/hashtree_range_reader.go:NewRangeReader` — error return instead of panic; double-check no remaining caller in the codebase passes a full-tree bitset (callers now must check `err`).
- `adapters/repos/db/shard_async_replication.go:HashTreeLevel` — validation hoisted before `RLock`; verify the chosen error messages are consistent with the rest of the package.
- `usecases/replica/hashtree/level_local_test.go:TestHashTreeLevelMarshalSizeScalesWithLevel` — the wire-payload regression check.

## Risks and mitigations

- **Wire-format change between Weaviate nodes during rolling upgrade.** `HashTreeLevel` ships a marshalled `Bitset` whose declared `Size()` field is part of the payload. An old node sending a full-tree bitset to a new node (or vice versa) will fail size validation and the diff for that pair fails for one cycle. Mitigation: async replication is self-healing — it retries on the next cycle, so a failed diff during the upgrade window is benign. Once both ends are upgraded, diffs succeed. Worth calling out in release notes; no on-disk format changes.
- **Off-by-one in the level-walk.** The previous code reused one bitset and relied on `SetCount() == 0` to break early; the new code explicitly handles `l == height` separately. Covered by `TestLevelDiffAtLeafLevel` (all-match clears, all-mismatch preserves, mixed clears only matched) and `TestLevelDiffInnerLevelSetsChildren` (mismatched nodes set both children in `next`, matched nodes do not).
- **`NewRangeReader` no longer panics on wrong-size input.** Callers must check the returned error. `Finder.CollectShardDifferences` does so and wraps with the target node address; the test suite covers full-tree, nil, and arbitrary wrong sizes via `TestNewRangeReaderRejectsWrongSize` (asserting `ErrorIs(err, ErrIllegalArguments)`).

No on-disk format changes. Internal API changes (`Level` signature, `LevelDiff` signature, `NewRangeReader` error return, removal of `DiffUsing`) only affect this package and its in-tree callers.

## Testing

New `usecases/replica/hashtree/level_local_test.go` covers:
- **`TestLevelValidation`** — `Level` rejects negative level, level too high, nil discriminant, wrong-size discriminant (both directions), and undersized output buffer.
- **`TestLevelDiffAtLeafLevel`** — all-match clears the discriminant, all-mismatch preserves it, mixed-case clears only matched bits; the returned `nextDiscriminant` is `nil`.
- **`TestLevelDiffInnerLevelSetsChildren`** — mismatched nodes set bits `2j` and `2j+1` in `next`; matched nodes do not; `next.Size() == nodesAtLevel(l+1)`.
- **`TestLevelDiffValidation`** — negative level (`ErrIllegalArguments`), level above height (`ErrIllegalState`), nil discriminant, wrong-sized discriminant, both digest-slice underruns.
- **`TestNewRangeReaderRejectsWrongSize`** — returns wrapped `ErrIllegalArguments` (no panic) for full-tree bitset, nil, and other wrong sizes.
- **`TestNewRangeReaderLeafIndices`** — adjacent and isolated set bits produce correct `[from, to]` leaf-index ranges (consumes the new error return).
- **`TestHashTreeLevelMarshalSizeScalesWithLevel`** — wire-size regression: the per-level marshalled payload equals `8 + ceil(nodesAtLevel(level)/64)*8` bytes, and at every non-leaf level it is strictly smaller than the previous full-tree payload. At height 16 this is the property that motivates the change.

Existing `replication_test.go:TestReplicationHashTreeLevel` updated to send a level-local discriminant (`hashtree.NewBitset(hashtree.LeavesCount(3))` for the level-3 case). Existing `hashtree_test.go` and `compact_hashtree_test.go` updated to construct level-local bitsets at the call sites and to consume the new `NewRangeReader` error return.
