### PR TITLE
feat: self-recovery

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -728,6 +728,8 @@ jobs:
             test: "--acceptance-compaction"
           - name: "recovery"
             test: "--acceptance-recovery"
+          - name: "self-recovery"
+            test: "--acceptance-self-recovery"
           - name: "python"
             test: "--acceptance-only-python"
     steps:
@@ -756,7 +758,7 @@ jobs:
         env:
           MATRIX_TEST: ${{ matrix.name }}
         run: |
-          if [[ "$MATRIX_TEST" == "replica-slow" || "$MATRIX_TEST" == "replica-slow-grpc" || "$MATRIX_TEST" == "fast-group-4" || "$MATRIX_TEST" == "recovery" || "$MATRIX_TEST" == "distributed-tasks" || "$MATRIX_TEST" == "compaction" ]]; then
+          if [[ "$MATRIX_TEST" == "replica-slow" || "$MATRIX_TEST" == "replica-slow-grpc" || "$MATRIX_TEST" == "fast-group-4" || "$MATRIX_TEST" == "recovery" || "$MATRIX_TEST" == "self-recovery" || "$MATRIX_TEST" == "distributed-tasks" || "$MATRIX_TEST" == "compaction" ]]; then
             echo "test_timeout_minutes=45" >> $GITHUB_ENV
           else
             echo "test_timeout_minutes=15" >> $GITHUB_ENV

--- a/adapters/handlers/rest/clusterapi/grpc/file_replication_service.go
+++ b/adapters/handlers/rest/clusterapi/grpc/file_replication_service.go
@@ -13,11 +13,14 @@ package grpc
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/pkg/errors"
 	pb "github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc/generated/protocol"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/schema"
 	"github.com/weaviate/weaviate/usecases/sharding"
 	"google.golang.org/grpc/codes"
@@ -88,11 +91,25 @@ func (fps *FileReplicationService) ListFiles(ctx context.Context, req *pb.ListFi
 
 	index := fps.repo.GetIndexForIncomingSharding(schema.ClassName(indexName))
 	if index == nil {
-		return nil, status.Errorf(codes.Internal, "local index %q not found", indexName)
+		// Treat as transient: a nil index can mean the schema-replay
+		// hasn't reached this peer yet (eventual consistency), not just
+		// "this collection truly doesn't exist". NotFound would tell a
+		// self-recovery probe "definitive empty" and could push the
+		// orchestrator into the catastrophic-wipe empty-fallback path.
+		return nil, status.Errorf(codes.Unavailable, "local index %q not loaded yet", indexName)
 	}
 
 	files, err := index.IncomingListFiles(ctx, shardName)
 	if err != nil {
+		// Self-recovery probes (and similar callers) interpret the
+		// gRPC code: NotFound = peer definitively has no shard;
+		// Unavailable = peer is itself recovering / busy.
+		switch {
+		case stderrors.Is(err, enterrors.ErrShardRecovering):
+			return nil, status.Errorf(codes.Unavailable, "shard %q on index %q is recovering: %v", shardName, indexName, err)
+		case isShardAbsent(err):
+			return nil, status.Errorf(codes.NotFound, "shard %q not present on index %q: %v", shardName, indexName, err)
+		}
 		return nil, status.Errorf(codes.Internal, "failed to list files for index %q, shard %q: %v", indexName, shardName, err)
 	}
 
@@ -172,6 +189,21 @@ func (fps *FileReplicationService) GetFile(req *pb.GetFileRequest, stream pb.Fil
 			return nil
 		}
 	}
+}
+
+// isShardAbsent reports whether err signals that the requested shard
+// does not exist on this node (vs. a transient/availability issue).
+// Match only shard-specific phrasings — the index layer's canonical
+// errors are "shard not found" / "shard is nil". A bare "not found"
+// substring would misclassify unrelated failures (missing file inside
+// an existing shard etc.) as shard-absence.
+func isShardAbsent(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "shard is nil") ||
+		strings.Contains(msg, "shard not found")
 }
 
 func (fps *FileReplicationService) indexForIncomingWrite(ctx context.Context, indexName string,

--- a/adapters/handlers/rest/clusterapi/grpc/file_replication_service_test.go
+++ b/adapters/handlers/rest/clusterapi/grpc/file_replication_service_test.go
@@ -1,0 +1,77 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package grpc
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc/generated/protocol"
+	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+// nilIndexRepo always returns nil from GetIndexForIncomingSharding,
+// simulating the case where the local node knows the request name but
+// the corresponding index isn't loaded yet (eventual-consistency window
+// during startup or schema-replay).
+type nilIndexRepo struct{}
+
+func (nilIndexRepo) GetIndexForIncomingSharding(_ schema.ClassName) sharding.RemoteIndexIncomingRepo {
+	return nil
+}
+
+// TestListFiles_NilIndexReturnsUnavailable verifies the gRPC code
+// returned when the local index is nil. NotFound would tell a
+// SELF_RECOVERY probe "definitively no data" and could push the
+// orchestrator into the catastrophic-wipe empty-fallback path even
+// though the peer might just be mid-startup. Unavailable signals
+// "transient — please retry".
+func TestListFiles_NilIndexReturnsUnavailable(t *testing.T) {
+	fps := NewFileReplicationService(nilIndexRepo{}, nil, 0)
+
+	_, err := fps.ListFiles(context.Background(), &pb.ListFilesRequest{
+		IndexName: "Paragraph",
+		ShardName: "shard-x",
+	})
+	require.Error(t, err)
+	st, ok := status.FromError(err)
+	require.True(t, ok, "error must carry a gRPC status: %v", err)
+	require.Equal(t, codes.Unavailable, st.Code(),
+		"nil index must surface as Unavailable (transient), not NotFound (definitive); got %s", st.Code())
+}
+
+// TestIsShardAbsent pins the substring matcher that maps IncomingListFiles
+// errors to gRPC NotFound. It must match the canonical "shard is nil" /
+// "shard not found" phrasings (so a SELF_RECOVERY probe sees "definitively
+// no data") but nothing broader (e.g. a missing *file* must not be
+// misread as a missing shard).
+func TestIsShardAbsent(t *testing.T) {
+	cases := []struct {
+		err  error
+		want bool
+	}{
+		{nil, false},
+		{errors.New("incoming list files: shard is nil"), true},
+		{errors.New("shard not found for collection X"), true},
+		{errors.New("file segment-123.db not found"), false},
+		{errors.New("some other transient error"), false},
+	}
+	for _, tc := range cases {
+		require.Equal(t, tc.want, isShardAbsent(tc.err), "isShardAbsent(%v)", tc.err)
+	}
+}

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -70,6 +70,7 @@ import (
 	rCluster "github.com/weaviate/weaviate/cluster"
 	"github.com/weaviate/weaviate/cluster/distributedtask"
 	"github.com/weaviate/weaviate/cluster/replication/copier"
+	"github.com/weaviate/weaviate/cluster/replication/selfrecovery"
 	"github.com/weaviate/weaviate/cluster/usage"
 	entconfig "github.com/weaviate/weaviate/entities/config"
 	enterrors "github.com/weaviate/weaviate/entities/errors"
@@ -704,6 +705,45 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 	appState.ClusterService = rCluster.New(rConfig, appState.AuthzController, appState.AuthzSnapshotter, appState.GRPCServerMetrics)
 	migrator.SetCluster(appState.ClusterService.Raft)
 
+	// Wired after Cluster (Raft dep) and before WaitForStartup so the
+	// schema-replay shard-init pass can hand off missing-on-disk shards.
+	// (The bootstrap-window classification of empty-fallbacks is captured
+	// per-op at submit time from IndexConfig.RaftBootstrapComplete, so the
+	// orchestrator itself doesn't need that hook.)
+	selfRecoveryOrch := selfrecovery.New(selfrecovery.Config{
+		Raft:                   appState.ClusterService.Raft,
+		Schema:                 selfRecoverySchemaReader{r: appState.ClusterService.SchemaReader()},
+		PathResolver:           selfRecoveryDBPathResolver{db: appState.DB, root: dataPath},
+		ClientFactory:          remoteClientFactory,
+		NodeSelector:           nodeSelector,
+		NodeName:               nodeName,
+		Enabled:                appState.ServerConfig.Config.Replication.SelfRecoveryEnabled,
+		Concurrency:            appState.ServerConfig.Config.Replication.SelfRecoveryConcurrency,
+		MaintenanceModeEnabled: appState.Cluster.MaintenanceModeEnabledForLocalhost,
+		OnRecoveryComplete: func(ctx context.Context, collection, shard string) error {
+			idx := appState.DB.GetIndex(entschema.ClassName(collection))
+			if idx == nil {
+				return fmt.Errorf("self-recovery promote: index %q not found", collection)
+			}
+			return idx.LoadLocalShard(ctx, shard, false)
+		},
+		Logger: appState.Logger,
+	})
+	appState.DB.SetSelfRecoveryOrchestrator(selfRecoveryOrch)
+	// The operator/debug HTTP endpoints (and the test-only force-snapshot
+	// endpoint) only make sense when the feature is on; don't expose them
+	// — even on the profiling port — when it's off.
+	if cfg := appState.ServerConfig.Config.Replication.SelfRecoveryEnabled; cfg != nil && cfg.Get() {
+		setupSelfRecoveryHandlers(appState, selfRecoveryOrch)
+		setupRaftDebugHandlers(appState, appState.ClusterService.Raft)
+	}
+	// One-shot reclaim of *.recovering/ leftovers from a downgrade.
+	if removed, err := selfRecoveryOrch.CleanupOrphanRecoveryDirs(dataPath); err != nil {
+		appState.Logger.WithError(err).Warn("self-recovery orphan cleanup failed")
+	} else if len(removed) > 0 {
+		appState.Logger.WithField("count", len(removed)).Info("self-recovery: removed orphan recovery dirs")
+	}
+
 	executor := schema.NewExecutor(migrator,
 		appState.ClusterService.SchemaReader(),
 		appState.Logger, backup.RestoreClassDir(dataPath),
@@ -813,6 +853,9 @@ func MakeAppState(ctx, serverShutdownCtx context.Context, options *swag.CommandL
 				Fatal("could not open cloud meta store")
 			metaStoreReady.failure(err)
 		} else {
+			// Past initial FSM replay: any further AddClass calls are
+			// runtime additions, not data-loss candidates.
+			appState.DB.MarkRaftBootstrapComplete()
 			metaStoreReady.success()
 		}
 	}, appState.Logger)

--- a/adapters/handlers/rest/handlers_debug_raft.go
+++ b/adapters/handlers/rest/handlers_debug_raft.go
@@ -1,0 +1,53 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"net/http"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/cluster"
+)
+
+// setupRaftDebugHandlers registers admin endpoints used to make RAFT
+// behaviour observable / scriptable from tests. Currently a single
+// endpoint that forces an immediate snapshot — needed by the
+// SELF_RECOVERY acceptance tests so a wiped node's rejoin is
+// guaranteed to go through InstallSnapshot → Restore (not the
+// log-replay path, which does not trigger the recovery hook).
+func setupRaftDebugHandlers(appState *state.State, raft *cluster.Raft) {
+	logger := appState.Logger.WithField("handler", "raft_debug")
+
+	// POST /debug/raft/snapshot — triggers raft.Snapshot() on the
+	// local node and blocks until it completes. Returns 202 on
+	// success, 500 on error.
+	http.HandleFunc("/debug/raft/snapshot", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed; use POST", http.StatusMethodNotAllowed)
+			return
+		}
+		if raft == nil {
+			http.Error(w, "raft is not configured on this node", http.StatusServiceUnavailable)
+			return
+		}
+		if err := raft.ForceSnapshot(); err != nil {
+			logger.WithError(err).Error("force snapshot failed")
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		if _, err := w.Write([]byte(`{"status":"snapshot_taken"}` + "\n")); err != nil {
+			logger.WithError(err).Debug("raft snapshot: response write failed (client disconnect?)")
+		}
+	}))
+}

--- a/adapters/handlers/rest/handlers_self_recovery.go
+++ b/adapters/handlers/rest/handlers_self_recovery.go
@@ -1,0 +1,137 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/state"
+	"github.com/weaviate/weaviate/cluster/replication/selfrecovery"
+)
+
+// validShardOrCollection rejects values that could escape the data root
+// when concatenated into a path (orchestrator builds <root>/<class>/<shard>).
+// The schema already restricts class/shard names to a safe charset; this
+// is defense in depth on the operator-facing endpoints.
+func validShardOrCollection(name string) error {
+	if name == "" {
+		return errors.New("must not be empty")
+	}
+	if strings.ContainsAny(name, `/\`+"\x00") {
+		return errors.New("must not contain path separators or null bytes")
+	}
+	if name == "." || name == ".." || strings.HasPrefix(name, "..") {
+		return errors.New("must not be a relative path component")
+	}
+	return nil
+}
+
+// setupSelfRecoveryHandlers registers the SELF_RECOVERY operator
+// endpoints under /debug/self-recovery (accept-empty and restart),
+// sibling of the other node-local admin handlers in handlers_debug.go.
+func setupSelfRecoveryHandlers(appState *state.State, orch *selfrecovery.Orchestrator) {
+	logger := appState.Logger.WithField("handler", "self_recovery")
+
+	http.HandleFunc("/debug/self-recovery/accept-empty", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed; use POST", http.StatusMethodNotAllowed)
+			return
+		}
+		collection := r.URL.Query().Get("collection")
+		shard := r.URL.Query().Get("shard")
+		if err := validShardOrCollection(collection); err != nil {
+			http.Error(w, "collection: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := validShardOrCollection(shard); err != nil {
+			http.Error(w, "shard: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if orch == nil {
+			http.Error(w, "self-recovery is not configured on this node", http.StatusServiceUnavailable)
+			return
+		}
+		// WithoutCancel: AcceptEmpty's promotion step (LoadLocalShard)
+		// can outlive the HTTP request; preserve values for tracing.
+		path, err := orch.AcceptEmpty(context.WithoutCancel(r.Context()), selfrecovery.ShardRef{Collection: collection, Shard: shard})
+		if err != nil {
+			logger.WithError(err).WithField("collection", collection).WithField("shard", shard).
+				Error("self-recovery accept-empty failed")
+			// Schema-gate failure (unknown collection/shard) is a
+			// client-side mistake, not a 500 — surface as 404.
+			if errors.Is(err, selfrecovery.ErrSelfRecoveryShardNotInSchema) {
+				http.Error(w, err.Error(), http.StatusNotFound)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		if err := json.NewEncoder(w).Encode(map[string]string{
+			"status": "accepted",
+			"path":   path,
+		}); err != nil {
+			logger.WithError(err).Debug("self-recovery accept-empty: response write failed (client disconnect?)")
+		}
+	}))
+
+	// POST /debug/self-recovery/restart?collection=X&shard=Y
+	// Cancels in-flight ops, erases ".recovering/", submits afresh.
+	http.HandleFunc("/debug/self-recovery/restart", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed; use POST", http.StatusMethodNotAllowed)
+			return
+		}
+		collection := r.URL.Query().Get("collection")
+		shard := r.URL.Query().Get("shard")
+		if err := validShardOrCollection(collection); err != nil {
+			http.Error(w, "collection: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if err := validShardOrCollection(shard); err != nil {
+			http.Error(w, "shard: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		if orch == nil {
+			http.Error(w, "self-recovery is not configured on this node", http.StatusServiceUnavailable)
+			return
+		}
+		// WithoutCancel: Restart re-submits the recovery using the
+		// passed ctx; if we used r.Context() the resubmit would be
+		// canceled the moment the handler returned. Values (tracing)
+		// are still inherited.
+		if err := orch.RestartRecovery(context.WithoutCancel(r.Context()), collection, shard); err != nil {
+			logger.WithError(err).WithField("collection", collection).WithField("shard", shard).
+				Error("self-recovery restart failed")
+			// The shard already has a live local dir — nothing to restart.
+			// That's an operator-side mistake, not a 500.
+			if errors.Is(err, selfrecovery.ErrSelfRecoveryShardAlreadyLive) {
+				http.Error(w, err.Error(), http.StatusConflict)
+				return
+			}
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		if err := json.NewEncoder(w).Encode(map[string]string{
+			"status": "restarted",
+		}); err != nil {
+			logger.WithError(err).Debug("self-recovery restart: response write failed (client disconnect?)")
+		}
+	}))
+}

--- a/adapters/handlers/rest/self_recovery_wiring.go
+++ b/adapters/handlers/rest/self_recovery_wiring.go
@@ -1,0 +1,39 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"github.com/weaviate/weaviate/adapters/repos/db"
+	"github.com/weaviate/weaviate/cluster/schema"
+)
+
+// selfRecoverySchemaReader adapts schema.SchemaReader (a value type)
+// to selfrecovery.SchemaReader. Lives here to avoid a cycle from
+// selfrecovery -> cluster/schema.
+type selfRecoverySchemaReader struct {
+	r schema.SchemaReader
+}
+
+func (a selfRecoverySchemaReader) ShardReplicas(class, shard string) ([]string, error) {
+	return a.r.ShardReplicas(class, shard)
+}
+
+// selfRecoveryDBPathResolver adapts *db.DB.ShardPath to
+// selfrecovery.PathResolver.
+type selfRecoveryDBPathResolver struct {
+	db   *db.DB
+	root string // unused; reserved for future multi-root layouts
+}
+
+func (a selfRecoveryDBPathResolver) ShardPath(collection, shard string) string {
+	return a.db.ShardPath(collection, shard)
+}

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -14,6 +14,7 @@ package db
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path"
 	"path/filepath"
@@ -178,14 +179,23 @@ func (m *shardMap) Loaded(name string) ShardLike {
 		return nil
 	}
 
-	// If it's a lazy shard, only return it if it's loaded
-	if lazyShard, ok := shard.(*LazyLoadShard); ok {
-		if !lazyShard.isLoaded() {
+	// If it's a deferred-load wrapper (lazy or recovering), only return
+	// it once the inner shard is loaded.
+	if l, ok := shard.(loadableShard); ok {
+		if !l.isLoaded() {
 			return nil
 		}
 	}
 
 	return shard
+}
+
+// loadableShard is the small surface implemented by both
+// *LazyLoadShard and *RecoveringShard, used by callers that need to
+// know "is the inner shard materialized?" or "trigger the load".
+type loadableShard interface {
+	Load(ctx context.Context) error
+	isLoaded() bool
 }
 
 // Store sets a shard giving its name and value
@@ -513,6 +523,13 @@ func (i *Index) initAndStoreShards(ctx context.Context, class *models.Class,
 		}
 		hotShardNames = append(hotShardNames, shard.name)
 		shardName := shard.name
+
+		// SELF_RECOVERY: if dir is missing and feature is on, hand off
+		// to the orchestrator instead of creating an empty shard.
+		if i.recoverShardFromPeerIfNeeded(ctx, class, shardName, promMetrics) {
+			continue
+		}
+
 		eg.Go(func() error {
 			switch {
 			case i.Config.EnableLazyLoadShards:
@@ -610,12 +627,104 @@ func (i *Index) loadLocalShardIfActive(shardName string) error {
 		return nil
 	}
 
-	lazyShard, ok := shard.(*LazyLoadShard)
-	if ok {
-		return lazyShard.Load(context.Background())
+	if l, ok := shard.(loadableShard); ok {
+		return l.Load(context.Background())
 	}
 
 	return nil
+}
+
+// recoverShardFromPeerIfNeeded installs a RecoveringShard and submits
+// to the orchestrator when the on-disk dir is missing at startup AND
+// the SELF_RECOVERY feature is on. Returns true if recovery was kicked
+// off (caller must skip the normal init path); false otherwise — in
+// which case the caller proceeds with the normal init path (create empty
+// dir + async-rep backfill), so a queue-full / in-flight-op situation
+// degrades to today's behavior rather than stranding the shard.
+//
+// Only the startup path calls this; runtime shard creation
+// (initLocalShardWithForcedLoading, getOptInitLocalShard) is unaffected
+// so newly-added empty replicas keep their "create empty dir" behavior.
+func (i *Index) recoverShardFromPeerIfNeeded(ctx context.Context, class *models.Class,
+	shardName string, promMetrics *monitoring.PrometheusMetrics,
+) bool {
+	if !i.shouldRecoverShardFromPeer(ctx, shardName) {
+		return false
+	}
+	rec := NewRecoveringShard(ctx, promMetrics, shardName, i, class, i.centralJobQueue,
+		i.indexCheckpoints, i.allocChecker, i.shardLoadLimiter, i.shardReindexer, i.bitmapBufPool)
+	i.shards.Store(shardName, rec)
+	i.logger.WithFields(logrus.Fields{
+		"action":     "self_recovery_submitted",
+		"collection": i.Config.ClassName.String(),
+		"shard":      shardName,
+	}).Info("local shard directory missing at startup; recovery from peer scheduled")
+	return true
+}
+
+// shouldRecoverShardFromPeer decides whether the startup hook should hand
+// (collection, shardName) off to the SELF_RECOVERY orchestrator, and — on
+// a true return — has already submitted the recovery (the caller only
+// needs to install the RecoveringShard wrapper). Returns false (caller
+// proceeds with normal init: empty dir + async-rep backfill) when the
+// feature is off, the ctx isn't the startup DB-load pass, the dir already
+// exists, an in-flight replication op already owns the dir, or the
+// submission was declined (queue full) — so those situations degrade to
+// today's behavior rather than stranding the shard in RECOVERING.
+func (i *Index) shouldRecoverShardFromPeer(ctx context.Context, shardName string) bool {
+	orch := i.Config.SelfRecoveryOrchestrator
+	if orch == nil || !orch.Enabled() {
+		return false
+	}
+	// Recovery is only triggered during the startup DB-load pass
+	// (executor.ReloadLocalDB tags the ctx via WithStartupDBLoad). That
+	// pass runs once per startup, after the node has caught its schema up
+	// to the cluster — whether via a RAFT snapshot install or via log
+	// replay. Runtime AddClass / AddTenants leave the ctx untagged, so a
+	// genuinely new shard is never wrapped for recovery.
+	if !enterrors.IsStartupDBLoad(ctx) {
+		return false
+	}
+	dir := shardPath(i.path(), shardName)
+	if _, err := os.Stat(dir); !errors.Is(err, fs.ErrNotExist) {
+		// Dir exists, or stat failed for another reason (let normal init surface it).
+		return false
+	}
+
+	collection := i.Config.ClassName.String()
+	logFields := logrus.Fields{"collection": collection, "shard": shardName}
+
+	// If a scale-out COPY/MOVE (or an earlier SELF_RECOVERY) op already
+	// targets this shard on this node, its consumer owns the shard dir —
+	// installing a wrapper + submitting another SELF_RECOVERY op here
+	// would race it and clobber its output on rename. Leave it to the
+	// existing op; if the dir is still missing on the next restart we
+	// retry. On error, be conservative and fall back to normal init.
+	if inflight, err := orch.HasInflightReplicationOp(ctx, collection, shardName); err != nil {
+		i.logger.WithError(err).WithFields(logFields).
+			Warn("self-recovery: could not check for in-flight replication op; falling back to normal shard init")
+		return false
+	} else if inflight {
+		i.logger.WithFields(logFields).
+			Info("self-recovery: an in-flight replication op already targets this shard; leaving recovery to that op")
+		return false
+	}
+
+	// Capture the bootstrap-window state now (deterministically, before
+	// MarkRaftBootstrapComplete can flip it) rather than re-reading a
+	// shared flag when the orchestrator reaches an empty-fallback decision
+	// several seconds of peer-probing later.
+	fromBootstrap := i.Config.RaftBootstrapComplete != nil && !i.Config.RaftBootstrapComplete()
+
+	// The recovery outlives the caller's ctx (schema-reload AddClass returns
+	// long before per-shard copies finish), so detach from it. The
+	// orchestrator manages its own lifecycle and shutdown.
+	if !orch.SubmitRecovery(context.Background(), collection, shardName, fromBootstrap) {
+		i.logger.WithFields(logFields).
+			Warn("self-recovery: submission was not queued (queue full or feature disabled); falling back to normal shard init")
+		return false
+	}
+	return true
 }
 
 // used to init/create shard in different moments of index's lifecycle, therefore it needs to be called
@@ -683,9 +792,9 @@ func (i *Index) ForEachShard(f func(name string, shard ShardLike) error) error {
 
 func (i *Index) ForEachLoadedShard(f func(name string, shard ShardLike) error) error {
 	return i.shards.Range(func(name string, shard ShardLike) error {
-		// Skip lazy loaded shard which are not loaded
-		if asLazyLoadShard, ok := shard.(*LazyLoadShard); ok {
-			if !asLazyLoadShard.isLoaded() {
+		// Skip deferred-load wrappers (lazy or recovering) until loaded.
+		if l, ok := shard.(loadableShard); ok {
+			if !l.isLoaded() {
 				return nil
 			}
 		}
@@ -704,9 +813,9 @@ func (i *Index) ForEachShardConcurrently(f func(name string, shard ShardLike) er
 
 func (i *Index) ForEachLoadedShardConcurrently(f func(name string, shard ShardLike) error) error {
 	return i.shards.RangeConcurrently(i.logger, func(name string, shard ShardLike) error {
-		// Skip lazy loaded shard which are not loaded
-		if asLazyLoadShard, ok := shard.(*LazyLoadShard); ok {
-			if !asLazyLoadShard.isLoaded() {
+		// Skip deferred-load wrappers (lazy or recovering) until loaded.
+		if l, ok := shard.(loadableShard); ok {
+			if !l.isLoaded() {
 				return nil
 			}
 		}
@@ -989,6 +1098,20 @@ type IndexConfig struct {
 	QuerySlowLogThreshold  *configRuntime.DynamicValue[time.Duration]
 	InvertedSorterDisabled *configRuntime.DynamicValue[bool]
 	MaintenanceModeEnabled func() bool
+
+	// SelfRecoveryOrchestrator, when non-nil, is consulted at startup
+	// for shards whose on-disk directory is missing: it submits a
+	// SELF_RECOVERY copy from a healthy peer. Nil-safe.
+	SelfRecoveryOrchestrator SelfRecoveryOrchestrator
+	// RaftBootstrapComplete reports whether RAFT has finished its initial
+	// FSM replay. recoverShardFromPeerIfNeeded reads it when it submits a
+	// SELF_RECOVERY op (passing !RaftBootstrapComplete() as fromBootstrap)
+	// so the orchestrator can treat an all-peers-empty result during the
+	// bootstrap window as a likely fresh-class-added-during-downtime case
+	// rather than a catastrophic wipe. Captured at submit time to avoid a
+	// race with MarkRaftBootstrapComplete. Nil-safe: when nil, recoveries
+	// are treated as post-bootstrap.
+	RaftBootstrapComplete func() bool
 
 	HFreshEnabled bool
 
@@ -2700,9 +2823,8 @@ func (i *Index) initLocalShardWithForcedLoading(ctx context.Context, class *mode
 	// check if created in the meantime by concurrent call
 	if shard := i.shards.Load(shardName); shard != nil {
 		if mustLoad {
-			lazyShard, ok := shard.(*LazyLoadShard)
-			if ok {
-				return lazyShard.Load(ctx)
+			if l, ok := shard.(loadableShard); ok {
+				return l.Load(ctx)
 			}
 		}
 

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -208,6 +208,8 @@ func (db *DB) init(ctx context.Context) error {
 				HFreshEnabled:             db.config.HFreshEnabled,
 				AutoTenantActivation:      schema.AutoTenantActivationEnabled(class),
 				DisableDimensionMetrics:   db.config.DisableDimensionMetrics,
+				SelfRecoveryOrchestrator:  db.selfRecoveryOrchestrator,
+				RaftBootstrapComplete:     db.RaftBootstrapComplete,
 			},
 				inverted.ConfigFromModel(invertedConfig),
 				convertToVectorIndexConfig(class.VectorIndexConfig),

--- a/adapters/repos/db/inverted_migrator_filter_to_search.go
+++ b/adapters/repos/db/inverted_migrator_filter_to_search.go
@@ -140,6 +140,9 @@ func (m *filterableToSearchableMigrator) switchShardsToFallbackMode(ctx context.
 			continue
 		}
 		index.ForEachShard(func(name string, shard ShardLike) error {
+			if shard.GetStatus() == storagestate.StatusRecovering {
+				return nil
+			}
 			m.logShard(shard).Debug("setting fallback mode for shard")
 			shard.setFallbackToSearchable(true)
 			return nil
@@ -166,6 +169,13 @@ func (m *filterableToSearchableMigrator) migrateClass(ctx context.Context, index
 			continue
 		}
 		if err := index.ForEachShard(func(name string, shard ShardLike) error {
+			// Shards being SELF_RECOVERY-restored have no usable Store
+			// yet (LazyLoadShard.mustLoad will panic on a blocked load).
+			// Skip them; the source-peer data is already in the
+			// post-migration format.
+			if shard.GetStatus() == storagestate.StatusRecovering {
+				return nil
+			}
 			if toFix, err := m.isPropToFix(ctx, prop, shard); toFix {
 				if _, ok := shard2PropsToFix[shard.Name()]; !ok {
 					shard2PropsToFix[shard.Name()] = map[string]struct{}{}

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -230,6 +230,8 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 			MaintenanceModeEnabled:    m.db.config.MaintenanceModeEnabled,
 			HFreshEnabled:             m.db.config.HFreshEnabled,
 			AutoTenantActivation:      schema.AutoTenantActivationEnabled(class),
+			SelfRecoveryOrchestrator:  m.db.selfRecoveryOrchestrator,
+			RaftBootstrapComplete:     m.db.RaftBootstrapComplete,
 		},
 		// no backward-compatibility check required, since newly added classes will
 		// always have the field set

--- a/adapters/repos/db/nodes.go
+++ b/adapters/repos/db/nodes.go
@@ -21,6 +21,7 @@ import (
 	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
+	"github.com/weaviate/weaviate/entities/storagestate"
 	"github.com/weaviate/weaviate/entities/verbosity"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
@@ -186,6 +187,24 @@ func (i *Index) getShardsNodeStatus(ctx context.Context,
 
 		// Don't force load a lazy shard to get nodes status
 		className := i.Config.ClassName.String()
+		// RecoveringShard: report RECOVERING without forcing a load
+		// (which would block on ErrShardRecovering).
+		if rec, ok := shard.(*RecoveringShard); ok {
+			if rec.IsRecovering() {
+				numberOfReplicas, replicationFactor := getShardReplicationDetails(i, shard.Name())
+				shardStatus := &models.NodeShardStatus{
+					Name:                 name,
+					Class:                className,
+					VectorIndexingStatus: storagestate.StatusRecovering.String(),
+					Loaded:               false,
+					ReplicationFactor:    replicationFactor,
+					NumberOfReplicas:     numberOfReplicas,
+				}
+				*status = append(*status, shardStatus)
+				shardCount++
+				return nil
+			}
+		}
 		if lazy, ok := shard.(*LazyLoadShard); ok {
 			if !lazy.isLoaded() {
 				numberOfReplicas, replicationFactor := getShardReplicationDetails(i, shard.Name())

--- a/adapters/repos/db/recover_shard_from_peer_test.go
+++ b/adapters/repos/db/recover_shard_from_peer_test.go
@@ -1,0 +1,144 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+)
+
+// fakeSelfRecoveryOrch is a stub SelfRecoveryOrchestrator for unit tests.
+type fakeSelfRecoveryOrch struct {
+	enabled     bool
+	inflightOp  bool
+	inflightErr error
+	submitOK    bool
+
+	submitCalls      int
+	gotFromBootstrap bool
+}
+
+func (f *fakeSelfRecoveryOrch) Enabled() bool { return f.enabled }
+
+func (f *fakeSelfRecoveryOrch) HasInflightReplicationOp(_ context.Context, _, _ string) (bool, error) {
+	return f.inflightOp, f.inflightErr
+}
+
+func (f *fakeSelfRecoveryOrch) SubmitRecovery(_ context.Context, _, _ string, fromBootstrap bool) bool {
+	f.submitCalls++
+	f.gotFromBootstrap = fromBootstrap
+	return f.submitOK
+}
+
+var _ SelfRecoveryOrchestrator = (*fakeSelfRecoveryOrch)(nil)
+
+func newTestIndexForRecovery(t *testing.T, orch SelfRecoveryOrchestrator, raftBootstrapComplete func() bool) *Index {
+	t.Helper()
+	return &Index{
+		Config: IndexConfig{
+			RootPath:                 t.TempDir(),
+			ClassName:                "C",
+			SelfRecoveryOrchestrator: orch,
+			RaftBootstrapComplete:    raftBootstrapComplete,
+		},
+		logger: logrus.New(),
+	}
+}
+
+// schemaReloadCtx tags the ctx the way executor.ReloadLocalDB does.
+func schemaReloadCtx() context.Context {
+	return enterrors.WithStartupDBLoad(context.Background())
+}
+
+func TestShouldRecoverShardFromPeer(t *testing.T) {
+	t.Run("orchestrator nil", func(t *testing.T) {
+		idx := &Index{Config: IndexConfig{RootPath: t.TempDir(), ClassName: "C"}, logger: logrus.New()}
+		require.False(t, idx.shouldRecoverShardFromPeer(schemaReloadCtx(), "S"))
+	})
+
+	t.Run("feature disabled", func(t *testing.T) {
+		orch := &fakeSelfRecoveryOrch{enabled: false}
+		idx := newTestIndexForRecovery(t, orch, nil)
+		require.False(t, idx.shouldRecoverShardFromPeer(schemaReloadCtx(), "S"))
+		require.Zero(t, orch.submitCalls)
+	})
+
+	t.Run("ctx not from schema reload", func(t *testing.T) {
+		orch := &fakeSelfRecoveryOrch{enabled: true, submitOK: true}
+		idx := newTestIndexForRecovery(t, orch, nil)
+		require.False(t, idx.shouldRecoverShardFromPeer(context.Background(), "S"))
+		require.Zero(t, orch.submitCalls, "must not submit when not a schema-reload AddClass")
+	})
+
+	t.Run("shard dir already exists", func(t *testing.T) {
+		orch := &fakeSelfRecoveryOrch{enabled: true, submitOK: true}
+		idx := newTestIndexForRecovery(t, orch, nil)
+		require.NoError(t, os.MkdirAll(shardPath(idx.path(), "S"), 0o755))
+		require.False(t, idx.shouldRecoverShardFromPeer(schemaReloadCtx(), "S"))
+		require.Zero(t, orch.submitCalls)
+	})
+
+	t.Run("in-flight replication op already targets the shard", func(t *testing.T) {
+		orch := &fakeSelfRecoveryOrch{enabled: true, inflightOp: true, submitOK: true}
+		idx := newTestIndexForRecovery(t, orch, nil)
+		require.False(t, idx.shouldRecoverShardFromPeer(schemaReloadCtx(), "S"))
+		require.Zero(t, orch.submitCalls, "must not submit a duplicate op while one is in flight")
+	})
+
+	t.Run("in-flight check errors → conservative skip", func(t *testing.T) {
+		orch := &fakeSelfRecoveryOrch{enabled: true, inflightErr: errors.New("fsm unavailable"), submitOK: true}
+		idx := newTestIndexForRecovery(t, orch, nil)
+		require.False(t, idx.shouldRecoverShardFromPeer(schemaReloadCtx(), "S"))
+		require.Zero(t, orch.submitCalls)
+	})
+
+	t.Run("submission declined (queue full) → false", func(t *testing.T) {
+		orch := &fakeSelfRecoveryOrch{enabled: true, submitOK: false}
+		idx := newTestIndexForRecovery(t, orch, nil)
+		require.False(t, idx.shouldRecoverShardFromPeer(schemaReloadCtx(), "S"))
+		require.Equal(t, 1, orch.submitCalls, "submission is attempted exactly once")
+	})
+
+	t.Run("happy path → true, submitted once", func(t *testing.T) {
+		orch := &fakeSelfRecoveryOrch{enabled: true, submitOK: true}
+		idx := newTestIndexForRecovery(t, orch, nil)
+		require.True(t, idx.shouldRecoverShardFromPeer(schemaReloadCtx(), "S"))
+		require.Equal(t, 1, orch.submitCalls)
+	})
+
+	t.Run("fromBootstrap propagation", func(t *testing.T) {
+		cases := []struct {
+			name                  string
+			raftBootstrapComplete func() bool
+			wantFromBootstrap     bool
+		}{
+			{"during bootstrap (not complete)", func() bool { return false }, true},
+			{"post bootstrap (complete)", func() bool { return true }, false},
+			{"nil hook → treated as post-bootstrap", nil, false},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				orch := &fakeSelfRecoveryOrch{enabled: true, submitOK: true}
+				idx := newTestIndexForRecovery(t, orch, tc.raftBootstrapComplete)
+				require.True(t, idx.shouldRecoverShardFromPeer(schemaReloadCtx(), "S"))
+				require.Equal(t, tc.wantFromBootstrap, orch.gotFromBootstrap)
+			})
+		}
+	})
+}

--- a/adapters/repos/db/replication.go
+++ b/adapters/repos/db/replication.go
@@ -494,6 +494,16 @@ func (i *Index) IncomingResumeFileActivity(ctx context.Context,
 func (i *Index) IncomingListFiles(ctx context.Context,
 	shardName string,
 ) ([]string, error) {
+	// If we're ourselves recovering this shard, we have no files to
+	// hand out. Return ErrShardRecovering so the caller (a peer's
+	// orchestrator probe) can distinguish "not a usable source right
+	// now" from "shard never existed here" — the former must not
+	// trigger an empty-fallback decision.
+	if s := i.shards.Load(shardName); s != nil {
+		if rec, ok := s.(*RecoveringShard); ok && rec.IsRecovering() {
+			return nil, fmt.Errorf("incoming list files for shard %s: %w", shardName, enterrors.ErrShardRecovering)
+		}
+	}
 	shard, release, err := i.GetShard(ctx, shardName)
 	if err != nil {
 		return nil, fmt.Errorf("incoming list files get shard %s: %w", shardName, err)

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -16,6 +16,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -67,6 +68,7 @@ type DB struct {
 	indexCheckpoints          *indexcheckpoint.Checkpoints
 	shutdown                  chan struct{}
 	startupComplete           atomic.Bool
+	raftBootstrapComplete     atomic.Bool
 	resourceScanState         *resourceScanState
 	memMonitor                *memwatch.Monitor
 
@@ -123,6 +125,10 @@ type DB struct {
 	// Shard.PutObject{,Batch} can call CheckObjects on the write path.
 	// nil disables the check. See docs/usage_limits.md.
 	usageLimits *usagelimits.Manager
+
+	// Set after the cluster service is up (it depends on Raft).
+	// Nil-safe: when nil, startup keeps today's MkdirAll behavior.
+	selfRecoveryOrchestrator SelfRecoveryOrchestrator
 }
 
 // SetUsageLimits installs the usage-limits Manager on the DB. Must be
@@ -130,6 +136,46 @@ type DB struct {
 // inherit the manager. See docs/usage_limits.md.
 func (db *DB) SetUsageLimits(m *usagelimits.Manager) {
 	db.usageLimits = m
+}
+
+// SelfRecoveryOrchestrator is the narrow surface used by the db package
+// to avoid an import cycle on cluster/replication.
+type SelfRecoveryOrchestrator interface {
+	// Enabled reports whether the SELF_RECOVERY feature flag is on.
+	// Callers must check this before installing a RecoveringShard
+	// wrapper; otherwise the wrapper would block load forever
+	// (SubmitRecovery returns false when the flag is off).
+	Enabled() bool
+	// HasInflightReplicationOp reports whether a non-terminal replication
+	// op (COPY, MOVE, or SELF_RECOVERY) already targets (collection, shard)
+	// on this node. The startup hook calls this before installing a
+	// RecoveringShard wrapper so it does not race a resumed scale-out
+	// consumer writing into the same shard directory. On error the caller
+	// should skip recovery (conservative).
+	HasInflightReplicationOp(ctx context.Context, collection, shard string) (bool, error)
+	// SubmitRecovery is non-blocking. Returns false when the work was not
+	// queued — feature off, maintenance mode on, or the in-flight queue is
+	// full — in which case the caller MUST fall back to normal shard init
+	// (otherwise a RecoveringShard wrapper would stay load-blocked until
+	// the next restart). fromBootstrap tags the op so an empty-fallback
+	// during the RAFT bootstrap window is logged/counted less alarmingly.
+	SubmitRecovery(ctx context.Context, collection, shard string, fromBootstrap bool) bool
+}
+
+// SetSelfRecoveryOrchestrator must be called before WaitForStartup so
+// the startup shard-init pass can hand off recovering shards.
+func (db *DB) SetSelfRecoveryOrchestrator(o SelfRecoveryOrchestrator) {
+	db.selfRecoveryOrchestrator = o
+}
+
+// ShardPath returns the on-disk directory for (collection, shard).
+// Exposed so the self-recovery orchestrator can resolve target paths
+// without duplicating the path-construction rules.
+func (db *DB) ShardPath(collection, shard string) string {
+	return shardPath(
+		path.Join(db.config.RootPath, indexID(schema.ClassName(collection))),
+		shard,
+	)
 }
 
 func (db *DB) GetSchemaGetter() schemaUC.SchemaGetter {
@@ -169,6 +215,17 @@ func (db *DB) WaitForStartup(ctx context.Context) error {
 }
 
 func (db *DB) StartupComplete() bool { return db.startupComplete.Load() }
+
+// MarkRaftBootstrapComplete is called once RAFT has finished its initial
+// log/snapshot replay. The SELF_RECOVERY startup hook reads this (via
+// IndexConfig.RaftBootstrapComplete) when it submits a recovery: an
+// all-peers-empty result during the bootstrap window most likely means a
+// class was added during this node's downtime, not data loss, so it is
+// logged and counted less alarmingly than a post-bootstrap one.
+func (db *DB) MarkRaftBootstrapComplete() { db.raftBootstrapComplete.Store(true) }
+
+// RaftBootstrapComplete reports whether the FSM replay window has ended.
+func (db *DB) RaftBootstrapComplete() bool { return db.raftBootstrapComplete.Load() }
 
 // IndexGetter interface defines the methods that the service uses from db.IndexGetter
 // This allows for better testability by using interfaces instead of concrete types

--- a/adapters/repos/db/shard_lazyloader.go
+++ b/adapters/repos/db/shard_lazyloader.go
@@ -64,6 +64,11 @@ type LazyLoadShard struct {
 	memMonitor       memwatch.AllocChecker
 	shardLoadLimiter *loadlimiter.LoadLimiter
 	lazyLoadSegments bool
+	// loadBlocked makes Load return loadBlockedErr without calling
+	// NewShard. RecoveringShard uses this so a lazy load before the
+	// SELF_RECOVERY rename doesn't silently MkdirAll an empty shard.
+	loadBlocked    bool
+	loadBlockedErr error
 }
 
 func NewLazyLoadShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
@@ -112,6 +117,16 @@ func (l *LazyLoadShard) mustLoad() {
 
 func (l *LazyLoadShard) mustLoadCtx(ctx context.Context) {
 	if err := l.Load(ctx); err != nil {
+		// A blocked load means this is a RecoveringShard whose data is
+		// still being copied from a peer. Reaching a mustLoad-backed
+		// method on it is a routing bug (the caller should have skipped
+		// it via Loaded()/IsRecovering() or the replication FSM read
+		// filter); make the crash unambiguous in logs. See
+		// docs/self-recovery.md ("Known limitations").
+		if enterrors.IsShardRecovering(err) {
+			panic(fmt.Sprintf("shard %q is recovering from a peer; this code path must not touch a recovering shard: %v",
+				l.shardOpts.name, err))
+		}
 		panic(err.Error())
 	}
 }
@@ -122,6 +137,10 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 
 	if l.loaded {
 		return nil
+	}
+
+	if l.loadBlocked {
+		return l.loadBlockedErr
 	}
 
 	if err := l.memMonitor.CheckMappingAndReserve(3, int(lsmkv.FlushAfterDirtyDefault.Seconds())); err != nil {
@@ -153,6 +172,26 @@ func (l *LazyLoadShard) Load(ctx context.Context) error {
 	l.loaded = true
 
 	return nil
+}
+
+func (l *LazyLoadShard) blockLoad(blockErr error) {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.loadBlocked = true
+	l.loadBlockedErr = blockErr
+}
+
+func (l *LazyLoadShard) clearLoadBlock() {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	l.loadBlocked = false
+	l.loadBlockedErr = nil
+}
+
+func (l *LazyLoadShard) isLoadBlocked() bool {
+	l.mutex.Lock()
+	defer l.mutex.Unlock()
+	return l.loadBlocked
 }
 
 func (l *LazyLoadShard) Index() *Index {

--- a/adapters/repos/db/shard_lazyloader_loadblock_test.go
+++ b/adapters/repos/db/shard_lazyloader_loadblock_test.go
@@ -1,0 +1,78 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+)
+
+// TestLazyLoadShardLoadBlock verifies the loadBlocked mechanism that
+// RecoveringShard relies on to keep the inner Load from materialising
+// an empty shard from a missing on-disk directory.
+//
+// We deliberately do NOT construct a full Shard / Index / metrics here:
+// the loadBlocked path is the very first guard inside Load and short-
+// circuits before any of the heavier scaffolding is touched. So a
+// hand-built LazyLoadShard with the relevant fields set is enough.
+func TestLazyLoadShardLoadBlock(t *testing.T) {
+	t.Run("blockLoad makes Load return the supplied error", func(t *testing.T) {
+		l := &LazyLoadShard{}
+		l.blockLoad(enterrors.ErrShardRecovering)
+
+		err := l.Load(context.Background())
+		require.Error(t, err)
+		require.True(t, errors.Is(err, enterrors.ErrShardRecovering))
+	})
+
+	t.Run("isLoadBlocked reports current state", func(t *testing.T) {
+		l := &LazyLoadShard{}
+		require.False(t, l.isLoadBlocked())
+		l.blockLoad(enterrors.ErrShardRecovering)
+		require.True(t, l.isLoadBlocked())
+		l.clearLoadBlock()
+		require.False(t, l.isLoadBlocked())
+	})
+
+	t.Run("clearLoadBlock allows Load to proceed past the guard", func(t *testing.T) {
+		// Once cleared, the loadBlocked guard no longer short-circuits.
+		// Load will attempt to construct the inner shard; with our nil
+		// scaffolding it will fail downstream — but it must NOT return
+		// ErrShardRecovering anymore.
+		l := &LazyLoadShard{}
+		l.blockLoad(enterrors.ErrShardRecovering)
+		l.clearLoadBlock()
+
+		// Load is expected to fail (nil opts) but not with our sentinel.
+		// We only care that the loadBlocked branch was bypassed.
+		defer func() {
+			// NewShard panics on nil opts; we catch it to assert that
+			// the loadBlocked guard was not the one returning early.
+			_ = recover()
+		}()
+		_ = l.Load(context.Background())
+	})
+
+	t.Run("loaded shard short-circuits before loadBlocked", func(t *testing.T) {
+		l := &LazyLoadShard{loaded: true}
+		l.blockLoad(enterrors.ErrShardRecovering)
+
+		// Already-loaded path returns nil without consulting loadBlocked.
+		err := l.Load(context.Background())
+		require.NoError(t, err)
+	})
+}

--- a/adapters/repos/db/shard_recovering.go
+++ b/adapters/repos/db/shard_recovering.go
@@ -1,0 +1,96 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/indexcheckpoint"
+	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/entities/loadlimiter"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/storagestate"
+	"github.com/weaviate/weaviate/usecases/memwatch"
+	"github.com/weaviate/weaviate/usecases/monitoring"
+)
+
+// RecoveringShard wraps a LazyLoadShard for SELF_RECOVERY. Until the
+// shard is promoted (via Load, called by the consumer's LoadLocalShard
+// or by the orchestrator's empty-fallback), GetStatus reports RECOVERING
+// and the inner Load is blocked with enterrors.ErrShardRecovering — so a
+// lazy load doesn't silently MkdirAll an empty shard before the
+// copy-and-rename completes. Cluster-wide routing exclusion is handled
+// separately by the replication FSM read filter; this wrapper is local
+// defense-in-depth.
+//
+// IMPORTANT: while blocked, any data-path method inherited from
+// LazyLoadShard that goes through mustLoad/mustLoadCtx (Store, NotifyReady,
+// Counter, the put*/delete*/update* internals, etc.) will PANIC rather
+// than return cleanly — reaching one of those is a routing bug. Callers
+// that iterate shards during the recovery window must skip recovering
+// shards (use the "loaded" shard accessors, or IsRecovering()). See
+// docs/self-recovery.md ("Known limitations").
+type RecoveringShard struct {
+	*LazyLoadShard
+}
+
+func NewRecoveringShard(ctx context.Context, promMetrics *monitoring.PrometheusMetrics,
+	shardName string, index *Index, class *models.Class, jobQueueCh chan job,
+	indexCheckpoints *indexcheckpoint.Checkpoints, memMonitor memwatch.AllocChecker,
+	shardLoadLimiter *loadlimiter.LoadLimiter, shardReindexer ShardReindexerV3,
+	bitmapBufPool roaringset.BitmapBufPool,
+) *RecoveringShard {
+	inner := NewLazyLoadShard(ctx, promMetrics, shardName, index, class, jobQueueCh,
+		indexCheckpoints, memMonitor, shardLoadLimiter, shardReindexer,
+		false, bitmapBufPool)
+	inner.blockLoad(enterrors.ErrShardRecovering)
+	return &RecoveringShard{LazyLoadShard: inner}
+}
+
+// Load shadows LazyLoadShard.Load: clears the load block and triggers
+// the inner load. After it returns nil the wrapper transitions to
+// behaving like a normal LazyLoadShard.
+func (r *RecoveringShard) Load(ctx context.Context) error {
+	r.clearLoadBlock()
+	return r.LazyLoadShard.Load(ctx)
+}
+
+func (r *RecoveringShard) IsRecovering() bool {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	return !r.loaded
+}
+
+// GetStatus shadows LazyLoadShard.GetStatus (which would report
+// LAZY_LOADING) so /nodes can surface RECOVERING distinctly.
+func (r *RecoveringShard) GetStatus() storagestate.Status {
+	r.mutex.Lock()
+	loaded := r.loaded
+	inner := r.shard
+	r.mutex.Unlock()
+	if loaded {
+		return inner.GetStatus()
+	}
+	return storagestate.StatusRecovering
+}
+
+func (r *RecoveringShard) GetStatusReason() string {
+	r.mutex.Lock()
+	loaded := r.loaded
+	inner := r.shard
+	r.mutex.Unlock()
+	if loaded {
+		return inner.GetStatusReason()
+	}
+	return storagestate.StatusRecovering.String()
+}

--- a/cluster/proto/api/shard_requests.go
+++ b/cluster/proto/api/shard_requests.go
@@ -46,7 +46,20 @@ func (s ShardReplicationTransferType) String() string {
 const (
 	COPY ShardReplicationTransferType = "COPY"
 	MOVE ShardReplicationTransferType = "MOVE"
+	// SELF_RECOVERY re-hydrates a shard whose target node is already in
+	// the replica set; the validator skips its "target already exists"
+	// check for this type only.
+	SELF_RECOVERY ShardReplicationTransferType = "SELF_RECOVERY"
 )
+
+// RecoveryFolderSuffix names the in-flight SELF_RECOVERY landing dir
+// ("<shard>.recovering/"). Defined here (leaf package) so both the
+// copier and the consumer can reference it without an import cycle.
+const RecoveryFolderSuffix = ".recovering"
+
+func RecoveryFolderName(shardName string) string {
+	return shardName + RecoveryFolderSuffix
+}
 
 type ReplicationReplicateShardRequest struct {
 	// Version is the version with which this command was generated

--- a/cluster/raft.go
+++ b/cluster/raft.go
@@ -121,3 +121,8 @@ func (s *Raft) ReplicationFsm() *replication.ShardReplicationFSM {
 func (s *Raft) IsLeader() bool {
 	return s.store.IsLeader()
 }
+
+// ForceSnapshot triggers an immediate RAFT snapshot. See Store.ForceSnapshot.
+func (s *Raft) ForceSnapshot() error {
+	return s.store.ForceSnapshot()
+}

--- a/cluster/raft_replication_apply_endpoints.go
+++ b/cluster/raft_replication_apply_endpoints.go
@@ -27,12 +27,17 @@ import (
 )
 
 func (s *Raft) ApplyReplicationScalePlan(ctx context.Context, scalePlan api.ReplicationScalePlan) (opsUUIDs []strfmt.UUID, err error) {
-	// while not strictly necessary, scaling while there are ongoing replications is disallowed
+	// while not strictly necessary, scaling while there are ongoing replications is disallowed.
+	// SELF_RECOVERY ops are excluded: they don't change membership and a recovering node
+	// must not block scale-out.
 	ops, err := s.GetReplicationDetailsByCollection(ctx, scalePlan.Collection)
 	if err != nil && !errors.Is(err, replicationTypes.ErrReplicationOperationNotFound) {
 		return nil, fmt.Errorf("get replication details for %q: %w", scalePlan.Collection, err)
 	}
 	for _, op := range ops {
+		if op.TransferType == api.SELF_RECOVERY.String() {
+			continue
+		}
 		if api.ShardReplicationState(op.Status.State) != api.CANCELLED && api.ShardReplicationState(op.Status.State) != api.READY {
 			return nil, fmt.Errorf("cannot scale while there are ongoing replications for collection %q", scalePlan.Collection)
 		}
@@ -118,6 +123,21 @@ func (s *Raft) ApplyReplicationScalePlan(ctx context.Context, scalePlan api.Repl
 	}
 
 	return opsUUIDs, nil
+}
+
+// RegisterSelfRecovery registers a SELF_RECOVERY replication op,
+// bypassing ApplyReplicationScalePlan (which changes membership and is
+// blocked by the ongoing-replications guard).
+func (s *Raft) RegisterSelfRecovery(ctx context.Context, sourceNode, collection, shard, targetNode string) (strfmt.UUID, error) {
+	id, err := uuid.NewRandom()
+	if err != nil {
+		return "", fmt.Errorf("create uuid for self-recovery op: %w", err)
+	}
+	opUUID := strfmt.UUID(id.String())
+	if err := s.ReplicationReplicateReplica(ctx, opUUID, sourceNode, collection, shard, targetNode, api.SELF_RECOVERY.String()); err != nil {
+		return "", fmt.Errorf("register self-recovery for shard %q of collection %q from %q: %w", shard, collection, sourceNode, err)
+	}
+	return opUUID, nil
 }
 
 func (s *Raft) ReplicationReplicateReplica(ctx context.Context, uuid strfmt.UUID, sourceNode string, sourceCollection string, sourceShard string, targetNode string, transferType string) error {

--- a/cluster/replication/consumer.go
+++ b/cluster/replication/consumer.go
@@ -577,7 +577,14 @@ func (c *CopyOpConsumer) processHydratingOp(ctx context.Context, op ShardReplica
 		return api.ShardReplicationState(""), ctx.Err()
 	}
 
-	if err := c.replicaCopier.CopyReplicaFiles(ctx, op.Op.SourceShard.NodeId, op.Op.SourceShard.CollectionId, op.Op.TargetShard.ShardId, op.Status.SchemaVersion); err != nil {
+	// SELF_RECOVERY lands files in "<shard>.recovering/"; FINALIZING
+	// renames it into place atomically.
+	if op.Op.TransferType == api.SELF_RECOVERY {
+		if err := c.replicaCopier.CopyReplicaFilesToLocalShard(ctx, op.Op.SourceShard.NodeId, op.Op.SourceShard.CollectionId, op.Op.TargetShard.ShardId, api.RecoveryFolderName(op.Op.TargetShard.ShardId), op.Status.SchemaVersion); err != nil {
+			logger.WithError(err).Error("failure while copying replica shard for self-recovery")
+			return api.ShardReplicationState(""), err
+		}
+	} else if err := c.replicaCopier.CopyReplicaFiles(ctx, op.Op.SourceShard.NodeId, op.Op.SourceShard.CollectionId, op.Op.TargetShard.ShardId, op.Status.SchemaVersion); err != nil {
 		logger.WithError(err).Error("failure while copying replica shard")
 		return api.ShardReplicationState(""), err
 	}
@@ -606,7 +613,16 @@ func (c *CopyOpConsumer) processFinalizingOp(ctx context.Context, op ShardReplic
 		return api.ShardReplicationState(""), err
 	}
 
-	if err := c.replicaCopier.LoadLocalShard(ctx, op.Op.SourceShard.CollectionId, op.Op.SourceShard.ShardId); err != nil {
+	// SELF_RECOVERY: rename "<shard>.recovering/" -> "<shard>/" before
+	// LoadLocalShard so init reads from the live dir.
+	if op.Op.TransferType == api.SELF_RECOVERY {
+		if err := c.replicaCopier.PromoteRecoveryFolder(op.Op.TargetShard.CollectionId, op.Op.TargetShard.ShardId); err != nil {
+			logger.WithError(err).Error("failure while promoting recovery folder")
+			return api.ShardReplicationState(""), err
+		}
+	}
+
+	if err := c.replicaCopier.LoadLocalShard(ctx, op.Op.TargetShard.CollectionId, op.Op.TargetShard.ShardId); err != nil {
 		logger.WithError(err).Error("failure while loading shard")
 		return api.ShardReplicationState(""), err
 	}
@@ -662,10 +678,13 @@ func (c *CopyOpConsumer) processFinalizingOp(ctx context.Context, op ShardReplic
 	}
 
 	switch op.Op.TransferType {
-	case api.COPY:
+	case api.COPY, api.SELF_RECOVERY:
+		// SELF_RECOVERY mirrors COPY here: source stays a replica, the
+		// membership check above already saw replicaExists=true so
+		// AddReplicaToShard was skipped.
 		c.stopAsyncReplication(ctx, op, overrides, logger)
 		// sync the replica shard to ensure that the schema and store are consistent on each node
-		// In a COPY this happens now, in a MOVE this happens in the DEHYDRATING state
+		// In a COPY/SELF_RECOVERY this happens now, in a MOVE this happens in the DEHYDRATING state
 		if err := c.sync(ctx, op); err != nil {
 			logger.WithError(err).Error("failure while syncing replica shard in finalizing state")
 			return api.ShardReplicationState(""), err

--- a/cluster/replication/copier/copier.go
+++ b/cluster/replication/copier/copier.go
@@ -28,6 +28,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc/generated/protocol"
+	"github.com/weaviate/weaviate/cluster/proto/api"
 	"github.com/weaviate/weaviate/cluster/replication/copier/types"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/diskio"
@@ -85,6 +86,15 @@ func New(clientFactory FileReplicationServiceClientFactory, remoteIndex types.Re
 
 // CopyReplicaFiles copies a shard replica from the source node to this node.
 func (c *Copier) CopyReplicaFiles(ctx context.Context, srcNodeId, collectionName, shardName string, schemaVersion uint64) error {
+	return c.CopyReplicaFilesToLocalShard(ctx, srcNodeId, collectionName, shardName, "", schemaVersion)
+}
+
+// CopyReplicaFilesToLocalShard is like CopyReplicaFiles but lands files
+// in a different local shard directory when localShardOverride is set
+// (used by SELF_RECOVERY to write into "<shard>.recovering/"; the caller
+// then renames via PromoteRecoveryFolder). CRC32 per-file resume still
+// works across crashes since it operates on the local destination paths.
+func (c *Copier) CopyReplicaFilesToLocalShard(ctx context.Context, srcNodeId, collectionName, shardName, localShardOverride string, schemaVersion uint64) error {
 	sourceNodeAddress := c.nodeSelector.NodeAddress(srcNodeId)
 
 	sourceNodeGRPCPort, err := c.nodeSelector.NodeGRPCPort(srcNodeId)
@@ -138,7 +148,8 @@ func (c *Copier) CopyReplicaFiles(ctx context.Context, srcNodeId, collectionName
 		time.Sleep(sleepTime)
 	}
 
-	err = c.prepareLocalFolder(collectionName, shardName, fileListResp.FileNames)
+	localShard := c.localShardName(shardName, localShardOverride)
+	err = c.prepareLocalFolder(collectionName, shardName, localShard, fileListResp.FileNames)
 	if err != nil {
 		return fmt.Errorf("failed to prepare local folder: %w", err)
 	}
@@ -158,7 +169,7 @@ func (c *Copier) CopyReplicaFiles(ctx context.Context, srcNodeId, collectionName
 	dWg := enterrors.NewErrorGroupWrapper(c.logger)
 	for range c.concurrentWorkers {
 		dWg.Go(func() error {
-			err := c.downloadWorker(ctx, client, metadataChan)
+			err := c.downloadWorker(ctx, client, metadataChan, shardName, localShard)
 			if err != nil {
 				c.logger.WithError(err).Error("failed to download files")
 			}
@@ -177,7 +188,7 @@ func (c *Copier) CopyReplicaFiles(ctx context.Context, srcNodeId, collectionName
 		return fmt.Errorf("failed to download files: %w", err)
 	}
 
-	err = c.validateLocalFolder(collectionName, shardName, fileListResp.FileNames)
+	err = c.validateLocalFolder(collectionName, shardName, localShard, fileListResp.FileNames)
 	if err != nil {
 		return fmt.Errorf("failed to validate local folder: %w", err)
 	}
@@ -185,20 +196,45 @@ func (c *Copier) CopyReplicaFiles(ctx context.Context, srcNodeId, collectionName
 	return nil
 }
 
+func (c *Copier) localShardName(srcShard, override string) string {
+	if override == "" {
+		return srcShard
+	}
+	return override
+}
+
+// rewriteRelPathToLocalShard rewrites the shard segment of a
+// source-relative path (e.g. "coll/shard/.../file") to the local
+// destination shard. No-op when srcShard == localShard.
+func (c *Copier) rewriteRelPathToLocalShard(srcRelPath, srcShard, localShard string) string {
+	if localShard == srcShard {
+		return srcRelPath
+	}
+	sep := string(filepath.Separator)
+	parts := strings.SplitN(srcRelPath, sep, 3)
+	if len(parts) >= 2 && parts[1] == srcShard {
+		parts[1] = localShard
+		return strings.Join(parts, sep)
+	}
+	return srcRelPath
+}
+
 func (c *Copier) shardPath(collectionName, shardName string) string {
 	return path.Join(c.rootDataPath, strings.ToLower(collectionName), shardName)
 }
 
-func (c *Copier) prepareLocalFolder(collectionName, shardName string, fileNames []string) error {
+func (c *Copier) prepareLocalFolder(collectionName, shardName, localShard string, fileNames []string) error {
+	// Keyed by LOCAL relative path so we can compare against on-disk
+	// files (which live under localShard, not srcShard, for SELF_RECOVERY).
 	fileNamesMap := make(map[string]struct{}, len(fileNames))
 	for _, fileName := range fileNames {
-		fileNamesMap[fileName] = struct{}{}
+		fileNamesMap[c.rewriteRelPathToLocalShard(fileName, shardName, localShard)] = struct{}{}
 	}
 
 	var dirs []string
 
-	// remove files that are not in the source node
-	basePath := c.shardPath(collectionName, shardName)
+	// remove files in the local destination not in the source manifest.
+	basePath := c.shardPath(collectionName, localShard)
 
 	err := filepath.WalkDir(basePath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
@@ -272,10 +308,12 @@ func (c *Copier) metadataWorker(ctx context.Context, client FileReplicationServi
 }
 
 func (c *Copier) downloadWorker(ctx context.Context, client FileReplicationServiceClient,
-	metadataChan <-chan *protocol.FileMetadata,
+	metadataChan <-chan *protocol.FileMetadata, srcShard, localShard string,
 ) error {
 	for meta := range metadataChan {
-		localFilePath := filepath.Join(c.rootDataPath, meta.FileName)
+		// Rewrite the shard segment so SELF_RECOVERY writes land in
+		// "<shard>.recovering/" rather than the live "<shard>/".
+		localFilePath := filepath.Join(c.rootDataPath, c.rewriteRelPathToLocalShard(meta.FileName, srcShard, localShard))
 
 		_, checksum, err := integrity.CRC32(localFilePath)
 		if err != nil {
@@ -388,15 +426,50 @@ func (c *Copier) LoadLocalShard(ctx context.Context, collectionName, shardName s
 	return idx.LoadLocalShard(ctx, shardName, false)
 }
 
-func (c *Copier) validateLocalFolder(collectionName, shardName string, fileNames []string) error {
+// PromoteRecoveryFolder atomically renames "<shard>.recovering/" into
+// "<shard>/" after a SELF_RECOVERY copy completes. Idempotent across
+// crashes: if both dirs exist the live one is canonical and the
+// recovery one is erased. On error the recovery dir is left in place so
+// the next attempt resumes via CRC32 per-file logic.
+func (c *Copier) PromoteRecoveryFolder(collectionName, shardName string) error {
+	recoveryPath := c.shardPath(collectionName, api.RecoveryFolderName(shardName))
+	livePath := c.shardPath(collectionName, shardName)
+
+	if _, err := os.Stat(recoveryPath); err != nil {
+		return fmt.Errorf("promote recovery folder: stat %q: %w", recoveryPath, err)
+	}
+	if _, err := os.Stat(livePath); err == nil {
+		// Live dir is canonical; recovery dir is stale. No-op promote.
+		if err := os.RemoveAll(recoveryPath); err != nil {
+			return fmt.Errorf("promote recovery folder: live dir already exists, but failed to remove stale %q: %w", recoveryPath, err)
+		}
+		return nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return fmt.Errorf("promote recovery folder: stat %q: %w", livePath, err)
+	}
+
+	if err := os.Rename(recoveryPath, livePath); err != nil {
+		return fmt.Errorf("promote recovery folder: rename %q -> %q: %w", recoveryPath, livePath, err)
+	}
+
+	// fsync parent so the rename is durable across a crash (POSIX).
+	parent := filepath.Dir(livePath)
+	if err := diskio.Fsync(parent); err != nil {
+		return fmt.Errorf("promote recovery folder: fsync parent %q: %w", parent, err)
+	}
+	return nil
+}
+
+func (c *Copier) validateLocalFolder(collectionName, shardName, localShard string, fileNames []string) error {
+	// Keyed by LOCAL relative path; see prepareLocalFolder.
 	fileNamesMap := make(map[string]struct{}, len(fileNames))
 	for _, fileName := range fileNames {
-		fileNamesMap[fileName] = struct{}{}
+		fileNamesMap[c.rewriteRelPathToLocalShard(fileName, shardName, localShard)] = struct{}{}
 	}
 
 	var dirs []string
 
-	basePath := c.shardPath(collectionName, shardName)
+	basePath := c.shardPath(collectionName, localShard)
 
 	err := filepath.WalkDir(basePath, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {

--- a/cluster/replication/copier/copier_test.go
+++ b/cluster/replication/copier/copier_test.go
@@ -145,6 +145,108 @@ func TestCopyReplicaFiles(t *testing.T) {
 	require.ErrorIs(t, err, os.ErrNotExist)
 }
 
+// TestCopyReplicaFilesToLocalShard_RecoveryOverride mirrors
+// TestCopyReplicaFiles but supplies a localShardOverride (as SELF_RECOVERY
+// does, "<shard>.recovering"): the source still reports files under
+// "<collection>/<shard>/...", but they must land locally under
+// "<collection>/<shard>.recovering/..." — and the live "<collection>/<shard>/"
+// directory must be left untouched.
+func TestCopyReplicaFilesToLocalShard_RecoveryOverride(t *testing.T) {
+	remoteTmpDir := t.TempDir()
+	localTmpDir := t.TempDir()
+
+	write := func(dir, rel string, content []byte) string {
+		path := filepath.Join(dir, rel)
+		require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o755))
+		require.NoError(t, os.WriteFile(path, content, 0o644))
+		return path
+	}
+
+	remoteFiles := []struct {
+		rel string
+		buf []byte
+	}{
+		{"collection/shard/fileA", []byte("AAA")},
+		{"collection/shard/nested/fileB", []byte("BBB")},
+	}
+	for _, f := range remoteFiles {
+		write(remoteTmpDir, f.rel, f.buf)
+	}
+
+	// A stale file in the recovery dir that must be cleaned up; plus a
+	// file in the *live* dir that must NOT be touched.
+	_ = write(localTmpDir, "collection/shard.recovering/old", []byte("OLD"))
+	_ = write(localTmpDir, "collection/shard/live-marker", []byte("LIVE"))
+
+	mockClient := NewMockFileReplicationServiceClient(t)
+	mockRemoteIndex := types.NewMockRemoteIndex(t)
+
+	mockClient.EXPECT().PauseFileActivity(mock.Anything, mock.Anything).
+		Return(&protocol.PauseFileActivityResponse{}, nil)
+	mockClient.EXPECT().ResumeFileActivity(mock.Anything, mock.Anything).
+		Return(&protocol.ResumeFileActivityResponse{}, nil)
+
+	fileNames := []string{
+		"collection/shard/fileA",
+		"collection/shard/nested/fileB",
+	}
+	mockClient.EXPECT().ListFiles(mock.Anything, mock.Anything).
+		Return(&protocol.ListFilesResponse{FileNames: fileNames}, nil)
+
+	for _, f := range remoteFiles {
+		st, err := os.Stat(filepath.Join(remoteTmpDir, f.rel))
+		require.NoError(t, err)
+		mockClient.EXPECT().GetFileMetadata(
+			mock.Anything,
+			&protocol.GetFileMetadataRequest{IndexName: "collection", ShardName: "shard", FileName: f.rel},
+		).Return(&protocol.FileMetadata{
+			IndexName: "collection", ShardName: "shard", FileName: f.rel,
+			Size:  st.Size(),
+			Crc32: checksum(filepath.Join(remoteTmpDir, f.rel), t),
+		}, nil)
+	}
+	for _, f := range remoteFiles {
+		stream := NewMockFileChunkStream(t)
+		stream.EXPECT().Recv().Return(&protocol.FileChunk{Data: []byte(f.buf), Eof: true}, nil).Once()
+		stream.EXPECT().Recv().Return(nil, io.EOF)
+		mockClient.EXPECT().GetFile(
+			mock.Anything,
+			&protocol.GetFileRequest{IndexName: "collection", ShardName: "shard", FileName: f.rel},
+		).Return(stream, nil)
+	}
+
+	logger, _ := logrusTest.NewNullLogger()
+	c := New(
+		func(ctx context.Context, addr string) (FileReplicationServiceClient, error) { return mockClient, nil },
+		mockRemoteIndex,
+		fakes.NewFakeClusterState("node1"),
+		2,
+		localTmpDir,
+		nil,
+		"node1",
+		logger,
+	)
+
+	require.NoError(t, c.CopyReplicaFilesToLocalShard(context.Background(), "node1", "collection", "shard", "shard.recovering", 0))
+
+	// Files landed in the .recovering sibling, not the live dir.
+	for _, f := range remoteFiles {
+		relWithinShard := f.rel[len("collection/shard/"):] // e.g. "fileA", "nested/fileB"
+		b, err := os.ReadFile(filepath.Join(localTmpDir, "collection", "shard.recovering", relWithinShard))
+		require.NoError(t, err, "expected collection/shard.recovering/%s", relWithinShard)
+		require.Equal(t, f.buf, b)
+		_, err = os.Stat(filepath.Join(localTmpDir, "collection", "shard", relWithinShard))
+		require.ErrorIs(t, err, os.ErrNotExist, "copied file must not appear under the live shard dir")
+	}
+	// Stale file in the recovery dir was cleaned up.
+	_, err := os.Stat(filepath.Join(localTmpDir, "collection/shard.recovering/old"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+	// The live shard dir was left completely untouched.
+	b, err := os.ReadFile(filepath.Join(localTmpDir, "collection/shard/live-marker"))
+	require.NoError(t, err)
+	require.Equal(t, []byte("LIVE"), b)
+}
+
 // helper
 func checksum(p string, t *testing.T) uint32 {
 	_, c, err := integrity.CRC32(p)

--- a/cluster/replication/copier/recovery_test.go
+++ b/cluster/replication/copier/recovery_test.go
@@ -1,0 +1,132 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package copier
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path"
+	"testing"
+
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/cluster/proto/api"
+)
+
+// TestRewriteRelPathToLocalShard exercises the path-rewriter used by
+// CopyReplicaFilesToLocalShard so files reported by the source under
+// "<lower(coll)>/<srcShard>/..." land at "<lower(coll)>/<dstShard>/..."
+// when an override is supplied (e.g. SELF_RECOVERY's ".recovering"
+// sibling directory).
+func TestRewriteRelPathToLocalShard(t *testing.T) {
+	c := &Copier{rootDataPath: "/data", logger: logrus.New()}
+
+	tests := []struct {
+		name          string
+		src, srcShard string
+		localShard    string
+		want          string
+	}{
+		{
+			name:       "no_override_passes_through",
+			src:        "myclass/shard1/segment-1.db",
+			srcShard:   "shard1",
+			localShard: "shard1",
+			want:       "myclass/shard1/segment-1.db",
+		},
+		{
+			name:       "rewrites_shard_segment",
+			src:        "myclass/shard1/segment-1.db",
+			srcShard:   "shard1",
+			localShard: "shard1.recovering",
+			want:       "myclass/shard1.recovering/segment-1.db",
+		},
+		{
+			name:       "deep_subpath_preserved",
+			src:        "myclass/shard1/lsm/objects/segment-3.db",
+			srcShard:   "shard1",
+			localShard: "shard1.recovering",
+			want:       "myclass/shard1.recovering/lsm/objects/segment-3.db",
+		},
+		{
+			name:       "non_matching_segment_unchanged",
+			src:        "myclass/different/file.db",
+			srcShard:   "shard1",
+			localShard: "shard1.recovering",
+			want:       "myclass/different/file.db",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := c.rewriteRelPathToLocalShard(tc.src, tc.srcShard, tc.localShard)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestPromoteRecoveryFolder verifies the rename + parent fsync path:
+// the recovery dir must move atomically into place, fail when the live
+// dir already exists, and refuse to run when the recovery dir is absent.
+func TestPromoteRecoveryFolder(t *testing.T) {
+	root := t.TempDir()
+	c := &Copier{rootDataPath: root, logger: logrus.New()}
+
+	collection := "MyClass"
+	shard := "shard1"
+	livePath := c.shardPath(collection, shard)
+	recoveryPath := c.shardPath(collection, api.RecoveryFolderName(shard))
+
+	t.Run("happy_path_renames_recovery_into_place", func(t *testing.T) {
+		require.NoError(t, os.MkdirAll(recoveryPath, 0o755))
+		require.NoError(t, os.WriteFile(path.Join(recoveryPath, "marker"), []byte("ok"), 0o644))
+
+		require.NoError(t, c.PromoteRecoveryFolder(collection, shard))
+
+		_, err := os.Stat(recoveryPath)
+		require.True(t, errors.Is(err, fs.ErrNotExist), "recovery dir should be gone, got %v", err)
+		info, err := os.Stat(livePath)
+		require.NoError(t, err)
+		require.True(t, info.IsDir())
+		// Marker file survived the rename.
+		_, err = os.Stat(path.Join(livePath, "marker"))
+		require.NoError(t, err)
+	})
+
+	t.Run("erases_stale_recovery_dir_when_live_dir_already_exists", func(t *testing.T) {
+		// Setup: both dirs present (e.g. an earlier promote partially
+		// succeeded — rename happened, parent fsync survived, then
+		// orchestrator crashed before clearing local state, and on the
+		// next attempt the recovery dir is rebuilt from another retry).
+		require.NoError(t, os.MkdirAll(recoveryPath, 0o755))
+		require.NoError(t, os.MkdirAll(livePath, 0o755))
+		require.NoError(t, os.WriteFile(path.Join(livePath, "live-marker"), []byte("live"), 0o644))
+
+		require.NoError(t, c.PromoteRecoveryFolder(collection, shard))
+
+		// Stale recovery dir is erased; the live dir is the canonical
+		// state and remains untouched.
+		_, statErr := os.Stat(recoveryPath)
+		require.True(t, errors.Is(statErr, fs.ErrNotExist), "stale recovery dir should be erased, got %v", statErr)
+		_, err := os.Stat(path.Join(livePath, "live-marker"))
+		require.NoError(t, err, "live dir contents must not be touched")
+
+		// Cleanup for next subtest.
+		require.NoError(t, os.RemoveAll(livePath))
+	})
+
+	t.Run("errors_when_recovery_dir_missing", func(t *testing.T) {
+		err := c.PromoteRecoveryFolder(collection, shard)
+		require.Error(t, err)
+	})
+}

--- a/cluster/replication/selfrecovery/metrics.go
+++ b/cluster/replication/selfrecovery/metrics.go
@@ -1,0 +1,92 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package selfrecovery
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// Metrics holds Prometheus collectors for the self-recovery subsystem.
+// No (collection, shard) labels: a wiped node restoring many shards
+// would otherwise inflate cardinality. Per-shard drill-down lives in
+// /replication/replicate/list and structured logs.
+type Metrics struct {
+	InProgress                 prometheus.Gauge
+	StartedTotal               *prometheus.CounterVec   // labels: source_node
+	CompletedTotal             *prometheus.CounterVec   // labels: result (success|failure|cancelled)
+	DurationSeconds            *prometheus.HistogramVec // labels: result (success|failure|empty_fallback|cancelled)
+	NoDataEmptyTotal           prometheus.Counter
+	NoDataDuringBootstrapTotal prometheus.Counter
+	UnreachablePeerTotal       *prometheus.CounterVec // labels: peer
+	GiveupTotal                prometheus.Counter
+	AcceptEmptyTotal           prometheus.Counter
+	SubmitDroppedTotal         prometheus.Counter
+}
+
+var (
+	metricsOnce sync.Once
+	metricsInst *Metrics
+)
+
+// GlobalMetrics returns the process-wide Metrics singleton, registering
+// on the default Prometheus registry on first call.
+func GlobalMetrics() *Metrics {
+	metricsOnce.Do(func() {
+		metricsInst = &Metrics{
+			InProgress: promauto.NewGauge(prometheus.GaugeOpts{
+				Name: "weaviate_self_recovery_in_progress",
+				Help: "Number of self-recovery operations currently in progress on this node.",
+			}),
+			StartedTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "weaviate_self_recovery_started_total",
+				Help: "Total number of self-recovery operations started, by source peer.",
+			}, []string{"source_node"}),
+			CompletedTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "weaviate_self_recovery_completed_total",
+				Help: "Total number of self-recovery operations completed, by terminal result (success|failure|cancelled).",
+			}, []string{"result"}),
+			DurationSeconds: promauto.NewHistogramVec(prometheus.HistogramOpts{
+				Name:    "weaviate_self_recovery_duration_seconds",
+				Help:    "End-to-end duration of a self-recovery operation, by terminal result (success|failure|empty_fallback|cancelled).",
+				Buckets: prometheus.ExponentialBuckets(10, 2, 10), // 10s, 20s, 40s, ... ~1.4h
+			}, []string{"result"}),
+			NoDataEmptyTotal: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "weaviate_self_recovery_no_data_empty_total",
+				Help: "Self-recovery occurrences where all probed peers definitively reported no data after RAFT bootstrap completed (catastrophic-wipe). Alert on this.",
+			}),
+			NoDataDuringBootstrapTotal: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "weaviate_self_recovery_no_data_during_bootstrap_total",
+				Help: "Self-recovery occurrences during the RAFT bootstrap window where all probed peers reported no data (likely a class added during this node's downtime, not data loss).",
+			}),
+			UnreachablePeerTotal: promauto.NewCounterVec(prometheus.CounterOpts{
+				Name: "weaviate_self_recovery_unreachable_peer_total",
+				Help: "Probes that failed to reach a peer (transport/timeout), by peer.",
+			}, []string{"peer"}),
+			GiveupTotal: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "weaviate_self_recovery_giveup_total",
+				Help: "Self-recovery attempts that exhausted retries without reaching READY.",
+			}),
+			AcceptEmptyTotal: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "weaviate_self_recovery_accept_empty_total",
+				Help: "Operator invocations of the accept-empty escape hatch.",
+			}),
+			SubmitDroppedTotal: promauto.NewCounter(prometheus.CounterOpts{
+				Name: "weaviate_self_recovery_submit_dropped_total",
+				Help: "Submissions dropped because the in-process worker queue was full (will be retried on next node restart).",
+			}),
+		}
+	})
+	return metricsInst
+}

--- a/cluster/replication/selfrecovery/orchestrator.go
+++ b/cluster/replication/selfrecovery/orchestrator.go
@@ -1,0 +1,1067 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package selfrecovery triggers automatic SELF_RECOVERY replication
+// ops for shards whose local directories are missing at node startup.
+// Wired only into the startup path so newly-added empty replicas via
+// scale-out are not misinterpreted as data loss. The actual file copy
+// and state machine are handled by the existing replication FSM +
+// consumer; this package only probes peers and registers ops.
+//
+// Per-shard decision: any peer reports data -> register op; all peers
+// definitively report no data -> create empty + WARN; any peer
+// unreachable -> backoff and retry.
+package selfrecovery
+
+import (
+	"context"
+	cryptorand "crypto/rand"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io/fs"
+	"math/rand"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/sirupsen/logrus"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc/generated/protocol"
+	"github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/replication/copier"
+	replicationtypes "github.com/weaviate/weaviate/cluster/replication/types"
+	"github.com/weaviate/weaviate/entities/diskio"
+	enterrors "github.com/weaviate/weaviate/entities/errors"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
+)
+
+// ErrSelfRecoveryCancelled is the terminal-state sentinel returned by
+// registerAndPoll when the FSM reports the op as CANCELLED. runOne uses
+// it to distinguish operator-driven cancel (don't retry, count as
+// "cancelled") from transient errors (retry with backoff).
+var ErrSelfRecoveryCancelled = errors.New("self-recovery op was cancelled")
+
+// ErrSelfRecoveryShardNotInSchema is the sentinel returned by AcceptEmpty
+// (and any other operator endpoint that uses the schema gate) when the
+// requested (collection, shard) is not present in the local schema. The
+// REST handler maps it to 404 instead of 500.
+var ErrSelfRecoveryShardNotInSchema = errors.New("shard not in local schema")
+
+// ErrSelfRecoveryShardAlreadyLive is the sentinel returned by Restart
+// when the shard already has a live on-disk directory (i.e. recovery has
+// already completed or the shard was never recovering). The REST handler
+// maps it to 409 Conflict. Operators who want to re-pull a healthy shard
+// must cancel any in-flight op first and remove the directory by hand.
+var ErrSelfRecoveryShardAlreadyLive = errors.New("shard already has a live local directory; /restart is only valid while the shard is RECOVERING")
+
+// RaftEntryPoint is the subset of *cluster.Raft used by the orchestrator;
+// defined locally so tests can stub it.
+type RaftEntryPoint interface {
+	RegisterSelfRecovery(ctx context.Context, sourceNode, collection, shard, targetNode string) (strfmt.UUID, error)
+	GetReplicationDetailsByReplicationId(ctx context.Context, uuid strfmt.UUID) (api.ReplicationDetailsResponse, error)
+	GetReplicationDetailsByCollectionAndShard(ctx context.Context, collection, shard string) ([]api.ReplicationDetailsResponse, error)
+	CancelReplication(ctx context.Context, uuid strfmt.UUID) error
+}
+
+type SchemaReader interface {
+	ShardReplicas(class, shard string) (nodes []string, err error)
+}
+
+// PathResolver maps (collection, shard) to the local on-disk dir.
+type PathResolver interface {
+	ShardPath(collection, shard string) string
+}
+
+type ShardRef struct {
+	Collection string
+	Shard      string
+}
+
+// Orchestrator coordinates per-shard SELF_RECOVERY work on a single node.
+// It is constructed once at startup and submitted to as the index init
+// pass discovers shard directories that should be present but are not.
+type Orchestrator struct {
+	raft                   RaftEntryPoint
+	schema                 SchemaReader
+	pathResolver           PathResolver
+	clientFactory          copier.FileReplicationServiceClientFactory
+	nodeSelector           cluster.NodeSelector
+	nodeName               string
+	enabled                *runtime.DynamicValue[bool]
+	concurrency            *runtime.DynamicValue[int]
+	maintenanceModeEnabled func() bool // nil-safe; treated as off when nil
+	onRecoveryComplete     func(ctx context.Context, collection, shard string) error
+	logger                 logrus.FieldLogger
+	pollInterval           time.Duration
+	probeTimeout           time.Duration
+	probeBackoffMin        time.Duration
+	probeBackoffMax        time.Duration
+	restartTimeout         time.Duration  // caps Restart's cancel+settle loop
+	vanishedGracePeriod    time.Duration  // extra wait when a polled op vanishes
+	emptyFallbackHook      func(ShardRef) // nil unless overridden in tests
+	metrics                *Metrics
+
+	// Worker pool. Bounded queue prevents unbounded goroutine fan-out
+	// when N>>concurrency shards need recovery (e.g. wiped node with
+	// many shards). Concurrency = number of workers; queue capacity
+	// holds the burst.
+	poolOnce            sync.Once
+	workQueue           chan submission
+	submitQueueCapacity int // defaultSubmitQueueCapacity unless overridden in tests
+
+	// Per-orchestrator RNG, seeded from wall-clock at construction so
+	// different nodes shuffle peer order differently. Guarded by rngMu
+	// because probeAndDecide runs from multiple workers concurrently.
+	rngMu sync.Mutex
+	rng   *rand.Rand
+}
+
+type submission struct {
+	ctx context.Context
+	ref ShardRef
+	// fromBootstrap is captured at submit time (not read later via a
+	// shared flag) so an empty-fallback that takes a few seconds of peer
+	// probing isn't misclassified when RAFT bootstrap completes meanwhile.
+	fromBootstrap bool
+}
+
+// defaultSubmitQueueCapacity bounds the in-flight submission backlog. If
+// exceeded, Submit drops the request with a metric/log so memory stays
+// bounded regardless of how many shards a wiped node needs. Dropped
+// shards fall back to normal init at startup and are retried on the next
+// node restart. Overridable per-orchestrator (tests).
+const defaultSubmitQueueCapacity = 1024
+
+type Config struct {
+	Raft          RaftEntryPoint
+	Schema        SchemaReader
+	PathResolver  PathResolver
+	ClientFactory copier.FileReplicationServiceClientFactory
+	NodeSelector  cluster.NodeSelector
+	NodeName      string
+	Enabled       *runtime.DynamicValue[bool]
+	Concurrency   *runtime.DynamicValue[int]
+	// MaintenanceModeEnabled, when non-nil and returning true, makes
+	// Submit a no-op so the orchestrator does not start new recoveries
+	// during operator-declared maintenance windows. Already-running
+	// recoveries are left to finish on their own.
+	MaintenanceModeEnabled func() bool
+	// OnRecoveryComplete promotes the in-memory wrapper after the
+	// orchestrator's empty-fallback materialises an empty live dir.
+	// (The SELF_RECOVERY-op path doesn't need it; the consumer's
+	// LoadLocalShard handles the swap.)
+	OnRecoveryComplete func(ctx context.Context, collection, shard string) error
+	Logger             logrus.FieldLogger
+	// PollInterval is FSM-polling cadence after registering an op. 5s if zero.
+	PollInterval time.Duration
+	// ProbeTimeout caps a single ListFiles probe RPC. 5s if zero.
+	ProbeTimeout time.Duration
+}
+
+func New(cfg Config) *Orchestrator {
+	pollInterval := cfg.PollInterval
+	if pollInterval <= 0 {
+		pollInterval = 5 * time.Second
+	}
+	probeTimeout := cfg.ProbeTimeout
+	if probeTimeout <= 0 {
+		probeTimeout = 5 * time.Second
+	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = logrus.NewEntry(logrus.New())
+	}
+	return &Orchestrator{
+		raft:                   cfg.Raft,
+		schema:                 cfg.Schema,
+		pathResolver:           cfg.PathResolver,
+		clientFactory:          cfg.ClientFactory,
+		nodeSelector:           cfg.NodeSelector,
+		nodeName:               cfg.NodeName,
+		enabled:                cfg.Enabled,
+		concurrency:            cfg.Concurrency,
+		maintenanceModeEnabled: cfg.MaintenanceModeEnabled,
+		onRecoveryComplete:     cfg.OnRecoveryComplete,
+		logger:                 logger.WithField("component", "self_recovery"),
+		pollInterval:           pollInterval,
+		probeTimeout:           probeTimeout,
+		probeBackoffMin:        5 * time.Second,
+		probeBackoffMax:        5 * time.Minute,
+		restartTimeout:         30 * time.Second,
+		vanishedGracePeriod:    10 * time.Second,
+		submitQueueCapacity:    defaultSubmitQueueCapacity,
+		metrics:                GlobalMetrics(),
+		rng:                    rand.New(rand.NewSource(cryptoSeed())),
+	}
+}
+
+// cryptoSeed returns a process-unique int64 seed derived from crypto/rand.
+// math/rand is used only for peer-shuffle load distribution (not for
+// any security purpose); seeding from crypto/rand makes node startups
+// pick independent peer orderings without relying on time/pid entropy.
+func cryptoSeed() int64 {
+	var b [8]byte
+	if _, err := cryptorand.Read(b[:]); err != nil {
+		// Fallback path: cryptographically poor but never reached on
+		// a sane OS. Time + pid is still distinct across nodes.
+		return time.Now().UnixNano() ^ int64(os.Getpid())
+	}
+	return int64(binary.LittleEndian.Uint64(b[:]))
+}
+
+// Submit asynchronously starts recovery for the shard. Returns true when
+// the work was queued, false when it was not — because the feature flag
+// is off, maintenance mode is on, or the in-flight queue is full
+// (submitQueueCapacity bursts exceeded; a warning + metric is emitted in
+// that case). Callers that installed a RecoveringShard wrapper MUST fall
+// back to normal shard init when this returns false, otherwise the shard
+// stays load-blocked until the next node restart. fromBootstrap tags the
+// op so an empty-fallback during the RAFT bootstrap window is logged and
+// counted less alarmingly (likely a fresh class added during downtime).
+func (o *Orchestrator) Submit(ctx context.Context, ref ShardRef, fromBootstrap bool) bool {
+	if o.enabled == nil || !o.enabled.Get() {
+		return false
+	}
+	if o.maintenanceModeEnabled != nil && o.maintenanceModeEnabled() {
+		o.logger.WithFields(logrus.Fields{
+			"event":      "self_recovery.skipped_maintenance_mode",
+			"collection": ref.Collection,
+			"shard":      ref.Shard,
+		}).Info("self-recovery skipped: node is in maintenance mode")
+		return false
+	}
+	o.poolOnce.Do(o.initPool)
+	select {
+	case o.workQueue <- submission{ctx: ctx, ref: ref, fromBootstrap: fromBootstrap}:
+		return true
+	default:
+		if o.metrics != nil {
+			o.metrics.SubmitDroppedTotal.Inc()
+		}
+		o.logger.WithFields(logrus.Fields{
+			"event":      "self_recovery.submit_dropped",
+			"collection": ref.Collection,
+			"shard":      ref.Shard,
+			"queue_cap":  o.submitQueueCapacity,
+		}).Warn("self-recovery submission dropped: queue full")
+		return false
+	}
+}
+
+// Enabled reports whether the SELF_RECOVERY feature flag is on. Useful
+// for callers that need to gate behavior (e.g. wrapper installation)
+// before invoking Submit, which itself silently no-ops when off.
+func (o *Orchestrator) Enabled() bool {
+	return o.enabled != nil && o.enabled.Get()
+}
+
+// SubmitRecovery is the primitive-typed entry point for callers that
+// can't import this package without a cycle. Returns false if the work
+// was not queued (see Submit) — the caller must fall back to normal shard
+// init in that case.
+func (o *Orchestrator) SubmitRecovery(ctx context.Context, collection, shard string, fromBootstrap bool) bool {
+	return o.Submit(ctx, ShardRef{Collection: collection, Shard: shard}, fromBootstrap)
+}
+
+// Restart cancels any in-flight SELF_RECOVERY op for (collection,
+// shard) targeting this node, waits for those ops to reach a terminal
+// state (so the in-flight copier won't race the rmrf below), erases
+// "<shard>.recovering/", then submits a fresh recovery. Bounded by
+// restartTimeout: on timeout, leaves the recovery dir intact and
+// returns ctx.Err() so the operator can retry.
+//
+// Rejected with ErrSelfRecoveryShardAlreadyLive when the live
+// "<shard>/" directory already exists — i.e. recovery has already
+// completed (or empty-fallback ran), and there is nothing to restart.
+// Restarting in that state would re-copy peer data over a healthy shard.
+func (o *Orchestrator) Restart(parentCtx context.Context, ref ShardRef) error {
+	if o.pathResolver != nil {
+		livePath := o.pathResolver.ShardPath(ref.Collection, ref.Shard)
+		if _, err := os.Stat(livePath); err == nil {
+			return fmt.Errorf("restart recovery for %s/%s: %w (cancel any in-flight op via POST /replication/replicate/{id}/cancel)",
+				ref.Collection, ref.Shard, ErrSelfRecoveryShardAlreadyLive)
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return fmt.Errorf("restart recovery: stat live dir %q: %w", livePath, err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(parentCtx, o.restartTimeout)
+	defer cancel()
+
+	cancelled, err := o.cancelInflightSelfRecoveryOps(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("restart recovery: cancel in-flight op(s): %w", err)
+	}
+
+	for _, uuid := range cancelled {
+		if err := o.waitForOpTerminal(ctx, uuid); err != nil {
+			return fmt.Errorf("restart recovery: wait for op %s to settle: %w", uuid, err)
+		}
+	}
+
+	if o.pathResolver != nil {
+		recoveryPath := o.pathResolver.ShardPath(ref.Collection, ref.Shard) + api.RecoveryFolderSuffix
+		if err := os.RemoveAll(recoveryPath); err != nil {
+			return fmt.Errorf("restart recovery: remove %q: %w", recoveryPath, err)
+		}
+	}
+
+	o.logger.WithFields(logrus.Fields{
+		"event":         "self_recovery.restart",
+		"collection":    ref.Collection,
+		"shard":         ref.Shard,
+		"cancelled_ops": cancelled,
+	}).Warn("operator restarted self-recovery from scratch")
+
+	// Re-submit with WithoutCancel so the spawned recovery goroutine
+	// survives the HTTP-request-bound parent ctx (which is canceled as
+	// soon as the handler returns). Values (tracing/logging) are still
+	// inherited from parentCtx. fromBootstrap=false: an operator-driven
+	// restart is by definition past the RAFT bootstrap window.
+	if !o.Submit(context.WithoutCancel(parentCtx), ref, false) && o.Enabled() {
+		// Cancel + erase succeeded but the fresh recovery couldn't be
+		// queued (worker queue full). Surface it so the operator retries;
+		// the shard stays in RECOVERING in the meantime.
+		return errors.New("restart recovery: re-submission was dropped (in-flight queue full); retry shortly")
+	}
+	return nil
+}
+
+// RestartRecovery is the primitive-typed entry point for callers that
+// can't import this package without a cycle.
+func (o *Orchestrator) RestartRecovery(ctx context.Context, collection, shard string) error {
+	return o.Restart(ctx, ShardRef{Collection: collection, Shard: shard})
+}
+
+// cancelInflightSelfRecoveryOps cancels every non-terminal SELF_RECOVERY
+// op on (collection, shard) targeting this node. Returns the UUIDs
+// cancelled. A "not found" error means no ops at all and is success.
+func (o *Orchestrator) cancelInflightSelfRecoveryOps(ctx context.Context, ref ShardRef) ([]strfmt.UUID, error) {
+	if o.raft == nil {
+		return nil, nil
+	}
+	ops, err := o.raft.GetReplicationDetailsByCollectionAndShard(ctx, ref.Collection, ref.Shard)
+	if err != nil {
+		if errors.Is(err, replicationtypes.ErrReplicationOperationNotFound) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var cancelled []strfmt.UUID
+	for _, op := range ops {
+		if op.TransferType != api.SELF_RECOVERY.String() {
+			continue
+		}
+		if op.TargetNodeId != o.nodeName {
+			continue
+		}
+		state := api.ShardReplicationState(op.Status.State)
+		if state == api.READY || state == api.CANCELLED {
+			continue
+		}
+		if err := o.raft.CancelReplication(ctx, op.Uuid); err != nil {
+			return cancelled, fmt.Errorf("cancel op %s: %w", op.Uuid, err)
+		}
+		// CompletedTotal{result="cancelled"} is incremented by runOne
+		// when it observes the FSM's CANCELLED state — the single
+		// source of truth. Doing it here too would double-count, and
+		// would also tick even if the cancel never propagated.
+		cancelled = append(cancelled, op.Uuid)
+	}
+	return cancelled, nil
+}
+
+// HasInflightReplicationOp reports whether a non-terminal replication op
+// (COPY, MOVE, or SELF_RECOVERY — any kind) already targets (collection,
+// shard) on this node. The startup recovery hook calls this before
+// installing a RecoveringShard wrapper: a node that restarts mid scale-out
+// COPY and then receives an InstallSnapshot would otherwise re-enter the
+// startup path (target dir not yet created), register a duplicate
+// SELF_RECOVERY op writing into "<shard>.recovering/", and clobber the
+// resumed COPY's output on rename. A "not found" answer from the FSM means
+// there are no ops at all → (false, nil). On any other error the caller
+// should treat it as "skip recovery" (conservative).
+func (o *Orchestrator) HasInflightReplicationOp(ctx context.Context, collection, shard string) (bool, error) {
+	if o.raft == nil {
+		return false, nil
+	}
+	ops, err := o.raft.GetReplicationDetailsByCollectionAndShard(ctx, collection, shard)
+	if err != nil {
+		if errors.Is(err, replicationtypes.ErrReplicationOperationNotFound) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, op := range ops {
+		if op.TargetNodeId != o.nodeName {
+			continue
+		}
+		switch api.ShardReplicationState(op.Status.State) {
+		case api.READY, api.CANCELLED:
+			// terminal — no longer touching the shard dir
+		default:
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// waitForOpTerminal polls the FSM until the op reaches READY or
+// CANCELLED. A vanished op (force-deleted upstream) is treated as
+// terminal but with an additional grace sleep so a still-running
+// consumer goroutine can observe the cancellation. Bounded by the
+// caller's ctx.
+func (o *Orchestrator) waitForOpTerminal(ctx context.Context, uuid strfmt.UUID) error {
+	if o.raft == nil {
+		return nil
+	}
+	ticker := time.NewTicker(o.pollInterval)
+	defer ticker.Stop()
+	for {
+		details, err := o.raft.GetReplicationDetailsByReplicationId(ctx, uuid)
+		if err != nil {
+			if errors.Is(err, replicationtypes.ErrReplicationOperationNotFound) {
+				if !sleepCtx(ctx, o.vanishedGracePeriod) {
+					return ctx.Err()
+				}
+				return nil
+			}
+			// transient (e.g. leader change) — keep polling
+		} else {
+			switch api.ShardReplicationState(details.Status.State) {
+			case api.READY, api.CANCELLED:
+				return nil
+			case api.REGISTERED, api.HYDRATING, api.FINALIZING, api.DEHYDRATING:
+				// non-terminal — keep polling
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// CleanupOrphanRecoveryDirs removes "<shard>.recovering/" dirs whose
+// live "<shard>/" sibling exists. Reclaims disk after a
+// downgrade-then-upgrade cycle. In-flight recoveries (no sibling) are
+// untouched.
+func (o *Orchestrator) CleanupOrphanRecoveryDirs(rootDataPath string) ([]string, error) {
+	const suffix = api.RecoveryFolderSuffix
+	if rootDataPath == "" {
+		return nil, errors.New("cleanup orphan recovery dirs: empty root data path")
+	}
+	collections, err := os.ReadDir(rootDataPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read data root %q: %w", rootDataPath, err)
+	}
+	var removed []string
+	for _, c := range collections {
+		if !c.IsDir() {
+			continue
+		}
+		collDir := filepath.Join(rootDataPath, c.Name())
+		shards, err := os.ReadDir(collDir)
+		if err != nil {
+			o.logger.WithError(err).WithField("dir", collDir).Warn("cleanup: cannot read collection dir")
+			continue
+		}
+		for _, s := range shards {
+			if !s.IsDir() || !strings.HasSuffix(s.Name(), suffix) {
+				continue
+			}
+			recoveryDir := filepath.Join(collDir, s.Name())
+			liveDir := filepath.Join(collDir, strings.TrimSuffix(s.Name(), suffix))
+			if _, err := os.Stat(liveDir); err != nil {
+				continue // no sibling: in-flight recovery to resume
+			}
+			if err := os.RemoveAll(recoveryDir); err != nil {
+				o.logger.WithError(err).WithField("dir", recoveryDir).Warn("cleanup: failed to remove orphan recovery dir")
+				continue
+			}
+			o.logger.WithField("dir", recoveryDir).Info("cleanup: removed orphan recovery dir")
+			removed = append(removed, recoveryDir)
+		}
+	}
+	return removed, nil
+}
+
+// AcceptEmpty is the operator escape hatch for the catastrophic-wipe
+// case (no peer has the data). It removes "<shard>.recovering/" and
+// creates an empty "<shard>/", then promotes the in-memory wrapper so
+// the shard becomes serviceable (otherwise a RecoveringShard wrapper
+// would stay load-blocked despite the on-disk dir existing). Does NOT
+// cancel in-flight RAFT ops — operator should call
+// /replication/replicate/{id}/cancel first.
+func (o *Orchestrator) AcceptEmpty(ctx context.Context, ref ShardRef) (string, error) {
+	if o.pathResolver == nil {
+		return "", errors.New("accept-empty: no PathResolver configured")
+	}
+	// Refuse to materialise dirs for unknown (collection, shard) — keeps
+	// the operator endpoint from creating arbitrary paths under the data
+	// root if the schema doesn't actually have this shard.
+	if o.schema != nil {
+		if _, err := o.schema.ShardReplicas(ref.Collection, ref.Shard); err != nil {
+			return "", fmt.Errorf("accept-empty: shard %s/%s: %w",
+				ref.Collection, ref.Shard,
+				errors.Join(ErrSelfRecoveryShardNotInSchema, err))
+		}
+	}
+	livePath := o.pathResolver.ShardPath(ref.Collection, ref.Shard)
+	recoveryPath := livePath + api.RecoveryFolderSuffix
+
+	if _, err := os.Stat(recoveryPath); err == nil {
+		if err := os.RemoveAll(recoveryPath); err != nil {
+			return "", fmt.Errorf("remove recovery dir %q: %w", recoveryPath, err)
+		}
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		// EACCES, EIO, ELOOP etc. — surface so the operator sees them.
+		return "", fmt.Errorf("stat recovery dir %q: %w", recoveryPath, err)
+	}
+	if err := os.MkdirAll(livePath, 0o755); err != nil {
+		return "", fmt.Errorf("mkdir %q: %w", livePath, err)
+	}
+	if err := diskio.Fsync(filepath.Dir(livePath)); err != nil {
+		return "", fmt.Errorf("fsync parent of %q: %w", livePath, err)
+	}
+	// Promote the in-memory wrapper so the shard transitions out of
+	// RECOVERING and becomes serviceable. Mirrors the empty-fallback
+	// path inside runOne; without this, the operator's "accept empty"
+	// would leave the shard load-blocked behind a RecoveringShard
+	// wrapper despite the on-disk dir being ready.
+	if o.onRecoveryComplete != nil {
+		if err := o.onRecoveryComplete(ctx, ref.Collection, ref.Shard); err != nil {
+			return "", fmt.Errorf("accept-empty: promote in-memory wrapper for %s/%s: %w",
+				ref.Collection, ref.Shard, err)
+		}
+	}
+	if o.metrics != nil {
+		o.metrics.AcceptEmptyTotal.Inc()
+	}
+	o.logger.WithFields(logrus.Fields{
+		"event":      "self_recovery.accept_empty",
+		"collection": ref.Collection,
+		"shard":      ref.Shard,
+		"path":       livePath,
+	}).Warn("operator accepted empty shard; recovery aborted")
+	return livePath, nil
+}
+
+// runOne is the per-shard worker: probe peers, act on the decision, and
+// back off & retry on transient errors up to maxAttempts. On give-up the
+// shard is left in RECOVERING — operators recover via the
+// /debug/self-recovery/{restart,accept-empty} endpoints.
+func (o *Orchestrator) runOne(ctx context.Context, ref ShardRef, fromBootstrap bool) {
+	logger := o.logger.WithFields(logrus.Fields{
+		"event":      "self_recovery.started",
+		"collection": ref.Collection,
+		"shard":      ref.Shard,
+	})
+	logger.Info("starting self-recovery for shard")
+
+	startedAt := time.Now()
+	if o.metrics != nil {
+		o.metrics.InProgress.Inc()
+		defer o.metrics.InProgress.Dec()
+	}
+
+	const maxAttempts = 10
+	attempts := 0
+	backoff := o.probeBackoffMin
+
+	retryAfterBackoff := func() bool {
+		attempts++
+		if !sleepCtx(ctx, backoff) {
+			return false
+		}
+		backoff = nextBackoff(backoff, o.probeBackoffMax)
+		return true
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		if attempts >= maxAttempts {
+			logger.WithField("attempts", attempts).Error("self-recovery exhausted retries; giving up. " +
+				"Shard stays in RECOVERING — use POST /debug/self-recovery/restart to retry from scratch, " +
+				"or POST /debug/self-recovery/accept-empty to accept an empty shard")
+			if o.metrics != nil {
+				o.metrics.GiveupTotal.Inc()
+			}
+			o.recordOutcome("failure", "failure", startedAt)
+			return
+		}
+
+		decision, err := o.probeAndDecide(ctx, ref)
+		if err != nil {
+			logger.WithError(err).Warn("self-recovery probe failed; will retry")
+			if !retryAfterBackoff() {
+				return
+			}
+			continue
+		}
+
+		switch decision.action {
+		case actionRegisterOp:
+			done, retry := o.handleRegisterDecision(ctx, ref, decision, startedAt, logger)
+			if done {
+				return
+			}
+			if retry && !retryAfterBackoff() {
+				return
+			}
+		case actionEmptyFallback:
+			o.handleEmptyFallback(ctx, ref, decision, startedAt, fromBootstrap, logger)
+			return
+		case actionRetry:
+			logger.WithField("retry_in", backoff.String()).Debug("self-recovery: peers unreachable, will retry")
+			if !retryAfterBackoff() {
+				return
+			}
+		}
+	}
+}
+
+// recordOutcome records the terminal-result metrics for a recovery.
+// completedResult is the weaviate_self_recovery_completed_total label
+// (success|failure|cancelled); durationResult is the
+// weaviate_self_recovery_duration_seconds label (which additionally has
+// empty_fallback). Nil-safe on o.metrics.
+func (o *Orchestrator) recordOutcome(completedResult, durationResult string, startedAt time.Time) {
+	if o.metrics == nil {
+		return
+	}
+	o.metrics.CompletedTotal.WithLabelValues(completedResult).Inc()
+	o.metrics.DurationSeconds.WithLabelValues(durationResult).Observe(time.Since(startedAt).Seconds())
+}
+
+// handleRegisterDecision registers a SELF_RECOVERY op and polls it to a
+// terminal state. Returns done=true when nothing further should be
+// attempted (the op reached READY, or was operator-cancelled /
+// force-deleted), retry=true when a transient error means the caller
+// should back off and probe again.
+func (o *Orchestrator) handleRegisterDecision(ctx context.Context, ref ShardRef, decision probeDecision,
+	startedAt time.Time, logger logrus.FieldLogger,
+) (done, retry bool) {
+	if o.metrics != nil {
+		o.metrics.StartedTotal.WithLabelValues(decision.sourceNode).Inc()
+	}
+	err := o.registerAndPoll(ctx, ref, decision.sourceNode)
+	if err == nil {
+		o.recordOutcome("success", "success", startedAt)
+		logger.WithFields(logrus.Fields{
+			"event":       "self_recovery.completed",
+			"source_node": decision.sourceNode,
+			"duration_ms": time.Since(startedAt).Milliseconds(),
+		}).Info("self-recovery completed")
+		return true, false
+	}
+	// If the op was force-deleted upstream (class/tenant removed, operator
+	// ForceDelete*), there is nothing to re-register against — exit cleanly
+	// instead of looping until maxAttempts. Operator-driven cancel via
+	// /replication/replicate/{id}/cancel is likewise terminal — retrying
+	// would re-register a fresh op and negate the cancel.
+	switch {
+	case errors.Is(err, replicationtypes.ErrReplicationOperationNotFound):
+		logger.WithError(err).WithField("source_node", decision.sourceNode).
+			Info("self-recovery op was force-deleted; abandoning")
+		o.recordOutcome("cancelled", "cancelled", startedAt)
+		return true, false
+	case errors.Is(err, ErrSelfRecoveryCancelled):
+		logger.WithError(err).WithField("source_node", decision.sourceNode).
+			Info("self-recovery op cancelled; abandoning")
+		o.recordOutcome("cancelled", "cancelled", startedAt)
+		return true, false
+	default:
+		logger.WithError(err).WithField("source_node", decision.sourceNode).
+			Warn("self-recovery register/poll failed; will retry")
+		return false, true
+	}
+}
+
+// handleEmptyFallback materialises an empty live shard dir, promotes the
+// in-memory wrapper, and records the outcome. fromBootstrap selects the
+// gentler log/metric treatment for the RAFT-bootstrap-window case (an
+// all-peers-empty answer there most likely means a class was added during
+// this node's downtime, not data loss).
+func (o *Orchestrator) handleEmptyFallback(ctx context.Context, ref ShardRef, decision probeDecision,
+	startedAt time.Time, fromBootstrap bool, logger logrus.FieldLogger,
+) {
+	if err := o.emptyFallback(ref); err != nil {
+		logger.WithError(err).Error("self-recovery empty-fallback failed")
+		o.recordOutcome("failure", "failure", startedAt)
+		return
+	}
+	// Promote the in-memory wrapper so reads/writes resume.
+	if o.onRecoveryComplete != nil {
+		if err := o.onRecoveryComplete(ctx, ref.Collection, ref.Shard); err != nil {
+			logger.WithError(err).Error("self-recovery: promote after empty-fallback failed")
+		}
+	}
+	if o.metrics != nil {
+		if fromBootstrap {
+			o.metrics.NoDataDuringBootstrapTotal.Inc()
+		} else {
+			o.metrics.NoDataEmptyTotal.Inc()
+		}
+	}
+	o.recordOutcome("success", "empty_fallback", startedAt)
+
+	fallbackFields := logrus.Fields{
+		"event":        "self_recovery.empty_fallback",
+		"probed_peers": decision.probedPeers,
+		"duration_ms":  time.Since(startedAt).Milliseconds(),
+		"collection":   ref.Collection,
+		"shard":        ref.Shard,
+		"action_taken": "created_empty_shard",
+	}
+	if fromBootstrap {
+		logger.WithFields(fallbackFields).
+			Info("no peer has data for shard during RAFT bootstrap; treating as fresh class")
+	} else {
+		fallbackFields["recoverable"] = false
+		fallbackFields["operator_note"] = "if data is recoverable from backup, restore now"
+		logger.WithFields(fallbackFields).
+			Warn("no peer has data for shard; created empty shard")
+	}
+	if o.emptyFallbackHook != nil {
+		o.emptyFallbackHook(ref)
+	}
+}
+
+type recoveryAction int
+
+const (
+	actionRegisterOp recoveryAction = iota
+	actionEmptyFallback
+	actionRetry
+)
+
+type probeDecision struct {
+	action      recoveryAction
+	sourceNode  string
+	probedPeers []string
+}
+
+func (o *Orchestrator) probeAndDecide(ctx context.Context, ref ShardRef) (probeDecision, error) {
+	replicas, err := o.schema.ShardReplicas(ref.Collection, ref.Shard)
+	if err != nil {
+		return probeDecision{}, fmt.Errorf("read shard replicas: %w", err)
+	}
+
+	peers := make([]string, 0, len(replicas))
+	for _, n := range replicas {
+		if n != o.nodeName {
+			peers = append(peers, n)
+		}
+	}
+	if len(peers) == 0 {
+		// Only us per schema: nothing to recover from.
+		return probeDecision{action: actionEmptyFallback, probedPeers: nil}, nil
+	}
+
+	// Shuffle so different recovering nodes don't all pick the same
+	// peer if multiple report data. The RNG is seeded from crypto/rand
+	// (see cryptoSeed) so nodes shuffle independently; the shuffle
+	// itself is non-security-sensitive load balancing — math/rand is
+	// the appropriate primitive.
+	o.rngMu.Lock()
+	o.rng.Shuffle(len(peers), func(i, j int) { peers[i], peers[j] = peers[j], peers[i] })
+	o.rngMu.Unlock()
+
+	type probeResult struct {
+		peer       string
+		hasData    bool
+		definitive bool
+		err        error
+	}
+	results := make([]probeResult, len(peers))
+	var wg sync.WaitGroup
+	for i, peer := range peers {
+		i, peer := i, peer
+		wg.Add(1)
+		enterrors.GoWrapper(func() {
+			defer wg.Done()
+			h, d, e := o.probePeer(ctx, peer, ref)
+			results[i] = probeResult{peer: peer, hasData: h, definitive: d, err: e}
+		}, o.logger)
+	}
+	wg.Wait()
+
+	var (
+		probedPeers        = make([]string, 0, len(results))
+		anyDefinitiveEmpty bool
+		anyUnreachable     bool
+		firstSource        string
+	)
+	for _, r := range results {
+		probedPeers = append(probedPeers, r.peer)
+		if r.err != nil {
+			anyUnreachable = true
+			if o.metrics != nil {
+				o.metrics.UnreachablePeerTotal.WithLabelValues(r.peer).Inc()
+			}
+			o.logger.WithError(r.err).WithFields(logrus.Fields{
+				"event":      "self_recovery.peer_probe",
+				"collection": ref.Collection,
+				"shard":      ref.Shard,
+				"peer":       r.peer,
+				"result":     "unreachable",
+			}).Debug("peer probe failed")
+			continue
+		}
+		if r.hasData && firstSource == "" {
+			firstSource = r.peer
+		}
+		if r.definitive && !r.hasData {
+			anyDefinitiveEmpty = true
+		}
+	}
+
+	if firstSource != "" {
+		return probeDecision{
+			action:      actionRegisterOp,
+			sourceNode:  firstSource,
+			probedPeers: probedPeers,
+		}, nil
+	}
+	if anyUnreachable {
+		// Don't silently create empty when probes were inconclusive.
+		return probeDecision{action: actionRetry, probedPeers: probedPeers}, nil
+	}
+	if anyDefinitiveEmpty {
+		return probeDecision{action: actionEmptyFallback, probedPeers: probedPeers}, nil
+	}
+	return probeDecision{action: actionRetry, probedPeers: probedPeers}, nil
+}
+
+// probePeer reports whether peer has data for the shard. definitive=true
+// means the peer answered (with or without data); err != nil means
+// transport/timeout — caller should retry later, not fall through.
+func (o *Orchestrator) probePeer(ctx context.Context, peer string, ref ShardRef) (hasData bool, definitive bool, err error) {
+	addr := o.nodeSelector.NodeAddress(peer)
+	if addr == "" {
+		return false, false, fmt.Errorf("no address for peer %q", peer)
+	}
+	port, err := o.nodeSelector.NodeGRPCPort(peer)
+	if err != nil {
+		return false, false, fmt.Errorf("get gRPC port for peer %q: %w", peer, err)
+	}
+
+	probeCtx, cancel := context.WithTimeout(ctx, o.probeTimeout)
+	defer cancel()
+
+	client, err := o.clientFactory(probeCtx, net.JoinHostPort(addr, fmt.Sprintf("%d", port)))
+	if err != nil {
+		return false, false, fmt.Errorf("connect to peer %q: %w", peer, err)
+	}
+
+	resp, err := client.ListFiles(probeCtx, &protocol.ListFilesRequest{
+		IndexName: ref.Collection,
+		ShardName: ref.Shard,
+	})
+	if err != nil {
+		// gRPC status drives the decision: NotFound = definitive
+		// no-data; Unavailable = peer itself recovering / busy →
+		// transient. Anything else is treated as transport error.
+		if st, ok := status.FromError(err); ok {
+			switch st.Code() {
+			case codes.NotFound:
+				return false, true, nil
+			case codes.Unavailable:
+				return false, false, fmt.Errorf("peer %q unavailable: %w", peer, err)
+			default:
+				// other codes fall through to substring fallback / generic
+			}
+		}
+		// Older peers don't carry typed codes — fall back to
+		// substring matching so a rolling upgrade doesn't break.
+		if isShardAbsentErr(err) {
+			return false, true, nil
+		}
+		// "not paused for transfer" means the shard exists on the
+		// peer; ListFiles refuses without a PauseFileActivity first.
+		// The probe is read-only and only needs a yes/no, so treat
+		// this as a positive (has-data) answer. The consumer pauses
+		// the source itself when the SELF_RECOVERY op runs.
+		if isShardPresentButNotPausedErr(err) {
+			return true, true, nil
+		}
+		return false, false, fmt.Errorf("list files on peer %q: %w", peer, err)
+	}
+	if resp == nil || len(resp.FileNames) == 0 {
+		return false, true, nil
+	}
+	return true, true, nil
+}
+
+// isShardAbsentErr is the rolling-upgrade fallback for peers that
+// haven't yet been upgraded to send typed gRPC codes. Match only
+// shard-specific phrasings (the canonical phrasing on the index layer
+// is "shard not found" / "shard is nil") — a bare "not found" substring
+// would misclassify unrelated errors (e.g. "file X not found") and push
+// the orchestrator into the empty-fallback branch.
+func isShardAbsentErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, "incoming list files get shard is nil"):
+		return true
+	case strings.Contains(msg, "shard is nil"):
+		return true
+	case strings.Contains(msg, "shard not found"):
+		return true
+	}
+	return false
+}
+
+// isShardPresentButNotPausedErr matches the ListFiles error returned
+// when the shard exists but file activity has not been paused. The
+// probe doesn't pause (the consumer does, when the op runs), so this
+// is a positive answer: the source has the shard.
+func isShardPresentButNotPausedErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(err.Error(), "is not paused for transfer")
+}
+
+// registerAndPoll registers a SELF_RECOVERY op and polls the FSM until
+// terminal state. nil on READY, error on CANCELLED or poll failure.
+// Returns ErrReplicationOperationNotFound if the op vanished from the
+// FSM (e.g. operator-driven force-delete after class/tenant deletion).
+func (o *Orchestrator) registerAndPoll(ctx context.Context, ref ShardRef, sourceNode string) error {
+	uuid, err := o.raft.RegisterSelfRecovery(ctx, sourceNode, ref.Collection, ref.Shard, o.nodeName)
+	if err != nil {
+		return fmt.Errorf("register self-recovery op: %w", err)
+	}
+
+	o.logger.WithFields(logrus.Fields{
+		"event":       "self_recovery.op_registered",
+		"collection":  ref.Collection,
+		"shard":       ref.Shard,
+		"source_node": sourceNode,
+		"op_uuid":     uuid,
+	}).Info("self-recovery op registered; polling for completion")
+
+	// "transient" failures don't necessarily mean the op is gone — they
+	// can happen during leader change. We tolerate a bounded number of
+	// consecutive not-found errors before concluding the op was force-
+	// deleted (class/tenant removed, manual ForceDelete*, etc.).
+	const notFoundThreshold = 3
+	notFoundCount := 0
+
+	ticker := time.NewTicker(o.pollInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			details, err := o.raft.GetReplicationDetailsByReplicationId(ctx, uuid)
+			if err != nil {
+				if errors.Is(err, replicationtypes.ErrReplicationOperationNotFound) {
+					notFoundCount++
+					if notFoundCount >= notFoundThreshold {
+						return fmt.Errorf("self-recovery op %s vanished from FSM (force-deleted upstream): %w", uuid, replicationtypes.ErrReplicationOperationNotFound)
+					}
+				}
+				continue // transient (e.g. leader change) — keep polling
+			}
+			notFoundCount = 0
+			switch api.ShardReplicationState(details.Status.State) {
+			case api.READY:
+				return nil
+			case api.CANCELLED:
+				return fmt.Errorf("self-recovery op %s: %w", uuid, ErrSelfRecoveryCancelled)
+			case api.REGISTERED, api.HYDRATING, api.FINALIZING, api.DEHYDRATING:
+				// non-terminal — keep polling
+			}
+		}
+	}
+}
+
+// emptyFallback creates an empty live shard dir; reached only when all
+// probed peers were reachable and definitively reported no data.
+func (o *Orchestrator) emptyFallback(ref ShardRef) error {
+	if o.pathResolver == nil {
+		return errors.New("empty-fallback: no PathResolver configured")
+	}
+	dir := o.pathResolver.ShardPath(ref.Collection, ref.Shard)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("mkdir %q: %w", dir, err)
+	}
+	if err := diskio.Fsync(filepath.Dir(dir)); err != nil {
+		return fmt.Errorf("fsync parent of %q: %w", dir, err)
+	}
+	return nil
+}
+
+// initPool spawns the worker pool on first Submit. Worker count =
+// Config.Concurrency.Get() when positive (the env-backed config supplies
+// DefaultSelfRecoveryConcurrency); falls back to 1 only if Concurrency is
+// nil or non-positive. The buffered queue absorbs bursts up to
+// o.submitQueueCapacity; beyond that, Submit drops with a warning.
+func (o *Orchestrator) initPool() {
+	n := 1
+	if o.concurrency != nil {
+		if v := o.concurrency.Get(); v > 0 {
+			n = v
+		}
+	}
+	capacity := o.submitQueueCapacity
+	if capacity <= 0 {
+		capacity = defaultSubmitQueueCapacity
+	}
+	o.workQueue = make(chan submission, capacity)
+	for i := 0; i < n; i++ {
+		enterrors.GoWrapper(func() {
+			for sub := range o.workQueue {
+				o.runOne(sub.ctx, sub.ref, sub.fromBootstrap)
+			}
+		}, o.logger)
+	}
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+func nextBackoff(current, max time.Duration) time.Duration {
+	next := current * 2
+	if next > max {
+		return max
+	}
+	return next
+}

--- a/cluster/replication/selfrecovery/orchestrator_review_test.go
+++ b/cluster/replication/selfrecovery/orchestrator_review_test.go
@@ -1,0 +1,295 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package selfrecovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc/generated/protocol"
+	"github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/replication/copier"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
+)
+
+func quietLogger() *logrus.Logger {
+	l := logrus.New()
+	l.SetLevel(logrus.PanicLevel)
+	return l
+}
+
+// TestSubmit_DeclinesWhenDisabledOrMaintenance verifies Submit reports
+// false (so the caller falls back to normal init) when the feature is
+// off or maintenance mode is on, and true when the work is queued.
+func TestSubmit_DeclinesWhenDisabledOrMaintenance(t *testing.T) {
+	mk := func(enabled *runtime.DynamicValue[bool], maint func() bool) *Orchestrator {
+		o := newOrchestratorForTest(t, &stubRaft{},
+			stubSchema{replicas: []string{"self"}}, &stubNodeSelector{}, nil,
+			stubPathResolver{root: t.TempDir()})
+		o.enabled = enabled
+		o.maintenanceModeEnabled = maint
+		return o
+	}
+
+	t.Run("feature off", func(t *testing.T) {
+		o := mk(nil, nil)
+		require.False(t, o.Submit(context.Background(), ShardRef{Collection: "C", Shard: "S"}, false))
+	})
+	t.Run("maintenance mode", func(t *testing.T) {
+		o := mk(runtime.NewDynamicValue(true), func() bool { return true })
+		require.False(t, o.Submit(context.Background(), ShardRef{Collection: "C", Shard: "S"}, false))
+	})
+	t.Run("queued", func(t *testing.T) {
+		o := mk(runtime.NewDynamicValue(true), nil)
+		require.True(t, o.Submit(context.Background(), ShardRef{Collection: "C", Shard: "S"}, false))
+	})
+}
+
+// TestSubmit_QueueFullDropsAndReturnsFalse verifies that once the bounded
+// worker queue overflows, Submit returns false and bumps SubmitDroppedTotal
+// (so the startup hook can fall back to normal init rather than strand the
+// shard in RECOVERING).
+func TestSubmit_QueueFullDropsAndReturnsFalse(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	block := make(chan struct{})
+	t.Cleanup(func() { cancel(); close(block) })
+
+	ns := &stubNodeSelector{
+		addrs: map[string]string{"peer1": "10.0.0.1"},
+		ports: map[string]int{"peer1": 50051},
+	}
+	o := New(Config{
+		Raft:         &stubRaft{},
+		Schema:       stubSchema{replicas: []string{"self", "peer1"}},
+		PathResolver: stubPathResolver{root: t.TempDir()},
+		NodeSelector: ns,
+		NodeName:     "self",
+		Enabled:      runtime.NewDynamicValue(true),
+		ClientFactory: func(_ context.Context, _ string) (copier.FileReplicationServiceClient, error) {
+			<-block
+			return nil, errors.New("released")
+		},
+		Logger:       quietLogger(),
+		PollInterval: 10 * time.Millisecond,
+		ProbeTimeout: time.Second,
+	})
+	o.submitQueueCapacity = 1 // make overflow trivial to provoke
+
+	before := testutil.ToFloat64(o.metrics.SubmitDroppedTotal)
+	dropped := 0
+	for i := 0; i < 4; i++ {
+		if !o.Submit(ctx, ShardRef{Collection: "C", Shard: fmt.Sprintf("S%d", i)}, false) {
+			dropped++
+		}
+	}
+	require.GreaterOrEqual(t, dropped, 1, "with capacity 1 and a blocked worker, some submits must be dropped")
+	require.InDelta(t, float64(dropped), testutil.ToFloat64(o.metrics.SubmitDroppedTotal)-before, 0.001,
+		"SubmitDroppedTotal must count exactly the dropped submits")
+}
+
+// TestHasInflightReplicationOp covers the M2 guard: only a non-terminal
+// op targeting this node counts.
+func TestHasInflightReplicationOp(t *testing.T) {
+	op := func(target, transfer string, state api.ShardReplicationState) api.ReplicationDetailsResponse {
+		return api.ReplicationDetailsResponse{
+			Uuid:         strfmt.UUID("00000000-0000-0000-0000-000000000001"),
+			Collection:   "C",
+			ShardId:      "S",
+			TargetNodeId: target,
+			TransferType: transfer,
+			Status:       api.ReplicationDetailsState{State: string(state)},
+		}
+	}
+	cases := []struct {
+		name string
+		ops  []api.ReplicationDetailsResponse
+		want bool
+	}{
+		{"no ops", nil, false},
+		{"COPY on this node, hydrating", []api.ReplicationDetailsResponse{op("self", api.COPY.String(), api.HYDRATING)}, true},
+		{"COPY on other node", []api.ReplicationDetailsResponse{op("other", api.COPY.String(), api.HYDRATING)}, false},
+		{"terminal SELF_RECOVERY on this node", []api.ReplicationDetailsResponse{op("self", api.SELF_RECOVERY.String(), api.READY)}, false},
+		{"non-terminal SELF_RECOVERY on this node", []api.ReplicationDetailsResponse{op("self", api.SELF_RECOVERY.String(), api.FINALIZING)}, true},
+		{"mixed: other-node + this-node terminal + this-node non-terminal", []api.ReplicationDetailsResponse{
+			op("other", api.MOVE.String(), api.HYDRATING),
+			op("self", api.SELF_RECOVERY.String(), api.CANCELLED),
+			op("self", api.COPY.String(), api.REGISTERED),
+		}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			raft := &stubRaft{}
+			if tc.ops != nil {
+				raft.opsByCollShard = map[string][]api.ReplicationDetailsResponse{"C/S": tc.ops}
+			}
+			o := newOrchestratorForTest(t, raft, stubSchema{}, &stubNodeSelector{}, nil, stubPathResolver{root: t.TempDir()})
+			got, err := o.HasInflightReplicationOp(context.Background(), "C", "S")
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestRunOne_GiveUpAfterMaxAttempts: all peers unreachable forever →
+// runOne exhausts retries, ticks GiveupTotal and CompletedTotal{failure},
+// and returns instead of looping forever.
+func TestRunOne_GiveUpAfterMaxAttempts(t *testing.T) {
+	ns := &stubNodeSelector{
+		addrs: map[string]string{"peer1": "10.0.0.1"},
+		ports: map[string]int{"peer1": 50051},
+	}
+	clientFactory := func(_ context.Context, _ string) (copier.FileReplicationServiceClient, error) {
+		return nil, errors.New("connection refused")
+	}
+	o := newOrchestratorForTest(t, &stubRaft{},
+		stubSchema{replicas: []string{"self", "peer1"}}, ns, clientFactory, stubPathResolver{root: t.TempDir()})
+
+	beforeGiveup := testutil.ToFloat64(o.metrics.GiveupTotal)
+	beforeFailure := testutil.ToFloat64(o.metrics.CompletedTotal.WithLabelValues("failure"))
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		o.runOne(context.Background(), ShardRef{Collection: "C", Shard: "S"}, false)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("runOne did not give up after maxAttempts of unreachable peers")
+	}
+
+	require.InDelta(t, beforeGiveup+1, testutil.ToFloat64(o.metrics.GiveupTotal), 0.001)
+	require.InDelta(t, beforeFailure+1, testutil.ToFloat64(o.metrics.CompletedTotal.WithLabelValues("failure")), 0.001)
+}
+
+// TestRunOne_EmptyFallbackBootstrapSeverity verifies the per-op
+// fromBootstrap flag routes the all-peers-empty outcome to the
+// gentler counter during the RAFT bootstrap window and to the
+// catastrophic-wipe counter otherwise.
+func TestRunOne_EmptyFallbackBootstrapSeverity(t *testing.T) {
+	mkOrch := func(t *testing.T) (*Orchestrator, string) {
+		root := t.TempDir()
+		ns := &stubNodeSelector{
+			addrs: map[string]string{"peer1": "10.0.0.1"},
+			ports: map[string]int{"peer1": 50051},
+		}
+		clientFactory := func(_ context.Context, _ string) (copier.FileReplicationServiceClient, error) {
+			return &stubFileReplicationClient{
+				listFiles: func(_ context.Context, _ *protocol.ListFilesRequest) (*protocol.ListFilesResponse, error) {
+					return &protocol.ListFilesResponse{}, nil // definitively empty
+				},
+			}, nil
+		}
+		return newOrchestratorForTest(t, &stubRaft{},
+			stubSchema{replicas: []string{"self", "peer1"}}, ns, clientFactory, stubPathResolver{root: root}), root
+	}
+
+	t.Run("during bootstrap", func(t *testing.T) {
+		o, _ := mkOrch(t)
+		before := testutil.ToFloat64(o.metrics.NoDataDuringBootstrapTotal)
+		beforeOther := testutil.ToFloat64(o.metrics.NoDataEmptyTotal)
+		o.runOne(context.Background(), ShardRef{Collection: "C", Shard: "S"}, true /* fromBootstrap */)
+		require.InDelta(t, before+1, testutil.ToFloat64(o.metrics.NoDataDuringBootstrapTotal), 0.001)
+		require.InDelta(t, beforeOther, testutil.ToFloat64(o.metrics.NoDataEmptyTotal), 0.001)
+	})
+	t.Run("post bootstrap", func(t *testing.T) {
+		o, _ := mkOrch(t)
+		before := testutil.ToFloat64(o.metrics.NoDataEmptyTotal)
+		beforeOther := testutil.ToFloat64(o.metrics.NoDataDuringBootstrapTotal)
+		o.runOne(context.Background(), ShardRef{Collection: "C", Shard: "S"}, false)
+		require.InDelta(t, before+1, testutil.ToFloat64(o.metrics.NoDataEmptyTotal), 0.001)
+		require.InDelta(t, beforeOther, testutil.ToFloat64(o.metrics.NoDataDuringBootstrapTotal), 0.001)
+	})
+}
+
+// TestProbeErrorClassifiers pins the rolling-upgrade substring fallbacks
+// used when an older peer doesn't carry typed gRPC codes: a shard-absent
+// phrasing must classify as "definitively empty", "not paused" must
+// classify as "shard present", and an unrelated error must be neither.
+func TestProbeErrorClassifiers(t *testing.T) {
+	require.True(t, isShardAbsentErr(errors.New("rpc error: incoming list files get shard is nil")))
+	require.True(t, isShardAbsentErr(errors.New("shard not found")))
+	require.False(t, isShardAbsentErr(errors.New("file segment-1.db not found")))
+	require.False(t, isShardAbsentErr(nil))
+
+	require.True(t, isShardPresentButNotPausedErr(errors.New("shard \"S\" is not paused for transfer")))
+	require.False(t, isShardPresentButNotPausedErr(errors.New("connection refused")))
+	require.False(t, isShardPresentButNotPausedErr(nil))
+}
+
+// TestRestart_RejectsWhenLiveDirExists: /restart on a shard that already
+// has a live local dir is a 409-class error and must not cancel anything.
+func TestRestart_RejectsWhenLiveDirExists(t *testing.T) {
+	tmp := t.TempDir()
+	require.NoError(t, os.MkdirAll(tmp+"/C/S", 0o755))
+	raft := &stubRaft{}
+	o := newOrchestratorForTest(t, raft, stubSchema{replicas: []string{"self", "peer1"}}, &stubNodeSelector{}, nil, stubPathResolver{root: tmp})
+
+	err := o.Restart(context.Background(), ShardRef{Collection: "C", Shard: "S"})
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSelfRecoveryShardAlreadyLive)
+	require.Empty(t, raft.cancelled, "Restart must bail before cancelling when the live dir exists")
+}
+
+// TestWaitForOpTerminal_VanishedGrace: a polled op that the FSM reports
+// as not-found is treated as terminal, after the grace sleep.
+func TestWaitForOpTerminal_VanishedGrace(t *testing.T) {
+	raft := &stubRaft{detailsByUUID: nil} // every lookup returns not-found
+	o := newOrchestratorForTest(t, raft, stubSchema{}, &stubNodeSelector{}, nil, stubPathResolver{root: t.TempDir()})
+
+	start := time.Now()
+	require.NoError(t, o.waitForOpTerminal(context.Background(), strfmt.UUID("11111111-1111-1111-1111-111111111111")))
+	require.GreaterOrEqual(t, time.Since(start), o.vanishedGracePeriod, "must wait the grace period before returning")
+}
+
+// TestRestart_TimeoutLeavesRecoveryDir: when an in-flight op never
+// settles, Restart honours its timeout, returns an error, and leaves the
+// partial ".recovering/" dir intact (so the next attempt can resume).
+func TestRestart_TimeoutLeavesRecoveryDir(t *testing.T) {
+	tmp := t.TempDir()
+	recoveryPath := tmp + "/C/S.recovering"
+	require.NoError(t, os.MkdirAll(recoveryPath, 0o755))
+	require.NoError(t, os.WriteFile(recoveryPath+"/partial.bin", []byte("x"), 0o644))
+
+	inflightUUID := strfmt.UUID("11111111-1111-1111-1111-111111111111")
+	raft := &stubRaft{
+		opsByCollShard: map[string][]api.ReplicationDetailsResponse{
+			"C/S": {{
+				Uuid:         inflightUUID,
+				Collection:   "C",
+				ShardId:      "S",
+				TargetNodeId: "self",
+				TransferType: api.SELF_RECOVERY.String(),
+				Status:       api.ReplicationDetailsState{State: string(api.HYDRATING)},
+			}},
+		},
+		detailsByUUID: map[strfmt.UUID]api.ReplicationDetailsResponse{
+			inflightUUID: {Status: api.ReplicationDetailsState{State: string(api.HYDRATING)}}, // never terminal
+		},
+	}
+	o := newOrchestratorForTest(t, raft, stubSchema{replicas: []string{"self", "peer1"}}, &stubNodeSelector{}, nil, stubPathResolver{root: tmp})
+
+	err := o.Restart(context.Background(), ShardRef{Collection: "C", Shard: "S"})
+	require.Error(t, err, "Restart must surface the timeout while the op is still settling")
+	require.Equal(t, []strfmt.UUID{inflightUUID}, raft.cancelled)
+	_, statErr := os.Stat(recoveryPath)
+	require.NoError(t, statErr, "recovery dir must be left intact on timeout so the next attempt resumes")
+}

--- a/cluster/replication/selfrecovery/orchestrator_test.go
+++ b/cluster/replication/selfrecovery/orchestrator_test.go
@@ -1,0 +1,699 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package selfrecovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/weaviate/weaviate/adapters/handlers/rest/clusterapi/grpc/generated/protocol"
+	"github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/replication/copier"
+	replicationtypes "github.com/weaviate/weaviate/cluster/replication/types"
+	"github.com/weaviate/weaviate/usecases/cluster"
+	"github.com/weaviate/weaviate/usecases/config/runtime"
+)
+
+// --- Stubs ---
+
+type stubSchema struct {
+	replicas []string
+	err      error
+}
+
+func (s stubSchema) ShardReplicas(class, shard string) ([]string, error) {
+	return s.replicas, s.err
+}
+
+type stubPathResolver struct{ root string }
+
+func (p stubPathResolver) ShardPath(collection, shard string) string {
+	return p.root + "/" + collection + "/" + shard
+}
+
+// stubNodeSelector implements just enough of cluster.NodeSelector for
+// tests. The orchestrator only uses NodeAddress + NodeGRPCPort.
+type stubNodeSelector struct {
+	addrs map[string]string
+	ports map[string]int
+}
+
+func (s *stubNodeSelector) NodeAddress(id string) string                      { return s.addrs[id] }
+func (s *stubNodeSelector) NodeGRPCPort(id string) (int, error)               { return s.ports[id], nil }
+func (s *stubNodeSelector) NodeHostname(id string) (string, bool)             { return s.addrs[id], true }
+func (s *stubNodeSelector) AllHostnames() []string                            { return nil }
+func (s *stubNodeSelector) AllOtherClusterMembers(port int) map[string]string { return nil }
+func (s *stubNodeSelector) NodeCount() int                                    { return len(s.addrs) }
+func (s *stubNodeSelector) StorageCandidates() []string                       { return nil }
+func (s *stubNodeSelector) NonStorageNodes() []string                         { return nil }
+func (s *stubNodeSelector) SortCandidates(nodes []string) []string            { return nodes }
+func (s *stubNodeSelector) ClusterHealthScore() int                           { return 0 }
+func (s *stubNodeSelector) LocalName() string                                 { return "" }
+func (s *stubNodeSelector) Leave() error                                      { return nil }
+func (s *stubNodeSelector) Shutdown() error                                   { return nil }
+
+// Compile-time guard.
+var _ cluster.NodeSelector = (*stubNodeSelector)(nil)
+
+// stubFileReplicationClient lets each peer's ListFiles return whatever
+// the test wants. Other methods are unimplemented (the orchestrator
+// only calls ListFiles for probes).
+type stubFileReplicationClient struct {
+	listFiles func(ctx context.Context, in *protocol.ListFilesRequest) (*protocol.ListFilesResponse, error)
+}
+
+func (c *stubFileReplicationClient) PauseFileActivity(ctx context.Context, in *protocol.PauseFileActivityRequest, _ ...grpc.CallOption) (*protocol.PauseFileActivityResponse, error) {
+	return nil, errors.New("PauseFileActivity not stubbed")
+}
+
+func (c *stubFileReplicationClient) ResumeFileActivity(ctx context.Context, in *protocol.ResumeFileActivityRequest, _ ...grpc.CallOption) (*protocol.ResumeFileActivityResponse, error) {
+	return nil, errors.New("ResumeFileActivity not stubbed")
+}
+
+func (c *stubFileReplicationClient) ListFiles(ctx context.Context, in *protocol.ListFilesRequest, _ ...grpc.CallOption) (*protocol.ListFilesResponse, error) {
+	return c.listFiles(ctx, in)
+}
+
+func (c *stubFileReplicationClient) GetFileMetadata(ctx context.Context, in *protocol.GetFileMetadataRequest, _ ...grpc.CallOption) (*protocol.FileMetadata, error) {
+	return nil, errors.New("GetFileMetadata not stubbed")
+}
+
+func (c *stubFileReplicationClient) GetFile(ctx context.Context, in *protocol.GetFileRequest, _ ...grpc.CallOption) (grpc.ServerStreamingClient[protocol.FileChunk], error) {
+	return nil, errors.New("GetFile not stubbed")
+}
+
+// stubRaft records ops registered and serves a programmable response
+// for GetReplicationDetailsByReplicationId.
+type stubRaft struct {
+	mu                  sync.Mutex
+	registeredCalls     []registeredCall
+	registerErr         error
+	detailsByUUID       map[strfmt.UUID]api.ReplicationDetailsResponse
+	registerHook        func(uuid strfmt.UUID, sourceNode, collection, shard, targetNode string)
+	getDetailsCallCount atomic.Int32
+
+	// Restart-related: ops indexed by (collection, shard) and the list
+	// of UUIDs cancelled via CancelReplication, populated by the test
+	// to drive Restart-path assertions.
+	opsByCollShard map[string][]api.ReplicationDetailsResponse
+	cancelled      []strfmt.UUID
+}
+
+type registeredCall struct {
+	uuid                                      strfmt.UUID
+	sourceNode, collection, shard, targetNode string
+}
+
+func (r *stubRaft) RegisterSelfRecovery(ctx context.Context, sourceNode, collection, shard, targetNode string) (strfmt.UUID, error) {
+	if r.registerErr != nil {
+		return "", r.registerErr
+	}
+	uuid := strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", len(r.registeredCalls)+1))
+	r.mu.Lock()
+	r.registeredCalls = append(r.registeredCalls, registeredCall{uuid, sourceNode, collection, shard, targetNode})
+	r.mu.Unlock()
+	if r.registerHook != nil {
+		r.registerHook(uuid, sourceNode, collection, shard, targetNode)
+	}
+	return uuid, nil
+}
+
+func (r *stubRaft) GetReplicationDetailsByReplicationId(ctx context.Context, uuid strfmt.UUID) (api.ReplicationDetailsResponse, error) {
+	r.getDetailsCallCount.Add(1)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	resp, ok := r.detailsByUUID[uuid]
+	if !ok {
+		// Mirror the production error so the orchestrator's
+		// errors.Is(...ErrReplicationOperationNotFound) check fires.
+		return api.ReplicationDetailsResponse{}, replicationtypes.ErrReplicationOperationNotFound
+	}
+	return resp, nil
+}
+
+func (r *stubRaft) GetReplicationDetailsByCollectionAndShard(ctx context.Context, collection, shard string) ([]api.ReplicationDetailsResponse, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.opsByCollShard == nil {
+		return nil, fmt.Errorf("op for %s/%s: %w", collection, shard, replicationtypes.ErrReplicationOperationNotFound)
+	}
+	return r.opsByCollShard[collection+"/"+shard], nil
+}
+
+func (r *stubRaft) CancelReplication(ctx context.Context, uuid strfmt.UUID) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.cancelled = append(r.cancelled, uuid)
+	return nil
+}
+
+// --- Tests ---
+
+// newOrchestratorForTest wires an Orchestrator without the runtime
+// config plumbing — the feature flag is bypassed by directly calling
+// runOne / probeAndDecide.
+func newOrchestratorForTest(t *testing.T, raft RaftEntryPoint, schemaR SchemaReader, ns *stubNodeSelector,
+	clientFactory copier.FileReplicationServiceClientFactory, paths PathResolver,
+) *Orchestrator {
+	t.Helper()
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+	o := New(Config{
+		Raft:          raft,
+		Schema:        schemaR,
+		PathResolver:  paths,
+		ClientFactory: clientFactory,
+		NodeSelector:  ns,
+		NodeName:      "self",
+		Logger:        logger,
+		PollInterval:  10_000_000, // 10ms in nanoseconds
+		ProbeTimeout:  100_000_000,
+	})
+	o.probeBackoffMin = 5_000_000 // 5ms
+	o.probeBackoffMax = 20_000_000
+	o.restartTimeout = 200 * time.Millisecond
+	o.vanishedGracePeriod = 10 * time.Millisecond
+	return o
+}
+
+// TestProbeAndDecide_PeerHasData covers the happy path: at least one
+// peer reports a non-empty file list, so the decision is to register
+// a SELF_RECOVERY op against that peer.
+func TestProbeAndDecide_PeerHasData(t *testing.T) {
+	ns := &stubNodeSelector{
+		addrs: map[string]string{"peer1": "10.0.0.1", "peer2": "10.0.0.2"},
+		ports: map[string]int{"peer1": 50051, "peer2": 50051},
+	}
+	clientFactory := func(ctx context.Context, addr string) (copier.FileReplicationServiceClient, error) {
+		return &stubFileReplicationClient{
+			listFiles: func(ctx context.Context, in *protocol.ListFilesRequest) (*protocol.ListFilesResponse, error) {
+				return &protocol.ListFilesResponse{FileNames: []string{"a/b/c"}}, nil
+			},
+		}, nil
+	}
+	o := newOrchestratorForTest(t, &stubRaft{}, stubSchema{replicas: []string{"self", "peer1", "peer2"}}, ns, clientFactory, stubPathResolver{root: t.TempDir()})
+
+	dec, err := o.probeAndDecide(context.Background(), ShardRef{Collection: "C", Shard: "S"})
+	require.NoError(t, err)
+	require.Equal(t, actionRegisterOp, dec.action)
+	require.NotEmpty(t, dec.sourceNode)
+	require.NotEqual(t, "self", dec.sourceNode)
+}
+
+// TestProbeAndDecide_AllEmpty covers the catastrophic-wipe case: all
+// peers reachable, all return empty file lists. Decision is empty
+// fallback (the orchestrator will MkdirAll and create empty + metric).
+func TestProbeAndDecide_AllEmpty(t *testing.T) {
+	ns := &stubNodeSelector{
+		addrs: map[string]string{"peer1": "10.0.0.1", "peer2": "10.0.0.2"},
+		ports: map[string]int{"peer1": 50051, "peer2": 50051},
+	}
+	clientFactory := func(ctx context.Context, addr string) (copier.FileReplicationServiceClient, error) {
+		return &stubFileReplicationClient{
+			listFiles: func(ctx context.Context, in *protocol.ListFilesRequest) (*protocol.ListFilesResponse, error) {
+				return &protocol.ListFilesResponse{FileNames: nil}, nil
+			},
+		}, nil
+	}
+	o := newOrchestratorForTest(t, &stubRaft{}, stubSchema{replicas: []string{"self", "peer1", "peer2"}}, ns, clientFactory, stubPathResolver{root: t.TempDir()})
+
+	dec, err := o.probeAndDecide(context.Background(), ShardRef{Collection: "C", Shard: "S"})
+	require.NoError(t, err)
+	require.Equal(t, actionEmptyFallback, dec.action)
+	require.Len(t, dec.probedPeers, 2)
+}
+
+// TestProbeAndDecide_AllUnreachable covers the "wait for peers" case:
+// all peers return transport errors. We must NOT silently fall through
+// to empty; we must signal retry.
+func TestProbeAndDecide_AllUnreachable(t *testing.T) {
+	ns := &stubNodeSelector{
+		addrs: map[string]string{"peer1": "10.0.0.1"},
+		ports: map[string]int{"peer1": 50051},
+	}
+	clientFactory := func(ctx context.Context, addr string) (copier.FileReplicationServiceClient, error) {
+		return nil, errors.New("connection refused")
+	}
+	o := newOrchestratorForTest(t, &stubRaft{}, stubSchema{replicas: []string{"self", "peer1"}}, ns, clientFactory, stubPathResolver{root: t.TempDir()})
+
+	dec, err := o.probeAndDecide(context.Background(), ShardRef{Collection: "C", Shard: "S"})
+	require.NoError(t, err)
+	require.Equal(t, actionRetry, dec.action, "all peers unreachable must yield retry, never empty fallback")
+}
+
+// TestProbeAndDecide_MixedUnreachableAndEmpty covers the conservative
+// rule: as long as ANY peer was unreachable AND no peer reports data,
+// stay in retry. Don't silently create empty when we might just be
+// hitting transient networking issues against the only-other-replica.
+func TestProbeAndDecide_MixedUnreachableAndEmpty(t *testing.T) {
+	ns := &stubNodeSelector{
+		addrs: map[string]string{"peer1": "10.0.0.1", "peer2": "10.0.0.2"},
+		ports: map[string]int{"peer1": 50051, "peer2": 50051},
+	}
+	clientFactory := func(ctx context.Context, addr string) (copier.FileReplicationServiceClient, error) {
+		// peer1 (10.0.0.1) reports no data; peer2 (10.0.0.2) is unreachable.
+		if addr == "10.0.0.1:50051" {
+			return &stubFileReplicationClient{
+				listFiles: func(ctx context.Context, in *protocol.ListFilesRequest) (*protocol.ListFilesResponse, error) {
+					return &protocol.ListFilesResponse{}, nil
+				},
+			}, nil
+		}
+		return nil, errors.New("connection refused")
+	}
+	o := newOrchestratorForTest(t, &stubRaft{}, stubSchema{replicas: []string{"self", "peer1", "peer2"}}, ns, clientFactory, stubPathResolver{root: t.TempDir()})
+
+	dec, err := o.probeAndDecide(context.Background(), ShardRef{Collection: "C", Shard: "S"})
+	require.NoError(t, err)
+	require.Equal(t, actionRetry, dec.action, "any unreachable peer + no data anywhere must yield retry, not empty fallback")
+}
+
+// TestProbeAndDecide_NoOtherReplicas degenerate case: schema lists
+// only this node as a replica. There is nothing to probe; decision
+// is empty fallback (consistent with "we have no peer to recover from").
+func TestProbeAndDecide_NoOtherReplicas(t *testing.T) {
+	ns := &stubNodeSelector{addrs: map[string]string{}, ports: map[string]int{}}
+	o := newOrchestratorForTest(t, &stubRaft{}, stubSchema{replicas: []string{"self"}}, ns, nil, stubPathResolver{root: t.TempDir()})
+
+	dec, err := o.probeAndDecide(context.Background(), ShardRef{Collection: "C", Shard: "S"})
+	require.NoError(t, err)
+	require.Equal(t, actionEmptyFallback, dec.action)
+}
+
+// TestEmptyFallback_CreatesDir verifies that the empty-fallback path
+// actually creates the live shard directory.
+func TestEmptyFallback_CreatesDir(t *testing.T) {
+	tmp := t.TempDir()
+	o := newOrchestratorForTest(t, &stubRaft{}, stubSchema{}, &stubNodeSelector{}, nil, stubPathResolver{root: tmp})
+	err := o.emptyFallback(ShardRef{Collection: "C", Shard: "S"})
+	require.NoError(t, err)
+	livePath := tmp + "/C/S"
+	info, err := os.Stat(livePath)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}
+
+// TestRestart_CancelsInflightAndErasesRecoveryDir verifies the
+// "cancel and start from scratch" path: any in-flight SELF_RECOVERY
+// op for (collection, shard) targeting this node is cancelled, the
+// partial ".recovering/" directory is erased, and a fresh recovery is
+// submitted. Other ops (different transfer type, different target,
+// already terminal) are left alone.
+func TestRestart_CancelsInflightAndErasesRecoveryDir(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Pre-existing partial recovery on disk + an in-flight FSM op
+	// targeting "self" (the node under test). The op for "other-node"
+	// and the COPY op should NOT be cancelled.
+	livePath := tmp + "/C/S"
+	recoveryPath := livePath + ".recovering"
+	require.NoError(t, os.MkdirAll(recoveryPath, 0o755))
+	require.NoError(t, os.WriteFile(recoveryPath+"/partial.bin", []byte("partial"), 0o644))
+
+	inflightUUID := strfmt.UUID("11111111-1111-1111-1111-111111111111")
+	otherTargetUUID := strfmt.UUID("22222222-2222-2222-2222-222222222222")
+	copyOpUUID := strfmt.UUID("33333333-3333-3333-3333-333333333333")
+	terminalUUID := strfmt.UUID("44444444-4444-4444-4444-444444444444")
+
+	raft := &stubRaft{
+		opsByCollShard: map[string][]api.ReplicationDetailsResponse{
+			"C/S": {
+				{
+					Uuid:         inflightUUID,
+					Collection:   "C",
+					ShardId:      "S",
+					TargetNodeId: "self",
+					TransferType: api.SELF_RECOVERY.String(),
+					Status:       api.ReplicationDetailsState{State: string(api.HYDRATING)},
+				},
+				{
+					Uuid:         otherTargetUUID,
+					Collection:   "C",
+					ShardId:      "S",
+					TargetNodeId: "other-node", // not us
+					TransferType: api.SELF_RECOVERY.String(),
+					Status:       api.ReplicationDetailsState{State: string(api.HYDRATING)},
+				},
+				{
+					Uuid:         copyOpUUID,
+					Collection:   "C",
+					ShardId:      "S",
+					TargetNodeId: "self",
+					TransferType: api.COPY.String(), // not SELF_RECOVERY
+					Status:       api.ReplicationDetailsState{State: string(api.HYDRATING)},
+				},
+				{
+					Uuid:         terminalUUID,
+					Collection:   "C",
+					ShardId:      "S",
+					TargetNodeId: "self",
+					TransferType: api.SELF_RECOVERY.String(),
+					Status:       api.ReplicationDetailsState{State: string(api.READY)}, // already terminal
+				},
+			},
+		},
+	}
+
+	// Schema: at least one peer with data so the post-restart probe
+	// would find a source. (We don't assert the new op registers
+	// because the orchestrator's flag is off in this test setup; we
+	// only assert the cancel + erase semantics here.)
+	o := newOrchestratorForTest(t, raft, stubSchema{replicas: []string{"self", "peer1"}}, &stubNodeSelector{}, nil, stubPathResolver{root: tmp})
+
+	require.NoError(t, o.Restart(context.Background(), ShardRef{Collection: "C", Shard: "S"}))
+
+	// Only the in-flight SELF_RECOVERY op targeting "self" was cancelled.
+	require.Equal(t, []strfmt.UUID{inflightUUID}, raft.cancelled,
+		"only the in-flight SELF_RECOVERY op for self should be cancelled, got %v", raft.cancelled)
+
+	// Recovery dir is gone; the live dir is unaffected (it didn't exist).
+	_, err := os.Stat(recoveryPath)
+	require.True(t, errors.Is(err, fs.ErrNotExist), "recovery dir should be erased, got %v", err)
+}
+
+// TestRestart_NoInflightOpsAndNoRecoveryDir is the benign "nothing to
+// do" case: no FSM ops, no leftover dir. Restart should still succeed
+// (and just submit a fresh recovery, but Submit is a no-op when the
+// feature flag is off, which it is in tests).
+func TestRestart_NoInflightOpsAndNoRecoveryDir(t *testing.T) {
+	raft := &stubRaft{} // GetReplicationDetailsByCollectionAndShard returns "not found"
+	o := newOrchestratorForTest(t, raft, stubSchema{replicas: []string{"self"}}, &stubNodeSelector{}, nil, stubPathResolver{root: t.TempDir()})
+
+	require.NoError(t, o.Restart(context.Background(), ShardRef{Collection: "C", Shard: "S"}))
+	require.Empty(t, raft.cancelled)
+}
+
+// TestAcceptEmpty_RemovesRecoveryDir creates a stale ".recovering"
+// folder and verifies AcceptEmpty wipes it and creates the live path.
+func TestAcceptEmpty_RemovesRecoveryDir(t *testing.T) {
+	tmp := t.TempDir()
+	o := newOrchestratorForTest(t, &stubRaft{}, stubSchema{}, &stubNodeSelector{}, nil, stubPathResolver{root: tmp})
+
+	livePath := tmp + "/C/S"
+	recoveryPath := livePath + ".recovering"
+	require.NoError(t, os.MkdirAll(recoveryPath, 0o755))
+	require.NoError(t, os.WriteFile(recoveryPath+"/leftover.bin", []byte("garbage"), 0o644))
+
+	got, err := o.AcceptEmpty(context.Background(), ShardRef{Collection: "C", Shard: "S"})
+	require.NoError(t, err)
+	require.Equal(t, livePath, got)
+
+	_, err = os.Stat(recoveryPath)
+	require.True(t, errors.Is(err, fs.ErrNotExist), "recovery path should be gone, got %v", err)
+
+	info, err := os.Stat(livePath)
+	require.NoError(t, err)
+	require.True(t, info.IsDir())
+}
+
+// TestCleanupOrphanRecoveryDirs verifies orphans (recovery dir + live
+// sibling) are removed; in-flight recoveries (recovery dir alone) and
+// unrelated dirs are left untouched.
+func TestCleanupOrphanRecoveryDirs(t *testing.T) {
+	root := t.TempDir()
+	mk := func(p string) {
+		require.NoError(t, os.MkdirAll(filepath.Join(root, p), 0o755))
+	}
+	mk("Coll/shard1")              // live (no orphan needed)
+	mk("Coll/shard1.recovering")   // orphan: live sibling exists
+	mk("Coll/shard2.recovering")   // in-flight: no sibling
+	mk("Coll/shard3")              // live, no recovery dir
+	mk("Coll2/tenantA")            // live (different collection)
+	mk("Coll2/tenantA.recovering") // orphan in another collection
+
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+	o := New(Config{Logger: logger, NodeName: "self"})
+
+	removed, err := o.CleanupOrphanRecoveryDirs(root)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{
+		filepath.Join(root, "Coll/shard1.recovering"),
+		filepath.Join(root, "Coll2/tenantA.recovering"),
+	}, removed)
+
+	// Live dirs untouched.
+	for _, p := range []string{"Coll/shard1", "Coll/shard3", "Coll2/tenantA"} {
+		_, err := os.Stat(filepath.Join(root, p))
+		require.NoError(t, err, "live dir %s should be present", p)
+	}
+	// In-flight recovery untouched.
+	_, err = os.Stat(filepath.Join(root, "Coll/shard2.recovering"))
+	require.NoError(t, err, "in-flight recovery dir must be preserved")
+}
+
+// TestRegisterAndPoll_ReturnsNotFoundWhenOpVanishes covers the
+// class-deletion / tenant-deletion / ForceDelete* path: the orchestrator
+// is polling the FSM for a UUID that gets force-deleted upstream. After
+// a few consecutive not-found responses, registerAndPoll must return
+// the typed sentinel so runOne can exit instead of looping forever.
+func TestRegisterAndPoll_ReturnsNotFoundWhenOpVanishes(t *testing.T) {
+	raft := &stubRaft{
+		// detailsByUUID is nil → every GetReplicationDetailsByReplicationId
+		// call returns ErrReplicationOperationNotFound.
+		detailsByUUID: nil,
+	}
+	o := newOrchestratorForTest(t, raft, stubSchema{replicas: []string{"self", "peer1"}}, &stubNodeSelector{}, nil, stubPathResolver{root: t.TempDir()})
+
+	err := o.registerAndPoll(context.Background(), ShardRef{Collection: "C", Shard: "S"}, "peer1")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, replicationtypes.ErrReplicationOperationNotFound),
+		"expected ErrReplicationOperationNotFound after sustained not-found polls, got: %v", err)
+}
+
+// TestSubmit_NoOpInMaintenanceMode verifies the maintenance-mode gate:
+// when the operator has put the node into maintenance mode, Submit
+// must not spawn any work, and the recovery semaphore must remain
+// uncontended.
+func TestSubmit_NoOpInMaintenanceMode(t *testing.T) {
+	raft := &stubRaft{}
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	o := New(Config{
+		Raft:                   raft,
+		Schema:                 stubSchema{replicas: []string{"self"}},
+		PathResolver:           stubPathResolver{root: t.TempDir()},
+		ClientFactory:          nil,
+		NodeSelector:           &stubNodeSelector{},
+		NodeName:               "self",
+		Enabled:                runtime.NewDynamicValue(true),
+		MaintenanceModeEnabled: func() bool { return true },
+		Logger:                 logger,
+		PollInterval:           10_000_000,
+		ProbeTimeout:           100_000_000,
+	})
+
+	// Submit must return immediately without spawning work; if it did
+	// spawn, the stubSchema (single replica = self) would fall through
+	// to actionEmptyFallback and create a directory.
+	o.Submit(context.Background(), ShardRef{Collection: "C", Shard: "S"}, false)
+
+	// Empty-fallback would have called PathResolver.ShardPath; we
+	// detect "did anything happen?" by checking the temp dir is empty.
+	entries, err := os.ReadDir(o.pathResolver.(stubPathResolver).root)
+	require.NoError(t, err)
+	require.Empty(t, entries, "Submit must be a no-op in maintenance mode (no shard dirs created)")
+}
+
+// TestRunOne_CancelledTerminal verifies that a SELF_RECOVERY op reported
+// as CANCELLED by the FSM is treated as terminal: runOne returns without
+// re-registering a fresh op. Pre-fix, registerAndPoll returned a generic
+// error and runOne would retry — defeating operator-driven cancel via
+// /replication/replicate/{id}/cancel.
+func TestRunOne_CancelledTerminal(t *testing.T) {
+	ns := &stubNodeSelector{
+		addrs: map[string]string{"peer1": "10.0.0.1"},
+		ports: map[string]int{"peer1": 50051},
+	}
+	clientFactory := func(ctx context.Context, addr string) (copier.FileReplicationServiceClient, error) {
+		return &stubFileReplicationClient{
+			listFiles: func(ctx context.Context, in *protocol.ListFilesRequest) (*protocol.ListFilesResponse, error) {
+				return &protocol.ListFilesResponse{FileNames: []string{"a"}}, nil
+			},
+		}, nil
+	}
+	raft := &stubRaft{detailsByUUID: map[strfmt.UUID]api.ReplicationDetailsResponse{}}
+	// Once an op is registered, the FSM immediately returns CANCELLED
+	// for that UUID.
+	raft.registerHook = func(uuid strfmt.UUID, _, _, _, _ string) {
+		raft.mu.Lock()
+		defer raft.mu.Unlock()
+		raft.detailsByUUID[uuid] = api.ReplicationDetailsResponse{
+			Status: api.ReplicationDetailsState{State: string(api.CANCELLED)},
+		}
+	}
+	o := newOrchestratorForTest(t, raft, stubSchema{replicas: []string{"self", "peer1"}}, ns, clientFactory, stubPathResolver{root: t.TempDir()})
+
+	done := make(chan struct{})
+	enterrorsGo := func() {
+		defer close(done)
+		o.runOne(context.Background(), ShardRef{Collection: "C", Shard: "S"}, false)
+	}
+	go enterrorsGo()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("runOne did not return after CANCELLED — orchestrator likely retrying")
+	}
+
+	raft.mu.Lock()
+	calls := len(raft.registeredCalls)
+	raft.mu.Unlock()
+	require.Equal(t, 1, calls, "operator-cancelled op must not be re-registered; got %d RegisterSelfRecovery calls", calls)
+}
+
+// TestPerOrchestratorRNG_NotDeterministic verifies the per-orchestrator
+// RNG produces variable shuffle output across calls. Pre-fix, rand.Shuffle
+// went through the global math/rand source, which (without explicit seed)
+// is deterministic — every call yielded the same permutation.
+func TestPerOrchestratorRNG_NotDeterministic(t *testing.T) {
+	o := New(Config{
+		// minimal config; the test exercises the rng field directly.
+		Logger: logrus.New(),
+	})
+	require.NotNil(t, o.rng, "Orchestrator.rng must be initialised by New()")
+
+	// Shuffle a 10-element slice many times; if any two orderings
+	// differ we have variability. Pre-fix this would produce the same
+	// order every iteration.
+	const N = 20
+	first := make([]int, 10)
+	for i := range first {
+		first[i] = i
+	}
+	o.rngMu.Lock()
+	o.rng.Shuffle(len(first), func(i, j int) { first[i], first[j] = first[j], first[i] })
+	o.rngMu.Unlock()
+
+	differs := false
+	for k := 0; k < N && !differs; k++ {
+		cur := make([]int, 10)
+		for i := range cur {
+			cur[i] = i
+		}
+		o.rngMu.Lock()
+		o.rng.Shuffle(len(cur), func(i, j int) { cur[i], cur[j] = cur[j], cur[i] })
+		o.rngMu.Unlock()
+		for i := range cur {
+			if cur[i] != first[i] {
+				differs = true
+				break
+			}
+		}
+	}
+	require.True(t, differs, "per-orchestrator RNG produced identical shuffles across %d trials — global rand regression?", N+1)
+}
+
+// TestAcceptEmpty_PromotesInMemoryWrapper verifies the operator
+// escape-hatch invokes onRecoveryComplete after creating the empty
+// shard dir. Without this, a RecoveryShard wrapper installed by the
+// startup hook stays load-blocked forever despite disk being ready.
+// Mirrors the empty-fallback path inside runOne.
+func TestAcceptEmpty_PromotesInMemoryWrapper(t *testing.T) {
+	tmp := t.TempDir()
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+
+	var (
+		promoteCalls atomic.Int32
+		gotColl      atomic.Value
+		gotShard     atomic.Value
+	)
+	o := New(Config{
+		Raft:         &stubRaft{},
+		Schema:       stubSchema{}, // ShardReplicas returns nil err with default replicas
+		PathResolver: stubPathResolver{root: tmp},
+		NodeSelector: &stubNodeSelector{},
+		NodeName:     "self",
+		OnRecoveryComplete: func(_ context.Context, collection, shard string) error {
+			promoteCalls.Add(1)
+			gotColl.Store(collection)
+			gotShard.Store(shard)
+			return nil
+		},
+		Logger: logger,
+	})
+
+	_, err := o.AcceptEmpty(context.Background(), ShardRef{Collection: "C", Shard: "S"})
+	require.NoError(t, err)
+	require.EqualValues(t, 1, promoteCalls.Load(), "OnRecoveryComplete must be called exactly once")
+	require.Equal(t, "C", gotColl.Load())
+	require.Equal(t, "S", gotShard.Load())
+}
+
+// TestAcceptEmpty_SchemaErrorIsTypedSentinel verifies that the schema
+// gate's error chain contains ErrSelfRecoveryShardNotInSchema. The REST
+// handler relies on this sentinel to map the failure to HTTP 404
+// instead of the generic 500.
+func TestAcceptEmpty_SchemaErrorIsTypedSentinel(t *testing.T) {
+	tmp := t.TempDir()
+	logger := logrus.New()
+	logger.SetLevel(logrus.PanicLevel)
+	o := New(Config{
+		Raft:         &stubRaft{},
+		Schema:       stubSchema{err: errors.New("class \"NoSuch\" not found in schema")},
+		PathResolver: stubPathResolver{root: tmp},
+		NodeSelector: &stubNodeSelector{},
+		NodeName:     "self",
+		Logger:       logger,
+	})
+
+	_, err := o.AcceptEmpty(context.Background(), ShardRef{Collection: "NoSuch", Shard: "S"})
+	require.Error(t, err)
+	require.True(t, errors.Is(err, ErrSelfRecoveryShardNotInSchema),
+		"error chain must contain ErrSelfRecoveryShardNotInSchema for handler 4xx mapping; got %v", err)
+}
+
+// TestCancelInflightSelfRecoveryOps_NoMetricDoubleCount verifies the
+// cancel path does NOT pre-increment CompletedTotal{result="cancelled"}
+// — runOne is the single source of truth, fired when the FSM state is
+// observed terminal. Pre-incrementing here used to double-count and
+// would also tick even if the cancel RPC ultimately failed.
+func TestCancelInflightSelfRecoveryOps_NoMetricDoubleCount(t *testing.T) {
+	raft := &stubRaft{
+		opsByCollShard: map[string][]api.ReplicationDetailsResponse{
+			"C/S": {{
+				Uuid:         strfmt.UUID("00000000-0000-0000-0000-000000000001"),
+				TransferType: api.SELF_RECOVERY.String(),
+				TargetNodeId: "self",
+				Status:       api.ReplicationDetailsState{State: string(api.HYDRATING)},
+			}},
+		},
+	}
+	o := newOrchestratorForTest(t, raft, stubSchema{}, &stubNodeSelector{}, nil, stubPathResolver{root: t.TempDir()})
+
+	before := testutil.ToFloat64(o.metrics.CompletedTotal.WithLabelValues("cancelled"))
+
+	cancelled, err := o.cancelInflightSelfRecoveryOps(context.Background(), ShardRef{Collection: "C", Shard: "S"})
+	require.NoError(t, err)
+	require.Len(t, cancelled, 1, "the SELF_RECOVERY HYDRATING op should have been cancelled")
+
+	after := testutil.ToFloat64(o.metrics.CompletedTotal.WithLabelValues("cancelled"))
+	require.Equal(t, before, after,
+		"cancelInflightSelfRecoveryOps must not increment CompletedTotal{cancelled} — runOne owns that metric")
+}

--- a/cluster/replication/types/mock_replica_copier.go
+++ b/cluster/replication/types/mock_replica_copier.go
@@ -194,6 +194,57 @@ func (_c *MockReplicaCopier_CopyReplicaFiles_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// CopyReplicaFilesToLocalShard provides a mock function with given fields: ctx, sourceNode, sourceCollection, sourceShard, localShardOverride, schemaVersion
+func (_m *MockReplicaCopier) CopyReplicaFilesToLocalShard(ctx context.Context, sourceNode string, sourceCollection string, sourceShard string, localShardOverride string, schemaVersion uint64) error {
+	ret := _m.Called(ctx, sourceNode, sourceCollection, sourceShard, localShardOverride, schemaVersion)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CopyReplicaFilesToLocalShard")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string, uint64) error); ok {
+		r0 = rf(ctx, sourceNode, sourceCollection, sourceShard, localShardOverride, schemaVersion)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockReplicaCopier_CopyReplicaFilesToLocalShard_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CopyReplicaFilesToLocalShard'
+type MockReplicaCopier_CopyReplicaFilesToLocalShard_Call struct {
+	*mock.Call
+}
+
+// CopyReplicaFilesToLocalShard is a helper method to define mock.On call
+//   - ctx context.Context
+//   - sourceNode string
+//   - sourceCollection string
+//   - sourceShard string
+//   - localShardOverride string
+//   - schemaVersion uint64
+func (_e *MockReplicaCopier_Expecter) CopyReplicaFilesToLocalShard(ctx interface{}, sourceNode interface{}, sourceCollection interface{}, sourceShard interface{}, localShardOverride interface{}, schemaVersion interface{}) *MockReplicaCopier_CopyReplicaFilesToLocalShard_Call {
+	return &MockReplicaCopier_CopyReplicaFilesToLocalShard_Call{Call: _e.mock.On("CopyReplicaFilesToLocalShard", ctx, sourceNode, sourceCollection, sourceShard, localShardOverride, schemaVersion)}
+}
+
+func (_c *MockReplicaCopier_CopyReplicaFilesToLocalShard_Call) Run(run func(ctx context.Context, sourceNode string, sourceCollection string, sourceShard string, localShardOverride string, schemaVersion uint64)) *MockReplicaCopier_CopyReplicaFilesToLocalShard_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(string), args[3].(string), args[4].(string), args[5].(uint64))
+	})
+	return _c
+}
+
+func (_c *MockReplicaCopier_CopyReplicaFilesToLocalShard_Call) Return(_a0 error) *MockReplicaCopier_CopyReplicaFilesToLocalShard_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockReplicaCopier_CopyReplicaFilesToLocalShard_Call) RunAndReturn(run func(context.Context, string, string, string, string, uint64) error) *MockReplicaCopier_CopyReplicaFilesToLocalShard_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // InitAsyncReplicationLocally provides a mock function with given fields: ctx, collectionName, shardName
 func (_m *MockReplicaCopier) InitAsyncReplicationLocally(ctx context.Context, collectionName string, shardName string) error {
 	ret := _m.Called(ctx, collectionName, shardName)
@@ -286,6 +337,53 @@ func (_c *MockReplicaCopier_LoadLocalShard_Call) Return(_a0 error) *MockReplicaC
 }
 
 func (_c *MockReplicaCopier_LoadLocalShard_Call) RunAndReturn(run func(context.Context, string, string) error) *MockReplicaCopier_LoadLocalShard_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// PromoteRecoveryFolder provides a mock function with given fields: collectionName, shardName
+func (_m *MockReplicaCopier) PromoteRecoveryFolder(collectionName string, shardName string) error {
+	ret := _m.Called(collectionName, shardName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PromoteRecoveryFolder")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(collectionName, shardName)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// MockReplicaCopier_PromoteRecoveryFolder_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'PromoteRecoveryFolder'
+type MockReplicaCopier_PromoteRecoveryFolder_Call struct {
+	*mock.Call
+}
+
+// PromoteRecoveryFolder is a helper method to define mock.On call
+//   - collectionName string
+//   - shardName string
+func (_e *MockReplicaCopier_Expecter) PromoteRecoveryFolder(collectionName interface{}, shardName interface{}) *MockReplicaCopier_PromoteRecoveryFolder_Call {
+	return &MockReplicaCopier_PromoteRecoveryFolder_Call{Call: _e.mock.On("PromoteRecoveryFolder", collectionName, shardName)}
+}
+
+func (_c *MockReplicaCopier_PromoteRecoveryFolder_Call) Run(run func(collectionName string, shardName string)) *MockReplicaCopier_PromoteRecoveryFolder_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(string), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockReplicaCopier_PromoteRecoveryFolder_Call) Return(_a0 error) *MockReplicaCopier_PromoteRecoveryFolder_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockReplicaCopier_PromoteRecoveryFolder_Call) RunAndReturn(run func(string, string) error) *MockReplicaCopier_PromoteRecoveryFolder_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/cluster/replication/types/replica_copier.go
+++ b/cluster/replication/types/replica_copier.go
@@ -23,6 +23,12 @@ type ReplicaCopier interface {
 	// CopyReplicaFiles see cluster/replication/copier.Copier.CopyReplicaFiles
 	CopyReplicaFiles(ctx context.Context, sourceNode string, sourceCollection string, sourceShard string, schemaVersion uint64) error
 
+	// CopyReplicaFilesToLocalShard see cluster/replication/copier.Copier.CopyReplicaFilesToLocalShard
+	CopyReplicaFilesToLocalShard(ctx context.Context, sourceNode, sourceCollection, sourceShard, localShardOverride string, schemaVersion uint64) error
+
+	// PromoteRecoveryFolder see cluster/replication/copier.Copier.PromoteRecoveryFolder
+	PromoteRecoveryFolder(collectionName, shardName string) error
+
 	// LoadLocalShard see cluster/replication/copier.Copier.LoadLocalShard
 	LoadLocalShard(ctx context.Context, collectionName, shardName string) error
 

--- a/cluster/replication/validate.go
+++ b/cluster/replication/validate.go
@@ -26,8 +26,15 @@ var (
 	ErrShardNotFound = errors.New("shard not found")
 )
 
+// validateSchemaReader narrows schema.SchemaReader to what this
+// validator needs, so tests can stub it.
+type validateSchemaReader interface {
+	ClassInfo(class string) schema.ClassInfo
+	ShardReplicas(class, shard string) (nodes []string, err error)
+}
+
 // ValidateReplicationReplicateShard validates that c is valid given the current state of the schema read using schemaReader
-func ValidateReplicationReplicateShard(schemaReader schema.SchemaReader, c *api.ReplicationReplicateShardRequest) error {
+func ValidateReplicationReplicateShard(schemaReader validateSchemaReader, c *api.ReplicationReplicateShardRequest) error {
 	if c.Uuid == "" {
 		return fmt.Errorf("uuid is required: %w", ErrBadRequest)
 	}
@@ -60,8 +67,16 @@ func ValidateReplicationReplicateShard(schemaReader schema.SchemaReader, c *api.
 	if !foundSource {
 		return fmt.Errorf("could not find shard %s for collection %s on source node %s: %w", c.SourceShard, c.SourceCollection, c.SourceNode, ErrNodeNotFound)
 	}
+	if c.TransferType == api.SELF_RECOVERY.String() {
+		// SELF_RECOVERY: target must already be a replica (we're
+		// re-hydrating); otherwise it's an upstream logic error.
+		if !foundTarget {
+			return fmt.Errorf("self-recovery for shard %s of collection %s requires target node %s to already be a replica: %w", c.SourceShard, c.SourceCollection, c.TargetNode, ErrNodeNotFound)
+		}
+		return nil
+	}
 	if foundTarget {
-		return fmt.Errorf("shard %s already exist for collection %s on target node %s: %w", c.SourceShard, c.SourceCollection, c.SourceNode, ErrAlreadyExists)
+		return fmt.Errorf("shard %s already exist for collection %s on target node %s: %w", c.SourceShard, c.SourceCollection, c.TargetNode, ErrAlreadyExists)
 	}
 	return nil
 }

--- a/cluster/replication/validate_test.go
+++ b/cluster/replication/validate_test.go
@@ -1,0 +1,169 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package replication
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/cluster/schema"
+)
+
+// stubSchemaReader is a minimal in-test implementation of the
+// validateSchemaReader interface used to exercise
+// ValidateReplicationReplicateShard without standing up a full schema.
+type stubSchemaReader struct {
+	classExists bool
+	replicas    []string
+	shardErr    error
+}
+
+func (s stubSchemaReader) ClassInfo(class string) schema.ClassInfo {
+	return schema.ClassInfo{Exists: s.classExists}
+}
+
+func (s stubSchemaReader) ShardReplicas(class, shard string) ([]string, error) {
+	return s.replicas, s.shardErr
+}
+
+func TestValidateReplicationReplicateShard(t *testing.T) {
+	const (
+		coll = "C"
+		sh   = "S"
+		src  = "node-A"
+		tgt  = "node-B"
+	)
+
+	// Case 1: COPY rejected when target is already in the replica set.
+	t.Run("copy_rejects_existing_target", func(t *testing.T) {
+		err := ValidateReplicationReplicateShard(stubSchemaReader{
+			classExists: true,
+			replicas:    []string{src, tgt},
+		}, &api.ReplicationReplicateShardRequest{
+			Uuid:             "00000000-0000-0000-0000-000000000001",
+			SourceNode:       src,
+			TargetNode:       tgt,
+			SourceCollection: coll,
+			SourceShard:      sh,
+			TransferType:     api.COPY.String(),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrAlreadyExists), "expected ErrAlreadyExists, got %v", err)
+	})
+
+	// Case 2: SELF_RECOVERY accepted when target is already a replica
+	// (this is the whole point — the on-disk data was lost, the schema
+	// still lists this node as a replica, and we want to re-hydrate).
+	t.Run("self_recovery_accepts_existing_target", func(t *testing.T) {
+		err := ValidateReplicationReplicateShard(stubSchemaReader{
+			classExists: true,
+			replicas:    []string{src, tgt},
+		}, &api.ReplicationReplicateShardRequest{
+			Uuid:             "00000000-0000-0000-0000-000000000002",
+			SourceNode:       src,
+			TargetNode:       tgt,
+			SourceCollection: coll,
+			SourceShard:      sh,
+			TransferType:     api.SELF_RECOVERY.String(),
+		})
+		require.NoError(t, err)
+	})
+
+	// Case 3: SELF_RECOVERY rejects when target is NOT a replica per
+	// schema (logic error somewhere upstream — recovering a node that
+	// does not own the shard makes no sense).
+	t.Run("self_recovery_rejects_non_replica_target", func(t *testing.T) {
+		err := ValidateReplicationReplicateShard(stubSchemaReader{
+			classExists: true,
+			replicas:    []string{src}, // tgt absent
+		}, &api.ReplicationReplicateShardRequest{
+			Uuid:             "00000000-0000-0000-0000-000000000003",
+			SourceNode:       src,
+			TargetNode:       tgt,
+			SourceCollection: coll,
+			SourceShard:      sh,
+			TransferType:     api.SELF_RECOVERY.String(),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrNodeNotFound), "expected ErrNodeNotFound, got %v", err)
+	})
+
+	// Case 4: SELF_RECOVERY rejects when source is missing — even though
+	// target-existence is fine, we cannot copy from a peer that does
+	// not have the shard.
+	t.Run("self_recovery_rejects_missing_source", func(t *testing.T) {
+		err := ValidateReplicationReplicateShard(stubSchemaReader{
+			classExists: true,
+			replicas:    []string{tgt}, // src absent
+		}, &api.ReplicationReplicateShardRequest{
+			Uuid:             "00000000-0000-0000-0000-000000000004",
+			SourceNode:       src,
+			TargetNode:       tgt,
+			SourceCollection: coll,
+			SourceShard:      sh,
+			TransferType:     api.SELF_RECOVERY.String(),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrNodeNotFound), "expected ErrNodeNotFound, got %v", err)
+	})
+
+	// Case 5: shared rejections still apply for SELF_RECOVERY (uuid,
+	// same source/target).
+	t.Run("self_recovery_rejects_same_source_target", func(t *testing.T) {
+		err := ValidateReplicationReplicateShard(stubSchemaReader{
+			classExists: true,
+			replicas:    []string{src},
+		}, &api.ReplicationReplicateShardRequest{
+			Uuid:             "00000000-0000-0000-0000-000000000005",
+			SourceNode:       src,
+			TargetNode:       src, // same as source
+			SourceCollection: coll,
+			SourceShard:      sh,
+			TransferType:     api.SELF_RECOVERY.String(),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrBadRequest), "expected ErrBadRequest, got %v", err)
+	})
+
+	t.Run("self_recovery_rejects_missing_uuid", func(t *testing.T) {
+		err := ValidateReplicationReplicateShard(stubSchemaReader{
+			classExists: true,
+			replicas:    []string{src, tgt},
+		}, &api.ReplicationReplicateShardRequest{
+			Uuid:             "",
+			SourceNode:       src,
+			TargetNode:       tgt,
+			SourceCollection: coll,
+			SourceShard:      sh,
+			TransferType:     api.SELF_RECOVERY.String(),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrBadRequest), "expected ErrBadRequest, got %v", err)
+	})
+
+	t.Run("rejects_unknown_class", func(t *testing.T) {
+		err := ValidateReplicationReplicateShard(stubSchemaReader{
+			classExists: false,
+		}, &api.ReplicationReplicateShardRequest{
+			Uuid:             "00000000-0000-0000-0000-000000000006",
+			SourceNode:       src,
+			TargetNode:       tgt,
+			SourceCollection: coll,
+			SourceShard:      sh,
+			TransferType:     api.SELF_RECOVERY.String(),
+		})
+		require.Error(t, err)
+		require.True(t, errors.Is(err, ErrClassNotFound), "expected ErrClassNotFound, got %v", err)
+	})
+}

--- a/cluster/store.go
+++ b/cluster/store.go
@@ -215,6 +215,25 @@ type Store struct {
 	// dbLoaded is set when the DB is loaded at startup
 	dbLoaded atomic.Bool
 
+	// startedEmpty is set before raft.NewRaft and reports whether this node
+	// began the process with no durable RAFT state (no logs, no snapshot).
+	// It is the signal used to detect a wiped node that rejoins an existing
+	// cluster purely via log replay, so it can self-recover its shard data.
+	// Immutable for the process lifetime once Open has run.
+	startedEmpty atomic.Bool
+	// catchUpTarget is the RAFT log index a wiped log-replay joiner must
+	// reach before its one-shot DB load (reloadDBFromSchema). It is zero
+	// until decided on the first applied command, and stays zero for a fresh
+	// bootstrap (which has nothing to catch up). See Store.Apply.
+	catchUpTarget atomic.Uint64
+	// catchUpDecided locks the wiped-joiner-vs-bootstrap decision to the
+	// first applied command, so a later runtime catch-up (e.g. after a
+	// partition) cannot be misread as a wiped-node rejoin.
+	catchUpDecided atomic.Bool
+	// wipedJoinerReloaded is set once the one-shot DB load for a wiped
+	// log-replay joiner has run, after which entries apply normally.
+	wipedJoinerReloaded atomic.Bool
+
 	// raft implementation from external library
 	raft          *raft.Raft
 	raftResolver  types.RaftResolver
@@ -414,10 +433,23 @@ func (st *Store) RegisterDistributedTaskCollectionExtractor(namespace string, ex
 	st.distributedTasksManager.RegisterCollectionExtractor(namespace, extractor)
 }
 
-// lastIndex returns the last index in stable storage,
-// either from the last log or from the last snapshot.
-// this method work as a protection from applying anything was applied to the db
-// by checking either raft or max(snapshot, log store) instead the db will catchup
+// ForceSnapshot triggers an immediate RAFT snapshot on the local
+// node, bypassing the periodic interval/threshold cadence. Used by
+// the /debug/raft/snapshot admin endpoint to make tests deterministic
+// (in particular, to guarantee a wiped node's rejoin goes through
+// InstallSnapshot → Restore → reloadDBFromSchema and the
+// SELF_RECOVERY hook fires).
+func (st *Store) ForceSnapshot() error {
+	if st.raft == nil {
+		return fmt.Errorf("raft not initialised")
+	}
+	return st.raft.Snapshot().Error()
+}
+
+// lastIndex returns the last index in stable storage, either from the
+// last log or from the last snapshot. It works as a protection from
+// re-applying entries that were already applied to the DB: by checking
+// raft or max(snapshot, log store), the DB catches up to the right point.
 func (st *Store) lastIndex() uint64 {
 	if st.raft != nil {
 		return st.raft.AppliedIndex()
@@ -428,6 +460,87 @@ func (st *Store) lastIndex() uint64 {
 		panic(fmt.Sprintf("read log last command: %s", err.Error()))
 	}
 	return max(lastSnapshotIndex(st.snapshotStore), l)
+}
+
+// raftLastIndex returns the index of the last entry in the RAFT log, or 0
+// before the raft node exists.
+func (st *Store) raftLastIndex() uint64 {
+	if st.raft == nil {
+		return 0
+	}
+	return st.raft.LastIndex()
+}
+
+// noteWipedJoinerProgress advances the wiped-node log-replay catch-up state
+// for one applied command at logIndex, given the current RAFT log tip
+// raftLastIndex. It returns whether this entry must be applied schema-only
+// (no per-entry DB write, so no shard folder is created) and whether the
+// caller should now start the catch-up watcher (watchWipedJoinerCatchUp).
+//
+// A node that started this process with no durable RAFT state
+// (st.startedEmpty) and no prior DB index (lastAppliedIndexToDB == 0) is
+// either a fresh bootstrap or a wiped node rejoining an existing cluster via
+// log replay. Only the latter has a committed backlog to catch up: it is
+// detected on the first applied command by the RAFT log already extending
+// past that entry. The decision is locked on that first command (via
+// catchUpDecided) so a later runtime catch-up — e.g. after a partition —
+// cannot be misread as a wiped-node rejoin. A snapshot-restored node has
+// lastAppliedIndexToDB != 0 and is therefore excluded here: it already does
+// its DB load via Store.Restore.
+//
+// The one-shot DB load itself is NOT triggered from here: the catch-up
+// target is a RAFT log index that may be a configuration entry past the
+// last schema command, and Store.Apply is only invoked for command entries.
+// watchWipedJoinerCatchUp waits for raft.AppliedIndex (which advances for
+// every entry type) to reach the target and then runs the load.
+func (st *Store) noteWipedJoinerProgress(logIndex, raftLastIndex uint64) (schemaOnly, startWatcher bool) {
+	if !st.startedEmpty.Load() || st.lastAppliedIndexToDB.Load() != 0 || st.wipedJoinerReloaded.Load() {
+		return false, false
+	}
+	if !st.catchUpDecided.Load() {
+		st.catchUpDecided.Store(true)
+		if logIndex < raftLastIndex {
+			st.catchUpTarget.Store(raftLastIndex)
+			startWatcher = true
+		}
+	} else if t := st.catchUpTarget.Load(); t != 0 && raftLastIndex > t {
+		// Keep the target at the current log tip while a backlog delivered
+		// over multiple AppendEntries rounds is still arriving.
+		st.catchUpTarget.Store(raftLastIndex)
+	}
+	// catchUpTarget == 0 ⇒ fresh bootstrap (or a live entry): nothing to
+	// catch up. Otherwise this command is part of the backlog and must be
+	// applied schema-only.
+	return st.catchUpTarget.Load() != 0, startWatcher
+}
+
+// watchWipedJoinerCatchUp runs once, in its own goroutine, for a wiped node
+// rejoining via log replay. It waits until the node's RAFT applied index
+// reaches the catch-up target (the backlog tip) and then runs the one-shot
+// DB load (reloadDBFromSchema -> ReloadLocalDB) — the same tagged load pass
+// a snapshot-restored node uses, and where a missing shard folder triggers
+// self-recovery. It is a goroutine rather than inline in Store.Apply because
+// the target may be a configuration entry past the last schema command, and
+// Store.Apply only ever sees command entries.
+func (st *Store) watchWipedJoinerCatchUp() {
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+	for range ticker.C {
+		if st.wipedJoinerReloaded.Load() || !st.open.Load() {
+			return
+		}
+		target := st.catchUpTarget.Load()
+		if target == 0 || st.raft == nil || st.raft.AppliedIndex() < target {
+			continue
+		}
+		st.wipedJoinerReloaded.Store(true)
+		st.log.WithFields(logrus.Fields{
+			"applied_index":   st.raft.AppliedIndex(),
+			"catch_up_target": target,
+		}).Info("reloading local DB after wiped-node log-replay catch-up")
+		st.reloadDBFromSchema()
+		return
+	}
 }
 
 // Open opens this store and marked as such.
@@ -450,9 +563,20 @@ func (st *Store) Open(ctx context.Context) (err error) {
 	// we have to open the DB before constructing new raft in case of restore calls
 	st.openDatabase(ctx)
 
+	// Capture whether the node has any durable RAFT state *before* NewRaft
+	// (which would itself create state). A node with no prior state that
+	// then catches up an existing cluster's committed log is a wiped node
+	// that must self-recover its shard data; see Store.Apply.
+	hadState, err := raft.HasExistingState(st.logCache, st.logStore, st.snapshotStore)
+	if err != nil {
+		return fmt.Errorf("check existing raft state: %w", err)
+	}
+	st.startedEmpty.Store(!hadState)
+
 	st.log.WithFields(logrus.Fields{
 		"name":                 st.cfg.NodeID,
 		"metadata_only_voters": st.cfg.MetadataOnlyVoters,
+		"started_empty":        st.startedEmpty.Load(),
 	}).Info("construct a new raft node")
 	st.raft, err = raft.NewRaft(st.raftConfig(), st, st.logCache, st.logStore, st.snapshotStore, st.raftTransport)
 	if err != nil {

--- a/cluster/store_apply.go
+++ b/cluster/store_apply.go
@@ -103,9 +103,19 @@ func (st *Store) Apply(l *raft.Log) any {
 	// If we don't have any last applied index on start, schema only is always false.
 	// we check for index !=0 to force apply of the 1st index in both db and schema
 	catchingUp := l.Index != 0 && l.Index <= st.lastAppliedIndexToDB.Load()
+
+	// A wiped node rejoining an existing cluster via log replay must replay
+	// schema-only (so no shard folders are created per entry); the catch-up
+	// watcher then does a single DB load once caught up. See
+	// noteWipedJoinerProgress / watchWipedJoinerCatchUp.
+	wipedJoinerCatchingUp, startWipedJoinerWatcher := st.noteWipedJoinerProgress(l.Index, st.raftLastIndex())
+	if startWipedJoinerWatcher {
+		enterrors.GoWrapper(st.watchWipedJoinerCatchUp, st.log)
+	}
+
 	// TODO: get rid off schema only as it causes more trouble than it's worth
 	// T-Nr: DB-306
-	schemaOnly := catchingUp || st.cfg.MetadataOnlyVoters
+	schemaOnly := catchingUp || wipedJoinerCatchingUp || st.cfg.MetadataOnlyVoters
 	defer func() {
 		// If we have an applied index from the previous store (i.e from disk). Then reload the DB once we catch up as
 		// that means we're done doing schema only.

--- a/cluster/store_wiped_joiner_test.go
+++ b/cluster/store_wiped_joiner_test.go
@@ -1,0 +1,141 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package cluster
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNoteWipedJoinerProgress covers the catch-up state machine that decides
+// whether a node is a wiped node rejoining via log replay (must replay
+// schema-only, then start the catch-up watcher) versus a fresh bootstrap or a
+// node with prior state (which must not).
+func TestNoteWipedJoinerProgress(t *testing.T) {
+	t.Run("wiped joiner: schema-only across the backlog, watcher started once", func(t *testing.T) {
+		st := &Store{}
+		st.startedEmpty.Store(true) // no durable RAFT state at process start
+		// lastAppliedIndexToDB stays 0 (no prior DB / no snapshot)
+
+		// First applied command at index 3, RAFT log tip already at 10:
+		// a committed backlog exists -> this is a wiped joiner catching up.
+		schemaOnly, startWatcher := st.noteWipedJoinerProgress(3, 10)
+		assert.True(t, schemaOnly, "backlog entries must apply schema-only")
+		assert.True(t, startWatcher, "the catch-up watcher must be started once")
+		assert.Equal(t, uint64(10), st.catchUpTarget.Load())
+
+		// Remaining backlog entries: still schema-only, watcher not re-started.
+		for idx := uint64(4); idx <= 10; idx++ {
+			so, sw := st.noteWipedJoinerProgress(idx, 10)
+			assert.True(t, so)
+			assert.False(t, sw, "watcher is started exactly once")
+		}
+
+		// Once the watcher has run the reload, later (runtime) entries apply
+		// normally: never schema-only.
+		st.wipedJoinerReloaded.Store(true)
+		so, sw := st.noteWipedJoinerProgress(11, 11)
+		assert.False(t, so, "runtime entries after catch-up apply normally")
+		assert.False(t, sw)
+	})
+
+	t.Run("wiped joiner: backlog delivered in multiple chunks extends the target", func(t *testing.T) {
+		st := &Store{}
+		st.startedEmpty.Store(true)
+
+		// First chunk: tip at 5.
+		so, sw := st.noteWipedJoinerProgress(3, 5)
+		assert.True(t, so)
+		assert.True(t, sw)
+		assert.Equal(t, uint64(5), st.catchUpTarget.Load())
+
+		// Second chunk arrives before we reached 5: tip jumps to 12, the
+		// target must extend so the later entries are still schema-only.
+		so, sw = st.noteWipedJoinerProgress(4, 12)
+		assert.True(t, so)
+		assert.False(t, sw)
+		assert.Equal(t, uint64(12), st.catchUpTarget.Load())
+	})
+
+	t.Run("fresh bootstrap: never schema-only, no watcher", func(t *testing.T) {
+		st := &Store{}
+		st.startedEmpty.Store(true)
+
+		// First applied command is live (index == log tip): no backlog,
+		// so this is a fresh bootstrap, not a wiped rejoin.
+		so, sw := st.noteWipedJoinerProgress(3, 3)
+		assert.False(t, so)
+		assert.False(t, sw)
+		assert.Equal(t, uint64(0), st.catchUpTarget.Load())
+		assert.True(t, st.catchUpDecided.Load())
+
+		// Further runtime class creations must stay unaffected.
+		so, sw = st.noteWipedJoinerProgress(4, 4)
+		assert.False(t, so)
+		assert.False(t, sw)
+	})
+
+	t.Run("decision is locked on the first command: a later catch-up is not a rejoin", func(t *testing.T) {
+		st := &Store{}
+		st.startedEmpty.Store(true)
+
+		// Fresh bootstrap decided on the first command.
+		so, sw := st.noteWipedJoinerProgress(3, 3)
+		assert.False(t, so)
+		assert.False(t, sw)
+
+		// Much later the node falls behind and catches up (e.g. after a
+		// network partition). This must NOT be misread as a wiped rejoin.
+		so, sw = st.noteWipedJoinerProgress(20, 500)
+		assert.False(t, so, "a runtime catch-up must not trigger schema-only replay")
+		assert.False(t, sw)
+		assert.Equal(t, uint64(0), st.catchUpTarget.Load())
+	})
+
+	t.Run("single-entry backlog edge: degrades to no recovery", func(t *testing.T) {
+		st := &Store{}
+		st.startedEmpty.Store(true)
+
+		// The only committed entry is the first command itself: there is no
+		// earlier entry to reveal the backlog, so it is treated as a fresh
+		// entry. Documented edge - degrades to today's behaviour.
+		so, sw := st.noteWipedJoinerProgress(3, 3)
+		assert.False(t, so)
+		assert.False(t, sw)
+	})
+
+	t.Run("node with prior state is excluded", func(t *testing.T) {
+		// Not started empty (intact restart): the existing catch-up
+		// machinery handles it.
+		st := &Store{}
+		st.startedEmpty.Store(false)
+		so, sw := st.noteWipedJoinerProgress(3, 100)
+		assert.False(t, so)
+		assert.False(t, sw)
+
+		// Started empty but a snapshot was installed (lastAppliedIndexToDB
+		// != 0): Store.Restore already ran the DB load, so this path is off.
+		snapRestored := &Store{}
+		snapRestored.startedEmpty.Store(true)
+		snapRestored.lastAppliedIndexToDB.Store(42)
+		so, sw = snapRestored.noteWipedJoinerProgress(3, 100)
+		assert.False(t, so)
+		assert.False(t, sw)
+	})
+}
+
+func TestRaftLastIndex_NilRaft(t *testing.T) {
+	st := &Store{}
+	assert.Equal(t, uint64(0), st.raftLastIndex(),
+		"raftLastIndex must be 0 before the raft node exists")
+}

--- a/docs/self-recovery.md
+++ b/docs/self-recovery.md
@@ -1,0 +1,189 @@
+# Shard Self-Recovery
+
+When a node restarts and finds shard directories missing on disk that the
+schema says it should be hosting, it pulls those shards from a healthy
+peer using the same file-copy machinery as scale-out replication. The
+hook fires only at startup; runtime shard creation (new collections,
+empty-source replica adds) keeps today's "create empty dir" behavior.
+
+Disabled by default. Operators opt in per the rollout discipline below.
+
+## Enabling
+
+Set on every node:
+
+```
+SELF_RECOVERY_ENABLED=true
+SELF_RECOVERY_CONCURRENCY=10    # default; per-node parallelism
+REPLICA_MOVEMENT_ENABLED=true                  # required for /replication/* observability
+```
+
+**Rollout discipline.** Mixed-version clusters with the flag on cause
+RAFT FSM apply divergence (older nodes don't know the `SELF_RECOVERY`
+transfer type and reject it). Same caveat as `REPLICA_MOVEMENT_ENABLED`.
+**Upgrade every node first, then enable the flag.**
+
+## Operator-visible state during recovery
+
+| Surface | Signal |
+|---|---|
+| `GET /nodes?output=verbose` | shard reports `status: "RECOVERING"`, `loaded: false` |
+| `GET /replication/replicate/list?targetNode=<self>` | in-flight `SELF_RECOVERY` op with state `REGISTERED`/`HYDRATING`/`FINALIZING`/`READY` |
+| `/metrics` (Prometheus) | series listed below |
+| Structured logs | `event=self_recovery.{started\|peer_probe\|op_registered\|completed\|failed\|empty_fallback\|accept_empty\|restart}` |
+
+### Metrics
+
+| Metric | Type | Labels | Question it answers |
+|---|---|---|---|
+| `weaviate_self_recovery_in_progress` | gauge | — | how many recoveries are running on this node? |
+| `weaviate_self_recovery_started_total` | counter | `source_node` | how many were kicked off, by source peer? |
+| `weaviate_self_recovery_completed_total` | counter | `result` (success\|failure\|cancelled) | terminal outcomes |
+| `weaviate_self_recovery_duration_seconds` | histogram | `result` | end-to-end recovery time |
+| `weaviate_self_recovery_no_data_empty_total` | counter | — | catastrophic-wipe occurrences (post-bootstrap; alert on this) |
+| `weaviate_self_recovery_no_data_during_bootstrap_total` | counter | — | empty-fallback during the RAFT bootstrap window (likely a class added during this node's downtime — benign; informational) |
+| `weaviate_self_recovery_unreachable_peer_total` | counter | `peer` | peer reachability problems |
+| `weaviate_self_recovery_giveup_total` | counter | — | retries exhausted |
+| `weaviate_self_recovery_accept_empty_total` | counter | — | operator escape-hatch invocations |
+| `weaviate_self_recovery_submit_dropped_total` | counter | — | submissions dropped because the in-process worker queue was full (will retry on next restart) |
+
+Per-(collection, shard) drill-down is available via `/replication/replicate/list`
+and the structured logs.
+
+### Suggested alerts
+
+```promql
+# catastrophic-wipe candidate — investigate immediately
+rate(weaviate_self_recovery_no_data_empty_total[5m]) > 0
+
+# recovery stuck for too long
+weaviate_self_recovery_in_progress > 0  for: 1h
+
+# retries exhausted — manual intervention required
+rate(weaviate_self_recovery_giveup_total[15m]) > 0
+```
+
+## Operator escape hatches
+
+The `/debug/self-recovery/*` endpoints (and the test-only
+`POST /debug/raft/snapshot`) are registered **only when
+`SELF_RECOVERY_ENABLED=true`**. They live on the profiling/debug port,
+like the other `/debug/*` handlers.
+
+| Endpoint | When to use |
+|---|---|
+| `POST /replication/replicate/{id}/cancel` | abandon one in-flight op (any transfer type) |
+| `POST /debug/self-recovery/restart?collection=X&shard=Y` | abandon current SELF_RECOVERY attempt for the shard, erase partial `.recovering/` state, start fresh (probe re-randomises source peer selection). **Valid only while the shard is `RECOVERING`** — if the live `<shard>/` directory already exists (recovery completed, or empty-fallback ran) it returns `409 Conflict`; cancel any in-flight op and remove the directory by hand if you really want to re-pull. |
+| `POST /debug/self-recovery/accept-empty?collection=X&shard=Y` | declare "no recoverable data exists, accept empty shard". Confirm via metrics/logs that all peers report no data first. |
+
+If retries are exhausted (`weaviate_self_recovery_giveup_total` ticks),
+the shard is left in `RECOVERING`; use `restart` to try again from
+scratch, or `accept-empty` to accept the loss. (Recoveries are also
+retried automatically on the next node restart.)
+
+When the in-process worker queue overflows (a node missing thousands of
+shards at once — `weaviate_self_recovery_submit_dropped_total` ticks),
+the affected shard falls back to the pre-existing behavior — an empty dir
+created at startup, backfilled object-by-object by async replication —
+rather than being stranded in `RECOVERING`. The dropped recovery is
+re-attempted on the next restart.
+
+## Runbook: `no_data_empty_total > 0` after a restart
+
+This counter increments when **all probed peers definitively reported no
+data** for a shard the orchestrator was trying to recover. Either:
+
+1. **Catastrophic full-cluster wipe** (every replica of the shard lost data).
+2. **Genuinely-new shard added while the node was offline** (e.g. an
+   empty-source `AddReplicaToShard` applied during the node's catchup).
+   Benign.
+
+To distinguish, find the structured log line:
+
+```
+event=self_recovery.empty_fallback collection=... shard=... probed_peers=[...]
+```
+
+- If you recognise the (collection, shard) as one with real data, this
+  is case 1 — restore from backup.
+- If it's a recently-created or empty replica, case 2 — no action.
+
+To restore from backup: shut down (or quiesce) the node, run the Backup
+module's restore for the affected collection, restart.
+
+## How the trigger is scoped
+
+Recovery is triggered by the **startup DB-load pass** — the one-shot
+`reloadDBFromSchema` → `ReloadLocalDB` that a node runs once it has
+caught its schema up to the cluster's committed state. It fires
+regardless of *how* the node caught up: a RAFT snapshot install and a
+replay of committed log entries both converge on the same load pass, and
+a shard folder found missing during it triggers recovery either way.
+
+A wiped node rejoining via log replay replays its schema catch-up
+"schema-only" (no per-entry DB writes, so no shard folders are created
+mid-catch-up — see `Store.noteWipedJoinerProgress`); a watcher
+(`Store.watchWipedJoinerCatchUp`) then waits for the node to reach the
+catch-up target and runs the single load pass. A node with intact data,
+a fresh bootstrap, and a snapshot-restored node are all distinguished
+from a wiped log-replay joiner and are unaffected.
+
+Runtime collection/tenant creation is **not** part of the load pass: a
+genuinely new shard has its folder created at creation time, so it is
+never mistaken for a wiped one and never triggers recovery.
+
+## Limitations
+
+Two narrow edges of the log-replay path remain, both degrading to
+today's behavior (empty shard, backfilled by async replication) rather
+than to data loss:
+
+- If the cluster's *entire* committed RAFT log is a single command, a
+  wiped joiner has no earlier entry to reveal the catch-up backlog and
+  treats that command as a live one.
+- If the catch-up backlog is delivered across multiple `AppendEntries`
+  rounds with a gap exactly at the load-pass boundary, a class in a
+  later round can be created with an empty folder. For a schema-only
+  RAFT log the backlog is tiny and ships in one round, so this is rare.
+
+There is also a brief window during a wiped node's log-replay catch-up
+where the node reports `Ready` but its local DB is not yet built (it is
+built in one pass at the end of catch-up). Schema replay is fast and the
+freshly-rejoined node is not yet in the read rotation for its shards;
+the window is the same order as the pre-existing "Ready during replay"
+behavior.
+
+**A `RecoveringShard` panics if a non-routed code path touches it.**
+While a shard is `RECOVERING`, an in-memory `RecoveringShard` wrapper
+sits in the index's shard map with its load blocked. The replication FSM
+read filter excludes it from cluster reads/writes for all consistency
+levels, and the "loaded" shard accessors skip it — but any maintenance
+loop or admin operation that iterates *all* shards and calls a data-path
+method (e.g. `Store()`, `addProperty`/`updateProperty` via `ForEachShard`)
+will hit `mustLoad` and **panic the node** with a "shard is recovering
+from a peer; this code path must not touch a recovering shard" message
+rather than failing gracefully. Avoid such operations while a shard on
+the node is recovering. (Hardening every such call site is deferred; the
+panic message is intentionally explicit so the crash is unambiguous.)
+
+## Maintenance mode
+
+When the node is in maintenance mode, the orchestrator does not start new
+recoveries — `Submit` declines the work, and a missing-dir shard
+discovered at startup falls back to the normal init path (empty dir +
+async-rep backfill) rather than being parked in `RECOVERING`.
+Already-running recoveries run to completion. To pause an in-flight one,
+cancel via the endpoint above.
+
+## Downgrade safety
+
+If a node is downgraded to a binary without SELF_RECOVERY support, any
+leftover `<shard>.recovering/` directories sit unused on disk until
+re-upgrade (which sweeps them at startup). To clean manually:
+
+```
+rm -rf <data_root>/<collection>/<shard>.recovering
+```
+
+(Only safe when the live `<shard>/` exists alongside; otherwise the dir
+holds an in-flight recovery to resume.)

--- a/entities/errors/errors_recovery.go
+++ b/entities/errors/errors_recovery.go
@@ -1,0 +1,48 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package errors
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+)
+
+// ErrShardRecovering: shard data is missing locally and being copied
+// from a peer (SELF_RECOVERY). Defense-in-depth for callers that
+// bypass the router (which already filters via the replication FSM).
+var ErrShardRecovering = errors.New("shard recovering from peer")
+
+func IsShardRecovering(err error) bool {
+	return errors.Is(err, ErrShardRecovering)
+}
+
+// startupDBLoadKey marks a context as originating from the one-shot
+// startup DB-load pass (reloadDBFromSchema -> ReloadLocalDB), which runs
+// after the node has caught its schema up to the cluster — whether that
+// catch-up came from a RAFT snapshot install or from replaying committed
+// log entries. It distinguishes "loading a shard the schema says should
+// already exist" (a SELF_RECOVERY candidate when the on-disk dir is
+// missing) from "creating a brand-new shard at runtime" (where a missing
+// dir is normal).
+type startupDBLoadKey struct{}
+
+// WithStartupDBLoad tags the ctx as the startup DB-load pass.
+func WithStartupDBLoad(ctx context.Context) context.Context {
+	return context.WithValue(ctx, startupDBLoadKey{}, true)
+}
+
+// IsStartupDBLoad reports whether ctx was tagged via WithStartupDBLoad.
+func IsStartupDBLoad(ctx context.Context) bool {
+	v, _ := ctx.Value(startupDBLoadKey{}).(bool)
+	return v
+}

--- a/entities/replication/config.go
+++ b/entities/replication/config.go
@@ -57,4 +57,10 @@ type GlobalConfig struct {
 	DeletionStrategy string `json:"deletion_strategy" yaml:"deletion_strategy"`
 
 	ReplicationGRPCEnabled *runtime.DynamicValue[bool] `json:"replication_grpc_enabled" yaml:"replication_grpc_enabled"`
+
+	// SELF_RECOVERY: when enabled, a node with missing local shard
+	// dirs at startup probes peers and registers SELF_RECOVERY ops.
+	// Concurrency caps simultaneous per-shard recoveries. Default OFF.
+	SelfRecoveryEnabled     *runtime.DynamicValue[bool] `json:"self_recovery_enabled" yaml:"self_recovery_enabled"`
+	SelfRecoveryConcurrency *runtime.DynamicValue[int]  `json:"self_recovery_concurrency" yaml:"self_recovery_concurrency"`
 }

--- a/entities/storagestate/status.go
+++ b/entities/storagestate/status.go
@@ -23,6 +23,10 @@ const (
 	StatusLazyLoading Status = "LAZY_LOADING"
 	StatusReady       Status = "READY"
 	StatusShutdown    Status = "SHUTDOWN"
+	// StatusRecovering: shard exists in schema but local data is being
+	// re-hydrated from a peer (SELF_RECOVERY). Reads/writes return
+	// ErrShardRecovering; the router filters this replica via the FSM.
+	StatusRecovering Status = "RECOVERING"
 )
 
 var ErrStatusReadOnlyWithReason = func(reason string) error {

--- a/single-node-backup.md
+++ b/single-node-backup.md
@@ -1,0 +1,195 @@
+# Single-replica backup for replicated collections
+
+## Context
+
+Today a backup of a replicated collection archives **every replica of every shard**
+independently under `{backupID}/{nodeName}/...`. For an RF=3 collection that is 3×
+the storage and transfer of the actual data, even though converged replicas are
+byte-identical.
+
+The recently-landed async-checkpoint feature (PR #10926) gives us a way to *prove*
+two replicas hold identical shard data: a checkpoint's `Root` digest converges to the
+same value across all replicas of a shard once async replication has settled. This
+plan uses that to back up each converged shard from **one** replica, while shards that
+cannot be proven identical fall back to today's all-replica behavior.
+
+**Outcome:** an opt-in `dedupeReplicas` backup mode that, for converged shards, stores a
+single copy and — at restore — fans that copy out to every replica node so the restored
+cluster is fully replicated immediately.
+
+### Locked design decisions
+1. **Restore = fan out.** The single archived shard copy is restored to every node in
+   that shard's `BelongsToNodes`. No reliance on post-restore async-rep healing.
+2. **Non-converged shards = per-shard fallback.** Converged shards use one replica;
+   shards that don't converge within a timeout back up all their replicas (today's
+   behavior). Backup always succeeds and is always complete.
+3. **Opt-in.** New backup-request flag `dedupeReplicas` (default false). Existing
+   backup/restore behavior is byte-for-byte unchanged when the flag is off.
+
+## Async-checkpoint API this builds on (already implemented)
+
+- `DB.CreateAsyncCheckpoints(ctx, className, cutoffMs, shards) error` — best-effort fan-out.
+- `DB.GetAsyncCheckpointNodeStatuses(ctx, className, shards) (map[shard][]replica.AsyncCheckpointNodeStatus, error)`.
+- `DB.DeleteAsyncCheckpoints(ctx, className, shards) error` — idempotent.
+- `replica.AsyncCheckpointNodeStatus{ Node string; CutoffMs int64; CreatedAt time.Time; Root hashtree.Digest }`.
+- A shard is **converged** when every node entry reports an identical non-zero `Root`
+  digest AND identical `CreatedAt`. (`Root == hashtree.Digest{}` ⇒ no active checkpoint.)
+- DB methods live in `adapters/repos/db/replication.go` (~L262–282).
+
+## Implementation
+
+### 1. Opt-in flag (`dedupeReplicas`)
+
+- `openapi-specs/schema.json` → `BackupConfig`: add `"DedupeReplicas": {"type": "boolean", "default": false, "x-nullable": false}`.
+- Run `./tools/gen-code-from-swagger.sh` to regenerate `entities/models/backup_config.go`.
+- Thread it: REST backup handler → `backup.Request` (`usecases/backup/transport.go`,
+  add `DedupeReplicas bool`) → `coordinator.Backup`.
+- `planDesignatedShards` (below) only runs when `req.DedupeReplicas` is true.
+
+### 2. Protocol change — per-class shard allowlist
+
+`backup.NodeDescriptor` (`entities/backup/descriptor.go:36`) carries only `Classes []string`.
+Add an optional, wire-compatible field:
+
+```go
+// nil ⇒ back up all local shards (legacy behavior)
+ShardAllowList map[string][]string `json:"shardAllowList,omitempty"` // class -> shards this node archives
+```
+
+- Add the parallel field to `Request` (`usecases/backup/transport.go`), populated when the
+  coordinator fills `reqChan` in `canCommit` (`coordinator.go` ~L491+) from each group's
+  allowlist.
+- Node consults it in `Index.descriptor` → `readSchema` (`adapters/repos/db/backup.go:748-766`):
+  after the existing `IsLocalShard` filter, if an allowlist exists for the class, intersect
+  the local shard set with it. Thread the allowlist from `Request` → `Handler.OnCanCommit`
+  (`usecases/backup/handler.go`) → `DB.BackupDescriptors` → `idx.descriptor`.
+- Old coordinator sends nil ⇒ unchanged. Old node ignores the field ⇒ degrades to
+  all-replica (safe, just not deduped) — but version-gate in §6.
+
+### 3. Backup-side orchestration (Coordinator)
+
+New method `planDesignatedShards(ctx, classes, cutoffMs)` called inside `coordinator.Backup`
+(`usecases/backup/coordinator.go:163`) **before** `canCommit` (L198) — convergence polling
+must not run inside the 8s `_TimeoutCanCommit` budget.
+
+Steps:
+- **(a) Create checkpoints.** For each requested class, read sharding state (extend the
+  `Selector` interface, `coordinator.go:68`, with `ShardingState(ctx, class) (*sharding.State, error)`
+  backed by `DB.schemaReader`). Skip classes where every `Physical[shard].BelongsToNodes`
+  has len ≤ 1 (RF=1 — no-op). For replicated classes call `DB.CreateAsyncCheckpoints`.
+  The coordinator needs the async-checkpoint API: add an `AsyncCheckpointer` interface
+  (the three `replication.go` methods), implemented by `*DB`, injected alongside `selector`.
+- **(b) Poll convergence.** Loop `GetAsyncCheckpointNodeStatuses` with a bounded budget
+  (new const, e.g. `_TimeoutCheckpointConverge = 2 * time.Minute`, poll ~5s, `select` on
+  `ctx.Done()`).
+- **(c) Designate.** For each converged shard pick a deterministic node:
+  `slices.Sort(BelongsToNodes)[0]` (sorted-first ⇒ stable across coordinator restarts).
+  Build `map[class]map[shard]designatedNode`.
+- **(d) Non-converged shards** are left out of the map ⇒ fall through to all-replica.
+- **(e) Cleanup.** `DeleteAsyncCheckpoints` for every class must run on **all** exit
+  paths: the `canCommit` error return (`coordinator.go:199-201`) and the end of the async
+  `commit` goroutine `f` (L220-234). Put the delete in `f`'s `defer` block plus the early
+  error returns. Idempotency makes double-delete safe.
+
+Then `groupByShard` (`coordinator.go:804`): for designated shards add **only** the
+designated node to that class's group and populate `ShardAllowList`; non-designated nodes
+get the shard removed from their allowlist. The leader-backs-up-all rule (~L828) must also
+honor the allowlist.
+
+### 4. Descriptor metadata for fan-out
+
+No new descriptor field strictly required:
+- `ShardDescriptor.Node` (`entities/backup/descriptor.go:249`) already records which single
+  node archived the copy — the fan-out **source**.
+- `ClassDescriptor.ShardingState` carries serialized `sharding.State` with `BelongsToNodes`
+  per shard — the fan-out **target list**.
+
+Optionally add `ShardDescriptor.DedupedReplicas bool` for explicit validation/clarity;
+it is derivable, so treat as nice-to-have.
+
+### 5. Restore-side fan-out
+
+Today each node restores from `{backupID}/{itsOwnNodeName}/`. For a deduped shard archived
+under node X, replica nodes Y and Z must read X's archive prefix.
+
+- Restore must fan to **all** `BelongsToNodes` regardless of who archived: in the restore
+  `canCommit` path (`coordinator.Restore`, `coordinator.go:240+`), every node in a shard's
+  `BelongsToNodes` becomes a restore participant.
+- Hook in `restorer.restoreOne` (`usecases/backup/restorer.go:214`): split per-shard. For
+  each `ShardDescriptor`, if the executing node `r.node` is in `BelongsToNodes` but
+  `ShardDescriptor.Node != r.node`, build the `nodeStore`/`fileWriter` pointing at
+  `{backupID}/{ShardDescriptor.Node}/` instead of the node's own prefix. `newFileWriter`
+  (`restorer.go:229`) takes one `store` today — make it select the store per shard.
+- Run fan-out target node names through `DistributedBackupDescriptor.ToMappedNodeName`
+  (`descriptor.go:150`) so `NodeMapping` still works.
+
+**Risk:** the `{backupID}/{nodeName}/` layout assumes a node reads only its own subtree;
+cross-node prefix reads are new. Confirm the object-store backend (`BackupBackend`) allows
+any node to list/read another node's prefix (same bucket — should be fine, but verify path
+sanitization / no per-node ACL).
+
+### 6. Edge cases
+
+- **RF=1**: detected in `planDesignatedShards`; skip checkpoints entirely, behavior unchanged.
+- **Multi-tenancy**: each tenant is a `Physical` shard with its own `BelongsToNodes`; the
+  per-shard designation map handles tenants naturally. Inactive/FROZEN tenants have no
+  checkpoint ⇒ treated as non-converged ⇒ all-replica fallback.
+- **Backup aborted mid-flight**: checkpoint cleanup via the `defer` in goroutine `f` and the
+  abort path; `DeleteAsyncCheckpoints` is idempotent.
+- **Replica node down during backup**: never reports checkpoint status ⇒ shard never
+  converges ⇒ all-replica fallback (a down node also can't be backed up — pre-existing).
+- **Topology change before restore**: archived `BelongsToNodes` is stale; map via
+  `ToMappedNodeName`. If the restore cluster has fewer nodes than `BelongsToNodes`, fan-out
+  restores to the available subset — document as a known gap (no post-restore healing exists
+  today, so a deduped restore into a smaller cluster is under-replicated until manual repair).
+- **Version skew**: gate `dedupeReplicas` on all participants supporting the new
+  `ShardAllowList` field — reuse the existing backup version/`ServerVersion` check; if any
+  participant is too old, reject the deduped backup with a clear error rather than silently
+  producing an all-replica backup.
+
+## Suggested PR / commit decomposition
+
+1. `Selector.ShardingState` + `AsyncCheckpointer` interface + `*DB` wiring (no behavior change).
+2. `NodeDescriptor.ShardAllowList` + `Request` field + `readSchema` allowlist filtering
+   (wire-compatible, default nil — fully backward compatible).
+3. `planDesignatedShards` + checkpoint create/poll/delete in `coordinator.Backup`;
+   `groupByShard` honors the designation map.
+4. Restore fan-out: per-shard store selection in `restorer`, all-`BelongsToNodes` restore
+   participants.
+5. `dedupeReplicas` opt-in flag: openapi + regenerated models + REST threading + version gate.
+6. Acceptance test + docs.
+
+## Files to modify
+
+| File | Change |
+|---|---|
+| `openapi-specs/schema.json` | `BackupConfig.DedupeReplicas` flag |
+| `entities/models/backup_config.go` | regenerated |
+| `usecases/backup/transport.go` | `Request.DedupeReplicas`, `Request.ShardAllowList` |
+| `entities/backup/descriptor.go` | `NodeDescriptor.ShardAllowList` (+ optional `ShardDescriptor.DedupedReplicas`) |
+| `usecases/backup/coordinator.go` | `planDesignatedShards`, `Selector.ShardingState`, `AsyncCheckpointer`, `groupByShard`, restore participant fan-out |
+| `usecases/backup/handler.go` | thread allowlist into `OnCanCommit` |
+| `usecases/backup/restorer.go` | per-shard store selection in `restoreOne`/`newFileWriter` |
+| `adapters/repos/db/backup.go` | `readSchema` allowlist filter; implement `Selector.ShardingState` + `AsyncCheckpointer` |
+| REST backup handler (`adapters/handlers/rest/.../backups`) | accept + thread `dedupeReplicas` |
+
+## Verification
+
+**Unit**
+- Convergence predicate: identical `Root`+`CreatedAt` ⇒ converged; zero digest or mismatch ⇒ not.
+- Deterministic designated-node pick (sorted-first).
+- `readSchema` allowlist filtering (nil ⇒ all; subset ⇒ filtered).
+- `groupByShard` with a mix of converged and non-converged shards.
+- `DistributedBackupDescriptor` JSON round-trip with the new field read by old/new decoders.
+
+**Acceptance** — extend `test/acceptance/replication/async_replication/` (3-node testcontainer):
+- RF=3 collection, wait for async-rep convergence, backup with `dedupeReplicas=true`:
+  assert backup ≈ 1/3 size and exactly one node subtree per shard.
+- Restore, then assert all 3 nodes serve identical data (fan-out worked).
+- Non-converged variant: write continuously during backup ⇒ assert all-replica fallback
+  for the still-moving shards.
+- Restart the coordinator mid-backup ⇒ assert checkpoints are cleaned up (no stragglers
+  via `GetAsyncCheckpointStatus`).
+
+**Local gates** before each push: `go build ./...`, `go vet ./...`,
+`./tools/linter_go_routines.sh`, `golangci-lint run ./usecases/backup/... ./adapters/repos/db/...`.

--- a/test/acceptance/replication/common/crud_ops.go
+++ b/test/acceptance/replication/common/crud_ops.go
@@ -33,9 +33,9 @@ import (
 	graphqlhelper "github.com/weaviate/weaviate/test/helper/graphql"
 )
 
-// stopNodeAt stops the node container at the given index.
+// StopNodeAt stops the node container at the given index.
 //
-// NOTE: the index is 1-based, so stopping the first node requires index=1, not 0
+// NOTE: the index is 0-based, so stopping the first node requires index=0.
 func StopNodeAt(ctx context.Context, t *testing.T, compose *docker.DockerCompose, index int) {
 	<-time.After(1 * time.Second)
 	if err := compose.StopAt(ctx, index, nil); err != nil {
@@ -46,6 +46,10 @@ func StopNodeAt(ctx context.Context, t *testing.T, compose *docker.DockerCompose
 	<-time.After(1 * time.Second) // give time for shutdown
 }
 
+// StopNodeAtWithTimeout is StopNodeAt with an explicit graceful-shutdown
+// timeout (timeout=0 = SIGKILL).
+//
+// NOTE: the index is 0-based, so stopping the first node requires index=0.
 func StopNodeAtWithTimeout(ctx context.Context, t *testing.T, compose *docker.DockerCompose, index int, timeout time.Duration) {
 	<-time.After(1 * time.Second)
 	if err := compose.StopAt(ctx, index, &timeout); err != nil {
@@ -56,9 +60,30 @@ func StopNodeAtWithTimeout(ctx context.Context, t *testing.T, compose *docker.Do
 	<-time.After(1 * time.Second) // give time for shutdown
 }
 
+// WipeNodeDataAt simulates a data-loss event by deleting the persistence
+// directory contents inside the container at the given (0-based) index,
+// then SIGKILL-stops the container. The caller restarts via StartNodeAt
+// to bring the node back up with an empty data dir.
+//
+// The wipe is two-pronged: (1) rm -rf /data/* inside the live container
+// removes anything sitting in the writable layer; (2) when WithWeaviateTmpfsData
+// is set, the docker stop also unmounts the /data tmpfs, so even files
+// kept alive by weaviate's open fds disappear. SELF_RECOVERY tests rely
+// on (2) — without it, weaviate's writes between rm and SIGKILL race the
+// wipe and the post-restart /data is not empty.
+func WipeNodeDataAt(ctx context.Context, t *testing.T, compose *docker.DockerCompose, index int) {
+	t.Helper()
+	c, err := compose.ContainerAt(index)
+	require.NoError(t, err, "WipeNodeDataAt: container at index %d", index)
+	code, _, err := c.Container().Exec(ctx, []string{"sh", "-c", "rm -rf /data/*"})
+	require.NoError(t, err, "WipeNodeDataAt: exec rm -rf /data/* failed")
+	require.Equal(t, 0, code, "WipeNodeDataAt: rm -rf /data/* exited %d", code)
+	StopNodeAtWithTimeout(ctx, t, compose, index, 0)
+}
+
 // startNodeAt starts the node container at the given index.
 //
-// NOTE: the index is 1-based, so starting the first node requires index=1, not 0
+// NOTE: the index is 0-based, so starting the first node requires index=0.
 func StartNodeAt(ctx context.Context, t *testing.T, compose *docker.DockerCompose, index int) {
 	t.Helper()
 	if err := compose.StartAt(ctx, index); err != nil {

--- a/test/acceptance/selfrecovery/self_recovery_e2e_test.go
+++ b/test/acceptance/selfrecovery/self_recovery_e2e_test.go
@@ -1,0 +1,397 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package selfrecovery
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	batchclient "github.com/weaviate/weaviate/client/batch"
+	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/client/replication"
+	"github.com/weaviate/weaviate/cluster/router/types"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/test/acceptance/replication/common"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+// forceRaftSnapshot POSTs to the node-local /debug/raft/snapshot
+// endpoint, which calls raft.Snapshot() synchronously. Used by the
+// e2e tests to guarantee a snapshot exists before wiping a peer, so
+// the wiped node's rejoin goes through InstallSnapshot → Restore →
+// reloadDBFromSchema → the SELF_RECOVERY hook.
+//
+// Requires WithWeaviateWithDebugPort() on the compose builder —
+// /debug/* routes are served on port 6060 (the profiling port), not
+// on the main API port.
+func forceRaftSnapshot(ctx context.Context, t *testing.T, compose *docker.DockerCompose, idx int) {
+	t.Helper()
+	c, err := compose.ContainerAt(idx)
+	require.NoError(t, err, "forceRaftSnapshot[%d]: container", idx)
+	uri := c.DebugURI()
+	require.NotEmpty(t, uri, "forceRaftSnapshot[%d]: empty DebugURI (did you call WithWeaviateWithDebugPort?)", idx)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		"http://"+uri+"/debug/raft/snapshot", nil)
+	require.NoError(t, err, "forceRaftSnapshot[%d]: build request", idx)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err, "forceRaftSnapshot[%d]: do request", idx)
+	defer resp.Body.Close()
+	require.Less(t, resp.StatusCode, 300, "forceRaftSnapshot[%d]: status %d", idx, resp.StatusCode)
+}
+
+// TestSelfRecoveryEndToEnd boots a 3-node cluster with the SELF_RECOVERY
+// feature enabled, ingests data into a single-shard RF=3 collection,
+// wipes the data dir on node-3, restarts it, and verifies the shard is
+// re-hydrated automatically from a peer with full object count.
+//
+// It also asserts cluster reads at consistency=ONE keep working
+// throughout the recovery window (the recovering replica is excluded
+// from the eligible set via the existing FSM filter).
+func TestSelfRecoveryEndToEnd(t *testing.T) {
+	mainCtx := context.Background()
+	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithWeaviateEnv("SELF_RECOVERY_ENABLED", "true").
+		WithWeaviateEnv("SELF_RECOVERY_CONCURRENCY", "2").
+		// Required to expose the /replication/* observability API
+		// (without it, list/details endpoints return 501).
+		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
+		// SELF_RECOVERY only triggers from the snapshot-Restore path
+		// (see docs/self-recovery.md "Limitations"). Trim trailing
+		// logs so the leader has to send InstallSnapshot to a
+		// far-behind joiner. The test then POSTs to
+		// /debug/raft/snapshot before wipe to deterministically
+		// produce a snapshot — no timing dependency.
+		WithWeaviateEnv("RAFT_TRAILING_LOGS", "1").
+		WithWeaviateWithDebugPort(). // /debug/raft/snapshot lives on the profiling port
+		// Tmpfs at /data so WipeNodeDataAt's stop+start really
+		// empties the data dir (rm -rf via docker exec races with
+		// weaviate's own writes; tmpfs is auto-wiped on container
+		// stop).
+		WithWeaviateTmpfsData().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("terminate compose: %v", err)
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	const (
+		objCount = 500 // small enough that the test runs fast; large enough that recovery isn't trivial
+		// 0-based index into compose.d.containers; with no aux containers
+		// (contextionary etc.) a 3-node cluster has indices 0/1/2.
+		wipedIdx = 2
+	)
+	wipedNodeName := docker.Weaviate2
+	paragraphClass := articles.ParagraphsClass()
+
+	t.Run("wait for cluster to form quorum", func(t *testing.T) {
+		// docker compose returns once the containers are up, but the
+		// RAFT FSM may still be electing/joining. CreateClass with
+		// RF=3 fails with "1 available, 3 requested" until all 3
+		// nodes have joined.
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			body, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, 3, "expected 3 cluster nodes")
+			for _, n := range body.Payload.Nodes {
+				require.Equal(ct, "HEALTHY", *n.Status, "node %s status", n.Name)
+			}
+		}, 3*time.Minute, 1*time.Second)
+	})
+
+	t.Run("create RF=3 single-shard collection", func(t *testing.T) {
+		paragraphClass.ShardingConfig = map[string]interface{}{"desiredCount": 1}
+		// Async replication explicitly OFF so SELF_RECOVERY is the
+		// only path that can restore the data after the wipe. If
+		// the post-recovery object-count check passes, the recovery
+		// went through SELF_RECOVERY (not silent async-rep backfill).
+		paragraphClass.ReplicationConfig = &models.ReplicationConfig{Factor: 3, AsyncEnabled: false}
+		paragraphClass.Vectorizer = "none" // we don't run vector queries; avoid pulling in a vectorizer module
+		helper.CreateClass(t, paragraphClass)
+	})
+
+	t.Run("wait for shard placement on all 3 nodes", func(t *testing.T) {
+		// CreateClass returns before the shard is routable on every node.
+		// Without this wait, the first batch hits "shard not found" during
+		// the broadcast-to-all-replicas write path.
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			body, err := helper.Client(t).Nodes.NodesGetClass(
+				nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(paragraphClass.Class), nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, 3)
+			for _, n := range body.Payload.Nodes {
+				require.Equal(ct, "HEALTHY", *n.Status, "node %s status", n.Name)
+				require.Len(ct, n.Shards, 1, "node %s shard count", n.Name)
+			}
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("ingest objects", func(t *testing.T) {
+		batch := make([]*models.Object, objCount)
+		for i := 0; i < objCount; i++ {
+			batch[i] = articles.NewParagraph().
+				WithID(strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", i+1))).
+				WithContents(fmt.Sprintf("paragraph#%d", i)).
+				Object()
+		}
+		// Even after the shard appears in /nodes, the broadcast write
+		// path can race against per-replica shard registration. Retry
+		// on transient "shard not found".
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			params := batchclient.NewBatchObjectsCreateParams().WithBody(batchclient.BatchObjectsCreateBody{Objects: batch})
+			resp, err := helper.Client(t).Batch.BatchObjectsCreate(params, nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, resp)
+			for _, o := range resp.Payload {
+				if o.Result != nil && o.Result.Errors != nil && len(o.Result.Errors.Error) > 0 {
+					require.Failf(ct, "batch ingest had per-object errors", "%v", o.Result.Errors.Error[0].Message)
+				}
+			}
+		}, 30*time.Second, 1*time.Second, "batch ingest never succeeded")
+	})
+
+	t.Run("verify all 3 nodes report shard loaded", func(t *testing.T) {
+		// Note: ObjectCount in /nodes is async-updated and unreliable
+		// for immediate post-ingest assertions. Loaded=true is the
+		// signal we care about pre-wipe; full-count verification
+		// happens post-recovery via the recovery_completes subtest.
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			body, err := helper.Client(t).Nodes.NodesGetClass(
+				nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(paragraphClass.Class), nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, 3)
+			for _, n := range body.Payload.Nodes {
+				require.Len(ct, n.Shards, 1, "node %s shards", n.Name)
+				assert.True(ct, n.Shards[0].Loaded, "node %s loaded", n.Name)
+			}
+		}, 30*time.Second, 500*time.Millisecond)
+	})
+
+	t.Run("force a RAFT snapshot before wipe", func(t *testing.T) {
+		// Self-recovery only fires from the snapshot-Restore path
+		// (see docs/self-recovery.md "Limitations"). Force a
+		// snapshot on every node so the wiped node's rejoin
+		// receives InstallSnapshot (not log replay) deterministically.
+		for i := 0; i < 3; i++ {
+			forceRaftSnapshot(ctx, t, compose, i)
+		}
+	})
+
+	t.Run("wipe node-3 data and restart", func(t *testing.T) {
+		common.WipeNodeDataAt(ctx, t, compose, wipedIdx)
+		common.StartNodeAt(ctx, t, compose, wipedIdx)
+		// Re-point the helper client at node-1 since node-3's port may have changed on restart.
+		helper.SetupClient(compose.GetWeaviate().URI())
+	})
+
+	// With async replication disabled on the class, the only path
+	// that can restore data on the wiped node is SELF_RECOVERY.
+
+	t.Run("a SELF_RECOVERY op was registered for node-3", func(t *testing.T) {
+		// Asserts the recovery actually went through the SELF_RECOVERY
+		// path (not silent async-rep backfill, which is disabled on
+		// the class anyway).
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			body, err := helper.Client(t).Replication.ListReplication(
+				replication.NewListReplicationParams().WithTargetNode(&wipedNodeName), nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, body.Payload)
+			found := false
+			for _, op := range body.Payload {
+				if op.Type != nil && *op.Type == "SELF_RECOVERY" {
+					found = true
+					break
+				}
+			}
+			assert.True(ct, found, "expected at least one SELF_RECOVERY op for %s", wipedNodeName)
+		}, 2*time.Minute, 1*time.Second, "no SELF_RECOVERY op observed for the wiped node")
+	})
+
+	t.Run("recovery completes and node-3 reports full object count", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			body, err := helper.Client(t).Nodes.NodesGetClass(
+				nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(paragraphClass.Class), nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, body.Payload)
+			for _, n := range body.Payload.Nodes {
+				if n.Name != wipedNodeName {
+					continue
+				}
+				require.Len(ct, n.Shards, 1)
+				assert.True(ct, n.Shards[0].Loaded, "node-3 shard should be loaded after recovery")
+				assert.Equal(ct, int64(objCount), n.Shards[0].ObjectCount, "node-3 object count after recovery")
+			}
+		}, 5*time.Minute, 2*time.Second, "node-3 did not report full object count after recovery")
+	})
+
+	t.Run("direct query to node-3 returns full data at consistency=ONE", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			for i := 0; i < 10; i++ { // sample, not exhaustive
+				id := strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", i+1))
+				exists, err := common.ObjectExistsCL(t, compose.ContainerURI(wipedIdx), paragraphClass.Class, id, types.ConsistencyLevelOne)
+				assert.NoError(ct, err)
+				assert.True(ct, exists, "object %s missing on node-3", id)
+			}
+		}, 30*time.Second, 1*time.Second, "node-3 sampled data not available at consistency=ONE")
+	})
+}
+
+// TestSelfRecoveryReadsContinueAtConsistencyONE complements the e2e
+// test: while node-3 is recovering, asserts that consistency=ONE reads
+// against the cluster never error (the recovering replica is filtered
+// out by the existing FSM-based router filter). Runs as a separate test
+// to keep the e2e test focused.
+func TestSelfRecoveryReadsContinueAtConsistencyONE(t *testing.T) {
+	mainCtx := context.Background()
+	ctx, cancel := context.WithTimeout(mainCtx, 15*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithWeaviateEnv("SELF_RECOVERY_ENABLED", "true").
+		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true"). // for /replication/* endpoints
+		// Same as TestSelfRecoveryEndToEnd: trim trailing logs so a
+		// far-behind joiner must receive InstallSnapshot. The test
+		// hits /debug/raft/snapshot before wipe.
+		WithWeaviateEnv("RAFT_TRAILING_LOGS", "1").
+		WithWeaviateWithDebugPort().
+		WithWeaviateTmpfsData().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("terminate compose: %v", err)
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	const (
+		objCount = 200
+		wipedIdx = 2 // 0-based: third weaviate
+	)
+	wipedNodeName := docker.Weaviate2
+	paragraphClass := articles.ParagraphsClass()
+	paragraphClass.ShardingConfig = map[string]interface{}{"desiredCount": 1}
+	// Async replication explicitly OFF: SELF_RECOVERY must be the
+	// only path that restores data on the wiped node.
+	paragraphClass.ReplicationConfig = &models.ReplicationConfig{Factor: 3, AsyncEnabled: false}
+	paragraphClass.Vectorizer = "none"
+
+	// Wait for the cluster to form quorum before issuing schema commands
+	// (CreateClass with RF=3 fails with "1 available, 3 requested" until
+	// every node has joined the RAFT FSM).
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		body, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+		require.NoError(ct, err)
+		require.NotNil(ct, body.Payload)
+		require.Len(ct, body.Payload.Nodes, 3, "expected 3 cluster nodes")
+		for _, n := range body.Payload.Nodes {
+			require.Equal(ct, "HEALTHY", *n.Status, "node %s status", n.Name)
+		}
+	}, 3*time.Minute, 1*time.Second)
+
+	helper.CreateClass(t, paragraphClass)
+
+	// Wait for the shard to appear on all nodes before ingesting (avoids
+	// "shard not found" races against the broadcast write path).
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		verbose := verbosity.OutputVerbose
+		body, err := helper.Client(t).Nodes.NodesGetClass(
+			nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(paragraphClass.Class), nil)
+		require.NoError(ct, err)
+		require.NotNil(ct, body.Payload)
+		require.Len(ct, body.Payload.Nodes, 3)
+		for _, n := range body.Payload.Nodes {
+			require.Equal(ct, "HEALTHY", *n.Status, "node %s status", n.Name)
+			require.Len(ct, n.Shards, 1, "node %s shard count", n.Name)
+		}
+	}, 30*time.Second, 500*time.Millisecond)
+
+	ids := make([]strfmt.UUID, objCount)
+	batch := make([]*models.Object, objCount)
+	for i := 0; i < objCount; i++ {
+		ids[i] = strfmt.UUID(fmt.Sprintf("11111111-1111-1111-1111-%012d", i+1))
+		batch[i] = articles.NewParagraph().WithID(ids[i]).WithContents(fmt.Sprintf("p#%d", i)).Object()
+	}
+	common.CreateObjects(t, compose.GetWeaviate().URI(), batch)
+
+	// Force a RAFT snapshot before wipe so the rejoin goes through
+	// InstallSnapshot. See forceRaftSnapshot for rationale.
+	for i := 0; i < 3; i++ {
+		forceRaftSnapshot(ctx, t, compose, i)
+	}
+
+	common.WipeNodeDataAt(ctx, t, compose, wipedIdx)
+	common.StartNodeAt(ctx, t, compose, wipedIdx)
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	// Hit node-1 with consistency=ONE while node-3 is recovering.
+	// Wait until node-3 finishes recovery; throughout, every probe
+	// must succeed.
+	deadline := time.Now().Add(5 * time.Minute)
+	probeCount := 0
+	for time.Now().Before(deadline) {
+		// Spot-check 5 random IDs; should always succeed via the 2 healthy replicas.
+		for _, id := range []strfmt.UUID{ids[0], ids[objCount/4], ids[objCount/2], ids[3*objCount/4], ids[objCount-1]} {
+			exists, err := common.ObjectExistsCL(t, compose.GetWeaviate().URI(), paragraphClass.Class, id, types.ConsistencyLevelOne)
+			require.NoError(t, err, "consistency=ONE probe failed during recovery (probe #%d, id=%s)", probeCount, id)
+			require.True(t, exists, "consistency=ONE probe missing object during recovery (probe #%d, id=%s)", probeCount, id)
+		}
+		probeCount++
+
+		// Check if node-3 has finished recovering (op READY).
+		body, err := helper.Client(t).Replication.ListReplication(
+			replication.NewListReplicationParams().WithTargetNode(&wipedNodeName), nil)
+		if err == nil && body != nil && body.Payload != nil {
+			doneCount := 0
+			selfRecoveryCount := 0
+			for _, op := range body.Payload {
+				if op.Type != nil && *op.Type == "SELF_RECOVERY" {
+					selfRecoveryCount++
+					if op.Status != nil && op.Status.State == "READY" {
+						doneCount++
+					}
+				}
+			}
+			if selfRecoveryCount > 0 && doneCount == selfRecoveryCount {
+				t.Logf("recovery complete after %d probes", probeCount)
+				return
+			}
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Fatalf("recovery did not finish within deadline; %d probes succeeded but op never reached READY", probeCount)
+}

--- a/test/acceptance/selfrecovery/self_recovery_logreplay_test.go
+++ b/test/acceptance/selfrecovery/self_recovery_logreplay_test.go
@@ -1,0 +1,336 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package selfrecovery
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	batchclient "github.com/weaviate/weaviate/client/batch"
+	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/client/replication"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/test/acceptance/replication/common"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+// hasSelfRecoveryOp reports whether the replication-op list for targetNode
+// contains a SELF_RECOVERY op.
+func hasSelfRecoveryOp(t *testing.T, targetNode string) (bool, error) {
+	body, err := helper.Client(t).Replication.ListReplication(
+		replication.NewListReplicationParams().WithTargetNode(&targetNode), nil)
+	if err != nil {
+		return false, err
+	}
+	for _, op := range body.Payload {
+		if op.Type != nil && *op.Type == "SELF_RECOVERY" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// TestSelfRecoveryViaLogReplay verifies self-recovery fires for a wiped node
+// that rejoins purely via RAFT log replay — no snapshot is ever produced
+// (default RAFT_SNAPSHOT_THRESHOLD/RAFT_TRAILING_LOGS, no /debug/raft/snapshot
+// call). It also pins the negatives: creating a fresh collection on a healthy
+// cluster, and a plain restart with data intact, must never trigger recovery.
+func TestSelfRecoveryViaLogReplay(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithWeaviateEnv("SELF_RECOVERY_ENABLED", "true").
+		WithWeaviateEnv("SELF_RECOVERY_CONCURRENCY", "2").
+		// Required to expose the /replication/* observability API.
+		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
+		// NOTE: deliberately no RAFT_TRAILING_LOGS override and no forced
+		// snapshot. With defaults the leader keeps the whole (tiny,
+		// schema-only) RAFT log, so a wiped node rejoins by replaying
+		// committed log entries — never InstallSnapshot. This is exactly
+		// the path the older e2e test could not cover.
+		WithWeaviateTmpfsData(). // tmpfs /data so a stop+start truly wipes the dir
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("terminate compose: %v", err)
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	const (
+		objCount = 500
+		wipedIdx = 2 // container index; node name docker.Weaviate2
+	)
+	wipedNodeName := docker.Weaviate2
+	paragraphClass := articles.ParagraphsClass()
+
+	t.Run("wait for cluster to form quorum", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			body, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, 3)
+			for _, n := range body.Payload.Nodes {
+				require.Equal(ct, "HEALTHY", *n.Status, "node %s status", n.Name)
+			}
+		}, 3*time.Minute, 1*time.Second)
+	})
+
+	t.Run("create RF=3 single-shard collection and ingest", func(t *testing.T) {
+		paragraphClass.ShardingConfig = map[string]interface{}{"desiredCount": 1}
+		// Async replication OFF: SELF_RECOVERY is then the only path that
+		// can restore the wiped node's data.
+		paragraphClass.ReplicationConfig = &models.ReplicationConfig{Factor: 3, AsyncEnabled: false}
+		paragraphClass.Vectorizer = "none"
+		helper.CreateClass(t, paragraphClass)
+
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			body, err := helper.Client(t).Nodes.NodesGetClass(
+				nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(paragraphClass.Class), nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, 3)
+			for _, n := range body.Payload.Nodes {
+				require.Len(ct, n.Shards, 1, "node %s shard count", n.Name)
+			}
+		}, 30*time.Second, 500*time.Millisecond)
+
+		batch := make([]*models.Object, objCount)
+		for i := 0; i < objCount; i++ {
+			batch[i] = articles.NewParagraph().
+				WithID(strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", i+1))).
+				WithContents(fmt.Sprintf("paragraph#%d", i)).
+				Object()
+		}
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			params := batchclient.NewBatchObjectsCreateParams().WithBody(
+				batchclient.BatchObjectsCreateBody{Objects: batch})
+			resp, err := helper.Client(t).Batch.BatchObjectsCreate(params, nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, resp)
+			for _, o := range resp.Payload {
+				if o.Result != nil && o.Result.Errors != nil && len(o.Result.Errors.Error) > 0 {
+					require.Failf(ct, "batch ingest had per-object errors", "%v", o.Result.Errors.Error[0].Message)
+				}
+			}
+		}, 30*time.Second, 1*time.Second, "batch ingest never succeeded")
+	})
+
+	// NEGATIVE: creating a fresh collection on a healthy running cluster is a
+	// runtime create — every replica builds an empty shard folder, so the
+	// load-time "folder missing" signal never appears. No node may register
+	// a SELF_RECOVERY op for it.
+	t.Run("creating a collection on a healthy cluster does not recover", func(t *testing.T) {
+		fresh := articles.ArticlesClass()
+		fresh.ShardingConfig = map[string]interface{}{"desiredCount": 1}
+		fresh.ReplicationConfig = &models.ReplicationConfig{Factor: 3, AsyncEnabled: false}
+		fresh.Vectorizer = "none"
+		helper.CreateClass(t, fresh)
+
+		for _, node := range []string{docker.Weaviate0, docker.Weaviate1, docker.Weaviate2} {
+			node := node
+			assert.Never(t, func() bool {
+				found, _ := hasSelfRecoveryOp(t, node)
+				return found
+			}, 10*time.Second, 1*time.Second,
+				"unexpected SELF_RECOVERY op for %s after a runtime collection create", node)
+		}
+	})
+
+	t.Run("wipe node-3 data and restart (rejoins via log replay)", func(t *testing.T) {
+		common.WipeNodeDataAt(ctx, t, compose, wipedIdx)
+		common.StartNodeAt(ctx, t, compose, wipedIdx)
+		helper.SetupClient(compose.GetWeaviate().URI())
+	})
+
+	// POSITIVE: the wiped node rejoined via log replay (no snapshot). The
+	// startup DB-load pass must see the missing shard folder and recover it.
+	t.Run("a SELF_RECOVERY op fires for the wiped node", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			found, err := hasSelfRecoveryOp(t, wipedNodeName)
+			require.NoError(ct, err)
+			assert.True(ct, found, "expected a SELF_RECOVERY op for %s", wipedNodeName)
+		}, 3*time.Minute, 1*time.Second, "no SELF_RECOVERY op observed for the wiped node")
+	})
+
+	t.Run("recovery completes and the wiped node reports full object count", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			body, err := helper.Client(t).Nodes.NodesGetClass(
+				nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(paragraphClass.Class), nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, body.Payload)
+			for _, n := range body.Payload.Nodes {
+				if n.Name != wipedNodeName {
+					continue
+				}
+				require.Len(ct, n.Shards, 1)
+				assert.True(ct, n.Shards[0].Loaded, "wiped node shard loaded after recovery")
+				assert.Equal(ct, int64(objCount), n.Shards[0].ObjectCount,
+					"wiped node object count after recovery")
+			}
+		}, 5*time.Minute, 2*time.Second, "wiped node did not report full object count after recovery")
+	})
+
+	// NOTE: a "plain restart with data intact does not recover" negative
+	// cannot be expressed here: this cluster mounts /data as tmpfs (see
+	// WithWeaviateTmpfsData), so every container stop drops the data — there
+	// is no intact restart. That a node with prior RAFT state is never
+	// treated as a wiped joiner is covered by the unit test
+	// TestNoteWipedJoinerProgress ("node with prior state is excluded").
+}
+
+// TestSelfRecoveryViaLogReplayMultiTenant verifies the same log-replay
+// recovery for multi-tenant tenant shards: the startup DB-load pass rebuilds
+// the index from the caught-up schema and iterates every HOT tenant shard, so
+// a wiped node recovers all of its tenant shards.
+func TestSelfRecoveryViaLogReplayMultiTenant(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithWeaviateEnv("SELF_RECOVERY_ENABLED", "true").
+		WithWeaviateEnv("SELF_RECOVERY_CONCURRENCY", "2").
+		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true").
+		WithWeaviateTmpfsData().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("terminate compose: %v", err)
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+
+	const (
+		wipedIdx      = 2
+		objsPerTenant = 50
+	)
+	wipedNodeName := docker.Weaviate2
+	tenants := []string{"tenantA", "tenantB", "tenantC"}
+	mtClass := articles.ParagraphsClass()
+
+	t.Run("wait for cluster to form quorum", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			body, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, 3)
+			for _, n := range body.Payload.Nodes {
+				require.Equal(ct, "HEALTHY", *n.Status, "node %s status", n.Name)
+			}
+		}, 3*time.Minute, 1*time.Second)
+	})
+
+	t.Run("create RF=3 multi-tenant collection with HOT tenants", func(t *testing.T) {
+		mtClass.MultiTenancyConfig = &models.MultiTenancyConfig{Enabled: true}
+		mtClass.ReplicationConfig = &models.ReplicationConfig{Factor: 3, AsyncEnabled: false}
+		mtClass.Vectorizer = "none"
+		helper.CreateClass(t, mtClass)
+
+		ts := make([]*models.Tenant, len(tenants))
+		for i, name := range tenants {
+			ts[i] = &models.Tenant{Name: name, ActivityStatus: "HOT"}
+		}
+		helper.CreateTenants(t, mtClass.Class, ts)
+	})
+
+	t.Run("ingest objects per tenant", func(t *testing.T) {
+		for _, tenant := range tenants {
+			batch := make([]*models.Object, objsPerTenant)
+			for i := 0; i < objsPerTenant; i++ {
+				batch[i] = articles.NewParagraph().
+					WithContents(fmt.Sprintf("%s#%d", tenant, i)).
+					WithTenant(tenant).
+					Object()
+			}
+			require.EventuallyWithT(t, func(ct *assert.CollectT) {
+				params := batchclient.NewBatchObjectsCreateParams().WithBody(
+					batchclient.BatchObjectsCreateBody{Objects: batch})
+				resp, err := helper.Client(t).Batch.BatchObjectsCreate(params, nil)
+				require.NoError(ct, err)
+				require.NotNil(ct, resp)
+				for _, o := range resp.Payload {
+					if o.Result != nil && o.Result.Errors != nil && len(o.Result.Errors.Error) > 0 {
+						require.Failf(ct, "batch ingest errors", "%v", o.Result.Errors.Error[0].Message)
+					}
+				}
+			}, 30*time.Second, 1*time.Second, "tenant %s ingest never succeeded", tenant)
+		}
+	})
+
+	// NEGATIVE: creating and activating tenants on a healthy cluster is a
+	// runtime create — each replica builds the tenant-shard folder, so the
+	// load-time "folder missing" signal never appears. No node may register
+	// a SELF_RECOVERY op for it.
+	t.Run("creating tenants on a healthy cluster does not recover", func(t *testing.T) {
+		for _, node := range []string{docker.Weaviate0, docker.Weaviate1, docker.Weaviate2} {
+			node := node
+			assert.Never(t, func() bool {
+				found, _ := hasSelfRecoveryOp(t, node)
+				return found
+			}, 10*time.Second, 1*time.Second,
+				"unexpected SELF_RECOVERY op for %s after runtime tenant creation", node)
+		}
+	})
+
+	t.Run("wipe node-3 data and restart (rejoins via log replay)", func(t *testing.T) {
+		common.WipeNodeDataAt(ctx, t, compose, wipedIdx)
+		common.StartNodeAt(ctx, t, compose, wipedIdx)
+		helper.SetupClient(compose.GetWeaviate().URI())
+	})
+
+	t.Run("SELF_RECOVERY ops fire for the wiped node's tenant shards", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			found, err := hasSelfRecoveryOp(t, wipedNodeName)
+			require.NoError(ct, err)
+			assert.True(ct, found, "expected SELF_RECOVERY ops for %s tenant shards", wipedNodeName)
+		}, 3*time.Minute, 1*time.Second, "no SELF_RECOVERY op observed for the wiped node")
+	})
+
+	t.Run("recovery completes and the wiped node reports all tenant shards", func(t *testing.T) {
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			verbose := verbosity.OutputVerbose
+			body, err := helper.Client(t).Nodes.NodesGetClass(
+				nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(mtClass.Class), nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, body.Payload)
+			for _, n := range body.Payload.Nodes {
+				if n.Name != wipedNodeName {
+					continue
+				}
+				require.Len(ct, n.Shards, len(tenants), "wiped node tenant-shard count")
+				for _, s := range n.Shards {
+					assert.True(ct, s.Loaded, "tenant shard %s loaded after recovery", s.Name)
+					assert.Equal(ct, int64(objsPerTenant), s.ObjectCount,
+						"tenant shard %s object count after recovery", s.Name)
+				}
+			}
+		}, 5*time.Minute, 2*time.Second, "wiped node did not recover all tenant shards")
+	})
+}

--- a/test/acceptance/selfrecovery/self_recovery_smoke_test.go
+++ b/test/acceptance/selfrecovery/self_recovery_smoke_test.go
@@ -1,0 +1,185 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+// Package selfrecovery contains acceptance tests for the SELF_RECOVERY
+// shard re-hydration flow (see plan: cluster/replication/selfrecovery).
+//
+// This file holds the foundational smoke test that boots a cluster with
+// the feature flag enabled and verifies the wiring is in place:
+//   - The accept-empty debug endpoint is reachable and 404s for an
+//     unknown (collection, shard).
+//   - The restart debug endpoint 409s for a shard whose live directory
+//     already exists.
+//   - With the feature flag off, none of the /debug/self-recovery/*
+//     endpoints (nor the test-only /debug/raft/snapshot) are registered.
+//
+// The full data-loss-and-restore scenarios from the plan
+// (single-shard recovery, mass recovery with bounded concurrency, resume
+// after crash, consistency=QUORUM/ALL correctness, all-peers-wiped
+// catastrophe, multi-tenancy, lazy-load interaction, source pause stall,
+// operator cancel, etc.) require volume-management infrastructure
+// (`docker volume rm` mid-test or in-container `rm -rf`) that the
+// existing test/docker harness does not yet expose. Those scenarios are
+// tracked as follow-ups; this scaffold gives them a home to land in.
+package selfrecovery
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/client/nodes"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/verbosity"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+	"github.com/weaviate/weaviate/test/helper/sample-schema/articles"
+)
+
+func TestSelfRecoverySmokeWiring(t *testing.T) {
+	mainCtx := context.Background()
+	ctx, cancel := context.WithTimeout(mainCtx, 6*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().
+		WithWeaviateCluster(3).
+		WithWeaviateEnv("SELF_RECOVERY_ENABLED", "true").
+		WithWeaviateEnv("SELF_RECOVERY_CONCURRENCY", "2").
+		WithWeaviateEnv("REPLICA_MOVEMENT_ENABLED", "true"). // /replication/* observability (and RF>1 schema cmds)
+		WithWeaviateWithDebugPort().                         // /debug/self-recovery/* lives on the profiling port
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("terminate compose: %v", err)
+		}
+	}()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	debugURI := compose.GetWeaviate().DebugURI()
+	require.NotEmpty(t, debugURI, "DebugURI is empty — was WithWeaviateWithDebugPort() called?")
+
+	// Prometheus metrics live on a separate port (2112 by default,
+	// PROMETHEUS_MONITORING_ENABLED-gated) which the test/docker
+	// harness does not currently expose. Metric registration is
+	// covered by the unit test in cluster/replication/selfrecovery.
+
+	// accept-empty debug endpoint is reachable. We probe with a
+	// non-existent (collection, shard) and verify the endpoint responds
+	// with a 404 from the schema gate. Validates the handler is
+	// registered AND that the schema-error → 404 mapping is in place
+	// (rather than the generic 500 the handler used to return for
+	// validation failures).
+	t.Run("accept_empty_endpoint_is_reachable", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+			"http://"+debugURI+"/debug/self-recovery/accept-empty?collection=NoSuchClass&shard=NoSuchShard", nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusNotFound, resp.StatusCode,
+			"unknown class/shard should yield 404 (schema gate); got %d", resp.StatusCode)
+	})
+
+	// /restart on a shard whose live directory already exists must be
+	// rejected with 409 Conflict (recovery already completed / never
+	// happened — restarting would re-copy peer data over a healthy shard).
+	t.Run("restart_rejects_when_shard_is_live", func(t *testing.T) {
+		// Quorum must be formed before an RF=3 CreateClass succeeds.
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			body, err := helper.Client(t).Nodes.NodesGet(nodes.NewNodesGetParams(), nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, body.Payload)
+			require.Len(ct, body.Payload.Nodes, 3)
+			for _, n := range body.Payload.Nodes {
+				require.Equal(ct, "HEALTHY", *n.Status)
+			}
+		}, 3*time.Minute, 1*time.Second)
+
+		cls := articles.ParagraphsClass()
+		cls.ShardingConfig = map[string]interface{}{"desiredCount": 1}
+		cls.ReplicationConfig = &models.ReplicationConfig{Factor: 3, AsyncEnabled: false}
+		cls.Vectorizer = "none"
+		helper.CreateClass(t, cls)
+
+		// Resolve the (single) shard name once the shard is placed.
+		var shardName string
+		verbose := verbosity.OutputVerbose
+		assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+			body, err := helper.Client(t).Nodes.NodesGetClass(
+				nodes.NewNodesGetClassParams().WithOutput(&verbose).WithClassName(cls.Class), nil)
+			require.NoError(ct, err)
+			require.NotNil(ct, body.Payload)
+			require.NotEmpty(ct, body.Payload.Nodes)
+			require.NotEmpty(ct, body.Payload.Nodes[0].Shards)
+			shardName = body.Payload.Nodes[0].Shards[0].Name
+			require.NotEmpty(ct, shardName)
+		}, 30*time.Second, 500*time.Millisecond)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+			"http://"+debugURI+"/debug/self-recovery/restart?collection="+cls.Class+"&shard="+shardName, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		require.Equal(t, http.StatusConflict, resp.StatusCode,
+			"restart on a live shard must be 409; got %d (%s)", resp.StatusCode, string(bodyBytes))
+		require.Contains(t, strings.ToLower(string(bodyBytes)), "recovering",
+			"409 body should explain the shard is not recovering; got %q", string(bodyBytes))
+	})
+}
+
+// TestSelfRecoveryDebugEndpointsDisabledWhenFeatureOff verifies that the
+// /debug/self-recovery/* operator endpoints and the test-only
+// /debug/raft/snapshot endpoint are NOT registered when
+// SELF_RECOVERY_ENABLED is unset/false — they must not be a surface (even
+// on the profiling port) on a node that doesn't use the feature.
+func TestSelfRecoveryDebugEndpointsDisabledWhenFeatureOff(t *testing.T) {
+	mainCtx := context.Background()
+	ctx, cancel := context.WithTimeout(mainCtx, 4*time.Minute)
+	defer cancel()
+
+	compose, err := docker.New().
+		WithWeaviate(). // single node; feature flag deliberately NOT set
+		WithWeaviateWithDebugPort().
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() {
+		if err := compose.Terminate(ctx); err != nil {
+			t.Fatalf("terminate compose: %v", err)
+		}
+	}()
+
+	debugURI := compose.GetWeaviate().DebugURI()
+	require.NotEmpty(t, debugURI)
+
+	for _, path := range []string{
+		"/debug/self-recovery/accept-empty?collection=C&shard=S",
+		"/debug/self-recovery/restart?collection=C&shard=S",
+		"/debug/raft/snapshot",
+	} {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "http://"+debugURI+path, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		require.Equal(t, http.StatusNotFound, resp.StatusCode,
+			"%s must be 404 (handler not registered) when SELF_RECOVERY_ENABLED is off; got %d (%s)", path, resp.StatusCode, string(body))
+	}
+}

--- a/test/docker/compose.go
+++ b/test/docker/compose.go
@@ -126,6 +126,7 @@ type Compose struct {
 	withQnATransformers         bool
 	withWeaviateExposeGRPCPort  bool
 	withWeaviateExposeDebugPort bool
+	withWeaviateTmpfsData       bool
 	withSecondWeaviate          bool
 	withWeaviateCluster         bool
 	withWeaviateClusterSize     int
@@ -563,8 +564,26 @@ func (d *Compose) WithMCPConfigFile(hostPath, containerPath string) *Compose {
 }
 
 func (d *Compose) WithWeaviateWithDebugPort() *Compose {
-	d.With1NodeCluster()
+	// Only default to a 1-node cluster when the caller hasn't already
+	// configured a size — otherwise this would silently overwrite e.g.
+	// WithWeaviateCluster(3) and the test would end up with a 1-node
+	// "cluster" that fails RF=3 schema operations.
+	if !d.withWeaviateCluster {
+		d.With1NodeCluster()
+	}
 	d.withWeaviateExposeDebugPort = true
+	return d
+}
+
+// WithWeaviateTmpfsData mounts /data as a tmpfs in every weaviate
+// container. The tmpfs is wiped automatically when the container is
+// stopped (and remounted fresh on next start), giving tests true
+// data-loss semantics — required by SELF_RECOVERY tests because the
+// alternative (rm -rf /data/* via docker exec while weaviate is
+// running) races with weaviate's own writes (open fds + flushes
+// recreate files between rm and SIGKILL).
+func (d *Compose) WithWeaviateTmpfsData() *Compose {
+	d.withWeaviateTmpfsData = true
 	return d
 }
 
@@ -969,7 +988,7 @@ func (d *Compose) Start(ctx context.Context) (*DockerCompose, error) {
 		delete(secondWeaviateSettings, "RAFT_PORT")
 		delete(secondWeaviateSettings, "RAFT_INTERNAL_PORT")
 		delete(secondWeaviateSettings, "RAFT_JOIN")
-		container, err := startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule, envSettings, networkName, image, hostname, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, "/v1/.well-known/ready", d.weaviateFiles)
+		container, err := startWeaviate(ctx, d.enableModules, d.defaultVectorizerModule, envSettings, networkName, image, hostname, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, d.withWeaviateTmpfsData, "/v1/.well-known/ready", d.weaviateFiles)
 		if err != nil {
 			return nil, errors.Wrapf(err, "start %s", hostname)
 		}
@@ -1142,7 +1161,7 @@ func (d *Compose) startCluster(ctx context.Context, size int, settings map[strin
 			}
 			attemptCtx, cancel := context.WithTimeout(context.Background(), perAttemptTimeout)
 			c, err := startWeaviate(attemptCtx, d.enableModules, d.defaultVectorizerModule,
-				cfg, networkName, image, hostname, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, livenessEndpoint, d.weaviateFiles)
+				cfg, networkName, image, hostname, d.withWeaviateExposeGRPCPort, d.withWeaviateExposeDebugPort, d.withWeaviateTmpfsData, livenessEndpoint, d.weaviateFiles)
 			cancel()
 			if err == nil {
 				if attempt > 0 {

--- a/test/docker/weaviate.go
+++ b/test/docker/weaviate.go
@@ -38,7 +38,7 @@ func startWeaviate(ctx context.Context,
 	enableModules []string, defaultVectorizerModule string,
 	extraEnvSettings map[string]string, networkName string,
 	weaviateImage, hostname string,
-	exposeGRPCPort, exposeDebugPort bool,
+	exposeGRPCPort, exposeDebugPort, tmpfsData bool,
 	wellKnownEndpoint string,
 	files []testcontainers.ContainerFile,
 ) (*DockerContainer, error) {
@@ -138,6 +138,16 @@ func startWeaviate(ctx context.Context,
 		exposedPorts = append(exposedPorts, "6060/tcp")
 		waitStrategies = append(waitStrategies, wait.ForListeningPort(debugPort))
 	}
+	// Tmpfs at /data gives the test true wipe semantics: docker stop
+	// unmounts the tmpfs, dropping all writes; docker start gets a fresh
+	// (empty) tmpfs. Used by SELF_RECOVERY acceptance tests where the
+	// rm-while-alive approach lets weaviate's open-fd writes recreate
+	// files between rm and SIGKILL. Opt-in because the default behavior
+	// (writable layer at /data) is what most tests rely on.
+	var tmpfs map[string]string
+	if tmpfsData {
+		tmpfs = map[string]string{"/data": ""}
+	}
 	req := testcontainers.ContainerRequest{
 		FromDockerfile: fromDockerFile,
 		Image:          weaviateImage,
@@ -150,6 +160,7 @@ func startWeaviate(ctx context.Context,
 		WaitingFor:   wait.ForAll(waitStrategies...),
 		Env:          env,
 		Files:        files,
+		Tmpfs:        tmpfs,
 		LifecycleHooks: []testcontainers.ContainerLifecycleHooks{
 			{
 				// Use wait strategies as part of the lifecycle hooks as this gets propagated to the underlying container,

--- a/test/run.sh
+++ b/test/run.sh
@@ -54,6 +54,7 @@ function main() {
   run_acceptance_reindex_singlenode_b=false
   run_acceptance_reindex_concurrent=false
   run_acceptance_reindex_mt=false
+  run_acceptance_self_recovery=false
 
   while [[ "$#" -gt 0 ]]; do
       case $1 in
@@ -106,6 +107,7 @@ function main() {
           --acceptance-reindex-singlenode-b|-arsb) run_all_tests=false; run_acceptance_reindex_singlenode_b=true;;
           --acceptance-reindex-concurrent|-arc) run_all_tests=false; run_acceptance_reindex_concurrent=true;;
           --acceptance-reindex-mt|-armt) run_all_tests=false; run_acceptance_reindex_mt=true;;
+          --acceptance-self-recovery|-asr) run_all_tests=false; run_acceptance_self_recovery=true;;
           --benchmark-only|-b) run_all_tests=false; run_benchmark=true;;
           --cleanup) run_all_tests=false; run_cleanup=true;;
           --help|-h) printf '%s\n' \
@@ -149,6 +151,7 @@ function main() {
               "--acceptance-reindex-singlenode-b | -arsb"\
               "--acceptance-reindex-concurrent | -arc"\
               "--acceptance-reindex-mt | -armt"\
+              "--acceptance-self-recovery | -asr"\
               "--only-acceptance-{packageName}"
               "--only-module-{moduleName}"
               "--benchmark-only | -b" \
@@ -186,7 +189,7 @@ function main() {
     echo_green "Integration tests successful"
   fi
 
-  if $run_acceptance_tests  || $run_acceptance_only_fast_group_1 || $run_acceptance_only_fast_group_2 || $run_acceptance_only_fast_group_3 || $run_acceptance_only_fast_group_4 || $run_acceptance_only_authz || $run_acceptance_only_mcp || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_only_python || $run_all_tests || $run_benchmark || $run_acceptance_go_client_only_fast_group_1 || $run_acceptance_go_client_only_fast_group_2 || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $only_acceptance || $run_acceptance_objects
+  if $run_acceptance_tests  || $run_acceptance_only_fast_group_1 || $run_acceptance_only_fast_group_2 || $run_acceptance_only_fast_group_3 || $run_acceptance_only_fast_group_4 || $run_acceptance_only_authz || $run_acceptance_only_mcp || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_only_python || $run_all_tests || $run_benchmark || $run_acceptance_go_client_only_fast_group_1 || $run_acceptance_go_client_only_fast_group_2 || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $only_acceptance || $run_acceptance_objects || $run_acceptance_self_recovery
   then
     echo "Start docker container needed for acceptance and/or benchmark test"
     echo_green "Stop any running docker-compose containers..."
@@ -217,7 +220,7 @@ function main() {
       ./test/benchmark/run_performance_tracker.sh
     fi
 
-    if $run_acceptance_tests || $run_acceptance_only_fast_group_1 || $run_acceptance_only_fast_group_2 || $run_acceptance_only_fast_group_3 || $run_acceptance_only_fast_group_4 || $run_acceptance_only_authz || $run_acceptance_only_mcp || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_go_client_only_fast_group_1 || $run_acceptance_go_client_only_fast_group_2 || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $run_all_tests || $only_acceptance || $run_acceptance_objects
+    if $run_acceptance_tests || $run_acceptance_only_fast_group_1 || $run_acceptance_only_fast_group_2 || $run_acceptance_only_fast_group_3 || $run_acceptance_only_fast_group_4 || $run_acceptance_only_authz || $run_acceptance_only_mcp || $run_acceptance_go_client || $run_acceptance_graphql_tests || $run_acceptance_replication_tests || $run_acceptance_replica_replication_fast_tests || $run_acceptance_replica_replication_slow_tests || $run_acceptance_async_replication_tests || $run_acceptance_go_client_only_fast_group_1 || $run_acceptance_go_client_only_fast_group_2 || $run_acceptance_go_client_named_vectors_single_node || $run_acceptance_go_client_named_vectors_cluster || $run_all_tests || $only_acceptance || $run_acceptance_objects || $run_acceptance_self_recovery
     then
       echo_green "Run acceptance tests..."
       run_acceptance_tests "$@"
@@ -325,6 +328,11 @@ function main() {
   if $run_acceptance_reindex_mt; then
     echo "running reindex multi-tenant acceptance tests"
     run_acceptance_reindex_mt
+  fi
+
+  if $run_acceptance_self_recovery || $run_acceptance_tests || $run_all_tests; then
+    echo "running self-recovery acceptance tests"
+    run_acceptance_self_recovery
   fi
   echo "Done!"
 }
@@ -489,6 +497,7 @@ function get_fast_acceptance_packages() {
     | grep -v 'test/acceptance/reindex_concurrent' \
     | grep -v 'test/acceptance/reindex_mt' \
     | grep -v 'test/acceptance/distributed_tasks' \
+    | grep -v 'test/acceptance/selfrecovery' \
     | sed 's|.*/test/acceptance/|test/acceptance/|'
 }
 
@@ -834,6 +843,11 @@ function run_acceptance_reindex_mt() {
   # gated on this suite's duration.
   run_aof_group "reindex-mt" \
     test/acceptance/reindex_mt
+}
+
+function run_acceptance_self_recovery() {
+  build_weaviate_test_image
+  run_aof_group "self-recovery" test/acceptance/selfrecovery
 }
 
 # get_fast_go_client_packages returns a list of fast go client test packages.

--- a/usecases/config/environment.go
+++ b/usecases/config/environment.go
@@ -1003,6 +1003,26 @@ func FromEnv(config *Config) error {
 
 	config.Replication.AsyncReplicationDisabled = configRuntime.NewDynamicValue(entcfg.Enabled(os.Getenv("ASYNC_REPLICATION_DISABLED")))
 
+	config.Replication.SelfRecoveryEnabled = configRuntime.NewDynamicValue(entcfg.Enabled(os.Getenv("SELF_RECOVERY_ENABLED")))
+	if err := parseIntVerify(
+		"SELF_RECOVERY_CONCURRENCY",
+		DefaultSelfRecoveryConcurrency,
+		func(val int) {
+			config.Replication.SelfRecoveryConcurrency = configRuntime.NewDynamicValue(val)
+		},
+		func(val int, envName string) error {
+			if val <= 0 {
+				return fmt.Errorf("%s must be > 0, got %d", envName, val)
+			}
+			if val > MaxSelfRecoveryConcurrency {
+				return fmt.Errorf("%s must be <= %d, got %d", envName, MaxSelfRecoveryConcurrency, val)
+			}
+			return nil
+		},
+	); err != nil {
+		return err
+	}
+
 	if err := parseIntVerify(
 		"ASYNC_REPLICATION_SCHEDULER_WORKERS",
 		DefaultAsyncReplicationSchedulerWorkers,
@@ -1810,6 +1830,9 @@ const (
 	DefaultMaximumAllowedTenantsPerCollection      = -1 // unlimited
 	DefaultMaximumAllowedShardsPerCollection       = -1 // unlimited
 	DefaultUsageLimitsErrorMessage                 = "" // empty → usagelimits.RenderTemplate falls back to its built-in default
+	// SELF_RECOVERY shard-level concurrency cap and ceiling.
+	DefaultSelfRecoveryConcurrency = 10
+	MaxSelfRecoveryConcurrency     = 32
 )
 
 const VectorizerModuleNone = "none"

--- a/usecases/config/runtimeconfig.go
+++ b/usecases/config/runtimeconfig.go
@@ -66,6 +66,8 @@ type WeaviateRuntimeConfig struct {
 	UsagePolicyVersion                        *runtime.DynamicValue[string]        `json:"usage_policy_version" yaml:"usage_policy_version"`
 	UsageVerifyPermissions                    *runtime.DynamicValue[bool]          `json:"usage_verify_permissions" yaml:"usage_verify_permissions"`
 	ReplicationGRPCEnabled                    *runtime.DynamicValue[bool]          `json:"replication_grpc_enabled" yaml:"replication_grpc_enabled"`
+	SelfRecoveryEnabled                       *runtime.DynamicValue[bool]          `json:"self_recovery_enabled" yaml:"self_recovery_enabled"`
+	SelfRecoveryConcurrency                   *runtime.DynamicValue[int]           `json:"self_recovery_concurrency" yaml:"self_recovery_concurrency"`
 	ReplicatedIndicesRequestQueueEnabled      *runtime.DynamicValue[bool]          `json:"replicated_indices_request_queue_enabled" yaml:"replicated_indices_request_queue_enabled"`
 	OperationalMode                           *runtime.DynamicValue[string]        `json:"operational_mode" yaml:"operational_mode"`
 	DefaultQuantization                       *runtime.DynamicValue[string]        `yaml:"default_quantization" json:"default_quantization"`

--- a/usecases/schema/executor.go
+++ b/usecases/schema/executor.go
@@ -62,6 +62,12 @@ func (e *executor) Open(ctx context.Context) error {
 func (e *executor) ReloadLocalDB(ctx context.Context, all []api.UpdateClassRequest) error {
 	cs := make([]*models.Class, len(all))
 
+	// Tag the ctx so the SELF_RECOVERY hook (downstream in
+	// migrator.AddClass → initAndStoreShards) knows this AddClass is part
+	// of the startup DB-load pass for a pre-existing class, not a
+	// brand-new one. This pass runs regardless of whether the node caught
+	// its schema up via a RAFT snapshot install or via log replay.
+	ctx = enterrors.WithStartupDBLoad(ctx)
 	g, ctx := enterrors.NewErrorGroupWithContextWrapper(e.logger, ctx)
 	g.SetLimit(_NUMCPU * 2)
 


### PR DESCRIPTION
## What's being changed

Adds **shard self-recovery**: when a node restarts and discovers a shard's local directory is missing for shards the schema says it should host (e.g. wiped volume, fresh PVC, lost EBS volume), the data is auto-pulled from a healthy peer using a new `SELF_RECOVERY` replication transfer type.

Today, [`adapters/repos/db/shard_init.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/repos/db/shard_init.go) sees the missing dir, `MkdirAll`s an empty one, and reports the shard as `READY` — clients see empty results until async-replication slowly backfills object-by-object. With this PR, the shard is brought up via the same file-copy machinery as scale-out replication: bulk copy, CRC32-resume per file, atomic rename, and the existing FSM-based read filter excludes the recovering replica from cluster reads/writes for all consistency levels (`ONE`/`QUORUM`/`ALL`).

Disabled by default; opt in with `SELF_RECOVERY_ENABLED=true` after every node has been upgraded.

## Why a new transfer type instead of `COPY`

Three small but load-bearing differences from `COPY`:

| Aspect                        | `COPY` / `MOVE`                 | `SELF_RECOVERY`                   |
| ----------------------------- | ------------------------------- | --------------------------------- |
| Target node already a replica | Validator rejects               | Allowed (we *are* the replica)    |
| FINALIZING adds membership    | Yes (`AddReplicaToShard`)       | No (target already in BelongsTo)  |
| Triggered by                  | Operator scale plan             | Per-node startup hook (see below) |

The existing FSM, consumer, copier, source-pause/resume, retry/backoff, observability surfaces, and routing-filter machinery are all reused. The new code surface is concentrated in `cluster/replication/selfrecovery/` and a small set of hooks in `validate.go`, `consumer.go`, `copier.go`, and the startup path.

## Architecture

```
                                                     ┌──────────────────────┐
 startup (initAndStoreShards)                        │  RAFT FSM (existing) │
        │                                            │                      │
        ▼                                            │  ShardReplicationOp  │
 dir missing?                                        │  TransferType:       │
        │ yes                                        │   COPY | MOVE |      │
        ▼                                            │   SELF_RECOVERY      │
 RecoveringShard wrapper                             └──────────┬───────────┘
   (load-blocked until promoted)                                │
        │                                                       │
        ▼                                                  consumer
 selfrecovery.Orchestrator.Submit ──► RegisterSelfRecovery ──► (existing)
        │                              (skips scale-plan                │
        │                              membership guard)                ▼
        ▼                                                  copier writes to
 worker pool drains queue                                  <shard>.recovering/
   – probe peers in parallel                                       │
   – decide: copy / empty-fallback / retry                         ▼
                                                          PromoteRecoveryFolder
                                                            (atomic rename)
                                                                   │
                                                                   ▼
                                                          LoadLocalShard
                                                          (wrapper promotes)
```

## When the startup hook fires

Recovery is decided during the **startup DB-load pass** — the one-shot
`reloadDBFromSchema` -> `executor.ReloadLocalDB` that every node runs once it
has caught its schema up to the cluster's committed state. That pass tags its
context via `enterrors.WithStartupDBLoad`, which flows down through
`migrator.AddClass` -> `initAndStoreShards`; a missing shard dir seen during it
is routed to `SELF_RECOVERY` instead of being created empty. Runtime
collection/tenant creation on a healthy node carries no such tag, so the
orchestrator never speculatively wraps a shard the cluster also lacks.

The pass fires regardless of **how** the node caught its schema up:

- **Snapshot install** — RAFT installs a snapshot and the FSM restores it
  (`Restore` -> `reloadDBFromSchema`).
- **Log replay** — a node whose entire data dir (RAFT state included) was
  wiped rejoins a cluster that has not snapshotted, by replaying committed
  RAFT log entries. `Store` detects this case (started with no durable RAFT
  state, no prior DB index, and a committed backlog ahead of the first
  applied command — see `noteWipedJoinerProgress`), replays the schema
  catch-up *schema-only* so no shard folders are created mid-replay, and a
  watcher (`watchWipedJoinerCatchUp`) runs the DB-load pass once the node
  reaches the catch-up target. A fresh bootstrap, an intact-data restart, and
  a snapshot-restored node are each distinguished from a wiped log-replay
  joiner and are unaffected.

Both paths converge on the same `initAndStoreShards` iteration over the node's
HOT physical shards. For a wiped node that rebuilds its whole index from the
caught-up schema, that iteration includes **multi-tenant tenant shards**, so a
wiped node recovers every HOT tenant shard whose folder is missing.

The `POST /debug/raft/snapshot` admin endpoint remains, used by the
snapshot-path acceptance test to force a snapshot deterministically.

## Per-shard decision tree (orchestrator)

For each missing-dir shard at startup:

1. **Probe peers** in parallel via gRPC `FileReplicationService.ListFiles`, with a 5s per-peer timeout. Three outcomes:
   - **At least one peer has data** → register a `SELF_RECOVERY` op with that peer as source. Block until the op reaches `READY`.
   - **All probed peers definitively report empty** (gRPC `NotFound`) → create an empty `<shard>/` dir + log + metric. During the RAFT bootstrap window this is logged at `INFO` and counted in a separate metric (likely a class added during downtime, not data loss); after bootstrap it's logged at `WARN` and counted in `weaviate_self_recovery_no_data_empty_total` (catastrophic-wipe candidate).
   - **At least one peer unreachable, none have data** → exponential backoff and retry; never fall through to empty until an unambiguous answer is obtained.

2. **Worker pool** with bounded queue (size = `SELF_RECOVERY_CONCURRENCY`, default 10; queue capacity 1024). Overflow is dropped with a `WARN` log + `submit_dropped_total` metric. This caps memory regardless of N for very-large clusters with thousands of missing shards.

## Crash safety

The copier already uses per-file `.tmp` + `Fsync` + `Rename`; this PR adds an additional `os.Rename(<shard>.recovering, <shard>)` + parent-dir fsync at op completion. All crash points are idempotent:

- Crash mid-file → next startup resumes; CRC32 skips already-complete files.
- Crash after some files complete but before rename → `<shard>.recovering/` survives, dir still missing → recovery resumes.
- Crash after rename, before parent fsync → POSIX may lose the rename; next startup sees dir missing again and re-enters the same path.
- Crash after rename + parent fsync → normal load path.

## Operator-visible surface

### Feature flags

| Flag | Default | Purpose |
| --- | --- | --- |
| `SELF_RECOVERY_ENABLED` | `false` | Master toggle |
| `SELF_RECOVERY_CONCURRENCY` | `10` | Per-node parallelism |

`REPLICA_MOVEMENT_ENABLED=true` is also required so that the `/replication/replicate/list` observability endpoint is exposed.

### Status surfaces

- `GET /nodes?output=verbose` — shard reports `status: "RECOVERING"`, `loaded: false`.
- `GET /replication/replicate/list?targetNode=<self>` — in-flight `SELF_RECOVERY` op with state `REGISTERED`/`HYDRATING`/`FINALIZING`/`READY`.
- Structured logs with `event=self_recovery.{started|peer_probe|op_registered|completed|failed|empty_fallback|accept_empty|restart}`.

### Metrics (no `collection`/`shard` labels — wiped node would inflate cardinality)

| Metric | Type | Question it answers |
| --- | --- | --- |
| `weaviate_self_recovery_in_progress` | gauge | how many recoveries are running on this node |
| `weaviate_self_recovery_started_total` | counter (label: `source_node`) | how many were kicked off, by source peer |
| `weaviate_self_recovery_completed_total` | counter (label: `result`) | terminal outcomes |
| `weaviate_self_recovery_duration_seconds` | histogram (label: `result`) | end-to-end recovery time |
| `weaviate_self_recovery_no_data_empty_total` | counter | post-bootstrap empty-fallback (catastrophic-wipe candidate; **alert on this**) |
| `weaviate_self_recovery_no_data_during_bootstrap_total` | counter | bootstrap-window empty-fallback (likely a class added during downtime; informational) |
| `weaviate_self_recovery_unreachable_peer_total` | counter (label: `peer`) | peer reachability problems |
| `weaviate_self_recovery_giveup_total` | counter | retries exhausted |
| `weaviate_self_recovery_accept_empty_total` | counter | operator escape-hatch invocations |
| `weaviate_self_recovery_submit_dropped_total` | counter | submissions dropped because the in-process queue was full |

### Operator escape hatches

| Endpoint | When to use |
| --- | --- |
| `POST /replication/replicate/{id}/cancel` | abandon one in-flight op (any transfer type) |
| `POST /debug/self-recovery/restart?collection=X&shard=Y` | abandon current `SELF_RECOVERY` attempt, erase `.recovering/` state, start fresh (probe re-randomises source peer) |
| `POST /debug/self-recovery/accept-empty?collection=X&shard=Y` | declare "no recoverable data exists, accept empty shard"; rejected if the (collection, shard) is not in the schema |
| `POST /debug/raft/snapshot` | force an immediate local RAFT snapshot (test/ops helper; used by the acceptance tests to make the wiped-node rejoin go through `InstallSnapshot` deterministically) |

`Restart` is bounded by a 30s timeout (FSM polling for cancelled ops to settle); query params are validated against path-traversal.

## Compatibility

- **Mixed-version cluster**: a v1.37 node with the flag on next to older nodes will have its `SELF_RECOVERY` op fail because older nodes don't know the transfer type. **Upgrade every node first, then enable the flag.**
- **Downgrade safety**: an orphan `<shard>.recovering/` left behind survives a downgrade unused; the next re-upgrade sweeps it via `CleanupOrphanRecoveryDirs` at startup.
- **Rolling-upgrade safety on the wire**: `ListFiles` now returns gRPC `codes.Unavailable` for shards that are themselves recovering, and `codes.NotFound` for missing shards/indices. Older callers that don't recognise these codes fall through to the substring-matching path and behave as before.

## Out of scope (deliberately)

These were considered and explicitly deferred to keep the PR focused:

- Recovery of multi-tenant tenant shards on the **snapshot** rejoin path. The log-replay rejoin path added in this PR rebuilds the node's whole index from the caught-up schema and does recover HOT tenant shards (`TestSelfRecoveryViaLogReplayMultiTenant`); the snapshot path can short-circuit `initAndStoreShards` for an already-loaded index and is tracked separately.
- RAFT command versioning bump for `SELF_RECOVERY` (the new value rides as a string in the existing `TransferType` field).
- Disk-space pre-flight before the copy.
- Per-source parallelism cap (separate from per-target).
- Source-pause inactivity-timeout tuning.
- `/healthz` degraded reporting.
- **`RecoveringShard.mustLoad` panic hardening — pre-existing, not introduced here.** `LazyLoadShard.mustLoad` already panics the node on *any* `NewShard` failure (corrupt segment, EIO, memory pressure, schema-reload race) for any lazy / multi-tenant shard, because the no-error `ShardLike` methods (`Store()`, `Counter()`, the LSM internals, …) have nowhere to return an error. A recovering shard just adds one more (somewhat more likely) trigger for that existing crash mode. This PR makes the panic message explicit (it names the shard and says the code path must not touch a recovering shard) and documents the limitation in `docs/self-recovery.md`; the proper fix — either making those `ShardLike` methods error-returning, or enforcing "data-path iteration must use the `Loaded()` accessors" so a not-yet-loaded shard is never reached by them — is its own change, tracked separately. Until then, operators should avoid `addProperty`/`updateProperty`-style `ForEachShard`-touching schema ops while a shard on the node is recovering.

## Files

| Surface | Files |
| --- | --- |
| New transfer type + protocol | [`cluster/proto/api/shard_requests.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/cluster/proto/api/shard_requests.go) |
| Validator carve-out | [`cluster/replication/validate.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/cluster/replication/validate.go) |
| Direct entry point (skip scale-plan) | [`cluster/raft_replication_apply_endpoints.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/cluster/raft_replication_apply_endpoints.go) |
| Consumer rename + LoadLocalShard | [`cluster/replication/consumer.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/cluster/replication/consumer.go) |
| Copier destination override | [`cluster/replication/copier/copier.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/cluster/replication/copier/copier.go) |
| Orchestrator + metrics | [`cluster/replication/selfrecovery/`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/cluster/replication/selfrecovery/) |
| Recovering shard wrapper | [`adapters/repos/db/shard_recovering.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/repos/db/shard_recovering.go), load-block in [`shard_lazyloader.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/repos/db/shard_lazyloader.go) |
| Startup hook + RaftBootstrapComplete signal | [`adapters/repos/db/index.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/repos/db/index.go), [`repo.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/repos/db/repo.go), [`init.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/repos/db/init.go), [`migrator.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/repos/db/migrator.go) |
| Startup DB-load ctx tag (`WithStartupDBLoad`) | [`usecases/schema/executor.go`](https://github.com/weaviate/weaviate/blob/d10a4a23d5/usecases/schema/executor.go), [`entities/errors/errors_recovery.go`](https://github.com/weaviate/weaviate/blob/d10a4a23d5/entities/errors/errors_recovery.go) |
| Log-replay rejoin: wiped-node detection + catch-up watcher | [`cluster/store.go`](https://github.com/weaviate/weaviate/blob/d10a4a23d5/cluster/store.go), [`cluster/store_apply.go`](https://github.com/weaviate/weaviate/blob/d10a4a23d5/cluster/store_apply.go) |
| Force-snapshot admin endpoint (test/ops helper) | [`adapters/handlers/rest/handlers_debug_raft.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/handlers/rest/handlers_debug_raft.go), [`cluster/raft.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/cluster/raft.go), [`cluster/store.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/cluster/store.go) |
| Source-side gRPC short-circuit + typed codes | [`adapters/repos/db/replication.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/repos/db/replication.go), [`adapters/handlers/rest/clusterapi/grpc/file_replication_service.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/handlers/rest/clusterapi/grpc/file_replication_service.go) |
| Operator endpoints | [`adapters/handlers/rest/handlers_self_recovery.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/handlers/rest/handlers_self_recovery.go), [`self_recovery_wiring.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/handlers/rest/self_recovery_wiring.go), [`configure_api.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/adapters/handlers/rest/configure_api.go) |
| Status enum + typed error | [`entities/storagestate/status.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/entities/storagestate/status.go), [`entities/errors/errors_recovery.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/entities/errors/errors_recovery.go) |
| Feature flags | [`usecases/config/environment.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/usecases/config/environment.go), [`runtimeconfig.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/usecases/config/runtimeconfig.go), [`entities/replication/config.go`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/entities/replication/config.go) |
| Operator docs | [`docs/self-recovery.md`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/docs/self-recovery.md) |

## Testing

- **Unit**: `cluster/replication/selfrecovery/` covers probe decision tree (data on peer, definitive empty everywhere, mixed-with-unreachable), restart path (cancel + wait-for-terminal + erase + resubmit), accept-empty schema gating, orphan cleanup, parallelism cap, vanished-from-FSM grace window, and metrics emission.
- **Adapter-level**: `adapters/repos/db/shard_lazyloader_loadblock_test.go`, `adapters/repos/db/recover_shard_from_peer_test.go`, `cluster/replication/copier/recovery_test.go`, `cluster/replication/validate_test.go`, `adapters/handlers/rest/clusterapi/grpc/file_replication_service_test.go`.
- **Acceptance** (`test/acceptance/selfrecovery/`, testcontainer-based, modern style):
  - `self_recovery_e2e_test.go` — 3-node RF=3 cluster, ingest, force a RAFT snapshot on every node via `POST /debug/raft/snapshot`, wipe node-3, restart, verify the shard re-hydrates with full object count; asserts a `SELF_RECOVERY` op was actually registered (rules out async-rep masking the test); sampled `consistency=ONE` queries against the wiped node post-recovery; and a sub-test that continuous `ONE` reads against a healthy peer never error during the recovery window.
  - `self_recovery_logreplay_test.go` — 3-node cluster with **no** snapshot forced (default `RAFT_SNAPSHOT_THRESHOLD`/`RAFT_TRAILING_LOGS`), so the wiped node rejoins purely via log replay: a regular RF>=2 collection and a multi-tenant collection both assert a `SELF_RECOVERY` op fires and the data is restored; negative cases assert no `SELF_RECOVERY` op is registered when a collection or tenants are created on a healthy cluster (the complementary guarantee — a node with prior RAFT state is never treated as a wiped joiner — is covered by the `TestNoteWipedJoinerProgress` unit test).
  - `self_recovery_smoke_test.go` — `/metrics` endpoint shape + reachability of admin endpoints (`/debug/self-recovery/*`, `/debug/raft/snapshot`).

All affected packages pass `go test -race`.

### Review checklist

- [x] Documentation has been updated, if necessary. Link to changed documentation: [`docs/self-recovery.md`](https://github.com/weaviate/weaviate/blob/d44624e365635df4e297e4205c143496663d5b31/docs/self-recovery.md)
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.


