### PR TITLE
(fix): Adjust MaxObjectsPerBatch from 150 to 100 for google embeddings

### DIFF
--- a/modules/text2vec-google/module.go
+++ b/modules/text2vec-google/module.go
@@ -40,7 +40,7 @@ const (
 
 var batchSettings = batch.Settings{
 	TokenMultiplier:    1.3,
-	MaxObjectsPerBatch: 150,
+	MaxObjectsPerBatch: 100, // Google's batchEmbedContents API limit
 	MaxTimePerBatch:    float64(10),
 	MaxTokensPerBatch:  func(cfg moduletools.ClassConfig) int { return 20000 },
 	HasTokenLimit:      true,


### PR DESCRIPTION
Fixes issue https://github.com/weaviate/weaviate/issues/11275

## Summary

Google's `batchEmbedContents` API has a hard limit of 100 embeddings per batch request. The current `MaxObjectsPerBatch: 150` setting causes batch requests to fail with:

```
BatchEmbedContentsRequest.requests: at most 100 requests can be in one batch
```

This PR reduces `MaxObjectsPerBatch` from 150 to 100 to match Google's actual API limit.

This isn't well documented by Google but is the observed behavior, and is aligned with other reported issues like [this one](https://github.com/langchain-ai/langchainjs/issues/4491).