### PR TITLE
fix(dynamic): clean stale HNSW commit log on shard restart when upgrade incomplete

### DIFF
--- a/adapters/repos/db/vector/dynamic/index.go
+++ b/adapters/repos/db/vector/dynamic/index.go
@@ -297,6 +297,18 @@ func (dynamic *dynamic) init(cfg *Config) (bool, error) {
 		return false, errors.Wrap(err, "get dynamic state")
 	}
 
+	// If not yet upgraded, remove any stale HNSW commit log left by a
+	// previous failed upgrade attempt. The compact-v2 Loader replays the
+	// live WAL file on every hnsw.New() call, so without this cleanup each
+	// retry inherits partial state from the prior attempt, corrupting the
+	// compressor and causing vector-dimension mismatches at search time.
+	if !upgraded {
+		commitLogDir := hnswCommitLogDirectory(cfg.RootPath, cfg.ID)
+		if err := os.RemoveAll(commitLogDir); err != nil {
+			return false, errors.Wrap(err, "clean up stale hnsw commit log")
+		}
+	}
+
 	return upgraded, nil
 }
 

--- a/adapters/repos/db/vector/dynamic/index_test.go
+++ b/adapters/repos/db/vector/dynamic/index_test.go
@@ -14,6 +14,7 @@ package dynamic
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"sync"
@@ -1020,4 +1021,154 @@ func TestDynamicStoreMigrationBug(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+}
+
+// TestDynamicStaleCommitLogCleanedOnRestart is a regression test for a
+// compact-v2 HNSW loader bug. When a flat→HNSW upgrade is interrupted
+// (e.g. context canceled during shard teardown), the HNSW commit log
+// directory may contain partial WAL data from that attempt.  On the next
+// shard startup the dynamic index is re-created with upgraded=false, but
+// the commit log directory persists on disk.  hnsw.New() then calls the
+// compact-v2 Loader which — unlike the compactor — explicitly includes the
+// live WAL file in its startup scan.  This causes the new HNSW to start in
+// a partially-built state with stale compressed-vector dimensions, producing
+// "vector lengths don't match" panics at search time.
+//
+// The fix: dynamic.init() removes the commit log directory whenever
+// upgraded=false, enforcing the invariant that an unupgraded shard has no
+// HNSW commit log state.
+func TestDynamicStaleCommitLogCleanedOnRestart(t *testing.T) {
+	ctx := context.Background()
+	const (
+		dimensions  = 8
+		vectorsSize = 200
+		queriesSize = 10
+		k           = 10
+		threshold   = 100
+	)
+
+	tempDir := t.TempDir()
+	db, err := bbolt.Open(filepath.Join(tempDir, "index.db"), 0o666, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { db.Close() })
+
+	vectors, queries := testinghelpers.RandomVecs(vectorsSize, queriesSize, dimensions)
+	dist := distancer.NewL2SquaredProvider()
+	// Truths are computed only against the first `threshold` vectors, since that
+	// is what we add to dyn2 before upgrading — the recall check would be unfairly
+	// low if truths include vectors that were never indexed.
+	truths := make([][]uint64, queriesSize)
+	compressionhelpers.Concurrently(logger, uint64(len(queries)), func(i uint64) {
+		truths[i], _ = testinghelpers.BruteForce(logger, vectors[:threshold], queries[i], k, testinghelpers.DistanceWrapper(dist))
+	})
+
+	noopCallback := cyclemanager.NewCallbackGroupNoop()
+	fuc := flatent.UserConfig{}
+	fuc.SetDefaults()
+	// BQ on the flat side matches the bq_dynamic scenario in the failing CI test.
+	fuc.BQ = flatent.CompressionUserConfig{Enabled: true, Cache: true}
+	hnswuc := hnswent.UserConfig{
+		MaxConnections:        16,
+		EFConstruction:        64,
+		EF:                    32,
+		VectorCacheMaxObjects: 1_000_000,
+	}
+	hnswuc.SetDefaults()
+
+	indexID := "stale-cl-test"
+	makeConfig := func() Config {
+		return Config{
+			AllocChecker: memwatch.NewDummyMonitor(),
+			RootPath:     tempDir,
+			ID:           indexID,
+			MakeCommitLoggerThunk: func(opts ...hnsw.CommitlogOption) (hnsw.CommitLogger, error) {
+				return hnsw.NewCommitLogger(tempDir, indexID, logger, noopCallback, opts...)
+			},
+			DistanceProvider: dist,
+			VectorForIDThunk: func(ctx context.Context, id uint64) ([]float32, error) {
+				vec := vectors[int(id)]
+				if vec == nil {
+					return nil, storobj.NewErrNotFoundf(id, "nil vec")
+				}
+				return vec, nil
+			},
+			GetViewThunk:                 GetViewThunk,
+			TempVectorForIDWithViewThunk: TempVectorForIDWithViewThunk(vectors),
+			TombstoneCallbacks:           noopCallback,
+			SharedDB:                     db,
+			MakeBucketOptions:            lsmkv.MakeNoopBucketOptions,
+			AsyncIndexingEnabled:         true,
+		}
+	}
+	uc := ent.UserConfig{
+		Threshold: uint64(threshold),
+		Distance:  dist.Type(),
+		HnswUC:    hnswuc,
+		FlatUC:    fuc,
+	}
+
+	// --- First shard lifetime: add vectors, trigger upgrade, cancel via shutdown ---
+
+	dyn1, err := New(makeConfig(), uc, testinghelpers.NewDummyStore(t))
+	require.NoError(t, err)
+
+	compressionhelpers.Concurrently(logger, uint64(threshold), func(i uint64) {
+		require.NoError(t, dyn1.Add(ctx, i, vectors[i]))
+	})
+	shouldUpgrade, _ := dyn1.ShouldUpgrade()
+	require.True(t, shouldUpgrade)
+	require.False(t, dyn1.Upgraded())
+
+	upgradeDone := make(chan struct{})
+	dyn1.Upgrade(func() { close(upgradeDone) })
+	// Shutdown cancels the upgrade context before it can commit the DB flag.
+	require.NoError(t, dyn1.Shutdown(context.Background()))
+	select {
+	case <-upgradeDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("upgrade callback not called after shutdown")
+	}
+	require.False(t, dyn1.upgraded.Load(), "upgrade must not have committed")
+
+	// Simulate stale WAL left by the aborted upgrade: if the shutdown was fast
+	// enough that hnsw.New() never ran, plant the directory+file manually.
+	// Either way, after this block the commit log dir exists and is non-empty.
+	commitLogDir := hnswCommitLogDirectory(tempDir, indexID)
+	require.NoError(t, os.MkdirAll(commitLogDir, 0o755))
+	staleFile := filepath.Join(commitLogDir, "000000000001.wal")
+	require.NoError(t, os.WriteFile(staleFile, []byte("stale partial wal data"), 0o644))
+
+	_, err = os.Stat(staleFile)
+	require.NoError(t, err, "stale commit log file must exist before shard restart")
+
+	// --- Second shard lifetime: shard is recreated (same rootPath, same DB) ---
+	// init() must clean the commit log directory because upgraded=false.
+
+	dyn2, err := New(makeConfig(), uc, testinghelpers.NewDummyStore(t))
+	require.NoError(t, err)
+
+	_, statErr := os.Stat(commitLogDir)
+	require.True(t, os.IsNotExist(statErr),
+		"init() must remove the stale HNSW commit log dir when upgraded=false")
+
+	// --- Upgrade on the clean shard must succeed without dimension mismatch ---
+
+	compressionhelpers.Concurrently(logger, uint64(threshold), func(i uint64) {
+		require.NoError(t, dyn2.Add(ctx, i, vectors[i]))
+	})
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	require.NoError(t, dyn2.Upgrade(func() { wg.Done() }))
+	wg.Wait()
+	// upgraded.Load() is the canonical "flat→HNSW swap committed" flag;
+	// dynamic.Upgraded() also requires HNSW to be compressed, which is not
+	// configured in this test, so we check the atomic directly.
+	require.True(t, dyn2.upgraded.Load(), "upgrade must have committed to HNSW")
+
+	// Searches must return correct results — no "vector lengths don't match" panic.
+	recall, _ := testinghelpers.RecallAndLatency(ctx, queries, k, dyn2, truths)
+	require.Greater(t, recall, float32(0.7))
+
+	require.NoError(t, dyn2.Shutdown(context.Background()))
 }


### PR DESCRIPTION
## Problem

When a flat→HNSW upgrade is interrupted (context canceled during shard teardown), the HNSW commit log directory is left with partial WAL data. On the next shard startup, a fresh dynamic index is created with the DB flag still at `upgraded=false`, but the commit log directory persists on disk.

The compact-v2 `Loader` explicitly includes the live WAL file in every `hnsw.New()` call (unlike the compactor — see `loader.go:202`). This causes each subsequent upgrade attempt to replay stale partial state from the previous attempt into the new HNSW, corrupting the compressor and producing `"vector lengths don't match"` panics at search time.

Observed in CI on the `hnsw-compact-v2` branch:
```
vector search: vector lengths don't match: 8 vs 80
```
The failure occurred **before any restart**, during the "verify queries before restart" phase of `test_named_vector_after_restart[non_rolling_restart-graceful_shutdown]`. Three `restore_from_disk` events with growing durations (166µs → 6ms → 4.5ms) confirmed the commit log was accumulating state across failed upgrade attempts. Tracked in weaviate/weaviate#11230.

## Fix

`dynamic.init()` now removes the HNSW commit log directory when `upgraded=false`, enforcing the invariant:

> **An unupgraded shard has no HNSW commit log state.**

The cleanup happens at construction time, before any concurrent access starts, so it is safe regardless of what the compact-v2 Loader does at startup.

```go
if !upgraded {
    commitLogDir := hnswCommitLogDirectory(cfg.RootPath, cfg.ID)
    if err := os.RemoveAll(commitLogDir); err != nil {
        return false, errors.Wrap(err, "clean up stale hnsw commit log")
    }
}
```

## Test

`TestDynamicStaleCommitLogCleanedOnRestart` (`adapters/repos/db/vector/dynamic/index_test.go`):

1. Creates a dynamic index with a **real commit logger** and BQ compression on the flat side (matching the `bq_dynamic` named vector from the failing CI test).
2. Adds threshold vectors, triggers an upgrade, then immediately shuts down to simulate a canceled upgrade.
3. Plants a sentinel WAL file to represent stale data left by the aborted attempt (deterministic even when the shutdown races before `hnsw.New()` runs).
4. Recreates the shard from the same `rootPath`/DB.
5. **Asserts the commit log directory is gone** — the invariant enforced by the fix.
6. Completes a fresh upgrade and verifies recall > 0.7 (no dimension mismatch panic).

Without the fix the test fails at step 5:
```
init() must remove the stale HNSW commit log dir when upgraded=false
```

It fixes https://github.com/weaviate/0-weaviate-issues/issues/207