### PR TITLE
fix(transformers): set Content-Type: application/json on vectorize requests

### DIFF
--- a/usecases/modulecomponents/clients/transformers/transformers.go
+++ b/usecases/modulecomponents/clients/transformers/transformers.go
@@ -136,6 +136,7 @@ func (c *Client) vectorize(ctx context.Context, input string,
 	if err != nil {
 		return nil, errors.Wrap(err, "create POST request")
 	}
+	req.Header.Set("Content-Type", "application/json")
 
 	res, err := c.httpClient.Do(req)
 	if err != nil {

--- a/usecases/modulecomponents/clients/transformers/transformers_test.go
+++ b/usecases/modulecomponents/clients/transformers/transformers_test.go
@@ -83,6 +83,7 @@ type fakeHandler struct {
 func (f *fakeHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	assert.Equal(f.t, "/vectors", r.URL.String())
 	assert.Equal(f.t, http.MethodPost, r.Method)
+	assert.Equal(f.t, "application/json", r.Header.Get("Content-Type"))
 
 	if f.serverError != nil {
 		w.WriteHeader(http.StatusInternalServerError)


### PR DESCRIPTION
## Summary

- Add `req.Header.Set("Content-Type", "application/json")` to the shared transformer client's `vectorize` method in `usecases/modulecomponents/clients/transformers/transformers.go`.

## Root cause

FastAPI **0.132.0** introduced `strict_content_type` checking (default `True`), which rejects JSON requests that do not carry `Content-Type: application/json` with **HTTP 422** before the body is parsed. The inference service upgraded to FastAPI 0.136.1 (via [t2v-model2vec-models#19](https://github.com/weaviate/t2v-model2vec-models/pull/19)), exposing this gap.

The shared transformer client built the POST request and sent it immediately without setting any `Content-Type` header. Every other external client in the codebase already sets this header:

| Client | File |
|--------|------|
| Cohere | `clients/cohere/cohere.go:128` |
| OpenAI | `clients/openai/openai.go:190` |
| VoyageAI | `clients/voyageai/voyageai.go:295` |
| JinaAI | `clients/jinaai/jinaai.go:215` |
| NVIDIA | `clients/nvidia/nvidia.go:122` |

The transformer client (used by text2vec-model2vec and other modules) was the only one missing it.

## Impact

All modules backed by the shared transformer client fail with 422 once the inference service runs FastAPI ≥ 0.132. Confirmed by the CI failure in [actions/runs/25919332947](https://github.com/weaviate/weaviate/actions/runs/25919332947/job/76183934579).

## Test plan

- [x] `go test ./usecases/modulecomponents/clients/transformers/...` passes
- [ ] `./test/run.sh --only-module-text2vec-model2vec` passes (running locally)
- [ ] CI green on this PR