### PR TITLE
Namespacs: Add namespace info to audit log

### DIFF
--- a/usecases/auth/authorization/rbac/authorizer.go
+++ b/usecases/auth/authorization/rbac/authorizer.go
@@ -38,10 +38,19 @@ func (m *Manager) auditFields(principal *models.Principal) logrus.Fields {
 		"rbac_log_version": AuditLogVersion,
 	}
 	if m.namespacesEnabled {
-		if principal.IsGlobalOperator {
+		switch {
+		case principal.IsGlobalOperator:
 			f["global_operator"] = true
-		} else if principal.Namespace != "" {
+		case principal.Namespace != "":
 			f["namespace"] = principal.Namespace
+		default:
+			// Defense-in-depth: every NS-enabled principal must be classified
+			// as namespace-bound or global upstream. If a producer drifts,
+			// default to global (no namespace claim is leaked) and warn so
+			// the gap surfaces.
+			m.logger.WithField("user", principal.Username).
+				Warn("rbac: principal missing namespace and global classification on NS-enabled cluster; defaulting to global_operator")
+			f["global_operator"] = true
 		}
 	}
 	return f

--- a/usecases/auth/authorization/rbac/authorizer.go
+++ b/usecases/auth/authorization/rbac/authorizer.go
@@ -56,7 +56,10 @@ func (m *Manager) authorize(ctx context.Context, principal *models.Principal, ve
 		return fmt.Errorf("at least 1 resource is required")
 	}
 
-	logger := m.logger.WithFields(m.auditFields(principal)).WithField("request_action", verb)
+	logger := m.logger.
+		WithFields(m.auditFields(principal)).
+		WithField("request_action", verb).
+		WithField("audit_mode", "authorize")
 	if !m.rbacConf.IpInAuditDisabled {
 		sourceIp := ctx.Value("sourceIp")
 		logger = logger.WithField("source_ip", sourceIp)
@@ -139,7 +142,10 @@ func (m *Manager) FilterAuthorizedResources(ctx context.Context, principal *mode
 		return nil, fmt.Errorf("at least 1 resource is required")
 	}
 
-	logger := m.logger.WithFields(m.auditFields(principal)).WithField("request_action", verb)
+	logger := m.logger.
+		WithFields(m.auditFields(principal)).
+		WithField("request_action", verb).
+		WithField("audit_mode", "filter")
 	if !m.rbacConf.IpInAuditDisabled {
 		sourceIp := ctx.Value("sourceIp")
 		logger = logger.WithField("source_ip", sourceIp)

--- a/usecases/auth/authorization/rbac/authorizer.go
+++ b/usecases/auth/authorization/rbac/authorizer.go
@@ -25,6 +25,28 @@ import (
 
 const AuditLogVersion = 2
 
+// auditFields produces the per-request audit log fields shared between
+// Authorize and FilterAuthorizedResources. On NS-enabled clusters it adds
+// either namespace=<short> for namespace-bound principals or
+// global_operator=true for operator-level principals; NS-disabled clusters
+// emit neither field.
+func (m *Manager) auditFields(principal *models.Principal) logrus.Fields {
+	f := logrus.Fields{
+		"action":           "authorize",
+		"user":             principal.Username,
+		"component":        authorization.ComponentName,
+		"rbac_log_version": AuditLogVersion,
+	}
+	if m.namespacesEnabled {
+		if principal.IsGlobalOperator {
+			f["global_operator"] = true
+		} else if principal.Namespace != "" {
+			f["namespace"] = principal.Namespace
+		}
+	}
+	return f
+}
+
 func (m *Manager) authorize(ctx context.Context, principal *models.Principal, verb string, skipAudit bool, resources ...string) error {
 	if principal == nil {
 		return fmt.Errorf("rbac: %w", errors.NewUnauthenticated())
@@ -34,13 +56,7 @@ func (m *Manager) authorize(ctx context.Context, principal *models.Principal, ve
 		return fmt.Errorf("at least 1 resource is required")
 	}
 
-	logger := m.logger.WithFields(logrus.Fields{
-		"action":           "authorize",
-		"user":             principal.Username,
-		"component":        authorization.ComponentName,
-		"request_action":   verb,
-		"rbac_log_version": AuditLogVersion,
-	})
+	logger := m.logger.WithFields(m.auditFields(principal)).WithField("request_action", verb)
 	if !m.rbacConf.IpInAuditDisabled {
 		sourceIp := ctx.Value("sourceIp")
 		logger = logger.WithField("source_ip", sourceIp)
@@ -80,7 +96,7 @@ func (m *Manager) authorize(ctx context.Context, principal *models.Principal, ve
 
 		if allowed {
 			permResults = append(permResults, logrus.Fields{
-				"resource": prettyPermissionsResources(perm),
+				"resource": prettyPermissionsResources(principal, perm),
 				"results":  prettyStatus(allowed),
 			})
 		}
@@ -89,7 +105,7 @@ func (m *Manager) authorize(ctx context.Context, principal *models.Principal, ve
 			if !skipAudit {
 				logger.WithField("permissions", permResults).Error("authorization denied")
 			}
-			return fmt.Errorf("rbac: %w", errors.NewForbidden(principal, prettyPermissionsActions(perm), prettyPermissionsResources(perm)))
+			return fmt.Errorf("rbac: %w", errors.NewForbidden(principal, prettyPermissionsActions(perm), prettyPermissionsResources(principal, perm)))
 		}
 	}
 
@@ -123,13 +139,7 @@ func (m *Manager) FilterAuthorizedResources(ctx context.Context, principal *mode
 		return nil, fmt.Errorf("at least 1 resource is required")
 	}
 
-	logger := m.logger.WithFields(logrus.Fields{
-		"action":           "authorize",
-		"user":             principal.Username,
-		"component":        authorization.ComponentName,
-		"request_action":   verb,
-		"rbac_log_version": AuditLogVersion,
-	})
+	logger := m.logger.WithFields(m.auditFields(principal)).WithField("request_action", verb)
 	if !m.rbacConf.IpInAuditDisabled {
 		sourceIp := ctx.Value("sourceIp")
 		logger = logger.WithField("source_ip", sourceIp)
@@ -170,7 +180,7 @@ func (m *Manager) FilterAuthorizedResources(ctx context.Context, principal *mode
 			}
 
 			permResults = append(permResults, logrus.Fields{
-				"resource": prettyPermissionsResources(perm),
+				"resource": prettyPermissionsResources(principal, perm),
 				"results":  prettyStatus(allowed),
 			})
 			allowedResources = append(allowedResources, resource)

--- a/usecases/auth/authorization/rbac/authorizer.go
+++ b/usecases/auth/authorization/rbac/authorizer.go
@@ -26,7 +26,7 @@ import (
 const AuditLogVersion = 2
 
 // auditFields produces the per-request audit log fields shared between
-// Authorize and FilterAuthorizedResources. On NS-enabled clusters it adds
+// Authorize and FilterAuthorizedResources. On namespace enabled clusters it adds
 // either namespace=<short> for namespace-bound principals or
 // global_operator=true for operator-level principals; NS-disabled clusters
 // emit neither field.
@@ -44,12 +44,12 @@ func (m *Manager) auditFields(principal *models.Principal) logrus.Fields {
 		case principal.Namespace != "":
 			f["namespace"] = principal.Namespace
 		default:
-			// Defense-in-depth: every NS-enabled principal must be classified
+			// Defense-in-depth: every namespace enabled principal must be classified
 			// as namespace-bound or global upstream. If a producer drifts,
 			// default to global (no namespace claim is leaked) and warn so
 			// the gap surfaces.
 			m.logger.WithField("user", principal.Username).
-				Warn("rbac: principal missing namespace and global classification on NS-enabled cluster; defaulting to global_operator")
+				Warn("rbac: principal missing namespace and global classification on namespace enabled cluster; defaulting to global_operator")
 			f["global_operator"] = true
 		}
 	}

--- a/usecases/auth/authorization/rbac/authorizer.go
+++ b/usecases/auth/authorization/rbac/authorizer.go
@@ -124,11 +124,16 @@ func (m *Manager) FilterAuthorizedResources(ctx context.Context, principal *mode
 	}
 
 	logger := m.logger.WithFields(logrus.Fields{
-		"action":         "authorize",
-		"user":           principal.Username,
-		"component":      authorization.ComponentName,
-		"request_action": verb,
+		"action":           "authorize",
+		"user":             principal.Username,
+		"component":        authorization.ComponentName,
+		"request_action":   verb,
+		"rbac_log_version": AuditLogVersion,
 	})
+	if !m.rbacConf.IpInAuditDisabled {
+		sourceIp := ctx.Value("sourceIp")
+		logger = logger.WithField("source_ip", sourceIp)
+	}
 	if clientIdentifier, _ := ctx.Value("clientIdentifier").(string); clientIdentifier != "" {
 		logger = logger.WithField("client_identifier", clientIdentifier)
 	}

--- a/usecases/auth/authorization/rbac/authorizer_test.go
+++ b/usecases/auth/authorization/rbac/authorizer_test.go
@@ -729,6 +729,152 @@ func TestFilterAuthorizedResourcesAggregation(t *testing.T) {
 	assert.Equal(t, "data/collections/ContactRecommendations/shards/*/objects/*", allowedResources[0], "returned resource should be the same as input")
 }
 
+// TestAudit_NamespaceFields verifies the top-level audit fields emitted by
+// the success paths of Authorize and FilterAuthorizedResources: NS-disabled
+// clusters never emit namespace/global_operator; NS-enabled clusters emit
+// exactly one of them depending on the principal shape. It also confirms
+// the permissions[].resource string strips own-namespace prefixes for
+// namespace-bound principals and keeps them raw for global operators.
+func TestAudit_NamespaceFields(t *testing.T) {
+	type principalCase struct {
+		name            string
+		nsEnabled       bool
+		principal       *models.Principal
+		resources       []string
+		wantField       map[string]any
+		wantAbsent      []string
+		wantPrettyMatch string
+	}
+
+	nsDisabledPrincipal := &models.Principal{Username: "alice", UserType: models.UserTypeInputDb}
+	nsNamespacedPrincipal := &models.Principal{Username: "customer1:alice", Namespace: "customer1", UserType: models.UserTypeInputDb}
+	nsGlobalPrincipal := &models.Principal{Username: "admin-key", IsGlobalOperator: true, UserType: models.UserTypeInputDb}
+
+	principalCases := []principalCase{
+		{
+			name:      "ns_disabled_no_new_fields",
+			nsEnabled: false,
+			principal: nsDisabledPrincipal,
+			resources: authorization.ShardsData("Movies", "#"),
+			wantField: map[string]any{
+				"rbac_log_version": AuditLogVersion,
+				"user":             "alice",
+				"action":           "authorize",
+			},
+			wantAbsent:      []string{"namespace", "global_operator"},
+			wantPrettyMatch: "Collection: Movies",
+		},
+		{
+			name:      "ns_enabled_namespaced_caller",
+			nsEnabled: true,
+			principal: nsNamespacedPrincipal,
+			resources: authorization.ShardsData("customer1:Movies", "#"),
+			wantField: map[string]any{
+				"namespace":        "customer1",
+				"rbac_log_version": AuditLogVersion,
+				"user":             "customer1:alice",
+				"action":           "authorize",
+			},
+			wantAbsent:      []string{"global_operator"},
+			wantPrettyMatch: "Collection: Movies",
+		},
+		{
+			name:      "ns_enabled_global_operator",
+			nsEnabled: true,
+			principal: nsGlobalPrincipal,
+			resources: authorization.ShardsData("customer1:Movies", "#"),
+			wantField: map[string]any{
+				"global_operator":  true,
+				"rbac_log_version": AuditLogVersion,
+				"user":             "admin-key",
+				"action":           "authorize",
+			},
+			wantAbsent:      []string{"namespace"},
+			wantPrettyMatch: "Collection: customer1:Movies",
+		},
+	}
+
+	callSites := []struct {
+		name string
+		run  func(m *Manager, p *models.Principal, rs []string) error
+	}{
+		{"Authorize", func(m *Manager, p *models.Principal, rs []string) error {
+			return m.Authorize(context.Background(), p, authorization.READ, rs...)
+		}},
+		{"FilterAuthorizedResources", func(m *Manager, p *models.Principal, rs []string) error {
+			_, err := m.FilterAuthorizedResources(context.Background(), p, authorization.READ, rs...)
+			return err
+		}},
+	}
+
+	for _, pc := range principalCases {
+		for _, cs := range callSites {
+			t.Run(pc.name+"/"+cs.name, func(t *testing.T) {
+				logger, hook := test.NewNullLogger()
+				var (
+					m   *Manager
+					err error
+				)
+				if pc.nsEnabled {
+					m, err = setupNSEnabledTestManager(t, logger)
+				} else {
+					m, err = setupTestManager(t, logger)
+				}
+				require.NoError(t, err)
+
+				// Grant a permissive READ in the data domain to the principal so
+				// the success path runs and emits one info-level entry.
+				_, err = m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("audit-role"),
+					"*", authorization.READ, authorization.DataDomain)
+				require.NoError(t, err)
+				_, err = m.casbin.AddRoleForUser(
+					conv.UserNameWithTypeFromId(pc.principal.Username, authentication.AuthTypeDb),
+					conv.PrefixRoleName("audit-role"))
+				require.NoError(t, err)
+
+				require.NoError(t, cs.run(m, pc.principal, pc.resources))
+
+				entry := hook.LastEntry()
+				require.NotNil(t, entry)
+				for k, v := range pc.wantField {
+					require.Equal(t, v, entry.Data[k], "field %q", k)
+				}
+				for _, k := range pc.wantAbsent {
+					_, present := entry.Data[k]
+					require.False(t, present, "field %q must be absent", k)
+				}
+				perms, ok := entry.Data["permissions"].([]logrus.Fields)
+				require.True(t, ok, "permissions should be []logrus.Fields")
+				require.NotEmpty(t, perms)
+				require.Contains(t, perms[0]["resource"].(string), pc.wantPrettyMatch)
+			})
+		}
+	}
+}
+
+// TestAudit_NamespaceFields_DenyPath ensures the deny-side log entry on an
+// NS-enabled cluster carries the top-level namespace field, matching the
+// success-path shape so SIEM consumers see consistent fields across allow
+// and deny.
+func TestAudit_NamespaceFields_DenyPath(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	m, err := setupNSEnabledTestManager(t, logger)
+	require.NoError(t, err)
+
+	p := &models.Principal{Username: "customer1:alice", Namespace: "customer1", UserType: models.UserTypeInputDb}
+	err = m.Authorize(context.Background(), p, authorization.READ,
+		authorization.ShardsData("customer1:Movies", "#")...)
+	require.Error(t, err)
+
+	entry := hook.LastEntry()
+	require.NotNil(t, entry)
+	require.Equal(t, logrus.ErrorLevel, entry.Level)
+	require.Equal(t, "customer1", entry.Data["namespace"])
+	require.Equal(t, AuditLogVersion, entry.Data["rbac_log_version"])
+	_, hasGlobal := entry.Data["global_operator"]
+	require.False(t, hasGlobal)
+}
+
 func setupTestManager(t *testing.T, logger *logrus.Logger) (*Manager, error) {
 	tmpDir, err := os.MkdirTemp("", "rbac-test-*")
 	if err != nil {

--- a/usecases/auth/authorization/rbac/authorizer_test.go
+++ b/usecases/auth/authorization/rbac/authorizer_test.go
@@ -573,6 +573,8 @@ func TestFilterAuthorizedResourcesLogging(t *testing.T) {
 	assert.Equal(t, principal.Groups, entry.Data["groups"])
 	assert.Equal(t, authorization.ComponentName, entry.Data["component"])
 	assert.Equal(t, authorization.READ, entry.Data["request_action"])
+	assert.Equal(t, AuditLogVersion, entry.Data["rbac_log_version"])
+	assert.Contains(t, entry.Data, "source_ip", "source_ip must be present when IpInAuditDisabled=false")
 
 	// Verify the final result matches the logged permissions
 	assert.ElementsMatch(t, testResources, allowedResources,
@@ -625,6 +627,8 @@ func TestAuthorizeResourceAggregation(t *testing.T) {
 	assert.Equal(t, "admin-user", lastEntry.Data["user"])
 	assert.Equal(t, authorization.ComponentName, lastEntry.Data["component"])
 	assert.Equal(t, authorization.READ, lastEntry.Data["request_action"])
+	assert.Equal(t, AuditLogVersion, lastEntry.Data["rbac_log_version"])
+	assert.Contains(t, lastEntry.Data, "source_ip", "source_ip must be present when IpInAuditDisabled=false")
 
 	// Verify permissions field exists
 	permissions, ok := lastEntry.Data["permissions"].([]logrus.Fields)
@@ -696,6 +700,8 @@ func TestFilterAuthorizedResourcesAggregation(t *testing.T) {
 	assert.Equal(t, "admin-user", lastEntry.Data["user"])
 	assert.Equal(t, authorization.ComponentName, lastEntry.Data["component"])
 	assert.Equal(t, authorization.READ, lastEntry.Data["request_action"])
+	assert.Equal(t, AuditLogVersion, lastEntry.Data["rbac_log_version"])
+	assert.Contains(t, lastEntry.Data, "source_ip", "source_ip must be present when IpInAuditDisabled=false")
 
 	// Verify permissions field exists
 	permissions, ok := lastEntry.Data["permissions"].([]logrus.Fields)

--- a/usecases/auth/authorization/rbac/authorizer_test.go
+++ b/usecases/auth/authorization/rbac/authorizer_test.go
@@ -731,7 +731,7 @@ func TestFilterAuthorizedResourcesAggregation(t *testing.T) {
 
 // TestAudit_NamespaceFields verifies the top-level audit fields emitted by
 // the success paths of Authorize and FilterAuthorizedResources: NS-disabled
-// clusters never emit namespace/global_operator; NS-enabled clusters emit
+// clusters never emit namespace/global_operator; namespace enabled clusters emit
 // exactly one of them depending on the principal shape. It also confirms
 // the permissions[].resource string strips own-namespace prefixes for
 // namespace-bound principals and keeps them raw for global operators.
@@ -855,7 +855,7 @@ func TestAudit_NamespaceFields(t *testing.T) {
 }
 
 // TestAudit_NamespaceFields_DenyPath ensures the deny-side log entry on an
-// NS-enabled cluster carries the top-level namespace field, matching the
+// namespace enabled cluster carries the top-level namespace field, matching the
 // success-path shape so SIEM consumers see consistent fields across allow
 // and deny.
 func TestAudit_NamespaceFields_DenyPath(t *testing.T) {
@@ -879,7 +879,7 @@ func TestAudit_NamespaceFields_DenyPath(t *testing.T) {
 }
 
 // TestAudit_MalformedPrincipal_DefaultsToGlobalAndWarns covers the
-// defense-in-depth branch in auditFields: an NS-enabled cluster receiving
+// defense-in-depth branch in auditFields: an namespace enabled cluster receiving
 // a principal with neither IsGlobalOperator nor Namespace set still emits
 // global_operator=true on the audit entry (audit invariant: exactly one
 // of the two top-level fields is present), and a Warn-level entry surfaces
@@ -967,7 +967,7 @@ func setupNSEnabledTestManager(t *testing.T, logger *logrus.Logger) (*Manager, e
 }
 
 // TestNarrowedViewerVsReadOnly_ClusterReadDenied asserts enforcement of
-// the narrowed viewer on NS-enabled clusters: a viewer-assigned principal
+// the narrowed viewer on namespace enabled clusters: a viewer-assigned principal
 // is denied on cluster-only read endpoints, while a read-only principal
 // is allowed.
 func TestNarrowedViewerVsReadOnly_ClusterReadDenied(t *testing.T) {

--- a/usecases/auth/authorization/rbac/authorizer_test.go
+++ b/usecases/auth/authorization/rbac/authorizer_test.go
@@ -755,7 +755,7 @@ func TestAudit_NamespaceFields(t *testing.T) {
 			name:      "ns_disabled_no_new_fields",
 			nsEnabled: false,
 			principal: nsDisabledPrincipal,
-			resources: authorization.ShardsData("Movies", "#"),
+			resources: authorization.ShardsData("Movies", "*"),
 			wantField: map[string]any{
 				"rbac_log_version": AuditLogVersion,
 				"user":             "alice",
@@ -768,7 +768,7 @@ func TestAudit_NamespaceFields(t *testing.T) {
 			name:      "ns_enabled_namespaced_caller",
 			nsEnabled: true,
 			principal: nsNamespacedPrincipal,
-			resources: authorization.ShardsData("customer1:Movies", "#"),
+			resources: authorization.ShardsData("customer1:Movies", "*"),
 			wantField: map[string]any{
 				"namespace":        "customer1",
 				"rbac_log_version": AuditLogVersion,
@@ -782,7 +782,7 @@ func TestAudit_NamespaceFields(t *testing.T) {
 			name:      "ns_enabled_global_operator",
 			nsEnabled: true,
 			principal: nsGlobalPrincipal,
-			resources: authorization.ShardsData("customer1:Movies", "#"),
+			resources: authorization.ShardsData("customer1:Movies", "*"),
 			wantField: map[string]any{
 				"global_operator":  true,
 				"rbac_log_version": AuditLogVersion,
@@ -865,7 +865,7 @@ func TestAudit_NamespaceFields_DenyPath(t *testing.T) {
 
 	p := &models.Principal{Username: "customer1:alice", Namespace: "customer1", UserType: models.UserTypeInputDb}
 	err = m.Authorize(context.Background(), p, authorization.READ,
-		authorization.ShardsData("customer1:Movies", "#")...)
+		authorization.ShardsData("customer1:Movies", "*")...)
 	require.Error(t, err)
 
 	entry := hook.LastEntry()
@@ -876,6 +876,50 @@ func TestAudit_NamespaceFields_DenyPath(t *testing.T) {
 	require.Equal(t, "authorize", entry.Data["audit_mode"])
 	_, hasGlobal := entry.Data["global_operator"]
 	require.False(t, hasGlobal)
+}
+
+// TestAudit_MalformedPrincipal_DefaultsToGlobalAndWarns covers the
+// defense-in-depth branch in auditFields: an NS-enabled cluster receiving
+// a principal with neither IsGlobalOperator nor Namespace set still emits
+// global_operator=true on the audit entry (audit invariant: exactly one
+// of the two top-level fields is present), and a Warn-level entry surfaces
+// to flag the producer-side drift. Upstream classification prevents this
+// in normal operation; this guards against future producers forgetting
+// to classify.
+func TestAudit_MalformedPrincipal_DefaultsToGlobalAndWarns(t *testing.T) {
+	logger, hook := test.NewNullLogger()
+	m, err := setupNSEnabledTestManager(t, logger)
+	require.NoError(t, err)
+
+	p := &models.Principal{Username: "alice", UserType: models.UserTypeInputDb}
+
+	_, err = m.casbin.AddNamedPolicy("p", conv.PrefixRoleName("audit-role"),
+		"*", authorization.READ, authorization.DataDomain)
+	require.NoError(t, err)
+	_, err = m.casbin.AddRoleForUser(
+		conv.UserNameWithTypeFromId(p.Username, authentication.AuthTypeDb),
+		conv.PrefixRoleName("audit-role"))
+	require.NoError(t, err)
+
+	require.NoError(t, m.Authorize(context.Background(), p, authorization.READ,
+		authorization.ShardsData("Movies", "*")...))
+
+	var warnEntry, infoEntry *logrus.Entry
+	for _, e := range hook.AllEntries() {
+		switch e.Level { //nolint:exhaustive // only Warn/Info are produced here
+		case logrus.WarnLevel:
+			warnEntry = e
+		case logrus.InfoLevel:
+			infoEntry = e
+		}
+	}
+	require.NotNil(t, warnEntry, "warn must surface for misclassified principal")
+	require.Contains(t, warnEntry.Message, "missing namespace and global classification")
+
+	require.NotNil(t, infoEntry, "audit info entry must still be emitted")
+	require.Equal(t, true, infoEntry.Data["global_operator"])
+	_, hasNS := infoEntry.Data["namespace"]
+	require.False(t, hasNS)
 }
 
 func setupTestManager(t *testing.T, logger *logrus.Logger) (*Manager, error) {

--- a/usecases/auth/authorization/rbac/authorizer_test.go
+++ b/usecases/auth/authorization/rbac/authorizer_test.go
@@ -795,13 +795,14 @@ func TestAudit_NamespaceFields(t *testing.T) {
 	}
 
 	callSites := []struct {
-		name string
-		run  func(m *Manager, p *models.Principal, rs []string) error
+		name          string
+		wantAuditMode string
+		run           func(m *Manager, p *models.Principal, rs []string) error
 	}{
-		{"Authorize", func(m *Manager, p *models.Principal, rs []string) error {
+		{"Authorize", "authorize", func(m *Manager, p *models.Principal, rs []string) error {
 			return m.Authorize(context.Background(), p, authorization.READ, rs...)
 		}},
-		{"FilterAuthorizedResources", func(m *Manager, p *models.Principal, rs []string) error {
+		{"FilterAuthorizedResources", "filter", func(m *Manager, p *models.Principal, rs []string) error {
 			_, err := m.FilterAuthorizedResources(context.Background(), p, authorization.READ, rs...)
 			return err
 		}},
@@ -843,6 +844,7 @@ func TestAudit_NamespaceFields(t *testing.T) {
 					_, present := entry.Data[k]
 					require.False(t, present, "field %q must be absent", k)
 				}
+				require.Equal(t, cs.wantAuditMode, entry.Data["audit_mode"])
 				perms, ok := entry.Data["permissions"].([]logrus.Fields)
 				require.True(t, ok, "permissions should be []logrus.Fields")
 				require.NotEmpty(t, perms)
@@ -871,6 +873,7 @@ func TestAudit_NamespaceFields_DenyPath(t *testing.T) {
 	require.Equal(t, logrus.ErrorLevel, entry.Level)
 	require.Equal(t, "customer1", entry.Data["namespace"])
 	require.Equal(t, AuditLogVersion, entry.Data["rbac_log_version"])
+	require.Equal(t, "authorize", entry.Data["audit_mode"])
 	_, hasGlobal := entry.Data["global_operator"]
 	require.False(t, hasGlobal)
 }

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -30,6 +30,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization/conv"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac/rbacconf"
 	"github.com/weaviate/weaviate/usecases/config"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 const (
@@ -496,16 +497,18 @@ func prettyPermissionsActions(perm *models.Permission) string {
 	return *perm.Action
 }
 
-func prettyPermissionsResources(perm *models.Permission) string {
+func prettyPermissionsResources(principal *models.Principal, perm *models.Permission) string {
 	res := ""
 	if perm == nil {
 		return ""
 	}
 
+	strip := func(s string) string { return namespacing.StripOwnNS(principal, s) }
+
 	if perm.Backups != nil {
 		s := fmt.Sprintf("Domain: %s,", authorization.BackupsDomain)
 		if perm.Backups.Collection != nil && *perm.Backups.Collection != "" {
-			s += fmt.Sprintf("Collection: %s", *perm.Backups.Collection)
+			s += fmt.Sprintf("Collection: %s", strip(*perm.Backups.Collection))
 		}
 		s = strings.TrimSuffix(s, ",")
 		res += fmt.Sprintf("[%s]", s)
@@ -514,10 +517,10 @@ func prettyPermissionsResources(perm *models.Permission) string {
 	if perm.Data != nil {
 		s := fmt.Sprintf("Domain: %s,", authorization.DataDomain)
 		if perm.Data.Collection != nil && *perm.Data.Collection != "" {
-			s += fmt.Sprintf(" Collection: %s,", *perm.Data.Collection)
+			s += fmt.Sprintf(" Collection: %s,", strip(*perm.Data.Collection))
 		}
 		if perm.Data.Tenant != nil && *perm.Data.Tenant != "" {
-			s += fmt.Sprintf(" Tenant: %s,", *perm.Data.Tenant)
+			s += fmt.Sprintf(" Tenant: %s,", strip(*perm.Data.Tenant))
 		}
 		if perm.Data.Object != nil && *perm.Data.Object != "" {
 			s += fmt.Sprintf(" Object: %s", *perm.Data.Object)
@@ -533,7 +536,7 @@ func prettyPermissionsResources(perm *models.Permission) string {
 			s += fmt.Sprintf(" Verbosity: %s,", *perm.Nodes.Verbosity)
 		}
 		if perm.Nodes.Collection != nil && *perm.Nodes.Collection != "" {
-			s += fmt.Sprintf(" Collection: %s", *perm.Nodes.Collection)
+			s += fmt.Sprintf(" Collection: %s", strip(*perm.Nodes.Collection))
 		}
 		s = strings.TrimSuffix(s, ",")
 		res += fmt.Sprintf("[%s]", s)
@@ -542,7 +545,7 @@ func prettyPermissionsResources(perm *models.Permission) string {
 	if perm.Roles != nil {
 		s := fmt.Sprintf("Domain: %s,", authorization.RolesDomain)
 		if perm.Roles.Role != nil && *perm.Roles.Role != "" {
-			s += fmt.Sprintf(" Role: %s,", *perm.Roles.Role)
+			s += fmt.Sprintf(" Role: %s,", strip(*perm.Roles.Role))
 		}
 		s = strings.TrimSuffix(s, ",")
 		res += fmt.Sprintf("[%s]", s)
@@ -552,7 +555,7 @@ func prettyPermissionsResources(perm *models.Permission) string {
 		s := fmt.Sprintf("Domain: %s,", authorization.CollectionsDomain)
 
 		if perm.Collections.Collection != nil && *perm.Collections.Collection != "" {
-			s += fmt.Sprintf(" Collection: %s,", *perm.Collections.Collection)
+			s += fmt.Sprintf(" Collection: %s,", strip(*perm.Collections.Collection))
 		}
 		s = strings.TrimSuffix(s, ",")
 		res += fmt.Sprintf("[%s]", s)
@@ -562,8 +565,8 @@ func prettyPermissionsResources(perm *models.Permission) string {
 		s := fmt.Sprintf("Domain: %s,", authorization.TenantsDomain)
 
 		if perm.Tenants.Tenant != nil && *perm.Tenants.Tenant != "" {
-			s += fmt.Sprintf(" Collection: %s,", *perm.Tenants.Collection)
-			s += fmt.Sprintf(" Tenant: %s", *perm.Tenants.Tenant)
+			s += fmt.Sprintf(" Collection: %s,", strip(*perm.Tenants.Collection))
+			s += fmt.Sprintf(" Tenant: %s", strip(*perm.Tenants.Tenant))
 		}
 		s = strings.TrimSuffix(s, ",")
 		res += fmt.Sprintf("[%s]", s)
@@ -573,7 +576,7 @@ func prettyPermissionsResources(perm *models.Permission) string {
 		s := fmt.Sprintf("Domain: %s,", authorization.UsersDomain)
 
 		if perm.Users.Users != nil {
-			s += fmt.Sprintf(" User: %s,", *perm.Users.Users)
+			s += fmt.Sprintf(" User: %s,", strip(*perm.Users.Users))
 		}
 		s = strings.TrimSuffix(s, ",")
 		res += fmt.Sprintf("[%s]", s)
@@ -583,10 +586,10 @@ func prettyPermissionsResources(perm *models.Permission) string {
 		s := fmt.Sprintf("Domain: %s,", authorization.ReplicateDomain)
 
 		if perm.Replicate.Collection != nil && *perm.Replicate.Collection != "" {
-			s += fmt.Sprintf(" Collection: %s,", *perm.Replicate.Collection)
+			s += fmt.Sprintf(" Collection: %s,", strip(*perm.Replicate.Collection))
 		}
 		if perm.Replicate.Shard != nil && *perm.Replicate.Shard != "" {
-			s += fmt.Sprintf(" Shard: %s,", *perm.Replicate.Shard)
+			s += fmt.Sprintf(" Shard: %s,", strip(*perm.Replicate.Shard))
 		}
 		s = strings.TrimSuffix(s, ",")
 		res += fmt.Sprintf("[%s]", s)
@@ -596,10 +599,10 @@ func prettyPermissionsResources(perm *models.Permission) string {
 		s := fmt.Sprintf("Domain: %s,", authorization.AliasesDomain)
 
 		if perm.Aliases.Collection != nil && *perm.Aliases.Collection != "" {
-			s += fmt.Sprintf(" Collection: %s,", *perm.Aliases.Collection)
+			s += fmt.Sprintf(" Collection: %s,", strip(*perm.Aliases.Collection))
 		}
 		if perm.Aliases.Alias != nil && *perm.Aliases.Alias != "" {
-			s += fmt.Sprintf(" Alias: %s,", *perm.Aliases.Alias)
+			s += fmt.Sprintf(" Alias: %s,", strip(*perm.Aliases.Alias))
 		}
 		s = strings.TrimSuffix(s, ",")
 		res += fmt.Sprintf("[%s]", s)

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -520,7 +520,7 @@ func prettyPermissionsResources(principal *models.Principal, perm *models.Permis
 			s += fmt.Sprintf(" Collection: %s,", strip(*perm.Data.Collection))
 		}
 		if perm.Data.Tenant != nil && *perm.Data.Tenant != "" {
-			s += fmt.Sprintf(" Tenant: %s,", strip(*perm.Data.Tenant))
+			s += fmt.Sprintf(" Tenant: %s,", *perm.Data.Tenant)
 		}
 		if perm.Data.Object != nil && *perm.Data.Object != "" {
 			s += fmt.Sprintf(" Object: %s", *perm.Data.Object)
@@ -566,7 +566,7 @@ func prettyPermissionsResources(principal *models.Principal, perm *models.Permis
 
 		if perm.Tenants.Tenant != nil && *perm.Tenants.Tenant != "" {
 			s += fmt.Sprintf(" Collection: %s,", strip(*perm.Tenants.Collection))
-			s += fmt.Sprintf(" Tenant: %s", strip(*perm.Tenants.Tenant))
+			s += fmt.Sprintf(" Tenant: %s", *perm.Tenants.Tenant)
 		}
 		s = strings.TrimSuffix(s, ",")
 		res += fmt.Sprintf("[%s]", s)

--- a/usecases/auth/authorization/rbac/manager_test.go
+++ b/usecases/auth/authorization/rbac/manager_test.go
@@ -304,7 +304,7 @@ func TestRestoreInvalidatesEnforceCache(t *testing.T) {
 }
 
 // TestPrettyPermissionsResources_NamespaceStripping exercises the pretty-
-// printer used in audit logs on NS-enabled clusters: a namespace-bound
+// printer used in audit logs on namespace enabled clusters: a namespace-bound
 // principal sees short entity names (own namespace stripped), while a
 // global principal (and any NS-disabled principal, since their Namespace
 // is always "") sees the raw qualified names. A foreign prefix is left

--- a/usecases/auth/authorization/rbac/manager_test.go
+++ b/usecases/auth/authorization/rbac/manager_test.go
@@ -330,25 +330,6 @@ func TestPrettyPermissionsResources_NamespaceStripping(t *testing.T) {
 			wantGlobal: "[Domain: collections, Collection: customer1:Movies]",
 		},
 		{
-			domain: "Data",
-			perm: &models.Permission{Data: &models.PermissionData{
-				Collection: strPtr("customer1:Movies"),
-				Tenant:     strPtr("customer1:tenant-a"),
-				Object:     strPtr("*"),
-			}},
-			wantNS:     "[Domain: data, Collection: Movies, Tenant: tenant-a, Object: *]",
-			wantGlobal: "[Domain: data, Collection: customer1:Movies, Tenant: customer1:tenant-a, Object: *]",
-		},
-		{
-			domain: "Tenants",
-			perm: &models.Permission{Tenants: &models.PermissionTenants{
-				Collection: strPtr("customer1:Movies"),
-				Tenant:     strPtr("customer1:tenant-a"),
-			}},
-			wantNS:     "[Domain: tenants, Collection: Movies, Tenant: tenant-a]",
-			wantGlobal: "[Domain: tenants, Collection: customer1:Movies, Tenant: customer1:tenant-a]",
-		},
-		{
 			domain: "Aliases",
 			perm: &models.Permission{Aliases: &models.PermissionAliases{
 				Collection: strPtr("customer1:Movies"),

--- a/usecases/auth/authorization/rbac/manager_test.go
+++ b/usecases/auth/authorization/rbac/manager_test.go
@@ -303,6 +303,122 @@ func TestRestoreInvalidatesEnforceCache(t *testing.T) {
 	assert.False(t, allowed, "enforce cache was not invalidated during Restore; stale cached result returned")
 }
 
+// TestPrettyPermissionsResources_NamespaceStripping exercises the pretty-
+// printer used in audit logs on NS-enabled clusters: a namespace-bound
+// principal sees short entity names (own namespace stripped), while a
+// global principal (and any NS-disabled principal, since their Namespace
+// is always "") sees the raw qualified names. A foreign prefix is left
+// intact so the embedded ":" remains visible in the audit trail.
+func TestPrettyPermissionsResources_NamespaceStripping(t *testing.T) {
+	nsCaller := &models.Principal{Username: "customer1:alice", Namespace: "customer1"}
+	globalCaller := &models.Principal{Username: "admin", IsGlobalOperator: true}
+
+	strPtr := func(s string) *string { return &s }
+
+	type row struct {
+		domain     string
+		perm       *models.Permission
+		wantNS     string
+		wantGlobal string
+	}
+
+	rows := []row{
+		{
+			domain:     "Collections",
+			perm:       &models.Permission{Collections: &models.PermissionCollections{Collection: strPtr("customer1:Movies")}},
+			wantNS:     "[Domain: collections, Collection: Movies]",
+			wantGlobal: "[Domain: collections, Collection: customer1:Movies]",
+		},
+		{
+			domain: "Data",
+			perm: &models.Permission{Data: &models.PermissionData{
+				Collection: strPtr("customer1:Movies"),
+				Tenant:     strPtr("customer1:tenant-a"),
+				Object:     strPtr("*"),
+			}},
+			wantNS:     "[Domain: data, Collection: Movies, Tenant: tenant-a, Object: *]",
+			wantGlobal: "[Domain: data, Collection: customer1:Movies, Tenant: customer1:tenant-a, Object: *]",
+		},
+		{
+			domain: "Tenants",
+			perm: &models.Permission{Tenants: &models.PermissionTenants{
+				Collection: strPtr("customer1:Movies"),
+				Tenant:     strPtr("customer1:tenant-a"),
+			}},
+			wantNS:     "[Domain: tenants, Collection: Movies, Tenant: tenant-a]",
+			wantGlobal: "[Domain: tenants, Collection: customer1:Movies, Tenant: customer1:tenant-a]",
+		},
+		{
+			domain: "Aliases",
+			perm: &models.Permission{Aliases: &models.PermissionAliases{
+				Collection: strPtr("customer1:Movies"),
+				Alias:      strPtr("customer1:Top10"),
+			}},
+			wantNS:     "[Domain: aliases, Collection: Movies, Alias: Top10]",
+			wantGlobal: "[Domain: aliases, Collection: customer1:Movies, Alias: customer1:Top10]",
+		},
+		{
+			domain:     "Users",
+			perm:       &models.Permission{Users: &models.PermissionUsers{Users: strPtr("customer1:bob")}},
+			wantNS:     "[Domain: users, User: bob]",
+			wantGlobal: "[Domain: users, User: customer1:bob]",
+		},
+		{
+			domain: "Replicate",
+			perm: &models.Permission{Replicate: &models.PermissionReplicate{
+				Collection: strPtr("customer1:Movies"),
+				Shard:      strPtr("shard-1"),
+			}},
+			wantNS:     "[Domain: replicate, Collection: Movies, Shard: shard-1]",
+			wantGlobal: "[Domain: replicate, Collection: customer1:Movies, Shard: shard-1]",
+		},
+		{
+			domain:     "Backups",
+			perm:       &models.Permission{Backups: &models.PermissionBackups{Collection: strPtr("customer1:Movies")}},
+			wantNS:     "[Domain: backups,Collection: Movies]",
+			wantGlobal: "[Domain: backups,Collection: customer1:Movies]",
+		},
+		{
+			domain: "Nodes",
+			perm: &models.Permission{Nodes: &models.PermissionNodes{
+				Verbosity:  strPtr("verbose"),
+				Collection: strPtr("customer1:Movies"),
+			}},
+			wantNS:     "[Domain: nodes, Verbosity: verbose, Collection: Movies]",
+			wantGlobal: "[Domain: nodes, Verbosity: verbose, Collection: customer1:Movies]",
+		},
+		{
+			domain:     "Roles",
+			perm:       &models.Permission{Roles: &models.PermissionRoles{Role: strPtr("admin")}},
+			wantNS:     "[Domain: roles, Role: admin]",
+			wantGlobal: "[Domain: roles, Role: admin]",
+		},
+	}
+
+	for _, r := range rows {
+		t.Run(r.domain+"/ns_caller_strips", func(t *testing.T) {
+			require.Equal(t, r.wantNS, prettyPermissionsResources(nsCaller, r.perm))
+		})
+		t.Run(r.domain+"/global_caller_raw", func(t *testing.T) {
+			require.Equal(t, r.wantGlobal, prettyPermissionsResources(globalCaller, r.perm))
+		})
+	}
+
+	// Foreign-namespace prefix must remain intact so the embedded ":"
+	// stays in the audit trail.
+	t.Run("ns_caller_foreign_namespace_kept", func(t *testing.T) {
+		perm := &models.Permission{Data: &models.PermissionData{
+			Collection: strPtr("customer2:Movies"),
+			Tenant:     strPtr("*"),
+			Object:     strPtr("*"),
+		}}
+		require.Equal(t,
+			"[Domain: data, Collection: customer2:Movies, Tenant: *, Object: *]",
+			prettyPermissionsResources(nsCaller, perm),
+		)
+	})
+}
+
 func TestSnapshotAndRestoreUpgrade(t *testing.T) {
 	tests := []struct {
 		name              string


### PR DESCRIPTION
### What's being changed:

This adds namespace support for the audit log:
- no changes to non-namespaced clusters
- for namespaced clusterd we _either_ add the namespace OR global operator=true to the log

This also adds an `audit_mode` to distinguish between filters and normal enforce 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
