### PR TITLE
Namespace: Fix getting roles for namespace users

### DIFF
--- a/test/acceptance/authz/namespaces_oidc_test.go
+++ b/test/acceptance/authz/namespaces_oidc_test.go
@@ -341,4 +341,30 @@ func TestNamespacesOIDC(t *testing.T) {
 		stored := helper.GetClassAuth(t, "customer1:Albums", adminKey)
 		assert.Equal(t, "customer1:Albums", stored.Class)
 	})
+
+	// Regression: GET /v1/authz/roles/{name}/users used to 500 once any
+	// namespaced principal was assigned to the role, because the internal
+	// casbin key for a namespaced DB user has three `:`-segments
+	// (`db:<namespace>:<username>`) and the prefix parser rejected it.
+	t.Run("GET roles/{name}/users lists namespaced DB users", func(t *testing.T) {
+		const shortSubject = "roles-endpoint-user"
+		const qualifiedID = "customer1:" + shortSubject
+
+		_ = helper.CreateUserWithNamespace(t, shortSubject, "customer1", adminKey)
+		defer helper.DeleteUser(t, qualifiedID, adminKey)
+
+		helper.AssignRoleToUser(t, adminKey, authorization.Admin, qualifiedID)
+		defer helper.RevokeRoleFromUser(t, adminKey, authorization.Admin, qualifiedID)
+
+		users := helper.GetUserForRolesBoth(t, authorization.Admin, adminKey)
+
+		var found bool
+		for _, u := range users {
+			if u.UserType != nil && *u.UserType == models.UserTypeOutputDbUser && u.UserID == qualifiedID {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "namespaced DB user %q must appear in GET roles/{name}/users; got %+v", qualifiedID, users)
+	})
 }

--- a/usecases/auth/authorization/conv/casbin_types.go
+++ b/usecases/auth/authorization/conv/casbin_types.go
@@ -581,10 +581,16 @@ func TrimRoleNamePrefix(name string) string {
 	return strings.TrimPrefix(name, ROLE_NAME_PREFIX)
 }
 
+// GetUserAndPrefix splits an internal casbin user key into the user
+// identifier and its prefix and returns them as (user, prefix). The key is
+// `<prefix>:<user>` where prefix is "db", "oidc", or "group" and `<user>`
+// is itself either a bare name or a namespace-qualified `<namespace>:<name>`.
+// Splitting on the first ":" only is what keeps namespaced principals (e.g.
+// `oidc:customer1:alice`) from being mistaken for malformed input.
 func GetUserAndPrefix(name string) (string, string, error) {
-	splits := strings.Split(name, PREFIX_SEPARATOR)
-	if len(splits) != 2 {
+	prefix, user, ok := strings.Cut(name, PREFIX_SEPARATOR)
+	if !ok || prefix == "" || user == "" {
 		return "", "", fmt.Errorf("invalid name: %s", name)
 	}
-	return splits[1], splits[0], nil
+	return user, prefix, nil
 }

--- a/usecases/auth/authorization/conv/casbin_types_test.go
+++ b/usecases/auth/authorization/conv/casbin_types_test.go
@@ -1178,3 +1178,66 @@ func TestValidVerb(t *testing.T) {
 		})
 	}
 }
+
+// TestGetUserAndPrefix locks in that the auth-type prefix is taken from the
+// first ":" and the remainder is returned as-is. Namespaced users
+// (`<authtype>:<namespace>:<username>`) must not be rejected as malformed —
+// that regression made GET /v1/authz/roles/{name}/users return 500 once any
+// namespaced principal was assigned to a role.
+func TestGetUserAndPrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		input      string
+		wantUser   string
+		wantPrefix string
+		wantErr    bool
+	}{
+		{
+			name:       "bare oidc user",
+			input:      "oidc:alice",
+			wantUser:   "alice",
+			wantPrefix: "oidc",
+		},
+		{
+			name:       "bare db user",
+			input:      "db:alice",
+			wantUser:   "alice",
+			wantPrefix: "db",
+		},
+		{
+			name:       "namespaced oidc user",
+			input:      "oidc:customer1:customer1user",
+			wantUser:   "customer1:customer1user",
+			wantPrefix: "oidc",
+		},
+		{
+			name:       "namespaced db user",
+			input:      "db:customer1:alice",
+			wantUser:   "customer1:alice",
+			wantPrefix: "db",
+		},
+		{
+			name:       "group prefix",
+			input:      "group:engineering",
+			wantUser:   "engineering",
+			wantPrefix: "group",
+		},
+		{name: "missing separator", input: "alice", wantErr: true},
+		{name: "empty", input: "", wantErr: true},
+		{name: "empty prefix", input: ":alice", wantErr: true},
+		{name: "empty user", input: "oidc:", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			user, prefix, err := GetUserAndPrefix(tt.input)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tt.wantUser, user)
+			require.Equal(t, tt.wantPrefix, prefix)
+		})
+	}
+}


### PR DESCRIPTION
### What's being changed:

GetUsersForRole did not work with namespaced users

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
