### PR TITLE
Namespaces: Add support for multi node apis

### DIFF
--- a/adapters/handlers/grpc/v1/batch/handler.go
+++ b/adapters/handlers/grpc/v1/batch/handler.go
@@ -31,22 +31,22 @@ import (
 )
 
 type Handler struct {
-	authorizer    authorization.Authorizer
-	authenticator *auth.Handler
-	batchManager  *objects.BatchManager
-	logger        logrus.FieldLogger
-	schemaManager *schema.Manager
-	nsEnabled     bool
+	authorizer        authorization.Authorizer
+	authenticator     *auth.Handler
+	batchManager      *objects.BatchManager
+	logger            logrus.FieldLogger
+	schemaManager     *schema.Manager
+	namespacesEnabled bool
 }
 
-func NewHandler(authorizer authorization.Authorizer, batchManager *objects.BatchManager, logger logrus.FieldLogger, authenticator *auth.Handler, schemaManager *schema.Manager, nsEnabled bool) *Handler {
+func NewHandler(authorizer authorization.Authorizer, batchManager *objects.BatchManager, logger logrus.FieldLogger, authenticator *auth.Handler, schemaManager *schema.Manager, namespacesEnabled bool) *Handler {
 	return &Handler{
-		authorizer:    authorizer,
-		authenticator: authenticator,
-		batchManager:  batchManager,
-		logger:        logger,
-		schemaManager: schemaManager,
-		nsEnabled:     nsEnabled,
+		authorizer:        authorizer,
+		authenticator:     authenticator,
+		batchManager:      batchManager,
+		logger:            logger,
+		schemaManager:     schemaManager,
+		namespacesEnabled: namespacesEnabled,
 	}
 }
 
@@ -66,7 +66,7 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 	knownClasses := map[string]versioned.Class{}
 	knownClassesAuthCheck := map[string]*models.Class{}
 	classGetter := func(classname, shard string) (*models.Class, error) {
-		classname, _ = namespacing.Resolve(principal, h.schemaManager, h.nsEnabled, classname)
+		classname, _ = namespacing.Resolve(principal, h.schemaManager, h.namespacesEnabled, classname)
 		// use a letter that cannot be in class/shard name to not allow different combinations leading to the same combined name
 		classTenantName := classname + "#" + shard
 		class, ok := knownClassesAuthCheck[classTenantName]

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -83,10 +83,6 @@ func (s *Service) Aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 	var result *pb.AggregateReply
 	var errInner error
 
-	if class := s.schemaManager.ResolveAlias(req.Collection); class != "" {
-		req.Collection = class
-	}
-
 	if err := enterrors.GoWrapperWithBlock(func() {
 		result, errInner = s.aggregate(ctx, req)
 	}, s.logger); err != nil {
@@ -104,6 +100,8 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
+
+	req.Collection, _ = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection)
 
 	parser := NewAggregateParser(
 		s.classGetterWithAuthzFunc(ctx, principal, req.Tenant),

--- a/adapters/handlers/rest/clusterapi/indices.go
+++ b/adapters/handlers/rest/clusterapi/indices.go
@@ -80,8 +80,8 @@ type indices struct {
 	logger logrus.FieldLogger
 }
 
-const (
-	cl = entschema.ClassNameRegexCore
+var (
+	cl = entschema.IndexNameRegexCore
 	sh = entschema.ShardNameRegexCore
 	ob = `[A-Za-z0-9_+-]+`
 	l  = "[0-9]+"

--- a/adapters/handlers/rest/clusterapi/nodes.go
+++ b/adapters/handlers/rest/clusterapi/nodes.go
@@ -40,7 +40,7 @@ func NewNodes(manager nodesManager, auth auth) *nodes {
 
 var (
 	regxNodes      = regexp.MustCompile(`/status`)
-	regxNodesClass = regexp.MustCompile(`/status/(` + entschema.ClassNameRegexCore + `)`)
+	regxNodesClass = regexp.MustCompile(`/status/(` + entschema.IndexNameRegexCore + `)`)
 	regxStatistics = regexp.MustCompile(`/statistics`)
 )
 

--- a/adapters/handlers/rest/handlers_nodes.go
+++ b/adapters/handlers/rest/handlers_nodes.go
@@ -29,10 +29,13 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	nodesUC "github.com/weaviate/weaviate/usecases/nodes"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 type nodesHandlers struct {
 	manager             *nodesUC.Manager
+	schemaManager       namespacing.SchemaManager
+	nsEnabled           bool
 	metricRequestsTotal restApiRequestsTotal
 }
 
@@ -66,7 +69,9 @@ func (n *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, 
 		shardName = *params.ShardName
 	}
 
-	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, params.ClassName, shardName, output)
+	className, _ := namespacing.Resolve(principal, n.schemaManager, n.nsEnabled, params.ClassName)
+
+	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, className, shardName, output)
 	if err != nil {
 		return n.handleGetNodesError(err)
 	}
@@ -129,7 +134,12 @@ func setupNodesHandlers(api *operations.WeaviateAPI,
 	nodesManager := nodesUC.NewManager(appState.Logger, appState.Authorizer,
 		repo, schemaManger, appState.ServerConfig.Config.Authorization.Rbac, appState.ServerConfig.Config.MinimumInternalTimeout)
 
-	h := &nodesHandlers{nodesManager, newNodesRequestsTotal(appState.Metrics, appState.Logger)}
+	h := &nodesHandlers{
+		manager:             nodesManager,
+		schemaManager:       schemaManger,
+		nsEnabled:           appState.ServerConfig.Config.Namespaces.Enabled,
+		metricRequestsTotal: newNodesRequestsTotal(appState.Metrics, appState.Logger),
+	}
 	api.NodesNodesGetHandler = nodes.
 		NodesGetHandlerFunc(h.getNodesStatus)
 	api.NodesNodesGetClassHandler = nodes.

--- a/adapters/handlers/rest/handlers_nodes.go
+++ b/adapters/handlers/rest/handlers_nodes.go
@@ -35,7 +35,7 @@ import (
 type nodesHandlers struct {
 	manager             *nodesUC.Manager
 	schemaManager       namespacing.SchemaManager
-	nsEnabled           bool
+	namespacesEnabled   bool
 	metricRequestsTotal restApiRequestsTotal
 }
 
@@ -69,7 +69,7 @@ func (n *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, 
 		shardName = *params.ShardName
 	}
 
-	className, _ := namespacing.Resolve(principal, n.schemaManager, n.nsEnabled, params.ClassName)
+	className, _ := namespacing.Resolve(principal, n.schemaManager, n.namespacesEnabled, params.ClassName)
 
 	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, className, shardName, output)
 	if err != nil {
@@ -137,7 +137,7 @@ func setupNodesHandlers(api *operations.WeaviateAPI,
 	h := &nodesHandlers{
 		manager:             nodesManager,
 		schemaManager:       schemaManger,
-		nsEnabled:           appState.ServerConfig.Config.Namespaces.Enabled,
+		namespacesEnabled:   appState.ServerConfig.Config.Namespaces.Enabled,
 		metricRequestsTotal: newNodesRequestsTotal(appState.Metrics, appState.Logger),
 	}
 	api.NodesNodesGetHandler = nodes.

--- a/adapters/handlers/rest/handlers_tokenize.go
+++ b/adapters/handlers/rest/handlers_tokenize.go
@@ -35,7 +35,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
-func setupTokenizeHandlers(api *operations.WeaviateAPI, schemaManager *schemaUC.Manager, nsEnabled bool, logger logrus.FieldLogger) {
+func setupTokenizeHandlers(api *operations.WeaviateAPI, schemaManager *schemaUC.Manager, namespacesEnabled bool, logger logrus.FieldLogger) {
 	api.TokenizeTokenizeHandler = tokenizeops.TokenizeHandlerFunc(
 		func(params tokenizeops.TokenizeParams, principal *models.Principal) middleware.Responder {
 			return genericTokenize(params)
@@ -43,7 +43,7 @@ func setupTokenizeHandlers(api *operations.WeaviateAPI, schemaManager *schemaUC.
 
 	api.SchemaSchemaObjectsPropertiesTokenizeHandler = schemaops.SchemaObjectsPropertiesTokenizeHandlerFunc(
 		func(params schemaops.SchemaObjectsPropertiesTokenizeParams, principal *models.Principal) middleware.Responder {
-			return propertyTokenize(params, principal, schemaManager, nsEnabled, logger)
+			return propertyTokenize(params, principal, schemaManager, namespacesEnabled, logger)
 		})
 }
 
@@ -170,11 +170,11 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 }
 
 func propertyTokenize(params schemaops.SchemaObjectsPropertiesTokenizeParams,
-	principal *models.Principal, schemaManager *schemaUC.Manager, nsEnabled bool, logger logrus.FieldLogger,
+	principal *models.Principal, schemaManager *schemaUC.Manager, namespacesEnabled bool, logger logrus.FieldLogger,
 ) middleware.Responder {
 	// Resolve before authorization so authz uses the real collection name
 	// for permissions and error UX.
-	className, _ := namespacing.Resolve(principal, schemaManager, nsEnabled, params.ClassName)
+	className, _ := namespacing.Resolve(principal, schemaManager, namespacesEnabled, params.ClassName)
 
 	// Authorize: reading collection metadata (same as other schema read operations)
 	err := schemaManager.Authorizer.Authorize(

--- a/cluster/raft_namespace_apply_endpoints.go
+++ b/cluster/raft_namespace_apply_endpoints.go
@@ -15,14 +15,21 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	usecasesNamespaces "github.com/weaviate/weaviate/usecases/namespaces"
 )
 
 // AddNamespace proposes an AddNamespace RAFT command. The apply side rejects
 // duplicates with [namespaces.ErrAlreadyExists] and invalid names with
 // [namespaces.ErrBadRequest]; callers that need to distinguish those should
 // use errors.Is.
+//
+// On success the call blocks until the local node has applied the new entry
+// so a follow-up local read (e.g. controller.Exists) on the same node sees
+// the change. On a follower this absorbs the leader→follower replication
+// delay; on the leader it returns immediately.
 func (s *Raft) AddNamespace(ns cmd.Namespace) error {
 	req := cmd.AddNamespaceRequest{
 		Namespace: ns,
@@ -36,8 +43,12 @@ func (s *Raft) AddNamespace(ns cmd.Namespace) error {
 		Type:       cmd.ApplyRequest_TYPE_ADD_NAMESPACE,
 		SubCommand: subCommand,
 	}
-	if _, err := s.Execute(context.Background(), command); err != nil {
-		return err
+	version, err := s.Execute(context.Background(), command)
+	if err != nil {
+		return rewrapNamespaceApplyError(err)
+	}
+	if err := s.WaitForUpdate(context.Background(), version); err != nil {
+		return fmt.Errorf("wait for local apply: %w", err)
 	}
 	return nil
 }
@@ -45,6 +56,9 @@ func (s *Raft) AddNamespace(ns cmd.Namespace) error {
 // DeleteNamespace proposes a DeleteNamespace RAFT command. The apply side
 // returns [namespaces.ErrNotFound] when the target namespace does not exist;
 // callers that want idempotent semantics should swallow that error.
+//
+// On success the call blocks until the local node has applied the entry so
+// subsequent local reads observe the namespace as gone.
 func (s *Raft) DeleteNamespace(name string) error {
 	req := cmd.DeleteNamespaceRequest{
 		Name:    name,
@@ -58,8 +72,35 @@ func (s *Raft) DeleteNamespace(name string) error {
 		Type:       cmd.ApplyRequest_TYPE_DELETE_NAMESPACE,
 		SubCommand: subCommand,
 	}
-	if _, err := s.Execute(context.Background(), command); err != nil {
-		return err
+	version, err := s.Execute(context.Background(), command)
+	if err != nil {
+		return rewrapNamespaceApplyError(err)
+	}
+	if err := s.WaitForUpdate(context.Background(), version); err != nil {
+		return fmt.Errorf("wait for local apply: %w", err)
 	}
 	return nil
+}
+
+// rewrapNamespaceApplyError restores typed sentinels on FSM errors that
+// flowed back through the follower→leader gRPC hop. The RPC layer serializes
+// the error to a plain status string and so erases errors.Is chains. The
+// handler matches usecasesNamespaces.Err* via errors.Is, so we string-match
+// known sentinels and rewrap. Mirrors the pattern in
+// cluster/raft_replication_apply_endpoints.go.
+func rewrapNamespaceApplyError(err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	switch {
+	case strings.Contains(msg, usecasesNamespaces.ErrAlreadyExists.Error()):
+		return fmt.Errorf("%w: %s", usecasesNamespaces.ErrAlreadyExists, msg)
+	case strings.Contains(msg, usecasesNamespaces.ErrNotFound.Error()):
+		return fmt.Errorf("%w: %s", usecasesNamespaces.ErrNotFound, msg)
+	case strings.Contains(msg, usecasesNamespaces.ErrBadRequest.Error()):
+		return fmt.Errorf("%w: %s", usecasesNamespaces.ErrBadRequest, msg)
+	default:
+		return err
+	}
 }

--- a/entities/schema/validation.go
+++ b/entities/schema/validation.go
@@ -22,6 +22,21 @@ var (
 	validatePropertyNameRegex       = regexp.MustCompile(`^` + PropertyNameRegex + `$`)
 	validateNestedPropertyNameRegex = regexp.MustCompile(`^` + NestedPropertyNameRegex + `$`)
 	reservedPropertyNames           = []string{"_additional", "_id", "id"}
+
+	// IndexNameRegexCore matches an internal index name as it appears on
+	// cluster-internal URLs: an optional "<namespace>:" prefix followed by a
+	// ClassNameRegexCore class name. The namespace portion mirrors the
+	// namespace-name contract — lowercase letter/digit edges, hyphens only
+	// internally, length NamespaceMinLength..NamespaceMaxLength.
+	//
+	// The {N,M} middle bound subtracts 2 to account for the required
+	// leading and trailing [a-z0-9] characters; total namespace length
+	// stays in [NamespaceMinLength, NamespaceMaxLength].
+	//
+	// Used only for cluster-API URL routing; user-facing class-name
+	// validation continues to use ClassNameRegexCore (which rejects ":").
+	IndexNameRegexCore = fmt.Sprintf(`(?:[a-z0-9][a-z0-9-]{%d,%d}[a-z0-9]%s)?`,
+		NamespaceMinLength-2, NamespaceMaxLength-2, NamespaceSeparator) + ClassNameRegexCore
 )
 
 const (

--- a/entities/schema/validation_test.go
+++ b/entities/schema/validation_test.go
@@ -12,6 +12,8 @@
 package schema
 
 import (
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -326,6 +328,54 @@ func TestValidateClassName_RejectsNamespaceSeparator(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			_, err := ValidateClassName(name)
 			assert.Error(t, err, "class name %q containing NamespaceSeparator must be rejected", name)
+		})
+	}
+}
+
+// TestIndexNameRegexCore covers what IndexNameRegexCore accepts and rejects:
+// plain class names, "<namespace>:<class>" with a 3-36 char namespace, and
+// the boundary cases (hyphen edges, leading/trailing ":", more than one ":",
+// out-of-range namespace lengths).
+func TestIndexNameRegexCore(t *testing.T) {
+	re := regexp.MustCompile(`^` + IndexNameRegexCore + `$`)
+
+	maxNs := strings.Repeat("a", NamespaceMaxLength)
+	tooLongNs := strings.Repeat("a", NamespaceMaxLength+1)
+	tooShortNs := strings.Repeat("a", NamespaceMinLength-1)
+
+	accept := []string{
+		"Movies",
+		"customer1:Movies",
+		"tenant-a:My_Class",
+		"abc:Movies",
+		maxNs + ":Movies",
+		"a-b-c:Movies",
+		"123:Movies",
+	}
+	for _, name := range accept {
+		t.Run("accept/"+name, func(t *testing.T) {
+			assert.True(t, re.MatchString(name), "expected %q to match", name)
+		})
+	}
+
+	reject := []string{
+		":Movies",
+		"customer:",
+		"customer:1Movies",
+		"-abc:Movies",
+		"abc-:Movies",
+		"Customer:Movies",
+		tooShortNs + ":Movies",
+		tooLongNs + ":Movies",
+		"a:b:Movies", // more than one ":" — no character class in the pattern accepts ":"
+		"customer/Movies",
+		"customer:Movies/extra",
+		"customer:movies",
+		"",
+	}
+	for _, name := range reject {
+		t.Run("reject/"+name, func(t *testing.T) {
+			assert.False(t, re.MatchString(name), "expected %q to be rejected", name)
 		})
 	}
 }

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -112,11 +112,18 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		defer helper.DeleteAliasWithAuthz(t, "customer2:E2EFilmsAlias", helper.CreateAuth(adminKey))
 
 		// user1 inserts via the alias name; on disk it lands as customer1:E2EFilmsTarget.
-		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
-			Class:      "E2EFilmsAlias",
-			Properties: map[string]any{"title": "Inception"},
-		}, user1Key)
-		require.NoError(t, err)
+		// retryOnAliasLag absorbs the brief window where the alias entry has
+		// been applied on the leader but the follower we are talking to has
+		// not yet replicated it, so local alias resolution would 500.
+		var obj *models.Object
+		retryOnAliasLag(t, func() error {
+			var err error
+			obj, err = helper.CreateObjectWithResponseAuth(t, &models.Object{
+				Class:      "E2EFilmsAlias",
+				Properties: map[string]any{"title": "Inception"},
+			}, user1Key)
+			return err
+		})
 		require.NotEmpty(t, obj.ID)
 
 		// user1 reads it back via the alias — Resolve qualifies + maps alias → target.

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -150,13 +150,6 @@ func TestNamespaces_GRPC(t *testing.T) {
 	})
 
 	t.Run("Aggregate count is namespace-scoped", func(t *testing.T) {
-		// gRPC Aggregate is not yet namespace-aware. Two gaps stand in the
-		// way: the handler doesn't qualify the class via namespacing.Resolve,
-		// and count(*) fan-out goes through a cluster-API HTTP route whose
-		// URL regex is built from ClassNameRegexCore — that regex excludes
-		// ":", so namespace-qualified index names never match the route.
-		t.Skip("aggregate on namespaced classes not yet wired; tracked separately")
-
 		for _, key := range []string{user1Key, user2Key} {
 			resp, err := grpcClient.Aggregate(authCtx(key), &pb.AggregateRequest{
 				Collection:   class,
@@ -168,13 +161,11 @@ func TestNamespaces_GRPC(t *testing.T) {
 		}
 	})
 
-	t.Run("Search via alias resolves per namespace", func(t *testing.T) {
+	t.Run("Search and Aggregate via alias resolve per namespace", func(t *testing.T) {
 		// Both namespaces register the same short alias name pointing at
 		// their own copy of MoviesGRPC. The handler must qualify the alias
 		// to "<ns>:MoviesGRPCAlias" before alias→target lookup, otherwise
 		// user1's request would land on user2's data (or vice versa).
-		// Aggregate-via-alias is intentionally not exercised — gRPC Aggregate
-		// is not yet namespace-aware (see Aggregate subtest above).
 		const aliasName = "MoviesGRPCAlias"
 		for _, key := range []string{user1Key, user2Key} {
 			_, err := helper.Client(t).Schema.AliasesCreate(
@@ -196,17 +187,29 @@ func TestNamespaces_GRPC(t *testing.T) {
 			searchResp, err := grpcClient.Search(authCtx(key), searchReq(aliasName, 10))
 			require.NoError(t, err)
 			assert.Len(t, searchResp.Results, 2)
+
+			aggResp, err := grpcClient.Aggregate(authCtx(key), &pb.AggregateRequest{
+				Collection:   aliasName,
+				ObjectsCount: true,
+			})
+			require.NoError(t, err)
+			require.NotNil(t, aggResp.GetSingleResult())
+			assert.Equal(t, int64(2), aggResp.GetSingleResult().GetObjectsCount())
 		}
 	})
 
 	t.Run("namespaced caller submitting :-qualified collection double-prefixes", func(t *testing.T) {
 		// user1 supplying "customer1:MoviesGRPC" gets qualified again to
 		// "customer1:customer1:MoviesGRPC" — no such class on disk.
-		// Aggregate is not exercised here — gRPC Aggregate is not yet
-		// namespace-aware (see Aggregate subtest above).
 		qualified := "customer1:" + class
 
 		_, err := grpcClient.Search(authCtx(user1Key), searchReq(qualified, 1))
+		require.Error(t, err)
+
+		_, err = grpcClient.Aggregate(authCtx(user1Key), &pb.AggregateRequest{
+			Collection:   qualified,
+			ObjectsCount: true,
+		})
 		require.Error(t, err)
 
 		batchResp, err := grpcClient.BatchObjects(authCtx(user1Key), &pb.BatchObjectsRequest{
@@ -222,8 +225,6 @@ func TestNamespaces_GRPC(t *testing.T) {
 		// Admin has no namespace, so qualify is a no-op and the supplied
 		// name flows through. Short name → no class on disk → error.
 		// Qualified name → matches storage → success.
-		// Aggregate is not exercised — gRPC Aggregate is not yet
-		// namespace-aware (see Aggregate subtest above).
 		shortReq := func() (*pb.SearchReply, error) {
 			return grpcClient.Search(authCtx(adminKey), searchReq(class, 10))
 		}
@@ -236,6 +237,19 @@ func TestNamespaces_GRPC(t *testing.T) {
 		searchResp, err := qualifiedReq()
 		require.NoError(t, err)
 		assert.Len(t, searchResp.Results, 2)
+
+		_, err = grpcClient.Aggregate(authCtx(adminKey), &pb.AggregateRequest{
+			Collection:   class,
+			ObjectsCount: true,
+		})
+		require.Error(t, err)
+		aggResp, err := grpcClient.Aggregate(authCtx(adminKey), &pb.AggregateRequest{
+			Collection:   "customer1:" + class,
+			ObjectsCount: true,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, aggResp.GetSingleResult())
+		assert.Equal(t, int64(2), aggResp.GetSingleResult().GetObjectsCount())
 
 		// BatchObjects: short → per-object error; qualified → success and
 		// the row shows up via REST.
@@ -257,4 +271,54 @@ func TestNamespaces_GRPC(t *testing.T) {
 		assert.Equal(t, "customer1:"+class, got.Class)
 		assert.Equal(t, "admin-qualified", got.Properties.(map[string]any)["title"])
 	})
+}
+
+// TestNamespaces_GRPC_MultiShardAggregate spreads a namespaced class across
+// every node in the 3-node cluster and asserts that count(*) fan-out
+// returns the right number. With shards on remote nodes the gRPC entry
+// point cannot answer count locally and must hop the cluster-API
+// /indices/<ns>:<class>/shards/<sh>/objects/_count route.
+func TestNamespaces_GRPC_MultiShardAggregate(t *testing.T) {
+	user1Key, _ := twoNamespaces(t)
+
+	grpcClient, conn := newGrpcClient(t)
+	defer conn.Close()
+
+	const class = "MoviesGRPCMultiShard"
+	helper.CreateClassAuth(t, &models.Class{
+		Class: class,
+		Properties: []*models.Property{
+			{Name: "title", DataType: []string{"text"}},
+		},
+		ShardingConfig: map[string]any{"desiredCount": 3},
+	}, user1Key)
+	t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+class, adminKey) })
+
+	const objCount = 12
+	objects := make([]*pb.BatchObject, 0, objCount)
+	for i := range objCount {
+		objects = append(objects, &pb.BatchObject{
+			Uuid:       strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012d", i)).String(),
+			Collection: class,
+			Properties: &pb.BatchObject_Properties{
+				NonRefProperties: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"title": structpb.NewStringValue(fmt.Sprintf("title-%d", i)),
+					},
+				},
+			},
+		})
+	}
+	resp, err := grpcClient.BatchObjects(authCtx(user1Key), &pb.BatchObjectsRequest{Objects: objects})
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.Empty(t, resp.Errors)
+
+	aggResp, err := grpcClient.Aggregate(authCtx(user1Key), &pb.AggregateRequest{
+		Collection:   class,
+		ObjectsCount: true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, aggResp.GetSingleResult())
+	assert.Equal(t, int64(objCount), aggResp.GetSingleResult().GetObjectsCount())
 }

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -184,8 +184,16 @@ func TestNamespaces_GRPC(t *testing.T) {
 		)
 
 		for _, key := range []string{user1Key, user2Key} {
-			searchResp, err := grpcClient.Search(authCtx(key), searchReq(aliasName, 10))
-			require.NoError(t, err)
+			// retryOnAliasLag absorbs the brief window where the alias
+			// entry has been applied on the leader but the follower has
+			// not yet replicated it. Once the first Search succeeds the
+			// alias is locally visible and the Aggregate below is safe.
+			var searchResp *pb.SearchReply
+			retryOnAliasLag(t, func() error {
+				var err error
+				searchResp, err = grpcClient.Search(authCtx(key), searchReq(aliasName, 10))
+				return err
+			})
 			assert.Len(t, searchResp.Results, 2)
 
 			aggResp, err := grpcClient.Aggregate(authCtx(key), &pb.AggregateRequest{

--- a/test/acceptance/namespace/schema_ops_test.go
+++ b/test/acceptance/namespace/schema_ops_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/client/nodes"
 	"github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/helper"
@@ -341,5 +342,138 @@ func TestNamespaces_PropertyTokenize(t *testing.T) {
 		got, err := tokenizePropertyAuth(t, "customer1:Shows", "title", "Hello World", adminKey)
 		require.NoError(t, err)
 		assert.Equal(t, []string{"hello", "world"}, got.Indexed)
+	})
+}
+
+// TestNamespaces_ShardsStatus exercises GET /v1/schema/<class>/shards on a
+// multi-shard namespaced class. With 3 shards on a 3-node cluster at least
+// one shard lives on a remote node, so the request must hop the
+// /indices/<ns>:<class>/shards/<sh>/status route to collect each shard's
+// status.
+func TestNamespaces_ShardsStatus(t *testing.T) {
+	const ns1 = "customer1"
+
+	helper.CreateNamespace(t, ns1, adminKey)
+	defer helper.DeleteNamespace(t, ns1, adminKey)
+
+	user1Key := createNamespacedUser(t, "u1", ns1, adminKey)
+	t.Cleanup(func() { helper.DeleteUser(t, ns1+":u1", adminKey) })
+
+	classWithShards := func(name string) *models.Class {
+		return &models.Class{
+			Class: name,
+			Properties: []*models.Property{
+				{Name: "title", DataType: []string{"text"}},
+			},
+			ShardingConfig: map[string]any{"desiredCount": 3},
+		}
+	}
+
+	getShards := func(t *testing.T, className, key string) (models.ShardStatusList, error) {
+		t.Helper()
+		params := schema.NewSchemaObjectsShardsGetParams().WithClassName(className)
+		resp, err := helper.Client(t).Schema.SchemaObjectsShardsGet(params, helper.CreateAuth(key))
+		if err != nil {
+			return nil, err
+		}
+		return resp.Payload, nil
+	}
+
+	t.Run("namespaced user gets shards by short name across nodes", func(t *testing.T) {
+		helper.CreateClassAuth(t, classWithShards("Movies"), user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+
+		shards, err := getShards(t, "Movies", user1Key)
+		require.NoError(t, err)
+		require.Len(t, shards, 3)
+		for _, s := range shards {
+			assert.NotEmpty(t, s.Status, "shard %q should have a populated status", s.Name)
+		}
+	})
+
+	t.Run("global admin gets shards by qualified name across nodes", func(t *testing.T) {
+		helper.CreateClassAuth(t, classWithShards("Shows"), user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Shows", adminKey)
+
+		shards, err := getShards(t, "customer1:Shows", adminKey)
+		require.NoError(t, err)
+		require.Len(t, shards, 3)
+		for _, s := range shards {
+			assert.NotEmpty(t, s.Status, "shard %q should have a populated status", s.Name)
+		}
+	})
+
+	t.Run("namespaced user gets shards via alias across nodes", func(t *testing.T) {
+		helper.CreateClassAuth(t, classWithShards("Concerts"), user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Concerts", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
+
+		shards, err := getShards(t, "Gigs", user1Key)
+		require.NoError(t, err)
+		require.Len(t, shards, 3)
+		for _, s := range shards {
+			assert.NotEmpty(t, s.Status, "shard %q should have a populated status", s.Name)
+		}
+	})
+}
+
+// TestNamespaces_NodesGetClass exercises GET /v1/nodes/<class> on a
+// namespaced class. The cluster-API URL routes through `regxNodesClass`
+// for cross-node hops, which only accepts namespace-qualified names once
+// it is built from IndexNameRegexCore.
+func TestNamespaces_NodesGetClass(t *testing.T) {
+	const ns1 = "customer1"
+
+	helper.CreateNamespace(t, ns1, adminKey)
+	defer helper.DeleteNamespace(t, ns1, adminKey)
+
+	user1Key := createNamespacedUser(t, "u1", ns1, adminKey)
+	t.Cleanup(func() { helper.DeleteUser(t, ns1+":u1", adminKey) })
+
+	helper.CreateClassAuth(t, &models.Class{
+		Class: "Movies",
+		Properties: []*models.Property{
+			{Name: "title", DataType: []string{"text"}},
+		},
+		ShardingConfig: map[string]any{"desiredCount": 3},
+	}, user1Key)
+	defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+
+	verbose := "verbose"
+
+	t.Run("namespaced user gets node status by short class name", func(t *testing.T) {
+		params := nodes.NewNodesGetClassParams().WithClassName("Movies").WithOutput(&verbose)
+		resp, err := helper.Client(t).Nodes.NodesGetClass(params, helper.CreateAuth(user1Key))
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload)
+		assert.NotEmpty(t, resp.Payload.Nodes)
+	})
+
+	t.Run("global admin gets node status by qualified class name", func(t *testing.T) {
+		params := nodes.NewNodesGetClassParams().WithClassName("customer1:Movies").WithOutput(&verbose)
+		resp, err := helper.Client(t).Nodes.NodesGetClass(params, helper.CreateAuth(adminKey))
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload)
+		assert.NotEmpty(t, resp.Payload.Nodes)
+	})
+
+	t.Run("namespaced user gets node status via alias", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{
+			Class: "Concerts",
+			Properties: []*models.Property{
+				{Name: "title", DataType: []string{"text"}},
+			},
+			ShardingConfig: map[string]any{"desiredCount": 3},
+		}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:Concerts", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "Gigs", Class: "Concerts"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:Gigs", helper.CreateAuth(adminKey))
+
+		params := nodes.NewNodesGetClassParams().WithClassName("Gigs").WithOutput(&verbose)
+		resp, err := helper.Client(t).Nodes.NodesGetClass(params, helper.CreateAuth(user1Key))
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload)
+		assert.NotEmpty(t, resp.Payload.Nodes)
 	})
 }

--- a/test/acceptance/namespace/schema_ops_test.go
+++ b/test/acceptance/namespace/schema_ops_test.go
@@ -354,7 +354,7 @@ func TestNamespaces_ShardsStatus(t *testing.T) {
 	const ns1 = "customer1"
 
 	helper.CreateNamespace(t, ns1, adminKey)
-	defer helper.DeleteNamespace(t, ns1, adminKey)
+	t.Cleanup(func() { helper.DeleteNamespace(t, ns1, adminKey) })
 
 	user1Key := createNamespacedUser(t, "u1", ns1, adminKey)
 	t.Cleanup(func() { helper.DeleteUser(t, ns1+":u1", adminKey) })
@@ -426,7 +426,7 @@ func TestNamespaces_NodesGetClass(t *testing.T) {
 	const ns1 = "customer1"
 
 	helper.CreateNamespace(t, ns1, adminKey)
-	defer helper.DeleteNamespace(t, ns1, adminKey)
+	t.Cleanup(func() { helper.DeleteNamespace(t, ns1, adminKey) })
 
 	user1Key := createNamespacedUser(t, "u1", ns1, adminKey)
 	t.Cleanup(func() { helper.DeleteUser(t, ns1+":u1", adminKey) })

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -18,10 +18,26 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/test/docker"
 	"github.com/weaviate/weaviate/test/helper"
 )
+
+// retryOnAliasLag retries op until it returns no error. Used after
+// CreateAliasAuth on the multi-node cluster: the create returns when the
+// leader has applied, but the follower the test client talks to may still
+// be replicating the alias entry, so the immediate next operation (which
+// resolves the alias via local schema state) can transiently fail with
+// "class not found" / 404 / 422. Pattern mirrors helper.CreateNamespace's
+// EventuallyWithT poll, just on the operation rather than the entity.
+func retryOnAliasLag(t *testing.T, op func() error) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, op())
+	}, 10*time.Second, 50*time.Millisecond, "operation kept failing while waiting for alias to be visible locally")
+}
 
 // Test personas. All API keys are statically declared at compose-up time.
 // Per-test work is limited to creating a role with the desired permissions

--- a/test/acceptance/namespace/setup_test.go
+++ b/test/acceptance/namespace/setup_test.go
@@ -37,7 +37,7 @@ const (
 var sharedCompose *docker.DockerCompose
 
 func TestMain(m *testing.M) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
 
 	compose, err := docker.New().
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 		WithDbUsers().
 		WithNamespaces().
 		WithWeaviateEnv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT", "true").
-		WithWeaviateWithGRPC().
+		WithWeaviateClusterWithGRPC().
 		Start(ctx)
 	if err != nil {
 		panic(errors.Wrap(err, "failed to start shared compose"))

--- a/test/acceptance/namespace/tenant_test.go
+++ b/test/acceptance/namespace/tenant_test.go
@@ -341,14 +341,21 @@ func TestNamespaces_TenantOps(t *testing.T) {
 		defer helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
 
 		// GetConsistentTenant via alias resolves to the underlying class.
-		got, err := getOneTenantAuth(t, alias, "present", user1Key)
-		require.NoError(t, err)
+		// retryOnAliasLag absorbs the brief window where the alias entry
+		// has been applied on the leader but the follower has not yet
+		// replicated it; once the first read succeeds the rest are safe.
+		var got *models.Tenant
+		retryOnAliasLag(t, func() error {
+			var err error
+			got, err = getOneTenantAuth(t, alias, "present", user1Key)
+			return err
+		})
 		assert.Equal(t, "present", got.Name)
 		assert.Equal(t, models.TenantActivityStatusHOT, got.ActivityStatus)
 
 		// Missing tenant on the same alias still 404s — alias resolution
 		// must not paper over a real not-found.
-		_, err = getOneTenantAuth(t, alias, "missing", user1Key)
+		_, err := getOneTenantAuth(t, alias, "missing", user1Key)
 		require.Error(t, err)
 
 		// ConsistentTenantExists via alias resolves to the underlying class.
@@ -368,8 +375,15 @@ func TestNamespaces_TenantOps(t *testing.T) {
 		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: class}, user1Key)
 		defer helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
 
-		listed, err := getTenantsAuth(t, alias, user1Key)
-		require.NoError(t, err)
+		// retryOnAliasLag absorbs the brief window where the alias entry
+		// has been applied on the leader but the follower has not yet
+		// replicated it; once the first read succeeds the rest are safe.
+		var listed []*models.Tenant
+		retryOnAliasLag(t, func() error {
+			var err error
+			listed, err = getTenantsAuth(t, alias, user1Key)
+			return err
+		})
 		assert.ElementsMatch(t, []string{"t1", "t2"}, tenantNames(listed))
 
 		got, err := getOneTenantAuth(t, alias, "t1", user1Key)

--- a/test/helper/namespaces.go
+++ b/test/helper/namespaces.go
@@ -13,7 +13,9 @@ package helper
 
 import (
 	"testing"
+	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/client/namespaces"
@@ -21,6 +23,10 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
 
+// CreateNamespace creates the namespace and blocks until a follow-up GET
+// succeeds. On multi-node clusters RAFT replication can lag a few hundred
+// milliseconds behind the CreateNamespace response; callers should be able
+// to use the namespace immediately on return.
 func CreateNamespace(t *testing.T, name, key string) *models.Namespace {
 	t.Helper()
 	resp, err := Client(t).Namespaces.CreateNamespace(
@@ -30,6 +36,15 @@ func CreateNamespace(t *testing.T, name, key string) *models.Namespace {
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 	require.NotNil(t, resp.Payload)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		_, err := Client(t).Namespaces.GetNamespace(
+			namespaces.NewGetNamespaceParams().WithNamespaceID(name),
+			CreateAuth(key),
+		)
+		assert.NoError(c, err)
+	}, 10*time.Second, 50*time.Millisecond, "namespace %q not visible after create", name)
+
 	return resp.Payload
 }
 

--- a/usecases/schema/authorization_test.go
+++ b/usecases/schema/authorization_test.go
@@ -324,6 +324,39 @@ func Test_Schema_Authorization_AliasResolution(t *testing.T) {
 		fakeSchemaManager.AssertExpectations(t)
 	})
 
+	t.Run("ShardsStatus - NS-enabled authorization uses namespace-qualified resolved class name", func(t *testing.T) {
+		authorizer := mocks.NewMockAuthorizer()
+		handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, &fakeDB{}, authorizer)
+		handler.config.Namespaces.Enabled = true
+
+		nsPrincipal := &models.Principal{Username: "u1", Namespace: "customer1"}
+		shortAlias := "Films"
+		qualifiedAlias := "customer1:Films"
+		qualifiedClass := "customer1:Movies"
+
+		expectedStatus := models.ShardStatusList{
+			&models.ShardStatusGetResponse{Name: shardName, Status: "READY"},
+		}
+		fakeSchemaManager.On("GetShardsStatus", qualifiedClass, shardName).Return(expectedStatus, nil)
+
+		handler.schemaReader = &fakeSchemaManagerWithAlias{
+			fakeSchemaManager: fakeSchemaManager,
+			aliasMap:          map[string]string{qualifiedAlias: qualifiedClass},
+		}
+
+		_, err := handler.ShardsStatus(context.Background(), nsPrincipal, shortAlias, shardName)
+		require.NoError(t, err)
+
+		require.Len(t, authorizer.Calls(), 1, "Authorizer must be called exactly once")
+		authCall := authorizer.Calls()[0]
+		assert.Equal(t, nsPrincipal, authCall.Principal)
+		assert.Equal(t, authorization.READ, authCall.Verb)
+		assert.Equal(t, authorization.ShardsMetadata(qualifiedClass, shardName), authCall.Resources,
+			"Authorization should use namespace-qualified resolved class %q, not short alias %q", qualifiedClass, shortAlias)
+
+		fakeSchemaManager.AssertExpectations(t)
+	})
+
 	t.Run("GetConsistentClass - authorization uses original class name when no alias resolution", func(t *testing.T) {
 		authorizer := mocks.NewMockAuthorizer()
 		handler, fakeSchemaManager := newTestHandlerWithCustomAuthorizer(t, &fakeDB{}, authorizer)

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/filter"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 	"github.com/weaviate/weaviate/usecases/sharding"
 )
 
@@ -259,13 +260,7 @@ func (h *Handler) UpdateShardStatus(ctx context.Context,
 func (h *Handler) ShardsStatus(ctx context.Context,
 	principal *models.Principal, class, shard string,
 ) (models.ShardStatusList, error) {
-	// NOTE: support get shard status via alias
-	// Also we resolve before doing `Authorize` so that Authorizer will work
-	// with correct `collectionName` for permissions and errors UX
-	class = schema.UppercaseClassName(class)
-	if rclass := h.schemaReader.ResolveAlias(class); rclass != "" {
-		class = rclass
-	}
+	class, _ = namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, class)
 
 	err := h.Authorizer.Authorize(ctx, principal, authorization.READ, authorization.ShardsMetadata(class, shard)...)
 	if err != nil {

--- a/usecases/schema/handler_test.go
+++ b/usecases/schema/handler_test.go
@@ -411,12 +411,12 @@ func TestShardsStatus(t *testing.T) {
 	}
 
 	cases := []struct {
-		name          string
-		nsEnabled     bool
-		principal     *models.Principal
-		aliasMap      map[string]string
-		inputClass    string
-		resolvedClass string
+		name              string
+		namespacesEnabled bool
+		principal         *models.Principal
+		aliasMap          map[string]string
+		inputClass        string
+		resolvedClass     string
 	}{
 		{
 			name:          "alias resolves to existing class",
@@ -437,33 +437,33 @@ func TestShardsStatus(t *testing.T) {
 			resolvedClass: "RealClass",
 		},
 		{
-			name:          "namespaced principal + alias short name resolves to qualified alias",
-			nsEnabled:     true,
-			principal:     namespacedPrincipal("customer1"),
-			aliasMap:      map[string]string{"customer1:Films": "customer1:Movies"},
-			inputClass:    "Films",
-			resolvedClass: "customer1:Movies",
+			name:              "namespaced principal + alias short name resolves to qualified alias",
+			namespacesEnabled: true,
+			principal:         namespacedPrincipal("customer1"),
+			aliasMap:          map[string]string{"customer1:Films": "customer1:Movies"},
+			inputClass:        "Films",
+			resolvedClass:     "customer1:Movies",
 		},
 		{
-			name:          "namespaced principal + raw class short name qualifies to <ns>:<class>",
-			nsEnabled:     true,
-			principal:     namespacedPrincipal("customer1"),
-			aliasMap:      map[string]string{},
-			inputClass:    "Movies",
-			resolvedClass: "customer1:Movies",
+			name:              "namespaced principal + raw class short name qualifies to <ns>:<class>",
+			namespacesEnabled: true,
+			principal:         namespacedPrincipal("customer1"),
+			aliasMap:          map[string]string{},
+			inputClass:        "Movies",
+			resolvedClass:     "customer1:Movies",
 		},
 		{
-			name:          "nsEnabled with nil principal skips qualification",
-			nsEnabled:     true,
-			aliasMap:      map[string]string{"TestAlias": "RealClass"},
-			inputClass:    "TestAlias",
-			resolvedClass: "RealClass",
+			name:              "namespacesEnabled with nil principal skips qualification",
+			namespacesEnabled: true,
+			aliasMap:          map[string]string{"TestAlias": "RealClass"},
+			inputClass:        "TestAlias",
+			resolvedClass:     "RealClass",
 		},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			handler, fakeSchemaManager := newTestHandlerWithNamespaces(t, tc.nsEnabled)
+			handler, fakeSchemaManager := newTestHandlerWithNamespaces(t, tc.namespacesEnabled)
 			fakeSchemaManager.On("GetShardsStatus", tc.resolvedClass, shardName).Return(expectedStatus, nil)
 			handler.schemaReader = &fakeSchemaManagerWithAlias{
 				fakeSchemaManager: fakeSchemaManager,

--- a/usecases/schema/handler_test.go
+++ b/usecases/schema/handler_test.go
@@ -402,94 +402,80 @@ func TestSchema(t *testing.T) {
 	})
 }
 
-func TestShardsStatus_WithAlias(t *testing.T) {
+func TestShardsStatus(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()
+	const shardName = "shard1"
+	expectedStatus := models.ShardStatusList{
+		&models.ShardStatusGetResponse{Name: shardName, Status: "READY"},
+	}
 
-	t.Run("get shard status via alias - alias resolves to existing class", func(t *testing.T) {
-		handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
+	cases := []struct {
+		name          string
+		nsEnabled     bool
+		principal     *models.Principal
+		aliasMap      map[string]string
+		inputClass    string
+		resolvedClass string
+	}{
+		{
+			name:          "alias resolves to existing class",
+			aliasMap:      map[string]string{"TestAlias": "RealClass"},
+			inputClass:    "TestAlias",
+			resolvedClass: "RealClass",
+		},
+		{
+			name:          "alias resolution empty falls back to input name",
+			aliasMap:      map[string]string{},
+			inputClass:    "NonExistentAlias",
+			resolvedClass: "NonExistentAlias",
+		},
+		{
+			name:          "direct class name needs no alias resolution",
+			aliasMap:      map[string]string{},
+			inputClass:    "RealClass",
+			resolvedClass: "RealClass",
+		},
+		{
+			name:          "namespaced principal + alias short name resolves to qualified alias",
+			nsEnabled:     true,
+			principal:     namespacedPrincipal("customer1"),
+			aliasMap:      map[string]string{"customer1:Films": "customer1:Movies"},
+			inputClass:    "Films",
+			resolvedClass: "customer1:Movies",
+		},
+		{
+			name:          "namespaced principal + raw class short name qualifies to <ns>:<class>",
+			nsEnabled:     true,
+			principal:     namespacedPrincipal("customer1"),
+			aliasMap:      map[string]string{},
+			inputClass:    "Movies",
+			resolvedClass: "customer1:Movies",
+		},
+		{
+			name:          "nsEnabled with nil principal skips qualification",
+			nsEnabled:     true,
+			aliasMap:      map[string]string{"TestAlias": "RealClass"},
+			inputClass:    "TestAlias",
+			resolvedClass: "RealClass",
+		},
+	}
 
-		className := "RealClass"
-		aliasName := "TestAlias"
-		shardName := "shard1"
-		expectedStatus := models.ShardStatusList{
-			&models.ShardStatusGetResponse{
-				Name:   shardName,
-				Status: "READY",
-			},
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			handler, fakeSchemaManager := newTestHandlerWithNamespaces(t, tc.nsEnabled)
+			fakeSchemaManager.On("GetShardsStatus", tc.resolvedClass, shardName).Return(expectedStatus, nil)
+			handler.schemaReader = &fakeSchemaManagerWithAlias{
+				fakeSchemaManager: fakeSchemaManager,
+				aliasMap:          tc.aliasMap,
+			}
 
-		// Mock the shard status retrieval with the resolved class name
-		fakeSchemaManager.On("GetShardsStatus", className, shardName).Return(expectedStatus, nil)
-
-		// Create a custom fakeSchemaManager with alias support
-		fakeSchemaManagerWithAlias := &fakeSchemaManagerWithAlias{
-			fakeSchemaManager: fakeSchemaManager,
-			aliasMap:          map[string]string{aliasName: className},
-		}
-		handler.schemaReader = fakeSchemaManagerWithAlias
-
-		status, err := handler.ShardsStatus(ctx, nil, aliasName, shardName)
-		require.NoError(t, err)
-		assert.Equal(t, expectedStatus, status)
-		fakeSchemaManager.AssertExpectations(t)
-	})
-
-	t.Run("get shard status via alias - alias resolves to empty (fallback to direct name)", func(t *testing.T) {
-		handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
-
-		aliasName := "NonExistentAlias"
-		shardName := "shard1"
-		expectedStatus := models.ShardStatusList{
-			&models.ShardStatusGetResponse{
-				Name:   shardName,
-				Status: "READY",
-			},
-		}
-
-		// Mock the shard status retrieval with the alias name (will be called since alias doesn't resolve)
-		fakeSchemaManager.On("GetShardsStatus", aliasName, shardName).Return(expectedStatus, nil)
-
-		// Create a custom fakeSchemaManager with empty alias resolution
-		fakeSchemaManagerWithAlias := &fakeSchemaManagerWithAlias{
-			fakeSchemaManager: fakeSchemaManager,
-			aliasMap:          map[string]string{}, // empty map
-		}
-		handler.schemaReader = fakeSchemaManagerWithAlias
-
-		status, err := handler.ShardsStatus(ctx, nil, aliasName, shardName)
-		require.NoError(t, err)
-		assert.Equal(t, expectedStatus, status)
-		fakeSchemaManager.AssertExpectations(t)
-	})
-
-	t.Run("get shard status via direct class name - no alias resolution needed", func(t *testing.T) {
-		handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
-
-		className := "RealClass"
-		shardName := "shard1"
-		expectedStatus := models.ShardStatusList{
-			&models.ShardStatusGetResponse{
-				Name:   shardName,
-				Status: "READY",
-			},
-		}
-
-		// Mock the direct shard status retrieval
-		fakeSchemaManager.On("GetShardsStatus", className, shardName).Return(expectedStatus, nil)
-
-		// Create a custom fakeSchemaManager (alias resolution returns empty for direct class names)
-		fakeSchemaManagerWithAlias := &fakeSchemaManagerWithAlias{
-			fakeSchemaManager: fakeSchemaManager,
-			aliasMap:          map[string]string{}, // empty map
-		}
-		handler.schemaReader = fakeSchemaManagerWithAlias
-
-		status, err := handler.ShardsStatus(ctx, nil, className, shardName)
-		require.NoError(t, err)
-		assert.Equal(t, expectedStatus, status)
-		fakeSchemaManager.AssertExpectations(t)
-	})
+			status, err := handler.ShardsStatus(ctx, tc.principal, tc.inputClass, shardName)
+			require.NoError(t, err)
+			assert.Equal(t, expectedStatus, status)
+			fakeSchemaManager.AssertExpectations(t)
+		})
+	}
 }
 
 func TestGetAliases_WithNonExistentClass(t *testing.T) {

--- a/usecases/schema/namespacing/namespacing.go
+++ b/usecases/schema/namespacing/namespacing.go
@@ -41,8 +41,8 @@ const ShortNameMaxLength = schema.ClassNameMaxLength - schema.NamespaceMaxLength
 // On NS-enabled clusters, callers without a namespace are rejected with
 // ErrCreateRequiresNamespace; the call site is responsible for translating
 // that into a 403 with the appropriate verb and resources.
-func QualifyForCreate(principal *models.Principal, nsEnabled bool, raw string) (string, error) {
-	if !nsEnabled {
+func QualifyForCreate(principal *models.Principal, namespacesEnabled bool, raw string) (string, error) {
+	if !namespacesEnabled {
 		return raw, nil
 	}
 	if principal == nil || principal.Namespace == "" {

--- a/usecases/schema/namespacing/namespacing_test.go
+++ b/usecases/schema/namespacing/namespacing_test.go
@@ -24,81 +24,81 @@ import (
 
 func TestQualifyForCreate(t *testing.T) {
 	cases := []struct {
-		name         string
-		principal    *models.Principal
-		nsEnabled    bool
-		raw          string
-		want         string
-		wantSentinel bool
-		wantOtherErr bool
+		name              string
+		principal         *models.Principal
+		namespacesEnabled bool
+		raw               string
+		want              string
+		wantSentinel      bool
+		wantOtherErr      bool
 	}{
 		{
-			name:      "namespaced principal qualifies",
-			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			nsEnabled: true,
-			raw:       "Movies",
-			want:      "customer1:Movies",
+			name:              "namespaced principal qualifies",
+			principal:         &models.Principal{Username: "u", Namespace: "customer1"},
+			namespacesEnabled: true,
+			raw:               "Movies",
+			want:              "customer1:Movies",
 		},
 		{
-			name:         "global principal rejected with sentinel on NS-enabled",
-			principal:    &models.Principal{Username: "admin", IsGlobalOperator: true},
-			nsEnabled:    true,
-			raw:          "Movies",
-			wantSentinel: true,
+			name:              "global principal rejected with sentinel on NS-enabled",
+			principal:         &models.Principal{Username: "admin", IsGlobalOperator: true},
+			namespacesEnabled: true,
+			raw:               "Movies",
+			wantSentinel:      true,
 		},
 		{
-			name:         "nil principal rejected with sentinel on NS-enabled",
-			principal:    nil,
-			nsEnabled:    true,
-			raw:          "Movies",
-			wantSentinel: true,
+			name:              "nil principal rejected with sentinel on NS-enabled",
+			principal:         nil,
+			namespacesEnabled: true,
+			raw:               "Movies",
+			wantSentinel:      true,
 		},
 		{
-			name:      "global principal allowed on NS-disabled (raw passthrough)",
-			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
-			nsEnabled: false,
-			raw:       "Movies",
-			want:      "Movies",
+			name:              "global principal allowed on NS-disabled (raw passthrough)",
+			principal:         &models.Principal{Username: "admin", IsGlobalOperator: true},
+			namespacesEnabled: false,
+			raw:               "Movies",
+			want:              "Movies",
 		},
 		{
-			name:      "NS-disabled passthrough does not enforce length cap",
-			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
-			nsEnabled: false,
-			raw:       "C" + strings.Repeat("x", ShortNameMaxLength+50),
-			want:      "C" + strings.Repeat("x", ShortNameMaxLength+50),
+			name:              "NS-disabled passthrough does not enforce length cap",
+			principal:         &models.Principal{Username: "admin", IsGlobalOperator: true},
+			namespacesEnabled: false,
+			raw:               "C" + strings.Repeat("x", ShortNameMaxLength+50),
+			want:              "C" + strings.Repeat("x", ShortNameMaxLength+50),
 		},
 		{
-			name:      "nil principal on NS-disabled returns raw unchanged",
-			principal: nil,
-			nsEnabled: false,
-			raw:       "Movies",
-			want:      "Movies",
+			name:              "nil principal on NS-disabled returns raw unchanged",
+			principal:         nil,
+			namespacesEnabled: false,
+			raw:               "Movies",
+			want:              "Movies",
 		},
 		{
-			name:      "namespaced principal at the cap accepted",
-			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			nsEnabled: true,
-			raw:       "C" + strings.Repeat("x", ShortNameMaxLength-1),
-			want:      "customer1:" + "C" + strings.Repeat("x", ShortNameMaxLength-1),
+			name:              "namespaced principal at the cap accepted",
+			principal:         &models.Principal{Username: "u", Namespace: "customer1"},
+			namespacesEnabled: true,
+			raw:               "C" + strings.Repeat("x", ShortNameMaxLength-1),
+			want:              "customer1:" + "C" + strings.Repeat("x", ShortNameMaxLength-1),
 		},
 		{
-			name:         "namespaced principal one over the cap rejected with non-sentinel error",
-			principal:    &models.Principal{Username: "u", Namespace: "customer1"},
-			nsEnabled:    true,
-			raw:          "C" + strings.Repeat("x", ShortNameMaxLength),
-			wantOtherErr: true,
+			name:              "namespaced principal one over the cap rejected with non-sentinel error",
+			principal:         &models.Principal{Username: "u", Namespace: "customer1"},
+			namespacesEnabled: true,
+			raw:               "C" + strings.Repeat("x", ShortNameMaxLength),
+			wantOtherErr:      true,
 		},
 		{
-			name:         "namespaced principal far over the cap rejected with non-sentinel error",
-			principal:    &models.Principal{Username: "u", Namespace: "customer1"},
-			nsEnabled:    true,
-			raw:          strings.Repeat("x", ShortNameMaxLength*2),
-			wantOtherErr: true,
+			name:              "namespaced principal far over the cap rejected with non-sentinel error",
+			principal:         &models.Principal{Username: "u", Namespace: "customer1"},
+			namespacesEnabled: true,
+			raw:               strings.Repeat("x", ShortNameMaxLength*2),
+			wantOtherErr:      true,
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := QualifyForCreate(tc.principal, tc.nsEnabled, tc.raw)
+			got, err := QualifyForCreate(tc.principal, tc.namespacesEnabled, tc.raw)
 			switch {
 			case tc.wantSentinel:
 				require.ErrorIs(t, err, ErrCreateRequiresNamespace)

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -59,9 +59,9 @@ func qualify(principal *models.Principal, name string) string {
 // namespaced principals, raw for global principals), "" otherwise — used by
 // the objects layer to preserve existing alias-aware flows. Sites that do
 // not need this can ignore the second return value.
-func Resolve(principal *models.Principal, sm SchemaManager, nsEnabled bool, name string) (class, originalAlias string) {
+func Resolve(principal *models.Principal, sm SchemaManager, namespacesEnabled bool, name string) (class, originalAlias string) {
 	qualified := schema.UppercaseClassName(name)
-	if nsEnabled {
+	if namespacesEnabled {
 		qualified = qualify(principal, qualified)
 	}
 
@@ -77,9 +77,9 @@ func Resolve(principal *models.Principal, sm SchemaManager, nsEnabled bool, name
 // QualifyClass uppercases the class portion of name and prepends the
 // principal's namespace when namespaces are enabled. Aliases are not
 // resolved.
-func QualifyClass(principal *models.Principal, nsEnabled bool, name string) string {
+func QualifyClass(principal *models.Principal, namespacesEnabled bool, name string) string {
 	qualified := schema.UppercaseClassName(name)
-	if nsEnabled {
+	if namespacesEnabled {
 		qualified = qualify(principal, qualified)
 	}
 	return qualified

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -107,58 +107,58 @@ func TestQualifiedName(t *testing.T) {
 
 func TestQualifyClass(t *testing.T) {
 	cases := []struct {
-		testName  string
-		principal *models.Principal
-		nsEnabled bool
-		input     string
-		want      string
+		testName          string
+		principal         *models.Principal
+		namespacesEnabled bool
+		input             string
+		want              string
 	}{
 		{
-			testName:  "namespaced principal lowercase short input is uppercased and qualified",
-			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			nsEnabled: true,
-			input:     "movies",
-			want:      "customer1:Movies",
+			testName:          "namespaced principal lowercase short input is uppercased and qualified",
+			principal:         &models.Principal{Username: "u", Namespace: "customer1"},
+			namespacesEnabled: true,
+			input:             "movies",
+			want:              "customer1:Movies",
 		},
 		{
-			testName:  "operator full name preserves namespace and uppercases only the class",
-			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
-			nsEnabled: true,
-			input:     "customer1:movies",
-			want:      "customer1:Movies",
+			testName:          "operator full name preserves namespace and uppercases only the class",
+			principal:         &models.Principal{Username: "admin", IsGlobalOperator: true},
+			namespacesEnabled: true,
+			input:             "customer1:movies",
+			want:              "customer1:Movies",
 		},
 		{
-			testName:  "operator already-uppercase full name passthrough",
-			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
-			nsEnabled: true,
-			input:     "customer1:Movies",
-			want:      "customer1:Movies",
+			testName:          "operator already-uppercase full name passthrough",
+			principal:         &models.Principal{Username: "admin", IsGlobalOperator: true},
+			namespacesEnabled: true,
+			input:             "customer1:Movies",
+			want:              "customer1:Movies",
 		},
 		{
-			testName:  "ns disabled lowercase input still uppercased",
-			principal: &models.Principal{Username: "u"},
-			nsEnabled: false,
-			input:     "movies",
-			want:      "Movies",
+			testName:          "ns disabled lowercase input still uppercased",
+			principal:         &models.Principal{Username: "u"},
+			namespacesEnabled: false,
+			input:             "movies",
+			want:              "Movies",
 		},
 		{
-			testName:  "alias-shaped input is not resolved (qualified, not retargeted)",
-			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			nsEnabled: true,
-			input:     "films",
-			want:      "customer1:Films",
+			testName:          "alias-shaped input is not resolved (qualified, not retargeted)",
+			principal:         &models.Principal{Username: "u", Namespace: "customer1"},
+			namespacesEnabled: true,
+			input:             "films",
+			want:              "customer1:Films",
 		},
 		{
-			testName:  "alias-shaped raw input on ns-disabled is not resolved",
-			principal: &models.Principal{Username: "u"},
-			nsEnabled: false,
-			input:     "films",
-			want:      "Films",
+			testName:          "alias-shaped raw input on ns-disabled is not resolved",
+			principal:         &models.Principal{Username: "u"},
+			namespacesEnabled: false,
+			input:             "films",
+			want:              "Films",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			got := QualifyClass(tc.principal, tc.nsEnabled, tc.input)
+			got := QualifyClass(tc.principal, tc.namespacesEnabled, tc.input)
 			assert.Equal(t, tc.want, got)
 		})
 	}
@@ -166,126 +166,126 @@ func TestQualifyClass(t *testing.T) {
 
 func TestResolve(t *testing.T) {
 	cases := []struct {
-		testName  string
-		principal *models.Principal
-		sm        SchemaManager
-		nsEnabled bool
-		input     string
-		wantClass string
-		wantAlias string
+		testName          string
+		principal         *models.Principal
+		sm                SchemaManager
+		namespacesEnabled bool
+		input             string
+		wantClass         string
+		wantAlias         string
 	}{
 		{
-			testName:  "namespaced principal resolves to qualified name",
-			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			sm:        &fakeSchemaManager{aliases: map[string]string{}},
-			nsEnabled: true,
-			input:     "Movies",
-			wantClass: "customer1:Movies",
-			wantAlias: "",
+			testName:          "namespaced principal resolves to qualified name",
+			principal:         &models.Principal{Username: "u", Namespace: "customer1"},
+			sm:                &fakeSchemaManager{aliases: map[string]string{}},
+			namespacesEnabled: true,
+			input:             "Movies",
+			wantClass:         "customer1:Movies",
+			wantAlias:         "",
 		},
 		{
-			testName:  "namespaced principal with alias",
-			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			sm:        &fakeSchemaManager{aliases: map[string]string{"customer1:Films": "customer1:Movies"}},
-			nsEnabled: true,
-			input:     "Films",
-			wantClass: "customer1:Movies",
-			wantAlias: "customer1:Films",
+			testName:          "namespaced principal with alias",
+			principal:         &models.Principal{Username: "u", Namespace: "customer1"},
+			sm:                &fakeSchemaManager{aliases: map[string]string{"customer1:Films": "customer1:Movies"}},
+			namespacesEnabled: true,
+			input:             "Films",
+			wantClass:         "customer1:Movies",
+			wantAlias:         "customer1:Films",
 		},
 		{
-			testName:  "global principal passthrough",
-			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
-			sm:        &fakeSchemaManager{aliases: map[string]string{}},
-			nsEnabled: true,
-			input:     "Movies",
-			wantClass: "Movies",
-			wantAlias: "",
+			testName:          "global principal passthrough",
+			principal:         &models.Principal{Username: "admin", IsGlobalOperator: true},
+			sm:                &fakeSchemaManager{aliases: map[string]string{}},
+			namespacesEnabled: true,
+			input:             "Movies",
+			wantClass:         "Movies",
+			wantAlias:         "",
 		},
 		{
-			testName:  "global principal qualified input with alias hit resolves normally",
-			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
-			sm:        &fakeSchemaManager{aliases: map[string]string{"customer1:Movies": "customer1:ActualMovies"}},
-			nsEnabled: true,
-			input:     "customer1:Movies",
-			wantClass: "customer1:ActualMovies",
-			wantAlias: "customer1:Movies",
+			testName:          "global principal qualified input with alias hit resolves normally",
+			principal:         &models.Principal{Username: "admin", IsGlobalOperator: true},
+			sm:                &fakeSchemaManager{aliases: map[string]string{"customer1:Movies": "customer1:ActualMovies"}},
+			namespacesEnabled: true,
+			input:             "customer1:Movies",
+			wantClass:         "customer1:ActualMovies",
+			wantAlias:         "customer1:Movies",
 		},
 		{
-			testName:  "nil principal passthrough",
-			principal: nil,
-			sm:        &fakeSchemaManager{aliases: map[string]string{}},
-			nsEnabled: true,
-			input:     "Movies",
-			wantClass: "Movies",
-			wantAlias: "",
+			testName:          "nil principal passthrough",
+			principal:         nil,
+			sm:                &fakeSchemaManager{aliases: map[string]string{}},
+			namespacesEnabled: true,
+			input:             "Movies",
+			wantClass:         "Movies",
+			wantAlias:         "",
 		},
 		{
-			testName:  "namespaced principal qualified input gets double prefixed",
-			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			sm:        &fakeSchemaManager{aliases: map[string]string{}},
-			nsEnabled: true,
-			input:     "customer2:Movies",
-			wantClass: "customer1:customer2:Movies",
-			wantAlias: "",
+			testName:          "namespaced principal qualified input gets double prefixed",
+			principal:         &models.Principal{Username: "u", Namespace: "customer1"},
+			sm:                &fakeSchemaManager{aliases: map[string]string{}},
+			namespacesEnabled: true,
+			input:             "customer2:Movies",
+			wantClass:         "customer1:customer2:Movies",
+			wantAlias:         "",
 		},
 		{
-			testName:  "namespaced principal with alias that resolves to target",
-			principal: &models.Principal{Username: "u", Namespace: "ns1"},
-			sm:        &fakeSchemaManager{aliases: map[string]string{"ns1:MyAlias": "ns1:MyClass"}},
-			nsEnabled: true,
-			input:     "MyAlias",
-			wantClass: "ns1:MyClass",
-			wantAlias: "ns1:MyAlias",
+			testName:          "namespaced principal with alias that resolves to target",
+			principal:         &models.Principal{Username: "u", Namespace: "ns1"},
+			sm:                &fakeSchemaManager{aliases: map[string]string{"ns1:MyAlias": "ns1:MyClass"}},
+			namespacesEnabled: true,
+			input:             "MyAlias",
+			wantClass:         "ns1:MyClass",
+			wantAlias:         "ns1:MyAlias",
 		},
 		{
-			testName:  "ns disabled ignores principal namespace",
-			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			sm:        &fakeSchemaManager{aliases: map[string]string{}},
-			nsEnabled: false,
-			input:     "Movies",
-			wantClass: "Movies",
-			wantAlias: "",
+			testName:          "ns disabled ignores principal namespace",
+			principal:         &models.Principal{Username: "u", Namespace: "customer1"},
+			sm:                &fakeSchemaManager{aliases: map[string]string{}},
+			namespacesEnabled: false,
+			input:             "Movies",
+			wantClass:         "Movies",
+			wantAlias:         "",
 		},
 		{
-			testName:  "ns disabled resolves alias on raw input for non-namespaced principal",
-			principal: &models.Principal{Username: "u"},
-			sm:        &fakeSchemaManager{aliases: map[string]string{"Films": "Movies"}},
-			nsEnabled: false,
-			input:     "Films",
-			wantClass: "Movies",
-			wantAlias: "Films",
+			testName:          "ns disabled resolves alias on raw input for non-namespaced principal",
+			principal:         &models.Principal{Username: "u"},
+			sm:                &fakeSchemaManager{aliases: map[string]string{"Films": "Movies"}},
+			namespacesEnabled: false,
+			input:             "Films",
+			wantClass:         "Movies",
+			wantAlias:         "Films",
 		},
 		{
-			testName:  "lowercase short input is uppercased before qualification",
-			principal: &models.Principal{Username: "u", Namespace: "customer1"},
-			sm:        &fakeSchemaManager{aliases: map[string]string{}},
-			nsEnabled: true,
-			input:     "movies",
-			wantClass: "customer1:Movies",
-			wantAlias: "",
+			testName:          "lowercase short input is uppercased before qualification",
+			principal:         &models.Principal{Username: "u", Namespace: "customer1"},
+			sm:                &fakeSchemaManager{aliases: map[string]string{}},
+			namespacesEnabled: true,
+			input:             "movies",
+			wantClass:         "customer1:Movies",
+			wantAlias:         "",
 		},
 		{
-			testName:  "lowercase qualified input uppercases only the class portion",
-			principal: &models.Principal{Username: "admin", IsGlobalOperator: true},
-			sm:        &fakeSchemaManager{aliases: map[string]string{}},
-			nsEnabled: true,
-			input:     "customer1:movies",
-			wantClass: "customer1:Movies",
-			wantAlias: "",
+			testName:          "lowercase qualified input uppercases only the class portion",
+			principal:         &models.Principal{Username: "admin", IsGlobalOperator: true},
+			sm:                &fakeSchemaManager{aliases: map[string]string{}},
+			namespacesEnabled: true,
+			input:             "customer1:movies",
+			wantClass:         "customer1:Movies",
+			wantAlias:         "",
 		},
 		{
-			testName:  "ns disabled still uppercases lowercase input",
-			principal: &models.Principal{Username: "u"},
-			sm:        &fakeSchemaManager{aliases: map[string]string{}},
-			nsEnabled: false,
-			input:     "movies",
-			wantClass: "Movies",
-			wantAlias: "",
+			testName:          "ns disabled still uppercases lowercase input",
+			principal:         &models.Principal{Username: "u"},
+			sm:                &fakeSchemaManager{aliases: map[string]string{}},
+			namespacesEnabled: false,
+			input:             "movies",
+			wantClass:         "Movies",
+			wantAlias:         "",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			gotClass, gotAlias := Resolve(tc.principal, tc.sm, tc.nsEnabled, tc.input)
+			gotClass, gotAlias := Resolve(tc.principal, tc.sm, tc.namespacesEnabled, tc.input)
 			assert.Equal(t, tc.wantClass, gotClass)
 			assert.Equal(t, tc.wantAlias, gotAlias)
 		})


### PR DESCRIPTION
### What's being changed:

This adds namespacing support for 3 new APIs that all require multi-node communication:
- Aggreagte (for count)
- ShardStatus
- Nodes API

All of them were blocked by an regExp for class names on the internal calls.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
