### PR TITLE
fix: duplicated words in commit_log_combiner, queue.go, and path.go comments

### DIFF
--- a/adapters/repos/db/queue/queue.go
+++ b/adapters/repos/db/queue/queue.go
@@ -523,7 +523,7 @@ func (q *DiskQueue) ForceSwitch(ctx context.Context, basePath string) ([]string,
 	q.m.Lock()
 	defer q.m.Unlock()
 
-	// if the writer is nil, the queue is is not initialized
+	// if the writer is nil, the queue is not initialized
 	if q.w == nil {
 		return nil, nil
 	}

--- a/adapters/repos/db/vector/hnsw/commit_log_combiner.go
+++ b/adapters/repos/db/vector/hnsw/commit_log_combiner.go
@@ -234,7 +234,7 @@ func (c *CommitLogCombiner) renameAndCleanUp(tmpName, finalName string,
 	// with duplicate files both with and without the ".condensed" suffix. The
 	// new (and complete) merged file will not carry the suffix whereas the
 	// sources will. This will look to the corrupted file fixer as if a
-	// condensing had gone wrong and will delete the the source
+	// condensing had gone wrong and will delete the source
 
 	if err := c.fs.Rename(tmpName, finalName); err != nil {
 		return errors.Wrapf(err, "rename tmp (%q) to final (%q)", tmpName, finalName)

--- a/entities/filters/path.go
+++ b/entities/filters/path.go
@@ -121,7 +121,7 @@ func ParsePath(pathElements []interface{}, rootClass string) (*Path, error) {
 		} else {
 			propertyName, err = schema.ValidatePropertyName(rawPropertyName)
 			// Invalid property name?
-			// Try to parse it as as a reference or a length.
+			// Try to parse it as a reference or a length.
 			if err != nil {
 				untitlizedPropertyName := strings.ToLower(rawPropertyName[0:1]) + rawPropertyName[1:]
 				propertyName, err = schema.ValidatePropertyName(untitlizedPropertyName)


### PR DESCRIPTION
Three one-line typo fixes for duplicated words:
- `adapters/repos/db/vector/hnsw/commit_log_combiner.go` — "// condensing had gone wrong and will delete the the source" → "...and will delete the source"
- `adapters/repos/db/queue/queue.go` — "// if the writer is nil, the queue is is not initialized" → "// if the writer is nil, the queue is not initialized"
- `entities/filters/path.go` — "// Try to parse it as as a reference or a length." → "// Try to parse it as a reference or a length."

No code/behavior change.