### PR TITLE
fix(lsmkv): recover from missing sidecar files on segment init

### DIFF
--- a/adapters/repos/db/lsmkv/segment_bloom_filters.go
+++ b/adapters/repos/db/lsmkv/segment_bloom_filters.go
@@ -88,9 +88,14 @@ func (s *segment) initBloomFilter(overwrite bool, existingFilesList map[string]i
 				return nil
 			}
 
-			if !errors.Is(err, ErrInvalidChecksum) {
-				// not a recoverable error
+			if !recoverableSidecarLoadErr(err) {
 				return err
+			}
+
+			if errors.Is(err, os.ErrNotExist) {
+				s.logger.WithField("action", "lsm_recover_missing_sidecar").
+					WithField("path", path).WithError(err).
+					Warn("primary bloom filter sidecar missing despite directory listing; recomputing from segment")
 			}
 
 			// now continue re-calculating
@@ -177,9 +182,16 @@ func (s *segment) initSecondaryBloomFilter(pos int, overwrite bool, existingFile
 				return nil
 			}
 
-			if !errors.Is(err, ErrInvalidChecksum) {
-				// not a recoverable error
+			if !recoverableSidecarLoadErr(err) {
 				return err
+			}
+
+			if errors.Is(err, os.ErrNotExist) {
+				s.logger.WithField("action", "lsm_recover_missing_sidecar").
+					WithField("path", path).
+					WithField("secondary_index_position", pos).
+					WithError(err).
+					Warn("secondary bloom filter sidecar missing despite directory listing; recomputing from segment")
 			}
 
 			// now continue re-calculating

--- a/adapters/repos/db/lsmkv/segment_metadata.go
+++ b/adapters/repos/db/lsmkv/segment_metadata.go
@@ -55,9 +55,14 @@ func (s *segment) initMetadata(metrics *Metrics, overwrite bool, exists existsOn
 			if err == nil {
 				return true, nil // successfully loaded
 			}
-			if !errors.Is(err, ErrInvalidChecksum) {
-				// not a recoverable error
+			if !recoverableSidecarLoadErr(err) {
 				return false, err
+			}
+
+			if errors.Is(err, os.ErrNotExist) {
+				s.logger.WithField("action", "lsm_recover_missing_sidecar").
+					WithField("path", path).WithError(err).
+					Warn("metadata sidecar missing despite directory listing; recomputing from segment")
 			}
 
 			// now continue re-calculating

--- a/adapters/repos/db/lsmkv/segment_net_count_additions.go
+++ b/adapters/repos/db/lsmkv/segment_net_count_additions.go
@@ -30,6 +30,25 @@ var ErrInvalidChecksum = errors.New("invalid checksum")
 
 const CountNetAdditionsFileSuffix = ".cna"
 
+// recoverableSidecarLoadErr reports whether err from loading a precomputed
+// sidecar file (.cna, .bloom, .metadata) can be recovered from by recomputing
+// the data from the underlying .db segment. The two recoverable cases are:
+//
+//   - ErrInvalidChecksum: the file is present but its contents are corrupt or
+//     truncated (e.g. a partial flush that did not survive a crash).
+//   - os.ErrNotExist: the file appeared in the directory listing built when
+//     the bucket was opened but is gone by the time the segment tries to
+//     read it. This has been observed after ungraceful shutdowns where the
+//     dirent is preserved but the file's inode/contents are not, and would
+//     otherwise leave the class permanently broken on the affected node.
+//
+// In both cases the data can be safely rebuilt from the .db segment, so the
+// caller should fall through to the recomputation path rather than aborting
+// segment init.
+func recoverableSidecarLoadErr(err error) bool {
+	return errors.Is(err, ErrInvalidChecksum) || errors.Is(err, os.ErrNotExist)
+}
+
 // existOnLowerSegments is a simple function that can be passed at segment
 // initialization time to check if any of the keys are truly new or previously
 // seen. This can in turn be used to build up the net count additions. The
@@ -65,9 +84,14 @@ func (s *segment) initCountNetAdditions(exists existsOnLowerSegmentsFn, overwrit
 				return nil
 			}
 
-			if !errors.Is(err, ErrInvalidChecksum) {
-				// not a recoverable error
+			if !recoverableSidecarLoadErr(err) {
 				return err
+			}
+
+			if errors.Is(err, os.ErrNotExist) {
+				s.logger.WithField("action", "lsm_recover_missing_sidecar").
+					WithField("path", path).WithError(err).
+					Warn("count net additions sidecar missing despite directory listing; recomputing from segment")
 			}
 
 			// now continue re-calculating

--- a/adapters/repos/db/lsmkv/segment_recovery_missing_sidecar_test.go
+++ b/adapters/repos/db/lsmkv/segment_recovery_missing_sidecar_test.go
@@ -1,0 +1,156 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package lsmkv
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/cyclemanager"
+	"github.com/weaviate/weaviate/entities/diskio"
+)
+
+// TestSegment_RecoverFromMissingSidecar reproduces the recovery failure
+// observed after ungraceful pod shutdown in
+// https://github.com/weaviate/0-weaviate-issues/issues/208 and pins the
+// expected behaviour: when a sidecar file (.cna, .bloom, .metadata) is
+// listed in the directory snapshot built on bucket open but is missing
+// from disk by the time newSegment opens it, the segment must still
+// initialise by recomputing the sidecar from the underlying .db segment.
+//
+// Before the fix, this test fails with "no such file or directory" and
+// the segment cannot be loaded; in production this manifests as a
+// permanently broken class on the affected node and DEADLINE_EXCEEDED
+// gRPC errors at the client.
+func TestSegment_RecoverFromMissingSidecar(t *testing.T) {
+	ctx := context.Background()
+	logger, _ := test.NewNullLogger()
+	existsOnLower := func(key []byte) (bool, error) { return false, nil }
+
+	cases := []struct {
+		name       string
+		suffix     string
+		bucketOpts []BucketOption
+		segCfg     segmentConfig
+	}{
+		{
+			name:   "missing .cna",
+			suffix: ".cna",
+			bucketOpts: []BucketOption{
+				WithStrategy(StrategyReplace),
+				WithPread(true),
+				WithUseBloomFilter(true),
+				WithCalcCountNetAdditions(true),
+				WithSegmentsChecksumValidationEnabled(false),
+			},
+			segCfg: segmentConfig{
+				useBloomFilter:        true,
+				calcCountNetAdditions: true,
+			},
+		},
+		{
+			name:   "missing primary .bloom",
+			suffix: ".bloom",
+			bucketOpts: []BucketOption{
+				WithStrategy(StrategyReplace),
+				WithPread(true),
+				WithUseBloomFilter(true),
+				WithCalcCountNetAdditions(true),
+				WithSegmentsChecksumValidationEnabled(false),
+			},
+			segCfg: segmentConfig{
+				useBloomFilter:        true,
+				calcCountNetAdditions: true,
+			},
+		},
+		{
+			name:   "missing .metadata",
+			suffix: ".metadata",
+			bucketOpts: []BucketOption{
+				WithStrategy(StrategyReplace),
+				WithPread(true),
+				WithUseBloomFilter(true),
+				WithCalcCountNetAdditions(true),
+				WithSegmentsChecksumValidationEnabled(false),
+				WithWriteMetadata(true),
+			},
+			segCfg: segmentConfig{
+				useBloomFilter:        true,
+				calcCountNetAdditions: true,
+				writeMetadata:         true,
+			},
+		},
+	}
+
+	const expectedCNA = 2
+
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+
+			// Create real .db plus sidecar files via a flushed bucket.
+			func() {
+				b, err := NewBucketCreator().NewBucket(ctx, dir, "", logger, nil,
+					cyclemanager.NewCallbackGroupNoop(), cyclemanager.NewCallbackGroupNoop(), c.bucketOpts...)
+				require.NoError(t, err)
+				defer b.Shutdown(ctx)
+				require.NoError(t, b.Put([]byte("k1"), []byte("v1")))
+				require.NoError(t, b.Put([]byte("k2"), []byte("v2")))
+				require.NoError(t, b.FlushMemtable())
+			}()
+
+			// Snapshot the directory the same way segment_group does on
+			// bucket open. Capture this *before* deleting the sidecar so the
+			// stale list still references the now-missing file.
+			fileList, _, err := diskio.GetFileWithSizes(dir)
+			require.NoError(t, err)
+
+			var dbName, sidecarName string
+			for name := range fileList {
+				switch {
+				case strings.HasSuffix(name, ".db") && dbName == "":
+					dbName = name
+				case strings.HasSuffix(name, c.suffix) && sidecarName == "":
+					sidecarName = name
+				}
+			}
+			require.NotEmpty(t, dbName, "expected a .db segment to be created")
+			require.NotEmpty(t, sidecarName, "expected a %s sidecar in the directory listing", c.suffix)
+
+			// Simulate the TOCTOU window: file was present at scan time, then
+			// vanishes before newSegment opens it. This is the surface
+			// behaviour observed after an ungraceful shutdown where the
+			// dirent is replayed but the inode/contents are not.
+			require.NoError(t, os.Remove(filepath.Join(dir, sidecarName)))
+
+			cfg := c.segCfg
+			cfg.fileList = fileList
+
+			seg, err := newSegment(filepath.Join(dir, dbName), logger, nil, existsOnLower, cfg)
+			require.NoError(t, err, "expected segment init to recover from missing %s sidecar; without the fix this fails with ENOENT", c.suffix)
+			t.Cleanup(func() { _ = seg.close() })
+
+			_, err = os.Stat(filepath.Join(dir, sidecarName))
+			assert.NoError(t, err, "expected %s sidecar to be recreated after recovery", c.suffix)
+
+			assert.Equal(t, expectedCNA, seg.getCountNetAdditions(),
+				"expected count net additions to be recomputed correctly after recovery")
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes recovery failure observed after ungraceful pod shutdown ([0-weaviate-issues#208](https://github.com/weaviate/0-weaviate-issues/issues/208)).

When a sidecar metadata file (`.cna`, `.bloom`, `.metadata`) is listed in the directory snapshot built on bucket open but is missing from disk by the time `newSegment` opens it, segment init currently returns the underlying `ENOENT` and the class becomes permanently broken on the affected node. The Python client surfaces this as `gRPC DEADLINE_EXCEEDED` because the read coordinator retries the broken host for up to 1 minute (longer than the client timeout).

Production trace from a recent CI failure on v1.37.2:
```
weaviate-5 ... msg: "failed to reload local index"
error: ... init segment .../objects/segment-1778237924230003200.l0.s0.db:
       open .../objects/segment-1778237924230003200.l0.s0.cna: no such file or directory
```

## What changed

The segment-init code path was already designed to handle one form of corrupt sidecar (`ErrInvalidChecksum`): it would log nothing, drop the broken file, and recompute the data from the `.db` segment. This change extends that same recovery to `os.ErrNotExist`, which is what surfaces when the dirent is preserved across crash recovery but the inode/contents are not.

- New helper `recoverableSidecarLoadErr` centralizes the predicate used at all four sidecar load sites:
  - `initCountNetAdditions` (`.cna`)
  - `initMetadata` (`.metadata`)
  - `initBloomFilter` (primary `.bloom`)
  - `initSecondaryBloomFilter` (secondary `.bloom`)
- A `Warn` log is emitted only on the new `os.ErrNotExist` branch (an unusual condition worth surfacing); existing `ErrInvalidChecksum` recovery remains silent to preserve current behavior.

## Test plan

- [x] `TestSegment_RecoverFromMissingSidecar` — reproduces the exact failure mode (sidecar listed in snapshot, missing on disk) for `.cna`, primary `.bloom`, and `.metadata`. Without the fix the test fails with `no such file or directory` (verified). With the fix, the segment initialises and the sidecar is recreated with the correct count.
- [x] Full `./adapters/repos/db/lsmkv/...` suite still passes.
- [x] `go vet` clean, `go build ./...` clean.

## Notes for reviewers

- The `Warn` log fires only on the new branch, so this PR doesn't change the volume of logs for already-known recovery (corrupt checksums after partial flush).
- The fix is intentionally minimal — same recovery semantics, broader trigger condition. No new abstractions beyond the small `recoverableSidecarLoadErr` predicate.
- Defense-in-depth in `usecases/schema/executor.go` (retrying `failed to reload local index` rather than leaving the class permanently broken) is a separate concern and not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
