### PR TITLE
Namespace deprecate incompatible endpoints

### DIFF
--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1133,7 +1133,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		appState.Modules, appState.Metrics)
 	setupObjectBatchHandlers(api, appState.BatchManager, appState.Metrics, appState.Logger)
 	setupGraphQLHandlers(api, appState, appState.SchemaManager, appState.ServerConfig.Config.DisableGraphQL,
-		appState.Metrics, appState.Logger)
+		appState.ServerConfig.Config.Namespaces.Enabled, appState.Metrics, appState.Logger)
 	setupMiscHandlers(api, appState.ServerConfig, appState.Modules,
 		appState.Metrics, appState.Logger)
 	setupClassificationHandlers(api, classifier, appState.Metrics, appState.Logger)

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1136,7 +1136,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 		appState.ServerConfig.Config.Namespaces.Enabled, appState.Metrics, appState.Logger)
 	setupMiscHandlers(api, appState.ServerConfig, appState.Modules,
 		appState.Metrics, appState.Logger)
-	setupClassificationHandlers(api, classifier, appState.Metrics, appState.Logger)
+	setupClassificationHandlers(api, classifier, appState.ServerConfig.Config.Namespaces.Enabled, appState.Metrics, appState.Logger)
 	backupScheduler := startBackupScheduler(appState)
 	setupBackupHandlers(api, backupScheduler, appState.Metrics, appState.Logger)
 	exportScheduler := startExportScheduler(appState)

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -2671,6 +2671,12 @@ func init() {
               "$ref": "#/definitions/ErrorResponse"
             }
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request.",
             "schema": {
@@ -2725,6 +2731,12 @@ func init() {
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -13063,6 +13075,12 @@ func init() {
               "$ref": "#/definitions/ErrorResponse"
             }
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request.",
             "schema": {
@@ -13117,6 +13135,12 @@ func init() {
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -3215,6 +3215,12 @@ func init() {
           "404": {
             "description": "Successful query result but no matching objects were found."
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request. Ensure the specified collection exists.",
             "schema": {
@@ -13635,6 +13641,12 @@ func init() {
           },
           "404": {
             "description": "Successful query result but no matching objects were found."
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           },
           "422": {
             "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request. Ensure the specified collection exists.",

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4054,6 +4054,12 @@ func init() {
           "404": {
             "description": "Object not found."
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "An error occurred while trying to fulfill the request. Check the ErrorResponse for details.",
             "schema": {
@@ -14546,6 +14552,12 @@ func init() {
           },
           "404": {
             "description": "Object not found."
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           },
           "500": {
             "description": "An error occurred while trying to fulfill the request. Check the ErrorResponse for details.",

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -2340,6 +2340,12 @@ func init() {
               "$ref": "#/definitions/ErrorResponse"
             }
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "An internal server error occurred while starting the classification task. Check the ErrorResponse for details.",
             "schema": {
@@ -2387,6 +2393,12 @@ func init() {
           },
           "404": {
             "description": "Classification with the given ID not found."
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           },
           "500": {
             "description": "An internal server error occurred while retrieving the classification status. Check the ErrorResponse for details.",
@@ -12792,6 +12804,12 @@ func init() {
               "$ref": "#/definitions/ErrorResponse"
             }
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "An internal server error occurred while starting the classification task. Check the ErrorResponse for details.",
             "schema": {
@@ -12839,6 +12857,12 @@ func init() {
           },
           "404": {
             "description": "Classification with the given ID not found."
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           },
           "500": {
             "description": "An internal server error occurred while retrieving the classification status. Check the ErrorResponse for details.",

--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -4122,6 +4122,12 @@ func init() {
           "404": {
             "description": "Object not found."
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request. Ensure the collection exists and the object properties are valid.",
             "schema": {
@@ -4181,6 +4187,12 @@ func init() {
           "404": {
             "description": "Object not found."
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "An error occurred while trying to fulfill the request. Check the ErrorResponse for details.",
             "schema": {
@@ -4227,6 +4239,12 @@ func init() {
           },
           "404": {
             "description": "Object does not exist."
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           },
           "500": {
             "description": "An error occurred while trying to fulfill the request. Check the ErrorResponse for details.",
@@ -4288,6 +4306,12 @@ func init() {
           },
           "404": {
             "description": "Object not found."
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           },
           "422": {
             "description": "The patch object is valid JSON but is unprocessable for other reasons (e.g., invalid schema).",
@@ -4360,6 +4384,12 @@ func init() {
               "$ref": "#/definitions/ErrorResponse"
             }
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request. Ensure the property exists and is a reference type.",
             "schema": {
@@ -4425,6 +4455,12 @@ func init() {
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -4500,6 +4536,12 @@ func init() {
           },
           "404": {
             "description": "Object or reference not found.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -14624,6 +14666,12 @@ func init() {
           "404": {
             "description": "Object not found."
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request. Ensure the collection exists and the object properties are valid.",
             "schema": {
@@ -14689,6 +14737,12 @@ func init() {
           "404": {
             "description": "Object not found."
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "An error occurred while trying to fulfill the request. Check the ErrorResponse for details.",
             "schema": {
@@ -14735,6 +14789,12 @@ func init() {
           },
           "404": {
             "description": "Object does not exist."
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           },
           "500": {
             "description": "An error occurred while trying to fulfill the request. Check the ErrorResponse for details.",
@@ -14799,6 +14859,12 @@ func init() {
           },
           "404": {
             "description": "Object not found."
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           },
           "422": {
             "description": "The patch object is valid JSON but is unprocessable for other reasons (e.g., invalid schema).",
@@ -14874,6 +14940,12 @@ func init() {
               "$ref": "#/definitions/ErrorResponse"
             }
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request. Ensure the property exists and is a reference type.",
             "schema": {
@@ -14942,6 +15014,12 @@ func init() {
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -15020,6 +15098,12 @@ func init() {
           },
           "404": {
             "description": "Object or reference not found.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }

--- a/adapters/handlers/rest/handlers_classification.go
+++ b/adapters/handlers/rest/handlers_classification.go
@@ -12,6 +12,8 @@
 package rest
 
 import (
+	"fmt"
+
 	middleware "github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
 	"github.com/pkg/errors"
@@ -26,11 +28,17 @@ import (
 )
 
 func setupClassificationHandlers(api *operations.WeaviateAPI,
-	classifier *classification.Classifier, metrics *monitoring.PrometheusMetrics, logger logrus.FieldLogger,
+	classifier *classification.Classifier, namespacesEnabled bool,
+	metrics *monitoring.PrometheusMetrics, logger logrus.FieldLogger,
 ) {
 	metricRequestsTotal := newClassificationRequestsTotal(metrics, logger)
 	api.ClassificationsClassificationsGetHandler = classifications.ClassificationsGetHandlerFunc(
 		func(params classifications.ClassificationsGetParams, principal *models.Principal) middleware.Responder {
+			if namespacesEnabled {
+				metricRequestsTotal.logUserError("")
+				return classifications.NewClassificationsGetGone().
+					WithPayload(errPayloadFromSingleErr(fmt.Errorf("classifications are not supported in the current cluster configuration")))
+			}
 			res, err := classifier.Get(params.HTTPRequest.Context(), principal, strfmt.UUID(params.ID))
 			if err != nil {
 				metricRequestsTotal.logError("", err)
@@ -56,6 +64,11 @@ func setupClassificationHandlers(api *operations.WeaviateAPI,
 
 	api.ClassificationsClassificationsPostHandler = classifications.ClassificationsPostHandlerFunc(
 		func(params classifications.ClassificationsPostParams, principal *models.Principal) middleware.Responder {
+			if namespacesEnabled {
+				metricRequestsTotal.logUserError("")
+				return classifications.NewClassificationsPostGone().
+					WithPayload(errPayloadFromSingleErr(fmt.Errorf("classifications are not supported in the current cluster configuration")))
+			}
 			res, err := classifier.Schedule(params.HTTPRequest.Context(), principal, *params.Params)
 			if err != nil {
 				metricRequestsTotal.logUserError("")

--- a/adapters/handlers/rest/handlers_graphql.go
+++ b/adapters/handlers/rest/handlers_graphql.go
@@ -53,11 +53,18 @@ func setupGraphQLHandlers(
 	gqlProvider graphQLProvider,
 	m *schema.Manager,
 	disabled bool,
+	namespacesEnabled bool,
 	metrics *monitoring.PrometheusMetrics,
 	logger logrus.FieldLogger,
 ) {
 	metricRequestsTotal := newGraphqlRequestsTotal(metrics, logger)
 	api.GraphqlGraphqlPostHandler = graphql.GraphqlPostHandlerFunc(func(params graphql.GraphqlPostParams, principal *models.Principal) middleware.Responder {
+		if namespacesEnabled {
+			metricRequestsTotal.logUserError()
+			return graphql.NewGraphqlPostGone().
+				WithPayload(errPayloadFromSingleErr(fmt.Errorf("graphql api is not supported in the current cluster configuration")))
+		}
+
 		// All requests to the graphQL API need at least permissions to read the schema. Request might have further
 		// authorization requirements.
 		err := m.Authorizer.Authorize(params.HTTPRequest.Context(), principal, authorization.READ, authorization.CollectionsMetadata()...)
@@ -154,6 +161,12 @@ func setupGraphQLHandlers(
 	})
 
 	api.GraphqlGraphqlBatchHandler = graphql.GraphqlBatchHandlerFunc(func(params graphql.GraphqlBatchParams, principal *models.Principal) middleware.Responder {
+		if namespacesEnabled {
+			metricRequestsTotal.logUserError()
+			return graphql.NewGraphqlBatchGone().
+				WithPayload(errPayloadFromSingleErr(fmt.Errorf("graphql api is not supported in the current cluster configuration")))
+		}
+
 		// this is barely used (if at all) - so require read access to all collections for data and metadata
 		err := m.Authorizer.Authorize(params.HTTPRequest.Context(), principal, authorization.READ, authorization.Collections()...)
 		if err != nil {

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -672,6 +672,10 @@ func (h *objectHandlers) getObjectDeprecated(params objects.ObjectsGetParams,
 	principal *models.Principal,
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "GET "+params.HTTPRequest.URL.Path)
+	if h.config.Namespaces.Enabled {
+		return objects.NewObjectsGetGone().
+			WithPayload(errPayloadFromSingleErr(fmt.Errorf("getting an object without a class is not supported; use /objects/{className}/{id}")))
+	}
 	ps := objects.ObjectsClassGetParams{
 		HTTPRequest: params.HTTPRequest,
 		ID:          params.ID,

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -251,6 +251,9 @@ func (h *objectHandlers) getObjects(params objects.ObjectsListParams,
 		case errors.As(err, &uco.ErrMultiTenancy{}):
 			return objects.NewObjectsListUnprocessableEntity().
 				WithPayload(errPayloadFromSingleErr(err))
+		case errors.As(err, &uco.ErrEndpointGone{}):
+			return objects.NewObjectsListGone().
+				WithPayload(errPayloadFromSingleErr(err))
 		default:
 			return objects.NewObjectsListInternalServerError().
 				WithPayload(errPayloadFromSingleErr(err))

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -673,6 +673,7 @@ func (h *objectHandlers) getObjectDeprecated(params objects.ObjectsGetParams,
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "GET "+params.HTTPRequest.URL.Path)
 	if h.config.Namespaces.Enabled {
+		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsGetGone().
 			WithPayload(errPayloadFromSingleErr(fmt.Errorf("getting an object without a class is not supported; use /objects/{className}/{id}")))
 	}
@@ -689,6 +690,7 @@ func (h *objectHandlers) headObjectDeprecated(params objects.ObjectsHeadParams,
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "HEAD "+params.HTTPRequest.URL.Path)
 	if h.config.Namespaces.Enabled {
+		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsHeadGone().
 			WithPayload(errPayloadFromSingleErr(fmt.Errorf("checking an object without a class is not supported; use /objects/{className}/{id}")))
 	}
@@ -702,6 +704,7 @@ func (h *objectHandlers) headObjectDeprecated(params objects.ObjectsHeadParams,
 func (h *objectHandlers) patchObjectDeprecated(params objects.ObjectsPatchParams, principal *models.Principal) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "PATCH "+params.HTTPRequest.URL.Path)
 	if h.config.Namespaces.Enabled {
+		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsPatchGone().
 			WithPayload(errPayloadFromSingleErr(fmt.Errorf("patching an object without a class is not supported; use /objects/{className}/{id}")))
 	}
@@ -721,6 +724,7 @@ func (h *objectHandlers) updateObjectDeprecated(params objects.ObjectsUpdatePara
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "PUT "+params.HTTPRequest.URL.Path)
 	if h.config.Namespaces.Enabled {
+		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsUpdateGone().
 			WithPayload(errPayloadFromSingleErr(fmt.Errorf("updating an object without a class is not supported; use /objects/{className}/{id}")))
 	}
@@ -738,6 +742,7 @@ func (h *objectHandlers) deleteObjectDeprecated(params objects.ObjectsDeletePara
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "DELETE "+params.HTTPRequest.URL.Path)
 	if h.config.Namespaces.Enabled {
+		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsDeleteGone().
 			WithPayload(errPayloadFromSingleErr(fmt.Errorf("deleting an object without a class is not supported; use /objects/{className}/{id}")))
 	}
@@ -753,6 +758,7 @@ func (h *objectHandlers) addObjectReferenceDeprecated(params objects.ObjectsRefe
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "POST "+params.HTTPRequest.URL.Path)
 	if h.config.Namespaces.Enabled {
+		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsReferencesCreateGone().
 			WithPayload(errPayloadFromSingleErr(fmt.Errorf("adding a reference without a class is not supported; use /objects/{className}/{id}/references/{propertyName}")))
 	}
@@ -770,6 +776,7 @@ func (h *objectHandlers) updateObjectReferencesDeprecated(params objects.Objects
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "PUT "+params.HTTPRequest.URL.Path)
 	if h.config.Namespaces.Enabled {
+		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsReferencesUpdateGone().
 			WithPayload(errPayloadFromSingleErr(fmt.Errorf("replacing references without a class is not supported; use /objects/{className}/{id}/references/{propertyName}")))
 	}
@@ -787,6 +794,7 @@ func (h *objectHandlers) deleteObjectReferenceDeprecated(params objects.ObjectsR
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "DELETE "+params.HTTPRequest.URL.Path)
 	if h.config.Namespaces.Enabled {
+		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsReferencesDeleteGone().
 			WithPayload(errPayloadFromSingleErr(fmt.Errorf("deleting a reference without a class is not supported; use /objects/{className}/{id}/references/{propertyName}")))
 	}
@@ -865,6 +873,8 @@ func (e *objectsRequestsTotal) logError(className string, err error) {
 	case errors.As(err, &authzerrors.Forbidden{}):
 		e.logUserError(className)
 	case errors.As(err, &uco.ErrInvalidUserInput{}), errors.As(err, &uco.ErrNotFound{}):
+		e.logUserError(className)
+	case errors.As(err, &uco.ErrEndpointGone{}):
 		e.logUserError(className)
 	case errors.As(err, &customError):
 		switch customError.Code {

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -688,6 +688,10 @@ func (h *objectHandlers) headObjectDeprecated(params objects.ObjectsHeadParams,
 	principal *models.Principal,
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "HEAD "+params.HTTPRequest.URL.Path)
+	if h.config.Namespaces.Enabled {
+		return objects.NewObjectsHeadGone().
+			WithPayload(errPayloadFromSingleErr(fmt.Errorf("checking an object without a class is not supported; use /objects/{className}/{id}")))
+	}
 	r := objects.ObjectsClassHeadParams{
 		HTTPRequest: params.HTTPRequest,
 		ID:          params.ID,
@@ -697,6 +701,10 @@ func (h *objectHandlers) headObjectDeprecated(params objects.ObjectsHeadParams,
 
 func (h *objectHandlers) patchObjectDeprecated(params objects.ObjectsPatchParams, principal *models.Principal) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "PATCH "+params.HTTPRequest.URL.Path)
+	if h.config.Namespaces.Enabled {
+		return objects.NewObjectsPatchGone().
+			WithPayload(errPayloadFromSingleErr(fmt.Errorf("patching an object without a class is not supported; use /objects/{className}/{id}")))
+	}
 	args := objects.ObjectsClassPatchParams{
 		HTTPRequest: params.HTTPRequest,
 		ID:          params.ID,
@@ -712,6 +720,10 @@ func (h *objectHandlers) updateObjectDeprecated(params objects.ObjectsUpdatePara
 	principal *models.Principal,
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "PUT "+params.HTTPRequest.URL.Path)
+	if h.config.Namespaces.Enabled {
+		return objects.NewObjectsUpdateGone().
+			WithPayload(errPayloadFromSingleErr(fmt.Errorf("updating an object without a class is not supported; use /objects/{className}/{id}")))
+	}
 	ps := objects.ObjectsClassPutParams{
 		HTTPRequest: params.HTTPRequest,
 		ClassName:   params.Body.Class,
@@ -725,6 +737,10 @@ func (h *objectHandlers) deleteObjectDeprecated(params objects.ObjectsDeletePara
 	principal *models.Principal,
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "DELETE "+params.HTTPRequest.URL.Path)
+	if h.config.Namespaces.Enabled {
+		return objects.NewObjectsDeleteGone().
+			WithPayload(errPayloadFromSingleErr(fmt.Errorf("deleting an object without a class is not supported; use /objects/{className}/{id}")))
+	}
 	ps := objects.ObjectsClassDeleteParams{
 		HTTPRequest: params.HTTPRequest,
 		ID:          params.ID,
@@ -736,6 +752,10 @@ func (h *objectHandlers) addObjectReferenceDeprecated(params objects.ObjectsRefe
 	principal *models.Principal,
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "POST "+params.HTTPRequest.URL.Path)
+	if h.config.Namespaces.Enabled {
+		return objects.NewObjectsReferencesCreateGone().
+			WithPayload(errPayloadFromSingleErr(fmt.Errorf("adding a reference without a class is not supported; use /objects/{className}/{id}/references/{propertyName}")))
+	}
 	req := objects.ObjectsClassReferencesCreateParams{
 		HTTPRequest:  params.HTTPRequest,
 		Body:         params.Body,
@@ -749,6 +769,10 @@ func (h *objectHandlers) updateObjectReferencesDeprecated(params objects.Objects
 	principal *models.Principal,
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "PUT "+params.HTTPRequest.URL.Path)
+	if h.config.Namespaces.Enabled {
+		return objects.NewObjectsReferencesUpdateGone().
+			WithPayload(errPayloadFromSingleErr(fmt.Errorf("replacing references without a class is not supported; use /objects/{className}/{id}/references/{propertyName}")))
+	}
 	req := objects.ObjectsClassReferencesPutParams{
 		HTTPRequest:  params.HTTPRequest,
 		ID:           params.ID,
@@ -762,6 +786,10 @@ func (h *objectHandlers) deleteObjectReferenceDeprecated(params objects.ObjectsR
 	principal *models.Principal,
 ) middleware.Responder {
 	h.logger.Warn("deprecated endpoint: ", "DELETE "+params.HTTPRequest.URL.Path)
+	if h.config.Namespaces.Enabled {
+		return objects.NewObjectsReferencesDeleteGone().
+			WithPayload(errPayloadFromSingleErr(fmt.Errorf("deleting a reference without a class is not supported; use /objects/{className}/{id}/references/{propertyName}")))
+	}
 	req := objects.ObjectsClassReferencesDeleteParams{
 		HTTPRequest:  params.HTTPRequest,
 		Body:         params.Body,

--- a/adapters/handlers/rest/operations/classifications/classifications_get_responses.go
+++ b/adapters/handlers/rest/operations/classifications/classifications_get_responses.go
@@ -164,6 +164,51 @@ func (o *ClassificationsGetNotFound) WriteResponse(rw http.ResponseWriter, produ
 	rw.WriteHeader(404)
 }
 
+// ClassificationsGetGoneCode is the HTTP code returned for type ClassificationsGetGone
+const ClassificationsGetGoneCode int = 410
+
+/*
+ClassificationsGetGone Endpoint not available in the current cluster configuration.
+
+swagger:response classificationsGetGone
+*/
+type ClassificationsGetGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewClassificationsGetGone creates ClassificationsGetGone with default headers values
+func NewClassificationsGetGone() *ClassificationsGetGone {
+
+	return &ClassificationsGetGone{}
+}
+
+// WithPayload adds the payload to the classifications get gone response
+func (o *ClassificationsGetGone) WithPayload(payload *models.ErrorResponse) *ClassificationsGetGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the classifications get gone response
+func (o *ClassificationsGetGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ClassificationsGetGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ClassificationsGetInternalServerErrorCode is the HTTP code returned for type ClassificationsGetInternalServerError
 const ClassificationsGetInternalServerErrorCode int = 500
 

--- a/adapters/handlers/rest/operations/classifications/classifications_post_responses.go
+++ b/adapters/handlers/rest/operations/classifications/classifications_post_responses.go
@@ -184,6 +184,51 @@ func (o *ClassificationsPostForbidden) WriteResponse(rw http.ResponseWriter, pro
 	}
 }
 
+// ClassificationsPostGoneCode is the HTTP code returned for type ClassificationsPostGone
+const ClassificationsPostGoneCode int = 410
+
+/*
+ClassificationsPostGone Endpoint not available in the current cluster configuration.
+
+swagger:response classificationsPostGone
+*/
+type ClassificationsPostGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewClassificationsPostGone creates ClassificationsPostGone with default headers values
+func NewClassificationsPostGone() *ClassificationsPostGone {
+
+	return &ClassificationsPostGone{}
+}
+
+// WithPayload adds the payload to the classifications post gone response
+func (o *ClassificationsPostGone) WithPayload(payload *models.ErrorResponse) *ClassificationsPostGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the classifications post gone response
+func (o *ClassificationsPostGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ClassificationsPostGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ClassificationsPostInternalServerErrorCode is the HTTP code returned for type ClassificationsPostInternalServerError
 const ClassificationsPostInternalServerErrorCode int = 500
 

--- a/adapters/handlers/rest/operations/graphql/graphql_batch_responses.go
+++ b/adapters/handlers/rest/operations/graphql/graphql_batch_responses.go
@@ -142,6 +142,51 @@ func (o *GraphqlBatchForbidden) WriteResponse(rw http.ResponseWriter, producer r
 	}
 }
 
+// GraphqlBatchGoneCode is the HTTP code returned for type GraphqlBatchGone
+const GraphqlBatchGoneCode int = 410
+
+/*
+GraphqlBatchGone Endpoint not available in the current cluster configuration.
+
+swagger:response graphqlBatchGone
+*/
+type GraphqlBatchGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewGraphqlBatchGone creates GraphqlBatchGone with default headers values
+func NewGraphqlBatchGone() *GraphqlBatchGone {
+
+	return &GraphqlBatchGone{}
+}
+
+// WithPayload adds the payload to the graphql batch gone response
+func (o *GraphqlBatchGone) WithPayload(payload *models.ErrorResponse) *GraphqlBatchGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the graphql batch gone response
+func (o *GraphqlBatchGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *GraphqlBatchGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // GraphqlBatchUnprocessableEntityCode is the HTTP code returned for type GraphqlBatchUnprocessableEntity
 const GraphqlBatchUnprocessableEntityCode int = 422
 

--- a/adapters/handlers/rest/operations/graphql/graphql_post_responses.go
+++ b/adapters/handlers/rest/operations/graphql/graphql_post_responses.go
@@ -139,6 +139,51 @@ func (o *GraphqlPostForbidden) WriteResponse(rw http.ResponseWriter, producer ru
 	}
 }
 
+// GraphqlPostGoneCode is the HTTP code returned for type GraphqlPostGone
+const GraphqlPostGoneCode int = 410
+
+/*
+GraphqlPostGone Endpoint not available in the current cluster configuration.
+
+swagger:response graphqlPostGone
+*/
+type GraphqlPostGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewGraphqlPostGone creates GraphqlPostGone with default headers values
+func NewGraphqlPostGone() *GraphqlPostGone {
+
+	return &GraphqlPostGone{}
+}
+
+// WithPayload adds the payload to the graphql post gone response
+func (o *GraphqlPostGone) WithPayload(payload *models.ErrorResponse) *GraphqlPostGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the graphql post gone response
+func (o *GraphqlPostGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *GraphqlPostGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // GraphqlPostUnprocessableEntityCode is the HTTP code returned for type GraphqlPostUnprocessableEntity
 const GraphqlPostUnprocessableEntityCode int = 422
 

--- a/adapters/handlers/rest/operations/objects/objects_delete_responses.go
+++ b/adapters/handlers/rest/operations/objects/objects_delete_responses.go
@@ -144,6 +144,51 @@ func (o *ObjectsDeleteNotFound) WriteResponse(rw http.ResponseWriter, producer r
 	rw.WriteHeader(404)
 }
 
+// ObjectsDeleteGoneCode is the HTTP code returned for type ObjectsDeleteGone
+const ObjectsDeleteGoneCode int = 410
+
+/*
+ObjectsDeleteGone Endpoint not available in the current cluster configuration.
+
+swagger:response objectsDeleteGone
+*/
+type ObjectsDeleteGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewObjectsDeleteGone creates ObjectsDeleteGone with default headers values
+func NewObjectsDeleteGone() *ObjectsDeleteGone {
+
+	return &ObjectsDeleteGone{}
+}
+
+// WithPayload adds the payload to the objects delete gone response
+func (o *ObjectsDeleteGone) WithPayload(payload *models.ErrorResponse) *ObjectsDeleteGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the objects delete gone response
+func (o *ObjectsDeleteGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ObjectsDeleteGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ObjectsDeleteInternalServerErrorCode is the HTTP code returned for type ObjectsDeleteInternalServerError
 const ObjectsDeleteInternalServerErrorCode int = 500
 

--- a/adapters/handlers/rest/operations/objects/objects_get_responses.go
+++ b/adapters/handlers/rest/operations/objects/objects_get_responses.go
@@ -209,6 +209,51 @@ func (o *ObjectsGetNotFound) WriteResponse(rw http.ResponseWriter, producer runt
 	rw.WriteHeader(404)
 }
 
+// ObjectsGetGoneCode is the HTTP code returned for type ObjectsGetGone
+const ObjectsGetGoneCode int = 410
+
+/*
+ObjectsGetGone Endpoint not available in the current cluster configuration.
+
+swagger:response objectsGetGone
+*/
+type ObjectsGetGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewObjectsGetGone creates ObjectsGetGone with default headers values
+func NewObjectsGetGone() *ObjectsGetGone {
+
+	return &ObjectsGetGone{}
+}
+
+// WithPayload adds the payload to the objects get gone response
+func (o *ObjectsGetGone) WithPayload(payload *models.ErrorResponse) *ObjectsGetGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the objects get gone response
+func (o *ObjectsGetGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ObjectsGetGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ObjectsGetInternalServerErrorCode is the HTTP code returned for type ObjectsGetInternalServerError
 const ObjectsGetInternalServerErrorCode int = 500
 

--- a/adapters/handlers/rest/operations/objects/objects_head_responses.go
+++ b/adapters/handlers/rest/operations/objects/objects_head_responses.go
@@ -144,6 +144,51 @@ func (o *ObjectsHeadNotFound) WriteResponse(rw http.ResponseWriter, producer run
 	rw.WriteHeader(404)
 }
 
+// ObjectsHeadGoneCode is the HTTP code returned for type ObjectsHeadGone
+const ObjectsHeadGoneCode int = 410
+
+/*
+ObjectsHeadGone Endpoint not available in the current cluster configuration.
+
+swagger:response objectsHeadGone
+*/
+type ObjectsHeadGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewObjectsHeadGone creates ObjectsHeadGone with default headers values
+func NewObjectsHeadGone() *ObjectsHeadGone {
+
+	return &ObjectsHeadGone{}
+}
+
+// WithPayload adds the payload to the objects head gone response
+func (o *ObjectsHeadGone) WithPayload(payload *models.ErrorResponse) *ObjectsHeadGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the objects head gone response
+func (o *ObjectsHeadGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ObjectsHeadGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ObjectsHeadInternalServerErrorCode is the HTTP code returned for type ObjectsHeadInternalServerError
 const ObjectsHeadInternalServerErrorCode int = 500
 

--- a/adapters/handlers/rest/operations/objects/objects_list_responses.go
+++ b/adapters/handlers/rest/operations/objects/objects_list_responses.go
@@ -209,6 +209,51 @@ func (o *ObjectsListNotFound) WriteResponse(rw http.ResponseWriter, producer run
 	rw.WriteHeader(404)
 }
 
+// ObjectsListGoneCode is the HTTP code returned for type ObjectsListGone
+const ObjectsListGoneCode int = 410
+
+/*
+ObjectsListGone Endpoint not available in the current cluster configuration.
+
+swagger:response objectsListGone
+*/
+type ObjectsListGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewObjectsListGone creates ObjectsListGone with default headers values
+func NewObjectsListGone() *ObjectsListGone {
+
+	return &ObjectsListGone{}
+}
+
+// WithPayload adds the payload to the objects list gone response
+func (o *ObjectsListGone) WithPayload(payload *models.ErrorResponse) *ObjectsListGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the objects list gone response
+func (o *ObjectsListGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ObjectsListGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ObjectsListUnprocessableEntityCode is the HTTP code returned for type ObjectsListUnprocessableEntity
 const ObjectsListUnprocessableEntityCode int = 422
 

--- a/adapters/handlers/rest/operations/objects/objects_patch_responses.go
+++ b/adapters/handlers/rest/operations/objects/objects_patch_responses.go
@@ -169,6 +169,51 @@ func (o *ObjectsPatchNotFound) WriteResponse(rw http.ResponseWriter, producer ru
 	rw.WriteHeader(404)
 }
 
+// ObjectsPatchGoneCode is the HTTP code returned for type ObjectsPatchGone
+const ObjectsPatchGoneCode int = 410
+
+/*
+ObjectsPatchGone Endpoint not available in the current cluster configuration.
+
+swagger:response objectsPatchGone
+*/
+type ObjectsPatchGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewObjectsPatchGone creates ObjectsPatchGone with default headers values
+func NewObjectsPatchGone() *ObjectsPatchGone {
+
+	return &ObjectsPatchGone{}
+}
+
+// WithPayload adds the payload to the objects patch gone response
+func (o *ObjectsPatchGone) WithPayload(payload *models.ErrorResponse) *ObjectsPatchGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the objects patch gone response
+func (o *ObjectsPatchGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ObjectsPatchGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ObjectsPatchUnprocessableEntityCode is the HTTP code returned for type ObjectsPatchUnprocessableEntity
 const ObjectsPatchUnprocessableEntityCode int = 422
 

--- a/adapters/handlers/rest/operations/objects/objects_references_create_responses.go
+++ b/adapters/handlers/rest/operations/objects/objects_references_create_responses.go
@@ -119,6 +119,51 @@ func (o *ObjectsReferencesCreateForbidden) WriteResponse(rw http.ResponseWriter,
 	}
 }
 
+// ObjectsReferencesCreateGoneCode is the HTTP code returned for type ObjectsReferencesCreateGone
+const ObjectsReferencesCreateGoneCode int = 410
+
+/*
+ObjectsReferencesCreateGone Endpoint not available in the current cluster configuration.
+
+swagger:response objectsReferencesCreateGone
+*/
+type ObjectsReferencesCreateGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewObjectsReferencesCreateGone creates ObjectsReferencesCreateGone with default headers values
+func NewObjectsReferencesCreateGone() *ObjectsReferencesCreateGone {
+
+	return &ObjectsReferencesCreateGone{}
+}
+
+// WithPayload adds the payload to the objects references create gone response
+func (o *ObjectsReferencesCreateGone) WithPayload(payload *models.ErrorResponse) *ObjectsReferencesCreateGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the objects references create gone response
+func (o *ObjectsReferencesCreateGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ObjectsReferencesCreateGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ObjectsReferencesCreateUnprocessableEntityCode is the HTTP code returned for type ObjectsReferencesCreateUnprocessableEntity
 const ObjectsReferencesCreateUnprocessableEntityCode int = 422
 

--- a/adapters/handlers/rest/operations/objects/objects_references_delete_responses.go
+++ b/adapters/handlers/rest/operations/objects/objects_references_delete_responses.go
@@ -164,6 +164,51 @@ func (o *ObjectsReferencesDeleteNotFound) WriteResponse(rw http.ResponseWriter, 
 	}
 }
 
+// ObjectsReferencesDeleteGoneCode is the HTTP code returned for type ObjectsReferencesDeleteGone
+const ObjectsReferencesDeleteGoneCode int = 410
+
+/*
+ObjectsReferencesDeleteGone Endpoint not available in the current cluster configuration.
+
+swagger:response objectsReferencesDeleteGone
+*/
+type ObjectsReferencesDeleteGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewObjectsReferencesDeleteGone creates ObjectsReferencesDeleteGone with default headers values
+func NewObjectsReferencesDeleteGone() *ObjectsReferencesDeleteGone {
+
+	return &ObjectsReferencesDeleteGone{}
+}
+
+// WithPayload adds the payload to the objects references delete gone response
+func (o *ObjectsReferencesDeleteGone) WithPayload(payload *models.ErrorResponse) *ObjectsReferencesDeleteGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the objects references delete gone response
+func (o *ObjectsReferencesDeleteGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ObjectsReferencesDeleteGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ObjectsReferencesDeleteInternalServerErrorCode is the HTTP code returned for type ObjectsReferencesDeleteInternalServerError
 const ObjectsReferencesDeleteInternalServerErrorCode int = 500
 

--- a/adapters/handlers/rest/operations/objects/objects_references_update_responses.go
+++ b/adapters/handlers/rest/operations/objects/objects_references_update_responses.go
@@ -119,6 +119,51 @@ func (o *ObjectsReferencesUpdateForbidden) WriteResponse(rw http.ResponseWriter,
 	}
 }
 
+// ObjectsReferencesUpdateGoneCode is the HTTP code returned for type ObjectsReferencesUpdateGone
+const ObjectsReferencesUpdateGoneCode int = 410
+
+/*
+ObjectsReferencesUpdateGone Endpoint not available in the current cluster configuration.
+
+swagger:response objectsReferencesUpdateGone
+*/
+type ObjectsReferencesUpdateGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewObjectsReferencesUpdateGone creates ObjectsReferencesUpdateGone with default headers values
+func NewObjectsReferencesUpdateGone() *ObjectsReferencesUpdateGone {
+
+	return &ObjectsReferencesUpdateGone{}
+}
+
+// WithPayload adds the payload to the objects references update gone response
+func (o *ObjectsReferencesUpdateGone) WithPayload(payload *models.ErrorResponse) *ObjectsReferencesUpdateGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the objects references update gone response
+func (o *ObjectsReferencesUpdateGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ObjectsReferencesUpdateGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ObjectsReferencesUpdateUnprocessableEntityCode is the HTTP code returned for type ObjectsReferencesUpdateUnprocessableEntity
 const ObjectsReferencesUpdateUnprocessableEntityCode int = 422
 

--- a/adapters/handlers/rest/operations/objects/objects_update_responses.go
+++ b/adapters/handlers/rest/operations/objects/objects_update_responses.go
@@ -164,6 +164,51 @@ func (o *ObjectsUpdateNotFound) WriteResponse(rw http.ResponseWriter, producer r
 	rw.WriteHeader(404)
 }
 
+// ObjectsUpdateGoneCode is the HTTP code returned for type ObjectsUpdateGone
+const ObjectsUpdateGoneCode int = 410
+
+/*
+ObjectsUpdateGone Endpoint not available in the current cluster configuration.
+
+swagger:response objectsUpdateGone
+*/
+type ObjectsUpdateGone struct {
+
+	/*
+	  In: Body
+	*/
+	Payload *models.ErrorResponse `json:"body,omitempty"`
+}
+
+// NewObjectsUpdateGone creates ObjectsUpdateGone with default headers values
+func NewObjectsUpdateGone() *ObjectsUpdateGone {
+
+	return &ObjectsUpdateGone{}
+}
+
+// WithPayload adds the payload to the objects update gone response
+func (o *ObjectsUpdateGone) WithPayload(payload *models.ErrorResponse) *ObjectsUpdateGone {
+	o.Payload = payload
+	return o
+}
+
+// SetPayload sets the payload to the objects update gone response
+func (o *ObjectsUpdateGone) SetPayload(payload *models.ErrorResponse) {
+	o.Payload = payload
+}
+
+// WriteResponse to the client
+func (o *ObjectsUpdateGone) WriteResponse(rw http.ResponseWriter, producer runtime.Producer) {
+
+	rw.WriteHeader(410)
+	if o.Payload != nil {
+		payload := o.Payload
+		if err := producer.Produce(rw, payload); err != nil {
+			panic(err) // let the recovery middleware deal with this
+		}
+	}
+}
+
 // ObjectsUpdateUnprocessableEntityCode is the HTTP code returned for type ObjectsUpdateUnprocessableEntity
 const ObjectsUpdateUnprocessableEntityCode int = 422
 

--- a/client/classifications/classifications_get_responses.go
+++ b/client/classifications/classifications_get_responses.go
@@ -58,6 +58,12 @@ func (o *ClassificationsGetReader) ReadResponse(response runtime.ClientResponse,
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewClassificationsGetGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewClassificationsGetInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -313,6 +319,74 @@ func (o *ClassificationsGetNotFound) String() string {
 }
 
 func (o *ClassificationsGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewClassificationsGetGone creates a ClassificationsGetGone with default headers values
+func NewClassificationsGetGone() *ClassificationsGetGone {
+	return &ClassificationsGetGone{}
+}
+
+/*
+ClassificationsGetGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type ClassificationsGetGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this classifications get gone response has a 2xx status code
+func (o *ClassificationsGetGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this classifications get gone response has a 3xx status code
+func (o *ClassificationsGetGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this classifications get gone response has a 4xx status code
+func (o *ClassificationsGetGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this classifications get gone response has a 5xx status code
+func (o *ClassificationsGetGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this classifications get gone response a status code equal to that given
+func (o *ClassificationsGetGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the classifications get gone response
+func (o *ClassificationsGetGone) Code() int {
+	return 410
+}
+
+func (o *ClassificationsGetGone) Error() string {
+	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetGone  %+v", 410, o.Payload)
+}
+
+func (o *ClassificationsGetGone) String() string {
+	return fmt.Sprintf("[GET /classifications/{id}][%d] classificationsGetGone  %+v", 410, o.Payload)
+}
+
+func (o *ClassificationsGetGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *ClassificationsGetGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/client/classifications/classifications_post_responses.go
+++ b/client/classifications/classifications_post_responses.go
@@ -58,6 +58,12 @@ func (o *ClassificationsPostReader) ReadResponse(response runtime.ClientResponse
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewClassificationsPostGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewClassificationsPostInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -318,6 +324,74 @@ func (o *ClassificationsPostForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ClassificationsPostForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewClassificationsPostGone creates a ClassificationsPostGone with default headers values
+func NewClassificationsPostGone() *ClassificationsPostGone {
+	return &ClassificationsPostGone{}
+}
+
+/*
+ClassificationsPostGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type ClassificationsPostGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this classifications post gone response has a 2xx status code
+func (o *ClassificationsPostGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this classifications post gone response has a 3xx status code
+func (o *ClassificationsPostGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this classifications post gone response has a 4xx status code
+func (o *ClassificationsPostGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this classifications post gone response has a 5xx status code
+func (o *ClassificationsPostGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this classifications post gone response a status code equal to that given
+func (o *ClassificationsPostGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the classifications post gone response
+func (o *ClassificationsPostGone) Code() int {
+	return 410
+}
+
+func (o *ClassificationsPostGone) Error() string {
+	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostGone  %+v", 410, o.Payload)
+}
+
+func (o *ClassificationsPostGone) String() string {
+	return fmt.Sprintf("[POST /classifications/][%d] classificationsPostGone  %+v", 410, o.Payload)
+}
+
+func (o *ClassificationsPostGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *ClassificationsPostGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.ErrorResponse)
 

--- a/client/graphql/graphql_batch_responses.go
+++ b/client/graphql/graphql_batch_responses.go
@@ -52,6 +52,12 @@ func (o *GraphqlBatchReader) ReadResponse(response runtime.ClientResponse, consu
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewGraphqlBatchGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewGraphqlBatchUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -248,6 +254,74 @@ func (o *GraphqlBatchForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GraphqlBatchForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewGraphqlBatchGone creates a GraphqlBatchGone with default headers values
+func NewGraphqlBatchGone() *GraphqlBatchGone {
+	return &GraphqlBatchGone{}
+}
+
+/*
+GraphqlBatchGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type GraphqlBatchGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this graphql batch gone response has a 2xx status code
+func (o *GraphqlBatchGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this graphql batch gone response has a 3xx status code
+func (o *GraphqlBatchGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this graphql batch gone response has a 4xx status code
+func (o *GraphqlBatchGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this graphql batch gone response has a 5xx status code
+func (o *GraphqlBatchGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this graphql batch gone response a status code equal to that given
+func (o *GraphqlBatchGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the graphql batch gone response
+func (o *GraphqlBatchGone) Code() int {
+	return 410
+}
+
+func (o *GraphqlBatchGone) Error() string {
+	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchGone  %+v", 410, o.Payload)
+}
+
+func (o *GraphqlBatchGone) String() string {
+	return fmt.Sprintf("[POST /graphql/batch][%d] graphqlBatchGone  %+v", 410, o.Payload)
+}
+
+func (o *GraphqlBatchGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *GraphqlBatchGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.ErrorResponse)
 

--- a/client/graphql/graphql_post_responses.go
+++ b/client/graphql/graphql_post_responses.go
@@ -52,6 +52,12 @@ func (o *GraphqlPostReader) ReadResponse(response runtime.ClientResponse, consum
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewGraphqlPostGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewGraphqlPostUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -250,6 +256,74 @@ func (o *GraphqlPostForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *GraphqlPostForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewGraphqlPostGone creates a GraphqlPostGone with default headers values
+func NewGraphqlPostGone() *GraphqlPostGone {
+	return &GraphqlPostGone{}
+}
+
+/*
+GraphqlPostGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type GraphqlPostGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this graphql post gone response has a 2xx status code
+func (o *GraphqlPostGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this graphql post gone response has a 3xx status code
+func (o *GraphqlPostGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this graphql post gone response has a 4xx status code
+func (o *GraphqlPostGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this graphql post gone response has a 5xx status code
+func (o *GraphqlPostGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this graphql post gone response a status code equal to that given
+func (o *GraphqlPostGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the graphql post gone response
+func (o *GraphqlPostGone) Code() int {
+	return 410
+}
+
+func (o *GraphqlPostGone) Error() string {
+	return fmt.Sprintf("[POST /graphql][%d] graphqlPostGone  %+v", 410, o.Payload)
+}
+
+func (o *GraphqlPostGone) String() string {
+	return fmt.Sprintf("[POST /graphql][%d] graphqlPostGone  %+v", 410, o.Payload)
+}
+
+func (o *GraphqlPostGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *GraphqlPostGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.ErrorResponse)
 

--- a/client/objects/objects_delete_responses.go
+++ b/client/objects/objects_delete_responses.go
@@ -58,6 +58,12 @@ func (o *ObjectsDeleteReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewObjectsDeleteGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewObjectsDeleteInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -301,6 +307,74 @@ func (o *ObjectsDeleteNotFound) String() string {
 }
 
 func (o *ObjectsDeleteNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewObjectsDeleteGone creates a ObjectsDeleteGone with default headers values
+func NewObjectsDeleteGone() *ObjectsDeleteGone {
+	return &ObjectsDeleteGone{}
+}
+
+/*
+ObjectsDeleteGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type ObjectsDeleteGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this objects delete gone response has a 2xx status code
+func (o *ObjectsDeleteGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this objects delete gone response has a 3xx status code
+func (o *ObjectsDeleteGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this objects delete gone response has a 4xx status code
+func (o *ObjectsDeleteGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this objects delete gone response has a 5xx status code
+func (o *ObjectsDeleteGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this objects delete gone response a status code equal to that given
+func (o *ObjectsDeleteGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the objects delete gone response
+func (o *ObjectsDeleteGone) Code() int {
+	return 410
+}
+
+func (o *ObjectsDeleteGone) Error() string {
+	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsDeleteGone) String() string {
+	return fmt.Sprintf("[DELETE /objects/{id}][%d] objectsDeleteGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsDeleteGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *ObjectsDeleteGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/client/objects/objects_get_responses.go
+++ b/client/objects/objects_get_responses.go
@@ -64,6 +64,12 @@ func (o *ObjectsGetReader) ReadResponse(response runtime.ClientResponse, consume
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewObjectsGetGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewObjectsGetInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -387,6 +393,74 @@ func (o *ObjectsGetNotFound) String() string {
 }
 
 func (o *ObjectsGetNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewObjectsGetGone creates a ObjectsGetGone with default headers values
+func NewObjectsGetGone() *ObjectsGetGone {
+	return &ObjectsGetGone{}
+}
+
+/*
+ObjectsGetGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type ObjectsGetGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this objects get gone response has a 2xx status code
+func (o *ObjectsGetGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this objects get gone response has a 3xx status code
+func (o *ObjectsGetGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this objects get gone response has a 4xx status code
+func (o *ObjectsGetGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this objects get gone response has a 5xx status code
+func (o *ObjectsGetGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this objects get gone response a status code equal to that given
+func (o *ObjectsGetGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the objects get gone response
+func (o *ObjectsGetGone) Code() int {
+	return 410
+}
+
+func (o *ObjectsGetGone) Error() string {
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsGetGone) String() string {
+	return fmt.Sprintf("[GET /objects/{id}][%d] objectsGetGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsGetGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *ObjectsGetGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/client/objects/objects_head_responses.go
+++ b/client/objects/objects_head_responses.go
@@ -58,6 +58,12 @@ func (o *ObjectsHeadReader) ReadResponse(response runtime.ClientResponse, consum
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewObjectsHeadGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewObjectsHeadInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -301,6 +307,74 @@ func (o *ObjectsHeadNotFound) String() string {
 }
 
 func (o *ObjectsHeadNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewObjectsHeadGone creates a ObjectsHeadGone with default headers values
+func NewObjectsHeadGone() *ObjectsHeadGone {
+	return &ObjectsHeadGone{}
+}
+
+/*
+ObjectsHeadGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type ObjectsHeadGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this objects head gone response has a 2xx status code
+func (o *ObjectsHeadGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this objects head gone response has a 3xx status code
+func (o *ObjectsHeadGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this objects head gone response has a 4xx status code
+func (o *ObjectsHeadGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this objects head gone response has a 5xx status code
+func (o *ObjectsHeadGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this objects head gone response a status code equal to that given
+func (o *ObjectsHeadGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the objects head gone response
+func (o *ObjectsHeadGone) Code() int {
+	return 410
+}
+
+func (o *ObjectsHeadGone) Error() string {
+	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsHeadGone) String() string {
+	return fmt.Sprintf("[HEAD /objects/{id}][%d] objectsHeadGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsHeadGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *ObjectsHeadGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/client/objects/objects_list_responses.go
+++ b/client/objects/objects_list_responses.go
@@ -64,6 +64,12 @@ func (o *ObjectsListReader) ReadResponse(response runtime.ClientResponse, consum
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewObjectsListGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewObjectsListUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -393,6 +399,74 @@ func (o *ObjectsListNotFound) String() string {
 }
 
 func (o *ObjectsListNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewObjectsListGone creates a ObjectsListGone with default headers values
+func NewObjectsListGone() *ObjectsListGone {
+	return &ObjectsListGone{}
+}
+
+/*
+ObjectsListGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type ObjectsListGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this objects list gone response has a 2xx status code
+func (o *ObjectsListGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this objects list gone response has a 3xx status code
+func (o *ObjectsListGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this objects list gone response has a 4xx status code
+func (o *ObjectsListGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this objects list gone response has a 5xx status code
+func (o *ObjectsListGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this objects list gone response a status code equal to that given
+func (o *ObjectsListGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the objects list gone response
+func (o *ObjectsListGone) Code() int {
+	return 410
+}
+
+func (o *ObjectsListGone) Error() string {
+	return fmt.Sprintf("[GET /objects][%d] objectsListGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsListGone) String() string {
+	return fmt.Sprintf("[GET /objects][%d] objectsListGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsListGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *ObjectsListGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/client/objects/objects_patch_responses.go
+++ b/client/objects/objects_patch_responses.go
@@ -64,6 +64,12 @@ func (o *ObjectsPatchReader) ReadResponse(response runtime.ClientResponse, consu
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewObjectsPatchGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewObjectsPatchUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -369,6 +375,74 @@ func (o *ObjectsPatchNotFound) String() string {
 }
 
 func (o *ObjectsPatchNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewObjectsPatchGone creates a ObjectsPatchGone with default headers values
+func NewObjectsPatchGone() *ObjectsPatchGone {
+	return &ObjectsPatchGone{}
+}
+
+/*
+ObjectsPatchGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type ObjectsPatchGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this objects patch gone response has a 2xx status code
+func (o *ObjectsPatchGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this objects patch gone response has a 3xx status code
+func (o *ObjectsPatchGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this objects patch gone response has a 4xx status code
+func (o *ObjectsPatchGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this objects patch gone response has a 5xx status code
+func (o *ObjectsPatchGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this objects patch gone response a status code equal to that given
+func (o *ObjectsPatchGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the objects patch gone response
+func (o *ObjectsPatchGone) Code() int {
+	return 410
+}
+
+func (o *ObjectsPatchGone) Error() string {
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsPatchGone) String() string {
+	return fmt.Sprintf("[PATCH /objects/{id}][%d] objectsPatchGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsPatchGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *ObjectsPatchGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/client/objects/objects_references_create_responses.go
+++ b/client/objects/objects_references_create_responses.go
@@ -52,6 +52,12 @@ func (o *ObjectsReferencesCreateReader) ReadResponse(response runtime.ClientResp
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewObjectsReferencesCreateGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewObjectsReferencesCreateUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -238,6 +244,74 @@ func (o *ObjectsReferencesCreateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsReferencesCreateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewObjectsReferencesCreateGone creates a ObjectsReferencesCreateGone with default headers values
+func NewObjectsReferencesCreateGone() *ObjectsReferencesCreateGone {
+	return &ObjectsReferencesCreateGone{}
+}
+
+/*
+ObjectsReferencesCreateGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type ObjectsReferencesCreateGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this objects references create gone response has a 2xx status code
+func (o *ObjectsReferencesCreateGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this objects references create gone response has a 3xx status code
+func (o *ObjectsReferencesCreateGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this objects references create gone response has a 4xx status code
+func (o *ObjectsReferencesCreateGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this objects references create gone response has a 5xx status code
+func (o *ObjectsReferencesCreateGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this objects references create gone response a status code equal to that given
+func (o *ObjectsReferencesCreateGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the objects references create gone response
+func (o *ObjectsReferencesCreateGone) Code() int {
+	return 410
+}
+
+func (o *ObjectsReferencesCreateGone) Error() string {
+	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsReferencesCreateGone) String() string {
+	return fmt.Sprintf("[POST /objects/{id}/references/{propertyName}][%d] objectsReferencesCreateGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsReferencesCreateGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *ObjectsReferencesCreateGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.ErrorResponse)
 

--- a/client/objects/objects_references_delete_responses.go
+++ b/client/objects/objects_references_delete_responses.go
@@ -58,6 +58,12 @@ func (o *ObjectsReferencesDeleteReader) ReadResponse(response runtime.ClientResp
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewObjectsReferencesDeleteGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 500:
 		result := NewObjectsReferencesDeleteInternalServerError()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -306,6 +312,74 @@ func (o *ObjectsReferencesDeleteNotFound) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsReferencesDeleteNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewObjectsReferencesDeleteGone creates a ObjectsReferencesDeleteGone with default headers values
+func NewObjectsReferencesDeleteGone() *ObjectsReferencesDeleteGone {
+	return &ObjectsReferencesDeleteGone{}
+}
+
+/*
+ObjectsReferencesDeleteGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type ObjectsReferencesDeleteGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this objects references delete gone response has a 2xx status code
+func (o *ObjectsReferencesDeleteGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this objects references delete gone response has a 3xx status code
+func (o *ObjectsReferencesDeleteGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this objects references delete gone response has a 4xx status code
+func (o *ObjectsReferencesDeleteGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this objects references delete gone response has a 5xx status code
+func (o *ObjectsReferencesDeleteGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this objects references delete gone response a status code equal to that given
+func (o *ObjectsReferencesDeleteGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the objects references delete gone response
+func (o *ObjectsReferencesDeleteGone) Code() int {
+	return 410
+}
+
+func (o *ObjectsReferencesDeleteGone) Error() string {
+	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsReferencesDeleteGone) String() string {
+	return fmt.Sprintf("[DELETE /objects/{id}/references/{propertyName}][%d] objectsReferencesDeleteGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsReferencesDeleteGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *ObjectsReferencesDeleteGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.ErrorResponse)
 

--- a/client/objects/objects_references_update_responses.go
+++ b/client/objects/objects_references_update_responses.go
@@ -52,6 +52,12 @@ func (o *ObjectsReferencesUpdateReader) ReadResponse(response runtime.ClientResp
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewObjectsReferencesUpdateGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewObjectsReferencesUpdateUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -238,6 +244,74 @@ func (o *ObjectsReferencesUpdateForbidden) GetPayload() *models.ErrorResponse {
 }
 
 func (o *ObjectsReferencesUpdateForbidden) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
+
+	return nil
+}
+
+// NewObjectsReferencesUpdateGone creates a ObjectsReferencesUpdateGone with default headers values
+func NewObjectsReferencesUpdateGone() *ObjectsReferencesUpdateGone {
+	return &ObjectsReferencesUpdateGone{}
+}
+
+/*
+ObjectsReferencesUpdateGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type ObjectsReferencesUpdateGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this objects references update gone response has a 2xx status code
+func (o *ObjectsReferencesUpdateGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this objects references update gone response has a 3xx status code
+func (o *ObjectsReferencesUpdateGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this objects references update gone response has a 4xx status code
+func (o *ObjectsReferencesUpdateGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this objects references update gone response has a 5xx status code
+func (o *ObjectsReferencesUpdateGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this objects references update gone response a status code equal to that given
+func (o *ObjectsReferencesUpdateGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the objects references update gone response
+func (o *ObjectsReferencesUpdateGone) Code() int {
+	return 410
+}
+
+func (o *ObjectsReferencesUpdateGone) Error() string {
+	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsReferencesUpdateGone) String() string {
+	return fmt.Sprintf("[PUT /objects/{id}/references/{propertyName}][%d] objectsReferencesUpdateGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsReferencesUpdateGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *ObjectsReferencesUpdateGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
 
 	o.Payload = new(models.ErrorResponse)
 

--- a/client/objects/objects_update_responses.go
+++ b/client/objects/objects_update_responses.go
@@ -58,6 +58,12 @@ func (o *ObjectsUpdateReader) ReadResponse(response runtime.ClientResponse, cons
 			return nil, err
 		}
 		return nil, result
+	case 410:
+		result := NewObjectsUpdateGone()
+		if err := result.readResponse(response, consumer, o.formats); err != nil {
+			return nil, err
+		}
+		return nil, result
 	case 422:
 		result := NewObjectsUpdateUnprocessableEntity()
 		if err := result.readResponse(response, consumer, o.formats); err != nil {
@@ -319,6 +325,74 @@ func (o *ObjectsUpdateNotFound) String() string {
 }
 
 func (o *ObjectsUpdateNotFound) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	return nil
+}
+
+// NewObjectsUpdateGone creates a ObjectsUpdateGone with default headers values
+func NewObjectsUpdateGone() *ObjectsUpdateGone {
+	return &ObjectsUpdateGone{}
+}
+
+/*
+ObjectsUpdateGone describes a response with status code 410, with default header values.
+
+Endpoint not available in the current cluster configuration.
+*/
+type ObjectsUpdateGone struct {
+	Payload *models.ErrorResponse
+}
+
+// IsSuccess returns true when this objects update gone response has a 2xx status code
+func (o *ObjectsUpdateGone) IsSuccess() bool {
+	return false
+}
+
+// IsRedirect returns true when this objects update gone response has a 3xx status code
+func (o *ObjectsUpdateGone) IsRedirect() bool {
+	return false
+}
+
+// IsClientError returns true when this objects update gone response has a 4xx status code
+func (o *ObjectsUpdateGone) IsClientError() bool {
+	return true
+}
+
+// IsServerError returns true when this objects update gone response has a 5xx status code
+func (o *ObjectsUpdateGone) IsServerError() bool {
+	return false
+}
+
+// IsCode returns true when this objects update gone response a status code equal to that given
+func (o *ObjectsUpdateGone) IsCode(code int) bool {
+	return code == 410
+}
+
+// Code gets the status code for the objects update gone response
+func (o *ObjectsUpdateGone) Code() int {
+	return 410
+}
+
+func (o *ObjectsUpdateGone) Error() string {
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsUpdateGone) String() string {
+	return fmt.Sprintf("[PUT /objects/{id}][%d] objectsUpdateGone  %+v", 410, o.Payload)
+}
+
+func (o *ObjectsUpdateGone) GetPayload() *models.ErrorResponse {
+	return o.Payload
+}
+
+func (o *ObjectsUpdateGone) readResponse(response runtime.ClientResponse, consumer runtime.Consumer, formats strfmt.Registry) error {
+
+	o.Payload = new(models.ErrorResponse)
+
+	// response payload
+	if err := consumer.Consume(response.Body(), o.Payload); err != nil && err != io.EOF {
+		return err
+	}
 
 	return nil
 }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -6140,6 +6140,12 @@
           "404": {
             "description": "Successful query result but no matching objects were found."
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request. Ensure the specified collection exists.",
             "schema": {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -6333,6 +6333,12 @@
           "404": {
             "description": "Object not found."
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "An error occurred while trying to fulfill the request. Check the ErrorResponse for details.",
             "schema": {

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -7701,6 +7701,12 @@
               "$ref": "#/definitions/ErrorResponse"
             }
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request.",
             "schema": {
@@ -7755,6 +7761,12 @@
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -10323,6 +10323,12 @@
               "$ref": "#/definitions/ErrorResponse"
             }
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "An internal server error occurred while starting the classification task. Check the ErrorResponse for details.",
             "schema": {
@@ -10370,6 +10376,12 @@
           },
           "404": {
             "description": "Classification with the given ID not found."
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           },
           "500": {
             "description": "An internal server error occurred while retrieving the classification status. Check the ErrorResponse for details.",

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -6274,6 +6274,12 @@
           "404": {
             "description": "Object not found."
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "500": {
             "description": "An error occurred while trying to fulfill the request. Check the ErrorResponse for details.",
             "schema": {
@@ -6401,6 +6407,12 @@
           "404": {
             "description": "Object not found."
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "The patch object is valid JSON but is unprocessable for other reasons (e.g., invalid schema).",
             "schema": {
@@ -6469,6 +6481,12 @@
           "404": {
             "description": "Object not found."
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request. Ensure the collection exists and the object properties are valid.",
             "schema": {
@@ -6521,6 +6539,12 @@
           },
           "404": {
             "description": "Object does not exist."
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
           },
           "500": {
             "description": "An error occurred while trying to fulfill the request. Check the ErrorResponse for details.",
@@ -6956,6 +6980,12 @@
               "$ref": "#/definitions/ErrorResponse"
             }
           },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
           "422": {
             "description": "The request syntax is correct, but the server couldn't process it due to semantic issues. Please check the values in your request. Ensure the property exists and is a reference type.",
             "schema": {
@@ -7021,6 +7051,12 @@
           },
           "403": {
             "description": "Forbidden",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }
@@ -7096,6 +7132,12 @@
           },
           "404": {
             "description": "Object or reference not found.",
+            "schema": {
+              "$ref": "#/definitions/ErrorResponse"
+            }
+          },
+          "410": {
+            "description": "Endpoint not available in the current cluster configuration.",
             "schema": {
               "$ref": "#/definitions/ErrorResponse"
             }

--- a/test/acceptance/namespace/endpoints_gone_test.go
+++ b/test/acceptance/namespace/endpoints_gone_test.go
@@ -1,0 +1,84 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespace
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	gql "github.com/weaviate/weaviate/client/graphql"
+	"github.com/weaviate/weaviate/client/objects"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// TestNamespaces_EndpointsGone locks in that endpoints incompatible with
+// namespace-enabled clusters return HTTP 410 Gone with an ErrorResponse body.
+func TestNamespaces_EndpointsGone(t *testing.T) {
+	t.Run("GET /v1/graphql returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Graphql.GraphqlPost(
+			gql.NewGraphqlPostParams().WithBody(&models.GraphQLQuery{Query: "{ Get { Foo { _additional { id } } } }"}),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *gql.GraphqlPostGone
+		require.True(t, errors.As(err, &gone), "expected GraphqlPostGone, got %T: %v", err, err)
+		require.NotNil(t, gone.Payload)
+		require.NotEmpty(t, gone.Payload.Error)
+		assert.NotEmpty(t, gone.Payload.Error[0].Message)
+	})
+
+	t.Run("POST /v1/graphql/batch returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Graphql.GraphqlBatch(
+			gql.NewGraphqlBatchParams().WithBody(models.GraphQLQueries{
+				{Query: "{ Get { Foo { _additional { id } } } }"},
+			}),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *gql.GraphqlBatchGone
+		require.True(t, errors.As(err, &gone), "expected GraphqlBatchGone, got %T: %v", err, err)
+		require.NotNil(t, gone.Payload)
+		require.NotEmpty(t, gone.Payload.Error)
+		assert.NotEmpty(t, gone.Payload.Error[0].Message)
+	})
+
+	t.Run("GET /v1/objects without ?class= returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Objects.ObjectsList(
+			objects.NewObjectsListParams(),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *objects.ObjectsListGone
+		require.True(t, errors.As(err, &gone), "expected ObjectsListGone, got %T: %v", err, err)
+		require.NotNil(t, gone.Payload)
+		require.NotEmpty(t, gone.Payload.Error)
+		assert.NotEmpty(t, gone.Payload.Error[0].Message)
+	})
+
+	t.Run("GET /v1/objects/{id} (deprecated, no class) returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Objects.ObjectsGet(
+			objects.NewObjectsGetParams().WithID(strfmt.UUID("11111111-1111-1111-1111-111111111111")),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *objects.ObjectsGetGone
+		require.True(t, errors.As(err, &gone), "expected ObjectsGetGone, got %T: %v", err, err)
+		require.NotNil(t, gone.Payload)
+		require.NotEmpty(t, gone.Payload.Error)
+		assert.NotEmpty(t, gone.Payload.Error[0].Message)
+	})
+}

--- a/test/acceptance/namespace/endpoints_gone_test.go
+++ b/test/acceptance/namespace/endpoints_gone_test.go
@@ -81,4 +81,102 @@ func TestNamespaces_EndpointsGone(t *testing.T) {
 		require.NotEmpty(t, gone.Payload.Error)
 		assert.NotEmpty(t, gone.Payload.Error[0].Message)
 	})
+
+	id := strfmt.UUID("11111111-1111-1111-1111-111111111111")
+
+	t.Run("HEAD /v1/objects/{id} (deprecated, no class) returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Objects.ObjectsHead(
+			objects.NewObjectsHeadParams().WithID(id),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *objects.ObjectsHeadGone
+		require.True(t, errors.As(err, &gone), "expected ObjectsHeadGone, got %T: %v", err, err)
+	})
+
+	t.Run("DELETE /v1/objects/{id} (deprecated, no class) returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Objects.ObjectsDelete(
+			objects.NewObjectsDeleteParams().WithID(id),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *objects.ObjectsDeleteGone
+		require.True(t, errors.As(err, &gone), "expected ObjectsDeleteGone, got %T: %v", err, err)
+		require.NotNil(t, gone.Payload)
+		require.NotEmpty(t, gone.Payload.Error)
+		assert.NotEmpty(t, gone.Payload.Error[0].Message)
+	})
+
+	t.Run("PATCH /v1/objects/{id} (deprecated, no class) returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Objects.ObjectsPatch(
+			objects.NewObjectsPatchParams().WithID(id).WithBody(&models.Object{ID: id}),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *objects.ObjectsPatchGone
+		require.True(t, errors.As(err, &gone), "expected ObjectsPatchGone, got %T: %v", err, err)
+		require.NotNil(t, gone.Payload)
+		require.NotEmpty(t, gone.Payload.Error)
+		assert.NotEmpty(t, gone.Payload.Error[0].Message)
+	})
+
+	t.Run("PUT /v1/objects/{id} (deprecated, no class) returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Objects.ObjectsUpdate(
+			objects.NewObjectsUpdateParams().WithID(id).WithBody(&models.Object{ID: id}),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *objects.ObjectsUpdateGone
+		require.True(t, errors.As(err, &gone), "expected ObjectsUpdateGone, got %T: %v", err, err)
+		require.NotNil(t, gone.Payload)
+		require.NotEmpty(t, gone.Payload.Error)
+		assert.NotEmpty(t, gone.Payload.Error[0].Message)
+	})
+
+	beacon := strfmt.URI("weaviate://localhost/Foo/22222222-2222-2222-2222-222222222222")
+
+	t.Run("POST /v1/objects/{id}/references/{propertyName} (deprecated, no class) returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Objects.ObjectsReferencesCreate(
+			objects.NewObjectsReferencesCreateParams().
+				WithID(id).WithPropertyName("ref").
+				WithBody(&models.SingleRef{Beacon: beacon}),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *objects.ObjectsReferencesCreateGone
+		require.True(t, errors.As(err, &gone), "expected ObjectsReferencesCreateGone, got %T: %v", err, err)
+		require.NotNil(t, gone.Payload)
+		require.NotEmpty(t, gone.Payload.Error)
+		assert.NotEmpty(t, gone.Payload.Error[0].Message)
+	})
+
+	t.Run("PUT /v1/objects/{id}/references/{propertyName} (deprecated, no class) returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Objects.ObjectsReferencesUpdate(
+			objects.NewObjectsReferencesUpdateParams().
+				WithID(id).WithPropertyName("ref").
+				WithBody(models.MultipleRef{{Beacon: beacon}}),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *objects.ObjectsReferencesUpdateGone
+		require.True(t, errors.As(err, &gone), "expected ObjectsReferencesUpdateGone, got %T: %v", err, err)
+		require.NotNil(t, gone.Payload)
+		require.NotEmpty(t, gone.Payload.Error)
+		assert.NotEmpty(t, gone.Payload.Error[0].Message)
+	})
+
+	t.Run("DELETE /v1/objects/{id}/references/{propertyName} (deprecated, no class) returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Objects.ObjectsReferencesDelete(
+			objects.NewObjectsReferencesDeleteParams().
+				WithID(id).WithPropertyName("ref").
+				WithBody(&models.SingleRef{Beacon: beacon}),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *objects.ObjectsReferencesDeleteGone
+		require.True(t, errors.As(err, &gone), "expected ObjectsReferencesDeleteGone, got %T: %v", err, err)
+		require.NotNil(t, gone.Payload)
+		require.NotEmpty(t, gone.Payload.Error)
+		assert.NotEmpty(t, gone.Payload.Error[0].Message)
+	})
 }

--- a/test/acceptance/namespace/endpoints_gone_test.go
+++ b/test/acceptance/namespace/endpoints_gone_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/weaviate/weaviate/client/classifications"
 	gql "github.com/weaviate/weaviate/client/graphql"
 	"github.com/weaviate/weaviate/client/objects"
 	"github.com/weaviate/weaviate/entities/models"
@@ -175,6 +176,32 @@ func TestNamespaces_EndpointsGone(t *testing.T) {
 		require.Error(t, err)
 		var gone *objects.ObjectsReferencesDeleteGone
 		require.True(t, errors.As(err, &gone), "expected ObjectsReferencesDeleteGone, got %T: %v", err, err)
+		require.NotNil(t, gone.Payload)
+		require.NotEmpty(t, gone.Payload.Error)
+		assert.NotEmpty(t, gone.Payload.Error[0].Message)
+	})
+
+	t.Run("POST /v1/classifications returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Classifications.ClassificationsPost(
+			classifications.NewClassificationsPostParams().WithParams(&models.Classification{}),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *classifications.ClassificationsPostGone
+		require.True(t, errors.As(err, &gone), "expected ClassificationsPostGone, got %T: %v", err, err)
+		require.NotNil(t, gone.Payload)
+		require.NotEmpty(t, gone.Payload.Error)
+		assert.NotEmpty(t, gone.Payload.Error[0].Message)
+	})
+
+	t.Run("GET /v1/classifications/{id} returns 410", func(t *testing.T) {
+		_, err := helper.Client(t).Classifications.ClassificationsGet(
+			classifications.NewClassificationsGetParams().WithID("11111111-1111-1111-1111-111111111111"),
+			helper.CreateAuth(adminKey),
+		)
+		require.Error(t, err)
+		var gone *classifications.ClassificationsGetGone
+		require.True(t, errors.As(err, &gone), "expected ClassificationsGetGone, got %T: %v", err, err)
 		require.NotNil(t, gone.Payload)
 		require.NotEmpty(t, gone.Payload.Error)
 		assert.NotEmpty(t, gone.Payload.Error[0].Message)

--- a/usecases/objects/errors.go
+++ b/usecases/objects/errors.go
@@ -98,6 +98,20 @@ func NewErrNotFound(format string, args ...interface{}) ErrNotFound {
 	return ErrNotFound{msg: fmt.Sprintf(format, args...)}
 }
 
+// ErrEndpointGone marks an operation that is no longer available in the
+// current cluster configuration. The REST layer maps this to HTTP 410.
+type ErrEndpointGone struct {
+	msg string
+}
+
+func (e ErrEndpointGone) Error() string {
+	return e.msg
+}
+
+func NewErrEndpointGone(format string, args ...interface{}) ErrEndpointGone {
+	return ErrEndpointGone{msg: fmt.Sprintf(format, args...)}
+}
+
 type ErrMultiTenancy struct {
 	err error
 }

--- a/usecases/objects/get.go
+++ b/usecases/objects/get.go
@@ -63,6 +63,10 @@ func (m *Manager) GetObjects(ctx context.Context, principal *models.Principal,
 	offset *int64, limit *int64, sort *string, order *string, after *string,
 	addl additional.Properties, tenant string,
 ) ([]*models.Object, error) {
+	if m.config.Config.Namespaces.Enabled {
+		return nil, NewErrEndpointGone("listing objects without a class is not supported; specify the ?class= query parameter")
+	}
+
 	err := m.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Objects("", tenant, ""))
 	if err != nil {
 		return nil, err
@@ -115,6 +119,10 @@ func (m *Manager) GetObjectsClass(ctx context.Context, principal *models.Princip
 func (m *Manager) GetObjectClassFromName(ctx context.Context, principal *models.Principal,
 	className string,
 ) (*models.Class, error) {
+	className, _, err := m.resolveNS(principal, className)
+	if err != nil {
+		return nil, NewErrInvalidUserInput("%v", err)
+	}
 	class, err := m.schemaManager.GetClass(ctx, principal, className)
 	return class, err
 }


### PR DESCRIPTION
### What's being changed:

We have some endpoints that are incompatible with namespaces:
- no classname support (== there is nothing to qualify)
- GQL
- classifications - because nobody knows what this actually does and its probably broken anyways

These now return 410 (gone) when namespaces are enabled. These cannot be used from out new clients, only the old ones or CURL

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
