### PR TITLE
chore: adjust text2vec-google batch logic

### DIFF
--- a/modules/text2vec-google/clients/google.go
+++ b/modules/text2vec-google/clients/google.go
@@ -79,15 +79,17 @@ type google struct {
 	apiKey        string
 	googleApiKey  *apikey.GoogleApiKey
 	useGoogleAuth bool
+	rpm           int
 	httpClient    *http.Client
 	urlBuilderFn  func(useGenerativeAI bool, apiEndpoint, projectID, modelID string) string
 	logger        logrus.FieldLogger
 }
 
-func New(apiKey string, useGoogleAuth bool, timeout time.Duration, logger logrus.FieldLogger) *google {
+func New(apiKey string, useGoogleAuth bool, rpm int, timeout time.Duration, logger logrus.FieldLogger) *google {
 	return &google{
 		apiKey:        apiKey,
 		useGoogleAuth: useGoogleAuth,
+		rpm:           rpm,
 		googleApiKey:  apikey.NewGoogleApiKey(),
 		httpClient:    modulecomponents.NewBaseHttpClient(timeout),
 		urlBuilderFn:  buildURL,
@@ -128,9 +130,9 @@ func (v *google) GetVectorizerRateLimit(ctx context.Context, config moduletools.
 			return
 		}
 
-		limits.LimitRequests = 30000
+		limits.LimitRequests = v.rpm
 		limits.LimitTokens = 1000000
-		limits.RemainingRequests = 30000
+		limits.RemainingRequests = v.rpm
 		limits.RemainingTokens = 1000000
 		limits.ResetRequests = time.Now().Add(time.Duration(61) * time.Second)
 		limits.ResetTokens = time.Now().Add(time.Duration(61) * time.Second)

--- a/modules/text2vec-google/module.go
+++ b/modules/text2vec-google/module.go
@@ -33,18 +33,22 @@ import (
 )
 
 const (
-	Name             = "text2vec-google"
-	LegacyName       = "text2vec-palm"
-	defaultBatchSize = 50
+	Name                      = "text2vec-google"
+	LegacyName                = "text2vec-palm"
+	defaultBatchSize          = 50
+	defaultMaxObjectsPerBatch = 100
+	defaultRPM                = 10000
 )
 
-var batchSettings = batch.Settings{
-	TokenMultiplier:    1.3,
-	MaxObjectsPerBatch: 150,
-	MaxTimePerBatch:    float64(10),
-	MaxTokensPerBatch:  func(cfg moduletools.ClassConfig) int { return 20000 },
-	HasTokenLimit:      true,
-	ReturnsRateLimit:   false,
+func newBatchSettings(maxObjectsPerBatch int) batch.Settings {
+	return batch.Settings{
+		TokenMultiplier:    1.3,
+		MaxObjectsPerBatch: maxObjectsPerBatch,
+		MaxTimePerBatch:    float64(10),
+		MaxTokensPerBatch:  func(cfg moduletools.ClassConfig) int { return 20000 },
+		HasTokenLimit:      true,
+		ReturnsRateLimit:   false,
+	}
 }
 
 func New() *GoogleModule {
@@ -55,6 +59,7 @@ type GoogleModule struct {
 	vectorizer                   text2vecbase.TextVectorizerBatch[[]float32]
 	vectorizerBatchSimple        batchtext.Vectorizer[[]float32]
 	useBatchSimpleVectorizer     bool
+	sendObjectsInBatch           bool
 	batchSize                    int
 	vectorizerWithTitleProperty  text2vecbase.TextVectorizer[[]float32]
 	metaProvider                 text2vecbase.MetaProvider
@@ -120,21 +125,17 @@ func (m *GoogleModule) initVectorizer(ctx context.Context, timeout time.Duration
 	}
 
 	useGoogleAuth := entcfg.Enabled(os.Getenv("USE_GOOGLE_AUTH"))
-	client := clients.New(apiKey, useGoogleAuth, timeout, logger)
-
 	m.useBatchSimpleVectorizer = entcfg.Enabled(os.Getenv("USE_T2V_GOOGLE_BATCH_SIMPLE_LOGIC"))
-	m.vectorizerBatchSimple = batchtext.NewWithAltNames(Name, m.AltNames(), vectorizer.LowerCaseInput, client)
-	m.batchSize = defaultBatchSize
-	if batchSizeStr := os.Getenv("T2V_GOOGLE_BATCH_SIMPLE_BATCH_SIZE"); batchSizeStr != "" {
-		if batchSize, err := strconv.Atoi(batchSizeStr); err == nil && batchSize > 0 {
-			m.batchSize = batchSize
-		} else {
-			logger.Warnf("invalid (must be a positive number > 0) T2V_GOOGLE_BATCH_SIMPLE_BATCH_SIZE value: %s, using default: %v", batchSizeStr, m.batchSize)
-		}
-	}
+	m.sendObjectsInBatch = entcfg.Enabled(os.Getenv("USE_T2V_GOOGLE_BATCH_SEND_OBJECTS_IN_BATCH"))
+	m.batchSize = m.envPositiveInt("T2V_GOOGLE_BATCH_SIMPLE_BATCH_SIZE", defaultBatchSize, logger)
+	maxObjectsPerBatch := m.envPositiveInt("T2V_GOOGLE_BATCH_MAX_OBJECTS_PER_BATCH", defaultMaxObjectsPerBatch, logger)
+	rpm := m.envPositiveInt("T2V_GOOGLE_BATCH_RPM", defaultRPM, logger)
 
+	client := clients.New(apiKey, useGoogleAuth, rpm, timeout, logger)
+	m.vectorizerBatchSimple = batchtext.NewWithAltNames(Name, m.AltNames(), vectorizer.LowerCaseInput, client)
 	m.vectorizerWithTitleProperty = vectorizer.New(client)
 
+	batchSettings := newBatchSettings(maxObjectsPerBatch)
 	m.vectorizer = text2vecbase.New(client,
 		batch.NewBatchVectorizer(client, 50*time.Second, batchSettings, logger, m.Name()),
 		batch.ReturnBatchTokenizerWithAltNames(batchSettings.TokenMultiplier, m.Name(), m.AltNames(), vectorizer.LowerCaseInput),
@@ -163,16 +164,18 @@ func (m *GoogleModule) VectorizeObject(ctx context.Context,
 }
 
 func (m *GoogleModule) VectorizeBatch(ctx context.Context, objs []*models.Object, skipObject []bool, cfg moduletools.ClassConfig) ([][]float32, []models.AdditionalProperties, map[int]error) {
-	icheck := vectorizer.NewClassSettings(cfg)
 	if m.useBatchSimpleVectorizer {
 		// use batch simple logic
 		return batch.VectorizeBatchObjects(ctx, objs, skipObject, cfg, m.logger, m.vectorizerBatchSimple.Objects, m.batchSize)
 	}
 	// use default batch logic
-	if icheck.TitleProperty() == "" {
+	icheck := vectorizer.NewClassSettings(cfg)
+	if m.sendObjectsInBatch && icheck.TitleProperty() == "" {
+		// this logic sends a batch of objects in 1 request
 		vecs, errs := m.vectorizer.ObjectBatch(ctx, objs, skipObject, cfg)
 		return vecs, nil, errs
 	}
+	// this logic always sends multiple requests, each containing 1 object
 	return batch.VectorizeBatch(ctx, objs, skipObject, cfg, m.logger, m.vectorizerWithTitleProperty.Object)
 }
 
@@ -197,6 +200,19 @@ func (m *GoogleModule) VectorizeInput(ctx context.Context,
 
 func (m *GoogleModule) VectorizableProperties(cfg moduletools.ClassConfig) (bool, []string, error) {
 	return true, nil, nil
+}
+
+func (m *GoogleModule) envPositiveInt(name string, defaultValue int, logger logrus.FieldLogger) int {
+	value := os.Getenv(name)
+	if value == "" {
+		return defaultValue
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		logger.Warnf("invalid (must be a positive number > 0) %s value: %s, using default: %v", name, value, defaultValue)
+		return defaultValue
+	}
+	return parsed
 }
 
 // verify we implement the modules.Module interface


### PR DESCRIPTION
### What's being changed:

This PR adjusts `text2vec-google` batch settings:
 - max objects per batch size: 100
 - RPM: 10k

it also changes the default batch logic to always send multiple requests, each containing only 1 object in them.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
