### PR TITLE
Add per-namespace restrictions for number of collections

### DIFF
--- a/cluster/proto/api/schema_requests.go
+++ b/cluster/proto/api/schema_requests.go
@@ -81,6 +81,11 @@ type QuerySchemaResponse struct {
 	Schema models.Schema
 }
 
+type QueryCollectionsCountRequest struct {
+	// Namespace selects classes belonging to that namespace; empty counts all.
+	Namespace string
+}
+
 type QueryCollectionsCountResponse struct {
 	Count int
 }

--- a/cluster/raft_query_endpoints.go
+++ b/cluster/raft_query_endpoints.go
@@ -118,20 +118,29 @@ func (s *Raft) QuerySchema() (models.Schema, error) {
 	return resp.Schema, nil
 }
 
-// QueryCollectionsCount build a Query to read the schema that will be directed to the leader to ensure we will read the class
-// with strong consistency
-func (s *Raft) QueryCollectionsCount() (int, error) {
+// QueryCollectionsCount issues a leader-directed count query. An empty
+// namespace returns the cluster-global total; a non-empty namespace returns
+// the count restricted to classes in that namespace.
+func (s *Raft) QueryCollectionsCount(namespace string) (int, error) {
 	ctx := context.Background()
 	if entSentry.Enabled() {
 		transaction := sentry.StartSpan(ctx, "grpc.client",
 			sentry.WithTransactionName("raft.query.collections.count"),
 			sentry.WithDescription("Query the collections count"),
 		)
+		transaction.SetData("namespace", namespace)
 		ctx = transaction.Context()
 		defer transaction.Finish()
 	}
+
+	req := cmd.QueryCollectionsCountRequest{Namespace: namespace}
+	subCommand, err := json.Marshal(&req)
+	if err != nil {
+		return 0, fmt.Errorf("marshal request: %w", err)
+	}
 	command := &cmd.QueryRequest{
-		Type: cmd.QueryRequest_TYPE_GET_COLLECTIONS_COUNT,
+		Type:       cmd.QueryRequest_TYPE_GET_COLLECTIONS_COUNT,
+		SubCommand: subCommand,
 	}
 	queryResp, err := s.Query(ctx, command)
 	if err != nil {

--- a/cluster/raft_query_endpoints.go
+++ b/cluster/raft_query_endpoints.go
@@ -136,7 +136,7 @@ func (s *Raft) QueryCollectionsCount(namespace string) (int, error) {
 	req := cmd.QueryCollectionsCountRequest{Namespace: namespace}
 	subCommand, err := json.Marshal(&req)
 	if err != nil {
-		return 0, fmt.Errorf("marshal request: %w", err)
+		return 0, fmt.Errorf("marshal collections count request (namespace=%q): %w", namespace, err)
 	}
 	command := &cmd.QueryRequest{
 		Type:       cmd.QueryRequest_TYPE_GET_COLLECTIONS_COUNT,
@@ -144,14 +144,12 @@ func (s *Raft) QueryCollectionsCount(namespace string) (int, error) {
 	}
 	queryResp, err := s.Query(ctx, command)
 	if err != nil {
-		return 0, fmt.Errorf("failed to execute query: %w", err)
+		return 0, fmt.Errorf("execute collections count query (namespace=%q): %w", namespace, err)
 	}
 
-	// Unmarshal the response
 	resp := cmd.QueryCollectionsCountResponse{}
-	err = json.Unmarshal(queryResp.Payload, &resp)
-	if err != nil {
-		return 0, fmt.Errorf("failed to unmarshal query result: %w", err)
+	if err := json.Unmarshal(queryResp.Payload, &resp); err != nil {
+		return 0, fmt.Errorf("unmarshal collections count response (namespace=%q): %w", namespace, err)
 	}
 	return resp.Count, nil
 }

--- a/cluster/schema/manager_query.go
+++ b/cluster/schema/manager_query.go
@@ -52,9 +52,18 @@ func (sm *SchemaManager) QuerySchema() ([]byte, error) {
 	return payload, nil
 }
 
-func (sm *SchemaManager) QueryCollectionsCount() ([]byte, error) {
-	// Build the response, marshal and return
-	response := cmd.QueryCollectionsCountResponse{Count: sm.schema.CollectionsCount()}
+func (sm *SchemaManager) QueryCollectionsCount(req *cmd.QueryRequest) ([]byte, error) {
+	// Empty SubCommand keeps the historical cluster-global behavior.
+	namespace := ""
+	if len(req.SubCommand) > 0 {
+		subCommand := cmd.QueryCollectionsCountRequest{}
+		if err := json.Unmarshal(req.SubCommand, &subCommand); err != nil {
+			return []byte{}, fmt.Errorf("%w: %w", ErrBadRequest, err)
+		}
+		namespace = subCommand.Namespace
+	}
+
+	response := cmd.QueryCollectionsCountResponse{Count: sm.schema.CollectionsCount(namespace)}
 	payload, err := json.Marshal(&response)
 	if err != nil {
 		return []byte{}, fmt.Errorf("could not marshal query response: %w", err)

--- a/cluster/schema/manager_query.go
+++ b/cluster/schema/manager_query.go
@@ -58,7 +58,7 @@ func (sm *SchemaManager) QueryCollectionsCount(req *cmd.QueryRequest) ([]byte, e
 	if len(req.SubCommand) > 0 {
 		subCommand := cmd.QueryCollectionsCountRequest{}
 		if err := json.Unmarshal(req.SubCommand, &subCommand); err != nil {
-			return []byte{}, fmt.Errorf("%w: %w", ErrBadRequest, err)
+			return []byte{}, fmt.Errorf("%w: unmarshal collections count request: %w", ErrBadRequest, err)
 		}
 		namespace = subCommand.Namespace
 	}
@@ -66,7 +66,7 @@ func (sm *SchemaManager) QueryCollectionsCount(req *cmd.QueryRequest) ([]byte, e
 	response := cmd.QueryCollectionsCountResponse{Count: sm.schema.CollectionsCount(namespace)}
 	payload, err := json.Marshal(&response)
 	if err != nil {
-		return []byte{}, fmt.Errorf("could not marshal query response: %w", err)
+		return []byte{}, fmt.Errorf("marshal collections count response (namespace=%q): %w", namespace, err)
 	}
 	return payload, nil
 }

--- a/cluster/schema/manager_query_test.go
+++ b/cluster/schema/manager_query_test.go
@@ -37,28 +37,38 @@ func TestQueryCollectionsCount(t *testing.T) {
 		return sm
 	}
 
-	t.Run("empty subcommand returns global count", func(t *testing.T) {
-		sm := newManager(t)
-		payload, err := sm.QueryCollectionsCount(&cmd.QueryRequest{})
-		require.NoError(t, err)
+	tests := []struct {
+		name      string
+		subCmd    []byte
+		wantCount int
+	}{
+		{
+			name:      "empty subcommand returns global count",
+			subCmd:    nil,
+			wantCount: 3,
+		},
+		{
+			name:      "explicit empty namespace returns global count",
+			subCmd:    mustMarshal(t, cmd.QueryCollectionsCountRequest{Namespace: ""}),
+			wantCount: 3,
+		},
+		{
+			name:      "namespace selector filters",
+			subCmd:    mustMarshal(t, cmd.QueryCollectionsCountRequest{Namespace: "customer1"}),
+			wantCount: 2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sm := newManager(t)
+			payload, err := sm.QueryCollectionsCount(&cmd.QueryRequest{SubCommand: tt.subCmd})
+			require.NoError(t, err)
 
-		var resp cmd.QueryCollectionsCountResponse
-		require.NoError(t, json.Unmarshal(payload, &resp))
-		assert.Equal(t, 3, resp.Count)
-	})
-
-	t.Run("namespace selector filters", func(t *testing.T) {
-		sm := newManager(t)
-		sub, err := json.Marshal(cmd.QueryCollectionsCountRequest{Namespace: "customer1"})
-		require.NoError(t, err)
-
-		payload, err := sm.QueryCollectionsCount(&cmd.QueryRequest{SubCommand: sub})
-		require.NoError(t, err)
-
-		var resp cmd.QueryCollectionsCountResponse
-		require.NoError(t, json.Unmarshal(payload, &resp))
-		assert.Equal(t, 2, resp.Count)
-	})
+			var resp cmd.QueryCollectionsCountResponse
+			require.NoError(t, json.Unmarshal(payload, &resp))
+			assert.Equal(t, tt.wantCount, resp.Count)
+		})
+	}
 
 	t.Run("invalid subcommand JSON is a bad request", func(t *testing.T) {
 		sm := newManager(t)
@@ -66,4 +76,11 @@ func TestQueryCollectionsCount(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, errors.Is(err, ErrBadRequest))
 	})
+}
+
+func mustMarshal(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	require.NoError(t, err)
+	return b
 }

--- a/cluster/schema/manager_query_test.go
+++ b/cluster/schema/manager_query_test.go
@@ -1,0 +1,69 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package schema
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	cmd "github.com/weaviate/weaviate/cluster/proto/api"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/sharding"
+)
+
+func TestQueryCollectionsCount(t *testing.T) {
+	newManager := func(t *testing.T) *SchemaManager {
+		sm := &SchemaManager{
+			schema: NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry()),
+		}
+		ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
+		require.NoError(t, sm.schema.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))
+		require.NoError(t, sm.schema.addClass(&models.Class{Class: "customer1:Films"}, ss, 2))
+		require.NoError(t, sm.schema.addClass(&models.Class{Class: "customer2:Movies"}, ss, 3))
+		return sm
+	}
+
+	t.Run("empty subcommand returns global count", func(t *testing.T) {
+		sm := newManager(t)
+		payload, err := sm.QueryCollectionsCount(&cmd.QueryRequest{})
+		require.NoError(t, err)
+
+		var resp cmd.QueryCollectionsCountResponse
+		require.NoError(t, json.Unmarshal(payload, &resp))
+		assert.Equal(t, 3, resp.Count)
+	})
+
+	t.Run("namespace selector filters", func(t *testing.T) {
+		sm := newManager(t)
+		sub, err := json.Marshal(cmd.QueryCollectionsCountRequest{Namespace: "customer1"})
+		require.NoError(t, err)
+
+		payload, err := sm.QueryCollectionsCount(&cmd.QueryRequest{SubCommand: sub})
+		require.NoError(t, err)
+
+		var resp cmd.QueryCollectionsCountResponse
+		require.NoError(t, json.Unmarshal(payload, &resp))
+		assert.Equal(t, 2, resp.Count)
+	})
+
+	t.Run("invalid subcommand JSON is a bad request", func(t *testing.T) {
+		sm := newManager(t)
+		_, err := sm.QueryCollectionsCount(&cmd.QueryRequest{SubCommand: []byte("not-json")})
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, ErrBadRequest))
+	})
+}

--- a/cluster/schema/schema.go
+++ b/cluster/schema/schema.go
@@ -248,11 +248,25 @@ func (s *schema) ReadOnlySchema() models.Schema {
 	return cp
 }
 
-func (s *schema) CollectionsCount() int {
+// CollectionsCount returns the number of stored classes. With an empty
+// namespace it is the cluster-global total. With a non-empty namespace it
+// counts only classes whose internal name carries that namespace prefix.
+func (s *schema) CollectionsCount(namespace string) int {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	return len(s.classes)
+	if namespace == "" {
+		return len(s.classes)
+	}
+
+	prefix := namespace + entSchema.NamespaceSeparator
+	count := 0
+	for name := range s.classes {
+		if strings.HasPrefix(name, prefix) {
+			count++
+		}
+	}
+	return count
 }
 
 // ShardOwner returns the node owner of the specified shard

--- a/cluster/schema/schema_test.go
+++ b/cluster/schema/schema_test.go
@@ -677,3 +677,18 @@ func TestAliasNamespacePrefixPreserved(t *testing.T) {
 
 	require.Equal(t, "delhappy:Movies", sc.ResolveAlias("delhappy:Films"))
 }
+
+func TestCollectionsCount_Namespaced(t *testing.T) {
+	sc := NewSchema(t.Name(), nil, prometheus.NewPedanticRegistry())
+	ss := &sharding.State{Physical: make(map[string]sharding.Physical)}
+
+	require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Movies"}, ss, 1))
+	require.NoError(t, sc.addClass(&models.Class{Class: "customer1:Films"}, ss, 2))
+	require.NoError(t, sc.addClass(&models.Class{Class: "customer2:Movies"}, ss, 3))
+	require.NoError(t, sc.addClass(&models.Class{Class: "Global"}, ss, 4))
+
+	assert.Equal(t, 4, sc.CollectionsCount(""), "empty namespace returns total")
+	assert.Equal(t, 2, sc.CollectionsCount("customer1"))
+	assert.Equal(t, 1, sc.CollectionsCount("customer2"))
+	assert.Equal(t, 0, sc.CollectionsCount("unknown"))
+}

--- a/cluster/store_query.go
+++ b/cluster/store_query.go
@@ -37,7 +37,7 @@ func (st *Store) Query(req *cmd.QueryRequest) (*cmd.QueryResponse, error) {
 			return &cmd.QueryResponse{}, fmt.Errorf("could not get schema: %w", err)
 		}
 	case cmd.QueryRequest_TYPE_GET_COLLECTIONS_COUNT:
-		payload, err = st.schemaManager.QueryCollectionsCount()
+		payload, err = st.schemaManager.QueryCollectionsCount(req)
 		if err != nil {
 			return &cmd.QueryResponse{}, fmt.Errorf("could not get schema: %w", err)
 		}

--- a/cluster/store_query.go
+++ b/cluster/store_query.go
@@ -39,7 +39,7 @@ func (st *Store) Query(req *cmd.QueryRequest) (*cmd.QueryResponse, error) {
 	case cmd.QueryRequest_TYPE_GET_COLLECTIONS_COUNT:
 		payload, err = st.schemaManager.QueryCollectionsCount(req)
 		if err != nil {
-			return &cmd.QueryResponse{}, fmt.Errorf("could not get schema: %w", err)
+			return &cmd.QueryResponse{}, fmt.Errorf("could not get collections count: %w", err)
 		}
 	case cmd.QueryRequest_TYPE_GET_TENANTS:
 		payload, err = st.schemaManager.QueryTenants(req)

--- a/docs/usage_limits.md
+++ b/docs/usage_limits.md
@@ -12,7 +12,7 @@ All limits are **opt-in**: env vars unset means no enforcement.
 |---|---|---|---|
 | `USAGE_LIMITS_ERROR_MESSAGE` | string | `"{limit} count limit of {value} reached for this instance."` | Operator-overridable template for the user-facing error message. Placeholders: `{limit}` (resource type) and `{value}` (configured threshold). |
 | `MAXIMUM_ALLOWED_OBJECTS_COUNT` | int | `-1` (unlimited) | Cap on live object count, summed across all loaded local shards (node-wide). Checked on every single + batch insert at the storage chokepoint. |
-| `MAXIMUM_ALLOWED_COLLECTIONS_COUNT` | int | `-1` (unlimited) | Cap on number of collections. Pre-existing env var; behavior preserved. |
+| `MAXIMUM_ALLOWED_COLLECTIONS_COUNT` | int | `-1` (unlimited) | Cap on number of collections. Cluster-global when `NAMESPACES_ENABLED=false`; per namespace when `NAMESPACES_ENABLED=true`. |
 | `MAXIMUM_ALLOWED_TENANTS_PER_COLLECTION` | int | `-1` (unlimited) | Cap on tenants per multi-tenant collection. Checked at tenant-create time only. |
 | `MAXIMUM_ALLOWED_SHARDS_PER_COLLECTION` | int | `-1` (unlimited) | Cap on `desiredCount` of a class create request's `shardingConfig`. Config-time check. |
 
@@ -43,6 +43,8 @@ The schema-side limits (collections, tenants, shards) stay at the use-case layer
 The object count is **node-wide** across local shards: the manager sums each loaded shard's `bucket.CountAsync()` (`adapters/repos/db/lsmkv/bucket.go`) on every enforced write. Each `CountAsync()` is O(segments-per-shard) — it walks the live segment list and sums each segment's already-loaded net-additions counter, no I/O. For the Free-Tier shape (few shards, few segments) that's a handful of atomic reads on the hot path.
 
 We deliberately don't route through `UsageForIndex` — that path triggers other usage-module computations beyond a count.
+
+The collection count is **schema/RAFT-backed**: the limit check in `AddClass()` calls `schemaManager.QueryCollectionsCount(namespace)`, which goes through RAFT to the leader. When `NAMESPACES_ENABLED=false` the namespace selector is empty and the response is the cluster-global `len(s.classes)`. When `NAMESPACES_ENABLED=true` the selector is the caller's `principal.Namespace` (namespaced creates already require a namespaced principal) and the count is restricted to stored class names whose `<namespace>:` prefix matches. Aliases live outside this map and do not consume the cap.
 
 ## Error response
 
@@ -80,7 +82,6 @@ Supported deployment shapes (where the cap is meaningful and exact):
 - **RF > 1.** The replicated write path bypasses `Shard.PutObject{,Batch}` (it goes through `shard_replication.go`'s `preparePutObject{,s}` → `s.putOne` / `s.putBatch` directly). Supporting RF>1 would require either dropping the check one level deeper or a smarter scheme like a lease-based quota.
 - **Hypothetical multi-node, non-namespaced, RF=1, single-shard clusters where collections are distributed across nodes.** Each node would only see its local slice of the count, so the effective cap stacks (`cap × min(N_collections, N_nodes_with_shards)`). Not a deployment shape we ship the cap in.
 - **Phase-2 namespaces** that spread a namespace's collections across nodes — same problem as the previous bullet.
-- **Cluster-wide enforcement.** Reserved for the future namespaces work; not API-stubbed here.
 
 ## Backward-compat note: collections-limit status code
 

--- a/test/acceptance/schema/namespace_collection_limit_test.go
+++ b/test/acceptance/schema/namespace_collection_limit_test.go
@@ -1,0 +1,97 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	clschema "github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// TestNamespacedCollectionCountLimit checks that MAXIMUM_ALLOWED_COLLECTIONS_COUNT
+// is enforced per namespace on NAMESPACES_ENABLED clusters. With a cap of 1,
+// each namespace gets its own budget — a second create in the same namespace
+// is rejected with 429 / USAGE_LIMIT_EXCEEDED, but a parallel namespace stays
+// unaffected.
+func TestNamespacedCollectionCountLimit(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	const (
+		adminUser = "admin-user"
+		adminKey  = "admin-key"
+	)
+
+	compose, err := docker.New().
+		WithWeaviate().
+		WithApiKey().
+		WithUserApiKey(adminUser, adminKey).
+		WithDbUsers().
+		WithRBAC().
+		WithRbacRoots(adminUser).
+		WithNamespaces().
+		WithWeaviateEnv("MAXIMUM_ALLOWED_COLLECTIONS_COUNT", "1").
+		Start(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, compose.Terminate(ctx)) }()
+
+	helper.SetupClient(compose.GetWeaviate().URI())
+	defer helper.ResetClient()
+
+	// Operator path: only root can create namespaces and namespaced DB users
+	// on an NS-enabled cluster. Namespaced users then create the collections.
+	helper.CreateNamespace(t, "customer1", adminKey)
+	defer helper.DeleteNamespace(t, "customer1", adminKey)
+
+	const u1Subject = "u1"
+	u1Key := helper.CreateUserWithNamespace(t, u1Subject, "customer1", adminKey)
+	defer helper.DeleteUser(t, "customer1:"+u1Subject, adminKey)
+	helper.AssignRoleToUser(t, adminKey, "admin", "customer1:"+u1Subject)
+	defer helper.RevokeRoleFromUser(t, adminKey, "admin", "customer1:"+u1Subject)
+
+	// First class in customer1 uses up that namespace's budget.
+	helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, u1Key)
+	defer helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+
+	// Second class in the same namespace hits the per-namespace cap.
+	_, err = helper.CreateClassAuthWithReturn(t, &models.Class{Class: "Films"}, u1Key)
+	require.Error(t, err)
+	var tooMany *clschema.SchemaObjectsCreateTooManyRequests
+	require.True(t, errors.As(err, &tooMany),
+		"expected SchemaObjectsCreateTooManyRequests, got %T: %v", err, err)
+	require.NotNil(t, tooMany.Payload)
+	assert.Equal(t, "USAGE_LIMIT_EXCEEDED", tooMany.Payload.ErrorCode)
+	assert.Equal(t, "collections", tooMany.Payload.Limit)
+	assert.Equal(t, int64(1), tooMany.Payload.Value)
+
+	// A different namespace has its own budget and can still create a class.
+	helper.CreateNamespace(t, "customer2", adminKey)
+	defer helper.DeleteNamespace(t, "customer2", adminKey)
+
+	const u2Subject = "u2"
+	u2Key := helper.CreateUserWithNamespace(t, u2Subject, "customer2", adminKey)
+	defer helper.DeleteUser(t, "customer2:"+u2Subject, adminKey)
+	helper.AssignRoleToUser(t, adminKey, "admin", "customer2:"+u2Subject)
+	defer helper.RevokeRoleFromUser(t, adminKey, "admin", "customer2:"+u2Subject)
+
+	helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, u2Key)
+	defer helper.DeleteClassAuth(t, "customer2:Movies", adminKey)
+}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -172,7 +172,7 @@ func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 
 	existingCollectionsCount, err := h.schemaManager.QueryCollectionsCount(countNamespace)
 	if err != nil {
-		h.logger.WithField("error", err).Error("could not query the collections count")
+		h.logger.WithField("namespace", countNamespace).Error(fmt.Errorf("could not query the collections count: %w", err))
 	}
 
 	limit := h.schemaConfig.MaximumAllowedCollectionsCount.Get()

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -162,7 +162,15 @@ func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 		return nil, 0, err
 	}
 
-	existingCollectionsCount, err := h.schemaManager.QueryCollectionsCount()
+	// On namespace-enabled clusters the cap is enforced per namespace.
+	// QualifyForCreate above already required principal.Namespace for this
+	// flow, so it is the correct selector here.
+	countNamespace := ""
+	if h.config.Namespaces.Enabled {
+		countNamespace = principal.Namespace
+	}
+
+	existingCollectionsCount, err := h.schemaManager.QueryCollectionsCount(countNamespace)
 	if err != nil {
 		h.logger.WithField("error", err).Error("could not query the collections count")
 	}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -172,7 +172,7 @@ func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 
 	existingCollectionsCount, err := h.schemaManager.QueryCollectionsCount(countNamespace)
 	if err != nil {
-		h.logger.WithField("namespace", countNamespace).Error(fmt.Errorf("could not query the collections count: %w", err))
+		h.logger.WithField("namespace", countNamespace).Errorf("could not query the collections count: %v", err)
 	}
 
 	limit := h.schemaConfig.MaximumAllowedCollectionsCount.Get()

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -61,7 +61,7 @@ func Test_AddClass_ObjectTTL_InvertedIndex(t *testing.T) {
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 
 	classValidated, _, err := handler.AddClass(ctx, nil, class)
 	assert.NoError(t, err)
@@ -93,7 +93,7 @@ func Test_AddClass(t *testing.T) {
 			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 
 		_, _, err := handler.AddClass(ctx, nil, class)
 		assert.Nil(t, err)
@@ -120,7 +120,7 @@ func Test_AddClass(t *testing.T) {
 			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 
 		_, _, err := handler.AddClass(ctx, nil, class)
 		require.NoError(t, err)
@@ -227,7 +227,7 @@ func Test_AddClass(t *testing.T) {
 			UsingBlockMaxWAND:      config.DefaultUsingBlockMaxWAND,
 		}
 		fakeSchemaManager.On("AddClass", expectedClass, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.Nil(t, err)
 		fakeSchemaManager.AssertExpectations(t)
@@ -262,7 +262,7 @@ func Test_AddClass(t *testing.T) {
 			UsingBlockMaxWAND:      config.DefaultUsingBlockMaxWAND,
 		}
 		fakeSchemaManager.On("AddClass", expectedClass, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.Nil(t, err)
 		fakeSchemaManager.AssertExpectations(t)
@@ -323,7 +323,7 @@ func Test_AddClass(t *testing.T) {
 					// fakeSchemaManager.On("ReadOnlyClass", mock.Anything).Return(&models.Class{Class: classes[tc.dataType[0]].Class, Vectorizer: classes[tc.dataType[0]].Vectorizer})
 					if tc.expectedErrMsg == "" {
 						fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-						fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+						fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					}
 
 					_, _, err := handler.AddClass(context.Background(), nil, class)
@@ -519,7 +519,7 @@ func Test_AddClassWithLimits(t *testing.T) {
 				handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
 
 				// Mock the schema count
-				fakeSchemaManager.On("QueryCollectionsCount").Return(tt.existingCount, nil)
+				fakeSchemaManager.On("QueryCollectionsCount", "").Return(tt.existingCount, nil)
 
 				// Set the max collections limit in config
 				handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(tt.maxAllowed)
@@ -532,7 +532,7 @@ func Test_AddClassWithLimits(t *testing.T) {
 
 				if !tt.expectExceed {
 					fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-					fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+					fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 				}
 
 				_, _, err := handler.AddClass(ctx, nil, class)
@@ -575,7 +575,7 @@ func Test_AddClassWithLimits(t *testing.T) {
 
 				if tt.expectError == "" {
 					schemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-					schemaManager.On("QueryCollectionsCount").Return(0, nil)
+					schemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					defer schemaManager.AssertExpectations(t)
 				}
 
@@ -703,7 +703,7 @@ func Test_AddClass_DefaultsAndMigration(t *testing.T) {
 
 		t.Run("create class with all properties", func(t *testing.T) {
 			fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-			fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+			fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 			handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 			_, _, err := handler.AddClass(ctx, nil, &class)
 			require.Nil(t, err)
@@ -870,7 +870,7 @@ func Test_AddClass_DefaultsAndMigration(t *testing.T) {
 		t.Run("create class with all properties", func(t *testing.T) {
 			handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
 			fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-			fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+			fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 			_, _, err := handler.AddClass(ctx, nil, &class)
 			require.Nil(t, err)
 			fakeSchemaManager.AssertExpectations(t)
@@ -978,7 +978,7 @@ func Test_AddClass_ObjectTTLConfig(t *testing.T) {
 				handler, fakeSchemaManager := newTestHandler(t, &fakeDB{})
 				handler.config.ObjectsTTLDeleteSchedule = runtime.NewDynamicValue("@every 1h")
 				fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-				fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+				fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 
 				_, _, err := handler.AddClass(context.Background(), nil, collection)
 
@@ -1163,7 +1163,7 @@ func Test_Validation_ClassNames(t *testing.T) {
 
 					if test.valid {
 						fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-						fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+						fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					}
 					_, _, err := handler.AddClass(context.Background(), nil, class)
 					t.Log(err)
@@ -1185,7 +1185,7 @@ func Test_Validation_ClassNames(t *testing.T) {
 
 					if test.valid {
 						fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-						fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+						fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					}
 					_, _, err := handler.AddClass(context.Background(), nil, class)
 					t.Log(err)
@@ -1283,7 +1283,7 @@ func Test_Validation_PropertyNames(t *testing.T) {
 
 					if test.valid {
 						fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-						fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+						fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					}
 					handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 					_, _, err := handler.AddClass(context.Background(), nil, class)
@@ -1309,7 +1309,7 @@ func Test_Validation_PropertyNames(t *testing.T) {
 
 					if test.valid {
 						fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-						fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+						fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					}
 					_, _, err := handler.AddClass(context.Background(), nil, class)
 					t.Log(err)
@@ -1338,7 +1338,7 @@ func Test_Validation_PropertyNames(t *testing.T) {
 					}
 
 					fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-					fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+					fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(class)
 					_, _, err := handler.AddClass(context.Background(), nil, class)
 					require.Nil(t, err)
@@ -1374,7 +1374,7 @@ func Test_Validation_PropertyNames(t *testing.T) {
 
 					if test.valid {
 						fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-						fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+						fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 					}
 					_, _, err := handler.AddClass(ctx, nil, class)
 					t.Log(err)
@@ -2335,7 +2335,7 @@ func Test_UpdateClass(t *testing.T) {
 				store.parser = handler.parser
 
 				fakeSchemaManager.On("AddClass", test.initial, mock.Anything).Return(nil)
-				fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+				fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 				fakeSchemaManager.On("UpdateClass", mock.Anything, mock.Anything).Return(nil)
 				fakeSchemaManager.On("ReadOnlyClass", test.initial.Class, mock.Anything).Return(test.initial)
 				fakeSchemaManager.On("CopyShardingState", mock.Anything).Return(&sharding.State{}, nil)
@@ -2434,7 +2434,7 @@ func Test_UpdateClass_ObjectTTLConfig(t *testing.T) {
 			store.parser = handler.parser
 
 			fakeSchemaManager.On("AddClass", initial, mock.Anything).Return(nil)
-			fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+			fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 			fakeSchemaManager.On("UpdateClass", mock.Anything, mock.Anything).Return(nil)
 			fakeSchemaManager.On("ReadOnlyClass", initial.Class, mock.Anything).Return(initial)
 
@@ -2505,7 +2505,7 @@ func Test_UpdateClass_ObjectTTLConfig(t *testing.T) {
 				store.parser = handler.parser
 
 				fakeSchemaManager.On("AddClass", initial, mock.Anything).Return(nil)
-				fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+				fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 				fakeSchemaManager.On("ReadOnlyClass", initial.Class, mock.Anything).Return(initial)
 
 				handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
@@ -2791,7 +2791,7 @@ func Test_AddClass_MultiTenancy(t *testing.T) {
 		}
 
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 		c, _, err := handler.AddClass(ctx, nil, &class)
 		require.Nil(t, err)
@@ -2813,7 +2813,7 @@ func Test_AddClass_MultiTenancy(t *testing.T) {
 		}
 
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 		c, _, err := handler.AddClass(ctx, nil, &class)
 		require.Nil(t, err)
@@ -2831,7 +2831,7 @@ func Test_AddClass_MultiTenancy(t *testing.T) {
 		}
 
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NotNil(t, err)
@@ -2847,7 +2847,7 @@ func Test_AddClass_MultiTenancy(t *testing.T) {
 		}
 
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NotNil(t, err)

--- a/usecases/schema/fakes_test.go
+++ b/usecases/schema/fakes_test.go
@@ -143,8 +143,8 @@ func (f *fakeSchemaManager) QuerySchema() (models.Schema, error) {
 	return args.Get(0).(models.Schema), args.Error(1)
 }
 
-func (f *fakeSchemaManager) QueryCollectionsCount() (int, error) {
-	args := f.Called()
+func (f *fakeSchemaManager) QueryCollectionsCount(namespace string) (int, error) {
+	args := f.Called(namespace)
 	return args.Get(0).(int), args.Error(1)
 }
 

--- a/usecases/schema/handler.go
+++ b/usecases/schema/handler.go
@@ -68,7 +68,10 @@ type SchemaManager interface {
 	QueryReadOnlyClasses(names ...string) (map[string]versioned.Class, error)
 	QuerySchema() (models.Schema, error)
 	QueryTenants(class string, tenants []string) ([]*models.Tenant, uint64, error)
-	QueryCollectionsCount() (int, error)
+	// QueryCollectionsCount returns a leader-consistent count. Empty
+	// namespace returns the cluster-global total; a non-empty namespace
+	// restricts the count to classes in that namespace.
+	QueryCollectionsCount(namespace string) (int, error)
 	QueryShardOwner(class, shard string) (string, uint64, error)
 	QueryTenantsShards(class string, tenants ...string) (map[string]string, uint64, error)
 	QueryShardingState(class string) (*sharding.State, uint64, error)

--- a/usecases/schema/handler_test.go
+++ b/usecases/schema/handler_test.go
@@ -59,7 +59,7 @@ func testAddObjectClass(t *testing.T, handler *Handler, fakeSchemaManager *fakeS
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	assert.Nil(t, err)
 }
@@ -79,7 +79,7 @@ func testAddObjectClassExplicitVectorizer(t *testing.T, handler *Handler, fakeSc
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	assert.Nil(t, err)
 }
@@ -98,7 +98,7 @@ func testAddObjectClassImplicitVectorizer(t *testing.T, handler *Handler, fakeSc
 	}
 
 	fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	assert.Nil(t, err)
 }
@@ -154,7 +154,7 @@ func testRemoveObjectClass(t *testing.T, handler *Handler, fakeSchemaManager *fa
 	}
 
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	require.Nil(t, err)
 
@@ -180,7 +180,7 @@ func testCantAddSameClassTwice(t *testing.T, handler *Handler, fakeSchemaManager
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	assert.Nil(t, err)
 
@@ -197,7 +197,7 @@ func testCantAddSameClassTwice(t *testing.T, handler *Handler, fakeSchemaManager
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.ExpectedCalls = fakeSchemaManager.ExpectedCalls[:0]
-	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(ErrNotFound)
 
 	// Add it again
@@ -218,7 +218,7 @@ func testCantAddSameClassTwiceDifferentKinds(t *testing.T, handler *Handler, fak
 		},
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
-	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
 	_, _, err := handler.AddClass(ctx, nil, class)
 	assert.Nil(t, err)
@@ -293,7 +293,7 @@ func testAddPropertyDuringCreation(t *testing.T, handler *Handler, fakeSchemaMan
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
-	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	assert.Nil(t, err)
 }
@@ -323,7 +323,7 @@ func testAddPropertyWithTargetVectorConfig(t *testing.T, handler *Handler, fakeS
 		},
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
-	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	require.NoError(t, err)
@@ -377,7 +377,7 @@ func testDropProperty(t *testing.T, handler *Handler, fakeSchemaManager *fakeSch
 		Properties:        properties,
 		ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 	}
-	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 	fakeSchemaManager.On("AddClass", class, mock.Anything).Return(nil)
 	_, _, err := handler.AddClass(context.Background(), nil, class)
 	assert.Nil(t, err)

--- a/usecases/schema/namespace_create_test.go
+++ b/usecases/schema/namespace_create_test.go
@@ -228,76 +228,73 @@ func TestAddAlias(t *testing.T) {
 // TestAddClass_NamespacedCollectionLimit checks that the
 // MAXIMUM_ALLOWED_COLLECTIONS_COUNT cap is enforced per namespace when
 // namespaces are enabled, using principal.Namespace as the selector.
+//
+// The mock matcher on QueryCollectionsCount(<principalNS>) is what proves
+// the selector: a row only passes if AddClass requested the count for the
+// caller's namespace.
 func TestAddClass_NamespacedCollectionLimit(t *testing.T) {
 	t.Parallel()
 
-	t.Run("same namespace at cap rejects", func(t *testing.T) {
-		t.Parallel()
-		handler, sm := newTestHandlerWithNamespaces(t, true)
-		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(1)
+	tests := []struct {
+		name          string
+		principalNS   string
+		limit         int
+		existingCount int
+		wantErr       bool
+	}{
+		{
+			name:          "same namespace at cap rejects",
+			principalNS:   "customer1",
+			limit:         1,
+			existingCount: 1,
+			wantErr:       true,
+		},
+		{
+			name:          "under cap succeeds",
+			principalNS:   "customer1",
+			limit:         1,
+			existingCount: 0,
+			wantErr:       false,
+		},
+		{
+			name:          "different namespace under cap succeeds",
+			principalNS:   "customer2",
+			limit:         10,
+			existingCount: 0,
+			wantErr:       false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler, sm := newTestHandlerWithNamespaces(t, true)
+			handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(tt.limit)
 
-		// Caller is in customer1; the count must be requested for that
-		// namespace, and we return a value at the cap.
-		sm.On("QueryCollectionsCount", "customer1").Return(1, nil)
+			sm.On("QueryCollectionsCount", tt.principalNS).Return(tt.existingCount, nil)
+			if !tt.wantErr {
+				sm.On("AddClass", mock.MatchedBy(func(c *models.Class) bool {
+					return c.Class == tt.principalNS+":Movies"
+				}), mock.Anything).Return(nil)
+			}
 
-		class := &models.Class{
-			Class:             "Movies",
-			Vectorizer:        "model1",
-			VectorIndexConfig: map[string]interface{}{},
-			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
-		}
-		_, _, err := handler.AddClass(context.Background(), namespacedPrincipal("customer1"), class)
+			class := &models.Class{
+				Class:             "Movies",
+				Vectorizer:        "model1",
+				VectorIndexConfig: map[string]interface{}{},
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+			}
+			_, _, err := handler.AddClass(context.Background(), namespacedPrincipal(tt.principalNS), class)
 
-		require.Error(t, err)
-		le, ok := usagelimits.AsLimitExceeded(err)
-		require.True(t, ok, "expected *LimitExceededError, got %T: %v", err, err)
-		assert.Equal(t, usagelimits.LimitCollections, le.Limit)
-		assert.Equal(t, int64(1), le.Value)
-		sm.AssertExpectations(t)
-	})
-
-	t.Run("other namespace under cap succeeds", func(t *testing.T) {
-		t.Parallel()
-		handler, sm := newTestHandlerWithNamespaces(t, true)
-		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(1)
-
-		// Caller in customer1 gets back 0 — the count returned is scoped
-		// to customer1, regardless of what may exist in other namespaces.
-		sm.On("QueryCollectionsCount", "customer1").Return(0, nil)
-		sm.On("AddClass", mock.MatchedBy(func(c *models.Class) bool {
-			return c.Class == "customer1:Movies"
-		}), mock.Anything).Return(nil)
-
-		class := &models.Class{
-			Class:             "Movies",
-			Vectorizer:        "model1",
-			VectorIndexConfig: map[string]interface{}{},
-			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
-		}
-		_, _, err := handler.AddClass(context.Background(), namespacedPrincipal("customer1"), class)
-		require.NoError(t, err)
-		sm.AssertExpectations(t)
-	})
-
-	t.Run("selector comes from principal namespace", func(t *testing.T) {
-		t.Parallel()
-		handler, sm := newTestHandlerWithNamespaces(t, true)
-		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(10)
-
-		// The matcher requires exactly the principal namespace string.
-		sm.On("QueryCollectionsCount", "customer2").Return(0, nil)
-		sm.On("AddClass", mock.MatchedBy(func(c *models.Class) bool {
-			return c.Class == "customer2:Movies"
-		}), mock.Anything).Return(nil)
-
-		class := &models.Class{
-			Class:             "Movies",
-			Vectorizer:        "model1",
-			VectorIndexConfig: map[string]interface{}{},
-			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
-		}
-		_, _, err := handler.AddClass(context.Background(), namespacedPrincipal("customer2"), class)
-		require.NoError(t, err)
-		sm.AssertExpectations(t)
-	})
+			if tt.wantErr {
+				require.Error(t, err)
+				le, ok := usagelimits.AsLimitExceeded(err)
+				require.True(t, ok, "expected *LimitExceededError, got %T: %v", err, err)
+				assert.Equal(t, usagelimits.LimitCollections, le.Limit)
+				assert.Equal(t, int64(tt.limit), le.Value)
+			} else {
+				require.NoError(t, err)
+			}
+			sm.AssertExpectations(t)
+		})
+	}
 }

--- a/usecases/schema/namespace_create_test.go
+++ b/usecases/schema/namespace_create_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/config/runtime"
 	"github.com/weaviate/weaviate/usecases/fakes"
+	"github.com/weaviate/weaviate/usecases/usagelimits"
 )
 
 // newTestHandlerWithNamespaces returns a Handler that has the cluster-wide
@@ -133,7 +134,7 @@ func TestAddClass(t *testing.T) {
 				sm.On("AddClass", mock.MatchedBy(func(c *models.Class) bool {
 					return c.Class == tt.wantClass
 				}), mock.Anything).Return(nil)
-				sm.On("QueryCollectionsCount").Return(0, nil)
+				sm.On("QueryCollectionsCount", mock.Anything).Return(0, nil)
 			}
 
 			got, _, err := handler.AddClass(context.Background(), tt.principal, class)
@@ -222,4 +223,81 @@ func TestAddAlias(t *testing.T) {
 			require.Equal(t, tt.wantClass, got.Class)
 		})
 	}
+}
+
+// TestAddClass_NamespacedCollectionLimit checks that the
+// MAXIMUM_ALLOWED_COLLECTIONS_COUNT cap is enforced per namespace when
+// namespaces are enabled, using principal.Namespace as the selector.
+func TestAddClass_NamespacedCollectionLimit(t *testing.T) {
+	t.Parallel()
+
+	t.Run("same namespace at cap rejects", func(t *testing.T) {
+		t.Parallel()
+		handler, sm := newTestHandlerWithNamespaces(t, true)
+		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(1)
+
+		// Caller is in customer1; the count must be requested for that
+		// namespace, and we return a value at the cap.
+		sm.On("QueryCollectionsCount", "customer1").Return(1, nil)
+
+		class := &models.Class{
+			Class:             "Movies",
+			Vectorizer:        "model1",
+			VectorIndexConfig: map[string]interface{}{},
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+		}
+		_, _, err := handler.AddClass(context.Background(), namespacedPrincipal("customer1"), class)
+
+		require.Error(t, err)
+		le, ok := usagelimits.AsLimitExceeded(err)
+		require.True(t, ok, "expected *LimitExceededError, got %T: %v", err, err)
+		assert.Equal(t, usagelimits.LimitCollections, le.Limit)
+		assert.Equal(t, int64(1), le.Value)
+		sm.AssertExpectations(t)
+	})
+
+	t.Run("other namespace under cap succeeds", func(t *testing.T) {
+		t.Parallel()
+		handler, sm := newTestHandlerWithNamespaces(t, true)
+		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(1)
+
+		// Caller in customer1 gets back 0 — the count returned is scoped
+		// to customer1, regardless of what may exist in other namespaces.
+		sm.On("QueryCollectionsCount", "customer1").Return(0, nil)
+		sm.On("AddClass", mock.MatchedBy(func(c *models.Class) bool {
+			return c.Class == "customer1:Movies"
+		}), mock.Anything).Return(nil)
+
+		class := &models.Class{
+			Class:             "Movies",
+			Vectorizer:        "model1",
+			VectorIndexConfig: map[string]interface{}{},
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+		}
+		_, _, err := handler.AddClass(context.Background(), namespacedPrincipal("customer1"), class)
+		require.NoError(t, err)
+		sm.AssertExpectations(t)
+	})
+
+	t.Run("selector comes from principal namespace", func(t *testing.T) {
+		t.Parallel()
+		handler, sm := newTestHandlerWithNamespaces(t, true)
+		handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(10)
+
+		// The matcher requires exactly the principal namespace string.
+		sm.On("QueryCollectionsCount", "customer2").Return(0, nil)
+		sm.On("AddClass", mock.MatchedBy(func(c *models.Class) bool {
+			return c.Class == "customer2:Movies"
+		}), mock.Anything).Return(nil)
+
+		class := &models.Class{
+			Class:             "Movies",
+			Vectorizer:        "model1",
+			VectorIndexConfig: map[string]interface{}{},
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+		}
+		_, _, err := handler.AddClass(context.Background(), namespacedPrincipal("customer2"), class)
+		require.NoError(t, err)
+		sm.AssertExpectations(t)
+	})
 }

--- a/usecases/schema/property_test.go
+++ b/usecases/schema/property_test.go
@@ -39,7 +39,7 @@ func TestHandler_AddProperty(t *testing.T) {
 			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NoError(t, err)
@@ -98,7 +98,7 @@ func TestHandler_AddProperty(t *testing.T) {
 			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NoError(t, err)
@@ -142,7 +142,7 @@ func TestHandler_AddProperty_Object(t *testing.T) {
 			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
 		}
 		fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil)
-		fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil)
+		fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil)
 		fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 		_, _, err := handler.AddClass(ctx, nil, &class)
 		require.NoError(t, err)
@@ -419,7 +419,7 @@ func TestHandler_AddProperty_Reference_Tokenization(t *testing.T) {
 	}
 	fakeSchemaManager.On("ReadOnlyClass", refClass.Class).Return(&refClass)
 	fakeSchemaManager.On("AddClass", mock.Anything, mock.Anything).Return(nil).Twice()
-	fakeSchemaManager.On("QueryCollectionsCount").Return(0, nil).Twice()
+	fakeSchemaManager.On("QueryCollectionsCount", "").Return(0, nil).Twice()
 	fakeSchemaManager.On("ReadOnlyClass", class.Class).Return(&class)
 	_, _, err := handler.AddClass(ctx, nil, &class)
 	require.NoError(t, err)

--- a/usecases/schema/usage_limits_shards_test.go
+++ b/usecases/schema/usage_limits_shards_test.go
@@ -51,7 +51,7 @@ func TestAddClass_WithShardLimit(t *testing.T) {
 			handler.config.UsageLimits.MaxShardsPerCollection = runtime.NewDynamicValue(tt.shardCap)
 			handler.schemaConfig.MaximumAllowedCollectionsCount = runtime.NewDynamicValue(-1)
 
-			fakeMgr.On("QueryCollectionsCount").Return(0, nil).Maybe()
+			fakeMgr.On("QueryCollectionsCount", "").Return(0, nil).Maybe()
 			if !tt.expectExceed {
 				fakeMgr.On("AddClass", mock.Anything, mock.Anything).Return(nil)
 			}


### PR DESCRIPTION
### What's being changed:

With this change the number of collections are restricted per namespace if `MAXIMUM_ALLOWED_COLLECTIONS_COUNT` is set on a namesapced cluster. Nothing changes on non-namespaced clusters

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
