### PR TITLE
Namespaces: Wire up remaining alias endpoints

### DIFF
--- a/adapters/handlers/rest/handlers_aliases.go
+++ b/adapters/handlers/rest/handlers_aliases.go
@@ -130,7 +130,8 @@ func (s *aliasesHandlers) updateAlias(params schema.AliasesUpdateParams,
 }
 
 func (s *aliasesHandlers) deleteAlias(params schema.AliasesDeleteParams, principal *models.Principal) middleware.Responder {
-	err := s.manager.DeleteAlias(params.HTTPRequest.Context(), principal, params.AliasName)
+	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
+	err := s.manager.DeleteAlias(ctx, principal, params.AliasName)
 	if err != nil {
 		s.metricRequestsTotal.logError(params.AliasName, err)
 		if errors.Is(err, schemaUC.ErrNotFound) {
@@ -141,7 +142,7 @@ func (s *aliasesHandlers) deleteAlias(params schema.AliasesDeleteParams, princip
 			return schema.NewAliasesDeleteForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
 		default:
-			return schema.NewAliasesCreateUnprocessableEntity().WithPayload(errPayloadFromSingleErr(err))
+			return schema.NewAliasesDeleteUnprocessableEntity().WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
 

--- a/adapters/handlers/rest/handlers_aliases.go
+++ b/adapters/handlers/rest/handlers_aliases.go
@@ -47,8 +47,11 @@ func (s *aliasesHandlers) getAliases(params schema.AliasesGetParams,
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewAliasesGetForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
+		case errors.Is(err, schemaUC.ErrValidation):
+			return schema.NewAliasesGetUnprocessableEntity().
+				WithPayload(errPayloadFromSingleErr(err))
 		default:
-			return schema.NewAliasesGetForbidden().
+			return schema.NewAliasesGetInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
@@ -74,8 +77,11 @@ func (s *aliasesHandlers) getAlias(params schema.AliasesGetAliasParams,
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewAliasesGetAliasForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
+		case errors.Is(err, schemaUC.ErrValidation):
+			return schema.NewAliasesGetAliasUnprocessableEntity().
+				WithPayload(errPayloadFromSingleErr(err))
 		default:
-			return schema.NewAliasesGetAliasForbidden().
+			return schema.NewAliasesGetAliasInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}

--- a/adapters/handlers/rest/handlers_aliases.go
+++ b/adapters/handlers/rest/handlers_aliases.go
@@ -101,8 +101,11 @@ func (s *aliasesHandlers) addAlias(params schema.AliasesCreateParams,
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewAliasesCreateForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
-		default:
+		case errors.Is(err, schemaUC.ErrValidation):
 			return schema.NewAliasesCreateUnprocessableEntity().
+				WithPayload(errPayloadFromSingleErr(err))
+		default:
+			return schema.NewAliasesCreateInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
@@ -125,8 +128,11 @@ func (s *aliasesHandlers) updateAlias(params schema.AliasesUpdateParams,
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewAliasesUpdateForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
-		default:
+		case errors.Is(err, schemaUC.ErrValidation):
 			return schema.NewAliasesUpdateUnprocessableEntity().
+				WithPayload(errPayloadFromSingleErr(err))
+		default:
+			return schema.NewAliasesUpdateInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
@@ -147,8 +153,12 @@ func (s *aliasesHandlers) deleteAlias(params schema.AliasesDeleteParams, princip
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewAliasesDeleteForbidden().
 				WithPayload(errPayloadFromSingleErr(err))
+		case errors.Is(err, schemaUC.ErrValidation):
+			return schema.NewAliasesDeleteUnprocessableEntity().
+				WithPayload(errPayloadFromSingleErr(err))
 		default:
-			return schema.NewAliasesDeleteUnprocessableEntity().WithPayload(errPayloadFromSingleErr(err))
+			return schema.NewAliasesDeleteInternalServerError().
+				WithPayload(errPayloadFromSingleErr(err))
 		}
 	}
 

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -389,4 +389,120 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		got := helper.GetClassAuth(t, "customer1:CaseGet", adminKey)
 		require.Equal(t, "customer1:CaseGet", got.Class)
 	})
+
+	// Alias update/delete inherit the same namespace-aware qualification as
+	// AddAlias. The next four tests pin two contracts: (a) global operators
+	// supplying a malformed namespace prefix get a clean 422, not a NotFound
+	// or 500; (b) namespaced callers can address their own aliases by the
+	// short name, exactly mirroring the create path.
+	t.Run("global admin alias delete with wrong-case namespace prefix returns 422", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "AliasCaseDeleteTarget"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AliasCaseDeleteTarget", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasCaseDelete", Class: "AliasCaseDeleteTarget"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasCaseDelete", helper.CreateAuth(adminKey))
+
+		_, err := helper.DeleteAliasAuthWithReturn(t, "Customer1:AliasCaseDelete", adminKey)
+		require.Error(t, err)
+		var unproc *schema.AliasesDeleteUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected AliasesDeleteUnprocessableEntity, got %T: %v", err, err)
+		assert.Contains(t, unproc.Payload.Error[0].Message, "invalid namespace prefix")
+
+		// Alias survives the malformed-prefix attempt.
+		got := helper.GetAliasWithAuthz(t, "customer1:AliasCaseDelete", helper.CreateAuth(adminKey))
+		require.Equal(t, "customer1:AliasCaseDelete", got.Alias)
+	})
+
+	t.Run("global admin alias update with wrong-case namespace prefix returns 422", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "AliasCaseUpdateA"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AliasCaseUpdateA", adminKey)
+		helper.CreateClassAuth(t, &models.Class{Class: "AliasCaseUpdateB"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AliasCaseUpdateB", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasCaseUpdate", Class: "AliasCaseUpdateA"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasCaseUpdate", helper.CreateAuth(adminKey))
+
+		// Wrong case in the alias path component is rejected.
+		_, err := helper.UpdateAliasAuthWithReturn(t, "Customer1:AliasCaseUpdate", "customer1:AliasCaseUpdateB", adminKey)
+		require.Error(t, err)
+		var unproc *schema.AliasesUpdateUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected AliasesUpdateUnprocessableEntity, got %T: %v", err, err)
+		assert.Contains(t, unproc.Payload.Error[0].Message, "invalid namespace prefix")
+
+		// Wrong case in the target class is also rejected.
+		_, err = helper.UpdateAliasAuthWithReturn(t, "customer1:AliasCaseUpdate", "Customer1:AliasCaseUpdateB", adminKey)
+		require.Error(t, err)
+		require.True(t, errors.As(err, &unproc), "expected AliasesUpdateUnprocessableEntity, got %T: %v", err, err)
+		assert.Contains(t, unproc.Payload.Error[0].Message, "invalid namespace prefix")
+
+		// Alias still points at its original target.
+		got := helper.GetAliasWithAuthz(t, "customer1:AliasCaseUpdate", helper.CreateAuth(adminKey))
+		require.Equal(t, "customer1:AliasCaseUpdateA", got.Class)
+	})
+
+	t.Run("namespaced caller deletes its own alias via short name", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "AliasShortDeleteTarget"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AliasShortDeleteTarget", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasShortDelete", Class: "AliasShortDeleteTarget"}, user1Key)
+
+		// Short name path is qualified by the principal's namespace, so the
+		// underlying "customer1:AliasShortDelete" alias is found and removed.
+		_, err := helper.DeleteAliasAuthWithReturn(t, "AliasShortDelete", user1Key)
+		require.NoError(t, err)
+
+		// Lookup against the qualified name returns 404 after delete.
+		_, err = helper.Client(t).Schema.AliasesGetAlias(
+			schema.NewAliasesGetAliasParams().WithAliasName("customer1:AliasShortDelete"),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("namespaced caller updates its own alias via short name", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "AliasShortUpdateA"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AliasShortUpdateA", adminKey)
+		helper.CreateClassAuth(t, &models.Class{Class: "AliasShortUpdateB"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AliasShortUpdateB", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasShortUpdate", Class: "AliasShortUpdateA"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasShortUpdate", helper.CreateAuth(adminKey))
+
+		// Short names on both the alias and target are qualified with the
+		// caller's namespace; the alias re-points to the qualified target.
+		_, err := helper.UpdateAliasAuthWithReturn(t, "AliasShortUpdate", "AliasShortUpdateB", user1Key)
+		require.NoError(t, err)
+
+		got := helper.GetAliasWithAuthz(t, "customer1:AliasShortUpdate", helper.CreateAuth(adminKey))
+		require.Equal(t, "customer1:AliasShortUpdateB", got.Class)
+	})
+
+	// Global operators do not have a namespace, so qualification is a no-op
+	// for them — the qualified name in the URL is what reaches the schema
+	// lookup. These tests confirm that path works end-to-end.
+	t.Run("global admin deletes alias via qualified name", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "AdminAliasQualifiedDeleteTarget"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AdminAliasQualifiedDeleteTarget", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AdminAliasQualifiedDelete", Class: "AdminAliasQualifiedDeleteTarget"}, user1Key)
+
+		_, err := helper.DeleteAliasAuthWithReturn(t, "customer1:AdminAliasQualifiedDelete", adminKey)
+		require.NoError(t, err)
+
+		_, err = helper.Client(t).Schema.AliasesGetAlias(
+			schema.NewAliasesGetAliasParams().WithAliasName("customer1:AdminAliasQualifiedDelete"),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+	})
+
+	t.Run("global admin updates alias via qualified name", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "AdminAliasQualifiedUpdateA"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AdminAliasQualifiedUpdateA", adminKey)
+		helper.CreateClassAuth(t, &models.Class{Class: "AdminAliasQualifiedUpdateB"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AdminAliasQualifiedUpdateB", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AdminAliasQualifiedUpdate", Class: "AdminAliasQualifiedUpdateA"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:AdminAliasQualifiedUpdate", helper.CreateAuth(adminKey))
+
+		_, err := helper.UpdateAliasAuthWithReturn(t, "customer1:AdminAliasQualifiedUpdate", "customer1:AdminAliasQualifiedUpdateB", adminKey)
+		require.NoError(t, err)
+
+		got := helper.GetAliasWithAuthz(t, "customer1:AdminAliasQualifiedUpdate", helper.CreateAuth(adminKey))
+		require.Equal(t, "customer1:AdminAliasQualifiedUpdateB", got.Class)
+	})
 }

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -505,4 +505,131 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		got := helper.GetAliasWithAuthz(t, "customer1:AdminAliasQualifiedUpdate", helper.CreateAuth(adminKey))
 		require.Equal(t, "customer1:AdminAliasQualifiedUpdateB", got.Class)
 	})
+
+	// Read paths (GET /aliases/{name} and GET /aliases?class=) qualify in
+	// the same way the write paths do: namespaced callers reach their own
+	// aliases via short names, global operators by the qualified name, and
+	// malformed prefixes surface as 422.
+	t.Run("namespaced caller gets its own alias via short name", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "AliasShortGetTarget"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AliasShortGetTarget", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasShortGet", Class: "AliasShortGetTarget"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasShortGet", helper.CreateAuth(adminKey))
+
+		// Short name is qualified with the principal's namespace.
+		resp, err := helper.GetAliasAuthWithReturn(t, "AliasShortGet", user1Key)
+		require.NoError(t, err)
+		require.Equal(t, "customer1:AliasShortGet", resp.Payload.Alias)
+		require.Equal(t, "customer1:AliasShortGetTarget", resp.Payload.Class)
+	})
+
+	t.Run("global admin alias get with wrong-case namespace prefix returns 422", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "AliasCaseGetTarget"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AliasCaseGetTarget", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasCaseGet", Class: "AliasCaseGetTarget"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasCaseGet", helper.CreateAuth(adminKey))
+
+		_, err := helper.GetAliasAuthWithReturn(t, "Customer1:AliasCaseGet", adminKey)
+		require.Error(t, err)
+		var unproc *schema.AliasesGetAliasUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected AliasesGetAliasUnprocessableEntity, got %T: %v", err, err)
+		assert.Contains(t, unproc.Payload.Error[0].Message, "invalid namespace prefix")
+
+		// Correct casing still resolves.
+		got := helper.GetAliasWithAuthz(t, "customer1:AliasCaseGet", helper.CreateAuth(adminKey))
+		require.Equal(t, "customer1:AliasCaseGet", got.Alias)
+	})
+
+	t.Run("namespaced caller submitting qualified alias name to GET is rejected", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "AliasQualifiedGetTarget"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AliasQualifiedGetTarget", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasQualifiedGet", Class: "AliasQualifiedGetTarget"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasQualifiedGet", helper.CreateAuth(adminKey))
+
+		// Namespaced principals are not allowed to type a "<ns>:" prefix —
+		// the resolver adds their namespace automatically. Generic 422.
+		_, err := helper.GetAliasAuthWithReturn(t, "customer1:AliasQualifiedGet", user1Key)
+		require.Error(t, err)
+		var unproc *schema.AliasesGetAliasUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected AliasesGetAliasUnprocessableEntity, got %T: %v", err, err)
+		assert.Contains(t, unproc.Payload.Error[0].Message, "is not a valid class name")
+	})
+
+	t.Run("namespaced caller lists aliases filtered by short class name", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "AliasListByClass"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AliasListByClass", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasListByClassA", Class: "AliasListByClass"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasListByClassA", helper.CreateAuth(adminKey))
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasListByClassB", Class: "AliasListByClass"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasListByClassB", helper.CreateAuth(adminKey))
+
+		// Short class filter must be qualified to customer1:AliasListByClass.
+		class := "AliasListByClass"
+		resp, err := helper.GetAliasesAuthWithReturn(t, &class, user1Key)
+		require.NoError(t, err)
+		require.Len(t, resp.Payload.Aliases, 2)
+		gotAliases := map[string]string{}
+		for _, a := range resp.Payload.Aliases {
+			gotAliases[a.Alias] = a.Class
+		}
+		assert.Equal(t, "customer1:AliasListByClass", gotAliases["customer1:AliasListByClassA"])
+		assert.Equal(t, "customer1:AliasListByClass", gotAliases["customer1:AliasListByClassB"])
+	})
+
+	t.Run("global admin alias list with wrong-case class filter returns 422", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "AliasListCaseTarget"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AliasListCaseTarget", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasListCase", Class: "AliasListCaseTarget"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasListCase", helper.CreateAuth(adminKey))
+
+		class := "Customer1:AliasListCaseTarget"
+		_, err := helper.GetAliasesAuthWithReturn(t, &class, adminKey)
+		require.Error(t, err)
+		var unproc *schema.AliasesGetUnprocessableEntity
+		require.True(t, errors.As(err, &unproc), "expected AliasesGetUnprocessableEntity, got %T: %v", err, err)
+		assert.Contains(t, unproc.Payload.Error[0].Message, "invalid namespace prefix")
+	})
+
+	t.Run("alias list is namespace-isolated when both namespaces share a short alias name", func(t *testing.T) {
+		for _, key := range []string{user1Key, user2Key} {
+			helper.CreateClassAuth(t, &models.Class{Class: "AliasListIsoTarget"}, key)
+			helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasListIso", Class: "AliasListIsoTarget"}, key)
+		}
+		defer helper.DeleteClassAuth(t, "customer1:AliasListIsoTarget", adminKey)
+		defer helper.DeleteClassAuth(t, "customer2:AliasListIsoTarget", adminKey)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasListIso", helper.CreateAuth(adminKey))
+		defer helper.DeleteAliasWithAuthz(t, "customer2:AliasListIso", helper.CreateAuth(adminKey))
+
+		// user1 lists without a class filter and only sees their namespace's
+		// alias. The schema layer is namespace-agnostic, so this exercises
+		// the usecase-level namespace filter (RBAC is off in this suite).
+		resp, err := helper.GetAliasesAuthWithReturn(t, nil, user1Key)
+		require.NoError(t, err)
+		seen := map[string]bool{}
+		for _, a := range resp.Payload.Aliases {
+			seen[a.Alias] = true
+		}
+		assert.True(t, seen["customer1:AliasListIso"], "user1 should see its own alias")
+		assert.False(t, seen["customer2:AliasListIso"], "user1 should not see customer2's alias")
+	})
+
+	t.Run("global admin lists aliases across namespaces", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "AdminListA"}, user1Key)
+		defer helper.DeleteClassAuth(t, "customer1:AdminListA", adminKey)
+		helper.CreateClassAuth(t, &models.Class{Class: "AdminListB"}, user2Key)
+		defer helper.DeleteClassAuth(t, "customer2:AdminListB", adminKey)
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AdminListAlphaA", Class: "AdminListA"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer1:AdminListAlphaA", helper.CreateAuth(adminKey))
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "AdminListAlphaB", Class: "AdminListB"}, user2Key)
+		defer helper.DeleteAliasWithAuthz(t, "customer2:AdminListAlphaB", helper.CreateAuth(adminKey))
+
+		resp, err := helper.GetAliasesAuthWithReturn(t, nil, adminKey)
+		require.NoError(t, err)
+		seen := map[string]bool{}
+		for _, a := range resp.Payload.Aliases {
+			seen[a.Alias] = true
+		}
+		assert.True(t, seen["customer1:AdminListAlphaA"], "admin should see customer1's alias")
+		assert.True(t, seen["customer2:AdminListAlphaB"], "admin should see customer2's alias")
+	})
 }

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -808,6 +808,15 @@ func UpdateAliasWithAuthz(t *testing.T, aliasName, targetClassName string, authI
 	AssertRequestOk(t, resp, err, nil)
 }
 
+// UpdateAliasAuthWithReturn issues an authenticated alias-update and
+// returns the raw response/error so the caller can assert on rejection
+// paths (e.g. malformed namespace prefix).
+func UpdateAliasAuthWithReturn(t *testing.T, aliasName, targetClassName, key string) (*schema.AliasesUpdateOK, error) {
+	t.Helper()
+	params := schema.NewAliasesUpdateParams().WithAliasName(aliasName).WithBody(schema.AliasesUpdateBody{Class: targetClassName})
+	return Client(t).Schema.AliasesUpdate(params, CreateAuth(key))
+}
+
 func DeleteAlias(t *testing.T, aliasName string) {
 	DeleteAliasWithAuthz(t, aliasName, nil)
 }
@@ -817,6 +826,15 @@ func DeleteAliasWithReturn(t *testing.T, aliasName string) (*schema.AliasesDelet
 	params := schema.NewAliasesDeleteParams().WithAliasName(aliasName)
 	resp, err := Client(t).Schema.AliasesDelete(params, nil)
 	return resp, err
+}
+
+// DeleteAliasAuthWithReturn issues an authenticated alias-delete and
+// returns the raw response/error so the caller can assert on rejection
+// paths (e.g. malformed namespace prefix).
+func DeleteAliasAuthWithReturn(t *testing.T, aliasName, key string) (*schema.AliasesDeleteNoContent, error) {
+	t.Helper()
+	params := schema.NewAliasesDeleteParams().WithAliasName(aliasName)
+	return Client(t).Schema.AliasesDelete(params, CreateAuth(key))
 }
 
 func DeleteAliasWithAuthz(t *testing.T, aliasName string, authInfo runtime.ClientAuthInfoWriter) {

--- a/test/helper/objects.go
+++ b/test/helper/objects.go
@@ -790,6 +790,24 @@ func GetAliasWithAuthzNotFound(t *testing.T, aliasName string, authInfo runtime.
 	return nil
 }
 
+// GetAliasAuthWithReturn issues an authenticated alias-get and returns
+// the raw response/error so the caller can assert on rejection paths
+// (e.g. malformed namespace prefix).
+func GetAliasAuthWithReturn(t *testing.T, aliasName, key string) (*schema.AliasesGetAliasOK, error) {
+	t.Helper()
+	params := schema.NewAliasesGetAliasParams().WithAliasName(aliasName)
+	return Client(t).Schema.AliasesGetAlias(params, CreateAuth(key))
+}
+
+// GetAliasesAuthWithReturn issues an authenticated alias-list and returns
+// the raw response/error so the caller can assert on rejection paths
+// (e.g. malformed namespace prefix on the class filter).
+func GetAliasesAuthWithReturn(t *testing.T, className *string, key string) (*schema.AliasesGetOK, error) {
+	t.Helper()
+	params := schema.NewAliasesGetParams().WithClass(className)
+	return Client(t).Schema.AliasesGet(params, CreateAuth(key))
+}
+
 func UpdateAlias(t *testing.T, aliasName, targetClassName string) {
 	UpdateAliasWithAuthz(t, aliasName, targetClassName, nil)
 }

--- a/usecases/schema/alias.go
+++ b/usecases/schema/alias.go
@@ -89,11 +89,11 @@ func (h *Handler) AddAlias(ctx context.Context, principal *models.Principal,
 		return nil, 0, authzerrors.NewNamespaceForbidden(principal)
 	}
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("%w: %w", ErrValidation, err)
 	}
 	qTarget, err := namespacing.QualifyForCreate(principal, h.config.Namespaces.Enabled, alias.Class, "class")
 	if err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("%w: %w", ErrValidation, err)
 	}
 	alias.Alias = qAlias
 	alias.Class = qTarget
@@ -104,15 +104,20 @@ func (h *Handler) AddAlias(ctx context.Context, principal *models.Principal,
 
 	// alias should have same validation as collection.
 	if _, err := schema.ValidateAliasName(originalAliasName); err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("%w: %w", ErrValidation, err)
 	}
 	if _, err := schema.ValidateClassName(originalTargetName); err != nil {
-		return nil, 0, err
+		return nil, 0, fmt.Errorf("%w: %w", ErrValidation, err)
 	}
 
 	class := h.schemaReader.ReadOnlyClass(alias.Class)
 	version, err := h.schemaManager.CreateAlias(ctx, alias.Alias, class)
 	if err != nil {
+		if errors.Is(err, cschema.ErrBadRequest) ||
+			errors.Is(err, cschema.ErrAliasExists) ||
+			errors.Is(err, cschema.ErrClassNotFound) {
+			return nil, 0, fmt.Errorf("%w: %w", ErrValidation, err)
+		}
 		return nil, 0, err
 	}
 	return &models.Alias{Alias: alias.Alias, Class: class.Class}, version, nil

--- a/usecases/schema/alias.go
+++ b/usecases/schema/alias.go
@@ -27,9 +27,14 @@ import (
 
 func (h *Handler) GetAliases(ctx context.Context, principal *models.Principal, alias, className string) ([]*models.Alias, error) {
 	var class *models.Class
+	var qClass string
 	if className != "" {
-		name := schema.UppercaseClassName(className)
-		class = h.schemaReader.ReadOnlyClass(name)
+		var err error
+		qClass, err = namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, className)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrValidation, err)
+		}
+		class = h.schemaReader.ReadOnlyClass(qClass)
 		if class == nil {
 			// Optional class Filter not found. So return empty aliases list
 			return []*models.Alias{}, nil
@@ -40,6 +45,19 @@ func (h *Handler) GetAliases(ctx context.Context, principal *models.Principal, a
 		return nil, err
 	}
 
+	// Namespaced principals see only aliases in their own namespace. The
+	// schema layer is namespace-agnostic, and on NS-enabled clusters with
+	// RBAC off this is the only thing keeping the list scoped.
+	if principal != nil && principal.Namespace != "" {
+		filtered := aliases[:0]
+		for _, a := range aliases {
+			if namespacing.NamespaceFromQualified(a.Alias) == principal.Namespace {
+				filtered = append(filtered, a)
+			}
+		}
+		aliases = filtered
+	}
+
 	filteredAliases := filter.New[*models.Alias](h.Authorizer, h.config.Authorization.Rbac).Filter(
 		ctx,
 		h.logger,
@@ -47,7 +65,7 @@ func (h *Handler) GetAliases(ctx context.Context, principal *models.Principal, a
 		aliases,
 		authorization.READ,
 		func(alias *models.Alias) string {
-			class := className
+			class := qClass
 			if class == "" {
 				class = alias.Class
 			}
@@ -60,6 +78,12 @@ func (h *Handler) GetAliases(ctx context.Context, principal *models.Principal, a
 
 func (h *Handler) GetAlias(ctx context.Context, principal *models.Principal, alias string) (*models.Alias, error) {
 	alias = schema.UppercaseClassName(alias)
+	qAlias, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, alias)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrValidation, err)
+	}
+	alias = qAlias
+
 	a, err := h.schemaManager.GetAlias(ctx, alias)
 	if err != nil {
 		if errors.Is(err, cschema.ErrAliasNotFound) {

--- a/usecases/schema/alias.go
+++ b/usecases/schema/alias.go
@@ -135,6 +135,9 @@ func (h *Handler) AddAlias(ctx context.Context, principal *models.Principal,
 	}
 
 	class := h.schemaReader.ReadOnlyClass(alias.Class)
+	if class == nil {
+		return nil, 0, fmt.Errorf("%w: target class %q does not exist", ErrValidation, alias.Class)
+	}
 	version, err := h.schemaManager.CreateAlias(ctx, alias.Alias, class)
 	if err != nil {
 		if errors.Is(err, cschema.ErrBadRequest) ||
@@ -177,9 +180,17 @@ func (h *Handler) UpdateAlias(ctx context.Context, principal *models.Principal,
 
 	alias := aliases[0]
 	targetClass := h.schemaReader.ReadOnlyClass(targetClassName)
+	if targetClass == nil {
+		return nil, fmt.Errorf("%w: target class %q does not exist", ErrValidation, targetClassName)
+	}
 
 	_, err = h.schemaManager.ReplaceAlias(ctx, alias, targetClass)
 	if err != nil {
+		if errors.Is(err, cschema.ErrBadRequest) ||
+			errors.Is(err, cschema.ErrClassNotFound) ||
+			errors.Is(err, cschema.ErrAliasNotFound) {
+			return nil, fmt.Errorf("%w: %w", ErrValidation, err)
+		}
 		return nil, err
 	}
 
@@ -207,6 +218,12 @@ func (h *Handler) DeleteAlias(ctx context.Context, principal *models.Principal, 
 	}
 
 	if _, err := h.schemaManager.DeleteAlias(ctx, aliasName); err != nil {
+		if errors.Is(err, cschema.ErrAliasNotFound) {
+			return fmt.Errorf("alias %s not found: %w", aliasName, ErrNotFound)
+		}
+		if errors.Is(err, cschema.ErrBadRequest) {
+			return fmt.Errorf("%w: %w", ErrValidation, err)
+		}
 		return err
 	}
 	return nil

--- a/usecases/schema/alias.go
+++ b/usecases/schema/alias.go
@@ -123,8 +123,18 @@ func (h *Handler) UpdateAlias(ctx context.Context, principal *models.Principal,
 ) (*models.Alias, error) {
 	targetClassName = schema.UppercaseClassName(targetClassName)
 	aliasName = schema.UppercaseClassName(aliasName)
-	err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Aliases(targetClassName, aliasName)...)
+	qAlias, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, aliasName)
 	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrValidation, err)
+	}
+	qTarget, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, targetClassName)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrValidation, err)
+	}
+	aliasName = qAlias
+	targetClassName = qTarget
+
+	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Aliases(targetClassName, aliasName)...); err != nil {
 		return nil, err
 	}
 	aliases, err := h.schemaManager.GetAliases(ctx, aliasName, nil)
@@ -149,6 +159,11 @@ func (h *Handler) UpdateAlias(ctx context.Context, principal *models.Principal,
 
 func (h *Handler) DeleteAlias(ctx context.Context, principal *models.Principal, aliasName string) error {
 	aliasName = schema.UppercaseClassName(aliasName)
+	qAlias, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, aliasName)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrValidation, err)
+	}
+	aliasName = qAlias
 
 	a, err := h.schemaManager.GetAlias(ctx, aliasName)
 	if err != nil {
@@ -158,12 +173,11 @@ func (h *Handler) DeleteAlias(ctx context.Context, principal *models.Principal, 
 		return err
 	}
 
-	err = h.Authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Aliases(a.Class, a.Alias)...)
-	if err != nil {
+	if err := h.Authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Aliases(a.Class, a.Alias)...); err != nil {
 		return err
 	}
 
-	if _, err = h.schemaManager.DeleteAlias(ctx, aliasName); err != nil {
+	if _, err := h.schemaManager.DeleteAlias(ctx, aliasName); err != nil {
 		return err
 	}
 	return nil


### PR DESCRIPTION
### What's being changed:

This PR adds namespace support for update/delete/get alias and adds test for all of them.

It also fixes wrong return codes that I noticed while doing these changes. Eg the default return code was forbidden which makes no sense

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
