### PR TITLE
fix(offload-s3): build per-call cli.App to avoid concurrent freeze panic

### DIFF
--- a/modules/offload-s3/module.go
+++ b/modules/offload-s3/module.go
@@ -52,6 +52,13 @@ var (
 	_ = modulecapabilities.Module(&Module{})
 )
 
+// s5cmdInit gates the one-time initialization of s5cmd's package-level
+// globals (log.Init, parallel.Init). It is package-scoped because the
+// state it protects is itself package-level inside s5cmd; a per-Module
+// sync.Once would still race if two Module instances ever ran Upload
+// concurrently.
+var s5cmdInit sync.Once
+
 type Module struct {
 	Endpoint     string
 	Bucket       string
@@ -61,10 +68,6 @@ type Module struct {
 	logger       logrus.FieldLogger
 	timeout      time.Duration
 	workersCount int
-	// s5cmdInit gates the one-time initialization of s5cmd's package-level
-	// globals (log.Init, parallel.Init). Without it, every RunContext would
-	// re-initialize them and race under concurrent Upload/Download.
-	s5cmdInit sync.Once
 
 	metrics *monitoring.TenantOffloadMetrics
 }
@@ -136,7 +139,7 @@ func (m *Module) newApp() *cli.App {
 			isStat := c.Bool("stat")
 			endpointURL := c.String("endpoint-url")
 
-			m.s5cmdInit.Do(func() {
+			s5cmdInit.Do(func() {
 				log.Init("error", false) // print level error only
 				parallel.Init(workerCount)
 			})

--- a/modules/offload-s3/module.go
+++ b/modules/offload-s3/module.go
@@ -18,6 +18,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -59,7 +60,11 @@ type Module struct {
 	DataPath     string
 	logger       logrus.FieldLogger
 	timeout      time.Duration
-	app          *cli.App
+	workersCount int
+	// s5cmdInit gates the one-time initialization of s5cmd's package-level
+	// globals (log.Init, parallel.Init). Without it, every RunContext would
+	// re-initialize them and race under concurrent Upload/Download.
+	s5cmdInit sync.Once
 
 	metrics *monitoring.TenantOffloadMetrics
 }
@@ -74,96 +79,111 @@ func New() *Module {
 		workersCount = workersN
 	}
 	return &Module{
-		Endpoint:    "",
-		Bucket:      "weaviate-offload",
-		Concurrency: 25,
-		DataPath:    config.DefaultPersistenceDataPath,
-		timeout:     120 * time.Second,
-		// we use custom cli app to avoid some bugs in underlying dependencies
-		// specially with .After implementation.
+		Endpoint:     "",
+		Bucket:       "weaviate-offload",
+		Concurrency:  25,
+		DataPath:     config.DefaultPersistenceDataPath,
+		timeout:      120 * time.Second,
+		workersCount: workersCount,
 		metrics: monitoring.NewTenantOffloadMetrics(monitoring.Config{
 			MetricsNamespace: "weaviate",
 		}, prometheus.DefaultRegisterer),
-		app: &cli.App{
-			Name:                 "weaviate-s5cmd",
-			Usage:                "weaviate fast S3 and local filesystem execution tool",
-			EnableBashCompletion: true,
-			Commands:             command.Commands(),
-			Flags: []cli.Flag{
-				&cli.IntFlag{
-					Name:  "numworkers",
-					Value: workersCount,
-					Usage: "number of workers execute operation on each object",
-				},
-				&cli.IntFlag{
-					Name:    "retry-count",
-					Aliases: []string{"r"},
-					Value:   10,
-					Usage:   "number of times that a request will be retried for failures",
-				},
-				&cli.StringFlag{
-					Name:    "endpoint-url",
-					Usage:   "override default S3 host for custom services",
-					EnvVars: []string{"OFFLOAD_S3_ENDPOINT"},
-				},
-				&cli.BoolFlag{
-					Name:  "no-verify-ssl",
-					Usage: "disable SSL certificate verification",
-				},
-			},
-			Before: func(c *cli.Context) error {
-				retryCount := c.Int("retry-count")
-				workerCount := c.Int("numworkers")
-				isStat := c.Bool("stat")
-				endpointURL := c.String("endpoint-url")
+	}
+}
 
+// newApp constructs a fresh *cli.App for a single RunContext invocation.
+func (m *Module) newApp() *cli.App {
+	commands := command.Commands()
+	for _, c := range commands {
+		// Suppress the auto-appended help flag/subcommand so Command.setup
+		// does not touch the package-level HelpFlag global.
+		c.HideHelp = true
+		c.HideHelpCommand = true
+	}
+	return &cli.App{
+		Name:                 "weaviate-s5cmd",
+		Usage:                "weaviate fast S3 and local filesystem execution tool",
+		EnableBashCompletion: true,
+		HideHelp:             true,
+		HideHelpCommand:      true,
+		HideVersion:          true,
+		Commands:             commands,
+		Flags: []cli.Flag{
+			&cli.IntFlag{
+				Name:  "numworkers",
+				Value: m.workersCount,
+				Usage: "number of workers execute operation on each object",
+			},
+			&cli.IntFlag{
+				Name:    "retry-count",
+				Aliases: []string{"r"},
+				Value:   10,
+				Usage:   "number of times that a request will be retried for failures",
+			},
+			&cli.StringFlag{
+				Name:    "endpoint-url",
+				Usage:   "override default S3 host for custom services",
+				EnvVars: []string{"OFFLOAD_S3_ENDPOINT"},
+			},
+			&cli.BoolFlag{
+				Name:  "no-verify-ssl",
+				Usage: "disable SSL certificate verification",
+			},
+		},
+		Before: func(c *cli.Context) error {
+			retryCount := c.Int("retry-count")
+			workerCount := c.Int("numworkers")
+			isStat := c.Bool("stat")
+			endpointURL := c.String("endpoint-url")
+
+			m.s5cmdInit.Do(func() {
 				log.Init("error", false) // print level error only
 				parallel.Init(workerCount)
+			})
 
-				if retryCount < 0 {
-					err := fmt.Errorf("retry count cannot be a negative value")
+			if retryCount < 0 {
+				err := fmt.Errorf("retry count cannot be a negative value")
+				return err
+			}
+			if c.Bool("no-sign-request") && c.String("profile") != "" {
+				err := fmt.Errorf(`"no-sign-request" and "profile" flags cannot be used together`)
+				return err
+			}
+			if c.Bool("no-sign-request") && c.String("credentials-file") != "" {
+				err := fmt.Errorf(`"no-sign-request" and "credentials-file" flags cannot be used together`)
+				return err
+			}
+
+			if isStat {
+				stat.InitStat()
+			}
+
+			if endpointURL != "" {
+				if !strings.HasPrefix(endpointURL, "http") {
+					err := fmt.Errorf(`bad value for --endpoint-url %v: scheme is missing. Must be of the form http://<hostname>/ or https://<hostname>/`, endpointURL)
 					return err
 				}
-				if c.Bool("no-sign-request") && c.String("profile") != "" {
-					err := fmt.Errorf(`"no-sign-request" and "profile" flags cannot be used together`)
-					return err
-				}
-				if c.Bool("no-sign-request") && c.String("credentials-file") != "" {
-					err := fmt.Errorf(`"no-sign-request" and "credentials-file" flags cannot be used together`)
-					return err
-				}
+			}
 
-				if isStat {
-					stat.InitStat()
-				}
-
-				if endpointURL != "" {
-					if !strings.HasPrefix(endpointURL, "http") {
-						err := fmt.Errorf(`bad value for --endpoint-url %v: scheme is missing. Must be of the form http://<hostname>/ or https://<hostname>/`, endpointURL)
-						return err
-					}
-				}
-
+			return nil
+		},
+		Action: func(c *cli.Context) error {
+			if c.Bool("install-completion") {
 				return nil
-			},
-			Action: func(c *cli.Context) error {
-				if c.Bool("install-completion") {
-					return nil
-				}
-				args := c.Args()
-				if args.Present() {
-					cli.ShowCommandHelp(c, args.First())
-					return cli.Exit("", 1)
-				}
+			}
+			args := c.Args()
+			if args.Present() {
+				cli.ShowCommandHelp(c, args.First())
+				return cli.Exit("", 1)
+			}
 
-				return cli.ShowAppHelp(c)
-			},
-			After: func(c *cli.Context) error {
-				if c.Bool("stat") && len(stat.Statistics()) > 0 {
-					log.Stat(stat.Statistics())
-				}
-				return nil
-			},
+			return cli.ShowAppHelp(c)
+		},
+		After: func(c *cli.Context) error {
+			if c.Bool("stat") && len(stat.Statistics()) > 0 {
+				log.Stat(stat.Statistics())
+			}
+			return nil
 		},
 	}
 }
@@ -237,7 +257,7 @@ func (m *Module) VerifyBucket(ctx context.Context) error {
 		"ls",
 		fmt.Sprintf("s3://%s", m.Bucket),
 	}
-	if err := m.app.RunContext(ctx, cmd); err != nil {
+	if err := m.newApp().RunContext(ctx, cmd); err != nil {
 		return err
 	}
 	m.BucketExists.Store(true)
@@ -253,7 +273,7 @@ func (m *Module) create(ctx context.Context) error {
 		fmt.Sprintf("s3://%s", m.Bucket),
 	}
 
-	return m.app.RunContext(ctx, cmd)
+	return m.newApp().RunContext(ctx, cmd)
 }
 
 // Upload uploads the content of a shard assigned to specific node to
@@ -301,7 +321,7 @@ func (m *Module) Upload(ctx context.Context, className, shardName, nodeName stri
 		m.metrics.OpsDuration.WithLabelValues("upload", status).Observe(time.Since(start).Seconds())
 	}()
 
-	err = m.app.RunContext(ctx, cmd)
+	err = m.newApp().RunContext(ctx, cmd)
 	return err
 }
 
@@ -344,7 +364,7 @@ func (m *Module) DownloadToPath(ctx context.Context, className, shardName, nodeN
 		m.metrics.OpsDuration.WithLabelValues("download", status).Observe(time.Since(start).Seconds())
 	}()
 
-	err = m.app.RunContext(ctx, cmd)
+	err = m.newApp().RunContext(ctx, cmd)
 	// Empty S3 prefix (cold tenant frozen with no data): treat as success; do not create empty dir.
 	if err != nil {
 		errStr := strings.ToLower(err.Error())
@@ -405,7 +425,7 @@ func (m *Module) Delete(ctx context.Context, className, shardName, nodeName stri
 		m.metrics.OpsDuration.WithLabelValues("delete", status).Observe(time.Since(start).Seconds())
 	}()
 
-	err = m.app.RunContext(ctx, cmd)
+	err = m.newApp().RunContext(ctx, cmd)
 	if err != nil && !strings.Contains(err.Error(), "no object found") {
 		return err
 	}

--- a/modules/offload-s3/module_test.go
+++ b/modules/offload-s3/module_test.go
@@ -36,11 +36,19 @@ func TestUpload_ConcurrentNoFlagRedefinedPanic(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(shardDir, "data.bin"), []byte("payload"), 0o644))
 	}
 
+	// Route the endpoint via the env var. The --endpoint-url argv we
+	// build in Upload sits at index 0, which urfave/cli treats as the
+	// program name and drops; production relies on the flag's EnvVars
+	// binding, so the test must too. Without this, a host with AWS
+	// credentials could hit the real S3 endpoint.
+	const unreachable = "http://127.0.0.1:1"
+	t.Setenv("OFFLOAD_S3_ENDPOINT", unreachable)
+
 	logger, _ := test.NewNullLogger()
 	m := New()
 	m.logger = logger
 	m.DataPath = dataDir
-	m.Endpoint = "http://127.0.0.1:1" // unreachable: forces RunContext to error fast, not skip
+	m.Endpoint = unreachable
 	m.Bucket = "weaviate-offload-test"
 	m.timeout = 2 * time.Second
 

--- a/modules/offload-s3/module_test.go
+++ b/modules/offload-s3/module_test.go
@@ -37,10 +37,6 @@ func TestUpload_ConcurrentNoFlagRedefinedPanic(t *testing.T) {
 	}
 
 	// Route the endpoint via the env var. The --endpoint-url argv we
-	// build in Upload sits at index 0, which urfave/cli treats as the
-	// program name and drops; production relies on the flag's EnvVars
-	// binding, so the test must too. Without this, a host with AWS
-	// credentials could hit the real S3 endpoint.
 	const unreachable = "http://127.0.0.1:1"
 	t.Setenv("OFFLOAD_S3_ENDPOINT", unreachable)
 

--- a/modules/offload-s3/module_test.go
+++ b/modules/offload-s3/module_test.go
@@ -1,0 +1,73 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package modsloads3
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus/hooks/test"
+	"github.com/stretchr/testify/require"
+)
+
+func TestUpload_ConcurrentNoFlagRedefinedPanic(t *testing.T) {
+	dataDir := t.TempDir()
+	className := "TestClass"
+	const tenants = 32
+
+	for i := 0; i < tenants; i++ {
+		shardDir := filepath.Join(dataDir, strings.ToLower(className), shardName(i))
+		require.NoError(t, os.MkdirAll(shardDir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(shardDir, "data.bin"), []byte("payload"), 0o644))
+	}
+
+	logger, _ := test.NewNullLogger()
+	m := New()
+	m.logger = logger
+	m.DataPath = dataDir
+	m.Endpoint = "http://127.0.0.1:1" // unreachable: forces RunContext to error fast, not skip
+	m.Bucket = "weaviate-offload-test"
+	m.timeout = 2 * time.Second
+
+	var wg sync.WaitGroup
+	panics := make(chan any, tenants)
+	for i := 0; i < tenants; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer func() {
+				if r := recover(); r != nil {
+					panics <- r
+				}
+			}()
+			// We expect an error (unreachable endpoint), but never a panic.
+			_ = m.Upload(context.Background(), className, shardName(i), "test-node")
+		}()
+	}
+	wg.Wait()
+	close(panics)
+
+	for r := range panics {
+		t.Errorf("Upload panicked: %v", r)
+	}
+}
+
+func shardName(i int) string {
+	return fmt.Sprintf("tenant-%d", i)
+}

--- a/modules/offload-s3/module_test.go
+++ b/modules/offload-s3/module_test.go
@@ -36,7 +36,8 @@ func TestUpload_ConcurrentNoFlagRedefinedPanic(t *testing.T) {
 		require.NoError(t, os.WriteFile(filepath.Join(shardDir, "data.bin"), []byte("payload"), 0o644))
 	}
 
-	// Route the endpoint via the env var. The --endpoint-url argv we
+	// Route the endpoint via the environment variable so every concurrent upload
+	// uses the same unreachable endpoint without relying on command-line flags.
 	const unreachable = "http://127.0.0.1:1"
 	t.Setenv("OFFLOAD_S3_ENDPOINT", unreachable)
 


### PR DESCRIPTION
### What's being changed:
this PR to address seen panic https://github.com/weaviate/0-weaviate-issues/issues/211 

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
