### PR TITLE
fix(monitoring): sum per-shard gauges when grouping is enabled

### DIFF
--- a/adapters/repos/db/lsmkv/metrics.go
+++ b/adapters/repos/db/lsmkv/metrics.go
@@ -627,7 +627,7 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		"path":       "n/a",
 	})
 
-	return &Metrics{
+	m := &Metrics{
 		register:            register,
 		groupClasses:        promMetrics.Group,
 		criticalBucketsOnly: promMetrics.LSMCriticalBucketsOnly,
@@ -711,10 +711,6 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 			"class_name": className,
 			"shard_name": shardName,
 		}),
-		objectCount: promMetrics.ObjectCount.With(prometheus.Labels{
-			"class_name": className,
-			"shard_name": shardName,
-		}),
 		memtableDurations: promMetrics.LSMMemtableDurations.MustCurryWith(prometheus.Labels{
 			"class_name": className,
 			"shard_name": shardName,
@@ -733,7 +729,14 @@ func NewMetrics(promMetrics *monitoring.PrometheusMetrics, className,
 		LazySegmentClose:  lazySegmentClose,
 		LazySegmentInit:   lazySegmentInit,
 		LazySegmentUnLoad: lazySegmentUnload,
-	}, nil
+	}
+	if !promMetrics.Group {
+		m.objectCount = promMetrics.ObjectCount.With(prometheus.Labels{
+			"class_name": className,
+			"shard_name": shardName,
+		})
+	}
+	return m, nil
 }
 
 // bucket metrics
@@ -1104,7 +1107,7 @@ func (m *Metrics) TrackStartupBucket(start time.Time) {
 }
 
 func (m *Metrics) ObjectCount(count int) {
-	if m == nil {
+	if m == nil || m.objectCount == nil {
 		return
 	}
 

--- a/adapters/repos/db/node_wide_metrics.go
+++ b/adapters/repos/db/node_wide_metrics.go
@@ -21,6 +21,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus"
 
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hfresh"
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
 	"github.com/weaviate/weaviate/entities/tenantactivity"
@@ -92,6 +94,7 @@ func (o *nodeWideMetricsObserver) observeShards() {
 			o.observeActivity()
 		case <-t30.C:
 			o.observeObjectCount()
+			o.observeAggregateGauges()
 		}
 	}
 }
@@ -153,6 +156,82 @@ func (o *nodeWideMetricsObserver) observeObjectCount() {
 		"took":         took,
 		"object_count": totalObjectCount,
 	}).Debug("observed node wide metrics")
+}
+
+// Sum per-shard gauges that are otherwise written under the shared n/a labels
+// in grouped mode. Per-shard write paths are no-ops when grouping is enabled,
+// so this sweep is the sole writer.
+//
+// Locking discipline (matches publishVectorMetrics): copy the indices map
+// under a brief indexLock.RLock and release it before iterating, so a long
+// sweep cannot starve schema writers. Per-shard work uses
+// index.dropIndex.RLock + index.shardCreateLocks.RLock, the same shape the
+// dimensions sweep already uses. ForEachLoadedShard skips cold tenants —
+// no force activation. Component reads (h.RLock, h.tombstoneLock.RLock,
+// queue.m.RLock) hold their locks just long enough to read a length and
+// contend with hot-path writers only briefly.
+func (o *nodeWideMetricsObserver) observeAggregateGauges() {
+	var indices map[string]*Index
+	func() {
+		o.db.indexLock.RLock()
+		defer o.db.indexLock.RUnlock()
+		indices = make(map[string]*Index, len(o.db.indices))
+		maps.Copy(indices, o.db.indices)
+	}()
+
+	var (
+		vectorIndexSize         int
+		vectorIndexTombstones   int
+		tombstoneDeleteListSize int
+		queueSize               int64
+		queueDiskUsage          int64
+	)
+
+	for _, index := range indices {
+		func() {
+			index.dropIndex.RLock()
+			defer index.dropIndex.RUnlock()
+
+			index.closeLock.RLock()
+			closed := index.closed
+			index.closeLock.RUnlock()
+			if closed {
+				return
+			}
+
+			index.ForEachLoadedShard(func(name string, shard ShardLike) error {
+				index.shardCreateLocks.RLock(name)
+				defer index.shardCreateLocks.RUnlock(name)
+
+				shard.ForEachVectorIndex(func(_ string, vi VectorIndex) error {
+					switch v := vi.(type) {
+					case *hnsw.HNSW:
+						vectorIndexSize += v.Size()
+						vectorIndexTombstones += v.TombstoneCount()
+						tombstoneDeleteListSize += v.TombstoneDeleteListSize()
+					case *hfresh.HFresh:
+						vectorIndexSize += int(v.PostingMap.TotalVectors())
+					}
+					return nil
+				})
+
+				shard.ForEachVectorQueue(func(_ string, q *VectorIndexQueue) error {
+					queueSize += q.Size()
+					queueDiskUsage += q.DiskUsage()
+					return nil
+				})
+
+				return nil
+			})
+		}()
+	}
+
+	naLabels := prometheus.Labels{"class_name": "n/a", "shard_name": "n/a"}
+	o.db.promMetrics.VectorIndexSize.With(naLabels).Set(float64(vectorIndexSize))
+	o.db.promMetrics.VectorIndexTombstones.With(naLabels).Set(float64(vectorIndexTombstones))
+	o.db.promMetrics.TombstoneDeleteListSize.With(naLabels).Set(float64(tombstoneDeleteListSize))
+	o.db.promMetrics.QueueSize.With(naLabels).Set(float64(queueSize))
+	o.db.promMetrics.QueueDiskUsage.With(naLabels).Set(float64(queueDiskUsage))
 }
 
 // NOTE(dyma): should this also chech that all indices report allShardsReady == true?

--- a/adapters/repos/db/node_wide_metrics_aggregate_test.go
+++ b/adapters/repos/db/node_wide_metrics_aggregate_test.go
@@ -1,0 +1,209 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/vector/hnsw"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storobj"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// TestObserveAggregateGauges_NoDeadlockWithBackupContention exercises the
+// new sweep against the contention pattern Etienne flagged: a backup holding
+// shardCreateLocks.Lock(name) while the sweep iterates loaded shards. The
+// sweep must not deadlock and must complete repeatedly within the test
+// budget. The race detector catches any data races introduced.
+func TestObserveAggregateGauges_NoDeadlockWithBackupContention(t *testing.T) {
+	metrics := monitoring.GetMetrics()
+	metrics.Group = true
+	t.Cleanup(func() { metrics.Group = false })
+
+	class := vectorTestClass()
+	db := createTestDatabaseWithClass(t, metrics, class)
+	idx := db.GetIndex(schema.ClassName(class.Class))
+	require.NotNil(t, idx)
+	insertVectors(t, idx, 200, defaultVectorDimensions)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	var sweepIters, backupIters atomic.Int64
+	var wg sync.WaitGroup
+
+	// Sweep loop: hammer observeAggregateGauges.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for ctx.Err() == nil {
+			db.metricsObserver.observeAggregateGauges()
+			sweepIters.Add(1)
+		}
+	}()
+
+	// Backup-style contention: take shardCreateLocks.Lock(name) on every
+	// shard for a brief moment, simulating backupShardWithHardlinks.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for ctx.Err() == nil {
+			idx.ForEachShard(func(name string, _ ShardLike) error {
+				idx.shardCreateLocks.Lock(name)
+				time.Sleep(200 * time.Microsecond)
+				idx.shardCreateLocks.Unlock(name)
+				return nil
+			})
+			backupIters.Add(1)
+		}
+	}()
+
+	// Hot-path inserts.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		i := 1000
+		for ctx.Err() == nil {
+			obj := buildVectorObject(class.Class, i, defaultVectorDimensions)
+			_ = idx.putObject(context.Background(), obj, nil, "", 0)
+			i++
+		}
+	}()
+
+	wg.Wait()
+
+	require.Greater(t, sweepIters.Load(), int64(0), "sweep must run at least once")
+	require.Greater(t, backupIters.Load(), int64(0), "backup contention must fire")
+}
+
+// TestObserveAggregateGauges_SkipsColdTenants verifies the sweep does not
+// force-activate lazy-loaded shards. With grouping on, the sweep must walk
+// only loaded shards.
+func TestObserveAggregateGauges_SkipsColdTenants(t *testing.T) {
+	metrics := monitoring.GetMetrics()
+	metrics.Group = true
+	t.Cleanup(func() { metrics.Group = false })
+
+	class := vectorTestClass()
+	db := createTestDatabaseWithClass(t, metrics, class)
+	idx := db.GetIndex(schema.ClassName(class.Class))
+	require.NotNil(t, idx)
+
+	loadedBefore := 0
+	idx.ForEachLoadedShard(func(string, ShardLike) error {
+		loadedBefore++
+		return nil
+	})
+
+	db.metricsObserver.observeAggregateGauges()
+
+	loadedAfter := 0
+	idx.ForEachLoadedShard(func(string, ShardLike) error {
+		loadedAfter++
+		return nil
+	})
+
+	assert.Equal(t, loadedBefore, loadedAfter, "sweep must not load cold shards")
+}
+
+// TestObserveAggregateGauges_SumsAcrossShard exercises the correctness path:
+// per-shard writes are gated off in grouped mode, so the n/a series must
+// reflect the values read directly from the shard's HNSW index.
+func TestObserveAggregateGauges_SumsAcrossShard(t *testing.T) {
+	metrics := monitoring.GetMetrics()
+	metrics.Group = true
+	t.Cleanup(func() { metrics.Group = false })
+
+	class := vectorTestClass()
+	db := createTestDatabaseWithClass(t, metrics, class)
+	idx := db.GetIndex(schema.ClassName(class.Class))
+	require.NotNil(t, idx)
+	const n = 50
+	insertVectors(t, idx, n, defaultVectorDimensions)
+
+	// Async indexing: wait until HNSW has caught up.
+	want := 0
+	require.Eventually(t, func() bool {
+		want = 0
+		idx.ForEachLoadedShard(func(_ string, sl ShardLike) error {
+			sl.ForEachVectorIndex(func(_ string, vi VectorIndex) error {
+				if h, ok := vi.(*hnsw.HNSW); ok {
+					want += h.Size()
+				}
+				return nil
+			})
+			return nil
+		})
+		return want > 0
+	}, 10*time.Second, 50*time.Millisecond, "HNSW must report non-zero size after inserts")
+
+	db.metricsObserver.observeAggregateGauges()
+
+	naLabels := prometheus.Labels{"class_name": "n/a", "shard_name": "n/a"}
+	got := testutil.ToFloat64(metrics.VectorIndexSize.With(naLabels))
+	assert.Equal(t, float64(want), got)
+}
+
+// vectorTestClass returns a single-tenant class with a default HNSW
+// vector index, suitable for the createTestDatabaseWithClass helper which
+// produces a singleShardState fixture.
+func vectorTestClass() *models.Class {
+	return &models.Class{
+		Class:             "VectorTestClass",
+		VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
+		Properties: []*models.Property{
+			{
+				Name:         "name",
+				DataType:     schema.DataTypeText.PropString(),
+				Tokenization: models.PropertyTokenizationWhitespace,
+			},
+		},
+		InvertedIndexConfig: &models.InvertedIndexConfig{},
+	}
+}
+
+func buildVectorObject(className string, i, dims int) *storobj.Object {
+	obj := &models.Object{
+		Class: className,
+		ID:    strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", i)),
+		Properties: map[string]interface{}{
+			"name": fmt.Sprintf("test-object-%d", i),
+		},
+	}
+	v := make([]float32, dims)
+	for j := range v {
+		v[j] = float32(i+j) / 1000.0
+	}
+	return storobj.FromObject(obj, v, nil, nil)
+}
+
+func insertVectors(t *testing.T, idx *Index, count, dims int) {
+	t.Helper()
+	for i := 0; i < count; i++ {
+		obj := buildVectorObject(string(idx.Config.ClassName), i, dims)
+		require.NoError(t, idx.putObject(context.Background(), obj, nil, "", 0))
+	}
+}

--- a/adapters/repos/db/queue/metrics.go
+++ b/adapters/repos/db/queue/metrics.go
@@ -45,8 +45,10 @@ func NewMetrics(
 
 	m.monitoring = true
 
-	m.queueSize = prom.QueueSize.With(labels)
-	m.queueDiskUsage = prom.QueueDiskUsage.With(labels)
+	if !prom.Group {
+		m.queueSize = prom.QueueSize.With(labels)
+		m.queueDiskUsage = prom.QueueDiskUsage.With(labels)
+	}
 	m.partitionProcessingDuration = prom.QueuePartitionProcessingDuration.With(labels)
 
 	return &m
@@ -69,7 +71,7 @@ func (m *Metrics) TasksProcessed(start time.Time, count int) {
 func (m *Metrics) Size(size uint64) {
 	m.logger.WithField("size", size).Tracef("queue size %d", size)
 
-	if !m.monitoring {
+	if !m.monitoring || m.queueSize == nil {
 		return
 	}
 
@@ -79,7 +81,7 @@ func (m *Metrics) Size(size uint64) {
 func (m *Metrics) DiskUsage(size int64) {
 	m.logger.WithField("disk_usage", size).Tracef("disk usage of queue %d", size)
 
-	if !m.monitoring {
+	if !m.monitoring || m.queueDiskUsage == nil {
 		return
 	}
 

--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -457,6 +457,17 @@ func (q *DiskQueue) Size() int64 {
 	return int64(q.recordCount)
 }
 
+func (q *DiskQueue) DiskUsage() int64 {
+	if q == nil {
+		return 0
+	}
+
+	q.m.RLock()
+	defer q.m.RUnlock()
+
+	return q.diskUsage
+}
+
 // Pause the dequeuing of tasks. If nowait is true, it returns immediately
 // without waiting for the currently running tasks to finish.
 // This does not prevent pushing new tasks to the queue.

--- a/adapters/repos/db/vector/hfresh/metrics.go
+++ b/adapters/repos/db/vector/hfresh/metrics.go
@@ -77,7 +77,10 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 		}
 	}
 
-	size := prom.VectorIndexSize.With(baseLabels)
+	var size prometheus.Gauge
+	if !prom.Group {
+		size = prom.VectorIndexSize.With(baseLabels)
+	}
 	insert := prom.VectorIndexOperations.With(opLabels("create"))
 	insertTime := prom.VectorIndexDurations.With(opStepLabels("create", "n/a"))
 	del := prom.VectorIndexOperations.With(opLabels("delete"))
@@ -136,7 +139,7 @@ func NewMetrics(prom *monitoring.PrometheusMetrics,
 }
 
 func (m *Metrics) SetSize(size int) {
-	if !m.enabled {
+	if !m.enabled || m.size == nil {
 		return
 	}
 

--- a/adapters/repos/db/vector/hfresh/posting_map.go
+++ b/adapters/repos/db/vector/hfresh/posting_map.go
@@ -18,6 +18,7 @@ import (
 	"iter"
 	"slices"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/pkg/errors"
@@ -34,10 +35,11 @@ type PostingMetadata struct {
 
 // PostingMap manages various information about postings.
 type PostingMap struct {
-	metrics    *Metrics
-	data       *xsync.Map[uint64, *PostingMetadata]
-	bucket     *PostingMapStore
-	sizeMetric *oncePer
+	metrics      *Metrics
+	data         *xsync.Map[uint64, *PostingMetadata]
+	bucket       *PostingMapStore
+	sizeMetric   *oncePer
+	totalVectors atomic.Uint64
 }
 
 func NewPostingMap(bucket *lsmkv.Bucket, metrics *Metrics) *PostingMap {
@@ -54,6 +56,10 @@ func NewPostingMap(bucket *lsmkv.Bucket, metrics *Metrics) *PostingMap {
 // Size returns the total number of postings in the map.
 func (v *PostingMap) Size() int {
 	return v.data.Size()
+}
+
+func (v *PostingMap) TotalVectors() uint64 {
+	return v.totalVectors.Load()
 }
 
 // Iter returns an iterator over all postings in the map.
@@ -222,6 +228,7 @@ func (v *PostingMap) setSizeMetricIfDue(ctx context.Context) {
 			return
 		}
 
+		v.totalVectors.Store(count)
 		v.metrics.SetSize(int(count))
 	})
 }

--- a/adapters/repos/db/vector/hnsw/delete.go
+++ b/adapters/repos/db/vector/hnsw/delete.go
@@ -385,6 +385,7 @@ func (h *hnsw) cleanUpTombstonedNodes(shouldAbort cyclemanager.ShouldAbortCallba
 	h.metrics.StartCleanup(tombstoneDeletionConcurrency())
 	defer h.metrics.EndCleanup(tombstoneDeletionConcurrency())
 
+	h.tombstoneDeleteListSize.Store(int64(deleteList.Len()))
 	h.metrics.SetTombstoneDeleteListSize(deleteList.Len())
 
 	h.tombstoneLock.Lock()

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -115,6 +115,7 @@ type hnsw struct {
 	trackMuveraOnce                   sync.Once
 	trackRQOnce                       sync.Once
 	dims                              atomic.Int32
+	tombstoneDeleteListSize           atomic.Int64
 
 	cache               cache.Cache[float32]
 	waitForCachePrefill bool
@@ -925,6 +926,22 @@ func (h *hnsw) CurrentVectorsLen() uint64 {
 		return h.compressor.MaxVectorID()
 	}
 	return uint64(h.cache.Len())
+}
+
+func (h *hnsw) Size() int {
+	h.RLock()
+	defer h.RUnlock()
+	return len(h.nodes)
+}
+
+func (h *hnsw) TombstoneCount() int {
+	h.tombstoneLock.RLock()
+	defer h.tombstoneLock.RUnlock()
+	return len(h.tombstones)
+}
+
+func (h *hnsw) TombstoneDeleteListSize() int {
+	return int(h.tombstoneDeleteListSize.Load())
 }
 
 func (h *hnsw) normalizeVec(vec []float32) []float32 {

--- a/adapters/repos/db/vector/hnsw/metrics.go
+++ b/adapters/repos/db/vector/hnsw/metrics.go
@@ -67,7 +67,10 @@ func newMetrics(prom *monitoring.PrometheusMetrics,
 		}
 	}
 
-	tombstones := prom.VectorIndexTombstones.With(baseLabels)
+	var tombstones prometheus.Gauge
+	if !prom.Group {
+		tombstones = prom.VectorIndexTombstones.With(baseLabels)
+	}
 	threads := prom.VectorIndexTombstoneCleanupThreads.With(baseLabels)
 	cleaned := prom.VectorIndexTombstoneCleanedCount.With(baseLabels)
 
@@ -85,7 +88,9 @@ func newMetrics(prom *monitoring.PrometheusMetrics,
 		insertTime = prom.VectorIndexDurations.MustCurryWith(opLabels("create"))
 		del = prom.VectorIndexOperations.With(opLabels("delete"))
 		deleteTime = prom.VectorIndexDurations.MustCurryWith(opLabels("delete"))
-		size = prom.VectorIndexSize.With(baseLabels)
+		if !prom.Group {
+			size = prom.VectorIndexSize.With(baseLabels)
+		}
 	}
 
 	grow := prom.VectorIndexMaintenanceDurations.With(opLabels("grow"))
@@ -100,7 +105,10 @@ func newMetrics(prom *monitoring.PrometheusMetrics,
 	tombstoneProgress := prom.VectorIndexTombstoneCycleProgress.With(baseLabels)
 	tombstoneFindGlobalEntrypoint := prom.TombstoneFindGlobalEntrypoint.With(baseLabels)
 	tombstoneFindLocalEntrypoint := prom.TombstoneFindLocalEntrypoint.With(baseLabels)
-	tombstoneDeleteListSize := prom.TombstoneDeleteListSize.With(baseLabels)
+	var tombstoneDeleteListSize prometheus.Gauge
+	if !prom.Group {
+		tombstoneDeleteListSize = prom.TombstoneDeleteListSize.With(baseLabels)
+	}
 
 	memoryAllocationRejected := prom.VectorIndexMemoryAllocationRejected
 
@@ -155,7 +163,7 @@ func (m *Metrics) TombstoneFindLocalEntrypoint() {
 }
 
 func (m *Metrics) SetTombstoneDeleteListSize(size int) {
-	if !m.enabled {
+	if !m.enabled || m.tombstoneDeleteListSize == nil {
 		return
 	}
 
@@ -163,7 +171,7 @@ func (m *Metrics) SetTombstoneDeleteListSize(size int) {
 }
 
 func (m *Metrics) AddTombstone() {
-	if !m.enabled {
+	if !m.enabled || m.tombstones == nil {
 		return
 	}
 
@@ -171,7 +179,7 @@ func (m *Metrics) AddTombstone() {
 }
 
 func (m *Metrics) SetTombstone(count int) {
-	if !m.enabled {
+	if !m.enabled || m.tombstones == nil {
 		return
 	}
 
@@ -213,7 +221,7 @@ func (m *Metrics) TombstoneCycleProgress(progress float64) {
 }
 
 func (m *Metrics) RemoveTombstone() {
-	if !m.enabled {
+	if !m.enabled || m.tombstones == nil {
 		return
 	}
 

--- a/usecases/monitoring/prometheus.go
+++ b/usecases/monitoring/prometheus.go
@@ -752,7 +752,7 @@ func newPrometheusMetrics() *PrometheusMetrics {
 
 		// Shard metrics
 		ShardsLoaded: promauto.NewGauge(prometheus.GaugeOpts{
-			Name: "7oaded",
+			Name: "shards_loaded",
 			Help: "Number of shards loaded",
 		}),
 		ShardsUnloaded: promauto.NewGauge(prometheus.GaugeOpts{


### PR DESCRIPTION
Same change as #11228, targeting `main` directly so we don't need to wait on the v1.37 cascade.

### What's being changed:

`PROMETHEUS_MONITORING_GROUP=true` is meant to collapse per-shard metrics onto a single `{class="n/a", shard="n/a"}` series so we don't blow up Prometheus cardinality at multi-tenant scale. For counter metrics this works: every shard's `Inc()` on the shared series accumulates into the node-wide total. For **gauge** metrics it's broken: every shard's `Set(v)` overwrites the shared series. Whichever shard wrote last wins, so the exported value is one arbitrary shard's, not the node total.

Concretely on a 3-pod cluster with ~9k multi-tenant shards per pod:

- `vector_index_size` jumps between ~1.5M and ~3.3M between scrapes (the actual node-wide total is ~76.5M).
- `queue_size` reports one shard's queue depth, not the total pending indexing work.
- `vector_index_tombstones` and `tombstone_delete_list_size` show the same: can't tell whether tombstones are accumulating cluster-wide or in one shard.

You can't run alerts or dashboards on these at MT scale: turning grouping off blows up cardinality (27k series per metric on a 3-node cluster), turning it on gives you a meaningless number.

### Fix

Same pattern we already use for `object_count` and `vector_dimensions_sum` in `node_wide_metrics.go`: in grouped mode, gate the per-shard writes on `!prom.Group` (so the per-shard `.Set` doesn't clobber the shared series), and have the existing `observeShards` 30s sweep walk loaded shards via `ForEachLoadedShard`, sum the values, and write the shared `n/a` series. Same metric name, same labels — just a correct value.

Affected gauges:

- `vector_index_size`
- `vector_index_tombstones`
- `tombstone_delete_list_size`
- `queue_size`
- `queue_disk_usage`

To support the sweep, added cheap getters: `hnsw.Size/TombstoneCount/TombstoneDeleteListSize`, `hfresh.PostingMap.TotalVectors` (cached from the existing throttled `setSizeMetricIfDue`), `queue.DiskUsage` (`Size` already existed). The HNSW delete-list size is now also tracked in an `atomic.Int64` on the index so the sweep can read it without holding any cleanup lock.

### Locking discipline

The sweep follows `publishVectorMetrics` exactly:

1. Copy the indices map under a brief `indexLock.RLock` and release before iterating (cannot starve schema writers).
2. Per-index: `dropIndex.RLock` + check `closed` flag under a transient `closeLock.RLock`.
3. Per-shard: `shardCreateLocks.RLock(name)`. `ForEachLoadedShard` skips cold/inactive tenants — no force activation.
4. Per-component reads (`h.RLock` for nodes, `h.tombstoneLock.RLock` for tombstones, `q.m.RLock` for queue) hold their locks just long enough to read a length.

Verified by static concurrency analysis and code inspection:

- No deadlock with backup. `BackupDescriptors` takes `dropIndex.RLock + closeLock.RLock` in the same order; `backupShardWithHardlinks` takes `shardCreateLocks.Lock(name)` but `hnsw.PrepareForBackup` does not acquire `h.Lock` or `h.tombstoneLock.Lock`, so the cycle Etienne flagged in past incidents does not exist.
- No lock inversion against `DeleteIndex` (`indexLock.Lock` -> `dropIndex.Lock`); the sweep takes the same direction with RLocks.
- Component-level writers (`hnsw/insert.go`, `hnsw/delete.go`, `queue/queue.go` Push) never recurse out to `dropIndex`/`closeLock`/`shardCreateLocks` — no back-edge.
- Worst case is brief per-shard contention behind a backup's `shardCreateLocks.Lock(name)`. Sweep continues to the next shard. No hot-path Search/Insert/Delete is affected.

### Tests

`adapters/repos/db/node_wide_metrics_aggregate_test.go`:

- `NoDeadlockWithBackupContention`: runs the sweep in a tight loop alongside a backup-style `shardCreateLocks.Lock(name)` goroutine and concurrent inserts for 2 seconds. Race detector + the test deadline would catch any race or hang.
- `SkipsColdTenants`: asserts the loaded shard count is unchanged after the sweep — no force activation.
- `SumsAcrossShard`: with grouping on, the sweep is the sole writer; the shared `n/a` series must equal the value read directly off the HNSW index.

### Bonus typo fix

`shards_loaded` was registered as `"7oaded"` (the `s_l` got mangled to `7`). Renamed to `shards_loaded`. No alias.

### Upgrade impact

Grouped-mode users will see `vector_index_size`, `vector_index_tombstones`, `tombstone_delete_list_size`, `queue_size`, `queue_disk_usage` step up to the actual node-wide totals (potentially 9000x for users at the reporter's scale). Absolute-threshold alerts on these will need re-tuning. The sweep runs every 30s, matching the existing `object_count` cadence.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.