### PR TITLE
fix(shard): skip READONLY/READY cycle in UpdateVectorIndexConfigs when already compressed

### DIFF
--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -480,7 +480,10 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 	for targetVector, targetCfg := range updated {
 		if index, ok := s.GetVectorIndex(targetVector); ok {
 			wg.Add(1)
-			if err = index.UpdateUserConfig(targetCfg, wg.Done); err != nil {
+			var once sync.Once
+			done := func() { once.Do(wg.Done) }
+			if err = index.UpdateUserConfig(targetCfg, done); err != nil {
+				done()
 				s.index.logger.WithFields(logrus.Fields{
 					"action":        "update_vector_index_config",
 					"shard_id":      s.ID(),

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -481,12 +481,23 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 		if index, ok := s.GetVectorIndex(targetVector); ok {
 			wg.Add(1)
 			if err = index.UpdateUserConfig(targetCfg, wg.Done); err != nil {
+				s.index.logger.WithFields(logrus.Fields{
+					"action":        "update_vector_index_config",
+					"shard_id":      s.ID(),
+					"target_vector": targetVector,
+				}).Errorf("failed to update vector index config: %v", err)
 				break
 			}
 		} else {
 			// dont lazy load segments on config update
 			if err = s.initTargetVector(ctx, targetVector, targetCfg, false); err != nil {
-				return fmt.Errorf("creating new vector index: %w", err)
+				err = fmt.Errorf("creating new vector index: %w, %s", err, targetVector)
+				s.index.logger.WithFields(logrus.Fields{
+					"action":        "init_target_vector",
+					"shard_id":      s.ID(),
+					"target_vector": targetVector,
+				}).Errorf("failed to init target vector index: %v", err)
+				break
 			}
 		}
 	}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -449,8 +449,30 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 		i++
 	}
 	reason := fmt.Sprintf("UpdateVectorIndexConfigs: %v", targetVecs)
-	if err := s.SetStatusReadonly(reason); err != nil {
-		return fmt.Errorf("attempt to mark read-only: %w", err)
+
+	// If every vector index is already compressed, UpdateUserConfig calls its
+	// callback synchronously — there is no async compression work to protect.
+	// Skip the READONLY/READY cycle entirely to avoid a RAFT log replay trap:
+	// when UpdateClass commands are replayed rapidly after a restart, the first
+	// call correctly sets READONLY and spawns a goroutine to restore READY, but
+	// all subsequent calls hit the isReadOnly() guard above and exit early
+	// without spawning their own goroutine.  If the goroutine from the first
+	// call has not been scheduled by the time the last replay fires, the shard
+	// is left permanently READONLY until the goroutine eventually runs — during
+	// which any concurrent search fails with "store is read-only".
+	allCompressed := true
+	for targetVector := range updated {
+		index, ok := s.GetVectorIndex(targetVector)
+		if !ok || !index.Compressed() {
+			allCompressed = false
+			break
+		}
+	}
+
+	if !allCompressed {
+		if err := s.SetStatusReadonly(reason); err != nil {
+			return fmt.Errorf("attempt to mark read-only: %w", err)
+		}
 	}
 
 	wg := new(sync.WaitGroup)
@@ -467,6 +489,11 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 				return fmt.Errorf("creating new vector index: %w", err)
 			}
 		}
+	}
+
+	if allCompressed {
+		// All callbacks were synchronous; wg is already at zero, nothing to wait for.
+		return err
 	}
 
 	f := func() {

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -494,7 +494,7 @@ func (s *Shard) UpdateVectorIndexConfigs(ctx context.Context, updated map[string
 		} else {
 			// dont lazy load segments on config update
 			if err = s.initTargetVector(ctx, targetVector, targetCfg, false); err != nil {
-				err = fmt.Errorf("creating new vector index: %w, %s", err, targetVector)
+				err = fmt.Errorf("creating new vector index for %s: %w", targetVector, err)
 				s.index.logger.WithFields(logrus.Fields{
 					"action":        "init_target_vector",
 					"shard_id":      s.ID(),

--- a/adapters/repos/db/shard_accessors.go
+++ b/adapters/repos/db/shard_accessors.go
@@ -87,8 +87,8 @@ func (s *Shard) GetVectorIndexQueue(targetVector string) (*VectorIndexQueue, boo
 	return queue, ok
 }
 
-// GetVectorIndex retrieves a vector index queue associated with the targetVector.
-// Empty targetVector is treated as a request to access a queue for the legacy vector index.
+// GetVectorIndex retrieves a vector index associated with the targetVector.
+// Empty targetVector is treated as a request to access the legacy vector index.
 func (s *Shard) GetVectorIndex(targetVector string) (VectorIndex, bool) {
 	s.vectorIndexMu.RLock()
 	defer s.vectorIndexMu.RUnlock()

--- a/adapters/repos/db/shard_update_vector_index_configs_test.go
+++ b/adapters/repos/db/shard_update_vector_index_configs_test.go
@@ -1,0 +1,116 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+//go:build integrationTest
+
+package db
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	schemaConfig "github.com/weaviate/weaviate/entities/schema/config"
+	"github.com/weaviate/weaviate/entities/storagestate"
+	enthnsw "github.com/weaviate/weaviate/entities/vectorindex/hnsw"
+)
+
+// Pins down the RAFT-replay regression: when every target vector is already
+// compressed, UpdateVectorIndexConfigs must not flip the shard READONLY and
+// rely on a goroutine to flip it back. The pre-fix code spawned that goroutine
+// on the first call, then short-circuited on every subsequent call (isReadOnly
+// guard) without spawning a replacement — so if the original goroutine had not
+// been scheduled by the end of the replay sequence, the shard stayed READONLY.
+// Looping 50 iterations is enough to expose any reintroduction: each iteration
+// asserts the shard is READY before the next call runs, so even a brief
+// READONLY window between calls fails the test.
+func TestShard_UpdateVectorIndexConfigs_AllCompressed_SkipsReadonlyCycle(t *testing.T) {
+	ctx := testCtx()
+	className := "TestClass"
+
+	shd, idx := testShardWithSettings(
+		t, ctx,
+		&models.Class{Class: className},
+		enthnsw.UserConfig{Skip: true},
+		false, false, false,
+		func(i *Index) {
+			// Two named vectors so the migrator's single-vector branch is
+			// skipped and the multi-vector path is exercised. Skip:true keeps
+			// the init lightweight (noop indexes), which we immediately
+			// replace with mocks below.
+			i.vectorIndexUserConfigs = map[string]schemaConfig.VectorIndexConfig{
+				"foo": enthnsw.UserConfig{Skip: true},
+				"bar": enthnsw.UserConfig{Skip: true},
+			}
+		},
+	)
+	defer func() {
+		require.Nil(t, idx.drop())
+		require.Nil(t, os.RemoveAll(idx.Config.RootPath))
+	}()
+
+	// testShardWithSettings disables lazy loading, so the returned ShardLike
+	// is the concrete *Shard. We need it directly to swap entries in the
+	// (unexported) vectorIndexes map.
+	actualShard, ok := shd.(*Shard)
+	require.True(t, ok, "expected *Shard, got %T", shd)
+
+	newCompressedMock := func() *MockVectorIndex {
+		m := NewMockVectorIndex(t)
+		// The hot-path methods we must observe: Compressed()==true forces the
+		// new short-circuit, and UpdateUserConfig must invoke its callback
+		// synchronously — exactly what the real HNSW does when already
+		// compressed.
+		m.EXPECT().Compressed().Return(true)
+		m.EXPECT().UpdateUserConfig(mock.Anything, mock.Anything).
+			RunAndReturn(func(_ schemaConfig.VectorIndexConfig, cb func()) error {
+				cb()
+				return nil
+			})
+		// Lifecycle calls fired by idx.drop() at the end of the test —
+		// tolerated, not required.
+		m.EXPECT().Flush().Return(nil).Maybe()
+		m.EXPECT().Shutdown(mock.Anything).Return(nil).Maybe()
+		m.EXPECT().Drop(mock.Anything, mock.Anything).Return(nil).Maybe()
+		return m
+	}
+
+	actualShard.vectorIndexMu.Lock()
+	actualShard.vectorIndexes["foo"] = newCompressedMock()
+	actualShard.vectorIndexes["bar"] = newCompressedMock()
+	actualShard.vectorIndexMu.Unlock()
+
+	require.Equal(t, storagestate.StatusReady, actualShard.GetStatus(),
+		"precondition: shard must be READY before the replay loop")
+	reasonBefore := actualShard.GetStatusReason()
+
+	updated := map[string]schemaConfig.VectorIndexConfig{
+		"foo": enthnsw.UserConfig{},
+		"bar": enthnsw.UserConfig{},
+	}
+	for i := 0; i < 50; i++ {
+		require.NoError(t, actualShard.UpdateVectorIndexConfigs(ctx, updated),
+			"iteration %d: UpdateVectorIndexConfigs returned an error", i)
+		require.Equal(t, storagestate.StatusReady, actualShard.GetStatus(),
+			"iteration %d: shard must remain READY (no READONLY/READY cycle when all indexes are already compressed)", i)
+	}
+
+	// Reason untouched means neither SetStatusReadonly nor the trailing
+	// UpdateStatus(READY) ran — both stamp the same "UpdateVectorIndexConfigs"
+	// reason, so a single substring check covers both.
+	require.False(t, strings.Contains(actualShard.GetStatusReason(), "UpdateVectorIndexConfigs"),
+		"status reason was rewritten by SetStatusReadonly / UpdateStatus(READY); the all-compressed branch should not touch status. before=%q after=%q",
+		reasonBefore, actualShard.GetStatusReason())
+}


### PR DESCRIPTION
Fixes weaviate/0-weaviate-issues#210 (Bug 1)

## Problem

During RAFT log replay after a node restart, `UpdateClass` commands are applied in a tight loop — one per schema change ever recorded for that collection. Each application calls `UpdateVectorIndexConfigs`, which:

1. Checks `isReadOnly()` — passes on the first call (shard is `READY`)
2. Sets the shard `READONLY`
3. Calls `UpdateUserConfig` for each named vector — callback is **synchronous** because `h.compressed` is already `true` after the clean restart
4. Spawns goroutine G: `wg.Wait()` → `UpdateStatus(READY)`

On the **second and all subsequent replays** the shard is still `READONLY` (goroutine G hasn't been scheduled yet — Go runtime hasn't yielded during the tight replay loop). `isReadOnly()` returns an error → early return → **no new goroutine is spawned**.

G eventually runs and restores `READY`, but the window between the first `SetStatusReadonly` and G's eventual scheduling can cover the entire replay sequence. Any concurrent search during that window fails:

```
recoverCompressedVector: persisting recovered vector: store is read-only
```

The transition back to `READY` was logged at `DebugLevel` (see `shard_status.go:123-127`), which is why log analysis showed 39 `READY→READONLY` transitions and zero `READONLY→READY` transitions.

## Fix

When every vector index in the `updated` map is already compressed, `UpdateUserConfig` calls its callback **synchronously** — there is no async compression work. There is no reason to set the shard `READONLY` at all. Skip `SetStatusReadonly` and the background goroutine; call `UpdateUserConfig` directly and return.

The `isReadOnly()` guard at the top is unaffected: if the shard is `READONLY` for an unrelated reason (memory pressure, backup, etc.) the call is still blocked.

## Behavior unchanged for

- **First-time compression** (`index.Compressed() == false` for any vector): `allCompressed = false` → existing READONLY/async-compress/READY cycle unchanged
- **Single legacy vector** (`UpdateVectorIndexConfig`, not `Configs`): separate code path, not touched

## Test plan
- [x] `go build ./adapters/repos/db/...`
- [x] E2E: `test_rq_compression_after_restart` with `rq_multi_name_vectors` on a multi-node cluster — shard must not get stuck `READONLY` after restart