### PR TITLE
queue: promote partial chunk in PrepareForBackup to prevent S3 BadDigest

### DIFF
--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -478,8 +478,15 @@ func (q *DiskQueue) Wait(ctx context.Context) error {
 	return q.scheduler.Wait(ctx, q.id)
 }
 
-// PrepareForBackup pauses the queue and flushes all tasks to disk to prepare for backup.
-// It also enables maintenance mode, which prevents processed chunk files from being deleted until the backup is complete.
+// PrepareForBackup pauses the queue and flushes all tasks to disk to prepare
+// for backup. It also promotes the current partial chunk into a sealed file
+// and enables maintenance mode, which prevents processed chunk files from
+// being deleted until the backup is complete.
+//
+// Promoting the partial chunk ensures that no open writer can modify files in
+// the queue directory while they are being uploaded. Without this, the resumed
+// queue writer could modify chunk files mid-upload, causing checksum mismatches
+// (e.g. S3 BadDigest errors).
 func (q *DiskQueue) PrepareForBackup(ctx context.Context) error {
 	err := q.Pause(ctx)
 	if err != nil {
@@ -490,6 +497,18 @@ func (q *DiskQueue) PrepareForBackup(ctx context.Context) error {
 	err = q.Flush()
 	if err != nil {
 		return err
+	}
+
+	// Seal the current partial chunk so the writer starts a fresh file on
+	// Resume. This guarantees all existing chunk files are immutable during
+	// the upload.
+	q.m.Lock()
+	if q.w != nil {
+		err = q.w.Promote()
+	}
+	q.m.Unlock()
+	if err != nil {
+		return errors.Wrap(err, "promote partial chunk for backup")
 	}
 
 	q.EnableMaintenanceMode()


### PR DESCRIPTION
PrepareForBackup resumes the queue after pausing and flushing, but the writer may still have a partial chunk file open. When the upload runs immediately after, the resumed writer can modify that chunk mid-read, causing Content-MD5 mismatches on S3 (BadDigest).

Fix: after Flush, call w.Promote() to seal the partial chunk into an immutable file. The writer will start a fresh file on Resume, so all existing chunk files are stable during the upload.

Fixes: https://github.com/weaviate/0-weaviate-issues/issues/201

### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
