### PR TITLE
Namespaces: Add support for filters and enable batch delete

### DIFF
--- a/adapters/handlers/graphql/local/common_filters/parse_filters_into_ast.go
+++ b/adapters/handlers/graphql/local/common_filters/parse_filters_into_ast.go
@@ -33,7 +33,9 @@ func ExtractFilters(args map[string]interface{}, rootClass string) (*filters.Loc
 			return nil, fmt.Errorf("failed to extract filters: %w", err)
 		}
 
-		return filterext.Parse(filter, rootClass)
+		// GraphQL is disabled on namespace-enabled clusters, so the
+		// namespacesEnabled flag is hard-wired to false here.
+		return filterext.Parse(filter, rootClass, false)
 	}
 }
 

--- a/adapters/handlers/grpc/v1/batch_delete.go
+++ b/adapters/handlers/grpc/v1/batch_delete.go
@@ -22,7 +22,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/objects"
 )
 
-func batchDeleteParamsFromProto(req *pb.BatchDeleteRequest, authorizedGetClass classGetterWithAuthzFunc) (objects.BatchDeleteParams, error) {
+func batchDeleteParamsFromProto(req *pb.BatchDeleteRequest, authorizedGetClass classGetterWithAuthzFunc, namespacesEnabled bool) (objects.BatchDeleteParams, error) {
 	params := objects.BatchDeleteParams{}
 
 	tenant := ""
@@ -52,7 +52,7 @@ func batchDeleteParamsFromProto(req *pb.BatchDeleteRequest, authorizedGetClass c
 		return objects.BatchDeleteParams{}, fmt.Errorf("no filters in batch delete request")
 	}
 
-	clause, err := ExtractFilters(req.Filters, authorizedGetClass, req.Collection, tenant)
+	clause, err := ExtractFilters(req.Filters, authorizedGetClass, req.Collection, tenant, namespacesEnabled)
 	if err != nil {
 		return objects.BatchDeleteParams{}, err
 	}

--- a/adapters/handlers/grpc/v1/batch_delete_test.go
+++ b/adapters/handlers/grpc/v1/batch_delete_test.go
@@ -26,11 +26,18 @@ import (
 
 func TestBatchDeleteRequest(t *testing.T) {
 	collection := "TestClass"
+	qualifiedCollection := "customer1:TestClass"
 	scheme := schema.Schema{
 		Objects: &models.Schema{
 			Classes: []*models.Class{
 				{
 					Class: collection,
+					Properties: []*models.Property{
+						{Name: "name", DataType: schema.DataTypeText.PropString()},
+					},
+				},
+				{
+					Class: qualifiedCollection,
 					Properties: []*models.Property{
 						{Name: "name", DataType: schema.DataTypeText.PropString()},
 					},
@@ -46,6 +53,13 @@ func TestBatchDeleteRequest(t *testing.T) {
 	simpleFilterOutput := &filters.LocalFilter{
 		Root: &filters.Clause{
 			On:       &filters.Path{Class: schema.ClassName(collection), Property: "name"},
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Value: "test", Type: schema.DataTypeText},
+		},
+	}
+	qualifiedFilterOutput := &filters.LocalFilter{
+		Root: &filters.Clause{
+			On:       &filters.Path{Class: schema.ClassName(qualifiedCollection), Property: "name"},
 			Operator: filters.OperatorEqual,
 			Value:    &filters.Value{Value: "test", Type: schema.DataTypeText},
 		},
@@ -113,11 +127,31 @@ func TestBatchDeleteRequest(t *testing.T) {
 			},
 			error: nil,
 		},
+		{
+			// Models the post-resolver input: namespacing.Resolve at
+			// service.go has already qualified req.Collection. The proto
+			// → params conversion must keep the qualified name on
+			// BatchDeleteParams.ClassName and on the filter root
+			// Path.Class so downstream schema lookups hit the right
+			// internal class.
+			name: "qualified collection preserves namespace prefix",
+			req: &pb.BatchDeleteRequest{
+				Collection: qualifiedCollection,
+				Filters:    simpleFilterInput,
+			},
+			out: objects.BatchDeleteParams{
+				ClassName: schema.ClassName(qualifiedCollection),
+				DryRun:    false,
+				Output:    "minimal",
+				Filters:   qualifiedFilterOutput,
+			},
+			error: nil,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			out, err := batchDeleteParamsFromProto(tt.req, getClass)
+			out, err := batchDeleteParamsFromProto(tt.req, getClass, false)
 			require.Equal(t, tt.error, err)
 
 			if tt.error == nil {
@@ -125,6 +159,60 @@ func TestBatchDeleteRequest(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBatchDeleteRequest_NamespacesEnabledRejectsRefPath asserts that on
+// namespace-enabled clusters an old-style reference-path filter (Filters.On
+// with more than one element, no Filters.Target) is rejected. The check
+// fires early in ExtractFilters with a message pointing clients at the
+// new-style FilterTarget, which auto-qualifies inner class segments via
+// the schema and so works correctly under namespacing.
+func TestBatchDeleteRequest_NamespacesEnabledRejectsRefPath(t *testing.T) {
+	collection := "TestClass"
+	scheme := schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{
+				{
+					Class: collection,
+					Properties: []*models.Property{
+						{Name: "name", DataType: schema.DataTypeText.PropString()},
+					},
+				},
+			},
+		},
+	}
+	getClass := func(name string) (*models.Class, error) {
+		return scheme.GetClass(name), nil
+	}
+
+	refPathFilter := &pb.Filters{
+		Operator:  pb.Filters_OPERATOR_EQUAL,
+		On:        []string{"inOther", "Other", "name"},
+		TestValue: &pb.Filters_ValueText{ValueText: "x"},
+	}
+	directFilter := &pb.Filters{
+		Operator:  pb.Filters_OPERATOR_EQUAL,
+		Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "name"}},
+		TestValue: &pb.Filters_ValueText{ValueText: "x"},
+	}
+
+	t.Run("rejects ref-path with namespacesEnabled", func(t *testing.T) {
+		_, err := batchDeleteParamsFromProto(&pb.BatchDeleteRequest{
+			Collection: collection,
+			Filters:    refPathFilter,
+		}, getClass, true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "reference-path filters")
+		require.Contains(t, err.Error(), "Filters.target")
+	})
+
+	t.Run("accepts direct property with namespacesEnabled", func(t *testing.T) {
+		_, err := batchDeleteParamsFromProto(&pb.BatchDeleteRequest{
+			Collection: collection,
+			Filters:    directFilter,
+		}, getClass, true)
+		require.NoError(t, err)
+	})
 }
 
 var (

--- a/adapters/handlers/grpc/v1/filters.go
+++ b/adapters/handlers/grpc/v1/filters.go
@@ -22,7 +22,17 @@ import (
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
 )
 
-func ExtractFilters(filterIn *pb.Filters, authorizedGetClass classGetterWithAuthzFunc, className, tenant string) (filters.Clause, error) {
+// ExtractFilters converts a proto Filters tree into an internal filter Clause.
+//
+// When namespacesEnabled is true, old-style reference-path filters
+// (filterIn.Target == nil with more than one element in filterIn.On) are
+// rejected. Inner class segments in such paths are taken from caller input
+// and are not auto-qualified by the resolver, so allowing them through
+// would silently fail downstream when the schema lookup misses the
+// unqualified inner class. New-style FilterTarget filters keep working
+// because their nested class segments come from the schema (which already
+// stores qualified names).
+func ExtractFilters(filterIn *pb.Filters, authorizedGetClass classGetterWithAuthzFunc, className, tenant string, namespacesEnabled bool) (filters.Clause, error) {
 	returnFilter := filters.Clause{}
 
 	switch filterIn.Operator {
@@ -39,7 +49,7 @@ func ExtractFilters(filterIn *pb.Filters, authorizedGetClass classGetterWithAuth
 
 		clauses := make([]filters.Clause, len(filterIn.Filters))
 		for i, clause := range filterIn.Filters {
-			retClause, err := ExtractFilters(clause, authorizedGetClass, className, tenant)
+			retClause, err := ExtractFilters(clause, authorizedGetClass, className, tenant, namespacesEnabled)
 			if err != nil {
 				return filters.Clause{}, err
 			}
@@ -52,6 +62,12 @@ func ExtractFilters(filterIn *pb.Filters, authorizedGetClass classGetterWithAuth
 		if filterIn.Target == nil && len(filterIn.On)%2 != 1 {
 			return filters.Clause{}, fmt.Errorf(
 				"paths needs to have a uneven number of components: property, class, property, ...., got %v", filterIn.On,
+			)
+		}
+
+		if namespacesEnabled && filterIn.Target == nil && len(filterIn.On) > 1 {
+			return filters.Clause{}, fmt.Errorf(
+				"reference-path filters via Filters.on are not supported on namespace-enabled clusters; use Filters.target with a SingleTarget instead",
 			)
 		}
 

--- a/adapters/handlers/grpc/v1/parse_aggregate_request.go
+++ b/adapters/handlers/grpc/v1/parse_aggregate_request.go
@@ -28,11 +28,13 @@ import (
 
 type AggregateParser struct {
 	authorizedGetClass classGetterWithAuthzFunc
+	namespacesEnabled  bool
 }
 
-func NewAggregateParser(authorizedGetClass classGetterWithAuthzFunc) *AggregateParser {
+func NewAggregateParser(authorizedGetClass classGetterWithAuthzFunc, namespacesEnabled bool) *AggregateParser {
 	return &AggregateParser{
 		authorizedGetClass: authorizedGetClass,
+		namespacesEnabled:  namespacesEnabled,
 	}
 }
 
@@ -76,7 +78,7 @@ func (p *AggregateParser) Aggregate(req *pb.AggregateRequest) (*aggregation.Para
 	}
 
 	if req.Filters != nil {
-		clause, err := ExtractFilters(req.Filters, p.authorizedGetClass, req.Collection, req.Tenant)
+		clause, err := ExtractFilters(req.Filters, p.authorizedGetClass, req.Collection, req.Tenant, p.namespacesEnabled)
 		if err != nil {
 			return nil, fmt.Errorf("extract filters: %w", err)
 		}

--- a/adapters/handlers/grpc/v1/parse_aggregate_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_aggregate_request_test.go
@@ -241,7 +241,7 @@ func TestGRPCAggregateRequest(t *testing.T) {
 		},
 	}
 
-	parser := NewAggregateParser(getClass)
+	parser := NewAggregateParser(getClass, false)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out, err := parser.Aggregate(tt.req)

--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -381,7 +381,7 @@ func (p *Parser) Search(req *pb.SearchRequest, config *config.Config) (dto.GetPa
 	}
 
 	if req.Filters != nil {
-		clause, err := ExtractFilters(req.Filters, p.authorizedGetClass, req.Collection, req.Tenant)
+		clause, err := ExtractFilters(req.Filters, p.authorizedGetClass, req.Collection, req.Tenant, config.Namespaces.Enabled)
 		if err != nil {
 			return dto.GetParams{}, err
 		}

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -105,6 +105,7 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 
 	parser := NewAggregateParser(
 		s.classGetterWithAuthzFunc(ctx, principal, req.Tenant),
+		s.config.Namespaces.Enabled,
 	)
 
 	params, err := parser.Aggregate(req)
@@ -179,15 +180,13 @@ func (s *Service) batchDelete(ctx context.Context, req *pb.BatchDeleteRequest) (
 		tenant = *req.Tenant
 	}
 
-	if class := s.schemaManager.ResolveAlias(req.Collection); class != "" {
-		req.Collection = class
-	}
+	req.Collection, _ = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection)
 
 	if err := s.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.ShardsData(req.Collection, tenant)...); err != nil {
 		return nil, err
 	}
 
-	params, err := batchDeleteParamsFromProto(req, s.classGetterWithAuthzFunc(ctx, principal, tenant))
+	params, err := batchDeleteParamsFromProto(req, s.classGetterWithAuthzFunc(ctx, principal, tenant), s.config.Namespaces.Enabled)
 	if err != nil {
 		return nil, fmt.Errorf("batch delete params: %w", err)
 	}

--- a/adapters/handlers/mcp/search/hybrid.go
+++ b/adapters/handlers/mcp/search/hybrid.go
@@ -96,8 +96,11 @@ func (s *WeaviateSearcher) Hybrid(ctx context.Context, req mcp.CallToolRequest, 
 			return nil, fmt.Errorf("failed to unmarshal filters: %w", err)
 		}
 
-		// Parse to LocalFilter
-		localFilter, err = filterext.Parse(&whereFilter, args.CollectionName)
+		// Parse to LocalFilter. MCP does not yet support namespaces, so the
+		// nested-path guard in filterext.Parse is hard-wired off here. Wire
+		// the real namespacesEnabled flag through when MCP gains namespace
+		// support.
+		localFilter, err = filterext.Parse(&whereFilter, args.CollectionName, false)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse filters: %w", err)
 		}

--- a/adapters/handlers/rest/filterext/parse.go
+++ b/adapters/handlers/rest/filterext/parse.go
@@ -18,8 +18,15 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 )
 
-// Parse Filter from REST construct to entities filter
-func Parse(in *models.WhereFilter, rootClass string) (*filters.LocalFilter, error) {
+// Parse Filter from REST construct to entities filter.
+//
+// When namespacesEnabled is true, reference-path filters (Path with more
+// than one element) are rejected. Inner class segments in such paths are
+// taken from caller input and are not auto-qualified by the resolver, so
+// allowing them through would silently fail downstream when the schema
+// lookup misses the unqualified inner class. Direct-property filters
+// (single-element Path) are unaffected.
+func Parse(in *models.WhereFilter, rootClass string, namespacesEnabled bool) (*filters.LocalFilter, error) {
 	if in == nil {
 		return nil, nil
 	}
@@ -30,14 +37,14 @@ func Parse(in *models.WhereFilter, rootClass string) (*filters.LocalFilter, erro
 	}
 
 	if operator.OnValue() {
-		filter, err := parseValueFilter(in, operator, rootClass)
+		filter, err := parseValueFilter(in, operator, rootClass, namespacesEnabled)
 		if err != nil {
 			return nil, fmt.Errorf("invalid where filter: %w", err)
 		}
 		return filter, nil
 	}
 
-	filter, err := parseNestedFilter(in, operator, rootClass)
+	filter, err := parseNestedFilter(in, operator, rootClass, namespacesEnabled)
 	if err != nil {
 		return nil, fmt.Errorf("invalid where filter: %w", err)
 	}
@@ -45,14 +52,14 @@ func Parse(in *models.WhereFilter, rootClass string) (*filters.LocalFilter, erro
 }
 
 func parseValueFilter(in *models.WhereFilter,
-	operator filters.Operator, rootClass string,
+	operator filters.Operator, rootClass string, namespacesEnabled bool,
 ) (*filters.LocalFilter, error) {
 	value, err := parseValue(in)
 	if err != nil {
 		return nil, err
 	}
 
-	path, err := parsePath(in.Path, rootClass)
+	path, err := parsePath(in.Path, rootClass, namespacesEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +74,7 @@ func parseValueFilter(in *models.WhereFilter,
 }
 
 func parseNestedFilter(in *models.WhereFilter,
-	operator filters.Operator, rootClass string,
+	operator filters.Operator, rootClass string, namespacesEnabled bool,
 ) (*filters.LocalFilter, error) {
 	if in.Path != nil {
 		return nil, fmt.Errorf(
@@ -90,7 +97,7 @@ func parseNestedFilter(in *models.WhereFilter,
 			operator.Name())
 	}
 
-	operands, err := parseOperands(in.Operands, rootClass)
+	operands, err := parseOperands(in.Operands, rootClass, namespacesEnabled)
 	if err != nil {
 		return nil, err
 	}
@@ -103,10 +110,10 @@ func parseNestedFilter(in *models.WhereFilter,
 	}, nil
 }
 
-func parseOperands(ops []*models.WhereFilter, rootClass string) ([]filters.Clause, error) {
+func parseOperands(ops []*models.WhereFilter, rootClass string, namespacesEnabled bool) ([]filters.Clause, error) {
 	out := make([]filters.Clause, len(ops))
 	for i, operand := range ops {
-		res, err := Parse(operand, rootClass)
+		res, err := Parse(operand, rootClass, namespacesEnabled)
 		if err != nil {
 			return nil, fmt.Errorf("operand %d: %w", i, err)
 		}
@@ -154,9 +161,13 @@ func parseOperator(in string) (filters.Operator, error) {
 	}
 }
 
-func parsePath(in []string, rootClass string) (*filters.Path, error) {
+func parsePath(in []string, rootClass string, namespacesEnabled bool) (*filters.Path, error) {
 	if len(in) == 0 {
 		return nil, fmt.Errorf("field 'path': must have at least one element")
+	}
+
+	if namespacesEnabled && len(in) > 1 {
+		return nil, fmt.Errorf("field 'path': reference-path filters (path with more than one element) are not supported on namespace-enabled clusters")
 	}
 
 	pathElements := make([]interface{}, len(in))

--- a/adapters/handlers/rest/filterext/parse_test.go
+++ b/adapters/handlers/rest/filterext/parse_test.go
@@ -180,7 +180,7 @@ func Test_ExtractFlatFilters(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				filter, err := Parse(test.input, "Todo")
+				filter, err := Parse(test.input, "Todo", false)
 				assert.Equal(t, test.expectedErr, err)
 				assert.Equal(t, test.expectedFilter, filter)
 			})
@@ -286,7 +286,7 @@ func Test_ExtractFlatFilters(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				filter, err := Parse(test.input, "Todo")
+				filter, err := Parse(test.input, "Todo", false)
 				assert.ErrorAs(t, err, &test.expectedErr)
 				assert.Equal(t, test.expectedFilter, filter)
 			})
@@ -335,7 +335,7 @@ func Test_ExtractFlatFilters(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				filter, err := Parse(test.input, "Todo")
+				filter, err := Parse(test.input, "Todo", false)
 				assert.Equal(t, test.expectedErr, err)
 				assert.Equal(t, test.expectedFilter, filter)
 			})
@@ -469,7 +469,7 @@ func Test_ExtractFlatFilters(t *testing.T) {
 
 		for _, test := range tests {
 			t.Run(test.name, func(t *testing.T) {
-				filter, err := Parse(test.input, "Todo")
+				filter, err := Parse(test.input, "Todo", false)
 				assert.Equal(t, test.expectedErr, err)
 				assert.Equal(t, test.expectedFilter, filter)
 			})
@@ -550,4 +550,51 @@ func inputGeoRangeFilter(lat, lon, max float64) *models.WhereFilterGeoRange {
 
 func ptFloat32(in float32) *float32 {
 	return &in
+}
+
+// Test_Parse_NamespacesEnabledRejectsRefPath asserts that on namespace-enabled
+// clusters reference-path filters (path with more than one element) are
+// rejected before parsing. Direct-property filters (single-element path)
+// are unaffected, and global-cluster behavior (namespacesEnabled == false)
+// keeps accepting nested paths so existing operator workloads keep working.
+func Test_Parse_NamespacesEnabledRejectsRefPath(t *testing.T) {
+	t.Parallel()
+
+	value := "v"
+	directProp := &models.WhereFilter{
+		Operator:  models.WhereFilterOperatorEqual,
+		Path:      []string{"name"},
+		ValueText: &value,
+	}
+	refPath := &models.WhereFilter{
+		Operator:  models.WhereFilterOperatorEqual,
+		Path:      []string{"inCountry", "Country", "name"},
+		ValueText: &value,
+	}
+	nestedAndWithRefPath := &models.WhereFilter{
+		Operator: models.WhereFilterOperatorAnd,
+		Operands: []*models.WhereFilter{directProp, refPath},
+	}
+
+	t.Run("namespacesEnabled rejects ref-path", func(t *testing.T) {
+		_, err := Parse(refPath, "City", true)
+		assert.ErrorContains(t, err, "reference-path filters")
+	})
+
+	t.Run("namespacesEnabled rejects ref-path nested in compound operand", func(t *testing.T) {
+		_, err := Parse(nestedAndWithRefPath, "City", true)
+		assert.ErrorContains(t, err, "reference-path filters")
+	})
+
+	t.Run("namespacesEnabled accepts direct property filter", func(t *testing.T) {
+		out, err := Parse(directProp, "City", true)
+		assert.NoError(t, err)
+		assert.NotNil(t, out)
+	})
+
+	t.Run("namespacesEnabled=false still accepts ref-path", func(t *testing.T) {
+		out, err := Parse(refPath, "City", false)
+		assert.NoError(t, err)
+		assert.NotNil(t, out)
+	})
 }

--- a/entities/filters/path.go
+++ b/entities/filters/path.go
@@ -104,7 +104,7 @@ func ParsePath(pathElements []interface{}, rootClass string) (*Path, error) {
 			return nil, fmt.Errorf("element %v is not a string", i+2)
 		}
 
-		className, err := schema.ValidateClassName(rawClassName)
+		className, err := schema.ValidateQualifiedClassName(rawClassName)
 		if err != nil {
 			return nil, fmt.Errorf("expected a valid class name in 'path' field for the filter but got '%s'", rawClassName)
 		}

--- a/entities/filters/path_test.go
+++ b/entities/filters/path_test.go
@@ -19,79 +19,158 @@ import (
 )
 
 func Test_ParsePath(t *testing.T) {
-	t.Run("with a primitive prop", func(t *testing.T) {
-		rootClass := "City"
-		segments := []interface{}{"population"}
-		expectedPath := &Path{
-			Class:    "City",
-			Property: "population",
-		}
-
-		path, err := ParsePath(segments, rootClass)
-
-		require.Nil(t, err, "should not error")
-		assert.Equal(t, expectedPath, path, "should parse the path correctly")
-	})
-
-	t.Run("with len prop", func(t *testing.T) {
-		rootClass := "City"
-		segments := []interface{}{"len(population)"}
-		expectedPath := &Path{
-			Class:    "City",
-			Property: "len(population)",
-		}
-
-		path, err := ParsePath(segments, rootClass)
-
-		require.Nil(t, err, "should not error")
-		assert.Equal(t, expectedPath, path, "should parse the path correctly")
-	})
-
-	t.Run("with nested refs", func(t *testing.T) {
-		rootClass := "City"
-		segments := []interface{}{"inCountry", "Country", "inContinent", "Continent", "onPlanet", "Planet", "name"}
-		expectedPath := &Path{
-			Class:    "City",
-			Property: "inCountry",
-			Child: &Path{
-				Class:    "Country",
-				Property: "inContinent",
+	tests := []struct {
+		name      string
+		rootClass string
+		segments  []interface{}
+		expected  *Path
+		expectErr bool
+	}{
+		{
+			name:      "primitive prop",
+			rootClass: "City",
+			segments:  []interface{}{"population"},
+			expected:  &Path{Class: "City", Property: "population"},
+		},
+		{
+			name:      "len prop",
+			rootClass: "City",
+			segments:  []interface{}{"len(population)"},
+			expected:  &Path{Class: "City", Property: "len(population)"},
+		},
+		{
+			name:      "nested refs",
+			rootClass: "City",
+			segments:  []interface{}{"inCountry", "Country", "inContinent", "Continent", "onPlanet", "Planet", "name"},
+			expected: &Path{
+				Class:    "City",
+				Property: "inCountry",
 				Child: &Path{
-					Class:    "Continent",
-					Property: "onPlanet",
+					Class:    "Country",
+					Property: "inContinent",
 					Child: &Path{
-						Class:    "Planet",
-						Property: "name",
+						Class:    "Continent",
+						Property: "onPlanet",
+						Child:    &Path{Class: "Planet", Property: "name"},
 					},
 				},
 			},
-		}
+		},
+		{
+			name:      "non-valid prop errors",
+			rootClass: "City",
+			segments:  []interface{}{"populatS356()ion"},
+			expectErr: true,
+		},
+		{
+			name:      "non-valid len prop errors",
+			rootClass: "City",
+			segments:  []interface{}{"len(populatS356()ion)"},
+			expectErr: true,
+		},
+		// namespace-qualified class names produced by namespacing.Resolve.
+		// The parser accepts "<ns>:<Class>" at every path position (root +
+		// nested) and preserves the qualification end to end so downstream
+		// schema lookups hit the correct internal class.
+		{
+			name:      "namespace-qualified root class",
+			rootClass: "customer1:City",
+			segments:  []interface{}{"population"},
+			expected:  &Path{Class: "customer1:City", Property: "population"},
+		},
+		{
+			name:      "namespace-qualified nested ref classes",
+			rootClass: "customer1:City",
+			segments:  []interface{}{"inCountry", "customer1:Country", "inContinent", "customer1:Continent", "name"},
+			expected: &Path{
+				Class:    "customer1:City",
+				Property: "inCountry",
+				Child: &Path{
+					Class:    "customer1:Country",
+					Property: "inContinent",
+					Child:    &Path{Class: "customer1:Continent", Property: "name"},
+				},
+			},
+		},
+		{
+			name:      "mixed: qualified root, plain nested",
+			rootClass: "customer1:City",
+			segments:  []interface{}{"inCountry", "Country", "name"},
+			expected: &Path{
+				Class:    "customer1:City",
+				Property: "inCountry",
+				Child:    &Path{Class: "Country", Property: "name"},
+			},
+		},
+		{
+			name:      "mixed: plain root, qualified nested",
+			rootClass: "City",
+			segments:  []interface{}{"inCountry", "customer1:Country", "name"},
+			expected: &Path{
+				Class:    "City",
+				Property: "inCountry",
+				Child:    &Path{Class: "customer1:Country", Property: "name"},
+			},
+		},
+		// Malformed namespace prefix on the root.
+		{
+			name:      "root with empty namespace errors",
+			rootClass: ":City",
+			segments:  []interface{}{"name"},
+			expectErr: true,
+		},
+		{
+			name:      "root with uppercase namespace errors",
+			rootClass: "Cust:City",
+			segments:  []interface{}{"name"},
+			expectErr: true,
+		},
+		{
+			name:      "root with empty class errors",
+			rootClass: "customer1:",
+			segments:  []interface{}{"name"},
+			expectErr: true,
+		},
+		// Malformed namespace prefix on a nested ref segment.
+		{
+			name:      "nested ref with empty namespace errors",
+			rootClass: "customer1:City",
+			segments:  []interface{}{"inCountry", ":Country", "name"},
+			expectErr: true,
+		},
+		{
+			name:      "nested ref with uppercase namespace errors",
+			rootClass: "customer1:City",
+			segments:  []interface{}{"inCountry", "Cust:Country", "name"},
+			expectErr: true,
+		},
+		{
+			name:      "nested ref with empty class errors",
+			rootClass: "customer1:City",
+			segments:  []interface{}{"inCountry", "customer1:", "name"},
+			expectErr: true,
+		},
+	}
 
-		path, err := ParsePath(segments, rootClass)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path, err := ParsePath(tt.segments, tt.rootClass)
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, path)
+		})
+	}
+}
 
-		require.Nil(t, err, "should not error")
-		assert.Equal(t, expectedPath, path, "should parse the path correctly")
-
-		// Extract innermost path element
-		innerMost := path.GetInnerMost()
-		assert.Equal(t, innerMost, &Path{Class: "Planet", Property: "name"})
-
-		// Print Slice
-	})
-
-	t.Run("with non-valid prop", func(t *testing.T) {
-		rootClass := "City"
-		segments := []interface{}{"populatS356()ion"}
-		_, err := ParsePath(segments, rootClass)
-		require.NotNil(t, err, "should error")
-	})
-
-	t.Run("with non-valid len prop", func(t *testing.T) {
-		rootClass := "City"
-		segments := []interface{}{"len(populatS356()ion)"}
-		_, err := ParsePath(segments, rootClass)
-		require.NotNil(t, err, "should error")
-	})
+func Test_PathGetInnerMost(t *testing.T) {
+	rootClass := "City"
+	segments := []interface{}{"inCountry", "Country", "inContinent", "Continent", "onPlanet", "Planet", "name"}
+	path, err := ParsePath(segments, rootClass)
+	require.NoError(t, err)
+	assert.Equal(t, &Path{Class: "Planet", Property: "name"}, path.GetInnerMost())
 }
 
 func Test_SlicePath(t *testing.T) {

--- a/entities/schema/validation.go
+++ b/entities/schema/validation.go
@@ -18,22 +18,24 @@ import (
 
 var (
 	validateClassNameRegex          = regexp.MustCompile(`^` + ClassNameRegexCore + `$`)
+	validateQualifiedClassNameRegex = regexp.MustCompile(`^` + IndexNameRegexCore + `$`)
 	validateTenantNameRegex         = regexp.MustCompile(`^` + ShardNameRegexCore + `$`)
 	validatePropertyNameRegex       = regexp.MustCompile(`^` + PropertyNameRegex + `$`)
 	validateNestedPropertyNameRegex = regexp.MustCompile(`^` + NestedPropertyNameRegex + `$`)
 	reservedPropertyNames           = []string{"_additional", "_id", "id"}
 
-	// IndexNameRegexCore matches an internal index name as it appears on
-	// cluster-internal URLs: an optional "<namespace>:" prefix followed by a
-	// ClassNameRegexCore class name. The namespace portion mirrors the
-	// namespace-name contract — lowercase letter/digit edges, hyphens only
-	// internally, length NamespaceMinLength..NamespaceMaxLength.
+	// IndexNameRegexCore matches an internal index name: an optional
+	// "<namespace>:" prefix followed by a ClassNameRegexCore class name.
+	// The namespace portion mirrors the namespace-name contract — lowercase
+	// letter/digit edges, hyphens only internally, length
+	// NamespaceMinLength..NamespaceMaxLength.
 	//
 	// The {N,M} middle bound subtracts 2 to account for the required
 	// leading and trailing [a-z0-9] characters; total namespace length
 	// stays in [NamespaceMinLength, NamespaceMaxLength].
 	//
-	// Used only for cluster-API URL routing; user-facing class-name
+	// Used by cluster-API URL routing and by ValidateQualifiedClassName
+	// at post-resolver boundaries (filter parser). User-facing class-name
 	// validation continues to use ClassNameRegexCore (which rejects ":").
 	IndexNameRegexCore = fmt.Sprintf(`(?:[a-z0-9][a-z0-9-]{%d,%d}[a-z0-9]%s)?`,
 		NamespaceMinLength-2, NamespaceMaxLength-2, NamespaceSeparator) + ClassNameRegexCore
@@ -106,6 +108,29 @@ func ValidateClassName(name string) (ClassName, error) {
 		return "", err
 	}
 	return ClassName(c), nil
+}
+
+// ValidateQualifiedClassName validates that name is either a plain class
+// name matching ClassNameRegexCore, or a namespace-qualified name
+// "<namespace>:<Class>" where the namespace portion matches the shared
+// namespace-name contract (lowercase ASCII letter/digit edges, hyphens
+// only internally, length NamespaceMinLength..NamespaceMaxLength) and the
+// class portion matches ClassNameRegexCore. The full qualified name is
+// returned unchanged.
+//
+// Use at post-resolver boundaries (e.g. the filter parser) where a
+// qualified class name is a legitimate input that has already been
+// produced by namespacing.Resolve. User-facing inputs (schema create,
+// alias create, cross-ref data types) must continue to call
+// ValidateClassName, which rejects ":".
+func ValidateQualifiedClassName(name string) (ClassName, error) {
+	if len(name) > NamespaceMaxLength+len(NamespaceSeparator)+ClassNameMaxLength {
+		return "", fmt.Errorf("'%s' is not a valid class name", name)
+	}
+	if !validateQualifiedClassNameRegex.MatchString(name) {
+		return "", fmt.Errorf("'%s' is not a valid class name", name)
+	}
+	return ClassName(name), nil
 }
 
 func ValidateAliasName(name string) (string, error) {

--- a/entities/schema/validation_test.go
+++ b/entities/schema/validation_test.go
@@ -379,3 +379,57 @@ func TestIndexNameRegexCore(t *testing.T) {
 		})
 	}
 }
+
+// TestValidateQualifiedClassName covers the post-resolver validator used by
+// the filter parser: plain class names continue to validate, qualified
+// "<namespace>:<Class>" names are accepted, and malformed qualified names
+// (uppercase namespace, lowercase class, empty parts, oversized namespace,
+// double-prefix, hyphen edges) are rejected. The function returns the input
+// name unchanged on success — qualification is preserved for downstream
+// schema lookups.
+func TestValidateQualifiedClassName(t *testing.T) {
+	minNs := strings.Repeat("a", NamespaceMinLength)
+	maxNs := strings.Repeat("a", NamespaceMaxLength)
+	tooShortNs := strings.Repeat("a", NamespaceMinLength-1)
+	tooLongNs := strings.Repeat("a", NamespaceMaxLength+1)
+
+	accept := []string{
+		"Movies",
+		"M",
+		"customer1:Movies",
+		"abc:M",
+		"cust--er:Movies", // consecutive hyphens are allowed in the namespace interior
+		"tenant-a:My_Class",
+		minNs + ":Movies",
+		maxNs + ":Movies",
+	}
+	for _, name := range accept {
+		t.Run("accept/"+name, func(t *testing.T) {
+			got, err := ValidateQualifiedClassName(name)
+			assert.NoError(t, err)
+			assert.Equal(t, ClassName(name), got, "qualified name must be returned unchanged")
+		})
+	}
+
+	reject := []string{
+		"",
+		":Movies",
+		"customer1:",
+		"cust:movies",  // lowercase class
+		"Cust:Movies",  // uppercase namespace
+		"-cust:Movies", // leading hyphen on namespace
+		"cust-:Movies", // trailing hyphen on namespace
+		tooShortNs + ":Movies",
+		tooLongNs + ":Movies",
+		"a:b:Movies",          // double-prefix — only one ":" is allowed
+		"customer:1Movies",    // class portion must start with [A-Z_]
+		"customer:Movies/bad", // class portion has invalid character
+		strings.Repeat("a", NamespaceMaxLength+1+ClassNameMaxLength+1), // exceeds combined cap
+	}
+	for _, name := range reject {
+		t.Run("reject/"+name, func(t *testing.T) {
+			_, err := ValidateQualifiedClassName(name)
+			assert.Error(t, err, "expected %q to be rejected", name)
+		})
+	}
+}

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -122,6 +122,171 @@ func TestNamespaces_GRPC(t *testing.T) {
 		assert.Equal(t, "ns2-Memento", got2.Properties.(map[string]any)["title"])
 	})
 
+	t.Run("BatchDelete by filter is namespace-scoped", func(t *testing.T) {
+		// Self-contained against the rest of TestNamespaces_GRPC: own class,
+		// own UUIDs, no reliance on (or mutation of) the MoviesGRPC rows above.
+		const delClass = "BatchDeleteGRPC"
+		setupClassInBothNamespaces(t, delClass, user1Key, user2Key)
+
+		killID := strfmt.UUID("33333333-cccc-cccc-cccc-cccccccccccc")
+		keepID := strfmt.UUID("44444444-dddd-dddd-dddd-dddddddddddd")
+
+		seedDelete := func(key, killTitle, keepTitle string) {
+			r, err := grpcClient.BatchObjects(authCtx(key), &pb.BatchObjectsRequest{
+				Objects: []*pb.BatchObject{
+					makeBatchObj(killID, delClass, killTitle),
+					makeBatchObj(keepID, delClass, keepTitle),
+				},
+			})
+			require.NoError(t, err)
+			require.Empty(t, r.Errors)
+		}
+		seedDelete(user1Key, "kill", "keep")
+		seedDelete(user2Key, "kill", "keep")
+
+		// Delete by filter from user1: title == "kill" → only ns1's kill row.
+		delResp, err := grpcClient.BatchDelete(authCtx(user1Key), &pb.BatchDeleteRequest{
+			Collection: delClass,
+			Filters: &pb.Filters{
+				Operator:  pb.Filters_OPERATOR_EQUAL,
+				TestValue: &pb.Filters_ValueText{ValueText: "kill"},
+				Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "title"}},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), delResp.Successful)
+		assert.Equal(t, int64(0), delResp.Failed)
+		assert.Equal(t, int64(1), delResp.Matches)
+
+		// ns1: kill is gone, keep survives.
+		_, err = helper.GetObjectAuth(t, delClass, killID, user1Key)
+		require.Error(t, err)
+		got1Keep, err := helper.GetObjectAuth(t, delClass, keepID, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "keep", got1Keep.Properties.(map[string]any)["title"])
+
+		// ns2: both rows untouched.
+		got2Kill, err := helper.GetObjectAuth(t, delClass, killID, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, "kill", got2Kill.Properties.(map[string]any)["title"])
+		got2Keep, err := helper.GetObjectAuth(t, delClass, keepID, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, "keep", got2Keep.Properties.(map[string]any)["title"])
+	})
+
+	t.Run("BatchDelete by filter via namespace-local alias", func(t *testing.T) {
+		// Each namespace registers its own short alias for its copy of the
+		// class. namespacing.Resolve in the gRPC handler resolves the alias
+		// after qualifying with the principal's namespace, so user1's delete
+		// only touches ns1 data.
+		const (
+			delClass = "BatchDeleteAliasGRPC"
+			alias    = "BDAliasGRPC"
+		)
+		setupClassInBothNamespaces(t, delClass, user1Key, user2Key)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: delClass}, user1Key)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: delClass}, user2Key)
+		t.Cleanup(func() {
+			helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+			helper.DeleteAliasWithAuthz(t, "customer2:"+alias, helper.CreateAuth(adminKey))
+		})
+
+		killID := strfmt.UUID("77777777-7777-7777-7777-777777777777")
+		keepID := strfmt.UUID("88888888-8888-8888-8888-888888888888")
+
+		seed := func(key string) {
+			r, err := grpcClient.BatchObjects(authCtx(key), &pb.BatchObjectsRequest{
+				Objects: []*pb.BatchObject{
+					makeBatchObj(killID, delClass, "kill"),
+					makeBatchObj(keepID, delClass, "keep"),
+				},
+			})
+			require.NoError(t, err)
+			require.Empty(t, r.Errors)
+		}
+		seed(user1Key)
+		seed(user2Key)
+
+		// Delete via the alias — retry to absorb leader→follower alias lag.
+		var delResp *pb.BatchDeleteReply
+		retryOnAliasLag(t, func() error {
+			var err error
+			delResp, err = grpcClient.BatchDelete(authCtx(user1Key), &pb.BatchDeleteRequest{
+				Collection: alias,
+				Filters: &pb.Filters{
+					Operator:  pb.Filters_OPERATOR_EQUAL,
+					TestValue: &pb.Filters_ValueText{ValueText: "kill"},
+					Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "title"}},
+				},
+			})
+			return err
+		})
+		assert.Equal(t, int64(1), delResp.Successful)
+		assert.Equal(t, int64(0), delResp.Failed)
+
+		// ns1: kill gone, keep survives.
+		_, err := helper.GetObjectAuth(t, delClass, killID, user1Key)
+		require.Error(t, err)
+		got1Keep, err := helper.GetObjectAuth(t, delClass, keepID, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "keep", got1Keep.Properties.(map[string]any)["title"])
+
+		// ns2 untouched.
+		got2Kill, err := helper.GetObjectAuth(t, delClass, killID, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, "kill", got2Kill.Properties.(map[string]any)["title"])
+		got2Keep, err := helper.GetObjectAuth(t, delClass, keepID, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, "keep", got2Keep.Properties.(map[string]any)["title"])
+	})
+
+	t.Run("BatchDelete as global admin via qualified class name", func(t *testing.T) {
+		// Admin has no namespace, so namespacing.Resolve is a no-op on the
+		// class portion: the qualified name flows through to storage and
+		// matches; the short name does not exist on disk.
+		const delClass = "BatchDeleteAdminGRPC"
+		setupClassInNs1(t, delClass, user1Key)
+
+		killID := strfmt.UUID("bbbbbbbb-3333-3333-3333-333333333333")
+		keepID := strfmt.UUID("cccccccc-4444-4444-4444-444444444444")
+		r, err := grpcClient.BatchObjects(authCtx(user1Key), &pb.BatchObjectsRequest{
+			Objects: []*pb.BatchObject{
+				makeBatchObj(killID, delClass, "kill"),
+				makeBatchObj(keepID, delClass, "keep"),
+			},
+		})
+		require.NoError(t, err)
+		require.Empty(t, r.Errors)
+
+		mkReq := func(collection string) *pb.BatchDeleteRequest {
+			return &pb.BatchDeleteRequest{
+				Collection: collection,
+				Filters: &pb.Filters{
+					Operator:  pb.Filters_OPERATOR_EQUAL,
+					TestValue: &pb.Filters_ValueText{ValueText: "kill"},
+					Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "title"}},
+				},
+			}
+		}
+
+		// Short class name → not found in storage, request errors.
+		_, err = grpcClient.BatchDelete(authCtx(adminKey), mkReq(delClass))
+		require.Error(t, err)
+
+		// Qualified class name → resolves to storage, delete succeeds.
+		delResp, err := grpcClient.BatchDelete(authCtx(adminKey), mkReq("customer1:"+delClass))
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), delResp.Successful)
+		assert.Equal(t, int64(0), delResp.Failed)
+
+		// kill is gone, keep survives — verify via the namespaced user.
+		_, err = helper.GetObjectAuth(t, delClass, killID, user1Key)
+		require.Error(t, err)
+		got, err := helper.GetObjectAuth(t, delClass, keepID, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "keep", got.Properties.(map[string]any)["title"])
+	})
+
 	t.Run("Search is namespace-scoped", func(t *testing.T) {
 		req := func(key string) (*pb.SearchReply, error) {
 			r := searchReq(class, 10)

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -314,6 +314,44 @@ func TestNamespaces_GRPC(t *testing.T) {
 		assert.ElementsMatch(t, []string{"ns2-Memento", "ns2-Tenet"}, titles2)
 	})
 
+	t.Run("Search by filter is namespace-scoped", func(t *testing.T) {
+		// Filter parser sanity check on the gRPC Search path: each
+		// namespace's row carries its own ns-prefixed title, so an exact
+		// match on "ns1-Inception" only hits user1's namespace and vice
+		// versa. Proves the qualified-class filter path round-trips
+		// through Search the same way it does through BatchDelete.
+		searchWithFilter := func(key, title string) (*pb.SearchReply, error) {
+			r := searchReq(class, 10)
+			r.Properties = &pb.PropertiesRequest{NonRefProperties: []string{"title"}}
+			r.Filters = &pb.Filters{
+				Operator:  pb.Filters_OPERATOR_EQUAL,
+				TestValue: &pb.Filters_ValueText{ValueText: title},
+				Target:    &pb.FilterTarget{Target: &pb.FilterTarget_Property{Property: "title"}},
+			}
+			return grpcClient.Search(authCtx(key), r)
+		}
+
+		// user1 matches their own row; user2 sees nothing for the same filter.
+		resp1, err := searchWithFilter(user1Key, "ns1-Inception")
+		require.NoError(t, err)
+		require.Len(t, resp1.Results, 1)
+		assert.Equal(t, "ns1-Inception", resp1.Results[0].Properties.NonRefProps.Fields["title"].GetTextValue())
+
+		resp2Miss, err := searchWithFilter(user2Key, "ns1-Inception")
+		require.NoError(t, err)
+		assert.Empty(t, resp2Miss.Results)
+
+		// And the symmetric case: user2's row is only visible to user2.
+		resp2, err := searchWithFilter(user2Key, "ns2-Tenet")
+		require.NoError(t, err)
+		require.Len(t, resp2.Results, 1)
+		assert.Equal(t, "ns2-Tenet", resp2.Results[0].Properties.NonRefProps.Fields["title"].GetTextValue())
+
+		resp1Miss, err := searchWithFilter(user1Key, "ns2-Tenet")
+		require.NoError(t, err)
+		assert.Empty(t, resp1Miss.Results)
+	})
+
 	t.Run("Aggregate count is namespace-scoped", func(t *testing.T) {
 		for _, key := range []string{user1Key, user2Key} {
 			resp, err := grpcClient.Aggregate(authCtx(key), &pb.AggregateRequest{

--- a/test/acceptance/namespace/objects_test.go
+++ b/test/acceptance/namespace/objects_test.go
@@ -343,13 +343,6 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 	})
 
 	t.Run("batch delete by filter is namespace-scoped", func(t *testing.T) {
-		// Filter validation rejects namespace-qualified class names: the path
-		// validator in entities/filters/path.go runs each path element through
-		// schema.ValidateClassName, whose regex disallows the `:` separator.
-		// Until filter parsing is taught to accept qualified names,
-		// namespace-aware batch delete cannot succeed.
-		t.Skip("blocked: filter parser rejects namespace-qualified class names; tracked as a separate WS item")
-
 		const class = "BatchDelete"
 		setupClassInBothNamespaces(t, class, user1Key, user2Key)
 
@@ -399,5 +392,150 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 		got22, err := helper.GetObjectAuth(t, class, id2, user2Key)
 		require.NoError(t, err)
 		assert.Equal(t, "keep", got22.Properties.(map[string]any)["title"])
+	})
+
+	t.Run("batch delete by filter via namespace-local alias", func(t *testing.T) {
+		// Each namespace registers its own short alias name for its copy of
+		// the class. b.resolveNS resolves "<ns>:BDAlias" to the underlying
+		// "<ns>:BatchDeleteAlias" before authz and filter parsing, so the
+		// delete must only touch user1's data.
+		const (
+			class = "BatchDeleteAlias"
+			alias = "BDAlias"
+		)
+		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: class}, user1Key)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: class}, user2Key)
+		t.Cleanup(func() {
+			helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+			helper.DeleteAliasWithAuthz(t, "customer2:"+alias, helper.CreateAuth(adminKey))
+		})
+
+		id1 := strfmt.UUID("55555555-eeee-eeee-eeee-eeeeeeeeeeee")
+		id2 := strfmt.UUID("66666666-ffff-ffff-ffff-ffffffffffff")
+		helper.CreateObjectsBatchAuth(t, []*models.Object{
+			{ID: id1, Class: class, Properties: map[string]any{"title": "kill"}},
+			{ID: id2, Class: class, Properties: map[string]any{"title": "keep"}},
+		}, user1Key)
+		helper.CreateObjectsBatchAuth(t, []*models.Object{
+			{ID: id1, Class: class, Properties: map[string]any{"title": "kill"}},
+			{ID: id2, Class: class, Properties: map[string]any{"title": "keep"}},
+		}, user2Key)
+
+		killText := "kill"
+		body := &models.BatchDelete{
+			Match: &models.BatchDeleteMatch{
+				Class: alias,
+				Where: &models.WhereFilter{
+					Operator:  "Equal",
+					Path:      []string{"title"},
+					ValueText: &killText,
+				},
+			},
+		}
+		var resp *batch.BatchObjectsDeleteOK
+		retryOnAliasLag(t, func() error {
+			var err error
+			resp, err = helper.Client(t).Batch.BatchObjectsDelete(
+				batch.NewBatchObjectsDeleteParams().WithBody(body),
+				helper.CreateAuth(user1Key),
+			)
+			return err
+		})
+		require.NotNil(t, resp.Payload.Results)
+		assert.EqualValues(t, 1, resp.Payload.Results.Successful)
+
+		// ns1: kill gone, keep survives.
+		_, err := helper.GetObjectAuth(t, class, id1, user1Key)
+		require.Error(t, err)
+		got1Keep, err := helper.GetObjectAuth(t, class, id2, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "keep", got1Keep.Properties.(map[string]any)["title"])
+
+		// ns2 untouched.
+		got2Kill, err := helper.GetObjectAuth(t, class, id1, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, "kill", got2Kill.Properties.(map[string]any)["title"])
+		got2Keep, err := helper.GetObjectAuth(t, class, id2, user2Key)
+		require.NoError(t, err)
+		assert.Equal(t, "keep", got2Keep.Properties.(map[string]any)["title"])
+	})
+
+	t.Run("batch delete by filter as global admin via qualified class name", func(t *testing.T) {
+		// Admin has no namespace, so namespacing.Resolve is a no-op on the
+		// class portion: the qualified name flows through to storage and
+		// matches; the short name does not exist on disk and 422s.
+		const class = "BatchDeleteAdmin"
+		setupClassInNs1(t, class, user1Key)
+
+		id1 := strfmt.UUID("99999999-1111-1111-1111-111111111111")
+		id2 := strfmt.UUID("aaaaaaaa-2222-2222-2222-222222222222")
+		helper.CreateObjectsBatchAuth(t, []*models.Object{
+			{ID: id1, Class: class, Properties: map[string]any{"title": "kill"}},
+			{ID: id2, Class: class, Properties: map[string]any{"title": "keep"}},
+		}, user1Key)
+
+		killText := "kill"
+		mkBody := func(matchClass string) *models.BatchDelete {
+			return &models.BatchDelete{
+				Match: &models.BatchDeleteMatch{
+					Class: matchClass,
+					Where: &models.WhereFilter{
+						Operator:  "Equal",
+						Path:      []string{"title"},
+						ValueText: &killText,
+					},
+				},
+			}
+		}
+
+		// Admin with the short class name cannot reach the namespaced data.
+		_, err := helper.Client(t).Batch.BatchObjectsDelete(
+			batch.NewBatchObjectsDeleteParams().WithBody(mkBody(class)),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+
+		// Admin with the qualified class name resolves directly to storage.
+		resp, err := helper.Client(t).Batch.BatchObjectsDelete(
+			batch.NewBatchObjectsDeleteParams().WithBody(mkBody("customer1:"+class)),
+			helper.CreateAuth(adminKey),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload.Results)
+		assert.EqualValues(t, 1, resp.Payload.Results.Successful)
+
+		// kill is gone, keep survives — verify via the namespaced user.
+		_, err = helper.GetObjectAuth(t, class, id1, user1Key)
+		require.Error(t, err)
+		got, err := helper.GetObjectAuth(t, class, id2, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "keep", got.Properties.(map[string]any)["title"])
+	})
+
+	t.Run("batch delete by reference-path filter is rejected", func(t *testing.T) {
+		// Inner class segments in reference-path filters are caller-supplied
+		// and not auto-qualified. The REST handler rejects path-len > 1
+		// upfront on namespace-enabled clusters; this guards against silent
+		// "class not found" failures downstream.
+		const class = "BatchDeleteRefPath"
+		setupClassInNs1(t, class, user1Key)
+
+		x := "x"
+		body := &models.BatchDelete{
+			Match: &models.BatchDeleteMatch{
+				Class: class,
+				Where: &models.WhereFilter{
+					Operator:  "Equal",
+					Path:      []string{"hasOther", "Other", "name"},
+					ValueText: &x,
+				},
+			},
+		}
+		_, err := helper.Client(t).Batch.BatchObjectsDelete(
+			batch.NewBatchObjectsDeleteParams().WithBody(body),
+			helper.CreateAuth(user1Key),
+		)
+		require.Error(t, err)
 	})
 }

--- a/usecases/classification/classifier.go
+++ b/usecases/classification/classifier.go
@@ -193,17 +193,21 @@ func (c *Classifier) extractFilters(ctx context.Context, principal *models.Princ
 		return classificationFilters{}, nil
 	}
 
-	source, err := filterext.Parse(params.Filters.SourceWhere, params.Class)
+	// Classification is not exercised on namespace-enabled clusters, so the
+	// nested-path guard in filterext.Parse is hard-wired off here.
+	const namespacesEnabled = false
+
+	source, err := filterext.Parse(params.Filters.SourceWhere, params.Class, namespacesEnabled)
 	if err != nil {
 		return classificationFilters{}, fmt.Errorf("field 'sourceWhere': %w", err)
 	}
 
-	trainingSet, err := filterext.Parse(params.Filters.TrainingSetWhere, params.Class)
+	trainingSet, err := filterext.Parse(params.Filters.TrainingSetWhere, params.Class, namespacesEnabled)
 	if err != nil {
 		return classificationFilters{}, fmt.Errorf("field 'trainingSetWhere': %w", err)
 	}
 
-	target, err := filterext.Parse(params.Filters.TargetWhere, params.Class)
+	target, err := filterext.Parse(params.Filters.TargetWhere, params.Class, namespacesEnabled)
 	if err != nil {
 		return classificationFilters{}, fmt.Errorf("field 'targetWhere': %w", err)
 	}

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -35,7 +35,7 @@ func (b *BatchManager) DeleteObjects(ctx context.Context, principal *models.Prin
 ) (*BatchDeleteResponse, error) {
 	class := "*"
 	if match != nil {
-		match.Class, _ = b.resolveAlias(match.Class)
+		match.Class, _ = b.resolveNS(principal, match.Class)
 		class = match.Class
 	}
 
@@ -141,7 +141,7 @@ func (b *BatchManager) validateBatchDelete(ctx context.Context, principal *model
 	}
 	class := vclasses[match.Class].Class
 
-	filter, err := filterext.Parse(match.Where, class.Class)
+	filter, err := filterext.Parse(match.Where, class.Class, b.config.Config.Namespaces.Enabled)
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to parse where filter: %w", err)
 	}

--- a/usecases/objects/batch_delete_test.go
+++ b/usecases/objects/batch_delete_test.go
@@ -14,10 +14,13 @@ package objects
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -178,6 +181,112 @@ func Test_BatchDelete_RequestValidation(t *testing.T) {
 			_, err := manager.DeleteObjects(ctx, nil, test.input.Match, test.input.DeletionTimeUnixMilli, test.input.DryRun, test.input.Output, nil, "")
 			assert.Equal(t, test.expectedError, err.Error())
 		}
+	})
+}
+
+// Test_BatchDelete_NamespaceResolution proves DeleteObjects routes the
+// caller's short class name through namespacing.Resolve before authz and
+// schema lookup. The namespaced principal submits "Foo"; the manager must
+// authorize and look up "customer1:Foo" and the qualified name must reach
+// the vector repo on BatchDeleteParams.ClassName. The global-principal
+// case is the regression guard that resolveNS is a no-op without a
+// namespace.
+func Test_BatchDelete_NamespaceResolution(t *testing.T) {
+	makeManager := func(t *testing.T, classes []*models.Class) (*BatchManager, *fakeVectorRepo, *mocks.FakeAuthorizer) {
+		t.Helper()
+		sch := schema.Schema{Objects: &models.Schema{Classes: classes}}
+		vectorRepo := &fakeVectorRepo{}
+		cfg := &config.WeaviateConfig{
+			Config: config.Config{
+				AutoSchema: config.AutoSchema{
+					Enabled: runtime.NewDynamicValue(false),
+				},
+				Namespaces: config.Namespaces{
+					Enabled: true,
+				},
+			},
+		}
+		schemaManager := &fakeSchemaManager{GetSchemaResponse: sch}
+		logger, _ := test.NewNullLogger()
+		authorizer := mocks.NewMockAuthorizer()
+		manager := NewBatchManager(vectorRepo, getFakeModulesProvider(), schemaManager, cfg, logger, authorizer, nil,
+			NewAutoSchemaManager(schemaManager, vectorRepo, cfg, authorizer, logger, prometheus.NewPedanticRegistry()))
+		return manager, vectorRepo, authorizer
+	}
+
+	fooClass := func(name string) *models.Class {
+		return &models.Class{
+			Class: name,
+			Properties: []*models.Property{
+				{
+					Name:         "name",
+					DataType:     schema.DataTypeText.PropString(),
+					Tokenization: models.PropertyTokenizationWhitespace,
+				},
+			},
+			VectorIndexConfig: hnsw.UserConfig{},
+			Vectorizer:        config.VectorizerModuleNone,
+		}
+	}
+
+	// DeleteObjects mutates match.Class in place via resolveNS, so each
+	// subtest builds its own match.
+	newMatch := func() *models.BatchDeleteMatch {
+		return &models.BatchDeleteMatch{
+			Class: "Foo",
+			Where: &models.WhereFilter{
+				Path:      []string{"name"},
+				Operator:  "Equal",
+				ValueText: ptString("v"),
+			},
+		}
+	}
+
+	t.Run("namespaced principal qualifies the class end to end", func(t *testing.T) {
+		manager, vectorRepo, authorizer := makeManager(t, []*models.Class{fooClass("customer1:Foo")})
+		vectorRepo.On("BatchDeleteObjects", mock.MatchedBy(func(p BatchDeleteParams) bool {
+			return string(p.ClassName) == "customer1:Foo" && p.Filters != nil && string(p.Filters.Root.On.Class) == "customer1:Foo"
+		})).Return(BatchDeleteResult{DeletionTime: time.Time{}}, nil)
+
+		principal := &models.Principal{Username: "u", Namespace: "customer1"}
+		_, err := manager.DeleteObjects(context.Background(), principal, newMatch(), nil, ptBool(false), ptString(verbosity.OutputMinimal), nil, "")
+		require.NoError(t, err)
+
+		// Authz was invoked against the qualified resource.
+		require.NotEmpty(t, authorizer.Calls())
+		require.Contains(t, authorizer.Calls()[0].Resources[0], "customer1:Foo")
+
+		vectorRepo.AssertExpectations(t)
+	})
+
+	t.Run("namespaced principal cannot reach a foreign-namespace class", func(t *testing.T) {
+		// Schema only has customer2:Foo. customer1's "Foo" resolves to
+		// "customer1:Foo" which is not present, so GetCachedClass fails
+		// and the delete is rejected before reaching the repo.
+		manager, _, _ := makeManager(t, []*models.Class{fooClass("customer2:Foo")})
+
+		principal := &models.Principal{Username: "u", Namespace: "customer1"}
+		_, err := manager.DeleteObjects(context.Background(), principal, newMatch(), nil, ptBool(false), ptString(verbosity.OutputMinimal), nil, "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "customer1:Foo")
+	})
+
+	t.Run("global principal leaves the class unchanged", func(t *testing.T) {
+		// Global principal (no namespace) must observe the pre-WS16
+		// behavior: short class name flows through untouched.
+		manager, vectorRepo, authorizer := makeManager(t, []*models.Class{fooClass("Foo")})
+		vectorRepo.On("BatchDeleteObjects", mock.MatchedBy(func(p BatchDeleteParams) bool {
+			return string(p.ClassName) == "Foo" && string(p.Filters.Root.On.Class) == "Foo"
+		})).Return(BatchDeleteResult{DeletionTime: time.Time{}}, nil)
+
+		principal := &models.Principal{Username: "admin"}
+		_, err := manager.DeleteObjects(context.Background(), principal, newMatch(), nil, ptBool(false), ptString(verbosity.OutputMinimal), nil, "")
+		require.NoError(t, err)
+		require.NotEmpty(t, authorizer.Calls())
+		require.Contains(t, authorizer.Calls()[0].Resources[0], "Foo")
+		require.NotContains(t, authorizer.Calls()[0].Resources[0], ":Foo")
+
+		vectorRepo.AssertExpectations(t)
 	})
 }
 

--- a/usecases/objects/batch_delete_test.go
+++ b/usecases/objects/batch_delete_test.go
@@ -210,7 +210,7 @@ func Test_BatchDelete_NamespaceResolution(t *testing.T) {
 		logger, _ := test.NewNullLogger()
 		authorizer := mocks.NewMockAuthorizer()
 		manager := NewBatchManager(vectorRepo, getFakeModulesProvider(), schemaManager, cfg, logger, authorizer, nil,
-			NewAutoSchemaManager(schemaManager, vectorRepo, cfg, authorizer, logger, prometheus.NewPedanticRegistry()))
+			NewAutoSchemaManager(schemaManager, vectorRepo, cfg, logger, prometheus.NewPedanticRegistry()))
 		return manager, vectorRepo, authorizer
 	}
 

--- a/usecases/objects/batch_manager.go
+++ b/usecases/objects/batch_manager.go
@@ -22,7 +22,6 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/monitoring"
-	"github.com/weaviate/weaviate/usecases/objects/alias"
 	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
@@ -71,11 +70,6 @@ func NewBatchManager(vectorRepo BatchVectorRepo, modulesProvider ModulesProvider
 		autoSchemaManager: autoSchemaManager,
 		metrics:           NewMetrics(prom),
 	}
-}
-
-// Alias support
-func (m *BatchManager) resolveAlias(class string) (className, aliasName string) {
-	return alias.ResolveAlias(m.schemaManager, class)
 }
 
 // resolveNS qualifies name with the principal's namespace (if enabled)


### PR DESCRIPTION
### What's being changed:

This allows qualified names in filters to support namespaces and enables batch delete. References are not yet supported yet by namespaces so nested filters are not tested yet

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
