### PR TITLE
Return query vector in GraphQL additional properties

### DIFF
--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -181,6 +181,7 @@ func (b *classBuilder) additionalFields(classProperties graphql.Fields, class *m
 	additionalProperties["certainty"] = b.additionalCertaintyField(class)
 	additionalProperties["distance"] = b.additionalDistanceField(class)
 	additionalProperties["vector"] = b.additionalVectorField(class)
+	additionalProperties["query_vector"] = b.additionalQueryVectorField(class)
 	additionalProperties["vectors"] = b.additionalVectorsField(class)
 	additionalProperties["id"] = b.additionalIDField()
 	additionalProperties["creationTimeUnix"] = b.additionalCreationTimeUnix()
@@ -243,6 +244,12 @@ func (b *classBuilder) additionalDistanceField(class *models.Class) *graphql.Fie
 func (b *classBuilder) additionalVectorField(class *models.Class) *graphql.Field {
 	return &graphql.Field{
 		Type: graphql.NewList(graphql.Float),
+	}
+}
+
+func (b *classBuilder) additionalQueryVectorField(class *models.Class) *graphql.Field {
+	return &graphql.Field{
+		Type: common_filters.Vector(fmt.Sprintf("%sAdditionalQueryVector", class.Class)),
 	}
 }
 

--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -587,7 +587,7 @@ type additionalCheck struct {
 func (ac *additionalCheck) isAdditional(parentName, name string) bool {
 	if parentName == "_additional" {
 		if name == "classification" || name == "certainty" ||
-			name == "distance" || name == "id" || name == "vector" || name == "vectors" ||
+			name == "distance" || name == "id" || name == "vector" || name == "query_vector" || name == "vectors" ||
 			name == "creationTimeUnix" || name == "lastUpdateTimeUnix" ||
 			name == "score" || name == "explainScore" || name == "isConsistent" ||
 			name == "group" || name == "queryProfile" {
@@ -671,6 +671,10 @@ func extractProperties(className string, selections *ast.SelectionSet,
 						}
 						if additionalProperty == "vector" {
 							additionalProps.Vector = true
+							continue
+						}
+						if additionalProperty == "query_vector" {
+							additionalProps.QueryVector = true
 							continue
 						}
 						if additionalProperty == "vectors" {

--- a/adapters/handlers/graphql/local/get/get_test.go
+++ b/adapters/handlers/graphql/local/get/get_test.go
@@ -14,6 +14,7 @@
 package get
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -434,6 +435,28 @@ func TestExtractAdditionalFields(t *testing.T) {
 			},
 		},
 		{
+			name:  "with _additional query_vector",
+			query: "{ Get { SomeAction { _additional { query_vector } } } }",
+			expectedParams: dto.GetParams{
+				ClassName: "SomeAction",
+				AdditionalProperties: additional.Properties{
+					QueryVector: true,
+				},
+			},
+			resolverReturn: []interface{}{
+				map[string]interface{}{
+					"_additional": map[string]interface{}{
+						"query_vector": []float32{0.8, 0.2, 0.7},
+					},
+				},
+			},
+			expectedResult: map[string]interface{}{
+				"_additional": map[string]interface{}{
+					"query_vector": []float32{0.8, 0.2, 0.7},
+				},
+			},
+		},
+		{
 			name:  "with _additional creationTimeUnix",
 			query: "{ Get { SomeAction { _additional { creationTimeUnix } } } }",
 			expectedParams: dto.GetParams{
@@ -741,6 +764,31 @@ func TestExtractAdditionalFields(t *testing.T) {
 			assert.Equal(t, test.expectedResult, result.Get("Get", "SomeAction").Result.([]interface{})[0])
 		})
 	}
+}
+
+func TestAdditionalQueryVectorJSONResponse(t *testing.T) {
+	resolver := newMockResolver()
+
+	query := "{ Get { SomeAction { _additional { query_vector } } } }"
+	expectedParams := dto.GetParams{
+		ClassName: "SomeAction",
+		AdditionalProperties: additional.Properties{
+			QueryVector: true,
+		},
+	}
+	resolverReturn := []interface{}{
+		map[string]interface{}{
+			"_additional": map[string]interface{}{
+				"query_vector": []float32{0.8, 0.2, 0.7},
+			},
+		},
+	}
+	resolver.On("GetClass", expectedParams).Return(resolverReturn, nil).Once()
+
+	result := resolver.AssertResolve(t, query)
+	actualJSON, err := json.Marshal(result.Result)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"Get":{"SomeAction":[{"_additional":{"query_vector":[0.8,0.2,0.7]}}]}}`, string(actualJSON))
 }
 
 func TestNearCustomTextRanker(t *testing.T) {

--- a/entities/additional/classification.go
+++ b/entities/additional/classification.go
@@ -25,6 +25,7 @@ type Properties struct {
 	Classification bool     `json:"classification"`
 	RefMeta        bool     `json:"refMeta"`
 	Vector         bool     `json:"vector"`
+	QueryVector    bool     `json:"query_vector"`
 	Vectors        []string `json:"vectors"`
 	// IncludeAllTargetVectors indicates that ALL target vectors should be included,
 	// regardless of the Vectors field. This is used internally by MarshalBinary

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -240,6 +240,9 @@ func (e *Explorer) getClassVectorSearch(ctx context.Context,
 
 func (e *Explorer) searchForTargets(ctx context.Context, params dto.GetParams, targetVectors []string, searchVectorParams *searchparams.NearVector) ([]search.Result, []models.Vector, error) {
 	var err error
+	if params.AdditionalProperties.QueryVector && len(targetVectors) > 1 {
+		return nil, nil, errors.New("additional property query_vector is only supported for single target vector searches")
+	}
 	searchVectors := make([]models.Vector, len(targetVectors))
 	eg := enterrors.NewErrorGroupWrapper(e.logger)
 	eg.SetLimit(2 * _NUMCPU)
@@ -506,6 +509,10 @@ func (e *Explorer) searchResultsToGetResponseWithType(ctx context.Context, input
 
 		if params.AdditionalProperties.Vector {
 			additionalProperties["vector"] = res.Vector
+		}
+
+		if params.AdditionalProperties.QueryVector && searchVector != nil {
+			additionalProperties["query_vector"] = searchVector
 		}
 
 		if len(params.AdditionalProperties.Vectors) > 0 {

--- a/usecases/traverser/explorer_hybrid.go
+++ b/usecases/traverser/explorer_hybrid.go
@@ -83,7 +83,7 @@ func sparseSearch(ctx context.Context, e *Explorer, params dto.GetParams) ([]*se
 }
 
 // Do a nearvector search.  The results will be used in the hybrid algorithm
-func denseSearch(ctx context.Context, e *Explorer, params dto.GetParams, searchname string, targetVectors []string, searchVector *searchparams.NearVector) ([]*search.Result, string, error) {
+func denseSearch(ctx context.Context, e *Explorer, params dto.GetParams, searchname string, targetVectors []string, searchVector *searchparams.NearVector) ([]*search.Result, string, models.Vector, error) {
 	params.Pagination.Offset = 0
 	if params.Pagination.Limit < int(e.config.QueryHybridMaximumResults) {
 		params.Pagination.Limit = int(e.config.QueryHybridMaximumResults)
@@ -93,17 +93,16 @@ func denseSearch(ctx context.Context, e *Explorer, params dto.GetParams, searchn
 
 	partialResults, searchVectors, err := e.searchForTargets(ctx, params, targetVectors, searchVector)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 	var vector models.Vector
 	if len(searchVectors) > 0 {
 		vector = searchVectors[0]
 	}
 
-	// Pass zero time to disable time-based filtering during hybrid search
-	results, err := e.searchResultsToGetResponseWithType(ctx, partialResults, vector, params, time.Time{})
+	results, err := e.hybridSearchResultsToGetResponse(ctx, partialResults, vector, params)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 
 	out := make([]*search.Result, 0, len(results))
@@ -113,7 +112,7 @@ func denseSearch(ctx context.Context, e *Explorer, params dto.GetParams, searchn
 		out = append(out, &out_sr)
 	}
 
-	return out, "vector," + searchname, nil
+	return out, "vector," + searchname, vector, nil
 }
 
 /*
@@ -131,7 +130,7 @@ type NearTextParams struct {
 }
 */
 // Do a nearText search.  The results will be used in the hybrid algorithm
-func nearTextSubSearch(ctx context.Context, e *Explorer, params dto.GetParams, targetVectors []string) ([]*search.Result, string, error) {
+func nearTextSubSearch(ctx context.Context, e *Explorer, params dto.GetParams, targetVectors []string) ([]*search.Result, string, models.Vector, error) {
 	var subSearchParams nearText2.NearTextParams
 
 	subSearchParams.Values = params.HybridSearch.NearTextParams.Values
@@ -167,7 +166,7 @@ func nearTextSubSearch(ctx context.Context, e *Explorer, params dto.GetParams, t
 	subsearchWrap.GroupBy = nil
 	partialResults, vectors, err := e.searchForTargets(ctx, subsearchWrap, targetVectors, nil)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 
 	var vector models.Vector
@@ -175,10 +174,9 @@ func nearTextSubSearch(ctx context.Context, e *Explorer, params dto.GetParams, t
 		vector = vectors[0]
 	}
 
-	// Pass zero time to disable time-based filtering during hybrid search
-	results, err := e.searchResultsToGetResponseWithType(ctx, partialResults, vector, params, time.Time{})
+	results, err := e.hybridSearchResultsToGetResponse(ctx, partialResults, vector, params)
 	if err != nil {
-		return nil, "", err
+		return nil, "", nil, err
 	}
 
 	var out []*search.Result
@@ -188,7 +186,15 @@ func nearTextSubSearch(ctx context.Context, e *Explorer, params dto.GetParams, t
 		out = append(out, &sr)
 	}
 
-	return out, "vector,nearText", nil
+	return out, "vector,nearText", vector, nil
+}
+
+func (e *Explorer) hybridSearchResultsToGetResponse(ctx context.Context, partialResults []search.Result,
+	vector models.Vector, params dto.GetParams,
+) ([]search.Result, error) {
+	responseParams := params
+	responseParams.AdditionalProperties.QueryVector = false
+	return e.searchResultsToGetResponseWithType(ctx, partialResults, vector, responseParams, time.Time{})
 }
 
 // Hybrid search.  This is the main entry point to the hybrid search algorithm
@@ -202,6 +208,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 	var weights []float64
 	var names []string
 	var targetVectors []string
+	var queryVector models.Vector
 
 	if params.HybridSearch.NearTextParams != nil && params.HybridSearch.NearVectorParams != nil {
 		return nil, fmt.Errorf("hybrid search cannot have both nearText and nearVector parameters")
@@ -259,9 +266,10 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 			var err error
 			var name string
 			var res []*search.Result
+			var vector models.Vector
 			var errorText string
 			if params.HybridSearch.NearTextParams != nil {
-				res, name, err = nearTextSubSearch(ctx, e, params, targetVectors)
+				res, name, vector, err = nearTextSubSearch(ctx, e, params, targetVectors)
 				errorText = "nearTextSubSearch"
 			} else if params.HybridSearch.NearVectorParams != nil {
 				searchVectors := make([]*searchparams.NearVector, len(targetVectors))
@@ -269,7 +277,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 					searchVectors[i] = params.HybridSearch.NearVectorParams
 					searchVectors[i].TargetVectors = []string{targetVector}
 				}
-				res, name, err = denseSearch(ctx, e, params, "nearVector", targetVectors, params.HybridSearch.NearVectorParams)
+				res, name, vector, err = denseSearch(ctx, e, params, "nearVector", targetVectors, params.HybridSearch.NearVectorParams)
 				errorText = "nearVectorSubSearch"
 			} else {
 				sch := e.schemaGetter.GetSchemaSkipAuth()
@@ -318,7 +326,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 					}
 				}
 
-				res, name, err = denseSearch(ctx, e, params, "hybridVector", targetVectors, searchVectors)
+				res, name, vector, err = denseSearch(ctx, e, params, "hybridVector", targetVectors, searchVectors)
 				errorText = "hybrid"
 			}
 
@@ -344,6 +352,7 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 				weights[0] = params.HybridSearch.Alpha
 				results[0] = res
 				names[0] = name
+				queryVector = vector
 			}
 
 			return nil
@@ -440,6 +449,9 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 	if origParams.AdditionalProperties.QueryProfile {
 		out = helpers.AttachQueryProfileToResults(ctx, out)
 	}
+	if origParams.AdditionalProperties.QueryVector && queryVector != nil {
+		attachQueryVectorToResults(out, queryVector)
+	}
 
 	if origParams.GroupBy != nil {
 		groupedResults, err := e.groupSearchResults(ctx, out, origParams.GroupBy)
@@ -449,4 +461,13 @@ func (e *Explorer) Hybrid(ctx context.Context, params dto.GetParams) ([]search.R
 		return groupedResults, nil
 	}
 	return out, nil
+}
+
+func attachQueryVectorToResults(results []search.Result, queryVector models.Vector) {
+	for i := range results {
+		if results[i].AdditionalProperties == nil {
+			results[i].AdditionalProperties = models.AdditionalProperties{}
+		}
+		results[i].AdditionalProperties["query_vector"] = queryVector
+	}
 }

--- a/usecases/traverser/explorer_test.go
+++ b/usecases/traverser/explorer_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/sirupsen/logrus/hooks/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/adapters/handlers/graphql/local/common_filters"
 	"github.com/weaviate/weaviate/entities/additional"
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/filters"
@@ -38,6 +39,83 @@ var defaultConfig = config.Config{
 		Limit: 100,
 	},
 	QueryMaximumResults: 100,
+}
+
+func newQueryVectorTestExplorer(searcher objectsSearcher, metrics explorerMetrics) *Explorer {
+	log, _ := test.NewNullLogger()
+	explorer := NewExplorer(searcher, log, getFakeModulesProvider(), metrics, defaultConfig)
+	explorer.SetSchemaGetter(&fakeSchemaGetter{
+		schema: schema.Schema{Objects: &models.Schema{Classes: []*models.Class{
+			{Class: "BestClass"},
+		}}},
+	})
+	return explorer
+}
+
+func assertSingleQueryVectorResult(t *testing.T, res []interface{}) {
+	require.Len(t, res, 1)
+	assert.Equal(t,
+		map[string]interface{}{
+			"name": "Foo",
+			"_additional": map[string]interface{}{
+				"query_vector": []float32{0.8, 0.2, 0.7},
+			},
+		}, res[0])
+}
+
+func Test_Explorer_QueryVectorAdditional(t *testing.T) {
+	t.Run("adds query vector during response shaping", func(t *testing.T) {
+		explorer := newQueryVectorTestExplorer(&fakeVectorSearcher{}, &fakeMetrics{})
+		res, err := explorer.searchResultsToGetResponse(context.Background(),
+			[]search.Result{{Schema: map[string]interface{}{"name": "Foo"}}},
+			[]float32{0.8, 0.2, 0.7},
+			dto.GetParams{ClassName: "BestClass", AdditionalProperties: additional.Properties{QueryVector: true}},
+			time.Time{})
+
+		require.NoError(t, err)
+		assertSingleQueryVectorResult(t, res)
+	})
+
+	t.Run("adds query vector after hybrid fusion", func(t *testing.T) {
+		params := dto.GetParams{
+			ClassName: "BestClass",
+			HybridSearch: &searchparams.HybridSearch{
+				Type:            "hybrid",
+				Alpha:           1,
+				FusionAlgorithm: common_filters.HybridRelativeScoreFusion,
+				NearVectorParams: &searchparams.NearVector{
+					Vectors: []models.Vector{[]float32{0.8, 0.2, 0.7}},
+				},
+			},
+			Pagination:           &filters.Pagination{Limit: 100},
+			AdditionalProperties: additional.Properties{QueryVector: true},
+		}
+		expectedParams := params
+		expectedParams.Pagination = &filters.Pagination{Limit: 100, Offset: 0, Autocut: -1}
+
+		searcher := &fakeHybridSearcher{}
+		searcher.On("VectorSearch", expectedParams, []models.Vector{[]float32{0.8, 0.2, 0.7}}).
+			Return([]search.Result{{ID: "id1", Schema: map[string]interface{}{"name": "Foo"}, Dist: 0.1, Dims: 128}}, nil)
+		metrics := &fakeMetrics{}
+		metrics.On("AddUsageDimensions", "BestClass", "get_graphql", "n/a", 128)
+
+		res, err := newQueryVectorTestExplorer(searcher, metrics).GetClass(context.Background(), params)
+
+		require.NoError(t, err)
+		searcher.AssertExpectations(t)
+		metrics.AssertExpectations(t)
+		assertSingleQueryVectorResult(t, res)
+	})
+
+	t.Run("rejects multiple target vectors", func(t *testing.T) {
+		_, _, err := newQueryVectorTestExplorer(&fakeVectorSearcher{}, &fakeMetrics{}).
+			searchForTargets(context.Background(),
+				dto.GetParams{AdditionalProperties: additional.Properties{QueryVector: true}},
+				[]string{"title", "body"}, nil)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "query_vector is only supported for single target vector searches")
+	})
 }
 
 func Test_Explorer_GetClass(t *testing.T) {
@@ -72,13 +150,7 @@ func Test_Explorer_GetClass(t *testing.T) {
 
 		search := &fakeVectorSearcher{}
 		metrics := &fakeMetrics{}
-		log, _ := test.NewNullLogger()
-		explorer := NewExplorer(search, log, getFakeModulesProvider(), metrics, defaultConfig)
-		explorer.SetSchemaGetter(&fakeSchemaGetter{
-			schema: schema.Schema{Objects: &models.Schema{Classes: []*models.Class{
-				{Class: "BestClass"},
-			}}},
-		})
+		explorer := newQueryVectorTestExplorer(search, metrics)
 		expectedParamsToSearch := params
 		search.
 			On("VectorSearch", expectedParamsToSearch, []models.Vector{[]float32{0.8, 0.2, 0.7}}).

--- a/usecases/traverser/fakes_for_test.go
+++ b/usecases/traverser/fakes_for_test.go
@@ -135,6 +135,17 @@ func (f *fakeVectorSearcher) ResolveReferences(ctx context.Context, objs search.
 	return nil, nil
 }
 
+type fakeHybridSearcher struct {
+	fakeVectorSearcher
+}
+
+func (f *fakeHybridSearcher) ResolveReferences(ctx context.Context, objs search.Results,
+	props search.SelectProperties, groupBy *searchparams.GroupBy,
+	additional additional.Properties, tenant string,
+) (search.Results, error) {
+	return objs, nil
+}
+
 type fakeVectorRepo struct {
 	mock.Mock
 }


### PR DESCRIPTION
## Summary
- add GraphQL `_additional { query_vector }` support for Get queries
- return the resolved single-target query vector for near and hybrid vector searches
- reject multi-target `query_vector` requests instead of returning an arbitrary target vector

Fixes #2496

## Tests
- `go test ./adapters/handlers/graphql/local/get ./usecases/traverser ./entities/additional -count=1`
- `go test ./adapters/handlers/graphql/local/get ./usecases/traverser -run 'TestAdditionalQueryVectorJSONResponse|TestExtractAdditionalFields/with__additional_query_vector|Test_Explorer_QueryVectorAdditional' -count=500`
- `go test -race ./adapters/handlers/graphql/local/get ./usecases/traverser -run 'TestAdditionalQueryVectorJSONResponse|TestExtractAdditionalFields/with__additional_query_vector|Test_Explorer_QueryVectorAdditional' -count=10`