### PR TITLE
fix(backup-gcs): use delimiter listing in AllBackups to avoid full object scan

### DIFF
--- a/modules/backup-gcs/client.go
+++ b/modules/backup-gcs/client.go
@@ -151,8 +151,15 @@ func (g *gcsClient) AllBackups(ctx context.Context) ([]*backup.DistributedBackup
 		return nil, fmt.Errorf("find bucket: %w", err)
 	}
 
+	// Use delimiter listing to get one-level-deep prefixes (one per backup ID)
+	// instead of scanning all objects
+	prefix := g.config.BackupPath
+	if prefix != "" {
+		prefix += "/"
+	}
+	iter := bucket.Objects(ctx, &storage.Query{Prefix: prefix, Delimiter: "/"})
+
 	var keys []string
-	iter := bucket.Objects(ctx, &storage.Query{Prefix: g.config.BackupPath, MatchGlob: "**/" + ubak.GlobalBackupFile})
 	for {
 		if err := ctx.Err(); err != nil {
 			return nil, err
@@ -166,7 +173,9 @@ func (g *gcsClient) AllBackups(ctx context.Context) ([]*backup.DistributedBackup
 			return nil, fmt.Errorf("get next object: %w", err)
 		}
 
-		keys = append(keys, next.Name)
+		if next.Prefix != "" {
+			keys = append(keys, next.Prefix+ubak.GlobalBackupFile)
+		}
 	}
 
 	return ubak.FetchBackupDescriptors(ctx, g.logger, keys, func(ctx context.Context, key string) ([]byte, error) {


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
