### PR TITLE
fix: update async replication frequency handling

### DIFF
--- a/adapters/repos/db/async_replication_scheduler.go
+++ b/adapters/repos/db/async_replication_scheduler.go
@@ -326,6 +326,12 @@ type AsyncReplicationScheduler struct {
 	metrics asyncReplicationSchedulerMetrics
 	logger  logrus.FieldLogger
 
+	// runtimeClampWarner surfaces sub-minimum global runtime overrides as a
+	// one-shot Warn so operator misconfiguration of the frequency env vars
+	// (or their runtime-YAML equivalent) does not stay invisible behind the
+	// per-cycle clamp in Effective().
+	runtimeClampWarner *asyncReplicationClampWarner
+
 	// closed is set true at the top of Close() (before cancel) and never reset.
 	// Read by Register/Deregister and handleAdd/handleRemove to reject
 	// post-Close calls deterministically.
@@ -410,6 +416,7 @@ func NewAsyncReplicationScheduler(
 		hashtreeInitSem:          semaphore.NewWeighted(int64(hashtreeInitConcurrency)),
 		metrics:                  m,
 		logger:                   logger,
+		runtimeClampWarner:       &asyncReplicationClampWarner{logger: logger},
 	}
 	heap.Init(&s.h)
 
@@ -995,6 +1002,7 @@ func (sched *AsyncReplicationScheduler) runEntry(entry *asyncSchedulerEntry) {
 
 	cfg := base
 	if s.index != nil && s.index.globalreplicationConfig != nil {
+		sched.runtimeClampWarner.checkGlobals(*s.index.globalreplicationConfig)
 		cfg = base.Effective(*s.index.globalreplicationConfig)
 	}
 

--- a/adapters/repos/db/async_replication_scheduler_test.go
+++ b/adapters/repos/db/async_replication_scheduler_test.go
@@ -15,6 +15,7 @@ import (
 	"container/heap"
 	"context"
 	"errors"
+	"math"
 	"sync"
 	"testing"
 	"time"
@@ -92,9 +93,10 @@ func TestAsyncRepRebuildBackoffDuration(t *testing.T) {
 // TestEffectivePropagationDelay verifies that:
 //   - propagationDelay=0 set via per-class API survives Effective() when no
 //     global DynamicValue is configured.
-//   - a sub-100ms propagationDelay set via global runtime config is correctly
+//   - a sub-second propagationDelay set via global runtime config is correctly
 //     applied (it was silently ignored before the applyDurPositive fix because
-//     the old applyDur required v >= minFrequency = 100ms).
+//     the old applyDur required v >= a frequency floor, which propagationDelay
+//     does not share).
 func TestEffectivePropagationDelay(t *testing.T) {
 	zero := time.Duration(0)
 	fifty := 50 * time.Millisecond
@@ -701,48 +703,262 @@ func TestAdjustWorkersConcurrent(t *testing.T) {
 }
 
 // TestAsyncReplicationConfigFromModelFrequencyFloor verifies that
-// asyncReplicationConfigFromModel rejects frequency / frequencyWhilePropagating
-// values below minFrequency (100ms) while accepting values at or above it.
+// asyncReplicationConfigFromModel clamps sub-minimum frequency /
+// frequencyWhilePropagating values up to the minimum (logging a Warn) and
+// preserves values at or above it. The lenient clamp-and-warn behavior is
+// required for backwards compatibility with collections persisted before the
+// minimums were raised.
 func TestAsyncReplicationConfigFromModelFrequencyFloor(t *testing.T) {
-	below := int64(minFrequency/time.Millisecond) - 1 // 99 ms → below the floor
-	exact := int64(minFrequency / time.Millisecond)   // 100 ms → exactly at floor
-	above := int64(minFrequency/time.Millisecond) + 1 // 101 ms → above the floor
+	// pick boundary inputs relative to each field's own minimum.
+	freqBelow := int64(minFrequency/time.Millisecond) - 1 // just below 5s
+	freqExact := int64(minFrequency / time.Millisecond)   // exactly at 5s
+	freqAbove := int64(minFrequency/time.Millisecond) + 1 // just above 5s
 
-	t.Run("frequency_below_min_rejected", func(t *testing.T) {
+	fwpBelow := int64(minFrequencyWhilePropagating/time.Millisecond) - 1 // just below 1s
+	fwpExact := int64(minFrequencyWhilePropagating / time.Millisecond)   // exactly at 1s
+	fwpAbove := int64(minFrequencyWhilePropagating/time.Millisecond) + 1 // just above 1s
+
+	newLogger := func() (logrus.FieldLogger, *test.Hook) {
+		l, h := test.NewNullLogger()
+		return l, h
+	}
+
+	t.Run("frequency_below_min_clamped_and_warned", func(t *testing.T) {
+		logger, hook := newLogger()
+		cfg, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
+			Frequency: &freqBelow,
+		}, logger)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.classOverrides.frequency)
+		assert.Equal(t, minFrequency, *cfg.classOverrides.frequency,
+			"sub-minimum frequency must be clamped to minFrequency")
+		require.Len(t, hook.Entries, 1, "exactly one Warn entry expected")
+		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
+		assert.Equal(t, "frequency", hook.LastEntry().Data["field"])
+	})
+
+	t.Run("frequency_at_min_accepted_no_warn", func(t *testing.T) {
+		logger, hook := newLogger()
+		cfg, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
+			Frequency: &freqExact,
+		}, logger)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.classOverrides.frequency)
+		assert.Equal(t, minFrequency, *cfg.classOverrides.frequency)
+		assert.Empty(t, hook.Entries, "no warning expected at minimum")
+	})
+
+	t.Run("frequency_above_min_accepted_no_warn", func(t *testing.T) {
+		logger, hook := newLogger()
+		cfg, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
+			Frequency: &freqAbove,
+		}, logger)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.classOverrides.frequency)
+		assert.Equal(t, time.Duration(freqAbove)*time.Millisecond, *cfg.classOverrides.frequency)
+		assert.Empty(t, hook.Entries, "no warning expected above minimum")
+	})
+
+	t.Run("frequencyWhilePropagating_below_min_clamped_and_warned", func(t *testing.T) {
+		logger, hook := newLogger()
+		cfg, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
+			FrequencyWhilePropagating: &fwpBelow,
+		}, logger)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.classOverrides.frequencyWhilePropagating)
+		assert.Equal(t, minFrequencyWhilePropagating, *cfg.classOverrides.frequencyWhilePropagating,
+			"sub-minimum frequencyWhilePropagating must be clamped to minFrequencyWhilePropagating")
+		require.Len(t, hook.Entries, 1, "exactly one Warn entry expected")
+		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
+		assert.Equal(t, "frequencyWhilePropagating", hook.LastEntry().Data["field"])
+	})
+
+	t.Run("frequencyWhilePropagating_at_min_accepted_no_warn", func(t *testing.T) {
+		logger, hook := newLogger()
+		cfg, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
+			FrequencyWhilePropagating: &fwpExact,
+		}, logger)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.classOverrides.frequencyWhilePropagating)
+		assert.Equal(t, minFrequencyWhilePropagating, *cfg.classOverrides.frequencyWhilePropagating)
+		assert.Empty(t, hook.Entries, "no warning expected at minimum")
+	})
+
+	t.Run("frequencyWhilePropagating_above_min_accepted_no_warn", func(t *testing.T) {
+		logger, hook := newLogger()
+		cfg, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
+			FrequencyWhilePropagating: &fwpAbove,
+		}, logger)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.classOverrides.frequencyWhilePropagating)
+		assert.Equal(t, time.Duration(fwpAbove)*time.Millisecond, *cfg.classOverrides.frequencyWhilePropagating)
+		assert.Empty(t, hook.Entries, "no warning expected above minimum")
+	})
+
+	// Policy for raw API inputs (ReplicationAsyncConfig has no minimum checks
+	// of its own on these int64 fields, so any value can reach this helper):
+	//   - zero: treated as below-minimum, clamped up to the minimum with a Warn,
+	//   - negative: rejected with an error (no meaningful interpretation),
+	//   - overflow (ms value > maxDurationMillis): rejected to avoid wrapping
+	//     to a negative time.Duration and silently clamping to the minimum.
+	t.Run("frequency_zero_clamped_and_warned", func(t *testing.T) {
+		zero := int64(0)
+		logger, hook := newLogger()
+		cfg, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
+			Frequency: &zero,
+		}, logger)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.classOverrides.frequency)
+		assert.Equal(t, minFrequency, *cfg.classOverrides.frequency)
+		require.Len(t, hook.Entries, 1, "exactly one Warn entry expected")
+		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
+		assert.Equal(t, "frequency", hook.LastEntry().Data["field"])
+	})
+
+	t.Run("frequency_negative_rejected", func(t *testing.T) {
+		neg := int64(-1)
+		logger, hook := newLogger()
 		_, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
-			Frequency: &below,
-		})
+			Frequency: &neg,
+		}, logger)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "frequency")
+		assert.Contains(t, err.Error(), "frequency must be >= 0")
+		assert.Empty(t, hook.Entries, "no clamp warning expected for negative input")
 	})
 
-	t.Run("frequency_at_min_accepted", func(t *testing.T) {
-		_, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
-			Frequency: &exact,
-		})
+	t.Run("frequencyWhilePropagating_zero_clamped_and_warned", func(t *testing.T) {
+		zero := int64(0)
+		logger, hook := newLogger()
+		cfg, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
+			FrequencyWhilePropagating: &zero,
+		}, logger)
 		require.NoError(t, err)
+		require.NotNil(t, cfg.classOverrides.frequencyWhilePropagating)
+		assert.Equal(t, minFrequencyWhilePropagating, *cfg.classOverrides.frequencyWhilePropagating)
+		require.Len(t, hook.Entries, 1, "exactly one Warn entry expected")
+		assert.Equal(t, logrus.WarnLevel, hook.LastEntry().Level)
+		assert.Equal(t, "frequencyWhilePropagating", hook.LastEntry().Data["field"])
 	})
 
-	t.Run("frequency_above_min_accepted", func(t *testing.T) {
+	t.Run("frequencyWhilePropagating_negative_rejected", func(t *testing.T) {
+		neg := int64(-100)
+		logger, hook := newLogger()
 		_, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
-			Frequency: &above,
-		})
-		require.NoError(t, err)
-	})
-
-	t.Run("frequencyWhilePropagating_below_min_rejected", func(t *testing.T) {
-		_, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
-			FrequencyWhilePropagating: &below,
-		})
+			FrequencyWhilePropagating: &neg,
+		}, logger)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "frequencyWhilePropagating")
+		assert.Contains(t, err.Error(), "frequencyWhilePropagating must be >= 0")
+		assert.Empty(t, hook.Entries, "no clamp warning expected for negative input")
 	})
 
-	t.Run("frequencyWhilePropagating_at_min_accepted", func(t *testing.T) {
+	// Inputs whose value in milliseconds does not fit in time.Duration would
+	// silently wrap to a negative duration on conversion and then be clamped
+	// to the minimum. Reject them explicitly so callers don't end up with the
+	// fastest cadence when they asked for the slowest.
+	t.Run("frequency_overflow_rejected", func(t *testing.T) {
+		overflow := int64(math.MaxInt64)
+		logger, hook := newLogger()
 		_, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
-			FrequencyWhilePropagating: &exact,
+			Frequency: &overflow,
+		}, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "frequency too large")
+		assert.Empty(t, hook.Entries, "no clamp warning expected for overflow input")
+	})
+
+	t.Run("frequencyWhilePropagating_overflow_rejected", func(t *testing.T) {
+		overflow := int64(math.MaxInt64)
+		logger, hook := newLogger()
+		_, err := asyncReplicationConfigFromModel(false, &models.ReplicationAsyncConfig{
+			FrequencyWhilePropagating: &overflow,
+		}, logger)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "frequencyWhilePropagating too large")
+		assert.Empty(t, hook.Entries, "no clamp warning expected for overflow input")
+	})
+}
+
+// TestAsyncReplicationClampWarner verifies the warner's consecutive-duplicate
+// suppression for positive-but-below-minimum runtime overrides on the two
+// Frequency fields. A stable sub-minimum value logs once; changing to a new
+// sub-minimum value re-arms the warning. Only the last warned value per field
+// is remembered, so an A→B→A alternation would log A twice — see the type's
+// doc comment for the tradeoff.
+func TestAsyncReplicationClampWarner(t *testing.T) {
+	makeWarner := func() (*asyncReplicationClampWarner, *test.Hook) {
+		l, h := test.NewNullLogger()
+		return &asyncReplicationClampWarner{logger: l}, h
+	}
+
+	t.Run("subfloor_frequency_warns_once_per_unique_value", func(t *testing.T) {
+		w, hook := makeWarner()
+		subfloor := minFrequency / 2
+		globals := replication.GlobalConfig{
+			AsyncReplicationFrequency: configRuntime.NewDynamicValue(subfloor),
+		}
+		w.checkGlobals(globals)
+		w.checkGlobals(globals)
+		w.checkGlobals(globals)
+		require.Len(t, hook.Entries, 1, "repeat checks with the same value must dedup")
+		assert.Equal(t, "frequency", hook.LastEntry().Data["field"])
+		assert.Equal(t, subfloor, hook.LastEntry().Data["requested"])
+		assert.Equal(t, minFrequency, hook.LastEntry().Data["applied"])
+		assert.Contains(t, hook.LastEntry().Message, "below minimum")
+	})
+
+	t.Run("changed_subfloor_value_warns_again", func(t *testing.T) {
+		w, hook := makeWarner()
+		w.checkGlobals(replication.GlobalConfig{
+			AsyncReplicationFrequency: configRuntime.NewDynamicValue(minFrequency / 2),
 		})
-		require.NoError(t, err)
+		w.checkGlobals(replication.GlobalConfig{
+			AsyncReplicationFrequency: configRuntime.NewDynamicValue(minFrequency / 3),
+		})
+		require.Len(t, hook.Entries, 2, "a different sub-minimum value must re-arm the warning")
+	})
+
+	t.Run("above_floor_value_does_not_warn", func(t *testing.T) {
+		w, hook := makeWarner()
+		w.checkGlobals(replication.GlobalConfig{
+			AsyncReplicationFrequency: configRuntime.NewDynamicValue(minFrequency * 2),
+		})
+		assert.Empty(t, hook.Entries)
+	})
+
+	t.Run("zero_value_does_not_warn", func(t *testing.T) {
+		// Zero is the DynamicValue "not configured" sentinel — not a sub-minimum
+		// override that warrants a Warn.
+		w, hook := makeWarner()
+		w.checkGlobals(replication.GlobalConfig{
+			AsyncReplicationFrequency: configRuntime.NewDynamicValue(time.Duration(0)),
+		})
+		assert.Empty(t, hook.Entries)
+	})
+
+	t.Run("negative_value_does_not_warn", func(t *testing.T) {
+		// Negative runtime overrides are silently ignored by the apply helpers
+		// (the prior cadence is preserved). The warner intentionally does not
+		// cover them — the right place to reject typos is the env-var / YAML
+		// loader at startup.
+		w, hook := makeWarner()
+		w.checkGlobals(replication.GlobalConfig{
+			AsyncReplicationFrequency: configRuntime.NewDynamicValue(-1 * time.Second),
+		})
+		assert.Empty(t, hook.Entries)
+	})
+
+	t.Run("each_field_warns_with_its_own_floor", func(t *testing.T) {
+		// Pick a value above minFrequencyWhilePropagating but below minFrequency.
+		// Both fields share the same value, but only frequency is considered
+		// sub-minimum.
+		w, hook := makeWarner()
+		shared := 2 * time.Second
+		w.checkGlobals(replication.GlobalConfig{
+			AsyncReplicationFrequency:                 configRuntime.NewDynamicValue(shared),
+			AsyncReplicationFrequencyWhilePropagating: configRuntime.NewDynamicValue(shared),
+		})
+		require.Len(t, hook.Entries, 1)
+		assert.Equal(t, "frequency", hook.LastEntry().Data["field"])
 	})
 }
 
@@ -1163,6 +1379,45 @@ func TestEffectiveThreeTierPrecedence(t *testing.T) {
 		result := cfg.Effective(globals)
 		assert.Equal(t, classOverride, result.frequency,
 			"zero global DynamicValue must not override a class-level setting")
+	})
+
+	t.Run("global_config_subfloor_clamps_to_floor", func(t *testing.T) {
+		// A positive but sub-minimum global DynamicValue must clamp up to the
+		// minimum rather than being silently dropped — otherwise an operator who
+		// tried to dial frequency down past the minimum would get the previous
+		// (class or default) value with no signal that their override was
+		// ineffective.
+		cfg := AsyncReplicationConfig{
+			frequency: codeDefault,
+			classOverrides: asyncReplicationClassOverrides{
+				frequency: durationPtr(classOverride),
+			},
+		}
+		globals := replication.GlobalConfig{
+			AsyncReplicationFrequency: configRuntime.NewDynamicValue(minFrequency - time.Second),
+		}
+		result := cfg.Effective(globals)
+		assert.Equal(t, minFrequency, result.frequency,
+			"sub-minimum global DynamicValue must clamp to minFrequency, not be ignored")
+	})
+
+	t.Run("global_config_frequencyWhilePropagating_subfloor_clamps_to_its_own_floor", func(t *testing.T) {
+		// Symmetric to frequency, but guards against a regression where a future
+		// edit might clamp this field against minFrequency instead of its own
+		// distinct minFrequencyWhilePropagating minimum.
+		const fwpClassOverride = 10 * time.Second
+		cfg := AsyncReplicationConfig{
+			frequencyWhilePropagating: defaultFrequencyWhilePropagating,
+			classOverrides: asyncReplicationClassOverrides{
+				frequencyWhilePropagating: durationPtr(fwpClassOverride),
+			},
+		}
+		globals := replication.GlobalConfig{
+			AsyncReplicationFrequencyWhilePropagating: configRuntime.NewDynamicValue(minFrequencyWhilePropagating - time.Millisecond),
+		}
+		result := cfg.Effective(globals)
+		assert.Equal(t, minFrequencyWhilePropagating, result.frequencyWhilePropagating,
+			"sub-minimum global DynamicValue must clamp to minFrequencyWhilePropagating, not minFrequency, and not be ignored")
 	})
 }
 

--- a/adapters/repos/db/index.go
+++ b/adapters/repos/db/index.go
@@ -882,7 +882,7 @@ func (i *Index) updateReplicationConfig(ctx context.Context, cfg *models.Replica
 	i.Config.DeletionStrategy = cfg.DeletionStrategy
 	i.Config.AsyncReplicationEnabled = cfg.AsyncEnabled
 
-	config, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(i.getClass().MultiTenancyConfig), cfg.AsyncConfig)
+	config, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(i.getClass().MultiTenancyConfig), cfg.AsyncConfig, i.logger.WithField("class", i.Config.ClassName))
 	if err != nil {
 		return err
 	}

--- a/adapters/repos/db/index_async_replication.go
+++ b/adapters/repos/db/index_async_replication.go
@@ -13,11 +13,19 @@ package db
 
 import (
 	"fmt"
+	"math"
 	"strconv"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/models"
 )
+
+// maxDurationMillis is the largest int64 millisecond value that still fits in
+// a time.Duration (nanoseconds) without wrapping. Used to reject schema inputs
+// that would otherwise overflow during the *time.Millisecond conversion and
+// silently clamp to the minimum.
+const maxDurationMillis = int64(math.MaxInt64 / int64(time.Millisecond))
 
 // asyncReplicationConfigFromModel builds an AsyncReplicationConfig from the
 // class model and multitenancy flag.
@@ -35,7 +43,14 @@ import (
 // values are surfaced through the GlobalConfig DynamicValues and applied by
 // Effective(), so removing an env var restores the per-class schema value
 // without any schema mutation.
-func asyncReplicationConfigFromModel(multiTenancyEnabled bool, cfg *models.ReplicationAsyncConfig) (config AsyncReplicationConfig, err error) {
+//
+// Frequency minimums (minFrequency, minFrequencyWhilePropagating) are enforced
+// by clamping sub-minimum values up to the minimum and emitting a Warn log
+// entry via the supplied logger. This is intentionally lenient so that
+// collections created before a minimum was raised continue to load and update;
+// the runtime defensive clamp in Effective() would otherwise be the only
+// safety net and would silence the legacy values without operator visibility.
+func asyncReplicationConfigFromModel(multiTenancyEnabled bool, cfg *models.ReplicationAsyncConfig, logger logrus.FieldLogger) (config AsyncReplicationConfig, err error) {
 	// ---- Code defaults (tier 1) ----
 	if multiTenancyEnabled {
 		config.hashtreeHeight = defaultHashtreeHeightMultiTenant
@@ -70,17 +85,41 @@ func asyncReplicationConfigFromModel(multiTenancyEnabled bool, cfg *models.Repli
 	}
 
 	if cfg.Frequency != nil {
+		if *cfg.Frequency < 0 {
+			return AsyncReplicationConfig{}, fmt.Errorf("frequency must be >= 0")
+		}
+		if *cfg.Frequency > maxDurationMillis {
+			return AsyncReplicationConfig{}, fmt.Errorf("frequency too large: %d ms exceeds max %d ms", *cfg.Frequency, maxDurationMillis)
+		}
 		v := time.Duration(*cfg.Frequency) * time.Millisecond
 		if v < minFrequency {
-			return AsyncReplicationConfig{}, fmt.Errorf("frequency must be >= %v", minFrequency)
+			logger.WithFields(logrus.Fields{
+				"field":     "frequency",
+				"requested": v,
+				"min":       minFrequency,
+				"applied":   minFrequency,
+			}).Warn("async-replication frequency below minimum; clamping to min")
+			v = minFrequency
 		}
 		config.classOverrides.frequency = &v
 	}
 
 	if cfg.FrequencyWhilePropagating != nil {
+		if *cfg.FrequencyWhilePropagating < 0 {
+			return AsyncReplicationConfig{}, fmt.Errorf("frequencyWhilePropagating must be >= 0")
+		}
+		if *cfg.FrequencyWhilePropagating > maxDurationMillis {
+			return AsyncReplicationConfig{}, fmt.Errorf("frequencyWhilePropagating too large: %d ms exceeds max %d ms", *cfg.FrequencyWhilePropagating, maxDurationMillis)
+		}
 		v := time.Duration(*cfg.FrequencyWhilePropagating) * time.Millisecond
-		if v < minFrequency {
-			return AsyncReplicationConfig{}, fmt.Errorf("frequencyWhilePropagating must be >= %v", minFrequency)
+		if v < minFrequencyWhilePropagating {
+			logger.WithFields(logrus.Fields{
+				"field":     "frequencyWhilePropagating",
+				"requested": v,
+				"min":       minFrequencyWhilePropagating,
+				"applied":   minFrequencyWhilePropagating,
+			}).Warn("async-replication frequencyWhilePropagating below minimum; clamping to min")
+			v = minFrequencyWhilePropagating
 		}
 		config.classOverrides.frequencyWhilePropagating = &v
 	}

--- a/adapters/repos/db/init.go
+++ b/adapters/repos/db/init.go
@@ -112,7 +112,7 @@ func (db *DB) init(ctx context.Context) error {
 				}
 			}
 
-			asyncConfig, err := asyncReplicationConfigFromModel(isMultiTenant, class.ReplicationConfig.AsyncConfig)
+			asyncConfig, err := asyncReplicationConfigFromModel(isMultiTenant, class.ReplicationConfig.AsyncConfig, db.logger.WithField("class", class.Class))
 			if err != nil {
 				return fmt.Errorf("async replication config: %w", err)
 			}

--- a/adapters/repos/db/migrator.go
+++ b/adapters/repos/db/migrator.go
@@ -109,7 +109,7 @@ func (m *Migrator) AddClass(ctx context.Context, class *models.Class) error {
 		return fmt.Errorf("index for class %v already found locally", idx.ID())
 	}
 
-	asyncConfig, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(class.MultiTenancyConfig), class.ReplicationConfig.AsyncConfig)
+	asyncConfig, err := asyncReplicationConfigFromModel(multitenancy.IsMultiTenant(class.MultiTenancyConfig), class.ReplicationConfig.AsyncConfig, m.logger.WithField("class", class.Class))
 	if err != nil {
 		return fmt.Errorf("async replication config: %w", err)
 	}

--- a/adapters/repos/db/shard_async_replication.go
+++ b/adapters/repos/db/shard_async_replication.go
@@ -76,10 +76,16 @@ const (
 	minHashtreeHeight = 0
 	maxHashtreeHeight = 20
 
-	// minFrequency is the smallest accepted value for frequency and
-	// frequencyWhilePropagating in both per-class API overrides and global
-	// runtime config. Values below this would spin the dispatcher excessively.
-	minFrequency = 100 * time.Millisecond
+	// minFrequency is the smallest accepted value for `frequency` in both
+	// per-class API overrides and global runtime config. Below this, hashbeats
+	// would run too often to be useful in a steady-state cluster.
+	minFrequency = 5 * time.Second
+
+	// minFrequencyWhilePropagating is the smallest accepted value for
+	// `frequencyWhilePropagating`. This rate kicks in only while propagation is
+	// actively in flight, so it can be tighter than minFrequency but must stay
+	// at or above 1s to avoid dispatcher thrash.
+	minFrequencyWhilePropagating = 1 * time.Second
 
 	// minLoggingFrequency is the floor for loggingFrequency. Sub-second logging
 	// at hashbeat rate would flood logs in busy clusters.
@@ -216,17 +222,24 @@ func (c AsyncReplicationConfig) Effective(globals entreplication.GlobalConfig) A
 		}
 		*field = v
 	}
-	// applyDurMinFrequency applies a DynamicValue[time.Duration] only when it is
-	// at or above minFrequency. Used for scheduling-frequency fields where
-	// sub-100ms values would spin the dispatcher excessively; zero (the
-	// DynamicValue "not configured" default) is silently ignored.
-	applyDurMinFrequency := func(dv *configRuntime.DynamicValue[time.Duration], field *time.Duration) {
+	// applyDurMinFrequency applies a DynamicValue[time.Duration], clamping it
+	// up to the supplied minimum when the configured value is positive but
+	// below the minimum. Zero (the DynamicValue "not configured" sentinel) is
+	// silently ignored — mirrors applyInt's clamp-on-configured semantics so
+	// that an operator who explicitly sets a sub-minimum runtime value still
+	// gets a working value (the minimum) rather than a silently-dropped override.
+	applyDurMinFrequency := func(dv *configRuntime.DynamicValue[time.Duration], field *time.Duration, minVal time.Duration) {
 		if dv == nil {
 			return
 		}
-		if v := dv.Get(); v >= minFrequency {
-			*field = v
+		v := dv.Get()
+		if v <= 0 {
+			return
 		}
+		if v < minVal {
+			v = minVal
+		}
+		*field = v
 	}
 	// applyDurPositive applies a DynamicValue[time.Duration] only when it is
 	// strictly positive. Used for timeout and delay fields where zero is the
@@ -241,8 +254,8 @@ func (c AsyncReplicationConfig) Effective(globals entreplication.GlobalConfig) A
 		}
 	}
 	applyInt(globals.AsyncReplicationHashtreeHeight, &result.hashtreeHeight, minHashtreeHeight, maxHashtreeHeight)
-	applyDurMinFrequency(globals.AsyncReplicationFrequency, &result.frequency)
-	applyDurMinFrequency(globals.AsyncReplicationFrequencyWhilePropagating, &result.frequencyWhilePropagating)
+	applyDurMinFrequency(globals.AsyncReplicationFrequency, &result.frequency, minFrequency)
+	applyDurMinFrequency(globals.AsyncReplicationFrequencyWhilePropagating, &result.frequencyWhilePropagating, minFrequencyWhilePropagating)
 	applyDurPositive(globals.AsyncReplicationLoggingFrequency, &result.loggingFrequency)
 	applyInt(globals.AsyncReplicationDiffBatchSize, &result.diffBatchSize, minDiffBatchSize, maxDiffBatchSize)
 	applyDurPositive(globals.AsyncReplicationDiffPerNodeTimeout, &result.diffPerNodeTimeout)
@@ -273,8 +286,8 @@ func (c AsyncReplicationConfig) Effective(globals entreplication.GlobalConfig) A
 	if result.frequency < minFrequency {
 		result.frequency = minFrequency
 	}
-	if result.frequencyWhilePropagating < minFrequency {
-		result.frequencyWhilePropagating = minFrequency
+	if result.frequencyWhilePropagating < minFrequencyWhilePropagating {
+		result.frequencyWhilePropagating = minFrequencyWhilePropagating
 	}
 	if result.loggingFrequency < minLoggingFrequency {
 		result.loggingFrequency = minLoggingFrequency
@@ -292,6 +305,61 @@ func (c AsyncReplicationConfig) Effective(globals entreplication.GlobalConfig) A
 	// Clear classOverrides in the snapshot — they have been applied.
 	result.classOverrides = asyncReplicationClassOverrides{}
 	return result
+}
+
+// asyncReplicationClampWarner surfaces positive-but-below-minimum global
+// runtime overrides on the two Frequency fields. Without it, an operator who
+// sets a frequency value below its declared minimum silently gets the
+// minimum, with no signal that their requested value was adjusted — the
+// per-class path emits this Warn, but the runtime path did not.
+//
+// Dedup is consecutive-duplicate suppression per field: only the last warned
+// value per field is remembered, so a stable misconfiguration logs exactly
+// once across all hashbeat cycles, and flipping to a new sub-minimum value
+// re-arms the warning. An A→B→A alternation would log A twice — a tradeoff
+// we accept to keep state O(fields).
+type asyncReplicationClampWarner struct {
+	mu     sync.Mutex
+	last   map[string]time.Duration
+	logger logrus.FieldLogger
+}
+
+// checkSubFloor emits one Warn per consecutive-distinct positive-but-below-minimum
+// requested value for the given field. Steady-state happy path returns under
+// the range check without touching the mutex.
+func (w *asyncReplicationClampWarner) checkSubFloor(field string, dv *configRuntime.DynamicValue[time.Duration], floor time.Duration) {
+	if w == nil || w.logger == nil || dv == nil {
+		return
+	}
+	v := dv.Get()
+	if v <= 0 || v >= floor {
+		return
+	}
+	w.mu.Lock()
+	if prev, ok := w.last[field]; ok && prev == v {
+		w.mu.Unlock()
+		return
+	}
+	if w.last == nil {
+		w.last = make(map[string]time.Duration)
+	}
+	w.last[field] = v
+	w.mu.Unlock()
+	w.logger.WithFields(logrus.Fields{
+		"field":     field,
+		"requested": v,
+		"min":       floor,
+		"applied":   floor,
+		"source":    "runtime",
+	}).Warn("async-replication global runtime value below minimum; clamping to min")
+}
+
+func (w *asyncReplicationClampWarner) checkGlobals(globals entreplication.GlobalConfig) {
+	if w == nil {
+		return
+	}
+	w.checkSubFloor("frequency", globals.AsyncReplicationFrequency, minFrequency)
+	w.checkSubFloor("frequencyWhilePropagating", globals.AsyncReplicationFrequencyWhilePropagating, minFrequencyWhilePropagating)
 }
 
 // initRetryBackoff returns the exponential backoff for hashtree initialisation


### PR DESCRIPTION
### What's being changed:

This pull request introduces stricter and safer validation for async replication frequency configuration, ensuring that sub-floor values are always clamped to their minimums with clear operator visibility via warning logs. It also improves test coverage and error handling for edge cases, such as negative and overflow values, and updates function signatures to pass loggers for better diagnostics.

**Validation and Clamping Improvements:**

* The `asyncReplicationConfigFromModel` function now clamps sub-floor `frequency` and `frequencyWhilePropagating` values up to their respective minimums and emits a warning log entry, instead of silently ignoring or rejecting them. Negative and overflow values are explicitly rejected with errors. The function now requires a logger parameter for this purpose. [[1]](diffhunk://#diff-4f91fe61f6a7baa52e723c4fdce2ef55b193172cd9c4f3171c80f8cdd87183beR16-R29) [[2]](diffhunk://#diff-4f91fe61f6a7baa52e723c4fdce2ef55b193172cd9c4f3171c80f8cdd87183beL38-R53) [[3]](diffhunk://#diff-4f91fe61f6a7baa52e723c4fdce2ef55b193172cd9c4f3171c80f8cdd87183beR88-R122)
* A new constant, `maxDurationMillis`, prevents time.Duration overflows by rejecting excessively large millisecond values in schema inputs.

**Logging and Operator Visibility:**

* Each `AsyncReplicationScheduler` now includes an `asyncReplicationClampWarner` that surfaces a one-shot warning for sub-floor global runtime overrides, ensuring misconfigurations are visible to operators. [[1]](diffhunk://#diff-d9b4b72ad2b208a33c48ee36baeecc6bf0a66dab8023035c360fcf280cfd6fd5R329-R334) [[2]](diffhunk://#diff-d9b4b72ad2b208a33c48ee36baeecc6bf0a66dab8023035c360fcf280cfd6fd5R419) [[3]](diffhunk://#diff-d9b4b72ad2b208a33c48ee36baeecc6bf0a66dab8023035c360fcf280cfd6fd5R1005)

**Test Enhancements:**

* The test suite for async replication configuration has been expanded to verify clamping, warning emission, deduplication of warnings, and correct error handling for negative, zero, and overflow values.
* Additional tests ensure that global configuration sub-floor values are clamped to their respective minimums, and that the correct minimum is used for each field.

**Codebase Updates:**

* All call sites of `asyncReplicationConfigFromModel` have been updated to pass a logger with class context, improving diagnostics. [[1]](diffhunk://#diff-d080e5efa621477a1d974bced14c39a8912fcb7a649eb4a0fb219647728dbc3dL885-R885) [[2]](diffhunk://#diff-781b381d5b43bd7163ae9e705641ff67efb27a7fd1910b4587a05c3ed49cefadL115-R115) [[3]](diffhunk://#diff-0dc6dc729205ff405d67d356b2577d699eac6b2b9bb6c128a668a263e6db796bL112-R112)

**Documentation and Clarity:**

* Comments and documentation have been updated to clarify the rationale for clamping, the behavior for legacy collections, and the distinction between the two frequency minimums. [[1]](diffhunk://#diff-4f91fe61f6a7baa52e723c4fdce2ef55b193172cd9c4f3171c80f8cdd87183beL38-R53) [[2]](diffhunk://#diff-fe05b346a7b75381b3cd60119652709d2e26282128dae8b23bd5d2256746c43dL95-R99)

These changes make async replication configuration more robust, operator-friendly, and future-proof.

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
