### PR TITLE
fix: prevent race condition in async replication scheduler's dispatch logic

### DIFF
--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -814,13 +814,18 @@ func (sched *AsyncReplicationScheduler) dispatchDueLocked() {
 		// Add(1) before sending to workCh so that Deregister+asyncRepWg.Wait()
 		// reliably waits for the cycle even if the worker hasn't started yet.
 		entry.shard.asyncRepWg.Add(1)
+		// Set inFlight before the send: the channel send→receive carries this
+		// write to the worker, so the worker's ctx-cancelled drain path (which
+		// also writes entry.inFlight without holding sched.mu) does not race.
+		entry.inFlight = true
 
 		select {
 		case sched.workCh <- entry:
 			heap.Pop(&sched.h)
-			entry.inFlight = true
 		default:
-			// workCh buffer full (all workers busy): undo Add(1) and leave entry in heap.
+			// workCh buffer full (all workers busy): roll back inFlight + Add(1)
+			// and leave entry in heap.
+			entry.inFlight = false
 			entry.shard.asyncRepWg.Done()
 			sched.metrics.setQueueDepth(len(sched.h))
 			return


### PR DESCRIPTION
### What's being changed:

This pull request refines the handling of the `inFlight` flag in the `AsyncReplicationScheduler` to ensure thread safety and eliminate potential race conditions between the scheduler and worker goroutines. The most important change is that the `inFlight` flag is now set before sending a work entry to the worker channel, and is properly rolled back if the channel is full.

**Concurrency and state management improvements:**

* Set `entry.inFlight = true` before sending the entry to `workCh`, ensuring that the state is safely communicated to the worker and preventing races with the worker's context-cancellation drain path.
* If the `workCh` buffer is full, roll back both `inFlight` and the wait group increment (`Add(1)`) to maintain consistent state and avoid leaks or incorrect state tracking.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
