### PR TITLE
ci: switch docker image PR builds and docker report CI jobs to use Ubicloud runners

### DIFF
--- a/.github/workflows/pull_requests.yaml
+++ b/.github/workflows/pull_requests.yaml
@@ -140,10 +140,10 @@ jobs:
       matrix:
         include:
           - arch: "amd64"
-            runner: ubuntu-latest
+            runner: ubicloud-standard-2
             push-args: "--amd64-only"
           - arch: "arm64"
-            runner: ubuntu-24.04-arm
+            runner: ubicloud-standard-2-arm
             push-args: "--arm64-only"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -248,7 +248,7 @@ jobs:
 
   Generate-Docker-Report:
     name: docker report
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     # Depends on both production and PR jobs, but only one will run based on the event type
     needs: [Multi-Arch-Docker-Build, PR-Docker-Build]
     # Always run if either dependency succeeded (pr or production build)


### PR DESCRIPTION
### What's being changed:

This PR switches docker image PR builds and docker report CI jobs to use Ubicloud runners.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
