### PR TITLE
Namespaces: Wire up remaining schema endpoints

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1091,7 +1091,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	rest_namespaces.SetupHandlers(appState.ServerConfig.Config.Namespaces.Enabled, api, appState.ClusterService.Raft, appState.Authorizer, appState.Logger)
 
 	setupSchemaHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger)
-	setupTokenizeHandlers(api, appState.SchemaManager, appState.Logger)
+	setupTokenizeHandlers(api, appState.SchemaManager, appState.ServerConfig.Config.Namespaces.Enabled, appState.Logger)
 	setupAliasesHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger)
 	objectsManager := objects.NewManager(appState.SchemaManager, appState.ServerConfig, appState.Logger,
 		appState.Authorizer, appState.DB, appState.Modules,

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -149,7 +149,7 @@ func (s *schemaHandlers) deleteClassPropertyIndex(params schema.SchemaObjectsPro
 	principal *models.Principal,
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
-	err := s.manager.DeleteClassPropertyIndex(ctx, principal, s.manager.ReadOnlyClass(params.ClassName), params.ClassName, params.PropertyName, params.IndexName)
+	err := s.manager.DeleteClassPropertyIndex(ctx, principal, params.ClassName, params.PropertyName, params.IndexName)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		switch {

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -128,7 +128,7 @@ func (s *schemaHandlers) addClassProperty(params schema.SchemaObjectsPropertiesA
 	principal *models.Principal,
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
-	_, _, err := s.manager.AddClassProperty(ctx, principal, s.manager.ReadOnlyClass(params.ClassName), params.ClassName, false, params.Body)
+	_, _, err := s.manager.AddClassProperty(ctx, principal, params.ClassName, false, params.Body)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.ClassName, err)
 		switch {

--- a/adapters/handlers/rest/handlers_tokenize.go
+++ b/adapters/handlers/rest/handlers_tokenize.go
@@ -176,7 +176,7 @@ func propertyTokenize(params schemaops.SchemaObjectsPropertiesTokenizeParams,
 	className := schema.UppercaseClassName(params.ClassName)
 
 	// Resolve before authorization so authz uses the real collection name
-	// for permissions and error UX (matches Handler.ShardsStatus).
+	// for permissions and error UX.
 	className, _ = namespacing.Resolve(principal, schemaManager, nsEnabled, className)
 
 	// Authorize: reading collection metadata (same as other schema read operations)

--- a/adapters/handlers/rest/handlers_tokenize.go
+++ b/adapters/handlers/rest/handlers_tokenize.go
@@ -33,9 +33,10 @@ import (
 	schemaops "github.com/weaviate/weaviate/adapters/handlers/rest/operations/schema"
 	tokenizeops "github.com/weaviate/weaviate/adapters/handlers/rest/operations/tokenize"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
-func setupTokenizeHandlers(api *operations.WeaviateAPI, schemaManager *schemaUC.Manager, logger logrus.FieldLogger) {
+func setupTokenizeHandlers(api *operations.WeaviateAPI, schemaManager *schemaUC.Manager, nsEnabled bool, logger logrus.FieldLogger) {
 	api.TokenizeTokenizeHandler = tokenizeops.TokenizeHandlerFunc(
 		func(params tokenizeops.TokenizeParams, principal *models.Principal) middleware.Responder {
 			return genericTokenize(params)
@@ -43,7 +44,7 @@ func setupTokenizeHandlers(api *operations.WeaviateAPI, schemaManager *schemaUC.
 
 	api.SchemaSchemaObjectsPropertiesTokenizeHandler = schemaops.SchemaObjectsPropertiesTokenizeHandlerFunc(
 		func(params schemaops.SchemaObjectsPropertiesTokenizeParams, principal *models.Principal) middleware.Responder {
-			return propertyTokenize(params, principal, schemaManager, logger)
+			return propertyTokenize(params, principal, schemaManager, nsEnabled, logger)
 		})
 }
 
@@ -170,15 +171,13 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 }
 
 func propertyTokenize(params schemaops.SchemaObjectsPropertiesTokenizeParams,
-	principal *models.Principal, schemaManager *schemaUC.Manager, logger logrus.FieldLogger,
+	principal *models.Principal, schemaManager *schemaUC.Manager, nsEnabled bool, logger logrus.FieldLogger,
 ) middleware.Responder {
 	className := schema.UppercaseClassName(params.ClassName)
 
-	// Resolve alias before authorization so authz uses the real collection name
+	// Resolve before authorization so authz uses the real collection name
 	// for permissions and error UX (matches Handler.ShardsStatus).
-	if resolved := schemaManager.ResolveAlias(className); resolved != "" {
-		className = resolved
-	}
+	className, _ = namespacing.Resolve(principal, schemaManager, nsEnabled, className)
 
 	// Authorize: reading collection metadata (same as other schema read operations)
 	err := schemaManager.Authorizer.Authorize(

--- a/test/acceptance/aliases/aliases_api_test.go
+++ b/test/acceptance/aliases/aliases_api_test.go
@@ -643,6 +643,19 @@ func Test_AliasesAPI(t *testing.T) {
 			assertGetObject(t, objID)
 		})
 
+		t.Run("tokenize property with alias", func(t *testing.T) {
+			text := "Hello World"
+			resp, err := helper.Client(t).Schema.SchemaObjectsPropertiesTokenize(
+				schema.NewSchemaObjectsPropertiesTokenizeParams().
+					WithClassName(aliasName).
+					WithPropertyName("title").
+					WithBody(&models.PropertyTokenizeRequest{Text: &text}),
+				nil,
+			)
+			require.NoError(t, err)
+			assert.Equal(t, []string{"Hello", "World"}, resp.Payload.Indexed)
+		})
+
 		t.Run("batch insert with alias", func(t *testing.T) {
 			objID1 := strfmt.UUID("67b79643-cf8b-4b22-b206-000000000001")
 			obj1 := &models.Object{

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -91,8 +91,15 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 	t.Run("end-to-end: insert and get object via alias, with cross-namespace isolation", func(t *testing.T) {
 		// Create the same class name in both namespaces so the only thing
 		// keeping user2 from reading user1's object is the resolver.
+		// The "title" property is declared up front so this test does not
+		// exercise auto-schema.
 		for _, key := range []string{user1Key, user2Key} {
-			helper.CreateClassAuth(t, &models.Class{Class: "E2EFilmsTarget"}, key)
+			helper.CreateClassAuth(t, &models.Class{
+				Class: "E2EFilmsTarget",
+				Properties: []*models.Property{
+					{Name: "title", DataType: []string{"text"}},
+				},
+			}, key)
 		}
 		defer helper.DeleteClassAuth(t, "customer1:E2EFilmsTarget", adminKey)
 		defer helper.DeleteClassAuth(t, "customer2:E2EFilmsTarget", adminKey)

--- a/test/acceptance/namespace/schema_ops_test.go
+++ b/test/acceptance/namespace/schema_ops_test.go
@@ -42,6 +42,15 @@ func deletePropertyIndexAuth(t *testing.T, className, propName, indexName, key s
 	return err
 }
 
+func deleteVectorIndexAuth(t *testing.T, className, vectorIndexName, key string) error {
+	t.Helper()
+	params := schema.NewSchemaObjectsVectorsDeleteParams().
+		WithClassName(className).
+		WithVectorIndexName(vectorIndexName)
+	_, err := helper.Client(t).Schema.SchemaObjectsVectorsDelete(params, helper.CreateAuth(key))
+	return err
+}
+
 // findProp returns the property with the given name (case-insensitive), or nil.
 func findProp(class *models.Class, name string) *models.Property {
 	for _, p := range class.Properties {
@@ -196,5 +205,76 @@ func TestNamespaces_DeleteClassPropertyIndex(t *testing.T) {
 		require.Error(t, err, "DeleteClassPropertyIndex must not resolve aliases on namespaced clusters")
 
 		requireFilterable(t, "customer1:Concerts", true)
+	})
+}
+
+func TestNamespaces_DeleteClassVectorIndex(t *testing.T) {
+	const ns1 = "customer1"
+
+	helper.CreateNamespace(t, ns1, adminKey)
+	defer helper.DeleteNamespace(t, ns1, adminKey)
+
+	user1Key := createNamespacedUser(t, "u1", ns1, adminKey)
+	t.Cleanup(func() { helper.DeleteUser(t, ns1+":u1", adminKey) })
+
+	// classWithTwoVectors returns a class with two named vectors (vec1, vec2),
+	// both backed by HNSW. Dropping one toggles its VectorIndexType to "none".
+	classWithTwoVectors := func(name string) *models.Class {
+		return &models.Class{
+			Class: name,
+			VectorConfig: map[string]models.VectorConfig{
+				"vec1": {
+					Vectorizer:      map[string]any{"none": map[string]any{}},
+					VectorIndexType: "hnsw",
+				},
+				"vec2": {
+					Vectorizer:      map[string]any{"none": map[string]any{}},
+					VectorIndexType: "hnsw",
+				},
+			},
+		}
+	}
+
+	// vectorIndexType returns the VectorIndexType of `vec` on `qualified`.
+	vectorIndexType := func(t *testing.T, qualified, vec string) string {
+		t.Helper()
+		got := helper.GetClassAuth(t, qualified, adminKey)
+		cfg, ok := got.VectorConfig[vec]
+		require.True(t, ok, "vector config %q missing on %q", vec, qualified)
+		return cfg.VectorIndexType
+	}
+
+	t.Run("namespaced user drops named vector by short name", func(t *testing.T) {
+		helper.CreateClassAuth(t, classWithTwoVectors("Movies"), user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+		require.Equal(t, "hnsw", vectorIndexType(t, "customer1:Movies", "vec1"))
+
+		require.NoError(t, deleteVectorIndexAuth(t, "Movies", "vec1", user1Key))
+
+		assert.Equal(t, "none", vectorIndexType(t, "customer1:Movies", "vec1"))
+		assert.Equal(t, "hnsw", vectorIndexType(t, "customer1:Movies", "vec2"))
+	})
+
+	t.Run("global admin drops named vector by qualified name", func(t *testing.T) {
+		helper.CreateClassAuth(t, classWithTwoVectors("Shows"), user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Shows", adminKey)
+		require.Equal(t, "hnsw", vectorIndexType(t, "customer1:Shows", "vec1"))
+
+		require.NoError(t, deleteVectorIndexAuth(t, "customer1:Shows", "vec1", adminKey))
+
+		assert.Equal(t, "none", vectorIndexType(t, "customer1:Shows", "vec1"))
+	})
+
+	t.Run("alias is not a backdoor: DeleteClassVectorIndex by alias name fails and underlying class unchanged", func(t *testing.T) {
+		helper.CreateClassAuth(t, classWithTwoVectors("Concerts"), user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Concerts", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
+		require.Equal(t, "hnsw", vectorIndexType(t, "customer1:Concerts", "vec1"))
+
+		err := deleteVectorIndexAuth(t, "Gigs", "vec1", user1Key)
+		require.Error(t, err, "DeleteClassVectorIndex must not resolve aliases on namespaced clusters")
+
+		assert.Equal(t, "hnsw", vectorIndexType(t, "customer1:Concerts", "vec1"))
 	})
 }

--- a/test/acceptance/namespace/schema_ops_test.go
+++ b/test/acceptance/namespace/schema_ops_test.go
@@ -12,6 +12,7 @@
 package namespace
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -29,6 +30,26 @@ func addPropertyAuth(t *testing.T, className string, prop *models.Property, key 
 		WithBody(prop)
 	_, err := helper.Client(t).Schema.SchemaObjectsPropertiesAdd(params, helper.CreateAuth(key))
 	return err
+}
+
+func deletePropertyIndexAuth(t *testing.T, className, propName, indexName, key string) error {
+	t.Helper()
+	params := schema.NewSchemaObjectsPropertiesDeleteParams().
+		WithClassName(className).
+		WithPropertyName(propName).
+		WithIndexName(indexName)
+	_, err := helper.Client(t).Schema.SchemaObjectsPropertiesDelete(params, helper.CreateAuth(key))
+	return err
+}
+
+// findProp returns the property with the given name (case-insensitive), or nil.
+func findProp(class *models.Class, name string) *models.Property {
+	for _, p := range class.Properties {
+		if strings.EqualFold(p.Name, name) {
+			return p
+		}
+	}
+	return nil
 }
 
 func TestNamespaces_AddClassProperty(t *testing.T) {
@@ -107,5 +128,73 @@ func TestNamespaces_AddClassProperty(t *testing.T) {
 
 		got := helper.GetClassAuth(t, "customer1:Concerts", adminKey)
 		assert.Empty(t, got.Properties, "underlying class must be unchanged")
+	})
+}
+
+func TestNamespaces_DeleteClassPropertyIndex(t *testing.T) {
+	const ns1 = "customer1"
+
+	helper.CreateNamespace(t, ns1, adminKey)
+	defer helper.DeleteNamespace(t, ns1, adminKey)
+
+	user1Key := createNamespacedUser(t, "u1", ns1, adminKey)
+	t.Cleanup(func() { helper.DeleteUser(t, ns1+":u1", adminKey) })
+
+	// Helper: build a class with a `title` text property that has the
+	// filterable index enabled (the index this test toggles off).
+	indexed := true
+	classWithFilterable := func(name string) *models.Class {
+		return &models.Class{
+			Class: name,
+			Properties: []*models.Property{{
+				Name:            "title",
+				DataType:        []string{"text"},
+				IndexFilterable: &indexed,
+			}},
+		}
+	}
+
+	// requireFilterable asserts that class `qualified` has property `title`
+	// with IndexFilterable set to `want`.
+	requireFilterable := func(t *testing.T, qualified string, want bool) {
+		t.Helper()
+		got := helper.GetClassAuth(t, qualified, adminKey)
+		prop := findProp(got, "title")
+		require.NotNil(t, prop)
+		require.NotNil(t, prop.IndexFilterable)
+		assert.Equal(t, want, *prop.IndexFilterable)
+	}
+
+	t.Run("namespaced user drops filterable index by short name", func(t *testing.T) {
+		helper.CreateClassAuth(t, classWithFilterable("Movies"), user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+		requireFilterable(t, "customer1:Movies", true)
+
+		require.NoError(t, deletePropertyIndexAuth(t, "Movies", "title", "filterable", user1Key))
+
+		requireFilterable(t, "customer1:Movies", false)
+	})
+
+	t.Run("global admin drops filterable index by qualified name", func(t *testing.T) {
+		helper.CreateClassAuth(t, classWithFilterable("Shows"), user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Shows", adminKey)
+		requireFilterable(t, "customer1:Shows", true)
+
+		require.NoError(t, deletePropertyIndexAuth(t, "customer1:Shows", "title", "filterable", adminKey))
+
+		requireFilterable(t, "customer1:Shows", false)
+	})
+
+	t.Run("alias is not a backdoor: DeleteClassPropertyIndex by alias name fails and underlying class unchanged", func(t *testing.T) {
+		helper.CreateClassAuth(t, classWithFilterable("Concerts"), user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Concerts", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
+		requireFilterable(t, "customer1:Concerts", true)
+
+		err := deletePropertyIndexAuth(t, "Gigs", "title", "filterable", user1Key)
+		require.Error(t, err, "DeleteClassPropertyIndex must not resolve aliases on namespaced clusters")
+
+		requireFilterable(t, "customer1:Concerts", true)
 	})
 }

--- a/test/acceptance/namespace/schema_ops_test.go
+++ b/test/acceptance/namespace/schema_ops_test.go
@@ -1,0 +1,111 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func addPropertyAuth(t *testing.T, className string, prop *models.Property, key string) error {
+	t.Helper()
+	params := schema.NewSchemaObjectsPropertiesAddParams().
+		WithClassName(className).
+		WithBody(prop)
+	_, err := helper.Client(t).Schema.SchemaObjectsPropertiesAdd(params, helper.CreateAuth(key))
+	return err
+}
+
+func TestNamespaces_AddClassProperty(t *testing.T) {
+	const (
+		ns1 = "customer1"
+		ns2 = "customer2"
+	)
+	helper.CreateNamespace(t, ns1, adminKey)
+	helper.CreateNamespace(t, ns2, adminKey)
+	defer helper.DeleteNamespace(t, ns1, adminKey)
+	defer helper.DeleteNamespace(t, ns2, adminKey)
+
+	user1Key := createNamespacedUser(t, "u1", ns1, adminKey)
+	user2Key := createNamespacedUser(t, "u2", ns2, adminKey)
+	t.Cleanup(func() {
+		helper.DeleteUser(t, ns1+":u1", adminKey)
+		helper.DeleteUser(t, ns2+":u2", adminKey)
+	})
+
+	t.Run("namespaced user adds property by short name; lands on qualified class", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+
+		err := addPropertyAuth(t, "Movies", &models.Property{
+			Name:     "genre",
+			DataType: []string{"text"},
+		}, user1Key)
+		require.NoError(t, err)
+
+		got := helper.GetClassAuth(t, "customer1:Movies", adminKey)
+		require.Len(t, got.Properties, 1)
+		assert.Equal(t, "genre", got.Properties[0].Name)
+	})
+
+	t.Run("each namespace mutates only its own class", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "Books"}, user1Key)
+		helper.CreateClassAuth(t, &models.Class{Class: "Books"}, user2Key)
+		defer helper.DeleteClassAuth(t, "customer1:Books", adminKey)
+		defer helper.DeleteClassAuth(t, "customer2:Books", adminKey)
+
+		require.NoError(t, addPropertyAuth(t, "Books", &models.Property{
+			Name: "author", DataType: []string{"text"},
+		}, user2Key))
+
+		c1 := helper.GetClassAuth(t, "customer1:Books", adminKey)
+		c2 := helper.GetClassAuth(t, "customer2:Books", adminKey)
+		assert.Empty(t, c1.Properties)
+		require.Len(t, c2.Properties, 1)
+		assert.Equal(t, "author", c2.Properties[0].Name)
+	})
+
+	t.Run("global admin adds property by qualified name", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "Shows"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Shows", adminKey)
+
+		err := addPropertyAuth(t, "customer1:Shows", &models.Property{
+			Name: "rating", DataType: []string{"text"},
+		}, adminKey)
+		require.NoError(t, err)
+
+		got := helper.GetClassAuth(t, "customer1:Shows", adminKey)
+		require.Len(t, got.Properties, 1)
+		assert.Equal(t, "rating", got.Properties[0].Name)
+	})
+
+	t.Run("alias is not a backdoor: AddClassProperty by alias name fails and underlying class unchanged", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "Concerts"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Concerts", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
+
+		err := addPropertyAuth(t, "Gigs", &models.Property{
+			Name: "venue", DataType: []string{"text"},
+		}, user1Key)
+		require.Error(t, err, "AddClassProperty must not resolve aliases on namespaced clusters")
+
+		got := helper.GetClassAuth(t, "customer1:Concerts", adminKey)
+		assert.Empty(t, got.Properties, "underlying class must be unchanged")
+	})
+}

--- a/test/acceptance/namespace/schema_ops_test.go
+++ b/test/acceptance/namespace/schema_ops_test.go
@@ -51,6 +51,19 @@ func deleteVectorIndexAuth(t *testing.T, className, vectorIndexName, key string)
 	return err
 }
 
+func tokenizePropertyAuth(t *testing.T, className, propName, text, key string) (*models.TokenizeResponse, error) {
+	t.Helper()
+	params := schema.NewSchemaObjectsPropertiesTokenizeParams().
+		WithClassName(className).
+		WithPropertyName(propName).
+		WithBody(&models.PropertyTokenizeRequest{Text: &text})
+	resp, err := helper.Client(t).Schema.SchemaObjectsPropertiesTokenize(params, helper.CreateAuth(key))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Payload, nil
+}
+
 // findProp returns the property with the given name (case-insensitive), or nil.
 func findProp(class *models.Class, name string) *models.Property {
 	for _, p := range class.Properties {
@@ -276,5 +289,57 @@ func TestNamespaces_DeleteClassVectorIndex(t *testing.T) {
 		require.Error(t, err, "DeleteClassVectorIndex must not resolve aliases on namespaced clusters")
 
 		assert.Equal(t, "hnsw", vectorIndexType(t, "customer1:Concerts", "vec1"))
+	})
+}
+
+func TestNamespaces_PropertyTokenize(t *testing.T) {
+	const ns1 = "customer1"
+
+	helper.CreateNamespace(t, ns1, adminKey)
+	defer helper.DeleteNamespace(t, ns1, adminKey)
+
+	user1Key := createNamespacedUser(t, "u1", ns1, adminKey)
+	t.Cleanup(func() { helper.DeleteUser(t, ns1+":u1", adminKey) })
+
+	// classWithTokenizedTitle returns a class with a `title` text property using
+	// the "word" tokenization, so propertyTokenize has something to split on.
+	classWithTokenizedTitle := func(name string) *models.Class {
+		return &models.Class{
+			Class: name,
+			Properties: []*models.Property{{
+				Name:         "title",
+				DataType:     []string{"text"},
+				Tokenization: "word",
+			}},
+		}
+	}
+
+	t.Run("namespaced user tokenizes property by short class name", func(t *testing.T) {
+		helper.CreateClassAuth(t, classWithTokenizedTitle("Movies"), user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+
+		got, err := tokenizePropertyAuth(t, "Movies", "title", "Hello World", user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"hello", "world"}, got.Indexed)
+	})
+
+	t.Run("namespaced user tokenizes property via alias resolves to underlying class", func(t *testing.T) {
+		helper.CreateClassAuth(t, classWithTokenizedTitle("Concerts"), user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Concerts", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
+
+		got, err := tokenizePropertyAuth(t, "Gigs", "title", "Hello World", user1Key)
+		require.NoError(t, err, "propertyTokenize should resolve alias to underlying class")
+		assert.Equal(t, []string{"hello", "world"}, got.Indexed)
+	})
+
+	t.Run("global admin tokenizes property by qualified class name", func(t *testing.T) {
+		helper.CreateClassAuth(t, classWithTokenizedTitle("Shows"), user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Shows", adminKey)
+
+		got, err := tokenizePropertyAuth(t, "customer1:Shows", "title", "Hello World", adminKey)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"hello", "world"}, got.Indexed)
 	})
 }

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -49,6 +49,7 @@ func TestMain(m *testing.M) {
 		WithUserApiKey(noPermsUser, noPermsKey).
 		WithDbUsers().
 		WithNamespaces().
+		WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true").
 		WithWeaviateWithGRPC().
 		Start(ctx)
 	if err != nil {

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -139,7 +139,7 @@ func (m *AutoSchemaManager) autoSchema(ctx context.Context, principal *models.Pr
 					return 0, fmt.Errorf("auto schema can't create objects because can't update collection: %w", err)
 				}
 				schemaClass, schemaVersion, err = m.schemaManager.AddClassProperty(ctx,
-					principal, schemaClass, schemaClass.Class, true, newProperties...)
+					principal, schemaClass.Class, true, newProperties...)
 				if err != nil {
 					return 0, err
 				}

--- a/usecases/objects/fakes_for_test.go
+++ b/usecases/objects/fakes_for_test.go
@@ -163,12 +163,12 @@ func (f *fakeSchemaManager) AddClass(ctx context.Context, principal *models.Prin
 }
 
 func (f *fakeSchemaManager) AddClassProperty(ctx context.Context, principal *models.Principal,
-	class *models.Class, className string, merge bool, newProps ...*models.Property,
+	className string, merge bool, newProps ...*models.Property,
 ) (*models.Class, uint64, error) {
 	existing := map[string]int{}
 	var existedClass *models.Class
 	for _, c := range f.GetSchemaResponse.Objects.Classes {
-		if c.Class == class.Class {
+		if c.Class == className {
 			existedClass = c
 			for idx, p := range c.Properties {
 				existing[strings.ToLower(p.Name)] = idx
@@ -188,7 +188,7 @@ func (f *fakeSchemaManager) AddClassProperty(ctx context.Context, principal *mod
 		}
 	}
 
-	return class, f.AutoSchemaVersion, nil
+	return existedClass, f.AutoSchemaVersion, nil
 }
 
 func (f *fakeSchemaManager) AddTenants(ctx context.Context,

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -47,7 +47,7 @@ type schemaManager interface {
 	ReadOnlyClass(name string) *models.Class
 	// AddClassProperty it is upsert operation. it adds properties to a class and updates
 	// existing properties if the merge bool passed true.
-	AddClassProperty(ctx context.Context, principal *models.Principal, class *models.Class, className string, merge bool, prop ...*models.Property) (*models.Class, uint64, error)
+	AddClassProperty(ctx context.Context, principal *models.Principal, className string, merge bool, prop ...*models.Property) (*models.Class, uint64, error)
 
 	// Consistent methods with the consistency flag.
 	// This is used to ensure that internal users will not miss-use the flag and it doesn't need to be set to a default

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -88,7 +88,7 @@ func Test_Schema_Authorization(t *testing.T) {
 		},
 		{
 			methodName:        "DeleteClassPropertyIndex",
-			additionalArgs:    []any{&models.Class{Class: "classname"}, "classname", "someprop", "someindex"},
+			additionalArgs:    []any{"classname", "someprop", "someindex"},
 			expectedVerb:      authorization.UPDATE,
 			expectedResources: authorization.CollectionsMetadata("classname"),
 		},

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -76,7 +76,7 @@ func Test_Schema_Authorization(t *testing.T) {
 		},
 		{
 			methodName:        "AddClassProperty",
-			additionalArgs:    []any{&models.Class{Class: "classname"}, "classname", false, &models.Property{}},
+			additionalArgs:    []any{"classname", false, &models.Property{}},
 			expectedVerb:      authorization.UPDATE,
 			expectedResources: authorization.CollectionsMetadata("classname"),
 		},

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -716,7 +716,6 @@ func Test_AddClass_DefaultsAndMigration(t *testing.T) {
 
 		t.Run("create class with all properties", func(t *testing.T) {
 			fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-			fakeSchemaManager.On("ReadOnlyClass", mock.Anything, mock.Anything).Return(nil)
 			fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
 			handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 			_, _, err := handler.AddClass(ctx, nil, &class)
@@ -724,12 +723,11 @@ func Test_AddClass_DefaultsAndMigration(t *testing.T) {
 		})
 
 		t.Run("add properties to existing class", func(t *testing.T) {
+			fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 			for _, tc := range testCases {
-				fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-				fakeSchemaManager.On("ReadOnlyClass", mock.Anything, mock.Anything).Return(&class)
 				fakeSchemaManager.On("AddProperty", mock.Anything, mock.Anything).Return(nil)
 				t.Run("added_"+tc.propName, func(t *testing.T) {
-					_, _, err := handler.AddClassProperty(ctx, nil, &class, class.Class, false, &models.Property{
+					_, _, err := handler.AddClassProperty(ctx, nil, class.Class, false, &models.Property{
 						Name:         "added_" + tc.propName,
 						DataType:     tc.dataType.PropString(),
 						Tokenization: tc.tokenization,
@@ -893,6 +891,7 @@ func Test_AddClass_DefaultsAndMigration(t *testing.T) {
 
 		t.Run("add properties to existing class", func(t *testing.T) {
 			handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
+			fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 			for _, tc := range testCases {
 				t.Run("added_"+tc.propName, func(t *testing.T) {
 					prop := &models.Property{
@@ -903,7 +902,7 @@ func Test_AddClass_DefaultsAndMigration(t *testing.T) {
 						IndexSearchable: tc.indexSearchable,
 					}
 					fakeSchemaManager.On("AddProperty", className, []*models.Property{prop}).Return(nil)
-					_, _, err := handler.AddClassProperty(ctx, nil, &class, class.Class, false, prop)
+					_, _, err := handler.AddClassProperty(ctx, nil, class.Class, false, prop)
 
 					require.Nil(t, err)
 				})
@@ -1353,6 +1352,7 @@ func Test_Validation_PropertyNames(t *testing.T) {
 
 					fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
 					fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+					fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(class)
 					_, _, err := handler.AddClass(context.Background(), nil, class)
 					require.Nil(t, err)
 
@@ -1363,7 +1363,7 @@ func Test_Validation_PropertyNames(t *testing.T) {
 					if test.valid {
 						fakeSchemaManager.On("AddProperty", class.Class, []*models.Property{property}).Return(nil)
 					}
-					_, _, err = handler.AddClassProperty(context.Background(), nil, class, class.Class, false, property)
+					_, _, err = handler.AddClassProperty(context.Background(), nil, class.Class, false, property)
 					t.Log(err)
 					require.Equal(t, test.valid, err == nil)
 					fakeSchemaManager.AssertExpectations(t)

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -73,11 +73,9 @@ func Resolve(principal *models.Principal, sm SchemaManager, nsEnabled bool, name
 	return qualified, ""
 }
 
-// QualifyClass title-cases the class portion of the input and qualifies
-// it with the principal's namespace when namespaces are enabled. Aliases
-// are not resolved. If a "<namespace>:" prefix is present, it is
-// preserved verbatim and only the class portion's first letter is
-// uppercased.
+// QualifyClass uppercases the class portion of name and prepends the
+// principal's namespace when namespaces are enabled. Aliases are not
+// resolved.
 func QualifyClass(principal *models.Principal, nsEnabled bool, name string) string {
 	qualified := schema.UppercaseClassName(name)
 	if nsEnabled {

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -174,6 +174,8 @@ func (h *Handler) DeleteClassVectorIndex(ctx context.Context, principal *models.
 	if !entcfg.Enabled(os.Getenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT")) {
 		return fmt.Errorf("alter schema drop vector index endpoint is experimental and disabled by default, set the environment variable ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT=true to enable it")
 	}
+	className = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
+
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil {
 		return err
 	}

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -102,14 +102,17 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 
 // DeleteClassPropertyIndex deletes collection's property index
 func (h *Handler) DeleteClassPropertyIndex(ctx context.Context, principal *models.Principal,
-	class *models.Class, className, propertyName, indexName string,
+	className, propertyName, indexName string,
 ) error {
+	className = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
+
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil {
 		return err
 	}
 
+	class := h.schemaReader.ReadOnlyClass(className)
 	if class == nil {
-		return fmt.Errorf("class is nil: %w", ErrNotFound)
+		return fmt.Errorf("class %q: %w", className, ErrNotFound)
 	}
 
 	if propertyName == "" {

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -24,13 +24,16 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/vectorindex"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // AddClassProperty it is upsert operation. it adds properties to a class and updates
 // existing properties if the merge bool passed true.
 func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Principal,
-	class *models.Class, className string, merge bool, newProps ...*models.Property,
+	className string, merge bool, newProps ...*models.Property,
 ) (*models.Class, uint64, error) {
+	className = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
+
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil {
 		return nil, 0, err
 	}
@@ -45,8 +48,9 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 		return h.schemaReader.ReadOnlyClass(name), nil
 	}
 
+	class := h.schemaReader.ReadOnlyClass(className)
 	if class == nil {
-		return nil, 0, fmt.Errorf("class is nil: %w", ErrNotFound)
+		return nil, 0, fmt.Errorf("class %q: %w", className, ErrNotFound)
 	}
 
 	if len(newProps) == 0 {

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/tokenizer"
 	"github.com/weaviate/weaviate/entities/versioned"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 func TestHandler_AddProperty(t *testing.T) {
@@ -39,6 +40,7 @@ func TestHandler_AddProperty(t *testing.T) {
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
 		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NoError(t, err)
 		dataTypes := []schema.DataType{
@@ -69,7 +71,7 @@ func TestHandler_AddProperty(t *testing.T) {
 						DataType: dt.PropString(),
 					}
 					fakeSchemaManager.On("AddProperty", class.Class, []*models.Property{prop}).Return(nil)
-					_, _, err := handler.AddClassProperty(ctx, nil, &class, class.Class, false, prop)
+					_, _, err := handler.AddClassProperty(ctx, nil, class.Class, false, prop)
 					require.NoError(t, err)
 				})
 			}
@@ -97,6 +99,7 @@ func TestHandler_AddProperty(t *testing.T) {
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
 		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NoError(t, err)
 
@@ -115,7 +118,7 @@ func TestHandler_AddProperty(t *testing.T) {
 						Name:     propName,
 						DataType: schema.DataTypeText.PropString(),
 					}
-					_, _, err := handler.AddClassProperty(ctx, nil, &class, class.Class, false, prop)
+					_, _, err := handler.AddClassProperty(ctx, nil, class.Class, false, prop)
 					require.ErrorContains(t, err, "conflict for property")
 					require.ErrorContains(t, err, "already in use or provided multiple times")
 				})
@@ -140,6 +143,7 @@ func TestHandler_AddProperty_Object(t *testing.T) {
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
 		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NoError(t, err)
 		dataTypes := []schema.DataType{
@@ -156,7 +160,7 @@ func TestHandler_AddProperty_Object(t *testing.T) {
 						NestedProperties: []*models.NestedProperty{{Name: "test", DataType: schema.DataTypeInt.PropString()}},
 					}
 					fakeSchemaManager.On("AddProperty", class.Class, []*models.Property{prop}).Return(nil)
-					_, _, err := handler.AddClassProperty(ctx, nil, &class, class.Class, false, prop)
+					_, _, err := handler.AddClassProperty(ctx, nil, class.Class, false, prop)
 					require.NoError(t, err)
 				})
 			}
@@ -185,7 +189,7 @@ func TestHandler_AddProperty_Tokenization(t *testing.T) {
 		for _, tc := range testCases {
 			// Set up schema independently for each test
 			handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
-			fakeSchemaManager.On("ReadOnlyClass", mock.Anything, mock.Anything).Return(&class)
+			fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 
 			strTokenization := "empty"
 			if tc.tokenization != "" {
@@ -207,14 +211,14 @@ func TestHandler_AddProperty_Tokenization(t *testing.T) {
 
 				// If we expect no error, assert that the call is made with the property, else assert that no call was made to add the
 				// property
-				fakeSchemaManager.On("ReadOnlyClass", mock.Anything, mock.Anything).Return(&class)
+				fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 				if len(tc.expectedErrContains) == 0 {
 					fakeSchemaManager.On("AddProperty", class.Class, []*models.Property{prop}).Return(nil)
 				} else {
 					fakeSchemaManager.AssertNotCalled(t, "AddProperty", mock.Anything, mock.Anything)
 				}
 
-				_, _, err := handler.AddClassProperty(ctx, nil, &class, class.Class, false, prop)
+				_, _, err := handler.AddClassProperty(ctx, nil, class.Class, false, prop)
 				if len(tc.expectedErrContains) == 0 {
 					require.NoError(t, err)
 				} else {
@@ -413,10 +417,10 @@ func TestHandler_AddProperty_Reference_Tokenization(t *testing.T) {
 		Vectorizer:        "none",
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
-	fakeSchemaManager.On("ReadOnlyClass", mock.Anything, mock.Anything).Return(&refClass)
+	fakeSchemaManager.On("ReadOnlyClass", refClass.Class).Return(&refClass)
 	fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil).Twice()
 	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil).Twice()
-	fakeSchemaManager.On("ReadOnlyClass", mock.Anything, mock.Anything).Return(&class)
+	fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 	_, _, err := handler.AddClass(ctx, nil, &class)
 	require.NoError(t, err)
 	_, _, err = handler.AddClass(ctx, nil, &refClass)
@@ -428,7 +432,7 @@ func TestHandler_AddProperty_Reference_Tokenization(t *testing.T) {
 	for _, tokenization := range tokenizer.Tokenizations {
 		propName := fmt.Sprintf("ref_%s", tokenization)
 		t.Run(propName, func(t *testing.T) {
-			_, _, err := handler.AddClassProperty(ctx, nil, &class, class.Class, false,
+			_, _, err := handler.AddClassProperty(ctx, nil, class.Class, false,
 				&models.Property{
 					Name:         propName,
 					DataType:     dataType,
@@ -444,7 +448,7 @@ func TestHandler_AddProperty_Reference_Tokenization(t *testing.T) {
 	// non-existent tokenization
 	propName := "ref_nonExistent"
 	t.Run(propName, func(t *testing.T) {
-		_, _, err := handler.AddClassProperty(ctx, nil, &class, class.Class, false,
+		_, _, err := handler.AddClassProperty(ctx, nil, class.Class, false,
 			&models.Property{
 				Name:         propName,
 				DataType:     dataType,
@@ -460,7 +464,7 @@ func TestHandler_AddProperty_Reference_Tokenization(t *testing.T) {
 	propName = "ref_empty"
 	t.Run(propName, func(t *testing.T) {
 		fakeSchemaManager.On("AddProperty", mock.Anything, mock.Anything).Return(nil)
-		_, _, err := handler.AddClassProperty(ctx, nil, &class, class.Class, false,
+		_, _, err := handler.AddClassProperty(ctx, nil, class.Class, false,
 			&models.Property{
 				Name:         propName,
 				DataType:     dataType,
@@ -878,4 +882,81 @@ func TestHandler_DeleteClassVectorIndex(t *testing.T) {
 
 		fakeSchemaManager.AssertExpectations(t)
 	})
+}
+
+func TestAddClassProperty_Namespacing(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		enabled      bool
+		principal    *models.Principal
+		inputName    string
+		stored       string // class name present in storage, "" if absent
+		wantAuthName string // qualified name authorized + persisted
+		wantErrIs    error
+	}{
+		{
+			name:         "namespaced: short input qualifies and authorizes against qualified",
+			enabled:      true,
+			principal:    namespacedPrincipal("customer1"),
+			inputName:    "Movies",
+			stored:       "customer1:Movies",
+			wantAuthName: "customer1:Movies",
+		},
+		{
+			name:         "global on namespaces enabled: qualified input passes through",
+			enabled:      true,
+			principal:    globalPrincipal(),
+			inputName:    "customer1:Movies",
+			stored:       "customer1:Movies",
+			wantAuthName: "customer1:Movies",
+		},
+		{
+			name:         "namespaces disabled: input passes through",
+			enabled:      false,
+			principal:    nil,
+			inputName:    "Movies",
+			stored:       "Movies",
+			wantAuthName: "Movies",
+		},
+		{
+			name:      "namespaced: alias name is not a backdoor (no class at qualified alias name)",
+			enabled:   true,
+			principal: namespacedPrincipal("customer1"),
+			inputName: "Films",
+			stored:    "customer1:Movies",
+			wantErrIs: ErrNotFound,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler, sm := newTestHandlerWithNamespaces(t, tt.enabled)
+
+			lookup := namespacing.QualifyClass(tt.principal, tt.enabled, tt.inputName)
+			if lookup == tt.stored {
+				sm.On("ReadOnlyClass", lookup).Return(&models.Class{
+					Class:             tt.stored,
+					Vectorizer:        "none",
+					ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				})
+			} else {
+				sm.On("ReadOnlyClass", lookup).Return((*models.Class)(nil))
+			}
+			if tt.wantErrIs == nil {
+				sm.On("AddProperty", tt.wantAuthName, mock.Anything).Return(nil)
+			}
+
+			prop := &models.Property{Name: "genre", DataType: schema.DataTypeText.PropString()}
+			_, _, err := handler.AddClassProperty(context.Background(), tt.principal,
+				tt.inputName, false, prop)
+			if tt.wantErrIs != nil {
+				require.ErrorIs(t, err, tt.wantErrIs)
+				return
+			}
+			require.NoError(t, err)
+			sm.AssertExpectations(t)
+		})
+	}
 }

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -960,3 +960,85 @@ func TestAddClassProperty_Namespacing(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteClassPropertyIndex_Namespacing(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		enabled      bool
+		principal    *models.Principal
+		inputName    string
+		stored       string
+		wantAuthName string
+		wantErrIs    error
+	}{
+		{
+			name:         "namespaced: short input qualifies and authorizes against qualified",
+			enabled:      true,
+			principal:    namespacedPrincipal("customer1"),
+			inputName:    "Movies",
+			stored:       "customer1:Movies",
+			wantAuthName: "customer1:Movies",
+		},
+		{
+			name:         "global on namespaces enabled: qualified input passes through",
+			enabled:      true,
+			principal:    globalPrincipal(),
+			inputName:    "customer1:Movies",
+			stored:       "customer1:Movies",
+			wantAuthName: "customer1:Movies",
+		},
+		{
+			name:         "namespaces disabled: input passes through",
+			enabled:      false,
+			principal:    nil,
+			inputName:    "Movies",
+			stored:       "Movies",
+			wantAuthName: "Movies",
+		},
+		{
+			name:      "namespaced: alias name is not a backdoor (no class at qualified alias name)",
+			enabled:   true,
+			principal: namespacedPrincipal("customer1"),
+			inputName: "Films",
+			stored:    "customer1:Movies",
+			wantErrIs: ErrNotFound,
+		},
+	}
+
+	indexed := true
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler, sm := newTestHandlerWithNamespaces(t, tt.enabled)
+
+			lookup := namespacing.QualifyClass(tt.principal, tt.enabled, tt.inputName)
+			prop := &models.Property{
+				Name:            "title",
+				DataType:        schema.DataTypeText.PropString(),
+				IndexFilterable: &indexed,
+			}
+			if lookup == tt.stored {
+				sm.On("ReadOnlyClass", lookup).Return(&models.Class{
+					Class:      tt.stored,
+					Vectorizer: "none",
+					Properties: []*models.Property{prop},
+				})
+			} else {
+				sm.On("ReadOnlyClass", lookup).Return((*models.Class)(nil))
+			}
+			if tt.wantErrIs == nil {
+				sm.On("UpdateProperty", tt.wantAuthName, mock.Anything).Return(nil)
+			}
+
+			err := handler.DeleteClassPropertyIndex(context.Background(), tt.principal,
+				tt.inputName, "title", "filterable")
+			if tt.wantErrIs != nil {
+				require.ErrorIs(t, err, tt.wantErrIs)
+				return
+			}
+			require.NoError(t, err)
+			sm.AssertExpectations(t)
+		})
+	}
+}

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -1042,3 +1042,84 @@ func TestDeleteClassPropertyIndex_Namespacing(t *testing.T) {
 		})
 	}
 }
+
+func TestDeleteClassVectorIndex_Namespacing(t *testing.T) {
+	t.Setenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true")
+	cases := []struct {
+		name         string
+		enabled      bool
+		principal    *models.Principal
+		inputName    string
+		stored       string
+		wantAuthName string
+		wantErrIs    error
+	}{
+		{
+			name:         "namespaced: short input qualifies and authorizes against qualified",
+			enabled:      true,
+			principal:    namespacedPrincipal("customer1"),
+			inputName:    "Movies",
+			stored:       "customer1:Movies",
+			wantAuthName: "customer1:Movies",
+		},
+		{
+			name:         "global on namespaces enabled: qualified input passes through",
+			enabled:      true,
+			principal:    globalPrincipal(),
+			inputName:    "customer1:Movies",
+			stored:       "customer1:Movies",
+			wantAuthName: "customer1:Movies",
+		},
+		{
+			name:         "namespaces disabled: input passes through",
+			enabled:      false,
+			principal:    nil,
+			inputName:    "Movies",
+			stored:       "Movies",
+			wantAuthName: "Movies",
+		},
+		{
+			name:      "namespaced: alias name is not a backdoor (no class at qualified alias name)",
+			enabled:   true,
+			principal: namespacedPrincipal("customer1"),
+			inputName: "Films",
+			stored:    "customer1:Movies",
+			wantErrIs: ErrNotFound,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, sm := newTestHandlerWithNamespaces(t, tt.enabled)
+
+			lookup := namespacing.QualifyClass(tt.principal, tt.enabled, tt.inputName)
+			storedClass := &models.Class{
+				Class: tt.stored,
+				VectorConfig: map[string]models.VectorConfig{
+					"vec1": {VectorIndexType: "hnsw", Vectorizer: "none"},
+				},
+			}
+			if lookup == tt.stored {
+				sm.On("QueryReadOnlyClasses", []string{lookup}).
+					Return(map[string]versioned.Class{lookup: {Class: storedClass}}, nil)
+			} else {
+				sm.On("QueryReadOnlyClasses", []string{lookup}).
+					Return(map[string]versioned.Class{}, nil)
+			}
+			if tt.wantErrIs == nil {
+				sm.On("UpdateClass", mock.MatchedBy(func(c *models.Class) bool {
+					return c.Class == tt.wantAuthName
+				}), mock.Anything).Return(nil)
+			}
+
+			err := handler.DeleteClassVectorIndex(context.Background(), tt.principal,
+				tt.inputName, "vec1")
+			if tt.wantErrIs != nil {
+				require.ErrorIs(t, err, tt.wantErrIs)
+				return
+			}
+			require.NoError(t, err)
+			sm.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

Anything under schema that has not been handled yet:
- DeletePropertyIndex
- AddProperty
- TokenizeProperty
- DeleteClassVectorIndex

The only thing remaining is `ShardsStatus` which will come later because it needs some multi-node changes that come in a separate PR

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
