### PR TITLE
feat: add keyword highlighting for BM25/Hybrid in _additional (#2567)

### DIFF
--- a/adapters/handlers/graphql/local/get/class_builder.go
+++ b/adapters/handlers/graphql/local/get/class_builder.go
@@ -189,6 +189,7 @@ func (b *classBuilder) additionalFields(classProperties graphql.Fields, class *m
 	additionalProperties["explainScore"] = b.additionalExplainScoreField()
 	additionalProperties["queryProfile"] = b.additionalQueryProfileField()
 	additionalProperties["group"] = b.additionalGroupField(classProperties, class)
+	additionalProperties["highlight"] = b.additionalHighlightField(class)
 	if replicationEnabled(class) {
 		additionalProperties["isConsistent"] = b.isConsistentField()
 	}
@@ -302,6 +303,48 @@ func (b *classBuilder) additionalLastUpdateTimeUnix() *graphql.Field {
 func (b *classBuilder) isConsistentField() *graphql.Field {
 	return &graphql.Field{
 		Type: graphql.Boolean,
+	}
+}
+
+// additionalHighlightField exposes keyword highlighting under
+// _additional { highlight { field snippets } } for BM25 / Hybrid queries.
+// All arguments are optional and carry sensible defaults.
+func (b *classBuilder) additionalHighlightField(class *models.Class) *graphql.Field {
+	return &graphql.Field{
+		Description: "Keyword highlighting for BM25 / Hybrid search results.",
+		Args: graphql.FieldConfigArgument{
+			"properties": &graphql.ArgumentConfig{
+				Description: "Text/string properties to highlight. Omit to highlight all string properties.",
+				Type:        graphql.NewList(graphql.String),
+			},
+			"fragmentSize": &graphql.ArgumentConfig{
+				Description:  "Approximate byte length of each returned snippet (default: 100).",
+				Type:         graphql.Int,
+				DefaultValue: 100,
+			},
+			"numberOfFragments": &graphql.ArgumentConfig{
+				Description:  "Maximum number of snippets returned per property (default: 3).",
+				Type:         graphql.Int,
+				DefaultValue: 3,
+			},
+			"prefix": &graphql.ArgumentConfig{
+				Description:  "String prepended to each matched term in a snippet (default: \"<em>\").",
+				Type:         graphql.String,
+				DefaultValue: "<em>",
+			},
+			"postfix": &graphql.ArgumentConfig{
+				Description:  "String appended to each matched term in a snippet (default: \"</em>\").",
+				Type:         graphql.String,
+				DefaultValue: "</em>",
+			},
+		},
+		Type: graphql.NewList(graphql.NewObject(graphql.ObjectConfig{
+			Name: fmt.Sprintf("%sAdditionalHighlight", class.Class),
+			Fields: graphql.Fields{
+				"field":    &graphql.Field{Type: graphql.String},
+				"snippets": &graphql.Field{Type: graphql.NewList(graphql.String)},
+			},
+		})),
 	}
 }
 

--- a/adapters/handlers/graphql/local/get/class_builder_fields.go
+++ b/adapters/handlers/graphql/local/get/class_builder_fields.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
@@ -590,7 +591,7 @@ func (ac *additionalCheck) isAdditional(parentName, name string) bool {
 			name == "distance" || name == "id" || name == "vector" || name == "vectors" ||
 			name == "creationTimeUnix" || name == "lastUpdateTimeUnix" ||
 			name == "score" || name == "explainScore" || name == "isConsistent" ||
-			name == "group" || name == "queryProfile" {
+			name == "group" || name == "queryProfile" || name == "highlight" {
 			return true
 		}
 		if ac.isModuleAdditional(name) {
@@ -716,6 +717,10 @@ func extractProperties(className string, selections *ast.SelectionSet,
 							if err != nil {
 								return nil, additionalProps, nil, err
 							}
+							continue
+						}
+						if additionalProperty == "highlight" {
+							additionalProps.Highlight = extractHighlightArgs(s.Arguments)
 							continue
 						}
 						if modulesProvider != nil {
@@ -893,4 +898,44 @@ func hackyWorkaroundToExtractClassName(def ast.Definition, name string) (string,
 	}
 
 	return string(matches[1]), nil
+}
+
+// extractHighlightArgs parses _additional { highlight(...) } arguments into
+// an additional.HighlightParams, applying defaults for any omitted arguments.
+func extractHighlightArgs(args []*ast.Argument) *additional.HighlightParams {
+	p := &additional.HighlightParams{
+		FragmentSize:      100,
+		NumberOfFragments: 3,
+		Prefix:            "<em>",
+		Postfix:           "</em>",
+	}
+
+	for _, arg := range args {
+		switch arg.Name.Value {
+		case "properties":
+			if listVal, ok := arg.Value.(*ast.ListValue); ok {
+				props := make([]string, 0, len(listVal.Values))
+				for _, v := range listVal.Values {
+					if s, ok := v.GetValue().(string); ok && s != "" {
+						props = append(props, s)
+					}
+				}
+				p.Properties = props
+			}
+		case "fragmentSize":
+			if v, err := strconv.Atoi(arg.Value.GetValue().(string)); err == nil && v > 0 {
+				p.FragmentSize = v
+			}
+		case "numberOfFragments":
+			if v, err := strconv.Atoi(arg.Value.GetValue().(string)); err == nil && v > 0 {
+				p.NumberOfFragments = v
+			}
+		case "prefix":
+			p.Prefix = arg.Value.GetValue().(string)
+		case "postfix":
+			p.Postfix = arg.Value.GetValue().(string)
+		}
+	}
+
+	return p
 }

--- a/entities/additional/classification.go
+++ b/entities/additional/classification.go
@@ -44,6 +44,10 @@ type Properties struct {
 	// QueryProfile enables per-shard query profiling data collection and return.
 	QueryProfile bool `json:"queryProfile"`
 
+	// Highlight, when non-nil, requests keyword snippet generation for BM25 /
+	// Hybrid searches via _additional { highlight { field snippets } }.
+	Highlight *HighlightParams `json:"highlight,omitempty"`
+
 	// The User is not interested in returning props, we can skip any costly
 	// operation that isn't required.
 	NoProps bool `json:"noProps"`

--- a/entities/additional/highlight.go
+++ b/entities/additional/highlight.go
@@ -1,0 +1,41 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package additional
+
+// HighlightParams holds the user-supplied configuration for the
+// _additional { highlight { ... } } query argument.
+type HighlightParams struct {
+	// Properties lists the text/string properties to highlight.
+	// An empty slice means "all string properties in the result".
+	Properties []string
+
+	// FragmentSize is the approximate byte length of each returned snippet.
+	// Defaults to 100 when unset (zero value).
+	FragmentSize int
+
+	// NumberOfFragments caps how many snippets are returned per property.
+	// Defaults to 3 when unset (zero value).
+	NumberOfFragments int
+
+	// Prefix is prepended to every matched term in a snippet (e.g. "<em>").
+	Prefix string
+
+	// Postfix is appended to every matched term in a snippet (e.g. "</em>").
+	Postfix string
+}
+
+// HighlightResult is the per-property payload returned in
+// _additional { highlight { field snippets } }.
+type HighlightResult struct {
+	Field    string   `json:"field"`
+	Snippets []string `json:"snippets"`
+}

--- a/usecases/highlight/snippet.go
+++ b/usecases/highlight/snippet.go
@@ -1,0 +1,202 @@
+package highlight
+
+import (
+	"sort"
+	"strings"
+	"unicode/utf8"
+)
+
+// GenerateSnippets extracts contextual text fragments from text that contain
+// any of the provided queryTerms. Matching is case-insensitive; the returned
+// snippets preserve the original casing of the source text.
+//
+// Each matched term inside a returned snippet is wrapped with prefix and postfix
+// (e.g. "<em>" / "</em>"). Up to maxFragments non-overlapping fragments of
+// approximately fragmentSize bytes are returned. An ellipsis ("...") is
+// prepended / appended when the fragment does not begin / end at the boundary
+// of the original text.
+//
+// Nil is returned when text is empty, queryTerms is empty / all blank,
+// fragmentSize ≤ 0, maxFragments ≤ 0, or no term is found in the text.
+func GenerateSnippets(
+	text string,
+	queryTerms []string,
+	fragmentSize int,
+	maxFragments int,
+	prefix string,
+	postfix string,
+) []string {
+	if text == "" || len(queryTerms) == 0 || fragmentSize <= 0 || maxFragments <= 0 {
+		return nil
+	}
+
+	textLower := strings.ToLower(text)
+	textLen := len(text)
+
+	type match struct{ start, end int }
+	var matches []match
+
+	for _, term := range queryTerms {
+		if term == "" {
+			continue
+		}
+		termLower := strings.ToLower(term)
+		termLen := len(termLower)
+		offset := 0
+		for {
+			idx := strings.Index(textLower[offset:], termLower)
+			if idx < 0 {
+				break
+			}
+			abs := offset + idx
+			matches = append(matches, match{abs, abs + termLen})
+			offset = abs + 1
+		}
+	}
+
+	if len(matches) == 0 {
+		return nil
+	}
+
+	sort.Slice(matches, func(i, j int) bool { return matches[i].start < matches[j].start })
+
+	// Compute a window centered on each match.
+	type window struct{ start, end int }
+	windows := make([]window, 0, len(matches))
+	half := fragmentSize / 2
+	for _, m := range matches {
+		wStart := m.start - half
+		wEnd := wStart + fragmentSize
+		if wStart < 0 {
+			wStart = 0
+			wEnd = fragmentSize
+		}
+		if wEnd > textLen {
+			wEnd = textLen
+			wStart = textLen - fragmentSize
+			if wStart < 0 {
+				wStart = 0
+			}
+		}
+		// Snap boundaries to valid UTF-8 rune starts to avoid slicing a
+		// multibyte character in half.
+		wStart = snapRuneStart(text, wStart, false)
+		wEnd = snapRuneStart(text, wEnd, true)
+		windows = append(windows, window{wStart, wEnd})
+	}
+
+	// Merge overlapping / adjacent windows.
+	merged := []window{windows[0]}
+	for _, w := range windows[1:] {
+		last := &merged[len(merged)-1]
+		if w.start <= last.end {
+			if w.end > last.end {
+				last.end = w.end
+			}
+		} else {
+			merged = append(merged, w)
+		}
+	}
+
+	if len(merged) > maxFragments {
+		merged = merged[:maxFragments]
+	}
+
+	snippets := make([]string, 0, len(merged))
+	for _, w := range merged {
+		fragment := text[w.start:w.end]
+		fragment = applyHighlight(fragment, queryTerms, prefix, postfix)
+		if w.start > 0 {
+			fragment = "..." + fragment
+		}
+		if w.end < textLen {
+			fragment = fragment + "..."
+		}
+		snippets = append(snippets, fragment)
+	}
+	return snippets
+}
+
+// applyHighlight wraps all case-insensitive occurrences of queryTerms within
+// fragment with prefix / postfix, preserving the original casing of the text.
+func applyHighlight(fragment string, queryTerms []string, prefix, postfix string) string {
+	if prefix == "" && postfix == "" {
+		return fragment
+	}
+
+	fragmentLower := strings.ToLower(fragment)
+
+	type span struct{ start, end int }
+	var spans []span
+
+	for _, term := range queryTerms {
+		if term == "" {
+			continue
+		}
+		termLower := strings.ToLower(term)
+		termLen := len(termLower)
+		offset := 0
+		for {
+			idx := strings.Index(fragmentLower[offset:], termLower)
+			if idx < 0 {
+				break
+			}
+			abs := offset + idx
+			spans = append(spans, span{abs, abs + termLen})
+			offset = abs + 1
+		}
+	}
+
+	if len(spans) == 0 {
+		return fragment
+	}
+
+	sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
+
+	// Merge overlapping spans so we never double-wrap.
+	mergedSpans := []span{spans[0]}
+	for _, s := range spans[1:] {
+		last := &mergedSpans[len(mergedSpans)-1]
+		if s.start < last.end {
+			if s.end > last.end {
+				last.end = s.end
+			}
+		} else {
+			mergedSpans = append(mergedSpans, s)
+		}
+	}
+
+	var sb strings.Builder
+	cursor := 0
+	for _, s := range mergedSpans {
+		sb.WriteString(fragment[cursor:s.start])
+		sb.WriteString(prefix)
+		sb.WriteString(fragment[s.start:s.end])
+		sb.WriteString(postfix)
+		cursor = s.end
+	}
+	sb.WriteString(fragment[cursor:])
+	return sb.String()
+}
+
+// snapRuneStart adjusts byte index i so that it points to the start of a valid
+// UTF-8 rune in s. When forward is false the index is moved backward; when
+// forward is true it is moved forward.
+func snapRuneStart(s string, i int, forward bool) int {
+	if i <= 0 {
+		return 0
+	}
+	if i >= len(s) {
+		return len(s)
+	}
+	if forward {
+		for i < len(s) && !utf8.RuneStart(s[i]) {
+			i++
+		}
+	} else {
+		for i > 0 && !utf8.RuneStart(s[i]) {
+			i--
+		}
+	}
+	return i
+}

--- a/usecases/highlight/snippet.go
+++ b/usecases/highlight/snippet.go
@@ -1,6 +1,7 @@
 package highlight
 
 import (
+	"regexp"
 	"sort"
 	"strings"
 	"unicode/utf8"
@@ -30,7 +31,6 @@ func GenerateSnippets(
 		return nil
 	}
 
-	textLower := strings.ToLower(text)
 	textLen := len(text)
 
 	type match struct{ start, end int }
@@ -40,17 +40,12 @@ func GenerateSnippets(
 		if term == "" {
 			continue
 		}
-		termLower := strings.ToLower(term)
-		termLen := len(termLower)
-		offset := 0
-		for {
-			idx := strings.Index(textLower[offset:], termLower)
-			if idx < 0 {
-				break
-			}
-			abs := offset + idx
-			matches = append(matches, match{abs, abs + termLen})
-			offset = abs + 1
+		re, err := regexp.Compile("(?i)" + regexp.QuoteMeta(term))
+		if err != nil {
+			continue
+		}
+		for _, loc := range re.FindAllStringIndex(text, -1) {
+			matches = append(matches, match{loc[0], loc[1]})
 		}
 	}
 
@@ -124,8 +119,6 @@ func applyHighlight(fragment string, queryTerms []string, prefix, postfix string
 		return fragment
 	}
 
-	fragmentLower := strings.ToLower(fragment)
-
 	type span struct{ start, end int }
 	var spans []span
 
@@ -133,17 +126,12 @@ func applyHighlight(fragment string, queryTerms []string, prefix, postfix string
 		if term == "" {
 			continue
 		}
-		termLower := strings.ToLower(term)
-		termLen := len(termLower)
-		offset := 0
-		for {
-			idx := strings.Index(fragmentLower[offset:], termLower)
-			if idx < 0 {
-				break
-			}
-			abs := offset + idx
-			spans = append(spans, span{abs, abs + termLen})
-			offset = abs + 1
+		re, err := regexp.Compile("(?i)" + regexp.QuoteMeta(term))
+		if err != nil {
+			continue
+		}
+		for _, loc := range re.FindAllStringIndex(fragment, -1) {
+			spans = append(spans, span{loc[0], loc[1]})
 		}
 	}
 

--- a/usecases/highlight/snippet_test.go
+++ b/usecases/highlight/snippet_test.go
@@ -1,0 +1,340 @@
+package highlight
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestGenerateSnippets(t *testing.T) {
+	const pre, post = "<em>", "</em>"
+
+	tests := []struct {
+		name               string
+		text               string
+		queryTerms         []string
+		fragmentSize       int
+		maxFragments       int
+		wantCount          int      // exact number of returned snippets
+		wantContains       []string // every entry must appear in ≥ 1 snippet
+		wantAbsent         []string // none of these may appear in any snippet
+		wantNoEllipsis     bool     // true → no snippet may contain "..."
+		wantLeadingEllipsis  bool   // true → first snippet must start with "..."
+		wantTrailingEllipsis bool   // true → last snippet must end with "..."
+	}{
+		// ------------------------------------------------------------------ //
+		// 1. Basic single-term match                                           //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "basic match",
+			text:         "The quick brown fox jumps over the lazy dog near the river bank.",
+			queryTerms:   []string{"fox"},
+			fragmentSize: 40,
+			maxFragments: 1,
+			wantCount:    1,
+			wantContains: []string{"<em>fox</em>"},
+		},
+
+		// ------------------------------------------------------------------ //
+		// 2. Case mismatch – query "fAsHiOn", text contains "fashionable"      //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "case mismatch",
+			text:         "The latest fashionable trends are everywhere in the world.",
+			queryTerms:   []string{"fAsHiOn"},
+			fragmentSize: 40,
+			maxFragments: 1,
+			wantCount:    1,
+			// "fashion" is the literal substring that matches "fAsHiOn" lowercased
+			wantContains: []string{"<em>fashion</em>"},
+		},
+
+		// ------------------------------------------------------------------ //
+		// 3. Match at the very start of the string (no negative index panic)  //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "match at start of string",
+			text:         "fox jumps over the lazy dog near the river bank.",
+			queryTerms:   []string{"fox"},
+			fragmentSize: 40,
+			maxFragments: 1,
+			wantCount:    1,
+			wantContains: []string{"<em>fox</em>"},
+			// window starts at byte 0 → no leading ellipsis
+			wantLeadingEllipsis: false,
+		},
+
+		// ------------------------------------------------------------------ //
+		// 4. Match at the very end of the string (no upper index panic)       //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "match at end of string",
+			text:         "The quick brown fox jumps over the lazy bank",
+			queryTerms:   []string{"bank"},
+			fragmentSize: 40,
+			maxFragments: 1,
+			wantCount:    1,
+			wantContains: []string{"<em>bank</em>"},
+			// window ends at textLen → no trailing ellipsis
+			wantTrailingEllipsis: false,
+		},
+
+		// ------------------------------------------------------------------ //
+		// 5. Short text (total length < fragmentSize) – no ellipsis at all    //
+		// ------------------------------------------------------------------ //
+		{
+			name:           "short text shorter than fragment size",
+			text:           "fox",
+			queryTerms:     []string{"fox"},
+			fragmentSize:   100,
+			maxFragments:   1,
+			wantCount:      1,
+			wantContains:   []string{"<em>fox</em>"},
+			wantNoEllipsis: true,
+		},
+
+		// ------------------------------------------------------------------ //
+		// 6a. Multiple matches – maxFragments respected (truncated to 2)      //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "multiple matches respects maxFragments",
+			text:         "aaa foo bbb. ccc foo ddd. eee foo fff.",
+			queryTerms:   []string{"foo"},
+			fragmentSize: 10,
+			maxFragments: 2,
+			wantCount:    2,
+			wantContains: []string{"<em>foo</em>"},
+		},
+
+		// ------------------------------------------------------------------ //
+		// 6b. Multiple matches – all three returned when limit allows         //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "multiple matches all returned when maxFragments allows",
+			text:         "aaa foo bbb. ccc foo ddd. eee foo fff.",
+			queryTerms:   []string{"foo"},
+			fragmentSize: 10,
+			maxFragments: 5,
+			wantCount:    3,
+			wantContains: []string{"<em>foo</em>"},
+		},
+
+		// ------------------------------------------------------------------ //
+		// 7a. Special characters and unicode near the match                   //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "unicode characters near match",
+			text:         "Привет! The keyword résumé is here. Goodbye! 日本語テスト",
+			queryTerms:   []string{"keyword"},
+			fragmentSize: 40,
+			maxFragments: 1,
+			wantCount:    1,
+			wantContains: []string{"<em>keyword</em>"},
+		},
+
+		// ------------------------------------------------------------------ //
+		// 7b. Newlines and punctuation near the match                         //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "newline and punctuation near match",
+			text:         "First line.\nSecond line with target word.\nThird line.",
+			queryTerms:   []string{"target"},
+			fragmentSize: 50,
+			maxFragments: 1,
+			wantCount:    1,
+			wantContains: []string{"<em>target</em>"},
+		},
+
+		// ------------------------------------------------------------------ //
+		// 8a. Empty text                                                       //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "empty text returns nil",
+			text:         "",
+			queryTerms:   []string{"fox"},
+			fragmentSize: 100,
+			maxFragments: 1,
+			wantCount:    0,
+		},
+
+		// ------------------------------------------------------------------ //
+		// 8b. Empty query terms slice                                          //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "empty query terms returns nil",
+			text:         "The quick brown fox.",
+			queryTerms:   []string{},
+			fragmentSize: 100,
+			maxFragments: 1,
+			wantCount:    0,
+		},
+
+		// ------------------------------------------------------------------ //
+		// 8c. Query terms slice with only a blank string                       //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "blank query term only returns nil",
+			text:         "The quick brown fox.",
+			queryTerms:   []string{""},
+			fragmentSize: 100,
+			maxFragments: 1,
+			wantCount:    0,
+		},
+
+		// ------------------------------------------------------------------ //
+		// 8d. Zero fragmentSize                                                //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "zero fragmentSize returns nil",
+			text:         "The quick brown fox.",
+			queryTerms:   []string{"fox"},
+			fragmentSize: 0,
+			maxFragments: 1,
+			wantCount:    0,
+		},
+
+		// ------------------------------------------------------------------ //
+		// 8e. Zero maxFragments                                                //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "zero maxFragments returns nil",
+			text:         "The quick brown fox.",
+			queryTerms:   []string{"fox"},
+			fragmentSize: 100,
+			maxFragments: 0,
+			wantCount:    0,
+		},
+
+		// ------------------------------------------------------------------ //
+		// 8f. Term not found in text                                           //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "no match returns nil",
+			text:         "The quick brown fox.",
+			queryTerms:   []string{"elephant"},
+			fragmentSize: 100,
+			maxFragments: 1,
+			wantCount:    0,
+		},
+
+		// ------------------------------------------------------------------ //
+		// 9. Multiple query terms in same window → both highlighted           //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "multiple query terms both highlighted",
+			text:         "The cat chased the dog across the yard.",
+			queryTerms:   []string{"cat", "dog"},
+			fragmentSize: 60,
+			maxFragments: 2,
+			wantCount:    1, // close together → merged into one window
+			wantContains: []string{"<em>cat</em>", "<em>dog</em>"},
+		},
+
+		// ------------------------------------------------------------------ //
+		// 10. Overlapping windows are merged into a single snippet            //
+		// ------------------------------------------------------------------ //
+		{
+			name: "overlapping windows merge into one snippet",
+			// "alpha" at bytes 10 and 20 with only 5 bytes gap → windows overlap
+			text:         strings.Repeat("x", 10) + "alpha" + strings.Repeat("x", 5) + "alpha" + strings.Repeat("x", 10),
+			queryTerms:   []string{"alpha"},
+			fragmentSize: 30,
+			maxFragments: 5,
+			wantCount:    1,
+			wantContains: []string{"<em>alpha</em>"},
+		},
+
+		// ------------------------------------------------------------------ //
+		// 11. Prefix / postfix preserved correctly, original casing kept      //
+		// ------------------------------------------------------------------ //
+		{
+			name:         "original casing preserved in highlight",
+			text:         "The Quick Brown FOX jumps.",
+			queryTerms:   []string{"fox"},
+			fragmentSize: 60,
+			maxFragments: 1,
+			wantCount:    1,
+			wantContains: []string{"<em>FOX</em>"},
+			wantAbsent:   []string{"<em>fox</em>"},
+		},
+
+		// ------------------------------------------------------------------ //
+		// 12. Fragment that exactly covers the text boundary (no panic)       //
+		// ------------------------------------------------------------------ //
+		{
+			name:           "fragment exactly covers full text",
+			text:           "hello world",
+			queryTerms:     []string{"world"},
+			fragmentSize:   11, // exact length of text
+			maxFragments:   1,
+			wantCount:      1,
+			wantContains:   []string{"<em>world</em>"},
+			wantNoEllipsis: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := GenerateSnippets(tc.text, tc.queryTerms, tc.fragmentSize, tc.maxFragments, pre, post)
+
+			// --- count check ----------------------------------------------- //
+			if len(got) != tc.wantCount {
+				t.Fatalf("snippet count = %d, want %d\nsnippets = %v", len(got), tc.wantCount, got)
+			}
+			if tc.wantCount == 0 {
+				return // nothing else to verify
+			}
+
+			// --- wantContains ---------------------------------------------- //
+			for _, want := range tc.wantContains {
+				found := false
+				for _, s := range got {
+					if strings.Contains(s, want) {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("no snippet contains %q\nsnippets = %v", want, got)
+				}
+			}
+
+			// --- wantAbsent ------------------------------------------------ //
+			for _, absent := range tc.wantAbsent {
+				for _, s := range got {
+					if strings.Contains(s, absent) {
+						t.Errorf("snippet %q must not contain %q", s, absent)
+					}
+				}
+			}
+
+			// --- ellipsis checks ------------------------------------------- //
+			if tc.wantNoEllipsis {
+				for _, s := range got {
+					if strings.Contains(s, "...") {
+						t.Errorf("snippet %q must not contain ellipsis", s)
+					}
+				}
+			}
+			if !tc.wantLeadingEllipsis {
+				// wantLeadingEllipsis == false means "it must NOT start with ..."
+				// (only enforced when the field is the zero value AND the test
+				//  explicitly documents this expectation via the field name)
+				if tc.name == "match at start of string" {
+					first := got[0]
+					// Strip any highlight tags to find the raw leading bytes.
+					if strings.HasPrefix(first, "...") {
+						t.Errorf("snippet %q must not have a leading ellipsis", first)
+					}
+				}
+			}
+			if !tc.wantTrailingEllipsis {
+				if tc.name == "match at end of string" {
+					last := got[len(got)-1]
+					if strings.HasSuffix(last, "...") {
+						t.Errorf("snippet %q must not have a trailing ellipsis", last)
+					}
+				}
+			}
+		})
+	}
+}

--- a/usecases/highlight/snippet_test.go
+++ b/usecases/highlight/snippet_test.go
@@ -25,13 +25,14 @@ func TestGenerateSnippets(t *testing.T) {
 		// 1. Basic single-term match                                           //
 		// ------------------------------------------------------------------ //
 		{
-			name:         "basic match",
-			text:         "The quick brown fox jumps over the lazy dog near the river bank.",
-			queryTerms:   []string{"fox"},
-			fragmentSize: 40,
-			maxFragments: 1,
-			wantCount:    1,
-			wantContains: []string{"<em>fox</em>"},
+			name:                 "basic match",
+			text:                 "The quick brown fox jumps over the lazy dog near the river bank.",
+			queryTerms:           []string{"fox"},
+			fragmentSize:         40,
+			maxFragments:         1,
+			wantCount:            1,
+			wantContains:         []string{"<em>fox</em>"},
+			wantTrailingEllipsis: true, // window ends before text end
 		},
 
 		// ------------------------------------------------------------------ //
@@ -67,14 +68,15 @@ func TestGenerateSnippets(t *testing.T) {
 		// 4. Match at the very end of the string (no upper index panic)       //
 		// ------------------------------------------------------------------ //
 		{
-			name:         "match at end of string",
-			text:         "The quick brown fox jumps over the lazy bank",
-			queryTerms:   []string{"bank"},
-			fragmentSize: 40,
-			maxFragments: 1,
-			wantCount:    1,
-			wantContains: []string{"<em>bank</em>"},
-			// window ends at textLen → no trailing ellipsis
+			name:                 "match at end of string",
+			text:                 "The quick brown fox jumps over the lazy bank",
+			queryTerms:           []string{"bank"},
+			fragmentSize:         40,
+			maxFragments:         1,
+			wantCount:            1,
+			wantContains:         []string{"<em>bank</em>"},
+			// window starts after byte 0 → leading ellipsis; ends at textLen → no trailing
+			wantLeadingEllipsis:  true,
 			wantTrailingEllipsis: false,
 		},
 
@@ -315,24 +317,16 @@ func TestGenerateSnippets(t *testing.T) {
 					}
 				}
 			}
-			if !tc.wantLeadingEllipsis {
-				// wantLeadingEllipsis == false means "it must NOT start with ..."
-				// (only enforced when the field is the zero value AND the test
-				//  explicitly documents this expectation via the field name)
-				if tc.name == "match at start of string" {
-					first := got[0]
-					// Strip any highlight tags to find the raw leading bytes.
-					if strings.HasPrefix(first, "...") {
-						t.Errorf("snippet %q must not have a leading ellipsis", first)
-					}
+			if tc.wantLeadingEllipsis {
+				first := got[0]
+				if !strings.HasPrefix(first, "...") {
+					t.Errorf("first snippet %q must start with leading ellipsis", first)
 				}
 			}
-			if !tc.wantTrailingEllipsis {
-				if tc.name == "match at end of string" {
-					last := got[len(got)-1]
-					if strings.HasSuffix(last, "...") {
-						t.Errorf("snippet %q must not have a trailing ellipsis", last)
-					}
+			if tc.wantTrailingEllipsis {
+				last := got[len(got)-1]
+				if !strings.HasSuffix(last, "...") {
+					t.Errorf("last snippet %q must end with trailing ellipsis", last)
 				}
 			}
 		})

--- a/usecases/traverser/explorer.go
+++ b/usecases/traverser/explorer.go
@@ -15,6 +15,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/ttl"
@@ -39,6 +40,7 @@ import (
 	"github.com/weaviate/weaviate/entities/storobj"
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/floatcomp"
+	highlightpkg "github.com/weaviate/weaviate/usecases/highlight"
 	uc "github.com/weaviate/weaviate/usecases/schema"
 	"github.com/weaviate/weaviate/usecases/traverser/grouper"
 )
@@ -528,6 +530,12 @@ func (e *Explorer) searchResultsToGetResponseWithType(ctx context.Context, input
 			additionalProperties["isConsistent"] = res.IsConsistent
 		}
 
+		if params.AdditionalProperties.Highlight != nil {
+			if highlights := generateHighlights(res.Schema, params); len(highlights) > 0 {
+				additionalProperties["highlight"] = highlights
+			}
+		}
+
 		if len(additionalProperties) > 0 {
 			if additionalProperties["group"] != nil {
 				e.extractAdditionalPropertiesFromGroupRefs(additionalProperties["group"], params.GroupBy.Properties)
@@ -991,4 +999,67 @@ func (e *Explorer) usageOperationFromExploreParams(params ExploreParams) string 
 	}
 
 	return "n/a"
+}
+
+// generateHighlights iterates over the string properties in a search result
+// and calls the highlight engine for each, returning a slice of
+// additional.HighlightResult ready to be attached to _additional.
+func generateHighlights(schema models.PropertySchema, params dto.GetParams) []additional.HighlightResult {
+	hp := params.AdditionalProperties.Highlight
+
+	// Extract query terms from BM25 or Hybrid params.
+	var queryTerms []string
+	if params.KeywordRanking != nil && params.KeywordRanking.Query != "" {
+		queryTerms = strings.Fields(params.KeywordRanking.Query)
+	} else if params.HybridSearch != nil && params.HybridSearch.Query != "" {
+		queryTerms = strings.Fields(params.HybridSearch.Query)
+	}
+	if len(queryTerms) == 0 {
+		return nil
+	}
+
+	schemaMap, ok := schema.(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	// Determine which properties to highlight.
+	propsToHighlight := hp.Properties
+	if len(propsToHighlight) == 0 {
+		for k, v := range schemaMap {
+			if k == "_additional" {
+				continue
+			}
+			if _, isStr := v.(string); isStr {
+				propsToHighlight = append(propsToHighlight, k)
+			}
+		}
+	}
+
+	var results []additional.HighlightResult
+	for _, prop := range propsToHighlight {
+		val, ok := schemaMap[prop]
+		if !ok {
+			continue
+		}
+		text, ok := val.(string)
+		if !ok || text == "" {
+			continue
+		}
+		snippets := highlightpkg.GenerateSnippets(
+			text,
+			queryTerms,
+			hp.FragmentSize,
+			hp.NumberOfFragments,
+			hp.Prefix,
+			hp.Postfix,
+		)
+		if len(snippets) > 0 {
+			results = append(results, additional.HighlightResult{
+				Field:    prop,
+				Snippets: snippets,
+			})
+		}
+	}
+	return results
 }


### PR DESCRIPTION
Closes #2567

This PR implements the highly requested keyword highlighting feature for BM25 and Hybrid searches. It introduces a robust, standalone snippet engine and wires it completely into the GraphQL `_additional` properties block.

### 1. Core Snippet Engine (`usecases/highlight`)
Implements `GenerateSnippets()` with strict adherence to edge cases and multibyte safety:
- Case-insensitive matching with original casing fully preserved in the output.
- Fragment windows are centered on matches and safely clamped to prevent out-of-bounds panics.
- UTF-8 rune-boundary snapping prevents slicing multibyte characters.
- Overlapping windows are intelligently merged before the `maxFragments` cap is applied to prevent double-wrapping.
- Ellipses (`...`) are prepended/appended only when the fragment is actually truncated.
- Covered by 19 table-driven unit tests handling edge cases (short text, multi-match, unicode, empty inputs).

### 2. GraphQL & Traverser Wiring
Exposes the `highlight` property under `_additional` for `Get` queries:
- **`adapters/handlers/graphql/local/get`**: Added `highlight` field parser with optional arguments (`properties`, `fragmentSize`, `numberOfFragments`, `prefix`, `postfix`).
- **`entities/additional`**: Created `HighlightParams` for query args and `HighlightResult` for the response payload.
- **`usecases/traverser/explorer.go`**: Intercepts `[]search.Result` post-search, extracting raw text and query terms to generate and attach the formatted snippets.

### Example Supported Query:
```graphql
{
  Get {
    Article(bm25: { query: "climate change" }) {
      title 
      body
      _additional {
        highlight(
          properties: ["title", "body"]
          fragmentSize: 120
          numberOfFragments: 3
          prefix: "<em>"
          postfix: "</em>"
        ) {
          field
          snippets
        }
      }
    }
  }
}