### PR TITLE
Wire up namespacing for tenant operations

### DIFF
--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -135,10 +135,6 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 func (s *Service) TenantsGet(ctx context.Context, req *pb.TenantsGetRequest) (*pb.TenantsGetReply, error) {
 	before := time.Now()
 
-	if class := s.schemaManager.ResolveAlias(req.Collection); class != "" {
-		req.Collection = class
-	}
-
 	principal, err := s.authenticator.PrincipalFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)

--- a/adapters/handlers/rest/handlers_tokenize.go
+++ b/adapters/handlers/rest/handlers_tokenize.go
@@ -23,7 +23,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted/stopwords"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/tokenizer"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
@@ -173,11 +172,9 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 func propertyTokenize(params schemaops.SchemaObjectsPropertiesTokenizeParams,
 	principal *models.Principal, schemaManager *schemaUC.Manager, nsEnabled bool, logger logrus.FieldLogger,
 ) middleware.Responder {
-	className := schema.UppercaseClassName(params.ClassName)
-
 	// Resolve before authorization so authz uses the real collection name
 	// for permissions and error UX.
-	className, _ = namespacing.Resolve(principal, schemaManager, nsEnabled, className)
+	className, _ := namespacing.Resolve(principal, schemaManager, nsEnabled, params.ClassName)
 
 	// Authorize: reading collection metadata (same as other schema read operations)
 	err := schemaManager.Authorizer.Authorize(

--- a/test/acceptance/aliases/aliases_api_grpc_test.go
+++ b/test/acceptance/aliases/aliases_api_grpc_test.go
@@ -300,6 +300,50 @@ func Test_AliasesAPI_gRPC(t *testing.T) {
 		require.NotNil(t, srep)
 		require.Len(t, srep.Results, 0)
 	})
+	t.Run("TenantsGet using alias", func(t *testing.T) {
+		mtClassName := "GRPCTenantsAliasTarget"
+		mtAliasName := "GRPCTenantsAlias"
+
+		helper.CreateClass(t, &models.Class{
+			Class:              mtClassName,
+			MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+			Properties:         []*models.Property{{Name: "title", DataType: []string{"text"}}},
+		})
+		defer helper.DeleteClass(t, mtClassName)
+
+		helper.CreateAlias(t, &models.Alias{Alias: mtAliasName, Class: mtClassName})
+		defer helper.DeleteAlias(t, mtAliasName)
+
+		helper.CreateTenants(t, mtClassName, []*models.Tenant{
+			{Name: "alphaT", ActivityStatus: "HOT"},
+			{Name: "betaT", ActivityStatus: "HOT"},
+			{Name: "gammaT", ActivityStatus: "HOT"},
+		})
+
+		// No Params → returns all tenants of the underlying class.
+		respAll, err := grpcClient.TenantsGet(ctx, &pb.TenantsGetRequest{Collection: mtAliasName})
+		require.NoError(t, err)
+		gotAll := make([]string, len(respAll.Tenants))
+		for i, tt := range respAll.Tenants {
+			gotAll[i] = tt.Name
+		}
+		assert.ElementsMatch(t, []string{"alphaT", "betaT", "gammaT"}, gotAll)
+
+		// Names param → filtered subset, also resolved via alias.
+		respFiltered, err := grpcClient.TenantsGet(ctx, &pb.TenantsGetRequest{
+			Collection: mtAliasName,
+			Params: &pb.TenantsGetRequest_Names{
+				Names: &pb.TenantNames{Values: []string{"alphaT", "gammaT"}},
+			},
+		})
+		require.NoError(t, err)
+		gotFiltered := make([]string, len(respFiltered.Tenants))
+		for i, tt := range respFiltered.Tenants {
+			gotFiltered[i] = tt.Name
+		}
+		assert.ElementsMatch(t, []string{"alphaT", "gammaT"}, gotFiltered)
+	})
+
 	t.Run("batch insert using alias", func(t *testing.T) {
 		theMartian := "67b79643-cf8b-4b22-b206-000000000001"
 		resp, err := grpcClient.BatchObjects(ctx, &pb.BatchObjectsRequest{

--- a/test/acceptance/aliases/aliases_api_test.go
+++ b/test/acceptance/aliases/aliases_api_test.go
@@ -476,6 +476,57 @@ func Test_AliasesAPI(t *testing.T) {
 			assert.Nil(t, dresp)
 		})
 
+		t.Run("read tenants via alias - should resolve", func(t *testing.T) {
+			className := "TenantReadViaAlias"
+			testClass := models.Class{
+				Class: className,
+				MultiTenancyConfig: &models.MultiTenancyConfig{
+					Enabled: true,
+				},
+				Properties: []*models.Property{
+					{
+						Name:     "name",
+						DataType: entschema.DataTypeText.PropString(),
+					},
+				},
+			}
+			helper.CreateClass(t, &testClass)
+			defer helper.DeleteClass(t, className)
+
+			aliasName := "TenantReadViaAliasAlias"
+			helper.CreateAlias(t, &models.Alias{Class: className, Alias: aliasName})
+			defer helper.DeleteAlias(t, aliasName)
+
+			tenantName := "T1"
+			helper.CreateTenants(t, className, []*models.Tenant{{
+				Name: tenantName, ActivityStatus: "HOT",
+			}})
+
+			// GetConsistentTenants via alias resolves to the underlying class.
+			gresp, err := helper.GetTenants(t, aliasName)
+			require.NoError(t, err)
+			require.NotNil(t, gresp)
+			require.Len(t, gresp.Payload, 1)
+			assert.Equal(t, tenantName, gresp.Payload[0].Name)
+
+			// GetConsistentTenant via alias resolves to the underlying class.
+			oneResp, err := helper.GetOneTenant(t, aliasName, tenantName)
+			require.NoError(t, err)
+			require.NotNil(t, oneResp)
+			assert.Equal(t, tenantName, oneResp.Payload.Name)
+
+			// TenantExists via alias resolves to the underlying class.
+			existsResp, err := helper.TenantExists(t, aliasName, tenantName)
+			require.NoError(t, err)
+			require.True(t, existsResp.IsSuccess())
+
+			// Missing tenant via alias still 404s rather than silently passing.
+			_, err = helper.GetOneTenant(t, aliasName, "Missing")
+			require.Error(t, err)
+			_, err = helper.TenantExists(t, aliasName, "Missing")
+			require.Error(t, err)
+		})
+
 		t.Run("create class with alias name", func(t *testing.T) {
 			class := books.ClassModel2VecVectorizerWithName(aliasName)
 			params := schema.NewSchemaObjectsCreateParams().WithObjectClass(class)

--- a/test/acceptance/namespace/tenant_test.go
+++ b/test/acceptance/namespace/tenant_test.go
@@ -311,7 +311,7 @@ func TestNamespaces_TenantOps(t *testing.T) {
 		assert.Equal(t, models.TenantActivityStatusHOT, listed[0].ActivityStatus)
 	})
 
-	t.Run("namespaced caller submitting :-qualified class double-prefixes", func(t *testing.T) {
+	t.Run("namespaced caller submitting namespace-qualified class double-prefixes", func(t *testing.T) {
 		const class = "TenantsDoublePrefix"
 		setupMTClassInNs1(t, class, user1Key)
 

--- a/test/acceptance/namespace/tenant_test.go
+++ b/test/acceptance/namespace/tenant_test.go
@@ -1,0 +1,389 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespace
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	schemaCli "github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+func mtClass(name string) *models.Class {
+	return &models.Class{
+		Class:              name,
+		MultiTenancyConfig: &models.MultiTenancyConfig{Enabled: true},
+		Properties:         []*models.Property{{Name: "title", DataType: []string{"text"}}},
+	}
+}
+
+// setupMTClassInBothNamespaces creates an MT-enabled class with the same short
+// name under each namespaced user and registers cleanup of the qualified names.
+func setupMTClassInBothNamespaces(t *testing.T, name, k1, k2 string) {
+	t.Helper()
+	for _, key := range []string{k1, k2} {
+		helper.CreateClassAuth(t, mtClass(name), key)
+	}
+	t.Cleanup(func() {
+		helper.DeleteClassAuth(t, "customer1:"+name, adminKey)
+		helper.DeleteClassAuth(t, "customer2:"+name, adminKey)
+	})
+}
+
+func setupMTClassInNs1(t *testing.T, name, key string) {
+	t.Helper()
+	helper.CreateClassAuth(t, mtClass(name), key)
+	t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+name, adminKey) })
+}
+
+func addTenantsAuth(t *testing.T, class string, tenants []*models.Tenant, key string) error {
+	t.Helper()
+	params := schemaCli.NewTenantsCreateParams().WithClassName(class).WithBody(tenants)
+	_, err := helper.Client(t).Schema.TenantsCreate(params, helper.CreateAuth(key))
+	return err
+}
+
+func updateTenantsAuth(t *testing.T, class string, tenants []*models.Tenant, key string) error {
+	t.Helper()
+	params := schemaCli.NewTenantsUpdateParams().WithClassName(class).WithBody(tenants)
+	_, err := helper.Client(t).Schema.TenantsUpdate(params, helper.CreateAuth(key))
+	return err
+}
+
+func deleteTenantsAuth(t *testing.T, class string, tenantNames []string, key string) error {
+	t.Helper()
+	params := schemaCli.NewTenantsDeleteParams().WithClassName(class).WithTenants(tenantNames)
+	_, err := helper.Client(t).Schema.TenantsDelete(params, helper.CreateAuth(key))
+	return err
+}
+
+func getTenantsAuth(t *testing.T, class, key string) ([]*models.Tenant, error) {
+	t.Helper()
+	params := schemaCli.NewTenantsGetParams().WithClassName(class)
+	resp, err := helper.Client(t).Schema.TenantsGet(params, helper.CreateAuth(key))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Payload, nil
+}
+
+func getOneTenantAuth(t *testing.T, class, tenant, key string) (*models.Tenant, error) {
+	t.Helper()
+	params := schemaCli.NewTenantsGetOneParams().WithClassName(class).WithTenantName(tenant)
+	resp, err := helper.Client(t).Schema.TenantsGetOne(params, helper.CreateAuth(key))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Payload, nil
+}
+
+func tenantExistsAuth(t *testing.T, class, tenant, key string) error {
+	t.Helper()
+	params := schemaCli.NewTenantExistsParams().WithClassName(class).WithTenantName(tenant)
+	_, err := helper.Client(t).Schema.TenantExists(params, helper.CreateAuth(key))
+	return err
+}
+
+func tenantNames(tenants []*models.Tenant) []string {
+	out := make([]string, len(tenants))
+	for i, tt := range tenants {
+		out[i] = tt.Name
+	}
+	return out
+}
+
+// TestNamespaces_TenantOps exercises namespace qualification and alias
+// resolution across the six REST tenant handlers and gRPC TenantsGet. Each
+// namespaced caller submits the short collection name; the handler must
+// qualify (mutations) or resolve (reads) it before any storage hit, so that
+// shards land under the qualified class name and tenant lookups never bleed
+// across namespaces.
+func TestNamespaces_TenantOps(t *testing.T) {
+	user1Key, user2Key := twoNamespaces(t)
+
+	grpcClient, conn := newGrpcClient(t)
+	defer conn.Close()
+
+	t.Run("REST mutations under namespaced principal land on qualified class", func(t *testing.T) {
+		const class = "TenantsCRUD"
+		setupMTClassInBothNamespaces(t, class, user1Key, user2Key)
+
+		// user1 adds two tenants by short name; user2 adds the same short
+		// "alpha" tenant under its own copy of the class.
+		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{
+			{Name: "alpha", ActivityStatus: models.TenantActivityStatusHOT},
+			{Name: "beta", ActivityStatus: models.TenantActivityStatusHOT},
+		}, user1Key))
+		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{
+			{Name: "alpha", ActivityStatus: models.TenantActivityStatusHOT},
+		}, user2Key))
+
+		// Admin's raw view of the qualified classes shows the per-namespace
+		// tenant sets exactly as written.
+		ns1, err := getTenantsAuth(t, "customer1:"+class, adminKey)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"alpha", "beta"}, tenantNames(ns1))
+
+		ns2, err := getTenantsAuth(t, "customer2:"+class, adminKey)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"alpha"}, tenantNames(ns2))
+
+		// user1 deactivates beta via the short class name.
+		require.NoError(t, updateTenantsAuth(t, class, []*models.Tenant{
+			{Name: "beta", ActivityStatus: models.TenantActivityStatusCOLD},
+		}, user1Key))
+		listed, err := getTenantsAuth(t, "customer1:"+class, adminKey)
+		require.NoError(t, err)
+		var betaActivity string
+		for _, tt := range listed {
+			if tt.Name == "beta" {
+				betaActivity = tt.ActivityStatus
+			}
+		}
+		assert.Equal(t, models.TenantActivityStatusCOLD, betaActivity)
+
+		// user1 deletes alpha by short name; ns2's alpha is untouched.
+		require.NoError(t, deleteTenantsAuth(t, class, []string{"alpha"}, user1Key))
+		ns1after, err := getTenantsAuth(t, "customer1:"+class, adminKey)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"beta"}, tenantNames(ns1after))
+		ns2after, err := getTenantsAuth(t, "customer2:"+class, adminKey)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"alpha"}, tenantNames(ns2after))
+	})
+
+	t.Run("REST reads are namespace-scoped", func(t *testing.T) {
+		const class = "TenantsRead"
+		setupMTClassInBothNamespaces(t, class, user1Key, user2Key)
+
+		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{
+			{Name: "shared"},
+		}, user1Key))
+		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{
+			{Name: "shared"},
+			{Name: "ns2only"},
+		}, user2Key))
+
+		ns1, err := getTenantsAuth(t, class, user1Key)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"shared"}, tenantNames(ns1))
+
+		ns2, err := getTenantsAuth(t, class, user2Key)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"shared", "ns2only"}, tenantNames(ns2))
+
+		got, err := getOneTenantAuth(t, class, "shared", user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "shared", got.Name)
+
+		// ns2only is invisible to user1 — qualifies to customer1:TenantsRead
+		// where no such tenant exists.
+		_, err = getOneTenantAuth(t, class, "ns2only", user1Key)
+		require.Error(t, err)
+
+		require.NoError(t, tenantExistsAuth(t, class, "shared", user1Key))
+		require.Error(t, tenantExistsAuth(t, class, "ns2only", user1Key))
+	})
+
+	t.Run("global principal uses qualified names; short names do not resolve", func(t *testing.T) {
+		const class = "TenantsAdmin"
+		setupMTClassInNs1(t, class, user1Key)
+
+		require.NoError(t, addTenantsAuth(t, "customer1:"+class, []*models.Tenant{
+			{Name: "byAdmin"},
+		}, adminKey))
+
+		listed, err := getTenantsAuth(t, "customer1:"+class, adminKey)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"byAdmin"}, tenantNames(listed))
+
+		// Short name from a global principal does not resolve — admin has no
+		// namespace, so the handler leaves the name as-is and the storage
+		// lookup misses.
+		_, err = getTenantsAuth(t, class, adminKey)
+		require.Error(t, err)
+	})
+
+	t.Run("gRPC TenantsGet under namespaced principal returns own tenants", func(t *testing.T) {
+		const class = "TenantsGRPC"
+		setupMTClassInBothNamespaces(t, class, user1Key, user2Key)
+
+		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{{Name: "g1"}}, user1Key))
+		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{{Name: "g2"}}, user2Key))
+
+		resp1, err := grpcClient.TenantsGet(authCtx(user1Key), &pb.TenantsGetRequest{Collection: class})
+		require.NoError(t, err)
+		require.Len(t, resp1.Tenants, 1)
+		assert.Equal(t, "g1", resp1.Tenants[0].Name)
+
+		resp2, err := grpcClient.TenantsGet(authCtx(user2Key), &pb.TenantsGetRequest{Collection: class})
+		require.NoError(t, err)
+		require.Len(t, resp2.Tenants, 1)
+		assert.Equal(t, "g2", resp2.Tenants[0].Name)
+	})
+
+	t.Run("gRPC TenantsGet with Names param filters to the requested subset", func(t *testing.T) {
+		const class = "TenantsGRPCNames"
+		setupMTClassInNs1(t, class, user1Key)
+
+		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{
+			{Name: "keep1"},
+			{Name: "keep2"},
+			{Name: "skip"},
+		}, user1Key))
+
+		resp, err := grpcClient.TenantsGet(authCtx(user1Key), &pb.TenantsGetRequest{
+			Collection: class,
+			Params: &pb.TenantsGetRequest_Names{
+				Names: &pb.TenantNames{Values: []string{"keep1", "keep2"}},
+			},
+		})
+		require.NoError(t, err)
+		got := make([]string, len(resp.Tenants))
+		for i, tt := range resp.Tenants {
+			got[i] = tt.Name
+		}
+		assert.ElementsMatch(t, []string{"keep1", "keep2"}, got)
+	})
+
+	t.Run("gRPC TenantsGet under global principal uses qualified collection name", func(t *testing.T) {
+		const class = "TenantsGRPCAdmin"
+		setupMTClassInNs1(t, class, user1Key)
+
+		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{{Name: "ga1"}}, user1Key))
+
+		resp, err := grpcClient.TenantsGet(authCtx(adminKey), &pb.TenantsGetRequest{Collection: "customer1:" + class})
+		require.NoError(t, err)
+		require.Len(t, resp.Tenants, 1)
+		assert.Equal(t, "ga1", resp.Tenants[0].Name)
+
+		// Short name from a global principal does not resolve.
+		_, err = grpcClient.TenantsGet(authCtx(adminKey), &pb.TenantsGetRequest{Collection: class})
+		require.Error(t, err)
+	})
+
+	t.Run("alias is not a backdoor: tenant mutations via alias name fail", func(t *testing.T) {
+		const (
+			class = "AliasBackdoorTarget"
+			alias = "AliasBackdoor"
+		)
+		setupMTClassInNs1(t, class, user1Key)
+
+		// Seed the underlying class with a known tenant so we can detect any
+		// state change after the rejected calls.
+		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{
+			{Name: "seed", ActivityStatus: models.TenantActivityStatusHOT},
+		}, user1Key))
+
+		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: class}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+
+		// Mutations qualify via QualifyClass, which does not resolve aliases.
+		// All three calls must fail.
+		require.Error(t, addTenantsAuth(t, alias, []*models.Tenant{
+			{Name: "viaAlias", ActivityStatus: models.TenantActivityStatusHOT},
+		}, user1Key))
+		require.Error(t, updateTenantsAuth(t, alias, []*models.Tenant{
+			{Name: "seed", ActivityStatus: models.TenantActivityStatusCOLD},
+		}, user1Key))
+		require.Error(t, deleteTenantsAuth(t, alias, []string{"seed"}, user1Key))
+
+		// Underlying class state must be unchanged: same single tenant, still
+		// HOT, no leaked "viaAlias" tenant.
+		listed, err := getTenantsAuth(t, "customer1:"+class, adminKey)
+		require.NoError(t, err)
+		require.Len(t, listed, 1)
+		assert.Equal(t, "seed", listed[0].Name)
+		assert.Equal(t, models.TenantActivityStatusHOT, listed[0].ActivityStatus)
+	})
+
+	t.Run("namespaced caller submitting :-qualified class double-prefixes", func(t *testing.T) {
+		const class = "TenantsDoublePrefix"
+		setupMTClassInNs1(t, class, user1Key)
+
+		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{{Name: "x"}}, user1Key))
+
+		// user1 supplying "customer1:TenantsDoublePrefix" qualifies again to
+		// "customer1:customer1:TenantsDoublePrefix" — no such class.
+		_, err := getTenantsAuth(t, "customer1:"+class, user1Key)
+		require.Error(t, err)
+
+		err = addTenantsAuth(t, "customer1:"+class, []*models.Tenant{{Name: "y"}}, user1Key)
+		require.Error(t, err)
+	})
+
+	t.Run("single-tenant read endpoints resolve aliases", func(t *testing.T) {
+		const (
+			class = "AliasSingleTarget"
+			alias = "AliasSingle"
+		)
+		setupMTClassInNs1(t, class, user1Key)
+
+		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{
+			{Name: "present", ActivityStatus: models.TenantActivityStatusHOT},
+		}, user1Key))
+
+		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: class}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+
+		// GetConsistentTenant via alias resolves to the underlying class.
+		got, err := getOneTenantAuth(t, alias, "present", user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "present", got.Name)
+		assert.Equal(t, models.TenantActivityStatusHOT, got.ActivityStatus)
+
+		// Missing tenant on the same alias still 404s — alias resolution
+		// must not paper over a real not-found.
+		_, err = getOneTenantAuth(t, alias, "missing", user1Key)
+		require.Error(t, err)
+
+		// ConsistentTenantExists via alias resolves to the underlying class.
+		require.NoError(t, tenantExistsAuth(t, alias, "present", user1Key))
+		require.Error(t, tenantExistsAuth(t, alias, "missing", user1Key))
+	})
+
+	t.Run("alias-resolved read returns tenants of underlying class", func(t *testing.T) {
+		const (
+			class = "TenantsAliasTarget"
+			alias = "TenantsAlias"
+		)
+		setupMTClassInNs1(t, class, user1Key)
+
+		require.NoError(t, addTenantsAuth(t, class, []*models.Tenant{{Name: "t1"}, {Name: "t2"}}, user1Key))
+
+		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: class}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+
+		listed, err := getTenantsAuth(t, alias, user1Key)
+		require.NoError(t, err)
+		assert.ElementsMatch(t, []string{"t1", "t2"}, tenantNames(listed))
+
+		got, err := getOneTenantAuth(t, alias, "t1", user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "t1", got.Name)
+
+		require.NoError(t, tenantExistsAuth(t, alias, "t2", user1Key))
+
+		resp, err := grpcClient.TenantsGet(authCtx(user1Key), &pb.TenantsGetRequest{Collection: alias})
+		require.NoError(t, err)
+		grpcNames := make([]string, len(resp.Tenants))
+		for i, tt := range resp.Tenants {
+			grpcNames[i] = tt.Name
+		}
+		assert.ElementsMatch(t, []string{"t1", "t2"}, grpcNames)
+	})
+}

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -37,8 +37,7 @@ import (
 func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, object *models.Object,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
-	className := schema.UppercaseClassName(object.Class)
-	className, _ = m.resolveNS(principal, className)
+	className, _ := m.resolveNS(principal, object.Class)
 	object.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.ShardsData(className, object.Tenant)...); err != nil {

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -39,7 +39,6 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 
 	classesShards := make(map[string][]string)
 	for _, obj := range objects {
-		obj.Class = schema.UppercaseClassName(obj.Class)
 		cls, _ := b.resolveNS(principal, obj.Class)
 		obj.Class = cls
 		classesShards[obj.Class] = append(classesShards[obj.Class], obj.Tenant)

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -22,7 +22,6 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/classcache"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/memwatch"
@@ -36,7 +35,6 @@ func (m *Manager) DeleteObject(ctx context.Context,
 	principal *models.Principal, className string, id strfmt.UUID,
 	repl *additional.ReplicationProperties, tenant string,
 ) error {
-	className = schema.UppercaseClassName(className)
 	className, _ = m.resolveNS(principal, className)
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Objects(className, tenant, id)); err != nil {

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -22,7 +22,6 @@ import (
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/filters"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/entities/search"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
@@ -34,7 +33,6 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal,
 	class string, id strfmt.UUID, additional additional.Properties,
 	replProps *additional.ReplicationProperties, tenant string,
 ) (*models.Object, error) {
-	class = schema.UppercaseClassName(class)
 	class, _ = m.resolveNS(principal, class)
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(class, tenant, id)); err != nil {

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -49,7 +49,7 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	if err := m.validateInputs(updates); err != nil {
 		return &Error{"bad request", StatusBadRequest, err}
 	}
-	className, aliasName := m.resolveNS(principal, schema.UppercaseClassName(updates.Class))
+	className, aliasName := m.resolveNS(principal, updates.Class)
 	updates.Class = className
 	cls, id := updates.Class, updates.ID
 	if err := m.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Objects(cls, updates.Tenant, id)); err != nil {

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -34,8 +34,7 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	class string, id strfmt.UUID, updates *models.Object,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
-	className := schema.UppercaseClassName(updates.Class)
-	className, _ = m.resolveNS(principal, className)
+	className, _ := m.resolveNS(principal, updates.Class)
 	updates.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Objects(updates.Class, updates.Tenant, updates.ID)); err != nil {

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -17,8 +17,6 @@ import (
 
 	"github.com/weaviate/weaviate/entities/classcache"
 
-	"github.com/weaviate/weaviate/entities/schema"
-
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -30,8 +28,7 @@ import (
 func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principal,
 	obj *models.Object, repl *additional.ReplicationProperties,
 ) error {
-	className := schema.UppercaseClassName(obj.Class)
-	className, _ = m.resolveNS(principal, className)
+	className, _ := m.resolveNS(principal, obj.Class)
 	obj.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(className, obj.Tenant, obj.ID)); err != nil {

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -66,7 +66,6 @@ func (h *Handler) GetConsistentClass(ctx context.Context, principal *models.Prin
 	// NOTE: Support getting class via alias name
 	// Also we resolve before doing `Authorize` so that Authorizer will work
 	// with correct `collectionName` for permissions and errors UX
-	name = schema.UppercaseClassName(name)
 	resolved, _ := namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, name)
 	name = resolved
 

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -45,12 +45,13 @@ func qualify(principal *models.Principal, name string) string {
 // Resolve is the read-side entry point used everywhere a user-supplied
 // class/alias name needs to become an internal class name:
 //
-//  1. If namespaces are enabled cluster-wide, qualify the input with the
-//     principal's namespace. When NS is disabled the qualification step is
-//     skipped — a stray principal.Namespace on an NS-disabled cluster is
-//     silently ignored here; rejecting that state is an upstream invariant
-//     enforced by startup gating, DB-user create, and OIDC classification.
-//  2. Look the (possibly qualified) name up as an alias via the existing
+//  1. Uppercase the class portion of the input so storage lookups hit the
+//     canonical case. UppercaseClassName preserves a leading "<namespace>:"
+//     prefix verbatim and only touches the class portion.
+//  2. If namespaces are enabled cluster-wide, qualify the (now-uppercased)
+//     input with the principal's namespace. When NS is disabled the
+//     qualification step is skipped.
+//  3. Look the (possibly qualified) name up as an alias via the existing
 //     in-memory resolver; if it matches an alias, return the alias target.
 //
 // Returns (class, originalAlias). originalAlias is the qualified alias name
@@ -59,9 +60,9 @@ func qualify(principal *models.Principal, name string) string {
 // the objects layer to preserve existing alias-aware flows. Sites that do
 // not need this can ignore the second return value.
 func Resolve(principal *models.Principal, sm SchemaManager, nsEnabled bool, name string) (class, originalAlias string) {
-	qualified := name
+	qualified := schema.UppercaseClassName(name)
 	if nsEnabled {
-		qualified = qualify(principal, name)
+		qualified = qualify(principal, qualified)
 	}
 
 	// Check if the qualified name is an alias

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -273,6 +273,15 @@ func TestResolve(t *testing.T) {
 			wantClass: "customer1:Movies",
 			wantAlias: "",
 		},
+		{
+			testName:  "ns disabled still uppercases lowercase input",
+			principal: &models.Principal{Username: "u"},
+			sm:        &fakeSchemaManager{aliases: map[string]string{}},
+			nsEnabled: false,
+			input:     "movies",
+			wantClass: "Movies",
+			wantAlias: "",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -255,6 +255,24 @@ func TestResolve(t *testing.T) {
 			wantClass: "Movies",
 			wantAlias: "Films",
 		},
+		{
+			testName:  "lowercase short input is uppercased before qualification",
+			principal: &models.Principal{Username: "u", Namespace: "customer1"},
+			sm:        &fakeSchemaManager{aliases: map[string]string{}},
+			nsEnabled: true,
+			input:     "movies",
+			wantClass: "customer1:Movies",
+			wantAlias: "",
+		},
+		{
+			testName:  "lowercase qualified input uppercases only the class portion",
+			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
+			sm:        &fakeSchemaManager{aliases: map[string]string{}},
+			nsEnabled: true,
+			input:     "customer1:movies",
+			wantClass: "customer1:Movies",
+			wantAlias: "",
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
 	uco "github.com/weaviate/weaviate/usecases/objects"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
@@ -40,6 +41,8 @@ func (h *Handler) AddTenants(ctx context.Context,
 	class string,
 	tenants []*models.Tenant,
 ) (uint64, error) {
+	class = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, class)
+
 	tenantNames := make([]string, len(tenants))
 	for i, tenant := range tenants {
 		tenantNames[i] = tenant.Name
@@ -145,6 +148,8 @@ func (h *Handler) validateActivityStatuses(ctx context.Context, tenants []*model
 func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal,
 	class string, tenants []*models.Tenant,
 ) ([]*models.Tenant, error) {
+	class = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, class)
+
 	shardNames := make([]string, len(tenants))
 	for idx := range tenants {
 		shardNames[idx] = tenants[idx].Name
@@ -202,6 +207,8 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal, class string, tenants []string) error {
+	class = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, class)
+
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.ShardsMetadata(class, tenants...)...); err != nil {
 		return err
 	}
@@ -227,11 +234,7 @@ func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Pr
 	var allTenants []*models.Tenant
 	var err error
 
-	// support getting tenants via alias
-	class = schema.UppercaseClassName(class)
-	if rclass := h.schemaReader.ResolveAlias(class); rclass != "" {
-		class = rclass
-	}
+	class, _ = namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, class)
 	if consistency {
 		allTenants, _, err = h.schemaManager.QueryTenants(class, tenants)
 	} else {
@@ -258,6 +261,8 @@ func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Pr
 }
 
 func (h *Handler) GetConsistentTenant(ctx context.Context, principal *models.Principal, class string, consistency bool, tenant string) (*models.Tenant, error) {
+	class, _ = namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, class)
+
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.READ, authorization.ShardsMetadata(class, tenant)...); err != nil {
 		return nil, err
 	}
@@ -299,6 +304,8 @@ func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) ConsistentTenantExists(ctx context.Context, principal *models.Principal, class string, consistency bool, tenant string) error {
+	class, _ = namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, class)
+
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.READ, authorization.ShardsMetadata(class, tenant)...); err != nil {
 		return err
 	}


### PR DESCRIPTION
### What's being changed:

Adds namespace handling for all tenant operation. Added alias support for tenant read operations where it was missing before and added tests for that. 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
