### PR TITLE
Add _additional.highlight support for GraphQL Get

### DIFF
--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -188,6 +188,7 @@ func (b *classBuilder) additionalFields(classProperties graphql.Fields, class *m
 	additionalProperties["score"] = b.additionalScoreField()
 	additionalProperties["explainScore"] = b.additionalExplainScoreField()
 	additionalProperties["queryProfile"] = b.additionalQueryProfileField()
+	additionalProperties["highlight"] = b.additionalHighlightField(class)
 	additionalProperties["group"] = b.additionalGroupField(classProperties, class)
 	if replicationEnabled(class) {
 		additionalProperties["isConsistent"] = b.isConsistentField()
@@ -276,6 +277,35 @@ func (b *classBuilder) additionalCreationTimeUnix() *graphql.Field {
 func (b *classBuilder) additionalScoreField() *graphql.Field {
 	return &graphql.Field{
 		Type: graphql.String,
+	}
+}
+
+func (b *classBuilder) additionalHighlightField(class *models.Class) *graphql.Field {
+	return &graphql.Field{
+		Type: graphql.NewList(graphql.NewObject(graphql.ObjectConfig{
+			Name: fmt.Sprintf("%sAdditionalHighlight", class.Class),
+			Fields: graphql.Fields{
+				"property":  &graphql.Field{Type: graphql.String},
+				"fragments": &graphql.Field{Type: graphql.NewList(graphql.String)},
+			},
+		})),
+		Args: graphql.FieldConfigArgument{
+			"fields": &graphql.ArgumentConfig{
+				Type: graphql.NewList(graphql.String),
+			},
+			"numberOfFragments": &graphql.ArgumentConfig{
+				Type: graphql.Int,
+			},
+			"fragmentSize": &graphql.ArgumentConfig{
+				Type: graphql.Int,
+			},
+			"preTag": &graphql.ArgumentConfig{
+				Type: graphql.String,
+			},
+			"postTag": &graphql.ArgumentConfig{
+				Type: graphql.String,
+			},
+		},
 	}
 }
 

--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -590,7 +591,7 @@ func (ac *additionalCheck) isAdditional(parentName, name string) bool {
 			name == "distance" || name == "id" || name == "vector" || name == "vectors" ||
 			name == "creationTimeUnix" || name == "lastUpdateTimeUnix" ||
 			name == "score" || name == "explainScore" || name == "isConsistent" ||
-			name == "group" || name == "queryProfile" {
+			name == "group" || name == "queryProfile" || name == "highlight" {
 			return true
 		}
 		if ac.isModuleAdditional(name) {
@@ -701,6 +702,10 @@ func extractProperties(className string, selections *ast.SelectionSet,
 							additionalProps.QueryProfile = true
 							continue
 						}
+						if additionalProperty == "highlight" {
+							additionalProps.Highlight = extractHighlightArgs(s.Arguments)
+							continue
+						}
 						if additionalProperty == "lastUpdateTimeUnix" {
 							additionalProps.LastUpdateTimeUnix = true
 							continue
@@ -767,6 +772,52 @@ func extractProperties(className string, selections *ast.SelectionSet,
 	}
 
 	return properties, additionalProps, additionalGroupHitProperties, nil
+}
+
+func extractHighlightArgs(args []*ast.Argument) *additional.Highlight {
+	highlight := &additional.Highlight{
+		NumberOfFragments: 1,
+		FragmentSize:      150,
+		PreTag:            "<em>",
+		PostTag:           "</em>",
+	}
+
+	for _, arg := range args {
+		switch arg.Name.Value {
+		case "fields":
+			if lv, ok := arg.Value.(*ast.ListValue); ok {
+				fields := make([]string, 0, len(lv.Values))
+				for _, v := range lv.Values {
+					if sv, ok := v.(*ast.StringValue); ok {
+						fields = append(fields, sv.Value)
+					}
+				}
+				highlight.Fields = fields
+			}
+		case "numberOfFragments":
+			if iv, ok := arg.Value.(*ast.IntValue); ok {
+				if n, err := strconv.Atoi(iv.Value); err == nil && n > 0 {
+					highlight.NumberOfFragments = n
+				}
+			}
+		case "fragmentSize":
+			if iv, ok := arg.Value.(*ast.IntValue); ok {
+				if n, err := strconv.Atoi(iv.Value); err == nil && n > 0 {
+					highlight.FragmentSize = n
+				}
+			}
+		case "preTag":
+			if sv, ok := arg.Value.(*ast.StringValue); ok && sv.Value != "" {
+				highlight.PreTag = sv.Value
+			}
+		case "postTag":
+			if sv, ok := arg.Value.(*ast.StringValue); ok && sv.Value != "" {
+				highlight.PostTag = sv.Value
+			}
+		}
+	}
+
+	return highlight
 }
 
 func extractGroupHitProperties(

--- a/adapters/handlers/graphql/local/get/get_test.go
+++ b/adapters/handlers/graphql/local/get/get_test.go
@@ -512,6 +512,46 @@ func TestExtractAdditionalFields(t *testing.T) {
 			},
 		},
 		{
+			name:  "with _additional highlight and args",
+			query: `{ Get { SomeAction { _additional { highlight(fields: ["title", "description"], numberOfFragments: 2, fragmentSize: 80, preTag: "<b>", postTag: "</b>") { property fragments } } } } }`,
+			expectedParams: dto.GetParams{
+				ClassName: "SomeAction",
+				AdditionalProperties: additional.Properties{
+					Highlight: &additional.Highlight{
+						Fields:            []string{"title", "description"},
+						NumberOfFragments: 2,
+						FragmentSize:      80,
+						PreTag:            "<b>",
+						PostTag:           "</b>",
+					},
+				},
+			},
+			resolverReturn: []interface{}{
+				map[string]interface{}{
+					"_additional": map[string]interface{}{
+						"highlight": []map[string]interface{}{
+							{
+								"property":  "title",
+								"fragments": []string{"...sample <b>query</b> fragment..."},
+							},
+						},
+					},
+				},
+			},
+			expectedResult: map[string]interface{}{
+				"_additional": map[string]interface{}{
+					"highlight": []interface{}{
+						map[string]interface{}{
+							"property": "title",
+							"fragments": []interface{}{
+								"...sample <b>query</b> fragment...",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
 			name:  "with _additional interpretation",
 			query: "{ Get { SomeAction { _additional { interpretation { source { concept weight occurrence } }  } } } }",
 			expectedParams: dto.GetParams{

--- a/entities/additional/classification.go
+++ b/entities/additional/classification.go
@@ -21,6 +21,14 @@ type Classification struct {
 	Scope            []string        `json:"scope"`
 }
 
+type Highlight struct {
+	Fields            []string `json:"fields,omitempty"`
+	NumberOfFragments int      `json:"numberOfFragments,omitempty"`
+	FragmentSize      int      `json:"fragmentSize,omitempty"`
+	PreTag            string   `json:"preTag,omitempty"`
+	PostTag           string   `json:"postTag,omitempty"`
+}
+
 type Properties struct {
 	Classification bool     `json:"classification"`
 	RefMeta        bool     `json:"refMeta"`
@@ -43,6 +51,7 @@ type Properties struct {
 	Group                   bool                   `json:"group"`
 	// QueryProfile enables per-shard query profiling data collection and return.
 	QueryProfile bool `json:"queryProfile"`
+	Highlight    *Highlight
 
 	// The User is not interested in returning props, we can skip any costly
 	// operation that isn't required.

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -14,7 +14,10 @@ package traverser
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"runtime"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/ttl"
@@ -503,6 +506,12 @@ func (e *Explorer) searchResultsToGetResponseWithType(ctx context.Context, input
 		if params.AdditionalProperties.ExplainScore {
 			additionalProperties["explainScore"] = res.ExplainScore
 		}
+		if params.AdditionalProperties.Highlight != nil {
+			highlight := buildHighlightResult(res.Schema, params)
+			if len(highlight) > 0 {
+				additionalProperties["highlight"] = highlight
+			}
+		}
 
 		if params.AdditionalProperties.Vector {
 			additionalProperties["vector"] = res.Vector
@@ -541,6 +550,145 @@ func (e *Explorer) searchResultsToGetResponseWithType(ctx context.Context, input
 	}
 
 	return output, nil
+}
+
+func buildHighlightResult(schemaObj interface{}, params dto.GetParams) []map[string]interface{} {
+	schemaMap, ok := schemaObj.(map[string]interface{})
+	if !ok || params.AdditionalProperties.Highlight == nil {
+		return nil
+	}
+	cfg := params.AdditionalProperties.Highlight
+	query := ""
+	switch {
+	case params.KeywordRanking != nil:
+		query = params.KeywordRanking.Query
+	case params.HybridSearch != nil:
+		query = params.HybridSearch.Query
+	}
+	terms := tokenizeHighlightTerms(query)
+	if len(terms) == 0 {
+		return nil
+	}
+
+	fields := cfg.Fields
+	if len(fields) == 0 {
+		fields = make([]string, 0, len(params.Properties))
+		for _, p := range params.Properties {
+			if p.IsPrimitive {
+				fields = append(fields, p.Name)
+			}
+		}
+	}
+
+	out := make([]map[string]interface{}, 0, len(fields))
+	for _, field := range fields {
+		raw, ok := schemaMap[field]
+		if !ok {
+			continue
+		}
+		text, ok := raw.(string)
+		if !ok || text == "" {
+			continue
+		}
+		fragments := extractHighlightedFragments(text, terms, cfg)
+		if len(fragments) == 0 {
+			continue
+		}
+		out = append(out, map[string]interface{}{
+			"property":  field,
+			"fragments": fragments,
+		})
+	}
+	return out
+}
+
+func tokenizeHighlightTerms(query string) []string {
+	normalized := strings.ToLower(query)
+	normalized = strings.NewReplacer(",", " ", ".", " ", ";", " ", ":", " ", "(", " ", ")", " ", "\"", " ", "'", " ").Replace(normalized)
+	parts := strings.Fields(normalized)
+	terms := make([]string, 0, len(parts))
+	seen := map[string]struct{}{}
+	for _, p := range parts {
+		if len(p) < 2 {
+			continue
+		}
+		if _, ok := seen[p]; ok {
+			continue
+		}
+		seen[p] = struct{}{}
+		terms = append(terms, p)
+	}
+	return terms
+}
+
+func extractHighlightedFragments(text string, terms []string, cfg *additional.Highlight) []string {
+	if cfg == nil || len(terms) == 0 || text == "" {
+		return nil
+	}
+	maxFragments := cfg.NumberOfFragments
+	if maxFragments <= 0 {
+		maxFragments = 1
+	}
+	fragmentSize := cfg.FragmentSize
+	if fragmentSize <= 0 {
+		fragmentSize = 150
+	}
+	preTag := cfg.PreTag
+	if preTag == "" {
+		preTag = "<em>"
+	}
+	postTag := cfg.PostTag
+	if postTag == "" {
+		postTag = "</em>"
+	}
+
+	lowerText := strings.ToLower(text)
+	type pos struct {
+		start int
+		end   int
+	}
+	positions := make([]pos, 0, len(terms))
+	for _, term := range terms {
+		idx := strings.Index(lowerText, term)
+		if idx >= 0 {
+			positions = append(positions, pos{start: idx, end: idx + len(term)})
+		}
+	}
+	if len(positions) == 0 {
+		return nil
+	}
+	sort.Slice(positions, func(i, j int) bool { return positions[i].start < positions[j].start })
+
+	fragments := make([]string, 0, maxFragments)
+	for _, p := range positions {
+		if len(fragments) >= maxFragments {
+			break
+		}
+		start := p.start - fragmentSize/2
+		if start < 0 {
+			start = 0
+		}
+		end := start + fragmentSize
+		if end > len(text) {
+			end = len(text)
+		}
+		frag := text[start:end]
+		for _, term := range terms {
+			re := regexp.MustCompile("(?i)" + regexp.QuoteMeta(term))
+			frag = re.ReplaceAllStringFunc(frag, func(m string) string {
+				return preTag + m + postTag
+			})
+		}
+		if start > 0 {
+			frag = "..." + frag
+		}
+		if end < len(text) {
+			frag = frag + "..."
+		}
+		fragments = append(fragments, frag)
+	}
+
+	return fragments
 }
 
 func (e *Explorer) extractAdditionalPropertiesFromGroupRefs(

--- a/usecases/traverser/explorer_test.go
+++ b/usecases/traverser/explorer_test.go
@@ -13,6 +13,7 @@ package traverser
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -2905,4 +2906,46 @@ func getFakeModulesProviderWithCustomExtenders(
 
 func getFakeModulesProvider() ModulesProvider {
 	return &fakeModulesProvider{}
+}
+
+func TestExtractHighlightedFragments(t *testing.T) {
+	cfg := &additional.Highlight{
+		NumberOfFragments: 2,
+		FragmentSize:      60,
+		PreTag:            "<b>",
+		PostTag:           "</b>",
+	}
+	text := "Weaviate supports keyword highlighting for search workflows and highlighting helps review relevance."
+	fragments := extractHighlightedFragments(text, []string{"highlighting"}, cfg)
+
+	require.NotEmpty(t, fragments)
+	assert.True(t, strings.Contains(strings.ToLower(fragments[0]), "<b>highlighting</b>"))
+}
+
+func TestBuildHighlightResult(t *testing.T) {
+	params := dto.GetParams{
+		Properties: []search.SelectProperty{
+			{Name: "title", IsPrimitive: true},
+		},
+		KeywordRanking: &searchparams.KeywordRanking{Query: "fusion"},
+		AdditionalProperties: additional.Properties{
+			Highlight: &additional.Highlight{
+				NumberOfFragments: 1,
+				FragmentSize:      80,
+				PreTag:            "<em>",
+				PostTag:           "</em>",
+			},
+		},
+	}
+
+	result := buildHighlightResult(map[string]interface{}{
+		"title": "Hybrid fusion in weaviate combines sparse and dense retrieval",
+	}, params)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "title", result[0]["property"])
+	frags, ok := result[0]["fragments"].([]string)
+	require.True(t, ok)
+	require.NotEmpty(t, frags)
+	assert.Contains(t, strings.ToLower(frags[0]), "<em>fusion</em>")
 }


### PR DESCRIPTION
## Summary
- add `_additional.highlight` GraphQL field for Get queries
- support args: `fields`, `numberOfFragments`, `fragmentSize`, `preTag`, `postTag`
- parse args into `additional.Highlight` and return property-scoped highlighted fragments in responses
- add tests for GraphQL extraction and highlight response-shape helpers

## Claim
/claim #2567

## Demo video
- https://github.com/aimqwest/gyroflow/releases/download/aimqwest-pr-demos-20260512/pr11280-demo-v6.mp4
