### PR TITLE
feat: async replication enabled by default

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1664,7 +1664,7 @@ func startupRoutine(ctx, serverShutdownCtx context.Context, options *swag.Comman
 	}
 
 	// Initialize runtime config hooks and start runtime config background process
-	postInitRuntimeOverrides(appState, runtimeConfigManager)
+	postInitRuntimeOverrides(appState, serverShutdownCtx, runtimeConfigManager)
 
 	return appState
 }
@@ -2606,7 +2606,7 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 }
 
 // postInitRuntimeOverrides registers hooks and starts runtime config background process
-func postInitRuntimeOverrides(appState *state.State, cm *configRuntime.ConfigManager[config.WeaviateRuntimeConfig]) {
+func postInitRuntimeOverrides(appState *state.State, serverShutdownCtx context.Context, cm *configRuntime.ConfigManager[config.WeaviateRuntimeConfig]) {
 	if appState.ServerConfig.Config.RuntimeOverrides.Enabled && cm != nil {
 		// register any additional runtime configs
 		if appState.Modules.UsageEnabled() {
@@ -2629,6 +2629,19 @@ func postInitRuntimeOverrides(appState *state.State, cm *configRuntime.ConfigMan
 		if appState.ServerConfig.Config.Authentication.OIDC.Enabled {
 			hooks["OIDC"] = appState.OIDC.Init
 		}
+		// Reconcile loaded shards when the async-replication kill-switch is
+		// toggled at runtime. Run in the background: ReconcileAsyncReplication
+		// does per-shard hashtree disk I/O, which must not block the runtime-
+		// config reload loop. serverShutdownCtx makes it cancellable on shutdown;
+		// errors are logged here and surfaced via the reconcileFailures metric.
+		hooks["AsyncReplicationDisabled"] = func() error {
+			enterrors.GoWrapper(func() {
+				if err := appState.DB.ReconcileAsyncReplication(serverShutdownCtx); err != nil {
+					appState.Logger.WithField("action", "reconcile_async_replication").Error(err)
+				}
+			}, appState.Logger)
+			return nil
+		}
 		maps.Copy(hooks, appState.Crons.RuntimeConfigHooks())
 
 		// Re-run cross-field restriction validation on runtime YAML pushes
@@ -2643,7 +2656,7 @@ func postInitRuntimeOverrides(appState *state.State, cm *configRuntime.ConfigMan
 		hooks["DefaultVectorIndexType"] = restrictionHook
 		hooks["DefaultQuantization"] = restrictionHook
 
-		appState.Logger.Log(logrus.InfoLevel, "registereing OIDC runtime overrides hooks")
+		appState.Logger.Log(logrus.InfoLevel, "registering runtime overrides hooks")
 		cm.RegisterHooks(hooks)
 		// reload current overrides file to take into account additional settings
 		if err := cm.ReloadConfig(); err != nil {

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -9735,11 +9735,6 @@ func init() {
           "x-omitempty": true,
           "$ref": "#/definitions/ReplicationAsyncConfig"
         },
-        "asyncEnabled": {
-          "description": "Enable asynchronous replication (default: ` + "`" + `false` + "`" + `).",
-          "type": "boolean",
-          "x-omitempty": false
-        },
         "deletionStrategy": {
           "description": "Conflict resolution strategy for deleted objects.",
           "type": "string",
@@ -21166,11 +21161,6 @@ func init() {
           "description": "Configuration parameters for asynchronous replication.",
           "x-omitempty": true,
           "$ref": "#/definitions/ReplicationAsyncConfig"
-        },
-        "asyncEnabled": {
-          "description": "Enable asynchronous replication (default: ` + "`" + `false` + "`" + `).",
-          "type": "boolean",
-          "x-omitempty": false
         },
         "deletionStrategy": {
           "description": "Conflict resolution strategy for deleted objects.",

--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -158,6 +158,11 @@ type asyncReplicationSchedulerMetrics struct {
 	queueDepth prometheus.Gauge
 	// workerPoolSize is the current target worker pool size.
 	workerPoolSize prometheus.Gauge
+	// reconcileFailures counts indices that failed to reconcile their async
+	// replication state with the global flag (see DB.ReconcileAsyncReplication).
+	// A non-zero rate means a cluster may be stuck partially reconciled until
+	// the next flag toggle or schema update.
+	reconcileFailures prometheus.Counter
 }
 
 func newAsyncReplicationSchedulerMetrics(prom *monitoring.PrometheusMetrics) (asyncReplicationSchedulerMetrics, error) {
@@ -215,6 +220,18 @@ func newAsyncReplicationSchedulerMetrics(prom *monitoring.PrometheusMetrics) (as
 		return m, err
 	}
 
+	m.reconcileFailures, _, err = monitoring.EnsureRegisteredMetric(
+		prom.Registerer,
+		prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "weaviate",
+			Name:      "async_replication_reconcile_failures_total",
+			Help:      "Number of indices that failed to reconcile async replication with the global AsyncReplicationDisabled flag.",
+		}),
+	)
+	if err != nil {
+		return m, err
+	}
+
 	return m, err
 }
 
@@ -245,6 +262,12 @@ func (m *asyncReplicationSchedulerMetrics) decShardsRegistered() {
 func (m *asyncReplicationSchedulerMetrics) setQueueDepth(n int) {
 	if m.monitoring {
 		m.queueDepth.Set(float64(n))
+	}
+}
+
+func (m *asyncReplicationSchedulerMetrics) addReconcileFailures(n int) {
+	if m.monitoring {
+		m.reconcileFailures.Add(float64(n))
 	}
 }
 
@@ -1145,7 +1168,8 @@ func (sched *AsyncReplicationScheduler) rebuildHashtree(s *Shard) {
 	// If Close() fired during enableAsyncReplication, or performShutdown set
 	// s.shut between the entry-time check and now, the enable touched a store
 	// being torn down or registered against a cancelled scheduler. Disable to
-	// clean up; disableAsyncReplication's fsync is bounded by hashtreeDumpTimeout.
+	// clean up; disableAsyncReplication does no disk I/O so this is bounded
+	// by the Deregister round-trip.
 	if sched.ctx.Err() != nil || s.shut.Load() {
 		s.disableAsyncReplication(sched.ctx)
 	}

--- a/adapters/repos/db/export.go
+++ b/adapters/repos/db/export.go
@@ -125,29 +125,17 @@ func (db *DB) IsMultiTenant(_ context.Context, className string) bool {
 	return class != nil && class.MultiTenancyConfig != nil && class.MultiTenancyConfig.Enabled
 }
 
-// IsAsyncReplicationEnabled returns true if async replication is either
-// enabled or not required for correctness. Classes with a replication
-// factor ≤ 1 have no replicas, so async replication is irrelevant and
-// the method returns true. For RF > 1 the class must have async
-// replication enabled and it must not be globally disabled at the
-// cluster level.
+// IsAsyncReplicationEnabled reports whether a class is safe to export: its
+// replicas are kept consistent by async replication, or it has no replicas.
+// It returns true for RF ≤ 1 (irrelevant), false for a missing local index,
+// and for RF > 1 delegates to Index.IsAsyncReplicationEnabledOrIrrelevant —
+// true unless async replication is globally disabled.
 func (db *DB) IsAsyncReplicationEnabled(_ context.Context, className string) bool {
 	idx := db.GetIndex(schema.ClassName(className))
 	if idx == nil {
 		return false
 	}
-	class := idx.getClass()
-	if class == nil {
-		return false
-	}
-	// No replicas → async replication is not needed for correctness.
-	if class.ReplicationConfig == nil || class.ReplicationConfig.Factor <= 1 {
-		return true
-	}
-	if db.config.Replication.AsyncReplicationDisabled.Get() {
-		return false
-	}
-	return class.ReplicationConfig.AsyncEnabled
+	return idx.IsAsyncReplicationEnabledOrIrrelevant()
 }
 
 // SnapshotShards creates point-in-time snapshots of the objects buckets for

--- a/adapters/repos/db/export_test.go
+++ b/adapters/repos/db/export_test.go
@@ -21,8 +21,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/schema"
 	esync "github.com/weaviate/weaviate/entities/sync"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 )
 
 func TestAssignShardsToNodes(t *testing.T) {
@@ -126,6 +128,110 @@ func newTestIndexForSnapshot(t *testing.T, className string) *Index {
 		logger:           logrus.New(),
 		shardCreateLocks: esync.NewKeyRWLocker(),
 	}
+}
+
+// TestIsAsyncReplicationEnabledOrIrrelevant covers the config-based export
+// gate: exportable when RF ≤ 1 (irrelevant) or RF > 1 and async replication is
+// not globally disabled.
+func TestIsAsyncReplicationEnabledOrIrrelevant(t *testing.T) {
+	disabled := func(v bool) *replication.GlobalConfig {
+		return &replication.GlobalConfig{
+			AsyncReplicationDisabled: configRuntime.NewDynamicValue(v),
+		}
+	}
+
+	tests := []struct {
+		name              string
+		replicationFactor int64
+		globalConfig      *replication.GlobalConfig
+		want              bool
+	}{
+		{
+			name:              "RF=1 is irrelevant: always exportable",
+			replicationFactor: 1,
+			globalConfig:      disabled(true),
+			want:              true,
+		},
+		{
+			name:              "RF=0 is irrelevant: always exportable",
+			replicationFactor: 0,
+			globalConfig:      nil,
+			want:              true,
+		},
+		{
+			name:              "RF>1 globally disabled: not exportable",
+			replicationFactor: 3,
+			globalConfig:      disabled(true),
+			want:              false,
+		},
+		{
+			name:              "RF>1 not globally disabled: exportable",
+			replicationFactor: 3,
+			globalConfig:      disabled(false),
+			want:              true,
+		},
+		{
+			name:              "RF>1 nil global config: enabled by default, exportable",
+			replicationFactor: 3,
+			globalConfig:      nil,
+			want:              true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			idx := &Index{
+				Config:                  IndexConfig{ReplicationFactor: tt.replicationFactor},
+				globalreplicationConfig: tt.globalConfig,
+			}
+			assert.Equal(t, tt.want, idx.IsAsyncReplicationEnabledOrIrrelevant())
+		})
+	}
+}
+
+// TestDBIsAsyncReplicationEnabled verifies the DB-level export gate: a missing
+// index is not exportable, and an existing index delegates to its own
+// IsAsyncReplicationEnabledOrIrrelevant predicate.
+func TestDBIsAsyncReplicationEnabled(t *testing.T) {
+	const className = "TestClass"
+
+	newDB := func(idx *Index) *DB {
+		indices := map[string]*Index{}
+		if idx != nil {
+			indices[indexID(schema.ClassName(className))] = idx
+		}
+		return &DB{indices: indices}
+	}
+
+	t.Run("index not found: not exportable", func(t *testing.T) {
+		db := newDB(nil)
+		assert.False(t, db.IsAsyncReplicationEnabled(context.Background(), className))
+	})
+
+	t.Run("RF=1 index: exportable (irrelevant)", func(t *testing.T) {
+		db := newDB(&Index{Config: IndexConfig{ReplicationFactor: 1}})
+		assert.True(t, db.IsAsyncReplicationEnabled(context.Background(), className))
+	})
+
+	t.Run("RF>1 not globally disabled: exportable", func(t *testing.T) {
+		db := newDB(&Index{
+			Config: IndexConfig{ReplicationFactor: 3},
+			globalreplicationConfig: &replication.GlobalConfig{
+				AsyncReplicationDisabled: configRuntime.NewDynamicValue(false),
+			},
+		})
+		assert.True(t, db.IsAsyncReplicationEnabled(context.Background(), className))
+	})
+
+	t.Run("RF>1 with async replication globally disabled: not exportable", func(t *testing.T) {
+		db := newDB(&Index{
+			Config: IndexConfig{ReplicationFactor: 3},
+			globalreplicationConfig: &replication.GlobalConfig{
+				AsyncReplicationDisabled: configRuntime.NewDynamicValue(true),
+			},
+		})
+		assert.False(t, db.IsAsyncReplicationEnabled(context.Background(), className))
+	})
 }
 
 // TestSnapshotShardsForExport_EmptyShardNames asserts that passing an empty

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -886,7 +886,6 @@ func (i *Index) updateReplicationConfig(ctx context.Context, cfg *models.Replica
 
 	i.Config.ReplicationFactor = cfg.Factor
 	i.Config.DeletionStrategy = cfg.DeletionStrategy
-	i.Config.AsyncReplicationEnabled = cfg.AsyncEnabled
 
 	config, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(i.getClass().MultiTenancyConfig), cfg.AsyncConfig, i.logger.WithField("class", i.Config.ClassName))
 	if err != nil {
@@ -895,18 +894,36 @@ func (i *Index) updateReplicationConfig(ctx context.Context, cfg *models.Replica
 	i.Config.AsyncReplicationConfig = config
 
 	// unloaded shards will fetch the latest config when they are loaded
-	err = i.ForEachLoadedShard(func(name string, shard ShardLike) error {
+	return i.applyAsyncReplicationToLoadedShardsLocked(ctx)
+}
+
+// applyAsyncReplicationToLoadedShardsLocked (re-)applies the current
+// enable/disable decision to every loaded shard. enable/disableAsyncReplication
+// are idempotent, so this is safe to call again.
+//
+// The caller MUST hold i.replicationConfigLock for writing; holding it across
+// the apply is deadlock-free (enable/disableAsyncReplication never reacquire it).
+// Note that enableAsyncReplication does synchronous hashtree disk I/O, so the
+// write lock is held for the whole per-shard apply: hashbeat cycles for this
+// index (which read the lock via AsyncReplicationEnabled) stall until it ends.
+func (i *Index) applyAsyncReplicationToLoadedShardsLocked(ctx context.Context) error {
+	enabled := i.asyncReplicationEnabled()
+	cfg := i.Config.AsyncReplicationConfig
+
+	return i.ForEachLoadedShard(func(name string, shard ShardLike) error {
+		// Stop the per-shard walk if the caller's context (e.g. server
+		// shutdown) was cancelled — the apply below does synchronous disk I/O.
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
 		ctrl, ok := shard.(asyncReplicationController)
 		if !ok {
 			return fmt.Errorf("shard %q does not implement asyncReplicationController", name)
 		}
 
-		if i.asyncReplicationEnabled() {
-			// enableAsyncReplication handles the already-running case by updating
-			// the stored config in-place. The scheduler's runEntry detects height
-			// changes and triggers a rebuild via asyncRepNeedsRebuild, so a
-			// stop/start cycle is only needed for height changes (handled there).
-			if err := ctrl.enableAsyncReplication(ctx, i.Config.AsyncReplicationConfig); err != nil {
+		if enabled {
+			if err := ctrl.enableAsyncReplication(ctx, cfg); err != nil {
 				return fmt.Errorf("updating async replication on shard %q: %w", name, err)
 			}
 		} else {
@@ -916,10 +933,82 @@ func (i *Index) updateReplicationConfig(ctx context.Context, cfg *models.Replica
 		}
 		return nil
 	})
-	if err != nil {
-		return err
-	}
+}
 
+// reconcileAsyncReplication re-applies the enable/disable decision to this
+// index's loaded shards. It reacts to a runtime change of the global
+// AsyncReplicationDisabled flag, which would otherwise leave shards loaded
+// while disabled permanently unregistered.
+func (i *Index) reconcileAsyncReplication(ctx context.Context) error {
+	// Exclusive lock (matching updateReplicationConfig) so the apply can't
+	// interleave with a concurrent reconcile or be observed half-applied.
+	i.replicationConfigLock.Lock()
+	defer i.replicationConfigLock.Unlock()
+
+	if i.Config.ReplicationFactor <= 1 {
+		return nil // never runs async replication; nothing to reconcile
+	}
+	return i.applyAsyncReplicationToLoadedShardsLocked(ctx)
+}
+
+// ReconcileAsyncReplication re-applies async replication to every loaded shard
+// of every index. The runtime-config hook calls it when the global
+// AsyncReplicationDisabled flag changes, so shards loaded while it was disabled
+// get (un)registered to match instead of staying stale until a reload.
+func (db *DB) ReconcileAsyncReplication(ctx context.Context) error {
+	// Snapshot only the index pointers under indexLock; the dropIndex read lock
+	// is taken per index just-in-time below, not up front. The pointers stay
+	// valid even if a concurrent DeleteIndex removes one from db.indices.
+	var indices []*Index
+	func() {
+		db.indexLock.RLock()
+		defer db.indexLock.RUnlock()
+		for _, idx := range db.indices {
+			indices = append(indices, idx)
+		}
+	}()
+
+	// Reconcile outside indexLock so the per-shard apply (which can do hashtree
+	// I/O) does not block index creation/deletion. Each index takes its own
+	// dropIndex.RLock only while it is being reconciled — the established
+	// discipline for using an index outside indexLock (see SnapshotShards) —
+	// so a concurrent DeleteIndex is blocked only on the current index, not on
+	// every index still queued. If a DeleteIndex completed between the snapshot
+	// and acquiring dropIndex.RLock, drop() has set idx.closed, so the closed
+	// check below skips the index.
+	var failed int
+	for processed, idx := range indices {
+		// Stop the walk if the caller's context (e.g. server shutdown) was
+		// cancelled; the per-index apply does synchronous hashtree disk I/O.
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("reconcile async replication interrupted after %d of %d indices: %w",
+				processed, len(indices), err)
+		}
+
+		err := func() error {
+			idx.dropIndex.RLock()
+			defer idx.dropIndex.RUnlock()
+			idx.closeLock.RLock()
+			defer idx.closeLock.RUnlock()
+			if idx.closed {
+				return nil // index is shutting down; nothing to reconcile
+			}
+			return idx.reconcileAsyncReplication(ctx)
+		}()
+		if err != nil {
+			failed++
+			db.logger.WithField("action", "reconcile_async_replication").
+				WithField("class", idx.Config.ClassName).Error(err)
+		}
+	}
+	if failed > 0 {
+		// Surface a metric: the only self-healing trigger is another flag toggle
+		// or schema update, so operators need to detect a partial reconcile.
+		if db.asyncReplicationScheduler != nil {
+			db.asyncReplicationScheduler.metrics.addReconcileFailures(failed)
+		}
+		return fmt.Errorf("reconcile async replication failed for %d of %d indices", failed, len(indices))
+	}
 	return nil
 }
 
@@ -961,7 +1050,6 @@ type IndexConfig struct {
 	MaxSegmentSize                      int64
 	ReplicationFactor                   int64
 	DeletionStrategy                    string
-	AsyncReplicationEnabled             bool
 	AsyncReplicationConfig              AsyncReplicationConfig
 	AsyncReplicationScheduler           *AsyncReplicationScheduler
 	AvoidMMap                           bool
@@ -1271,7 +1359,22 @@ func (i *Index) AsyncReplicationEnabled() bool {
 }
 
 func (i *Index) asyncReplicationEnabled() bool {
-	return i.Config.ReplicationFactor > 1 && i.Config.AsyncReplicationEnabled && !i.asyncReplicationGloballyDisabled()
+	return i.Config.ReplicationFactor > 1 && !i.asyncReplicationGloballyDisabled()
+}
+
+// IsAsyncReplicationEnabledOrIrrelevant is the export gate: true if async
+// replication is irrelevant (RF ≤ 1) or enabled (RF > 1 and not globally
+// disabled).
+//
+// It is config-level by design — per-shard readiness inspection is unstable
+// for multi-tenant classes (tenant shards constantly transition) and would
+// reject create-then-export during warm-up. Reconciliation keeps this view
+// honest by applying the config to loaded shards.
+func (i *Index) IsAsyncReplicationEnabledOrIrrelevant() bool {
+	i.replicationConfigLock.RLock()
+	defer i.replicationConfigLock.RUnlock()
+
+	return i.Config.ReplicationFactor <= 1 || i.asyncReplicationEnabled()
 }
 
 func (i *Index) AsyncReplicationConfig() AsyncReplicationConfig {
@@ -1294,15 +1397,17 @@ func (i *Index) InitAsyncReplicationOnShard(ctx context.Context, shardName strin
 	}
 	defer release()
 
-	i.replicationConfigLock.RLock()
-	cfg := i.Config.AsyncReplicationConfig
-	i.replicationConfigLock.RUnlock()
-
 	ctrl, ok := shard.(asyncReplicationController)
 	if !ok {
 		return fmt.Errorf("shard %q does not implement asyncReplicationController", shardName)
 	}
-	return ctrl.enableAsyncReplication(ctx, cfg)
+
+	// Hold replicationConfigLock across the apply so the config read and the
+	// enable cannot be interleaved by a concurrent updateReplicationConfig. See
+	// RevertAsyncReplicationOnShard for why this is deadlock-free.
+	i.replicationConfigLock.RLock()
+	defer i.replicationConfigLock.RUnlock()
+	return ctrl.enableAsyncReplication(ctx, i.Config.AsyncReplicationConfig)
 }
 
 // RevertAsyncReplicationOnShard reverts a shard to the async replication state
@@ -1323,12 +1428,16 @@ func (i *Index) RevertAsyncReplicationOnShard(ctx context.Context, shardName str
 		return fmt.Errorf("shard %q does not implement asyncReplicationController", shardName)
 	}
 
+	// Hold replicationConfigLock across the apply (not just the snapshot) so a
+	// concurrent updateReplicationConfig cannot interleave and let stale state
+	// win. Deadlock-free: updateReplicationConfig already calls
+	// enable/disableAsyncReplication under the write lock, so they never
+	// reacquire replicationConfigLock.
 	i.replicationConfigLock.RLock()
-	cfg := i.Config.AsyncReplicationConfig
-	i.replicationConfigLock.RUnlock()
+	defer i.replicationConfigLock.RUnlock()
 
 	if i.asyncReplicationEnabled() {
-		return ctrl.enableAsyncReplication(ctx, cfg)
+		return ctrl.enableAsyncReplication(ctx, i.Config.AsyncReplicationConfig)
 	}
 	return ctrl.disableAsyncReplication(ctx)
 }

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -178,7 +178,6 @@ func (db *DB) init(ctx context.Context) error {
 				LSMEnableSegmentsChecksumValidation:          db.config.LSMEnableSegmentsChecksumValidation,
 				SkipWriteClassNameOnDisk:                     db.config.LSMSkipWriteClassNameEnabled,
 				ReplicationFactor:                            class.ReplicationConfig.Factor,
-				AsyncReplicationEnabled:                      class.ReplicationConfig.AsyncEnabled,
 				AsyncReplicationConfig:                       asyncConfig,
 				AsyncReplicationScheduler:                    db.asyncReplicationScheduler,
 				DeletionStrategy:                             class.ReplicationConfig.DeletionStrategy,

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -202,7 +202,6 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 			LSMEnableSegmentsChecksumValidation:          m.db.config.LSMEnableSegmentsChecksumValidation,
 			SkipWriteClassNameOnDisk:                     m.db.config.LSMSkipWriteClassNameEnabled,
 			ReplicationFactor:                            class.ReplicationConfig.Factor,
-			AsyncReplicationEnabled:                      class.ReplicationConfig.AsyncEnabled,
 			AsyncReplicationConfig:                       asyncConfig,
 			AsyncReplicationScheduler:                    m.db.asyncReplicationScheduler,
 			DeletionStrategy:                             class.ReplicationConfig.DeletionStrategy,
@@ -248,6 +247,30 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 	m.db.indexLock.Lock()
 	m.db.indices[idx.ID()] = idx
 	m.db.indexLock.Unlock()
+
+	// NewIndex loaded shards reading the live AsyncReplicationDisabled flag, but
+	// the index was not yet in db.indices, so a concurrent runtime flag toggle's
+	// reconcile hook could have skipped it. Re-reconcile now that it is visible
+	// so its shards match the current flag. Non-fatal: a hiccup here must not
+	// fail class creation — the next toggle/schema update will correct it.
+	//
+	// Take dropIndex.RLock only after publishing the index, keeping the
+	// indexLock -> dropIndex order used everywhere else (acquiring dropIndex
+	// first would invert it against DeleteIndex). classLocks already serialises
+	// a same-class DeleteIndex, so the index cannot be dropped before this runs.
+	func() {
+		idx.dropIndex.RLock()
+		defer idx.dropIndex.RUnlock()
+		idx.closeLock.RLock()
+		defer idx.closeLock.RUnlock()
+		if idx.closed {
+			return
+		}
+		if err := idx.reconcileAsyncReplication(ctx); err != nil {
+			m.logger.WithField("action", "add_class").WithField("class", class.Class).
+				Errorf("reconcile async replication for new index: %v", err)
+		}
+	}()
 
 	m.logger.WithFields(logrus.Fields{
 		"action":                  "lazy_shard_auto_detection",

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -558,6 +558,41 @@ func (s *Shard) initAsyncReplication(config AsyncReplicationConfig, cached hasht
 	return nil
 }
 
+// removePersistedHashtree deletes any persisted hashtree (.ht) files for the
+// shard without deserialising them. Called at shard init when async
+// replication is disabled: the shard will serve writes while async is off,
+// so a leftover .ht from a previous async-enabled shutdown goes stale on the
+// first write — a later runtime enable would otherwise load it as the
+// "cached" hashtree and miss the divergence. Missing directory is success.
+// See disableAsyncReplication for the symmetric rationale.
+func (s *Shard) removePersistedHashtree() error {
+	dir := s.pathHashTree()
+	dirEntries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	removedAny := false
+	for _, dirEntry := range dirEntries {
+		if dirEntry.IsDir() || filepath.Ext(dirEntry.Name()) != ".ht" {
+			continue
+		}
+		filename := filepath.Join(dir, dirEntry.Name())
+		if err := os.Remove(filename); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+		removedAny = true
+	}
+	if removedAny {
+		if err := diskio.Fsync(dir); err != nil {
+			return fmt.Errorf("fsync hashtree directory %q: %w", dir, err)
+		}
+	}
+	return nil
+}
+
 // tryLoadHashtreeFromDisk scans the shard's hashtree directory for a persisted
 // hashtree file, loads the most-recent one, and removes it from disk (along
 // with any older duplicates). Returns nil without error when no file is found
@@ -932,71 +967,51 @@ func (s *Shard) enableAsyncReplication(ctx context.Context, config AsyncReplicat
 }
 
 // disableAsyncReplication cancels the per-shard async-replication context,
-// nils the hashtree, deregisters the shard from the scheduler, and persists
-// the hashtree to disk if it was fully initialised.
+// nils the hashtree, and deregisters the shard from the scheduler.
 //
-// Unlike mayStopAsyncReplication, this function does NOT call asyncRepWg.Wait().
-// Callers that need a strict happens-before guarantee against in-flight cycle
-// completion should use mayStopAsyncReplication instead, or call Deregister
-// followed by asyncRepWg.Wait() explicitly.
+// It deliberately does NOT persist the hashtree. This is the runtime path
+// (kill-switch / rebuild / target-node-override): the shard stays live and
+// keeps serving writes, so any snapshot would go stale on the next write and
+// the next enableAsyncReplication would load it as the "cached" hashtree and
+// miss the disabled-window divergence — re-enable must always rebuild from a
+// full scan. mayStopAsyncReplication (shutdown/drop/backup) is the only
+// safe producer of a .ht because the shard serves no further writes.
+//
+// Unlike mayStopAsyncReplication, this function does NOT call
+// asyncRepWg.Wait(); use mayStopAsyncReplication (or Deregister + explicit
+// Wait) when a happens-before with in-flight cycles is required.
 func (s *Shard) disableAsyncReplication(_ context.Context) error {
-	var afterRelease func()
-	var needDeregister bool
-
-	err := func() error {
+	stopped := func() bool {
 		s.asyncReplicationRWMux.Lock()
 		defer s.asyncReplicationRWMux.Unlock()
-
 		if s.hashtree == nil {
-			return nil // already stopped, idempotent
+			return false // already stopped, idempotent
 		}
-
 		s.asyncReplicationCancelFunc()
-
-		// Capture before clearing so afterRelease can persist the hashtree
-		// outside the write lock (same pattern as mayStopAsyncReplication).
-		var capturedHT hashtree.AggregatedHashTree
-		if s.hashtreeFullyInitialized {
-			capturedHT = s.hashtree
-		}
-
 		s.hashtree = nil
 		s.hashtreeFullyInitialized = false
 		s.clearAsyncCheckpointLocked()
-
-		needDeregister = true
-
-		if capturedHT != nil {
-			afterRelease = func() {
-				s.dumpHashTreeWithTimeout(capturedHT)
-			}
-		}
-
-		return nil
+		return true
 	}()
-	if err != nil {
-		return err
+	if !stopped {
+		return nil
 	}
-	if needDeregister {
-		// Remove from the scheduler. The context has already been cancelled so
-		// any in-flight cycle will exit promptly; we do not wait for it here.
-		// Deregister may return context.Canceled if the scheduler is shutting
-		// down concurrently; that is safe to ignore because the rebuild path
-		// does not require a strict happens-before with the scheduler's shutdown.
-		if s.index.asyncReplicationScheduler != nil {
-			if err := s.index.asyncReplicationScheduler.Deregister(s); err != nil {
-				s.index.logger.WithField("action", "async_replication").Error(err)
-			}
+
+	// Remove from the scheduler. The context has already been cancelled so any
+	// in-flight cycle will exit promptly; we do not wait for it here.
+	// Deregister may return context.Canceled if the scheduler is shutting down
+	// concurrently; that is safe to ignore because the rebuild path does not
+	// require a strict happens-before with the scheduler's shutdown.
+	if s.index.asyncReplicationScheduler != nil {
+		if err := s.index.asyncReplicationScheduler.Deregister(s); err != nil {
+			s.index.logger.WithField("action", "async_replication").Error(err)
 		}
-		// Clear stats outside asyncReplicationRWMux to avoid nesting
-		// asyncReplicationStatsMux inside a write lock.
-		s.asyncReplicationStatsMux.Lock()
-		s.asyncReplicationStatsByTargetNode = nil
-		s.asyncReplicationStatsMux.Unlock()
 	}
-	if afterRelease != nil {
-		afterRelease()
-	}
+	// Clear stats outside asyncReplicationRWMux to avoid nesting
+	// asyncReplicationStatsMux inside a write lock.
+	s.asyncReplicationStatsMux.Lock()
+	s.asyncReplicationStatsByTargetNode = nil
+	s.asyncReplicationStatsMux.Unlock()
 	return nil
 }
 
@@ -1024,9 +1039,13 @@ func (s *Shard) addTargetNodeOverride(ctx context.Context, targetNodeOverride ad
 		}
 		s.targetNodeOverrides = append(s.targetNodeOverrides, targetNodeOverride)
 	}()
-	// we call update async replication config here to ensure that async replication starts
-	// if it's not already running
-	return s.enableAsyncReplication(ctx, s.index.AsyncReplicationConfig())
+	// Ensure async replication is started. Hold replicationConfigLock across the
+	// apply so a concurrent updateReplicationConfig can't interleave (see
+	// RevertAsyncReplicationOnShard); read the config field directly, as the
+	// AsyncReplicationConfig() getter would reacquire the lock.
+	s.index.replicationConfigLock.RLock()
+	defer s.index.replicationConfigLock.RUnlock()
+	return s.enableAsyncReplication(ctx, s.index.Config.AsyncReplicationConfig)
 }
 
 func (s *Shard) removeTargetNodeOverride(ctx context.Context, targetNodeOverrideToRemove additional.AsyncReplicationTargetNodeOverride) error {
@@ -1064,23 +1083,13 @@ func (s *Shard) removeTargetNodeOverride(ctx context.Context, targetNodeOverride
 	// if there are no overrides left, return the async replication config to what it
 	// was before overrides were added
 	if targetNodeOverrideLen == 0 {
-		// Snapshot enabled + config atomically under a single replicationConfigLock
-		// RLock to close the TOCTOU window: a concurrent updateReplicationConfig
-		// (WLock) could disable async replication between the AsyncReplicationEnabled
-		// check and the AsyncReplicationConfig read, causing us to re-enable a shard
-		// that should be off. asyncReplicationEnabled and Config are lock-free reads;
-		// we release before calling enable/disable, which need asyncReplicationRWMux.
-		//
-		// Known limitation: a TOCTOU window remains between the RUnlock and the
-		// enable/disable call — a concurrent updateReplicationConfig could flip the
-		// state in that gap. The inconsistency is transient; the next
-		// updateReplicationConfig call will correct it.
+		// Restore the shard to the index's configured async-replication state,
+		// holding replicationConfigLock across the apply so a concurrent
+		// updateReplicationConfig can't interleave (see RevertAsyncReplicationOnShard).
 		s.index.replicationConfigLock.RLock()
-		enabled := s.index.asyncReplicationEnabled()
-		cfg := s.index.Config.AsyncReplicationConfig
-		s.index.replicationConfigLock.RUnlock()
-		if enabled {
-			return s.enableAsyncReplication(ctx, cfg)
+		defer s.index.replicationConfigLock.RUnlock()
+		if s.index.asyncReplicationEnabled() {
+			return s.enableAsyncReplication(ctx, s.index.Config.AsyncReplicationConfig)
 		}
 		return s.disableAsyncReplication(ctx)
 	}
@@ -1094,15 +1103,12 @@ func (s *Shard) removeAllTargetNodeOverrides(ctx context.Context) error {
 		defer s.asyncReplicationRWMux.Unlock()
 		s.targetNodeOverrides = make(additional.AsyncReplicationTargetNodeOverrides, 0)
 	}()
-	// Same atomic snapshot as removeTargetNodeOverride: hold replicationConfigLock
-	// RLock across both reads to prevent updateReplicationConfig from toggling the
-	// state between the enabled check and the config read.
+	// Restore the shard to the index's configured async-replication state; see
+	// removeTargetNodeOverride for the locking rationale.
 	s.index.replicationConfigLock.RLock()
-	enabled := s.index.asyncReplicationEnabled()
-	cfg := s.index.Config.AsyncReplicationConfig
-	s.index.replicationConfigLock.RUnlock()
-	if enabled {
-		return s.enableAsyncReplication(ctx, cfg)
+	defer s.index.replicationConfigLock.RUnlock()
+	if s.index.asyncReplicationEnabled() {
+		return s.enableAsyncReplication(ctx, s.index.Config.AsyncReplicationConfig)
 	}
 	return s.disableAsyncReplication(ctx)
 }

--- a/adapters/repos/db/shard_async_replication_test.go
+++ b/adapters/repos/db/shard_async_replication_test.go
@@ -35,6 +35,7 @@ import (
 	entreplication "github.com/weaviate/weaviate/entities/replication"
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/cluster"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
 	"github.com/weaviate/weaviate/usecases/replica"
@@ -475,6 +476,129 @@ func TestAsyncReplicationEnableDisableCycle(t *testing.T) {
 	require.NoError(t, s.disableAsyncReplication(context.Background()))
 }
 
+// TestReconcileAsyncReplicationOnFlagToggle verifies that
+// Index.reconcileAsyncReplication starts async replication on a shard that
+// skipped initialisation because the global AsyncReplicationDisabled flag was
+// set at load time, and stops it again when the flag is re-disabled.
+func TestReconcileAsyncReplicationOnFlagToggle(t *testing.T) {
+	ctx := context.Background()
+	const class = "ReconcileAsyncReplicationTest"
+
+	logger, _ := test.NewNullLogger()
+
+	// Index-level flag the test toggles.
+	disabled := configRuntime.NewDynamicValue(true)
+	globalConfig := &entreplication.GlobalConfig{AsyncReplicationDisabled: disabled}
+
+	sl, idx := testShard(t, ctx, class, func(i *Index) {
+		i.Config.ReplicationFactor = 3
+		i.globalreplicationConfig = globalConfig
+
+		// A scheduler whose own disabled flag is permanently set: it accepts
+		// Register/Deregister but never dispatches a hashbeat cycle. This keeps
+		// the test focused on reconcile's effect on shard state (hashtree +
+		// registration) without needing to mock the per-cycle router calls.
+		sched, err := NewAsyncReplicationScheduler(ctx,
+			entreplication.GlobalConfig{
+				AsyncReplicationSchedulerWorkers: configRuntime.NewDynamicValue(1),
+				AsyncReplicationDisabled:         configRuntime.NewDynamicValue(true),
+			}, nil, logger)
+		require.NoError(t, err)
+		t.Cleanup(sched.Close)
+		i.asyncReplicationScheduler = sched
+	})
+	s := concreteShard(t, sl)
+
+	// The shard loaded while async replication was globally disabled, so
+	// shard_init_lsm skipped init: no hashtree, not registered with the scheduler.
+	s.asyncReplicationRWMux.RLock()
+	require.Nil(t, s.hashtree, "async replication must be off when loaded while globally disabled")
+	s.asyncReplicationRWMux.RUnlock()
+
+	// Re-enable the flag at runtime and reconcile: the already-loaded shard must
+	// now start async replication.
+	disabled.SetValue(false)
+	require.NoError(t, idx.reconcileAsyncReplication(ctx))
+	s.asyncReplicationRWMux.RLock()
+	require.NotNil(t, s.hashtree, "reconcile must start async replication after the flag is re-enabled")
+	s.asyncReplicationRWMux.RUnlock()
+	awaitHashtreeInitialized(t, s)
+
+	// Reconcile again with the flag still enabled: idempotent no-op.
+	require.NoError(t, idx.reconcileAsyncReplication(ctx))
+	s.asyncReplicationRWMux.RLock()
+	require.NotNil(t, s.hashtree, "reconcile must be idempotent while the flag stays enabled")
+	s.asyncReplicationRWMux.RUnlock()
+
+	// Disable the flag again and reconcile: async replication must stop.
+	disabled.SetValue(true)
+	require.NoError(t, idx.reconcileAsyncReplication(ctx))
+	s.asyncReplicationRWMux.RLock()
+	require.Nil(t, s.hashtree, "reconcile must stop async replication after the flag is disabled")
+	s.asyncReplicationRWMux.RUnlock()
+}
+
+// asyncSchedulerOption returns a testShard index option installing a started
+// scheduler whose own disabled flag is permanently set — it accepts
+// Register/Deregister but never dispatches a hashbeat cycle.
+func asyncSchedulerOption(t *testing.T, ctx context.Context) func(*Index) {
+	t.Helper()
+	return func(i *Index) {
+		logger, _ := test.NewNullLogger()
+		sched, err := NewAsyncReplicationScheduler(ctx,
+			entreplication.GlobalConfig{
+				AsyncReplicationSchedulerWorkers: configRuntime.NewDynamicValue(1),
+				AsyncReplicationDisabled:         configRuntime.NewDynamicValue(true),
+			}, nil, logger)
+		require.NoError(t, err)
+		t.Cleanup(sched.Close)
+		i.asyncReplicationScheduler = sched
+	}
+}
+
+// TestDBReconcileAsyncReplicationAggregatesErrors verifies that
+// DB.ReconcileAsyncReplication walks every index, and that a reconcile failure
+// on one index (here: a misconfigured index with no scheduler) is aggregated
+// into the returned error without preventing the other index from reconciling.
+func TestDBReconcileAsyncReplicationAggregatesErrors(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+
+	// Index-level flag shared by both indices; both load with it disabled.
+	disabled := configRuntime.NewDynamicValue(true)
+	globalConfig := &entreplication.GlobalConfig{AsyncReplicationDisabled: disabled}
+
+	// Healthy index: RF > 1 with a scheduler installed → reconcile succeeds.
+	healthySL, healthy := testShard(t, ctx, "ReconcileHealthy", func(i *Index) {
+		i.Config.ReplicationFactor = 3
+		i.globalreplicationConfig = globalConfig
+		asyncSchedulerOption(t, ctx)(i)
+	})
+	// Broken index: RF > 1 but no scheduler → enableAsyncReplication errors.
+	_, broken := testShard(t, ctx, "ReconcileBroken", func(i *Index) {
+		i.Config.ReplicationFactor = 3
+		i.globalreplicationConfig = globalConfig
+	})
+
+	db := &DB{
+		logger:  logger,
+		indices: map[string]*Index{healthy.ID(): healthy, broken.ID(): broken},
+	}
+
+	disabled.SetValue(false)
+	err := db.ReconcileAsyncReplication(ctx)
+	require.Error(t, err, "a per-index reconcile failure must surface as an error")
+	require.Contains(t, err.Error(), "1 of 2",
+		"the error must report how many indices failed")
+
+	// The broken index must not have blocked the healthy one.
+	healthyShard := concreteShard(t, healthySL)
+	healthyShard.asyncReplicationRWMux.RLock()
+	require.NotNil(t, healthyShard.hashtree,
+		"the healthy index must still be reconciled despite the other index failing")
+	healthyShard.asyncReplicationRWMux.RUnlock()
+}
+
 // TestInitScanPopulatesHashtree validates that objects on disk when async
 // replication is enabled are correctly registered in the hashtree by the init
 // scan (ApplyToOnDiskObjectDigests), producing a non-zero root digest.
@@ -752,10 +876,11 @@ func TestEnableAsyncReplication_LoadsHashtreeFromDisk(t *testing.T) {
 
 	htPath := s.pathHashTree()
 
-	// Disable: mayStopAsyncReplication serialises the hashtree to a .ht file.
-	require.NoError(t, s.disableAsyncReplication(ctx))
+	// mayStopAsyncReplication is the legitimate .ht producer (shutdown path);
+	// disableAsyncReplication is the runtime path and does not dump.
+	s.mayStopAsyncReplication()
 	require.Len(t, htFilesInDir(t, htPath), 1,
-		"pre-condition: disableAsyncReplication must have written a .ht file")
+		"pre-condition: mayStopAsyncReplication must have written a .ht file")
 
 	// Re-enable: tryLoadHashtreeFromDisk should load the .ht file.
 	require.NoError(t, s.enableAsyncReplication(ctx, cfg))
@@ -780,6 +905,111 @@ func TestEnableAsyncReplication_LoadsHashtreeFromDisk(t *testing.T) {
 		".ht file must be consumed by enableAsyncReplication on successful load")
 
 	require.NoError(t, s.disableAsyncReplication(ctx))
+}
+
+// TestEnableAsyncReplicationRescansAfterRuntimeDisable pins the silent
+// replica-inconsistency bug from PR #11214: disableAsyncReplication is the
+// runtime path (shard stays live and serves writes), so any hashtree it
+// persists goes stale immediately. Before the fix it dumped a .ht and
+// enableAsyncReplication loaded that snapshot verbatim — CollectShardDifferences
+// then returned ErrNoDiffFound forever and async repair silently abandoned
+// the disabled-window divergence. (mayStopAsyncReplication remains the only
+// safe .ht producer; covered by TestMayStopAsyncReplicationDumpsHashtreeOnSuccess.)
+//
+// Falsifiable assertion: after enable → disable → write → re-enable, the
+// hashtree root must differ from its pre-disable value. With the bug the
+// cached .ht restores the pre-write root and the assertion fires; with the
+// fix re-enable rebuilds from a full scan and the new object shifts the root.
+func TestEnableAsyncReplicationRescansAfterRuntimeDisable(t *testing.T) {
+	ctx := context.Background()
+	const class = "AsyncRescanAfterRuntimeDisable"
+
+	sl, _ := testShard(t, ctx, class, withAsyncScheduler(t))
+	s := concreteShard(t, sl)
+	t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+
+	cfg := minAsyncReplicationConfig()
+
+	// Seed: three flushed objects so the first init has non-trivial state.
+	for _, id := range []strfmt.UUID{uuidLow, uuidMid, uuidHigh} {
+		require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, id, tsFarPast)))
+	}
+	require.NoError(t, s.store.FlushMemtables(ctx))
+
+	require.NoError(t, s.enableAsyncReplication(ctx, cfg))
+	awaitHashtreeInitialized(t, s)
+
+	s.asyncReplicationRWMux.RLock()
+	rootBeforeDisable := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+	require.NotEqual(t, hashtree.Digest{}, rootBeforeDisable,
+		"sanity: seeded hashtree must have a non-zero root")
+
+	// Runtime kill-switch flipped to disabled. Shard stays live.
+	require.NoError(t, s.disableAsyncReplication(ctx))
+
+	// disableAsyncReplication must not leave a .ht behind — the shard will
+	// serve writes from here on, so any snapshot is stale.
+	require.Empty(t, htFilesInDir(t, s.pathHashTree()),
+		"runtime disableAsyncReplication must not persist the hashtree; only "+
+			"mayStopAsyncReplication (shutdown) may write a .ht")
+
+	// Write a fourth object while async replication is disabled. With the
+	// bug, this write is invisible to any future hashtree comparison.
+	const uuidWhileDisabled = strfmt.UUID("44444444-4444-4444-4444-444444444444")
+	require.NoError(t, sl.PutObject(ctx, testObjWithTime(class, uuidWhileDisabled, tsFarPast)))
+	require.NoError(t, s.store.FlushMemtables(ctx))
+
+	// Flip the kill-switch back to false. The shard must rebuild the hashtree
+	// from the current object store (a full scan) — not trust a leftover .ht.
+	require.NoError(t, s.enableAsyncReplication(ctx, cfg))
+	awaitHashtreeInitialized(t, s)
+
+	s.asyncReplicationRWMux.RLock()
+	rootAfterReEnable := s.hashtree.Root()
+	s.asyncReplicationRWMux.RUnlock()
+
+	require.NotEqual(t, rootBeforeDisable, rootAfterReEnable,
+		"hashtree must reflect the disabled-window write; if it does not, a "+
+			"stale snapshot was trusted and divergence is invisible to repair")
+
+	require.NoError(t, s.disableAsyncReplication(ctx))
+}
+
+// TestShardLoadDiscardsStaleHashtreeWhenAsyncDisabled pins the second arm of
+// the stale-cache bug: a node booted with ASYNC_REPLICATION_DISABLED=true
+// after a previous async-enabled shutdown must not let the leftover .ht
+// survive into a later runtime re-enable — the shard will serve writes while
+// async is off, invalidating the snapshot. shard_init_lsm.go discards the
+// .ht in this branch; this test exercises the helper it relies on.
+func TestShardLoadDiscardsStaleHashtreeWhenAsyncDisabled(t *testing.T) {
+	ctx := context.Background()
+	const class = "DiscardStaleHashtreeOnDisabledLoad"
+
+	sl, _ := testShard(t, ctx, class, withAsyncScheduler(t))
+	s := concreteShard(t, sl)
+	t.Cleanup(func() { _ = sl.Shutdown(ctx) })
+
+	cfg := minAsyncReplicationConfig()
+
+	// Produce a legitimate .ht the way a graceful shutdown would: enable async,
+	// let the init scan complete, then mayStopAsyncReplication serialises the
+	// in-memory tree to disk.
+	require.NoError(t, s.enableAsyncReplication(ctx, cfg))
+	awaitHashtreeInitialized(t, s)
+	s.mayStopAsyncReplication()
+	require.Len(t, htFilesInDir(t, s.pathHashTree()), 1,
+		"pre-condition: mayStopAsyncReplication must have produced a .ht")
+
+	// Simulate the shard-init path running with async replication disabled,
+	// i.e. the else-branch of shard_init_lsm.go. The .ht must be discarded
+	// so a later runtime enable cannot load a stale snapshot.
+	require.NoError(t, s.removePersistedHashtree())
+
+	require.Empty(t, htFilesInDir(t, s.pathHashTree()),
+		"shard-load with async replication disabled must discard the "+
+			"persisted .ht; otherwise a later runtime enable would load a "+
+			"snapshot that the shard's disabled-window writes have invalidated")
 }
 
 // TestEnableAsyncReplication_ConcurrentCallsAreSafe verifies that multiple
@@ -853,14 +1083,16 @@ func TestEnableAsyncReplication_DiskIONotBlockedByRLock(t *testing.T) {
 
 	cfg := minAsyncReplicationConfig()
 
-	// Enable and wait for a full init so that disable will produce a .ht file.
+	// Enable and wait for a full init so that mayStopAsyncReplication will
+	// produce a .ht file we can later load.
 	require.NoError(t, s.enableAsyncReplication(ctx, cfg))
 	awaitHashtreeInitialized(t, s)
 
 	htPath := s.pathHashTree()
 
-	// Disable: persists the hashtree to disk.
-	require.NoError(t, s.disableAsyncReplication(ctx))
+	// mayStopAsyncReplication is the legitimate .ht producer; disable is the
+	// runtime path and does not dump.
+	s.mayStopAsyncReplication()
 	require.Len(t, htFilesInDir(t, htPath), 1,
 		"pre-condition: one .ht file must exist before the RLock test")
 
@@ -966,12 +1198,14 @@ func TestDisableRacingInitLeavesNoRegistration(t *testing.T) {
 
 	cfg := minAsyncReplicationConfig()
 
-	// Bootstrap: enable → full init scan → disable. disableAsyncReplication
-	// persists the initialised tree to a .ht file. Every subsequent enable will
-	// hit the cached-tree path (goroutine = lock-check + Register + TOCTOU guard).
+	// Bootstrap: enable → full init scan → mayStop persists a .ht. The first
+	// loop iteration's enable hits the cached-tree path (short goroutine =
+	// lock-check + Register + TOCTOU guard); iterations 2..N go through
+	// disableAsyncReplication, which does not dump, so they exercise the same
+	// TOCTOU race against the longer full-scan path. Both are worth covering.
 	require.NoError(t, s.enableAsyncReplication(ctx, cfg))
 	awaitHashtreeInitialized(t, s)
-	require.NoError(t, s.disableAsyncReplication(ctx))
+	s.mayStopAsyncReplication()
 	s.asyncRepWg.Wait()
 
 	// awaitWg blocks until asyncRepWg reaches zero or the deadline fires. It
@@ -1099,16 +1333,16 @@ func TestLoadHashtreeIgnoresTmpFile(t *testing.T) {
 
 	cfg := minAsyncReplicationConfig()
 
-	// Enable and wait for a full init so that disableAsyncReplication produces a
-	// well-formed .ht file we can rename in the next step.
+	// Enable, await full init, then mayStop persists a well-formed .ht we
+	// can rename in the next step. (disableAsyncReplication does not dump.)
 	require.NoError(t, s.enableAsyncReplication(ctx, cfg))
 	awaitHashtreeInitialized(t, s)
-	require.NoError(t, s.disableAsyncReplication(ctx))
+	s.mayStopAsyncReplication()
 
 	htPath := s.pathHashTree()
 
 	htFiles := htFilesInDir(t, htPath)
-	require.Len(t, htFiles, 1, "pre-condition: exactly one .ht file must exist after disable")
+	require.Len(t, htFiles, 1, "pre-condition: exactly one .ht file must exist after mayStop")
 
 	// Simulate a crash mid-rename: rename the committed .ht file to .ht.tmp so
 	// the directory contains a well-formed hashtree payload but with the wrong

--- a/adapters/repos/db/shard_init_lsm.go
+++ b/adapters/repos/db/shard_init_lsm.go
@@ -118,8 +118,17 @@ func (s *Shard) initNonVector(ctx context.Context, class *models.Class) error {
 		if err != nil {
 			return fmt.Errorf("init async replication on shard %q: %w", s.ID(), err)
 		}
-	} else if s.index.replicationEnabled() {
-		s.index.logger.Debugf("async replication disabled on shard %q", s.ID())
+	} else {
+		// Discard any .ht left by a previous async-enabled shutdown: the shard
+		// will serve writes with async off, which would invalidate the
+		// snapshot, and a later runtime enable would otherwise load it stale.
+		// See disableAsyncReplication for the symmetric rationale.
+		if err := s.removePersistedHashtree(); err != nil {
+			return fmt.Errorf("discard stale hashtree on shard %q: %w", s.ID(), err)
+		}
+		if s.index.replicationEnabled() {
+			s.index.logger.Debugf("async replication disabled on shard %q", s.ID())
+		}
 	}
 
 	// check if we need to set Inverted Index config to use BlockMax inverted format for new properties

--- a/entities/deepcopy/models_deepcopy.go
+++ b/entities/deepcopy/models_deepcopy.go
@@ -46,7 +46,6 @@ func Class(c *models.Class) *models.Class {
 		replicationConf = &models.ReplicationConfig{
 			Factor:           c.ReplicationConfig.Factor,
 			DeletionStrategy: c.ReplicationConfig.DeletionStrategy,
-			AsyncEnabled:     c.ReplicationConfig.AsyncEnabled,
 			AsyncConfig:      asyncConfig,
 		}
 	}

--- a/entities/models/replication_config.go
+++ b/entities/models/replication_config.go
@@ -34,9 +34,6 @@ type ReplicationConfig struct {
 	// Configuration parameters for asynchronous replication.
 	AsyncConfig *ReplicationAsyncConfig `json:"asyncConfig,omitempty"`
 
-	// Enable asynchronous replication (default: `false`).
-	AsyncEnabled bool `json:"asyncEnabled"`
-
 	// Conflict resolution strategy for deleted objects.
 	// Enum: [NoAutomatedResolution DeleteOnConflict TimeBasedResolution]
 	DeletionStrategy string `json:"deletionStrategy,omitempty"`

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -1142,11 +1142,6 @@
           "description": "Number of times a collection (class) is replicated (default: 1).",
           "type": "integer"
         },
-        "asyncEnabled": {
-          "description": "Enable asynchronous replication (default: `false`).",
-          "type": "boolean",
-          "x-omitempty": false
-        },
         "asyncConfig": {
           "description": "Configuration parameters for asynchronous replication.",
           "$ref": "#/definitions/ReplicationAsyncConfig",

--- a/test/acceptance/grpc/batching_test.go
+++ b/test/acceptance/grpc/batching_test.go
@@ -452,13 +452,11 @@ func TestGRPC_ClusterBatching(t *testing.T) {
 
 	clsA := articles.ArticlesClass()
 	clsA.ReplicationConfig = &models.ReplicationConfig{
-		Factor:       3,
-		AsyncEnabled: true,
+		Factor: 3,
 	}
 	clsP := articles.ParagraphsClass()
 	clsP.ReplicationConfig = &models.ReplicationConfig{
-		Factor:       3,
-		AsyncEnabled: true,
+		Factor: 3,
 	}
 
 	setupClasses := func() func() {

--- a/test/acceptance/recovery/scale_down_after_remove_node_test.go
+++ b/test/acceptance/recovery/scale_down_after_remove_node_test.go
@@ -60,8 +60,7 @@ func TestScaleDownAfterRemoveNode(t *testing.T) {
 	paragraphClass := articles.ParagraphsClass()
 	paragraphClass.ShardingConfig = map[string]interface{}{"desiredCount": 3}
 	paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-		Factor:       2,
-		AsyncEnabled: false,
+		Factor: 2,
 	}
 	paragraphClass.Vectorizer = "text2vec-contextionary"
 

--- a/test/acceptance/replication/async_replication/async_checkpoint_convergence_test.go
+++ b/test/acceptance/replication/async_replication/async_checkpoint_convergence_test.go
@@ -189,8 +189,7 @@ func (suite *AsyncCheckpointConvergenceTestSuite) TestAsyncCheckpoint_Convergenc
 
 	t.Run("create schema with async replication enabled", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       3,
-			AsyncEnabled: true,
+			Factor: 3,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
@@ -360,7 +359,7 @@ func (suite *AsyncCheckpointConvergenceTestSuite) TestAsyncCheckpoint_RestartDro
 
 	helper.SetupClient(node1REST)
 	paragraphClass := articles.ParagraphsClass()
-	paragraphClass.ReplicationConfig = &models.ReplicationConfig{Factor: 3, AsyncEnabled: true}
+	paragraphClass.ReplicationConfig = &models.ReplicationConfig{Factor: 3}
 	paragraphClass.Vectorizer = "text2vec-contextionary"
 	helper.CreateClass(t, paragraphClass)
 

--- a/test/acceptance/replication/async_replication/async_repair_deletes_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_deletes_test.go
@@ -55,7 +55,6 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectDeleteScenario() {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
 			Factor:           int64(clusterSize),
 			DeletionStrategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
-			AsyncEnabled:     true,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 

--- a/test/acceptance/replication/async_replication/async_repair_insertions_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_insertions_test.go
@@ -53,8 +53,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectInsertionScenario()
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       int64(clusterSize),
-			AsyncEnabled: true,
+			Factor: int64(clusterSize),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 

--- a/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go
@@ -14,11 +14,13 @@ package replication
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
 	"github.com/weaviate/weaviate/client/nodes"
 	"github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/cluster/router/types"
@@ -30,25 +32,19 @@ import (
 	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
 )
 
-// In this scenario, we are testing two things:
-//
-//  1. The invocation of shard.UpdateAsyncReplication on an index with inactive tenants,
-//     using ForEachLoadedShard to avoid force loading shards for the purpose of enabling
-//     async replication, ensuring that if it is enabled when some tenants are inactive,
-//     that the change is correctly applied to the tenants if they are later activated
-//
-//  2. That once (1) occurs, the hashBeat process is correctly initiated at the time that
-//     the tenant is activated, and any missing objects are successfully propagated to the
-//     nodes which are missing them.
+// This scenario verifies that async replication — which is on by default for
+// any class with replication factor > 1 — repairs a multi-tenant tenant's
+// shard on a node that missed writes, and that the hashBeat process starts
+// correctly when an inactive tenant is later activated (without force-loading
+// shards: it is applied via ForEachLoadedShard once the tenant is active).
 //
 // The actual scenario is as follows:
 //   - Create a class with multi-tenancy enabled, replicated by a factor of 3
 //   - Create a tenant, and set it to inactive
 //   - Stop the second node
-//   - Activate the tenant, and insert 1000 objects into the 2 surviving nodes
+//   - Activate the tenant, and insert objects into the 2 surviving nodes
 //   - Restart the second node and ensure it has an object count of 0
-//   - Update the class to enabled async replication
-//   - Wait a few seconds for objects to propagate
+//   - Wait for objects to propagate via async replication
 //   - Verify that the resurrected node contains all objects
 func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 	t := suite.T()
@@ -78,8 +74,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       int64(clusterSize),
-			AsyncEnabled: true,
+			Factor: int64(clusterSize),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
@@ -141,22 +136,30 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyScenario() {
 	})
 }
 
-// In this scenario, we are testing that a tenant in COLD state fetches the latest
-// async replication config when it is loaded (activated). The scenario is:
+// TestAsyncRepairMultiTenancyColdTenantConfigUpdate verifies that a tenant
+// created COLD picks up an async replication config update made while it was
+// COLD, once activated.
 //
-//   - Create a class with multi-tenancy enabled, replicated by a factor of 3,
-//     with async replication DISABLED
-//   - Create a tenant in COLD state
-//   - Enable async replication on the class (while tenant is still in COLD state)
-//   - Stop one node
-//   - Insert data into the surviving nodes (this will activate the tenant)
-//   - Restart the stopped node
-//   - Verify that the restarted node eventually receives all the data,
-//     demonstrating that the tenant fetched the latest async replication config
-//     when it was loaded/activated
+// Async repair is push-only — a behind node is repaired by its peers. Phase 1
+// throttles async replication (far-future frequency + a propagation delay
+// larger than the observation window) while the tenant is COLD, so once the
+// peers fetch that config no hashbeat cycle can repair the restarted node
+// within the window; stale defaults would, failing the test. Phase 2 restores
+// a normal config and restarts the peers, so the node catches up — proving
+// repair still works and config is re-fetched on shard load.
 func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantConfigUpdate() {
 	t := suite.T()
 	mainCtx := context.Background()
+
+	const (
+		// throttled frequency set while the tenant is COLD; far above the
+		// observation window so peers that fetched it cannot repair in time.
+		asyncRepairThrottledFrequency = 1 * time.Hour
+		// normal frequency restored before phase 2.
+		asyncRepairRestoredFrequency = 5 * time.Second
+		// window to watch the restarted node; exceeds the 30s/5s defaults.
+		asyncRepairObservationWindow = 90 * time.Second
+	)
 
 	var (
 		clusterSize = 3
@@ -180,10 +183,31 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 
 	paragraphClass := articles.ParagraphsClass()
 
-	t.Run("create schema with async replication disabled", func(t *testing.T) {
+	// setAsyncFrequency throttles (or restores) the class's async replication,
+	// setting Frequency, FrequencyWhilePropagating and PropagationDelay to freq.
+	// The delay is what makes "no repair within the window" hold regardless of
+	// cycle timing: even the immediate first cycle can't propagate objects
+	// younger than it.
+	setAsyncFrequency := func(t *testing.T, freq time.Duration) {
+		t.Helper()
+		getParams := schema.NewSchemaObjectsGetParams().WithClassName(paragraphClass.Class)
+		res, err := helper.Client(t).Schema.SchemaObjectsGet(getParams, nil)
+		require.NoError(t, err)
+		require.NotNil(t, res.Payload)
+		require.NotNil(t, res.Payload.ReplicationConfig)
+
+		freqMs := int64(freq / time.Millisecond)
+		res.Payload.ReplicationConfig.AsyncConfig = &models.ReplicationAsyncConfig{
+			Frequency:                 &freqMs,
+			FrequencyWhilePropagating: &freqMs,
+			PropagationDelay:          &freqMs,
+		}
+		helper.UpdateClass(t, res.Payload)
+	}
+
+	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       int64(clusterSize),
-			AsyncEnabled: false,
+			Factor: int64(clusterSize),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
@@ -200,19 +224,12 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 		helper.CreateTenants(t, paragraphClass.Class, tenants)
 	})
 
-	t.Run("enable async replication on class", func(t *testing.T) {
-		// Get the current class
-		getParams := schema.NewSchemaObjectsGetParams().WithClassName(paragraphClass.Class)
-		res, err := helper.Client(t).Schema.SchemaObjectsGet(getParams, nil)
-		require.NoError(t, err)
-		require.NotNil(t, res.Payload)
-
-		// Update to enable async replication
-		class := res.Payload
-		class.ReplicationConfig.AsyncEnabled = true
-
-		// Update the class
-		helper.UpdateClass(t, class)
+	t.Run("update async replication config on class", func(t *testing.T) {
+		// Throttle async replication (frequency + propagation delay) far above
+		// the observation window. The peers that will repair the restarted node
+		// fetch this config when the insert activates the tenant, making the
+		// config fetch observable.
+		setAsyncFrequency(t, asyncRepairThrottledFrequency)
 	})
 
 	t.Run("stop node 2", func(t *testing.T) {
@@ -251,10 +268,263 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyColdTenantCon
 		}, 15*time.Second, 500*time.Millisecond)
 	})
 
-	t.Run("validate async object propagation to restarted node", func(t *testing.T) {
+	t.Run("validate surviving nodes hold all objects", func(t *testing.T) {
+		// Control: confirm the data exists on the nodes that stayed up, so a
+		// missing object on the restarted node can only mean missed repair.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			resp := common.GQLTenantGet(t, compose.GetWeaviate().URI(), paragraphClass.Class, types.ConsistencyLevelOne, tenantName)
+			require.Len(ct, resp, objectCount)
+		}, 30*time.Second, 5*time.Second, "surviving nodes are missing objects")
+	})
+
+	t.Run("validate restarted node does not repair while throttled", func(t *testing.T) {
+		// The peers fetched the throttled config on activation; its propagation
+		// delay exceeds this window, so no cycle can repair node 2 regardless of
+		// timing. Stale defaults would repair within the window, failing this.
+		require.Never(t, func() bool {
+			resp := common.GQLTenantGet(t, compose.GetWeaviateNode(2).URI(), paragraphClass.Class, types.ConsistencyLevelOne, tenantName)
+			return len(resp) == objectCount
+		}, asyncRepairObservationWindow, 5*time.Second,
+			"restarted node received all objects despite async replication being throttled — the peers did not pick up the COLD-time config update")
+	})
+
+	t.Run("restore async replication frequency", func(t *testing.T) {
+		setAsyncFrequency(t, asyncRepairRestoredFrequency)
+	})
+
+	t.Run("restart the peer nodes", func(t *testing.T) {
+		// An in-place config update does not reschedule already-running shards,
+		// so restart the peers (nodes 1 and 3, which repair node 2 by pushing):
+		// their shards reload and run an immediate cycle under the restored
+		// config. Node 3 first, so the helper client (node 1) is only briefly down.
+		common.StopNodeAt(ctx, t, compose, 3)
+		common.StartNodeAt(ctx, t, compose, 3)
+		common.StopNodeAt(ctx, t, compose, 1)
+		common.StartNodeAt(ctx, t, compose, 1)
+	})
+
+	t.Run("verify that all nodes are running after peer restart", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			params := nodes.NewNodesGetClassParams().WithOutput(&verbose)
+			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+			require.NoError(ct, clientErr)
+			require.NotNil(ct, body.Payload)
+
+			resp := body.Payload
+			require.Len(ct, resp.Nodes, clusterSize)
+			for _, n := range resp.Nodes {
+				require.NotNil(ct, n.Status)
+				require.Equal(ct, "HEALTHY", *n.Status)
+			}
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("validate restarted node catches up after peer restart", func(t *testing.T) {
+		// Touch the peers so their lazily loaded tenant shards load and start
+		// async replication.
+		common.GQLTenantGet(t, compose.GetWeaviate().URI(), paragraphClass.Class, types.ConsistencyLevelOne, tenantName)
+		common.GQLTenantGet(t, compose.GetWeaviateNode(3).URI(), paragraphClass.Class, types.ConsistencyLevelOne, tenantName)
+
+		// The peers' immediate cycle pushes the missing objects to node 2 —
+		// proving repair still works (rules out async replication never starting).
 		require.EventuallyWithT(t, func(ct *assert.CollectT) {
 			resp := common.GQLTenantGet(t, compose.GetWeaviateNode(2).URI(), paragraphClass.Class, types.ConsistencyLevelOne, tenantName)
 			require.Len(ct, resp, objectCount)
-		}, 120*time.Second, 5*time.Second, "not all the objects have been asynchronously replicated to the restarted node")
+		}, 120*time.Second, 5*time.Second, "restarted node did not catch up after the peer nodes were restarted")
+	})
+}
+
+// TestAsyncRepairMultiTenancyRuntimeToggle exercises the
+// ASYNC_REPLICATION_DISABLED kill-switch on a multi-tenant class: HOT
+// tenants drain asyncReplicationStatus on disable, miss writes during the
+// disabled window, and are repaired by the reconcile hook on re-enable. A
+// COLD-then-activated tenant whose shards load while the flag is disabled
+// honors the live flag (no async on those shards) and only gets registered
+// once the flag flips back.
+//
+// This catches a regression class that the existing MT tests do not cover:
+// the toggle path through `runtime-overrides → AsyncReplicationDisabled hook
+// → DB.ReconcileAsyncReplication → per-tenant-shard apply` on a real
+// multi-tenant cluster.
+func (suite *AsyncReplicationTestSuite) TestAsyncRepairMultiTenancyRuntimeToggle() {
+	t := suite.T()
+	mainCtx := context.Background()
+
+	const (
+		overridePath  = "/etc/weaviate/runtime-overrides.yaml"
+		clusterSize   = 3
+		hotTenantA    = "hot-a"
+		hotTenantB    = "hot-b"
+		coldTenant    = "cold-c"
+		baselineCount = 5
+	)
+
+	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
+	defer cancel()
+
+	emptyOverride := testcontainers.ContainerFile{
+		Reader:            strings.NewReader(""),
+		ContainerFilePath: overridePath,
+		FileMode:          0o644,
+	}
+
+	// Boot with async replication ENABLED by default — no ASYNC_REPLICATION_DISABLED env.
+	compose, err := docker.New().
+		WithWeaviateCluster(clusterSize).
+		WithText2VecContextionary().
+		WithWeaviateEnv("RUNTIME_OVERRIDES_ENABLED", "true").
+		WithWeaviateEnv("RUNTIME_OVERRIDES_PATH", overridePath).
+		WithWeaviateEnv("RUNTIME_OVERRIDES_LOAD_INTERVAL", "1s").
+		WithWeaviateFiles(emptyOverride).
+		Start(ctx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	paragraphClass := articles.ParagraphsClass()
+
+	t.Run("create RF=3 multi-tenant class", func(t *testing.T) {
+		paragraphClass.ReplicationConfig = &models.ReplicationConfig{Factor: int64(clusterSize)}
+		paragraphClass.Vectorizer = "text2vec-contextionary"
+		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
+		helper.CreateClass(t, paragraphClass)
+	})
+
+	t.Run("add hot and cold tenants", func(t *testing.T) {
+		helper.CreateTenants(t, paragraphClass.Class, []*models.Tenant{
+			{Name: hotTenantA, ActivityStatus: "HOT"},
+			{Name: hotTenantB, ActivityStatus: "HOT"},
+			{Name: coldTenant, ActivityStatus: "COLD"},
+		})
+	})
+
+	t.Run("insert baseline objects into hot tenants", func(t *testing.T) {
+		for _, tn := range []string{hotTenantA, hotTenantB} {
+			batch := make([]*models.Object, baselineCount)
+			for i := 0; i < baselineCount; i++ {
+				batch[i] = articles.NewParagraph().
+					WithContents(fmt.Sprintf("%s-baseline-%d", tn, i)).
+					WithTenant(tn).
+					Object()
+			}
+			// CL=All so every replica is on disk before we start toggling.
+			common.CreateObjectsCL(t, compose.GetWeaviate().URI(), batch, types.ConsistencyLevelAll)
+		}
+	})
+
+	t.Run("async replication is registered on hot tenant shards", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			n, err := shardsAsyncReplicationLen(t, paragraphClass.Class)
+			require.NoError(ct, err)
+			require.Greater(ct, n, 0,
+				"asyncReplicationStatus must be populated on hot tenant shards at boot")
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("admin disables async replication via the runtime-overrides file", func(t *testing.T) {
+		writeAsyncReplicationOverride(ctx, t, compose, clusterSize, overridePath, true)
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			n, err := shardsAsyncReplicationLen(t, paragraphClass.Class)
+			require.NoError(ct, err)
+			require.Equal(ct, 0, n,
+				"asyncReplicationStatus must drain on all hot tenant shards when disabled")
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("stop node 3", func(t *testing.T) {
+		common.StopNodeAt(ctx, t, compose, 3)
+	})
+
+	t.Run("write probe into hot tenant B while node 3 is down", func(t *testing.T) {
+		probe := articles.NewParagraph().
+			WithContents("probe written into hot-b while async disabled + node 3 down").
+			WithTenant(hotTenantB).
+			Object()
+		common.CreateObjectsCL(t, compose.GetWeaviate().URI(),
+			[]*models.Object{probe}, types.ConsistencyLevelOne)
+	})
+
+	t.Run("activate the cold tenant and insert (live flag must keep async off on the new shards)", func(t *testing.T) {
+		helper.UpdateTenants(t, paragraphClass.Class, []*models.Tenant{
+			{Name: coldTenant, ActivityStatus: "HOT"},
+		})
+		batch := make([]*models.Object, baselineCount)
+		for i := 0; i < baselineCount; i++ {
+			batch[i] = articles.NewParagraph().
+				WithContents(fmt.Sprintf("%s-late-%d", coldTenant, i)).
+				WithTenant(coldTenant).
+				Object()
+		}
+		common.CreateObjectsCL(t, compose.GetWeaviate().URI(), batch, types.ConsistencyLevelOne)
+		// All loaded tenant shards (hot-a, hot-b, cold-c on surviving nodes)
+		// must observe asyncReplicationStatus=0: Migrator / tenant-activation
+		// read the live disabled flag during shard load.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			n, err := shardsAsyncReplicationLen(t, paragraphClass.Class)
+			require.NoError(ct, err)
+			require.Equal(ct, 0, n,
+				"newly-activated tenant shards must honor the live disabled flag")
+		}, 15*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("restart node 3", func(t *testing.T) {
+		common.StartNodeAt(ctx, t, compose, 3)
+	})
+
+	t.Run("verify all nodes are running", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			params := nodes.NewNodesGetClassParams().WithOutput(&verbose)
+			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+			require.NoError(ct, clientErr)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, clusterSize)
+			for _, n := range body.Payload.Nodes {
+				require.NotNil(ct, n.Status)
+				require.Equal(ct, "HEALTHY", *n.Status)
+			}
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("node 3 is behind on hot tenant B while async is disabled", func(t *testing.T) {
+		resp := common.GQLTenantGet(t, compose.GetWeaviateNode(3).URI(),
+			paragraphClass.Class, types.ConsistencyLevelOne, hotTenantB)
+		require.Less(t, len(resp), baselineCount+1,
+			"node 3 must be behind on hot-b (missing the disabled-window probe)")
+	})
+
+	t.Run("re-enable async replication via the runtime-overrides file", func(t *testing.T) {
+		writeAsyncReplicationOverride(ctx, t, compose, clusterSize, overridePath, false)
+	})
+
+	t.Run("hot tenant B is repaired on node 3 without a restart", func(t *testing.T) {
+		// runtime-overrides → AsyncReplicationDisabled hook →
+		// DB.ReconcileAsyncReplication → per-tenant-shard enable → fresh
+		// hashtree scan → CollectShardDifferences finds the missing probe →
+		// async repair propagates it to node 3.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			resp := common.GQLTenantGet(t, compose.GetWeaviateNode(3).URI(),
+				paragraphClass.Class, types.ConsistencyLevelOne, hotTenantB)
+			require.Len(ct, resp, baselineCount+1,
+				"node 3 must catch up to baseline+1 on hot-b once async is re-enabled")
+		}, 120*time.Second, 2*time.Second)
+	})
+
+	t.Run("reconcile registers async on tenant shards loaded under the disabled flag", func(t *testing.T) {
+		// hot-a, hot-b, and cold-c shards all came up while the flag was
+		// disabled at some point; the reconcile must register every loaded
+		// shard. We assert > 0 globally; the per-tenant repair above already
+		// proved hot-b is back.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			n, err := shardsAsyncReplicationLen(t, paragraphClass.Class)
+			require.NoError(ct, err)
+			require.Greater(ct, n, 0,
+				"reconcile hook must register async replication on tenant shards loaded while disabled")
+		}, 30*time.Second, 500*time.Millisecond)
 	})
 }

--- a/test/acceptance/replication/async_replication/async_repair_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_test.go
@@ -95,14 +95,12 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairSimpleScenario() {
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       3,
-			AsyncEnabled: true,
+			Factor: 3,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
 		articleClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       3,
-			AsyncEnabled: true,
+			Factor: 3,
 		}
 		helper.CreateClass(t, articleClass)
 	})

--- a/test/acceptance/replication/async_replication/async_repair_updates_test.go
+++ b/test/acceptance/replication/async_replication/async_repair_updates_test.go
@@ -54,8 +54,7 @@ func (suite *AsyncReplicationTestSuite) TestAsyncRepairObjectUpdateScenario() {
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       int64(clusterSize),
-			AsyncEnabled: true,
+			Factor: int64(clusterSize),
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 

--- a/test/acceptance/replication/async_replication/async_replication_runtime_toggle_test.go
+++ b/test/acceptance/replication/async_replication/async_replication_runtime_toggle_test.go
@@ -1,0 +1,449 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replication
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/test/acceptance/replication/common"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+// TestAsyncReplicationRuntimeToggle exercises the runtime kill-switch end to
+// end: a runtime-overrides file change flips AsyncReplicationDisabled, the
+// config manager fires the registered hook, and DB.ReconcileAsyncReplication
+// (un)registers already-loaded shards so async repair starts without a restart.
+//
+// The cluster boots with ASYNC_REPLICATION_DISABLED=true, so shards load with
+// async replication off (unregistered). Node 3 misses a write while down and,
+// once restarted, stays behind because nothing repairs it. Writing
+// `async_replication_disabled: false` into the runtime-overrides file then
+// drives the hook → reconcile → registration, and the missing object is
+// asynchronously repaired — proving the hook reconciles shards that were
+// already loaded while the flag was disabled.
+func TestAsyncReplicationRuntimeToggle(t *testing.T) {
+	t.Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
+
+	const overridePath = "/etc/weaviate/runtime-overrides.yaml"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	// Empty overrides file at boot; ASYNC_REPLICATION_DISABLED=true keeps async
+	// replication off on every node until the file flips it.
+	emptyOverride := testcontainers.ContainerFile{
+		Reader:            strings.NewReader(""),
+		ContainerFilePath: overridePath,
+		FileMode:          0o644,
+	}
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithText2VecContextionary().
+		WithWeaviateEnv("ASYNC_REPLICATION_DISABLED", "true").
+		WithWeaviateEnv("RUNTIME_OVERRIDES_ENABLED", "true").
+		WithWeaviateEnv("RUNTIME_OVERRIDES_PATH", overridePath).
+		WithWeaviateEnv("RUNTIME_OVERRIDES_LOAD_INTERVAL", "1s").
+		WithWeaviateFiles(emptyOverride).
+		Start(ctx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	paragraphClass := articles.ParagraphsClass()
+
+	t.Run("create RF=3 schema", func(t *testing.T) {
+		paragraphClass.ReplicationConfig = &models.ReplicationConfig{Factor: 3}
+		paragraphClass.Vectorizer = "text2vec-contextionary"
+		helper.CreateClass(t, paragraphClass)
+	})
+
+	t.Run("stop node 3", func(t *testing.T) {
+		common.StopNodeAt(ctx, t, compose, 3)
+	})
+
+	repairObj := &models.Object{
+		ID:         "e5390693-5a22-44b8-997d-2a213aaf5884",
+		Class:      paragraphClass.Class,
+		Properties: map[string]interface{}{"contents": "written while node 3 was down"},
+	}
+
+	t.Run("write an object while node 3 is down", func(t *testing.T) {
+		common.CreateObjectCL(t, compose.GetWeaviate().URI(), repairObj, types.ConsistencyLevelOne)
+	})
+
+	t.Run("restart node 3", func(t *testing.T) {
+		common.StartNodeAt(ctx, t, compose, 3)
+	})
+
+	t.Run("verify all nodes are running", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			params := nodes.NewNodesGetClassParams().WithOutput(&verbose)
+			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+			require.NoError(ct, clientErr)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, 3)
+			for _, n := range body.Payload.Nodes {
+				require.NotNil(ct, n.Status)
+				require.Equal(ct, "HEALTHY", *n.Status)
+			}
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("node 3 stays behind while async replication is disabled", func(t *testing.T) {
+		// Async replication is off (booted disabled), so the loaded shards are
+		// unregistered and nothing repairs node 3 — the object is not found there.
+		_, err := common.GetObjectCL(t, compose.GetWeaviateNode(3).URI(),
+			repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
+		require.Error(t, err, "node 3 must not have the object while async replication is disabled")
+	})
+
+	t.Run("enable async replication via the runtime-overrides file", func(t *testing.T) {
+		for i := 1; i <= 3; i++ {
+			node := compose.GetWeaviateNode(i)
+			exitCode, _, err := node.Container().Exec(ctx, []string{
+				"sh", "-c",
+				fmt.Sprintf("printf 'async_replication_disabled: false\\n' > %s", overridePath),
+			})
+			require.NoError(t, err, "write runtime override on node %d", i)
+			require.Equal(t, 0, exitCode, "exec returned non-zero on node %d", i)
+		}
+	})
+
+	t.Run("node 3 is repaired once the hook re-enables async replication", func(t *testing.T) {
+		// runtime-overrides file change → config manager → AsyncReplicationDisabled
+		// hook → DB.ReconcileAsyncReplication registers the already-loaded shards;
+		// async repair then propagates the missing object to node 3.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			obj, err := common.GetObjectCL(t, compose.GetWeaviateNode(3).URI(),
+				repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
+			require.NoError(ct, err)
+			require.NotNil(ct, obj)
+		}, 120*time.Second, 2*time.Second,
+			"node 3 was not repaired after the runtime override re-enabled async replication")
+	})
+}
+
+// writeAsyncReplicationOverride writes the given disabled value into the
+// runtime-overrides file on every node in the cluster. The 1s poll interval
+// configured by the surrounding tests means the change is picked up within a
+// few seconds.
+func writeAsyncReplicationOverride(ctx context.Context, t *testing.T, compose *docker.DockerCompose, nodes int, overridePath string, disabled bool) {
+	t.Helper()
+	for i := 1; i <= nodes; i++ {
+		node := compose.GetWeaviateNode(i)
+		exitCode, _, err := node.Container().Exec(ctx, []string{
+			"sh", "-c",
+			fmt.Sprintf("printf 'async_replication_disabled: %t\\n' > %s", disabled, overridePath),
+		})
+		require.NoError(t, err, "write runtime override on node %d", i)
+		require.Equal(t, 0, exitCode, "exec returned non-zero on node %d", i)
+	}
+}
+
+// shardsAsyncReplicationLen returns the total len(asyncReplicationStatus)
+// across every node × every shard of the given class as seen from the
+// verbose nodes endpoint. Zero means async replication is registered
+// nowhere; >0 means at least one shard has it active. Returns an error so
+// callers can use it inside EventuallyWithT's CollectT scope (assertions
+// retry instead of failing the outer test on a transient HTTP error).
+func shardsAsyncReplicationLen(t *testing.T, class string) (int, error) {
+	verbose := verbosity.OutputVerbose
+	params := nodes.NewNodesGetClassParams().WithClassName(class).WithOutput(&verbose)
+	body, err := helper.Client(t).Nodes.NodesGetClass(params, nil)
+	if err != nil {
+		return 0, err
+	}
+	if body.Payload == nil {
+		return 0, fmt.Errorf("nil payload from NodesGetClass")
+	}
+	total := 0
+	for _, n := range body.Payload.Nodes {
+		for _, s := range n.Shards {
+			total += len(s.AsyncReplicationStatus)
+		}
+	}
+	return total, nil
+}
+
+// TestAsyncReplicationRuntimeToggle_EnableDisableEnable exercises the runtime
+// kill-switch from the opposite direction of TestAsyncReplicationRuntimeToggle:
+// the cluster boots with async replication ENABLED (the new default at RF>1).
+// The operator flips the runtime-overrides file to disabled while shards are
+// live, a peer node misses a write during the disabled window, and the
+// operator then flips the override back to enabled.
+//
+// This catches the bug class that disableAsyncReplication used to introduce —
+// persisting a hashtree snapshot that goes stale on the first write while
+// disabled and is then loaded verbatim on re-enable, hiding the divergence
+// from CollectShardDifferences. With the fix in place, re-enable rebuilds the
+// hashtree from a full object-store scan and the missed write is repaired.
+func TestAsyncReplicationRuntimeToggle_EnableDisableEnable(t *testing.T) {
+	t.Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
+
+	const overridePath = "/etc/weaviate/runtime-overrides.yaml"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	emptyOverride := testcontainers.ContainerFile{
+		Reader:            strings.NewReader(""),
+		ContainerFilePath: overridePath,
+		FileMode:          0o644,
+	}
+
+	// Boot with async replication ENABLED by default — no ASYNC_REPLICATION_DISABLED env.
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithText2VecContextionary().
+		WithWeaviateEnv("RUNTIME_OVERRIDES_ENABLED", "true").
+		WithWeaviateEnv("RUNTIME_OVERRIDES_PATH", overridePath).
+		WithWeaviateEnv("RUNTIME_OVERRIDES_LOAD_INTERVAL", "1s").
+		WithWeaviateFiles(emptyOverride).
+		Start(ctx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	paragraphClass := articles.ParagraphsClass()
+
+	t.Run("create RF=3 schema (async on by default)", func(t *testing.T) {
+		paragraphClass.ReplicationConfig = &models.ReplicationConfig{Factor: 3}
+		paragraphClass.Vectorizer = "text2vec-contextionary"
+		helper.CreateClass(t, paragraphClass)
+	})
+
+	t.Run("async replication is registered on every shard at boot", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			n, err := shardsAsyncReplicationLen(t, paragraphClass.Class)
+			require.NoError(ct, err)
+			require.Greater(ct, n, 0,
+				"asyncReplicationStatus must be populated on at least one shard at boot")
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("admin disables async replication via the runtime-overrides file", func(t *testing.T) {
+		writeAsyncReplicationOverride(ctx, t, compose, 3, overridePath, true)
+		// The hook drains asyncReplicationStatus on every loaded shard.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			n, err := shardsAsyncReplicationLen(t, paragraphClass.Class)
+			require.NoError(ct, err)
+			require.Equal(ct, 0, n,
+				"asyncReplicationStatus must drain to empty on every shard once the override disables it")
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("stop node 3", func(t *testing.T) {
+		common.StopNodeAt(ctx, t, compose, 3)
+	})
+
+	repairObj := &models.Object{
+		ID:         "aaaa1111-1111-1111-1111-111111111111",
+		Class:      paragraphClass.Class,
+		Properties: map[string]interface{}{"contents": "written while async replication was runtime-disabled and node 3 was down"},
+	}
+
+	t.Run("write an object while node 3 is down and async is disabled", func(t *testing.T) {
+		common.CreateObjectCL(t, compose.GetWeaviate().URI(), repairObj, types.ConsistencyLevelOne)
+	})
+
+	t.Run("restart node 3", func(t *testing.T) {
+		common.StartNodeAt(ctx, t, compose, 3)
+	})
+
+	t.Run("verify all nodes are running", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			params := nodes.NewNodesGetClassParams().WithOutput(&verbose)
+			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+			require.NoError(ct, clientErr)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, 3)
+			for _, n := range body.Payload.Nodes {
+				require.NotNil(ct, n.Status)
+				require.Equal(ct, "HEALTHY", *n.Status)
+			}
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("node 3 stays behind while async replication is disabled", func(t *testing.T) {
+		_, err := common.GetObjectCL(t, compose.GetWeaviateNode(3).URI(),
+			repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
+		require.Error(t, err, "node 3 must not have the object while async replication is disabled")
+	})
+
+	t.Run("re-enable async replication via the runtime-overrides file", func(t *testing.T) {
+		writeAsyncReplicationOverride(ctx, t, compose, 3, overridePath, false)
+	})
+
+	t.Run("node 3 is repaired without restart", func(t *testing.T) {
+		// runtime-overrides → hook → DB.ReconcileAsyncReplication → per-shard
+		// enableAsyncReplication (with no leftover .ht, because disable did not
+		// persist one) → fresh hashtree scan that observes the disabled-window
+		// write → CollectShardDifferences sees the diff and repairs node 3.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			obj, err := common.GetObjectCL(t, compose.GetWeaviateNode(3).URI(),
+				repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
+			require.NoError(ct, err)
+			require.NotNil(ct, obj)
+		}, 120*time.Second, 2*time.Second,
+			"node 3 was not repaired after the runtime override re-enabled async replication on a previously-enabled cluster")
+	})
+}
+
+// TestAsyncReplicationRuntimeToggle_ClassCreatedWhileDisabled exercises the
+// Migrator.AddClass reconcile race at the cluster level: a class created
+// while ASYNC_REPLICATION_DISABLED is on must boot with async off (the live
+// flag is read during shard load), and re-enabling the flag must pick it up
+// via the runtime hook without a restart.
+//
+// This catches regressions in the new index path through Migrator.AddClass
+// that wires the reconcile under dropIndex.RLock + closeLock.RLock, separate
+// from the already-loaded shard reconcile covered by TestAsyncReplicationRuntimeToggle.
+func TestAsyncReplicationRuntimeToggle_ClassCreatedWhileDisabled(t *testing.T) {
+	t.Setenv("TEST_WEAVIATE_IMAGE", "weaviate/test-server")
+
+	const overridePath = "/etc/weaviate/runtime-overrides.yaml"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	emptyOverride := testcontainers.ContainerFile{
+		Reader:            strings.NewReader(""),
+		ContainerFilePath: overridePath,
+		FileMode:          0o644,
+	}
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithText2VecContextionary().
+		WithWeaviateEnv("RUNTIME_OVERRIDES_ENABLED", "true").
+		WithWeaviateEnv("RUNTIME_OVERRIDES_PATH", overridePath).
+		WithWeaviateEnv("RUNTIME_OVERRIDES_LOAD_INTERVAL", "1s").
+		WithWeaviateFiles(emptyOverride).
+		Start(ctx)
+	require.Nil(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("failed to terminate test containers: %s", err.Error())
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	paragraphClass := articles.ParagraphsClass()
+
+	t.Run("admin disables async replication before any class exists", func(t *testing.T) {
+		writeAsyncReplicationOverride(ctx, t, compose, 3, overridePath, true)
+		// Give the config manager and hook a beat to settle. Verified indirectly
+		// by the next subtest: a new class created now must come up with async off.
+		time.Sleep(3 * time.Second)
+	})
+
+	t.Run("create an RF=3 class while disabled — Migrator.AddClass honors the live flag", func(t *testing.T) {
+		paragraphClass.ReplicationConfig = &models.ReplicationConfig{Factor: 3}
+		paragraphClass.Vectorizer = "text2vec-contextionary"
+		helper.CreateClass(t, paragraphClass)
+
+		// asyncReplicationStatus must be empty across every shard on every node:
+		// the new index's shards loaded while the live flag was disabled.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			n, err := shardsAsyncReplicationLen(t, paragraphClass.Class)
+			require.NoError(ct, err)
+			require.Equal(ct, 0, n,
+				"asyncReplicationStatus must be empty for a class created while async replication is runtime-disabled")
+		}, 15*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("stop node 3", func(t *testing.T) {
+		common.StopNodeAt(ctx, t, compose, 3)
+	})
+
+	repairObj := &models.Object{
+		ID:         "bbbb2222-2222-2222-2222-222222222222",
+		Class:      paragraphClass.Class,
+		Properties: map[string]interface{}{"contents": "written into a class created while async was disabled, with node 3 down"},
+	}
+
+	t.Run("write an object while node 3 is down", func(t *testing.T) {
+		common.CreateObjectCL(t, compose.GetWeaviate().URI(), repairObj, types.ConsistencyLevelOne)
+	})
+
+	t.Run("restart node 3", func(t *testing.T) {
+		common.StartNodeAt(ctx, t, compose, 3)
+	})
+
+	t.Run("verify all nodes are running", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			params := nodes.NewNodesGetClassParams().WithOutput(&verbose)
+			body, clientErr := helper.Client(t).Nodes.NodesGetClass(params, nil)
+			require.NoError(ct, clientErr)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, 3)
+			for _, n := range body.Payload.Nodes {
+				require.NotNil(ct, n.Status)
+				require.Equal(ct, "HEALTHY", *n.Status)
+			}
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("node 3 stays behind while async replication is disabled", func(t *testing.T) {
+		_, err := common.GetObjectCL(t, compose.GetWeaviateNode(3).URI(),
+			repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
+		require.Error(t, err, "node 3 must not have the object while async replication is disabled")
+	})
+
+	t.Run("re-enable async replication via the runtime-overrides file", func(t *testing.T) {
+		writeAsyncReplicationOverride(ctx, t, compose, 3, overridePath, false)
+	})
+
+	t.Run("async replication is now registered on the new class's shards", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			n, err := shardsAsyncReplicationLen(t, paragraphClass.Class)
+			require.NoError(ct, err)
+			require.Greater(ct, n, 0,
+				"reconcile hook must register async replication on the class created while disabled")
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("node 3 is repaired without restart", func(t *testing.T) {
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			obj, err := common.GetObjectCL(t, compose.GetWeaviateNode(3).URI(),
+				repairObj.Class, repairObj.ID, types.ConsistencyLevelOne)
+			require.NoError(ct, err)
+			require.NotNil(ct, obj)
+		}, 120*time.Second, 2*time.Second,
+			"node 3 was not repaired after the runtime override re-enabled async replication on a class created while disabled")
+	})
+}

--- a/test/acceptance/replication/replica_replication/fast/replica_replication_test.go
+++ b/test/acceptance/replication/replica_replication/fast/replica_replication_test.go
@@ -103,15 +103,13 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementHappyPath() {
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ShardingConfig = map[string]any{"desiredCount": 1}
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
 		articleClass.ShardingConfig = map[string]any{"desiredCount": 1}
 		articleClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		helper.CreateClass(t, articleClass)
 	})
@@ -283,8 +281,7 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementTenantHappyPath()
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
 			Enabled:              true,
@@ -294,8 +291,7 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementTenantHappyPath()
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
 		articleClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		articleClass.MultiTenancyConfig = &models.MultiTenancyConfig{
 			Enabled:              true,
@@ -478,8 +474,7 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementTenantParallelWri
 
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       2,
-			AsyncEnabled: false,
+			Factor: 2,
 		}
 		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
 			Enabled: true,
@@ -488,8 +483,7 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementTenantParallelWri
 		helper.CreateClass(t, paragraphClass)
 		helper.CreateTenants(t, paragraphClass.Class, []*models.Tenant{{Name: tenant}})
 		articleClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       2,
-			AsyncEnabled: false,
+			Factor: 2,
 		}
 		articleClass.MultiTenancyConfig = &models.MultiTenancyConfig{
 			Enabled: true,

--- a/test/acceptance/replication/replica_replication/fast/shard_scale_out_test.go
+++ b/test/acceptance/replication/replica_replication/fast/shard_scale_out_test.go
@@ -36,9 +36,9 @@ import (
 // TestReplicaMovementShardScaleOutParallelWrites: COPY/single-tenant
 // analogue of TestReplicaMovementTenantParallelWrites. Scales a 3-shard
 // collection rf=1→3 (six COPY ops, two per source shard) while parallel
-// writes hammer every node at CL=ALL. AsyncEnabled=false so the CCL is
-// the only path bringing in-flight writes onto a fresh replica — any
-// lost write surfaces directly.
+// writes hammer every node at CL=ALL. With async replication off (the
+// cluster default in this suite) the CCL is the only path bringing
+// in-flight writes onto a fresh replica — any lost write surfaces directly.
 func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementShardScaleOutParallelWrites() {
 	t := suite.T()
 	mainCtx := context.Background()
@@ -62,8 +62,7 @@ func (suite *ReplicationHappyPathTestSuite) TestReplicaMovementShardScaleOutPara
 
 	t.Run("create thrice-sharded single-tenant class at rf=1", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		paragraphClass.ShardingConfig = map[string]any{"desiredCount": 3}
 		helper.CreateClass(t, paragraphClass)

--- a/test/acceptance/replication/replica_replication/scale/scale_test.go
+++ b/test/acceptance/replication/replica_replication/scale/scale_test.go
@@ -81,8 +81,7 @@ func (suite *ScaleTestSuite) TestScalingSingleTenant() {
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ShardingConfig = map[string]interface{}{"desiredCount": shardsCount}
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)
@@ -273,8 +272,7 @@ func (suite *ScaleTestSuite) TestScalingMultiTenant() {
 
 	t.Run("create schema (multi-tenant)", func(t *testing.T) {
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		paragraphClass.MultiTenancyConfig = &models.MultiTenancyConfig{
 			Enabled:              true,

--- a/test/acceptance/replication/replica_replication/slow/slow_file_copy_test.go
+++ b/test/acceptance/replication/replica_replication/slow/slow_file_copy_test.go
@@ -79,8 +79,7 @@ func (suite *ReplicationTestSuiteSlow) TestReplicaMovementOneWriteExtraSlowFileC
 	t.Run("create schema", func(t *testing.T) {
 		paragraphClass.ShardingConfig = map[string]interface{}{"desiredCount": 1}
 		paragraphClass.ReplicationConfig = &models.ReplicationConfig{
-			Factor:       1,
-			AsyncEnabled: false,
+			Factor: 1,
 		}
 		paragraphClass.Vectorizer = "text2vec-contextionary"
 		helper.CreateClass(t, paragraphClass)

--- a/test/acceptance/schema/get_schema_without_client_test.go
+++ b/test/acceptance/schema/get_schema_without_client_test.go
@@ -100,7 +100,6 @@ func testGetSchemaWithoutClient(t *testing.T) {
 					"virtualPerPhysical":  float64(128),
 				},
 				"replicationConfig": map[string]interface{}{
-					"asyncEnabled":     false,
 					"factor":           float64(1),
 					"deletionStrategy": "TimeBasedResolution",
 				},

--- a/test/acceptance/schema/update_class_async_replication_test.go
+++ b/test/acceptance/schema/update_class_async_replication_test.go
@@ -33,12 +33,10 @@ func TestUpdateClassAsyncReplicationConfig(t *testing.T) {
 		require.Nil(t, err)
 	})
 
-	t.Run("create class with async replication disabled", func(t *testing.T) {
+	t.Run("create class", func(t *testing.T) {
 		c := &models.Class{
-			Class: className,
-			ReplicationConfig: &models.ReplicationConfig{
-				AsyncEnabled: false,
-			},
+			Class:             className,
+			ReplicationConfig: &models.ReplicationConfig{},
 		}
 
 		params := clschema.NewSchemaObjectsCreateParams().WithObjectClass(c)
@@ -97,7 +95,6 @@ func TestUpdateClassAsyncReplicationConfig(t *testing.T) {
 			require.Nil(t, err)
 
 			class := res.Payload
-			class.ReplicationConfig.AsyncEnabled = true
 			class.ReplicationConfig.AsyncConfig = tc.config
 
 			// update
@@ -114,7 +111,6 @@ func TestUpdateClassAsyncReplicationConfig(t *testing.T) {
 
 			rc := res.Payload.ReplicationConfig
 			require.NotNil(t, rc)
-			require.True(t, rc.AsyncEnabled)
 			require.NotNil(t, rc.AsyncConfig)
 
 			requireAsyncConfigEquals(t, tc.config, rc.AsyncConfig)

--- a/test/modules/export-s3/export_test.go
+++ b/test/modules/export-s3/export_test.go
@@ -51,8 +51,7 @@ func TestExport_SingleShard(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -153,8 +152,7 @@ func TestExport_MultiShard(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(3),
@@ -234,8 +232,7 @@ func TestExport_DeletedAndUpdatedObjects(t *testing.T) {
 			},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -436,8 +433,7 @@ func TestExport_EmptyCollection(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -468,8 +464,7 @@ func TestExport_MultipleClasses(t *testing.T) {
 				{Name: "text", DataType: []string{"text"}},
 			},
 			ReplicationConfig: &models.ReplicationConfig{
-				AsyncEnabled: true,
-				Factor:       3,
+				Factor: 3,
 			},
 			ShardingConfig: map[string]interface{}{
 				"desiredCount": float64(1),
@@ -507,7 +502,7 @@ func TestExport_MultiTenant_SingleShard(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: "text", DataType: []string{"text"}},
 		},
-		ReplicationConfig:  &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		ReplicationConfig:  &models.ReplicationConfig{Factor: 3},
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 	})
 	defer helper.DeleteClass(t, className)
@@ -565,7 +560,7 @@ func TestExport_MultiTenant_MultiShard(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: "text", DataType: []string{"text"}},
 		},
-		ReplicationConfig:  &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		ReplicationConfig:  &models.ReplicationConfig{Factor: 3},
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 	})
 	defer helper.DeleteClass(t, className)
@@ -616,8 +611,7 @@ func TestExport_NamedVectorAndMultiVector(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		VectorConfig: map[string]models.VectorConfig{
 			"regular": {
@@ -771,7 +765,7 @@ func TestExport_MultiTenant_ActiveAndInactive(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: "text", DataType: []string{"text"}},
 		},
-		ReplicationConfig: &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 3},
 		MultiTenancyConfig: &models.MultiTenancyConfig{
 			Enabled:              true,
 			AutoTenantActivation: false,
@@ -860,7 +854,7 @@ func TestExport_MultiTenant_AllCold(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: "text", DataType: []string{"text"}},
 		},
-		ReplicationConfig: &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 3},
 		MultiTenancyConfig: &models.MultiTenancyConfig{
 			Enabled:              true,
 			AutoTenantActivation: false,
@@ -952,7 +946,7 @@ func TestExport_MultiTenant_HotEmptyTenants(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: "text", DataType: []string{"text"}},
 		},
-		ReplicationConfig:  &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		ReplicationConfig:  &models.ReplicationConfig{Factor: 3},
 		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
 	})
 	defer helper.DeleteClass(t, className)
@@ -1043,7 +1037,7 @@ func TestExport_ColdTenantReactivatedDuringExport(t *testing.T) {
 		Properties: []*models.Property{
 			{Name: "text", DataType: []string{"text"}},
 		},
-		ReplicationConfig: &models.ReplicationConfig{AsyncEnabled: true, Factor: 3},
+		ReplicationConfig: &models.ReplicationConfig{Factor: 3},
 		MultiTenancyConfig: &models.MultiTenancyConfig{
 			Enabled:              true,
 			AutoTenantActivation: false,
@@ -1330,8 +1324,7 @@ func TestExport_Validation(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -1415,8 +1408,7 @@ func TestExport_ExcludeFilter(t *testing.T) {
 				{Name: "text", DataType: []string{"text"}},
 			},
 			ReplicationConfig: &models.ReplicationConfig{
-				AsyncEnabled: true,
-				Factor:       3,
+				Factor: 3,
 			},
 			ShardingConfig: map[string]interface{}{
 				"desiredCount": float64(1),
@@ -1479,8 +1471,7 @@ func TestExport_DuplicateID(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -1517,8 +1508,7 @@ func TestExport_ConcurrentExport(t *testing.T) {
 				{Name: "text", DataType: []string{"text"}},
 			},
 			ReplicationConfig: &models.ReplicationConfig{
-				AsyncEnabled: true,
-				Factor:       3,
+				Factor: 3,
 			},
 			ShardingConfig: map[string]interface{}{
 				"desiredCount": float64(1),
@@ -1565,8 +1555,7 @@ func TestExport_Cancel(t *testing.T) {
 				{Name: "text", DataType: []string{"text"}},
 			},
 			ReplicationConfig: &models.ReplicationConfig{
-				AsyncEnabled: true,
-				Factor:       3,
+				Factor: 3,
 			},
 			ShardingConfig: map[string]interface{}{
 				"desiredCount": float64(1),
@@ -1606,8 +1595,7 @@ func TestExport_Cancel(t *testing.T) {
 				{Name: "text", DataType: []string{"text"}},
 			},
 			ReplicationConfig: &models.ReplicationConfig{
-				AsyncEnabled: true,
-				Factor:       3,
+				Factor: 3,
 			},
 			ShardingConfig: map[string]interface{}{
 				"desiredCount": float64(1),
@@ -1654,8 +1642,7 @@ func TestExport_Cancel_AlreadyFinished(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),
@@ -1678,35 +1665,6 @@ func TestExport_Cancel_AlreadyFinished(t *testing.T) {
 	require.Contains(t, cancelErr.Error(), "409")
 }
 
-func TestExport_RejectsWithoutAsyncReplication(t *testing.T) {
-	className := sanitizeClassName(t.Name())
-	exportID := strings.ToLower(sanitizeClassName(t.Name()))
-
-	// Create a class with RF > 1 but async replication disabled.
-	helper.CreateClass(t, &models.Class{
-		Class: className,
-		Properties: []*models.Property{
-			{Name: "text", DataType: []string{"text"}},
-		},
-		ReplicationConfig: &models.ReplicationConfig{
-			Factor:       3,
-			AsyncEnabled: false,
-		},
-		ShardingConfig: map[string]interface{}{
-			"desiredCount": float64(1),
-		},
-	})
-	defer helper.DeleteClass(t, className)
-
-	objects := makeObjects(className, "", 5)
-	helper.CreateObjectsBatchCL(t, objects, types.ConsistencyLevelAll)
-
-	_, err := exporttest.CreateExport(t, "s3", exportID, []string{className})
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "422",
-		"export without async replication should be rejected with 422, got: %v", err)
-}
-
 // TestExport_SequentialSnapshots verifies that successive exports capture
 // point-in-time snapshots: inserts and deletes between exports are reflected
 // only in the export that follows them.
@@ -1720,8 +1678,7 @@ func TestExport_SequentialSnapshots(t *testing.T) {
 			{Name: "text", DataType: []string{"text"}},
 		},
 		ReplicationConfig: &models.ReplicationConfig{
-			AsyncEnabled: true,
-			Factor:       3,
+			Factor: 3,
 		},
 		ShardingConfig: map[string]interface{}{
 			"desiredCount": float64(1),

--- a/usecases/export/helpers_for_test.go
+++ b/usecases/export/helpers_for_test.go
@@ -131,6 +131,7 @@ type fakeSelector struct {
 	shards        map[string]map[string]*testShard
 	skipped       map[string]map[string]string
 	mt            map[string]bool
+	asyncDisabled map[string]bool
 	snapshotsRoot string
 }
 
@@ -146,8 +147,8 @@ func (s *fakeSelector) IsMultiTenant(_ context.Context, className string) bool {
 	return s.mt[className]
 }
 
-func (s *fakeSelector) IsAsyncReplicationEnabled(_ context.Context, _ string) bool {
-	return true
+func (s *fakeSelector) IsAsyncReplicationEnabled(_ context.Context, className string) bool {
+	return !s.asyncDisabled[className]
 }
 
 func (s *fakeSelector) SnapshotShards(ctx context.Context, className string, shardNames []string, _ string) ([]ShardSnapshotResult, error) {

--- a/usecases/export/scheduler.go
+++ b/usecases/export/scheduler.go
@@ -170,7 +170,9 @@ func (s *Scheduler) Export(ctx context.Context, principal *models.Principal, id,
 		return nil, fmt.Errorf("%w: no exportable classes", ErrExportValidation)
 	}
 
-	// Require async replication for all exported classes that have RF > 1.
+	// Require async replication for every exported class with RF > 1. The
+	// selector also returns false when the class has no local index, so the
+	// error below keeps both causes in view.
 	var noAsync []string
 	for _, class := range classes {
 		if !s.selector.IsAsyncReplicationEnabled(ctx, class) {
@@ -178,9 +180,12 @@ func (s *Scheduler) Export(ctx context.Context, principal *models.Principal, id,
 		}
 	}
 	if len(noAsync) > 0 {
-		return nil, fmt.Errorf("%w: collections %v require async replication for export "+
-			"(replication factor > 1) but it is not active; either enable it per collection "+
-			"or check whether it is globally disabled at the cluster level", ErrExportValidation, noAsync)
+		return nil, fmt.Errorf("%w: collections %v are not exportable: export "+
+			"requires async replication for every collection with replication "+
+			"factor > 1. This usually means async replication is disabled "+
+			"cluster-wide — unset ASYNC_REPLICATION_DISABLED (or the equivalent "+
+			"runtime override) to re-enable it — but it can also mean the "+
+			"collection is not yet known to this node", ErrExportValidation, noAsync)
 	}
 
 	backendStore, err := s.backends.BackupBackend(backend, modulecapabilities.BackendUseCaseExport)

--- a/usecases/export/scheduler_test.go
+++ b/usecases/export/scheduler_test.go
@@ -224,6 +224,34 @@ func TestScheduler_StorageConfigValidation(t *testing.T) {
 	})
 }
 
+// TestScheduler_RejectsWhenAsyncReplicationDisabled verifies that Export is
+// rejected when a class with replication factor > 1 has async replication
+// disabled cluster-wide. Async replication is on by default for RF > 1, so the
+// only way to reach this path is the cluster-wide ASYNC_REPLICATION_DISABLED
+// kill-switch — surfaced here via fakeSelector.asyncDisabled.
+func TestScheduler_RejectsWhenAsyncReplicationDisabled(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	s := &Scheduler{
+		logger:       logger,
+		authorizer:   mocks.NewMockAuthorizer(),
+		exportConfig: testExportConfig(),
+		backends:     &fakeBackendProvider{backend: &fakeBackend{}},
+		client:       &fakeExportClient{},
+		nodeResolver: &fakeNodeResolver{nodes: map[string]string{}},
+		selector: &fakeSelector{
+			classList:     []string{"Article"},
+			asyncDisabled: map[string]bool{"Article": true},
+		},
+		metrics: testMetrics(),
+	}
+
+	_, err := s.Export(context.Background(), nil, "my-export", "s3", nil, nil)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrExportValidation)
+	assert.Contains(t, err.Error(), "ASYNC_REPLICATION_DISABLED")
+	assert.Contains(t, err.Error(), "Article")
+}
+
 func TestScheduler_ErrorPaths(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/usecases/export/types.go
+++ b/usecases/export/types.go
@@ -35,6 +35,10 @@ type Selector interface {
 	ListClasses(ctx context.Context) []string
 	ShardOwnership(ctx context.Context, className string) (map[string][]string, error)
 	IsMultiTenant(ctx context.Context, className string) bool
+
+	// IsAsyncReplicationEnabled reports whether async replication is active or
+	// irrelevant for the class. It also returns false when the class has no
+	// local index, so a false result is not necessarily a config problem.
 	IsAsyncReplicationEnabled(ctx context.Context, className string) bool
 
 	// SnapshotShards creates point-in-time snapshots of the objects buckets

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -660,7 +660,6 @@ func (m *Handler) setNewClassDefaults(class *models.Class, globalCfg replication
 		class.ReplicationConfig = &models.ReplicationConfig{
 			Factor:           int64(m.config.Replication.MinimumFactor),
 			DeletionStrategy: models.ReplicationConfigDeletionStrategyTimeBasedResolution,
-			AsyncEnabled:     false,
 		}
 		return nil
 	}

--- a/usecases/schema/schema_comparison_test.go
+++ b/usecases/schema/schema_comparison_test.go
@@ -247,7 +247,7 @@ func Test_SchemaComparison_VariousMismatches(t *testing.T) {
 		"class Foo: module config mismatch: " +
 			"L has \"bar\", but R has null",
 		"class Foo: replication config mismatch: " +
-			"L has {\"asyncEnabled\":false,\"factor\":7}, but R has {\"asyncEnabled\":false,\"factor\":8}",
+			"L has {\"factor\":7}, but R has {\"factor\":8}",
 		"class Foo: sharding config mismatch: " +
 			"L has {\"desiredCount\":7}, but R has null",
 		"class Foo: vector index config mismatch: " +


### PR DESCRIPTION
### Motivation

Async replication has graduated from an opt-in feature to the default for any replicated collection. Previously, users had to set `replicationConfig.asyncEnabled = true` per class to get repair behavior — a footgun, since the natural assumption is that "replication factor > 1" already implies eventual-consistency repair. This PR removes the per-class toggle so any class with `factor > 1` gets async repair automatically. Operators who need to disable it cluster-wide (resource isolation, debugging, staged rollout) still have the existing `ASYNC_REPLICATION_DISABLED` runtime/env flag as the single kill-switch.

Making the kill-switch a first-class operational lever required closing a two-armed gap:

1. **Loaded shards stay unregistered after a runtime flip from disabled → enabled.** Without something to re-evaluate them, they remained unrepaired until a reload or schema update.
2. **Re-enabling silently abandoned disabled-window divergence.** `disableAsyncReplication` persisted the in-memory hashtree to a `.ht` file, but the shard kept serving writes while disabled — so the snapshot went stale on the very next write. The next `enableAsyncReplication` then loaded that stale tree as the cached hashtree without any consistency check, `CollectShardDifferences` returned `ErrNoDiffFound` against peers, and async repair never propagated the missed writes. An object missed by a replica during the kill-switch window stayed missed indefinitely.

Both arms are addressed below.

### Approach

**Field removal.** Drop `AsyncEnabled bool` from `models.ReplicationConfig` (and `openapi-specs/schema.json`, `embedded_spec.go`, `deepcopy`) and the parallel `AsyncReplicationEnabled` from `db.IndexConfig`. `Index.asyncReplicationEnabled()` is now `ReplicationFactor > 1 && !globallyDisabled`. A nil guard on `globalreplicationConfig` keeps test paths that don't wire it from panicking.

**Runtime reconciliation.** Add `DB.ReconcileAsyncReplication`, wired as a runtime-config hook on the `AsyncReplicationDisabled` override in `configure_api.go`. When the flag toggles, it walks every loaded shard of every index and (de)registers async replication to match the new state, reusing the same per-shard apply loop as `updateReplicationConfig`. `enableAsyncReplication`/`disableAsyncReplication` are idempotent, so reconciliation is safe to call repeatedly. It snapshots the indices and takes each one's `dropIndex.RLock` under `indexLock`, then reconciles outside `indexLock` — the established delete-safety discipline, so a concurrent `DeleteIndex` cannot drop shards mid-reconcile while per-shard hashtree I/O still does not block unrelated index create/delete. `Migrator.AddClass` runs the same reconcile (under the same `dropIndex`/`closeLock` guards) on a newly created index: it loads shards reading the live flag before the index is visible in `db.indices`, so a flag toggle racing class creation would otherwise miss it.

**Hashtree-cache lifecycle.** A persisted `.ht` is only valid across a clean shutdown → next-startup boundary, where the shard serves no writes in between. Two changes enforce this:

- `disableAsyncReplication` no longer persists the hashtree. It is the runtime path (kill-switch, rebuild, target-node-override) — the shard stays live and any snapshot would go stale on the very next write. `mayStopAsyncReplication` (shutdown/drop/backup) remains the only safe producer of a `.ht`, because there the shard is being torn down.
- `shard_init_lsm.go`'s async-disabled branch discards any leftover `.ht` via a new `removePersistedHashtree()` helper. Without this, a node booted with `ASYNC_REPLICATION_DISABLED=true` after a prior async-enabled shutdown would leave the snapshot on disk; the shard would serve writes (invalidating it), and a later runtime enable's `tryLoadHashtreeFromDisk` would load it verbatim.

With these in place, every runtime re-enable rebuilds the hashtree from a full object-store scan and `CollectShardDifferences` sees disabled-window divergence again.

**Lock discipline.** Several call sites previously snapshotted `asyncReplicationEnabled` + `AsyncReplicationConfig` under `replicationConfigLock`, released, then applied — leaving a TOCTOU window where a concurrent `updateReplicationConfig` could flip the state and let a stale apply win. They now hold `replicationConfigLock` (read) across the *whole apply*, not just the snapshot. This is deadlock-free because `updateReplicationConfig` already calls `enable/disableAsyncReplication` under the write lock, so those calls never reacquire `replicationConfigLock`.

**Export gate.** `DB.IsAsyncReplicationEnabled` delegates to `Index.IsAsyncReplicationEnabledOrIrrelevant()`, a config-level predicate that reads `ReplicationFactor` and the async-enabled state under a single `replicationConfigLock` snapshot: exportable when RF ≤ 1 (irrelevant) or RF > 1 and not globally disabled. Per-shard inspection of live readiness was considered and rejected — a multi-tenant class's tenant shards continuously transition (loading, registering, deactivating, offloading), so "is every loaded shard registered" is unstable and would also reject the normal create-then-export flow during async replication's brief warm-up. The reconciliation above is what keeps this config view honest. The export scheduler's RF>1 rejection message also accounts for "class not yet known to this node" (the selector returns false for a missing local index too, not only for a disabled flag).

Alternatives considered: keeping `AsyncEnabled` as a deprecated/ignored field for API back-compat — rejected, the field was a dead toggle and clients on RF>1 clusters already saw repair traffic whenever `AsyncReplicationDisabled=false`.

### Key areas for review

- [`entities/models/replication_config.go`](https://github.com/weaviate/weaviate/blob/main/entities/models/replication_config.go) and `openapi-specs/schema.json` — confirm the field removal is intentional with no remaining producers/consumers.
- `adapters/repos/db/index.go` — `applyAsyncReplicationToLoadedShardsLocked` / `reconcileAsyncReplication` / `DB.ReconcileAsyncReplication`: the runtime reconciliation path.
- `adapters/repos/db/index.go` — `IsAsyncReplicationEnabledOrIrrelevant()`: config-level predicate (single `replicationConfigLock` read) backing the export gate.
- `adapters/repos/db/index.go` — `InitAsyncReplicationOnShard` / `RevertAsyncReplicationOnShard`: lock held across the apply, not just the snapshot. Confirm no path under `enable/disableAsyncReplication` reacquires `replicationConfigLock`.
- `adapters/repos/db/shard_async_replication.go` — `disableAsyncReplication`: no longer persists the hashtree (godoc explains why). Confirm `mayStopAsyncReplication` remains the only path that calls `dumpHashTreeWithTimeout`.
- `adapters/repos/db/shard_async_replication.go` — new `removePersistedHashtree()` helper.
- `adapters/repos/db/shard_init_lsm.go` — async-disabled branch discards any leftover `.ht` via `removePersistedHashtree()`.
- `adapters/repos/db/shard_async_replication.go` — `addTargetNodeOverride` / `removeTargetNodeOverride` / `removeAllTargetNodeOverrides`: lock-across-apply change; `addTargetNodeOverride` reads the config field directly instead of via the `AsyncReplicationConfig()` getter to avoid re-locking.
- `adapters/repos/db/migrator.go` — `AddClass` reconciles async replication on the new index, under `dropIndex.RLock` + `closeLock.RLock`, to cover a flag toggle that races class creation.
- `adapters/handlers/rest/configure_api.go` — the new `AsyncReplicationDisabled` runtime-config hook entry.
- `adapters/repos/db/export.go` / `usecases/export/scheduler.go` / `usecases/export/types.go` — `IsAsyncReplicationEnabled` semantics and the reworded rejection message / `Selector` interface contract.
- `adapters/repos/db/index.go` — `updateReplicationConfig` no longer pre-disables async before re-applying; it shares the extracted apply loop.

### Risks and mitigations

- **Behavior change for RF>1 clusters that relied on `asyncEnabled=false`**: after upgrade those classes start performing async repair. Mitigated by `ASYNC_REPLICATION_DISABLED` (runtime-overrides.yaml or env) as an immediate cluster-wide kill-switch. Workload is bounded by the existing `AsyncReplicationWorkersLimiter`.
- **Hashtree rescan on every runtime re-enable.** Trade-off accepted for correctness: a persisted snapshot from `disableAsyncReplication` cannot be safely trusted because the shard kept serving writes. The startup-load fast path (clean shutdown → next startup) is unchanged. Concurrent rescan I/O across shards is bounded by `hashtreeInitSem`.
- **Shards stranded after a runtime flag toggle**: the loaded-but-unregistered arm is fixed by `DB.ReconcileAsyncReplication`; `Migrator.AddClass` covers the class-creation race. The stale-cache arm is closed by the `disableAsyncReplication` + `shard_init_lsm` changes above — a divergence created while the kill-switch was on is now visible to the next hashbeat after re-enable. If individual indices fail to reconcile, the error is logged per-class, the aggregate returns "failed for N of M", and the `weaviate_async_replication_reconcile_failures_total` counter is incremented so operators can alert on a partially-reconciled cluster.
- **Deadlock from holding `replicationConfigLock` across the apply**: addressed by design — `enable/disableAsyncReplication` never reacquire that lock (proven by `updateReplicationConfig` already calling them under the write lock). Documented inline at each call site.
- **Nil `globalreplicationConfig`**: production paths always set it via `MakeAppState`; the explicit nil guard in `asyncReplicationGloballyDisabled()` covers tests that bypass `init.go`/`migrator.go`.
- **API forward-compat**: go-swagger silently drops unknown fields, so old clients sending `asyncEnabled` will not error; the field is simply ignored. Persisted RAFT schema snapshots containing `AsyncEnabled` unmarshal fine — the key becomes a no-op, no migration needed.
- **Mixed-version rolling upgrade**: a new node serializes `ReplicationConfig` without `asyncEnabled`, an old peer with it. This can produce spurious "schema mismatch" diffs in logs during rollout — informational only, not correctness-affecting.

### Testing

- `adapters/repos/db/export_test.go` — `TestIsAsyncReplicationEnabledOrIrrelevant` (table-driven: RF≤1 irrelevant, RF>1 enabled / nil global config / globally disabled) and `TestDBIsAsyncReplicationEnabled` (missing index → not exportable; existing index delegates to the predicate).
- `adapters/repos/db/shard_async_replication_test.go` — `TestReconcileAsyncReplicationOnFlagToggle` (integration): loads an RF>1 shard with the global flag disabled (async replication off — no hashtree, not scheduler-registered), flips the flag and runs `reconcileAsyncReplication`, asserts async replication starts; then re-disables and asserts it stops. `TestDBReconcileAsyncReplicationAggregatesErrors` (integration): `DB.ReconcileAsyncReplication` walks every index, and a reconcile failure on one index is aggregated into the returned error without blocking the others.
- `adapters/repos/db/shard_async_replication_test.go` — `TestEnableAsyncReplicationRescansAfterRuntimeDisable` (integration): pins the stale-cache invariant. Asserts no `.ht` is persisted by `disableAsyncReplication` and that re-enable's hashtree reflects a write made during the disabled window. `TestShardLoadDiscardsStaleHashtreeWhenAsyncDisabled` (integration): covers the boot-disabled-after-async-on path by planting a `.ht` via `mayStopAsyncReplication` and asserting `removePersistedHashtree()` discards it.
- `adapters/repos/db/shard_async_replication_test.go` — four pre-existing tests that planted a `.ht` via `disableAsyncReplication` were retargeted to use `mayStopAsyncReplication`, the only safe producer: `TestEnableAsyncReplication_LoadsHashtreeFromDisk`, `TestEnableAsyncReplication_DiskIONotBlockedByRLock`, `TestDisableRacingInitLeavesNoRegistration`, `TestLoadHashtreeIgnoresTmpFile`. The load-path / disk-I/O / TOCTOU / tmp-file behaviour they cover is preserved.
- `test/acceptance/replication/async_replication/async_replication_runtime_toggle_test.go` — `TestAsyncReplicationRuntimeToggle`: end-to-end coverage of the boot-disabled arm of the runtime kill-switch (cluster boots disabled, node misses a write, flag flipped to enabled → repair). The enable → disable → write → re-enable arm is covered by the shard-level `TestEnableAsyncReplicationRescansAfterRuntimeDisable` above.
- `usecases/export/scheduler_test.go` — `TestScheduler_RejectsWhenAsyncReplicationDisabled` replaces the removed `test/modules/export-s3` e2e test (`TestExport_RejectsWithoutAsyncReplication`); the rejection path is now reachable only via the cluster-wide flag, which can't be toggled per-test on the shared export-s3 cluster, so it is exercised with no cluster.
- Acceptance tests under `test/acceptance/replication/async_replication/...` and `.../replica_replication/...` updated to drop the `AsyncEnabled` flag and exercise the implicit-on path: async repair, deletes, insertions, updates, multi-tenancy, scale up/down, slow file copy, replica movement, node-removal recovery.
- `test/acceptance/replication/async_replication/async_repair_multi_tenancy_test.go` (`TestAsyncRepairMultiTenancyColdTenantConfigUpdate`) reworked into a real, falsifiable assertion that a COLD tenant fetches an async-config update made while it was COLD.
- `test/acceptance/schema/update_class_async_replication_test.go` reworked: previously verified `false → true`; now verifies `AsyncConfig` updates apply without the boolean.
- `usecases/schema/schema_comparison_test.go` updated to the new serialized shape.

**Extended testing**: chaos + e2e pipelines not yet triggered — recommended before merge given this is a default-behavior change affecting every replicated cluster.

### Breaking changes

- **API**: `ReplicationConfig.asyncEnabled` removed from the OpenAPI schema and Go model. Clients reading it from responses no longer receive it; clients sending it have it ignored. Downstream clients that explicitly type the field will need coordinated updates.
- **Behavioral**: any RF>1 collection that relied on `asyncEnabled=false` to suppress repair will perform async repair after upgrade unless `ASYNC_REPLICATION_DISABLED=true` is set cluster-wide.
- **Operational**: runtime re-enables of async replication now trigger a full hashtree rescan per shard (the previous cached-tree fast path could not safely survive a kill-switch window). Bounded by `hashtreeInitSem`; observed cost is in seconds even on RF=3 multi-shard classes in local testing.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Cross-functional impact (uncomment if needed):

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated.
- Client libraries impacted:
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
