### PR TITLE
Namespaces: Add cascading delete

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -158,6 +158,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/memwatch"
 	"github.com/weaviate/weaviate/usecases/modules"
 	"github.com/weaviate/weaviate/usecases/monitoring"
+	namespacecleanup "github.com/weaviate/weaviate/usecases/namespace_cleanup"
 	usecasesNamespaces "github.com/weaviate/weaviate/usecases/namespaces"
 	objectttl "github.com/weaviate/weaviate/usecases/object_ttl"
 	"github.com/weaviate/weaviate/usecases/objects"
@@ -839,6 +840,14 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	appState.ObjectTTLCoordinator = objectttl.NewCoordinator(appState.ClusterService.SchemaReader(), appState.SchemaManager, appState.DB,
 		appState.Logger, appState.ClusterHttpClient, appState.Cluster, appState.ObjectTTLLocalStatus)
 
+	namespaceCleanupCoordinator := namespacecleanup.NewCoordinator(
+		appState.NamespacesController,
+		rCluster.NewSchemaNamespaceLister(appState.ClusterService.SchemaReader()),
+		appState.ClusterService.Raft,
+		appState.ClusterService.IsLeader,
+		appState.Logger,
+	)
+
 	enterrors.GoWrapper(func() {
 		l := appState.Logger.WithField("action", "startup")
 		if err := metaStoreReady.waitForMetaStore(); err != nil {
@@ -846,7 +855,7 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 			return
 		}
 		l.Info("Configuring crons")
-		if err := appState.Crons.Init(appState.ClusterService, appState.ObjectTTLCoordinator); err != nil {
+		if err := appState.Crons.Init(appState.ClusterService, appState.ObjectTTLCoordinator, namespaceCleanupCoordinator); err != nil {
 			l.WithError(err).Fatal("Configuring crons failed")
 		}
 	}, appState.Logger)
@@ -2320,6 +2329,7 @@ func initRuntimeOverrides(appState *state.State) *configRuntime.ConfigManager[co
 		registered.RaftTimoutsMultiplier = appState.ServerConfig.Config.Raft.TimeoutsMultiplier
 		registered.ReplicatedIndicesRequestQueueEnabled = appState.ServerConfig.Config.Cluster.RequestQueueConfig.IsEnabled
 		registered.OperationalMode = appState.ServerConfig.Config.OperationalMode
+		registered.NamespaceCleanupInterval = appState.ServerConfig.Config.Namespaces.CleanupInterval
 		registered.ObjectsTTLDeleteSchedule = appState.ServerConfig.Config.ObjectsTTLDeleteSchedule
 		registered.ObjectsTTLBatchSize = appState.ServerConfig.Config.ObjectsTTLBatchSize
 		registered.ObjectsTTLPauseEveryNoBatches = appState.ServerConfig.Config.ObjectsTTLPauseEveryNoBatches

--- a/adapters/handlers/rest/db_users/activate_user_test.go
+++ b/adapters/handlers/rest/db_users/activate_user_test.go
@@ -35,7 +35,7 @@ func TestSuccessActivate(t *testing.T) {
 	authorizer.On("Authorize", mock.Anything, principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
 	dynUser := NewMockDbUserAndRolesGetter(t)
 	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{"user": {Id: "user", Active: false}}, nil)
-	dynUser.On("ActivateUser", "user").Return(nil)
+	dynUser.On("ActivateUser", mock.Anything, "user").Return(nil)
 
 	h := dynUserHandler{
 		dbUsers:    dynUser,

--- a/adapters/handlers/rest/db_users/create_user_test.go
+++ b/adapters/handlers/rest/db_users/create_user_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/users"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
@@ -86,7 +87,7 @@ func TestCreateInternalServerError(t *testing.T) {
 				dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(tt.CheckUserIdentifierExistsValueReturn, tt.CheckUserIdentifierExistsErrorReturn)
 			}
 			if tt.CheckUserIdentifierExistsErrorReturn == nil && !tt.CheckUserIdentifierExistsValueReturn && tt.GetUserReturn == nil {
-				dynUser.On("CreateUser", "user", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.CreateUserReturn)
+				dynUser.On("CreateUser", mock.Anything, "user", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.CreateUserReturn)
 			}
 
 			h := dynUserHandler{
@@ -146,7 +147,7 @@ func TestCreateSuccess(t *testing.T) {
 	dynUser := NewMockDbUserAndRolesGetter(t)
 	dynUser.On("GetUsers", user).Return(map[string]*apikey.User{}, nil)
 	dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(false, nil)
-	dynUser.On("CreateUser", user, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	dynUser.On("CreateUser", mock.Anything, user, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	h := dynUserHandler{
 		dbUsers:    dynUser,
@@ -166,7 +167,7 @@ func TestCreateSuccessWithKey(t *testing.T) {
 	authorizer.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Users(user)[0]).Return(nil)
 
 	dynUser := NewMockDbUserAndRolesGetter(t)
-	dynUser.On("CreateUserWithKey", user, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	dynUser.On("CreateUserWithKey", mock.Anything, user, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	h := dynUserHandler{
 		dbUsers:              dynUser,
@@ -359,7 +360,7 @@ func TestCreateUser_Namespaces(t *testing.T) {
 				expectedKey := apikey.MakeUserKey(userID, tt.body.Namespace)
 				dynUser.On("GetUsers", expectedKey).Return(map[string]*apikey.User{}, nil)
 				dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(false, nil)
-				dynUser.On("CreateUser", expectedKey, mock.Anything, mock.Anything, mock.Anything, tt.body.Namespace, mock.Anything).Return(nil)
+				dynUser.On("CreateUser", mock.Anything, expectedKey, mock.Anything, mock.Anything, mock.Anything, tt.body.Namespace, mock.Anything).Return(nil)
 			}
 
 			ns := namespaces.NewMockExister(t)
@@ -368,6 +369,10 @@ func TestCreateUser_Namespaces(t *testing.T) {
 				known[n] = struct{}{}
 			}
 			ns.On("Exists", mock.AnythingOfType("string")).Return(func(name string) bool {
+				_, ok := known[name]
+				return ok
+			}).Maybe()
+			ns.On("IsActive", mock.AnythingOfType("string")).Return(func(name string) bool {
 				_, ok := known[name]
 				return ok
 			}).Maybe()
@@ -384,6 +389,43 @@ func TestCreateUser_Namespaces(t *testing.T) {
 			assert.IsType(t, tt.wantStatus, res)
 		})
 	}
+}
+
+// TestCreateUser_DeletingNamespaceFastPath asserts the handler returns
+// 422 without dispatching to RAFT when the namespace exists but is
+// being deleted. The apply path would catch this too, but the local
+// IsActive check avoids the round-trip on a guaranteed-failed request.
+func TestCreateUser_DeletingNamespaceFastPath(t *testing.T) {
+	const userID = "user"
+	principal := &models.Principal{IsGlobalOperator: true}
+	authorizer := authorization.NewMockAuthorizer(t)
+	authorizer.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Users(userID)[0]).Return(nil)
+
+	// dynUser must not be called: the local check has to short-circuit.
+	dynUser := NewMockDbUserAndRolesGetter(t)
+
+	ns := namespaces.NewMockExister(t)
+	ns.On("Exists", "ns1").Return(true)
+	ns.On("IsActive", "ns1").Return(false)
+
+	h := dynUserHandler{
+		dbUsers:           dynUser,
+		authorizer:        authorizer,
+		dbUserEnabled:     true,
+		namespacesEnabled: true,
+		namespaces:        ns,
+	}
+
+	res := h.createUser(users.CreateUserParams{
+		UserID:      userID,
+		HTTPRequest: req,
+		Body:        users.CreateUserBody{Namespace: "ns1"},
+	}, principal)
+	parsed, ok := res.(*users.CreateUserUnprocessableEntity)
+	assert.True(t, ok, "expected 422, got %T", res)
+	require.NotNil(t, parsed.Payload)
+	require.Len(t, parsed.Payload.Error, 1)
+	assert.Contains(t, parsed.Payload.Error[0].Message, "being deleted")
 }
 
 // TestCreateUser_MapsApplyNamespaceErrorsTo422 asserts the createUser
@@ -427,10 +469,11 @@ func TestCreateUser_MapsApplyNamespaceErrorsTo422(t *testing.T) {
 			expectedKey := apikey.MakeUserKey(userID, "ns1")
 			dynUser.On("GetUsers", expectedKey).Return(map[string]*apikey.User{}, nil)
 			dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(false, nil)
-			dynUser.On("CreateUser", expectedKey, mock.Anything, mock.Anything, mock.Anything, "ns1", mock.Anything).Return(tt.applyErr)
+			dynUser.On("CreateUser", mock.Anything, expectedKey, mock.Anything, mock.Anything, mock.Anything, "ns1", mock.Anything).Return(tt.applyErr)
 
 			ns := namespaces.NewMockExister(t)
 			ns.On("Exists", mock.AnythingOfType("string")).Return(true).Maybe()
+			ns.On("IsActive", mock.AnythingOfType("string")).Return(true).Maybe()
 
 			h := dynUserHandler{
 				dbUsers:           dynUser,

--- a/adapters/handlers/rest/db_users/create_user_test.go
+++ b/adapters/handlers/rest/db_users/create_user_test.go
@@ -407,11 +407,6 @@ func TestCreateUser_NamespaceTOCTOU(t *testing.T) {
 			expect:   &users.CreateUserUnprocessableEntity{},
 		},
 		{
-			name:     "wrapped via string returns 422",
-			applyErr: errors.New("creating user: " + namespaces.ErrNamespaceDeleting.Error()),
-			expect:   &users.CreateUserUnprocessableEntity{},
-		},
-		{
 			name:     "unrelated error returns 500",
 			applyErr: errors.New("disk full"),
 			expect:   &users.CreateUserInternalServerError{},

--- a/adapters/handlers/rest/db_users/create_user_test.go
+++ b/adapters/handlers/rest/db_users/create_user_test.go
@@ -386,9 +386,13 @@ func TestCreateUser_Namespaces(t *testing.T) {
 	}
 }
 
-// TestCreateUser_NamespaceTOCTOU asserts apply-time namespace-gone /
-// namespace-deleting errors map to 422, unrelated errors to 500.
-func TestCreateUser_NamespaceTOCTOU(t *testing.T) {
+// TestCreateUser_MapsApplyNamespaceErrorsTo422 asserts the createUser
+// handler classifies apply-layer namespace sentinels as retryable client
+// errors (422) and everything else as 500. The handler's pre-flight
+// Exists check can race with a concurrent namespace delete, so a 500
+// would be misleading: the request is well-formed, the namespace just
+// vanished underneath it.
+func TestCreateUser_MapsApplyNamespaceErrorsTo422(t *testing.T) {
 	const userID = "user"
 
 	tests := []struct {

--- a/adapters/handlers/rest/db_users/create_user_test.go
+++ b/adapters/handlers/rest/db_users/create_user_test.go
@@ -13,6 +13,7 @@ package db_users
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -381,6 +382,71 @@ func TestCreateUser_Namespaces(t *testing.T) {
 
 			res := h.createUser(users.CreateUserParams{UserID: userID, HTTPRequest: req, Body: tt.body}, principal)
 			assert.IsType(t, tt.wantStatus, res)
+		})
+	}
+}
+
+// TestCreateUser_NamespaceTOCTOU asserts apply-time namespace-gone /
+// namespace-deleting errors map to 422, unrelated errors to 500.
+func TestCreateUser_NamespaceTOCTOU(t *testing.T) {
+	const userID = "user"
+
+	tests := []struct {
+		name     string
+		applyErr error
+		expect   any
+	}{
+		{
+			name:     "ErrNamespaceGone returns 422",
+			applyErr: fmt.Errorf("apply: %w", namespaces.ErrNamespaceGone),
+			expect:   &users.CreateUserUnprocessableEntity{},
+		},
+		{
+			name:     "ErrNamespaceDeleting returns 422",
+			applyErr: fmt.Errorf("apply: %w", namespaces.ErrNamespaceDeleting),
+			expect:   &users.CreateUserUnprocessableEntity{},
+		},
+		{
+			name:     "wrapped via string returns 422",
+			applyErr: errors.New("creating user: " + namespaces.ErrNamespaceDeleting.Error()),
+			expect:   &users.CreateUserUnprocessableEntity{},
+		},
+		{
+			name:     "unrelated error returns 500",
+			applyErr: errors.New("disk full"),
+			expect:   &users.CreateUserInternalServerError{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			principal := &models.Principal{IsGlobalOperator: true}
+			authorizer := authorization.NewMockAuthorizer(t)
+			authorizer.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Users(userID)[0]).Return(nil)
+
+			dynUser := NewMockDbUserAndRolesGetter(t)
+			expectedKey := apikey.MakeUserKey(userID, "ns1")
+			dynUser.On("GetUsers", expectedKey).Return(map[string]*apikey.User{}, nil)
+			dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(false, nil)
+			dynUser.On("CreateUser", expectedKey, mock.Anything, mock.Anything, mock.Anything, "ns1", mock.Anything).Return(tt.applyErr)
+
+			ns := namespaces.NewMockExister(t)
+			ns.On("Exists", mock.AnythingOfType("string")).Return(true).Maybe()
+
+			h := dynUserHandler{
+				dbUsers:           dynUser,
+				authorizer:        authorizer,
+				dbUserEnabled:     true,
+				namespacesEnabled: true,
+				namespaces:        ns,
+			}
+
+			res := h.createUser(users.CreateUserParams{
+				UserID:      userID,
+				HTTPRequest: req,
+				Body:        users.CreateUserBody{Namespace: "ns1"},
+			}, principal)
+			assert.IsType(t, tt.expect, res)
 		})
 	}
 }

--- a/adapters/handlers/rest/db_users/deactivate_user_test.go
+++ b/adapters/handlers/rest/db_users/deactivate_user_test.go
@@ -40,7 +40,7 @@ func TestSuccessDeactivate(t *testing.T) {
 			authorizer.On("Authorize", mock.Anything, principal, authorization.UPDATE, authorization.Users("user")[0]).Return(nil)
 			dynUser := NewMockDbUserAndRolesGetter(t)
 			dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{"user": {Id: "user", Active: true}}, nil)
-			dynUser.On("DeactivateUser", "user", test.revokeKey).Return(nil)
+			dynUser.On("DeactivateUser", mock.Anything, "user", test.revokeKey).Return(nil)
 
 			h := dynUserHandler{
 				dbUsers:    dynUser,

--- a/adapters/handlers/rest/db_users/delete_user_test.go
+++ b/adapters/handlers/rest/db_users/delete_user_test.go
@@ -38,7 +38,7 @@ func TestDeleteSuccess(t *testing.T) {
 	dynUser := NewMockDbUserAndRolesGetter(t)
 	dynUser.On("GetRolesForUserOrGroup", "user", authentication.AuthTypeDb, false).Return(map[string][]authorization.Policy{"role": {}}, nil)
 	dynUser.On("RevokeRolesForUser", conv.UserNameWithTypeFromId("user", authentication.AuthType(models.UserTypeInputDb)), "role").Return(nil)
-	dynUser.On("DeleteUser", "user").Return(nil)
+	dynUser.On("DeleteUser", mock.Anything, "user").Return(nil)
 	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{"user": {}}, nil)
 
 	h := dynUserHandler{

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -360,8 +360,15 @@ func (h *dynUserHandler) createUser(params users.CreateUserParams, principal *mo
 		if params.Body.Namespace == "" {
 			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("namespace is required on namespace-enabled clusters")))
 		}
+		// Fast-path local check before the RAFT round-trip. The apply
+		// path re-validates against authoritative state and surfaces
+		// the same sentinels (mapped below), so the worst case for a
+		// stale local view is a redundant 422.
 		if !h.namespaces.Exists(params.Body.Namespace) {
 			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q does not exist", params.Body.Namespace)))
+		}
+		if !h.namespaces.IsActive(params.Body.Namespace) {
+			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q is being deleted", params.Body.Namespace)))
 		}
 	}
 
@@ -390,7 +397,7 @@ func (h *dynUserHandler) createUser(params users.CreateUserParams, principal *mo
 			createdAt = time.Time(params.Body.CreateTime).UTC()
 		}
 
-		if err := h.dbUsers.CreateUserWithKey(params.UserID, apiKey[:3], sha256.Sum256([]byte(apiKey)), createdAt); err != nil {
+		if err := h.dbUsers.CreateUserWithKey(ctx, params.UserID, apiKey[:3], sha256.Sum256([]byte(apiKey)), createdAt); err != nil {
 			return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("creating user: %w", err)))
 		}
 
@@ -427,7 +434,7 @@ func (h *dynUserHandler) createUser(params users.CreateUserParams, principal *mo
 		return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
-	if err := h.dbUsers.CreateUser(internalKey, hash, userIdentifier, apiKey[:3], params.Body.Namespace, time.Now()); err != nil {
+	if err := h.dbUsers.CreateUser(ctx, internalKey, hash, userIdentifier, apiKey[:3], params.Body.Namespace, time.Now()); err != nil {
 		// Apply-time race: surface a deleted/deleting namespace as 422 so
 		// clients can retry against current state.
 		if errors.Is(err, namespaces.ErrNamespaceGone) || errors.Is(err, namespaces.ErrNamespaceDeleting) {
@@ -473,7 +480,7 @@ func (h *dynUserHandler) rotateKey(params users.RotateUserAPIKeyParams, principa
 		return users.NewRotateUserAPIKeyInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
-	if err := h.dbUsers.RotateKey(params.UserID, apiKey[:3], hash, oldUserIdentifier, newUserIdentifier); err != nil {
+	if err := h.dbUsers.RotateKey(ctx, params.UserID, apiKey[:3], hash, oldUserIdentifier, newUserIdentifier); err != nil {
 		return users.NewRotateUserAPIKeyInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("rotate key: %w", err)))
 	}
 
@@ -553,7 +560,7 @@ func (h *dynUserHandler) deleteUser(params users.DeleteUserParams, principal *mo
 		}
 	}
 
-	if err := h.dbUsers.DeleteUser(params.UserID); err != nil {
+	if err := h.dbUsers.DeleteUser(ctx, params.UserID); err != nil {
 		return users.NewDeleteUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 	return users.NewDeleteUserNoContent()
@@ -603,7 +610,7 @@ func (h *dynUserHandler) deactivateUser(params users.DeactivateUserParams, princ
 		revokeKey = *params.Body.RevokeKey
 	}
 
-	if err := h.dbUsers.DeactivateUser(params.UserID, revokeKey); err != nil {
+	if err := h.dbUsers.DeactivateUser(ctx, params.UserID, revokeKey); err != nil {
 		return users.NewDeactivateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("deactivate user: %w", err)))
 	}
 
@@ -644,7 +651,7 @@ func (h *dynUserHandler) activateUser(params users.ActivateUserParams, principal
 		return users.NewActivateUserConflict()
 	}
 
-	if err := h.dbUsers.ActivateUser(params.UserID); err != nil {
+	if err := h.dbUsers.ActivateUser(ctx, params.UserID); err != nil {
 		return users.NewActivateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("activate user: %w", err)))
 	}
 

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -36,7 +36,6 @@ import (
 	cerrors "github.com/weaviate/weaviate/adapters/handlers/rest/errors"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations"
 	"github.com/weaviate/weaviate/adapters/handlers/rest/operations/users"
-	"github.com/weaviate/weaviate/cluster/dynusers"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey"
 	"github.com/weaviate/weaviate/usecases/auth/authentication/apikey/keys"
@@ -430,10 +429,9 @@ func (h *dynUserHandler) createUser(params users.CreateUserParams, principal *mo
 	}
 
 	if err := h.dbUsers.CreateUser(internalKey, hash, userIdentifier, apiKey[:3], params.Body.Namespace, time.Now()); err != nil {
-		// TOCTOU: namespace deleted between handler validation and RAFT apply.
-		// Surface as 422 instead of 500 so clients can retry against current state.
-		if errors.Is(err, dynusers.ErrNamespaceNotFound) ||
-			strings.Contains(err.Error(), dynusers.ErrNamespaceNotFound.Error()) {
+		// Apply-time race: surface a deleted/deleting namespace as 422 so
+		// clients can retry against current state.
+		if isNamespaceTOCTOUErr(err) {
 			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("creating user: %w", err)))
 		}
 		return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("creating user: %w", err)))
@@ -705,6 +703,21 @@ func (h *dynUserHandler) isRequestFromRootUser(principal *models.Principal) bool
 		return false
 	}
 	return h.rbacConfig.IsRoot(principal.Username, principal.Groups)
+}
+
+// isNamespaceTOCTOUErr matches the namespace-gone/deleting sentinels. The
+// string fallback handles errors that lost their wrapping crossing the
+// RAFT boundary.
+func isNamespaceTOCTOUErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, namespaces.ErrNamespaceGone) || errors.Is(err, namespaces.ErrNamespaceDeleting) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, namespaces.ErrNamespaceGone.Error()) ||
+		strings.Contains(msg, namespaces.ErrNamespaceDeleting.Error())
 }
 
 // validateRoleName validates that this string is a valid role name (format wise)

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
-	"strings"
 	"sync"
 	"time"
 
@@ -431,7 +430,7 @@ func (h *dynUserHandler) createUser(params users.CreateUserParams, principal *mo
 	if err := h.dbUsers.CreateUser(internalKey, hash, userIdentifier, apiKey[:3], params.Body.Namespace, time.Now()); err != nil {
 		// Apply-time race: surface a deleted/deleting namespace as 422 so
 		// clients can retry against current state.
-		if isNamespaceTOCTOUErr(err) {
+		if errors.Is(err, namespaces.ErrNamespaceGone) || errors.Is(err, namespaces.ErrNamespaceDeleting) {
 			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("creating user: %w", err)))
 		}
 		return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("creating user: %w", err)))
@@ -703,21 +702,6 @@ func (h *dynUserHandler) isRequestFromRootUser(principal *models.Principal) bool
 		return false
 	}
 	return h.rbacConfig.IsRoot(principal.Username, principal.Groups)
-}
-
-// isNamespaceTOCTOUErr matches the namespace-gone/deleting sentinels. The
-// string fallback handles errors that lost their wrapping crossing the
-// RAFT boundary.
-func isNamespaceTOCTOUErr(err error) bool {
-	if err == nil {
-		return false
-	}
-	if errors.Is(err, namespaces.ErrNamespaceGone) || errors.Is(err, namespaces.ErrNamespaceDeleting) {
-		return true
-	}
-	msg := err.Error()
-	return strings.Contains(msg, namespaces.ErrNamespaceGone.Error()) ||
-		strings.Contains(msg, namespaces.ErrNamespaceDeleting.Error())
 }
 
 // validateRoleName validates that this string is a valid role name (format wise)

--- a/adapters/handlers/rest/db_users/mock_db_user_and_roles_getter.go
+++ b/adapters/handlers/rest/db_users/mock_db_user_and_roles_getter.go
@@ -19,6 +19,8 @@ import (
 
 	authorization "github.com/weaviate/weaviate/usecases/auth/authorization"
 
+	context "context"
+
 	mock "github.com/stretchr/testify/mock"
 
 	time "time"
@@ -37,17 +39,17 @@ func (_m *MockDbUserAndRolesGetter) EXPECT() *MockDbUserAndRolesGetter_Expecter 
 	return &MockDbUserAndRolesGetter_Expecter{mock: &_m.Mock}
 }
 
-// ActivateUser provides a mock function with given fields: userId
-func (_m *MockDbUserAndRolesGetter) ActivateUser(userId string) error {
-	ret := _m.Called(userId)
+// ActivateUser provides a mock function with given fields: ctx, userId
+func (_m *MockDbUserAndRolesGetter) ActivateUser(ctx context.Context, userId string) error {
+	ret := _m.Called(ctx, userId)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ActivateUser")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(userId)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, userId)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -61,14 +63,15 @@ type MockDbUserAndRolesGetter_ActivateUser_Call struct {
 }
 
 // ActivateUser is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userId string
-func (_e *MockDbUserAndRolesGetter_Expecter) ActivateUser(userId interface{}) *MockDbUserAndRolesGetter_ActivateUser_Call {
-	return &MockDbUserAndRolesGetter_ActivateUser_Call{Call: _e.mock.On("ActivateUser", userId)}
+func (_e *MockDbUserAndRolesGetter_Expecter) ActivateUser(ctx interface{}, userId interface{}) *MockDbUserAndRolesGetter_ActivateUser_Call {
+	return &MockDbUserAndRolesGetter_ActivateUser_Call{Call: _e.mock.On("ActivateUser", ctx, userId)}
 }
 
-func (_c *MockDbUserAndRolesGetter_ActivateUser_Call) Run(run func(userId string)) *MockDbUserAndRolesGetter_ActivateUser_Call {
+func (_c *MockDbUserAndRolesGetter_ActivateUser_Call) Run(run func(ctx context.Context, userId string)) *MockDbUserAndRolesGetter_ActivateUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -78,7 +81,7 @@ func (_c *MockDbUserAndRolesGetter_ActivateUser_Call) Return(_a0 error) *MockDbU
 	return _c
 }
 
-func (_c *MockDbUserAndRolesGetter_ActivateUser_Call) RunAndReturn(run func(string) error) *MockDbUserAndRolesGetter_ActivateUser_Call {
+func (_c *MockDbUserAndRolesGetter_ActivateUser_Call) RunAndReturn(run func(context.Context, string) error) *MockDbUserAndRolesGetter_ActivateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -139,17 +142,17 @@ func (_c *MockDbUserAndRolesGetter_CheckUserIdentifierExists_Call) RunAndReturn(
 	return _c
 }
 
-// CreateUser provides a mock function with given fields: userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace, createdAt
-func (_m *MockDbUserAndRolesGetter) CreateUser(userId string, secureHash string, userIdentifier string, apiKeyFirstLetters string, namespace string, createdAt time.Time) error {
-	ret := _m.Called(userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace, createdAt)
+// CreateUser provides a mock function with given fields: ctx, userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace, createdAt
+func (_m *MockDbUserAndRolesGetter) CreateUser(ctx context.Context, userId string, secureHash string, userIdentifier string, apiKeyFirstLetters string, namespace string, createdAt time.Time) error {
+	ret := _m.Called(ctx, userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace, createdAt)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateUser")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, string, time.Time) error); ok {
-		r0 = rf(userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace, createdAt)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string, time.Time) error); ok {
+		r0 = rf(ctx, userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace, createdAt)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -163,19 +166,20 @@ type MockDbUserAndRolesGetter_CreateUser_Call struct {
 }
 
 // CreateUser is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userId string
 //   - secureHash string
 //   - userIdentifier string
 //   - apiKeyFirstLetters string
 //   - namespace string
 //   - createdAt time.Time
-func (_e *MockDbUserAndRolesGetter_Expecter) CreateUser(userId interface{}, secureHash interface{}, userIdentifier interface{}, apiKeyFirstLetters interface{}, namespace interface{}, createdAt interface{}) *MockDbUserAndRolesGetter_CreateUser_Call {
-	return &MockDbUserAndRolesGetter_CreateUser_Call{Call: _e.mock.On("CreateUser", userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace, createdAt)}
+func (_e *MockDbUserAndRolesGetter_Expecter) CreateUser(ctx interface{}, userId interface{}, secureHash interface{}, userIdentifier interface{}, apiKeyFirstLetters interface{}, namespace interface{}, createdAt interface{}) *MockDbUserAndRolesGetter_CreateUser_Call {
+	return &MockDbUserAndRolesGetter_CreateUser_Call{Call: _e.mock.On("CreateUser", ctx, userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace, createdAt)}
 }
 
-func (_c *MockDbUserAndRolesGetter_CreateUser_Call) Run(run func(userId string, secureHash string, userIdentifier string, apiKeyFirstLetters string, namespace string, createdAt time.Time)) *MockDbUserAndRolesGetter_CreateUser_Call {
+func (_c *MockDbUserAndRolesGetter_CreateUser_Call) Run(run func(ctx context.Context, userId string, secureHash string, userIdentifier string, apiKeyFirstLetters string, namespace string, createdAt time.Time)) *MockDbUserAndRolesGetter_CreateUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(time.Time))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string), args[6].(time.Time))
 	})
 	return _c
 }
@@ -185,22 +189,22 @@ func (_c *MockDbUserAndRolesGetter_CreateUser_Call) Return(_a0 error) *MockDbUse
 	return _c
 }
 
-func (_c *MockDbUserAndRolesGetter_CreateUser_Call) RunAndReturn(run func(string, string, string, string, string, time.Time) error) *MockDbUserAndRolesGetter_CreateUser_Call {
+func (_c *MockDbUserAndRolesGetter_CreateUser_Call) RunAndReturn(run func(context.Context, string, string, string, string, string, time.Time) error) *MockDbUserAndRolesGetter_CreateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// CreateUserWithKey provides a mock function with given fields: userId, apiKeyFirstLetters, weakHash, createdAt
-func (_m *MockDbUserAndRolesGetter) CreateUserWithKey(userId string, apiKeyFirstLetters string, weakHash [32]byte, createdAt time.Time) error {
-	ret := _m.Called(userId, apiKeyFirstLetters, weakHash, createdAt)
+// CreateUserWithKey provides a mock function with given fields: ctx, userId, apiKeyFirstLetters, weakHash, createdAt
+func (_m *MockDbUserAndRolesGetter) CreateUserWithKey(ctx context.Context, userId string, apiKeyFirstLetters string, weakHash [32]byte, createdAt time.Time) error {
+	ret := _m.Called(ctx, userId, apiKeyFirstLetters, weakHash, createdAt)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateUserWithKey")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, [32]byte, time.Time) error); ok {
-		r0 = rf(userId, apiKeyFirstLetters, weakHash, createdAt)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, [32]byte, time.Time) error); ok {
+		r0 = rf(ctx, userId, apiKeyFirstLetters, weakHash, createdAt)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -214,17 +218,18 @@ type MockDbUserAndRolesGetter_CreateUserWithKey_Call struct {
 }
 
 // CreateUserWithKey is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userId string
 //   - apiKeyFirstLetters string
 //   - weakHash [32]byte
 //   - createdAt time.Time
-func (_e *MockDbUserAndRolesGetter_Expecter) CreateUserWithKey(userId interface{}, apiKeyFirstLetters interface{}, weakHash interface{}, createdAt interface{}) *MockDbUserAndRolesGetter_CreateUserWithKey_Call {
-	return &MockDbUserAndRolesGetter_CreateUserWithKey_Call{Call: _e.mock.On("CreateUserWithKey", userId, apiKeyFirstLetters, weakHash, createdAt)}
+func (_e *MockDbUserAndRolesGetter_Expecter) CreateUserWithKey(ctx interface{}, userId interface{}, apiKeyFirstLetters interface{}, weakHash interface{}, createdAt interface{}) *MockDbUserAndRolesGetter_CreateUserWithKey_Call {
+	return &MockDbUserAndRolesGetter_CreateUserWithKey_Call{Call: _e.mock.On("CreateUserWithKey", ctx, userId, apiKeyFirstLetters, weakHash, createdAt)}
 }
 
-func (_c *MockDbUserAndRolesGetter_CreateUserWithKey_Call) Run(run func(userId string, apiKeyFirstLetters string, weakHash [32]byte, createdAt time.Time)) *MockDbUserAndRolesGetter_CreateUserWithKey_Call {
+func (_c *MockDbUserAndRolesGetter_CreateUserWithKey_Call) Run(run func(ctx context.Context, userId string, apiKeyFirstLetters string, weakHash [32]byte, createdAt time.Time)) *MockDbUserAndRolesGetter_CreateUserWithKey_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].([32]byte), args[3].(time.Time))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].([32]byte), args[4].(time.Time))
 	})
 	return _c
 }
@@ -234,22 +239,22 @@ func (_c *MockDbUserAndRolesGetter_CreateUserWithKey_Call) Return(_a0 error) *Mo
 	return _c
 }
 
-func (_c *MockDbUserAndRolesGetter_CreateUserWithKey_Call) RunAndReturn(run func(string, string, [32]byte, time.Time) error) *MockDbUserAndRolesGetter_CreateUserWithKey_Call {
+func (_c *MockDbUserAndRolesGetter_CreateUserWithKey_Call) RunAndReturn(run func(context.Context, string, string, [32]byte, time.Time) error) *MockDbUserAndRolesGetter_CreateUserWithKey_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DeactivateUser provides a mock function with given fields: userId, revokeKey
-func (_m *MockDbUserAndRolesGetter) DeactivateUser(userId string, revokeKey bool) error {
-	ret := _m.Called(userId, revokeKey)
+// DeactivateUser provides a mock function with given fields: ctx, userId, revokeKey
+func (_m *MockDbUserAndRolesGetter) DeactivateUser(ctx context.Context, userId string, revokeKey bool) error {
+	ret := _m.Called(ctx, userId, revokeKey)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeactivateUser")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, bool) error); ok {
-		r0 = rf(userId, revokeKey)
+	if rf, ok := ret.Get(0).(func(context.Context, string, bool) error); ok {
+		r0 = rf(ctx, userId, revokeKey)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -263,15 +268,16 @@ type MockDbUserAndRolesGetter_DeactivateUser_Call struct {
 }
 
 // DeactivateUser is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userId string
 //   - revokeKey bool
-func (_e *MockDbUserAndRolesGetter_Expecter) DeactivateUser(userId interface{}, revokeKey interface{}) *MockDbUserAndRolesGetter_DeactivateUser_Call {
-	return &MockDbUserAndRolesGetter_DeactivateUser_Call{Call: _e.mock.On("DeactivateUser", userId, revokeKey)}
+func (_e *MockDbUserAndRolesGetter_Expecter) DeactivateUser(ctx interface{}, userId interface{}, revokeKey interface{}) *MockDbUserAndRolesGetter_DeactivateUser_Call {
+	return &MockDbUserAndRolesGetter_DeactivateUser_Call{Call: _e.mock.On("DeactivateUser", ctx, userId, revokeKey)}
 }
 
-func (_c *MockDbUserAndRolesGetter_DeactivateUser_Call) Run(run func(userId string, revokeKey bool)) *MockDbUserAndRolesGetter_DeactivateUser_Call {
+func (_c *MockDbUserAndRolesGetter_DeactivateUser_Call) Run(run func(ctx context.Context, userId string, revokeKey bool)) *MockDbUserAndRolesGetter_DeactivateUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(bool))
+		run(args[0].(context.Context), args[1].(string), args[2].(bool))
 	})
 	return _c
 }
@@ -281,22 +287,22 @@ func (_c *MockDbUserAndRolesGetter_DeactivateUser_Call) Return(_a0 error) *MockD
 	return _c
 }
 
-func (_c *MockDbUserAndRolesGetter_DeactivateUser_Call) RunAndReturn(run func(string, bool) error) *MockDbUserAndRolesGetter_DeactivateUser_Call {
+func (_c *MockDbUserAndRolesGetter_DeactivateUser_Call) RunAndReturn(run func(context.Context, string, bool) error) *MockDbUserAndRolesGetter_DeactivateUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// DeleteUser provides a mock function with given fields: userId
-func (_m *MockDbUserAndRolesGetter) DeleteUser(userId string) error {
-	ret := _m.Called(userId)
+// DeleteUser provides a mock function with given fields: ctx, userId
+func (_m *MockDbUserAndRolesGetter) DeleteUser(ctx context.Context, userId string) error {
+	ret := _m.Called(ctx, userId)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteUser")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(userId)
+	if rf, ok := ret.Get(0).(func(context.Context, string) error); ok {
+		r0 = rf(ctx, userId)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -310,14 +316,15 @@ type MockDbUserAndRolesGetter_DeleteUser_Call struct {
 }
 
 // DeleteUser is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userId string
-func (_e *MockDbUserAndRolesGetter_Expecter) DeleteUser(userId interface{}) *MockDbUserAndRolesGetter_DeleteUser_Call {
-	return &MockDbUserAndRolesGetter_DeleteUser_Call{Call: _e.mock.On("DeleteUser", userId)}
+func (_e *MockDbUserAndRolesGetter_Expecter) DeleteUser(ctx interface{}, userId interface{}) *MockDbUserAndRolesGetter_DeleteUser_Call {
+	return &MockDbUserAndRolesGetter_DeleteUser_Call{Call: _e.mock.On("DeleteUser", ctx, userId)}
 }
 
-func (_c *MockDbUserAndRolesGetter_DeleteUser_Call) Run(run func(userId string)) *MockDbUserAndRolesGetter_DeleteUser_Call {
+func (_c *MockDbUserAndRolesGetter_DeleteUser_Call) Run(run func(ctx context.Context, userId string)) *MockDbUserAndRolesGetter_DeleteUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string))
+		run(args[0].(context.Context), args[1].(string))
 	})
 	return _c
 }
@@ -327,7 +334,7 @@ func (_c *MockDbUserAndRolesGetter_DeleteUser_Call) Return(_a0 error) *MockDbUse
 	return _c
 }
 
-func (_c *MockDbUserAndRolesGetter_DeleteUser_Call) RunAndReturn(run func(string) error) *MockDbUserAndRolesGetter_DeleteUser_Call {
+func (_c *MockDbUserAndRolesGetter_DeleteUser_Call) RunAndReturn(run func(context.Context, string) error) *MockDbUserAndRolesGetter_DeleteUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -524,17 +531,17 @@ func (_c *MockDbUserAndRolesGetter_RevokeRolesForUser_Call) RunAndReturn(run fun
 	return _c
 }
 
-// RotateKey provides a mock function with given fields: userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier
-func (_m *MockDbUserAndRolesGetter) RotateKey(userId string, apiKeyFirstLetters string, secureHash string, oldIdentifier string, newIdentifier string) error {
-	ret := _m.Called(userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier)
+// RotateKey provides a mock function with given fields: ctx, userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier
+func (_m *MockDbUserAndRolesGetter) RotateKey(ctx context.Context, userId string, apiKeyFirstLetters string, secureHash string, oldIdentifier string, newIdentifier string) error {
+	ret := _m.Called(ctx, userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RotateKey")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string, string) error); ok {
-		r0 = rf(userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, string) error); ok {
+		r0 = rf(ctx, userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -548,18 +555,19 @@ type MockDbUserAndRolesGetter_RotateKey_Call struct {
 }
 
 // RotateKey is a helper method to define mock.On call
+//   - ctx context.Context
 //   - userId string
 //   - apiKeyFirstLetters string
 //   - secureHash string
 //   - oldIdentifier string
 //   - newIdentifier string
-func (_e *MockDbUserAndRolesGetter_Expecter) RotateKey(userId interface{}, apiKeyFirstLetters interface{}, secureHash interface{}, oldIdentifier interface{}, newIdentifier interface{}) *MockDbUserAndRolesGetter_RotateKey_Call {
-	return &MockDbUserAndRolesGetter_RotateKey_Call{Call: _e.mock.On("RotateKey", userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier)}
+func (_e *MockDbUserAndRolesGetter_Expecter) RotateKey(ctx interface{}, userId interface{}, apiKeyFirstLetters interface{}, secureHash interface{}, oldIdentifier interface{}, newIdentifier interface{}) *MockDbUserAndRolesGetter_RotateKey_Call {
+	return &MockDbUserAndRolesGetter_RotateKey_Call{Call: _e.mock.On("RotateKey", ctx, userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier)}
 }
 
-func (_c *MockDbUserAndRolesGetter_RotateKey_Call) Run(run func(userId string, apiKeyFirstLetters string, secureHash string, oldIdentifier string, newIdentifier string)) *MockDbUserAndRolesGetter_RotateKey_Call {
+func (_c *MockDbUserAndRolesGetter_RotateKey_Call) Run(run func(ctx context.Context, userId string, apiKeyFirstLetters string, secureHash string, oldIdentifier string, newIdentifier string)) *MockDbUserAndRolesGetter_RotateKey_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(string), args[1].(string), args[2].(string), args[3].(string), args[4].(string))
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(string))
 	})
 	return _c
 }
@@ -569,7 +577,7 @@ func (_c *MockDbUserAndRolesGetter_RotateKey_Call) Return(_a0 error) *MockDbUser
 	return _c
 }
 
-func (_c *MockDbUserAndRolesGetter_RotateKey_Call) RunAndReturn(run func(string, string, string, string, string) error) *MockDbUserAndRolesGetter_RotateKey_Call {
+func (_c *MockDbUserAndRolesGetter_RotateKey_Call) RunAndReturn(run func(context.Context, string, string, string, string, string) error) *MockDbUserAndRolesGetter_RotateKey_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/adapters/handlers/rest/db_users/rotate_key_test.go
+++ b/adapters/handlers/rest/db_users/rotate_key_test.go
@@ -34,7 +34,7 @@ func TestSuccessRotate(t *testing.T) {
 	dynUser := NewMockDbUserAndRolesGetter(t)
 	dynUser.On("GetUsers", "user").Return(map[string]*apikey.User{"user": {Id: "user"}}, nil)
 	dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(false, nil)
-	dynUser.On("RotateKey", "user", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	dynUser.On("RotateKey", mock.Anything, "user", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	h := dynUserHandler{
 		dbUsers:       dynUser,
@@ -70,7 +70,7 @@ func TestRotateInternalServerError(t *testing.T) {
 			dynUser.On("GetUsers", "user").Return(tt.GetUserReturnValue, tt.GetUserReturnErr)
 			if tt.GetUserReturnErr == nil {
 				dynUser.On("CheckUserIdentifierExists", mock.Anything).Return(false, nil)
-				dynUser.On("RotateKey", "user", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.RotateKeyError)
+				dynUser.On("RotateKey", mock.Anything, "user", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(tt.RotateKeyError)
 			}
 
 			h := dynUserHandler{

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -2969,7 +2969,7 @@ func init() {
             }
           },
           "409": {
-            "description": "A namespace with the specified name already exists.",
+            "description": "A namespace with the specified name already exists, or a namespace with the same name is currently being deleted. Differentiate by reading the human-readable message in the error payload.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -2989,7 +2989,7 @@ func init() {
         }
       },
       "delete": {
-        "description": "Hard-delete a namespace by its name.",
+        "description": "Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the \"deleting\" state and its dynamic users are removed synchronously; classes and aliases are torn down by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the \"deleting\" state are idempotent and return 202.",
         "tags": [
           "namespaces"
         ],
@@ -3005,8 +3005,8 @@ func init() {
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successfully deleted."
+          "202": {
+            "description": "The namespace has been marked for deletion. Cleanup of its classes, aliases, and users completes asynchronously."
           },
           "401": {
             "description": "Unauthorized or invalid credentials."
@@ -8242,6 +8242,14 @@ func init() {
         "name": {
           "description": "The unique name of the namespace.",
           "type": "string"
+        },
+        "state": {
+          "description": "Lifecycle state. \"active\" namespaces accept all operations; \"deleting\" namespaces are being torn down by the leader and reject create-like operations until the entry is fully removed.",
+          "type": "string",
+          "enum": [
+            "active",
+            "deleting"
+          ]
         }
       }
     },
@@ -13341,7 +13349,7 @@ func init() {
             }
           },
           "409": {
-            "description": "A namespace with the specified name already exists.",
+            "description": "A namespace with the specified name already exists, or a namespace with the same name is currently being deleted. Differentiate by reading the human-readable message in the error payload.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -13361,7 +13369,7 @@ func init() {
         }
       },
       "delete": {
-        "description": "Hard-delete a namespace by its name.",
+        "description": "Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the \"deleting\" state and its dynamic users are removed synchronously; classes and aliases are torn down by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the \"deleting\" state are idempotent and return 202.",
         "tags": [
           "namespaces"
         ],
@@ -13377,8 +13385,8 @@ func init() {
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successfully deleted."
+          "202": {
+            "description": "The namespace has been marked for deletion. Cleanup of its classes, aliases, and users completes asynchronously."
           },
           "401": {
             "description": "Unauthorized or invalid credentials."
@@ -18909,6 +18917,14 @@ func init() {
         "name": {
           "description": "The unique name of the namespace.",
           "type": "string"
+        },
+        "state": {
+          "description": "Lifecycle state. \"active\" namespaces accept all operations; \"deleting\" namespaces are being torn down by the leader and reject create-like operations until the entry is fully removed.",
+          "type": "string",
+          "enum": [
+            "active",
+            "deleting"
+          ]
         }
       }
     },

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -8244,7 +8244,7 @@ func init() {
           "type": "string"
         },
         "state": {
-          "description": "Lifecycle state. \"active\" namespaces accept all operations; \"deleting\" namespaces are being torn down by the leader and reject create-like operations until the entry is fully removed.",
+          "description": "Lifecycle state. \"active\" namespaces accept all operations. \"deleting\" namespaces are being removed: new classes, aliases, and users can no longer be created in the namespace, and the namespace itself disappears once removal completes.",
           "type": "string",
           "enum": [
             "active",
@@ -18919,7 +18919,7 @@ func init() {
           "type": "string"
         },
         "state": {
-          "description": "Lifecycle state. \"active\" namespaces accept all operations; \"deleting\" namespaces are being torn down by the leader and reject create-like operations until the entry is fully removed.",
+          "description": "Lifecycle state. \"active\" namespaces accept all operations. \"deleting\" namespaces are being removed: new classes, aliases, and users can no longer be created in the namespace, and the namespace itself disappears once removal completes.",
           "type": "string",
           "enum": [
             "active",

--- a/adapters/handlers/rest/namespaces/handlers_namespaces.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces.go
@@ -12,6 +12,7 @@
 package namespaces
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -33,9 +34,9 @@ import (
 // NamespaceRaftGetter is the subset of cluster.Raft the handlers use. Keeping
 // it narrow makes the unit tests easy to mock.
 type NamespaceRaftGetter interface {
-	AddNamespace(ns cmd.Namespace) error
-	ChangeNamespaceState(name string, target cmd.NamespaceState) error
-	DeleteUsersInNamespace(name string) error
+	AddNamespace(ctx context.Context, ns cmd.Namespace) error
+	ChangeNamespaceState(ctx context.Context, name string, target cmd.NamespaceState) error
+	DeleteUsersInNamespace(ctx context.Context, name string) error
 	GetNamespaces(names ...string) ([]cmd.Namespace, error)
 }
 
@@ -107,7 +108,7 @@ func (h *namespaceHandler) createNamespace(params nsops.CreateNamespaceParams, p
 	// of truth for uniqueness, so we translate its error sentinels directly.
 	// This avoids a TOCTOU where two concurrent creates both pass a pre-check
 	// and the loser would surface a misleading 500.
-	if err := h.raft.AddNamespace(cmd.Namespace{Name: name}); err != nil {
+	if err := h.raft.AddNamespace(ctx, cmd.Namespace{Name: name}); err != nil {
 		switch {
 		case errors.Is(err, usecasesNamespaces.ErrAlreadyExists):
 			return nsops.NewCreateNamespaceConflict().WithPayload(
@@ -182,7 +183,7 @@ func (h *namespaceHandler) deleteNamespace(params nsops.DeleteNamespaceParams, p
 	// namespace-scoped user delete. Order matters: marking first ensures
 	// the dynusers active-namespace gate rejects any concurrent CreateUser
 	// before we drain the user list.
-	if err := h.raft.ChangeNamespaceState(name, cmd.NamespaceStateDeleting); err != nil {
+	if err := h.raft.ChangeNamespaceState(ctx, name, cmd.NamespaceStateDeleting); err != nil {
 		if errors.Is(err, usecasesNamespaces.ErrNotFound) {
 			return nsops.NewDeleteNamespaceNotFound().WithPayload(
 				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q not found", name)))
@@ -190,7 +191,7 @@ func (h *namespaceHandler) deleteNamespace(params nsops.DeleteNamespaceParams, p
 		return nsops.NewDeleteNamespaceInternalServerError().WithPayload(
 			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("marking namespace for deletion: %w", err)))
 	}
-	if err := h.raft.DeleteUsersInNamespace(name); err != nil {
+	if err := h.raft.DeleteUsersInNamespace(ctx, name); err != nil {
 		return nsops.NewDeleteNamespaceInternalServerError().WithPayload(
 			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("deleting users in namespace: %w", err)))
 	}

--- a/adapters/handlers/rest/namespaces/handlers_namespaces.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces.go
@@ -183,16 +183,12 @@ func (h *namespaceHandler) deleteNamespace(params nsops.DeleteNamespaceParams, p
 	// the dynusers active-namespace gate rejects any concurrent CreateUser
 	// before we drain the user list.
 	if err := h.raft.ChangeNamespaceState(name, cmd.NamespaceStateDeleting); err != nil {
-		switch {
-		case errors.Is(err, usecasesNamespaces.ErrNotFound):
+		if errors.Is(err, usecasesNamespaces.ErrNotFound) {
 			return nsops.NewDeleteNamespaceNotFound().WithPayload(
 				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q not found", name)))
-		case errors.Is(err, usecasesNamespaces.ErrBadRequest):
-			return nsops.NewDeleteNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
-		default:
-			return nsops.NewDeleteNamespaceInternalServerError().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("marking namespace for deletion: %w", err)))
 		}
+		return nsops.NewDeleteNamespaceInternalServerError().WithPayload(
+			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("marking namespace for deletion: %w", err)))
 	}
 	if err := h.raft.DeleteUsersInNamespace(name); err != nil {
 		return nsops.NewDeleteNamespaceInternalServerError().WithPayload(

--- a/adapters/handlers/rest/namespaces/handlers_namespaces.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces.go
@@ -34,8 +34,8 @@ import (
 // NamespaceRaftGetter is the subset of cluster.Raft the handlers use. Keeping
 // it narrow makes the unit tests easy to mock.
 type NamespaceRaftGetter interface {
-	AddNamespace(ctx context.Context, ns cmd.Namespace) error
-	ChangeNamespaceState(ctx context.Context, name string, target cmd.NamespaceState) error
+	AddNamespace(ctx context.Context, ns cmd.Namespace) (uint64, error)
+	ChangeNamespaceState(ctx context.Context, name string, target cmd.NamespaceState) (uint64, error)
 	DeleteUsersInNamespace(ctx context.Context, name string) error
 	GetNamespaces(names ...string) ([]cmd.Namespace, error)
 }
@@ -108,7 +108,7 @@ func (h *namespaceHandler) createNamespace(params nsops.CreateNamespaceParams, p
 	// of truth for uniqueness, so we translate its error sentinels directly.
 	// This avoids a TOCTOU where two concurrent creates both pass a pre-check
 	// and the loser would surface a misleading 500.
-	if err := h.raft.AddNamespace(ctx, cmd.Namespace{Name: name}); err != nil {
+	if _, err := h.raft.AddNamespace(ctx, cmd.Namespace{Name: name}); err != nil {
 		switch {
 		case errors.Is(err, usecasesNamespaces.ErrAlreadyExists):
 			return nsops.NewCreateNamespaceConflict().WithPayload(
@@ -183,7 +183,7 @@ func (h *namespaceHandler) deleteNamespace(params nsops.DeleteNamespaceParams, p
 	// namespace-scoped user delete. Order matters: marking first ensures
 	// the dynusers active-namespace gate rejects any concurrent CreateUser
 	// before we drain the user list.
-	if err := h.raft.ChangeNamespaceState(ctx, name, cmd.NamespaceStateDeleting); err != nil {
+	if _, err := h.raft.ChangeNamespaceState(ctx, name, cmd.NamespaceStateDeleting); err != nil {
 		if errors.Is(err, usecasesNamespaces.ErrNotFound) {
 			return nsops.NewDeleteNamespaceNotFound().WithPayload(
 				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q not found", name)))

--- a/adapters/handlers/rest/namespaces/handlers_namespaces.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces.go
@@ -34,7 +34,8 @@ import (
 // it narrow makes the unit tests easy to mock.
 type NamespaceRaftGetter interface {
 	AddNamespace(ns cmd.Namespace) error
-	DeleteNamespace(name string) error
+	ChangeNamespaceState(name string, target cmd.NamespaceState) error
+	DeleteUsersInNamespace(name string) error
 	GetNamespaces(names ...string) ([]cmd.Namespace, error)
 }
 
@@ -111,6 +112,9 @@ func (h *namespaceHandler) createNamespace(params nsops.CreateNamespaceParams, p
 		case errors.Is(err, usecasesNamespaces.ErrAlreadyExists):
 			return nsops.NewCreateNamespaceConflict().WithPayload(
 				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q already exists", name)))
+		case errors.Is(err, usecasesNamespaces.ErrNamespaceDeleting):
+			return nsops.NewCreateNamespaceConflict().WithPayload(
+				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q is being deleted; retry after cleanup completes", name)))
 		case errors.Is(err, usecasesNamespaces.ErrBadRequest):
 			return nsops.NewCreateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 		default:
@@ -119,7 +123,10 @@ func (h *namespaceHandler) createNamespace(params nsops.CreateNamespaceParams, p
 		}
 	}
 
-	return nsops.NewCreateNamespaceCreated().WithPayload(&models.Namespace{Name: name})
+	return nsops.NewCreateNamespaceCreated().WithPayload(&models.Namespace{
+		Name:  name,
+		State: string(cmd.NamespaceStateActive),
+	})
 }
 
 func (h *namespaceHandler) getNamespace(params nsops.GetNamespaceParams, principal *models.Principal) middleware.Responder {
@@ -148,7 +155,10 @@ func (h *namespaceHandler) getNamespace(params nsops.GetNamespaceParams, princip
 			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q not found", name)))
 	}
 
-	return nsops.NewGetNamespaceOK().WithPayload(&models.Namespace{Name: got[0].Name})
+	return nsops.NewGetNamespaceOK().WithPayload(&models.Namespace{
+		Name:  got[0].Name,
+		State: string(got[0].State),
+	})
 }
 
 func (h *namespaceHandler) deleteNamespace(params nsops.DeleteNamespaceParams, principal *models.Principal) middleware.Responder {
@@ -167,10 +177,12 @@ func (h *namespaceHandler) deleteNamespace(params nsops.DeleteNamespaceParams, p
 		return nsops.NewDeleteNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 	}
 
-	// No pre-check for existence: the RAFT apply layer returns ErrNotFound
-	// for missing entries, so we translate directly. Avoids a TOCTOU where
-	// two concurrent deletes would both see the entry and only one succeeds.
-	if err := h.raft.DeleteNamespace(name); err != nil {
+	// Two-phase delete. First flip to deleting; the apply handler is
+	// idempotent on already-deleting (returns nil). Then issue the
+	// namespace-scoped user delete. Order matters: marking first ensures
+	// the dynusers active-namespace gate rejects any concurrent CreateUser
+	// before we drain the user list.
+	if err := h.raft.ChangeNamespaceState(name, cmd.NamespaceStateDeleting); err != nil {
 		switch {
 		case errors.Is(err, usecasesNamespaces.ErrNotFound):
 			return nsops.NewDeleteNamespaceNotFound().WithPayload(
@@ -179,11 +191,15 @@ func (h *namespaceHandler) deleteNamespace(params nsops.DeleteNamespaceParams, p
 			return nsops.NewDeleteNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
 		default:
 			return nsops.NewDeleteNamespaceInternalServerError().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("deleting namespace: %w", err)))
+				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("marking namespace for deletion: %w", err)))
 		}
 	}
+	if err := h.raft.DeleteUsersInNamespace(name); err != nil {
+		return nsops.NewDeleteNamespaceInternalServerError().WithPayload(
+			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("deleting users in namespace: %w", err)))
+	}
 
-	return nsops.NewDeleteNamespaceNoContent()
+	return nsops.NewDeleteNamespaceAccepted()
 }
 
 // listNamespaces never returns 403. Callers without any applicable
@@ -224,7 +240,7 @@ func (h *namespaceHandler) listNamespaces(params nsops.ListNamespacesParams, pri
 	out := make([]*models.Namespace, 0, len(allowed))
 	for _, ns := range all {
 		if _, ok := allowedSet[authorization.Namespaces(ns.Name)[0]]; ok {
-			out = append(out, &models.Namespace{Name: ns.Name})
+			out = append(out, &models.Namespace{Name: ns.Name, State: string(ns.State)})
 		}
 	}
 	return nsops.NewListNamespacesOK().WithPayload(out)

--- a/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
@@ -125,10 +125,11 @@ func TestCreateNamespace_UnprocessableEntity(t *testing.T) {
 	}
 }
 
-// TestCreateNamespace_Conflict covers both 409 flavors. ErrAlreadyExists
-// is the TOCTOU "name in use" case; ErrNamespaceDeleting is the recreate-
-// while-deleting case. They share the response type but carry different
-// human-readable messages.
+// TestCreateNamespace_Conflict checks that create returns 409 in two
+// cases: when the name belongs to an active namespace, and when the name
+// belongs to one that is still being deleted. Both map to the same
+// response type, so the test also asserts each carries its own distinct
+// message so clients can tell the two situations apart.
 func TestCreateNamespace_Conflict(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
@@ -46,12 +46,14 @@ var req, _ = http.NewRequest("POST", "/namespaces/test", nil)
 // in this package — a generated mock would be more churn than value.
 type mockRaft struct{ mock.Mock }
 
-func (m *mockRaft) AddNamespace(ctx context.Context, ns cmd.Namespace) error {
-	return m.Called(ctx, ns).Error(0)
+func (m *mockRaft) AddNamespace(ctx context.Context, ns cmd.Namespace) (uint64, error) {
+	args := m.Called(ctx, ns)
+	return uint64(args.Int(0)), args.Error(1)
 }
 
-func (m *mockRaft) ChangeNamespaceState(ctx context.Context, name string, target cmd.NamespaceState) error {
-	return m.Called(ctx, name, target).Error(0)
+func (m *mockRaft) ChangeNamespaceState(ctx context.Context, name string, target cmd.NamespaceState) (uint64, error) {
+	args := m.Called(ctx, name, target)
+	return uint64(args.Int(0)), args.Error(1)
 }
 
 func (m *mockRaft) DeleteUsersInNamespace(ctx context.Context, name string) error {
@@ -152,7 +154,7 @@ func TestCreateNamespace_Conflict(t *testing.T) {
 			h, authz, raft := newHandler(t)
 			principal := &models.Principal{}
 			authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
-			raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(tc.raftErr)
+			raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(0, tc.raftErr)
 
 			res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 			parsed, ok := res.(*nsops.CreateNamespaceConflict)
@@ -172,7 +174,7 @@ func TestCreateNamespace_UnprocessableOnRaftBadRequest(t *testing.T) {
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
 	raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).
-		Return(fmt.Errorf("%w: bad payload", usecasesNamespaces.ErrBadRequest))
+		Return(0, fmt.Errorf("%w: bad payload", usecasesNamespaces.ErrBadRequest))
 
 	res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 	_, ok := res.(*nsops.CreateNamespaceUnprocessableEntity)
@@ -183,7 +185,7 @@ func TestCreateNamespace_RaftAddError(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(errors.New("raft boom"))
+	raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(0, errors.New("raft boom"))
 
 	res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 	_, ok := res.(*nsops.CreateNamespaceInternalServerError)
@@ -194,7 +196,7 @@ func TestCreateNamespace_Created(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(nil)
+	raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(0, nil)
 
 	res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 	parsed, ok := res.(*nsops.CreateNamespaceCreated)
@@ -307,7 +309,7 @@ func TestDeleteNamespace_NotFoundOnRaftErrNotFound(t *testing.T) {
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
 	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).
-		Return(fmt.Errorf("%w: %q", usecasesNamespaces.ErrNotFound, "customer1"))
+		Return(0, fmt.Errorf("%w: %q", usecasesNamespaces.ErrNotFound, "customer1"))
 
 	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 	_, ok := res.(*nsops.DeleteNamespaceNotFound)
@@ -318,7 +320,7 @@ func TestDeleteNamespace_ChangeStateError(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(errors.New("raft boom"))
+	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(0, errors.New("raft boom"))
 
 	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 	_, ok := res.(*nsops.DeleteNamespaceInternalServerError)
@@ -329,7 +331,7 @@ func TestDeleteNamespace_DeleteUsersError(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(nil)
+	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(0, nil)
 	raft.On("DeleteUsersInNamespace", mock.Anything, "customer1").Return(errors.New("dynusers boom"))
 
 	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
@@ -343,7 +345,7 @@ func TestDeleteNamespace_Accepted(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(nil)
+	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(0, nil)
 	raft.On("DeleteUsersInNamespace", mock.Anything, "customer1").Return(nil)
 
 	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
@@ -360,7 +362,7 @@ func TestDeleteNamespace_IdempotentRecall(t *testing.T) {
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
 	// ChangeNamespaceState is idempotent: deleting -> deleting returns nil.
-	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(nil)
+	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(0, nil)
 	// DeleteUsersInNamespace is idempotent: no users left → returns nil.
 	raft.On("DeleteUsersInNamespace", mock.Anything, "customer1").Return(nil)
 

--- a/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
@@ -49,7 +49,11 @@ func (m *mockRaft) AddNamespace(ns cmd.Namespace) error {
 	return m.Called(ns).Error(0)
 }
 
-func (m *mockRaft) DeleteNamespace(name string) error {
+func (m *mockRaft) ChangeNamespaceState(name string, target cmd.NamespaceState) error {
+	return m.Called(name, target).Error(0)
+}
+
+func (m *mockRaft) DeleteUsersInNamespace(name string) error {
 	return m.Called(name).Error(0)
 }
 
@@ -120,19 +124,42 @@ func TestCreateNamespace_UnprocessableEntity(t *testing.T) {
 	}
 }
 
-// TestCreateNamespace_ConflictOnRaftAlreadyExists covers the TOCTOU race:
-// two concurrent creates can both pass validation; the loser must get 409,
-// not 500. The handler translates usecasesNamespaces.ErrAlreadyExists → 409.
-func TestCreateNamespace_ConflictOnRaftAlreadyExists(t *testing.T) {
-	h, authz, raft := newHandler(t)
-	principal := &models.Principal{}
-	authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("AddNamespace", cmd.Namespace{Name: "customer1"}).
-		Return(fmt.Errorf("%w: %q", usecasesNamespaces.ErrAlreadyExists, "customer1"))
+// TestCreateNamespace_Conflict covers both 409 flavors. ErrAlreadyExists
+// is the TOCTOU "name in use" case; ErrNamespaceDeleting is the recreate-
+// while-deleting case. They share the response type but carry different
+// human-readable messages.
+func TestCreateNamespace_Conflict(t *testing.T) {
+	tests := []struct {
+		name       string
+		raftErr    error
+		wantSubstr string
+	}{
+		{
+			name:       "already exists",
+			raftErr:    fmt.Errorf("%w: %q", usecasesNamespaces.ErrAlreadyExists, "customer1"),
+			wantSubstr: "already exists",
+		},
+		{
+			name:       "is being deleted",
+			raftErr:    fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceDeleting, "customer1"),
+			wantSubstr: "being deleted",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h, authz, raft := newHandler(t)
+			principal := &models.Principal{}
+			authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
+			raft.On("AddNamespace", cmd.Namespace{Name: "customer1"}).Return(tc.raftErr)
 
-	res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
-	_, ok := res.(*nsops.CreateNamespaceConflict)
-	assert.True(t, ok, "expected 409, got %T", res)
+			res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
+			parsed, ok := res.(*nsops.CreateNamespaceConflict)
+			require.True(t, ok, "expected 409, got %T", res)
+			require.NotNil(t, parsed.Payload)
+			require.Len(t, parsed.Payload.Error, 1)
+			assert.Contains(t, parsed.Payload.Error[0].Message, tc.wantSubstr)
+		})
+	}
 }
 
 // TestCreateNamespace_UnprocessableOnRaftBadRequest covers the defense-in-depth
@@ -172,6 +199,7 @@ func TestCreateNamespace_Created(t *testing.T) {
 	require.True(t, ok, "expected 201, got %T", res)
 	require.NotNil(t, parsed.Payload)
 	assert.Equal(t, "customer1", parsed.Payload.Name)
+	assert.Equal(t, string(cmd.NamespaceStateActive), parsed.Payload.State)
 }
 
 // -----------------------------------------------------------------------------
@@ -222,16 +250,29 @@ func TestGetNamespace_RaftError(t *testing.T) {
 }
 
 func TestGetNamespace_OK(t *testing.T) {
-	h, authz, raft := newHandler(t)
-	principal := &models.Principal{}
-	authz.On("Authorize", mock.Anything, principal, authorization.READ, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("GetNamespaces", "customer1").Return([]cmd.Namespace{{Name: "customer1"}}, nil)
+	tests := []struct {
+		name      string
+		nsState   cmd.NamespaceState
+		wantState string
+	}{
+		{name: "active is surfaced", nsState: cmd.NamespaceStateActive, wantState: string(cmd.NamespaceStateActive)},
+		{name: "deleting is surfaced", nsState: cmd.NamespaceStateDeleting, wantState: string(cmd.NamespaceStateDeleting)},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			h, authz, raft := newHandler(t)
+			principal := &models.Principal{}
+			authz.On("Authorize", mock.Anything, principal, authorization.READ, authorization.Namespaces("customer1")[0]).Return(nil)
+			raft.On("GetNamespaces", "customer1").Return([]cmd.Namespace{{Name: "customer1", State: tc.nsState}}, nil)
 
-	res := h.getNamespace(nsops.GetNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
-	parsed, ok := res.(*nsops.GetNamespaceOK)
-	require.True(t, ok, "expected 200, got %T", res)
-	require.NotNil(t, parsed.Payload)
-	assert.Equal(t, "customer1", parsed.Payload.Name)
+			res := h.getNamespace(nsops.GetNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
+			parsed, ok := res.(*nsops.GetNamespaceOK)
+			require.True(t, ok, "expected 200, got %T", res)
+			require.NotNil(t, parsed.Payload)
+			assert.Equal(t, "customer1", parsed.Payload.Name)
+			assert.Equal(t, tc.wantState, parsed.Payload.State)
+		})
+	}
 }
 
 // -----------------------------------------------------------------------------
@@ -263,7 +304,7 @@ func TestDeleteNamespace_NotFoundOnRaftErrNotFound(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("DeleteNamespace", "customer1").
+	raft.On("ChangeNamespaceState", "customer1", cmd.NamespaceStateDeleting).
 		Return(fmt.Errorf("%w: %q", usecasesNamespaces.ErrNotFound, "customer1"))
 
 	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
@@ -271,26 +312,59 @@ func TestDeleteNamespace_NotFoundOnRaftErrNotFound(t *testing.T) {
 	assert.True(t, ok, "expected 404, got %T", res)
 }
 
-func TestDeleteNamespace_RaftDeleteError(t *testing.T) {
+func TestDeleteNamespace_ChangeStateError(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("DeleteNamespace", "customer1").Return(errors.New("raft boom"))
+	raft.On("ChangeNamespaceState", "customer1", cmd.NamespaceStateDeleting).Return(errors.New("raft boom"))
 
 	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 	_, ok := res.(*nsops.DeleteNamespaceInternalServerError)
 	assert.True(t, ok, "expected 500, got %T", res)
 }
 
-func TestDeleteNamespace_NoContent(t *testing.T) {
+func TestDeleteNamespace_DeleteUsersError(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("DeleteNamespace", "customer1").Return(nil)
+	raft.On("ChangeNamespaceState", "customer1", cmd.NamespaceStateDeleting).Return(nil)
+	raft.On("DeleteUsersInNamespace", "customer1").Return(errors.New("dynusers boom"))
 
 	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
-	_, ok := res.(*nsops.DeleteNamespaceNoContent)
-	assert.True(t, ok, "expected 204, got %T", res)
+	_, ok := res.(*nsops.DeleteNamespaceInternalServerError)
+	assert.True(t, ok, "expected 500, got %T", res)
+}
+
+// TestDeleteNamespace_Accepted is the happy path: 202 returned, both RAFT
+// commands issued in order (mark first, then drain users).
+func TestDeleteNamespace_Accepted(t *testing.T) {
+	h, authz, raft := newHandler(t)
+	principal := &models.Principal{}
+	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
+	raft.On("ChangeNamespaceState", "customer1", cmd.NamespaceStateDeleting).Return(nil)
+	raft.On("DeleteUsersInNamespace", "customer1").Return(nil)
+
+	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
+	_, ok := res.(*nsops.DeleteNamespaceAccepted)
+	assert.True(t, ok, "expected 202, got %T", res)
+}
+
+// TestDeleteNamespace_IdempotentRecall ensures that calling DELETE on an
+// already-deleting namespace still returns 202 (the apply handler is a
+// no-op and returns nil for that case, so the handler reaches the user-
+// drain step and returns Accepted).
+func TestDeleteNamespace_IdempotentRecall(t *testing.T) {
+	h, authz, raft := newHandler(t)
+	principal := &models.Principal{}
+	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
+	// ChangeNamespaceState is idempotent: deleting -> deleting returns nil.
+	raft.On("ChangeNamespaceState", "customer1", cmd.NamespaceStateDeleting).Return(nil)
+	// DeleteUsersInNamespace is idempotent: no users left → returns nil.
+	raft.On("DeleteUsersInNamespace", "customer1").Return(nil)
+
+	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
+	_, ok := res.(*nsops.DeleteNamespaceAccepted)
+	assert.True(t, ok, "expected 202 on re-call, got %T", res)
 }
 
 // -----------------------------------------------------------------------------
@@ -321,7 +395,11 @@ func TestListNamespaces_RaftError(t *testing.T) {
 func TestListNamespaces_FilteredByAuthz(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
-	all := []cmd.Namespace{{Name: "customer1"}, {Name: "customer2"}, {Name: "customer3"}}
+	all := []cmd.Namespace{
+		{Name: "customer1", State: cmd.NamespaceStateActive},
+		{Name: "customer2", State: cmd.NamespaceStateDeleting},
+		{Name: "customer3", State: cmd.NamespaceStateActive},
+	}
 	raft.On("GetNamespaces").Return(all, nil)
 
 	// Caller only has permission on customer2.
@@ -337,6 +415,7 @@ func TestListNamespaces_FilteredByAuthz(t *testing.T) {
 	require.True(t, ok, "expected 200, got %T", res)
 	require.Len(t, parsed.Payload, 1)
 	assert.Equal(t, "customer2", parsed.Payload[0].Name)
+	assert.Equal(t, string(cmd.NamespaceStateDeleting), parsed.Payload[0].State)
 }
 
 func TestListNamespaces_NoPermissionsReturnsEmpty(t *testing.T) {

--- a/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces_test.go
@@ -12,6 +12,7 @@
 package namespaces
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -45,16 +46,16 @@ var req, _ = http.NewRequest("POST", "/namespaces/test", nil)
 // in this package — a generated mock would be more churn than value.
 type mockRaft struct{ mock.Mock }
 
-func (m *mockRaft) AddNamespace(ns cmd.Namespace) error {
-	return m.Called(ns).Error(0)
+func (m *mockRaft) AddNamespace(ctx context.Context, ns cmd.Namespace) error {
+	return m.Called(ctx, ns).Error(0)
 }
 
-func (m *mockRaft) ChangeNamespaceState(name string, target cmd.NamespaceState) error {
-	return m.Called(name, target).Error(0)
+func (m *mockRaft) ChangeNamespaceState(ctx context.Context, name string, target cmd.NamespaceState) error {
+	return m.Called(ctx, name, target).Error(0)
 }
 
-func (m *mockRaft) DeleteUsersInNamespace(name string) error {
-	return m.Called(name).Error(0)
+func (m *mockRaft) DeleteUsersInNamespace(ctx context.Context, name string) error {
+	return m.Called(ctx, name).Error(0)
 }
 
 func (m *mockRaft) GetNamespaces(names ...string) ([]cmd.Namespace, error) {
@@ -150,7 +151,7 @@ func TestCreateNamespace_Conflict(t *testing.T) {
 			h, authz, raft := newHandler(t)
 			principal := &models.Principal{}
 			authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
-			raft.On("AddNamespace", cmd.Namespace{Name: "customer1"}).Return(tc.raftErr)
+			raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(tc.raftErr)
 
 			res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 			parsed, ok := res.(*nsops.CreateNamespaceConflict)
@@ -169,7 +170,7 @@ func TestCreateNamespace_UnprocessableOnRaftBadRequest(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("AddNamespace", cmd.Namespace{Name: "customer1"}).
+	raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).
 		Return(fmt.Errorf("%w: bad payload", usecasesNamespaces.ErrBadRequest))
 
 	res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
@@ -181,7 +182,7 @@ func TestCreateNamespace_RaftAddError(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("AddNamespace", cmd.Namespace{Name: "customer1"}).Return(errors.New("raft boom"))
+	raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(errors.New("raft boom"))
 
 	res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 	_, ok := res.(*nsops.CreateNamespaceInternalServerError)
@@ -192,7 +193,7 @@ func TestCreateNamespace_Created(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.CREATE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("AddNamespace", cmd.Namespace{Name: "customer1"}).Return(nil)
+	raft.On("AddNamespace", mock.Anything, cmd.Namespace{Name: "customer1"}).Return(nil)
 
 	res := h.createNamespace(nsops.CreateNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 	parsed, ok := res.(*nsops.CreateNamespaceCreated)
@@ -304,7 +305,7 @@ func TestDeleteNamespace_NotFoundOnRaftErrNotFound(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("ChangeNamespaceState", "customer1", cmd.NamespaceStateDeleting).
+	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).
 		Return(fmt.Errorf("%w: %q", usecasesNamespaces.ErrNotFound, "customer1"))
 
 	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
@@ -316,7 +317,7 @@ func TestDeleteNamespace_ChangeStateError(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("ChangeNamespaceState", "customer1", cmd.NamespaceStateDeleting).Return(errors.New("raft boom"))
+	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(errors.New("raft boom"))
 
 	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 	_, ok := res.(*nsops.DeleteNamespaceInternalServerError)
@@ -327,8 +328,8 @@ func TestDeleteNamespace_DeleteUsersError(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("ChangeNamespaceState", "customer1", cmd.NamespaceStateDeleting).Return(nil)
-	raft.On("DeleteUsersInNamespace", "customer1").Return(errors.New("dynusers boom"))
+	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(nil)
+	raft.On("DeleteUsersInNamespace", mock.Anything, "customer1").Return(errors.New("dynusers boom"))
 
 	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 	_, ok := res.(*nsops.DeleteNamespaceInternalServerError)
@@ -341,8 +342,8 @@ func TestDeleteNamespace_Accepted(t *testing.T) {
 	h, authz, raft := newHandler(t)
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
-	raft.On("ChangeNamespaceState", "customer1", cmd.NamespaceStateDeleting).Return(nil)
-	raft.On("DeleteUsersInNamespace", "customer1").Return(nil)
+	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(nil)
+	raft.On("DeleteUsersInNamespace", mock.Anything, "customer1").Return(nil)
 
 	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 	_, ok := res.(*nsops.DeleteNamespaceAccepted)
@@ -358,9 +359,9 @@ func TestDeleteNamespace_IdempotentRecall(t *testing.T) {
 	principal := &models.Principal{}
 	authz.On("Authorize", mock.Anything, principal, authorization.DELETE, authorization.Namespaces("customer1")[0]).Return(nil)
 	// ChangeNamespaceState is idempotent: deleting -> deleting returns nil.
-	raft.On("ChangeNamespaceState", "customer1", cmd.NamespaceStateDeleting).Return(nil)
+	raft.On("ChangeNamespaceState", mock.Anything, "customer1", cmd.NamespaceStateDeleting).Return(nil)
 	// DeleteUsersInNamespace is idempotent: no users left → returns nil.
-	raft.On("DeleteUsersInNamespace", "customer1").Return(nil)
+	raft.On("DeleteUsersInNamespace", mock.Anything, "customer1").Return(nil)
 
 	res := h.deleteNamespace(nsops.DeleteNamespaceParams{NamespaceID: "customer1", HTTPRequest: req}, principal)
 	_, ok := res.(*nsops.DeleteNamespaceAccepted)

--- a/adapters/handlers/rest/operations/namespaces/create_namespace_responses.go
+++ b/adapters/handlers/rest/operations/namespaces/create_namespace_responses.go
@@ -33,6 +33,7 @@ CreateNamespaceCreated Namespace created successfully.
 swagger:response createNamespaceCreated
 */
 type CreateNamespaceCreated struct {
+
 	/*
 	  In: Body
 	*/
@@ -41,6 +42,7 @@ type CreateNamespaceCreated struct {
 
 // NewCreateNamespaceCreated creates CreateNamespaceCreated with default headers values
 func NewCreateNamespaceCreated() *CreateNamespaceCreated {
+
 	return &CreateNamespaceCreated{}
 }
 
@@ -57,6 +59,7 @@ func (o *CreateNamespaceCreated) SetPayload(payload *models.Namespace) {
 
 // WriteResponse to the client
 func (o *CreateNamespaceCreated) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(201)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -74,16 +77,19 @@ CreateNamespaceUnauthorized Unauthorized or invalid credentials.
 
 swagger:response createNamespaceUnauthorized
 */
-type CreateNamespaceUnauthorized struct{}
+type CreateNamespaceUnauthorized struct {
+}
 
 // NewCreateNamespaceUnauthorized creates CreateNamespaceUnauthorized with default headers values
 func NewCreateNamespaceUnauthorized() *CreateNamespaceUnauthorized {
+
 	return &CreateNamespaceUnauthorized{}
 }
 
 // WriteResponse to the client
 func (o *CreateNamespaceUnauthorized) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-	rw.Header().Del(runtime.HeaderContentType) // Remove Content-Type on empty responses
+
+	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
 
 	rw.WriteHeader(401)
 }
@@ -97,6 +103,7 @@ CreateNamespaceForbidden Forbidden
 swagger:response createNamespaceForbidden
 */
 type CreateNamespaceForbidden struct {
+
 	/*
 	  In: Body
 	*/
@@ -105,6 +112,7 @@ type CreateNamespaceForbidden struct {
 
 // NewCreateNamespaceForbidden creates CreateNamespaceForbidden with default headers values
 func NewCreateNamespaceForbidden() *CreateNamespaceForbidden {
+
 	return &CreateNamespaceForbidden{}
 }
 
@@ -121,6 +129,7 @@ func (o *CreateNamespaceForbidden) SetPayload(payload *models.ErrorResponse) {
 
 // WriteResponse to the client
 func (o *CreateNamespaceForbidden) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(403)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -139,6 +148,7 @@ CreateNamespaceNotFound Not Found - The namespaces feature is not enabled on thi
 swagger:response createNamespaceNotFound
 */
 type CreateNamespaceNotFound struct {
+
 	/*
 	  In: Body
 	*/
@@ -147,6 +157,7 @@ type CreateNamespaceNotFound struct {
 
 // NewCreateNamespaceNotFound creates CreateNamespaceNotFound with default headers values
 func NewCreateNamespaceNotFound() *CreateNamespaceNotFound {
+
 	return &CreateNamespaceNotFound{}
 }
 
@@ -163,6 +174,7 @@ func (o *CreateNamespaceNotFound) SetPayload(payload *models.ErrorResponse) {
 
 // WriteResponse to the client
 func (o *CreateNamespaceNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(404)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -181,6 +193,7 @@ CreateNamespaceConflict A namespace with the specified name already exists, or a
 swagger:response createNamespaceConflict
 */
 type CreateNamespaceConflict struct {
+
 	/*
 	  In: Body
 	*/
@@ -189,6 +202,7 @@ type CreateNamespaceConflict struct {
 
 // NewCreateNamespaceConflict creates CreateNamespaceConflict with default headers values
 func NewCreateNamespaceConflict() *CreateNamespaceConflict {
+
 	return &CreateNamespaceConflict{}
 }
 
@@ -205,6 +219,7 @@ func (o *CreateNamespaceConflict) SetPayload(payload *models.ErrorResponse) {
 
 // WriteResponse to the client
 func (o *CreateNamespaceConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(409)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -223,6 +238,7 @@ CreateNamespaceUnprocessableEntity The request syntax is correct, but the server
 swagger:response createNamespaceUnprocessableEntity
 */
 type CreateNamespaceUnprocessableEntity struct {
+
 	/*
 	  In: Body
 	*/
@@ -231,6 +247,7 @@ type CreateNamespaceUnprocessableEntity struct {
 
 // NewCreateNamespaceUnprocessableEntity creates CreateNamespaceUnprocessableEntity with default headers values
 func NewCreateNamespaceUnprocessableEntity() *CreateNamespaceUnprocessableEntity {
+
 	return &CreateNamespaceUnprocessableEntity{}
 }
 
@@ -247,6 +264,7 @@ func (o *CreateNamespaceUnprocessableEntity) SetPayload(payload *models.ErrorRes
 
 // WriteResponse to the client
 func (o *CreateNamespaceUnprocessableEntity) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(422)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -265,6 +283,7 @@ CreateNamespaceInternalServerError An error has occurred while trying to fulfill
 swagger:response createNamespaceInternalServerError
 */
 type CreateNamespaceInternalServerError struct {
+
 	/*
 	  In: Body
 	*/
@@ -273,6 +292,7 @@ type CreateNamespaceInternalServerError struct {
 
 // NewCreateNamespaceInternalServerError creates CreateNamespaceInternalServerError with default headers values
 func NewCreateNamespaceInternalServerError() *CreateNamespaceInternalServerError {
+
 	return &CreateNamespaceInternalServerError{}
 }
 
@@ -289,6 +309,7 @@ func (o *CreateNamespaceInternalServerError) SetPayload(payload *models.ErrorRes
 
 // WriteResponse to the client
 func (o *CreateNamespaceInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
 	rw.WriteHeader(500)
 	if o.Payload != nil {
 		payload := o.Payload

--- a/adapters/handlers/rest/operations/namespaces/create_namespace_responses.go
+++ b/adapters/handlers/rest/operations/namespaces/create_namespace_responses.go
@@ -188,7 +188,7 @@ func (o *CreateNamespaceNotFound) WriteResponse(rw http.ResponseWriter, producer
 const CreateNamespaceConflictCode int = 409
 
 /*
-CreateNamespaceConflict A namespace with the specified name already exists.
+CreateNamespaceConflict A namespace with the specified name already exists, or a namespace with the same name is currently being deleted. Differentiate by reading the human-readable message in the error payload.
 
 swagger:response createNamespaceConflict
 */

--- a/adapters/handlers/rest/operations/namespaces/create_namespace_responses.go
+++ b/adapters/handlers/rest/operations/namespaces/create_namespace_responses.go
@@ -33,7 +33,6 @@ CreateNamespaceCreated Namespace created successfully.
 swagger:response createNamespaceCreated
 */
 type CreateNamespaceCreated struct {
-
 	/*
 	  In: Body
 	*/
@@ -42,7 +41,6 @@ type CreateNamespaceCreated struct {
 
 // NewCreateNamespaceCreated creates CreateNamespaceCreated with default headers values
 func NewCreateNamespaceCreated() *CreateNamespaceCreated {
-
 	return &CreateNamespaceCreated{}
 }
 
@@ -59,7 +57,6 @@ func (o *CreateNamespaceCreated) SetPayload(payload *models.Namespace) {
 
 // WriteResponse to the client
 func (o *CreateNamespaceCreated) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(201)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -77,19 +74,16 @@ CreateNamespaceUnauthorized Unauthorized or invalid credentials.
 
 swagger:response createNamespaceUnauthorized
 */
-type CreateNamespaceUnauthorized struct {
-}
+type CreateNamespaceUnauthorized struct{}
 
 // NewCreateNamespaceUnauthorized creates CreateNamespaceUnauthorized with default headers values
 func NewCreateNamespaceUnauthorized() *CreateNamespaceUnauthorized {
-
 	return &CreateNamespaceUnauthorized{}
 }
 
 // WriteResponse to the client
 func (o *CreateNamespaceUnauthorized) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
-	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
+	rw.Header().Del(runtime.HeaderContentType) // Remove Content-Type on empty responses
 
 	rw.WriteHeader(401)
 }
@@ -103,7 +97,6 @@ CreateNamespaceForbidden Forbidden
 swagger:response createNamespaceForbidden
 */
 type CreateNamespaceForbidden struct {
-
 	/*
 	  In: Body
 	*/
@@ -112,7 +105,6 @@ type CreateNamespaceForbidden struct {
 
 // NewCreateNamespaceForbidden creates CreateNamespaceForbidden with default headers values
 func NewCreateNamespaceForbidden() *CreateNamespaceForbidden {
-
 	return &CreateNamespaceForbidden{}
 }
 
@@ -129,7 +121,6 @@ func (o *CreateNamespaceForbidden) SetPayload(payload *models.ErrorResponse) {
 
 // WriteResponse to the client
 func (o *CreateNamespaceForbidden) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(403)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -148,7 +139,6 @@ CreateNamespaceNotFound Not Found - The namespaces feature is not enabled on thi
 swagger:response createNamespaceNotFound
 */
 type CreateNamespaceNotFound struct {
-
 	/*
 	  In: Body
 	*/
@@ -157,7 +147,6 @@ type CreateNamespaceNotFound struct {
 
 // NewCreateNamespaceNotFound creates CreateNamespaceNotFound with default headers values
 func NewCreateNamespaceNotFound() *CreateNamespaceNotFound {
-
 	return &CreateNamespaceNotFound{}
 }
 
@@ -174,7 +163,6 @@ func (o *CreateNamespaceNotFound) SetPayload(payload *models.ErrorResponse) {
 
 // WriteResponse to the client
 func (o *CreateNamespaceNotFound) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(404)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -193,7 +181,6 @@ CreateNamespaceConflict A namespace with the specified name already exists, or a
 swagger:response createNamespaceConflict
 */
 type CreateNamespaceConflict struct {
-
 	/*
 	  In: Body
 	*/
@@ -202,7 +189,6 @@ type CreateNamespaceConflict struct {
 
 // NewCreateNamespaceConflict creates CreateNamespaceConflict with default headers values
 func NewCreateNamespaceConflict() *CreateNamespaceConflict {
-
 	return &CreateNamespaceConflict{}
 }
 
@@ -219,7 +205,6 @@ func (o *CreateNamespaceConflict) SetPayload(payload *models.ErrorResponse) {
 
 // WriteResponse to the client
 func (o *CreateNamespaceConflict) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(409)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -238,7 +223,6 @@ CreateNamespaceUnprocessableEntity The request syntax is correct, but the server
 swagger:response createNamespaceUnprocessableEntity
 */
 type CreateNamespaceUnprocessableEntity struct {
-
 	/*
 	  In: Body
 	*/
@@ -247,7 +231,6 @@ type CreateNamespaceUnprocessableEntity struct {
 
 // NewCreateNamespaceUnprocessableEntity creates CreateNamespaceUnprocessableEntity with default headers values
 func NewCreateNamespaceUnprocessableEntity() *CreateNamespaceUnprocessableEntity {
-
 	return &CreateNamespaceUnprocessableEntity{}
 }
 
@@ -264,7 +247,6 @@ func (o *CreateNamespaceUnprocessableEntity) SetPayload(payload *models.ErrorRes
 
 // WriteResponse to the client
 func (o *CreateNamespaceUnprocessableEntity) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(422)
 	if o.Payload != nil {
 		payload := o.Payload
@@ -283,7 +265,6 @@ CreateNamespaceInternalServerError An error has occurred while trying to fulfill
 swagger:response createNamespaceInternalServerError
 */
 type CreateNamespaceInternalServerError struct {
-
 	/*
 	  In: Body
 	*/
@@ -292,7 +273,6 @@ type CreateNamespaceInternalServerError struct {
 
 // NewCreateNamespaceInternalServerError creates CreateNamespaceInternalServerError with default headers values
 func NewCreateNamespaceInternalServerError() *CreateNamespaceInternalServerError {
-
 	return &CreateNamespaceInternalServerError{}
 }
 
@@ -309,7 +289,6 @@ func (o *CreateNamespaceInternalServerError) SetPayload(payload *models.ErrorRes
 
 // WriteResponse to the client
 func (o *CreateNamespaceInternalServerError) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
-
 	rw.WriteHeader(500)
 	if o.Payload != nil {
 		payload := o.Payload

--- a/adapters/handlers/rest/operations/namespaces/delete_namespace.go
+++ b/adapters/handlers/rest/operations/namespaces/delete_namespace.go
@@ -59,7 +59,7 @@ func (o *DeleteNamespace) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if rCtx != nil {
 		*r = *rCtx
 	}
-	Params := NewDeleteNamespaceParams()
+	var Params = NewDeleteNamespaceParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -80,4 +80,5 @@ func (o *DeleteNamespace) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
+
 }

--- a/adapters/handlers/rest/operations/namespaces/delete_namespace.go
+++ b/adapters/handlers/rest/operations/namespaces/delete_namespace.go
@@ -59,7 +59,7 @@ func (o *DeleteNamespace) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 	if rCtx != nil {
 		*r = *rCtx
 	}
-	var Params = NewDeleteNamespaceParams()
+	Params := NewDeleteNamespaceParams()
 	uprinc, aCtx, err := o.Context.Authorize(r, route)
 	if err != nil {
 		o.Context.Respond(rw, r, route.Produces, route, err)
@@ -80,5 +80,4 @@ func (o *DeleteNamespace) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
 
 	res := o.Handler.Handle(Params, principal) // actually handle the request
 	o.Context.Respond(rw, r, route.Produces, route, res)
-
 }

--- a/adapters/handlers/rest/operations/namespaces/delete_namespace.go
+++ b/adapters/handlers/rest/operations/namespaces/delete_namespace.go
@@ -47,7 +47,7 @@ func NewDeleteNamespace(ctx *middleware.Context, handler DeleteNamespaceHandler)
 
 # Delete a namespace
 
-Hard-delete a namespace by its name.
+Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the "deleting" state and its dynamic users are removed synchronously; classes and aliases are torn down by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the "deleting" state are idempotent and return 202.
 */
 type DeleteNamespace struct {
 	Context *middleware.Context

--- a/adapters/handlers/rest/operations/namespaces/delete_namespace_responses.go
+++ b/adapters/handlers/rest/operations/namespaces/delete_namespace_responses.go
@@ -24,29 +24,29 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
-// DeleteNamespaceNoContentCode is the HTTP code returned for type DeleteNamespaceNoContent
-const DeleteNamespaceNoContentCode int = 204
+// DeleteNamespaceAcceptedCode is the HTTP code returned for type DeleteNamespaceAccepted
+const DeleteNamespaceAcceptedCode int = 202
 
 /*
-DeleteNamespaceNoContent Successfully deleted.
+DeleteNamespaceAccepted The namespace has been marked for deletion. Cleanup of its classes, aliases, and users completes asynchronously.
 
-swagger:response deleteNamespaceNoContent
+swagger:response deleteNamespaceAccepted
 */
-type DeleteNamespaceNoContent struct {
+type DeleteNamespaceAccepted struct {
 }
 
-// NewDeleteNamespaceNoContent creates DeleteNamespaceNoContent with default headers values
-func NewDeleteNamespaceNoContent() *DeleteNamespaceNoContent {
+// NewDeleteNamespaceAccepted creates DeleteNamespaceAccepted with default headers values
+func NewDeleteNamespaceAccepted() *DeleteNamespaceAccepted {
 
-	return &DeleteNamespaceNoContent{}
+	return &DeleteNamespaceAccepted{}
 }
 
 // WriteResponse to the client
-func (o *DeleteNamespaceNoContent) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+func (o *DeleteNamespaceAccepted) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
 
 	rw.Header().Del(runtime.HeaderContentType) //Remove Content-Type on empty responses
 
-	rw.WriteHeader(204)
+	rw.WriteHeader(202)
 }
 
 // DeleteNamespaceUnauthorizedCode is the HTTP code returned for type DeleteNamespaceUnauthorized

--- a/client/namespaces/create_namespace_responses.go
+++ b/client/namespaces/create_namespace_responses.go
@@ -349,7 +349,7 @@ func NewCreateNamespaceConflict() *CreateNamespaceConflict {
 /*
 CreateNamespaceConflict describes a response with status code 409, with default header values.
 
-A namespace with the specified name already exists.
+A namespace with the specified name already exists, or a namespace with the same name is currently being deleted. Differentiate by reading the human-readable message in the error payload.
 */
 type CreateNamespaceConflict struct {
 	Payload *models.ErrorResponse

--- a/client/namespaces/create_namespace_responses.go
+++ b/client/namespaces/create_namespace_responses.go
@@ -138,7 +138,6 @@ func (o *CreateNamespaceCreated) GetPayload() *models.Namespace {
 }
 
 func (o *CreateNamespaceCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.Namespace)
 
 	// response payload
@@ -159,8 +158,7 @@ CreateNamespaceUnauthorized describes a response with status code 401, with defa
 
 Unauthorized or invalid credentials.
 */
-type CreateNamespaceUnauthorized struct {
-}
+type CreateNamespaceUnauthorized struct{}
 
 // IsSuccess returns true when this create namespace unauthorized response has a 2xx status code
 func (o *CreateNamespaceUnauthorized) IsSuccess() bool {
@@ -201,7 +199,6 @@ func (o *CreateNamespaceUnauthorized) String() string {
 }
 
 func (o *CreateNamespaceUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	return nil
 }
 
@@ -262,7 +259,6 @@ func (o *CreateNamespaceForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateNamespaceForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -330,7 +326,6 @@ func (o *CreateNamespaceNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateNamespaceNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -398,7 +393,6 @@ func (o *CreateNamespaceConflict) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateNamespaceConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -466,7 +460,6 @@ func (o *CreateNamespaceUnprocessableEntity) GetPayload() *models.ErrorResponse 
 }
 
 func (o *CreateNamespaceUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -534,7 +527,6 @@ func (o *CreateNamespaceInternalServerError) GetPayload() *models.ErrorResponse 
 }
 
 func (o *CreateNamespaceInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
-
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/namespaces/create_namespace_responses.go
+++ b/client/namespaces/create_namespace_responses.go
@@ -138,6 +138,7 @@ func (o *CreateNamespaceCreated) GetPayload() *models.Namespace {
 }
 
 func (o *CreateNamespaceCreated) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.Namespace)
 
 	// response payload
@@ -158,7 +159,8 @@ CreateNamespaceUnauthorized describes a response with status code 401, with defa
 
 Unauthorized or invalid credentials.
 */
-type CreateNamespaceUnauthorized struct{}
+type CreateNamespaceUnauthorized struct {
+}
 
 // IsSuccess returns true when this create namespace unauthorized response has a 2xx status code
 func (o *CreateNamespaceUnauthorized) IsSuccess() bool {
@@ -199,6 +201,7 @@ func (o *CreateNamespaceUnauthorized) String() string {
 }
 
 func (o *CreateNamespaceUnauthorized) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	return nil
 }
 
@@ -259,6 +262,7 @@ func (o *CreateNamespaceForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateNamespaceForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -326,6 +330,7 @@ func (o *CreateNamespaceNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateNamespaceNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -393,6 +398,7 @@ func (o *CreateNamespaceConflict) GetPayload() *models.ErrorResponse {
 }
 
 func (o *CreateNamespaceConflict) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -460,6 +466,7 @@ func (o *CreateNamespaceUnprocessableEntity) GetPayload() *models.ErrorResponse 
 }
 
 func (o *CreateNamespaceUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload
@@ -527,6 +534,7 @@ func (o *CreateNamespaceInternalServerError) GetPayload() *models.ErrorResponse 
 }
 
 func (o *CreateNamespaceInternalServerError) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
 	o.Payload = new(models.ErrorResponse)
 
 	// response payload

--- a/client/namespaces/delete_namespace_responses.go
+++ b/client/namespaces/delete_namespace_responses.go
@@ -34,8 +34,8 @@ type DeleteNamespaceReader struct {
 // ReadResponse reads a server response into the received o.
 func (o *DeleteNamespaceReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {
 	switch response.Code() {
-	case 204:
-		result := NewDeleteNamespaceNoContent()
+	case 202:
+		result := NewDeleteNamespaceAccepted()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
 			return nil, err
 		}
@@ -75,58 +75,58 @@ func (o *DeleteNamespaceReader) ReadResponse(response runtime.ClientResponse, co
 	}
 }
 
-// NewDeleteNamespaceNoContent creates a DeleteNamespaceNoContent with default headers values
-func NewDeleteNamespaceNoContent() *DeleteNamespaceNoContent {
-	return &DeleteNamespaceNoContent{}
+// NewDeleteNamespaceAccepted creates a DeleteNamespaceAccepted with default headers values
+func NewDeleteNamespaceAccepted() *DeleteNamespaceAccepted {
+	return &DeleteNamespaceAccepted{}
 }
 
 /*
-DeleteNamespaceNoContent describes a response with status code 204, with default header values.
+DeleteNamespaceAccepted describes a response with status code 202, with default header values.
 
-Successfully deleted.
+The namespace has been marked for deletion. Cleanup of its classes, aliases, and users completes asynchronously.
 */
-type DeleteNamespaceNoContent struct {
+type DeleteNamespaceAccepted struct {
 }
 
-// IsSuccess returns true when this delete namespace no content response has a 2xx status code
-func (o *DeleteNamespaceNoContent) IsSuccess() bool {
+// IsSuccess returns true when this delete namespace accepted response has a 2xx status code
+func (o *DeleteNamespaceAccepted) IsSuccess() bool {
 	return true
 }
 
-// IsRedirect returns true when this delete namespace no content response has a 3xx status code
-func (o *DeleteNamespaceNoContent) IsRedirect() bool {
+// IsRedirect returns true when this delete namespace accepted response has a 3xx status code
+func (o *DeleteNamespaceAccepted) IsRedirect() bool {
 	return false
 }
 
-// IsClientError returns true when this delete namespace no content response has a 4xx status code
-func (o *DeleteNamespaceNoContent) IsClientError() bool {
+// IsClientError returns true when this delete namespace accepted response has a 4xx status code
+func (o *DeleteNamespaceAccepted) IsClientError() bool {
 	return false
 }
 
-// IsServerError returns true when this delete namespace no content response has a 5xx status code
-func (o *DeleteNamespaceNoContent) IsServerError() bool {
+// IsServerError returns true when this delete namespace accepted response has a 5xx status code
+func (o *DeleteNamespaceAccepted) IsServerError() bool {
 	return false
 }
 
-// IsCode returns true when this delete namespace no content response a status code equal to that given
-func (o *DeleteNamespaceNoContent) IsCode(code int) bool {
-	return code == 204
+// IsCode returns true when this delete namespace accepted response a status code equal to that given
+func (o *DeleteNamespaceAccepted) IsCode(code int) bool {
+	return code == 202
 }
 
-// Code gets the status code for the delete namespace no content response
-func (o *DeleteNamespaceNoContent) Code() int {
-	return 204
+// Code gets the status code for the delete namespace accepted response
+func (o *DeleteNamespaceAccepted) Code() int {
+	return 202
 }
 
-func (o *DeleteNamespaceNoContent) Error() string {
-	return fmt.Sprintf("[DELETE /namespaces/{namespace_id}][%d] deleteNamespaceNoContent ", 204)
+func (o *DeleteNamespaceAccepted) Error() string {
+	return fmt.Sprintf("[DELETE /namespaces/{namespace_id}][%d] deleteNamespaceAccepted ", 202)
 }
 
-func (o *DeleteNamespaceNoContent) String() string {
-	return fmt.Sprintf("[DELETE /namespaces/{namespace_id}][%d] deleteNamespaceNoContent ", 204)
+func (o *DeleteNamespaceAccepted) String() string {
+	return fmt.Sprintf("[DELETE /namespaces/{namespace_id}][%d] deleteNamespaceAccepted ", 202)
 }
 
-func (o *DeleteNamespaceNoContent) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+func (o *DeleteNamespaceAccepted) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	return nil
 }

--- a/client/namespaces/namespaces_client.go
+++ b/client/namespaces/namespaces_client.go
@@ -96,7 +96,7 @@ func (a *Client) CreateNamespace(params *CreateNamespaceParams, authInfo runtime
 /*
 DeleteNamespace deletes a namespace
 
-Hard-delete a namespace by its name.
+Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the "deleting" state and its dynamic users are removed synchronously; classes and aliases are torn down by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the "deleting" state are idempotent and return 202.
 */
 func (a *Client) DeleteNamespace(params *DeleteNamespaceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteNamespaceAccepted, error) {
 	// TODO: Validate the params before sending

--- a/client/namespaces/namespaces_client.go
+++ b/client/namespaces/namespaces_client.go
@@ -43,7 +43,7 @@ type ClientOption func(*runtime.ClientOperation)
 type ClientService interface {
 	CreateNamespace(params *CreateNamespaceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*CreateNamespaceCreated, error)
 
-	DeleteNamespace(params *DeleteNamespaceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteNamespaceNoContent, error)
+	DeleteNamespace(params *DeleteNamespaceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteNamespaceAccepted, error)
 
 	GetNamespace(params *GetNamespaceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*GetNamespaceOK, error)
 
@@ -98,7 +98,7 @@ DeleteNamespace deletes a namespace
 
 Hard-delete a namespace by its name.
 */
-func (a *Client) DeleteNamespace(params *DeleteNamespaceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteNamespaceNoContent, error) {
+func (a *Client) DeleteNamespace(params *DeleteNamespaceParams, authInfo runtime.ClientAuthInfoWriter, opts ...ClientOption) (*DeleteNamespaceAccepted, error) {
 	// TODO: Validate the params before sending
 	if params == nil {
 		params = NewDeleteNamespaceParams()
@@ -124,7 +124,7 @@ func (a *Client) DeleteNamespace(params *DeleteNamespaceParams, authInfo runtime
 	if err != nil {
 		return nil, err
 	}
-	success, ok := result.(*DeleteNamespaceNoContent)
+	success, ok := result.(*DeleteNamespaceAccepted)
 	if ok {
 		return success, nil
 	}

--- a/cluster/dynusers/dynamic_users.go
+++ b/cluster/dynusers/dynamic_users.go
@@ -12,6 +12,7 @@
 package dynusers
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -60,7 +61,7 @@ func (m *Manager) CreateUser(c *cmd.ApplyRequest) error {
 		}
 	}
 
-	return m.dynUser.CreateUser(req.UserId, req.SecureHash, req.UserIdentifier, req.ApiKeyFirstLetters, req.Namespace, req.CreatedAt)
+	return m.dynUser.CreateUser(context.Background(), req.UserId, req.SecureHash, req.UserIdentifier, req.ApiKeyFirstLetters, req.Namespace, req.CreatedAt)
 }
 
 func (m *Manager) CreateUserWithKeyRequest(c *cmd.ApplyRequest) error {
@@ -72,7 +73,7 @@ func (m *Manager) CreateUserWithKeyRequest(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	return m.dynUser.CreateUserWithKey(req.UserId, req.ApiKeyFirstLetters, req.WeakHash, req.CreatedAt)
+	return m.dynUser.CreateUserWithKey(context.Background(), req.UserId, req.ApiKeyFirstLetters, req.WeakHash, req.CreatedAt)
 }
 
 func (m *Manager) DeleteUser(c *cmd.ApplyRequest) error {
@@ -84,7 +85,7 @@ func (m *Manager) DeleteUser(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	return m.dynUser.DeleteUser(req.UserId)
+	return m.dynUser.DeleteUser(context.Background(), req.UserId)
 }
 
 func (m *Manager) DeleteUsersInNamespace(c *cmd.ApplyRequest) error {
@@ -110,7 +111,7 @@ func (m *Manager) ActivateUser(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	return m.dynUser.ActivateUser(req.UserId)
+	return m.dynUser.ActivateUser(context.Background(), req.UserId)
 }
 
 func (m *Manager) SuspendUser(c *cmd.ApplyRequest) error {
@@ -122,7 +123,7 @@ func (m *Manager) SuspendUser(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	return m.dynUser.DeactivateUser(req.UserId, req.RevokeKey)
+	return m.dynUser.DeactivateUser(context.Background(), req.UserId, req.RevokeKey)
 }
 
 func (m *Manager) RotateKey(c *cmd.ApplyRequest) error {
@@ -134,7 +135,7 @@ func (m *Manager) RotateKey(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	return m.dynUser.RotateKey(req.UserId, req.ApiKeyFirstLetters, req.SecureHash, req.OldIdentifier, req.NewIdentifier)
+	return m.dynUser.RotateKey(context.Background(), req.UserId, req.ApiKeyFirstLetters, req.SecureHash, req.OldIdentifier, req.NewIdentifier)
 }
 
 func (m *Manager) GetUsers(req *cmd.QueryRequest) ([]byte, error) {

--- a/cluster/dynusers/dynamic_users.go
+++ b/cluster/dynusers/dynamic_users.go
@@ -22,10 +22,7 @@ import (
 	usecasesNamespaces "github.com/weaviate/weaviate/usecases/namespaces"
 )
 
-var (
-	ErrBadRequest        = errors.New("bad request")
-	ErrNamespaceNotFound = errors.New("namespace not found")
-)
+var ErrBadRequest = errors.New("bad request")
 
 type Manager struct {
 	dynUser           *apikey.DBUser
@@ -50,20 +47,17 @@ func (m *Manager) CreateUser(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	// Defense-in-depth: on namespace-enabled clusters every db user must be
-	// bound to a namespace. The handler already enforces this, but a stale
-	// or hand-crafted RAFT command must not be able to slip an unbound user
-	// past the apply path.
 	if m.namespacesEnabled && req.Namespace == "" {
 		return fmt.Errorf("%w: namespace is required on namespace-enabled clusters", ErrBadRequest)
 	}
 
-	// Authoritative existence re-check at apply time. Closes the
-	// handler→apply TOCTOU when a delete-namespace command is RAFT-ordered
-	// before this create-user command: every node observes identical state
-	// and rejects deterministically.
-	if req.Namespace != "" && !m.namespaces.Exists(req.Namespace) {
-		return fmt.Errorf("%w: namespace %q does not exist", ErrNamespaceNotFound, req.Namespace)
+	if req.Namespace != "" {
+		if !m.namespaces.Exists(req.Namespace) {
+			return fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceGone, req.Namespace)
+		}
+		if !m.namespaces.IsActive(req.Namespace) {
+			return fmt.Errorf("%w: %q", usecasesNamespaces.ErrNamespaceDeleting, req.Namespace)
+		}
 	}
 
 	return m.dynUser.CreateUser(req.UserId, req.SecureHash, req.UserIdentifier, req.ApiKeyFirstLetters, req.Namespace, req.CreatedAt)

--- a/cluster/dynusers/dynamic_users.go
+++ b/cluster/dynusers/dynamic_users.go
@@ -93,6 +93,20 @@ func (m *Manager) DeleteUser(c *cmd.ApplyRequest) error {
 	return m.dynUser.DeleteUser(req.UserId)
 }
 
+func (m *Manager) DeleteUsersInNamespace(c *cmd.ApplyRequest) error {
+	if m.dynUser == nil {
+		return nil
+	}
+	req := &cmd.DeleteUsersInNamespaceRequest{}
+	if err := json.Unmarshal(c.SubCommand, req); err != nil {
+		return fmt.Errorf("%w: %w", ErrBadRequest, err)
+	}
+	if req.Namespace == "" {
+		return fmt.Errorf("%w: namespace is required", ErrBadRequest)
+	}
+	return m.dynUser.DeleteUsersInNamespace(req.Namespace)
+}
+
 func (m *Manager) ActivateUser(c *cmd.ApplyRequest) error {
 	if m.dynUser == nil {
 		return nil

--- a/cluster/dynusers/dynamic_users.go
+++ b/cluster/dynusers/dynamic_users.go
@@ -12,7 +12,6 @@
 package dynusers
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -61,7 +60,7 @@ func (m *Manager) CreateUser(c *cmd.ApplyRequest) error {
 		}
 	}
 
-	return m.dynUser.CreateUser(context.Background(), req.UserId, req.SecureHash, req.UserIdentifier, req.ApiKeyFirstLetters, req.Namespace, req.CreatedAt)
+	return m.dynUser.CreateUser(req.UserId, req.SecureHash, req.UserIdentifier, req.ApiKeyFirstLetters, req.Namespace, req.CreatedAt)
 }
 
 func (m *Manager) CreateUserWithKeyRequest(c *cmd.ApplyRequest) error {
@@ -73,7 +72,7 @@ func (m *Manager) CreateUserWithKeyRequest(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	return m.dynUser.CreateUserWithKey(context.Background(), req.UserId, req.ApiKeyFirstLetters, req.WeakHash, req.CreatedAt)
+	return m.dynUser.CreateUserWithKey(req.UserId, req.ApiKeyFirstLetters, req.WeakHash, req.CreatedAt)
 }
 
 func (m *Manager) DeleteUser(c *cmd.ApplyRequest) error {
@@ -85,7 +84,7 @@ func (m *Manager) DeleteUser(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	return m.dynUser.DeleteUser(context.Background(), req.UserId)
+	return m.dynUser.DeleteUser(req.UserId)
 }
 
 func (m *Manager) DeleteUsersInNamespace(c *cmd.ApplyRequest) error {
@@ -111,7 +110,7 @@ func (m *Manager) ActivateUser(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	return m.dynUser.ActivateUser(context.Background(), req.UserId)
+	return m.dynUser.ActivateUser(req.UserId)
 }
 
 func (m *Manager) SuspendUser(c *cmd.ApplyRequest) error {
@@ -123,7 +122,7 @@ func (m *Manager) SuspendUser(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	return m.dynUser.DeactivateUser(context.Background(), req.UserId, req.RevokeKey)
+	return m.dynUser.DeactivateUser(req.UserId, req.RevokeKey)
 }
 
 func (m *Manager) RotateKey(c *cmd.ApplyRequest) error {
@@ -135,7 +134,7 @@ func (m *Manager) RotateKey(c *cmd.ApplyRequest) error {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
 	}
 
-	return m.dynUser.RotateKey(context.Background(), req.UserId, req.ApiKeyFirstLetters, req.SecureHash, req.OldIdentifier, req.NewIdentifier)
+	return m.dynUser.RotateKey(req.UserId, req.ApiKeyFirstLetters, req.SecureHash, req.OldIdentifier, req.NewIdentifier)
 }
 
 func (m *Manager) GetUsers(req *cmd.QueryRequest) ([]byte, error) {

--- a/cluster/dynusers/dynamic_users_test.go
+++ b/cluster/dynusers/dynamic_users_test.go
@@ -28,10 +28,8 @@ import (
 	usecasesNamespaces "github.com/weaviate/weaviate/usecases/namespaces"
 )
 
-// newNamespacesMock returns an Exister mock that reports `known` as the set
-// of existing namespaces. AssertExpectations is intentionally suppressed via
-// MaybeCalled so tests that exercise the empty-namespace short-circuit don't
-// fail when Exists never gets called.
+// newNamespacesMock returns an Exister mock that reports `known` as active
+// namespaces (Exists and IsActive both return true).
 func newNamespacesMock(t *testing.T, known ...string) *usecasesNamespaces.MockExister {
 	t.Helper()
 	m := &usecasesNamespaces.MockExister{}
@@ -44,6 +42,23 @@ func newNamespacesMock(t *testing.T, known ...string) *usecasesNamespaces.MockEx
 		_, ok := set[name]
 		return ok
 	}).Maybe()
+	m.On("IsActive", mock.AnythingOfType("string")).Return(func(name string) bool {
+		_, ok := set[name]
+		return ok
+	}).Maybe()
+	return m
+}
+
+// newNamespacesMockDeleting reports `name` as existing-but-deleting
+// (Exists=true, IsActive=false).
+func newNamespacesMockDeleting(t *testing.T, name string) *usecasesNamespaces.MockExister {
+	t.Helper()
+	m := &usecasesNamespaces.MockExister{}
+	m.Test(t)
+	m.On("Exists", mock.AnythingOfType("string")).Return(func(n string) bool {
+		return n == name
+	}).Maybe()
+	m.On("IsActive", mock.AnythingOfType("string")).Return(false).Maybe()
 	return m
 }
 
@@ -77,23 +92,36 @@ func TestManager_CreateUser(t *testing.T) {
 	tests := []struct {
 		name      string
 		namespace string
-		nsKnown   bool
-		wantErr   bool
+		makeMock  func(t *testing.T) *usecasesNamespaces.MockExister
+		wantErrIs error
 	}{
-		{name: "namespace exists", namespace: "ns1", nsKnown: true},
-		{name: "empty namespace skips check", namespace: ""},
-		{name: "namespace deleted before apply", namespace: "ns1", nsKnown: false, wantErr: true},
+		{
+			name:      "active namespace passes",
+			namespace: "ns1",
+			makeMock:  func(t *testing.T) *usecasesNamespaces.MockExister { return newNamespacesMock(t, "ns1") },
+		},
+		{
+			name:      "empty namespace skips check",
+			namespace: "",
+			makeMock:  func(t *testing.T) *usecasesNamespaces.MockExister { return newNamespacesMock(t) },
+		},
+		{
+			name:      "missing namespace returns ErrNamespaceGone",
+			namespace: "ns1",
+			makeMock:  func(t *testing.T) *usecasesNamespaces.MockExister { return newNamespacesMock(t) },
+			wantErrIs: usecasesNamespaces.ErrNamespaceGone,
+		},
+		{
+			name:      "deleting namespace returns ErrNamespaceDeleting",
+			namespace: "ns1",
+			makeMock:  func(t *testing.T) *usecasesNamespaces.MockExister { return newNamespacesMockDeleting(t, "ns1") },
+			wantErrIs: usecasesNamespaces.ErrNamespaceDeleting,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			var ns *usecasesNamespaces.MockExister
-			if tc.nsKnown {
-				ns = newNamespacesMock(t, tc.namespace)
-			} else {
-				ns = newNamespacesMock(t)
-			}
-			m, dynUser := newTestManager(t, ns)
+			m, dynUser := newTestManager(t, tc.makeMock(t))
 
 			apply := &cmd.ApplyRequest{SubCommand: mustMarshalJSON(t, cmd.CreateUsersRequest{
 				UserId:         "u1",
@@ -103,8 +131,8 @@ func TestManager_CreateUser(t *testing.T) {
 				CreatedAt:      time.Now(),
 			})}
 			err := m.CreateUser(apply)
-			if tc.wantErr {
-				require.Error(t, err)
+			if tc.wantErrIs != nil {
+				require.ErrorIs(t, err, tc.wantErrIs)
 				users, _ := dynUser.GetUsers("u1")
 				assert.Empty(t, users, "user must not be persisted on rejection")
 				return

--- a/cluster/dynusers/dynamic_users_test.go
+++ b/cluster/dynusers/dynamic_users_test.go
@@ -158,6 +158,7 @@ func TestManager_MalformedJSON(t *testing.T) {
 	}{
 		{name: "CreateUser", call: func(m *Manager) error { return m.CreateUser(apply) }},
 		{name: "DeleteUser", call: func(m *Manager) error { return m.DeleteUser(apply) }},
+		{name: "DeleteUsersInNamespace", call: func(m *Manager) error { return m.DeleteUsersInNamespace(apply) }},
 		{name: "ActivateUser", call: func(m *Manager) error { return m.ActivateUser(apply) }},
 		{name: "SuspendUser", call: func(m *Manager) error { return m.SuspendUser(apply) }},
 		{name: "RotateKey", call: func(m *Manager) error { return m.RotateKey(apply) }},
@@ -174,4 +175,60 @@ func TestManager_MalformedJSON(t *testing.T) {
 			assert.ErrorIs(t, err, ErrBadRequest)
 		})
 	}
+}
+
+func TestManager_DeleteUsersInNamespace(t *testing.T) {
+	seed := func(t *testing.T, m *Manager, id, namespace string) {
+		t.Helper()
+		_, hash, identifier, err := keys.CreateApiKeyAndHash()
+		require.NoError(t, err)
+		apply := &cmd.ApplyRequest{SubCommand: mustMarshalJSON(t, cmd.CreateUsersRequest{
+			UserId:         id,
+			SecureHash:     hash,
+			UserIdentifier: identifier,
+			Namespace:      namespace,
+			CreatedAt:      time.Now(),
+		})}
+		require.NoError(t, m.CreateUser(apply))
+	}
+
+	t.Run("removes only matching users", func(t *testing.T) {
+		m, dyn := newTestManager(t, newNamespacesMock(t, "alpha", "beta"))
+		seed(t, m, "u-alpha-1", "alpha")
+		seed(t, m, "u-alpha-2", "alpha")
+		seed(t, m, "u-beta", "beta")
+
+		apply := &cmd.ApplyRequest{SubCommand: mustMarshalJSON(t, cmd.DeleteUsersInNamespaceRequest{Namespace: "alpha"})}
+		require.NoError(t, m.DeleteUsersInNamespace(apply))
+
+		users, err := dyn.GetUsers()
+		require.NoError(t, err)
+		require.Len(t, users, 1)
+		require.Contains(t, users, "u-beta")
+	})
+
+	t.Run("rerun on already-empty namespace is a no-op", func(t *testing.T) {
+		m, _ := newTestManager(t, newNamespacesMock(t, "alpha"))
+		seed(t, m, "u1", "alpha")
+		apply := &cmd.ApplyRequest{SubCommand: mustMarshalJSON(t, cmd.DeleteUsersInNamespaceRequest{Namespace: "alpha"})}
+
+		require.NoError(t, m.DeleteUsersInNamespace(apply))
+		require.NoError(t, m.DeleteUsersInNamespace(apply))
+	})
+
+	t.Run("empty namespace is rejected", func(t *testing.T) {
+		m, _ := newTestManager(t, newNamespacesMock(t))
+		apply := &cmd.ApplyRequest{SubCommand: mustMarshalJSON(t, cmd.DeleteUsersInNamespaceRequest{Namespace: ""})}
+		err := m.DeleteUsersInNamespace(apply)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrBadRequest)
+	})
+
+	t.Run("nil dynUser is a no-op", func(t *testing.T) {
+		logger, _ := test.NewNullLogger()
+		ns := newNamespacesMock(t)
+		m := NewManager(nil, ns, false, logger)
+		apply := &cmd.ApplyRequest{SubCommand: mustMarshalJSON(t, cmd.DeleteUsersInNamespaceRequest{Namespace: "alpha"})}
+		require.NoError(t, m.DeleteUsersInNamespace(apply))
+	})
 }

--- a/cluster/dynusers/dynamic_users_test.go
+++ b/cluster/dynusers/dynamic_users_test.go
@@ -220,37 +220,65 @@ func TestManager_DeleteUsersInNamespace(t *testing.T) {
 		require.NoError(t, m.CreateUser(apply))
 	}
 
-	t.Run("removes only matching users", func(t *testing.T) {
-		m, dyn := newTestManager(t, newNamespacesMock(t, "alpha", "beta"))
-		seed(t, m, "u-alpha-1", "alpha")
-		seed(t, m, "u-alpha-2", "alpha")
-		seed(t, m, "u-beta", "beta")
+	type user struct{ id, namespace string }
+	tests := []struct {
+		name            string
+		known           []string
+		seeds           []user
+		deleteNamespace string
+		extraRuns       int
+		wantErrIs       error
+		wantRemaining   []string
+	}{
+		{
+			name:            "removes only matching users",
+			known:           []string{"alpha", "beta"},
+			seeds:           []user{{"u-alpha-1", "alpha"}, {"u-alpha-2", "alpha"}, {"u-beta", "beta"}},
+			deleteNamespace: "alpha",
+			wantRemaining:   []string{"u-beta"},
+		},
+		{
+			name:            "rerun on already-empty namespace is a no-op",
+			known:           []string{"alpha"},
+			seeds:           []user{{"u1", "alpha"}},
+			deleteNamespace: "alpha",
+			extraRuns:       1,
+		},
+		{
+			name:            "empty namespace is rejected",
+			deleteNamespace: "",
+			wantErrIs:       ErrBadRequest,
+		},
+	}
 
-		apply := &cmd.ApplyRequest{SubCommand: mustMarshalJSON(t, cmd.DeleteUsersInNamespaceRequest{Namespace: "alpha"})}
-		require.NoError(t, m.DeleteUsersInNamespace(apply))
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m, dyn := newTestManager(t, newNamespacesMock(t, tc.known...))
+			for _, s := range tc.seeds {
+				seed(t, m, s.id, s.namespace)
+			}
 
-		users, err := dyn.GetUsers()
-		require.NoError(t, err)
-		require.Len(t, users, 1)
-		require.Contains(t, users, "u-beta")
-	})
-
-	t.Run("rerun on already-empty namespace is a no-op", func(t *testing.T) {
-		m, _ := newTestManager(t, newNamespacesMock(t, "alpha"))
-		seed(t, m, "u1", "alpha")
-		apply := &cmd.ApplyRequest{SubCommand: mustMarshalJSON(t, cmd.DeleteUsersInNamespaceRequest{Namespace: "alpha"})}
-
-		require.NoError(t, m.DeleteUsersInNamespace(apply))
-		require.NoError(t, m.DeleteUsersInNamespace(apply))
-	})
-
-	t.Run("empty namespace is rejected", func(t *testing.T) {
-		m, _ := newTestManager(t, newNamespacesMock(t))
-		apply := &cmd.ApplyRequest{SubCommand: mustMarshalJSON(t, cmd.DeleteUsersInNamespaceRequest{Namespace: ""})}
-		err := m.DeleteUsersInNamespace(apply)
-		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrBadRequest)
-	})
+			apply := &cmd.ApplyRequest{SubCommand: mustMarshalJSON(t, cmd.DeleteUsersInNamespaceRequest{Namespace: tc.deleteNamespace})}
+			var err error
+			for i := 0; i <= tc.extraRuns; i++ {
+				err = m.DeleteUsersInNamespace(apply)
+			}
+			if tc.wantErrIs != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.wantErrIs)
+				return
+			}
+			require.NoError(t, err)
+			if tc.wantRemaining != nil {
+				users, err := dyn.GetUsers()
+				require.NoError(t, err)
+				require.Len(t, users, len(tc.wantRemaining))
+				for _, id := range tc.wantRemaining {
+					require.Contains(t, users, id)
+				}
+			}
+		})
+	}
 
 	t.Run("nil dynUser is a no-op", func(t *testing.T) {
 		logger, _ := test.NewNullLogger()

--- a/cluster/namespaces/namespaces.go
+++ b/cluster/namespaces/namespaces.go
@@ -27,7 +27,7 @@ import (
 // SchemaNamespaceLister returns the classes and aliases that belong to a
 // namespace.
 type SchemaNamespaceLister interface {
-	ClassesInNamespace(namespace string) []string
+	ClassesInNamespace(namespace string) ([]string, error)
 	AliasesInNamespace(namespace string) []string
 }
 
@@ -105,7 +105,11 @@ func (m *Manager) RemoveEntity(c *cmd.ApplyRequest) error {
 	if err := json.Unmarshal(c.SubCommand, req); err != nil {
 		return fmt.Errorf("%w: %w", usecasesNamespaces.ErrBadRequest, err)
 	}
-	if classes := m.schema.ClassesInNamespace(req.Name); len(classes) > 0 {
+	classes, err := m.schema.ClassesInNamespace(req.Name)
+	if err != nil {
+		return fmt.Errorf("list classes in namespace %q: %w", req.Name, err)
+	}
+	if len(classes) > 0 {
 		return fmt.Errorf("%w: %d class(es) remain in %q", usecasesNamespaces.ErrNamespaceNotEmpty, len(classes), req.Name)
 	}
 	if aliases := m.schema.AliasesInNamespace(req.Name); len(aliases) > 0 {

--- a/cluster/namespaces/namespaces.go
+++ b/cluster/namespaces/namespaces.go
@@ -124,14 +124,13 @@ func (m *Manager) RemoveEntity(c *cmd.ApplyRequest) error {
 	return m.controller.RemoveEntity(req.Name)
 }
 
-// Exists proxies to the controller so the apply switch can satisfy
-// [usecasesNamespaces.Exister] with a single namespaceManager reference
-// instead of threading the controller through every call site.
+// Exists proxies to the controller. Lets the apply switch satisfy
+// [usecasesNamespaces.Exister] from a single namespaceManager reference.
 func (m *Manager) Exists(name string) bool {
 	return m.controller.Exists(name)
 }
 
-// IsActive proxies to the controller. Same rationale as Exists.
+// IsActive proxies to the controller.
 func (m *Manager) IsActive(name string) bool {
 	return m.controller.IsActive(name)
 }

--- a/cluster/namespaces/namespaces.go
+++ b/cluster/namespaces/namespaces.go
@@ -111,6 +111,7 @@ func (m *Manager) RemoveEntity(c *cmd.ApplyRequest) error {
 	if aliases := m.schema.AliasesInNamespace(req.Name); len(aliases) > 0 {
 		return fmt.Errorf("%w: %d alias(es) remain in %q", usecasesNamespaces.ErrNamespaceNotEmpty, len(aliases), req.Name)
 	}
+	// dynusers is nil when dynamic users are disabled.
 	if m.dynusers != nil {
 		if users := m.dynusers.UsersInNamespace(req.Name); len(users) > 0 {
 			return fmt.Errorf("%w: %d user(s) remain in %q", usecasesNamespaces.ErrNamespaceNotEmpty, len(users), req.Name)

--- a/cluster/namespaces/namespaces.go
+++ b/cluster/namespaces/namespaces.go
@@ -64,6 +64,45 @@ func (m *Manager) Delete(c *cmd.ApplyRequest) error {
 	return m.controller.Delete(req.Name)
 }
 
+// ChangeState applies a ChangeNamespaceState RAFT command, transitioning
+// the namespace into the target state. Returns
+// [usecasesNamespaces.ErrBadRequest] for malformed payloads or unknown
+// target states, [usecasesNamespaces.ErrNotFound] when the namespace does
+// not exist, and [usecasesNamespaces.ErrInvalidStateTransition] when the
+// requested transition is forbidden.
+func (m *Manager) ChangeState(c *cmd.ApplyRequest) error {
+	req := &cmd.ChangeNamespaceStateRequest{}
+	if err := json.Unmarshal(c.SubCommand, req); err != nil {
+		return fmt.Errorf("%w: %w", usecasesNamespaces.ErrBadRequest, err)
+	}
+	return m.controller.ChangeState(req.Name, req.TargetState)
+}
+
+// RemoveEntity applies a RemoveNamespaceEntity RAFT command, deleting the
+// map entry for a deleting namespace. Returns
+// [usecasesNamespaces.ErrBadRequest] for malformed payloads,
+// [usecasesNamespaces.ErrNotFound] when the namespace does not exist, and
+// [usecasesNamespaces.ErrInvalidState] when called on an active namespace.
+func (m *Manager) RemoveEntity(c *cmd.ApplyRequest) error {
+	req := &cmd.RemoveNamespaceEntityRequest{}
+	if err := json.Unmarshal(c.SubCommand, req); err != nil {
+		return fmt.Errorf("%w: %w", usecasesNamespaces.ErrBadRequest, err)
+	}
+	return m.controller.RemoveEntity(req.Name)
+}
+
+// Exists proxies to the controller so the apply switch can satisfy
+// [usecasesNamespaces.Exister] with a single namespaceManager reference
+// instead of threading the controller through every call site.
+func (m *Manager) Exists(name string) bool {
+	return m.controller.Exists(name)
+}
+
+// IsActive proxies to the controller. Same rationale as Exists.
+func (m *Manager) IsActive(name string) bool {
+	return m.controller.IsActive(name)
+}
+
 // Get handles a QueryGetNamespaces query. An empty Names slice returns all
 // known namespaces; otherwise only the named ones that exist are returned
 // (missing names are silently omitted).

--- a/cluster/namespaces/namespaces.go
+++ b/cluster/namespaces/namespaces.go
@@ -80,18 +80,6 @@ func (m *Manager) Add(c *cmd.ApplyRequest) error {
 	return m.controller.Create(req.Namespace)
 }
 
-// Delete applies a DeleteNamespace RAFT command. It returns
-// [usecasesNamespaces.ErrNotFound] when the target namespace does not
-// exist, and [usecasesNamespaces.ErrBadRequest] when the payload is
-// malformed.
-func (m *Manager) Delete(c *cmd.ApplyRequest) error {
-	req := &cmd.DeleteNamespaceRequest{}
-	if err := json.Unmarshal(c.SubCommand, req); err != nil {
-		return fmt.Errorf("%w: %w", usecasesNamespaces.ErrBadRequest, err)
-	}
-	return m.controller.Delete(req.Name)
-}
-
 // ChangeState applies a ChangeNamespaceState RAFT command, transitioning
 // the namespace into the target state. Returns
 // [usecasesNamespaces.ErrBadRequest] for malformed payloads or unknown

--- a/cluster/namespaces/namespaces.go
+++ b/cluster/namespaces/namespaces.go
@@ -24,21 +24,49 @@ import (
 	usecasesNamespaces "github.com/weaviate/weaviate/usecases/namespaces"
 )
 
+// SchemaNamespaceLister returns the classes and aliases that belong to a
+// namespace.
+type SchemaNamespaceLister interface {
+	ClassesInNamespace(namespace string) []string
+	AliasesInNamespace(namespace string) []string
+}
+
+// DynusersNamespaceLister returns the dynamic DB users that belong to a
+// namespace.
+type DynusersNamespaceLister interface {
+	UsersInNamespace(namespace string) []string
+}
+
 // Manager is the RAFT FSM adapter. It does not own state.
 type Manager struct {
 	controller *usecasesNamespaces.Controller
+	schema     SchemaNamespaceLister
+	dynusers   DynusersNamespaceLister
 	logger     logrus.FieldLogger
 }
 
-// NewManager wraps the provided controller. A nil controller is a wiring
-// bug — panic so a missing controller fails loudly at startup rather than
-// letting the Count()==0 startup invariant pass against an uninitialized
-// state map.
-func NewManager(controller *usecasesNamespaces.Controller, logger logrus.FieldLogger) *Manager {
+// NewManager wraps the controller and the listers RemoveEntity consults
+// to verify the namespace is empty. Panics on a nil controller or nil
+// schema lister. The dynusers lister is optional: deployments without
+// dynamic users pass nil and the user check is skipped.
+func NewManager(
+	controller *usecasesNamespaces.Controller,
+	schema SchemaNamespaceLister,
+	dynusers DynusersNamespaceLister,
+	logger logrus.FieldLogger,
+) *Manager {
 	if controller == nil {
 		panic("cluster/namespaces: controller must not be nil")
 	}
-	return &Manager{controller: controller, logger: logger}
+	if schema == nil {
+		panic("cluster/namespaces: schema lister must not be nil")
+	}
+	return &Manager{
+		controller: controller,
+		schema:     schema,
+		dynusers:   dynusers,
+		logger:     logger,
+	}
 }
 
 // Add applies an AddNamespace RAFT command. It rejects malformed payloads
@@ -78,15 +106,27 @@ func (m *Manager) ChangeState(c *cmd.ApplyRequest) error {
 	return m.controller.ChangeState(req.Name, req.TargetState)
 }
 
-// RemoveEntity applies a RemoveNamespaceEntity RAFT command, deleting the
-// map entry for a deleting namespace. Returns
+// RemoveEntity applies a RemoveNamespaceEntity RAFT command. Returns
 // [usecasesNamespaces.ErrBadRequest] for malformed payloads,
-// [usecasesNamespaces.ErrNotFound] when the namespace does not exist, and
-// [usecasesNamespaces.ErrInvalidState] when called on an active namespace.
+// [usecasesNamespaces.ErrNotFound] when the namespace does not exist,
+// [usecasesNamespaces.ErrInvalidState] when called on an active namespace,
+// and [usecasesNamespaces.ErrNamespaceNotEmpty] when classes, aliases, or
+// users still remain in the namespace.
 func (m *Manager) RemoveEntity(c *cmd.ApplyRequest) error {
 	req := &cmd.RemoveNamespaceEntityRequest{}
 	if err := json.Unmarshal(c.SubCommand, req); err != nil {
 		return fmt.Errorf("%w: %w", usecasesNamespaces.ErrBadRequest, err)
+	}
+	if classes := m.schema.ClassesInNamespace(req.Name); len(classes) > 0 {
+		return fmt.Errorf("%w: %d class(es) remain in %q", usecasesNamespaces.ErrNamespaceNotEmpty, len(classes), req.Name)
+	}
+	if aliases := m.schema.AliasesInNamespace(req.Name); len(aliases) > 0 {
+		return fmt.Errorf("%w: %d alias(es) remain in %q", usecasesNamespaces.ErrNamespaceNotEmpty, len(aliases), req.Name)
+	}
+	if m.dynusers != nil {
+		if users := m.dynusers.UsersInNamespace(req.Name); len(users) > 0 {
+			return fmt.Errorf("%w: %d user(s) remain in %q", usecasesNamespaces.ErrNamespaceNotEmpty, len(users), req.Name)
+		}
 	}
 	return m.controller.RemoveEntity(req.Name)
 }

--- a/cluster/namespaces/namespaces_test.go
+++ b/cluster/namespaces/namespaces_test.go
@@ -28,10 +28,10 @@ func newTestManager(t *testing.T) *Manager {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
 	logger.SetLevel(logrus.DebugLevel)
-	return NewManager(usecasesNamespaces.NewController(logger), stubResiduals{}, nil, logger)
+	return NewManager(usecasesNamespaces.NewController(logger), stubLeftovers{}, nil, logger)
 }
 
-func newTestManagerWithResiduals(t *testing.T, schema SchemaNamespaceLister, dynusers DynusersNamespaceLister) *Manager {
+func newTestManagerWithLeftovers(t *testing.T, schema SchemaNamespaceLister, dynusers DynusersNamespaceLister) *Manager {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
 	logger.SetLevel(logrus.DebugLevel)
@@ -81,7 +81,7 @@ func TestNewManager_RequiredArgsPanic(t *testing.T) {
 		controller *usecasesNamespaces.Controller
 		schema     SchemaNamespaceLister
 	}{
-		{name: "nil controller panics", controller: nil, schema: stubResiduals{}},
+		{name: "nil controller panics", controller: nil, schema: stubLeftovers{}},
 		{name: "nil schema lister panics", controller: controller, schema: nil},
 	}
 	for _, tc := range tests {
@@ -159,39 +159,39 @@ func TestManager_RemoveEntity(t *testing.T) {
 	}
 }
 
-// stubResiduals is a residuals reader stub.
-type stubResiduals struct {
+// stubLeftovers is a leftovers reader stub.
+type stubLeftovers struct {
 	classes []string
 	aliases []string
 	users   []string
 }
 
-func (s stubResiduals) ClassesInNamespace(string) []string { return s.classes }
-func (s stubResiduals) AliasesInNamespace(string) []string { return s.aliases }
-func (s stubResiduals) UsersInNamespace(string) []string   { return s.users }
+func (s stubLeftovers) ClassesInNamespace(string) ([]string, error) { return s.classes, nil }
+func (s stubLeftovers) AliasesInNamespace(string) []string          { return s.aliases }
+func (s stubLeftovers) UsersInNamespace(string) []string            { return s.users }
 
-func TestManager_RemoveEntity_Residuals(t *testing.T) {
+func TestManager_RemoveEntity_Leftovers(t *testing.T) {
 	tests := []struct {
 		name      string
-		residuals stubResiduals
+		leftovers stubLeftovers
 		wantErr   error
 	}{
-		{name: "no residuals removes the entity", residuals: stubResiduals{}},
-		{name: "residual class blocks", residuals: stubResiduals{classes: []string{"customer1:Foo"}}, wantErr: usecasesNamespaces.ErrNamespaceNotEmpty},
-		{name: "residual alias blocks", residuals: stubResiduals{aliases: []string{"customer1:Bar"}}, wantErr: usecasesNamespaces.ErrNamespaceNotEmpty},
-		{name: "residual user blocks", residuals: stubResiduals{users: []string{"u1"}}, wantErr: usecasesNamespaces.ErrNamespaceNotEmpty},
+		{name: "no leftovers removes the entity", leftovers: stubLeftovers{}},
+		{name: "leftover class blocks", leftovers: stubLeftovers{classes: []string{"customer1:Foo"}}, wantErr: usecasesNamespaces.ErrNamespaceNotEmpty},
+		{name: "leftover alias blocks", leftovers: stubLeftovers{aliases: []string{"customer1:Bar"}}, wantErr: usecasesNamespaces.ErrNamespaceNotEmpty},
+		{name: "leftover user blocks", leftovers: stubLeftovers{users: []string{"u1"}}, wantErr: usecasesNamespaces.ErrNamespaceNotEmpty},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			m := newTestManagerWithResiduals(t, tc.residuals, tc.residuals)
+			m := newTestManagerWithLeftovers(t, tc.leftovers, tc.leftovers)
 			require.NoError(t, m.Add(addCmd(t, "customer1")))
 			require.NoError(t, m.ChangeState(changeStateCmd(t, "customer1", cmd.NamespaceStateDeleting)))
 
 			err := m.RemoveEntity(removeEntityCmd(t, "customer1"))
 			if tc.wantErr != nil {
 				require.ErrorIs(t, err, tc.wantErr)
-				assert.True(t, m.Exists("customer1"), "namespace must remain when residuals block removal")
+				assert.True(t, m.Exists("customer1"), "namespace must remain when leftovers block removal")
 				return
 			}
 			require.NoError(t, err)

--- a/cluster/namespaces/namespaces_test.go
+++ b/cluster/namespaces/namespaces_test.go
@@ -28,7 +28,14 @@ func newTestManager(t *testing.T) *Manager {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
 	logger.SetLevel(logrus.DebugLevel)
-	return NewManager(usecasesNamespaces.NewController(logger), logger)
+	return NewManager(usecasesNamespaces.NewController(logger), stubResiduals{}, nil, logger)
+}
+
+func newTestManagerWithResiduals(t *testing.T, schema SchemaNamespaceLister, dynusers DynusersNamespaceLister) *Manager {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+	return NewManager(usecasesNamespaces.NewController(logger), schema, dynusers, logger)
 }
 
 func addCmd(t *testing.T, name string) *cmd.ApplyRequest {
@@ -72,11 +79,25 @@ func seedNamespace(t *testing.T, m *Manager, name string, seedState cmd.Namespac
 	}
 }
 
-func TestNewManager_NilControllerPanics(t *testing.T) {
+func TestNewManager_RequiredArgsPanic(t *testing.T) {
 	logger, _ := test.NewNullLogger()
-	assert.Panics(t, func() {
-		NewManager(nil, logger)
-	})
+	controller := usecasesNamespaces.NewController(logger)
+
+	tests := []struct {
+		name       string
+		controller *usecasesNamespaces.Controller
+		schema     SchemaNamespaceLister
+	}{
+		{name: "nil controller panics", controller: nil, schema: stubResiduals{}},
+		{name: "nil schema lister panics", controller: controller, schema: nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Panics(t, func() {
+				NewManager(tc.controller, tc.schema, nil, logger)
+			})
+		})
+	}
 }
 
 func TestManager_Add(t *testing.T) {
@@ -144,6 +165,47 @@ func TestManager_RemoveEntity(t *testing.T) {
 			if tc.wantErr != nil {
 				require.Error(t, err)
 				assert.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.False(t, m.Exists("customer1"))
+		})
+	}
+}
+
+// stubResiduals is a residuals reader stub.
+type stubResiduals struct {
+	classes []string
+	aliases []string
+	users   []string
+}
+
+func (s stubResiduals) ClassesInNamespace(string) []string { return s.classes }
+func (s stubResiduals) AliasesInNamespace(string) []string { return s.aliases }
+func (s stubResiduals) UsersInNamespace(string) []string   { return s.users }
+
+func TestManager_RemoveEntity_Residuals(t *testing.T) {
+	tests := []struct {
+		name      string
+		residuals stubResiduals
+		wantErr   error
+	}{
+		{name: "no residuals removes the entity", residuals: stubResiduals{}},
+		{name: "residual class blocks", residuals: stubResiduals{classes: []string{"customer1:Foo"}}, wantErr: usecasesNamespaces.ErrNamespaceNotEmpty},
+		{name: "residual alias blocks", residuals: stubResiduals{aliases: []string{"customer1:Bar"}}, wantErr: usecasesNamespaces.ErrNamespaceNotEmpty},
+		{name: "residual user blocks", residuals: stubResiduals{users: []string{"u1"}}, wantErr: usecasesNamespaces.ErrNamespaceNotEmpty},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestManagerWithResiduals(t, tc.residuals, tc.residuals)
+			require.NoError(t, m.Add(addCmd(t, "customer1")))
+			require.NoError(t, m.ChangeState(changeStateCmd(t, "customer1", cmd.NamespaceStateDeleting)))
+
+			err := m.RemoveEntity(removeEntityCmd(t, "customer1"))
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				assert.True(t, m.Exists("customer1"), "namespace must remain when residuals block removal")
 				return
 			}
 			require.NoError(t, err)

--- a/cluster/namespaces/namespaces_test.go
+++ b/cluster/namespaces/namespaces_test.go
@@ -45,6 +45,33 @@ func deleteCmd(t *testing.T, name string) *cmd.ApplyRequest {
 	return &cmd.ApplyRequest{SubCommand: payload}
 }
 
+func changeStateCmd(t *testing.T, name string, target cmd.NamespaceState) *cmd.ApplyRequest {
+	t.Helper()
+	payload, err := json.Marshal(cmd.ChangeNamespaceStateRequest{Name: name, TargetState: target})
+	require.NoError(t, err)
+	return &cmd.ApplyRequest{SubCommand: payload}
+}
+
+func removeEntityCmd(t *testing.T, name string) *cmd.ApplyRequest {
+	t.Helper()
+	payload, err := json.Marshal(cmd.RemoveNamespaceEntityRequest{Name: name})
+	require.NoError(t, err)
+	return &cmd.ApplyRequest{SubCommand: payload}
+}
+
+// seedNamespace creates name and transitions it to seedState. An empty
+// seedState seeds nothing.
+func seedNamespace(t *testing.T, m *Manager, name string, seedState cmd.NamespaceState) {
+	t.Helper()
+	if seedState == "" {
+		return
+	}
+	require.NoError(t, m.Add(addCmd(t, name)))
+	if seedState == cmd.NamespaceStateDeleting {
+		require.NoError(t, m.ChangeState(changeStateCmd(t, name, cmd.NamespaceStateDeleting)))
+	}
+}
+
 func TestNewManager_NilControllerPanics(t *testing.T) {
 	logger, _ := test.NewNullLogger()
 	assert.Panics(t, func() {
@@ -54,33 +81,110 @@ func TestNewManager_NilControllerPanics(t *testing.T) {
 
 func TestManager_Add(t *testing.T) {
 	m := newTestManager(t)
-
-	t.Run("happy path dispatches to controller", func(t *testing.T) {
-		require.NoError(t, m.Add(addCmd(t, "customer1")))
-		assert.Equal(t, 1, m.Count())
-	})
-
-	t.Run("malformed payload is rejected", func(t *testing.T) {
-		err := m.Add(&cmd.ApplyRequest{SubCommand: []byte("not-json")})
-		require.Error(t, err)
-		assert.ErrorIs(t, err, usecasesNamespaces.ErrBadRequest)
-	})
+	require.NoError(t, m.Add(addCmd(t, "customer1")))
+	assert.Equal(t, 1, m.Count())
 }
 
 func TestManager_Delete(t *testing.T) {
 	m := newTestManager(t)
 	require.NoError(t, m.Add(addCmd(t, "customer1")))
+	require.NoError(t, m.Delete(deleteCmd(t, "customer1")))
+	assert.Equal(t, 0, m.Count())
+}
 
-	t.Run("happy path dispatches to controller", func(t *testing.T) {
-		require.NoError(t, m.Delete(deleteCmd(t, "customer1")))
-		assert.Equal(t, 0, m.Count())
-	})
+func TestManager_ChangeState(t *testing.T) {
+	tests := []struct {
+		name      string
+		seedState cmd.NamespaceState // empty = no namespace exists
+		target    cmd.NamespaceState
+		wantErr   error
+	}{
+		{name: "active -> deleting flips state", seedState: cmd.NamespaceStateActive, target: cmd.NamespaceStateDeleting},
+		{name: "active -> active is idempotent", seedState: cmd.NamespaceStateActive, target: cmd.NamespaceStateActive},
+		{name: "deleting -> deleting is idempotent", seedState: cmd.NamespaceStateDeleting, target: cmd.NamespaceStateDeleting},
+		{name: "deleting -> active is forbidden", seedState: cmd.NamespaceStateDeleting, target: cmd.NamespaceStateActive, wantErr: usecasesNamespaces.ErrInvalidStateTransition},
+		{name: "missing namespace returns ErrNotFound", target: cmd.NamespaceStateDeleting, wantErr: usecasesNamespaces.ErrNotFound},
+	}
 
-	t.Run("malformed payload is rejected", func(t *testing.T) {
-		err := m.Delete(&cmd.ApplyRequest{SubCommand: []byte("not-json")})
-		require.Error(t, err)
-		assert.ErrorIs(t, err, usecasesNamespaces.ErrBadRequest)
-	})
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestManager(t)
+			seedNamespace(t, m, "customer1", tc.seedState)
+
+			err := m.ChangeState(changeStateCmd(t, "customer1", tc.target))
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, m.Exists("customer1"))
+			assert.Equal(t, tc.target == cmd.NamespaceStateActive, m.IsActive("customer1"))
+		})
+	}
+}
+
+func TestManager_RemoveEntity(t *testing.T) {
+	tests := []struct {
+		name      string
+		seedState cmd.NamespaceState // empty = no namespace exists
+		wantErr   error
+	}{
+		{name: "deleting namespace is removed", seedState: cmd.NamespaceStateDeleting},
+		{name: "active namespace returns ErrInvalidState", seedState: cmd.NamespaceStateActive, wantErr: usecasesNamespaces.ErrInvalidState},
+		{name: "missing namespace returns ErrNotFound", wantErr: usecasesNamespaces.ErrNotFound},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestManager(t)
+			seedNamespace(t, m, "customer1", tc.seedState)
+
+			err := m.RemoveEntity(removeEntityCmd(t, "customer1"))
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.False(t, m.Exists("customer1"))
+		})
+	}
+}
+
+func TestManager_RejectsMalformedApplyRequest(t *testing.T) {
+	bad := &cmd.ApplyRequest{SubCommand: []byte("not-json")}
+	tests := []struct {
+		name string
+		call func(*Manager) error
+	}{
+		{name: "Add", call: func(m *Manager) error { return m.Add(bad) }},
+		{name: "Delete", call: func(m *Manager) error { return m.Delete(bad) }},
+		{name: "ChangeState", call: func(m *Manager) error { return m.ChangeState(bad) }},
+		{name: "RemoveEntity", call: func(m *Manager) error { return m.RemoveEntity(bad) }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			m := newTestManager(t)
+			err := tc.call(m)
+			require.Error(t, err)
+			assert.ErrorIs(t, err, usecasesNamespaces.ErrBadRequest)
+		})
+	}
+}
+
+func TestManager_ExistsAndIsActiveProxies(t *testing.T) {
+	m := newTestManager(t)
+	require.NoError(t, m.Add(addCmd(t, "customer1")))
+
+	assert.True(t, m.Exists("customer1"))
+	assert.True(t, m.IsActive("customer1"))
+	assert.False(t, m.Exists("never-existed"))
+	assert.False(t, m.IsActive("never-existed"))
+
+	require.NoError(t, m.ChangeState(changeStateCmd(t, "customer1", cmd.NamespaceStateDeleting)))
+	assert.True(t, m.Exists("customer1"))
+	assert.False(t, m.IsActive("customer1"))
 }
 
 func TestManager_Get(t *testing.T) {

--- a/cluster/namespaces/namespaces_test.go
+++ b/cluster/namespaces/namespaces_test.go
@@ -45,13 +45,6 @@ func addCmd(t *testing.T, name string) *cmd.ApplyRequest {
 	return &cmd.ApplyRequest{SubCommand: payload}
 }
 
-func deleteCmd(t *testing.T, name string) *cmd.ApplyRequest {
-	t.Helper()
-	payload, err := json.Marshal(cmd.DeleteNamespaceRequest{Name: name})
-	require.NoError(t, err)
-	return &cmd.ApplyRequest{SubCommand: payload}
-}
-
 func changeStateCmd(t *testing.T, name string, target cmd.NamespaceState) *cmd.ApplyRequest {
 	t.Helper()
 	payload, err := json.Marshal(cmd.ChangeNamespaceStateRequest{Name: name, TargetState: target})
@@ -104,13 +97,6 @@ func TestManager_Add(t *testing.T) {
 	m := newTestManager(t)
 	require.NoError(t, m.Add(addCmd(t, "customer1")))
 	assert.Equal(t, 1, m.Count())
-}
-
-func TestManager_Delete(t *testing.T) {
-	m := newTestManager(t)
-	require.NoError(t, m.Add(addCmd(t, "customer1")))
-	require.NoError(t, m.Delete(deleteCmd(t, "customer1")))
-	assert.Equal(t, 0, m.Count())
 }
 
 func TestManager_ChangeState(t *testing.T) {
@@ -221,7 +207,6 @@ func TestManager_RejectsMalformedApplyRequest(t *testing.T) {
 		call func(*Manager) error
 	}{
 		{name: "Add", call: func(m *Manager) error { return m.Add(bad) }},
-		{name: "Delete", call: func(m *Manager) error { return m.Delete(bad) }},
 		{name: "ChangeState", call: func(m *Manager) error { return m.ChangeState(bad) }},
 		{name: "RemoveEntity", call: func(m *Manager) error { return m.RemoveEntity(bad) }},
 	}

--- a/cluster/proto/api/dyn_user_requests.go
+++ b/cluster/proto/api/dyn_user_requests.go
@@ -55,6 +55,12 @@ type DeleteUsersRequest struct {
 	Version int
 }
 
+// DeleteUsersInNamespaceRequest deletes every DB user bound to Namespace.
+type DeleteUsersInNamespaceRequest struct {
+	Namespace string
+	Version   int
+}
+
 type ActivateUsersRequest struct {
 	UserId  string
 	Version int

--- a/cluster/proto/api/message.pb.go
+++ b/cluster/proto/api/message.pb.go
@@ -58,6 +58,7 @@ const (
 	ApplyRequest_TYPE_DELETE_NAMESPACE                                           ApplyRequest_Type = 91
 	ApplyRequest_TYPE_CHANGE_NAMESPACE_STATE                                     ApplyRequest_Type = 92
 	ApplyRequest_TYPE_REMOVE_NAMESPACE_ENTITY                                    ApplyRequest_Type = 93
+	ApplyRequest_TYPE_DELETE_USERS_IN_NAMESPACE                                  ApplyRequest_Type = 94
 	ApplyRequest_TYPE_REPLICATION_REPLICATE                                      ApplyRequest_Type = 200
 	ApplyRequest_TYPE_REPLICATION_REPLICATE_UPDATE_STATE                         ApplyRequest_Type = 201
 	ApplyRequest_TYPE_REPLICATION_REPLICATE_REGISTER_ERROR                       ApplyRequest_Type = 202
@@ -120,6 +121,7 @@ var (
 		91:  "TYPE_DELETE_NAMESPACE",
 		92:  "TYPE_CHANGE_NAMESPACE_STATE",
 		93:  "TYPE_REMOVE_NAMESPACE_ENTITY",
+		94:  "TYPE_DELETE_USERS_IN_NAMESPACE",
 		200: "TYPE_REPLICATION_REPLICATE",
 		201: "TYPE_REPLICATION_REPLICATE_UPDATE_STATE",
 		202: "TYPE_REPLICATION_REPLICATE_REGISTER_ERROR",
@@ -178,6 +180,7 @@ var (
 		"TYPE_DELETE_NAMESPACE":                                           91,
 		"TYPE_CHANGE_NAMESPACE_STATE":                                     92,
 		"TYPE_REMOVE_NAMESPACE_ENTITY":                                    93,
+		"TYPE_DELETE_USERS_IN_NAMESPACE":                                  94,
 		"TYPE_REPLICATION_REPLICATE":                                      200,
 		"TYPE_REPLICATION_REPLICATE_UPDATE_STATE":                         201,
 		"TYPE_REPLICATION_REPLICATE_REGISTER_ERROR":                       202,
@@ -2035,13 +2038,13 @@ const file_api_message_proto_rawDesc = "" +
 	"\x11NotifyPeerRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\"\x14\n" +
-	"\x12NotifyPeerResponse\"\xf0\x10\n" +
+	"\x12NotifyPeerResponse\"\x94\x11\n" +
 	"\fApplyRequest\x12@\n" +
 	"\x04type\x18\x01 \x01(\x0e2,.weaviate.internal.cluster.ApplyRequest.TypeR\x04type\x12\x14\n" +
 	"\x05class\x18\x02 \x01(\tR\x05class\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\x04R\aversion\x12\x1f\n" +
 	"\vsub_command\x18\x04 \x01(\fR\n" +
-	"subCommand\"\xcc\x0f\n" +
+	"subCommand\"\xf0\x0f\n" +
 	"\x04Type\x12\x14\n" +
 	"\x10TYPE_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eTYPE_ADD_CLASS\x10\x01\x12\x15\n" +
@@ -2075,7 +2078,8 @@ const file_api_message_proto_rawDesc = "" +
 	"\x12TYPE_ADD_NAMESPACE\x10Z\x12\x19\n" +
 	"\x15TYPE_DELETE_NAMESPACE\x10[\x12\x1f\n" +
 	"\x1bTYPE_CHANGE_NAMESPACE_STATE\x10\\\x12 \n" +
-	"\x1cTYPE_REMOVE_NAMESPACE_ENTITY\x10]\x12\x1f\n" +
+	"\x1cTYPE_REMOVE_NAMESPACE_ENTITY\x10]\x12\"\n" +
+	"\x1eTYPE_DELETE_USERS_IN_NAMESPACE\x10^\x12\x1f\n" +
 	"\x1aTYPE_REPLICATION_REPLICATE\x10\xc8\x01\x12,\n" +
 	"'TYPE_REPLICATION_REPLICATE_UPDATE_STATE\x10\xc9\x01\x12.\n" +
 	")TYPE_REPLICATION_REPLICATE_REGISTER_ERROR\x10\xca\x01\x12&\n" +

--- a/cluster/proto/api/message.pb.go
+++ b/cluster/proto/api/message.pb.go
@@ -56,6 +56,8 @@ const (
 	ApplyRequest_TYPE_CREATE_USER_WITH_KEY                                       ApplyRequest_Type = 85
 	ApplyRequest_TYPE_ADD_NAMESPACE                                              ApplyRequest_Type = 90
 	ApplyRequest_TYPE_DELETE_NAMESPACE                                           ApplyRequest_Type = 91
+	ApplyRequest_TYPE_CHANGE_NAMESPACE_STATE                                     ApplyRequest_Type = 92
+	ApplyRequest_TYPE_REMOVE_NAMESPACE_ENTITY                                    ApplyRequest_Type = 93
 	ApplyRequest_TYPE_REPLICATION_REPLICATE                                      ApplyRequest_Type = 200
 	ApplyRequest_TYPE_REPLICATION_REPLICATE_UPDATE_STATE                         ApplyRequest_Type = 201
 	ApplyRequest_TYPE_REPLICATION_REPLICATE_REGISTER_ERROR                       ApplyRequest_Type = 202
@@ -116,6 +118,8 @@ var (
 		85:  "TYPE_CREATE_USER_WITH_KEY",
 		90:  "TYPE_ADD_NAMESPACE",
 		91:  "TYPE_DELETE_NAMESPACE",
+		92:  "TYPE_CHANGE_NAMESPACE_STATE",
+		93:  "TYPE_REMOVE_NAMESPACE_ENTITY",
 		200: "TYPE_REPLICATION_REPLICATE",
 		201: "TYPE_REPLICATION_REPLICATE_UPDATE_STATE",
 		202: "TYPE_REPLICATION_REPLICATE_REGISTER_ERROR",
@@ -172,6 +176,8 @@ var (
 		"TYPE_CREATE_USER_WITH_KEY":                                       85,
 		"TYPE_ADD_NAMESPACE":                                              90,
 		"TYPE_DELETE_NAMESPACE":                                           91,
+		"TYPE_CHANGE_NAMESPACE_STATE":                                     92,
+		"TYPE_REMOVE_NAMESPACE_ENTITY":                                    93,
 		"TYPE_REPLICATION_REPLICATE":                                      200,
 		"TYPE_REPLICATION_REPLICATE_UPDATE_STATE":                         201,
 		"TYPE_REPLICATION_REPLICATE_REGISTER_ERROR":                       202,
@@ -2029,13 +2035,13 @@ const file_api_message_proto_rawDesc = "" +
 	"\x11NotifyPeerRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\"\x14\n" +
-	"\x12NotifyPeerResponse\"\xad\x10\n" +
+	"\x12NotifyPeerResponse\"\xf0\x10\n" +
 	"\fApplyRequest\x12@\n" +
 	"\x04type\x18\x01 \x01(\x0e2,.weaviate.internal.cluster.ApplyRequest.TypeR\x04type\x12\x14\n" +
 	"\x05class\x18\x02 \x01(\tR\x05class\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\x04R\aversion\x12\x1f\n" +
 	"\vsub_command\x18\x04 \x01(\fR\n" +
-	"subCommand\"\x89\x0f\n" +
+	"subCommand\"\xcc\x0f\n" +
 	"\x04Type\x12\x14\n" +
 	"\x10TYPE_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eTYPE_ADD_CLASS\x10\x01\x12\x15\n" +
@@ -2068,6 +2074,8 @@ const file_api_message_proto_rawDesc = "" +
 	"\x19TYPE_CREATE_USER_WITH_KEY\x10U\x12\x16\n" +
 	"\x12TYPE_ADD_NAMESPACE\x10Z\x12\x19\n" +
 	"\x15TYPE_DELETE_NAMESPACE\x10[\x12\x1f\n" +
+	"\x1bTYPE_CHANGE_NAMESPACE_STATE\x10\\\x12 \n" +
+	"\x1cTYPE_REMOVE_NAMESPACE_ENTITY\x10]\x12\x1f\n" +
 	"\x1aTYPE_REPLICATION_REPLICATE\x10\xc8\x01\x12,\n" +
 	"'TYPE_REPLICATION_REPLICATE_UPDATE_STATE\x10\xc9\x01\x12.\n" +
 	")TYPE_REPLICATION_REPLICATE_REGISTER_ERROR\x10\xca\x01\x12&\n" +

--- a/cluster/proto/api/message.pb.go
+++ b/cluster/proto/api/message.pb.go
@@ -55,10 +55,9 @@ const (
 	ApplyRequest_TYPE_ACTIVATE_USER                                              ApplyRequest_Type = 84
 	ApplyRequest_TYPE_CREATE_USER_WITH_KEY                                       ApplyRequest_Type = 85
 	ApplyRequest_TYPE_ADD_NAMESPACE                                              ApplyRequest_Type = 90
-	ApplyRequest_TYPE_DELETE_NAMESPACE                                           ApplyRequest_Type = 91
+	ApplyRequest_TYPE_DELETE_USERS_IN_NAMESPACE                                  ApplyRequest_Type = 91
 	ApplyRequest_TYPE_CHANGE_NAMESPACE_STATE                                     ApplyRequest_Type = 92
 	ApplyRequest_TYPE_REMOVE_NAMESPACE_ENTITY                                    ApplyRequest_Type = 93
-	ApplyRequest_TYPE_DELETE_USERS_IN_NAMESPACE                                  ApplyRequest_Type = 94
 	ApplyRequest_TYPE_REPLICATION_REPLICATE                                      ApplyRequest_Type = 200
 	ApplyRequest_TYPE_REPLICATION_REPLICATE_UPDATE_STATE                         ApplyRequest_Type = 201
 	ApplyRequest_TYPE_REPLICATION_REPLICATE_REGISTER_ERROR                       ApplyRequest_Type = 202
@@ -118,10 +117,9 @@ var (
 		84:  "TYPE_ACTIVATE_USER",
 		85:  "TYPE_CREATE_USER_WITH_KEY",
 		90:  "TYPE_ADD_NAMESPACE",
-		91:  "TYPE_DELETE_NAMESPACE",
+		91:  "TYPE_DELETE_USERS_IN_NAMESPACE",
 		92:  "TYPE_CHANGE_NAMESPACE_STATE",
 		93:  "TYPE_REMOVE_NAMESPACE_ENTITY",
-		94:  "TYPE_DELETE_USERS_IN_NAMESPACE",
 		200: "TYPE_REPLICATION_REPLICATE",
 		201: "TYPE_REPLICATION_REPLICATE_UPDATE_STATE",
 		202: "TYPE_REPLICATION_REPLICATE_REGISTER_ERROR",
@@ -177,10 +175,9 @@ var (
 		"TYPE_ACTIVATE_USER":                                              84,
 		"TYPE_CREATE_USER_WITH_KEY":                                       85,
 		"TYPE_ADD_NAMESPACE":                                              90,
-		"TYPE_DELETE_NAMESPACE":                                           91,
+		"TYPE_DELETE_USERS_IN_NAMESPACE":                                  91,
 		"TYPE_CHANGE_NAMESPACE_STATE":                                     92,
 		"TYPE_REMOVE_NAMESPACE_ENTITY":                                    93,
-		"TYPE_DELETE_USERS_IN_NAMESPACE":                                  94,
 		"TYPE_REPLICATION_REPLICATE":                                      200,
 		"TYPE_REPLICATION_REPLICATE_UPDATE_STATE":                         201,
 		"TYPE_REPLICATION_REPLICATE_REGISTER_ERROR":                       202,
@@ -2038,13 +2035,13 @@ const file_api_message_proto_rawDesc = "" +
 	"\x11NotifyPeerRequest\x12\x0e\n" +
 	"\x02id\x18\x01 \x01(\tR\x02id\x12\x18\n" +
 	"\aaddress\x18\x02 \x01(\tR\aaddress\"\x14\n" +
-	"\x12NotifyPeerResponse\"\x94\x11\n" +
+	"\x12NotifyPeerResponse\"\xf9\x10\n" +
 	"\fApplyRequest\x12@\n" +
 	"\x04type\x18\x01 \x01(\x0e2,.weaviate.internal.cluster.ApplyRequest.TypeR\x04type\x12\x14\n" +
 	"\x05class\x18\x02 \x01(\tR\x05class\x12\x18\n" +
 	"\aversion\x18\x03 \x01(\x04R\aversion\x12\x1f\n" +
 	"\vsub_command\x18\x04 \x01(\fR\n" +
-	"subCommand\"\xf0\x0f\n" +
+	"subCommand\"\xd5\x0f\n" +
 	"\x04Type\x12\x14\n" +
 	"\x10TYPE_UNSPECIFIED\x10\x00\x12\x12\n" +
 	"\x0eTYPE_ADD_CLASS\x10\x01\x12\x15\n" +
@@ -2075,11 +2072,10 @@ const file_api_message_proto_rawDesc = "" +
 	"\x11TYPE_SUSPEND_USER\x10S\x12\x16\n" +
 	"\x12TYPE_ACTIVATE_USER\x10T\x12\x1d\n" +
 	"\x19TYPE_CREATE_USER_WITH_KEY\x10U\x12\x16\n" +
-	"\x12TYPE_ADD_NAMESPACE\x10Z\x12\x19\n" +
-	"\x15TYPE_DELETE_NAMESPACE\x10[\x12\x1f\n" +
+	"\x12TYPE_ADD_NAMESPACE\x10Z\x12\"\n" +
+	"\x1eTYPE_DELETE_USERS_IN_NAMESPACE\x10[\x12\x1f\n" +
 	"\x1bTYPE_CHANGE_NAMESPACE_STATE\x10\\\x12 \n" +
-	"\x1cTYPE_REMOVE_NAMESPACE_ENTITY\x10]\x12\"\n" +
-	"\x1eTYPE_DELETE_USERS_IN_NAMESPACE\x10^\x12\x1f\n" +
+	"\x1cTYPE_REMOVE_NAMESPACE_ENTITY\x10]\x12\x1f\n" +
 	"\x1aTYPE_REPLICATION_REPLICATE\x10\xc8\x01\x12,\n" +
 	"'TYPE_REPLICATION_REPLICATE_UPDATE_STATE\x10\xc9\x01\x12.\n" +
 	")TYPE_REPLICATION_REPLICATE_REGISTER_ERROR\x10\xca\x01\x12&\n" +

--- a/cluster/proto/api/message.proto
+++ b/cluster/proto/api/message.proto
@@ -74,6 +74,8 @@ message ApplyRequest {
 
     TYPE_ADD_NAMESPACE = 90;
     TYPE_DELETE_NAMESPACE = 91;
+    TYPE_CHANGE_NAMESPACE_STATE = 92;
+    TYPE_REMOVE_NAMESPACE_ENTITY = 93;
 
     // originally was rolling back schema before raft
     reserved 99;

--- a/cluster/proto/api/message.proto
+++ b/cluster/proto/api/message.proto
@@ -76,6 +76,7 @@ message ApplyRequest {
     TYPE_DELETE_NAMESPACE = 91;
     TYPE_CHANGE_NAMESPACE_STATE = 92;
     TYPE_REMOVE_NAMESPACE_ENTITY = 93;
+    TYPE_DELETE_USERS_IN_NAMESPACE = 94;
 
     // originally was rolling back schema before raft
     reserved 99;

--- a/cluster/proto/api/message.proto
+++ b/cluster/proto/api/message.proto
@@ -73,10 +73,9 @@ message ApplyRequest {
     TYPE_CREATE_USER_WITH_KEY = 85;
 
     TYPE_ADD_NAMESPACE = 90;
-    TYPE_DELETE_NAMESPACE = 91;
+    TYPE_DELETE_USERS_IN_NAMESPACE = 91;
     TYPE_CHANGE_NAMESPACE_STATE = 92;
     TYPE_REMOVE_NAMESPACE_ENTITY = 93;
-    TYPE_DELETE_USERS_IN_NAMESPACE = 94;
 
     // originally was rolling back schema before raft
     reserved 99;

--- a/cluster/proto/api/namespace_requests.go
+++ b/cluster/proto/api/namespace_requests.go
@@ -46,12 +46,6 @@ type AddNamespaceRequest struct {
 	Version   int
 }
 
-// DeleteNamespaceRequest is the RAFT apply payload for deleting a namespace.
-type DeleteNamespaceRequest struct {
-	Name    string
-	Version int
-}
-
 // ChangeNamespaceStateRequest transitions a namespace into TargetState.
 // Same-state transitions are idempotent.
 type ChangeNamespaceStateRequest struct {

--- a/cluster/proto/api/namespace_requests.go
+++ b/cluster/proto/api/namespace_requests.go
@@ -12,25 +12,32 @@
 package api
 
 const (
-	// NamespaceLatestCommandPolicyVersion is bumped when the on-the-wire
-	// shape of a namespace RAFT command changes in a way that requires
-	// version-gated handling on the apply side.
+	// NamespaceLatestCommandPolicyVersion is bumped when a namespace RAFT
+	// command's wire shape requires version-gated apply handling.
 	NamespaceLatestCommandPolicyVersion = iota
 )
 
-// Namespace is the cluster-level control-plane entity. It is the sole source
-// of truth for namespace existence. Restrictions is a forward-compatible
-// placeholder so later work can add namespace-scoped knobs without a schema
-// reshape. A State field is intentionally omitted: the current delete
-// semantics are a hard delete, so there is no active/deleting lifecycle to
-// represent. A future addition will be tolerated by the JSON-based snapshot
-// format (unknown-field defaults).
+// Namespace is the cluster-level control-plane entity. State drives the
+// deletion lifecycle (active → deleting → entity removed); empty State
+// restores as NamespaceStateActive.
 type Namespace struct {
 	Name         string
 	Restrictions NamespaceRestrictions
+	State        NamespaceState
 }
 
-// NamespaceRestrictions is an empty forward-compatibility placeholder.
+// NamespaceState is the lifecycle state of a Namespace entity.
+type NamespaceState string
+
+const (
+	// NamespaceStateActive accepts create-like operations against the namespace.
+	NamespaceStateActive NamespaceState = "active"
+	// NamespaceStateDeleting rejects create-like operations; the entity is
+	// removed once cleanup empties it.
+	NamespaceStateDeleting NamespaceState = "deleting"
+)
+
+// NamespaceRestrictions is a forward-compatibility placeholder.
 type NamespaceRestrictions struct{}
 
 // AddNamespaceRequest is the RAFT apply payload for creating a namespace.
@@ -40,14 +47,26 @@ type AddNamespaceRequest struct {
 }
 
 // DeleteNamespaceRequest is the RAFT apply payload for deleting a namespace.
-// Delete is hard and idempotent at the manager layer.
 type DeleteNamespaceRequest struct {
 	Name    string
 	Version int
 }
 
-// QueryGetNamespacesRequest lists namespaces. Empty Names returns all known
-// namespaces.
+// ChangeNamespaceStateRequest transitions a namespace into TargetState.
+// Same-state transitions are idempotent.
+type ChangeNamespaceStateRequest struct {
+	Name        string
+	TargetState NamespaceState
+	Version     int
+}
+
+// RemoveNamespaceEntityRequest removes a deleting namespace's entity.
+type RemoveNamespaceEntityRequest struct {
+	Name    string
+	Version int
+}
+
+// QueryGetNamespacesRequest lists namespaces. Empty Names returns all.
 type QueryGetNamespacesRequest struct {
 	Names []string
 }

--- a/cluster/raft_dynuser_apply_endpoints.go
+++ b/cluster/raft_dynuser_apply_endpoints.go
@@ -109,6 +109,25 @@ func (s *Raft) DeleteUser(userId string) error {
 	return nil
 }
 
+func (s *Raft) DeleteUsersInNamespace(namespace string) error {
+	req := cmd.DeleteUsersInNamespaceRequest{
+		Namespace: namespace,
+		Version:   cmd.DynUserLatestCommandPolicyVersion,
+	}
+	subCommand, err := json.Marshal(&req)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+	command := &cmd.ApplyRequest{
+		Type:       cmd.ApplyRequest_TYPE_DELETE_USERS_IN_NAMESPACE,
+		SubCommand: subCommand,
+	}
+	if _, err := s.Execute(context.Background(), command); err != nil {
+		return err
+	}
+	return nil
+}
+
 func (s *Raft) ActivateUser(userId string) error {
 	req := cmd.ActivateUsersRequest{
 		UserId:  userId,

--- a/cluster/raft_dynuser_apply_endpoints.go
+++ b/cluster/raft_dynuser_apply_endpoints.go
@@ -109,7 +109,7 @@ func (s *Raft) DeleteUser(userId string) error {
 	return nil
 }
 
-func (s *Raft) DeleteUsersInNamespace(namespace string) error {
+func (s *Raft) DeleteUsersInNamespace(ctx context.Context, namespace string) error {
 	req := cmd.DeleteUsersInNamespaceRequest{
 		Namespace: namespace,
 		Version:   cmd.DynUserLatestCommandPolicyVersion,
@@ -122,7 +122,7 @@ func (s *Raft) DeleteUsersInNamespace(namespace string) error {
 		Type:       cmd.ApplyRequest_TYPE_DELETE_USERS_IN_NAMESPACE,
 		SubCommand: subCommand,
 	}
-	if _, err := s.Execute(context.Background(), command); err != nil {
+	if _, err := s.Execute(ctx, command); err != nil {
 		return err
 	}
 	return nil

--- a/cluster/raft_dynuser_apply_endpoints.go
+++ b/cluster/raft_dynuser_apply_endpoints.go
@@ -21,7 +21,7 @@ import (
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 )
 
-func (s *Raft) CreateUser(userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace string, createdAt time.Time) error {
+func (s *Raft) CreateUser(ctx context.Context, userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace string, createdAt time.Time) error {
 	req := cmd.CreateUsersRequest{
 		UserId:             userId,
 		SecureHash:         secureHash,
@@ -39,13 +39,13 @@ func (s *Raft) CreateUser(userId, secureHash, userIdentifier, apiKeyFirstLetters
 		Type:       cmd.ApplyRequest_TYPE_UPSERT_USER,
 		SubCommand: subCommand,
 	}
-	if _, err := s.Execute(context.Background(), command); err != nil {
+	if _, err := s.Execute(ctx, command); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (s *Raft) CreateUserWithKey(userId, apiKeyFirstLetters string, weakHash [sha256.Size]byte, createdAt time.Time) error {
+func (s *Raft) CreateUserWithKey(ctx context.Context, userId, apiKeyFirstLetters string, weakHash [sha256.Size]byte, createdAt time.Time) error {
 	req := cmd.CreateUserWithKeyRequest{
 		UserId:             userId,
 		CreatedAt:          createdAt,
@@ -61,13 +61,13 @@ func (s *Raft) CreateUserWithKey(userId, apiKeyFirstLetters string, weakHash [sh
 		Type:       cmd.ApplyRequest_TYPE_CREATE_USER_WITH_KEY,
 		SubCommand: subCommand,
 	}
-	if _, err := s.Execute(context.Background(), command); err != nil {
+	if _, err := s.Execute(ctx, command); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (s *Raft) RotateKey(userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier string) error {
+func (s *Raft) RotateKey(ctx context.Context, userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier string) error {
 	req := cmd.RotateUserApiKeyRequest{
 		UserId:             userId,
 		ApiKeyFirstLetters: apiKeyFirstLetters,
@@ -84,13 +84,13 @@ func (s *Raft) RotateKey(userId, apiKeyFirstLetters, secureHash, oldIdentifier, 
 		Type:       cmd.ApplyRequest_TYPE_ROTATE_USER_API_KEY,
 		SubCommand: subCommand,
 	}
-	if _, err := s.Execute(context.Background(), command); err != nil {
+	if _, err := s.Execute(ctx, command); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (s *Raft) DeleteUser(userId string) error {
+func (s *Raft) DeleteUser(ctx context.Context, userId string) error {
 	req := cmd.DeleteUsersRequest{
 		UserId:  userId,
 		Version: cmd.DynUserLatestCommandPolicyVersion,
@@ -103,7 +103,7 @@ func (s *Raft) DeleteUser(userId string) error {
 		Type:       cmd.ApplyRequest_TYPE_DELETE_USER,
 		SubCommand: subCommand,
 	}
-	if _, err := s.Execute(context.Background(), command); err != nil {
+	if _, err := s.Execute(ctx, command); err != nil {
 		return err
 	}
 	return nil
@@ -128,7 +128,7 @@ func (s *Raft) DeleteUsersInNamespace(ctx context.Context, namespace string) err
 	return nil
 }
 
-func (s *Raft) ActivateUser(userId string) error {
+func (s *Raft) ActivateUser(ctx context.Context, userId string) error {
 	req := cmd.ActivateUsersRequest{
 		UserId:  userId,
 		Version: cmd.DynUserLatestCommandPolicyVersion,
@@ -141,13 +141,13 @@ func (s *Raft) ActivateUser(userId string) error {
 		Type:       cmd.ApplyRequest_TYPE_ACTIVATE_USER,
 		SubCommand: subCommand,
 	}
-	if _, err := s.Execute(context.Background(), command); err != nil {
+	if _, err := s.Execute(ctx, command); err != nil {
 		return err
 	}
 	return nil
 }
 
-func (s *Raft) DeactivateUser(userId string, revokeKey bool) error {
+func (s *Raft) DeactivateUser(ctx context.Context, userId string, revokeKey bool) error {
 	req := cmd.SuspendUserRequest{
 		UserId:    userId,
 		RevokeKey: revokeKey,
@@ -161,7 +161,7 @@ func (s *Raft) DeactivateUser(userId string, revokeKey bool) error {
 		Type:       cmd.ApplyRequest_TYPE_SUSPEND_USER,
 		SubCommand: subCommand,
 	}
-	if _, err := s.Execute(context.Background(), command); err != nil {
+	if _, err := s.Execute(ctx, command); err != nil {
 		return err
 	}
 	return nil

--- a/cluster/raft_namespace_apply_endpoints.go
+++ b/cluster/raft_namespace_apply_endpoints.go
@@ -53,35 +53,6 @@ func (s *Raft) AddNamespace(ns cmd.Namespace) error {
 	return nil
 }
 
-// DeleteNamespace proposes a DeleteNamespace RAFT command. The apply side
-// returns [namespaces.ErrNotFound] when the target namespace does not exist;
-// callers that want idempotent semantics should swallow that error.
-//
-// On success the call blocks until the local node has applied the entry so
-// subsequent local reads observe the namespace as gone.
-func (s *Raft) DeleteNamespace(name string) error {
-	req := cmd.DeleteNamespaceRequest{
-		Name:    name,
-		Version: cmd.NamespaceLatestCommandPolicyVersion,
-	}
-	subCommand, err := json.Marshal(&req)
-	if err != nil {
-		return fmt.Errorf("marshal request: %w", err)
-	}
-	command := &cmd.ApplyRequest{
-		Type:       cmd.ApplyRequest_TYPE_DELETE_NAMESPACE,
-		SubCommand: subCommand,
-	}
-	version, err := s.Execute(context.Background(), command)
-	if err != nil {
-		return rewrapNamespaceApplyError(err)
-	}
-	if err := s.WaitForUpdate(context.Background(), version); err != nil {
-		return fmt.Errorf("wait for local apply: %w", err)
-	}
-	return nil
-}
-
 // ChangeNamespaceState proposes a ChangeNamespaceState RAFT command. The
 // apply side returns [namespaces.ErrNotFound] when the namespace does not
 // exist and [namespaces.ErrInvalidStateTransition] when the transition is

--- a/cluster/raft_namespace_apply_endpoints.go
+++ b/cluster/raft_namespace_apply_endpoints.go
@@ -82,6 +82,67 @@ func (s *Raft) DeleteNamespace(name string) error {
 	return nil
 }
 
+// ChangeNamespaceState proposes a ChangeNamespaceState RAFT command. The
+// apply side returns [namespaces.ErrNotFound] when the namespace does not
+// exist and [namespaces.ErrInvalidStateTransition] when the transition is
+// forbidden; same-state transitions are idempotent.
+//
+// On success the call blocks until the local node has applied the entry so
+// subsequent local reads observe the new state.
+func (s *Raft) ChangeNamespaceState(name string, target cmd.NamespaceState) error {
+	req := cmd.ChangeNamespaceStateRequest{
+		Name:        name,
+		TargetState: target,
+		Version:     cmd.NamespaceLatestCommandPolicyVersion,
+	}
+	subCommand, err := json.Marshal(&req)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+	command := &cmd.ApplyRequest{
+		Type:       cmd.ApplyRequest_TYPE_CHANGE_NAMESPACE_STATE,
+		SubCommand: subCommand,
+	}
+	version, err := s.Execute(context.Background(), command)
+	if err != nil {
+		return rewrapNamespaceApplyError(err)
+	}
+	if err := s.WaitForUpdate(context.Background(), version); err != nil {
+		return fmt.Errorf("wait for local apply: %w", err)
+	}
+	return nil
+}
+
+// RemoveNamespaceEntity proposes a RemoveNamespaceEntity RAFT command,
+// removing the namespace map entry. The apply side returns
+// [namespaces.ErrNotFound] when the namespace does not exist and
+// [namespaces.ErrInvalidState] when called on an active namespace.
+//
+// On success the call blocks until the local node has applied the entry so
+// subsequent local reads observe the namespace as gone.
+func (s *Raft) RemoveNamespaceEntity(name string) error {
+	req := cmd.RemoveNamespaceEntityRequest{
+		Name:    name,
+		Version: cmd.NamespaceLatestCommandPolicyVersion,
+	}
+	subCommand, err := json.Marshal(&req)
+	if err != nil {
+		return fmt.Errorf("marshal request: %w", err)
+	}
+	command := &cmd.ApplyRequest{
+		Type:       cmd.ApplyRequest_TYPE_REMOVE_NAMESPACE_ENTITY,
+		SubCommand: subCommand,
+	}
+	version, err := s.Execute(context.Background(), command)
+	if err != nil {
+		return rewrapNamespaceApplyError(err)
+	}
+	if err := s.WaitForUpdate(context.Background(), version); err != nil {
+		return fmt.Errorf("wait for local apply: %w", err)
+	}
+	return nil
+}
+
 // rewrapNamespaceApplyError restores typed sentinels on FSM errors that
 // flowed back through the follower→leader gRPC hop. The RPC layer serializes
 // the error to a plain status string and so erases errors.Is chains. The
@@ -100,6 +161,10 @@ func rewrapNamespaceApplyError(err error) error {
 		return fmt.Errorf("%w: %s", usecasesNamespaces.ErrNotFound, msg)
 	case strings.Contains(msg, usecasesNamespaces.ErrBadRequest.Error()):
 		return fmt.Errorf("%w: %s", usecasesNamespaces.ErrBadRequest, msg)
+	case strings.Contains(msg, usecasesNamespaces.ErrInvalidStateTransition.Error()):
+		return fmt.Errorf("%w: %s", usecasesNamespaces.ErrInvalidStateTransition, msg)
+	case strings.Contains(msg, usecasesNamespaces.ErrInvalidState.Error()):
+		return fmt.Errorf("%w: %s", usecasesNamespaces.ErrInvalidState, msg)
 	default:
 		return err
 	}

--- a/cluster/raft_namespace_apply_endpoints.go
+++ b/cluster/raft_namespace_apply_endpoints.go
@@ -30,7 +30,7 @@ import (
 // so a follow-up local read (e.g. controller.Exists) on the same node sees
 // the change. On a follower this absorbs the leader→follower replication
 // delay; on the leader it returns immediately.
-func (s *Raft) AddNamespace(ns cmd.Namespace) error {
+func (s *Raft) AddNamespace(ctx context.Context, ns cmd.Namespace) error {
 	req := cmd.AddNamespaceRequest{
 		Namespace: ns,
 		Version:   cmd.NamespaceLatestCommandPolicyVersion,
@@ -43,11 +43,11 @@ func (s *Raft) AddNamespace(ns cmd.Namespace) error {
 		Type:       cmd.ApplyRequest_TYPE_ADD_NAMESPACE,
 		SubCommand: subCommand,
 	}
-	version, err := s.Execute(context.Background(), command)
+	version, err := s.Execute(ctx, command)
 	if err != nil {
 		return rewrapNamespaceApplyError(err)
 	}
-	if err := s.WaitForUpdate(context.Background(), version); err != nil {
+	if err := s.WaitForUpdate(ctx, version); err != nil {
 		return fmt.Errorf("wait for local apply: %w", err)
 	}
 	return nil
@@ -60,7 +60,7 @@ func (s *Raft) AddNamespace(ns cmd.Namespace) error {
 //
 // On success the call blocks until the local node has applied the entry so
 // subsequent local reads observe the new state.
-func (s *Raft) ChangeNamespaceState(name string, target cmd.NamespaceState) error {
+func (s *Raft) ChangeNamespaceState(ctx context.Context, name string, target cmd.NamespaceState) error {
 	req := cmd.ChangeNamespaceStateRequest{
 		Name:        name,
 		TargetState: target,
@@ -74,11 +74,11 @@ func (s *Raft) ChangeNamespaceState(name string, target cmd.NamespaceState) erro
 		Type:       cmd.ApplyRequest_TYPE_CHANGE_NAMESPACE_STATE,
 		SubCommand: subCommand,
 	}
-	version, err := s.Execute(context.Background(), command)
+	version, err := s.Execute(ctx, command)
 	if err != nil {
 		return rewrapNamespaceApplyError(err)
 	}
-	if err := s.WaitForUpdate(context.Background(), version); err != nil {
+	if err := s.WaitForUpdate(ctx, version); err != nil {
 		return fmt.Errorf("wait for local apply: %w", err)
 	}
 	return nil
@@ -91,7 +91,7 @@ func (s *Raft) ChangeNamespaceState(name string, target cmd.NamespaceState) erro
 //
 // On success the call blocks until the local node has applied the entry so
 // subsequent local reads observe the namespace as gone.
-func (s *Raft) RemoveNamespaceEntity(name string) error {
+func (s *Raft) RemoveNamespaceEntity(ctx context.Context, name string) error {
 	req := cmd.RemoveNamespaceEntityRequest{
 		Name:    name,
 		Version: cmd.NamespaceLatestCommandPolicyVersion,
@@ -104,11 +104,11 @@ func (s *Raft) RemoveNamespaceEntity(name string) error {
 		Type:       cmd.ApplyRequest_TYPE_REMOVE_NAMESPACE_ENTITY,
 		SubCommand: subCommand,
 	}
-	version, err := s.Execute(context.Background(), command)
+	version, err := s.Execute(ctx, command)
 	if err != nil {
 		return rewrapNamespaceApplyError(err)
 	}
-	if err := s.WaitForUpdate(context.Background(), version); err != nil {
+	if err := s.WaitForUpdate(ctx, version); err != nil {
 		return fmt.Errorf("wait for local apply: %w", err)
 	}
 	return nil

--- a/cluster/raft_namespace_apply_endpoints.go
+++ b/cluster/raft_namespace_apply_endpoints.go
@@ -15,10 +15,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
-	usecasesNamespaces "github.com/weaviate/weaviate/usecases/namespaces"
 )
 
 // AddNamespace proposes an AddNamespace RAFT command. The apply side rejects
@@ -45,7 +43,7 @@ func (s *Raft) AddNamespace(ctx context.Context, ns cmd.Namespace) error {
 	}
 	version, err := s.Execute(ctx, command)
 	if err != nil {
-		return rewrapNamespaceApplyError(err)
+		return err
 	}
 	if err := s.WaitForUpdate(ctx, version); err != nil {
 		return fmt.Errorf("wait for local apply: %w", err)
@@ -76,7 +74,7 @@ func (s *Raft) ChangeNamespaceState(ctx context.Context, name string, target cmd
 	}
 	version, err := s.Execute(ctx, command)
 	if err != nil {
-		return rewrapNamespaceApplyError(err)
+		return err
 	}
 	if err := s.WaitForUpdate(ctx, version); err != nil {
 		return fmt.Errorf("wait for local apply: %w", err)
@@ -106,37 +104,10 @@ func (s *Raft) RemoveNamespaceEntity(ctx context.Context, name string) error {
 	}
 	version, err := s.Execute(ctx, command)
 	if err != nil {
-		return rewrapNamespaceApplyError(err)
+		return err
 	}
 	if err := s.WaitForUpdate(ctx, version); err != nil {
 		return fmt.Errorf("wait for local apply: %w", err)
 	}
 	return nil
-}
-
-// rewrapNamespaceApplyError restores typed sentinels on FSM errors that
-// flowed back through the follower→leader gRPC hop. The RPC layer serializes
-// the error to a plain status string and so erases errors.Is chains. The
-// handler matches usecasesNamespaces.Err* via errors.Is, so we string-match
-// known sentinels and rewrap. Mirrors the pattern in
-// cluster/raft_replication_apply_endpoints.go.
-func rewrapNamespaceApplyError(err error) error {
-	if err == nil {
-		return nil
-	}
-	msg := err.Error()
-	switch {
-	case strings.Contains(msg, usecasesNamespaces.ErrAlreadyExists.Error()):
-		return fmt.Errorf("%w: %s", usecasesNamespaces.ErrAlreadyExists, msg)
-	case strings.Contains(msg, usecasesNamespaces.ErrNotFound.Error()):
-		return fmt.Errorf("%w: %s", usecasesNamespaces.ErrNotFound, msg)
-	case strings.Contains(msg, usecasesNamespaces.ErrBadRequest.Error()):
-		return fmt.Errorf("%w: %s", usecasesNamespaces.ErrBadRequest, msg)
-	case strings.Contains(msg, usecasesNamespaces.ErrInvalidStateTransition.Error()):
-		return fmt.Errorf("%w: %s", usecasesNamespaces.ErrInvalidStateTransition, msg)
-	case strings.Contains(msg, usecasesNamespaces.ErrInvalidState.Error()):
-		return fmt.Errorf("%w: %s", usecasesNamespaces.ErrInvalidState, msg)
-	default:
-		return err
-	}
 }

--- a/cluster/raft_namespace_apply_endpoints.go
+++ b/cluster/raft_namespace_apply_endpoints.go
@@ -19,46 +19,32 @@ import (
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 )
 
-// AddNamespace proposes an AddNamespace RAFT command. The apply side rejects
-// duplicates with [namespaces.ErrAlreadyExists] and invalid names with
-// [namespaces.ErrBadRequest]; callers that need to distinguish those should
-// use errors.Is.
-//
-// On success the call blocks until the local node has applied the new entry
-// so a follow-up local read (e.g. controller.Exists) on the same node sees
-// the change. On a follower this absorbs the leader→follower replication
-// delay; on the leader it returns immediately.
-func (s *Raft) AddNamespace(ctx context.Context, ns cmd.Namespace) error {
+// AddNamespace proposes an AddNamespace RAFT command and returns the apply
+// version. The apply side rejects duplicates with
+// [namespaces.ErrAlreadyExists] and invalid names with
+// [namespaces.ErrBadRequest]. Callers that need a follow-up local read on
+// a non-leader node should pass the returned version to WaitForUpdate.
+func (s *Raft) AddNamespace(ctx context.Context, ns cmd.Namespace) (uint64, error) {
 	req := cmd.AddNamespaceRequest{
 		Namespace: ns,
 		Version:   cmd.NamespaceLatestCommandPolicyVersion,
 	}
 	subCommand, err := json.Marshal(&req)
 	if err != nil {
-		return fmt.Errorf("marshal request: %w", err)
+		return 0, fmt.Errorf("marshal request: %w", err)
 	}
 	command := &cmd.ApplyRequest{
 		Type:       cmd.ApplyRequest_TYPE_ADD_NAMESPACE,
 		SubCommand: subCommand,
 	}
-	version, err := s.Execute(ctx, command)
-	if err != nil {
-		return err
-	}
-	if err := s.WaitForUpdate(ctx, version); err != nil {
-		return fmt.Errorf("wait for local apply: %w", err)
-	}
-	return nil
+	return s.Execute(ctx, command)
 }
 
-// ChangeNamespaceState proposes a ChangeNamespaceState RAFT command. The
-// apply side returns [namespaces.ErrNotFound] when the namespace does not
-// exist and [namespaces.ErrInvalidStateTransition] when the transition is
-// forbidden; same-state transitions are idempotent.
-//
-// On success the call blocks until the local node has applied the entry so
-// subsequent local reads observe the new state.
-func (s *Raft) ChangeNamespaceState(ctx context.Context, name string, target cmd.NamespaceState) error {
+// ChangeNamespaceState proposes a ChangeNamespaceState RAFT command and
+// returns the apply version. The apply side returns [namespaces.ErrNotFound]
+// for unknown namespaces and [namespaces.ErrInvalidStateTransition] for
+// forbidden transitions; same-state transitions are idempotent.
+func (s *Raft) ChangeNamespaceState(ctx context.Context, name string, target cmd.NamespaceState) (uint64, error) {
 	req := cmd.ChangeNamespaceStateRequest{
 		Name:        name,
 		TargetState: target,
@@ -66,48 +52,31 @@ func (s *Raft) ChangeNamespaceState(ctx context.Context, name string, target cmd
 	}
 	subCommand, err := json.Marshal(&req)
 	if err != nil {
-		return fmt.Errorf("marshal request: %w", err)
+		return 0, fmt.Errorf("marshal request: %w", err)
 	}
 	command := &cmd.ApplyRequest{
 		Type:       cmd.ApplyRequest_TYPE_CHANGE_NAMESPACE_STATE,
 		SubCommand: subCommand,
 	}
-	version, err := s.Execute(ctx, command)
-	if err != nil {
-		return err
-	}
-	if err := s.WaitForUpdate(ctx, version); err != nil {
-		return fmt.Errorf("wait for local apply: %w", err)
-	}
-	return nil
+	return s.Execute(ctx, command)
 }
 
-// RemoveNamespaceEntity proposes a RemoveNamespaceEntity RAFT command,
-// removing the namespace map entry. The apply side returns
-// [namespaces.ErrNotFound] when the namespace does not exist and
-// [namespaces.ErrInvalidState] when called on an active namespace.
-//
-// On success the call blocks until the local node has applied the entry so
-// subsequent local reads observe the namespace as gone.
-func (s *Raft) RemoveNamespaceEntity(ctx context.Context, name string) error {
+// RemoveNamespaceEntity proposes a RemoveNamespaceEntity RAFT command and
+// returns the apply version. The apply side returns [namespaces.ErrNotFound]
+// for unknown namespaces and [namespaces.ErrInvalidState] when called on an
+// active namespace.
+func (s *Raft) RemoveNamespaceEntity(ctx context.Context, name string) (uint64, error) {
 	req := cmd.RemoveNamespaceEntityRequest{
 		Name:    name,
 		Version: cmd.NamespaceLatestCommandPolicyVersion,
 	}
 	subCommand, err := json.Marshal(&req)
 	if err != nil {
-		return fmt.Errorf("marshal request: %w", err)
+		return 0, fmt.Errorf("marshal request: %w", err)
 	}
 	command := &cmd.ApplyRequest{
 		Type:       cmd.ApplyRequest_TYPE_REMOVE_NAMESPACE_ENTITY,
 		SubCommand: subCommand,
 	}
-	version, err := s.Execute(ctx, command)
-	if err != nil {
-		return err
-	}
-	if err := s.WaitForUpdate(ctx, version); err != nil {
-		return fmt.Errorf("wait for local apply: %w", err)
-	}
-	return nil
+	return s.Execute(ctx, command)
 }

--- a/cluster/raft_namespace_endpoints_test.go
+++ b/cluster/raft_namespace_endpoints_test.go
@@ -54,7 +54,7 @@ func setupRaftForNamespaceTests(t *testing.T) (*Raft, context.Context, func()) {
 }
 
 func TestRaftNamespaceEndpoints(t *testing.T) {
-	srv, _, cleanup := setupRaftForNamespaceTests(t)
+	srv, ctx, cleanup := setupRaftForNamespaceTests(t)
 	defer cleanup()
 
 	// Initially empty.
@@ -64,30 +64,30 @@ func TestRaftNamespaceEndpoints(t *testing.T) {
 	assert.Empty(t, all)
 
 	t.Run("add a namespace", func(t *testing.T) {
-		require.NoError(t, srv.AddNamespace(cmd.Namespace{Name: "customer1"}))
+		require.NoError(t, srv.AddNamespace(ctx, cmd.Namespace{Name: "customer1"}))
 		assert.Equal(t, 1, srv.NamespaceCount())
 	})
 
 	t.Run("add a duplicate returns ErrAlreadyExists", func(t *testing.T) {
-		err := srv.AddNamespace(cmd.Namespace{Name: "customer1"})
+		err := srv.AddNamespace(ctx, cmd.Namespace{Name: "customer1"})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, usecasesNamespaces.ErrAlreadyExists)
 	})
 
 	t.Run("add an invalid name returns ErrBadRequest", func(t *testing.T) {
-		err := srv.AddNamespace(cmd.Namespace{Name: "BadName"})
+		err := srv.AddNamespace(ctx, cmd.Namespace{Name: "BadName"})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, usecasesNamespaces.ErrBadRequest)
 	})
 
 	t.Run("add a reserved name returns ErrBadRequest", func(t *testing.T) {
-		err := srv.AddNamespace(cmd.Namespace{Name: "admin"})
+		err := srv.AddNamespace(ctx, cmd.Namespace{Name: "admin"})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, usecasesNamespaces.ErrBadRequest)
 	})
 
 	t.Run("add a second namespace and list all", func(t *testing.T) {
-		require.NoError(t, srv.AddNamespace(cmd.Namespace{Name: "customer2"}))
+		require.NoError(t, srv.AddNamespace(ctx, cmd.Namespace{Name: "customer2"}))
 		assert.Equal(t, 2, srv.NamespaceCount())
 
 		all, err := srv.GetNamespaces()
@@ -107,14 +107,14 @@ func TestRaftNamespaceEndpoints(t *testing.T) {
 	})
 
 	t.Run("two-phase delete an existing namespace", func(t *testing.T) {
-		require.NoError(t, srv.ChangeNamespaceState("customer1", cmd.NamespaceStateDeleting))
+		require.NoError(t, srv.ChangeNamespaceState(ctx, "customer1", cmd.NamespaceStateDeleting))
 		assert.Equal(t, 2, srv.NamespaceCount(), "entity stays until RemoveNamespaceEntity")
-		require.NoError(t, srv.RemoveNamespaceEntity("customer1"))
+		require.NoError(t, srv.RemoveNamespaceEntity(ctx, "customer1"))
 		assert.Equal(t, 1, srv.NamespaceCount())
 	})
 
 	t.Run("ChangeNamespaceState on missing returns ErrNotFound", func(t *testing.T) {
-		err := srv.ChangeNamespaceState("never-existed", cmd.NamespaceStateDeleting)
+		err := srv.ChangeNamespaceState(ctx, "never-existed", cmd.NamespaceStateDeleting)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, usecasesNamespaces.ErrNotFound)
 		assert.Equal(t, 1, srv.NamespaceCount())

--- a/cluster/raft_namespace_endpoints_test.go
+++ b/cluster/raft_namespace_endpoints_test.go
@@ -64,30 +64,34 @@ func TestRaftNamespaceEndpoints(t *testing.T) {
 	assert.Empty(t, all)
 
 	t.Run("add a namespace", func(t *testing.T) {
-		require.NoError(t, srv.AddNamespace(ctx, cmd.Namespace{Name: "customer1"}))
+		version, err := srv.AddNamespace(ctx, cmd.Namespace{Name: "customer1"})
+		require.NoError(t, err)
+		require.NoError(t, srv.WaitForUpdate(ctx, version))
 		assert.Equal(t, 1, srv.NamespaceCount())
 	})
 
 	t.Run("add a duplicate returns ErrAlreadyExists", func(t *testing.T) {
-		err := srv.AddNamespace(ctx, cmd.Namespace{Name: "customer1"})
+		_, err := srv.AddNamespace(ctx, cmd.Namespace{Name: "customer1"})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, usecasesNamespaces.ErrAlreadyExists)
 	})
 
 	t.Run("add an invalid name returns ErrBadRequest", func(t *testing.T) {
-		err := srv.AddNamespace(ctx, cmd.Namespace{Name: "BadName"})
+		_, err := srv.AddNamespace(ctx, cmd.Namespace{Name: "BadName"})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, usecasesNamespaces.ErrBadRequest)
 	})
 
 	t.Run("add a reserved name returns ErrBadRequest", func(t *testing.T) {
-		err := srv.AddNamespace(ctx, cmd.Namespace{Name: "admin"})
+		_, err := srv.AddNamespace(ctx, cmd.Namespace{Name: "admin"})
 		require.Error(t, err)
 		assert.ErrorIs(t, err, usecasesNamespaces.ErrBadRequest)
 	})
 
 	t.Run("add a second namespace and list all", func(t *testing.T) {
-		require.NoError(t, srv.AddNamespace(ctx, cmd.Namespace{Name: "customer2"}))
+		version, err := srv.AddNamespace(ctx, cmd.Namespace{Name: "customer2"})
+		require.NoError(t, err)
+		require.NoError(t, srv.WaitForUpdate(ctx, version))
 		assert.Equal(t, 2, srv.NamespaceCount())
 
 		all, err := srv.GetNamespaces()
@@ -107,14 +111,19 @@ func TestRaftNamespaceEndpoints(t *testing.T) {
 	})
 
 	t.Run("two-phase delete an existing namespace", func(t *testing.T) {
-		require.NoError(t, srv.ChangeNamespaceState(ctx, "customer1", cmd.NamespaceStateDeleting))
+		version, err := srv.ChangeNamespaceState(ctx, "customer1", cmd.NamespaceStateDeleting)
+		require.NoError(t, err)
+		require.NoError(t, srv.WaitForUpdate(ctx, version))
 		assert.Equal(t, 2, srv.NamespaceCount(), "entity stays until RemoveNamespaceEntity")
-		require.NoError(t, srv.RemoveNamespaceEntity(ctx, "customer1"))
+
+		version, err = srv.RemoveNamespaceEntity(ctx, "customer1")
+		require.NoError(t, err)
+		require.NoError(t, srv.WaitForUpdate(ctx, version))
 		assert.Equal(t, 1, srv.NamespaceCount())
 	})
 
 	t.Run("ChangeNamespaceState on missing returns ErrNotFound", func(t *testing.T) {
-		err := srv.ChangeNamespaceState(ctx, "never-existed", cmd.NamespaceStateDeleting)
+		_, err := srv.ChangeNamespaceState(ctx, "never-existed", cmd.NamespaceStateDeleting)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, usecasesNamespaces.ErrNotFound)
 		assert.Equal(t, 1, srv.NamespaceCount())

--- a/cluster/raft_namespace_endpoints_test.go
+++ b/cluster/raft_namespace_endpoints_test.go
@@ -28,8 +28,8 @@ import (
 
 // setupRaftForNamespaceTests spins up a single-node RAFT cluster wired through
 // NewMockStore and waits until it has leadership. Tests can then exercise the
-// AddNamespace / DeleteNamespace / GetNamespaces endpoints end-to-end (from
-// client call through Execute/Query, RAFT apply, back up).
+// namespace endpoints end-to-end (from client call through Execute/Query,
+// RAFT apply, back up).
 func setupRaftForNamespaceTests(t *testing.T) (*Raft, context.Context, func()) {
 	t.Helper()
 	ctx := context.Background()
@@ -106,17 +106,17 @@ func TestRaftNamespaceEndpoints(t *testing.T) {
 		assert.Equal(t, "customer1", got[0].Name)
 	})
 
-	t.Run("delete an existing namespace", func(t *testing.T) {
-		require.NoError(t, srv.DeleteNamespace("customer1"))
+	t.Run("two-phase delete an existing namespace", func(t *testing.T) {
+		require.NoError(t, srv.ChangeNamespaceState("customer1", cmd.NamespaceStateDeleting))
+		assert.Equal(t, 2, srv.NamespaceCount(), "entity stays until RemoveNamespaceEntity")
+		require.NoError(t, srv.RemoveNamespaceEntity("customer1"))
 		assert.Equal(t, 1, srv.NamespaceCount())
 	})
 
-	t.Run("delete a missing namespace returns ErrNotFound", func(t *testing.T) {
-		err := srv.DeleteNamespace("never-existed")
+	t.Run("ChangeNamespaceState on missing returns ErrNotFound", func(t *testing.T) {
+		err := srv.ChangeNamespaceState("never-existed", cmd.NamespaceStateDeleting)
 		require.Error(t, err)
 		assert.ErrorIs(t, err, usecasesNamespaces.ErrNotFound)
-
-		// State was not altered.
 		assert.Equal(t, 1, srv.NamespaceCount())
 	})
 }

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -15,11 +15,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 
 	grpc_sentry "github.com/johnbellone/grpc-middleware-sentry"
 	"github.com/sirupsen/logrus"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/usecases/namespaces"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -280,13 +282,33 @@ func (cl *Client) getConn(ctx context.Context, leaderRaftAddr string) (*grpc.Cli
 }
 
 // fromRPCError parses the error sent by rpc server
-// to identify status and chain sentinal errors accordingly.
+// to identify status and chain sentinel errors accordingly.
 // This is helpful on the client side to make decision based on
-// type-full errors rather than just string-based error
+// type-full errors rather than just string-based error.
 func fromRPCError(err error) error {
+	if err == nil {
+		return nil
+	}
 	st, ok := status.FromError(err)
-	if ok && (st.Code() == codes.NotFound) {
+	if !ok {
+		return err
+	}
+	msg := err.Error()
+	switch st.Code() {
+	case codes.NotFound:
+		if strings.Contains(msg, namespaces.ErrNamespaceGone.Error()) {
+			return errors.Join(err, namespaces.ErrNamespaceGone)
+		}
 		return errors.Join(err, schemaUC.ErrNotFound)
+	case codes.FailedPrecondition:
+		switch {
+		case strings.Contains(msg, namespaces.ErrNamespaceNotEmpty.Error()):
+			return errors.Join(err, namespaces.ErrNamespaceNotEmpty)
+		case strings.Contains(msg, namespaces.ErrNamespaceDeleting.Error()):
+			return errors.Join(err, namespaces.ErrNamespaceDeleting)
+		}
+	default:
+		// All other codes pass through unchanged.
 	}
 	return err
 }

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -297,8 +297,11 @@ func fromRPCError(err error) error {
 	msg := err.Error()
 	switch st.Code() {
 	case codes.NotFound:
-		if strings.Contains(msg, namespaces.ErrNamespaceGone.Error()) {
+		switch {
+		case strings.Contains(msg, namespaces.ErrNamespaceGone.Error()):
 			return errors.Join(err, namespaces.ErrNamespaceGone)
+		case strings.Contains(msg, namespaces.ErrNotFound.Error()):
+			return errors.Join(err, namespaces.ErrNotFound)
 		}
 		return errors.Join(err, schemaUC.ErrNotFound)
 	case codes.FailedPrecondition:

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -282,10 +282,11 @@ func (cl *Client) getConn(ctx context.Context, leaderRaftAddr string) (*grpc.Cli
 	return cl.leaderRpcConn, nil
 }
 
-// fromRPCError parses the error sent by rpc server
-// to identify status and chain sentinel errors accordingly.
-// This is helpful on the client side to make decision based on
-// type-full errors rather than just string-based error.
+// fromRPCError parses the error sent by rpc server to identify status
+// and chain sentinel errors accordingly. This is the only sentinel
+// re-chain point on the client side; the gRPC hop drops the errors.Is
+// chain and callers expect typed sentinels they can match against.
+// Sentinels that share a status code are disambiguated by message text.
 func fromRPCError(err error) error {
 	if err == nil {
 		return nil
@@ -310,6 +311,18 @@ func fromRPCError(err error) error {
 			return errors.Join(err, namespaces.ErrNamespaceNotEmpty)
 		case strings.Contains(msg, namespaces.ErrNamespaceDeleting.Error()):
 			return errors.Join(err, namespaces.ErrNamespaceDeleting)
+		case strings.Contains(msg, namespaces.ErrInvalidStateTransition.Error()):
+			return errors.Join(err, namespaces.ErrInvalidStateTransition)
+		case strings.Contains(msg, namespaces.ErrInvalidState.Error()):
+			return errors.Join(err, namespaces.ErrInvalidState)
+		}
+	case codes.AlreadyExists:
+		if strings.Contains(msg, namespaces.ErrAlreadyExists.Error()) {
+			return errors.Join(err, namespaces.ErrAlreadyExists)
+		}
+	case codes.InvalidArgument:
+		if strings.Contains(msg, namespaces.ErrBadRequest.Error()) {
+			return errors.Join(err, namespaces.ErrBadRequest)
 		}
 	default:
 		// All other codes pass through unchanged.

--- a/cluster/rpc/client.go
+++ b/cluster/rpc/client.go
@@ -199,7 +199,8 @@ func (cl *Client) Apply(ctx context.Context, leaderRaftAddr string, req *cmd.App
 		return nil, err
 	}
 
-	return cmd.NewClusterServiceClient(conn).Apply(ctx, req)
+	resp, err := cmd.NewClusterServiceClient(conn).Apply(ctx, req)
+	return resp, fromRPCError(err)
 }
 
 // Query will contact the node at leaderRaftAddr and send req to read data in the RAFT store

--- a/cluster/rpc/client_test.go
+++ b/cluster/rpc/client_test.go
@@ -140,14 +140,19 @@ func TestClient_Query_ParseError(t *testing.T) {
 }
 
 // TestFromRPCError_NamespaceSentinels covers the round-trip from
-// toRPCError on the server to fromRPCError on the client for the three
-// namespace sentinels. After this round-trip a caller must be able to
-// errors.Is the returned error to the original sentinel.
+// toRPCError on the server to fromRPCError on the client for every
+// namespace sentinel. After this round-trip a caller must be able to
+// errors.Is the returned error to the original sentinel — the RPC pair
+// is the only sentinel re-chain point.
 func TestFromRPCError_NamespaceSentinels(t *testing.T) {
 	tests := []struct {
 		name string
 		send error
 	}{
+		{name: "ErrAlreadyExists", send: namespaces.ErrAlreadyExists},
+		{name: "ErrBadRequest", send: namespaces.ErrBadRequest},
+		{name: "ErrInvalidState", send: namespaces.ErrInvalidState},
+		{name: "ErrInvalidStateTransition", send: namespaces.ErrInvalidStateTransition},
 		{name: "ErrNamespaceDeleting", send: namespaces.ErrNamespaceDeleting},
 		{name: "ErrNamespaceGone", send: namespaces.ErrNamespaceGone},
 		{name: "ErrNamespaceNotEmpty", send: namespaces.ErrNamespaceNotEmpty},
@@ -164,14 +169,18 @@ func TestFromRPCError_NamespaceSentinels(t *testing.T) {
 
 // TestClient_Apply_ReChainsNamespaceSentinels exercises the live
 // Client.Apply -> mock server -> client return path. The leader's apply
-// can return ErrNamespaceDeleting/Gone/NotEmpty when a follower forwards
-// a create-like request; the round-trip must preserve the typed sentinel
+// can return any namespace sentinel when a follower forwards a
+// create-like request; the round-trip must preserve the typed sentinel
 // so handler errors.Is checks classify correctly.
 func TestClient_Apply_ReChainsNamespaceSentinels(t *testing.T) {
 	tests := []struct {
 		name string
 		send error
 	}{
+		{name: "ErrAlreadyExists", send: namespaces.ErrAlreadyExists},
+		{name: "ErrBadRequest", send: namespaces.ErrBadRequest},
+		{name: "ErrInvalidState", send: namespaces.ErrInvalidState},
+		{name: "ErrInvalidStateTransition", send: namespaces.ErrInvalidStateTransition},
 		{name: "ErrNamespaceDeleting", send: namespaces.ErrNamespaceDeleting},
 		{name: "ErrNamespaceGone", send: namespaces.ErrNamespaceGone},
 		{name: "ErrNamespaceNotEmpty", send: namespaces.ErrNamespaceNotEmpty},

--- a/cluster/rpc/client_test.go
+++ b/cluster/rpc/client_test.go
@@ -151,6 +151,7 @@ func TestFromRPCError_NamespaceSentinels(t *testing.T) {
 		{name: "ErrNamespaceDeleting", send: namespaces.ErrNamespaceDeleting},
 		{name: "ErrNamespaceGone", send: namespaces.ErrNamespaceGone},
 		{name: "ErrNamespaceNotEmpty", send: namespaces.ErrNamespaceNotEmpty},
+		{name: "ErrNotFound", send: namespaces.ErrNotFound},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -174,6 +175,7 @@ func TestClient_Apply_ReChainsNamespaceSentinels(t *testing.T) {
 		{name: "ErrNamespaceDeleting", send: namespaces.ErrNamespaceDeleting},
 		{name: "ErrNamespaceGone", send: namespaces.ErrNamespaceGone},
 		{name: "ErrNamespaceNotEmpty", send: namespaces.ErrNamespaceNotEmpty},
+		{name: "ErrNotFound", send: namespaces.ErrNotFound},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -218,4 +220,11 @@ func TestFromRPCError_NotFoundDisambiguation(t *testing.T) {
 	// Namespace-gone uses the same code but is disambiguated by message.
 	parsed = fromRPCError(toRPCError(namespaces.ErrNamespaceGone))
 	require.ErrorIs(t, parsed, namespaces.ErrNamespaceGone)
+
+	// namespaces.ErrNotFound also uses NotFound — the message must drive
+	// re-chain to the namespace sentinel, not schemaUC.ErrNotFound, so the
+	// REST handler's errors.Is mapping returns 404 instead of 500.
+	parsed = fromRPCError(toRPCError(namespaces.ErrNotFound))
+	require.ErrorIs(t, parsed, namespaces.ErrNotFound)
+	require.NotErrorIs(t, parsed, schemaUC.ErrNotFound)
 }

--- a/cluster/rpc/client_test.go
+++ b/cluster/rpc/client_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/usecases/fakes"
+	"github.com/weaviate/weaviate/usecases/namespaces"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -128,4 +129,39 @@ func TestClient_Query_ParseError(t *testing.T) {
 	st, ok := status.FromError(err)
 	require.True(t, ok)
 	require.Equal(t, codes.NotFound, st.Code())
+}
+
+// TestFromRPCError_NamespaceSentinels covers the round-trip from
+// toRPCError on the server to fromRPCError on the client for the three
+// namespace sentinels. After this round-trip a caller must be able to
+// errors.Is the returned error to the original sentinel.
+func TestFromRPCError_NamespaceSentinels(t *testing.T) {
+	tests := []struct {
+		name string
+		send error
+	}{
+		{name: "ErrNamespaceDeleting", send: namespaces.ErrNamespaceDeleting},
+		{name: "ErrNamespaceGone", send: namespaces.ErrNamespaceGone},
+		{name: "ErrNamespaceNotEmpty", send: namespaces.ErrNamespaceNotEmpty},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			wireErr := toRPCError(tc.send)
+			parsed := fromRPCError(wireErr)
+			require.ErrorIs(t, parsed, tc.send)
+		})
+	}
+}
+
+// TestFromRPCError_NotFoundDisambiguation asserts that a NotFound code
+// re-chains the namespace sentinel when the message identifies it,
+// otherwise falls back to schemaUC.ErrNotFound.
+func TestFromRPCError_NotFoundDisambiguation(t *testing.T) {
+	// Schema-flavour NotFound — message does not mention the namespace sentinel.
+	parsed := fromRPCError(toRPCError(schemaUC.ErrNotFound))
+	require.ErrorIs(t, parsed, schemaUC.ErrNotFound)
+
+	// Namespace-gone uses the same code but is disambiguated by message.
+	parsed = fromRPCError(toRPCError(namespaces.ErrNamespaceGone))
+	require.ErrorIs(t, parsed, namespaces.ErrNamespaceGone)
 }

--- a/cluster/rpc/client_test.go
+++ b/cluster/rpc/client_test.go
@@ -85,10 +85,18 @@ func TestClient(t *testing.T) {
 
 type mockClusterService struct {
 	cmd.UnimplementedClusterServiceServer
+	applyErr error
 }
 
 func (m *mockClusterService) Query(ctx context.Context, req *cmd.QueryRequest) (*cmd.QueryResponse, error) {
 	return nil, status.Error(codes.NotFound, "resource not found")
+}
+
+func (m *mockClusterService) Apply(ctx context.Context, req *cmd.ApplyRequest) (*cmd.ApplyResponse, error) {
+	if m.applyErr != nil {
+		return nil, m.applyErr
+	}
+	return &cmd.ApplyResponse{}, nil
 }
 
 func TestClient_Query_ParseError(t *testing.T) {
@@ -149,6 +157,52 @@ func TestFromRPCError_NamespaceSentinels(t *testing.T) {
 			wireErr := toRPCError(tc.send)
 			parsed := fromRPCError(wireErr)
 			require.ErrorIs(t, parsed, tc.send)
+		})
+	}
+}
+
+// TestClient_Apply_ReChainsNamespaceSentinels exercises the live
+// Client.Apply -> mock server -> client return path. The leader's apply
+// can return ErrNamespaceDeleting/Gone/NotEmpty when a follower forwards
+// a create-like request; the round-trip must preserve the typed sentinel
+// so handler errors.Is checks classify correctly.
+func TestClient_Apply_ReChainsNamespaceSentinels(t *testing.T) {
+	tests := []struct {
+		name string
+		send error
+	}{
+		{name: "ErrNamespaceDeleting", send: namespaces.ErrNamespaceDeleting},
+		{name: "ErrNamespaceGone", send: namespaces.ErrNamespaceGone},
+		{name: "ErrNamespaceNotEmpty", send: namespaces.ErrNamespaceNotEmpty},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			lis := bufconn.Listen(1024 * 1024)
+			s := grpc.NewServer()
+			cmd.RegisterClusterServiceServer(s, &mockClusterService{applyErr: toRPCError(tc.send)})
+
+			go func() {
+				_ = s.Serve(lis)
+			}()
+			defer s.Stop()
+
+			conn, err := grpc.NewClient("passthrough:bufnet",
+				grpc.WithContextDialer(func(ctx context.Context, address string) (net.Conn, error) {
+					return lis.Dial()
+				}),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			require.NoError(t, err)
+			defer conn.Close()
+
+			cl := &Client{addrResolver: fakes.NewFakeRPCAddressResolver("bufnet", nil), rpcMessageMaxSize: 1024 * 1024, logger: logrus.StandardLogger()}
+			cl.leaderRpcConn = conn
+			cl.leaderRaftAddr = "bufnet"
+
+			_, err = cl.Apply(ctx, "bufnet", &cmd.ApplyRequest{Type: cmd.ApplyRequest_TYPE_ADD_CLASS})
+			require.Error(t, err)
+			require.ErrorIs(t, err, tc.send)
 		})
 	}
 }

--- a/cluster/rpc/server.go
+++ b/cluster/rpc/server.go
@@ -186,7 +186,10 @@ func (s *Server) Close() {
 	}
 }
 
-// toRPCError returns a gRPC error with the right error code based on the error.
+// toRPCError returns a gRPC error with the right error code based on the
+// error. Sentinel mapping is the leader→follower contract: every
+// namespace sentinel that callers errors.Is against must appear here so
+// fromRPCError can re-chain it after the gRPC hop strips type info.
 func toRPCError(err error) error {
 	if err == nil {
 		return nil
@@ -198,12 +201,19 @@ func toRPCError(err error) error {
 		ec = NotLeaderRPCCode
 	case errors.Is(err, types.ErrNotOpen):
 		ec = codes.Unavailable
-	case errors.Is(err, namespaces.ErrNamespaceGone):
+	case errors.Is(err, namespaces.ErrNamespaceGone),
+		errors.Is(err, namespaces.ErrNotFound):
 		ec = codes.NotFound
 	case errors.Is(err, namespaces.ErrNamespaceDeleting),
 		errors.Is(err, namespaces.ErrNamespaceNotEmpty),
+		errors.Is(err, namespaces.ErrInvalidState),
+		errors.Is(err, namespaces.ErrInvalidStateTransition),
 		errors.Is(err, schema.ErrMTDisabled):
 		ec = codes.FailedPrecondition
+	case errors.Is(err, namespaces.ErrAlreadyExists):
+		ec = codes.AlreadyExists
+	case errors.Is(err, namespaces.ErrBadRequest):
+		ec = codes.InvalidArgument
 	case strings.Contains(err.Error(), types.ErrNotFound.Error()):
 		ec = codes.NotFound
 	default:

--- a/cluster/rpc/server.go
+++ b/cluster/rpc/server.go
@@ -30,6 +30,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/types"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/usecases/namespaces"
 )
 
 const NotLeaderRPCCode = codes.ResourceExhausted
@@ -197,7 +198,11 @@ func toRPCError(err error) error {
 		ec = NotLeaderRPCCode
 	case errors.Is(err, types.ErrNotOpen):
 		ec = codes.Unavailable
-	case errors.Is(err, schema.ErrMTDisabled):
+	case errors.Is(err, namespaces.ErrNamespaceGone):
+		ec = codes.NotFound
+	case errors.Is(err, namespaces.ErrNamespaceDeleting),
+		errors.Is(err, namespaces.ErrNamespaceNotEmpty),
+		errors.Is(err, schema.ErrMTDisabled):
 		ec = codes.FailedPrecondition
 	case strings.Contains(err.Error(), types.ErrNotFound.Error()):
 		ec = codes.NotFound

--- a/cluster/rpc/server_test.go
+++ b/cluster/rpc/server_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/cluster/utils"
 	"github.com/weaviate/weaviate/usecases/fakes"
 	"github.com/weaviate/weaviate/usecases/monitoring"
+	"github.com/weaviate/weaviate/usecases/namespaces"
 )
 
 const raftGrpcMessageMaxSize = 1024 * 1024 * 1024
@@ -405,6 +406,21 @@ func TestToRPCError(t *testing.T) {
 			name:     "ErrNotFound maps to NotFound",
 			err:      types.ErrNotFound,
 			expected: codes.NotFound,
+		},
+		{
+			name:     "ErrNamespaceDeleting maps to FailedPrecondition",
+			err:      namespaces.ErrNamespaceDeleting,
+			expected: codes.FailedPrecondition,
+		},
+		{
+			name:     "ErrNamespaceGone maps to NotFound",
+			err:      namespaces.ErrNamespaceGone,
+			expected: codes.NotFound,
+		},
+		{
+			name:     "ErrNamespaceNotEmpty maps to FailedPrecondition",
+			err:      namespaces.ErrNamespaceNotEmpty,
+			expected: codes.FailedPrecondition,
 		},
 		{
 			name:     "Unknown error maps to Internal",

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -741,16 +741,12 @@ func (s *schema) unsafeAliasExists(alias string) bool {
 	return false
 }
 
+// canonicalAlias normalizes an alias name to its stored form. On
+// namespaced names ("<ns>:<Name>") only the class portion is uppercased;
+// the lowercase namespace prefix is preserved verbatim so namespace-prefix
+// matchers (e.g. AliasesInNamespace) and the canonical store key agree.
 func (s *schema) canonicalAlias(alias string) string {
-	if len(alias) < 1 {
-		return alias
-	}
-
-	if len(alias) == 1 {
-		return strings.ToUpper(alias)
-	}
-
-	return strings.ToUpper(string(alias[0])) + alias[1:]
+	return entSchema.UppercaseClassName(alias)
 }
 
 func (s *schema) GetAliasesForClass(class string) []*models.Alias {

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -661,13 +661,10 @@ func TestGetAlias(t *testing.T) {
 	})
 }
 
-// TestAliasNamespacePrefixPreserved guards the canonicalAlias contract for
-// namespace-qualified aliases: the lowercase namespace prefix must be
-// preserved verbatim so callers like SchemaNamespaceLister can match
-// "<ns>:" to find every alias in a namespace. Before the fix, canonical
-// uppercased the very first character and stored "delhappy:Films" as
-// "Delhappy:Films" — making AliasesInNamespace("delhappy") return nothing
-// and the namespace-delete cascade orphan the alias.
+// TestAliasNamespacePrefixPreserved checks that creating an alias with a
+// namespace-qualified name stores it under a key whose namespace prefix is
+// kept lowercase, and that ResolveAlias still finds it under that key. Only
+// the class portion of the name is normalized.
 func TestAliasNamespacePrefixPreserved(t *testing.T) {
 	sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
 	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -660,3 +660,23 @@ func TestGetAlias(t *testing.T) {
 		assert.EqualValues(t, expected, aliases)
 	})
 }
+
+// TestAliasNamespacePrefixPreserved guards the canonicalAlias contract for
+// namespace-qualified aliases: the lowercase namespace prefix must be
+// preserved verbatim so callers like SchemaNamespaceLister can match
+// "<ns>:" to find every alias in a namespace. Before the fix, canonical
+// uppercased the very first character and stored "delhappy:Films" as
+// "Delhappy:Films" — making AliasesInNamespace("delhappy") return nothing
+// and the namespace-delete cascade orphan the alias.
+func TestAliasNamespacePrefixPreserved(t *testing.T) {
+	sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
+	require.NoError(t, sc.addClass(&models.Class{Class: "delhappy:Movies"}, ss, 1))
+	require.NoError(t, sc.createAlias("delhappy:Movies", "delhappy:Films"))
+
+	stored := sc.getAliases("", "")
+	require.Contains(t, stored, "delhappy:Films",
+		"alias stored under lowercase-namespace key; got %v", stored)
+
+	require.Equal(t, "delhappy:Movies", sc.ResolveAlias("delhappy:Films"))
+}

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -342,7 +342,7 @@ func NewFSM(cfg Config, authZController authorization.Controller, snapshotter fs
 		authZController:    authZController,
 		authZManager:       rbacRaft.NewManager(cfg.RBAC, cfg.AuthNConfig, snapshotter, cfg.Logger),
 		dynUserManager:     dynusers.NewManager(cfg.DynamicUserController, cfg.NamespacesController, cfg.NamespacesEnabled, cfg.Logger),
-		namespaceManager:   namespaces.NewManager(cfg.NamespacesController, newSchemaNamespaceLister(schemaManager), dynusersLister, cfg.Logger),
+		namespaceManager:   namespaces.NewManager(cfg.NamespacesController, NewSchemaNamespaceLister(schemaManager.NewSchemaReader()), dynusersLister, cfg.Logger),
 		replicationManager: replicationManager,
 		distributedTasksManager: distributedtask.NewManager(distributedtask.ManagerParameters{
 			Clock:            clockwork.NewRealClock(),

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -319,6 +319,11 @@ func NewFSM(cfg Config, authZController authorization.Controller, snapshotter fs
 	replicationManager := replication.NewManager(schemaManager.NewSchemaReader(), cfg.NodeSelector, reg)
 	schemaManager.SetReplicationFSM(replicationManager.GetReplicationFSM())
 
+	var dynusersLister namespaces.DynusersNamespaceLister
+	if cfg.DynamicUserController != nil {
+		dynusersLister = cfg.DynamicUserController
+	}
+
 	return Store{
 		cfg:          cfg,
 		log:          cfg.Logger,
@@ -337,7 +342,7 @@ func NewFSM(cfg Config, authZController authorization.Controller, snapshotter fs
 		authZController:    authZController,
 		authZManager:       rbacRaft.NewManager(cfg.RBAC, cfg.AuthNConfig, snapshotter, cfg.Logger),
 		dynUserManager:     dynusers.NewManager(cfg.DynamicUserController, cfg.NamespacesController, cfg.NamespacesEnabled, cfg.Logger),
-		namespaceManager:   namespaces.NewManager(cfg.NamespacesController, cfg.Logger),
+		namespaceManager:   namespaces.NewManager(cfg.NamespacesController, newSchemaNamespaceLister(schemaManager), dynusersLister, cfg.Logger),
 		replicationManager: replicationManager,
 		distributedTasksManager: distributedtask.NewManager(distributedtask.ManagerParameters{
 			Clock:            clockwork.NewRealClock(),

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -333,6 +333,10 @@ func (st *Store) Apply(l *raft.Log) any {
 		f = func() {
 			ret.Error = st.namespaceManager.RemoveEntity(&cmd)
 		}
+	case api.ApplyRequest_TYPE_DELETE_USERS_IN_NAMESPACE:
+		f = func() {
+			ret.Error = st.dynUserManager.DeleteUsersInNamespace(&cmd)
+		}
 
 	case api.ApplyRequest_TYPE_REPLICATION_REPLICATE:
 		f = func() {

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -325,6 +325,14 @@ func (st *Store) Apply(l *raft.Log) any {
 		f = func() {
 			ret.Error = st.namespaceManager.Delete(&cmd)
 		}
+	case api.ApplyRequest_TYPE_CHANGE_NAMESPACE_STATE:
+		f = func() {
+			ret.Error = st.namespaceManager.ChangeState(&cmd)
+		}
+	case api.ApplyRequest_TYPE_REMOVE_NAMESPACE_ENTITY:
+		f = func() {
+			ret.Error = st.namespaceManager.RemoveEntity(&cmd)
+		}
 
 	case api.ApplyRequest_TYPE_REPLICATION_REPLICATE:
 		f = func() {

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -347,10 +347,6 @@ func (st *Store) Apply(l *raft.Log) any {
 		f = func() {
 			ret.Error = st.namespaceManager.Add(&cmd)
 		}
-	case api.ApplyRequest_TYPE_DELETE_NAMESPACE:
-		f = func() {
-			ret.Error = st.namespaceManager.Delete(&cmd)
-		}
 	case api.ApplyRequest_TYPE_CHANGE_NAMESPACE_STATE:
 		f = func() {
 			ret.Error = st.namespaceManager.ChangeState(&cmd)

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -177,11 +177,19 @@ func (st *Store) Apply(l *raft.Log) any {
 
 	case api.ApplyRequest_TYPE_ADD_CLASS:
 		f = func() {
+			if err := requireNamespaceActive(st.namespaceManager, namespaceFromQualified(cmd.Class)); err != nil {
+				ret.Error = err
+				return
+			}
 			ret.Error = st.schemaManager.AddClass(&cmd, st.cfg.NodeID, schemaOnly, !catchingUp)
 		}
 
 	case api.ApplyRequest_TYPE_RESTORE_CLASS:
 		f = func() {
+			if err := requireNamespaceActive(st.namespaceManager, namespaceFromQualified(cmd.Class)); err != nil {
+				ret.Error = err
+				return
+			}
 			ret.Error = st.schemaManager.RestoreClass(&cmd, st.cfg.NodeID, schemaOnly, !catchingUp)
 		}
 
@@ -223,10 +231,28 @@ func (st *Store) Apply(l *raft.Log) any {
 		}
 	case api.ApplyRequest_TYPE_CREATE_ALIAS:
 		f = func() {
+			req := &api.CreateAliasRequest{}
+			if err := proto.Unmarshal(cmd.SubCommand, req); err != nil {
+				ret.Error = fmt.Errorf("unmarshal create-alias subcommand: %w", err)
+				return
+			}
+			if err := requireNamespaceActive(st.namespaceManager, namespaceFromQualified(req.Alias)); err != nil {
+				ret.Error = err
+				return
+			}
 			ret.Error = st.schemaManager.CreateAlias(&cmd)
 		}
 	case api.ApplyRequest_TYPE_REPLACE_ALIAS:
 		f = func() {
+			req := &api.ReplaceAliasRequest{}
+			if err := proto.Unmarshal(cmd.SubCommand, req); err != nil {
+				ret.Error = fmt.Errorf("unmarshal replace-alias subcommand: %w", err)
+				return
+			}
+			if err := requireNamespaceActive(st.namespaceManager, namespaceFromQualified(req.Alias)); err != nil {
+				ret.Error = err
+				return
+			}
 			ret.Error = st.schemaManager.ReplaceAlias(&cmd)
 		}
 	case api.ApplyRequest_TYPE_DELETE_ALIAS:

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/weaviate/weaviate/cluster/proto/api"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 func (st *Store) Execute(req *api.ApplyRequest) (uint64, error) {
@@ -177,7 +178,7 @@ func (st *Store) Apply(l *raft.Log) any {
 
 	case api.ApplyRequest_TYPE_ADD_CLASS:
 		f = func() {
-			if err := requireNamespaceActive(st.namespaceManager, namespaceFromQualified(cmd.Class)); err != nil {
+			if err := requireNamespaceActive(st.namespaceManager, namespacing.NamespaceFromQualified(cmd.Class)); err != nil {
 				ret.Error = err
 				return
 			}
@@ -186,7 +187,7 @@ func (st *Store) Apply(l *raft.Log) any {
 
 	case api.ApplyRequest_TYPE_RESTORE_CLASS:
 		f = func() {
-			if err := requireNamespaceActive(st.namespaceManager, namespaceFromQualified(cmd.Class)); err != nil {
+			if err := requireNamespaceActive(st.namespaceManager, namespacing.NamespaceFromQualified(cmd.Class)); err != nil {
 				ret.Error = err
 				return
 			}
@@ -236,7 +237,7 @@ func (st *Store) Apply(l *raft.Log) any {
 				ret.Error = fmt.Errorf("unmarshal create-alias subcommand: %w", err)
 				return
 			}
-			if err := requireNamespaceActive(st.namespaceManager, namespaceFromQualified(req.Alias)); err != nil {
+			if err := requireNamespaceActive(st.namespaceManager, namespacing.NamespaceFromQualified(req.Alias)); err != nil {
 				ret.Error = err
 				return
 			}
@@ -249,7 +250,7 @@ func (st *Store) Apply(l *raft.Log) any {
 				ret.Error = fmt.Errorf("unmarshal replace-alias subcommand: %w", err)
 				return
 			}
-			if err := requireNamespaceActive(st.namespaceManager, namespaceFromQualified(req.Alias)); err != nil {
+			if err := requireNamespaceActive(st.namespaceManager, namespacing.NamespaceFromQualified(req.Alias)); err != nil {
 				ret.Error = err
 				return
 			}

--- a/cluster/store_apply_namespace_active_test.go
+++ b/cluster/store_apply_namespace_active_test.go
@@ -117,7 +117,7 @@ func TestRequireNamespaceActive(t *testing.T) {
 	require.NoError(t, controller.Create(api.Namespace{Name: "active1"}))
 	require.NoError(t, controller.Create(api.Namespace{Name: "deleting1"}))
 	require.NoError(t, controller.ChangeState("deleting1", api.NamespaceStateDeleting))
-	exister := clusternamespaces.NewManager(controller, logger)
+	exister := clusternamespaces.NewManager(controller, emptySchemaLister{}, nil, logger)
 
 	tests := []struct {
 		name      string
@@ -264,3 +264,8 @@ func TestApplyGate_PassesActiveNamespace(t *testing.T) {
 	require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceDeleting)
 	require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceGone)
 }
+
+type emptySchemaLister struct{}
+
+func (emptySchemaLister) ClassesInNamespace(string) []string { return nil }
+func (emptySchemaLister) AliasesInNamespace(string) []string { return nil }

--- a/cluster/store_apply_namespace_active_test.go
+++ b/cluster/store_apply_namespace_active_test.go
@@ -1,0 +1,266 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+//
+
+package cluster
+
+import (
+	"testing"
+
+	logrustest "github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+
+	clusternamespaces "github.com/weaviate/weaviate/cluster/namespaces"
+	"github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/namespaces"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// namespaceTouchingCreateLikeApplyTypes lists apply types gated by
+// requireNamespaceActive. New create-like types that own namespace-bound
+// state must be added here; the drift test fails otherwise.
+var namespaceTouchingCreateLikeApplyTypes = map[api.ApplyRequest_Type]struct{}{
+	api.ApplyRequest_TYPE_ADD_CLASS:     {},
+	api.ApplyRequest_TYPE_RESTORE_CLASS: {},
+	api.ApplyRequest_TYPE_CREATE_ALIAS:  {},
+	api.ApplyRequest_TYPE_REPLACE_ALIAS: {},
+	api.ApplyRequest_TYPE_UPSERT_USER:   {},
+}
+
+// nonNamespaceTouchingApplyTypes lists apply types the gate must not
+// reject — either they don't mint namespace-owned state or they are the
+// namespace lifecycle commands themselves.
+var nonNamespaceTouchingApplyTypes = map[api.ApplyRequest_Type]struct{}{
+	api.ApplyRequest_TYPE_UPDATE_CLASS:                                               {},
+	api.ApplyRequest_TYPE_DELETE_CLASS:                                               {},
+	api.ApplyRequest_TYPE_ADD_PROPERTY:                                               {},
+	api.ApplyRequest_TYPE_UPDATE_PROPERTY:                                            {},
+	api.ApplyRequest_TYPE_UPDATE_SHARD_STATUS:                                        {},
+	api.ApplyRequest_TYPE_ADD_REPLICA_TO_SHARD:                                       {},
+	api.ApplyRequest_TYPE_DELETE_REPLICA_FROM_SHARD:                                  {},
+	api.ApplyRequest_TYPE_ADD_TENANT:                                                 {},
+	api.ApplyRequest_TYPE_UPDATE_TENANT:                                              {},
+	api.ApplyRequest_TYPE_DELETE_TENANT:                                              {},
+	api.ApplyRequest_TYPE_TENANT_PROCESS:                                             {},
+	api.ApplyRequest_TYPE_DELETE_ALIAS:                                               {},
+	api.ApplyRequest_TYPE_UPSERT_ROLES_PERMISSIONS:                                   {},
+	api.ApplyRequest_TYPE_DELETE_ROLES:                                               {},
+	api.ApplyRequest_TYPE_REMOVE_PERMISSIONS:                                         {},
+	api.ApplyRequest_TYPE_ADD_ROLES_FOR_USER:                                         {},
+	api.ApplyRequest_TYPE_REVOKE_ROLES_FOR_USER:                                      {},
+	api.ApplyRequest_TYPE_DELETE_USER:                                                {},
+	api.ApplyRequest_TYPE_ROTATE_USER_API_KEY:                                        {},
+	api.ApplyRequest_TYPE_SUSPEND_USER:                                               {},
+	api.ApplyRequest_TYPE_ACTIVATE_USER:                                              {},
+	api.ApplyRequest_TYPE_CREATE_USER_WITH_KEY:                                       {},
+	api.ApplyRequest_TYPE_DELETE_USERS_IN_NAMESPACE:                                  {},
+	api.ApplyRequest_TYPE_ADD_NAMESPACE:                                              {},
+	api.ApplyRequest_TYPE_DELETE_NAMESPACE:                                           {},
+	api.ApplyRequest_TYPE_CHANGE_NAMESPACE_STATE:                                     {},
+	api.ApplyRequest_TYPE_REMOVE_NAMESPACE_ENTITY:                                    {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE:                                      {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_UPDATE_STATE:                         {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_REGISTER_ERROR:                       {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_CANCEL:                               {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_DELETE:                               {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_REMOVE:                               {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_CANCELLATION_COMPLETE:                {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_DELETE_ALL:                           {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_DELETE_BY_COLLECTION:                 {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_DELETE_BY_TENANTS:                    {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_SYNC_SHARD:                           {},
+	api.ApplyRequest_TYPE_REPLICATION_REGISTER_SCHEMA_VERSION:                        {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_ADD_REPLICA_TO_SHARD:                 {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_FORCE_DELETE_ALL:                     {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_FORCE_DELETE_BY_COLLECTION:           {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_FORCE_DELETE_BY_COLLECTION_AND_SHARD: {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_FORCE_DELETE_BY_TARGET_NODE:          {},
+	api.ApplyRequest_TYPE_REPLICATION_REPLICATE_FORCE_DELETE_BY_UUID:                 {},
+	api.ApplyRequest_TYPE_DISTRIBUTED_TASK_ADD:                                       {},
+	api.ApplyRequest_TYPE_DISTRIBUTED_TASK_CANCEL:                                    {},
+	api.ApplyRequest_TYPE_DISTRIBUTED_TASK_RECORD_NODE_COMPLETED:                     {}, //nolint:staticcheck // deprecated but must stay classified for the drift check
+	api.ApplyRequest_TYPE_DISTRIBUTED_TASK_CLEAN_UP:                                  {},
+	api.ApplyRequest_TYPE_DISTRIBUTED_TASK_RECORD_UNIT_COMPLETED:                     {},
+	api.ApplyRequest_TYPE_DISTRIBUTED_TASK_UPDATE_UNIT_PROGRESS:                      {},
+}
+
+// TestApplyTypeNamespaceGateClassification fails when a new
+// ApplyRequest_Type value isn't classified in exactly one of the two lists.
+func TestApplyTypeNamespaceGateClassification(t *testing.T) {
+	for value := range api.ApplyRequest_Type_name {
+		applyType := api.ApplyRequest_Type(value)
+		if applyType == api.ApplyRequest_TYPE_UNSPECIFIED {
+			continue
+		}
+		_, gated := namespaceTouchingCreateLikeApplyTypes[applyType]
+		_, nonGated := nonNamespaceTouchingApplyTypes[applyType]
+		assert.True(t, gated != nonGated,
+			"unclassified or double-classified apply type %s: must appear in exactly one of the two lists in store_apply_namespace_active_test.go",
+			applyType)
+	}
+}
+
+func TestRequireNamespaceActive(t *testing.T) {
+	logger, _ := logrustest.NewNullLogger()
+	controller := namespaces.NewController(logger)
+	require.NoError(t, controller.Create(api.Namespace{Name: "active1"}))
+	require.NoError(t, controller.Create(api.Namespace{Name: "deleting1"}))
+	require.NoError(t, controller.ChangeState("deleting1", api.NamespaceStateDeleting))
+	exister := clusternamespaces.NewManager(controller, logger)
+
+	tests := []struct {
+		name      string
+		namespace string
+		wantErr   error
+	}{
+		{name: "empty namespace passes", namespace: ""},
+		{name: "active namespace passes", namespace: "active1"},
+		{name: "deleting namespace returns ErrNamespaceDeleting", namespace: "deleting1", wantErr: namespaces.ErrNamespaceDeleting},
+		{name: "missing namespace returns ErrNamespaceGone", namespace: "never-existed", wantErr: namespaces.ErrNamespaceGone},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := requireNamespaceActive(exister, tc.namespace)
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestNamespaceFromQualified(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "no separator returns empty", in: "MyClass", want: ""},
+		{name: "qualified name returns namespace", in: "alpha:MyClass", want: "alpha"},
+		{name: "empty input returns empty", in: "", want: ""},
+		{name: "leading separator returns empty namespace prefix", in: ":MyClass", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, namespaceFromQualified(tc.in))
+		})
+	}
+}
+
+// TestApplyGate_RejectsCreateLikeApplyTypes drives each schema/alias gate
+// through the live apply switch and asserts deleting/missing namespaces
+// are rejected. TYPE_UPSERT_USER is covered by the dynusers manager tests.
+func TestApplyGate_RejectsCreateLikeApplyTypes(t *testing.T) {
+	cls := func(name string) *models.Class {
+		return &models.Class{
+			Class:              name,
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+		}
+	}
+	ss := &sharding.State{Physical: map[string]sharding.Physical{
+		"T1": {Name: "T1", BelongsToNodes: []string{"Node-1"}, Status: "HOT"},
+	}}
+
+	tests := []struct {
+		name    string
+		cmdType api.ApplyRequest_Type
+		jsonSub any
+		rpcSub  protoreflect.ProtoMessage
+	}{
+		{
+			name:    "TYPE_ADD_CLASS",
+			cmdType: api.ApplyRequest_TYPE_ADD_CLASS,
+			jsonSub: api.AddClassRequest{Class: cls("alpha:Foo"), State: ss},
+		},
+		{
+			name:    "TYPE_RESTORE_CLASS",
+			cmdType: api.ApplyRequest_TYPE_RESTORE_CLASS,
+			jsonSub: api.AddClassRequest{Class: cls("alpha:Foo"), State: ss},
+		},
+		{
+			name:    "TYPE_CREATE_ALIAS",
+			cmdType: api.ApplyRequest_TYPE_CREATE_ALIAS,
+			rpcSub:  &api.CreateAliasRequest{Collection: "alpha:Foo", Alias: "alpha:Bar"},
+		},
+		{
+			name:    "TYPE_REPLACE_ALIAS",
+			cmdType: api.ApplyRequest_TYPE_REPLACE_ALIAS,
+			rpcSub:  &api.ReplaceAliasRequest{Collection: "alpha:Foo", Alias: "alpha:Bar"},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		seed      func(*namespaces.Controller)
+		wantErr   error
+		className string
+	}{
+		{
+			name:      "deleting namespace rejected with ErrNamespaceDeleting",
+			className: "alpha:Foo",
+			seed: func(c *namespaces.Controller) {
+				require.NoError(t, c.Create(api.Namespace{Name: "alpha"}))
+				require.NoError(t, c.ChangeState("alpha", api.NamespaceStateDeleting))
+			},
+			wantErr: namespaces.ErrNamespaceDeleting,
+		},
+		{
+			name:      "missing namespace rejected with ErrNamespaceGone",
+			className: "alpha:Foo",
+			seed:      func(c *namespaces.Controller) {},
+			wantErr:   namespaces.ErrNamespaceGone,
+		},
+	}
+
+	for _, tt := range tests {
+		for _, c := range cases {
+			t.Run(tt.name+"/"+c.name, func(t *testing.T) {
+				ms, log := setupApplyTest(t)
+				c.seed(ms.cfg.NamespacesController)
+
+				log.Data = cmdAsBytes(c.className, tt.cmdType, tt.jsonSub, tt.rpcSub)
+
+				result := ms.store.Apply(log)
+				resp, ok := result.(Response)
+				require.True(t, ok)
+				require.ErrorIs(t, resp.Error, c.wantErr)
+			})
+		}
+	}
+}
+
+// TestApplyGate_PassesActiveNamespace asserts the gate doesn't reject when
+// the namespace is active.
+func TestApplyGate_PassesActiveNamespace(t *testing.T) {
+	ms, log := setupApplyTest(t)
+	require.NoError(t, ms.cfg.NamespacesController.Create(api.Namespace{Name: "alpha"}))
+
+	cls := &models.Class{
+		Class:              "alpha:Foo",
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+	}
+	ss := &sharding.State{Physical: map[string]sharding.Physical{
+		"T1": {Name: "T1", BelongsToNodes: []string{"Node-1"}, Status: "HOT"},
+	}}
+	log.Data = cmdAsBytes("alpha:Foo", api.ApplyRequest_TYPE_ADD_CLASS,
+		api.AddClassRequest{Class: cls, State: ss}, nil)
+
+	result := ms.store.Apply(log)
+	resp, ok := result.(Response)
+	require.True(t, ok)
+	require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceDeleting)
+	require.NotErrorIs(t, resp.Error, namespaces.ErrNamespaceGone)
+}

--- a/cluster/store_apply_namespace_active_test.go
+++ b/cluster/store_apply_namespace_active_test.go
@@ -26,9 +26,17 @@ import (
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
-// namespaceTouchingCreateLikeApplyTypes lists apply types gated by
-// requireNamespaceActive. New create-like types that own namespace-bound
-// state must be added here; the drift test fails otherwise.
+// This file tests the namespace check at the top of store.Apply. The
+// check rejects any command that would create a class, alias, or user
+// inside a namespace that does not exist or is being deleted.
+//
+// The two maps below split every ApplyRequest type into the commands the
+// check must reject and the commands it must let through (including the
+// namespace lifecycle commands themselves). TestApplyTypeNamespaceGate-
+// Classification fails the build when a new type is added without being
+// placed in one of the two maps, so the author has to pick a side.
+
+// Commands the namespace check rejects when the namespace is gone or deleting.
 var namespaceTouchingCreateLikeApplyTypes = map[api.ApplyRequest_Type]struct{}{
 	api.ApplyRequest_TYPE_ADD_CLASS:     {},
 	api.ApplyRequest_TYPE_RESTORE_CLASS: {},
@@ -37,9 +45,7 @@ var namespaceTouchingCreateLikeApplyTypes = map[api.ApplyRequest_Type]struct{}{
 	api.ApplyRequest_TYPE_UPSERT_USER:   {},
 }
 
-// nonNamespaceTouchingApplyTypes lists apply types the gate must not
-// reject — either they don't mint namespace-owned state or they are the
-// namespace lifecycle commands themselves.
+// Commands the namespace check always lets through.
 var nonNamespaceTouchingApplyTypes = map[api.ApplyRequest_Type]struct{}{
 	api.ApplyRequest_TYPE_UPDATE_CLASS:                                               {},
 	api.ApplyRequest_TYPE_DELETE_CLASS:                                               {},
@@ -136,24 +142,6 @@ func TestRequireNamespaceActive(t *testing.T) {
 				return
 			}
 			require.NoError(t, err)
-		})
-	}
-}
-
-func TestNamespaceFromQualified(t *testing.T) {
-	tests := []struct {
-		name string
-		in   string
-		want string
-	}{
-		{name: "no separator returns empty", in: "MyClass", want: ""},
-		{name: "qualified name returns namespace", in: "alpha:MyClass", want: "alpha"},
-		{name: "empty input returns empty", in: "", want: ""},
-		{name: "leading separator returns empty namespace prefix", in: ":MyClass", want: ""},
-	}
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, namespaceFromQualified(tc.in))
 		})
 	}
 }
@@ -265,5 +253,5 @@ func TestApplyGate_PassesActiveNamespace(t *testing.T) {
 
 type emptySchemaLister struct{}
 
-func (emptySchemaLister) ClassesInNamespace(string) []string { return nil }
-func (emptySchemaLister) AliasesInNamespace(string) []string { return nil }
+func (emptySchemaLister) ClassesInNamespace(string) ([]string, error) { return nil, nil }
+func (emptySchemaLister) AliasesInNamespace(string) []string          { return nil }

--- a/cluster/store_apply_namespace_active_test.go
+++ b/cluster/store_apply_namespace_active_test.go
@@ -66,7 +66,6 @@ var nonNamespaceTouchingApplyTypes = map[api.ApplyRequest_Type]struct{}{
 	api.ApplyRequest_TYPE_CREATE_USER_WITH_KEY:                                       {},
 	api.ApplyRequest_TYPE_DELETE_USERS_IN_NAMESPACE:                                  {},
 	api.ApplyRequest_TYPE_ADD_NAMESPACE:                                              {},
-	api.ApplyRequest_TYPE_DELETE_NAMESPACE:                                           {},
 	api.ApplyRequest_TYPE_CHANGE_NAMESPACE_STATE:                                     {},
 	api.ApplyRequest_TYPE_REMOVE_NAMESPACE_ENTITY:                                    {},
 	api.ApplyRequest_TYPE_REPLICATION_REPLICATE:                                      {},

--- a/cluster/store_apply_namespace_active_test.go
+++ b/cluster/store_apply_namespace_active_test.go
@@ -8,7 +8,6 @@
 //
 //  CONTACT: hello@weaviate.io
 //
-//
 
 package cluster
 

--- a/cluster/store_namespace_active.go
+++ b/cluster/store_namespace_active.go
@@ -1,0 +1,46 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+//
+
+package cluster
+
+import (
+	"strings"
+
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/namespaces"
+)
+
+// requireNamespaceActive returns nil for an empty namespace,
+// [namespaces.ErrNamespaceGone] when the namespace does not exist, or
+// [namespaces.ErrNamespaceDeleting] when it exists but is not active.
+func requireNamespaceActive(exister namespaces.Exister, namespace string) error {
+	if namespace == "" {
+		return nil
+	}
+	if !exister.Exists(namespace) {
+		return namespaces.ErrNamespaceGone
+	}
+	if exister.IsActive(namespace) {
+		return nil
+	}
+	return namespaces.ErrNamespaceDeleting
+}
+
+// namespaceFromQualified returns the namespace portion of a qualified name
+// ("<ns>:<entity>"). Names without the separator are unnamespaced and
+// return "".
+func namespaceFromQualified(name string) string {
+	if ns, _, ok := strings.Cut(name, schema.NamespaceSeparator); ok {
+		return ns
+	}
+	return ""
+}

--- a/cluster/store_namespace_active.go
+++ b/cluster/store_namespace_active.go
@@ -12,9 +12,6 @@
 package cluster
 
 import (
-	"strings"
-
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/namespaces"
 )
 
@@ -32,14 +29,4 @@ func requireNamespaceActive(exister namespaces.Exister, namespace string) error 
 		return nil
 	}
 	return namespaces.ErrNamespaceDeleting
-}
-
-// namespaceFromQualified returns the namespace portion of a qualified name
-// ("<ns>:<entity>"). Names without the separator are unnamespaced and
-// return "".
-func namespaceFromQualified(name string) string {
-	if ns, _, ok := strings.Cut(name, schema.NamespaceSeparator); ok {
-		return ns
-	}
-	return ""
 }

--- a/cluster/store_namespace_active.go
+++ b/cluster/store_namespace_active.go
@@ -8,7 +8,6 @@
 //
 //  CONTACT: hello@weaviate.io
 //
-//
 
 package cluster
 

--- a/cluster/store_namespace_lister.go
+++ b/cluster/store_namespace_lister.go
@@ -14,29 +14,28 @@ package cluster
 import (
 	"strings"
 
-	"github.com/weaviate/weaviate/cluster/schema"
 	"github.com/weaviate/weaviate/entities/models"
 	entschema "github.com/weaviate/weaviate/entities/schema"
 )
 
-// schemaSource is the subset of [schema.SchemaReader] used here; it is an
-// interface so tests can substitute a stub.
-type schemaSource interface {
+// SchemaSource is the subset of [schema.SchemaReader] consumed by
+// [SchemaNamespaceLister]; defined as an interface so tests can stub it.
+type SchemaSource interface {
 	ReadSchema(reader func(models.Class, uint64)) error
 	Aliases() map[string]string
 }
 
-// schemaNamespaceLister returns the classes and aliases whose name starts
+// SchemaNamespaceLister returns the classes and aliases whose name starts
 // with "<namespace>:".
-type schemaNamespaceLister struct {
-	src schemaSource
+type SchemaNamespaceLister struct {
+	src SchemaSource
 }
 
-func newSchemaNamespaceLister(manager *schema.SchemaManager) *schemaNamespaceLister {
-	return &schemaNamespaceLister{src: manager.NewSchemaReader()}
+func NewSchemaNamespaceLister(src SchemaSource) *SchemaNamespaceLister {
+	return &SchemaNamespaceLister{src: src}
 }
 
-func (a *schemaNamespaceLister) ClassesInNamespace(namespace string) []string {
+func (a *SchemaNamespaceLister) ClassesInNamespace(namespace string) []string {
 	if namespace == "" {
 		return nil
 	}
@@ -50,7 +49,7 @@ func (a *schemaNamespaceLister) ClassesInNamespace(namespace string) []string {
 	return out
 }
 
-func (a *schemaNamespaceLister) AliasesInNamespace(namespace string) []string {
+func (a *SchemaNamespaceLister) AliasesInNamespace(namespace string) []string {
 	if namespace == "" {
 		return nil
 	}

--- a/cluster/store_namespace_lister.go
+++ b/cluster/store_namespace_lister.go
@@ -18,8 +18,7 @@ import (
 	entschema "github.com/weaviate/weaviate/entities/schema"
 )
 
-// SchemaSource is the subset of [schema.SchemaReader] consumed by
-// [SchemaNamespaceLister]; defined as an interface so tests can stub it.
+// SchemaSource is the subset of the schema reader used here.
 type SchemaSource interface {
 	ReadSchema(reader func(models.Class, uint64)) error
 	Aliases() map[string]string
@@ -35,18 +34,20 @@ func NewSchemaNamespaceLister(src SchemaSource) *SchemaNamespaceLister {
 	return &SchemaNamespaceLister{src: src}
 }
 
-func (a *SchemaNamespaceLister) ClassesInNamespace(namespace string) []string {
+func (a *SchemaNamespaceLister) ClassesInNamespace(namespace string) ([]string, error) {
 	if namespace == "" {
-		return nil
+		return nil, nil
 	}
 	prefix := namespace + entschema.NamespaceSeparator
 	out := make([]string, 0)
-	_ = a.src.ReadSchema(func(class models.Class, _ uint64) {
+	if err := a.src.ReadSchema(func(class models.Class, _ uint64) {
 		if strings.HasPrefix(class.Class, prefix) {
 			out = append(out, class.Class)
 		}
-	})
-	return out
+	}); err != nil {
+		return nil, err
+	}
+	return out, nil
 }
 
 func (a *SchemaNamespaceLister) AliasesInNamespace(namespace string) []string {

--- a/cluster/store_namespace_lister.go
+++ b/cluster/store_namespace_lister.go
@@ -1,0 +1,65 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"strings"
+
+	"github.com/weaviate/weaviate/cluster/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	entschema "github.com/weaviate/weaviate/entities/schema"
+)
+
+// schemaSource is the subset of [schema.SchemaReader] used here; it is an
+// interface so tests can substitute a stub.
+type schemaSource interface {
+	ReadSchema(reader func(models.Class, uint64)) error
+	Aliases() map[string]string
+}
+
+// schemaNamespaceLister returns the classes and aliases whose name starts
+// with "<namespace>:".
+type schemaNamespaceLister struct {
+	src schemaSource
+}
+
+func newSchemaNamespaceLister(manager *schema.SchemaManager) *schemaNamespaceLister {
+	return &schemaNamespaceLister{src: manager.NewSchemaReader()}
+}
+
+func (a *schemaNamespaceLister) ClassesInNamespace(namespace string) []string {
+	if namespace == "" {
+		return nil
+	}
+	prefix := namespace + entschema.NamespaceSeparator
+	out := make([]string, 0)
+	_ = a.src.ReadSchema(func(class models.Class, _ uint64) {
+		if strings.HasPrefix(class.Class, prefix) {
+			out = append(out, class.Class)
+		}
+	})
+	return out
+}
+
+func (a *schemaNamespaceLister) AliasesInNamespace(namespace string) []string {
+	if namespace == "" {
+		return nil
+	}
+	prefix := namespace + entschema.NamespaceSeparator
+	out := make([]string, 0)
+	for alias := range a.src.Aliases() {
+		if strings.HasPrefix(alias, prefix) {
+			out = append(out, alias)
+		}
+	}
+	return out
+}

--- a/cluster/store_namespace_lister_test.go
+++ b/cluster/store_namespace_lister_test.go
@@ -12,9 +12,11 @@
 package cluster
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -32,6 +34,13 @@ func (f fakeSchemaSource) ReadSchema(reader func(models.Class, uint64)) error {
 }
 
 func (f fakeSchemaSource) Aliases() map[string]string { return f.aliases }
+
+type failingSchemaSource struct {
+	err error
+}
+
+func (f failingSchemaSource) ReadSchema(func(models.Class, uint64)) error { return f.err }
+func (f failingSchemaSource) Aliases() map[string]string                  { return nil }
 
 func TestSchemaNamespaceLister_ClassesInNamespace(t *testing.T) {
 	src := fakeSchemaSource{classes: []string{
@@ -55,9 +64,20 @@ func TestSchemaNamespaceLister_ClassesInNamespace(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, a.ClassesInNamespace(tc.namespace))
+			got, err := a.ClassesInNamespace(tc.namespace)
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+func TestSchemaNamespaceLister_ClassesInNamespace_ReadSchemaError(t *testing.T) {
+	wantErr := errors.New("boom")
+	a := &SchemaNamespaceLister{src: failingSchemaSource{err: wantErr}}
+
+	got, err := a.ClassesInNamespace("alpha")
+	require.ErrorIs(t, err, wantErr)
+	assert.Nil(t, got)
 }
 
 func TestSchemaNamespaceLister_AliasesInNamespace(t *testing.T) {
@@ -94,6 +114,8 @@ func TestSchemaNamespaceLister_PrefixIsExact(t *testing.T) {
 	}
 	a := &SchemaNamespaceLister{src: src}
 
-	assert.Equal(t, []string{"alpha:Foo"}, a.ClassesInNamespace("alpha"))
+	classes, err := a.ClassesInNamespace("alpha")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"alpha:Foo"}, classes)
 	assert.ElementsMatch(t, []string{"alpha:A1"}, a.AliasesInNamespace("alpha"))
 }

--- a/cluster/store_namespace_lister_test.go
+++ b/cluster/store_namespace_lister_test.go
@@ -40,7 +40,7 @@ func TestSchemaNamespaceLister_ClassesInNamespace(t *testing.T) {
 		"beta:Baz",
 		"Unscoped",
 	}}
-	a := &schemaNamespaceLister{src: src}
+	a := &SchemaNamespaceLister{src: src}
 
 	tests := []struct {
 		name      string
@@ -67,7 +67,7 @@ func TestSchemaNamespaceLister_AliasesInNamespace(t *testing.T) {
 		"beta:B1":  "beta:Baz",
 		"Unscoped": "SomeClass",
 	}}
-	a := &schemaNamespaceLister{src: src}
+	a := &SchemaNamespaceLister{src: src}
 
 	tests := []struct {
 		name      string
@@ -92,7 +92,7 @@ func TestSchemaNamespaceLister_PrefixIsExact(t *testing.T) {
 		classes: []string{"alpha:Foo", "alphabet:Bar"},
 		aliases: map[string]string{"alpha:A1": "alpha:Foo", "alphabet:B1": "alphabet:Bar"},
 	}
-	a := &schemaNamespaceLister{src: src}
+	a := &SchemaNamespaceLister{src: src}
 
 	assert.Equal(t, []string{"alpha:Foo"}, a.ClassesInNamespace("alpha"))
 	assert.ElementsMatch(t, []string{"alpha:A1"}, a.AliasesInNamespace("alpha"))

--- a/cluster/store_namespace_lister_test.go
+++ b/cluster/store_namespace_lister_test.go
@@ -1,0 +1,99 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+type fakeSchemaSource struct {
+	classes []string
+	aliases map[string]string
+}
+
+func (f fakeSchemaSource) ReadSchema(reader func(models.Class, uint64)) error {
+	for _, name := range f.classes {
+		reader(models.Class{Class: name}, 0)
+	}
+	return nil
+}
+
+func (f fakeSchemaSource) Aliases() map[string]string { return f.aliases }
+
+func TestSchemaNamespaceLister_ClassesInNamespace(t *testing.T) {
+	src := fakeSchemaSource{classes: []string{
+		"alpha:Foo",
+		"alpha:Bar",
+		"beta:Baz",
+		"Unscoped",
+	}}
+	a := &schemaNamespaceLister{src: src}
+
+	tests := []struct {
+		name      string
+		namespace string
+		want      []string
+	}{
+		{name: "namespace with multiple classes", namespace: "alpha", want: []string{"alpha:Foo", "alpha:Bar"}},
+		{name: "namespace with one class", namespace: "beta", want: []string{"beta:Baz"}},
+		{name: "missing namespace returns empty", namespace: "ghost", want: []string{}},
+		{name: "empty namespace returns nil", namespace: "", want: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, a.ClassesInNamespace(tc.namespace))
+		})
+	}
+}
+
+func TestSchemaNamespaceLister_AliasesInNamespace(t *testing.T) {
+	src := fakeSchemaSource{aliases: map[string]string{
+		"alpha:A1": "alpha:Foo",
+		"alpha:A2": "alpha:Bar",
+		"beta:B1":  "beta:Baz",
+		"Unscoped": "SomeClass",
+	}}
+	a := &schemaNamespaceLister{src: src}
+
+	tests := []struct {
+		name      string
+		namespace string
+		want      []string
+	}{
+		{name: "namespace with multiple aliases", namespace: "alpha", want: []string{"alpha:A1", "alpha:A2"}},
+		{name: "namespace with one alias", namespace: "beta", want: []string{"beta:B1"}},
+		{name: "missing namespace returns empty", namespace: "ghost", want: []string{}},
+		{name: "empty namespace returns nil", namespace: "", want: nil},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.ElementsMatch(t, tc.want, a.AliasesInNamespace(tc.namespace))
+		})
+	}
+}
+
+func TestSchemaNamespaceLister_PrefixIsExact(t *testing.T) {
+	src := fakeSchemaSource{
+		classes: []string{"alpha:Foo", "alphabet:Bar"},
+		aliases: map[string]string{"alpha:A1": "alpha:Foo", "alphabet:B1": "alphabet:Bar"},
+	}
+	a := &schemaNamespaceLister{src: src}
+
+	assert.Equal(t, []string{"alpha:Foo"}, a.ClassesInNamespace("alpha"))
+	assert.ElementsMatch(t, []string{"alpha:A1"}, a.AliasesInNamespace("alpha"))
+}

--- a/entities/models/namespace.go
+++ b/entities/models/namespace.go
@@ -18,9 +18,12 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // Namespace A cluster-level namespace used to group resources under a common administrative unit. Namespace names must contain only lowercase letters, digits, and hyphens, must start and end with a letter or digit, must be 3-36 characters long, and must not be a reserved name.
@@ -38,6 +41,57 @@ type Namespace struct {
 
 // Validate validates this namespace
 func (m *Namespace) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateState(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+var namespaceTypeStatePropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["active","deleting"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		namespaceTypeStatePropEnum = append(namespaceTypeStatePropEnum, v)
+	}
+}
+
+const (
+
+	// NamespaceStateActive captures enum value "active"
+	NamespaceStateActive string = "active"
+
+	// NamespaceStateDeleting captures enum value "deleting"
+	NamespaceStateDeleting string = "deleting"
+)
+
+// prop value enum
+func (m *Namespace) validateStateEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, namespaceTypeStatePropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Namespace) validateState(formats strfmt.Registry) error {
+	if swag.IsZero(m.State) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateStateEnum("state", "body", m.State); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/entities/models/namespace.go
+++ b/entities/models/namespace.go
@@ -30,6 +30,7 @@ import (
 //
 // swagger:model Namespace
 type Namespace struct {
+
 	// The unique name of the namespace.
 	Name string `json:"name,omitempty"`
 

--- a/entities/models/namespace.go
+++ b/entities/models/namespace.go
@@ -30,11 +30,10 @@ import (
 //
 // swagger:model Namespace
 type Namespace struct {
-
 	// The unique name of the namespace.
 	Name string `json:"name,omitempty"`
 
-	// Lifecycle state. "active" namespaces accept all operations; "deleting" namespaces are being torn down by the leader and reject create-like operations until the entry is fully removed.
+	// Lifecycle state. "active" namespaces accept all operations. "deleting" namespaces are being removed: new classes, aliases, and users can no longer be created in the namespace, and the namespace itself disappears once removal completes.
 	// Enum: [active deleting]
 	State string `json:"state,omitempty"`
 }

--- a/entities/models/namespace.go
+++ b/entities/models/namespace.go
@@ -30,6 +30,10 @@ type Namespace struct {
 
 	// The unique name of the namespace.
 	Name string `json:"name,omitempty"`
+
+	// Lifecycle state. "active" namespaces accept all operations; "deleting" namespaces are being torn down by the leader and reject create-like operations until the entry is fully removed.
+	// Enum: [active deleting]
+	State string `json:"state,omitempty"`
 }
 
 // Validate validates this namespace

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -3535,6 +3535,11 @@
         "name": {
           "description": "The unique name of the namespace.",
           "type": "string"
+        },
+        "state": {
+          "description": "Lifecycle state. \"active\" namespaces accept all operations; \"deleting\" namespaces are being torn down by the leader and reject create-like operations until the entry is fully removed.",
+          "type": "string",
+          "enum": ["active", "deleting"]
         }
       }
     },
@@ -9221,7 +9226,7 @@
             }
           },
           "409": {
-            "description": "A namespace with the specified name already exists.",
+            "description": "A namespace with the specified name already exists, or a namespace with the same name is currently being deleted. Differentiate by reading the human-readable message in the error payload.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -9294,7 +9299,7 @@
       },
       "delete": {
         "summary": "Delete a namespace",
-        "description": "Hard-delete a namespace by its name.",
+        "description": "Mark a namespace for deletion. The endpoint is asynchronous: the namespace is flipped to the \"deleting\" state and its dynamic users are removed synchronously; classes and aliases are torn down by the leader on a periodic cleanup tick. Repeated calls while the namespace is still in the \"deleting\" state are idempotent and return 202.",
         "operationId": "deleteNamespace",
         "tags": [
           "namespaces"
@@ -9309,8 +9314,8 @@
           }
         ],
         "responses": {
-          "204": {
-            "description": "Successfully deleted."
+          "202": {
+            "description": "The namespace has been marked for deletion. Cleanup of its classes, aliases, and users completes asynchronously."
           },
           "401": {
             "description": "Unauthorized or invalid credentials."

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -3537,7 +3537,7 @@
           "type": "string"
         },
         "state": {
-          "description": "Lifecycle state. \"active\" namespaces accept all operations; \"deleting\" namespaces are being torn down by the leader and reject create-like operations until the entry is fully removed.",
+          "description": "Lifecycle state. \"active\" namespaces accept all operations. \"deleting\" namespaces are being removed: new classes, aliases, and users can no longer be created in the namespace, and the namespace itself disappears once removal completes.",
           "type": "string",
           "enum": ["active", "deleting"]
         }

--- a/test/acceptance/authz/namespaces_oidc_test.go
+++ b/test/acceptance/authz/namespaces_oidc_test.go
@@ -94,6 +94,28 @@ func TestNamespacesOIDC(t *testing.T) {
 		require.True(t, errors.As(err, &unauth), "expected GetOwnInfoUnauthorized, got %T: %v", err, err)
 	})
 
+	t.Run("deleting namespace claim → 401", func(t *testing.T) {
+		// Create customer2 so the OIDC token authenticates first, then
+		// mark it for deletion. Whether the cleanup tick has finished or
+		// not, the principal builder rejects with 401: deleting → 401
+		// via IsActive; gone → 401 via the same error message.
+		const ns = "customer2"
+		helper.CreateNamespace(t, ns, adminKey)
+		defer helper.WaitForNamespaceGone(t, ns, adminKey, 30*time.Second)
+
+		token, _ := docker.GetTokensFromMockOIDCWithHelperFor(t, helperURI, "oidc-namespaced-"+ns)
+		// Sanity: pre-delete, the OIDC token authenticates.
+		info := helper.GetInfoForOwnUser(t, token)
+		require.NotNil(t, info.Username)
+
+		helper.DeleteNamespace(t, ns, adminKey, helper.WithoutWaitForCleanup())
+
+		_, err := helper.Client(t).Users.GetOwnInfo(users.NewGetOwnInfoParams(), helper.CreateAuth(token))
+		require.Error(t, err)
+		var unauth *users.GetOwnInfoUnauthorized
+		require.True(t, errors.As(err, &unauth), "expected GetOwnInfoUnauthorized, got %T: %v", err, err)
+	})
+
 	t.Run("bare-form OIDC user ID: assignment rejected at the API", func(t *testing.T) {
 		// validateUserIDForNamespaces rejects bare-form IDs on NS-enabled.
 		_, err := helper.Client(t).Authz.AssignRoleToUser(

--- a/test/acceptance/multi_node/collection_naming_test.go
+++ b/test/acceptance/multi_node/collection_naming_test.go
@@ -84,12 +84,12 @@ func TestCollectionNamingGQL(t *testing.T) {
 
 			if c.shouldFail {
 				// get should fail
-				class, err := helper.GetClassWithoutAssert(t, c.getWith)
+				class, err := helper.GetClassWithoutAssert(t, c.getWith, "")
 				require.Nil(t, class)
 				require.Error(t, err)
 
-				helper.SetupClient(compose.GetWeaviateNode2().URI())    // node2
-				class, err = helper.GetClassWithoutAssert(t, c.getWith) // try getting it from different node
+				helper.SetupClient(compose.GetWeaviateNode2().URI())        // node2
+				class, err = helper.GetClassWithoutAssert(t, c.getWith, "") // try getting it from different node
 				require.Nil(t, class)
 				require.Error(t, err)
 
@@ -108,7 +108,7 @@ func TestCollectionNamingGQL(t *testing.T) {
 			helper.DeleteClass(t, c.deleteWith)                  // try deleting it from different node
 
 			// make sure after delete, collection should not exist
-			class, err := helper.GetClassWithoutAssert(t, c.deleteWith)
+			class, err := helper.GetClassWithoutAssert(t, c.deleteWith, "")
 			require.Nil(t, class)
 			require.Error(t, err)
 		})

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -28,13 +28,26 @@ import (
 
 func createNamespacedUser(t *testing.T, userID, ns, adminKey string) string {
 	t.Helper()
-	resp, err := helper.Client(t).Users.CreateUser(
-		users.NewCreateUserParams().WithUserID(userID).WithBody(users.CreateUserBody{Namespace: ns}),
-		helper.CreateAuth(adminKey),
-	)
-	require.NoError(t, err)
-	require.NotNil(t, resp.Payload.Apikey)
-	apikey := *resp.Payload.Apikey
+
+	// AddNamespace no longer waits for local apply, so the follower the test
+	// client talks to may not yet see the namespace in its local controller
+	// when CreateUser arrives. The createUser handler's fast-path Exists()
+	// check then 422s with "namespace does not exist"; the local check 422s
+	// before any RAFT command is sent, so retries are safe.
+	var apikey string
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		resp, err := helper.Client(t).Users.CreateUser(
+			users.NewCreateUserParams().WithUserID(userID).WithBody(users.CreateUserBody{Namespace: ns}),
+			helper.CreateAuth(adminKey),
+		)
+		if !assert.NoError(c, err) {
+			return
+		}
+		if !assert.NotNil(c, resp.Payload.Apikey) {
+			return
+		}
+		apikey = *resp.Payload.Apikey
+	}, 10*time.Second, 50*time.Millisecond, "user %q could not be created", userID)
 
 	// On a multi-node cluster CreateUser is RAFT-forwarded to the leader and
 	// returns once the leader applies the FSM entry; the follower the test

--- a/test/acceptance/namespace/deletion_test.go
+++ b/test/acceptance/namespace/deletion_test.go
@@ -125,14 +125,20 @@ func TestNamespaces_DeleteUserAuthBlockedClusterWide(t *testing.T) {
 // 409 (still deleting) and success are acceptable; any other response
 // fails the test.
 func TestNamespaces_RecreateAfterDelete(t *testing.T) {
-	const ns = "delrecreate"
-	const className = "Movies"
+	const (
+		ns        = "delrecreate"
+		userID    = "creator"
+		className = "Movies"
+	)
 
 	helper.CreateNamespace(t, ns, adminKey)
+	// On NS-enabled clusters QualifyForCreate rejects principals without a
+	// namespace claim, so class creation must run as a namespaced user.
+	userKey := createNamespacedUser(t, userID, ns, adminKey)
 	helper.CreateClassAuth(t, &models.Class{
 		Class:      className,
 		Properties: []*models.Property{{Name: "title", DataType: []string{"text"}}},
-	}, adminKey)
+	}, userKey)
 	// Best-effort cleanup in case the namespace delete fails partway
 	// through; if it succeeds the cascade has already removed the class.
 	defer helper.DeleteClassWithoutAssert(t, ns+":"+className, adminKey)

--- a/test/acceptance/namespace/deletion_test.go
+++ b/test/acceptance/namespace/deletion_test.go
@@ -1,0 +1,246 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespace
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/client/namespaces"
+	"github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// rawDeleteNamespace issues the DELETE and returns the typed response.
+// helper.DeleteNamespace asserts NoError, which is wrong for tests that
+// expect a 404 (idempotent re-call after removal) or that drive the
+// endpoint from a goroutine where require.* is unsafe.
+func rawDeleteNamespace(t *testing.T, name, key string) (*namespaces.DeleteNamespaceAccepted, error) {
+	t.Helper()
+	return helper.Client(t).Namespaces.DeleteNamespace(
+		namespaces.NewDeleteNamespaceParams().WithNamespaceID(name),
+		helper.CreateAuth(key),
+	)
+}
+
+// TestNamespaces_DeleteHappyPath creates a namespace with a class, an
+// alias, and a DB user, deletes it, and verifies that the namespace,
+// its class, its alias, and the user are all gone.
+func TestNamespaces_DeleteHappyPath(t *testing.T) {
+	const (
+		ns        = "delhappy"
+		userID    = "alice"
+		className = "Movies"
+		aliasName = "Films"
+	)
+	qualifiedClass := ns + ":" + className
+	qualifiedAlias := ns + ":" + aliasName
+	qualifiedUser := ns + ":" + userID
+
+	helper.CreateNamespace(t, ns, adminKey)
+	userKey := createNamespacedUser(t, userID, ns, adminKey)
+	helper.CreateClassAuth(t, &models.Class{
+		Class:      className,
+		Properties: []*models.Property{{Name: "title", DataType: []string{"text"}}},
+	}, userKey)
+	helper.CreateAliasAuth(t, &models.Alias{Alias: aliasName, Class: className}, userKey)
+
+	// Trigger the async delete and wait for full removal. The helper
+	// polls Get until 404, so by the time it returns the namespace is
+	// gone — making the per-resource checks below assertions about the
+	// cascade cleanup, not the namespace itself.
+	helper.DeleteNamespace(t, ns, adminKey)
+
+	_, err := helper.GetClassWithoutAssert(t, qualifiedClass, adminKey)
+	require.Error(t, err, "class %q should have been deleted", qualifiedClass)
+
+	helper.GetAliasWithAuthzNotFound(t, qualifiedAlias, helper.CreateAuth(adminKey))
+
+	_, err = schemaDumpAs(t, userKey)
+	require.Error(t, err, "user %q should no longer authenticate", qualifiedUser)
+}
+
+// TestNamespaces_DeleteUserAuthBlockedClusterWide creates a namespace +
+// DB user, deletes the namespace, and asserts the user's API key fails
+// with 401 against every replica. The synchronous DeleteUsersInNamespace
+// command combined with RAFT replication means the user record is gone
+// on all nodes by the time DELETE returns 202.
+func TestNamespaces_DeleteUserAuthBlockedClusterWide(t *testing.T) {
+	const (
+		ns     = "delauth"
+		userID = "bob"
+	)
+
+	helper.CreateNamespace(t, ns, adminKey)
+	userKey := createNamespacedUser(t, userID, ns, adminKey)
+
+	// Sanity: the user can authenticate before the delete.
+	_, err := schemaDumpAs(t, userKey)
+	require.NoError(t, err, "fresh DB user should authenticate")
+
+	// Issue the delete; do not wait for full cleanup — the auth-blocked
+	// guarantee is established by the synchronous user-delete RAFT
+	// command, which has applied by the time the 202 is received.
+	helper.DeleteNamespace(t, ns, adminKey, helper.WithoutWaitForCleanup())
+
+	// On every replica, the user's API key must now be rejected.
+	originalURI := sharedCompose.GetWeaviate().URI()
+	t.Cleanup(func() { helper.SetupClient(originalURI) })
+	for i := 1; i <= 3; i++ {
+		nodeURI := sharedCompose.GetWeaviateNode(i).URI()
+		helper.SetupClient(nodeURI)
+		_, err := schemaDumpAs(t, userKey)
+		require.Error(t, err, "auth must fail on node %s after namespace delete", nodeURI)
+		assertUnauthorized(t, err)
+	}
+	// Restore for subsequent tests; t.Cleanup also covers it.
+	helper.SetupClient(originalURI)
+	helper.WaitForNamespaceGone(t, ns, adminKey, 30*time.Second)
+}
+
+// TestNamespaces_RecreateAfterDelete creates a namespace with a class so
+// the cleanup tick has work to do, deletes the namespace, then polls
+// CreateNamespace until cleanup finishes and recreation succeeds. Only
+// 409 (still deleting) and success are acceptable; any other response
+// fails the test.
+func TestNamespaces_RecreateAfterDelete(t *testing.T) {
+	const ns = "delrecreate"
+	const className = "Movies"
+
+	helper.CreateNamespace(t, ns, adminKey)
+	helper.CreateClassAuth(t, &models.Class{
+		Class:      className,
+		Properties: []*models.Property{{Name: "title", DataType: []string{"text"}}},
+	}, adminKey)
+	// Best-effort cleanup in case the namespace delete fails partway
+	// through; if it succeeds the cascade has already removed the class.
+	defer helper.DeleteClassWithoutAssert(t, ns+":"+className, adminKey)
+
+	helper.DeleteNamespace(t, ns, adminKey, helper.WithoutWaitForCleanup())
+
+	// Poll until recreate succeeds. While cleanup is in progress the
+	// namespace is in the deleting state and create returns 409 — keep
+	// retrying. Any other response is a real failure.
+	assert.Eventually(t, func() bool {
+		_, err := helper.Client(t).Namespaces.CreateNamespace(
+			namespaces.NewCreateNamespaceParams().WithNamespaceID(ns),
+			helper.CreateAuth(adminKey),
+		)
+		if err == nil {
+			return true
+		}
+		var conflict *namespaces.CreateNamespaceConflict
+		if errors.As(err, &conflict) {
+			return false
+		}
+		require.Failf(t, "unexpected response during recreate", "%T: %v", err, err)
+		return true
+	}, 5*time.Second, 50*time.Millisecond,
+		"namespace did not become recreatable within 5s")
+
+	t.Cleanup(func() { helper.DeleteNamespace(t, ns, adminKey) })
+}
+
+// TestNamespaces_DeleteIsIdempotent calls DELETE twice in a row while
+// the namespace is still in the deleting state and asserts both return
+// 202. After cleanup completes, DELETE returns 404.
+func TestNamespaces_DeleteIsIdempotent(t *testing.T) {
+	const ns = "delidempotent"
+	helper.CreateNamespace(t, ns, adminKey)
+
+	// First DELETE: 202.
+	helper.DeleteNamespace(t, ns, adminKey, helper.WithoutWaitForCleanup())
+
+	// Second DELETE while still deleting: 202 (best-effort — if cleanup is
+	// fast and removes the entity between the two calls, the second one
+	// returns 404, which is also acceptable per the contract).
+	_, err := rawDeleteNamespace(t, ns, adminKey)
+	if err != nil {
+		var nf *namespaces.DeleteNamespaceNotFound
+		require.True(t, errors.As(err, &nf),
+			"second DELETE should be 202 (still deleting) or 404 (already removed); got %T: %v", err, err)
+	}
+
+	helper.WaitForNamespaceGone(t, ns, adminKey, 30*time.Second)
+
+	// After cleanup: 404.
+	_, err = rawDeleteNamespace(t, ns, adminKey)
+	require.Error(t, err)
+	var nf *namespaces.DeleteNamespaceNotFound
+	require.True(t, errors.As(err, &nf), "DELETE after removal should return 404, got %T: %v", err, err)
+}
+
+// TestNamespaces_ConcurrentDeleteAndAddClass launches a DELETE and an
+// AddClass concurrently. The add-class apply gate may reject
+// (ErrNamespaceDeleting/ErrNamespaceGone) or it may succeed and then be
+// cleaned up — both outcomes are acceptable. The post-condition is that
+// no orphan class survives once the namespace entity is gone.
+func TestNamespaces_ConcurrentDeleteAndAddClass(t *testing.T) {
+	const ns = "delrace"
+	const className = "Films"
+	qualifiedClass := ns + ":" + className
+
+	helper.CreateNamespace(t, ns, adminKey)
+	userKey := createNamespacedUser(t, "carol", ns, adminKey)
+	// No explicit user cleanup: the namespace delete below removes the
+	// user as part of the cascade.
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = rawDeleteNamespace(t, ns, adminKey)
+	}()
+	go func() {
+		defer wg.Done()
+		// Best-effort: may succeed, may be rejected.
+		_, _ = helper.Client(t).Schema.SchemaObjectsCreate(
+			schema.NewSchemaObjectsCreateParams().WithObjectClass(&models.Class{
+				Class:      className,
+				Properties: []*models.Property{{Name: "title", DataType: []string{"text"}}},
+			}),
+			helper.CreateAuth(userKey),
+		)
+	}()
+	wg.Wait()
+
+	helper.WaitForNamespaceGone(t, ns, adminKey, 30*time.Second)
+
+	// Post-condition: no class with the qualified name survives.
+	_, err := helper.GetClassWithoutAssert(t, qualifiedClass, adminKey)
+	require.Error(t, err, "class %q must not survive namespace removal", qualifiedClass)
+}
+
+// schemaDumpAs hits a generic authenticated endpoint with the given key.
+// Used to probe whether the key still authenticates.
+func schemaDumpAs(t *testing.T, key string) (any, error) {
+	t.Helper()
+	return helper.Client(t).Schema.SchemaDump(
+		schema.NewSchemaDumpParams(),
+		helper.CreateAuth(key),
+	)
+}
+
+// assertUnauthorized fails the test unless err is the swagger-generated
+// 401 type for SchemaDump.
+func assertUnauthorized(t *testing.T, err error) {
+	t.Helper()
+	require.Error(t, err)
+	var unauth *schema.SchemaDumpUnauthorized
+	require.True(t, errors.As(err, &unauth), "expected 401 SchemaDumpUnauthorized, got %T: %v", err, err)
+}

--- a/test/acceptance/namespace/deletion_test.go
+++ b/test/acceptance/namespace/deletion_test.go
@@ -76,10 +76,10 @@ func TestNamespaces_DeleteHappyPath(t *testing.T) {
 }
 
 // TestNamespaces_DeleteUserAuthBlockedClusterWide creates a namespace +
-// DB user, deletes the namespace, and asserts the user's API key fails
-// with 401 against every replica. The synchronous DeleteUsersInNamespace
-// command combined with RAFT replication means the user record is gone
-// on all nodes by the time DELETE returns 202.
+// DB user, deletes the namespace, and asserts the user's API key
+// eventually fails with 401 against every replica. The leader applies
+// the synchronous DeleteUsersInNamespace before returning 202; followers
+// apply asynchronously, so each node is polled until auth is rejected.
 func TestNamespaces_DeleteUserAuthBlockedClusterWide(t *testing.T) {
 	const (
 		ns     = "delauth"
@@ -95,18 +95,24 @@ func TestNamespaces_DeleteUserAuthBlockedClusterWide(t *testing.T) {
 
 	// Issue the delete; do not wait for full cleanup — the auth-blocked
 	// guarantee is established by the synchronous user-delete RAFT
-	// command, which has applied by the time the 202 is received.
+	// command, which has committed by the time the 202 is received.
 	helper.DeleteNamespace(t, ns, adminKey, helper.WithoutWaitForCleanup())
 
-	// On every replica, the user's API key must now be rejected.
+	// On every replica, the user's API key must eventually be rejected.
 	originalURI := sharedCompose.GetWeaviate().URI()
 	t.Cleanup(func() { helper.SetupClient(originalURI) })
 	for i := 1; i <= 3; i++ {
 		nodeURI := sharedCompose.GetWeaviateNode(i).URI()
 		helper.SetupClient(nodeURI)
-		_, err := schemaDumpAs(t, userKey)
-		require.Error(t, err, "auth must fail on node %s after namespace delete", nodeURI)
-		assertUnauthorized(t, err)
+		assert.Eventually(t, func() bool {
+			_, err := schemaDumpAs(t, userKey)
+			if err == nil {
+				return false
+			}
+			var unauth *schema.SchemaDumpUnauthorized
+			return errors.As(err, &unauth)
+		}, 10*time.Second, 50*time.Millisecond,
+			"auth must fail on node %s after namespace delete", nodeURI)
 	}
 	// Restore for subsequent tests; t.Cleanup also covers it.
 	helper.SetupClient(originalURI)
@@ -234,13 +240,4 @@ func schemaDumpAs(t *testing.T, key string) (any, error) {
 		schema.NewSchemaDumpParams(),
 		helper.CreateAuth(key),
 	)
-}
-
-// assertUnauthorized fails the test unless err is the swagger-generated
-// 401 type for SchemaDump.
-func assertUnauthorized(t *testing.T, err error) {
-	t.Helper()
-	require.Error(t, err)
-	var unauth *schema.SchemaDumpUnauthorized
-	require.True(t, errors.As(err, &unauth), "expected 401 SchemaDumpUnauthorized, got %T: %v", err, err)
 }

--- a/test/acceptance/namespace/deletion_test.go
+++ b/test/acceptance/namespace/deletion_test.go
@@ -232,6 +232,30 @@ func TestNamespaces_ConcurrentDeleteAndAddClass(t *testing.T) {
 	require.Error(t, err, "class %q must not survive namespace removal", qualifiedClass)
 }
 
+// TestNamespaces_DeleteMissingReturns404FromEveryReplica drives DELETE
+// on a non-existent namespace against each replica in turn and asserts a
+// 404 response. The Apply path forwards from any non-leader replica to
+// the leader, so at least two of the three iterations exercise the
+// follower-forward path. The leader's apply returns ErrNotFound, which
+// must round-trip through gRPC and re-chain on the client so the
+// handler's errors.Is mapping returns 404 rather than 500.
+func TestNamespaces_DeleteMissingReturns404FromEveryReplica(t *testing.T) {
+	const ns = "neverexisted"
+
+	originalURI := sharedCompose.GetWeaviate().URI()
+	t.Cleanup(func() { helper.SetupClient(originalURI) })
+
+	for i := 1; i <= 3; i++ {
+		nodeURI := sharedCompose.GetWeaviateNode(i).URI()
+		helper.SetupClient(nodeURI)
+		_, err := rawDeleteNamespace(t, ns, adminKey)
+		require.Error(t, err, "DELETE on missing namespace must return an error from %s", nodeURI)
+		var nf *namespaces.DeleteNamespaceNotFound
+		require.True(t, errors.As(err, &nf),
+			"DELETE on %s should return 404, got %T: %v", nodeURI, err, err)
+	}
+}
+
 // schemaDumpAs hits a generic authenticated endpoint with the given key.
 // Used to probe whether the key still authenticates.
 func schemaDumpAs(t *testing.T, key string) (any, error) {

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -625,22 +625,22 @@ func TestNamespaces_GRPC(t *testing.T) {
 		}
 
 		// retryOnAliasLag absorbs the brief leader→follower replication gap
-		// after CreateAliasAuth; once the first stream succeeds the alias is
-		// locally visible and the second stream is safe to run directly.
-		var successes int
-		var errs []*pb.BatchStreamReply_Results_Error
-		retryOnAliasLag(t, func() error {
-			successes, errs = runBatchStream(t, user1Key, []*pb.BatchObject{objFor(id1, "ns1-alias-stream")})
-			if len(errs) > 0 {
-				return fmt.Errorf("per-object errors: %v", errs[0].GetError())
-			}
-			return nil
-		})
-		assert.Equal(t, 1, successes)
-
-		successes, errs = runBatchStream(t, user2Key, []*pb.BatchObject{objFor(id2, "ns2-alias-stream")})
-		require.Empty(t, errs)
-		assert.Equal(t, 1, successes)
+		// after CreateAliasAuth. Each per-namespace alias replicates
+		// independently, so both streams need their own retry.
+		runStream := func(key string, obj *pb.BatchObject) {
+			var successes int
+			var errs []*pb.BatchStreamReply_Results_Error
+			retryOnAliasLag(t, func() error {
+				successes, errs = runBatchStream(t, key, []*pb.BatchObject{obj})
+				if len(errs) > 0 {
+					return fmt.Errorf("per-object errors: %v", errs[0].GetError())
+				}
+				return nil
+			})
+			assert.Equal(t, 1, successes)
+		}
+		runStream(user1Key, objFor(id1, "ns1-alias-stream"))
+		runStream(user2Key, objFor(id2, "ns2-alias-stream"))
 
 		// The alias resolved to each namespace's own copy of the class.
 		got1, err := helper.GetObjectAuth(t, streamClass, id1, user1Key)

--- a/test/acceptance/schema/default_sharding_count_test.go
+++ b/test/acceptance/schema/default_sharding_count_test.go
@@ -254,7 +254,7 @@ func TestDefaultShardingCountRuntimeOverride(t *testing.T) {
 				continue
 			}
 
-			cls, err := helper.GetClassWithoutAssert(t, className)
+			cls, err := helper.GetClassWithoutAssert(t, className, "")
 			if err != nil || cls == nil {
 				continue
 			}

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -1084,6 +1084,10 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 	if d.withWeaviateNamespaces {
 		settings["NAMESPACES_ENABLED"] = "true"
 		settings["DISABLE_GRAPHQL"] = "true"
+		// Tight cleanup tick for acceptance: deletion tests poll for the
+		// 404 that arrives once the leader has finished tearing down the
+		// namespace's classes, aliases, and users.
+		settings["NAMESPACE_CLEANUP_INTERVAL"] = "1s"
 	}
 
 	if d.withAutoschema {

--- a/test/helper/backuptest/suite.go
+++ b/test/helper/backuptest/suite.go
@@ -575,7 +575,7 @@ func (s *BackupTestSuite) VerifyObjectsDoNotExist(t *testing.T) {
 	t.Helper()
 
 	// After class deletion, trying to get the class should return an error
-	_, err := helper.GetClassWithoutAssert(t, s.config.ClassName)
+	_, err := helper.GetClassWithoutAssert(t, s.config.ClassName, "")
 	require.Error(t, err, "class %s should not exist after deletion", s.config.ClassName)
 }
 

--- a/test/helper/namespaces.go
+++ b/test/helper/namespaces.go
@@ -12,6 +12,7 @@
 package helper
 
 import (
+	"errors"
 	"testing"
 	"time"
 
@@ -68,13 +69,59 @@ func ListNamespaces(t *testing.T, key string) []*models.Namespace {
 	return resp.Payload
 }
 
-func DeleteNamespace(t *testing.T, name, key string) {
+// DeleteNamespaceOption configures DeleteNamespace.
+type DeleteNamespaceOption func(*deleteNamespaceOptions)
+
+type deleteNamespaceOptions struct {
+	skipWait bool
+}
+
+// WithoutWaitForCleanup makes DeleteNamespace return as soon as the 202
+// is received instead of polling Get until 404. Use it when the test
+// wants to observe the deleting state itself.
+func WithoutWaitForCleanup() DeleteNamespaceOption {
+	return func(o *deleteNamespaceOptions) { o.skipWait = true }
+}
+
+// DeleteNamespace marks a namespace for deletion. The delete returns
+// HTTP 202; by default the helper then polls Get until 404 so callers
+// can treat removal as complete. Pass WithoutWaitForCleanup to skip the
+// polling.
+func DeleteNamespace(t *testing.T, name, key string, opts ...DeleteNamespaceOption) {
 	t.Helper()
+	o := deleteNamespaceOptions{}
+	for _, opt := range opts {
+		opt(&o)
+	}
 	_, err := Client(t).Namespaces.DeleteNamespace(
 		namespaces.NewDeleteNamespaceParams().WithNamespaceID(name),
 		CreateAuth(key),
 	)
 	require.NoError(t, err)
+	if !o.skipWait {
+		WaitForNamespaceGone(t, name, key, 30*time.Second)
+	}
+}
+
+// WaitForNamespaceGone polls Get on the named namespace until it returns
+// 404 or the timeout elapses.
+func WaitForNamespaceGone(t *testing.T, name, key string, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		_, err := Client(t).Namespaces.GetNamespace(
+			namespaces.NewGetNamespaceParams().WithNamespaceID(name),
+			CreateAuth(key),
+		)
+		var notFound *namespaces.GetNamespaceNotFound
+		if errors.As(err, &notFound) {
+			return
+		}
+		if time.Now().After(deadline) {
+			require.FailNowf(t, "namespace %q still present after %s", name, timeout)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }
 
 // NamespacesPermission is a builder for namespace-scoped permissions. Mirrors

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -181,10 +181,17 @@ func GetClassAuthWithReturn(t *testing.T, class string, key string) (*schema.Sch
 	return Client(t).Schema.SchemaObjectsGet(params, CreateAuth(key))
 }
 
-func GetClassWithoutAssert(t *testing.T, class string) (*models.Class, error) {
+// GetClassWithoutAssert fetches a class without asserting on the result.
+// An empty key skips authentication; otherwise the call is made with the
+// given API key.
+func GetClassWithoutAssert(t *testing.T, class, key string) (*models.Class, error) {
 	t.Helper()
 	params := schema.NewSchemaObjectsGetParams().WithClassName(class)
-	resp, err := Client(t).Schema.SchemaObjectsGet(params, nil)
+	var auth runtime.ClientAuthInfoWriter
+	if key != "" {
+		auth = CreateAuth(key)
+	}
+	resp, err := Client(t).Schema.SchemaObjectsGet(params, auth)
 	if err != nil {
 		return nil, err
 	}
@@ -405,6 +412,19 @@ func DeleteClassAuth(t *testing.T, class string, key string) {
 	delParams := schema.NewSchemaObjectsDeleteParams().WithClassName(class)
 	delRes, err := Client(t).Schema.SchemaObjectsDelete(delParams, CreateAuth(key))
 	AssertRequestOk(t, delRes, err, nil)
+}
+
+// DeleteClassWithoutAssert deletes a class without asserting on the
+// result. Use it for best-effort cleanup where the class may already
+// have been removed by another path (e.g. a cascading namespace delete).
+func DeleteClassWithoutAssert(t *testing.T, class, key string) {
+	t.Helper()
+	params := schema.NewSchemaObjectsDeleteParams().WithClassName(class)
+	var auth runtime.ClientAuthInfoWriter
+	if key != "" {
+		auth = CreateAuth(key)
+	}
+	_, _ = Client(t).Schema.SchemaObjectsDelete(params, auth)
 }
 
 func DeleteObject(t *testing.T, object *models.Object) {

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -557,6 +557,75 @@ func TestValidateAndExtractReturnsNamespace(t *testing.T) {
 	}
 }
 
+func TestDeleteUsersInNamespace(t *testing.T) {
+	t.Run("removes only matching users", func(t *testing.T) {
+		dynUsers, err := NewDBUser(t.TempDir(), false, log)
+		require.NoError(t, err)
+
+		seeds := []struct {
+			id, namespace string
+		}{
+			{"u-alpha-1", "alpha"},
+			{"u-alpha-2", "alpha"},
+			{"u-beta", "beta"},
+			{"u-unscoped", ""},
+		}
+		for _, s := range seeds {
+			_, hash, identifier, err := keys.CreateApiKeyAndHash()
+			require.NoError(t, err)
+			require.NoError(t, dynUsers.CreateUser(s.id, hash, identifier, "", s.namespace, time.Now()))
+		}
+
+		require.NoError(t, dynUsers.DeleteUsersInNamespace("alpha"))
+
+		users, err := dynUsers.GetUsers()
+		require.NoError(t, err)
+		require.Len(t, users, 2)
+		require.NotContains(t, users, "u-alpha-1")
+		require.NotContains(t, users, "u-alpha-2")
+		require.Contains(t, users, "u-beta")
+		require.Contains(t, users, "u-unscoped")
+	})
+
+	t.Run("rerun on empty namespace is a no-op", func(t *testing.T) {
+		dynUsers, err := NewDBUser(t.TempDir(), false, log)
+		require.NoError(t, err)
+
+		_, hash, identifier, err := keys.CreateApiKeyAndHash()
+		require.NoError(t, err)
+		require.NoError(t, dynUsers.CreateUser("u1", hash, identifier, "", "alpha", time.Now()))
+
+		require.NoError(t, dynUsers.DeleteUsersInNamespace("alpha"))
+		require.NoError(t, dynUsers.DeleteUsersInNamespace("alpha"))
+		require.NoError(t, dynUsers.DeleteUsersInNamespace("never-existed"))
+	})
+
+	t.Run("frees the user id for re-creation", func(t *testing.T) {
+		dynUsers, err := NewDBUser(t.TempDir(), false, log)
+		require.NoError(t, err)
+
+		_, hash, identifier, err := keys.CreateApiKeyAndHash()
+		require.NoError(t, err)
+		require.NoError(t, dynUsers.CreateUser("u1", hash, identifier, "", "alpha", time.Now()))
+		require.NoError(t, dynUsers.DeleteUsersInNamespace("alpha"))
+
+		_, hash2, identifier2, err := keys.CreateApiKeyAndHash()
+		require.NoError(t, err)
+		require.NoError(t, dynUsers.CreateUser("u1", hash2, identifier2, "", "alpha", time.Now()))
+
+		users, err := dynUsers.GetUsers("u1")
+		require.NoError(t, err)
+		require.NotNil(t, users["u1"])
+		require.Equal(t, "alpha", users["u1"].Namespace)
+	})
+
+	t.Run("empty namespace argument is rejected", func(t *testing.T) {
+		dynUsers, err := NewDBUser(t.TempDir(), false, log)
+		require.NoError(t, err)
+		require.Error(t, dynUsers.DeleteUsersInNamespace(""))
+	})
+}
+
 func TestRestoreIncompleteData(t *testing.T) {
 	dynUsers, err := NewDBUser(t.TempDir(), false, log)
 	require.NoError(t, err)

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -42,7 +42,7 @@ func TestDynUserConcurrency(t *testing.T) {
 	for i := 0; i < numUsers; i++ {
 		userName := fmt.Sprintf("user%v", i)
 		go func() {
-			err := dynUsers.CreateUser(t.Context(), userName, "something", userName, "", "", time.Now())
+			err := dynUsers.CreateUser(userName, "something", userName, "", "", time.Now())
 			require.NoError(t, err)
 			wg.Done()
 		}()
@@ -64,12 +64,12 @@ func TestConcurrentValidate(t *testing.T) {
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(t.Context(), userId1, hash, identifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId1, hash, identifier, "", "", time.Now()))
 
 	apiKey2, hash2, identifier2, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(t.Context(), userId2, hash2, identifier2, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId2, hash2, identifier2, "", "", time.Now()))
 
 	randomKey, _, err := keys.DecodeApiKey(apiKey)
 	require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestDynUserTestSlowAfterWeakHash(t *testing.T) {
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(t.Context(), userId, hash, identifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, "", "", time.Now()))
 
 	randomKey, _, err := keys.DecodeApiKey(apiKey)
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestUpdateUser(t *testing.T) {
 	apiKey, hash, oldIdentifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(t.Context(), userId, hash, oldIdentifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId, hash, oldIdentifier, "", "", time.Now()))
 
 	// login works
 	randomKeyOld, _, err := keys.DecodeApiKey(apiKey)
@@ -151,7 +151,7 @@ func TestUpdateUser(t *testing.T) {
 	// update key and check that original key does not work, but new one does
 	apiKeyNew, hashNew, newIdentifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
-	require.NoError(t, dynUsers.RotateKey(t.Context(), userId, apiKeyNew[:3], hashNew, oldIdentifier, newIdentifier))
+	require.NoError(t, dynUsers.RotateKey(userId, apiKeyNew[:3], hashNew, oldIdentifier, newIdentifier))
 
 	randomKeyNew, _, err := keys.DecodeApiKey(apiKeyNew)
 	require.NoError(t, err)
@@ -184,13 +184,13 @@ func TestSnapShotAndRestore(t *testing.T) {
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(t.Context(), userId1, hash, identifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId1, hash, identifier, "", "", time.Now()))
 	login1, _, err := keys.DecodeApiKey(apiKey)
 	require.NoError(t, err)
 
 	apiKey2, hash2, identifier2, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
-	require.NoError(t, dynUsers.CreateUser(t.Context(), userId2, hash2, identifier2, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId2, hash2, identifier2, "", "", time.Now()))
 	login2, _, err := keys.DecodeApiKey(apiKey2)
 	require.NoError(t, err)
 
@@ -211,7 +211,7 @@ func TestSnapShotAndRestore(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, principal2)
 
-	require.NoError(t, dynUsers.DeactivateUser(t.Context(), userId2, true))
+	require.NoError(t, dynUsers.DeactivateUser(userId2, true))
 
 	// create snapshot and restore to an empty new DBUser struct
 	snapShot, err := dynUsers.Snapshot()
@@ -240,7 +240,7 @@ func TestSnapShotAndRestore(t *testing.T) {
 
 	apiKey3, hash3, identifier3, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
-	require.NoError(t, dynUsers2.RotateKey(t.Context(), userId2, apiKey3[:3], hash3, identifier2, identifier3))
+	require.NoError(t, dynUsers2.RotateKey(userId2, apiKey3[:3], hash3, identifier2, identifier3))
 
 	login3, _, err := keys.DecodeApiKey(apiKey3)
 	require.NoError(t, err)
@@ -256,19 +256,19 @@ func TestSuspendAfterDelete(t *testing.T) {
 	_, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(t.Context(), userId, hash, identifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, "", "", time.Now()))
 
 	users, err := dynUsers.GetUsers(userId)
 	require.NoError(t, err)
 	require.Contains(t, users, userId)
 	require.Len(t, users, 1)
 
-	require.NoError(t, dynUsers.DeleteUser(t.Context(), userId))
+	require.NoError(t, dynUsers.DeleteUser(userId))
 
-	require.Error(t, dynUsers.DeactivateUser(t.Context(), userId, false))
-	require.Error(t, dynUsers.ActivateUser(t.Context(), userId))
-	require.Error(t, dynUsers.RotateKey(t.Context(), userId, "", "", "", ""))
-	require.Error(t, dynUsers.ActivateUser(t.Context(), userId))
+	require.Error(t, dynUsers.DeactivateUser(userId, false))
+	require.Error(t, dynUsers.ActivateUser(userId))
+	require.Error(t, dynUsers.RotateKey(userId, "", "", "", ""))
+	require.Error(t, dynUsers.ActivateUser(userId))
 }
 
 func TestLastUsedTime(t *testing.T) {
@@ -281,7 +281,7 @@ func TestLastUsedTime(t *testing.T) {
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(t.Context(), userId, hash, identifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, "", "", time.Now()))
 
 	user, err := dynUsers.GetUsers(userId)
 	require.NoError(t, err)
@@ -333,27 +333,27 @@ func TestImportingAndSuspendingStaticKeys(t *testing.T) {
 	createdAt := time.Now()
 	userId := "user"
 	importedApiKey := "importedApiKey"
-	require.NoError(t, dynUsers.CreateUserWithKey(t.Context(), userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
+	require.NoError(t, dynUsers.CreateUserWithKey(userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
 
 	principal, err := dynUsers.ValidateImportedKey(importedApiKey)
 	require.NoError(t, err)
 	require.NotNil(t, principal)
 	require.Equal(t, userId, principal.Username)
 
-	require.NoError(t, dynUsers.DeactivateUser(t.Context(), userId, true))
+	require.NoError(t, dynUsers.DeactivateUser(userId, true))
 
 	principal, err = dynUsers.ValidateImportedKey(importedApiKey)
 	require.Error(t, err)
 	require.Nil(t, principal)
 
-	require.NoError(t, dynUsers.ActivateUser(t.Context(), userId))
+	require.NoError(t, dynUsers.ActivateUser(userId))
 	principal, err = dynUsers.ValidateImportedKey(importedApiKey)
 	require.Error(t, err)
 	require.Nil(t, principal)
 
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
-	require.NoError(t, dynUsers.RotateKey(t.Context(), userId, apiKey[:3], hash, "imported_"+userId, identifier))
+	require.NoError(t, dynUsers.RotateKey(userId, apiKey[:3], hash, "imported_"+userId, identifier))
 
 	login, _, err := keys.DecodeApiKey(apiKey)
 	require.NoError(t, err)
@@ -372,7 +372,7 @@ func TestImportingStaticKeys(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		userId := "user" + strconv.Itoa(i)
 		importedApiKey := "importedApiKey" + strconv.Itoa(i)
-		require.NoError(t, dynUsers.CreateUserWithKey(t.Context(), userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
+		require.NoError(t, dynUsers.CreateUserWithKey(userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
 
 		principal, err := dynUsers.ValidateImportedKey(importedApiKey)
 		require.NoError(t, err)
@@ -399,7 +399,7 @@ func TestImportingStaticKeys(t *testing.T) {
 
 		apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 		require.NoError(t, err)
-		require.NoError(t, dynUsers.RotateKey(t.Context(), userId, apiKey[:3], hash, "imported_"+userId, identifier))
+		require.NoError(t, dynUsers.RotateKey(userId, apiKey[:3], hash, "imported_"+userId, identifier))
 
 		login, _, err := keys.DecodeApiKey(apiKey)
 		require.NoError(t, err)
@@ -428,7 +428,7 @@ func TestImportingStaticKeysWithTime(t *testing.T) {
 
 	importedApiKey := "importedApiKey"
 	userId := "user"
-	require.NoError(t, dynUsers.CreateUserWithKey(t.Context(), userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
+	require.NoError(t, dynUsers.CreateUserWithKey(userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
 
 	users, err := dynUsers.GetUsers(userId)
 	require.NoError(t, err)
@@ -446,7 +446,7 @@ func TestSnapshotRestoreEmpty(t *testing.T) {
 	_, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(t.Context(), userId, hash, identifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, "", "", time.Now()))
 	user, err := dynUsers.GetUsers(userId)
 	require.NoError(t, err)
 	require.Equal(t, user[userId].Id, userId)
@@ -484,7 +484,7 @@ func TestCreateUserStoresNamespace(t *testing.T) {
 			_, hash, identifier, err := keys.CreateApiKeyAndHash()
 			require.NoError(t, err)
 
-			require.NoError(t, dynUsers.CreateUser(t.Context(), "u1", hash, identifier, "", tc.namespace, time.Now()))
+			require.NoError(t, dynUsers.CreateUser("u1", hash, identifier, "", tc.namespace, time.Now()))
 
 			users, err := dynUsers.GetUsers("u1")
 			require.NoError(t, err)
@@ -510,7 +510,7 @@ func TestSnapshotRestoreMultipleNamespaces(t *testing.T) {
 	for _, s := range seeds {
 		_, hash, identifier, err := keys.CreateApiKeyAndHash()
 		require.NoError(t, err)
-		require.NoError(t, dynUsers.CreateUser(t.Context(), s.userId, hash, identifier, "", s.namespace, time.Now()))
+		require.NoError(t, dynUsers.CreateUser(s.userId, hash, identifier, "", s.namespace, time.Now()))
 	}
 
 	snap, err := dynUsers.Snapshot()
@@ -544,7 +544,7 @@ func TestValidateAndExtractReturnsNamespace(t *testing.T) {
 
 			apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 			require.NoError(t, err)
-			require.NoError(t, dynUsers.CreateUser(t.Context(), "u1", hash, identifier, "", tc.namespace, time.Now()))
+			require.NoError(t, dynUsers.CreateUser("u1", hash, identifier, "", tc.namespace, time.Now()))
 
 			randomKey, _, err := keys.DecodeApiKey(apiKey)
 			require.NoError(t, err)
@@ -572,7 +572,7 @@ func TestUsersInNamespace(t *testing.T) {
 	for _, s := range seeds {
 		_, hash, identifier, err := keys.CreateApiKeyAndHash()
 		require.NoError(t, err)
-		require.NoError(t, dynUsers.CreateUser(t.Context(), s.id, hash, identifier, "", s.namespace, time.Now()))
+		require.NoError(t, dynUsers.CreateUser(s.id, hash, identifier, "", s.namespace, time.Now()))
 	}
 
 	require.ElementsMatch(t, []string{"u-alpha-1", "u-alpha-2"}, dynUsers.UsersInNamespace("alpha"))
@@ -597,7 +597,7 @@ func TestDeleteUsersInNamespace(t *testing.T) {
 		for _, s := range seeds {
 			_, hash, identifier, err := keys.CreateApiKeyAndHash()
 			require.NoError(t, err)
-			require.NoError(t, dynUsers.CreateUser(t.Context(), s.id, hash, identifier, "", s.namespace, time.Now()))
+			require.NoError(t, dynUsers.CreateUser(s.id, hash, identifier, "", s.namespace, time.Now()))
 		}
 
 		require.NoError(t, dynUsers.DeleteUsersInNamespace("alpha"))
@@ -617,7 +617,7 @@ func TestDeleteUsersInNamespace(t *testing.T) {
 
 		_, hash, identifier, err := keys.CreateApiKeyAndHash()
 		require.NoError(t, err)
-		require.NoError(t, dynUsers.CreateUser(t.Context(), "u1", hash, identifier, "", "alpha", time.Now()))
+		require.NoError(t, dynUsers.CreateUser("u1", hash, identifier, "", "alpha", time.Now()))
 
 		require.NoError(t, dynUsers.DeleteUsersInNamespace("alpha"))
 		require.NoError(t, dynUsers.DeleteUsersInNamespace("alpha"))
@@ -630,12 +630,12 @@ func TestDeleteUsersInNamespace(t *testing.T) {
 
 		_, hash, identifier, err := keys.CreateApiKeyAndHash()
 		require.NoError(t, err)
-		require.NoError(t, dynUsers.CreateUser(t.Context(), "u1", hash, identifier, "", "alpha", time.Now()))
+		require.NoError(t, dynUsers.CreateUser("u1", hash, identifier, "", "alpha", time.Now()))
 		require.NoError(t, dynUsers.DeleteUsersInNamespace("alpha"))
 
 		_, hash2, identifier2, err := keys.CreateApiKeyAndHash()
 		require.NoError(t, err)
-		require.NoError(t, dynUsers.CreateUser(t.Context(), "u1", hash2, identifier2, "", "alpha", time.Now()))
+		require.NoError(t, dynUsers.CreateUser("u1", hash2, identifier2, "", "alpha", time.Now()))
 
 		users, err := dynUsers.GetUsers("u1")
 		require.NoError(t, err)
@@ -673,7 +673,7 @@ func TestRestoreIncompleteData(t *testing.T) {
 	importedApiKey := "importedApiKey"
 	userId := "user"
 	createdAt := time.Now().Add(-time.Hour)
-	require.NoError(t, dynUsers2.CreateUserWithKey(t.Context(), userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
+	require.NoError(t, dynUsers2.CreateUserWithKey(userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
 	user, err := dynUsers2.GetUsers(userId)
 	require.NoError(t, err)
 	require.Equal(t, user[userId].Id, userId)

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -557,6 +557,30 @@ func TestValidateAndExtractReturnsNamespace(t *testing.T) {
 	}
 }
 
+func TestUsersInNamespace(t *testing.T) {
+	dynUsers, err := NewDBUser(t.TempDir(), false, log)
+	require.NoError(t, err)
+
+	seeds := []struct {
+		id, namespace string
+	}{
+		{"u-alpha-1", "alpha"},
+		{"u-alpha-2", "alpha"},
+		{"u-beta", "beta"},
+		{"u-unscoped", ""},
+	}
+	for _, s := range seeds {
+		_, hash, identifier, err := keys.CreateApiKeyAndHash()
+		require.NoError(t, err)
+		require.NoError(t, dynUsers.CreateUser(s.id, hash, identifier, "", s.namespace, time.Now()))
+	}
+
+	require.ElementsMatch(t, []string{"u-alpha-1", "u-alpha-2"}, dynUsers.UsersInNamespace("alpha"))
+	require.ElementsMatch(t, []string{"u-beta"}, dynUsers.UsersInNamespace("beta"))
+	require.Empty(t, dynUsers.UsersInNamespace("never-existed"))
+	require.Nil(t, dynUsers.UsersInNamespace(""))
+}
+
 func TestDeleteUsersInNamespace(t *testing.T) {
 	t.Run("removes only matching users", func(t *testing.T) {
 		dynUsers, err := NewDBUser(t.TempDir(), false, log)

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -42,7 +42,7 @@ func TestDynUserConcurrency(t *testing.T) {
 	for i := 0; i < numUsers; i++ {
 		userName := fmt.Sprintf("user%v", i)
 		go func() {
-			err := dynUsers.CreateUser(userName, "something", userName, "", "", time.Now())
+			err := dynUsers.CreateUser(t.Context(), userName, "something", userName, "", "", time.Now())
 			require.NoError(t, err)
 			wg.Done()
 		}()
@@ -64,12 +64,12 @@ func TestConcurrentValidate(t *testing.T) {
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(userId1, hash, identifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(t.Context(), userId1, hash, identifier, "", "", time.Now()))
 
 	apiKey2, hash2, identifier2, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(userId2, hash2, identifier2, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(t.Context(), userId2, hash2, identifier2, "", "", time.Now()))
 
 	randomKey, _, err := keys.DecodeApiKey(apiKey)
 	require.NoError(t, err)
@@ -107,7 +107,7 @@ func TestDynUserTestSlowAfterWeakHash(t *testing.T) {
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(t.Context(), userId, hash, identifier, "", "", time.Now()))
 
 	randomKey, _, err := keys.DecodeApiKey(apiKey)
 	require.NoError(t, err)
@@ -138,7 +138,7 @@ func TestUpdateUser(t *testing.T) {
 	apiKey, hash, oldIdentifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(userId, hash, oldIdentifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(t.Context(), userId, hash, oldIdentifier, "", "", time.Now()))
 
 	// login works
 	randomKeyOld, _, err := keys.DecodeApiKey(apiKey)
@@ -151,7 +151,7 @@ func TestUpdateUser(t *testing.T) {
 	// update key and check that original key does not work, but new one does
 	apiKeyNew, hashNew, newIdentifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
-	require.NoError(t, dynUsers.RotateKey(userId, apiKeyNew[:3], hashNew, oldIdentifier, newIdentifier))
+	require.NoError(t, dynUsers.RotateKey(t.Context(), userId, apiKeyNew[:3], hashNew, oldIdentifier, newIdentifier))
 
 	randomKeyNew, _, err := keys.DecodeApiKey(apiKeyNew)
 	require.NoError(t, err)
@@ -184,13 +184,13 @@ func TestSnapShotAndRestore(t *testing.T) {
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(userId1, hash, identifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(t.Context(), userId1, hash, identifier, "", "", time.Now()))
 	login1, _, err := keys.DecodeApiKey(apiKey)
 	require.NoError(t, err)
 
 	apiKey2, hash2, identifier2, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
-	require.NoError(t, dynUsers.CreateUser(userId2, hash2, identifier2, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(t.Context(), userId2, hash2, identifier2, "", "", time.Now()))
 	login2, _, err := keys.DecodeApiKey(apiKey2)
 	require.NoError(t, err)
 
@@ -211,7 +211,7 @@ func TestSnapShotAndRestore(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, principal2)
 
-	require.NoError(t, dynUsers.DeactivateUser(userId2, true))
+	require.NoError(t, dynUsers.DeactivateUser(t.Context(), userId2, true))
 
 	// create snapshot and restore to an empty new DBUser struct
 	snapShot, err := dynUsers.Snapshot()
@@ -240,7 +240,7 @@ func TestSnapShotAndRestore(t *testing.T) {
 
 	apiKey3, hash3, identifier3, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
-	require.NoError(t, dynUsers2.RotateKey(userId2, apiKey3[:3], hash3, identifier2, identifier3))
+	require.NoError(t, dynUsers2.RotateKey(t.Context(), userId2, apiKey3[:3], hash3, identifier2, identifier3))
 
 	login3, _, err := keys.DecodeApiKey(apiKey3)
 	require.NoError(t, err)
@@ -256,19 +256,19 @@ func TestSuspendAfterDelete(t *testing.T) {
 	_, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(t.Context(), userId, hash, identifier, "", "", time.Now()))
 
 	users, err := dynUsers.GetUsers(userId)
 	require.NoError(t, err)
 	require.Contains(t, users, userId)
 	require.Len(t, users, 1)
 
-	require.NoError(t, dynUsers.DeleteUser(userId))
+	require.NoError(t, dynUsers.DeleteUser(t.Context(), userId))
 
-	require.Error(t, dynUsers.DeactivateUser(userId, false))
-	require.Error(t, dynUsers.ActivateUser(userId))
-	require.Error(t, dynUsers.RotateKey(userId, "", "", "", ""))
-	require.Error(t, dynUsers.ActivateUser(userId))
+	require.Error(t, dynUsers.DeactivateUser(t.Context(), userId, false))
+	require.Error(t, dynUsers.ActivateUser(t.Context(), userId))
+	require.Error(t, dynUsers.RotateKey(t.Context(), userId, "", "", "", ""))
+	require.Error(t, dynUsers.ActivateUser(t.Context(), userId))
 }
 
 func TestLastUsedTime(t *testing.T) {
@@ -281,7 +281,7 @@ func TestLastUsedTime(t *testing.T) {
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(t.Context(), userId, hash, identifier, "", "", time.Now()))
 
 	user, err := dynUsers.GetUsers(userId)
 	require.NoError(t, err)
@@ -333,27 +333,27 @@ func TestImportingAndSuspendingStaticKeys(t *testing.T) {
 	createdAt := time.Now()
 	userId := "user"
 	importedApiKey := "importedApiKey"
-	require.NoError(t, dynUsers.CreateUserWithKey(userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
+	require.NoError(t, dynUsers.CreateUserWithKey(t.Context(), userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
 
 	principal, err := dynUsers.ValidateImportedKey(importedApiKey)
 	require.NoError(t, err)
 	require.NotNil(t, principal)
 	require.Equal(t, userId, principal.Username)
 
-	require.NoError(t, dynUsers.DeactivateUser(userId, true))
+	require.NoError(t, dynUsers.DeactivateUser(t.Context(), userId, true))
 
 	principal, err = dynUsers.ValidateImportedKey(importedApiKey)
 	require.Error(t, err)
 	require.Nil(t, principal)
 
-	require.NoError(t, dynUsers.ActivateUser(userId))
+	require.NoError(t, dynUsers.ActivateUser(t.Context(), userId))
 	principal, err = dynUsers.ValidateImportedKey(importedApiKey)
 	require.Error(t, err)
 	require.Nil(t, principal)
 
 	apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
-	require.NoError(t, dynUsers.RotateKey(userId, apiKey[:3], hash, "imported_"+userId, identifier))
+	require.NoError(t, dynUsers.RotateKey(t.Context(), userId, apiKey[:3], hash, "imported_"+userId, identifier))
 
 	login, _, err := keys.DecodeApiKey(apiKey)
 	require.NoError(t, err)
@@ -372,7 +372,7 @@ func TestImportingStaticKeys(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		userId := "user" + strconv.Itoa(i)
 		importedApiKey := "importedApiKey" + strconv.Itoa(i)
-		require.NoError(t, dynUsers.CreateUserWithKey(userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
+		require.NoError(t, dynUsers.CreateUserWithKey(t.Context(), userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
 
 		principal, err := dynUsers.ValidateImportedKey(importedApiKey)
 		require.NoError(t, err)
@@ -399,7 +399,7 @@ func TestImportingStaticKeys(t *testing.T) {
 
 		apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 		require.NoError(t, err)
-		require.NoError(t, dynUsers.RotateKey(userId, apiKey[:3], hash, "imported_"+userId, identifier))
+		require.NoError(t, dynUsers.RotateKey(t.Context(), userId, apiKey[:3], hash, "imported_"+userId, identifier))
 
 		login, _, err := keys.DecodeApiKey(apiKey)
 		require.NoError(t, err)
@@ -428,7 +428,7 @@ func TestImportingStaticKeysWithTime(t *testing.T) {
 
 	importedApiKey := "importedApiKey"
 	userId := "user"
-	require.NoError(t, dynUsers.CreateUserWithKey(userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
+	require.NoError(t, dynUsers.CreateUserWithKey(t.Context(), userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
 
 	users, err := dynUsers.GetUsers(userId)
 	require.NoError(t, err)
@@ -446,7 +446,7 @@ func TestSnapshotRestoreEmpty(t *testing.T) {
 	_, hash, identifier, err := keys.CreateApiKeyAndHash()
 	require.NoError(t, err)
 
-	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, "", "", time.Now()))
+	require.NoError(t, dynUsers.CreateUser(t.Context(), userId, hash, identifier, "", "", time.Now()))
 	user, err := dynUsers.GetUsers(userId)
 	require.NoError(t, err)
 	require.Equal(t, user[userId].Id, userId)
@@ -484,7 +484,7 @@ func TestCreateUserStoresNamespace(t *testing.T) {
 			_, hash, identifier, err := keys.CreateApiKeyAndHash()
 			require.NoError(t, err)
 
-			require.NoError(t, dynUsers.CreateUser("u1", hash, identifier, "", tc.namespace, time.Now()))
+			require.NoError(t, dynUsers.CreateUser(t.Context(), "u1", hash, identifier, "", tc.namespace, time.Now()))
 
 			users, err := dynUsers.GetUsers("u1")
 			require.NoError(t, err)
@@ -510,7 +510,7 @@ func TestSnapshotRestoreMultipleNamespaces(t *testing.T) {
 	for _, s := range seeds {
 		_, hash, identifier, err := keys.CreateApiKeyAndHash()
 		require.NoError(t, err)
-		require.NoError(t, dynUsers.CreateUser(s.userId, hash, identifier, "", s.namespace, time.Now()))
+		require.NoError(t, dynUsers.CreateUser(t.Context(), s.userId, hash, identifier, "", s.namespace, time.Now()))
 	}
 
 	snap, err := dynUsers.Snapshot()
@@ -544,7 +544,7 @@ func TestValidateAndExtractReturnsNamespace(t *testing.T) {
 
 			apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 			require.NoError(t, err)
-			require.NoError(t, dynUsers.CreateUser("u1", hash, identifier, "", tc.namespace, time.Now()))
+			require.NoError(t, dynUsers.CreateUser(t.Context(), "u1", hash, identifier, "", tc.namespace, time.Now()))
 
 			randomKey, _, err := keys.DecodeApiKey(apiKey)
 			require.NoError(t, err)
@@ -572,7 +572,7 @@ func TestUsersInNamespace(t *testing.T) {
 	for _, s := range seeds {
 		_, hash, identifier, err := keys.CreateApiKeyAndHash()
 		require.NoError(t, err)
-		require.NoError(t, dynUsers.CreateUser(s.id, hash, identifier, "", s.namespace, time.Now()))
+		require.NoError(t, dynUsers.CreateUser(t.Context(), s.id, hash, identifier, "", s.namespace, time.Now()))
 	}
 
 	require.ElementsMatch(t, []string{"u-alpha-1", "u-alpha-2"}, dynUsers.UsersInNamespace("alpha"))
@@ -597,7 +597,7 @@ func TestDeleteUsersInNamespace(t *testing.T) {
 		for _, s := range seeds {
 			_, hash, identifier, err := keys.CreateApiKeyAndHash()
 			require.NoError(t, err)
-			require.NoError(t, dynUsers.CreateUser(s.id, hash, identifier, "", s.namespace, time.Now()))
+			require.NoError(t, dynUsers.CreateUser(t.Context(), s.id, hash, identifier, "", s.namespace, time.Now()))
 		}
 
 		require.NoError(t, dynUsers.DeleteUsersInNamespace("alpha"))
@@ -617,7 +617,7 @@ func TestDeleteUsersInNamespace(t *testing.T) {
 
 		_, hash, identifier, err := keys.CreateApiKeyAndHash()
 		require.NoError(t, err)
-		require.NoError(t, dynUsers.CreateUser("u1", hash, identifier, "", "alpha", time.Now()))
+		require.NoError(t, dynUsers.CreateUser(t.Context(), "u1", hash, identifier, "", "alpha", time.Now()))
 
 		require.NoError(t, dynUsers.DeleteUsersInNamespace("alpha"))
 		require.NoError(t, dynUsers.DeleteUsersInNamespace("alpha"))
@@ -630,12 +630,12 @@ func TestDeleteUsersInNamespace(t *testing.T) {
 
 		_, hash, identifier, err := keys.CreateApiKeyAndHash()
 		require.NoError(t, err)
-		require.NoError(t, dynUsers.CreateUser("u1", hash, identifier, "", "alpha", time.Now()))
+		require.NoError(t, dynUsers.CreateUser(t.Context(), "u1", hash, identifier, "", "alpha", time.Now()))
 		require.NoError(t, dynUsers.DeleteUsersInNamespace("alpha"))
 
 		_, hash2, identifier2, err := keys.CreateApiKeyAndHash()
 		require.NoError(t, err)
-		require.NoError(t, dynUsers.CreateUser("u1", hash2, identifier2, "", "alpha", time.Now()))
+		require.NoError(t, dynUsers.CreateUser(t.Context(), "u1", hash2, identifier2, "", "alpha", time.Now()))
 
 		users, err := dynUsers.GetUsers("u1")
 		require.NoError(t, err)
@@ -673,7 +673,7 @@ func TestRestoreIncompleteData(t *testing.T) {
 	importedApiKey := "importedApiKey"
 	userId := "user"
 	createdAt := time.Now().Add(-time.Hour)
-	require.NoError(t, dynUsers2.CreateUserWithKey(userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
+	require.NoError(t, dynUsers2.CreateUserWithKey(t.Context(), userId, importedApiKey[:3], sha256.Sum256([]byte(importedApiKey)), createdAt))
 	user, err := dynUsers2.GetUsers(userId)
 	require.NoError(t, err)
 	require.Equal(t, user[userId].Id, userId)

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -12,6 +12,7 @@
 package apikey
 
 import (
+	"context"
 	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/json"
@@ -50,14 +51,18 @@ func MakeUserKey(userId, namespace string) string {
 	return namespacing.QualifiedName(namespace, userId)
 }
 
+// DBUsers is implemented by both the in-process storage (*DBUser) and the
+// cluster apply path (*cluster.Raft). Write methods accept a context so
+// the cluster implementation can propagate request cancellation through
+// RAFT; the storage implementation accepts but does not consult it.
 type DBUsers interface {
-	CreateUser(userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace string, createdAt time.Time) error
-	CreateUserWithKey(userId, apiKeyFirstLetters string, weakHash [sha256.Size]byte, createdAt time.Time) error
-	DeleteUser(userId string) error
-	ActivateUser(userId string) error
-	DeactivateUser(userId string, revokeKey bool) error
+	CreateUser(ctx context.Context, userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace string, createdAt time.Time) error
+	CreateUserWithKey(ctx context.Context, userId, apiKeyFirstLetters string, weakHash [sha256.Size]byte, createdAt time.Time) error
+	DeleteUser(ctx context.Context, userId string) error
+	ActivateUser(ctx context.Context, userId string) error
+	DeactivateUser(ctx context.Context, userId string, revokeKey bool) error
 	GetUsers(userIds ...string) (map[string]*User, error)
-	RotateKey(userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier string) error
+	RotateKey(ctx context.Context, userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier string) error
 	CheckUserIdentifierExists(userIdentifier string) (bool, error)
 }
 
@@ -190,7 +195,7 @@ func restoreAllFields(data dbUserdata) dbUserdata {
 	return data
 }
 
-func (c *DBUser) CreateUser(userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace string, createdAt time.Time) error {
+func (c *DBUser) CreateUser(_ context.Context, userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace string, createdAt time.Time) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -212,7 +217,7 @@ func (c *DBUser) CreateUser(userId, secureHash, userIdentifier, apiKeyFirstLette
 	return c.storeToFile()
 }
 
-func (c *DBUser) CreateUserWithKey(userId, apiKeyFirstLetters string, weakHash [sha256.Size]byte, createdAt time.Time) error {
+func (c *DBUser) CreateUserWithKey(_ context.Context, userId, apiKeyFirstLetters string, weakHash [sha256.Size]byte, createdAt time.Time) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -233,7 +238,7 @@ func (c *DBUser) CreateUserWithKey(userId, apiKeyFirstLetters string, weakHash [
 	return c.storeToFile()
 }
 
-func (c *DBUser) RotateKey(userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier string) error {
+func (c *DBUser) RotateKey(_ context.Context, userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier string) error {
 	if len(apiKeyFirstLetters) > 3 {
 		return errors.New("api key first letters too long")
 	}
@@ -265,7 +270,7 @@ func (c *DBUser) RotateKey(userId, apiKeyFirstLetters, secureHash, oldIdentifier
 	return c.storeToFile()
 }
 
-func (c *DBUser) DeleteUser(userId string) error {
+func (c *DBUser) DeleteUser(_ context.Context, userId string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -331,7 +336,7 @@ func (c *DBUser) DeleteUsersInNamespace(namespace string) error {
 	return c.storeToFile()
 }
 
-func (c *DBUser) ActivateUser(userId string) error {
+func (c *DBUser) ActivateUser(_ context.Context, userId string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -343,7 +348,7 @@ func (c *DBUser) ActivateUser(userId string) error {
 	return c.storeToFile()
 }
 
-func (c *DBUser) DeactivateUser(userId string, revokeKey bool) error {
+func (c *DBUser) DeactivateUser(_ context.Context, userId string, revokeKey bool) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if _, ok := c.data.Users[userId]; !ok {

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -287,6 +287,11 @@ func (c *DBUser) deleteUserLocked(userId string) {
 
 // UsersInNamespace returns the IDs of users bound to namespace in
 // unspecified order. An empty namespace returns nil.
+//
+// The returned IDs are the internal qualified storage keys
+// ([MakeUserKey] form, e.g. "alpha:bob"), not the bare short IDs the
+// caller passed to CreateUser. Treat them as opaque handles for
+// existence/count checks; do not surface them in user-facing responses.
 func (c *DBUser) UsersInNamespace(namespace string) []string {
 	if namespace == "" {
 		return nil

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -288,10 +288,11 @@ func (c *DBUser) deleteUserLocked(userId string) {
 // UsersInNamespace returns the IDs of users bound to namespace in
 // unspecified order. An empty namespace returns nil.
 //
-// The returned IDs are the internal qualified storage keys
-// ([MakeUserKey] form, e.g. "alpha:bob"), not the bare short IDs the
-// caller passed to CreateUser. Treat them as opaque handles for
-// existence/count checks; do not surface them in user-facing responses.
+// The returned IDs are whatever userId was passed to CreateUser. In the
+// namespaced-handler path that is the [MakeUserKey] qualified form (e.g.
+// "alpha:bob"); DBUser itself does not enforce that shape. Treat them as
+// opaque handles for existence/count checks; do not surface them in
+// user-facing responses.
 func (c *DBUser) UsersInNamespace(namespace string) []string {
 	if namespace == "" {
 		return nil
@@ -317,17 +318,15 @@ func (c *DBUser) DeleteUsersInNamespace(namespace string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
-	matches := make([]string, 0)
+	deleted := false
 	for id, u := range c.data.Users {
 		if u != nil && u.Namespace == namespace {
-			matches = append(matches, id)
+			c.deleteUserLocked(id)
+			deleted = true
 		}
 	}
-	if len(matches) == 0 {
+	if !deleted {
 		return nil
-	}
-	for _, id := range matches {
-		c.deleteUserLocked(id)
 	}
 	return c.storeToFile()
 }

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -269,6 +269,13 @@ func (c *DBUser) DeleteUser(userId string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
+	c.deleteUserLocked(userId)
+	return c.storeToFile()
+}
+
+// deleteUserLocked removes userId from every in-memory map. Caller must
+// hold the write lock and call storeToFile.
+func (c *DBUser) deleteUserLocked(userId string) {
 	delete(c.data.SecureKeyStorageById, userId)
 	delete(c.data.IdentifierToId, c.data.IdToIdentifier[userId])
 	delete(c.data.IdToIdentifier, userId)
@@ -276,6 +283,29 @@ func (c *DBUser) DeleteUser(userId string) error {
 	c.memoryOnlyData.weakKeyStorageById.Delete(userId)
 	delete(c.data.UserKeyRevoked, userId)
 	delete(c.data.ImportedApiKeysWeakHash, userId)
+}
+
+// DeleteUsersInNamespace removes every user bound to namespace. An empty
+// namespace argument is rejected so the helper cannot wipe unscoped users.
+func (c *DBUser) DeleteUsersInNamespace(namespace string) error {
+	if namespace == "" {
+		return errors.New("namespace is required")
+	}
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	matches := make([]string, 0)
+	for id, u := range c.data.Users {
+		if u != nil && u.Namespace == namespace {
+			matches = append(matches, id)
+		}
+	}
+	if len(matches) == 0 {
+		return nil
+	}
+	for _, id := range matches {
+		c.deleteUserLocked(id)
+	}
 	return c.storeToFile()
 }
 

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -51,10 +51,9 @@ func MakeUserKey(userId, namespace string) string {
 	return namespacing.QualifiedName(namespace, userId)
 }
 
-// DBUsers is implemented by both the in-process storage (*DBUser) and the
-// cluster apply path (*cluster.Raft). Write methods accept a context so
-// the cluster implementation can propagate request cancellation through
-// RAFT; the storage implementation accepts but does not consult it.
+// DBUsers is the cluster-side interface implemented by *cluster.Raft.
+// Write methods accept a context so the implementation can propagate
+// request cancellation through RAFT.
 type DBUsers interface {
 	CreateUser(ctx context.Context, userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace string, createdAt time.Time) error
 	CreateUserWithKey(ctx context.Context, userId, apiKeyFirstLetters string, weakHash [sha256.Size]byte, createdAt time.Time) error
@@ -195,7 +194,7 @@ func restoreAllFields(data dbUserdata) dbUserdata {
 	return data
 }
 
-func (c *DBUser) CreateUser(_ context.Context, userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace string, createdAt time.Time) error {
+func (c *DBUser) CreateUser(userId, secureHash, userIdentifier, apiKeyFirstLetters, namespace string, createdAt time.Time) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -217,7 +216,7 @@ func (c *DBUser) CreateUser(_ context.Context, userId, secureHash, userIdentifie
 	return c.storeToFile()
 }
 
-func (c *DBUser) CreateUserWithKey(_ context.Context, userId, apiKeyFirstLetters string, weakHash [sha256.Size]byte, createdAt time.Time) error {
+func (c *DBUser) CreateUserWithKey(userId, apiKeyFirstLetters string, weakHash [sha256.Size]byte, createdAt time.Time) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -238,7 +237,7 @@ func (c *DBUser) CreateUserWithKey(_ context.Context, userId, apiKeyFirstLetters
 	return c.storeToFile()
 }
 
-func (c *DBUser) RotateKey(_ context.Context, userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier string) error {
+func (c *DBUser) RotateKey(userId, apiKeyFirstLetters, secureHash, oldIdentifier, newIdentifier string) error {
 	if len(apiKeyFirstLetters) > 3 {
 		return errors.New("api key first letters too long")
 	}
@@ -270,7 +269,7 @@ func (c *DBUser) RotateKey(_ context.Context, userId, apiKeyFirstLetters, secure
 	return c.storeToFile()
 }
 
-func (c *DBUser) DeleteUser(_ context.Context, userId string) error {
+func (c *DBUser) DeleteUser(userId string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -336,7 +335,7 @@ func (c *DBUser) DeleteUsersInNamespace(namespace string) error {
 	return c.storeToFile()
 }
 
-func (c *DBUser) ActivateUser(_ context.Context, userId string) error {
+func (c *DBUser) ActivateUser(userId string) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 
@@ -348,7 +347,7 @@ func (c *DBUser) ActivateUser(_ context.Context, userId string) error {
 	return c.storeToFile()
 }
 
-func (c *DBUser) DeactivateUser(_ context.Context, userId string, revokeKey bool) error {
+func (c *DBUser) DeactivateUser(userId string, revokeKey bool) error {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	if _, ok := c.data.Users[userId]; !ok {

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -285,6 +285,24 @@ func (c *DBUser) deleteUserLocked(userId string) {
 	delete(c.data.ImportedApiKeysWeakHash, userId)
 }
 
+// UsersInNamespace returns the IDs of users bound to namespace in
+// unspecified order. An empty namespace returns nil.
+func (c *DBUser) UsersInNamespace(namespace string) []string {
+	if namespace == "" {
+		return nil
+	}
+	c.lock.RLock()
+	defer c.lock.RUnlock()
+
+	out := make([]string, 0)
+	for id, u := range c.data.Users {
+		if u != nil && u.Namespace == namespace {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
 // DeleteUsersInNamespace removes every user bound to namespace. An empty
 // namespace argument is rejected so the helper cannot wipe unscoped users.
 func (c *DBUser) DeleteUsersInNamespace(namespace string) error {

--- a/usecases/auth/authentication/apikey/wrapper_test.go
+++ b/usecases/auth/authentication/apikey/wrapper_test.go
@@ -126,7 +126,7 @@ func TestValidDynamicKey(t *testing.T) {
 			apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 			require.NoError(t, err)
 
-			require.NoError(t, wrapper.Dynamic.CreateUser(t.Context(), userId, hash, identifier, "", "", time.Now()))
+			require.NoError(t, wrapper.Dynamic.CreateUser(userId, hash, identifier, "", "", time.Now()))
 
 			principal, err := wrapper.ValidateAndExtract(apiKey, nil)
 			if testCase.expectError {

--- a/usecases/auth/authentication/apikey/wrapper_test.go
+++ b/usecases/auth/authentication/apikey/wrapper_test.go
@@ -126,7 +126,7 @@ func TestValidDynamicKey(t *testing.T) {
 			apiKey, hash, identifier, err := keys.CreateApiKeyAndHash()
 			require.NoError(t, err)
 
-			require.NoError(t, wrapper.Dynamic.CreateUser(userId, hash, identifier, "", "", time.Now()))
+			require.NoError(t, wrapper.Dynamic.CreateUser(t.Context(), userId, hash, identifier, "", "", time.Now()))
 
 			principal, err := wrapper.ValidateAndExtract(apiKey, nil)
 			if testCase.expectError {

--- a/usecases/auth/authentication/oidc/middleware.go
+++ b/usecases/auth/authentication/oidc/middleware.go
@@ -278,10 +278,11 @@ func (c *Client) classifyPrincipal(claims map[string]interface{}, username strin
 	case nsValue != "" && globalSet && globalValue:
 		return "", false, errors.New(401, "unauthorized: token must not carry both a namespace claim and a global-principal claim set to true")
 	case nsValue != "":
-		if !c.nsExister.Exists(nsValue) {
-			return "", false, errors.New(401, "unauthorized: namespace '%s' does not exist", nsValue)
+		// Error message is intentionally vague to avoid leaking namespace
+		// existence to unauthenticated clients.
+		if !c.nsExister.IsActive(nsValue) {
+			return "", false, errors.New(401, "unauthorized: namespace '%s' does not exist or is being deleted", nsValue)
 		}
-		// TODO: also reject when namespace is in 'deleting' state.
 		return nsValue, false, nil
 	case globalSet && globalValue:
 		return "", true, nil

--- a/usecases/auth/authentication/oidc/middleware_test.go
+++ b/usecases/auth/authentication/oidc/middleware_test.go
@@ -425,6 +425,12 @@ func (f *fakeExister) Exists(name string) bool {
 	return ok
 }
 
+// IsActive treats every known namespace as active.
+func (f *fakeExister) IsActive(name string) bool {
+	_, ok := f.known[name]
+	return ok
+}
+
 // TestClassifyPrincipal exercises the per-token classification matrix.
 // The fake exister recognizes only "customer1", covering the rejection path.
 func TestClassifyPrincipal(t *testing.T) {

--- a/usecases/auth/authentication/oidc/middleware_test.go
+++ b/usecases/auth/authentication/oidc/middleware_test.go
@@ -407,9 +407,11 @@ func Test_Middleware_CertificateDownload(t *testing.T) {
 }
 
 // fakeExister is a minimal namespaces.Exister stub for classifyPrincipal
-// matrix testing. Names in the map are treated as existing.
+// matrix testing. Names in `known` are active; names in `deleting` exist
+// but are not active.
 type fakeExister struct {
-	known map[string]struct{}
+	known    map[string]struct{}
+	deleting map[string]struct{}
 }
 
 func newFakeExister(names ...string) *fakeExister {
@@ -417,15 +419,23 @@ func newFakeExister(names ...string) *fakeExister {
 	for _, n := range names {
 		m[n] = struct{}{}
 	}
-	return &fakeExister{known: m}
+	return &fakeExister{known: m, deleting: map[string]struct{}{}}
+}
+
+// markDeleting flips name from active to deleting.
+func (f *fakeExister) markDeleting(name string) {
+	delete(f.known, name)
+	f.deleting[name] = struct{}{}
 }
 
 func (f *fakeExister) Exists(name string) bool {
-	_, ok := f.known[name]
+	if _, ok := f.known[name]; ok {
+		return true
+	}
+	_, ok := f.deleting[name]
 	return ok
 }
 
-// IsActive treats every known namespace as active.
 func (f *fakeExister) IsActive(name string) bool {
 	_, ok := f.known[name]
 	return ok
@@ -451,6 +461,7 @@ func TestClassifyPrincipal(t *testing.T) {
 		namespacesEnabled bool
 		username          string
 		claims            map[string]any
+		markDeleting      string // optional: flip this namespace to deleting before classify
 		want              want
 	}{
 		{
@@ -521,7 +532,15 @@ func TestClassifyPrincipal(t *testing.T) {
 			namespacesEnabled: true,
 			username:          "alice",
 			claims:            map[string]any{nsClaimKey: "ghost"},
-			want:              want{errCode: 401, errSubstr: "namespace 'ghost' does not exist"},
+			want:              want{errCode: 401, errSubstr: "namespace 'ghost'"},
+		},
+		{
+			name:              "NS-enabled, namespace claim names a deleting namespace → reject",
+			namespacesEnabled: true,
+			username:          "alice",
+			claims:            map[string]any{nsClaimKey: "customer1"},
+			markDeleting:      "customer1",
+			want:              want{errCode: 401, errSubstr: "namespace 'customer1'"},
 		},
 		{
 			name:              "NS-enabled, namespace claim type mismatch → reject",
@@ -548,12 +567,16 @@ func TestClassifyPrincipal(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			exister := newFakeExister("customer1")
+			if tt.markDeleting != "" {
+				exister.markDeleting(tt.markDeleting)
+			}
 			c := &Client{
 				Config: config.OIDC{
 					NamespaceClaim:       runtime.NewDynamicValue(nsClaimKey),
 					GlobalPrincipalClaim: runtime.NewDynamicValue(globalClaimKey),
 				},
-				nsExister:         newFakeExister("customer1"),
+				nsExister:         exister,
 				namespacesEnabled: tt.namespacesEnabled,
 			}
 			// On NS-disabled the classifier must work even if the claim

--- a/usecases/config/config_handler.go
+++ b/usecases/config/config_handler.go
@@ -729,6 +729,10 @@ type Export struct {
 // already-populated cluster; startup invariants refuse such configurations.
 type Namespaces struct {
 	Enabled bool `json:"enabled" yaml:"enabled"`
+
+	// CleanupInterval drives the deleting-namespace sweep on the leader.
+	// NAMESPACE_CLEANUP_INTERVAL; <= 0 disables.
+	CleanupInterval *runtime.DynamicValue[time.Duration] `json:"cleanup_interval" yaml:"cleanup_interval"`
 }
 
 const (

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -61,6 +61,8 @@ const (
 	DefaultTransferInactivityTimeout = 5 * time.Minute
 
 	DefaultTrackVectorDimensionsInterval = 5 * time.Minute
+
+	DefaultNamespaceCleanupInterval = 30 * time.Second
 )
 
 // FromEnv takes a *Config as it will respect initial config that has been
@@ -986,6 +988,13 @@ func FromEnv(config *Config) error {
 	config.DisableGraphQL = entcfg.Enabled(os.Getenv("DISABLE_GRAPHQL"))
 
 	config.Namespaces.Enabled = entcfg.Enabled(os.Getenv("NAMESPACES_ENABLED"))
+
+	if err := parser.ParseDynamicDurationWithValidation("NAMESPACE_CLEANUP_INTERVAL",
+		DefaultNamespaceCleanupInterval,
+		parser.ValidateDurationGreaterThanEqual0,
+		func(val *configRuntime.DynamicValue[time.Duration]) { config.Namespaces.CleanupInterval = val }); err != nil {
+		return err
+	}
 
 	if config.Raft, err = parseRAFTConfig(config.Cluster.Hostname); err != nil {
 		return fmt.Errorf("parse raft config: %w", err)

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -72,6 +72,8 @@ type WeaviateRuntimeConfig struct {
 	DefaultVectorIndexType                    *runtime.DynamicValue[string]        `yaml:"default_vector_index" json:"default_vector_index"`
 	DefaultShardingCount                      *runtime.DynamicValue[int]           `yaml:"default_sharding_count" json:"default_sharding_count"`
 
+	NamespaceCleanupInterval *runtime.DynamicValue[time.Duration] `json:"namespace_cleanup_interval" yaml:"namespace_cleanup_interval"`
+
 	ObjectsTTLDeleteSchedule      *runtime.DynamicValue[string]        `json:"objects_ttl_delete_schedule" yaml:"objects_ttl_delete_schedule"`
 	ObjectsTTLBatchSize           *runtime.DynamicValue[int]           `json:"objects_ttl_batch_size" yaml:"objects_ttl_batch_size"`
 	ObjectsTTLPauseEveryNoBatches *runtime.DynamicValue[int]           `json:"objects_ttl_pause_every_no_batches" yaml:"objects_ttl_pause_every_no_batches"`

--- a/usecases/cron/gocron.go
+++ b/usecases/cron/gocron.go
@@ -23,13 +23,15 @@ import (
 	"github.com/weaviate/weaviate/entities/cron"
 	"github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/config"
+	namespacecleanup "github.com/weaviate/weaviate/usecases/namespace_cleanup"
 	objectttl "github.com/weaviate/weaviate/usecases/object_ttl"
 )
 
 type configGetter func() config.Config
 
 type Crons struct {
-	objectsttl *cronsObjectsTTL
+	objectsttl       *cronsObjectsTTL
+	namespaceCleanup *cronsNamespaceCleanup
 
 	logger            logrus.FieldLogger
 	gocronLogger      gocron.Logger
@@ -42,6 +44,7 @@ func NewCrons(serverShutdownCtx context.Context, logger logrus.FieldLogger, conf
 
 	return &Crons{
 		objectsttl:        newCronsObjectsTTL(serverShutdownCtx, logger, gocronLogger, configGetter),
+		namespaceCleanup:  newCronsNamespaceCleanup(serverShutdownCtx, logger, gocronLogger, configGetter),
 		logger:            logger,
 		gocronLogger:      gocronLogger,
 		serverShutdownCtx: serverShutdownCtx,
@@ -49,11 +52,17 @@ func NewCrons(serverShutdownCtx context.Context, logger logrus.FieldLogger, conf
 }
 
 // blocking
-func (c *Crons) Init(clusterService *cluster.Service, coordinator *objectttl.Coordinator) error {
+func (c *Crons) Init(clusterService *cluster.Service, ttlCoordinator *objectttl.Coordinator,
+	nsCleanupCoordinator *namespacecleanup.Coordinator,
+) error {
 	cr := initGoCron(c.serverShutdownCtx, c.gocronLogger)
 
-	if err := c.objectsttl.Init(cr, clusterService, coordinator); err != nil {
+	if err := c.objectsttl.Init(cr, clusterService, ttlCoordinator); err != nil {
 		return fmt.Errorf("init objects ttl cron: %w", err)
+	}
+
+	if err := c.namespaceCleanup.Init(cr, clusterService, nsCleanupCoordinator); err != nil {
+		return fmt.Errorf("init namespace cleanup cron: %w", err)
 	}
 
 	cr.Start()
@@ -65,7 +74,8 @@ func (c *Crons) Init(clusterService *cluster.Service, coordinator *objectttl.Coo
 
 func (c *Crons) RuntimeConfigHooks() map[string]func() error {
 	return map[string]func() error{
-		"ObjectsTTL": c.objectsttl.RuntimeConfigHook,
+		"ObjectsTTL":       c.objectsttl.RuntimeConfigHook,
+		"NamespaceCleanup": c.namespaceCleanup.RuntimeConfigHook,
 	}
 }
 

--- a/usecases/cron/namespace_cleanup.go
+++ b/usecases/cron/namespace_cleanup.go
@@ -1,0 +1,157 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cron
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	gocron "github.com/netresearch/go-cron"
+	"github.com/sirupsen/logrus"
+
+	"github.com/weaviate/weaviate/cluster"
+	"github.com/weaviate/weaviate/entities/errors"
+	namespacecleanup "github.com/weaviate/weaviate/usecases/namespace_cleanup"
+)
+
+const namespaceCleanupJobName = "namespace_cleanup"
+
+// cronsNamespaceCleanup runs Coordinator.Tick on a configurable interval.
+// The interval is read from runtime config and hot-reloads via
+// RuntimeConfigHook.
+type cronsNamespaceCleanup struct {
+	currentInterval atomic.Int64 // time.Duration nanoseconds
+	intervalCh      chan time.Duration
+
+	logger            logrus.FieldLogger
+	gocronLogger      gocron.Logger
+	configGetter      configGetter
+	serverShutdownCtx context.Context
+}
+
+func newCronsNamespaceCleanup(serverShutdownCtx context.Context,
+	logger logrus.FieldLogger, gocronLogger gocron.Logger, configGetter configGetter,
+) *cronsNamespaceCleanup {
+	current := configGetter().Namespaces.CleanupInterval.Get()
+	intervalCh := make(chan time.Duration, 1)
+	intervalCh <- current
+
+	c := &cronsNamespaceCleanup{
+		intervalCh:        intervalCh,
+		logger:            logger,
+		gocronLogger:      gocronLogger,
+		configGetter:      configGetter,
+		serverShutdownCtx: serverShutdownCtx,
+	}
+	c.currentInterval.Store(int64(current))
+	return c
+}
+
+// Init launches a goroutine that registers (and re-registers, on
+// interval changes) the cleanup job. Returns immediately when namespaces
+// are disabled. Rejects a nil coordinator.
+func (c *cronsNamespaceCleanup) Init(cr *gocron.Cron, clusterService *cluster.Service,
+	coordinator *namespacecleanup.Coordinator,
+) error {
+	if !c.configGetter().Namespaces.Enabled {
+		c.logger.WithField("job", namespaceCleanupJobName).Info("cron job skipped, namespaces disabled")
+		return nil
+	}
+	if coordinator == nil {
+		return fmt.Errorf("namespace cleanup coordinator is nil")
+	}
+	errors.GoWrapper(func() {
+		jobLogger := c.logger.WithField("job", namespaceCleanupJobName)
+		wgRunning := new(sync.WaitGroup)
+
+		for {
+			select {
+			case interval := <-c.intervalCh:
+				if cr.RemoveByName(namespaceCleanupJobName) {
+					jobLogger.Info("cron job removed")
+				}
+				if interval <= 0 {
+					jobLogger.Info("cron job skipped, interval <= 0")
+					continue
+				}
+
+				wgRunning.Wait()
+				select {
+				case <-c.serverShutdownCtx.Done():
+					jobLogger.Debug("server shutdown context cancelled")
+					return
+				default:
+				}
+
+				schedule := fmt.Sprintf("@every %s", interval)
+				job := c.createJob(jobLogger, clusterService, coordinator, wgRunning)
+				entryId, err := cr.AddJob(schedule, job, gocron.WithName(namespaceCleanupJobName))
+				if err != nil {
+					jobLogger.WithError(err).Error("cron job not added")
+					continue
+				}
+				jobLogger.WithFields(logrus.Fields{
+					"entry_id": entryId,
+					"schedule": schedule,
+				}).Info("cron job added")
+
+			case <-c.serverShutdownCtx.Done():
+				jobLogger.Debug("server shutdown context cancelled")
+				return
+			}
+		}
+	}, c.logger)
+
+	return nil
+}
+
+// createJob returns the per-tick callback. SkipIfStillRunning prevents
+// overlap at the cron layer; the coordinator additionally guards against
+// concurrent ticks.
+func (c *cronsNamespaceCleanup) createJob(jobLogger logrus.FieldLogger,
+	clusterService *cluster.Service, coordinator *namespacecleanup.Coordinator,
+	wgRunning *sync.WaitGroup,
+) gocron.Job {
+	return gocron.NewChain(
+		gocron.SkipIfStillRunning(c.gocronLogger),
+	).Then(gocron.FuncJob(func() {
+		wgRunning.Add(1)
+		defer wgRunning.Done()
+
+		if !clusterService.IsLeader() {
+			return
+		}
+		if err := coordinator.Tick(c.serverShutdownCtx); err != nil {
+			jobLogger.WithError(err).Error("namespace cleanup tick failed")
+		}
+	}))
+}
+
+// RuntimeConfigHook re-reads the interval from config; on change, pushes
+// the new value to the registration loop.
+func (c *cronsNamespaceCleanup) RuntimeConfigHook() error {
+	newInterval := int64(c.configGetter().Namespaces.CleanupInterval.Get())
+	old := c.currentInterval.Load()
+	if old == newInterval || !c.currentInterval.CompareAndSwap(old, newInterval) {
+		return nil
+	}
+
+	select {
+	case <-c.intervalCh:
+	default:
+	}
+	c.intervalCh <- time.Duration(newInterval)
+	return nil
+}

--- a/usecases/cron/namespace_cleanup.go
+++ b/usecases/cron/namespace_cleanup.go
@@ -74,7 +74,12 @@ func (c *cronsNamespaceCleanup) Init(cr *gocron.Cron, clusterService *cluster.Se
 	}
 	errors.GoWrapper(func() {
 		jobLogger := c.logger.WithField("job", namespaceCleanupJobName)
-		wgRunning := new(sync.WaitGroup)
+		// runMu is held by the cron callback for the duration of one tick.
+		// The registration loop acquires/releases it as a barrier to wait
+		// for an in-flight tick before re-registering. Mutex is used over
+		// WaitGroup because Add called concurrently with Wait is documented
+		// WaitGroup misuse.
+		runMu := new(sync.Mutex)
 
 		for {
 			select {
@@ -87,7 +92,8 @@ func (c *cronsNamespaceCleanup) Init(cr *gocron.Cron, clusterService *cluster.Se
 					continue
 				}
 
-				wgRunning.Wait()
+				runMu.Lock()
+				runMu.Unlock()
 				select {
 				case <-c.serverShutdownCtx.Done():
 					jobLogger.Debug("server shutdown context cancelled")
@@ -96,7 +102,7 @@ func (c *cronsNamespaceCleanup) Init(cr *gocron.Cron, clusterService *cluster.Se
 				}
 
 				schedule := fmt.Sprintf("@every %s", interval)
-				job := c.createJob(jobLogger, clusterService, coordinator, wgRunning)
+				job := c.createJob(jobLogger, clusterService, coordinator, runMu)
 				entryId, err := cr.AddJob(schedule, job, gocron.WithName(namespaceCleanupJobName))
 				if err != nil {
 					jobLogger.WithError(err).Error("cron job not added")
@@ -119,16 +125,17 @@ func (c *cronsNamespaceCleanup) Init(cr *gocron.Cron, clusterService *cluster.Se
 
 // createJob returns the per-tick callback. SkipIfStillRunning prevents
 // overlap at the cron layer; the coordinator additionally guards against
-// concurrent ticks.
+// concurrent ticks. runMu is held for the tick duration so the
+// registration loop can barrier-wait via Lock/Unlock before re-registering.
 func (c *cronsNamespaceCleanup) createJob(jobLogger logrus.FieldLogger,
 	clusterService *cluster.Service, coordinator *namespacecleanup.Coordinator,
-	wgRunning *sync.WaitGroup,
+	runMu *sync.Mutex,
 ) gocron.Job {
 	return gocron.NewChain(
 		gocron.SkipIfStillRunning(c.gocronLogger),
 	).Then(gocron.FuncJob(func() {
-		wgRunning.Add(1)
-		defer wgRunning.Done()
+		runMu.Lock()
+		defer runMu.Unlock()
 
 		if !clusterService.IsLeader() {
 			return

--- a/usecases/cron/namespace_cleanup.go
+++ b/usecases/cron/namespace_cleanup.go
@@ -74,11 +74,9 @@ func (c *cronsNamespaceCleanup) Init(cr *gocron.Cron, clusterService *cluster.Se
 	}
 	errors.GoWrapper(func() {
 		jobLogger := c.logger.WithField("job", namespaceCleanupJobName)
-		// runMu is held by the cron callback for the duration of one tick.
-		// The registration loop acquires/releases it as a barrier to wait
-		// for an in-flight tick before re-registering. Mutex is used over
-		// WaitGroup because Add called concurrently with Wait is documented
-		// WaitGroup misuse.
+		// runMu serialises the cron callback with the re-registration
+		// loop: the callback holds it for one tick, the loop Lock/Unlocks
+		// as a barrier before swapping the job.
 		runMu := new(sync.Mutex)
 
 		for {
@@ -125,8 +123,7 @@ func (c *cronsNamespaceCleanup) Init(cr *gocron.Cron, clusterService *cluster.Se
 
 // createJob returns the per-tick callback. SkipIfStillRunning prevents
 // overlap at the cron layer; the coordinator additionally guards against
-// concurrent ticks. runMu is held for the tick duration so the
-// registration loop can barrier-wait via Lock/Unlock before re-registering.
+// concurrent ticks.
 func (c *cronsNamespaceCleanup) createJob(jobLogger logrus.FieldLogger,
 	clusterService *cluster.Service, coordinator *namespacecleanup.Coordinator,
 	runMu *sync.Mutex,

--- a/usecases/cron/namespace_cleanup_test.go
+++ b/usecases/cron/namespace_cleanup_test.go
@@ -38,13 +38,14 @@ func intervalConfig(d time.Duration) configGetter {
 	}
 }
 
-func newTestNamespaceCleanup(t *testing.T, interval time.Duration) (*cronsNamespaceCleanup, *gocron.Cron) {
+func newTestNamespaceCleanup(t *testing.T, interval time.Duration) (*cronsNamespaceCleanup, *gocron.Cron, context.CancelFunc) {
 	t.Helper()
 	logger, _ := test.NewNullLogger()
 	logger.SetLevel(logrus.DebugLevel)
-	cr := initGoCron(context.Background(), gocron.DiscardLogger)
-	c := newCronsNamespaceCleanup(context.Background(), logger, gocron.DiscardLogger, intervalConfig(interval))
-	return c, cr
+	ctx, cancel := context.WithCancel(context.Background())
+	cr := initGoCron(ctx, gocron.DiscardLogger)
+	c := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, intervalConfig(interval))
+	return c, cr, cancel
 }
 
 func nonNilCoordinator(t *testing.T) *namespacecleanup.Coordinator {
@@ -63,10 +64,10 @@ func nonNilCoordinator(t *testing.T) *namespacecleanup.Coordinator {
 // values; the cron-level tests don't invoke them.
 type stubLister struct{}
 
-func (stubLister) ListDeleting() []string              { return nil }
-func (stubLister) ClassesInNamespace(string) []string  { return nil }
-func (stubLister) AliasesInNamespace(string) []string  { return nil }
-func (stubLister) DeleteUsersInNamespace(string) error { return nil }
+func (stubLister) ListDeleting() []string                               { return nil }
+func (stubLister) ClassesInNamespace(string) []string                   { return nil }
+func (stubLister) AliasesInNamespace(string) []string                   { return nil }
+func (stubLister) DeleteUsersInNamespace(context.Context, string) error { return nil }
 func (stubLister) DeleteAlias(context.Context, string) (uint64, error) {
 	return 0, nil
 }
@@ -74,10 +75,11 @@ func (stubLister) DeleteAlias(context.Context, string) (uint64, error) {
 func (stubLister) DeleteClass(context.Context, string) (uint64, error) {
 	return 0, nil
 }
-func (stubLister) RemoveNamespaceEntity(string) error { return nil }
+func (stubLister) RemoveNamespaceEntity(context.Context, string) error { return nil }
 
 func TestCronsNamespaceCleanup_Init_NilCoordinator(t *testing.T) {
-	c, cr := newTestNamespaceCleanup(t, time.Minute)
+	c, cr, cancel := newTestNamespaceCleanup(t, time.Minute)
+	defer cancel()
 	require.Error(t, c.Init(cr, nil, nil))
 }
 
@@ -89,8 +91,10 @@ func TestCronsNamespaceCleanup_Init_SkipsWhenNamespacesDisabled(t *testing.T) {
 			CleanupInterval: configRuntime.NewDynamicValue(time.Minute),
 		}}
 	}
-	c := newCronsNamespaceCleanup(context.Background(), logger, gocron.DiscardLogger, getter)
-	cr := initGoCron(context.Background(), gocron.DiscardLogger)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
+	cr := initGoCron(ctx, gocron.DiscardLogger)
 
 	require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
 	time.Sleep(50 * time.Millisecond)
@@ -99,7 +103,8 @@ func TestCronsNamespaceCleanup_Init_SkipsWhenNamespacesDisabled(t *testing.T) {
 }
 
 func TestCronsNamespaceCleanup_Init_RegistersForPositiveInterval(t *testing.T) {
-	c, cr := newTestNamespaceCleanup(t, time.Minute)
+	c, cr, cancel := newTestNamespaceCleanup(t, time.Minute)
+	defer cancel()
 	require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
 	assert.Eventually(t, func() bool {
 		return cr.RemoveByName(namespaceCleanupJobName)
@@ -111,7 +116,8 @@ func TestCronsNamespaceCleanup_Init_SkipsForNonPositiveInterval(t *testing.T) {
 	tests := []time.Duration{0, -time.Second}
 	for _, interval := range tests {
 		t.Run(interval.String(), func(t *testing.T) {
-			c, cr := newTestNamespaceCleanup(t, interval)
+			c, cr, cancel := newTestNamespaceCleanup(t, interval)
+			defer cancel()
 			require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
 			// Give the registration goroutine a moment; it must not register.
 			time.Sleep(50 * time.Millisecond)
@@ -130,7 +136,9 @@ func TestCronsNamespaceCleanup_RuntimeConfigHook(t *testing.T) {
 		return config.Config{Namespaces: config.Namespaces{Enabled: true, CleanupInterval: current}}
 	}
 	logger, _ := test.NewNullLogger()
-	c := newCronsNamespaceCleanup(context.Background(), logger, gocron.DiscardLogger, getter)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := newCronsNamespaceCleanup(ctx, logger, gocron.DiscardLogger, getter)
 	// Drain the initial value pushed by the constructor.
 	<-c.intervalCh
 

--- a/usecases/cron/namespace_cleanup_test.go
+++ b/usecases/cron/namespace_cleanup_test.go
@@ -1,0 +1,153 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cron
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	gocron "github.com/netresearch/go-cron"
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/usecases/config"
+	configRuntime "github.com/weaviate/weaviate/usecases/config/runtime"
+	namespacecleanup "github.com/weaviate/weaviate/usecases/namespace_cleanup"
+)
+
+func intervalConfig(d time.Duration) configGetter {
+	return func() config.Config {
+		return config.Config{
+			Namespaces: config.Namespaces{
+				Enabled:         true,
+				CleanupInterval: configRuntime.NewDynamicValue(d),
+			},
+		}
+	}
+}
+
+func newTestNamespaceCleanup(t *testing.T, interval time.Duration) (*cronsNamespaceCleanup, *gocron.Cron) {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+	cr := initGoCron(context.Background(), gocron.DiscardLogger)
+	c := newCronsNamespaceCleanup(context.Background(), logger, gocron.DiscardLogger, intervalConfig(interval))
+	return c, cr
+}
+
+func nonNilCoordinator(t *testing.T) *namespacecleanup.Coordinator {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	return namespacecleanup.NewCoordinator(
+		stubLister{},
+		stubLister{},
+		stubLister{},
+		func() bool { return true },
+		logger,
+	)
+}
+
+// stubLister satisfies every coordinator dependency. Methods return zero
+// values; the cron-level tests don't invoke them.
+type stubLister struct{}
+
+func (stubLister) ListDeleting() []string              { return nil }
+func (stubLister) ClassesInNamespace(string) []string  { return nil }
+func (stubLister) AliasesInNamespace(string) []string  { return nil }
+func (stubLister) DeleteUsersInNamespace(string) error { return nil }
+func (stubLister) DeleteAlias(context.Context, string) (uint64, error) {
+	return 0, nil
+}
+
+func (stubLister) DeleteClass(context.Context, string) (uint64, error) {
+	return 0, nil
+}
+func (stubLister) RemoveNamespaceEntity(string) error { return nil }
+
+func TestCronsNamespaceCleanup_Init_NilCoordinator(t *testing.T) {
+	c, cr := newTestNamespaceCleanup(t, time.Minute)
+	require.Error(t, c.Init(cr, nil, nil))
+}
+
+func TestCronsNamespaceCleanup_Init_SkipsWhenNamespacesDisabled(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	getter := func() config.Config {
+		return config.Config{Namespaces: config.Namespaces{
+			Enabled:         false,
+			CleanupInterval: configRuntime.NewDynamicValue(time.Minute),
+		}}
+	}
+	c := newCronsNamespaceCleanup(context.Background(), logger, gocron.DiscardLogger, getter)
+	cr := initGoCron(context.Background(), gocron.DiscardLogger)
+
+	require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
+	time.Sleep(50 * time.Millisecond)
+	assert.False(t, cr.RemoveByName(namespaceCleanupJobName),
+		"job must not be registered when namespaces are disabled")
+}
+
+func TestCronsNamespaceCleanup_Init_RegistersForPositiveInterval(t *testing.T) {
+	c, cr := newTestNamespaceCleanup(t, time.Minute)
+	require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
+	assert.Eventually(t, func() bool {
+		return cr.RemoveByName(namespaceCleanupJobName)
+	}, 2*time.Second, 10*time.Millisecond,
+		"job should have been registered under the documented name")
+}
+
+func TestCronsNamespaceCleanup_Init_SkipsForNonPositiveInterval(t *testing.T) {
+	tests := []time.Duration{0, -time.Second}
+	for _, interval := range tests {
+		t.Run(interval.String(), func(t *testing.T) {
+			c, cr := newTestNamespaceCleanup(t, interval)
+			require.NoError(t, c.Init(cr, nil, nonNilCoordinator(t)))
+			// Give the registration goroutine a moment; it must not register.
+			time.Sleep(50 * time.Millisecond)
+			assert.False(t, cr.RemoveByName(namespaceCleanupJobName),
+				"job must not be registered when interval <= 0")
+		})
+	}
+}
+
+func TestCronsNamespaceCleanup_RuntimeConfigHook(t *testing.T) {
+	// Drive the hook directly: set up a configGetter whose returned value
+	// can change between Hook calls, and assert the new value reaches
+	// intervalCh.
+	current := configRuntime.NewDynamicValue(time.Minute)
+	getter := func() config.Config {
+		return config.Config{Namespaces: config.Namespaces{Enabled: true, CleanupInterval: current}}
+	}
+	logger, _ := test.NewNullLogger()
+	c := newCronsNamespaceCleanup(context.Background(), logger, gocron.DiscardLogger, getter)
+	// Drain the initial value pushed by the constructor.
+	<-c.intervalCh
+
+	require.NoError(t, current.SetValue(2*time.Minute))
+	require.NoError(t, c.RuntimeConfigHook())
+	select {
+	case got := <-c.intervalCh:
+		assert.Equal(t, 2*time.Minute, got)
+	case <-time.After(time.Second):
+		t.Fatal("hook did not push the new interval")
+	}
+
+	// Same value again is a no-op (no push, channel stays empty).
+	require.NoError(t, c.RuntimeConfigHook())
+	select {
+	case got := <-c.intervalCh:
+		t.Fatalf("hook pushed on unchanged value: %s", got)
+	case <-time.After(50 * time.Millisecond):
+	}
+}

--- a/usecases/cron/namespace_cleanup_test.go
+++ b/usecases/cron/namespace_cleanup_test.go
@@ -65,7 +65,7 @@ func nonNilCoordinator(t *testing.T) *namespacecleanup.Coordinator {
 type stubLister struct{}
 
 func (stubLister) ListDeleting() []string                               { return nil }
-func (stubLister) ClassesInNamespace(string) []string                   { return nil }
+func (stubLister) ClassesInNamespace(string) ([]string, error)          { return nil, nil }
 func (stubLister) AliasesInNamespace(string) []string                   { return nil }
 func (stubLister) DeleteUsersInNamespace(context.Context, string) error { return nil }
 func (stubLister) DeleteAlias(context.Context, string) (uint64, error) {

--- a/usecases/cron/namespace_cleanup_test.go
+++ b/usecases/cron/namespace_cleanup_test.go
@@ -75,7 +75,10 @@ func (stubLister) DeleteAlias(context.Context, string) (uint64, error) {
 func (stubLister) DeleteClass(context.Context, string) (uint64, error) {
 	return 0, nil
 }
-func (stubLister) RemoveNamespaceEntity(context.Context, string) error { return nil }
+
+func (stubLister) RemoveNamespaceEntity(context.Context, string) (uint64, error) {
+	return 0, nil
+}
 
 func TestCronsNamespaceCleanup_Init_NilCoordinator(t *testing.T) {
 	c, cr, cancel := newTestNamespaceCleanup(t, time.Minute)

--- a/usecases/namespace_cleanup/coordinator.go
+++ b/usecases/namespace_cleanup/coordinator.go
@@ -65,7 +65,7 @@ type raftExecutor interface {
 	DeleteUsersInNamespace(ctx context.Context, name string) error
 	DeleteAlias(ctx context.Context, alias string) (uint64, error)
 	DeleteClass(ctx context.Context, name string) (uint64, error)
-	RemoveNamespaceEntity(ctx context.Context, name string) error
+	RemoveNamespaceEntity(ctx context.Context, name string) (uint64, error)
 }
 
 // Coordinator runs one cleanup pass per Tick on the leader. isLeader is
@@ -167,14 +167,9 @@ func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, ns string) err
 	if !c.isLeader() {
 		return types.ErrNotLeader
 	}
-	if err := c.raft.RemoveNamespaceEntity(ctx, ns); err != nil {
-		// Residuals can survive into RemoveNamespaceEntity when the
-		// coordinator's local view lagged the leader (a class or alias
-		// from before MarkDeleting wasn't visible when we enumerated)
-		// or when a leader-flip mid-tick split the cleanup across two
-		// nodes. The apply handler re-checks against authoritative
-		// state and rejects with ErrNamespaceNotEmpty; the next tick
-		// re-enumerates and retries.
+	if _, err := c.raft.RemoveNamespaceEntity(ctx, ns); err != nil {
+		// Apply re-checks emptiness against authoritative state; the
+		// next tick retries if anything still owns the namespace.
 		if errors.Is(err, namespaces.ErrNamespaceNotEmpty) {
 			return nil
 		}

--- a/usecases/namespace_cleanup/coordinator.go
+++ b/usecases/namespace_cleanup/coordinator.go
@@ -9,9 +9,25 @@
 //  CONTACT: hello@weaviate.io
 //
 
-// Package namespacecleanup deletes the contents of a namespace in the
-// deleting state and then removes the namespace entry. Runs on the
-// leader only.
+// Package namespacecleanup runs the leader-side cascade that empties a
+// namespace once it has been marked for deletion.
+//
+// Deletion is split into a fast synchronous half and a slow
+// asynchronous half. The DELETE handler flips the namespace to
+// deleting, drains its DB users, and returns 202. This package then
+// removes the rest on a periodic tick: aliases, then classes, then
+// the namespace entry itself. Aliases come before classes because an
+// alias points at a class. Class deletion is the slow part, which is
+// why it lives here rather than in the request path.
+//
+// The user delete is re-run on every tick as a safety net in case the
+// handler crashed between marking and the eager drain.
+//
+// Every step is a separate replicated command, so any failure is
+// retried on the next tick. Because the coordinator's view of what
+// still belongs to a namespace can lag behind the leader, the final
+// entity removal is re-checked at apply time and rejected if anything
+// still owns the namespace; the next tick retries.
 package namespacecleanup
 
 import (
@@ -33,7 +49,7 @@ type namespaceLister interface {
 
 // schemaLister returns the classes and aliases that belong to a namespace.
 type schemaLister interface {
-	ClassesInNamespace(namespace string) []string
+	ClassesInNamespace(namespace string) ([]string, error)
 	AliasesInNamespace(namespace string) []string
 }
 
@@ -129,7 +145,11 @@ func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, ns string) err
 			return err
 		}
 	}
-	for _, cls := range c.schema.ClassesInNamespace(ns) {
+	classes, err := c.schema.ClassesInNamespace(ns)
+	if err != nil {
+		return fmt.Errorf("list classes in namespace %q: %w", ns, err)
+	}
+	for _, cls := range classes {
 		if !c.isLeader() {
 			return types.ErrNotLeader
 		}

--- a/usecases/namespace_cleanup/coordinator.go
+++ b/usecases/namespace_cleanup/coordinator.go
@@ -39,10 +39,10 @@ type schemaLister interface {
 
 // raftExecutor is the subset of cluster.Raft used here.
 type raftExecutor interface {
-	DeleteUsersInNamespace(name string) error
+	DeleteUsersInNamespace(ctx context.Context, name string) error
 	DeleteAlias(ctx context.Context, alias string) (uint64, error)
 	DeleteClass(ctx context.Context, name string) (uint64, error)
-	RemoveNamespaceEntity(name string) error
+	RemoveNamespaceEntity(ctx context.Context, name string) error
 }
 
 // Coordinator runs one cleanup pass per Tick on the leader. isLeader is
@@ -118,7 +118,7 @@ func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, ns string) err
 	if !c.isLeader() {
 		return types.ErrNotLeader
 	}
-	if err := c.raft.DeleteUsersInNamespace(ns); err != nil {
+	if err := c.raft.DeleteUsersInNamespace(ctx, ns); err != nil {
 		return err
 	}
 	for _, alias := range c.schema.AliasesInNamespace(ns) {
@@ -140,7 +140,7 @@ func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, ns string) err
 	if !c.isLeader() {
 		return types.ErrNotLeader
 	}
-	if err := c.raft.RemoveNamespaceEntity(ns); err != nil {
+	if err := c.raft.RemoveNamespaceEntity(ctx, ns); err != nil {
 		// This can happen when an in-flight requests creates a new entity between cleanup start and here
 		if errors.Is(err, namespaces.ErrNamespaceNotEmpty) {
 			return nil

--- a/usecases/namespace_cleanup/coordinator.go
+++ b/usecases/namespace_cleanup/coordinator.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 	"sync/atomic"
 
 	"github.com/sirupsen/logrus"
@@ -122,8 +121,6 @@ func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, ns string) err
 	if err := c.raft.DeleteUsersInNamespace(ns); err != nil {
 		return err
 	}
-	// Aliases first: DeleteClass refuses to drop a class that still has
-	// aliases pointing at it.
 	for _, alias := range c.schema.AliasesInNamespace(ns) {
 		if !c.isLeader() {
 			return types.ErrNotLeader
@@ -145,20 +142,10 @@ func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, ns string) err
 	}
 	if err := c.raft.RemoveNamespaceEntity(ns); err != nil {
 		// This can happen when an in-flight requests creates a new entity between cleanup start and here
-		if isNamespaceNotEmpty(err) {
+		if errors.Is(err, namespaces.ErrNamespaceNotEmpty) {
 			return nil
 		}
 		return err
 	}
 	return nil
-}
-
-// isNamespaceNotEmpty returns true for ErrNamespaceNotEmpty, including
-// the case where RAFT serialization stripped the wrapping and only the
-// error message survives.
-func isNamespaceNotEmpty(err error) bool {
-	if errors.Is(err, namespaces.ErrNamespaceNotEmpty) {
-		return true
-	}
-	return strings.Contains(err.Error(), namespaces.ErrNamespaceNotEmpty.Error())
 }

--- a/usecases/namespace_cleanup/coordinator.go
+++ b/usecases/namespace_cleanup/coordinator.go
@@ -1,0 +1,164 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package namespacecleanup deletes the contents of a namespace in the
+// deleting state and then removes the namespace entry. Runs on the
+// leader only.
+package namespacecleanup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/weaviate/weaviate/cluster/types"
+	"github.com/weaviate/weaviate/usecases/namespaces"
+)
+
+// namespaceLister lists namespaces in the deleting state.
+type namespaceLister interface {
+	ListDeleting() []string
+}
+
+// schemaLister returns the classes and aliases that belong to a namespace.
+type schemaLister interface {
+	ClassesInNamespace(namespace string) []string
+	AliasesInNamespace(namespace string) []string
+}
+
+// raftExecutor is the subset of cluster.Raft used here.
+type raftExecutor interface {
+	DeleteUsersInNamespace(name string) error
+	DeleteAlias(ctx context.Context, alias string) (uint64, error)
+	DeleteClass(ctx context.Context, name string) (uint64, error)
+	RemoveNamespaceEntity(name string) error
+}
+
+// Coordinator runs one cleanup pass per Tick on the leader. isLeader is
+// re-checked before every RAFT write so the old leader stops issuing
+// writes once leadership moves.
+type Coordinator struct {
+	namespaces namespaceLister
+	schema     schemaLister
+	raft       raftExecutor
+	isLeader   func() bool
+	logger     logrus.FieldLogger
+	ongoing    atomic.Bool
+}
+
+func NewCoordinator(
+	nsLister namespaceLister,
+	schema schemaLister,
+	raft raftExecutor,
+	isLeader func() bool,
+	logger logrus.FieldLogger,
+) *Coordinator {
+	if nsLister == nil {
+		panic("namespacecleanup: namespace lister must not be nil")
+	}
+	if schema == nil {
+		panic("namespacecleanup: schema lister must not be nil")
+	}
+	if raft == nil {
+		panic("namespacecleanup: raft executor must not be nil")
+	}
+	if isLeader == nil {
+		panic("namespacecleanup: isLeader must not be nil")
+	}
+	return &Coordinator{
+		namespaces: nsLister,
+		schema:     schema,
+		raft:       raft,
+		isLeader:   isLeader,
+		logger:     logger,
+	}
+}
+
+// Tick cleans up every namespace currently in the deleting state. A
+// per-namespace error is logged and the loop moves on; a not-leader
+// error stops the tick so the new leader can take over.
+//
+// Returns an error if another Tick is already running.
+func (c *Coordinator) Tick(ctx context.Context) error {
+	if !c.ongoing.CompareAndSwap(false, true) {
+		return fmt.Errorf("namespace cleanup already ongoing")
+	}
+	defer c.ongoing.Store(false)
+
+	if !c.isLeader() {
+		return nil
+	}
+	for _, ns := range c.namespaces.ListDeleting() {
+		if err := c.cleanupSingleNamespace(ctx, ns); err != nil {
+			if errors.Is(err, types.ErrNotLeader) {
+				return nil
+			}
+			c.logger.WithField("namespace", ns).Error(err)
+		}
+	}
+	return nil
+}
+
+// cleanupSingleNamespace deletes the users, aliases, and classes (in this order) that
+// belong to ns, then removes the namespace entry. If the entry is not
+// empty when RemoveNamespaceEntity reaches the apply path, the error is
+// ignored and the next tick retries.
+func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, ns string) error {
+	if !c.isLeader() {
+		return types.ErrNotLeader
+	}
+	if err := c.raft.DeleteUsersInNamespace(ns); err != nil {
+		return err
+	}
+	// Aliases first: DeleteClass refuses to drop a class that still has
+	// aliases pointing at it.
+	for _, alias := range c.schema.AliasesInNamespace(ns) {
+		if !c.isLeader() {
+			return types.ErrNotLeader
+		}
+		if _, err := c.raft.DeleteAlias(ctx, alias); err != nil {
+			return err
+		}
+	}
+	for _, cls := range c.schema.ClassesInNamespace(ns) {
+		if !c.isLeader() {
+			return types.ErrNotLeader
+		}
+		if _, err := c.raft.DeleteClass(ctx, cls); err != nil {
+			return err
+		}
+	}
+	if !c.isLeader() {
+		return types.ErrNotLeader
+	}
+	if err := c.raft.RemoveNamespaceEntity(ns); err != nil {
+		// This can happen when an in-flight requests creates a new entity between cleanup start and here
+		if isNamespaceNotEmpty(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// isNamespaceNotEmpty returns true for ErrNamespaceNotEmpty, including
+// the case where RAFT serialization stripped the wrapping and only the
+// error message survives.
+func isNamespaceNotEmpty(err error) bool {
+	if errors.Is(err, namespaces.ErrNamespaceNotEmpty) {
+		return true
+	}
+	return strings.Contains(err.Error(), namespaces.ErrNamespaceNotEmpty.Error())
+}

--- a/usecases/namespace_cleanup/coordinator.go
+++ b/usecases/namespace_cleanup/coordinator.go
@@ -20,6 +20,13 @@
 // alias points at a class. Class deletion is the slow part, which is
 // why it lives here rather than in the request path.
 //
+// The split is driven by two concerns. First, class deletion can run
+// long on large collections and would otherwise risk request
+// timeouts. Second, a node can crash mid-delete at any time, so the
+// cluster needs an after-the-fact cleanup path regardless; once that
+// path exists, routing the bulk of the work through it is cheaper
+// than duplicating the logic in the request handler.
+//
 // The user delete is re-run on every tick as a safety net in case the
 // handler crashed between marking and the eager drain.
 //
@@ -161,7 +168,13 @@ func (c *Coordinator) cleanupSingleNamespace(ctx context.Context, ns string) err
 		return types.ErrNotLeader
 	}
 	if err := c.raft.RemoveNamespaceEntity(ctx, ns); err != nil {
-		// This can happen when an in-flight requests creates a new entity between cleanup start and here
+		// Residuals can survive into RemoveNamespaceEntity when the
+		// coordinator's local view lagged the leader (a class or alias
+		// from before MarkDeleting wasn't visible when we enumerated)
+		// or when a leader-flip mid-tick split the cleanup across two
+		// nodes. The apply handler re-checks against authoritative
+		// state and rejects with ErrNamespaceNotEmpty; the next tick
+		// re-enumerates and retries.
 		if errors.Is(err, namespaces.ErrNamespaceNotEmpty) {
 			return nil
 		}

--- a/usecases/namespace_cleanup/coordinator_test.go
+++ b/usecases/namespace_cleanup/coordinator_test.go
@@ -171,21 +171,6 @@ func TestCoordinator_Tick_OrderingAcrossPhases(t *testing.T) {
 	assert.Equal(t, recordedCall{op: "entity", arg: "alpha", from: "alpha"}, raft.calls[5])
 }
 
-func TestCoordinator_Tick_ClassesInNamespaceErrorAbortsNamespace(t *testing.T) {
-	raft := newStubRaft()
-	wantErr := errors.New("read schema failed")
-	ns := stubNamespaces{deleting: []string{"alpha"}}
-	schema := stubSchema{classesErr: wantErr}
-	c := newTestCoordinator(t, ns, schema, raft, alwaysLeader)
-
-	// Tick logs the per-namespace error and returns nil; RemoveNamespaceEntity
-	// must not be issued because we cannot prove the namespace is empty.
-	require.NoError(t, c.Tick(context.Background()))
-	for _, call := range raft.calls {
-		assert.NotEqual(t, "entity", call.op, "RemoveNamespaceEntity must not run after a ClassesInNamespace error")
-	}
-}
-
 func TestCoordinator_Tick_RemoveEntityNotEmptyIsSwallowed(t *testing.T) {
 	tests := []struct {
 		name string
@@ -301,31 +286,66 @@ func TestCoordinator_Tick_LeaderFlipBetweenPhasesAborts(t *testing.T) {
 	}
 }
 
-func TestCoordinator_Tick_PerNamespaceErrorContinuesToNext(t *testing.T) {
-	raft := newStubRaft()
-	raft.deleteUsersErr["alpha"] = errors.New("boom")
-	ns := stubNamespaces{deleting: []string{"alpha", "beta"}}
-	schema := stubSchema{}
-	c := newTestCoordinator(t, ns, schema, raft, alwaysLeader)
-	c.Tick(context.Background())
+// TestCoordinator_Tick_ErrorBlastRadius covers how the tick contains errors.
+// A schema or per-namespace RAFT error aborts only the failing namespace and
+// leaves its entity in place; ErrNotLeader aborts the whole tick so the new
+// leader can pick up.
+func TestCoordinator_Tick_ErrorBlastRadius(t *testing.T) {
+	tests := []struct {
+		name              string
+		deleting          []string
+		schema            stubSchema
+		setupRaft         func(*stubRaft)
+		wantEntityRemoved map[string]int // expected RemoveNamespaceEntity count per namespace
+		wantUntouchedNS   []string       // namespaces that must not appear in any recorded call
+	}{
+		{
+			name:              "schema error aborts only the failing namespace",
+			deleting:          []string{"alpha"},
+			schema:            stubSchema{classesErr: errors.New("read schema failed")},
+			wantEntityRemoved: map[string]int{"alpha": 0},
+		},
+		{
+			name:     "per-namespace raft error continues to next namespace",
+			deleting: []string{"alpha", "beta"},
+			schema:   stubSchema{},
+			setupRaft: func(s *stubRaft) {
+				s.deleteUsersErr["alpha"] = errors.New("boom")
+			},
+			wantEntityRemoved: map[string]int{"alpha": 0, "beta": 1},
+		},
+		{
+			name:     "ErrNotLeader aborts the whole tick",
+			deleting: []string{"alpha", "beta"},
+			schema:   stubSchema{},
+			setupRaft: func(s *stubRaft) {
+				s.deleteUsersErr["alpha"] = types.ErrNotLeader
+			},
+			wantEntityRemoved: map[string]int{"alpha": 0, "beta": 0},
+			wantUntouchedNS:   []string{"beta"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raft := newStubRaft()
+			if tc.setupRaft != nil {
+				tc.setupRaft(raft)
+			}
+			ns := stubNamespaces{deleting: tc.deleting}
+			c := newTestCoordinator(t, ns, tc.schema, raft, alwaysLeader)
+			require.NoError(t, c.Tick(context.Background()))
 
-	// alpha aborts after the failed users call (no aliases, no classes,
-	// no entity removal). beta proceeds to entity removal.
-	assert.Contains(t, opsOf(raft.calls), "entity")
-	assert.Equal(t, 1, raft.removeEntityCall["beta"])
-	assert.Equal(t, 0, raft.removeEntityCall["alpha"])
-}
-
-func TestCoordinator_Tick_NotLeaderInsidePhaseAbortsWholeTick(t *testing.T) {
-	raft := newStubRaft()
-	raft.deleteUsersErr["alpha"] = types.ErrNotLeader
-	ns := stubNamespaces{deleting: []string{"alpha", "beta"}}
-	c := newTestCoordinator(t, ns, stubSchema{}, raft, alwaysLeader)
-	c.Tick(context.Background())
-
-	// beta must not be processed.
-	for _, call := range raft.calls {
-		assert.NotEqual(t, "beta", call.from, "tick should have aborted before reaching beta")
+			for n, want := range tc.wantEntityRemoved {
+				assert.Equal(t, want, raft.removeEntityCall[n],
+					"namespace %q: unexpected RemoveNamespaceEntity count", n)
+			}
+			for _, n := range tc.wantUntouchedNS {
+				for _, call := range raft.calls {
+					assert.NotEqual(t, n, call.from,
+						"namespace %q must not be touched after the tick aborted", n)
+				}
+			}
+		})
 	}
 }
 

--- a/usecases/namespace_cleanup/coordinator_test.go
+++ b/usecases/namespace_cleanup/coordinator_test.go
@@ -33,11 +33,17 @@ func (s stubNamespaces) ListDeleting() []string { return s.deleting }
 
 // stubSchema returns the configured per-namespace residuals.
 type stubSchema struct {
-	classes map[string][]string
-	aliases map[string][]string
+	classes    map[string][]string
+	aliases    map[string][]string
+	classesErr error
 }
 
-func (s stubSchema) ClassesInNamespace(ns string) []string { return s.classes[ns] }
+func (s stubSchema) ClassesInNamespace(ns string) ([]string, error) {
+	if s.classesErr != nil {
+		return nil, s.classesErr
+	}
+	return s.classes[ns], nil
+}
 func (s stubSchema) AliasesInNamespace(ns string) []string { return s.aliases[ns] }
 
 // recordedCall captures a single RAFT call for ordering assertions.
@@ -163,6 +169,21 @@ func TestCoordinator_Tick_OrderingAcrossPhases(t *testing.T) {
 	assert.Equal(t, "class", raft.calls[3].op)
 	assert.Equal(t, "class", raft.calls[4].op)
 	assert.Equal(t, recordedCall{op: "entity", arg: "alpha", from: "alpha"}, raft.calls[5])
+}
+
+func TestCoordinator_Tick_ClassesInNamespaceErrorAbortsNamespace(t *testing.T) {
+	raft := newStubRaft()
+	wantErr := errors.New("read schema failed")
+	ns := stubNamespaces{deleting: []string{"alpha"}}
+	schema := stubSchema{classesErr: wantErr}
+	c := newTestCoordinator(t, ns, schema, raft, alwaysLeader)
+
+	// Tick logs the per-namespace error and returns nil; RemoveNamespaceEntity
+	// must not be issued because we cannot prove the namespace is empty.
+	require.NoError(t, c.Tick(context.Background()))
+	for _, call := range raft.calls {
+		assert.NotEqual(t, "entity", call.op, "RemoveNamespaceEntity must not run after a ClassesInNamespace error")
+	}
 }
 
 func TestCoordinator_Tick_RemoveEntityNotEmptyIsSwallowed(t *testing.T) {

--- a/usecases/namespace_cleanup/coordinator_test.go
+++ b/usecases/namespace_cleanup/coordinator_test.go
@@ -68,7 +68,7 @@ func newStubRaft() *stubRaft {
 	}
 }
 
-func (s *stubRaft) DeleteUsersInNamespace(name string) error {
+func (s *stubRaft) DeleteUsersInNamespace(_ context.Context, name string) error {
 	s.calls = append(s.calls, recordedCall{op: "users", arg: name, from: name})
 	return s.deleteUsersErr[name]
 }
@@ -83,7 +83,7 @@ func (s *stubRaft) DeleteClass(_ context.Context, name string) (uint64, error) {
 	return 0, s.deleteClassErr[name]
 }
 
-func (s *stubRaft) RemoveNamespaceEntity(name string) error {
+func (s *stubRaft) RemoveNamespaceEntity(_ context.Context, name string) error {
 	s.calls = append(s.calls, recordedCall{op: "entity", arg: name, from: name})
 	s.removeEntityCall[name]++
 	return s.removeEntityErr[name]

--- a/usecases/namespace_cleanup/coordinator_test.go
+++ b/usecases/namespace_cleanup/coordinator_test.go
@@ -89,10 +89,10 @@ func (s *stubRaft) DeleteClass(_ context.Context, name string) (uint64, error) {
 	return 0, s.deleteClassErr[name]
 }
 
-func (s *stubRaft) RemoveNamespaceEntity(_ context.Context, name string) error {
+func (s *stubRaft) RemoveNamespaceEntity(_ context.Context, name string) (uint64, error) {
 	s.calls = append(s.calls, recordedCall{op: "entity", arg: name, from: name})
 	s.removeEntityCall[name]++
-	return s.removeEntityErr[name]
+	return 0, s.removeEntityErr[name]
 }
 
 func newTestCoordinator(t *testing.T,

--- a/usecases/namespace_cleanup/coordinator_test.go
+++ b/usecases/namespace_cleanup/coordinator_test.go
@@ -1,0 +1,334 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespacecleanup
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/types"
+	"github.com/weaviate/weaviate/usecases/namespaces"
+)
+
+// stubNamespaces returns a fixed deleting list.
+type stubNamespaces struct{ deleting []string }
+
+func (s stubNamespaces) ListDeleting() []string { return s.deleting }
+
+// stubSchema returns the configured per-namespace residuals.
+type stubSchema struct {
+	classes map[string][]string
+	aliases map[string][]string
+}
+
+func (s stubSchema) ClassesInNamespace(ns string) []string { return s.classes[ns] }
+func (s stubSchema) AliasesInNamespace(ns string) []string { return s.aliases[ns] }
+
+// recordedCall captures a single RAFT call for ordering assertions.
+type recordedCall struct {
+	op   string
+	arg  string
+	from string // namespace context, when applicable
+}
+
+// stubRaft records calls and lets tests inject errors per op.
+type stubRaft struct {
+	calls []recordedCall
+
+	deleteUsersErr   map[string]error
+	deleteAliasErr   map[string]error
+	deleteClassErr   map[string]error
+	removeEntityErr  map[string]error
+	removeEntityCall map[string]int
+}
+
+func newStubRaft() *stubRaft {
+	return &stubRaft{
+		deleteUsersErr:   map[string]error{},
+		deleteAliasErr:   map[string]error{},
+		deleteClassErr:   map[string]error{},
+		removeEntityErr:  map[string]error{},
+		removeEntityCall: map[string]int{},
+	}
+}
+
+func (s *stubRaft) DeleteUsersInNamespace(name string) error {
+	s.calls = append(s.calls, recordedCall{op: "users", arg: name, from: name})
+	return s.deleteUsersErr[name]
+}
+
+func (s *stubRaft) DeleteAlias(_ context.Context, alias string) (uint64, error) {
+	s.calls = append(s.calls, recordedCall{op: "alias", arg: alias})
+	return 0, s.deleteAliasErr[alias]
+}
+
+func (s *stubRaft) DeleteClass(_ context.Context, name string) (uint64, error) {
+	s.calls = append(s.calls, recordedCall{op: "class", arg: name})
+	return 0, s.deleteClassErr[name]
+}
+
+func (s *stubRaft) RemoveNamespaceEntity(name string) error {
+	s.calls = append(s.calls, recordedCall{op: "entity", arg: name, from: name})
+	s.removeEntityCall[name]++
+	return s.removeEntityErr[name]
+}
+
+func newTestCoordinator(t *testing.T,
+	nsLister namespaceLister,
+	schema schemaLister,
+	raft raftExecutor,
+	isLeader func() bool,
+) *Coordinator {
+	t.Helper()
+	logger, _ := test.NewNullLogger()
+	logger.SetLevel(logrus.DebugLevel)
+	return NewCoordinator(nsLister, schema, raft, isLeader, logger)
+}
+
+func alwaysLeader() bool { return true }
+
+func TestCoordinator_NewCoordinator_PanicsOnNilArgs(t *testing.T) {
+	logger, _ := test.NewNullLogger()
+	nsLister := stubNamespaces{}
+	schema := stubSchema{}
+	raft := newStubRaft()
+
+	tests := []struct {
+		name     string
+		ns       namespaceLister
+		schema   schemaLister
+		raft     raftExecutor
+		isLeader func() bool
+	}{
+		{name: "nil namespace lister", ns: nil, schema: schema, raft: raft, isLeader: alwaysLeader},
+		{name: "nil schema lister", ns: nsLister, schema: nil, raft: raft, isLeader: alwaysLeader},
+		{name: "nil raft executor", ns: nsLister, schema: schema, raft: nil, isLeader: alwaysLeader},
+		{name: "nil isLeader", ns: nsLister, schema: schema, raft: raft, isLeader: nil},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Panics(t, func() {
+				NewCoordinator(tc.ns, tc.schema, tc.raft, tc.isLeader, logger)
+			})
+		})
+	}
+}
+
+func TestCoordinator_Tick_EmptyDeletingSetIsNoop(t *testing.T) {
+	raft := newStubRaft()
+	c := newTestCoordinator(t, stubNamespaces{}, stubSchema{}, raft, alwaysLeader)
+	c.Tick(context.Background())
+	assert.Empty(t, raft.calls)
+}
+
+func TestCoordinator_Tick_NotLeaderReturnsBeforeAnyCall(t *testing.T) {
+	raft := newStubRaft()
+	ns := stubNamespaces{deleting: []string{"alpha"}}
+	c := newTestCoordinator(t, ns, stubSchema{}, raft, func() bool { return false })
+	c.Tick(context.Background())
+	assert.Empty(t, raft.calls)
+}
+
+func TestCoordinator_Tick_OrderingAcrossPhases(t *testing.T) {
+	raft := newStubRaft()
+	ns := stubNamespaces{deleting: []string{"alpha"}}
+	schema := stubSchema{
+		classes: map[string][]string{"alpha": {"alpha:Foo", "alpha:Bar"}},
+		aliases: map[string][]string{"alpha": {"alpha:A1", "alpha:A2"}},
+	}
+	c := newTestCoordinator(t, ns, schema, raft, alwaysLeader)
+	c.Tick(context.Background())
+
+	// Expected order: users first; then both aliases; then both classes; then RemoveNamespaceEntity.
+	require.Len(t, raft.calls, 6)
+	assert.Equal(t, recordedCall{op: "users", arg: "alpha", from: "alpha"}, raft.calls[0])
+	assert.Equal(t, "alias", raft.calls[1].op)
+	assert.Equal(t, "alias", raft.calls[2].op)
+	assert.Equal(t, "class", raft.calls[3].op)
+	assert.Equal(t, "class", raft.calls[4].op)
+	assert.Equal(t, recordedCall{op: "entity", arg: "alpha", from: "alpha"}, raft.calls[5])
+}
+
+func TestCoordinator_Tick_RemoveEntityNotEmptyIsSwallowed(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{name: "wrapped sentinel", err: fmt.Errorf("apply: %w", namespaces.ErrNamespaceNotEmpty)},
+		{name: "string fallback", err: errors.New("apply: " + namespaces.ErrNamespaceNotEmpty.Error())},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raft := newStubRaft()
+			raft.removeEntityErr["alpha"] = tc.err
+			ns := stubNamespaces{deleting: []string{"alpha"}}
+			c := newTestCoordinator(t, ns, stubSchema{}, raft, alwaysLeader)
+			// Tick must not panic, must not return; the retry will happen
+			// at the next tick.
+			require.NoError(t, c.Tick(context.Background()))
+			assert.Equal(t, 1, raft.removeEntityCall["alpha"])
+		})
+	}
+}
+
+// TestCoordinator_Tick_LeaderFlipBetweenPhasesAborts walks an isLeader
+// sequence: every call returns true except the configured one. The
+// coordinator must abort the tick once it sees false.
+//
+// isLeader call sequence per Tick over a single namespace with N aliases
+// and M classes:
+//
+//	1: Tick top-of-loop guard
+//	2: cleanupOne entry guard
+//	3..2+N: before each DeleteAlias
+//	3+N..2+N+M: before each DeleteClass
+//	3+N+M: before RemoveNamespaceEntity
+func TestCoordinator_Tick_LeaderFlipBetweenPhasesAborts(t *testing.T) {
+	tests := []struct {
+		name           string
+		falseAtCallNum int // 1-based index of the isLeader call that returns false
+		schema         stubSchema
+		wantOps        []string // RAFT ops the coordinator must have issued before aborting
+	}{
+		{
+			name:           "flip on Tick guard issues nothing",
+			falseAtCallNum: 1,
+			schema: stubSchema{
+				aliases: map[string][]string{"alpha": {"alpha:A1"}},
+				classes: map[string][]string{"alpha": {"alpha:Foo"}},
+			},
+			wantOps: []string{},
+		},
+		{
+			name:           "flip on cleanupOne entry issues nothing",
+			falseAtCallNum: 2,
+			schema: stubSchema{
+				aliases: map[string][]string{"alpha": {"alpha:A1"}},
+				classes: map[string][]string{"alpha": {"alpha:Foo"}},
+			},
+			wantOps: []string{},
+		},
+		{
+			name:           "flip before first alias stops after users",
+			falseAtCallNum: 3,
+			schema: stubSchema{
+				aliases: map[string][]string{"alpha": {"alpha:A1", "alpha:A2"}},
+				classes: map[string][]string{"alpha": {"alpha:Foo"}},
+			},
+			wantOps: []string{"users"},
+		},
+		{
+			name:           "flip before second alias stops after first alias",
+			falseAtCallNum: 4,
+			schema: stubSchema{
+				aliases: map[string][]string{"alpha": {"alpha:A1", "alpha:A2"}},
+				classes: map[string][]string{"alpha": {"alpha:Foo"}},
+			},
+			wantOps: []string{"users", "alias"},
+		},
+		{
+			name:           "flip before first class stops after aliases",
+			falseAtCallNum: 4,
+			schema: stubSchema{
+				aliases: map[string][]string{"alpha": {"alpha:A1"}},
+				classes: map[string][]string{"alpha": {"alpha:Foo", "alpha:Bar"}},
+			},
+			wantOps: []string{"users", "alias"},
+		},
+		{
+			name:           "flip before remove entity stops after classes",
+			falseAtCallNum: 5,
+			schema: stubSchema{
+				aliases: map[string][]string{"alpha": {"alpha:A1"}},
+				classes: map[string][]string{"alpha": {"alpha:Foo"}},
+			},
+			wantOps: []string{"users", "alias", "class"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raft := newStubRaft()
+			ns := stubNamespaces{deleting: []string{"alpha"}}
+			calls := 0
+			isLeader := func() bool {
+				calls++
+				return calls != tc.falseAtCallNum
+			}
+			c := newTestCoordinator(t, ns, tc.schema, raft, isLeader)
+			require.NoError(t, c.Tick(context.Background()))
+
+			assert.Equal(t, tc.wantOps, opsOf(raft.calls))
+			assert.NotContains(t, opsOf(raft.calls), "entity",
+				"RemoveNamespaceEntity must not run on a flipped tick")
+		})
+	}
+}
+
+func TestCoordinator_Tick_PerNamespaceErrorContinuesToNext(t *testing.T) {
+	raft := newStubRaft()
+	raft.deleteUsersErr["alpha"] = errors.New("boom")
+	ns := stubNamespaces{deleting: []string{"alpha", "beta"}}
+	schema := stubSchema{}
+	c := newTestCoordinator(t, ns, schema, raft, alwaysLeader)
+	c.Tick(context.Background())
+
+	// alpha aborts after the failed users call (no aliases, no classes,
+	// no entity removal). beta proceeds to entity removal.
+	assert.Contains(t, opsOf(raft.calls), "entity")
+	assert.Equal(t, 1, raft.removeEntityCall["beta"])
+	assert.Equal(t, 0, raft.removeEntityCall["alpha"])
+}
+
+func TestCoordinator_Tick_NotLeaderInsidePhaseAbortsWholeTick(t *testing.T) {
+	raft := newStubRaft()
+	raft.deleteUsersErr["alpha"] = types.ErrNotLeader
+	ns := stubNamespaces{deleting: []string{"alpha", "beta"}}
+	c := newTestCoordinator(t, ns, stubSchema{}, raft, alwaysLeader)
+	c.Tick(context.Background())
+
+	// beta must not be processed.
+	for _, call := range raft.calls {
+		assert.NotEqual(t, "beta", call.from, "tick should have aborted before reaching beta")
+	}
+}
+
+// TestCoordinator_Tick_RejectsConcurrentRun forces a Tick to overlap with
+// itself by holding the ongoing flag set. The second call must short-
+// circuit with an error and must not enter cleanup.
+func TestCoordinator_Tick_RejectsConcurrentRun(t *testing.T) {
+	raft := newStubRaft()
+	ns := stubNamespaces{deleting: []string{"alpha"}}
+	c := newTestCoordinator(t, ns, stubSchema{}, raft, alwaysLeader)
+
+	c.ongoing.Store(true)
+	defer c.ongoing.Store(false)
+
+	err := c.Tick(context.Background())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "already ongoing")
+	assert.Empty(t, raft.calls, "Tick must not enter cleanup while another run is ongoing")
+}
+
+func opsOf(calls []recordedCall) []string {
+	out := make([]string, 0, len(calls))
+	for _, c := range calls {
+		out = append(out, c.op)
+	}
+	return out
+}

--- a/usecases/namespaces/controller.go
+++ b/usecases/namespaces/controller.go
@@ -40,9 +40,10 @@ var (
 	// errors.Is rather than string-matching the error message.
 	ErrAlreadyExists = errors.New("namespace already exists")
 
-	// ErrNotFound is returned by Delete when the target namespace does not
-	// exist. Callers that need a distinct status for missing entries
-	// (e.g. an HTTP handler mapping to 404) should check with errors.Is.
+	// ErrNotFound is returned by ChangeState and RemoveEntity when the
+	// target namespace does not exist. Callers that need a distinct status
+	// for missing entries (e.g. an HTTP handler mapping to 404) should
+	// check with errors.Is.
 	ErrNotFound = errors.New("namespace not found")
 
 	// ErrNamespaceDeleting is returned when a create-like operation targets

--- a/usecases/namespaces/controller.go
+++ b/usecases/namespaces/controller.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"sync"
 
 	"github.com/sirupsen/logrus"
@@ -43,6 +44,28 @@ var (
 	// exist. Callers that need a distinct status for missing entries
 	// (e.g. an HTTP handler mapping to 404) should check with errors.Is.
 	ErrNotFound = errors.New("namespace not found")
+
+	// ErrNamespaceDeleting is returned when a create-like operation targets
+	// a namespace that exists but is currently being torn down. Distinct
+	// from ErrAlreadyExists so REST can render a different conflict message.
+	ErrNamespaceDeleting = errors.New("namespace is being deleted")
+
+	// ErrNamespaceGone is returned by apply-time checks when a namespace
+	// the caller validated earlier no longer exists.
+	ErrNamespaceGone = errors.New("namespace no longer exists")
+
+	// ErrNamespaceNotEmpty is returned by RemoveEntity at the apply layer
+	// when the namespace still owns classes, aliases, or DB users.
+	ErrNamespaceNotEmpty = errors.New("namespace still has owned resources")
+
+	// ErrInvalidState is a defense-in-depth sentinel for operations called
+	// on a namespace whose current state forbids them (e.g. RemoveEntity on
+	// an active namespace).
+	ErrInvalidState = errors.New("namespace is in an invalid state for this operation")
+
+	// ErrInvalidStateTransition is returned by ChangeState when the target
+	// state is unreachable from the namespace's current state.
+	ErrInvalidStateTransition = errors.New("invalid namespace state transition")
 )
 
 // See entschema.NamespaceMinLength for the full namespace name validation
@@ -62,12 +85,11 @@ var reservedNames = map[string]struct{}{
 	"public":   {},
 }
 
-// Exister is the minimal namespace existence check consumers depend on for
-// dependency injection. *Controller satisfies it. Defined here (alongside
-// the producer) rather than on each consumer side so we can share a single
-// generated mock across the apply-layer and REST handler test suites.
+// Exister exposes namespace presence and lifecycle state. Exists matches
+// any state; IsActive excludes the deleting state.
 type Exister interface {
 	Exists(name string) bool
+	IsActive(name string) bool
 }
 
 // Controller owns the namespace control-plane state.
@@ -91,8 +113,12 @@ func NewController(logger logrus.FieldLogger) *Controller {
 	}
 }
 
-// Create inserts a namespace. It rejects invalid names with [ErrBadRequest]
-// and duplicates with [ErrAlreadyExists].
+// Create inserts a namespace as [cmd.NamespaceStateActive]; the input's
+// State field is ignored so RAFT callers cannot inject a deleting entry.
+//
+// Returns [ErrBadRequest] for invalid names, [ErrAlreadyExists] when the
+// name maps to an active namespace, and [ErrNamespaceDeleting] when the
+// name is currently being torn down.
 func (c *Controller) Create(ns cmd.Namespace) error {
 	if err := ValidateName(ns.Name); err != nil {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
@@ -101,10 +127,14 @@ func (c *Controller) Create(ns cmd.Namespace) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if _, ok := c.namespaces[ns.Name]; ok {
+	if existing, ok := c.namespaces[ns.Name]; ok {
+		if existing.State == cmd.NamespaceStateDeleting {
+			return fmt.Errorf("%w: %q", ErrNamespaceDeleting, ns.Name)
+		}
 		return fmt.Errorf("%w: %q", ErrAlreadyExists, ns.Name)
 	}
 
+	ns.State = cmd.NamespaceStateActive
 	c.namespaces[ns.Name] = &ns
 	return nil
 }
@@ -117,6 +147,53 @@ func (c *Controller) Delete(name string) error {
 	defer c.mu.Unlock()
 	if _, ok := c.namespaces[name]; !ok {
 		return fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+	delete(c.namespaces, name)
+	return nil
+}
+
+// ChangeState transitions a namespace into target. Same-state transitions
+// are idempotent and return nil. Returns [ErrBadRequest] when target is not
+// a recognized state, [ErrNotFound] when the namespace does not exist, and
+// [ErrInvalidStateTransition] when the transition is forbidden (e.g.
+// deleting back to active).
+func (c *Controller) ChangeState(name string, target cmd.NamespaceState) error {
+	switch target {
+	case cmd.NamespaceStateActive, cmd.NamespaceStateDeleting:
+	default:
+		return fmt.Errorf("%w: unknown namespace state %q", ErrBadRequest, target)
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ns, ok := c.namespaces[name]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+	if ns.State == target {
+		return nil
+	}
+	// deleting is terminal: re-entry only via RemoveEntity + fresh Create.
+	if ns.State == cmd.NamespaceStateDeleting {
+		return fmt.Errorf("%w: %q is %s, cannot transition to %s",
+			ErrInvalidStateTransition, name, ns.State, target)
+	}
+	ns.State = target
+	return nil
+}
+
+// RemoveEntity removes the namespace map entry. Callable only on a
+// namespace already marked for deletion; an active namespace returns
+// [ErrInvalidState]. Returns [ErrNotFound] when the namespace does not exist.
+func (c *Controller) RemoveEntity(name string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	ns, ok := c.namespaces[name]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrNotFound, name)
+	}
+	if ns.State != cmd.NamespaceStateDeleting {
+		return fmt.Errorf("%w: %q is not in deleting state", ErrInvalidState, name)
 	}
 	delete(c.namespaces, name)
 	return nil
@@ -160,14 +237,42 @@ func (c *Controller) Count() int {
 	return len(c.namespaces)
 }
 
-// Exists reports whether a namespace with the given name is known. Intended
-// for non-cluster callers (REST handlers, OIDC claim resolution) that need
-// a fast existence check without constructing a RAFT subcommand.
+// Exists reports whether a namespace with the given name is known.
+// Intended for non-cluster callers (REST handlers, OIDC claim resolution)
+// that need a fast existence check without constructing a RAFT subcommand.
+// Returns true for entries in any state.
 func (c *Controller) Exists(name string) bool {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 	_, ok := c.namespaces[name]
 	return ok
+}
+
+// IsActive reports whether the named namespace exists and is in the
+// [cmd.NamespaceStateActive] state.
+func (c *Controller) IsActive(name string) bool {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	ns, ok := c.namespaces[name]
+	if !ok {
+		return false
+	}
+	return ns.State == cmd.NamespaceStateActive
+}
+
+// ListDeleting returns the names of namespaces currently in the deleting
+// state, sorted lexicographically.
+func (c *Controller) ListDeleting() []string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	out := make([]string, 0)
+	for name, ns := range c.namespaces {
+		if ns.State == cmd.NamespaceStateDeleting {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
 }
 
 // Snapshot serializes the entire namespace map. See the Controller godoc for
@@ -180,8 +285,8 @@ func (c *Controller) Snapshot() ([]byte, error) {
 
 // Restore replaces the current state with the snapshot contents. A nil or
 // empty snapshot leaves state empty (fresh bootstrap). Unknown JSON fields
-// are tolerated to preserve forward-compatibility with future entity
-// additions (e.g. a state field).
+// are tolerated to preserve forward-compatibility. Entries with empty
+// State are normalized to [cmd.NamespaceStateActive].
 func (c *Controller) Restore(snapshot []byte) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -195,6 +300,11 @@ func (c *Controller) Restore(snapshot []byte) error {
 	if err := json.Unmarshal(snapshot, &restored); err != nil {
 		c.logger.Errorf("restoring namespaces from snapshot failed with: %v", err)
 		return err
+	}
+	for _, ns := range restored {
+		if ns.State == "" {
+			ns.State = cmd.NamespaceStateActive
+		}
 	}
 	c.namespaces = restored
 	c.logger.Info("successfully restored namespaces from snapshot")

--- a/usecases/namespaces/controller.go
+++ b/usecases/namespaces/controller.go
@@ -114,12 +114,10 @@ func NewController(logger logrus.FieldLogger) *Controller {
 	}
 }
 
-// Create inserts a namespace as [cmd.NamespaceStateActive]; the input's
-// State field is ignored so RAFT callers cannot inject a deleting entry.
-//
-// Returns [ErrBadRequest] for invalid names, [ErrAlreadyExists] when the
-// name maps to an active namespace, and [ErrNamespaceDeleting] when the
-// name is currently being torn down.
+// Create inserts a namespace in the [cmd.NamespaceStateActive] state; the
+// input's State is ignored. Returns [ErrBadRequest] for invalid names,
+// [ErrAlreadyExists] when the name maps to an active namespace, and
+// [ErrNamespaceDeleting] when the name is currently being torn down.
 func (c *Controller) Create(ns cmd.Namespace) error {
 	if err := ValidateName(ns.Name); err != nil {
 		return fmt.Errorf("%w: %w", ErrBadRequest, err)
@@ -273,16 +271,9 @@ func (c *Controller) Snapshot() ([]byte, error) {
 
 // Restore replaces the current state with the snapshot contents. A nil or
 // empty snapshot leaves state empty (fresh bootstrap). Unknown JSON fields
-// are tolerated to preserve forward-compatibility. Entries with empty
-// State are normalized to [cmd.NamespaceStateActive].
-//
-// Returns an error if any entry's State is not one of the known values.
-// The only realistic source of an unknown State is a snapshot produced
-// by a future binary; coercing silently would mis-classify the namespace
-// (e.g. accept writes against what should be suspended), so we fail-loud
-// and let the operator investigate. Forward-compatible state additions
-// must bump [cmd.NamespaceLatestCommandPolicyVersion] and gate at the
-// apply layer, not rely on string-matching here.
+// are tolerated. Entries with empty State are normalized to
+// [cmd.NamespaceStateActive]; entries with an unknown State return an
+// error so a future binary's snapshot is not silently mis-classified.
 func (c *Controller) Restore(snapshot []byte) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/usecases/namespaces/controller.go
+++ b/usecases/namespaces/controller.go
@@ -139,19 +139,6 @@ func (c *Controller) Create(ns cmd.Namespace) error {
 	return nil
 }
 
-// Delete removes a namespace. Returns [ErrNotFound] when the target
-// namespace does not exist. Non-idempotent by design: callers that need
-// idempotent semantics should swallow ErrNotFound at their layer.
-func (c *Controller) Delete(name string) error {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	if _, ok := c.namespaces[name]; !ok {
-		return fmt.Errorf("%w: %q", ErrNotFound, name)
-	}
-	delete(c.namespaces, name)
-	return nil
-}
-
 // ChangeState transitions a namespace into target. Same-state transitions
 // are idempotent and return nil. Returns [ErrBadRequest] when target is not
 // a recognized state, [ErrNotFound] when the namespace does not exist, and

--- a/usecases/namespaces/controller.go
+++ b/usecases/namespaces/controller.go
@@ -274,6 +274,14 @@ func (c *Controller) Snapshot() ([]byte, error) {
 // empty snapshot leaves state empty (fresh bootstrap). Unknown JSON fields
 // are tolerated to preserve forward-compatibility. Entries with empty
 // State are normalized to [cmd.NamespaceStateActive].
+//
+// Returns an error if any entry's State is not one of the known values.
+// The only realistic source of an unknown State is a snapshot produced
+// by a future binary; coercing silently would mis-classify the namespace
+// (e.g. accept writes against what should be suspended), so we fail-loud
+// and let the operator investigate. Forward-compatible state additions
+// must bump [cmd.NamespaceLatestCommandPolicyVersion] and gate at the
+// apply layer, not rely on string-matching here.
 func (c *Controller) Restore(snapshot []byte) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -288,9 +296,15 @@ func (c *Controller) Restore(snapshot []byte) error {
 		c.logger.Errorf("restoring namespaces from snapshot failed with: %v", err)
 		return err
 	}
-	for _, ns := range restored {
+	for name, ns := range restored {
 		if ns.State == "" {
 			ns.State = cmd.NamespaceStateActive
+			continue
+		}
+		switch ns.State {
+		case cmd.NamespaceStateActive, cmd.NamespaceStateDeleting:
+		default:
+			return fmt.Errorf("namespace %q has unknown state %q in snapshot", name, ns.State)
 		}
 	}
 	c.namespaces = restored

--- a/usecases/namespaces/controller_test.go
+++ b/usecases/namespaces/controller_test.go
@@ -267,30 +267,6 @@ func TestController_RestoreNormalizesEmptyState(t *testing.T) {
 	assert.Equal(t, cmd.NamespaceStateActive, got[0].State)
 }
 
-func TestController_Delete(t *testing.T) {
-	c := newTestController(t)
-	require.NoError(t, c.Create(cmd.Namespace{Name: "customer1"}))
-	require.NoError(t, c.Create(cmd.Namespace{Name: "customer2"}))
-
-	t.Run("delete existing", func(t *testing.T) {
-		require.NoError(t, c.Delete("customer1"))
-		assert.Equal(t, 1, c.Count())
-	})
-
-	t.Run("delete missing returns ErrNotFound", func(t *testing.T) {
-		err := c.Delete("customer1") // already deleted above
-		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrNotFound)
-
-		err = c.Delete("never-existed")
-		require.Error(t, err)
-		assert.ErrorIs(t, err, ErrNotFound)
-
-		// State was not altered by the failed deletes.
-		assert.Equal(t, 1, c.Count())
-	})
-}
-
 func TestController_Get(t *testing.T) {
 	c := newTestController(t)
 	require.NoError(t, c.Create(cmd.Namespace{Name: "customer1"}))
@@ -332,7 +308,8 @@ func TestController_Exists(t *testing.T) {
 	assert.True(t, c.Exists("customer1"))
 	assert.False(t, c.Exists("never-existed"))
 
-	require.NoError(t, c.Delete("customer1"))
+	require.NoError(t, c.ChangeState("customer1", cmd.NamespaceStateDeleting))
+	require.NoError(t, c.RemoveEntity("customer1"))
 	assert.False(t, c.Exists("customer1"))
 }
 

--- a/usecases/namespaces/controller_test.go
+++ b/usecases/namespaces/controller_test.go
@@ -267,6 +267,34 @@ func TestController_RestoreNormalizesEmptyState(t *testing.T) {
 	assert.Equal(t, cmd.NamespaceStateActive, got[0].State)
 }
 
+// TestController_RestoreRejectsUnknownState locks in fail-loud behaviour
+// for snapshots that carry a State value the current binary does not
+// know. Silently coercing would mis-classify the namespace; the
+// startup-time error forces the operator to investigate.
+func TestController_RestoreRestoresKnownStates(t *testing.T) {
+	c := newTestController(t)
+	snap := []byte(`{
+		"customer1":{"Name":"customer1","State":"active","Restrictions":{}},
+		"customer2":{"Name":"customer2","State":"deleting","Restrictions":{}}
+	}`)
+	require.NoError(t, c.Restore(snap))
+
+	assert.True(t, c.IsActive("customer1"))
+	assert.False(t, c.IsActive("customer2"))
+	assert.Equal(t, []string{"customer2"}, c.ListDeleting())
+}
+
+func TestController_RestoreRejectsUnknownState(t *testing.T) {
+	c := newTestController(t)
+	snap := []byte(`{"customer1":{"Name":"customer1","State":"suspended","Restrictions":{}}}`)
+	err := c.Restore(snap)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown state")
+	// The controller must remain unchanged on rejection so that the
+	// caller (RAFT FSM) can fail startup cleanly.
+	assert.Equal(t, 0, c.Count())
+}
+
 func TestController_Get(t *testing.T) {
 	c := newTestController(t)
 	require.NoError(t, c.Create(cmd.Namespace{Name: "customer1"}))

--- a/usecases/namespaces/controller_test.go
+++ b/usecases/namespaces/controller_test.go
@@ -31,6 +31,19 @@ func newTestController(t *testing.T) *Controller {
 	return NewController(logger)
 }
 
+// seedNamespace creates name and transitions it to seedState. An empty
+// seedState seeds nothing.
+func seedNamespace(t *testing.T, c *Controller, name string, seedState cmd.NamespaceState) {
+	t.Helper()
+	if seedState == "" {
+		return
+	}
+	require.NoError(t, c.Create(cmd.Namespace{Name: name}))
+	if seedState == cmd.NamespaceStateDeleting {
+		require.NoError(t, c.ChangeState(name, cmd.NamespaceStateDeleting))
+	}
+}
+
 func TestValidateName(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -130,6 +143,128 @@ func TestController_Create(t *testing.T) {
 			assert.Equal(t, len(tc.seed)+1, c.Count())
 		})
 	}
+}
+
+func TestController_Create_StoresActiveState(t *testing.T) {
+	c := newTestController(t)
+	// Caller-provided State is ignored: stored entries are always active.
+	require.NoError(t, c.Create(cmd.Namespace{Name: "customer1", State: cmd.NamespaceStateDeleting}))
+	got := c.Get("customer1")
+	require.Len(t, got, 1)
+	assert.Equal(t, cmd.NamespaceStateActive, got[0].State)
+	assert.True(t, c.IsActive("customer1"))
+}
+
+func TestController_Create_RejectsDeletingWithDistinctSentinel(t *testing.T) {
+	c := newTestController(t)
+	require.NoError(t, c.Create(cmd.Namespace{Name: "customer1"}))
+	require.NoError(t, c.ChangeState("customer1", cmd.NamespaceStateDeleting))
+
+	err := c.Create(cmd.Namespace{Name: "customer1"})
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrNamespaceDeleting)
+	assert.NotErrorIs(t, err, ErrAlreadyExists,
+		"deleting must surface as a distinct conflict so REST can render a different message")
+}
+
+func TestController_ChangeState(t *testing.T) {
+	tests := []struct {
+		name      string
+		seedState cmd.NamespaceState // empty = no namespace exists
+		target    cmd.NamespaceState
+		wantErr   error
+	}{
+		{name: "active -> deleting flips state", seedState: cmd.NamespaceStateActive, target: cmd.NamespaceStateDeleting},
+		{name: "active -> active is idempotent", seedState: cmd.NamespaceStateActive, target: cmd.NamespaceStateActive},
+		{name: "deleting -> deleting is idempotent", seedState: cmd.NamespaceStateDeleting, target: cmd.NamespaceStateDeleting},
+		{name: "deleting -> active is forbidden", seedState: cmd.NamespaceStateDeleting, target: cmd.NamespaceStateActive, wantErr: ErrInvalidStateTransition},
+		{name: "unknown target state is rejected", seedState: cmd.NamespaceStateActive, target: cmd.NamespaceState("not-a-state"), wantErr: ErrBadRequest},
+		{name: "missing namespace returns ErrNotFound", target: cmd.NamespaceStateDeleting, wantErr: ErrNotFound},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestController(t)
+			seedNamespace(t, c, "customer1", tc.seedState)
+
+			err := c.ChangeState("customer1", tc.target)
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, c.Exists("customer1"))
+			assert.Equal(t, tc.target == cmd.NamespaceStateActive, c.IsActive("customer1"))
+		})
+	}
+}
+
+func TestController_RemoveEntity(t *testing.T) {
+	tests := []struct {
+		name      string
+		seedState cmd.NamespaceState // empty = no namespace exists
+		wantErr   error
+	}{
+		{name: "deleting namespace is removed", seedState: cmd.NamespaceStateDeleting},
+		{name: "active namespace returns ErrInvalidState", seedState: cmd.NamespaceStateActive, wantErr: ErrInvalidState},
+		{name: "missing namespace returns ErrNotFound", wantErr: ErrNotFound},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := newTestController(t)
+			seedNamespace(t, c, "customer1", tc.seedState)
+
+			err := c.RemoveEntity("customer1")
+			if tc.wantErr != nil {
+				require.Error(t, err)
+				assert.ErrorIs(t, err, tc.wantErr)
+				assert.Equal(t, tc.seedState != "", c.Exists("customer1"))
+				return
+			}
+			require.NoError(t, err)
+			assert.False(t, c.Exists("customer1"))
+		})
+	}
+}
+
+func TestController_RecreateAfterRemoval(t *testing.T) {
+	c := newTestController(t)
+	require.NoError(t, c.Create(cmd.Namespace{Name: "customer1"}))
+	require.NoError(t, c.ChangeState("customer1", cmd.NamespaceStateDeleting))
+	require.NoError(t, c.RemoveEntity("customer1"))
+
+	require.NoError(t, c.Create(cmd.Namespace{Name: "customer1"}))
+	assert.True(t, c.IsActive("customer1"))
+}
+
+func TestController_IsActiveAndListDeleting(t *testing.T) {
+	c := newTestController(t)
+	require.NoError(t, c.Create(cmd.Namespace{Name: "customer1"}))
+	require.NoError(t, c.Create(cmd.Namespace{Name: "customer2"}))
+	require.NoError(t, c.Create(cmd.Namespace{Name: "customer3"}))
+	require.NoError(t, c.ChangeState("customer3", cmd.NamespaceStateDeleting))
+	require.NoError(t, c.ChangeState("customer1", cmd.NamespaceStateDeleting))
+
+	assert.True(t, c.IsActive("customer2"))
+	assert.False(t, c.IsActive("customer1"))
+	assert.False(t, c.IsActive("customer3"))
+	assert.False(t, c.IsActive("never-existed"))
+
+	assert.Equal(t, []string{"customer1", "customer3"}, c.ListDeleting())
+}
+
+func TestController_RestoreNormalizesEmptyState(t *testing.T) {
+	// Snapshots without a State field must restore as active.
+	c := newTestController(t)
+	snap := []byte(`{"customer1":{"Name":"customer1","Restrictions":{}}}`)
+	require.NoError(t, c.Restore(snap))
+
+	assert.True(t, c.IsActive("customer1"))
+	got := c.Get("customer1")
+	require.Len(t, got, 1)
+	assert.Equal(t, cmd.NamespaceStateActive, got[0].State)
 }
 
 func TestController_Delete(t *testing.T) {

--- a/usecases/namespaces/mock_exister.go
+++ b/usecases/namespaces/mock_exister.go
@@ -74,6 +74,52 @@ func (_c *MockExister_Exists_Call) RunAndReturn(run func(string) bool) *MockExis
 	return _c
 }
 
+// IsActive provides a mock function with given fields: name
+func (_m *MockExister) IsActive(name string) bool {
+	ret := _m.Called(name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsActive")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(name)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockExister_IsActive_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'IsActive'
+type MockExister_IsActive_Call struct {
+	*mock.Call
+}
+
+// IsActive is a helper method to define mock.On call
+//   - name string
+func (_e *MockExister_Expecter) IsActive(name interface{}) *MockExister_IsActive_Call {
+	return &MockExister_IsActive_Call{Call: _e.mock.On("IsActive", name)}
+}
+
+func (_c *MockExister_IsActive_Call) Run(run func(name string)) *MockExister_IsActive_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string))
+	})
+	return _c
+}
+
+func (_c *MockExister_IsActive_Call) Return(_a0 bool) *MockExister_IsActive_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockExister_IsActive_Call) RunAndReturn(run func(string) bool) *MockExister_IsActive_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // NewMockExister creates a new instance of MockExister. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.
 // The first argument is typically a *testing.T value.
 func NewMockExister(t interface {

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -36,6 +36,16 @@ func QualifiedName(namespace, name string) string {
 	return namespace + schema.NamespaceSeparator + name
 }
 
+// NamespaceFromQualified returns the namespace portion of a qualified name
+// ("<ns>:<entity>"). Names without the separator are unnamespaced and
+// return "".
+func NamespaceFromQualified(name string) string {
+	if ns, _, ok := strings.Cut(name, schema.NamespaceSeparator); ok {
+		return ns
+	}
+	return ""
+}
+
 // qualify prepends principal.Namespace to name.
 func qualify(principal *models.Principal, name string) string {
 	if principal == nil {

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -105,6 +105,24 @@ func TestQualifiedName(t *testing.T) {
 	}
 }
 
+func TestNamespaceFromQualified(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "no separator returns empty", in: "MyClass", want: ""},
+		{name: "qualified name returns namespace", in: "alpha:MyClass", want: "alpha"},
+		{name: "empty input returns empty", in: "", want: ""},
+		{name: "leading separator returns empty namespace prefix", in: ":MyClass", want: ""},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, NamespaceFromQualified(tc.in))
+		})
+	}
+}
+
 func TestQualifyClass(t *testing.T) {
 	cases := []struct {
 		testName          string


### PR DESCRIPTION
### What's being changed:

This adds cascading deletes to a namespace. When you delete it, it will automatically clear out all associated users, aliases and classes. 

The deletion consists of two parts:
- when calling the API, we switch the namespace to state `deleting` and remove all associated users
- a periodically running background process on the RAFT leader will then clean up the remaining aliases and classes and act as safety net against crashes during the command

I went for the periodic background task for a few reasons
- deleting classes can take some time if there are bigger collections around, we dont want the delete namespace call to time out
- I thought about simply kicking off a background goroutine from the handler, however that has its own complications (who is responsible for cleanup if something crashes?)
- the cronjob seemed like the easiest and least-footgunny solution

Important note: With sync-part being completed new requests are immediately impossible (DB Users are deleted, OIDC checks for namespace state). However, there might be in-flight requests that have already cleared the auth before the flip but haven't yet hit Apply: we deal with this by an additional check in Apply for namespace state. This will prevent the creation of additional users/classes/aliases for a namespace that has already been flipped

THE BUF CHECK ERROR IS OK: THE PREVIOUS ENTRY WAS ONLY EVER PRESENT IN MAIN AND NEVER RELEASED
