### PR TITLE
Namespaces: Validate namespaces provided by global operator

### DIFF
--- a/adapters/handlers/grpc/v1/batch/handler.go
+++ b/adapters/handlers/grpc/v1/batch/handler.go
@@ -66,7 +66,11 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 	knownClasses := map[string]versioned.Class{}
 	knownClassesAuthCheck := map[string]*models.Class{}
 	classGetter := func(classname, shard string) (*models.Class, error) {
-		classname, _ = namespacing.Resolve(principal, h.schemaManager, h.namespacesEnabled, classname)
+		resolved, _, err := namespacing.Resolve(principal, h.schemaManager, h.namespacesEnabled, classname)
+		if err != nil {
+			return nil, err
+		}
+		classname = resolved
 		// use a letter that cannot be in class/shard name to not allow different combinations leading to the same combined name
 		classTenantName := classname + "#" + shard
 		class, ok := knownClassesAuthCheck[classTenantName]

--- a/adapters/handlers/grpc/v1/batch/stream.go
+++ b/adapters/handlers/grpc/v1/batch/stream.go
@@ -498,7 +498,10 @@ func (h *StreamHandler) receiver(ctx context.Context, streamId string, principal
 				if _, ok := resolvedByRaw[obj.Collection]; ok {
 					continue
 				}
-				resolved, _ := namespacing.Resolve(principal, h.schemaManager, h.namespacesEnabled, obj.Collection)
+				resolved, _, err := namespacing.Resolve(principal, h.schemaManager, h.namespacesEnabled, obj.Collection)
+				if err != nil {
+					return err
+				}
 				resolvedNames = append(resolvedNames, resolved)
 				resolvedByRaw[obj.Collection] = resolved
 			}

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -101,7 +101,9 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 	}
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
-	req.Collection, _ = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection)
+	if req.Collection, _, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {
+		return nil, err
+	}
 
 	parser := NewAggregateParser(
 		s.classGetterWithAuthzFunc(ctx, principal, req.Tenant),
@@ -180,7 +182,9 @@ func (s *Service) batchDelete(ctx context.Context, req *pb.BatchDeleteRequest) (
 		tenant = *req.Tenant
 	}
 
-	req.Collection, _ = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection)
+	if req.Collection, _, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {
+		return nil, err
+	}
 
 	if err := s.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.ShardsData(req.Collection, tenant)...); err != nil {
 		return nil, err
@@ -281,7 +285,9 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	}
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
-	req.Collection, _ = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection)
+	if req.Collection, _, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {
+		return nil, err
+	}
 
 	parser := NewParser(
 		req.Uses_127Api,

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -5291,6 +5291,12 @@ func init() {
           "404": {
             "description": "Collection not found."
           },
+          "422": {
+            "description": "Invalid collection name provided (e.g. malformed namespace prefix). Check the ErrorResponse for details.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "An error occurred while retrieving the collection definition. Check the ErrorResponse for details.",
             "schema": {
@@ -15780,6 +15786,12 @@ func init() {
           },
           "404": {
             "description": "Collection not found."
+          },
+          "422": {
+            "description": "Invalid collection name provided (e.g. malformed namespace prefix). Check the ErrorResponse for details.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           },
           "500": {
             "description": "An error occurred while retrieving the collection definition. Check the ErrorResponse for details.",

--- a/adapters/handlers/rest/handlers_nodes.go
+++ b/adapters/handlers/rest/handlers_nodes.go
@@ -69,7 +69,10 @@ func (n *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, 
 		shardName = *params.ShardName
 	}
 
-	className, _ := namespacing.Resolve(principal, n.schemaManager, n.namespacesEnabled, params.ClassName)
+	className, _, err := namespacing.Resolve(principal, n.schemaManager, n.namespacesEnabled, params.ClassName)
+	if err != nil {
+		return nodes.NewNodesGetUnprocessableEntity().WithPayload(errPayloadFromSingleErr(err))
+	}
 
 	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, className, shardName, output)
 	if err != nil {

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -202,6 +202,9 @@ func (h *objectHandlers) getObject(params objects.ObjectsClassGetParams,
 				WithPayload(errPayloadFromSingleErr(err))
 		case errors.As(err, &uco.ErrNotFound{}):
 			return objects.NewObjectsClassGetNotFound()
+		case errors.As(err, &uco.ErrInvalidUserInput{}):
+			return objects.NewObjectsClassGetUnprocessableEntity().
+				WithPayload(errPayloadFromSingleErr(err))
 		case errors.As(err, &uco.ErrMultiTenancy{}):
 			return objects.NewObjectsClassGetUnprocessableEntity().
 				WithPayload(errPayloadFromSingleErr(err))

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -97,6 +97,9 @@ func (s *schemaHandlers) getClass(params schema.SchemaObjectsGetParams,
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsGetForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
+		case errors.Is(err, schemaUC.ErrValidation):
+			return schema.NewSchemaObjectsGetUnprocessableEntity().
+				WithPayload(errPayloadFromSingleErr(err))
 		default:
 			return schema.NewSchemaObjectsGetInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))

--- a/adapters/handlers/rest/handlers_tokenize.go
+++ b/adapters/handlers/rest/handlers_tokenize.go
@@ -174,10 +174,14 @@ func propertyTokenize(params schemaops.SchemaObjectsPropertiesTokenizeParams,
 ) middleware.Responder {
 	// Resolve before authorization so authz uses the real collection name
 	// for permissions and error UX.
-	className, _ := namespacing.Resolve(principal, schemaManager, namespacesEnabled, params.ClassName)
+	className, _, err := namespacing.Resolve(principal, schemaManager, namespacesEnabled, params.ClassName)
+	if err != nil {
+		return schemaops.NewSchemaObjectsPropertiesTokenizeUnprocessableEntity().
+			WithPayload(errPayloadFromSingleErr(err))
+	}
 
 	// Authorize: reading collection metadata (same as other schema read operations)
-	err := schemaManager.Authorizer.Authorize(
+	err = schemaManager.Authorizer.Authorize(
 		params.HTTPRequest.Context(), principal, authorization.READ,
 		authorization.CollectionsMetadata(className)...,
 	)

--- a/adapters/handlers/rest/operations/schema/schema_objects_get_responses.go
+++ b/adapters/handlers/rest/operations/schema/schema_objects_get_responses.go
@@ -164,6 +164,51 @@ func (o *SchemaObjectsGetNotFound) WriteResponse(rw http.ResponseWriter, produce
 	rw.WriteHeader(404)
 }
 
+// SchemaObjectsGetUnprocessableEntityCode is the HTTP code returned for type SchemaObjectsGetUnprocessableEntity
+const SchemaObjectsGetUnprocessableEntityCode int = 422
+
+/*
+SchemaObjectsGetUnprocessableEntity Invalid collection name provided (e.g. malformed namespace prefix). Check the ErrorResponse for details.
+
+swagger:response schemaObjectsGetUnprocessableEntity
+*/
+type SchemaObjectsGetUnprocessableEntity struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewSchemaObjectsGetUnprocessableEntity creates SchemaObjectsGetUnprocessableEntity with default headers values
+func NewSchemaObjectsGetUnprocessableEntity() *SchemaObjectsGetUnprocessableEntity {
+
+	return &SchemaObjectsGetUnprocessableEntity{}
+}
+
+// WithPayload adds the payload to the schema objects get unprocessable entity response
+func (o *SchemaObjectsGetUnprocessableEntity) WithPayload(payload *models.ErrorResponse) *SchemaObjectsGetUnprocessableEntity {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the schema objects get unprocessable entity response
+func (o *SchemaObjectsGetUnprocessableEntity) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *SchemaObjectsGetUnprocessableEntity) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(422)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // SchemaObjectsGetInternalServerErrorCode is the HTTP code returned for type SchemaObjectsGetInternalServerError
 const SchemaObjectsGetInternalServerErrorCode int = 500
 

--- a/client/schema/schema_objects_get_responses.go
+++ b/client/schema/schema_objects_get_responses.go
@@ -58,6 +58,12 @@ func (o *SchemaObjectsGetReader) ReadResponse(response runtime.ClientResponse, c
 			return nil, err
 		}
 		return nil, result
+	case 422:
+		result := NewSchemaObjectsGetUnprocessableEntity()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewSchemaObjectsGetInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -313,6 +319,74 @@ func (o *SchemaObjectsGetNotFound) String() string {
 }
 
 func (o *SchemaObjectsGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewSchemaObjectsGetUnprocessableEntity creates a SchemaObjectsGetUnprocessableEntity with default headers values
+func NewSchemaObjectsGetUnprocessableEntity() *SchemaObjectsGetUnprocessableEntity {
+	return &SchemaObjectsGetUnprocessableEntity{}
+}
+
+/*
+SchemaObjectsGetUnprocessableEntity describes a response with status code 422, with default header values.
+
+Invalid collection name provided (e.g. malformed namespace prefix). Check the ErrorResponse for details.
+*/
+type SchemaObjectsGetUnprocessableEntity struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this schema objects get unprocessable entity response has a 2xx status code
+func (o *SchemaObjectsGetUnprocessableEntity) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this schema objects get unprocessable entity response has a 3xx status code
+func (o *SchemaObjectsGetUnprocessableEntity) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this schema objects get unprocessable entity response has a 4xx status code
+func (o *SchemaObjectsGetUnprocessableEntity) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this schema objects get unprocessable entity response has a 5xx status code
+func (o *SchemaObjectsGetUnprocessableEntity) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this schema objects get unprocessable entity response a status code equal to that given
+func (o *SchemaObjectsGetUnprocessableEntity) IsCode(code int) bool {
+	return code == 422
+}
+
+// Code gets the status code for the schema objects get unprocessable entity response
+func (o *SchemaObjectsGetUnprocessableEntity) Code() int {
+	return 422
+}
+
+func (o *SchemaObjectsGetUnprocessableEntity) Error() string {
+	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetUnprocessableEntity  %+v", 422, o.Payload)
+}
+
+func (o *SchemaObjectsGetUnprocessableEntity) String() string {
+	return fmt.Sprintf("[GET /schema/{className}][%d] schemaObjectsGetUnprocessableEntity  %+v", 422, o.Payload)
+}
+
+func (o *SchemaObjectsGetUnprocessableEntity) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *SchemaObjectsGetUnprocessableEntity) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/entities/schema/validation.go
+++ b/entities/schema/validation.go
@@ -22,23 +22,30 @@ var (
 	validateTenantNameRegex         = regexp.MustCompile(`^` + ShardNameRegexCore + `$`)
 	validatePropertyNameRegex       = regexp.MustCompile(`^` + PropertyNameRegex + `$`)
 	validateNestedPropertyNameRegex = regexp.MustCompile(`^` + NestedPropertyNameRegex + `$`)
+	validateNamespaceNameRegex      = regexp.MustCompile(`^` + NamespaceNameRegexCore + `$`)
 	reservedPropertyNames           = []string{"_additional", "_id", "id"}
+
+	// NamespaceNameRegexCore is the single source of truth for the namespace
+	// name character set + length contract: lowercase letter/digit edges,
+	// hyphens only internally, total length in [NamespaceMinLength,
+	// NamespaceMaxLength]. The {N,M} middle bound subtracts 2 to account for
+	// the required leading and trailing [a-z0-9] characters.
+	//
+	// Used both by the anchored validateNamespaceNameRegex (callers that
+	// receive a bare namespace name) and by IndexNameRegexCore (the
+	// cluster-API URL router, which needs the same syntax embedded in a
+	// larger pattern). Do not duplicate this regex elsewhere — extend or
+	// reuse this constant so the contract stays in one place.
+	NamespaceNameRegexCore = fmt.Sprintf(`[a-z0-9][a-z0-9-]{%d,%d}[a-z0-9]`,
+		NamespaceMinLength-2, NamespaceMaxLength-2)
 
 	// IndexNameRegexCore matches an internal index name: an optional
 	// "<namespace>:" prefix followed by a ClassNameRegexCore class name.
-	// The namespace portion mirrors the namespace-name contract — lowercase
-	// letter/digit edges, hyphens only internally, length
-	// NamespaceMinLength..NamespaceMaxLength.
-	//
-	// The {N,M} middle bound subtracts 2 to account for the required
-	// leading and trailing [a-z0-9] characters; total namespace length
-	// stays in [NamespaceMinLength, NamespaceMaxLength].
 	//
 	// Used by cluster-API URL routing and by ValidateQualifiedClassName
 	// at post-resolver boundaries (filter parser). User-facing class-name
 	// validation continues to use ClassNameRegexCore (which rejects ":").
-	IndexNameRegexCore = fmt.Sprintf(`(?:[a-z0-9][a-z0-9-]{%d,%d}[a-z0-9]%s)?`,
-		NamespaceMinLength-2, NamespaceMaxLength-2, NamespaceSeparator) + ClassNameRegexCore
+	IndexNameRegexCore = `(?:` + NamespaceNameRegexCore + NamespaceSeparator + `)?` + ClassNameRegexCore
 )
 
 const (
@@ -100,6 +107,23 @@ const (
 	NamespaceMinLength = 3
 	NamespaceMaxLength = 36
 )
+
+// ValidateNamespaceNameSyntax checks the syntax of a namespace name: length
+// bounds, lowercase ASCII letters/digits/hyphens, no leading/trailing hyphen.
+// It does NOT check reserved names — that policy lives in usecases/namespaces
+// alongside ValidateName and is enforced at Create time. This split lets the
+// name-resolver (usecases/schema/namespacing) reuse the syntactic part without
+// importing the namespace controller (which would form a cycle via the apikey
+// dependency chain).
+func ValidateNamespaceNameSyntax(name string) error {
+	if l := len(name); l < NamespaceMinLength || l > NamespaceMaxLength {
+		return fmt.Errorf("namespace name %q must be %d-%d characters", name, NamespaceMinLength, NamespaceMaxLength)
+	}
+	if !validateNamespaceNameRegex.MatchString(name) {
+		return fmt.Errorf("namespace name %q must contain only lowercase letters, digits, and hyphens, must start and end with a letter or digit, and must not contain ':'", name)
+	}
+	return nil
+}
 
 // ValidateClassName validates that this string is a valid class name (format wise)
 func ValidateClassName(name string) (ClassName, error) {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -8013,6 +8013,12 @@
           "404": {
             "description": "Collection not found."
           },
+          "422": {
+            "description": "Invalid collection name provided (e.g. malformed namespace prefix). Check the ErrorResponse for details.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "An error occurred while retrieving the collection definition. Check the ErrorResponse for details.",
             "schema": {

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -371,4 +371,22 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		helper.DeleteClassAuth(t, "customer1:CaseDelete", adminKey)
 		helper.CreateClassAuth(t, &models.Class{Class: "CaseDelete"}, user1Key)
 	})
+
+	// Read path: GET /schema/{className} with a wrong-case namespace prefix
+	// must surface a 422 (not a 500), so the 422 contract has end-to-end
+	// coverage on the read side too.
+	t.Run("get with wrong-case namespace prefix returns 422", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "CaseGet"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:CaseGet", adminKey)
+
+		_, err := helper.GetClassAuthWithReturn(t, "Customer1:CaseGet", adminKey)
+		require.Error(t, err)
+		var unproc *schema.SchemaObjectsGetUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected SchemaObjectsGetUnprocessableEntity, got %T: %v", err, err)
+		assert.Contains(t, unproc.Payload.Error[0].Message, "invalid namespace prefix")
+
+		// Correct casing still works — the class is reachable as registered.
+		got := helper.GetClassAuth(t, "customer1:CaseGet", adminKey)
+		require.Equal(t, "customer1:CaseGet", got.Class)
+	})
 }

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -351,4 +351,24 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		got := helper.GetClassAuth(t, "customer1:AdminAliasDeleteTarget", adminKey)
 		require.Equal(t, "customer1:AdminAliasDeleteTarget", got.Class)
 	})
+
+	// A delete with a wrong-case namespace prefix must be rejected at the
+	// resolver boundary; the class must survive untouched. Without this
+	// guard the qualify path accepted the casing variant, removed the data
+	// directory, and left the schema entry behind — blocking recreation.
+	t.Run("delete with wrong-case namespace prefix is rejected and class is untouched", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "CaseDelete"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:CaseDelete", adminKey)
+
+		err := helper.DeleteClassAuthWithReturn(t, "Customer1:CaseDelete", adminKey)
+		require.Error(t, err)
+
+		got := helper.GetClassAuth(t, "customer1:CaseDelete", adminKey)
+		require.Equal(t, "customer1:CaseDelete", got.Class)
+
+		// Caller can still recreate after attempted bad-case delete fails,
+		// confirming no partial deletion occurred.
+		helper.DeleteClassAuth(t, "customer1:CaseDelete", adminKey)
+		helper.CreateClassAuth(t, &models.Class{Class: "CaseDelete"}, user1Key)
+	})
 }

--- a/test/acceptance/namespace/objects_test.go
+++ b/test/acceptance/namespace/objects_test.go
@@ -252,7 +252,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("namespaced caller submitting :-qualified class on read double-prefixes to 404", func(t *testing.T) {
+	t.Run("namespaced caller submitting :-qualified class on read is rejected as 422", func(t *testing.T) {
 		const class = "DoublePrefix"
 		setupClassInNs1(t, class, user1Key)
 
@@ -263,12 +263,12 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, obj.ID)
 
-		// user1 supplying the already-qualified name double-prefixes to
-		// "customer1:customer1:DoublePrefix" — no such class, 404.
+		// user1 supplying the already-qualified name is rejected by namespace
+		// prefix validation — namespaced callers must use the short name.
 		_, err = helper.GetObjectAuth(t, "customer1:"+class, obj.ID, user1Key)
 		require.Error(t, err)
-		var nf *objects.ObjectsClassGetNotFound
-		require.True(t, errors.As(err, &nf), "expected ObjectsClassGetNotFound, got %T: %v", err, err)
+		var unproc *objects.ObjectsClassGetUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected ObjectsClassGetUnprocessableEntity, got %T: %v", err, err)
 	})
 
 	t.Run("global admin reads object via qualified class name", func(t *testing.T) {

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -427,6 +427,16 @@ func DeleteClassWithoutAssert(t *testing.T, class, key string) {
 	_, _ = Client(t).Schema.SchemaObjectsDelete(params, auth)
 }
 
+// DeleteClassAuthWithReturn issues an authenticated class-delete and
+// returns the raw error so callers can assert on rejection (e.g. malformed
+// namespace prefix in the URL).
+func DeleteClassAuthWithReturn(t *testing.T, class string, key string) error {
+	t.Helper()
+	delParams := schema.NewSchemaObjectsDeleteParams().WithClassName(class)
+	_, err := Client(t).Schema.SchemaObjectsDelete(delParams, CreateAuth(key))
+	return err
+}
+
 func DeleteObject(t *testing.T, object *models.Object) {
 	t.Helper()
 	params := objects.NewObjectsClassDeleteParams().

--- a/usecases/namespaces/controller.go
+++ b/usecases/namespaces/controller.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"regexp"
 	"sort"
 	"sync"
 
@@ -69,13 +68,10 @@ var (
 	ErrInvalidStateTransition = errors.New("invalid namespace state transition")
 )
 
-// See entschema.NamespaceMinLength for the full namespace name validation
-// contract. The regex and reserved-name list below are the non-length parts
-// that live in this package.
-var namespaceNameRegex = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`)
-
 // reservedNames are refused at Create time. Kept as a package variable (not a
-// const) so tests can inspect it; not mutated at runtime.
+// const) so tests can inspect it; not mutated at runtime. The lowercase/length
+// regex lives in entities/schema.ValidateNamespaceNameSyntax so the
+// name-resolver can reuse it without forming an import cycle.
 var reservedNames = map[string]struct{}{
 	"admin":    {},
 	"system":   {},
@@ -309,11 +305,8 @@ func (c *Controller) Restore(snapshot []byte) error {
 // REST handler (for fast 422 rejection without a RAFT round-trip) and from
 // the apply path (as a defense-in-depth check).
 func ValidateName(name string) error {
-	if l := len(name); l < entschema.NamespaceMinLength || l > entschema.NamespaceMaxLength {
-		return fmt.Errorf("namespace name %q must be %d-%d characters", name, entschema.NamespaceMinLength, entschema.NamespaceMaxLength)
-	}
-	if !namespaceNameRegex.MatchString(name) {
-		return fmt.Errorf("namespace name %q must contain only lowercase letters, digits, and hyphens, must start and end with a letter or digit, and must not contain ':'", name)
+	if err := entschema.ValidateNamespaceNameSyntax(name); err != nil {
+		return err
 	}
 	if _, reserved := reservedNames[name]; reserved {
 		return fmt.Errorf("namespace name %q is reserved", name)

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -39,7 +39,7 @@ func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, ob
 ) (*models.Object, error) {
 	className, _, err := m.resolveNS(principal, object.Class)
 	if err != nil {
-		return nil, err
+		return nil, NewErrInvalidUserInput("%v", err)
 	}
 	object.Class = className
 

--- a/usecases/objects/add.go
+++ b/usecases/objects/add.go
@@ -37,7 +37,10 @@ import (
 func (m *Manager) AddObject(ctx context.Context, principal *models.Principal, object *models.Object,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
-	className, _ := m.resolveNS(principal, object.Class)
+	className, _, err := m.resolveNS(principal, object.Class)
+	if err != nil {
+		return nil, err
+	}
 	object.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.ShardsData(className, object.Tenant)...); err != nil {

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -40,7 +40,10 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 
 	classesShards := make(map[string][]string)
 	for _, obj := range objects {
-		cls, _ := b.resolveNS(principal, obj.Class)
+		cls, _, err := b.resolveNS(principal, obj.Class)
+		if err != nil {
+			return nil, err
+		}
 		obj.Class = cls
 		classesShards[obj.Class] = append(classesShards[obj.Class], obj.Tenant)
 	}

--- a/usecases/objects/batch_add.go
+++ b/usecases/objects/batch_add.go
@@ -42,7 +42,7 @@ func (b *BatchManager) AddObjects(ctx context.Context, principal *models.Princip
 	for _, obj := range objects {
 		cls, _, err := b.resolveNS(principal, obj.Class)
 		if err != nil {
-			return nil, err
+			return nil, NewErrInvalidUserInput("%v", err)
 		}
 		obj.Class = cls
 		classesShards[obj.Class] = append(classesShards[obj.Class], obj.Tenant)

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -37,7 +37,7 @@ func (b *BatchManager) DeleteObjects(ctx context.Context, principal *models.Prin
 	if match != nil {
 		resolved, _, err := b.resolveNS(principal, match.Class)
 		if err != nil {
-			return nil, err
+			return nil, NewErrInvalidUserInput("%v", err)
 		}
 		match.Class = resolved
 		class = match.Class

--- a/usecases/objects/batch_delete.go
+++ b/usecases/objects/batch_delete.go
@@ -35,7 +35,11 @@ func (b *BatchManager) DeleteObjects(ctx context.Context, principal *models.Prin
 ) (*BatchDeleteResponse, error) {
 	class := "*"
 	if match != nil {
-		match.Class, _ = b.resolveNS(principal, match.Class)
+		resolved, _, err := b.resolveNS(principal, match.Class)
+		if err != nil {
+			return nil, err
+		}
+		match.Class = resolved
 		class = match.Class
 	}
 

--- a/usecases/objects/batch_manager.go
+++ b/usecases/objects/batch_manager.go
@@ -74,6 +74,6 @@ func NewBatchManager(vectorRepo BatchVectorRepo, modulesProvider ModulesProvider
 
 // resolveNS qualifies name with the principal's namespace (if enabled)
 // and resolves any alias to its underlying class.
-func (b *BatchManager) resolveNS(principal *models.Principal, name string) (class, originalAlias string) {
+func (b *BatchManager) resolveNS(principal *models.Principal, name string) (class, originalAlias string, err error) {
 	return namespacing.Resolve(principal, b.schemaManager, b.config.Config.Namespaces.Enabled, name)
 }

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -37,7 +37,7 @@ func (m *Manager) DeleteObject(ctx context.Context,
 ) error {
 	className, _, err := m.resolveNS(principal, className)
 	if err != nil {
-		return err
+		return NewErrInvalidUserInput("%v", err)
 	}
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Objects(className, tenant, id)); err != nil {

--- a/usecases/objects/delete.go
+++ b/usecases/objects/delete.go
@@ -35,7 +35,10 @@ func (m *Manager) DeleteObject(ctx context.Context,
 	principal *models.Principal, className string, id strfmt.UUID,
 	repl *additional.ReplicationProperties, tenant string,
 ) error {
-	className, _ = m.resolveNS(principal, className)
+	className, _, err := m.resolveNS(principal, className)
+	if err != nil {
+		return err
+	}
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Objects(className, tenant, id)); err != nil {
 		return err

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -35,7 +35,7 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal,
 ) (*models.Object, error) {
 	class, _, err := m.resolveNS(principal, class)
 	if err != nil {
-		return nil, err
+		return nil, NewErrInvalidUserInput("%v", err)
 	}
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(class, tenant, id)); err != nil {

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -33,7 +33,10 @@ func (m *Manager) GetObject(ctx context.Context, principal *models.Principal,
 	class string, id strfmt.UUID, additional additional.Properties,
 	replProps *additional.ReplicationProperties, tenant string,
 ) (*models.Object, error) {
-	class, _ = m.resolveNS(principal, class)
+	class, _, err := m.resolveNS(principal, class)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(class, tenant, id)); err != nil {
 		return nil, err

--- a/usecases/objects/head.go
+++ b/usecases/objects/head.go
@@ -26,7 +26,10 @@ import (
 func (m *Manager) HeadObject(ctx context.Context, principal *models.Principal, className string,
 	id strfmt.UUID, repl *additional.ReplicationProperties, tenant string,
 ) (bool, *Error) {
-	className, _ = m.resolveNS(principal, className)
+	className, _, err := m.resolveNS(principal, className)
+	if err != nil {
+		return false, &Error{err.Error(), StatusUnprocessableEntity, err}
+	}
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(className, tenant, id)); err != nil {
 		return false, &Error{err.Error(), StatusForbidden, err}
 	}

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -198,7 +198,7 @@ func (m *Manager) resolveAlias(class string) (className, aliasName string) {
 
 // resolveNS qualifies name with the principal's namespace (if enabled)
 // and resolves any alias to its underlying class.
-func (m *Manager) resolveNS(principal *models.Principal, name string) (class, originalAlias string) {
+func (m *Manager) resolveNS(principal *models.Principal, name string) (class, originalAlias string, err error) {
 	return namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, name)
 }
 

--- a/usecases/objects/merge.go
+++ b/usecases/objects/merge.go
@@ -49,7 +49,10 @@ func (m *Manager) MergeObject(ctx context.Context, principal *models.Principal,
 	if err := m.validateInputs(updates); err != nil {
 		return &Error{"bad request", StatusBadRequest, err}
 	}
-	className, aliasName := m.resolveNS(principal, updates.Class)
+	className, aliasName, err := m.resolveNS(principal, updates.Class)
+	if err != nil {
+		return &Error{err.Error(), StatusUnprocessableEntity, err}
+	}
 	updates.Class = className
 	cls, id := updates.Class, updates.ID
 	if err := m.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Objects(cls, updates.Tenant, id)); err != nil {

--- a/usecases/objects/query.go
+++ b/usecases/objects/query.go
@@ -71,7 +71,11 @@ func (m *Manager) Query(ctx context.Context, principal *models.Principal, params
 	class := "*"
 
 	if params != nil && params.Class != "" {
-		params.Class, _ = m.resolveNS(principal, params.Class)
+		resolved, _, err := m.resolveNS(principal, params.Class)
+		if err != nil {
+			return nil, &Error{err.Error(), StatusUnprocessableEntity, err}
+		}
+		params.Class = resolved
 		class = params.Class
 	}
 

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -36,7 +36,7 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 ) (*models.Object, error) {
 	className, _, err := m.resolveNS(principal, updates.Class)
 	if err != nil {
-		return nil, err
+		return nil, NewErrInvalidUserInput("%v", err)
 	}
 	updates.Class = className
 

--- a/usecases/objects/update.go
+++ b/usecases/objects/update.go
@@ -34,7 +34,10 @@ func (m *Manager) UpdateObject(ctx context.Context, principal *models.Principal,
 	class string, id strfmt.UUID, updates *models.Object,
 	repl *additional.ReplicationProperties,
 ) (*models.Object, error) {
-	className, _ := m.resolveNS(principal, updates.Class)
+	className, _, err := m.resolveNS(principal, updates.Class)
+	if err != nil {
+		return nil, err
+	}
 	updates.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Objects(updates.Class, updates.Tenant, updates.ID)); err != nil {

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -28,7 +28,10 @@ import (
 func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principal,
 	obj *models.Object, repl *additional.ReplicationProperties,
 ) error {
-	className, _ := m.resolveNS(principal, obj.Class)
+	className, _, err := m.resolveNS(principal, obj.Class)
+	if err != nil {
+		return err
+	}
 	obj.Class = className
 
 	if err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects(className, obj.Tenant, obj.ID)); err != nil {

--- a/usecases/objects/validate.go
+++ b/usecases/objects/validate.go
@@ -30,7 +30,7 @@ func (m *Manager) ValidateObject(ctx context.Context, principal *models.Principa
 ) error {
 	className, _, err := m.resolveNS(principal, obj.Class)
 	if err != nil {
-		return err
+		return NewErrInvalidUserInput("%v", err)
 	}
 	obj.Class = className
 

--- a/usecases/schema/alias.go
+++ b/usecases/schema/alias.go
@@ -84,14 +84,14 @@ func (h *Handler) AddAlias(ctx context.Context, principal *models.Principal,
 	// Captured for the entity-name validators, which forbid ":".
 	originalAliasName := alias.Alias
 	originalTargetName := alias.Class
-	qAlias, err := namespacing.QualifyForCreate(principal, h.config.Namespaces.Enabled, alias.Alias)
+	qAlias, err := namespacing.QualifyForCreate(principal, h.config.Namespaces.Enabled, alias.Alias, "alias")
 	if errors.Is(err, namespacing.ErrCreateRequiresNamespace) {
 		return nil, 0, authzerrors.NewNamespaceForbidden(principal)
 	}
 	if err != nil {
 		return nil, 0, err
 	}
-	qTarget, err := namespacing.QualifyForCreate(principal, h.config.Namespaces.Enabled, alias.Class)
+	qTarget, err := namespacing.QualifyForCreate(principal, h.config.Namespaces.Enabled, alias.Class, "class")
 	if err != nil {
 		return nil, 0, err
 	}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -123,7 +123,7 @@ func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 	// caller-supplied ":" and the success of the namespaced-create flow are
 	// covered by test/acceptance/namespace/collection_alias_test.go.
 	originalClassName := cls.Class
-	qualified, err := namespacing.QualifyForCreate(principal, h.config.Namespaces.Enabled, cls.Class)
+	qualified, err := namespacing.QualifyForCreate(principal, h.config.Namespaces.Enabled, cls.Class, "class")
 	if errors.Is(err, namespacing.ErrCreateRequiresNamespace) {
 		return nil, 0, authzerrors.NewNamespaceForbidden(principal)
 	}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -67,7 +67,10 @@ func (h *Handler) GetConsistentClass(ctx context.Context, principal *models.Prin
 	// NOTE: Support getting class via alias name
 	// Also we resolve before doing `Authorize` so that Authorizer will work
 	// with correct `collectionName` for permissions and errors UX
-	resolved, _ := namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, name)
+	resolved, _, err := namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, name)
+	if err != nil {
+		return nil, 0, err
+	}
 	name = resolved
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.READ, authorization.CollectionsMetadata(name)...); err != nil {
@@ -335,7 +338,10 @@ func (h *Handler) RestoreClass(ctx context.Context, d *backup.ClassDescriptor, m
 // here: deleting via an alias name must be a no-op on the underlying
 // class, otherwise an alias becomes a backdoor to drop its target.
 func (h *Handler) DeleteClass(ctx context.Context, principal *models.Principal, class string) error {
-	class = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, class)
+	class, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, class)
+	if err != nil {
+		return err
+	}
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.CollectionsMetadata(class)...); err != nil {
 		return err
@@ -351,10 +357,12 @@ func (h *Handler) DeleteClass(ctx context.Context, principal *models.Principal, 
 func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 	className string, updated *models.Class,
 ) error {
-	className = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
+	className, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
+	if err != nil {
+		return err
+	}
 
-	err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...)
-	if err != nil || updated == nil {
+	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil || updated == nil {
 		return err
 	}
 

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -69,7 +69,7 @@ func (h *Handler) GetConsistentClass(ctx context.Context, principal *models.Prin
 	// with correct `collectionName` for permissions and errors UX
 	resolved, _, err := namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, name)
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("%w: %w", ErrValidation, err)
 	}
 	name = resolved
 

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -270,10 +270,12 @@ func (h *Handler) UpdateShardStatus(ctx context.Context,
 func (h *Handler) ShardsStatus(ctx context.Context,
 	principal *models.Principal, class, shard string,
 ) (models.ShardStatusList, error) {
-	class, _ = namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, class)
-
-	err := h.Authorizer.Authorize(ctx, principal, authorization.READ, authorization.ShardsMetadata(class, shard)...)
+	class, _, err := namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, class)
 	if err != nil {
+		return nil, err
+	}
+
+	if err := h.Authorizer.Authorize(ctx, principal, authorization.READ, authorization.ShardsMetadata(class, shard)...); err != nil {
 		return nil, err
 	}
 

--- a/usecases/schema/namespace_create_test.go
+++ b/usecases/schema/namespace_create_test.go
@@ -193,7 +193,7 @@ func TestAddAlias(t *testing.T) {
 			principal:  namespacedPrincipal("customer1"),
 			alias:      "Customer2:Films",
 			class:      "Movies",
-			wantErrMsg: "is not a valid class name",
+			wantErrMsg: "is not a valid alias name",
 		},
 	}
 

--- a/usecases/schema/namespace_create_test.go
+++ b/usecases/schema/namespace_create_test.go
@@ -193,7 +193,7 @@ func TestAddAlias(t *testing.T) {
 			principal:  namespacedPrincipal("customer1"),
 			alias:      "Customer2:Films",
 			class:      "Movies",
-			wantErrMsg: "is not a valid alias name",
+			wantErrMsg: "is not a valid class name",
 		},
 	}
 

--- a/usecases/schema/namespacing/namespacing.go
+++ b/usecases/schema/namespacing/namespacing.go
@@ -18,6 +18,7 @@ package namespacing
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -28,6 +29,40 @@ import (
 // Call sites translate this into authzerrors.NewNamespaceForbidden — the namespacing
 // package stays free of auth vocabulary.
 var ErrCreateRequiresNamespace = errors.New("create requires a namespaced principal on a namespaces-enabled cluster")
+
+// ValidateNamespacePrefix rejects user-supplied class/alias names whose
+// "<namespace>:" prefix is malformed. Returns nil when name has no separator.
+//
+// The error wording depends on the caller's context so namespaces stay
+// invisible to principals who shouldn't know about them:
+//
+//   - Namespaced principal, or NS-disabled cluster: returns a generic
+//     "is not a valid class name" error — namespaced users should never
+//     send qualified names (the resolver adds their prefix automatically),
+//     and on NS-disabled clusters namespaces simply don't exist as a
+//     concept.
+//   - Global principal on NS-enabled cluster: returns the specific
+//     "invalid namespace prefix" error — these are the operators who
+//     legitimately type qualified names and benefit from an actionable
+//     message about which part is wrong.
+//
+// Without this check, a casing variant (e.g. "Customer1:Foo" against the
+// registered "customer1" namespace) sent by an operator propagates through
+// QualifyClass/Resolve unchanged and the lookup hits a different key than
+// the one the schema and data directory are stored under.
+func ValidateNamespacePrefix(principal *models.Principal, namespacesEnabled bool, name string) error {
+	if !strings.Contains(name, schema.NamespaceSeparator) {
+		return nil
+	}
+	if !namespacesEnabled || (principal != nil && principal.Namespace != "") {
+		return fmt.Errorf("'%s' is not a valid class name", name)
+	}
+	ns, _, _ := strings.Cut(name, schema.NamespaceSeparator)
+	if err := schema.ValidateNamespaceNameSyntax(ns); err != nil {
+		return fmt.Errorf("invalid namespace prefix in %q: %w", name, err)
+	}
+	return nil
+}
 
 // ShortNameMaxLength caps the raw (pre-qualification) name length for
 // namespaced principals. The cap is computed from the maximum namespace
@@ -42,6 +77,9 @@ const ShortNameMaxLength = schema.ClassNameMaxLength - schema.NamespaceMaxLength
 // ErrCreateRequiresNamespace; the call site is responsible for translating
 // that into a 403 with the appropriate verb and resources.
 func QualifyForCreate(principal *models.Principal, namespacesEnabled bool, raw string) (string, error) {
+	if err := ValidateNamespacePrefix(principal, namespacesEnabled, raw); err != nil {
+		return "", err
+	}
 	if !namespacesEnabled {
 		return raw, nil
 	}

--- a/usecases/schema/namespacing/namespacing.go
+++ b/usecases/schema/namespacing/namespacing.go
@@ -32,12 +32,14 @@ var ErrCreateRequiresNamespace = errors.New("create requires a namespaced princi
 
 // ValidateNamespacePrefix rejects user-supplied class/alias names whose
 // "<namespace>:" prefix is malformed. Returns nil when name has no separator.
+// kind is the noun ("class" or "alias") used in the generic error message so
+// the wording matches the field the caller is validating.
 //
 // The error wording depends on the caller's context so namespaces stay
 // invisible to principals who shouldn't know about them:
 //
 //   - Namespaced principal, or NS-disabled cluster: returns a generic
-//     "is not a valid class name" error — namespaced users should never
+//     "is not a valid <kind> name" error — namespaced users should never
 //     send qualified names (the resolver adds their prefix automatically),
 //     and on NS-disabled clusters namespaces simply don't exist as a
 //     concept.
@@ -50,12 +52,12 @@ var ErrCreateRequiresNamespace = errors.New("create requires a namespaced princi
 // registered "customer1" namespace) sent by an operator propagates through
 // QualifyClass/Resolve unchanged and the lookup hits a different key than
 // the one the schema and data directory are stored under.
-func ValidateNamespacePrefix(principal *models.Principal, namespacesEnabled bool, name string) error {
+func ValidateNamespacePrefix(principal *models.Principal, namespacesEnabled bool, name, kind string) error {
 	if !strings.Contains(name, schema.NamespaceSeparator) {
 		return nil
 	}
 	if !namespacesEnabled || (principal != nil && principal.Namespace != "") {
-		return fmt.Errorf("'%s' is not a valid class name", name)
+		return fmt.Errorf("'%s' is not a valid %s name", name, kind)
 	}
 	ns, _, _ := strings.Cut(name, schema.NamespaceSeparator)
 	if err := schema.ValidateNamespaceNameSyntax(ns); err != nil {
@@ -75,9 +77,11 @@ const ShortNameMaxLength = schema.ClassNameMaxLength - schema.NamespaceMaxLength
 // policy, length-checks the raw short name, and returns the qualified form.
 // On NS-enabled clusters, callers without a namespace are rejected with
 // ErrCreateRequiresNamespace; the call site is responsible for translating
-// that into a 403 with the appropriate verb and resources.
-func QualifyForCreate(principal *models.Principal, namespacesEnabled bool, raw string) (string, error) {
-	if err := ValidateNamespacePrefix(principal, namespacesEnabled, raw); err != nil {
+// that into a 403 with the appropriate verb and resources. kind is the noun
+// ("class" or "alias") used in the prefix-rejection error so the wording
+// matches the field the caller is validating.
+func QualifyForCreate(principal *models.Principal, namespacesEnabled bool, raw, kind string) (string, error) {
+	if err := ValidateNamespacePrefix(principal, namespacesEnabled, raw, kind); err != nil {
 		return "", err
 	}
 	if !namespacesEnabled {

--- a/usecases/schema/namespacing/namespacing_test.go
+++ b/usecases/schema/namespacing/namespacing_test.go
@@ -98,7 +98,7 @@ func TestQualifyForCreate(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := QualifyForCreate(tc.principal, tc.namespacesEnabled, tc.raw)
+			got, err := QualifyForCreate(tc.principal, tc.namespacesEnabled, tc.raw, "class")
 			switch {
 			case tc.wantSentinel:
 				require.ErrorIs(t, err, ErrCreateRequiresNamespace)

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -73,7 +73,7 @@ func qualify(principal *models.Principal, name string) string {
 // namespaced principals, raw for global principals), "" otherwise — used by
 // the objects layer to preserve existing alias-aware flows.
 func Resolve(principal *models.Principal, sm SchemaManager, namespacesEnabled bool, name string) (class, originalAlias string, err error) {
-	if err := ValidateNamespacePrefix(principal, namespacesEnabled, name); err != nil {
+	if err := ValidateNamespacePrefix(principal, namespacesEnabled, name, "class"); err != nil {
 		return "", "", err
 	}
 	qualified := schema.UppercaseClassName(name)
@@ -95,7 +95,7 @@ func Resolve(principal *models.Principal, sm SchemaManager, namespacesEnabled bo
 // resolved. Rejects user-supplied names whose "<namespace>:" prefix is not
 // syntactically valid.
 func QualifyClass(principal *models.Principal, namespacesEnabled bool, name string) (string, error) {
-	if err := ValidateNamespacePrefix(principal, namespacesEnabled, name); err != nil {
+	if err := ValidateNamespacePrefix(principal, namespacesEnabled, name, "class"); err != nil {
 		return "", err
 	}
 	qualified := schema.UppercaseClassName(name)

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -57,21 +57,25 @@ func qualify(principal *models.Principal, name string) string {
 // Resolve is the read-side entry point used everywhere a user-supplied
 // class/alias name needs to become an internal class name:
 //
-//  1. Uppercase the class portion of the input so storage lookups hit the
+//  1. Reject inputs whose "<namespace>:" prefix is not syntactically a valid
+//     namespace name (lowercase letters/digits/hyphens, length bounds).
+//  2. Uppercase the class portion of the input so storage lookups hit the
 //     canonical case. UppercaseClassName preserves a leading "<namespace>:"
 //     prefix verbatim and only touches the class portion.
-//  2. If namespaces are enabled cluster-wide, qualify the (now-uppercased)
+//  3. If namespaces are enabled cluster-wide, qualify the (now-uppercased)
 //     input with the principal's namespace. When NS is disabled the
 //     qualification step is skipped.
-//  3. Look the (possibly qualified) name up as an alias via the existing
+//  4. Look the (possibly qualified) name up as an alias via the existing
 //     in-memory resolver; if it matches an alias, return the alias target.
 //
-// Returns (class, originalAlias). originalAlias is the qualified alias name
-// used for lookup when an alias was hit (i.e. namespace-prefixed for
+// Returns (class, originalAlias, err). originalAlias is the qualified alias
+// name used for lookup when an alias was hit (i.e. namespace-prefixed for
 // namespaced principals, raw for global principals), "" otherwise — used by
-// the objects layer to preserve existing alias-aware flows. Sites that do
-// not need this can ignore the second return value.
-func Resolve(principal *models.Principal, sm SchemaManager, namespacesEnabled bool, name string) (class, originalAlias string) {
+// the objects layer to preserve existing alias-aware flows.
+func Resolve(principal *models.Principal, sm SchemaManager, namespacesEnabled bool, name string) (class, originalAlias string, err error) {
+	if err := ValidateNamespacePrefix(principal, namespacesEnabled, name); err != nil {
+		return "", "", err
+	}
 	qualified := schema.UppercaseClassName(name)
 	if namespacesEnabled {
 		qualified = qualify(principal, qualified)
@@ -79,22 +83,26 @@ func Resolve(principal *models.Principal, sm SchemaManager, namespacesEnabled bo
 
 	// Check if the qualified name is an alias
 	if resolvedClass := sm.ResolveAlias(qualified); resolvedClass != "" {
-		return resolvedClass, qualified
+		return resolvedClass, qualified, nil
 	}
 
 	// Not an alias, return the qualified name
-	return qualified, ""
+	return qualified, "", nil
 }
 
 // QualifyClass uppercases the class portion of name and prepends the
 // principal's namespace when namespaces are enabled. Aliases are not
-// resolved.
-func QualifyClass(principal *models.Principal, namespacesEnabled bool, name string) string {
+// resolved. Rejects user-supplied names whose "<namespace>:" prefix is not
+// syntactically valid.
+func QualifyClass(principal *models.Principal, namespacesEnabled bool, name string) (string, error) {
+	if err := ValidateNamespacePrefix(principal, namespacesEnabled, name); err != nil {
+		return "", err
+	}
 	qualified := schema.UppercaseClassName(name)
 	if namespacesEnabled {
 		qualified = qualify(principal, qualified)
 	}
-	return qualified
+	return qualified, nil
 }
 
 // StripOwnNS removes the principal's own namespace prefix from name when

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -176,10 +177,66 @@ func TestQualifyClass(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			got := QualifyClass(tc.principal, tc.namespacesEnabled, tc.input)
+			got, err := QualifyClass(tc.principal, tc.namespacesEnabled, tc.input)
+			require.NoError(t, err)
 			assert.Equal(t, tc.want, got)
 		})
 	}
+}
+
+// TestQualifyClass_RejectsInvalidNamespacePrefix verifies that a wrong-case
+// namespace prefix from a global operator on an NS-enabled cluster surfaces
+// the specific "invalid namespace prefix" message so they can correct the
+// request, rather than propagating through the resolver into lookup.
+func TestQualifyClass_RejectsInvalidNamespacePrefix(t *testing.T) {
+	cases := []struct {
+		testName string
+		input    string
+	}{
+		{testName: "uppercase prefix", input: "Customer1:Movies"},
+		{testName: "mixed-case prefix", input: "Customer1:movies"},
+		{testName: "uppercase in middle of prefix", input: "cusTomer1:Movies"},
+		{testName: "leading-hyphen prefix", input: "-customer1:Movies"},
+		{testName: "trailing-hyphen prefix", input: "customer1-:Movies"},
+		{testName: "empty prefix", input: ":Movies"},
+		{testName: "too-short prefix", input: "ab:Movies"},
+	}
+	principal := &models.Principal{Username: "admin", IsGlobalOperator: true}
+	for _, tc := range cases {
+		t.Run(tc.testName, func(t *testing.T) {
+			_, err := QualifyClass(principal, true, tc.input)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "invalid namespace prefix")
+		})
+	}
+}
+
+// TestQualifyClass_NamespacedPrincipalSeesClassNameError verifies the
+// transparency contract: a namespaced caller who mistakenly includes a ":"
+// in their input gets a generic class-name error instead of one that
+// mentions namespaces.
+func TestQualifyClass_NamespacedPrincipalSeesClassNameError(t *testing.T) {
+	principal := &models.Principal{Username: "u", Namespace: "customer1"}
+	cases := []string{"Customer2:Movies", "customer2:Movies", "FOO:bar"}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			_, err := QualifyClass(principal, true, input)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "is not a valid class name")
+			require.NotContains(t, err.Error(), "namespace")
+		})
+	}
+}
+
+// TestQualifyClass_NSDisabledSeesClassNameError verifies that on
+// NS-disabled clusters the resolver does not mention namespaces — the
+// concept simply does not exist for the operator there.
+func TestQualifyClass_NSDisabledSeesClassNameError(t *testing.T) {
+	principal := &models.Principal{Username: "admin", IsGlobalOperator: true}
+	_, err := QualifyClass(principal, false, "customer1:Movies")
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "is not a valid class name")
+	require.NotContains(t, err.Error(), "namespace")
 }
 
 func TestResolve(t *testing.T) {
@@ -235,15 +292,6 @@ func TestResolve(t *testing.T) {
 			namespacesEnabled: true,
 			input:             "Movies",
 			wantClass:         "Movies",
-			wantAlias:         "",
-		},
-		{
-			testName:          "namespaced principal qualified input gets double prefixed",
-			principal:         &models.Principal{Username: "u", Namespace: "customer1"},
-			sm:                &fakeSchemaManager{aliases: map[string]string{}},
-			namespacesEnabled: true,
-			input:             "customer2:Movies",
-			wantClass:         "customer1:customer2:Movies",
 			wantAlias:         "",
 		},
 		{
@@ -303,9 +351,30 @@ func TestResolve(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			gotClass, gotAlias := Resolve(tc.principal, tc.sm, tc.namespacesEnabled, tc.input)
+			gotClass, gotAlias, err := Resolve(tc.principal, tc.sm, tc.namespacesEnabled, tc.input)
+			require.NoError(t, err)
 			assert.Equal(t, tc.wantClass, gotClass)
 			assert.Equal(t, tc.wantAlias, gotAlias)
+		})
+	}
+}
+
+// TestResolve_RejectsInvalidNamespacePrefix mirrors the QualifyClass guard
+// on the read path so list/get/aggregate/search callers also surface a 4xx
+// instead of routing the wrong-case input into schema/alias lookup.
+func TestResolve_RejectsInvalidNamespacePrefix(t *testing.T) {
+	sm := &fakeSchemaManager{aliases: map[string]string{}}
+	principal := &models.Principal{Username: "admin", IsGlobalOperator: true}
+	cases := []string{
+		"Customer1:Movies",
+		"FOO:bar",
+		"-bad:Movies",
+		":Movies",
+	}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			_, _, err := Resolve(principal, sm, true, input)
+			require.Error(t, err)
 		})
 	}
 }

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -32,7 +32,10 @@ import (
 func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Principal,
 	className string, merge bool, newProps ...*models.Property,
 ) (*models.Class, uint64, error) {
-	className = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
+	className, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
+	if err != nil {
+		return nil, 0, err
+	}
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil {
 		return nil, 0, err
@@ -104,7 +107,10 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 func (h *Handler) DeleteClassPropertyIndex(ctx context.Context, principal *models.Principal,
 	className, propertyName, indexName string,
 ) error {
-	className = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
+	className, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
+	if err != nil {
+		return err
+	}
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil {
 		return err
@@ -161,8 +167,7 @@ func (h *Handler) DeleteClassPropertyIndex(ctx context.Context, principal *model
 	if err := h.validatePropertyIndexing(prop); err != nil {
 		return err
 	}
-	_, err := h.schemaManager.UpdateProperty(ctx, class.Class, prop)
-	if err != nil {
+	if _, err := h.schemaManager.UpdateProperty(ctx, class.Class, prop); err != nil {
 		return err
 	}
 	return nil
@@ -174,7 +179,10 @@ func (h *Handler) DeleteClassVectorIndex(ctx context.Context, principal *models.
 	if !entcfg.Enabled(os.Getenv("ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT")) {
 		return fmt.Errorf("alter schema drop vector index endpoint is experimental and disabled by default, set the environment variable ENABLE_EXPERIMENTAL_ALTER_SCHEMA_DROP_VECTOR_INDEX_ENDPOINT=true to enable it")
 	}
-	className = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
+	className, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
+	if err != nil {
+		return err
+	}
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil {
 		return err

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -181,7 +181,7 @@ func (h *Handler) DeleteClassVectorIndex(ctx context.Context, principal *models.
 	}
 	className, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
 	if err != nil {
-		return err
+		return fmt.Errorf("%w: %w", ErrValidation, err)
 	}
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil {

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -934,7 +934,8 @@ func TestAddClassProperty_Namespacing(t *testing.T) {
 			t.Parallel()
 			handler, sm := newTestHandlerWithNamespaces(t, tt.enabled)
 
-			lookup := namespacing.QualifyClass(tt.principal, tt.enabled, tt.inputName)
+			lookup, err := namespacing.QualifyClass(tt.principal, tt.enabled, tt.inputName)
+			require.NoError(t, err)
 			if lookup == tt.stored {
 				sm.On("ReadOnlyClass", lookup).Return(&models.Class{
 					Class:             tt.stored,
@@ -949,7 +950,7 @@ func TestAddClassProperty_Namespacing(t *testing.T) {
 			}
 
 			prop := &models.Property{Name: "genre", DataType: schema.DataTypeText.PropString()}
-			_, _, err := handler.AddClassProperty(context.Background(), tt.principal,
+			_, _, err = handler.AddClassProperty(context.Background(), tt.principal,
 				tt.inputName, false, prop)
 			if tt.wantErrIs != nil {
 				require.ErrorIs(t, err, tt.wantErrIs)
@@ -1012,7 +1013,8 @@ func TestDeleteClassPropertyIndex_Namespacing(t *testing.T) {
 			t.Parallel()
 			handler, sm := newTestHandlerWithNamespaces(t, tt.enabled)
 
-			lookup := namespacing.QualifyClass(tt.principal, tt.enabled, tt.inputName)
+			lookup, err := namespacing.QualifyClass(tt.principal, tt.enabled, tt.inputName)
+			require.NoError(t, err)
 			prop := &models.Property{
 				Name:            "title",
 				DataType:        schema.DataTypeText.PropString(),
@@ -1031,7 +1033,7 @@ func TestDeleteClassPropertyIndex_Namespacing(t *testing.T) {
 				sm.On("UpdateProperty", tt.wantAuthName, mock.Anything).Return(nil)
 			}
 
-			err := handler.DeleteClassPropertyIndex(context.Background(), tt.principal,
+			err = handler.DeleteClassPropertyIndex(context.Background(), tt.principal,
 				tt.inputName, "title", "filterable")
 			if tt.wantErrIs != nil {
 				require.ErrorIs(t, err, tt.wantErrIs)
@@ -1092,7 +1094,8 @@ func TestDeleteClassVectorIndex_Namespacing(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler, sm := newTestHandlerWithNamespaces(t, tt.enabled)
 
-			lookup := namespacing.QualifyClass(tt.principal, tt.enabled, tt.inputName)
+			lookup, err := namespacing.QualifyClass(tt.principal, tt.enabled, tt.inputName)
+			require.NoError(t, err)
 			storedClass := &models.Class{
 				Class: tt.stored,
 				VectorConfig: map[string]models.VectorConfig{
@@ -1112,7 +1115,7 @@ func TestDeleteClassVectorIndex_Namespacing(t *testing.T) {
 				}), mock.Anything).Return(nil)
 			}
 
-			err := handler.DeleteClassVectorIndex(context.Background(), tt.principal,
+			err = handler.DeleteClassVectorIndex(context.Background(), tt.principal,
 				tt.inputName, "vec1")
 			if tt.wantErrIs != nil {
 				require.ErrorIs(t, err, tt.wantErrIs)

--- a/usecases/schema/tenant.go
+++ b/usecases/schema/tenant.go
@@ -42,7 +42,10 @@ func (h *Handler) AddTenants(ctx context.Context,
 	class string,
 	tenants []*models.Tenant,
 ) (uint64, error) {
-	class = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, class)
+	class, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, class)
+	if err != nil {
+		return 0, err
+	}
 
 	tenantNames := make([]string, len(tenants))
 	for i, tenant := range tenants {
@@ -167,7 +170,10 @@ func (h *Handler) validateActivityStatuses(ctx context.Context, tenants []*model
 func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal,
 	class string, tenants []*models.Tenant,
 ) ([]*models.Tenant, error) {
-	class = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, class)
+	class, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, class)
+	if err != nil {
+		return nil, err
+	}
 
 	shardNames := make([]string, len(tenants))
 	for idx := range tenants {
@@ -226,7 +232,10 @@ func (h *Handler) UpdateTenants(ctx context.Context, principal *models.Principal
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) DeleteTenants(ctx context.Context, principal *models.Principal, class string, tenants []string) error {
-	class = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, class)
+	class, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, class)
+	if err != nil {
+		return err
+	}
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.ShardsMetadata(class, tenants...)...); err != nil {
 		return err
@@ -253,7 +262,9 @@ func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Pr
 	var allTenants []*models.Tenant
 	var err error
 
-	class, _ = namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, class)
+	if class, _, err = namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, class); err != nil {
+		return nil, err
+	}
 	if consistency {
 		allTenants, _, err = h.schemaManager.QueryTenants(class, tenants)
 	} else {
@@ -280,14 +291,16 @@ func (h *Handler) GetConsistentTenants(ctx context.Context, principal *models.Pr
 }
 
 func (h *Handler) GetConsistentTenant(ctx context.Context, principal *models.Principal, class string, consistency bool, tenant string) (*models.Tenant, error) {
-	class, _ = namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, class)
+	class, _, err := namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, class)
+	if err != nil {
+		return nil, err
+	}
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.READ, authorization.ShardsMetadata(class, tenant)...); err != nil {
 		return nil, err
 	}
 
 	var allTenants []*models.Tenant
-	var err error
 
 	tenants := []string{tenant}
 	if consistency {
@@ -323,14 +336,16 @@ func (h *Handler) multiTenancy(class string) (clusterSchema.ClassInfo, error) {
 //
 // Class must exist and has partitioning enabled
 func (h *Handler) ConsistentTenantExists(ctx context.Context, principal *models.Principal, class string, consistency bool, tenant string) error {
-	class, _ = namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, class)
+	class, _, err := namespacing.Resolve(principal, h.schemaReader, h.config.Namespaces.Enabled, class)
+	if err != nil {
+		return err
+	}
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.READ, authorization.ShardsMetadata(class, tenant)...); err != nil {
 		return err
 	}
 
 	var tenants []*models.Tenant
-	var err error
 	if consistency {
 		tenants, _, err = h.schemaManager.QueryTenants(class, []string{tenant})
 	} else {


### PR DESCRIPTION
### What's being changed:

Reject upper case namespaces by global operator to avoid problems further down in the stack with case-sensitive operations

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
