### PR TITLE
Nested object filtering — Part 13: DB-level test consolidation and same-K-different-parent fix

### DIFF
--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -2659,7 +2659,12 @@ func TestPlanCasesIntegration(t *testing.T) {
 			},
 		},
 		{
-			// Plan: single group, groupRunIdxLoop, lcaPath="cars.tires".
+			// Plan: hierarchical groupRunIdxLoop — outer GROUP@cars iterates
+			// _idx.cars[K] (preserved by needsWrappingGroup because the inner
+			// GROUP@cars.tires has multi-subs). Inner GROUP@cars.tires
+			// iterates _idx.cars.tires[K] AND parentScope to disambiguate
+			// same-K-different-parent physical instances.
+			//
 			// nested  doc7: bolts in tires[0], caps in tires[1] within root=1.
 			// nestedArray doc7: bolts in nestedArray[0].tires[0] (root=1), caps in nestedArray[1].tires[0] (root=2).
 			// nestedArray doc9: nestedArray[0].cars[0].tires[0]={bolts}, tires[1]={caps}
@@ -2668,22 +2673,31 @@ func TestPlanCasesIntegration(t *testing.T) {
 			nestedSetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
 				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E1(1, doc5), E1(1, doc7)}))
 				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E1(2, doc5), E1(2, doc7)})
+				// _idx.cars[0]: cars[0].descendants for each doc.
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(1, doc5), E1(2, doc5), E1(1, doc7), E1(2, doc7)}))
+				// _idx.cars.tires[K]: per-tires element positions.
 				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E1(1, doc5), E1(2, doc5)}))
 				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E1(1, doc7)}))
 				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 1), []uint64{E1(2, doc7)}))
 			},
 			nestedArraySetup: func(t *testing.T, vb, mb *lsmkv.Bucket) {
-				// doc5: tires[0]={bolts(leaf=1),caps(leaf=2)} — both in same tires element
+				// doc5: tires[0]={bolts(leaf=1),caps(leaf=2)} — both in same tires element.
+				// cars[0].descendants = [L1, L2].
 				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E1(1, doc5)}))
 				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E1(2, doc5)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E1(1, doc5), E1(2, doc5)}))
 				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E1(1, doc5), E1(2, doc5)}))
-				// doc7 cross-root: bolts in nestedArray[0].tires[0] (root=1), caps in nestedArray[1].tires[0] (root=2)
+				// doc7 cross-root: bolts in nestedArray[0].cars[0].tires[0] (root=1), caps in nestedArray[1].cars[0].tires[0] (root=2).
+				// cars[0].descendants per root: root=1→[L1], root=2→[L1].
 				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E(1, 1, doc7)}))
 				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E(2, 1, doc7)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 1, doc7), E(2, 1, doc7)}))
 				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E(1, 1, doc7), E(2, 1, doc7)}))
-				// doc9 same-root intermediate: tires[0]={bolts}, tires[1]={caps} within nestedArray[0]
+				// doc9 same-root intermediate: nestedArray[0].cars[0].tires[0]={bolts}, tires[1]={caps}.
+				// cars[0].descendants = [L1, L2] under root=1.
 				require.NoError(t, vb.RoaringSetAddList(invnested.ValueKey("cars.tires.bolts.size", size10), []uint64{E(1, 1, doc9)}))
 				writeNestedValue(t, vb, "cars.tires.caps.color", "red", []uint64{E(1, 2, doc9)})
+				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{E(1, 1, doc9), E(1, 2, doc9)}))
 				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 0), []uint64{E(1, 1, doc9)}))
 				require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars.tires", 1), []uint64{E(1, 2, doc9)}))
 			},
@@ -6043,27 +6057,44 @@ func TestCorrelatedAndFilterExamples(t *testing.T) {
 		const (
 			docMatch   = uint64(1)
 			docNoMatch = uint64(2)
+
+			// docMatch data: countries[0].garages=[{city, cars:[{}, {make}]}].
+			// cars[0]/cars[1] each get a fresh leaf; garages[0].elementPositions
+			// is the union of cars's leaves; city inherits both.
+			leafMatchC0 = uint16(1) // garages[0].cars[0]
+			leafMatchC1 = uint16(2) // garages[0].cars[1]
+			// docNoMatch data: countries[0].garages=[{city}, {cars:[{}, {make}]}].
+			// garages[0]={city} has no descendants → its own leaf. garages[1] has
+			// cars descendants.
+			leafNoMatchG0 = uint16(1) // garages[0] (city only)
+			leafNoMatchC0 = uint16(2) // garages[1].cars[0]
+			leafNoMatchC1 = uint16(3) // garages[1].cars[1]
 		)
 		searcher, vb, mb := newFilterExamplesSearcher(t, "countries")
 
-		// docMatch: city and cars[1].make in same garage (garages[0])
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG0Direct, docMatch)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG0Cars1, docMatch)})
-		// docNoMatch: city in garages[0], make in garages[1]
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG0Direct, docNoMatch)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG1Cars1, docNoMatch)})
+		// docMatch: city inherits BOTH cars' leaves in garages[0]; cars[1].make
+		// at cars[1]'s own leaf.
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafMatchC0, docMatch), enc(1, leafMatchC1, docMatch)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafMatchC1, docMatch)})
+		// docNoMatch: city at garages[0]'s own leaf; cars[1].make at garages[1].cars[1].
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafNoMatchG0, docNoMatch)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafNoMatchC1, docNoMatch)})
 
-		// _idx.garages[N]: positions of garages[N] across all countries
+		// _idx[garages, 0]: garages[0]'s elementPositions per doc.
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 0),
 			[]uint64{
-				enc(1, leafG0Direct, docMatch), enc(1, leafG0Cars1, docMatch),
-				enc(1, leafG0Direct, docNoMatch),
+				enc(1, leafMatchC0, docMatch), enc(1, leafMatchC1, docMatch),
+				enc(1, leafNoMatchG0, docNoMatch),
 			}))
+		// _idx[garages, 1]: only docNoMatch has garages[1].
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 1),
-			[]uint64{enc(1, leafG1Cars1, docNoMatch)}))
-		// _idx.cars[1]: positions of cars[1] in all garages
+			[]uint64{enc(1, leafNoMatchC0, docNoMatch), enc(1, leafNoMatchC1, docNoMatch)}))
+		// _idx[cars, 0]: cars[0] across docs.
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
+			[]uint64{enc(1, leafMatchC0, docMatch), enc(1, leafNoMatchC0, docNoMatch)}))
+		// _idx[cars, 1]: cars[1] across docs.
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
-			[]uint64{enc(1, leafG0Cars1, docMatch), enc(1, leafG1Cars1, docNoMatch)}))
+			[]uint64{enc(1, leafMatchC1, docMatch), enc(1, leafNoMatchC1, docNoMatch)}))
 
 		idx1cars := filnested.ArrayIndex{RelPath: "cars", Index: 1}
 		city := makeLeafPvp(class, "countries", "garages.city", "berlin")
@@ -6092,38 +6123,66 @@ func TestCorrelatedAndFilterExamples(t *testing.T) {
 			docMatch    = uint64(1)
 			docNoMatch1 = uint64(2)
 			docNoMatch2 = uint64(3)
+
+			// docMatch data: countries[0]={garages:[{}, {}, {city, cars:[{}, {make}]}]}.
+			// Walker leaves are assigned in DFS order:
+			//   garages[0]={} → leaf 1. garages[1]={} → leaf 2.
+			//   garages[2].cars[0]={} → leaf 3. garages[2].cars[1]={make} → leaf 4.
+			//   city inherits garages[2].descendants = [3, 4].
+			leafM_G0 = uint16(1)
+			leafM_G1 = uint16(2)
+			leafM_C0 = uint16(3) // garages[2].cars[0]
+			leafM_C1 = uint16(4) // garages[2].cars[1]
+
+			// docNoMatch1 data: countries[0]={garages:[{}, {cars:[{}, {make}]}, {city}]}.
+			//   garages[0]={} → 1. garages[1].cars[0] → 2. garages[1].cars[1]={make} → 3.
+			//   garages[2]={city} → 4. city at 4 (no descendants under garages[2]).
+			leafN1_G0 = uint16(1)
+			leafN1_C0 = uint16(2) // garages[1].cars[0]
+			leafN1_C1 = uint16(3) // garages[1].cars[1]
+			leafN1_G2 = uint16(4) // garages[2] (city only)
+
+			// docNoMatch2 data: countries[0]={garages:[{}, {city}, {cars:[{}, {make}]}]}.
+			//   garages[0]={} → 1. garages[1]={city} → 2.
+			//   garages[2].cars[0] → 3. garages[2].cars[1]={make} → 4.
+			leafN2_G0 = uint16(1)
+			leafN2_G1 = uint16(2) // garages[1] (city only)
+			leafN2_C0 = uint16(3) // garages[2].cars[0]
+			leafN2_C1 = uint16(4) // garages[2].cars[1]
 		)
 		searcher, vb, mb := newFilterExamplesSearcher(t, "countries")
 
-		// docMatch: city and cars[1].make both in garages[2] of country[0]
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG2Direct, docMatch)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG1Cars1+2, docMatch)}) // garages[2].cars[1]
+		// docMatch: city inherits garages[2].cars's leaves; cars[1].make at cars[1].
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafM_C0, docMatch), enc(1, leafM_C1, docMatch)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafM_C1, docMatch)})
 
-		// docNoMatch1: city in garages[2], make in garages[1] — different garages
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG2Direct, docNoMatch1)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG1Cars1, docNoMatch1)}) // garages[1].cars[1]
+		// docNoMatch1: city at garages[2]'s own leaf (no cars in g[2]); make in garages[1].cars[1].
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafN1_G2, docNoMatch1)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafN1_C1, docNoMatch1)})
 
-		// docNoMatch2: city in garages[1] (not garages[2]), make in garages[2]
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG1Direct, docNoMatch2)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG1Cars1+2, docNoMatch2)}) // garages[2].cars[1]
+		// docNoMatch2: city at garages[1]'s own leaf; make in garages[2].cars[1].
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafN2_G1, docNoMatch2)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafN2_C1, docNoMatch2)})
 
-		// _idx.garages[1]: garages[1] positions
+		// _idx.garages[1]: garages[1]'s elementPositions per doc.
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 1),
 			[]uint64{
-				enc(1, leafG1Direct, docNoMatch1), enc(1, leafG1Cars1, docNoMatch1),
-				enc(1, leafG1Direct, docNoMatch2),
+				enc(1, leafN1_C0, docNoMatch1), enc(1, leafN1_C1, docNoMatch1),
+				enc(1, leafN2_G1, docNoMatch2),
 			}))
-		// _idx.garages[2]: garages[2] positions
+		// _idx.garages[2]: garages[2]'s elementPositions per doc.
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 2),
 			[]uint64{
-				enc(1, leafG2Direct, docMatch), enc(1, leafG1Cars1+2, docMatch),
-				enc(1, leafG2Direct, docNoMatch1), enc(1, leafG1Cars1+2, docNoMatch2),
+				enc(1, leafM_C0, docMatch), enc(1, leafM_C1, docMatch),
+				enc(1, leafN1_G2, docNoMatch1),
+				enc(1, leafN2_C0, docNoMatch2), enc(1, leafN2_C1, docNoMatch2),
 			}))
-		// _idx.cars[1]: cars[1] positions across all garages
+		// _idx.cars[1]: cars[1] positions across all garages.
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
 			[]uint64{
-				enc(1, leafG1Cars1+2, docMatch), enc(1, leafG1Cars1, docNoMatch1),
-				enc(1, leafG1Cars1+2, docNoMatch2),
+				enc(1, leafM_C1, docMatch),
+				enc(1, leafN1_C1, docNoMatch1),
+				enc(1, leafN2_C1, docNoMatch2),
 			}))
 
 		idx2g := filnested.ArrayIndex{RelPath: "garages", Index: 2}
@@ -6151,27 +6210,42 @@ func TestCorrelatedAndFilterExamples(t *testing.T) {
 	// -----------------------------------------------------------------------
 	t.Run("C5_countries.garages.city_AND_countries.garages.cars.make_AND_countries.garages.cars.model", func(t *testing.T) {
 		const (
-			docMatch    = uint64(1)
-			docNoMatch  = uint64(2)
-			leafG0Cars0 = uint16(6) // garages[0].cars[0] (extends the leaf table for this test)
+			docMatch   = uint64(1)
+			docNoMatch = uint64(2)
+
+			// docMatch data: countries[0].garages[0]={city, cars:[{}, {make, model}]}.
+			//   cars[0]={} → leaf 1. cars[1]={make, model} → leaf 2 (make+model share).
+			//   city inherits garages[0].descendants = [1, 2].
+			leafM_C0 = uint16(1) // garages[0].cars[0]
+			leafM_C1 = uint16(2) // garages[0].cars[1]
+
+			// docNoMatch data: countries[0].garages[0]={city, cars:[{make}, {model}]}.
+			//   cars[0]={make} → leaf 1 (make at 1). cars[1]={model} → leaf 2 (model at 2).
+			//   city inherits both leaves [1, 2].
+			leafN_C0 = uint16(1) // garages[0].cars[0] (make-only)
+			leafN_C1 = uint16(2) // garages[0].cars[1] (model-only)
 		)
 		searcher, vb, mb := newFilterExamplesSearcher(t, "countries")
 
-		// docMatch: city, make, model all in garages[0].cars[1] of country[0]
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG0Direct, docMatch)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG0Cars1, docMatch)})
-		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafG0Cars1, docMatch)})
-		// docNoMatch: city in garages[0], make in cars[0], model in cars[1] — different cars
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG0Direct, docNoMatch)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG0Cars0, docNoMatch)})
-		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafG0Cars1, docNoMatch)})
+		// docMatch: same-car make+model at cars[1]; city inherits BOTH cars' leaves.
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafM_C0, docMatch), enc(1, leafM_C1, docMatch)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafM_C1, docMatch)})
+		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafM_C1, docMatch)})
+		// docNoMatch: make in cars[0], model in cars[1]; city inherits both.
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafN_C0, docNoMatch), enc(1, leafN_C1, docNoMatch)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafN_C0, docNoMatch)})
+		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafN_C1, docNoMatch)})
 
-		// _idx.garages[0]: all positions belonging to garages[0] across both docs
+		// _idx.garages[0]: garages[0].elementPositions per doc.
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 0),
 			[]uint64{
-				enc(1, leafG0Direct, docMatch), enc(1, leafG0Cars1, docMatch),
-				enc(1, leafG0Direct, docNoMatch), enc(1, leafG0Cars0, docNoMatch), enc(1, leafG0Cars1, docNoMatch),
+				enc(1, leafM_C0, docMatch), enc(1, leafM_C1, docMatch),
+				enc(1, leafN_C0, docNoMatch), enc(1, leafN_C1, docNoMatch),
 			}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
+			[]uint64{enc(1, leafM_C0, docMatch), enc(1, leafN_C0, docNoMatch)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
+			[]uint64{enc(1, leafM_C1, docMatch), enc(1, leafN_C1, docNoMatch)}))
 
 		city := makeLeafPvp(class, "countries", "garages.city", "berlin")
 		carsMake := makeLeafPvp(class, "countries", "garages.cars.make", "honda")
@@ -6232,36 +6306,40 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 			docMatch   = uint64(1)
 			docNoMatch = uint64(2)
 
-			leafG0Direct = uint16(1)
-			leafG1Direct = uint16(2)
-			leafG1Cars0  = uint16(3)
-			leafG1Cars1  = uint16(4)
+			// Per assign.go's walkObject: postcode (a scalar on garages[1])
+			// inherits garages[1].elementPositions, which equals cars's
+			// leaves. So postcode lands at the same leaves as make/model,
+			// not at a distinct "g1.direct" leaf.
+			leafG0   = uint16(1) // garages[0]'s leaf (city, no descendants)
+			leafG1C0 = uint16(2) // garages[1].cars[0]'s leaf
+			leafG1C1 = uint16(3) // garages[1].cars[1]'s leaf (docNoMatch only)
 		)
 		searcher, vb, mb := newFilterExamplesSearcher(t, "countries")
 
-		// docMatch: city in g[0]; postcode in g[1]; make+model both in g[1].cars[0].
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG0Direct, docMatch)})
-		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(1, leafG1Direct, docMatch)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG1Cars0, docMatch)})
-		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafG1Cars0, docMatch)})
+		// docMatch: c[0].garages=[{city:berlin}, {postcode:12345, cars:[{make:honda, model:civic}]}]
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG0, docMatch)})
+		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(1, leafG1C0, docMatch)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG1C0, docMatch)})
+		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafG1C0, docMatch)})
 
-		// docNoMatch: same as docMatch but make in cars[0] and model in cars[1].
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG0Direct, docNoMatch)})
-		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(1, leafG1Direct, docNoMatch)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG1Cars0, docNoMatch)})
-		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafG1Cars1, docNoMatch)})
+		// docNoMatch: same but garages[1].cars=[{make:honda}, {model:civic}].
+		// postcode inherits both cars's leaves.
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG0, docNoMatch)})
+		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(1, leafG1C0, docNoMatch), enc(1, leafG1C1, docNoMatch)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG1C0, docNoMatch)})
+		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafG1C1, docNoMatch)})
 
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 0),
-			[]uint64{enc(1, leafG0Direct, docMatch), enc(1, leafG0Direct, docNoMatch)}))
+			[]uint64{enc(1, leafG0, docMatch), enc(1, leafG0, docNoMatch)}))
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 1),
 			[]uint64{
-				enc(1, leafG1Direct, docMatch), enc(1, leafG1Cars0, docMatch),
-				enc(1, leafG1Direct, docNoMatch), enc(1, leafG1Cars0, docNoMatch), enc(1, leafG1Cars1, docNoMatch),
+				enc(1, leafG1C0, docMatch),
+				enc(1, leafG1C0, docNoMatch), enc(1, leafG1C1, docNoMatch),
 			}))
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
-			[]uint64{enc(1, leafG1Cars0, docMatch), enc(1, leafG1Cars0, docNoMatch)}))
+			[]uint64{enc(1, leafG1C0, docMatch), enc(1, leafG1C0, docNoMatch)}))
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
-			[]uint64{enc(1, leafG1Cars1, docNoMatch)}))
+			[]uint64{enc(1, leafG1C1, docNoMatch)}))
 
 		idx0g := filnested.ArrayIndex{RelPath: "garages", Index: 0}
 		idx1g := filnested.ArrayIndex{RelPath: "garages", Index: 1}
@@ -6359,45 +6437,50 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 			docMatch   = uint64(1)
 			docNoMatch = uint64(2)
 
-			leafC0G0Direct = uint16(1)
-			leafC1G0Direct = uint16(1)
-			leafC1G0Cars0  = uint16(2)
-			leafC1G0Cars1  = uint16(3)
+			// Per assign.go: each countries[N] gets its own walker with
+			// leafIdx restarting at 1. countries[1].garages[0].cars[0]'s
+			// leaf is 1; postcode (scalar on garages[0]) inherits that
+			// leaf. In docNoMatch with two cars, cars[0] is leaf 1 and
+			// cars[1] is leaf 2; postcode inherits both.
+			leafC0G0   = uint16(1) // countries[0].garages[0]'s leaf (city only)
+			leafC1G0C0 = uint16(1) // countries[1].garages[0].cars[0]'s leaf
+			leafC1G0C1 = uint16(2) // countries[1].garages[0].cars[1]'s leaf (docNoMatch only)
 		)
 		searcher, vb, mb := newFilterExamplesSearcher(t, "countries")
 
-		// docMatch: city in c[0].g[0]; postcode in c[1].g[0]; cars[0].make+model in c[1].g[0].
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafC0G0Direct, docMatch)})
-		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(2, leafC1G0Direct, docMatch)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(2, leafC1G0Cars0, docMatch)})
-		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(2, leafC1G0Cars0, docMatch)})
+		// docMatch: c[0]={garages:[{city:berlin}]};
+		//           c[1]={garages:[{postcode:12345, cars:[{make:honda, model:civic}]}]}
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafC0G0, docMatch)})
+		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(2, leafC1G0C0, docMatch)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(2, leafC1G0C0, docMatch)})
+		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(2, leafC1G0C0, docMatch)})
 
-		// docNoMatch: same but make in cars[0] and model in cars[1] within c[1].g[0].
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafC0G0Direct, docNoMatch)})
-		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(2, leafC1G0Direct, docNoMatch)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(2, leafC1G0Cars0, docNoMatch)})
-		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(2, leafC1G0Cars1, docNoMatch)})
+		// docNoMatch: c[1].g[0].cars=[{make}, {model}]. postcode inherits both cars.
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafC0G0, docNoMatch)})
+		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(2, leafC1G0C0, docNoMatch), enc(2, leafC1G0C1, docNoMatch)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(2, leafC1G0C0, docNoMatch)})
+		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(2, leafC1G0C1, docNoMatch)})
 
 		// _idx[""][0]: country[0] root positions
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 0),
-			[]uint64{enc(1, leafC0G0Direct, docMatch), enc(1, leafC0G0Direct, docNoMatch)}))
+			[]uint64{enc(1, leafC0G0, docMatch), enc(1, leafC0G0, docNoMatch)}))
 		// _idx[""][1]: country[1] root positions
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("", 1),
 			[]uint64{
-				enc(2, leafC1G0Direct, docMatch), enc(2, leafC1G0Cars0, docMatch),
-				enc(2, leafC1G0Direct, docNoMatch), enc(2, leafC1G0Cars0, docNoMatch), enc(2, leafC1G0Cars1, docNoMatch),
+				enc(2, leafC1G0C0, docMatch),
+				enc(2, leafC1G0C0, docNoMatch), enc(2, leafC1G0C1, docNoMatch),
 			}))
 		// _idx.garages[0]: garages[0] positions across all countries
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 0),
 			[]uint64{
-				enc(1, leafC0G0Direct, docMatch), enc(1, leafC0G0Direct, docNoMatch),
-				enc(2, leafC1G0Direct, docMatch), enc(2, leafC1G0Cars0, docMatch),
-				enc(2, leafC1G0Direct, docNoMatch), enc(2, leafC1G0Cars0, docNoMatch), enc(2, leafC1G0Cars1, docNoMatch),
+				enc(1, leafC0G0, docMatch), enc(1, leafC0G0, docNoMatch),
+				enc(2, leafC1G0C0, docMatch),
+				enc(2, leafC1G0C0, docNoMatch), enc(2, leafC1G0C1, docNoMatch),
 			}))
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
-			[]uint64{enc(2, leafC1G0Cars0, docMatch), enc(2, leafC1G0Cars0, docNoMatch)}))
+			[]uint64{enc(2, leafC1G0C0, docMatch), enc(2, leafC1G0C0, docNoMatch)}))
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
-			[]uint64{enc(2, leafC1G0Cars1, docNoMatch)}))
+			[]uint64{enc(2, leafC1G0C1, docNoMatch)}))
 
 		idx0c := filnested.ArrayIndex{RelPath: "", Index: 0}
 		idx1c := filnested.ArrayIndex{RelPath: "", Index: 1}
@@ -6569,31 +6652,41 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 			docMatch   = uint64(1)
 			docNoMatch = uint64(2)
 
-			leafG0Direct = uint16(1)
-			leafG0Cars0  = uint16(2)
-			leafG0Cars1  = uint16(3)
+			// Per assign.go's walkObject: scalar fields inherit their
+			// parent element's positions, which equal the union of
+			// descendant leaves when descendants exist. So city/postcode
+			// at garages[0] inherit from cars's leaves; they do not get
+			// their own distinct leaf.
+			leafCar0 = uint16(1) // cars[0]'s leaf (per doc)
+			leafCar1 = uint16(2) // cars[1]'s leaf (docNoMatch only)
 		)
 		searcher, vb, mb := newFilterExamplesSearcher(t, "countries")
 
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG0Direct, docMatch)})
-		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(1, leafG0Direct, docMatch)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG0Cars0, docMatch)})
-		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafG0Cars0, docMatch)})
+		// docMatch: c[0].g[0]={city, postcode, cars:[{make, model}]}.
+		// Single car → all four conditions land at the same leaf.
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafCar0, docMatch)})
+		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(1, leafCar0, docMatch)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafCar0, docMatch)})
+		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafCar0, docMatch)})
 
-		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG0Direct, docNoMatch)})
-		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(1, leafG0Direct, docNoMatch)})
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG0Cars0, docNoMatch)})
-		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafG0Cars1, docNoMatch)})
+		// docNoMatch: c[0].g[0]={city, postcode, cars:[{make}, {model}]}.
+		// Two cars → city/postcode inherit BOTH cars' leaves; make is at
+		// cars[0]'s leaf only; model is at cars[1]'s leaf only.
+		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafCar0, docNoMatch), enc(1, leafCar1, docNoMatch)})
+		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(1, leafCar0, docNoMatch), enc(1, leafCar1, docNoMatch)})
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafCar0, docNoMatch)})
+		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafCar1, docNoMatch)})
 
+		// _idx[garages, 0]: union of cars's leaves (garages[0].elementPositions).
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 0),
 			[]uint64{
-				enc(1, leafG0Direct, docMatch), enc(1, leafG0Cars0, docMatch),
-				enc(1, leafG0Direct, docNoMatch), enc(1, leafG0Cars0, docNoMatch), enc(1, leafG0Cars1, docNoMatch),
+				enc(1, leafCar0, docMatch),
+				enc(1, leafCar0, docNoMatch), enc(1, leafCar1, docNoMatch),
 			}))
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
-			[]uint64{enc(1, leafG0Cars0, docMatch), enc(1, leafG0Cars0, docNoMatch)}))
+			[]uint64{enc(1, leafCar0, docMatch), enc(1, leafCar0, docNoMatch)}))
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
-			[]uint64{enc(1, leafG0Cars1, docNoMatch)}))
+			[]uint64{enc(1, leafCar1, docNoMatch)}))
 
 		city := makeLeafPvp(class, "countries", "garages.city", "berlin")
 		postcode := makeLeafPvp(class, "countries", "garages.postcode", "12345")

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -6296,20 +6296,38 @@ func TestCorrelatedAndFilterExamples(t *testing.T) {
 		const (
 			docMatch   = uint64(1)
 			docNoMatch = uint64(2)
+
+			// docMatch:   countries[0].garages[0]={cars:[{}, {make:honda, model:civic}]}.
+			// DFS leaves: garages[0].cars[0]={} → 1; garages[0].cars[1]={make,model} → 2
+			// (make and model share the same leaf).
+			leafM_C0 = uint16(1)
+			leafM_C1 = uint16(2)
+			// docNoMatch: countries[0].garages[0]={cars:[{model:civic}, {make:honda}]}.
+			// DFS leaves: garages[0].cars[0]={model} → 1; garages[0].cars[1]={make} → 2.
+			// Make at cars[1]'s leaf, model at cars[0]'s leaf — different cars.
+			leafN_C0 = uint16(1)
+			leafN_C1 = uint16(2)
 		)
 		searcher, vb, mb := newFilterExamplesSearcher(t, "countries")
 
-		// docMatch: make and model both in cars[1] of garages[0] of country[0]
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG0Cars1, docMatch)})
-		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafG0Cars1, docMatch)})
-		// docNoMatch: make in cars[1], model in a different car (leaf ≠ leafG0Cars1)
-		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG0Cars1, docNoMatch)})
-		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafG0Direct, docNoMatch)})
+		// docMatch: make and model both in cars[1] of garages[0] of country[0].
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafM_C1, docMatch)})
+		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafM_C1, docMatch)})
+		// docNoMatch: make in cars[1], model in cars[0] — different cars in same garage.
+		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafN_C1, docNoMatch)})
+		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafN_C0, docNoMatch)})
 
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
-			[]uint64{enc(1, leafG0Cars1, docMatch), enc(1, leafG0Cars1, docNoMatch)}))
+		// _idx.garages.cars[N]: positions for each cars[N] across both garages and
+		// countries. The countries-root planner builds the nested cars group at
+		// LCA "garages.cars" (not "cars"), so the executor reads these keys to
+		// scope the cars[1] branch's parentScope during runIdxLoopRecursive /
+		// SPLIT dispatch.
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages.cars", 0),
+			[]uint64{enc(1, leafM_C0, docMatch), enc(1, leafN_C0, docNoMatch)}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages.cars", 1),
+			[]uint64{enc(1, leafM_C1, docMatch), enc(1, leafN_C1, docNoMatch)}))
 
-		idx1cars := filnested.ArrayIndex{RelPath: "cars", Index: 1}
+		idx1cars := filnested.ArrayIndex{RelPath: "garages.cars", Index: 1}
 		carsMake := makeLeafPvpWithIdx(class, "countries", "garages.cars.make", "honda", idx1cars)
 		carsModel := makeLeafPvp(class, "countries", "garages.cars.model", "civic")
 
@@ -6332,7 +6350,7 @@ func TestCorrelatedAndFilterExamples(t *testing.T) {
 
 			// docMatch data: countries[0].garages=[{city, cars:[{}, {make}]}].
 			// cars[0]/cars[1] each get a fresh leaf; garages[0].elementPositions
-			// is the union of cars's leaves; city inherits both.
+			// is the union of cars' leaves; city inherits both.
 			leafMatchC0 = uint16(1) // garages[0].cars[0]
 			leafMatchC1 = uint16(2) // garages[0].cars[1]
 			// docNoMatch data: countries[0].garages=[{city}, {cars:[{}, {make}]}].
@@ -6361,14 +6379,14 @@ func TestCorrelatedAndFilterExamples(t *testing.T) {
 		// _idx[garages, 1]: only docNoMatch has garages[1].
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 1),
 			[]uint64{enc(1, leafNoMatchC0, docNoMatch), enc(1, leafNoMatchC1, docNoMatch)}))
-		// _idx[cars, 0]: cars[0] across docs.
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
+		// _idx.garages.cars[0]: cars[0] positions across docs at LCA "garages.cars".
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages.cars", 0),
 			[]uint64{enc(1, leafMatchC0, docMatch), enc(1, leafNoMatchC0, docNoMatch)}))
-		// _idx[cars, 1]: cars[1] across docs.
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
+		// _idx.garages.cars[1]: cars[1] positions across docs at LCA "garages.cars".
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages.cars", 1),
 			[]uint64{enc(1, leafMatchC1, docMatch), enc(1, leafNoMatchC1, docNoMatch)}))
 
-		idx1cars := filnested.ArrayIndex{RelPath: "cars", Index: 1}
+		idx1cars := filnested.ArrayIndex{RelPath: "garages.cars", Index: 1}
 		city := makeLeafPvp(class, "countries", "garages.city", "berlin")
 		carsMake := makeLeafPvpWithIdx(class, "countries", "garages.cars.make", "honda", idx1cars)
 
@@ -6424,7 +6442,7 @@ func TestCorrelatedAndFilterExamples(t *testing.T) {
 		)
 		searcher, vb, mb := newFilterExamplesSearcher(t, "countries")
 
-		// docMatch: city inherits garages[2].cars's leaves; cars[1].make at cars[1].
+		// docMatch: city inherits garages[2].cars' leaves; cars[1].make at cars[1].
 		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafM_C0, docMatch), enc(1, leafM_C1, docMatch)})
 		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafM_C1, docMatch)})
 
@@ -6449,8 +6467,8 @@ func TestCorrelatedAndFilterExamples(t *testing.T) {
 				enc(1, leafN1_G2, docNoMatch1),
 				enc(1, leafN2_C0, docNoMatch2), enc(1, leafN2_C1, docNoMatch2),
 			}))
-		// _idx.cars[1]: cars[1] positions across all garages.
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
+		// _idx.garages.cars[1]: cars[1] positions across all garages at LCA "garages.cars".
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages.cars", 1),
 			[]uint64{
 				enc(1, leafM_C1, docMatch),
 				enc(1, leafN1_C1, docNoMatch1),
@@ -6458,7 +6476,7 @@ func TestCorrelatedAndFilterExamples(t *testing.T) {
 			}))
 
 		idx2g := filnested.ArrayIndex{RelPath: "garages", Index: 2}
-		idx1cars := filnested.ArrayIndex{RelPath: "cars", Index: 1}
+		idx1cars := filnested.ArrayIndex{RelPath: "garages.cars", Index: 1}
 		g2city := makeLeafPvpWithIdx(class, "countries", "garages.city", "berlin", idx2g)
 		carsMake := makeLeafPvpWithIdx(class, "countries", "garages.cars.make", "honda", idx1cars)
 
@@ -6514,10 +6532,6 @@ func TestCorrelatedAndFilterExamples(t *testing.T) {
 				enc(1, leafM_C0, docMatch), enc(1, leafM_C1, docMatch),
 				enc(1, leafN_C0, docNoMatch), enc(1, leafN_C1, docNoMatch),
 			}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
-			[]uint64{enc(1, leafM_C0, docMatch), enc(1, leafN_C0, docNoMatch)}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
-			[]uint64{enc(1, leafM_C1, docMatch), enc(1, leafN_C1, docNoMatch)}))
 
 		city := makeLeafPvp(class, "countries", "garages.city", "berlin")
 		carsMake := makeLeafPvp(class, "countries", "garages.cars.make", "honda")
@@ -6579,7 +6593,7 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 			docNoMatch = uint64(2)
 
 			// Per assign.go's walkObject: postcode (a scalar on garages[1])
-			// inherits garages[1].elementPositions, which equals cars's
+			// inherits garages[1].elementPositions, which equals cars'
 			// leaves. So postcode lands at the same leaves as make/model,
 			// not at a distinct "g1.direct" leaf.
 			leafG0   = uint16(1) // garages[0]'s leaf (city, no descendants)
@@ -6595,7 +6609,7 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafG1C0, docMatch)})
 
 		// docNoMatch: same but garages[1].cars=[{make:honda}, {model:civic}].
-		// postcode inherits both cars's leaves.
+		// postcode inherits both cars' leaves.
 		writeNestedValue(t, vb, "garages.city", "berlin", []uint64{enc(1, leafG0, docNoMatch)})
 		writeNestedValue(t, vb, "garages.postcode", "12345", []uint64{enc(1, leafG1C0, docNoMatch), enc(1, leafG1C1, docNoMatch)})
 		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafG1C0, docNoMatch)})
@@ -6608,10 +6622,6 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 				enc(1, leafG1C0, docMatch),
 				enc(1, leafG1C0, docNoMatch), enc(1, leafG1C1, docNoMatch),
 			}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
-			[]uint64{enc(1, leafG1C0, docMatch), enc(1, leafG1C0, docNoMatch)}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
-			[]uint64{enc(1, leafG1C1, docNoMatch)}))
 
 		idx0g := filnested.ArrayIndex{RelPath: "garages", Index: 0}
 		idx1g := filnested.ArrayIndex{RelPath: "garages", Index: 1}
@@ -6672,10 +6682,6 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 				enc(1, leafG2Cars0, docMatch),
 				enc(1, leafG2Cars0, docNoMatch), enc(1, leafG2Cars1, docNoMatch),
 			}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
-			[]uint64{enc(1, leafG2Cars0, docMatch), enc(1, leafG2Cars0, docNoMatch)}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
-			[]uint64{enc(1, leafG2Cars1, docNoMatch)}))
 
 		idx0g := filnested.ArrayIndex{RelPath: "garages", Index: 0}
 		idx1g := filnested.ArrayIndex{RelPath: "garages", Index: 1}
@@ -6749,10 +6755,6 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 				enc(2, leafC1G0C0, docMatch),
 				enc(2, leafC1G0C0, docNoMatch), enc(2, leafC1G0C1, docNoMatch),
 			}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
-			[]uint64{enc(2, leafC1G0C0, docMatch), enc(2, leafC1G0C0, docNoMatch)}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
-			[]uint64{enc(2, leafC1G0C1, docNoMatch)}))
 
 		idx0c := filnested.ArrayIndex{RelPath: "", Index: 0}
 		idx1c := filnested.ArrayIndex{RelPath: "", Index: 1}
@@ -6817,10 +6819,6 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 				enc(3, leafC2G0Cars0, docMatch),
 				enc(3, leafC2G0Cars0, docNoMatch), enc(3, leafC2G0Cars1, docNoMatch),
 			}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
-			[]uint64{enc(3, leafC2G0Cars0, docMatch), enc(3, leafC2G0Cars0, docNoMatch)}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
-			[]uint64{enc(3, leafC2G0Cars1, docNoMatch)}))
 
 		idx0c := filnested.ArrayIndex{RelPath: "", Index: 0}
 		idx1c := filnested.ArrayIndex{RelPath: "", Index: 1}
@@ -6887,10 +6885,6 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 				enc(3, leafC2G3Cars0, docMatch),
 				enc(3, leafC2G3Cars0, docNoMatch), enc(3, leafC2G3Cars1, docNoMatch),
 			}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
-			[]uint64{enc(3, leafC2G3Cars0, docMatch), enc(3, leafC2G3Cars0, docNoMatch)}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
-			[]uint64{enc(3, leafC2G3Cars1, docNoMatch)}))
 
 		idx0c := filnested.ArrayIndex{RelPath: "", Index: 0}
 		idx1c := filnested.ArrayIndex{RelPath: "", Index: 1}
@@ -6927,7 +6921,7 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 			// Per assign.go's walkObject: scalar fields inherit their
 			// parent element's positions, which equal the union of
 			// descendant leaves when descendants exist. So city/postcode
-			// at garages[0] inherit from cars's leaves; they do not get
+			// at garages[0] inherit from cars' leaves; they do not get
 			// their own distinct leaf.
 			leafCar0 = uint16(1) // cars[0]'s leaf (per doc)
 			leafCar1 = uint16(2) // cars[1]'s leaf (docNoMatch only)
@@ -6949,16 +6943,12 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 		writeNestedValue(t, vb, "garages.cars.make", "honda", []uint64{enc(1, leafCar0, docNoMatch)})
 		writeNestedValue(t, vb, "garages.cars.model", "civic", []uint64{enc(1, leafCar1, docNoMatch)})
 
-		// _idx[garages, 0]: union of cars's leaves (garages[0].elementPositions).
+		// _idx[garages, 0]: union of cars' leaves (garages[0].elementPositions).
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 0),
 			[]uint64{
 				enc(1, leafCar0, docMatch),
 				enc(1, leafCar0, docNoMatch), enc(1, leafCar1, docNoMatch),
 			}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0),
-			[]uint64{enc(1, leafCar0, docMatch), enc(1, leafCar0, docNoMatch)}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1),
-			[]uint64{enc(1, leafCar1, docNoMatch)}))
 
 		city := makeLeafPvp(class, "countries", "garages.city", "berlin")
 		postcode := makeLeafPvp(class, "countries", "garages.postcode", "12345")
@@ -7012,6 +7002,9 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 				enc(1, leafG0Direct, docMatch), enc(1, leafG0Cars0Tag, docMatch), enc(1, leafG0Cars0Access, docMatch),
 				enc(1, leafG0Direct, docNoMatch), enc(1, leafG0Cars0Access, docNoMatch), enc(1, leafG0Cars1Tag, docNoMatch),
 			}))
+		// _idx.garages.cars[K]: scalar-array terminal (cars.tags) and deeper sub-array
+		// (cars.accessories) force runIdxLoopRecursive at the cars LCA, which reads
+		// these entries to scope same-car evaluation.
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages.cars", 0),
 			[]uint64{
 				enc(1, leafG0Cars0Tag, docMatch), enc(1, leafG0Cars0Access, docMatch),
@@ -7073,6 +7066,9 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 				enc(1, leafG0Direct, docMatch), enc(1, leafG0Cars0Access, docMatch), enc(1, leafG0Cars0Tire, docMatch),
 				enc(1, leafG0Direct, docNoMatch), enc(1, leafG0Cars0Access, docNoMatch), enc(1, leafG0Cars1Tire, docNoMatch),
 			}))
+		// _idx.garages.cars[K]: two deeper sub-arrays under cars (accessories, tires)
+		// force runIdxLoopRecursive at the cars LCA, which reads these entries to
+		// scope same-car evaluation.
 		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages.cars", 0),
 			[]uint64{
 				enc(1, leafG0Cars0Access, docMatch), enc(1, leafG0Cars0Tire, docMatch),

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -1322,6 +1322,278 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		requireBitmapValid(t, result.docIDs)
 		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
 	})
+
+	t.Run("two scalar-array siblings — single value each — same-car semantics", func(t *testing.T) {
+		// garages.cars.tags = "german" AND garages.cars.labels = "red"
+		//
+		// Two scalar-array (text[]) terminals at the same parent (cars), each
+		// constrained to one value. canUseRawAndAll's current dispatch fires
+		// (unique paths, no subs) and routes to evalGroupRoot's raw AndAll;
+		// however walkScalarArray assigns DISTINCT leaves per text[] element
+		// so tags="german" and labels="red" never share a leaf within the
+		// same car — raw AndAll returns empty for every doc, including the
+		// case where both values are present in the same car.
+		//
+		// Schema-aware dispatch (canUseRawAndAll detecting scalar-array
+		// terminals) routes to runIdxLoopRecursive instead, whose
+		// matchElementRecursive uses MaskLeafAnd to compare rootDoc after
+		// stripping leaves — both leaves co-locate at the same rootDoc.
+		//
+		// doc5: cars[0]={tags:["german"], labels:["red"]} → should match
+		// doc7: cars[0]={tags:["german"]}, cars[1]={labels:["red"]} → should NOT match
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "garages",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "cars",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+								{Name: "labels", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("garages")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("garages")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: cars[0] has both tags="german" (leaf=1) and labels="red" (leaf=2).
+		writeNestedValue(t, vb, "cars.tags", "german", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "cars.labels", "red", []uint64{invnested.Encode(1, 2, doc5)})
+		// doc7: tags="german" in cars[0] (leaf=1), labels="red" in cars[1] (leaf=2).
+		writeNestedValue(t, vb, "cars.tags", "german", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "cars.labels", "red", []uint64{invnested.Encode(1, 2, doc7)})
+
+		mb := store.Bucket(metaBucketName)
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5),
+			invnested.Encode(1, 1, doc7), // doc7 tags in cars[0]
+		}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("cars", 1), []uint64{
+			invnested.Encode(1, 2, doc7), // doc7 labels in cars[1]
+		}))
+
+		pv := makeCorrelatedPvp(class, "garages",
+			makeLeafPvp(class, "garages", "cars.tags", "german"),
+			makeLeafPvp(class, "garages", "cars.labels", "red"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("two scalar-array siblings at intermediate LCA — same-car-across-garages disambiguation", func(t *testing.T) {
+		// countries.garages.cars.tags = "german" AND countries.garages.cars.labels = "red"
+		//
+		// Two scalar-array (text[]) terminals at an intermediate LCA (garages.cars)
+		// inside a 3-level structure (countries > garages > cars). The planner's
+		// dispatch routes to runIdxLoopRecursive at "garages.cars" (2+ scalar-array
+		// here paths force canUseRawAndAll to bail; collectFlatSubtree also bails
+		// on scalar-array). _idx.garages.cars[K] aggregates positions across all
+		// garages — so K=0 covers g[0].cars[0], g[1].cars[0], etc.
+		//
+		// Without an outer wrapping GROUP at "garages" providing per-garage
+		// parentScope, runIdxLoopRecursive cannot disambiguate same-K elements
+		// under different parents: a doc with tags=german in g[0].cars[0] and
+		// labels=red in g[1].cars[0] (different cars at the same K under
+		// different garages) erroneously matches.
+		//
+		// The planner's needsWrappingGroup is supposed to keep the outer wrap
+		// when the inner group uses runIdxLoopRecursive. groupSubtreeNeedsOuterScope
+		// currently detects ≥2 subs and duplicate here paths but NOT scalar-array
+		// terminals — so the outer wrap collapses incorrectly here.
+		//
+		// doc5: country[0].garages[0].cars[0]={tags:["german"], labels:["red"]} → should match
+		// doc7: country[0].garages[0].cars[0]={tags:["german"]},
+		//       country[0].garages[1].cars[0]={labels:["red"]} → should NOT match
+		//       (different cars at same K under different garages — leak case)
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "countries",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "garages",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{
+									Name:     "cars",
+									DataType: schema.DataTypeObjectArray.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+										{Name: "labels", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("countries")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("countries")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: country[0].garages[0].cars[0] has both tags=german (leaf=1) and labels=red (leaf=2).
+		writeNestedValue(t, vb, "garages.cars.tags", "german", []uint64{invnested.Encode(1, 1, doc5)})
+		writeNestedValue(t, vb, "garages.cars.labels", "red", []uint64{invnested.Encode(1, 2, doc5)})
+		// doc7: country[0]={garages:[{cars:[{tags:[german]}]}, {cars:[{labels:[red]}]}]}.
+		// DFS leaves within country[0]: g[0].cars[0].tags[0]=1, g[1].cars[0].labels[0]=2.
+		writeNestedValue(t, vb, "garages.cars.tags", "german", []uint64{invnested.Encode(1, 1, doc7)})
+		writeNestedValue(t, vb, "garages.cars.labels", "red", []uint64{invnested.Encode(1, 2, doc7)})
+
+		mb := store.Bucket(metaBucketName)
+		// _idx.garages[J]: positions per garage element.
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5), // doc5 g[0]
+			invnested.Encode(1, 1, doc7), // doc7 g[0]
+		}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 1), []uint64{
+			invnested.Encode(1, 2, doc7), // doc7 g[1]
+		}))
+		// _idx.garages.cars[K]: cars[K] positions aggregated across all garages.
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages.cars", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5),
+			invnested.Encode(1, 1, doc7), invnested.Encode(1, 2, doc7),
+		}))
+
+		pv := makeCorrelatedPvp(class, "countries",
+			makeLeafPvp(class, "countries", "garages.cars.tags", "german"),
+			makeLeafPvp(class, "countries", "garages.cars.labels", "red"),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
+
+	t.Run("two scalar-array siblings under 1-branch SPLIT — wrapping group preserves per-garage scope", func(t *testing.T) {
+		// countries.garages.cars[1].tags = "german" AND
+		// countries.garages.cars[1].labels = "red"
+		//
+		// Both conditions pin to cars[1] (constraint at "garages.cars"). The
+		// planner produces:
+		//   GROUP@"garages" {here:[], subs:[
+		//     SPLIT@"garages.cars" 1-branch [GROUP@"garages.cars" {here:[tags, labels]}]
+		//   ]}
+		//
+		// The SPLIT pins to cars[1] at its lcaPath but doesn't disambiguate K=1
+		// across different garages within the same country. The inner GROUP
+		// dispatches to runIdxLoopRecursive (after the scalar-array fix), which
+		// reads _idx.garages.cars[K] aggregating cars[K] positions across all
+		// garages. Without the outer wrapping GROUP@"garages" iterating
+		// _idx.garages[J] to scope per-garage, the inner matchElementRecursive
+		// can match positions from DIFFERENT garages' cars[1] elements as if
+		// they were the same — the MaskLeafAnd zeroes leaf bits and collapses
+		// to (root, doc), conflating across garage parents.
+		//
+		// The planner's needsWrappingGroup for a 1-branch SPLIT must therefore
+		// recurse into the branch plan: if the branch needs outer scope, the
+		// wrapping group must be kept.
+		//
+		// doc5: country[0].garages[0].cars[1] = {tags:[german], labels:[red]}
+		//       → should match (same car has both)
+		// doc7: country[0].garages[0].cars[1] = {tags:[german]},
+		//       country[0].garages[1].cars[1] = {labels:[red]}
+		//       → should NOT match (cars[1] in different garages — leak case)
+
+		vTrue := true
+		class := &models.Class{
+			Class: "TestClass",
+			Properties: []*models.Property{
+				{
+					Name:     "countries",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{
+							Name:     "garages",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{
+									Name:     "cars",
+									DataType: schema.DataTypeObjectArray.PropString(),
+									NestedProperties: []*models.NestedProperty{
+										{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+										{Name: "labels", DataType: schema.DataTypeTextArray.PropString(), IndexFilterable: &vTrue},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		valueBucketName := helpers.BucketNestedFromPropNameLSM("countries")
+		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("countries")
+		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
+
+		vb := store.Bucket(valueBucketName)
+		// doc5: country[0]={garages:[{cars:[{}, {tags:[german], labels:[red]}]}]}
+		// DFS leaves within country[0]: garages[0].cars[0]={} → 1; garages[0].cars[1].tags[0] → 2; garages[0].cars[1].labels[0] → 3.
+		writeNestedValue(t, vb, "garages.cars.tags", "german", []uint64{invnested.Encode(1, 2, doc5)})
+		writeNestedValue(t, vb, "garages.cars.labels", "red", []uint64{invnested.Encode(1, 3, doc5)})
+		// doc7: country[0]={garages:[
+		//   {cars:[{}, {tags:[german]}]},
+		//   {cars:[{}, {labels:[red]}]},
+		// ]}
+		// DFS within country[0]: g[0].cars[0]={}→1; g[0].cars[1].tags[0]→2;
+		//                       g[1].cars[0]={}→3; g[1].cars[1].labels[0]→4.
+		writeNestedValue(t, vb, "garages.cars.tags", "german", []uint64{invnested.Encode(1, 2, doc7)})
+		writeNestedValue(t, vb, "garages.cars.labels", "red", []uint64{invnested.Encode(1, 4, doc7)})
+
+		mb := store.Bucket(metaBucketName)
+		// _idx.garages[J]: per-garage element positions.
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 0), []uint64{
+			invnested.Encode(1, 1, doc5), invnested.Encode(1, 2, doc5), invnested.Encode(1, 3, doc5),
+			invnested.Encode(1, 1, doc7), invnested.Encode(1, 2, doc7),
+		}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages", 1), []uint64{
+			invnested.Encode(1, 3, doc7), invnested.Encode(1, 4, doc7),
+		}))
+		// _idx.garages.cars[K]: cars[K] positions aggregated across all garages.
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages.cars", 0), []uint64{
+			invnested.Encode(1, 1, doc5), // doc5 g[0].cars[0]
+			invnested.Encode(1, 1, doc7), // doc7 g[0].cars[0]
+			invnested.Encode(1, 3, doc7), // doc7 g[1].cars[0]
+		}))
+		require.NoError(t, mb.RoaringSetAddList(invnested.IdxKey("garages.cars", 1), []uint64{
+			invnested.Encode(1, 2, doc5), invnested.Encode(1, 3, doc5), // doc5 g[0].cars[1]
+			invnested.Encode(1, 2, doc7), // doc7 g[0].cars[1]
+			invnested.Encode(1, 4, doc7), // doc7 g[1].cars[1]
+		}))
+
+		idx1cars := filnested.ArrayIndex{RelPath: "garages.cars", Index: 1}
+		pv := makeCorrelatedPvp(class, "countries",
+			makeLeafPvpWithIdx(class, "countries", "garages.cars.tags", "german", idx1cars),
+			makeLeafPvpWithIdx(class, "countries", "garages.cars.labels", "red", idx1cars),
+		)
+		result, err := pv.resolveDocIDs(context.Background(), searcher, 0)
+		require.NoError(t, err)
+		defer result.release()
+		requireBitmapValid(t, result.docIDs)
+		assert.Equal(t, []uint64{doc5}, result.docIDs.ToArray())
+	})
 	// -----------------------------------------------------------------------
 	// Known bugs — tokens + independent mixed in the same directAnd path.
 	//

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
@@ -297,7 +297,8 @@ func (pv *propValuePair) buildRecGroupExecutor(
 	exec := newRecExecutor(input.rawsByCond, metaBucket, s.nestedBitmapOps, concurrency.SROAR_MERGE).
 		withExcludes(excludes).
 		withPlanLCAs(collectPlanLCAs(plan)).
-		withRootAnchor(input.rootAnchor)
+		withRootAnchor(input.rootAnchor).
+		withProps(rootProp.NestedProperties)
 
 	return plan, exec, input.releases, nil
 }

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
@@ -19,6 +19,9 @@ import (
 	"github.com/weaviate/sroar"
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+	filnested "github.com/weaviate/weaviate/entities/filters/nested"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/entities/schema"
 )
 
 // recExclude carries an IsNull=true raw _exists.{path} bitmap together with the
@@ -62,6 +65,12 @@ type recExecutor struct {
 	bitmapOps      *invnested.BitmapOps
 	maxConcurrency int
 	returnMasked   bool
+	// props is the nested schema of the root property the executor operates
+	// on. Used by collectFlatSubtree to identify scalar-array (text[], int[],
+	// …) here paths — those values get distinct leaves per element from
+	// walkScalarArray and break the inheritance bridge that flat raw AndAll
+	// relies on.
+	props []*models.NestedProperty
 }
 
 func newRecExecutor(
@@ -130,6 +139,14 @@ func (e *recExecutor) withRootAnchor(anchor *sroar.Bitmap) *recExecutor {
 // AND multiple groups at root+docID level before stripping root bits.
 func (e *recExecutor) withReturnMasked(returnMasked bool) *recExecutor {
 	e.returnMasked = returnMasked
+	return e
+}
+
+// withProps attaches the root property's nested schema. Required for the
+// flat raw-AndAll path in evalGroup to detect scalar-array (narrow-leaf)
+// here paths.
+func (e *recExecutor) withProps(props []*models.NestedProperty) *recExecutor {
+	e.props = props
 	return e
 }
 
@@ -228,10 +245,20 @@ func (e *recExecutor) evalNode(ctx context.Context, node recPlanNode, parentScop
 //     short-circuit (1 here leaf, 0 subs).
 //   - lcaPath == "" (and not raw-AndAll-eligible): AndAllMaskLeaf — root_idx
 //     encodes element identity at root scope, no per-element loop needed.
+//   - flat subtree (no SPLITs, every here path globally unique, ≤1 deeper
+//     group with here, no scalar-array terminals): fold the entire subtree
+//     into one raw AndAll. Same-element semantics is preserved by the
+//     analyzer's scalar inheritance — a scalar at depth d inherits its
+//     parent element's positions, which equal the descendant leaves when
+//     descendants exist, so leaves of conditions on different paths within
+//     the same physical element coincide. Avoids the idx loop, which is
+//     otherwise expensive and (for non-canUseRawAndAll groups at non-root
+//     lcaPath) loses leaf precision when _idx.{lca}[K] lumps multiple
+//     physical instances at the same K under different parents.
 //   - lcaPath != "" with multiple contributors and at least one masked input
-//     (sub plan, or here paths going deeper): per-element idx loop — each
-//     element of lcaPath is a candidate; here MaskLeafAnd and sub plans must
-//     all match within the same element.
+//     (sub plan, or here paths going deeper) AND not flat: per-element idx
+//     loop — each element of lcaPath is a candidate; here MaskLeafAnd and
+//     sub plans must all match within the same element.
 //
 // The here=0, subs=1 case is collapsed away by the planner so it does not
 // reach evalGroup (see buildGroup).
@@ -239,7 +266,154 @@ func (e *recExecutor) evalGroup(ctx context.Context, g *recGroupNode, parentScop
 	if canUseRawAndAll(g) || g.lcaPath == "" {
 		return e.evalGroupRoot(ctx, g, parentScope)
 	}
+	if flat, ok := e.collectFlatSubtree(g); ok {
+		return e.evalFlatRawAndAll(ctx, flat, parentScope)
+	}
 	return e.runIdxLoopRecursive(ctx, g, parentScope)
+}
+
+// flatSubtree summarizes a recGroupNode tree where raw AndAll over the
+// union of all here leaves is guaranteed to enforce same-element semantics
+// correctly. leaves is the union of here leaves; lcaPaths is the set of
+// lcaPaths covered by the subtree's groups (used to match excludes).
+type flatSubtree struct {
+	leaves   []*propValuePair
+	lcaPaths map[string]struct{}
+}
+
+// collectFlatSubtree walks the subtree rooted at g and returns a flatSubtree
+// when every node is a recGroupNode in a single chain (≤1 sub per group),
+// every here path is globally unique, no here targets a scalar-array path,
+// and at most one group below the root carries here conditions. Bails
+// (returns ok=false) on any of:
+//   - empty props (without schema we cannot identify scalar-array paths;
+//     stay on runIdxLoopRecursive)
+//   - recSplitNode anywhere (arr[N] requires per-element evaluation)
+//   - duplicate here paths (each value lives at a distinct leaf — raw AndAll
+//     over duplicates over-rejects, even within the same physical element)
+//   - any group with ≥2 subs (sibling sub-arrays produce conditions at
+//     distinct leaves with no inheritance bridge — raw AndAll fails)
+//   - any here condition on a scalar-array (text[], int[], …) path. These
+//     values are written by walkScalarArray with one leaf per element
+//     (assign.go), so they don't share leaves via Phase-3 inheritance with
+//     other conditions.
+//   - more than one group below the root carrying here conditions. A
+//     deeper-group here may introduce a narrow leaf bitmap; combining two
+//     such narrow leaves at distinct sub-paths fails raw AndAll. (One
+//     deeper group is fine because the root's wide here bitmaps inherit
+//     through to the deeper leaf.)
+func (e *recExecutor) collectFlatSubtree(g *recGroupNode) (*flatSubtree, bool) {
+	if len(e.props) == 0 {
+		return nil, false
+	}
+	out := &flatSubtree{lcaPaths: map[string]struct{}{}}
+	seen := map[string]struct{}{}
+	deeperWithHere := 0
+	var walk func(n recPlanNode, isRoot bool) bool
+	walk = func(n recPlanNode, isRoot bool) bool {
+		grp, ok := n.(*recGroupNode)
+		if !ok {
+			return false
+		}
+		if len(grp.subs) > 1 {
+			return false
+		}
+		if !isRoot && len(grp.here) > 0 {
+			deeperWithHere++
+			if deeperWithHere > 1 {
+				return false
+			}
+		}
+		out.lcaPaths[grp.lcaPath] = struct{}{}
+		for _, leaf := range grp.here {
+			path := childRelPath(leaf)
+			if _, dup := seen[path]; dup {
+				return false
+			}
+			seen[path] = struct{}{}
+			if e.pathTerminalIsScalarArray(path) {
+				return false
+			}
+			out.leaves = append(out.leaves, leaf)
+		}
+		for _, sub := range grp.subs {
+			if !walk(sub, false) {
+				return false
+			}
+		}
+		return true
+	}
+	if !walk(g, true) {
+		return nil, false
+	}
+	return out, true
+}
+
+// pathTerminalIsScalarArray reports whether path's terminal property in the
+// nested schema is a scalar-array type (text[], int[], number[], boolean[],
+// date[]).
+func (e *recExecutor) pathTerminalIsScalarArray(path string) bool {
+	if path == "" {
+		return false
+	}
+	segs := filnested.SplitPath(path)
+	props := e.props
+	for i, seg := range segs {
+		np := filnested.FindNestedProp(props, seg)
+		if np == nil {
+			return false
+		}
+		dt := schema.DataType(np.DataType[0])
+		if i == len(segs)-1 {
+			return schema.IsScalarArrayType(dt)
+		}
+		if !schema.IsNested(dt) {
+			return false
+		}
+		props = np.NestedProperties
+	}
+	return false
+}
+
+// evalFlatRawAndAll evaluates a flat subtree by raw-AndAll'ing every here
+// leaf's bitmap together with parentScope. Same-element semantics holds via
+// scalar inheritance — a position survives raw AndAll only when every
+// condition lands on a leaf shared with all the others, which by the
+// analyzer's DFS encoding means they belong to the same physical element.
+//
+// Excludes whose lcaPath is in the subtree's lcaPaths are AndNot'd at raw
+// level (sibling-element semantics, §8.5). Excludes whose lcaPath is outside
+// the subtree's lcaPaths are left for execute()'s rootDoc subtraction.
+func (e *recExecutor) evalFlatRawAndAll(ctx context.Context, flat *flatSubtree, parentScope *sroar.Bitmap) (*sroar.Bitmap, func(), error) {
+	if err := ctxExpired(ctx); err != nil {
+		return nil, nil, err
+	}
+	bitmaps := make([]*sroar.Bitmap, 0, len(flat.leaves)+1)
+	for _, leaf := range flat.leaves {
+		bm, ok := e.rawsByCond[leaf]
+		if !ok {
+			return nil, nil, fmt.Errorf("evalFlatRawAndAll: no raw bitmap for leaf %q", childRelPath(leaf))
+		}
+		bitmaps = append(bitmaps, bm)
+	}
+	if parentScope != nil {
+		bitmaps = append(bitmaps, parentScope)
+	}
+	if len(bitmaps) == 0 {
+		return nil, nil, fmt.Errorf("evalFlatRawAndAll: no inputs")
+	}
+	anded, andedRel := e.bitmapOps.AndAll(bitmaps, e.maxConcurrency)
+	for _, excl := range e.excludes {
+		if excl.lcaPath == "" {
+			continue
+		}
+		if _, ok := flat.lcaPaths[excl.lcaPath]; ok {
+			anded.AndNotConc(excl.bitmap, e.maxConcurrency)
+		}
+	}
+	result, resultRel := e.bitmapOps.MaskLeaf(anded)
+	andedRel()
+	return result, resultRel, nil
 }
 
 // evalGroupRoot collects raw bitmaps for here conditions and rootDoc bitmaps

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
@@ -19,9 +19,7 @@ import (
 	"github.com/weaviate/sroar"
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
-	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
-	"github.com/weaviate/weaviate/entities/schema"
 )
 
 // recExclude carries an IsNull=true raw _exists.{path} bitmap together with the
@@ -67,9 +65,9 @@ type recExecutor struct {
 	returnMasked   bool
 	// props is the nested schema of the root property the executor operates
 	// on. Used by collectFlatSubtree to identify scalar-array (text[], int[],
-	// …) here paths — those values get distinct leaves per element from
-	// walkScalarArray and break the inheritance bridge that flat raw AndAll
-	// relies on.
+	// uuid[], …) here paths — those values get distinct leaves per element
+	// from walkScalarArray and break the inheritance bridge that flat raw
+	// AndAll relies on.
 	props []*models.NestedProperty
 }
 
@@ -289,12 +287,16 @@ type flatSubtree struct {
 //   - empty props (without schema we cannot identify scalar-array paths;
 //     stay on runIdxLoopRecursive)
 //   - recSplitNode anywhere (arr[N] requires per-element evaluation)
-//   - duplicate here paths (each value lives at a distinct leaf — raw AndAll
-//     over duplicates over-rejects, even within the same physical element)
+//   - duplicate here paths (each text[]/scalar-array value lives at a distinct
+//     leaf assigned by walkScalarArray, so duplicate-path filters over a scalar
+//     array cannot match at the same leaf via raw AndAll — they need
+//     per-element evaluation. Regular scalars under Phase-3 inheritance can
+//     legitimately share leaves, but the planner only emits duplicate here
+//     paths when at least one terminal is a scalar-array, so this bail is safe)
 //   - any group with ≥2 subs (sibling sub-arrays produce conditions at
 //     distinct leaves with no inheritance bridge — raw AndAll fails)
-//   - any here condition on a scalar-array (text[], int[], …) path. These
-//     values are written by walkScalarArray with one leaf per element
+//   - any here condition on a scalar-array (text[], int[], uuid[], …) path.
+//     These values are written by walkScalarArray with one leaf per element
 //     (assign.go), so they don't share leaves via Phase-3 inheritance with
 //     other conditions.
 //   - more than one group below the root carrying here conditions. A
@@ -331,7 +333,7 @@ func (e *recExecutor) collectFlatSubtree(g *recGroupNode) (*flatSubtree, bool) {
 				return false
 			}
 			seen[path] = struct{}{}
-			if e.pathTerminalIsScalarArray(path) {
+			if pathTerminalIsScalarArray(e.props, path) {
 				return false
 			}
 			out.leaves = append(out.leaves, leaf)
@@ -347,32 +349,6 @@ func (e *recExecutor) collectFlatSubtree(g *recGroupNode) (*flatSubtree, bool) {
 		return nil, false
 	}
 	return out, true
-}
-
-// pathTerminalIsScalarArray reports whether path's terminal property in the
-// nested schema is a scalar-array type (text[], int[], number[], boolean[],
-// date[]).
-func (e *recExecutor) pathTerminalIsScalarArray(path string) bool {
-	if path == "" {
-		return false
-	}
-	segs := filnested.SplitPath(path)
-	props := e.props
-	for i, seg := range segs {
-		np := filnested.FindNestedProp(props, seg)
-		if np == nil {
-			return false
-		}
-		dt := schema.DataType(np.DataType[0])
-		if i == len(segs)-1 {
-			return schema.IsScalarArrayType(dt)
-		}
-		if !schema.IsNested(dt) {
-			return false
-		}
-		props = np.NestedProperties
-	}
-	return false
 }
 
 // evalFlatRawAndAll evaluates a flat subtree by raw-AndAll'ing every here
@@ -523,6 +499,12 @@ func (e *recExecutor) canUseRawAndAll(g *recGroupNode) bool {
 	if len(g.here) == 1 {
 		return true
 	}
+	if len(e.props) == 0 {
+		// Without schema we cannot identify scalar-array terminals, and the
+		// raw AndAll fast path silently produces empty results for ≥2 scalar
+		// arrays in the same group. Bail to runIdxLoopRecursive's masked path.
+		return false
+	}
 	seen := make(map[string]struct{}, len(g.here))
 	scalarArrays := 0
 	for _, leaf := range g.here {
@@ -531,7 +513,7 @@ func (e *recExecutor) canUseRawAndAll(g *recGroupNode) bool {
 			return false
 		}
 		seen[path] = struct{}{}
-		if e.pathTerminalIsScalarArray(path) {
+		if pathTerminalIsScalarArray(e.props, path) {
 			scalarArrays++
 			if scalarArrays >= 2 {
 				return false

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
@@ -263,7 +263,7 @@ func (e *recExecutor) evalNode(ctx context.Context, node recPlanNode, parentScop
 // The here=0, subs=1 case is collapsed away by the planner so it does not
 // reach evalGroup (see buildGroup).
 func (e *recExecutor) evalGroup(ctx context.Context, g *recGroupNode, parentScope *sroar.Bitmap) (*sroar.Bitmap, func(), error) {
-	if canUseRawAndAll(g) || g.lcaPath == "" {
+	if e.canUseRawAndAll(g) || g.lcaPath == "" {
 		return e.evalGroupRoot(ctx, g, parentScope)
 	}
 	if flat, ok := e.collectFlatSubtree(g); ok {
@@ -471,7 +471,7 @@ func (e *recExecutor) evalGroupRoot(ctx context.Context, g *recGroupNode, parent
 		return nil, nil, fmt.Errorf("evalGroupRoot: no inputs for group at lcaPath=%q", g.lcaPath)
 	}
 
-	if canUseRawAndAll(g) {
+	if e.canUseRawAndAll(g) {
 		anded, andedRel := e.bitmapOps.AndAll(bitmaps, e.maxConcurrency)
 		// Apply matching excludes (lcaPath == g.lcaPath) at raw level — the
 		// anded bitmap is still raw-shape (leaf-precise) here, so AndNot'ing a
@@ -503,10 +503,20 @@ func (e *recExecutor) evalGroupRoot(ctx context.Context, g *recGroupNode, parent
 
 // canUseRawAndAll reports whether evalGroupRoot can combine bitmaps with raw
 // AndAll (preserving leaf-precise same-element semantics) instead of
-// AndAllMaskLeaf. True only when every here path is unique and there are no
-// subs; subs produce already-masked rootDoc bitmaps that cannot AND against
-// raw leaf-precise positions.
-func canUseRawAndAll(g *recGroupNode) bool {
+// AndAllMaskLeaf. True only when every here path is unique, at most one path
+// is a scalar-array terminal, and there are no subs. Subs produce already-
+// masked rootDoc bitmaps that cannot AND against raw leaf-precise positions.
+//
+// Scalar-array terminals (text[], int[], uuid[], …) get distinct leaves per
+// element from walkScalarArray. A single scalar-array sibling combined with
+// regular scalars works under raw AndAll because Phase-3 inheritance makes
+// the regular scalars' leaves the union of all descendants — which includes
+// the scalar-array's leaves. But two scalar-array siblings never share a
+// leaf even within the same parent element, so raw AndAll would yield empty
+// for genuine same-element matches. Routing to runIdxLoopRecursive's
+// MaskLeafAnd preserves correctness by comparing rootDoc after stripping
+// leaves.
+func (e *recExecutor) canUseRawAndAll(g *recGroupNode) bool {
 	if len(g.subs) > 0 || len(g.here) == 0 {
 		return false
 	}
@@ -514,12 +524,19 @@ func canUseRawAndAll(g *recGroupNode) bool {
 		return true
 	}
 	seen := make(map[string]struct{}, len(g.here))
+	scalarArrays := 0
 	for _, leaf := range g.here {
 		path := childRelPath(leaf)
 		if _, dup := seen[path]; dup {
 			return false
 		}
 		seen[path] = struct{}{}
+		if e.pathTerminalIsScalarArray(path) {
+			scalarArrays++
+			if scalarArrays >= 2 {
+				return false
+			}
+		}
 	}
 	return true
 }

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
@@ -254,7 +254,7 @@ func (b *recPlanBuilder) groupSubtreeNeedsOuterScope(g *recGroupNode) bool {
 func (b *recPlanBuilder) groupNeedsIdxLoop(g *recGroupNode) bool {
 	scalarArrays := 0
 	for _, leaf := range g.here {
-		if b.pathTerminalIsScalarArray(childRelPath(leaf)) {
+		if pathTerminalIsScalarArray(b.props, childRelPath(leaf)) {
 			scalarArrays++
 			if scalarArrays >= 2 {
 				return true
@@ -265,14 +265,14 @@ func (b *recPlanBuilder) groupNeedsIdxLoop(g *recGroupNode) bool {
 }
 
 // pathTerminalIsScalarArray reports whether path's terminal property in the
-// nested schema is a scalar-array type (text[], int[], number[], boolean[],
-// date[], uuid[]).
-func (b *recPlanBuilder) pathTerminalIsScalarArray(path string) bool {
+// given nested schema is a scalar-array type (text[], int[], number[],
+// boolean[], date[], uuid[]). Shared by recPlanBuilder and recExecutor so
+// planning and execution stay in sync on scalar-array detection.
+func pathTerminalIsScalarArray(props []*models.NestedProperty, path string) bool {
 	if path == "" {
 		return false
 	}
 	segs := filnested.SplitPath(path)
-	props := b.props
 	for i, seg := range segs {
 		np := filnested.FindNestedProp(props, seg)
 		if np == nil {

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
@@ -170,22 +170,78 @@ func (b *recPlanBuilder) buildGroup(items []*propValuePair, scope string) recPla
 // needsWrappingGroup reports whether the wrapping GROUP at scope must be kept
 // even when there are no here conditions and only a single sub. The wrapping
 // GROUP's per-element loop (runIdxLoopRecursive at intermediate scope) is what
-// enforces same-element semantics around a multi-branch SPLIT — collapsing it
-// away would let the SPLIT combiner AND branches at rootDoc only, losing the
-// "same element at the LCA above the conflict" guarantee.
+// enforces same-element semantics around constructs that need an outer scope:
 //
-// Returns true iff scope is intermediate (non-root) AND the sub is a
-// multi-branch SPLIT. Single-branch SPLITs simply pin to one index and don't
-// need an outer loop; SPLITs at root scope have nothing to loop over.
+//   - Multi-branch SPLIT — collapsing the wrapper away would let the SPLIT
+//     combiner AND branches at rootDoc only, losing the "same element at the
+//     LCA above the conflict" guarantee.
+//   - GROUP whose subtree contains a non-root multi-sub GROUP — that deeper
+//     GROUP uses runIdxLoopRecursive (the flat path bails on multi-sub) and
+//     iterates `_idx.{lca}[K]` keys that aggregate across all parents at the
+//     intermediate level. Without the wrapping GROUP at the parent's scope
+//     to provide parentScope, the K bucket conflates physical instances at
+//     the same K under different parents (case-3 same-K-different-parent bug).
+//
+// Returns false at root scope: root-level same-element is handled implicitly
+// by root_idx in the position encoding, no outer loop needed.
 func needsWrappingGroup(scope string, sub recPlanNode) bool {
 	if scope == "" {
 		return false
 	}
-	split, ok := sub.(*recSplitNode)
-	if !ok {
+	switch n := sub.(type) {
+	case *recSplitNode:
+		return len(n.branches) > 1
+	case *recGroupNode:
+		return groupSubtreeNeedsOuterScope(n)
+	}
+	return false
+}
+
+// groupSubtreeNeedsOuterScope reports whether g (or any descendant
+// recGroupNode in g's subtree) will use runIdxLoopRecursive — which requires
+// the immediate ancestor's _idx scope to disambiguate same-K-different-parent
+// physical instances. A non-root recGroupNode uses runIdxLoopRecursive when:
+//
+//   - It has ≥2 subs (the flat raw-AndAll path bails on multi-sub since
+//     sibling sub-arrays produce conditions at distinct leaves with no
+//     inheritance bridge).
+//   - It has duplicate here paths (same-path values land at distinct leaves
+//     per walkScalarArray, so canUseRawAndAll is false and the flat path
+//     bails). Same-element semantics for these requires per-element _idx
+//     iteration scoped by the outer parent.
+func groupSubtreeNeedsOuterScope(g *recGroupNode) bool {
+	if g.lcaPath != "" && (len(g.subs) >= 2 || hasDuplicateHerePaths(g)) {
+		return true
+	}
+	for _, sub := range g.subs {
+		if grp, ok := sub.(*recGroupNode); ok {
+			if groupSubtreeNeedsOuterScope(grp) {
+				return true
+			}
+		}
+		// recSplitNode descendants handle their own scoping at their level
+		// via needsWrappingGroup invocations during their own buildPlan.
+	}
+	return false
+}
+
+// hasDuplicateHerePaths reports whether two or more here entries in g share
+// the same childRelPath. Each text[]/scalar-array value lives at a distinct
+// leaf assigned by walkScalarArray, so duplicate-path filters cannot match
+// at the same leaf via raw AndAll — they need per-element evaluation.
+func hasDuplicateHerePaths(g *recGroupNode) bool {
+	if len(g.here) < 2 {
 		return false
 	}
-	return len(split.branches) > 1
+	seen := make(map[string]struct{}, len(g.here))
+	for _, leaf := range g.here {
+		path := childRelPath(leaf)
+		if _, dup := seen[path]; dup {
+			return true
+		}
+		seen[path] = struct{}{}
+	}
+	return false
 }
 
 // constraintAtScope returns the arr[N] index whose RelPath == scope, if any.

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
@@ -161,7 +161,7 @@ func (b *recPlanBuilder) buildGroup(items []*propValuePair, scope string) recPla
 		subs = append(subs, b.buildPlan(subsByPath[p], p))
 	}
 
-	if len(here) == 0 && len(subs) == 1 && !needsWrappingGroup(scope, subs[0]) {
+	if len(here) == 0 && len(subs) == 1 && !b.needsWrappingGroup(scope, subs[0]) {
 		return subs[0]
 	}
 	return &recGroupNode{lcaPath: scope, here: here, subs: subs}
@@ -184,15 +184,23 @@ func (b *recPlanBuilder) buildGroup(items []*propValuePair, scope string) recPla
 //
 // Returns false at root scope: root-level same-element is handled implicitly
 // by root_idx in the position encoding, no outer loop needed.
-func needsWrappingGroup(scope string, sub recPlanNode) bool {
+func (b *recPlanBuilder) needsWrappingGroup(scope string, sub recPlanNode) bool {
 	if scope == "" {
 		return false
 	}
 	switch n := sub.(type) {
 	case *recSplitNode:
-		return len(n.branches) > 1
+		if len(n.branches) > 1 {
+			return true
+		}
+		// 1-branch SPLIT pins to one K at its lcaPath but doesn't disambiguate
+		// that K across different parents at the same level. If the branch's
+		// plan itself needs outer scope (e.g. its descendants dispatch through
+		// runIdxLoopRecursive), the parent-level wrap must be kept so the
+		// outer iteration provides per-parent disambiguation.
+		return b.needsWrappingGroup(scope, n.branches[0].plan)
 	case *recGroupNode:
-		return groupSubtreeNeedsOuterScope(n)
+		return b.groupSubtreeNeedsOuterScope(n)
 	}
 	return false
 }
@@ -200,7 +208,8 @@ func needsWrappingGroup(scope string, sub recPlanNode) bool {
 // groupSubtreeNeedsOuterScope reports whether g (or any descendant
 // recGroupNode in g's subtree) will use runIdxLoopRecursive — which requires
 // the immediate ancestor's _idx scope to disambiguate same-K-different-parent
-// physical instances. A non-root recGroupNode uses runIdxLoopRecursive when:
+// physical instances. A non-root recGroupNode uses runIdxLoopRecursive when
+// neither canUseRawAndAll nor collectFlatSubtree succeeds:
 //
 //   - It has ≥2 subs (the flat raw-AndAll path bails on multi-sub since
 //     sibling sub-arrays produce conditions at distinct leaves with no
@@ -209,18 +218,74 @@ func needsWrappingGroup(scope string, sub recPlanNode) bool {
 //     per walkScalarArray, so canUseRawAndAll is false and the flat path
 //     bails). Same-element semantics for these requires per-element _idx
 //     iteration scoped by the outer parent.
-func groupSubtreeNeedsOuterScope(g *recGroupNode) bool {
-	if g.lcaPath != "" && (len(g.subs) >= 2 || hasDuplicateHerePaths(g)) {
+//   - It has ≥2 scalar-array (text[], int[], …) here paths — two scalar
+//     arrays never share a leaf even within the same parent element, so
+//     canUseRawAndAll bails and collectFlatSubtree bails on scalar-array.
+//   - It has ≥1 scalar-array here AND ≥1 sub — collectFlatSubtree bails on
+//     scalar-array, canUseRawAndAll bails on subs.
+func (b *recPlanBuilder) groupSubtreeNeedsOuterScope(g *recGroupNode) bool {
+	if g.lcaPath != "" && (len(g.subs) >= 2 || hasDuplicateHerePaths(g) || b.groupNeedsIdxLoop(g)) {
 		return true
 	}
 	for _, sub := range g.subs {
 		if grp, ok := sub.(*recGroupNode); ok {
-			if groupSubtreeNeedsOuterScope(grp) {
+			if b.groupSubtreeNeedsOuterScope(grp) {
 				return true
 			}
 		}
 		// recSplitNode descendants handle their own scoping at their level
 		// via needsWrappingGroup invocations during their own buildPlan.
+	}
+	return false
+}
+
+// groupNeedsIdxLoop reports whether g (considered in isolation, not its
+// descendants) will dispatch to runIdxLoopRecursive due to scalar-array
+// terminals among its here paths. Two cases:
+//
+//   - ≥2 scalar-array here paths: canUseRawAndAll bails (after counting
+//     scalar-arrays); collectFlatSubtree bails on the first scalar-array.
+//   - ≥1 scalar-array here AND ≥1 sub: canUseRawAndAll bails on subs;
+//     collectFlatSubtree bails on the scalar-array.
+//
+// A single scalar-array here with no subs goes through canUseRawAndAll's raw
+// AndAll path (works via Phase-3 inheritance with regular scalars) — no idx
+// loop, no outer scope needed.
+func (b *recPlanBuilder) groupNeedsIdxLoop(g *recGroupNode) bool {
+	scalarArrays := 0
+	for _, leaf := range g.here {
+		if b.pathTerminalIsScalarArray(childRelPath(leaf)) {
+			scalarArrays++
+			if scalarArrays >= 2 {
+				return true
+			}
+		}
+	}
+	return scalarArrays >= 1 && len(g.subs) >= 1
+}
+
+// pathTerminalIsScalarArray reports whether path's terminal property in the
+// nested schema is a scalar-array type (text[], int[], number[], boolean[],
+// date[], uuid[]).
+func (b *recPlanBuilder) pathTerminalIsScalarArray(path string) bool {
+	if path == "" {
+		return false
+	}
+	segs := filnested.SplitPath(path)
+	props := b.props
+	for i, seg := range segs {
+		np := filnested.FindNestedProp(props, seg)
+		if np == nil {
+			return false
+		}
+		dt := schema.DataType(np.DataType[0])
+		if i == len(segs)-1 {
+			return schema.IsScalarArrayType(dt)
+		}
+		if !schema.IsNested(dt) {
+			return false
+		}
+		props = np.NestedProperties
 	}
 	return false
 }

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -8895,6 +8895,38 @@ func TestNestedFilteringIsNullArrayIndexFollowups(t *testing.T) {
 		})
 	})
 
+	// ----- 5. IsNull on scalar-array positional element (text[] arr[N]) -----
+	// `addresses.tags[2] IsNotNull` — does any address have a third tag?
+	// IsNull is restricted to the IdxKey on the scalar-array index, exercising
+	// the rarely-used path where the IsNull's arrayIndices target the scalar
+	// array itself rather than its parent. Different from `addresses[1].tags`
+	// (parent pinned, child IsNull) and `addresses.tags` (whole array IsNull).
+	t.Run("scalar_array_positional_addresses.tags[2]_IsNull", func(t *testing.T) {
+		idHasThirdTag := uuid(1)      // addresses=[{tags:[a,b,c]}]
+		idHasThirdInSecond := uuid(2) // addresses=[{tags:[a]},{tags:[a,b,c]}]
+		idTwoTagsOnly := uuid(3)      // addresses=[{tags:[a,b]}]
+		idEmptyTags := uuid(4)        // addresses=[{tags:[]}]
+		idNoTags := uuid(5)           // addresses=[{}]
+		idAbsent := uuid(6)           // no addresses
+		docs := []docDef{
+			{id: idHasThirdTag, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("tags", tagsAny("a", "b", "c")))}}, note: "addresses[0].tags[2]=c"},
+			{id: idHasThirdInSecond, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("tags", tagsAny("a")), addr("tags", tagsAny("a", "b", "c")))}}, note: "addresses[1].tags[2]=c"},
+			{id: idTwoTagsOnly, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("tags", tagsAny("a", "b")))}}, note: "no tags[2]"},
+			{id: idEmptyTags, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("tags", tagsAny()))}}, note: "empty tags"},
+			{id: idNoTags, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr())}}, note: "no tags field"},
+			{id: idAbsent, props: map[string]any{"doc": map[string]any{}}, note: "no addresses"},
+		}
+
+		t.Run("addresses.tags[2]_IsNotNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.addresses.tags[2]", false),
+				[]strfmt.UUID{idHasThirdTag, idHasThirdInSecond})
+		})
+		t.Run("addresses.tags[2]_IsNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.addresses.tags[2]", true),
+				[]strfmt.UUID{idTwoTagsOnly, idEmptyTags, idNoTags, idAbsent})
+		})
+	})
+
 	// ----- 4. Mixed constrained/unconstrained IsNull in correlated AND -----
 	// `addresses.tags IsNotNull AND addresses[1].city = berlin`.
 	// IsNotNull is unconstrained (empty arrayIndices); value pins addresses[1].
@@ -8933,5 +8965,341 @@ func TestNestedFilteringIsNullArrayIndexFollowups(t *testing.T) {
 			textFilter("doc.addresses[1].city", "berlin"),
 		)
 		runScenario(t, docs, filter, []strfmt.UUID{idMatch1, idMatch2})
+	})
+}
+
+// TestNestedFilteringScalarArrayIndex covers positional access on scalar
+// arrays (text[]) within nested objects. Mirrors lower-level
+// TestNestedFilteringIsNullAndMultiLevelArrayIndex Cases 2 and 3:
+//
+//   - Basic positional: cars.colors[N] = red — IdxKey("cars.colors", N)
+//     restriction on a scalar-array element.
+//   - Out-of-range: cars.colors[5] = red against docs with shorter arrays.
+//   - Multi-level pin: cars[N].colors[M] = red — both object[] and scalar
+//     array indices restrict the same path.
+//   - Same-parent correlated AND: cars.colors[0]=red AND cars.colors[1]=blue
+//     — both clauses share LCA=cars; same-element AND requires the same
+//     car's colors to satisfy both positional clauses.
+//
+// Also covers a single docs_array variant to exercise root_idx in
+// combination with scalar-array positional access.
+func TestNestedFilteringScalarArrayIndex(t *testing.T) {
+	const nestedClass = "ScalarArrIdx"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	rootProps := []*models.NestedProperty{
+		{
+			Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{Name: "colors", DataType: schema.DataTypeTextArray.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{
+					Name: "tires", DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+					},
+				},
+			},
+		},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "doc", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+			{Name: "docs", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	colorsAny := func(colors ...string) []any {
+		out := make([]any, len(colors))
+		for i, c := range colors {
+			out[i] = c
+		}
+		return out
+	}
+	carColors := func(colors ...string) map[string]any {
+		return map[string]any{"colors": colorsAny(colors...)}
+	}
+	carWithMakeAndColors := func(make string, colors ...string) map[string]any {
+		out := map[string]any{"make": make}
+		if len(colors) > 0 {
+			out["colors"] = colorsAny(colors...)
+		}
+		return out
+	}
+	tireWithTags := func(tags ...string) map[string]any {
+		return map[string]any{"tags": colorsAny(tags...)}
+	}
+	carWithTires := func(tires ...map[string]any) map[string]any {
+		out := make([]any, len(tires))
+		for i, t := range tires {
+			out[i] = t
+		}
+		return map[string]any{"tires": out}
+	}
+	carEmpty := func() map[string]any { return map[string]any{} }
+
+	textFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	// ----- Sub-test 1: basic scalar-array positional, no parent arr[N] -----
+	// `doc.cars.colors[2] = red` — match docs where any car has colors[2]=red.
+	t.Run("basic_cars.colors[2]_eq_red", func(t *testing.T) {
+		idMatchPosition2 := uuid(1)     // colors=[blue,green,red]
+		idNoMatchAtPosition0 := uuid(2) // colors=[red]
+		idNoMatchTooShort := uuid(3)    // colors=[red,red]
+		idMatchSecondCar := uuid(4)     // first car short, second has [2]=red
+		idNoMatchEmptyColors := uuid(5) // colors=[]
+		idNoMatchNoColors := uuid(6)    // car with no colors field
+		idNoMatchNoCars := uuid(7)      // no cars at all
+		docs := []docDef{
+			{id: idMatchPosition2, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("blue", "green", "red"))}}, note: "colors[2]=red"},
+			{id: idNoMatchAtPosition0, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red"))}}, note: "red at colors[0] only"},
+			{id: idNoMatchTooShort, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red", "red"))}}, note: "no colors[2]"},
+			{id: idMatchSecondCar, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("blue"), carColors("green", "blue", "red"))}}, note: "cars[1].colors[2]=red"},
+			{id: idNoMatchEmptyColors, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors())}}, note: "empty colors"},
+			{id: idNoMatchNoColors, props: map[string]any{"doc": map[string]any{"cars": asArr(carEmpty())}}, note: "car with no colors field"},
+			{id: idNoMatchNoCars, props: map[string]any{"doc": map[string]any{}}, note: "no cars"},
+		}
+		runScenario(t, docs, textFilter("doc.cars.colors[2]", "red"), []strfmt.UUID{idMatchPosition2, idMatchSecondCar})
+	})
+
+	// ----- Sub-test 2: out-of-range scalar-array positional -----
+	t.Run("out_of_range_cars.colors[5]_eq_red", func(t *testing.T) {
+		idDoc := uuid(1)
+		docs := []docDef{
+			{id: idDoc, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red", "red", "red"))}}, note: "only 3 colors"},
+		}
+		runScenario(t, docs, textFilter("doc.cars.colors[5]", "red"), []strfmt.UUID{})
+	})
+
+	// ----- Sub-test 3: multi-level pin (object[] + scalar array) -----
+	// `doc.cars[1].colors[2] = red` — two arr[N] segments restrict the same
+	// path. Restriction order: cars[1] first, then colors[2] within that car.
+	t.Run("multi_level_cars[1].colors[2]_eq_red", func(t *testing.T) {
+		idMatch := uuid(1)                 // cars=[{colors:[x]},{colors:[a,b,red]}]
+		idNoMatchOnlyFirstCar := uuid(2)   // cars=[{colors:[a,b,red]}] — no cars[1]
+		idNoMatchSecondTooShort := uuid(3) // cars=[{colors:[a,b,red]},{colors:[red]}] — cars[1].colors[0]=red, no [2]
+		idNoMatchSecondAtZero := uuid(4)   // cars=[{},{colors:[red,blue,green]}] — cars[1].colors[0]=red, [2]=green
+		idMatchExtraCars := uuid(5)        // 3 cars, [1] satisfies, [2] is extra
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("x"), carColors("a", "b", "red"))}}, note: "cars[1].colors[2]=red"},
+			{id: idNoMatchOnlyFirstCar, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("a", "b", "red"))}}, note: "no cars[1]"},
+			{id: idNoMatchSecondTooShort, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("a", "b", "red"), carColors("red"))}}, note: "cars[1] only has colors[0]"},
+			{id: idNoMatchSecondAtZero, props: map[string]any{"doc": map[string]any{"cars": asArr(carEmpty(), carColors("red", "blue", "green"))}}, note: "cars[1].colors[0]=red, [2]=green"},
+			{id: idMatchExtraCars, props: map[string]any{"doc": map[string]any{"cars": asArr(carEmpty(), carColors("a", "b", "red"), carColors("red"))}}, note: "cars[1].colors[2]=red, extra cars[2]"},
+		}
+		runScenario(t, docs, textFilter("doc.cars[1].colors[2]", "red"), []strfmt.UUID{idMatch, idMatchExtraCars})
+	})
+
+	// ----- Sub-test 4: same-parent correlated AND on scalar-array positional -----
+	// `doc.cars.colors[0]=red AND doc.cars.colors[1]=blue` — both clauses share
+	// LCA=cars; same-element AND requires the same car's colors[0]=red AND
+	// colors[1]=blue.
+	t.Run("AND_cars.colors[0]_eq_red_AND_cars.colors[1]_eq_blue", func(t *testing.T) {
+		idMatchSingleCar := uuid(1)         // cars=[{colors:[red,blue]}] — same car satisfies
+		idMatchSecondCar := uuid(2)         // cars[0] partial; cars[1] satisfies
+		idNoMatchSplitAcrossCars := uuid(3) // cars[0].colors[0]=red, cars[1].colors[1]=blue — different cars
+		idNoMatchWrongOrder := uuid(4)      // cars=[{colors:[blue,red]}] — wrong positions
+		idNoMatchOnlyFirst := uuid(5)       // cars=[{colors:[red]}] — no [1]
+		docs := []docDef{
+			{id: idMatchSingleCar, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red", "blue"))}}, note: "cars[0].colors=[red,blue]"},
+			{id: idMatchSecondCar, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("green"), carColors("red", "blue", "green"))}}, note: "cars[1].colors=[red,blue,...]"},
+			{id: idNoMatchSplitAcrossCars, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red", "green"), carColors("green", "blue"))}}, note: "red in cars[0].colors[0]; blue in cars[1].colors[1]"},
+			{id: idNoMatchWrongOrder, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("blue", "red"))}}, note: "swapped positions"},
+			{id: idNoMatchOnlyFirst, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red"))}}, note: "no colors[1]"},
+		}
+		filter := andFilter(
+			textFilter("doc.cars.colors[0]", "red"),
+			textFilter("doc.cars.colors[1]", "blue"),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchSingleCar, idMatchSecondCar})
+	})
+
+	// ----- Sub-test 5: docs_array root variant -----
+	// `docs[1].cars.colors[2] = red` — root_idx pin combined with scalar-array
+	// positional. Verifies the dispatch works across DataTypeObjectArray root.
+	t.Run("docs_array_docs[1].cars.colors[2]_eq_red", func(t *testing.T) {
+		idMatch := uuid(1)              // docs[1].cars[0].colors[2]=red
+		idNoMatchInFirstRoot := uuid(2) // docs[0] has it; docs[1] doesn't
+		idNoMatchSingleRoot := uuid(3)  // single root only
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"docs": asArr(
+				map[string]any{"cars": asArr(carColors("blue"))},
+				map[string]any{"cars": asArr(carColors("a", "b", "red"))},
+			)}, note: "docs[1].cars[0].colors[2]=red"},
+			{id: idNoMatchInFirstRoot, props: map[string]any{"docs": asArr(
+				map[string]any{"cars": asArr(carColors("a", "b", "red"))},
+				map[string]any{"cars": asArr(carColors("blue"))},
+			)}, note: "red at docs[0].cars[0].colors[2], not docs[1]"},
+			{id: idNoMatchSingleRoot, props: map[string]any{"docs": asArr(
+				map[string]any{"cars": asArr(carColors("a", "b", "red"))},
+			)}, note: "no docs[1]"},
+		}
+		runScenario(t, docs, textFilter("docs[1].cars.colors[2]", "red"), []strfmt.UUID{idMatch})
+	})
+
+	// ----- Sub-test 6: mixed scalar + scalar-array positional, same-element AND -----
+	// `cars.make=tesla AND cars.colors[0]=red` — same-element AND at LCA=cars
+	// across two clause types (regular text scalar + text[] positional). Both
+	// must hold on the same physical car.
+	t.Run("AND_cars.make_AND_cars.colors[0]_same_car", func(t *testing.T) {
+		idMatch := uuid(1)               // cars=[{make:tesla,colors:[red]}]
+		idMatchSecondCar := uuid(2)      // cars[0] partial, cars[1] satisfies
+		idNoMatchSplit := uuid(3)        // tesla in cars[1], red in cars[0]
+		idNoMatchTeslaNoColor := uuid(4) // tesla car has no colors
+		idNoMatchWrongColor := uuid(5)   // tesla car has colors[0]=blue
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithMakeAndColors("tesla", "red"))}}, note: "single car: tesla, colors[0]=red"},
+			{id: idMatchSecondCar, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithMakeAndColors("bmw", "red"), carWithMakeAndColors("tesla", "red", "blue"))}}, note: "cars[1] has tesla and colors[0]=red"},
+			{id: idNoMatchSplit, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithMakeAndColors("bmw", "red"), carWithMakeAndColors("tesla"))}}, note: "tesla car has no colors"},
+			{id: idNoMatchTeslaNoColor, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithMakeAndColors("tesla"))}}, note: "tesla; no colors"},
+			{id: idNoMatchWrongColor, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithMakeAndColors("tesla", "blue", "red"))}}, note: "tesla; colors[0]=blue"},
+		}
+		filter := andFilter(
+			textFilter("doc.cars.make", "tesla"),
+			textFilter("doc.cars.colors[0]", "red"),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchSecondCar})
+	})
+
+	// ----- Sub-test 7: multi-level pin + same-parent correlated AND -----
+	// `cars[1].colors[0]=red AND cars[1].colors[1]=blue` — both clauses pinned
+	// to cars[1]; same-parent correlated AND requires both color positions to
+	// be satisfied within the same cars[1].
+	t.Run("AND_cars[1].colors[0]_AND_cars[1].colors[1]_pinned", func(t *testing.T) {
+		idMatch := uuid(1)            // cars=[{},{colors:[red,blue]}]
+		idNoMatchOnlyFirst := uuid(2) // cars=[{colors:[red,blue]}] — no [1]
+		idNoMatchSwapped := uuid(3)   // cars[1].colors=[blue,red]
+		idNoMatchTooShort := uuid(4)  // cars[1].colors=[red]
+		idMatchExtraColors := uuid(5) // cars[1].colors=[red,blue,green]
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(carEmpty(), carColors("red", "blue"))}}, note: "cars[1].colors=[red,blue]"},
+			{id: idNoMatchOnlyFirst, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red", "blue"))}}, note: "no cars[1]"},
+			{id: idNoMatchSwapped, props: map[string]any{"doc": map[string]any{"cars": asArr(carEmpty(), carColors("blue", "red"))}}, note: "swapped"},
+			{id: idNoMatchTooShort, props: map[string]any{"doc": map[string]any{"cars": asArr(carEmpty(), carColors("red"))}}, note: "no colors[1]"},
+			{id: idMatchExtraColors, props: map[string]any{"doc": map[string]any{"cars": asArr(carEmpty(), carColors("red", "blue", "green"))}}, note: "cars[1].colors=[red,blue,green]"},
+		}
+		filter := andFilter(
+			textFilter("doc.cars[1].colors[0]", "red"),
+			textFilter("doc.cars[1].colors[1]", "blue"),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchExtraColors})
+	})
+
+	// ----- Sub-test 8: scalar-array partition with different parents -----
+	// `cars[0].colors[0]=red AND cars[1].colors[0]=blue` — different cars,
+	// each with its own positional clause. The dispatch's
+	// groupChildrenByArrayIndicesKey partitions {cars:0} and {cars:1} into
+	// independent groups → ANDed at docID level.
+	t.Run("AND_cars[0].colors[0]_red_AND_cars[1].colors[0]_blue_partition", func(t *testing.T) {
+		idMatch := uuid(1)              // cars=[{colors:[red]},{colors:[blue]}]
+		idMatchExtraColors := uuid(2)   // cars=[{colors:[red,green]},{colors:[blue,red]}]
+		idNoMatchSwapped := uuid(3)     // cars=[{colors:[blue]},{colors:[red]}]
+		idNoMatchOnlyFirst := uuid(4)   // cars=[{colors:[red]}]
+		idNoMatchSecondWrong := uuid(5) // cars[0]=red ok, cars[1].colors[0]=red not blue
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red"), carColors("blue"))}}, note: "cars=[{red},{blue}]"},
+			{id: idMatchExtraColors, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red", "green"), carColors("blue", "red"))}}, note: "cars=[{red,green},{blue,red}]"},
+			{id: idNoMatchSwapped, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("blue"), carColors("red"))}}, note: "swapped"},
+			{id: idNoMatchOnlyFirst, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red"))}}, note: "no cars[1]"},
+			{id: idNoMatchSecondWrong, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red"), carColors("red"))}}, note: "cars[1].colors[0]=red not blue"},
+		}
+		filter := andFilter(
+			textFilter("doc.cars[0].colors[0]", "red"),
+			textFilter("doc.cars[1].colors[0]", "blue"),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchExtraColors})
+	})
+
+	// ----- Sub-test 9: deeper-nested scalar array (cars.tires.tags[N]) -----
+	// `cars.tires.tags[2] = red` — text[] positional inside a 2-level-deep
+	// nested object[]. Exercises lcaPath calculation for scalar arrays at a
+	// deeper LCA than the cars-direct case.
+	t.Run("deeper_cars.tires.tags[2]_eq_red", func(t *testing.T) {
+		idMatch := uuid(1)           // tires=[{tags:[a,b,red]}]
+		idMatchSecondTire := uuid(2) // tires=[{},{tags:[a,b,red]}]
+		idNoMatchAtZero := uuid(3)   // tires=[{tags:[red]}]
+		idNoMatchTooShort := uuid(4) // tires=[{tags:[a,b]}]
+		idNoMatchNoTires := uuid(5)  // car with no tires
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithTires(tireWithTags("a", "b", "red")))}}, note: "tires[0].tags[2]=red"},
+			{id: idMatchSecondTire, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithTires(map[string]any{}, tireWithTags("a", "b", "red")))}}, note: "tires[1].tags[2]=red"},
+			{id: idNoMatchAtZero, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithTires(tireWithTags("red")))}}, note: "tags[0]=red only"},
+			{id: idNoMatchTooShort, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithTires(tireWithTags("a", "b")))}}, note: "no tags[2]"},
+			{id: idNoMatchNoTires, props: map[string]any{"doc": map[string]any{"cars": asArr(carEmpty())}}, note: "no tires"},
+		}
+		runScenario(t, docs, textFilter("doc.cars.tires.tags[2]", "red"), []strfmt.UUID{idMatch, idMatchSecondTire})
+	})
+
+	// ----- Sub-test 10: same-position contradiction -----
+	// `cars.colors[0]=red AND cars.colors[0]=blue` — single position cannot
+	// equal two different values; should always return empty.
+	t.Run("contradiction_cars.colors[0]_eq_red_AND_eq_blue", func(t *testing.T) {
+		idHasRed := uuid(1)
+		idHasBlue := uuid(2)
+		idHasBoth := uuid(3) // colors=[red,blue] — but [0]=red, [1]=blue, neither position has both
+		docs := []docDef{
+			{id: idHasRed, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red"))}}, note: "colors[0]=red"},
+			{id: idHasBlue, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("blue"))}}, note: "colors[0]=blue"},
+			{id: idHasBoth, props: map[string]any{"doc": map[string]any{"cars": asArr(carColors("red", "blue"))}}, note: "colors=[red,blue]"},
+		}
+		filter := andFilter(
+			textFilter("doc.cars.colors[0]", "red"),
+			textFilter("doc.cars.colors[0]", "blue"),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{})
 	})
 }

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -7518,93 +7518,141 @@ func TestNestedFilteringCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 	// countries.garages.cars.tags = "sport". Two filter conditions on the
 	// same multi-value text[] field with different values.
 	//
-	// Observed behavior: same-element correlation enforces same-car within a
-	// garage, but NOT across garages. Documented as-is — this is the current
-	// behavior of same-path multi-value AND.
+	// Same-element semantics at the LCA (cars): both values must be on the
+	// same physical car's tags array.
+	//
+	// Plan: GROUP@cars { here:[tags=electric, tags=sport], subs:[] }. Has
+	// duplicate here paths → groupSubtreeNeedsOuterScope returns true →
+	// the wrapping outer GROUP@garages is preserved. Hierarchical
+	// runIdxLoopRecursive enforces same-car semantics: outer iterates
+	// _idx.garages[K_g], inner iterates _idx.garages.cars[K_c] AND
+	// parent_scope, evaluating both tag values within each physical car.
 	//
 	//   - same car has both tags                         → match
-	//   - same garage, different cars                    → reject (per-car AND)
-	//   - same country, different garages, one tag each  → match (no per-garage AND)
-	//   - only one tag anywhere                          → reject (each filter must hit)
+	//   - same country, different garages, one tag each  → reject (different cars)
+	//   - same garage, different cars                    → reject (different cars)
+	//   - only one tag anywhere                          → reject
 	t.Run("F_tags_double_value_cars.tags=electric_AND_cars.tags=sport", func(t *testing.T) {
 		idMatch := uuid(1)
-		idMatchSplitGarages := uuid(2)
+		idNoMatchSplitGarages := uuid(2)
 		idNoMatchOnlyOne := uuid(3)
 		idNoMatchSplitCars := uuid(4)
 		docs := []docDef{
 			{id: idMatch, props: map[string]any{"countries": asArr(
 				country(garage(nil, map[string]any{"tags": []any{"electric", "sport"}})),
 			)}, note: "single car has both tags"},
-			{id: idMatchSplitGarages, props: map[string]any{"countries": asArr(
+			{id: idNoMatchSplitGarages, props: map[string]any{"countries": asArr(
 				country(
 					garage(nil, map[string]any{"tags": []any{"electric"}}),
 					garage(nil, map[string]any{"tags": []any{"sport"}}),
 				),
-			)}, note: "tags split across g[0].cars[0]/g[1].cars[0] — currently matches"},
+			)}, note: "tags split across g[0].cars[0]/g[1].cars[0] — different physical cars"},
 			{id: idNoMatchOnlyOne, props: map[string]any{"countries": asArr(
 				country(garage(nil, map[string]any{"tags": []any{"electric"}})),
-			)}, note: "only one tag in country — fails the second filter"},
+			)}, note: "only one tag in country"},
 			{id: idNoMatchSplitCars, props: map[string]any{"countries": asArr(
 				country(garage(nil,
 					map[string]any{"tags": []any{"electric"}},
 					map[string]any{"tags": []any{"sport"}},
 				)),
-			)}, note: "tags split across cars[0]/cars[1] of same garage — per-car AND rejects"},
+			)}, note: "tags split across cars[0]/cars[1] of same garage"},
 		}
 		parts := []*filters.LocalFilter{
 			valueFilter("countries.garages.cars.tags", "electric"),
 			valueFilter("countries.garages.cars.tags", "sport"),
 		}
-		runOrderings(t, docs, parts, []strfmt.UUID{idMatch, idMatchSplitGarages})
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
 	})
 
-	// SameKDifferentParent_with_subs: documents a confirmed bug in same-element
-	// semantics when the executor takes the runIdxLoopRecursive path
-	// (canUseRawAndAll=false, lcaPath != "").
+	// SameKDifferentParent_with_subs: regression test for the flat-AndAll path
+	// in evalGroup. Filter: cars.make = "honda" AND cars.tires.width = "205".
 	//
-	// Filter: cars.make = "honda" AND cars.tires.width = "205"
-	//   - cars.make sits at GROUP@cars (here)
-	//   - cars.tires.width sits at GROUP@cars.tires (sub)
-	//   - GROUP@cars has 1 here + 1 sub → canUseRawAndAll=false → runIdxLoopRecursive
+	// Plan: GROUP@cars { here:[make], subs:[GROUP@cars.tires { here:[width] }] }
+	// → not canUseRawAndAll (has subs), but the subtree is "flat" (no SPLITs,
+	// all here paths globally unique, no scalar-array terminals, ≤1 deeper
+	// here-group), so the executor uses evalFlatRawAndAll. Raw AndAll
+	// preserves leaf-precise same-element semantics via the analyzer's scalar
+	// inheritance — make on cars[K] inherits cars[K].elementPositions, which
+	// equals the descendant leaves (incl. tires.width's leaf) when descendants
+	// exist. Different physical cars at the same K live at disjoint leaves so
+	// the cross-instance false positive is naturally rejected by raw AndAll.
 	//
-	// Bug: matchElementRecursive uses MaskLeafAnd, which strips leaf bits before
-	// ANDing per-condition bitmaps. When _idx.cars[K] lumps multiple physical
-	// cars (e.g., g[0].cars[0] and g[1].cars[0] both at K=0), MaskLeafAnd loses
-	// the leaf-level distinction that would have rejected cross-physical-instance
-	// matches. The doc with make in g[0].cars[0] and tires in g[1].cars[0]
-	// incorrectly matches.
-	//
-	// Asserts CURRENT (buggy) behavior so a future fix gets caught and the
-	// expected list updated to just {idMatch}.
-	t.Run("SameKDifferentParent_with_subs_make_AND_tires_BUG", func(t *testing.T) {
+	// Discriminating shapes:
+	//   - same physical car has both → match
+	//   - split garages, same K=0 → reject (different physical cars under
+	//     g[0] vs g[1] have disjoint leaves)
+	//   - different K within same garage → reject
+	//   - only one condition → reject
+	t.Run("SameKDifferentParent_with_subs_make_AND_tires", func(t *testing.T) {
 		idMatch := uuid(1)
-		idBuggyMatchSplitGaragesSameK := uuid(2)
+		idNoMatchSplitGaragesSameK := uuid(2)
 		idNoMatchSplitCarsSameGarage := uuid(3)
 		idNoMatchOnlyMake := uuid(4)
 		docs := []docDef{
 			{id: idMatch, props: map[string]any{"countries": asArr(
 				country(garage(nil, map[string]any{"make": "honda", "tires": asArr(tire("205"))})),
-			)}, note: "correct: single car has both"},
-			{id: idBuggyMatchSplitGaragesSameK, props: map[string]any{"countries": asArr(
+			)}, note: "single car has both"},
+			{id: idNoMatchSplitGaragesSameK, props: map[string]any{"countries": asArr(
 				country(
 					garage(nil, map[string]any{"make": "honda"}),
 					garage(nil, map[string]any{"tires": asArr(tire("205"))}),
 				),
-			)}, note: "BUG: make in g[0].cars[0]; tires in g[1].cars[0] — currently matches; should reject"},
+			)}, note: "make in g[0].cars[0]; tires in g[1].cars[0] — same K=0, different garages"},
 			{id: idNoMatchSplitCarsSameGarage, props: map[string]any{"countries": asArr(
 				country(garage(nil,
 					map[string]any{"make": "honda"},
 					map[string]any{"tires": asArr(tire("205"))},
 				)),
-			)}, note: "different K within same garage — correctly rejects"},
+			)}, note: "different K within same garage"},
 			{id: idNoMatchOnlyMake, props: map[string]any{"countries": asArr(
 				country(garage(nil, map[string]any{"make": "honda"})),
-			)}, note: "only one condition — rejects"},
+			)}, note: "only one condition"},
 		}
 		parts := []*filters.LocalFilter{
 			valueFilter("countries.garages.cars.make", "honda"),
 			valueFilter("countries.garages.cars.tires.width", "205"),
 		}
-		runOrderings(t, docs, parts, []strfmt.UUID{idMatch, idBuggyMatchSplitGaragesSameK})
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// SameKDifferentParent_with_two_sub_arrays: regression test for the case-3
+	// fix. Filter: cars.accessories.type AND cars.tires.width — two
+	// sibling sub-arrays under the same cars LCA.
+	//
+	// Plan: GROUP@garages { here:[], subs:[GROUP@garages.cars { here:[],
+	//        subs:[GROUP@accessories here:[type], GROUP@tires here:[width]] }] }
+	// canUseRawAndAll false (multi-sub at GROUP@cars), flat-AndAll bails on
+	// multi-sub → runIdxLoopRecursive. The wrapping GROUP@garages must be
+	// kept (not collapsed away) so its _idx.garages[K_g] iteration provides
+	// per-garage parentScope to the inner GROUP@cars's _idx.cars[K_c]
+	// iteration, disambiguating same-K-different-parent physical cars.
+	//
+	// Discriminating shapes:
+	//   - same physical car has both → match
+	//   - split garages, same K=0 → reject (different physical cars under
+	//     g[0] vs g[1] have disjoint leaves; per-garage parentScope rejects)
+	t.Run("SameKDifferentParent_with_two_sub_arrays_accessories_AND_tires", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitGaragesSameK := uuid(2)
+		accessory := func(typ string) map[string]any { return map[string]any{"type": typ} }
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(nil, map[string]any{
+					"accessories": asArr(accessory("spoiler")),
+					"tires":       asArr(tire("205")),
+				})),
+			)}, note: "single car has both accessories.type and tires.width"},
+			{id: idNoMatchSplitGaragesSameK, props: map[string]any{"countries": asArr(
+				country(
+					garage(nil, map[string]any{"accessories": asArr(accessory("spoiler"))}),
+					garage(nil, map[string]any{"tires": asArr(tire("205"))}),
+				),
+			)}, note: "spoiler in g[0].cars[0]; 205 in g[1].cars[0] — same K=0, different garages"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages.cars.accessories.type", "spoiler"),
+			valueFilter("countries.garages.cars.tires.width", "205"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
 	})
 }

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -4977,3 +4977,1368 @@ func TestNestedFilteringIsNullStandalone(t *testing.T) {
 		})
 	})
 }
+
+// TestNestedFilteringIsNullInCorrelatedAnd exercises IsNull / IsNotNull
+// combined with a positive condition (or another IsNull) inside a correlated
+// AND, end-to-end through the production write+search pipeline. Coverage is
+// duplicated under both DataTypeObject (top-level "country") and
+// DataTypeObjectArray (top-level "countries") root properties, and across
+// three nesting depths: root-level fields, L1 (garages) fields, and L2 (cars)
+// fields. At each depth we test:
+//
+//   - value + IsNull=false (positive value AND sibling property present)
+//   - value + IsNull=true  (positive value AND sibling property absent)
+//
+// At L2 we also test:
+//
+//   - dual IsNull (one IS NOT NULL + one IS NULL, no positive value)
+//   - tokenization compound + IsNull
+//   - direct contradiction on the same property (always empty)
+//
+// Same-element correlation requires both conditions in correlated AND to be
+// satisfied at the same array element of the deepest unconstrained ancestor —
+// "same root" for root-level conditions, "same garage" for L1, "same car"
+// for L2.
+func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
+	const nestedClass = "IsNullCorr"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	// Both top-level prop variants share the same nested schema:
+	// {name, capital} + garages [{city, postcode} + cars [{make, model}]].
+	rootProps := []*models.NestedProperty{
+		{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "capital", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{
+			Name:     "garages",
+			DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{Name: "postcode", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{
+					Name:     "cars",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						// Word-tokenized so multi-token tests work for sub-test 8.
+						{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: models.NestedPropertyTokenizationWord, IndexFilterable: &vTrue},
+						{Name: "model", DataType: schema.DataTypeText.PropString(), Tokenization: models.NestedPropertyTokenizationWord, IndexFilterable: &vTrue},
+						{Name: "year", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+						{
+							Name:     "tires",
+							DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{Name: "width", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "country", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+			{Name: "countries", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	car := func(props ...string) map[string]any {
+		out := map[string]any{}
+		for i := 0; i < len(props); i += 2 {
+			out[props[i]] = props[i+1]
+		}
+		return out
+	}
+
+	valueFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	isNullFilter := func(path string, isNull bool) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorIsNull,
+			Value:    &filters.Value{Type: schema.DataTypeBoolean, Value: isNull},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(a, b *filters.LocalFilter) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: []filters.Clause{*a.Root, *b.Root},
+		}}
+	}
+	andFilterN := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: operands,
+		}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id,
+				Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	// ---------- DataTypeObject (top-level "country") ----------
+	t.Run("country_object", func(t *testing.T) {
+		// Sub-test 1: country.name = "germany" AND country.capital IS NOT NULL
+		t.Run("root_value_isNotNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchExtraFields := uuid(2)
+			idNoMatchNoCapital := uuid(3)
+			idNoMatchWrongName := uuid(4)
+			idNoMatchEmptyCountry := uuid(5)
+			idNoMatchNoCountryProp := uuid(6)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"name": "germany", "capital": "berlin"}}, note: "name=germany, capital=berlin"},
+				{id: idMatchExtraFields, props: map[string]any{"country": map[string]any{"name": "germany", "capital": "berlin", "garages": asArr(map[string]any{"city": "munich"})}}, note: "extra fields don't break the match"},
+				{id: idNoMatchNoCapital, props: map[string]any{"country": map[string]any{"name": "germany"}}, note: "name=germany but capital absent"},
+				{id: idNoMatchWrongName, props: map[string]any{"country": map[string]any{"name": "france", "capital": "paris"}}, note: "wrong name"},
+				{id: idNoMatchEmptyCountry, props: map[string]any{"country": map[string]any{}}, note: "empty country"},
+				{id: idNoMatchNoCountryProp, props: map[string]any{}, note: "no country prop"},
+			}
+			filter := andFilter(valueFilter("country.name", "germany"), isNullFilter("country.capital", false))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchExtraFields})
+		})
+
+		// Sub-test 2: country.name = "germany" AND country.capital IS NULL
+		t.Run("root_value_isNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchWithGarages := uuid(2)
+			idNoMatchCapitalPresent := uuid(3)
+			idNoMatchWrongName := uuid(4)
+			idNoMatchNoName := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"name": "germany"}}, note: "name=germany, no capital"},
+				{id: idMatchWithGarages, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "munich"})}}, note: "name=germany, no capital but has garages"},
+				{id: idNoMatchCapitalPresent, props: map[string]any{"country": map[string]any{"name": "germany", "capital": "berlin"}}, note: "capital present → no match"},
+				{id: idNoMatchWrongName, props: map[string]any{"country": map[string]any{"name": "france"}}, note: "wrong name"},
+				{id: idNoMatchNoName, props: map[string]any{"country": map[string]any{"capital": "berlin"}}, note: "no name → no match"},
+			}
+			filter := andFilter(valueFilter("country.name", "germany"), isNullFilter("country.capital", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchWithGarages})
+		})
+
+		// Sub-test 3: country.garages.city = "berlin" AND country.garages.postcode IS NOT NULL
+		t.Run("L1_value_isNotNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchSecondGarage := uuid(2)
+			idMatchExtraGarages := uuid(3)
+			idNoMatchSplit := uuid(4)
+			idNoMatchWrongCity := uuid(5)
+			idNoMatchNoPostcode := uuid(6)
+			idNoMatchNoGarages := uuid(7)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin", "postcode": "10115"})}}, note: "garage with city=berlin, postcode present"},
+				{id: idMatchSecondGarage, props: map[string]any{"country": map[string]any{"garages": asArr(
+					map[string]any{"city": "munich"},
+					map[string]any{"city": "berlin", "postcode": "10115"},
+				)}}, note: "match in second garage"},
+				{id: idMatchExtraGarages, props: map[string]any{"country": map[string]any{"garages": asArr(
+					map[string]any{"city": "berlin", "postcode": "10115"},
+					map[string]any{"city": "paris", "postcode": "75000"},
+					map[string]any{"city": "munich"},
+				)}}, note: "first garage matches; others irrelevant"},
+				{id: idNoMatchSplit, props: map[string]any{"country": map[string]any{"garages": asArr(
+					map[string]any{"city": "berlin"},
+					map[string]any{"city": "munich", "postcode": "80331"},
+				)}}, note: "berlin in g0; postcode in g1 — different garages"},
+				{id: idNoMatchWrongCity, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "munich", "postcode": "80331"})}}, note: "wrong city"},
+				{id: idNoMatchNoPostcode, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin"})}}, note: "berlin but no postcode"},
+				{id: idNoMatchNoGarages, props: map[string]any{"country": map[string]any{"name": "germany"}}, note: "no garages"},
+			}
+			filter := andFilter(valueFilter("country.garages.city", "berlin"), isNullFilter("country.garages.postcode", false))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchSecondGarage, idMatchExtraGarages})
+		})
+
+		// Sub-test 4: country.garages.city = "berlin" AND country.garages.postcode IS NULL
+		t.Run("L1_value_isNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchWithCars := uuid(2)
+			idNoMatchPostcodePresent := uuid(3)
+			idNoMatchWrongCity := uuid(4)
+			idNoMatchSplit := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin"})}}, note: "garage with city=berlin, no postcode"},
+				{id: idMatchWithCars, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": asArr(car("make", "honda"))})}}, note: "city=berlin, no postcode, has cars"},
+				{id: idNoMatchPostcodePresent, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin", "postcode": "10115"})}}, note: "city=berlin AND postcode → no match"},
+				{id: idNoMatchWrongCity, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "munich"})}}, note: "wrong city"},
+				{id: idNoMatchSplit, props: map[string]any{"country": map[string]any{"garages": asArr(
+					map[string]any{"city": "berlin", "postcode": "10115"},
+					map[string]any{"city": "munich"},
+				)}}, note: "g0 has berlin+postcode; g1 has no postcode but wrong city — no garage satisfies"},
+			}
+			filter := andFilter(valueFilter("country.garages.city", "berlin"), isNullFilter("country.garages.postcode", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchWithCars})
+		})
+
+		// Sub-test 5: country.garages.cars.make = "honda" AND country.garages.cars.model IS NOT NULL
+		t.Run("L2_value_isNotNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchSecondCar := uuid(2)
+			idNoMatchSplit := uuid(3)
+			idNoMatchWrongMake := uuid(4)
+			idNoMatchNoModel := uuid(5)
+			idNoMatchSplitGarages := uuid(6)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})}}, note: "honda+civic at same car"},
+				{id: idMatchSecondCar, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "toyota", "model", "corolla"),
+					car("make", "honda", "model", "civic"),
+				)})}}, note: "second car satisfies"},
+				{id: idNoMatchSplit, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda"),
+					car("model", "civic"),
+				)})}}, note: "honda in c0, model in c1 — different cars"},
+				{id: idNoMatchWrongMake, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota", "model", "corolla"))})}}, note: "wrong make"},
+				{id: idNoMatchNoModel, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "honda but no model"},
+				{id: idNoMatchSplitGarages, props: map[string]any{"country": map[string]any{"garages": asArr(
+					map[string]any{"cars": asArr(car("make", "honda"))},
+					map[string]any{"cars": asArr(car("model", "civic"))},
+				)}}, note: "honda in g0.cars; model in g1.cars — different cars across garages"},
+			}
+			filter := andFilter(valueFilter("country.garages.cars.make", "honda"), isNullFilter("country.garages.cars.model", false))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchSecondCar})
+		})
+
+		// Sub-test 6: country.garages.cars.make = "honda" AND country.garages.cars.model IS NULL
+		t.Run("L2_value_isNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchExtraCar := uuid(2)
+			idNoMatchModelPresent := uuid(3)
+			idNoMatchSplit := uuid(4)
+			idNoMatchWrongMake := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "honda, no model"},
+				{id: idMatchExtraCar, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda"),
+					car("make", "toyota", "model", "corolla"),
+				)})}}, note: "first car satisfies (honda, no model)"},
+				{id: idNoMatchModelPresent, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})}}, note: "honda but model present"},
+				{id: idNoMatchSplit, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda", "model", "civic"),
+					car("make", "toyota"),
+				)})}}, note: "honda in c0 has model; honda absent in c1"},
+				{id: idNoMatchWrongMake, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota"))})}}, note: "wrong make"},
+			}
+			filter := andFilter(valueFilter("country.garages.cars.make", "honda"), isNullFilter("country.garages.cars.model", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchExtraCar})
+		})
+
+		// Sub-test 7: dual IsNull at L2 — make IS NOT NULL AND model IS NULL
+		t.Run("L2_dual_isNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchExtraCar := uuid(2)
+			idNoMatchModelPresent := uuid(3)
+			idNoMatchNoMake := uuid(4)
+			idNoMatchEveryCarHasModel := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "make present, no model"},
+				{id: idMatchExtraCar, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "kia", "model", "sportage"),
+					car("make", "toyota"),
+				)})}}, note: "second car has make but no model"},
+				{id: idNoMatchModelPresent, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})}}, note: "single car has both"},
+				{id: idNoMatchNoMake, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("model", "civic"))})}}, note: "model only, no make"},
+				{id: idNoMatchEveryCarHasModel, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda", "model", "civic"),
+					car("make", "toyota", "model", "corolla"),
+				)})}}, note: "every car has both"},
+			}
+			filter := andFilter(isNullFilter("country.garages.cars.make", false), isNullFilter("country.garages.cars.model", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchExtraCar})
+		})
+
+		// Sub-test 8: tokenization + IsNull at L2
+		// make = "honda civic" (tokenizes to [honda, civic]) AND model IS NULL
+		t.Run("L2_tokenization_isNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idNoMatchModelPresent := uuid(2)
+			idNoMatchTokensSplit := uuid(3)
+			idNoMatchOneTokenMissing := uuid(4)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda civic"))})}}, note: "make='honda civic' tokens at same leaf, no model"},
+				{id: idNoMatchModelPresent, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda civic", "model", "anything"))})}}, note: "tokens align but model present"},
+				{id: idNoMatchTokensSplit, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda"),
+					car("make", "civic"),
+				)})}}, note: "tokens split across cars — AndAll fails"},
+				{id: idNoMatchOneTokenMissing, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "only one token; civic missing"},
+			}
+			filter := andFilter(valueFilter("country.garages.cars.make", "honda civic"), isNullFilter("country.garages.cars.model", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch})
+		})
+
+		// Sub-test 9: contradiction — IS NULL AND IS NOT NULL on same property
+		t.Run("L2_contradiction", func(t *testing.T) {
+			idDoc := uuid(1)
+			docs := []docDef{
+				{id: idDoc, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})}}, note: "any doc; filter is contradictory"},
+			}
+			filter := andFilter(
+				isNullFilter("country.garages.cars.model", true),
+				isNullFilter("country.garages.cars.model", false),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{})
+		})
+
+		// Sub-test 10 (cross-level): country.name = "germany" AND country.garages.cars.model IS NULL
+		// Value condition at root scope; IsNull at deeper L2. Under universal
+		// semantics the IsNull exclude is applied at rootDoc level — "no model
+		// anywhere within this country."
+		t.Run("crossLevel_root_value_isNull_at_L2", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchEmpty := uuid(2)
+			idMatchNoCarsAtAll := uuid(3)
+			idNoMatchModelExists := uuid(4)
+			idNoMatchModelInOtherGarage := uuid(5)
+			idNoMatchWrongName := uuid(6)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})}}, note: "germany; cars have only make, no model anywhere"},
+				{id: idMatchEmpty, props: map[string]any{"country": map[string]any{"name": "germany"}}, note: "germany; no garages → vacuous match (universal)"},
+				{id: idMatchNoCarsAtAll, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})}}, note: "germany; garage has no cars"},
+				{id: idNoMatchModelExists, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})}}, note: "germany has model"},
+				{id: idNoMatchModelInOtherGarage, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(
+					map[string]any{"cars": asArr(car("make", "x"))},
+					map[string]any{"cars": asArr(car("model", "y"))},
+				)}}, note: "germany has model in second garage's car"},
+				{id: idNoMatchWrongName, props: map[string]any{"country": map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})}}, note: "wrong name"},
+			}
+			filter := andFilter(valueFilter("country.name", "germany"), isNullFilter("country.garages.cars.model", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchEmpty, idMatchNoCarsAtAll})
+		})
+
+		// Sub-test 11 (cross-level): country.name = "germany" AND country.garages.cars.model IS NOT NULL
+		// Existential reading is natural here — model exists somewhere within country.
+		t.Run("crossLevel_root_value_isNotNull_at_L2", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchModelInDeepCar := uuid(2)
+			idNoMatchNoModel := uuid(3)
+			idNoMatchWrongName := uuid(4)
+			idNoMatchNoCars := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})}}, note: "germany has model in cars"},
+				{id: idMatchModelInDeepCar, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(
+					map[string]any{"cars": asArr(car("make", "x"))},
+					map[string]any{"cars": asArr(car("make", "y"), car("model", "z"))},
+				)}}, note: "model exists in g1.cars[1]"},
+				{id: idNoMatchNoModel, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})}}, note: "germany; no model anywhere"},
+				{id: idNoMatchWrongName, props: map[string]any{"country": map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})}}, note: "wrong name"},
+				{id: idNoMatchNoCars, props: map[string]any{"country": map[string]any{"name": "germany"}}, note: "germany; no cars at all → no model"},
+			}
+			filter := andFilter(valueFilter("country.name", "germany"), isNullFilter("country.garages.cars.model", false))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchModelInDeepCar})
+		})
+
+		// Sub-test 12 (cross-level): country.garages.city = "berlin" AND country.garages.cars.make IS NULL
+		// Value at L1 (garages); IsNull on L2 descendant. Under current universal
+		// semantics the IsNull exclude is applied at rootDoc level (country
+		// scope). The country with city=berlin somewhere must have NO cars.make
+		// anywhere within it — even in a different garage. The existential
+		// rewrite would change this to per-garage scope.
+		t.Run("crossLevel_L1_value_isNull_at_L2", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchEmptyCars := uuid(2)
+			idNoMatchMakeInOtherGarage := uuid(3)
+			idNoMatchMakeInBerlinGarage := uuid(4)
+			idNoMatchWrongCity := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin"})}}, note: "berlin garage; no cars anywhere in country"},
+				{id: idMatchEmptyCars, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": []any{}})}}, note: "berlin garage with empty cars array; no cars.make anywhere"},
+				{id: idNoMatchMakeInOtherGarage, props: map[string]any{"country": map[string]any{"garages": asArr(
+					map[string]any{"city": "berlin"},
+					map[string]any{"city": "munich", "cars": asArr(car("make", "honda"))},
+				)}}, note: "make exists in country (other garage) — universal exclude rejects (existential would match)"},
+				{id: idNoMatchMakeInBerlinGarage, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": asArr(car("make", "honda"))})}}, note: "berlin garage has cars.make"},
+				{id: idNoMatchWrongCity, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "munich"})}}, note: "wrong city"},
+			}
+			filter := andFilter(valueFilter("country.garages.city", "berlin"), isNullFilter("country.garages.cars.make", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchEmptyCars})
+		})
+
+		// Sub-test 13 (no-positive / rootAnchor path):
+		// country.garages.cars.make IS NULL AND country.garages.cars.model IS NULL
+		// No positive leaf to seed the plan — resolver uses the rootAnchor
+		// (_exists.""). Result: docs with at least one position not in either
+		// excluded _exists set. Note: under the analyzer's DFS leaf encoding,
+		// scalar fields at intermediate levels share the leaf positions of their
+		// descendants — so a country with both name and a make-only car shares
+		// the make's leaf for both, and the AndNot of make removes that shared
+		// leaf, leaving no surviving position.
+		t.Run("L2_all_isNull_no_positive", func(t *testing.T) {
+			idMatchCarWithNeither := uuid(1)
+			idMatchMixedCars := uuid(2)
+			idMatchOtherFieldSurvives := uuid(3)
+			idNoMatchSharedLeafExcluded := uuid(4)
+			idNoMatchOnlyCarsWithMake := uuid(5)
+			idNoMatchOnlyCarsWithBoth := uuid(6)
+			docs := []docDef{
+				{id: idMatchCarWithNeither, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(map[string]any{})})}}, note: "single car with neither make nor model"},
+				{id: idMatchMixedCars, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"), map[string]any{})})}}, note: "second car has neither field — fresh leaf survives"},
+				{id: idMatchOtherFieldSurvives, props: map[string]any{"country": map[string]any{"name": "germany"}}, note: "name has fresh leaf (no descendants to share with) — survives"},
+				{id: idNoMatchSharedLeafExcluded, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "name shares its leaf with the cars descendants under DFS encoding; the make exclude removes the shared leaf"},
+				{id: idNoMatchOnlyCarsWithMake, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "only leaf is the make leaf — excluded"},
+				{id: idNoMatchOnlyCarsWithBoth, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})}}, note: "every leaf in cars.make or cars.model"},
+			}
+			filter := andFilter(isNullFilter("country.garages.cars.make", true), isNullFilter("country.garages.cars.model", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatchCarWithNeither, idMatchMixedCars, idMatchOtherFieldSurvives})
+		})
+
+		// Sub-test 14 (3-condition AND):
+		// country.garages.cars.make = "honda" AND country.garages.cars.model IS NOT NULL
+		// AND country.garages.cars.year IS NULL
+		// Same-car correlation: same car has make=honda AND model present AND year absent.
+		t.Run("L2_three_condition", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchSecondCar := uuid(2)
+			idNoMatchYearPresent := uuid(3)
+			idNoMatchNoModel := uuid(4)
+			idNoMatchSplit := uuid(5)
+			idNoMatchWrongMake := uuid(6)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})}}, note: "honda + model + no year"},
+				{id: idMatchSecondCar, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "toyota", "model", "corolla", "year", "2020"),
+					car("make", "honda", "model", "civic"),
+				)})}}, note: "second car satisfies all three"},
+				{id: idNoMatchYearPresent, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic", "year", "2020"))})}}, note: "year present"},
+				{id: idNoMatchNoModel, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "no model"},
+				{id: idNoMatchSplit, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda", "year", "2020"),
+					car("model", "civic"),
+				)})}}, note: "honda+year in c0; model in c1 — split across cars"},
+				{id: idNoMatchWrongMake, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota", "model", "corolla"))})}}, note: "wrong make"},
+			}
+			filter := andFilterN(
+				valueFilter("country.garages.cars.make", "honda"),
+				isNullFilter("country.garages.cars.model", false),
+				isNullFilter("country.garages.cars.year", true),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchSecondCar})
+		})
+
+		// Sub-test 15: country.name = "germany" AND country.garages IS NOT NULL
+		// Array-prop IsNotNull at root, paired with a sibling root scalar.
+		t.Run("root_value_arrayIsNotNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchMultiple := uuid(2)
+			idNoMatchNoGarages := uuid(3)
+			idNoMatchWrongName := uuid(4)
+			idNoMatchEmpty := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})}}, note: "germany with one garage"},
+				{id: idMatchMultiple, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "munich"}, map[string]any{"city": "berlin"})}}, note: "germany with multiple garages"},
+				{id: idNoMatchNoGarages, props: map[string]any{"country": map[string]any{"name": "germany"}}, note: "germany but no garages prop"},
+				{id: idNoMatchWrongName, props: map[string]any{"country": map[string]any{"name": "france", "garages": asArr(map[string]any{"city": "paris"})}}, note: "wrong name"},
+				{id: idNoMatchEmpty, props: map[string]any{"country": map[string]any{}}, note: "empty country"},
+			}
+			filter := andFilter(valueFilter("country.name", "germany"), isNullFilter("country.garages", false))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultiple})
+		})
+
+		// Sub-test 16: country.name = "germany" AND country.garages IS NULL
+		// Array-prop IsNull at root — distinct code path from leaf-IsNull (no
+		// synthetic IS NOT NULL rewrite).
+		t.Run("root_value_arrayIsNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchOtherFields := uuid(2)
+			idNoMatchHasGarages := uuid(3)
+			idNoMatchWrongName := uuid(4)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"name": "germany"}}, note: "germany with no garages"},
+				{id: idMatchOtherFields, props: map[string]any{"country": map[string]any{"name": "germany", "capital": "berlin"}}, note: "germany with capital but no garages"},
+				{id: idNoMatchHasGarages, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})}}, note: "germany has garages"},
+				{id: idNoMatchWrongName, props: map[string]any{"country": map[string]any{"name": "france"}}, note: "wrong name"},
+			}
+			filter := andFilter(valueFilter("country.name", "germany"), isNullFilter("country.garages", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchOtherFields})
+		})
+
+		// Sub-test 17 (cross-level): country.name = "germany" AND country.garages.cars IS NULL
+		// Root scalar + L1 intermediate-array IsNull. Universal at country
+		// scope: no cars anywhere within country.
+		t.Run("crossLevel_root_value_intermediateArrayIsNull", func(t *testing.T) {
+			idMatchNoCarsAnywhere := uuid(1)
+			idMatchNoGarages := uuid(2)
+			idMatchAllGaragesNoCars := uuid(3)
+			idNoMatchHasCars := uuid(4)
+			idNoMatchCarsInOtherGarage := uuid(5)
+			idNoMatchWrongName := uuid(6)
+			docs := []docDef{
+				{id: idMatchNoCarsAnywhere, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})}}, note: "garage with no cars"},
+				{id: idMatchNoGarages, props: map[string]any{"country": map[string]any{"name": "germany"}}, note: "germany; no garages → vacuous match"},
+				{id: idMatchAllGaragesNoCars, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"}, map[string]any{"city": "munich"})}}, note: "multiple garages, none with cars"},
+				{id: idNoMatchHasCars, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "garage has cars"},
+				{id: idNoMatchCarsInOtherGarage, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"}, map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "cars exist in another garage"},
+				{id: idNoMatchWrongName, props: map[string]any{"country": map[string]any{"name": "france"}}, note: "wrong name"},
+			}
+			filter := andFilter(valueFilter("country.name", "germany"), isNullFilter("country.garages.cars", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatchNoCarsAnywhere, idMatchNoGarages, idMatchAllGaragesNoCars})
+		})
+
+		// Sub-test 18 (inverse cross-level): country.garages.cars.make = "honda"
+		// AND country.name IS NULL. Deep value + shallower leaf IsNull.
+		t.Run("inverseCrossLevel_L2_value_root_isNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idNoMatchNameSet := uuid(2)
+			idNoMatchWrongMake := uuid(3)
+			idNoMatchNoCars := uuid(4)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "honda exists; no name"},
+				{id: idNoMatchNameSet, props: map[string]any{"country": map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "honda exists but name is set"},
+				{id: idNoMatchWrongMake, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota"))})}}, note: "wrong make; no name"},
+				{id: idNoMatchNoCars, props: map[string]any{"country": map[string]any{"capital": "berlin"}}, note: "no cars; no name"},
+			}
+			filter := andFilter(valueFilter("country.garages.cars.make", "honda"), isNullFilter("country.name", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch})
+		})
+
+		// Sub-test 19 (mixed): country.garages.cars.make = "honda" AND
+		// country.garages.postcode IS NULL. L2 value + L1 leaf IsNull. Under
+		// current universal IsNull semantics, "postcode IS NULL" applies at
+		// country scope: the country must have no postcode anywhere AND honda
+		// must exist in some car. Same-garage correlation is not enforced
+		// across mixed L1/L2 conditions.
+		t.Run("mixed_L2_value_L1_leafIsNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchHondaInSecondGarage := uuid(2)
+			idNoMatchPostcodePresent := uuid(3)
+			idNoMatchPostcodeInOtherGarage := uuid(4)
+			idNoMatchWrongMake := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "garage with honda, no postcode"},
+				{id: idMatchHondaInSecondGarage, props: map[string]any{"country": map[string]any{"garages": asArr(
+					map[string]any{"cars": asArr(car("make", "toyota"))},
+					map[string]any{"cars": asArr(car("make", "honda"))},
+				)}}, note: "honda exists in g1; no postcode anywhere"},
+				{id: idNoMatchPostcodePresent, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"postcode": "10115", "cars": asArr(car("make", "honda"))})}}, note: "honda garage has postcode"},
+				{id: idNoMatchPostcodeInOtherGarage, props: map[string]any{"country": map[string]any{"garages": asArr(
+					map[string]any{"cars": asArr(car("make", "honda"))},
+					map[string]any{"postcode": "10115"},
+				)}}, note: "honda in g0 (no postcode), but postcode in g1 — universal at country rejects"},
+				{id: idNoMatchWrongMake, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota"))})}}, note: "wrong make"},
+			}
+			filter := andFilter(valueFilter("country.garages.cars.make", "honda"), isNullFilter("country.garages.postcode", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchHondaInSecondGarage})
+		})
+
+		// Sub-test 20 (no-positive / rootAnchor with three excludes):
+		// country.garages.cars.make IS NULL AND country.garages.cars.model IS NULL
+		// AND country.garages.cars.year IS NULL. Stress-tests rootAnchor with 3 excludes.
+		t.Run("L2_three_isNull_no_positive", func(t *testing.T) {
+			idMatchCarWithNothing := uuid(1)
+			idMatchOtherFieldSurvives := uuid(2)
+			idNoMatchHasMake := uuid(3)
+			idNoMatchHasYear := uuid(4)
+			idNoMatchAllSet := uuid(5)
+			docs := []docDef{
+				{id: idMatchCarWithNothing, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(map[string]any{})})}}, note: "single car with no fields"},
+				{id: idMatchOtherFieldSurvives, props: map[string]any{"country": map[string]any{"capital": "berlin"}}, note: "capital has fresh leaf (no descendants)"},
+				{id: idNoMatchHasMake, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "only leaf in cars.make exclude"},
+				{id: idNoMatchHasYear, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("year", "2020"))})}}, note: "only leaf in cars.year exclude"},
+				{id: idNoMatchAllSet, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic", "year", "2020"))})}}, note: "every leaf in some exclude"},
+			}
+			filter := andFilterN(
+				isNullFilter("country.garages.cars.make", true),
+				isNullFilter("country.garages.cars.model", true),
+				isNullFilter("country.garages.cars.year", true),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{idMatchCarWithNothing, idMatchOtherFieldSurvives})
+		})
+
+		// Sub-test 21: country.garages.city = "berlin" AND country.garages.cars IS NULL.
+		// L1 leaf + L1 intermediate-array IsNull. Array-prop IsNull is universal
+		// at country scope (no synthetic rewrite for array-prop IsNull) — the
+		// country containing a berlin garage must have no cars anywhere. Within
+		// a single country, same-garage correlation does not apply.
+		t.Run("L1_value_intermediateArrayIsNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchMultipleGarages := uuid(2)
+			idNoMatchHasCarsSameGarage := uuid(3)
+			idNoMatchHasCarsOtherGarage := uuid(4)
+			idNoMatchWrongCity := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin"})}}, note: "berlin garage, no cars anywhere"},
+				{id: idMatchMultipleGarages, props: map[string]any{"country": map[string]any{"garages": asArr(
+					map[string]any{"city": "munich"},
+					map[string]any{"city": "berlin"},
+				)}}, note: "berlin in g1; no cars in any garage"},
+				{id: idNoMatchHasCarsSameGarage, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": asArr(car("make", "honda"))})}}, note: "berlin garage has cars"},
+				{id: idNoMatchHasCarsOtherGarage, props: map[string]any{"country": map[string]any{"garages": asArr(
+					map[string]any{"city": "berlin"},
+					map[string]any{"city": "munich", "cars": asArr(car("make", "honda"))},
+				)}}, note: "berlin garage has no cars but other garage does — universal at country rejects"},
+				{id: idNoMatchWrongCity, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "munich"})}}, note: "wrong city"},
+			}
+			filter := andFilter(valueFilter("country.garages.city", "berlin"), isNullFilter("country.garages.cars", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultipleGarages})
+		})
+
+		// Sub-test 22: country.garages.cars.make = "honda" AND
+		// country.garages.cars.tires IS NULL. L2 leaf + L2 intermediate-array
+		// IsNull. Array-prop IsNull is universal at country scope: the country
+		// must have no tires anywhere AND honda must exist in some car. Within
+		// a single country, same-car correlation does not apply.
+		t.Run("L2_value_intermediateArrayIsNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchMultipleCars := uuid(2)
+			idNoMatchHasTiresSameCar := uuid(3)
+			idNoMatchHasTiresOtherCar := uuid(4)
+			idNoMatchWrongMake := uuid(5)
+			tire := func(width string) map[string]any { return map[string]any{"width": width} }
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})}}, note: "honda car, no tires anywhere"},
+				{id: idMatchMultipleCars, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "toyota"),
+					car("make", "honda"),
+				)})}}, note: "honda in c1; no tires anywhere"},
+				{id: idNoMatchHasTiresSameCar, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(map[string]any{"make": "honda", "tires": asArr(tire("205"))})})}}, note: "honda car has tires"},
+				{id: idNoMatchHasTiresOtherCar, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda"),
+					map[string]any{"make": "toyota", "tires": asArr(tire("205"))},
+				)})}}, note: "honda car has no tires but other car does — universal at country rejects"},
+				{id: idNoMatchWrongMake, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota"))})}}, note: "wrong make"},
+			}
+			filter := andFilter(valueFilter("country.garages.cars.make", "honda"), isNullFilter("country.garages.cars.tires", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultipleCars})
+		})
+
+		// Sub-test 23 (cross-level L1+L2): country.garages.city = "berlin" AND
+		// country.garages.cars.tires IS NULL. L1 leaf + L2 intermediate-array
+		// IsNull. Universal at country scope: berlin garage exists somewhere
+		// AND no tires anywhere in the country.
+		t.Run("crossLevel_L1_value_intermediateArrayIsNull_at_L2", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchCarsNoTires := uuid(2)
+			idNoMatchTiresInBerlinCar := uuid(3)
+			idNoMatchTiresInOtherGarage := uuid(4)
+			idNoMatchWrongCity := uuid(5)
+			tire := func(width string) map[string]any { return map[string]any{"width": width} }
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin"})}}, note: "berlin garage, no tires anywhere"},
+				{id: idMatchCarsNoTires, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": asArr(car("make", "honda"))})}}, note: "berlin garage with cars but cars have no tires"},
+				{id: idNoMatchTiresInBerlinCar, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": asArr(map[string]any{"make": "honda", "tires": asArr(tire("205"))})})}}, note: "tires in berlin garage's car"},
+				{id: idNoMatchTiresInOtherGarage, props: map[string]any{"country": map[string]any{"garages": asArr(
+					map[string]any{"city": "berlin"},
+					map[string]any{"city": "munich", "cars": asArr(map[string]any{"make": "honda", "tires": asArr(tire("205"))})},
+				)}}, note: "tires in other garage — universal at country scope rejects"},
+				{id: idNoMatchWrongCity, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "munich"})}}, note: "wrong city"},
+			}
+			filter := andFilter(valueFilter("country.garages.city", "berlin"), isNullFilter("country.garages.cars.tires", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchCarsNoTires})
+		})
+	})
+
+	// ---------- DataTypeObjectArray (top-level "countries") ----------
+	t.Run("countries_array", func(t *testing.T) {
+		// Sub-test 1: countries.name = "germany" AND countries.capital IS NOT NULL
+		t.Run("root_value_isNotNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchExtraFields := uuid(2)
+			idMatchSecondCountry := uuid(3)
+			idMatchExtraCountries := uuid(4)
+			idNoMatchSplit := uuid(5)
+			idNoMatchWrongName := uuid(6)
+			idNoMatchNoCapital := uuid(7)
+			idNoMatchEmptyCountries := uuid(8)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "capital": "berlin"})}, note: "single country: germany+berlin"},
+				{id: idMatchExtraFields, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "capital": "berlin", "garages": asArr(map[string]any{"city": "munich"})})}, note: "germany country with extra populated fields"},
+				{id: idMatchSecondCountry, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "france", "capital": "paris"},
+					map[string]any{"name": "germany", "capital": "berlin"},
+				)}, note: "second country satisfies"},
+				{id: idMatchExtraCountries, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "germany", "capital": "berlin"},
+					map[string]any{"name": "france"},
+					map[string]any{"name": "italy", "capital": "rome"},
+				)}, note: "first country matches; others irrelevant"},
+				{id: idNoMatchSplit, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "germany"},
+					map[string]any{"capital": "berlin"},
+				)}, note: "name and capital in different countries — same-element fails"},
+				{id: idNoMatchWrongName, props: map[string]any{"countries": asArr(map[string]any{"name": "france", "capital": "paris"})}, note: "wrong name"},
+				{id: idNoMatchNoCapital, props: map[string]any{"countries": asArr(map[string]any{"name": "germany"})}, note: "no capital"},
+				{id: idNoMatchEmptyCountries, props: map[string]any{"countries": []any{}}, note: "empty countries"},
+			}
+			filter := andFilter(valueFilter("countries.name", "germany"), isNullFilter("countries.capital", false))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchExtraFields, idMatchSecondCountry, idMatchExtraCountries})
+		})
+
+		// Sub-test 2: countries.name = "germany" AND countries.capital IS NULL
+		t.Run("root_value_isNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchWithGarages := uuid(2)
+			idMatchInSecondPos := uuid(3)
+			idNoMatchCapitalPresent := uuid(4)
+			idNoMatchSplitCapitalElsewhere := uuid(5)
+			idNoMatchWrongName := uuid(6)
+			idNoMatchNoName := uuid(7)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"name": "germany"})}, note: "single country: germany, no capital"},
+				{id: idMatchWithGarages, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "munich"})})}, note: "germany, no capital but has garages"},
+				{id: idMatchInSecondPos, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "france", "capital": "paris"},
+					map[string]any{"name": "germany"},
+				)}, note: "germany in [1] without capital"},
+				{id: idNoMatchCapitalPresent, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "capital": "berlin"})}, note: "germany has capital"},
+				{id: idNoMatchSplitCapitalElsewhere, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "germany", "capital": "berlin"},
+					map[string]any{"name": "france"},
+				)}, note: "germany country has capital — same-element rejects"},
+				{id: idNoMatchWrongName, props: map[string]any{"countries": asArr(map[string]any{"name": "france"})}, note: "wrong name"},
+				{id: idNoMatchNoName, props: map[string]any{"countries": asArr(map[string]any{"capital": "berlin"})}, note: "country has capital but no name"},
+			}
+			filter := andFilter(valueFilter("countries.name", "germany"), isNullFilter("countries.capital", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchWithGarages, idMatchInSecondPos})
+		})
+
+		// Sub-test 3: countries.garages.city = "berlin" AND countries.garages.postcode IS NOT NULL
+		t.Run("L1_value_isNotNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchSecondGarage := uuid(2)
+			idMatchExtraGarages := uuid(3)
+			idMatchInSecondCountry := uuid(4)
+			idNoMatchSplitWithinCountry := uuid(5)
+			idNoMatchSplitAcrossCountries := uuid(6)
+			idNoMatchWrongCity := uuid(7)
+			idNoMatchNoPostcode := uuid(8)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin", "postcode": "10115"})})}, note: "single country, garage with both fields"},
+				{id: idMatchSecondGarage, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(
+					map[string]any{"city": "munich"},
+					map[string]any{"city": "berlin", "postcode": "10115"},
+				)})}, note: "single country; second garage satisfies"},
+				{id: idMatchExtraGarages, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(
+					map[string]any{"city": "berlin", "postcode": "10115"},
+					map[string]any{"city": "paris", "postcode": "75000"},
+					map[string]any{"city": "munich"},
+				)})}, note: "first garage matches; others irrelevant"},
+				{id: idMatchInSecondCountry, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"city": "munich"})},
+					map[string]any{"garages": asArr(map[string]any{"city": "berlin", "postcode": "10115"})},
+				)}, note: "second country has matching garage"},
+				{id: idNoMatchSplitWithinCountry, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(
+					map[string]any{"city": "berlin"},
+					map[string]any{"city": "munich", "postcode": "80331"},
+				)})}, note: "berlin in g0; postcode in g1 — different garages within same country"},
+				{id: idNoMatchSplitAcrossCountries, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"city": "berlin"})},
+					map[string]any{"garages": asArr(map[string]any{"city": "munich", "postcode": "80331"})},
+				)}, note: "berlin and postcode in different countries"},
+				{id: idNoMatchWrongCity, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "munich", "postcode": "80331"})})}, note: "wrong city"},
+				{id: idNoMatchNoPostcode, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin"})})}, note: "berlin but no postcode"},
+			}
+			filter := andFilter(valueFilter("countries.garages.city", "berlin"), isNullFilter("countries.garages.postcode", false))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchSecondGarage, idMatchExtraGarages, idMatchInSecondCountry})
+		})
+
+		// Sub-test 4: countries.garages.city = "berlin" AND countries.garages.postcode IS NULL
+		t.Run("L1_value_isNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchWithCars := uuid(2)
+			idMatchInSecondCountry := uuid(3)
+			idNoMatchPostcodePresent := uuid(4)
+			idNoMatchSplit := uuid(5)
+			idNoMatchWrongCity := uuid(6)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin"})})}, note: "garage city=berlin, no postcode"},
+				{id: idMatchWithCars, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": asArr(car("make", "honda"))})})}, note: "city=berlin, no postcode, has cars"},
+				{id: idMatchInSecondCountry, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"city": "munich", "postcode": "80331"})},
+					map[string]any{"garages": asArr(map[string]any{"city": "berlin"})},
+				)}, note: "second country has matching garage"},
+				{id: idNoMatchPostcodePresent, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin", "postcode": "10115"})})}, note: "city=berlin but postcode present"},
+				{id: idNoMatchSplit, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(
+					map[string]any{"city": "berlin", "postcode": "10115"},
+					map[string]any{"city": "munich"},
+				)})}, note: "g0 has berlin+postcode; g1 has wrong city — no garage satisfies both"},
+				{id: idNoMatchWrongCity, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "munich"})})}, note: "wrong city"},
+			}
+			filter := andFilter(valueFilter("countries.garages.city", "berlin"), isNullFilter("countries.garages.postcode", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchWithCars, idMatchInSecondCountry})
+		})
+
+		// Sub-test 5: countries.garages.cars.make = "honda" AND countries.garages.cars.model IS NOT NULL
+		t.Run("L2_value_isNotNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchSecondCar := uuid(2)
+			idMatchInSecondCountry := uuid(3)
+			idNoMatchSplitCars := uuid(4)
+			idNoMatchSplitGarages := uuid(5)
+			idNoMatchSplitAcrossCountries := uuid(6)
+			idNoMatchWrongMake := uuid(7)
+			idNoMatchNoModel := uuid(8)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})})}, note: "single car with both"},
+				{id: idMatchSecondCar, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "toyota", "model", "corolla"),
+					car("make", "honda", "model", "civic"),
+				)})})}, note: "second car satisfies"},
+				{id: idMatchInSecondCountry, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota", "model", "corolla"))})},
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})},
+				)}, note: "second country has matching car"},
+				{id: idNoMatchSplitCars, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda"),
+					car("model", "civic"),
+				)})})}, note: "honda in cars[0], model in cars[1] — different cars"},
+				{id: idNoMatchSplitGarages, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(
+					map[string]any{"cars": asArr(car("make", "honda"))},
+					map[string]any{"cars": asArr(car("model", "civic"))},
+				)})}, note: "honda in g0.cars; model in g1.cars — different cars across garages within country"},
+				{id: idNoMatchSplitAcrossCountries, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})},
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("model", "civic"))})},
+				)}, note: "honda and model in different countries"},
+				{id: idNoMatchWrongMake, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota", "model", "corolla"))})})}, note: "wrong make"},
+				{id: idNoMatchNoModel, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "honda but no model"},
+			}
+			filter := andFilter(valueFilter("countries.garages.cars.make", "honda"), isNullFilter("countries.garages.cars.model", false))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchSecondCar, idMatchInSecondCountry})
+		})
+
+		// Sub-test 6: countries.garages.cars.make = "honda" AND countries.garages.cars.model IS NULL
+		t.Run("L2_value_isNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchExtraCar := uuid(2)
+			idMatchInSecondCountry := uuid(3)
+			idNoMatchModelPresent := uuid(4)
+			idNoMatchSplit := uuid(5)
+			idNoMatchWrongMake := uuid(6)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "single car: make=honda, no model"},
+				{id: idMatchExtraCar, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda"),
+					car("make", "toyota", "model", "corolla"),
+				)})})}, note: "first car satisfies; extra car irrelevant"},
+				{id: idMatchInSecondCountry, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota", "model", "corolla"))})},
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})},
+				)}, note: "second country has matching car"},
+				{id: idNoMatchModelPresent, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})})}, note: "honda has model"},
+				{id: idNoMatchSplit, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda", "model", "civic"),
+					car("make", "toyota"),
+				)})})}, note: "honda has model in cars[0]; cars[1] has no make"},
+				{id: idNoMatchWrongMake, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota"))})})}, note: "wrong make"},
+			}
+			filter := andFilter(valueFilter("countries.garages.cars.make", "honda"), isNullFilter("countries.garages.cars.model", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchExtraCar, idMatchInSecondCountry})
+		})
+
+		// Sub-test 7: dual IsNull at L2
+		t.Run("L2_dual_isNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchExtraCar := uuid(2)
+			idMatchAcrossCountries := uuid(3)
+			idNoMatchModelPresent := uuid(4)
+			idNoMatchNoMake := uuid(5)
+			idNoMatchEveryCarHasModel := uuid(6)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "make present, no model"},
+				{id: idMatchExtraCar, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "kia", "model", "sportage"),
+					car("make", "toyota"),
+				)})})}, note: "second car has make but no model"},
+				{id: idMatchAcrossCountries, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("model", "civic"))})},
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "kia"))})},
+				)}, note: "second country has car satisfying same-element"},
+				{id: idNoMatchModelPresent, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})})}, note: "single car has both"},
+				{id: idNoMatchNoMake, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("model", "civic"))})})}, note: "no make"},
+				{id: idNoMatchEveryCarHasModel, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda", "model", "civic"),
+					car("make", "toyota", "model", "corolla"),
+				)})})}, note: "every car has both → no satisfying car"},
+			}
+			filter := andFilter(isNullFilter("countries.garages.cars.make", false), isNullFilter("countries.garages.cars.model", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchExtraCar, idMatchAcrossCountries})
+		})
+
+		// Sub-test 8: tokenization + IsNull at L2
+		t.Run("L2_tokenization_isNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchInSecondCountry := uuid(2)
+			idNoMatchModelPresent := uuid(3)
+			idNoMatchTokensSplit := uuid(4)
+			idNoMatchOneTokenMissing := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda civic"))})})}, note: "tokens at same leaf, no model"},
+				{id: idMatchInSecondCountry, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota corolla"))})},
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda civic"))})},
+				)}, note: "second country satisfies"},
+				{id: idNoMatchModelPresent, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda civic", "model", "anything"))})})}, note: "tokens align but model present"},
+				{id: idNoMatchTokensSplit, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda"),
+					car("make", "civic"),
+				)})})}, note: "tokens split across cars"},
+				{id: idNoMatchOneTokenMissing, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "only one token (honda); civic missing"},
+			}
+			filter := andFilter(valueFilter("countries.garages.cars.make", "honda civic"), isNullFilter("countries.garages.cars.model", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchInSecondCountry})
+		})
+
+		// Sub-test 9: contradiction
+		t.Run("L2_contradiction", func(t *testing.T) {
+			idDoc := uuid(1)
+			docs := []docDef{
+				{id: idDoc, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})})}, note: "any doc; filter is contradictory"},
+			}
+			filter := andFilter(
+				isNullFilter("countries.garages.cars.model", true),
+				isNullFilter("countries.garages.cars.model", false),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{})
+		})
+
+		// Sub-test 10 (cross-level): countries.name = "germany" AND countries.garages.cars.model IS NULL
+		// Same-element correlation at root (countries) — the country with
+		// name=germany must have no model anywhere within (universal at country scope).
+		t.Run("crossLevel_root_value_isNull_at_L2", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchModelInOtherCntr := uuid(2)
+			idMatchEmptyCntr := uuid(3)
+			idMatchNoCarsAtAll := uuid(4)
+			idNoMatchModelInGermany := uuid(5)
+			idNoMatchModelInDeepCar := uuid(6)
+			idNoMatchSplitNameAndCntr := uuid(7)
+			idNoMatchWrongName := uuid(8)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})})}, note: "germany; no model"},
+				{id: idMatchModelInOtherCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "germany"},
+					map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("model", "y"))})},
+				)}, note: "germany has no model; model is in france country"},
+				{id: idMatchEmptyCntr, props: map[string]any{"countries": asArr(map[string]any{"name": "germany"})}, note: "germany; no garages → vacuous match"},
+				{id: idMatchNoCarsAtAll, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})})}, note: "germany; garage with no cars"},
+				{id: idNoMatchModelInGermany, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})})}, note: "germany has model"},
+				{id: idNoMatchModelInDeepCar, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(
+					map[string]any{"cars": asArr(car("make", "x"))},
+					map[string]any{"cars": asArr(car("model", "y"))},
+				)})}, note: "germany has model in second garage"},
+				{id: idNoMatchSplitNameAndCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})},
+					map[string]any{"name": "france"},
+				)}, note: "germany country has model — fails despite france country having no model"},
+				{id: idNoMatchWrongName, props: map[string]any{"countries": asArr(map[string]any{"name": "france"})}, note: "wrong name"},
+			}
+			filter := andFilter(valueFilter("countries.name", "germany"), isNullFilter("countries.garages.cars.model", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchModelInOtherCntr, idMatchEmptyCntr, idMatchNoCarsAtAll})
+		})
+
+		// Sub-test 11 (cross-level): countries.name = "germany" AND countries.garages.cars.model IS NOT NULL
+		t.Run("crossLevel_root_value_isNotNull_at_L2", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchSecondCntr := uuid(2)
+			idNoMatchModelInOtherCntr := uuid(3)
+			idNoMatchNoModel := uuid(4)
+			idNoMatchWrongName := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})})}, note: "germany has model"},
+				{id: idMatchSecondCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})},
+					map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "z", "model", "y"))})},
+				)}, note: "germany country in second position satisfies"},
+				{id: idNoMatchModelInOtherCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})},
+					map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("model", "y"))})},
+				)}, note: "model only in france; germany has no model"},
+				{id: idNoMatchNoModel, props: map[string]any{"countries": asArr(map[string]any{"name": "germany"})}, note: "no model anywhere"},
+				{id: idNoMatchWrongName, props: map[string]any{"countries": asArr(map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})})}, note: "wrong name"},
+			}
+			filter := andFilter(valueFilter("countries.name", "germany"), isNullFilter("countries.garages.cars.model", false))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchSecondCntr})
+		})
+
+		// Sub-test 12 (cross-level): countries.garages.city = "berlin" AND countries.garages.cars.make IS NULL
+		// Value at L1; IsNull on L2 descendant. Under current universal semantics
+		// the IsNull exclude is applied at root (countries) level — the country
+		// containing the berlin garage must have NO cars.make ANYWHERE within
+		// (any of its garages). Existential rewrite would change this to
+		// per-garage scope.
+		t.Run("crossLevel_L1_value_isNull_at_L2", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchEmptyCars := uuid(2)
+			idMatchInSecondCntr := uuid(3)
+			idMatchSplitAcrossCountries := uuid(4)
+			idNoMatchMakeInOtherGarageSameCntr := uuid(5)
+			idNoMatchMakeInBerlinGarage := uuid(6)
+			idNoMatchWrongCity := uuid(7)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin"})})}, note: "berlin garage; no make anywhere"},
+				{id: idMatchEmptyCars, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": []any{}})})}, note: "berlin garage with empty cars array; no cars.make anywhere"},
+				{id: idMatchInSecondCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"city": "munich", "cars": asArr(car("make", "honda"))})},
+					map[string]any{"garages": asArr(map[string]any{"city": "berlin"})},
+				)}, note: "second country has berlin garage with no make; first country (with make) is independent"},
+				{id: idMatchSplitAcrossCountries, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": asArr(car("make", "honda"))})},
+					map[string]any{"garages": asArr(map[string]any{"city": "berlin"})},
+				)}, note: "second country has berlin garage with no make — independently satisfies"},
+				{id: idNoMatchMakeInOtherGarageSameCntr, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(
+					map[string]any{"city": "berlin"},
+					map[string]any{"city": "munich", "cars": asArr(car("make", "honda"))},
+				)})}, note: "country has make in munich garage — universal at country scope rejects (existential would match via berlin garage)"},
+				{id: idNoMatchMakeInBerlinGarage, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": asArr(car("make", "honda"))})})}, note: "berlin garage has cars.make"},
+				{id: idNoMatchWrongCity, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "munich"})})}, note: "wrong city"},
+			}
+			filter := andFilter(valueFilter("countries.garages.city", "berlin"), isNullFilter("countries.garages.cars.make", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchEmptyCars, idMatchInSecondCntr, idMatchSplitAcrossCountries})
+		})
+
+		// Sub-test 13 (no-positive / rootAnchor path):
+		// countries.garages.cars.make IS NULL AND countries.garages.cars.model IS NULL
+		t.Run("L2_all_isNull_no_positive", func(t *testing.T) {
+			idMatchCarWithNeither := uuid(1)
+			idMatchInSecondCntr := uuid(2)
+			idMatchOtherFieldSurvives := uuid(3)
+			idNoMatchAllCarsWithMake := uuid(4)
+			idNoMatchSharedLeafExcluded := uuid(5)
+			idNoMatchOnlyCarsWithBoth := uuid(6)
+			docs := []docDef{
+				{id: idMatchCarWithNeither, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(map[string]any{})})})}, note: "single car with neither field"},
+				{id: idMatchInSecondCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})},
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(map[string]any{})})},
+				)}, note: "second country has a car with neither field"},
+				{id: idMatchOtherFieldSurvives, props: map[string]any{"countries": asArr(map[string]any{"name": "germany"})}, note: "name has fresh leaf (no descendants to share with) — survives"},
+				{id: idNoMatchAllCarsWithMake, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "only leaf is in cars.make exclude"},
+				{id: idNoMatchSharedLeafExcluded, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "name shares its leaf with the cars descendants under DFS encoding; the make exclude removes the shared leaf"},
+				{id: idNoMatchOnlyCarsWithBoth, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})})}, note: "every leaf in cars.make or cars.model"},
+			}
+			filter := andFilter(isNullFilter("countries.garages.cars.make", true), isNullFilter("countries.garages.cars.model", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatchCarWithNeither, idMatchInSecondCntr, idMatchOtherFieldSurvives})
+		})
+
+		// Sub-test 14 (3-condition AND):
+		// countries.garages.cars.make = "honda" AND countries.garages.cars.model IS NOT NULL
+		// AND countries.garages.cars.year IS NULL
+		t.Run("L2_three_condition", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchInSecondCntr := uuid(2)
+			idNoMatchYearPresent := uuid(3)
+			idNoMatchNoModel := uuid(4)
+			idNoMatchSplit := uuid(5)
+			idNoMatchWrongMake := uuid(6)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})})}, note: "honda + model + no year"},
+				{id: idMatchInSecondCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota", "model", "corolla", "year", "2020"))})},
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic"))})},
+				)}, note: "second country has matching car"},
+				{id: idNoMatchYearPresent, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic", "year", "2020"))})})}, note: "year present"},
+				{id: idNoMatchNoModel, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "no model"},
+				{id: idNoMatchSplit, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda", "year", "2020"),
+					car("model", "civic"),
+				)})})}, note: "honda+year in c0, model in c1 — split"},
+				{id: idNoMatchWrongMake, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota", "model", "corolla"))})})}, note: "wrong make"},
+			}
+			filter := andFilterN(
+				valueFilter("countries.garages.cars.make", "honda"),
+				isNullFilter("countries.garages.cars.model", false),
+				isNullFilter("countries.garages.cars.year", true),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchInSecondCntr})
+		})
+
+		// Sub-test 15: countries.name = "germany" AND countries.garages IS NOT NULL
+		// Same-element correlation: a country named germany that has at least one garage.
+		t.Run("root_value_arrayIsNotNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchInSecondCntr := uuid(2)
+			idNoMatchSplit := uuid(3)
+			idNoMatchNoGarages := uuid(4)
+			idNoMatchWrongName := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})})}, note: "single country with garages"},
+				{id: idMatchInSecondCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "france", "garages": asArr(map[string]any{"city": "paris"})},
+					map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})},
+				)}, note: "second country satisfies"},
+				{id: idNoMatchSplit, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "germany"},
+					map[string]any{"garages": asArr(map[string]any{"city": "berlin"})},
+				)}, note: "name and garages in different countries"},
+				{id: idNoMatchNoGarages, props: map[string]any{"countries": asArr(map[string]any{"name": "germany"})}, note: "germany without garages"},
+				{id: idNoMatchWrongName, props: map[string]any{"countries": asArr(map[string]any{"name": "france", "garages": asArr(map[string]any{"city": "paris"})})}, note: "wrong name"},
+			}
+			filter := andFilter(valueFilter("countries.name", "germany"), isNullFilter("countries.garages", false))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchInSecondCntr})
+		})
+
+		// Sub-test 16: countries.name = "germany" AND countries.garages IS NULL
+		// Same-element correlation: a country named germany that has no garages.
+		t.Run("root_value_arrayIsNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchInSecondCntr := uuid(2)
+			idNoMatchHasGarages := uuid(3)
+			idNoMatchSplit := uuid(4)
+			idNoMatchWrongName := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"name": "germany"})}, note: "germany no garages"},
+				{id: idMatchInSecondCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "france", "garages": asArr(map[string]any{"city": "paris"})},
+					map[string]any{"name": "germany"},
+				)}, note: "germany country in [1] without garages"},
+				{id: idNoMatchHasGarages, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})})}, note: "germany has garages"},
+				{id: idNoMatchSplit, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})},
+					map[string]any{"name": "france"},
+				)}, note: "germany country has garages — same-element fails"},
+				{id: idNoMatchWrongName, props: map[string]any{"countries": asArr(map[string]any{"name": "france"})}, note: "wrong name"},
+			}
+			filter := andFilter(valueFilter("countries.name", "germany"), isNullFilter("countries.garages", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchInSecondCntr})
+		})
+
+		// Sub-test 17 (cross-level): countries.name = "germany" AND countries.garages.cars IS NULL
+		// Universal at countries (root) scope: the germany country must have no
+		// cars anywhere within its garages.
+		t.Run("crossLevel_root_value_intermediateArrayIsNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchNoGarages := uuid(2)
+			idMatchCarsInOtherCntr := uuid(3)
+			idNoMatchHasCars := uuid(4)
+			idNoMatchCarsInOtherGarage := uuid(5)
+			idNoMatchWrongName := uuid(6)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})})}, note: "germany; garage with no cars"},
+				{id: idMatchNoGarages, props: map[string]any{"countries": asArr(map[string]any{"name": "germany"})}, note: "germany; no garages → vacuous match"},
+				{id: idMatchCarsInOtherCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})},
+					map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})},
+				)}, note: "germany has no cars; cars in france"},
+				{id: idNoMatchHasCars, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "germany has cars"},
+				{id: idNoMatchCarsInOtherGarage, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(
+					map[string]any{"city": "berlin"},
+					map[string]any{"cars": asArr(car("make", "honda"))},
+				)})}, note: "cars exist in germany country (other garage)"},
+				{id: idNoMatchWrongName, props: map[string]any{"countries": asArr(map[string]any{"name": "france"})}, note: "wrong name"},
+			}
+			filter := andFilter(valueFilter("countries.name", "germany"), isNullFilter("countries.garages.cars", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchNoGarages, idMatchCarsInOtherCntr})
+		})
+
+		// Sub-test 18 (inverse cross-level): countries.garages.cars.make = "honda"
+		// AND countries.name IS NULL. Same-element correlation: a country with
+		// cars containing honda AND no name on that same country.
+		t.Run("inverseCrossLevel_L2_value_root_isNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchInSecondCntr := uuid(2)
+			idNoMatchNameSet := uuid(3)
+			idNoMatchSplit := uuid(4)
+			idNoMatchWrongMake := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "country with honda and no name"},
+				{id: idMatchInSecondCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "france"},
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})},
+				)}, note: "second country: honda, no name"},
+				{id: idNoMatchNameSet, props: map[string]any{"countries": asArr(map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "honda but name is set"},
+				{id: idNoMatchSplit, props: map[string]any{"countries": asArr(
+					map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})},
+					map[string]any{"capital": "paris"},
+				)}, note: "honda in named country; nameless country has no honda"},
+				{id: idNoMatchWrongMake, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota"))})})}, note: "wrong make"},
+			}
+			filter := andFilter(valueFilter("countries.garages.cars.make", "honda"), isNullFilter("countries.name", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchInSecondCntr})
+		})
+
+		// Sub-test 19 (mixed): countries.garages.cars.make = "honda" AND
+		// countries.garages.postcode IS NULL. Same-garage correlation.
+		t.Run("mixed_L2_value_L1_leafIsNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchInSecondCntr := uuid(2)
+			idNoMatchPostcodePresent := uuid(3)
+			idNoMatchSplit := uuid(4)
+			idNoMatchWrongMake := uuid(5)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "garage with honda, no postcode"},
+				{id: idMatchInSecondCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"postcode": "10115", "cars": asArr(car("make", "toyota"))})},
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})},
+				)}, note: "second country has satisfying garage"},
+				{id: idNoMatchPostcodePresent, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"postcode": "10115", "cars": asArr(car("make", "honda"))})})}, note: "honda garage has postcode"},
+				{id: idNoMatchSplit, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(
+					map[string]any{"postcode": "10115", "cars": asArr(car("make", "honda"))},
+					map[string]any{"cars": asArr(car("make", "toyota"))},
+				)})}, note: "honda+postcode in g0; no-postcode+wrong-make in g1"},
+				{id: idNoMatchWrongMake, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota"))})})}, note: "wrong make"},
+			}
+			filter := andFilter(valueFilter("countries.garages.cars.make", "honda"), isNullFilter("countries.garages.postcode", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchInSecondCntr})
+		})
+
+		// Sub-test 20 (no-positive / rootAnchor with three excludes).
+		t.Run("L2_three_isNull_no_positive", func(t *testing.T) {
+			idMatchCarWithNothing := uuid(1)
+			idMatchInSecondCntr := uuid(2)
+			idMatchOtherFieldSurvives := uuid(3)
+			idNoMatchHasMake := uuid(4)
+			idNoMatchHasYear := uuid(5)
+			idNoMatchAllSet := uuid(6)
+			docs := []docDef{
+				{id: idMatchCarWithNothing, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(map[string]any{})})})}, note: "single car with no fields"},
+				{id: idMatchInSecondCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic", "year", "2020"))})},
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(map[string]any{})})},
+				)}, note: "second country has a car with no fields"},
+				{id: idMatchOtherFieldSurvives, props: map[string]any{"countries": asArr(map[string]any{"capital": "berlin"})}, note: "capital has fresh leaf"},
+				{id: idNoMatchHasMake, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "only leaf in cars.make exclude"},
+				{id: idNoMatchHasYear, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("year", "2020"))})})}, note: "only leaf in cars.year exclude"},
+				{id: idNoMatchAllSet, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda", "model", "civic", "year", "2020"))})})}, note: "every leaf in some exclude"},
+			}
+			filter := andFilterN(
+				isNullFilter("countries.garages.cars.make", true),
+				isNullFilter("countries.garages.cars.model", true),
+				isNullFilter("countries.garages.cars.year", true),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{idMatchCarWithNothing, idMatchInSecondCntr, idMatchOtherFieldSurvives})
+		})
+
+		// Sub-test 21: countries.garages.city = "berlin" AND
+		// countries.garages.cars IS NULL. Per-country correlation: each country
+		// is evaluated independently for same-element. Within a single country,
+		// the array-prop IsNull is universal — no cars anywhere within the
+		// country containing the berlin garage.
+		t.Run("L1_value_intermediateArrayIsNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchMultipleGarages := uuid(2)
+			idMatchInSecondCntr := uuid(3)
+			idNoMatchHasCarsSameGarage := uuid(4)
+			idNoMatchHasCarsOtherGarageSameCntr := uuid(5)
+			idNoMatchWrongCity := uuid(6)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin"})})}, note: "berlin garage, no cars"},
+				{id: idMatchMultipleGarages, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(
+					map[string]any{"city": "munich"},
+					map[string]any{"city": "berlin"},
+				)})}, note: "berlin in g1; no cars in country"},
+				{id: idMatchInSecondCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"city": "munich", "cars": asArr(car("make", "honda"))})},
+					map[string]any{"garages": asArr(map[string]any{"city": "berlin"})},
+				)}, note: "second country independently satisfies (berlin, no cars in that country)"},
+				{id: idNoMatchHasCarsSameGarage, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": asArr(car("make", "honda"))})})}, note: "berlin garage has cars"},
+				{id: idNoMatchHasCarsOtherGarageSameCntr, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(
+					map[string]any{"city": "berlin"},
+					map[string]any{"city": "munich", "cars": asArr(car("make", "honda"))},
+				)})}, note: "single country: berlin garage has no cars but other garage does — universal at country rejects"},
+				{id: idNoMatchWrongCity, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "munich"})})}, note: "wrong city"},
+			}
+			filter := andFilter(valueFilter("countries.garages.city", "berlin"), isNullFilter("countries.garages.cars", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultipleGarages, idMatchInSecondCntr})
+		})
+
+		// Sub-test 22: countries.garages.cars.make = "honda" AND
+		// countries.garages.cars.tires IS NULL. Per-country correlation; within
+		// a single country, array-prop IsNull is universal — no tires anywhere
+		// in the country that has honda.
+		t.Run("L2_value_intermediateArrayIsNull", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchMultipleCars := uuid(2)
+			idMatchInSecondCntr := uuid(3)
+			idNoMatchHasTiresSameCar := uuid(4)
+			idNoMatchHasTiresOtherCarSameCntr := uuid(5)
+			idNoMatchWrongMake := uuid(6)
+			tire := func(width string) map[string]any { return map[string]any{"width": width} }
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})})}, note: "honda car, no tires"},
+				{id: idMatchMultipleCars, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "toyota"),
+					car("make", "honda"),
+				)})})}, note: "honda in c1; no tires in country"},
+				{id: idMatchInSecondCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(map[string]any{"make": "toyota", "tires": asArr(tire("205"))})})},
+					map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "honda"))})},
+				)}, note: "second country independently satisfies"},
+				{id: idNoMatchHasTiresSameCar, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(map[string]any{"make": "honda", "tires": asArr(tire("205"))})})})}, note: "honda car has tires"},
+				{id: idNoMatchHasTiresOtherCarSameCntr, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "honda"),
+					map[string]any{"make": "toyota", "tires": asArr(tire("205"))},
+				)})})}, note: "single country: honda car has no tires but other car does — universal at country rejects"},
+				{id: idNoMatchWrongMake, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota"))})})}, note: "wrong make"},
+			}
+			filter := andFilter(valueFilter("countries.garages.cars.make", "honda"), isNullFilter("countries.garages.cars.tires", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultipleCars, idMatchInSecondCntr})
+		})
+
+		// Sub-test 23 (cross-level L1+L2): countries.garages.city = "berlin" AND
+		// countries.garages.cars.tires IS NULL. Universal at country scope:
+		// the country containing the berlin garage must have no tires anywhere
+		// within it.
+		t.Run("crossLevel_L1_value_intermediateArrayIsNull_at_L2", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchCarsNoTires := uuid(2)
+			idMatchInSecondCntr := uuid(3)
+			idNoMatchTiresInBerlinCar := uuid(4)
+			idNoMatchTiresInOtherGarageSameCntr := uuid(5)
+			idNoMatchWrongCity := uuid(6)
+			tire := func(width string) map[string]any { return map[string]any{"width": width} }
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin"})})}, note: "berlin garage, no tires anywhere"},
+				{id: idMatchCarsNoTires, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": asArr(car("make", "honda"))})})}, note: "cars but no tires"},
+				{id: idMatchInSecondCntr, props: map[string]any{"countries": asArr(
+					map[string]any{"garages": asArr(map[string]any{"city": "munich", "cars": asArr(map[string]any{"make": "honda", "tires": asArr(tire("205"))})})},
+					map[string]any{"garages": asArr(map[string]any{"city": "berlin"})},
+				)}, note: "second country has berlin garage, no tires; first country independent"},
+				{id: idNoMatchTiresInBerlinCar, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "berlin", "cars": asArr(map[string]any{"make": "honda", "tires": asArr(tire("205"))})})})}, note: "tires in berlin garage car"},
+				{id: idNoMatchTiresInOtherGarageSameCntr, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(
+					map[string]any{"city": "berlin"},
+					map[string]any{"city": "munich", "cars": asArr(map[string]any{"make": "honda", "tires": asArr(tire("205"))})},
+				)})}, note: "tires in other garage of same country — universal at country scope rejects"},
+				{id: idNoMatchWrongCity, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "munich"})})}, note: "wrong city"},
+			}
+			filter := andFilter(valueFilter("countries.garages.city", "berlin"), isNullFilter("countries.garages.cars.tires", true))
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchCarsNoTires, idMatchInSecondCntr})
+		})
+	})
+}

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -6342,3 +6342,656 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 		})
 	})
 }
+
+// TestNestedFilteringCorrelatedAndFilterExamples ports the G1-G6 / C1-C5
+// "filter examples" coverage to the DB level. Each sub-test exercises a
+// correlated AND of two or three conditions with explicit arr[N] indices
+// and/or unconstrained paths, where same-element semantics must hold at the
+// shared LCA. Each filter is run twice (forward and reversed condition order)
+// to confirm bucketing/dispatch are order-independent.
+//
+// Schema mirrors filterExamplesClass:
+//
+//	garages (object[]): city, make, postcode, cars (object[]): make, model, color
+//	countries (object[]): garages (same shape as above)
+func TestNestedFilteringCorrelatedAndFilterExamples(t *testing.T) {
+	const nestedClass = "FilterExamplesDB"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	carsProps := []*models.NestedProperty{
+		{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "model", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "color", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+	}
+	garagesProps := []*models.NestedProperty{
+		{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "postcode", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "cars", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: carsProps},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "garages", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: garagesProps},
+			{Name: "countries", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: []*models.NestedProperty{
+				{Name: "garages", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: garagesProps},
+			}},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	car := func(props ...string) map[string]any {
+		out := map[string]any{}
+		for i := 0; i < len(props); i += 2 {
+			out[props[i]] = props[i+1]
+		}
+		return out
+	}
+	garage := func(fields map[string]any, cars ...map[string]any) map[string]any {
+		out := map[string]any{}
+		for k, v := range fields {
+			out[k] = v
+		}
+		if len(cars) > 0 {
+			out["cars"] = asArr(cars...)
+		}
+		return out
+	}
+	country := func(garages ...map[string]any) map[string]any {
+		return map[string]any{"garages": asArr(garages...)}
+	}
+
+	valueFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andClauses := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: operands,
+		}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	// runOrderings runs the filter twice — once with parts in given order,
+	// once reversed — and asserts each yields want.
+	runOrderings := func(t *testing.T, docs []docDef, parts []*filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		for _, ordering := range []string{"forward", "reverse"} {
+			ordered := make([]*filters.LocalFilter, len(parts))
+			if ordering == "forward" {
+				copy(ordered, parts)
+			} else {
+				for i, p := range parts {
+					ordered[len(parts)-1-i] = p
+				}
+			}
+			res, err := db.Search(ctx, dto.GetParams{
+				ClassName:  nestedClass,
+				Pagination: &filters.Pagination{Limit: 100},
+				Filters:    andClauses(ordered...),
+			})
+			require.NoError(t, err, "ordering=%s", ordering)
+			got := make([]strfmt.UUID, len(res))
+			for i, r := range res {
+				got[i] = r.ID
+			}
+			assert.ElementsMatch(t, want, got, "ordering=%s", ordering)
+		}
+	}
+
+	// ----------------------------------------------------------------- G1-G6
+	// Top-level "garages" root.
+
+	// G1: garages[0].city = berlin AND garages[1].make = honda.
+	// Different garage indices → docID-level AND, same-doc enforced.
+	t.Run("G1_garages[0].city_AND_garages[1].make", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitDocs := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}),
+				garage(map[string]any{"make": "honda"}),
+			)}, note: "g[0].city=berlin AND g[1].make=honda"},
+			{id: idNoMatchSplitDocs, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}),
+				garage(map[string]any{"make": "toyota"}),
+			)}, note: "g[1].make wrong"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages[0].city", "berlin"),
+			valueFilter("garages[1].make", "honda"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// G2: garages.city = berlin AND garages[1].make = honda.
+	// Unconstrained city scoped to garages[1] (same-element).
+	t.Run("G2_garages.city_AND_garages[1].make", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplit := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "munich"}),
+				garage(map[string]any{"city": "berlin", "make": "honda"}),
+			)}, note: "g[1] has city=berlin AND make=honda"},
+			{id: idNoMatchSplit, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}),
+				garage(map[string]any{"make": "honda"}),
+			)}, note: "city in g[0], make in g[1] — same-element fails"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages.city", "berlin"),
+			valueFilter("garages[1].make", "honda"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// G3: garages.cars[1].make = honda AND garages.city = berlin.
+	// Unconstrained city scoped to same garage as the constrained car.
+	t.Run("G3_garages.cars[1].make_AND_garages.city", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplit := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}, car(), car("make", "honda")),
+			)}, note: "same garage has city AND cars[1].make=honda"},
+			{id: idNoMatchSplit, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}),
+				garage(map[string]any{}, car(), car("make", "honda")),
+			)}, note: "city in g[0], cars[1].make in g[1] — different garages"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages.cars[1].make", "honda"),
+			valueFilter("garages.city", "berlin"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// G4: garages.cars[1].make = honda AND garages.cars.model = civic.
+	// Unconstrained model scoped to same car (cars[1]) via groupAndAll.
+	t.Run("G4_garages.cars[1].make_AND_garages.cars.model", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplit := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(nil, car(), car("make", "honda", "model", "civic")),
+			)}, note: "cars[1] has both"},
+			{id: idNoMatchSplit, props: map[string]any{"garages": asArr(
+				garage(nil, car("model", "civic"), car("make", "honda")),
+			)}, note: "make in cars[1], model in cars[0] — different cars"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages.cars[1].make", "honda"),
+			valueFilter("garages.cars.model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// G5: garages.cars[1].make = honda AND garages.cars[2].color = red.
+	// Different car indices but root+docID AND enforces same garage.
+	t.Run("G5_garages.cars[1].make_AND_garages.cars[2].color", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitGarages := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(nil, car(), car("make", "honda"), car("color", "red")),
+			)}, note: "g[0] has cars[1].make AND cars[2].color"},
+			{id: idNoMatchSplitGarages, props: map[string]any{"garages": asArr(
+				garage(nil, car(), car("make", "honda")),
+				garage(nil, car(), car(), car("color", "red")),
+			)}, note: "make in g[0].cars[1], color in g[1].cars[2] — different garages"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages.cars[1].make", "honda"),
+			valueFilter("garages.cars[2].color", "red"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// G6: garages.city = berlin AND garages.cars.make = honda AND
+	// garages.cars.model = civic. Mixed-depth, no explicit indices.
+	// Same garage AND same car (make+model leaf-precise via groupAndAll).
+	t.Run("G6_garages.city_AND_garages.cars.{make,model}", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}, car(), car("make", "honda", "model", "civic")),
+			)}, note: "city + same-car make+model"},
+			{id: idNoMatchSplitCars, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}, car("make", "honda"), car("model", "civic")),
+			)}, note: "make in cars[0], model in cars[1] — different cars same garage"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages.city", "berlin"),
+			valueFilter("garages.cars.make", "honda"),
+			valueFilter("garages.cars.model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// G7: garages[2].city = berlin AND garages.cars[1].make = honda.
+	// Outer pinned to garages[2]; unconstrained cars[1] scoped to that same
+	// garage via runIdxLoop on garages.
+	t.Run("G7_garages[2].city_AND_garages.cars[1].make", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchMakeWrongGarage := uuid(2)
+		idNoMatchCityWrongGarage := uuid(3)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(nil), garage(nil), garage(map[string]any{"city": "berlin"}, car(), car("make", "honda")),
+			)}, note: "g[2] has city AND cars[1].make"},
+			{id: idNoMatchMakeWrongGarage, props: map[string]any{"garages": asArr(
+				garage(nil), garage(nil, car(), car("make", "honda")), garage(map[string]any{"city": "berlin"}),
+			)}, note: "city in g[2], make in g[1] — different garages"},
+			{id: idNoMatchCityWrongGarage, props: map[string]any{"garages": asArr(
+				garage(nil), garage(map[string]any{"city": "berlin"}), garage(nil, car(), car("make", "honda")),
+			)}, note: "city in g[1] (not g[2]); make in g[2]"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages[2].city", "berlin"),
+			valueFilter("garages.cars[1].make", "honda"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// G8: garages.cars.make = honda AND garages.cars.model = civic. Pure
+	// unconstrained correlation at cars level; same-car required via
+	// groupAndAll (no arr[N] anywhere).
+	t.Run("G8_garages.cars.make_AND_garages.cars.model", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		idNoMatchSplitGarages := uuid(3)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(nil, car("make", "honda", "model", "civic")),
+			)}, note: "single car has both"},
+			{id: idNoMatchSplitCars, props: map[string]any{"garages": asArr(
+				garage(nil, car("make", "honda"), car("model", "civic")),
+			)}, note: "make in cars[0], model in cars[1] — different cars same garage"},
+			{id: idNoMatchSplitGarages, props: map[string]any{"garages": asArr(
+				garage(nil, car("make", "honda")),
+				garage(nil, car("model", "civic")),
+			)}, note: "make in g[0].cars, model in g[1].cars — different garages"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages.cars.make", "honda"),
+			valueFilter("garages.cars.model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// G9: garages[1].city = berlin AND garages[1].make = honda. Same arr[N]
+	// index on both conditions; single-bucket split holds both conditions in
+	// the same bucket.
+	t.Run("G9_garages[1].city_AND_garages[1].make", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchAtIdx0 := uuid(2)
+		idNoMatchSplitIndices := uuid(3)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(nil), garage(map[string]any{"city": "berlin", "make": "honda"}),
+			)}, note: "g[1] has both"},
+			{id: idNoMatchAtIdx0, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin", "make": "honda"}),
+			)}, note: "both at g[0] — wrong index"},
+			{id: idNoMatchSplitIndices, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}), garage(map[string]any{"make": "honda"}),
+			)}, note: "city at g[0], make at g[1] — neither index has both"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages[1].city", "berlin"),
+			valueFilter("garages[1].make", "honda"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// G10: garages[0].city = berlin AND garages[1].make = honda AND
+	// garages[2].postcode = "10115". Three different arr[N] indices →
+	// three-way multi-bucket split at garages.
+	t.Run("G10_garages[0].city_AND_garages[1].make_AND_garages[2].postcode", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchMissingThird := uuid(2)
+		idNoMatchWrongIndex := uuid(3)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}),
+				garage(map[string]any{"make": "honda"}),
+				garage(map[string]any{"postcode": "10115"}),
+			)}, note: "all three indices satisfied"},
+			{id: idNoMatchMissingThird, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}),
+				garage(map[string]any{"make": "honda"}),
+			)}, note: "g[2] missing"},
+			{id: idNoMatchWrongIndex, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}),
+				garage(map[string]any{"make": "honda", "postcode": "10115"}),
+			)}, note: "postcode at g[1] not g[2]"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages[0].city", "berlin"),
+			valueFilter("garages[1].make", "honda"),
+			valueFilter("garages[2].postcode", "10115"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// ----------------------------------------------------------------- C1-C10
+	// Top-level "countries" root. Each Cn mirrors Gn one level deeper:
+	// G's "garages" → C's "countries.garages", G's "garages.cars" → C's
+	// "countries.garages.cars".
+
+	// C1 (mirror of G1): countries.garages[0].city = berlin AND
+	// countries.garages[1].make = honda. Different garages within a country →
+	// split at garages enforces same country implicitly via root+docID AND.
+	t.Run("C1_countries.garages[0].city_AND_countries.garages[1].make", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCntr := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"}), garage(map[string]any{"make": "honda"})),
+			)}, note: "country[0]: g[0].city AND g[1].make"},
+			{id: idNoMatchSplitCntr, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"})),
+				country(garage(nil), garage(map[string]any{"make": "honda"})),
+			)}, note: "city in c[0], make in c[1] — different countries"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages[0].city", "berlin"),
+			valueFilter("countries.garages[1].make", "honda"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// C2 (mirror of G2): countries.garages.city = berlin AND
+	// countries.garages[1].make = honda. Unconstrained city scoped to
+	// garages[1] (same-element).
+	t.Run("C2_countries.garages.city_AND_countries.garages[1].make", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitGarages := uuid(2)
+		idNoMatchSplitCntr := uuid(3)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "munich"}), garage(map[string]any{"city": "berlin", "make": "honda"})),
+			)}, note: "g[1] has city=berlin AND make=honda"},
+			{id: idNoMatchSplitGarages, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"}), garage(map[string]any{"make": "honda"})),
+			)}, note: "city in g[0], make in g[1] within same country — same-element fails"},
+			{id: idNoMatchSplitCntr, props: map[string]any{"countries": asArr(
+				country(garage(nil), garage(map[string]any{"city": "berlin"})),
+				country(garage(nil), garage(map[string]any{"make": "honda"})),
+			)}, note: "city in c[0].g[1], make in c[1].g[1] — different countries"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages.city", "berlin"),
+			valueFilter("countries.garages[1].make", "honda"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// C3 (mirror of G3): countries.garages.cars[1].make = honda AND
+	// countries.garages.city = berlin. Unconstrained city scoped to same
+	// garage as the constrained car.
+	t.Run("C3_countries.garages.cars[1].make_AND_countries.garages.city", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitGarages := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"}, car(), car("make", "honda"))),
+			)}, note: "same garage has city AND cars[1].make"},
+			{id: idNoMatchSplitGarages, props: map[string]any{"countries": asArr(
+				country(
+					garage(map[string]any{"city": "berlin"}),
+					garage(nil, car(), car("make", "honda")),
+				),
+			)}, note: "city in g[0], cars[1].make in g[1] within same country"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages.cars[1].make", "honda"),
+			valueFilter("countries.garages.city", "berlin"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// C4 (mirror of G4): countries.garages.cars[1].make = honda AND
+	// countries.garages.cars.model = civic. Same car required.
+	t.Run("C4_countries.garages.cars[1].make_AND_countries.garages.cars.model", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(nil, car(), car("make", "honda", "model", "civic"))),
+			)}, note: "cars[1] has both"},
+			{id: idNoMatchSplitCars, props: map[string]any{"countries": asArr(
+				country(garage(nil, car("model", "civic"), car("make", "honda"))),
+			)}, note: "make in cars[1], model in cars[0]"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages.cars[1].make", "honda"),
+			valueFilter("countries.garages.cars.model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// C5 (mirror of G5): countries.garages.cars[1].make = honda AND
+	// countries.garages.cars[2].color = red. Different car indices, same
+	// garage required (root+docID AND enforces same country implicitly).
+	t.Run("C5_countries.garages.cars[1].make_AND_countries.garages.cars[2].color", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitGarages := uuid(2)
+		idNoMatchSplitCntr := uuid(3)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(nil, car(), car("make", "honda"), car("color", "red"))),
+			)}, note: "same garage: cars[1].make AND cars[2].color"},
+			{id: idNoMatchSplitGarages, props: map[string]any{"countries": asArr(
+				country(
+					garage(nil, car(), car("make", "honda")),
+					garage(nil, car(), car(), car("color", "red")),
+				),
+			)}, note: "make in g[0], color in g[1] within same country — different garages"},
+			{id: idNoMatchSplitCntr, props: map[string]any{"countries": asArr(
+				country(garage(nil, car(), car("make", "honda"))),
+				country(garage(nil, car(), car(), car("color", "red"))),
+			)}, note: "make in c[0], color in c[1] — different countries"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages.cars[1].make", "honda"),
+			valueFilter("countries.garages.cars[2].color", "red"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// C6 (mirror of G6): countries.garages.city = berlin AND
+	// countries.garages.cars.make = honda AND countries.garages.cars.model = civic.
+	// Mixed depth, no indices. Same garage AND same car required.
+	t.Run("C6_countries.garages.city_AND_countries.garages.cars.{make,model}", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		idNoMatchSplitGarages := uuid(3)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"}, car(), car("make", "honda", "model", "civic"))),
+			)}, note: "city + same-car make+model in same garage"},
+			{id: idNoMatchSplitCars, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"}, car("make", "honda"), car("model", "civic"))),
+			)}, note: "make in cars[0], model in cars[1] — different cars same garage"},
+			{id: idNoMatchSplitGarages, props: map[string]any{"countries": asArr(
+				country(
+					garage(map[string]any{"city": "berlin"}),
+					garage(nil, car("make", "honda", "model", "civic")),
+				),
+			)}, note: "city in g[0], same-car make+model in g[1] — different garages"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages.city", "berlin"),
+			valueFilter("countries.garages.cars.make", "honda"),
+			valueFilter("countries.garages.cars.model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// C7 (mirror of G7): countries.garages[2].city = berlin AND
+	// countries.garages.cars[1].make = honda. City pinned to garages[2];
+	// unconstrained make scoped to same garage.
+	t.Run("C7_countries.garages[2].city_AND_countries.garages.cars[1].make", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchMakeWrongGarage := uuid(2)
+		idNoMatchCityWrongGarage := uuid(3)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(nil), garage(nil), garage(map[string]any{"city": "berlin"}, car(), car("make", "honda"))),
+			)}, note: "g[2] has city AND cars[1].make"},
+			{id: idNoMatchMakeWrongGarage, props: map[string]any{"countries": asArr(
+				country(
+					garage(nil),
+					garage(nil, car(), car("make", "honda")),
+					garage(map[string]any{"city": "berlin"}),
+				),
+			)}, note: "city in g[2], make in g[1] — different garages"},
+			{id: idNoMatchCityWrongGarage, props: map[string]any{"countries": asArr(
+				country(
+					garage(nil),
+					garage(map[string]any{"city": "berlin"}),
+					garage(nil, car(), car("make", "honda")),
+				),
+			)}, note: "city in g[1] (not g[2]); make in g[2]"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages[2].city", "berlin"),
+			valueFilter("countries.garages.cars[1].make", "honda"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// C8 (mirror of G8): countries.garages.cars.make = honda AND
+	// countries.garages.cars.model = civic. Pure unconstrained correlation at
+	// cars level; same-car required via groupAndAll.
+	t.Run("C8_countries.garages.cars.make_AND_countries.garages.cars.model", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		idNoMatchSplitGarages := uuid(3)
+		idNoMatchSplitCntr := uuid(4)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(nil, car("make", "honda", "model", "civic"))),
+			)}, note: "single car has both"},
+			{id: idNoMatchSplitCars, props: map[string]any{"countries": asArr(
+				country(garage(nil, car("make", "honda"), car("model", "civic"))),
+			)}, note: "make in cars[0], model in cars[1] — different cars"},
+			{id: idNoMatchSplitGarages, props: map[string]any{"countries": asArr(
+				country(garage(nil, car("make", "honda")), garage(nil, car("model", "civic"))),
+			)}, note: "make in g[0].cars, model in g[1].cars within same country"},
+			{id: idNoMatchSplitCntr, props: map[string]any{"countries": asArr(
+				country(garage(nil, car("make", "honda"))),
+				country(garage(nil, car("model", "civic"))),
+			)}, note: "make in c[0], model in c[1] — different countries"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages.cars.make", "honda"),
+			valueFilter("countries.garages.cars.model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// C9 (mirror of G9): countries.garages[1].city = berlin AND
+	// countries.garages[1].make = honda. Same arr[N] index on both conditions.
+	t.Run("C9_countries.garages[1].city_AND_countries.garages[1].make", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchAtIdx0 := uuid(2)
+		idNoMatchSplitIndices := uuid(3)
+		idNoMatchSplitCntr := uuid(4)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(nil), garage(map[string]any{"city": "berlin", "make": "honda"})),
+			)}, note: "c[0].g[1] has both"},
+			{id: idNoMatchAtIdx0, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin", "make": "honda"})),
+			)}, note: "both at g[0] — wrong index"},
+			{id: idNoMatchSplitIndices, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"}), garage(map[string]any{"make": "honda"})),
+			)}, note: "city at g[0], make at g[1] — neither index has both"},
+			{id: idNoMatchSplitCntr, props: map[string]any{"countries": asArr(
+				country(garage(nil), garage(map[string]any{"city": "berlin"})),
+				country(garage(nil), garage(map[string]any{"make": "honda"})),
+			)}, note: "city in c[0].g[1], make in c[1].g[1] — different countries"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages[1].city", "berlin"),
+			valueFilter("countries.garages[1].make", "honda"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// C10 (mirror of G10): countries.garages[0].city = berlin AND
+	// countries.garages[1].make = honda AND countries.garages[2].postcode =
+	// "10115". Three-way multi-bucket split at garages within a country.
+	t.Run("C10_countries.garages[0].city_AND_countries.garages[1].make_AND_countries.garages[2].postcode", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchMissingThird := uuid(2)
+		idNoMatchSplitCntr := uuid(3)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(
+					garage(map[string]any{"city": "berlin"}),
+					garage(map[string]any{"make": "honda"}),
+					garage(map[string]any{"postcode": "10115"}),
+				),
+			)}, note: "all three indices satisfied within same country"},
+			{id: idNoMatchMissingThird, props: map[string]any{"countries": asArr(
+				country(
+					garage(map[string]any{"city": "berlin"}),
+					garage(map[string]any{"make": "honda"}),
+				),
+			)}, note: "g[2] missing"},
+			{id: idNoMatchSplitCntr, props: map[string]any{"countries": asArr(
+				country(
+					garage(map[string]any{"city": "berlin"}),
+					garage(map[string]any{"make": "honda"}),
+				),
+				country(
+					garage(nil), garage(nil),
+					garage(map[string]any{"postcode": "10115"}),
+				),
+			)}, note: "city+make in c[0], postcode in c[1] — different countries"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages[0].city", "berlin"),
+			valueFilter("countries.garages[1].make", "honda"),
+			valueFilter("countries.garages[2].postcode", "10115"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+}

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -10394,3 +10394,152 @@ func TestNestedFilteringSamePathMultiValueNonTokenized(t *testing.T) {
 		runDocs(t, class2, docs, filter, []strfmt.UUID{idMatch, idMatchSecondCar})
 	})
 }
+
+// TestNestedFilteringContextCancellation verifies that a cancelled context
+// propagates correctly through db.Search → nested-filter dispatch and is
+// returned as context.Canceled. Mirrors the lower-level
+// TestRecExecutorContextCancellation but at the production read path.
+//
+// Each sub-test exercises a different executor entry path:
+//   - simple value (canUseRawAndAll)
+//   - correlated AND with subs (runIdxLoopRecursive)
+//   - IsNull standalone (rootAnchor)
+//   - conflicting arr[N] partition (split)
+//
+// The lower-level test covers per-path internals (top-level + inner
+// guards); this DB-level test verifies that whichever path the dispatch
+// chooses, db.Search surfaces the cancellation correctly.
+func TestNestedFilteringContextCancellation(t *testing.T) {
+	const nestedClass = "CtxCancel"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{{
+			Name:     "countries",
+			DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{{
+				Name:     "garages",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+					{Name: "postcode", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+					{
+						Name:     "cars",
+						DataType: schema.DataTypeObjectArray.PropString(),
+						NestedProperties: []*models.NestedProperty{
+							{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+							{
+								Name: "tires", DataType: schema.DataTypeObjectArray.PropString(),
+								NestedProperties: []*models.NestedProperty{
+									{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+								},
+							},
+						},
+					},
+				},
+			}},
+		}},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+
+	db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+	bgCtx := context.Background()
+
+	id1 := strfmt.UUID("00000000-0000-0000-0000-000000000001")
+	require.NoError(t, db.PutObject(bgCtx, &models.Object{
+		Class: nestedClass, ID: id1,
+		Properties: map[string]any{"countries": asArr(map[string]any{
+			"garages": asArr(map[string]any{
+				"city": "berlin", "postcode": "10115",
+				"cars": asArr(map[string]any{"make": "honda", "tires": asArr(map[string]any{"width": 205})}),
+			}),
+		})},
+	}, nil, nil, nil, nil, 0))
+
+	textFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	intFilter := func(path string, val int) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeInt, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	isNullFilter := func(path string, isNull bool) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorIsNull,
+			Value:    &filters.Value{Type: schema.DataTypeBoolean, Value: isNull},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+
+	cancelled := func() context.Context {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		return ctx
+	}
+
+	runCancelled := func(t *testing.T, filter *filters.LocalFilter) {
+		t.Helper()
+		_, err := db.Search(cancelled(), dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.Error(t, err, "expected cancellation error")
+		require.ErrorIs(t, err, context.Canceled, "expected context.Canceled, got: %v", err)
+	}
+
+	// canUseRawAndAll path: a single positive at intermediate scope —
+	// GROUP@"garages.cars" with one here, no subs. Cancellation must surface
+	// before the AndAll runs.
+	t.Run("simple_value_canUseRawAndAll_path", func(t *testing.T) {
+		runCancelled(t, textFilter("countries.garages.cars.make", "honda"))
+	})
+
+	// runIdxLoopRecursive path: two clauses at different LCAs forces evalGroup
+	// into the idx-loop branch (subs reject canUseRawAndAll).
+	t.Run("correlated_AND_idxLoopRecursive_path", func(t *testing.T) {
+		runCancelled(t, andFilter(
+			textFilter("countries.garages.postcode", "10115"),
+			intFilter("countries.garages.cars.tires.width", 205),
+		))
+	})
+
+	// rootAnchor path: standalone IsNull falls through to rootAnchor seeding.
+	t.Run("isNull_rootAnchor_path", func(t *testing.T) {
+		runCancelled(t, isNullFilter("countries.garages.cars.make", false))
+	})
+
+	// SPLIT path: two arr[N] indices on the same LCA → SPLIT@"garages" with
+	// two branches. The cancellation must surface before evalSplit's branch
+	// loop completes.
+	t.Run("conflicting_arrN_split_path", func(t *testing.T) {
+		runCancelled(t, andFilter(
+			textFilter("countries.garages[0].city", "berlin"),
+			textFilter("countries.garages[1].city", "munich"),
+		))
+	})
+}

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -8499,3 +8499,439 @@ func TestNestedFilteringMixedArrayIndexConstraints(t *testing.T) {
 		})
 	})
 }
+
+// TestNestedFilteringIsNullWithArrayIndex covers IsNull / IsNotNull combined
+// with arr[N] in *standalone* form (no AND wrapper). Three shapes:
+//   - addresses[N] IsNull/IsNotNull  → existence of a Nth element in the array
+//   - addresses[N].leaf IsNull/IsNotNull → presence of leaf within the Nth element
+//
+// IsNotNull (IsNull=false) returns docs where the Nth element exists AND the
+// queried path is present at that element. IsNull=true is the complement
+// (denylist) under current universal semantics.
+//
+// The existing TestNestedFilteringIsNullStandalone covers IsNull at all
+// nesting levels but never with arr[N]; the existing
+// TestNestedFilteringIsNullWithArrNInCorrelatedAnd always combines IsNull with
+// a value clause. This test fills the standalone+arr[N] gap.
+func TestNestedFilteringIsNullWithArrayIndex(t *testing.T) {
+	const nestedClass = "IsNullArrIdx"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	rootProps := []*models.NestedProperty{
+		{
+			Name: "addresses", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+			},
+		},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "doc", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+			{Name: "docs", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	addr := func(props ...any) map[string]any {
+		out := map[string]any{}
+		for i := 0; i < len(props); i += 2 {
+			out[props[i].(string)] = props[i+1]
+		}
+		return out
+	}
+
+	isNullFilter := func(path string, isNull bool) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorIsNull,
+			Value:    &filters.Value{Type: schema.DataTypeBoolean, Value: isNull},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	// ---------- DataTypeObject (top-level "doc") ----------
+	t.Run("doc_object", func(t *testing.T) {
+		// docs share across the four sub-tests:
+		//   doc1: addresses=[{city:berlin},{city:paris}] — both elements have city
+		//   doc2: addresses=[{city:berlin},{}]          — [0] has city, [1] is empty
+		//   doc3: addresses=[{city:berlin}]              — only [0]; no [1]
+		//   doc4: addresses=[]                           — empty array
+		//   doc5: doc has no addresses key               — absent entirely
+		idBoth := uuid(1)
+		idSecondNoCity := uuid(2)
+		idOnlyOne := uuid(3)
+		idEmpty := uuid(4)
+		idAbsent := uuid(5)
+		docs := []docDef{
+			{id: idBoth, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("city", "berlin"), addr("city", "paris"))}}, note: "[1] has city"},
+			{id: idSecondNoCity, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("city", "berlin"), addr())}}, note: "[1] is empty (no city)"},
+			{id: idOnlyOne, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("city", "berlin"))}}, note: "only [0]; no [1]"},
+			{id: idEmpty, props: map[string]any{"doc": map[string]any{"addresses": []any{}}}, note: "empty addresses"},
+			{id: idAbsent, props: map[string]any{"doc": map[string]any{}}, note: "no addresses key"},
+		}
+
+		t.Run("addresses[1]_IsNotNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.addresses[1]", false), []strfmt.UUID{idBoth, idSecondNoCity})
+		})
+		t.Run("addresses[1]_IsNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.addresses[1]", true), []strfmt.UUID{idOnlyOne, idEmpty, idAbsent})
+		})
+		t.Run("addresses[1].city_IsNotNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.addresses[1].city", false), []strfmt.UUID{idBoth})
+		})
+		t.Run("addresses[1].city_IsNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.addresses[1].city", true), []strfmt.UUID{idSecondNoCity, idOnlyOne, idEmpty, idAbsent})
+		})
+	})
+
+	// ---------- DataTypeObjectArray (top-level "docs") ----------
+	t.Run("docs_array", func(t *testing.T) {
+		// Tests root-level arr[N] applied to IsNull (docs[N]).
+		idBoth := uuid(1)         // docs=[{addr=[{berlin}]},{addr=[{paris}]}]
+		idSecondNoAddr := uuid(2) // docs=[{addr=[{berlin}]},{}]
+		idOnlyOne := uuid(3)      // docs=[{addr=[{berlin}]}]
+		idEmpty := uuid(4)        // docs=[]
+		idAbsent := uuid(5)       // no docs key
+		docs := []docDef{
+			{id: idBoth, props: map[string]any{"docs": asArr(
+				map[string]any{"addresses": asArr(addr("city", "berlin"))},
+				map[string]any{"addresses": asArr(addr("city", "paris"))},
+			)}, note: "docs[1] has addresses"},
+			{id: idSecondNoAddr, props: map[string]any{"docs": asArr(
+				map[string]any{"addresses": asArr(addr("city", "berlin"))},
+				map[string]any{},
+			)}, note: "docs[1] empty (no addresses)"},
+			{id: idOnlyOne, props: map[string]any{"docs": asArr(
+				map[string]any{"addresses": asArr(addr("city", "berlin"))},
+			)}, note: "only docs[0]"},
+			{id: idEmpty, props: map[string]any{"docs": []any{}}, note: "empty docs"},
+			{id: idAbsent, props: map[string]any{}, note: "no docs key"},
+		}
+
+		t.Run("docs[1]_IsNotNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("docs[1]", false), []strfmt.UUID{idBoth, idSecondNoAddr})
+		})
+		t.Run("docs[1]_IsNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("docs[1]", true), []strfmt.UUID{idOnlyOne, idEmpty, idAbsent})
+		})
+		t.Run("docs[1].addresses.city_IsNotNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("docs[1].addresses.city", false), []strfmt.UUID{idBoth})
+		})
+		t.Run("docs[1].addresses.city_IsNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("docs[1].addresses.city", true), []strfmt.UUID{idSecondNoAddr, idOnlyOne, idEmpty, idAbsent})
+		})
+	})
+}
+
+// TestNestedFilteringIsNullArrayIndexFollowups fills four IsNull-cluster
+// coverage gaps surfaced by audit:
+//
+//  1. Multi-level arr[N] + IsNull standalone — `cars[1].tires[0] IsNotNull`,
+//     `cars[1].tires[0].width IsNotNull`. Existing IsNull+arr[N] tests use a
+//     single arr[N] segment; multi-level pin with IsNull is its own dispatch
+//     path.
+//  2. Multi-level nested object[] standalone IsNull (no arr[N]) —
+//     `cars.tires IsNotNull`, `cars.tires.width IsNotNull`. The existing
+//     standalone test uses single-level object[] (addresses); deeper nested
+//     paths exercise different lcaPath / restriction logic.
+//  3. text[] (scalar array) IsNull combined with arr[N] —
+//     `addresses[1].tags IsNotNull`. text[] IsNull is covered standalone in
+//     IsNullStandalone, but never with an arr[N] restriction on its parent.
+//  4. Mixed constrained/unconstrained IsNull in correlated AND —
+//     `addresses.tags IsNotNull AND addresses[1].city = berlin`. The IsNotNull
+//     side has empty constraints, the value side pins addresses[1];
+//     compatibility grouping puts both in the same group, forcing the
+//     IsNotNull to be satisfied at the same address as the value clause.
+func TestNestedFilteringIsNullArrayIndexFollowups(t *testing.T) {
+	const nestedClass = "IsNullArrFollowups"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	rootProps := []*models.NestedProperty{
+		{
+			Name: "addresses", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+			},
+		},
+		{
+			Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{
+					Name: "tires", DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+					},
+				},
+			},
+		},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "doc", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	tire := func(width ...int) map[string]any {
+		if len(width) == 0 {
+			return map[string]any{}
+		}
+		return map[string]any{"width": width[0]}
+	}
+	car := func(props ...any) map[string]any {
+		out := map[string]any{}
+		for i := 0; i < len(props); i += 2 {
+			out[props[i].(string)] = props[i+1]
+		}
+		return out
+	}
+	addr := func(props ...any) map[string]any {
+		out := map[string]any{}
+		for i := 0; i < len(props); i += 2 {
+			out[props[i].(string)] = props[i+1]
+		}
+		return out
+	}
+	tagsAny := func(tags ...string) []any {
+		out := make([]any, len(tags))
+		for i, t := range tags {
+			out[i] = t
+		}
+		return out
+	}
+
+	textFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	isNullFilter := func(path string, isNull bool) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorIsNull,
+			Value:    &filters.Value{Type: schema.DataTypeBoolean, Value: isNull},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	// ----- 1. Multi-level arr[N] + IsNull standalone -----
+	t.Run("multi_level_arrN_cars[1].tires[0]_IsNull", func(t *testing.T) {
+		idCar1HasTireWithWidth := uuid(1) // cars=[{},{tires:[{305}]}]
+		idCar1HasEmptyTire := uuid(2)     // cars=[{},{tires:[{}]}]      (tire exists, no width)
+		idCar1NoTires := uuid(3)          // cars=[{},{}]
+		idNoCar1 := uuid(4)               // cars=[{tires:[{305}]}]      (only cars[0])
+		idAbsent := uuid(5)               // no cars
+
+		docs := []docDef{
+			{id: idCar1HasTireWithWidth, props: map[string]any{"doc": map[string]any{"cars": asArr(car(), car("tires", asArr(tire(305))))}}, note: "cars[1].tires[0]={width:305}"},
+			{id: idCar1HasEmptyTire, props: map[string]any{"doc": map[string]any{"cars": asArr(car(), car("tires", asArr(tire())))}}, note: "cars[1].tires[0]={} (no width)"},
+			{id: idCar1NoTires, props: map[string]any{"doc": map[string]any{"cars": asArr(car(), car())}}, note: "cars[1] has no tires"},
+			{id: idNoCar1, props: map[string]any{"doc": map[string]any{"cars": asArr(car("tires", asArr(tire(305))))}}, note: "only cars[0]; no cars[1]"},
+			{id: idAbsent, props: map[string]any{"doc": map[string]any{}}, note: "no cars at all"},
+		}
+
+		t.Run("cars[1].tires[0]_IsNotNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.cars[1].tires[0]", false),
+				[]strfmt.UUID{idCar1HasTireWithWidth, idCar1HasEmptyTire})
+		})
+		t.Run("cars[1].tires[0]_IsNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.cars[1].tires[0]", true),
+				[]strfmt.UUID{idCar1NoTires, idNoCar1, idAbsent})
+		})
+		t.Run("cars[1].tires[0].width_IsNotNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.cars[1].tires[0].width", false),
+				[]strfmt.UUID{idCar1HasTireWithWidth})
+		})
+		t.Run("cars[1].tires[0].width_IsNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.cars[1].tires[0].width", true),
+				[]strfmt.UUID{idCar1HasEmptyTire, idCar1NoTires, idNoCar1, idAbsent})
+		})
+	})
+
+	// ----- 2. Multi-level nested object[] standalone IsNull (no arr[N]) -----
+	t.Run("multi_level_nested_objArr_cars.tires_IsNull", func(t *testing.T) {
+		idAllTires := uuid(1)       // cars=[{tires:[{305}]}]
+		idSecondCarTires := uuid(2) // cars=[{},{tires:[{305}]}]
+		idTiresNoWidth := uuid(3)   // cars=[{tires:[{}]}]              (tires exist, no width)
+		idCarsNoTires := uuid(4)    // cars=[{}]
+		idAbsent := uuid(5)         // no cars
+		docs := []docDef{
+			{id: idAllTires, props: map[string]any{"doc": map[string]any{"cars": asArr(car("tires", asArr(tire(305))))}}, note: "cars[0].tires[0]={width:305}"},
+			{id: idSecondCarTires, props: map[string]any{"doc": map[string]any{"cars": asArr(car(), car("tires", asArr(tire(305))))}}, note: "tires only in cars[1]"},
+			{id: idTiresNoWidth, props: map[string]any{"doc": map[string]any{"cars": asArr(car("tires", asArr(tire())))}}, note: "tires exist but no width"},
+			{id: idCarsNoTires, props: map[string]any{"doc": map[string]any{"cars": asArr(car())}}, note: "cars[0] has no tires"},
+			{id: idAbsent, props: map[string]any{"doc": map[string]any{}}, note: "no cars"},
+		}
+
+		// Universal: tires/width IsNull matches docs where the property is absent
+		// everywhere within the addressed scope.
+		t.Run("cars.tires_IsNotNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.cars.tires", false),
+				[]strfmt.UUID{idAllTires, idSecondCarTires, idTiresNoWidth})
+		})
+		t.Run("cars.tires_IsNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.cars.tires", true),
+				[]strfmt.UUID{idCarsNoTires, idAbsent})
+		})
+		t.Run("cars.tires.width_IsNotNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.cars.tires.width", false),
+				[]strfmt.UUID{idAllTires, idSecondCarTires})
+		})
+		t.Run("cars.tires.width_IsNull_universal", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.cars.tires.width", true),
+				[]strfmt.UUID{idTiresNoWidth, idCarsNoTires, idAbsent})
+		})
+	})
+
+	// ----- 3. text[] IsNull combined with arr[N] standalone -----
+	t.Run("text_array_with_arrN_addresses[1].tags_IsNull", func(t *testing.T) {
+		idBothHaveTags := uuid(1) // addresses=[{tags:[a]},{tags:[b]}]
+		idSecondNoTags := uuid(2) // addresses=[{tags:[a]},{}]
+		idOnlyFirst := uuid(3)    // addresses=[{tags:[a]}]
+		idAbsent := uuid(4)       // no addresses
+		docs := []docDef{
+			{id: idBothHaveTags, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("tags", tagsAny("a")), addr("tags", tagsAny("b")))}}, note: "[1] has tags=[b]"},
+			{id: idSecondNoTags, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("tags", tagsAny("a")), addr())}}, note: "[1] is empty (no tags)"},
+			{id: idOnlyFirst, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("tags", tagsAny("a")))}}, note: "only [0]; no [1]"},
+			{id: idAbsent, props: map[string]any{"doc": map[string]any{}}, note: "no addresses"},
+		}
+
+		t.Run("addresses[1].tags_IsNotNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.addresses[1].tags", false), []strfmt.UUID{idBothHaveTags})
+		})
+		t.Run("addresses[1].tags_IsNull", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("doc.addresses[1].tags", true),
+				[]strfmt.UUID{idSecondNoTags, idOnlyFirst, idAbsent})
+		})
+	})
+
+	// ----- 4. Mixed constrained/unconstrained IsNull in correlated AND -----
+	// `addresses.tags IsNotNull AND addresses[1].city = berlin`.
+	// IsNotNull is unconstrained (empty arrayIndices); value pins addresses[1].
+	// Compatibility grouping puts both in the same group → same-element AND
+	// forces tags to be present at the same address as city=berlin (i.e., [1]).
+	t.Run("mixed_constrained_unconstrained_isNull_AND_value", func(t *testing.T) {
+		idMatch1 := uuid(1)                 // [{munich,a},{berlin,b}] — [1] has city+tags
+		idMatch2 := uuid(2)                 // [{berlin,a},{berlin,b}] — [1] has city+tags
+		idNoMatchSecondNoTags := uuid(3)    // [{berlin,a},{berlin}] — [1] has city but no tags
+		idNoMatchOnlyFirst := uuid(4)       // [{berlin,a}] — only [0]
+		idNoMatchTagsAtFirstOnly := uuid(5) // [{munich,a},{berlin}] — [1] city ok, no tags; tags only at [0]
+		docs := []docDef{
+			{id: idMatch1, props: map[string]any{"doc": map[string]any{"addresses": asArr(
+				addr("city", "munich", "tags", tagsAny("a")),
+				addr("city", "berlin", "tags", tagsAny("b")),
+			)}}, note: "[1] city=berlin AND tags present"},
+			{id: idMatch2, props: map[string]any{"doc": map[string]any{"addresses": asArr(
+				addr("city", "berlin", "tags", tagsAny("a")),
+				addr("city", "berlin", "tags", tagsAny("b")),
+			)}}, note: "both have berlin and tags"},
+			{id: idNoMatchSecondNoTags, props: map[string]any{"doc": map[string]any{"addresses": asArr(
+				addr("city", "berlin", "tags", tagsAny("a")),
+				addr("city", "berlin"),
+			)}}, note: "[1] city=berlin but no tags; tags only at [0]"},
+			{id: idNoMatchOnlyFirst, props: map[string]any{"doc": map[string]any{"addresses": asArr(
+				addr("city", "berlin", "tags", tagsAny("a")),
+			)}}, note: "only [0]"},
+			{id: idNoMatchTagsAtFirstOnly, props: map[string]any{"doc": map[string]any{"addresses": asArr(
+				addr("city", "munich", "tags", tagsAny("a")),
+				addr("city", "berlin"),
+			)}}, note: "[1] city=berlin; tags only at [0] (different address)"},
+		}
+
+		filter := andFilter(
+			isNullFilter("doc.addresses.tags", false),
+			textFilter("doc.addresses[1].city", "berlin"),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatch1, idMatch2})
+	})
+}

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -6995,3 +6995,616 @@ func TestNestedFilteringCorrelatedAndFilterExamples(t *testing.T) {
 		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
 	})
 }
+
+// TestNestedFilteringCorrelatedAndFilterExamplesIndexed ports the F1-F12 / F14
+// indexed filter examples to the DB level. Each is a 4-condition filter with
+// arr[N] constraints at one or more depths. Sub-tests are forward and reverse
+// ordered to confirm bucketing/dispatch are order-independent.
+//
+// Schema extends FilterExamplesClass with two object[] sub-arrays inside cars
+// (accessories and tires) and a text[] tags field.
+func TestNestedFilteringCorrelatedAndFilterExamplesIndexed(t *testing.T) {
+	const nestedClass = "FilterExamplesIndexedDB"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	carsProps := []*models.NestedProperty{
+		{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "model", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "color", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "accessories", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: []*models.NestedProperty{
+			{Name: "type", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		}},
+		{Name: "tires", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: []*models.NestedProperty{
+			{Name: "width", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		}},
+	}
+	garagesProps := []*models.NestedProperty{
+		{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "postcode", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "cars", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: carsProps},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "garages", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: garagesProps},
+			{Name: "countries", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: []*models.NestedProperty{
+				{Name: "garages", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: garagesProps},
+			}},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	tire := func(width string) map[string]any { return map[string]any{"width": width} }
+	accessory := func(typ string) map[string]any { return map[string]any{"type": typ} }
+	garage := func(fields map[string]any, cars ...map[string]any) map[string]any {
+		out := map[string]any{}
+		for k, v := range fields {
+			out[k] = v
+		}
+		if len(cars) > 0 {
+			out["cars"] = asArr(cars...)
+		}
+		return out
+	}
+	country := func(garages ...map[string]any) map[string]any {
+		return map[string]any{"garages": asArr(garages...)}
+	}
+
+	valueFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andClauses := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: operands,
+		}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	runOrderings := func(t *testing.T, docs []docDef, parts []*filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		for _, ordering := range []string{"forward", "reverse"} {
+			ordered := make([]*filters.LocalFilter, len(parts))
+			if ordering == "forward" {
+				copy(ordered, parts)
+			} else {
+				for i, p := range parts {
+					ordered[len(parts)-1-i] = p
+				}
+			}
+			res, err := db.Search(ctx, dto.GetParams{
+				ClassName:  nestedClass,
+				Pagination: &filters.Pagination{Limit: 100},
+				Filters:    andClauses(ordered...),
+			})
+			require.NoError(t, err, "ordering=%s", ordering)
+			got := make([]strfmt.UUID, len(res))
+			for i, r := range res {
+				got[i] = r.ID
+			}
+			assert.ElementsMatch(t, want, got, "ordering=%s", ordering)
+		}
+	}
+
+	carWith := func(fields map[string]any) map[string]any {
+		out := map[string]any{}
+		for k, v := range fields {
+			out[k] = v
+		}
+		return out
+	}
+
+	// F1: garages-rooted. garages[0].city AND garages[1].postcode AND
+	// garages[1].cars.{make, model}. Split at garages with two buckets;
+	// within g[1] same-car required for make+model.
+	t.Run("F1_garages[0].city_AND_garages[1].postcode_AND_garages[1].cars.{make,model}", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}),
+				garage(map[string]any{"postcode": "12345"}, carWith(map[string]any{"make": "honda", "model": "civic"})),
+			)}, note: "g[0].city + g[1].{postcode,cars[0].make+model}"},
+			{id: idNoMatchSplitCars, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}),
+				garage(map[string]any{"postcode": "12345"}, carWith(map[string]any{"make": "honda"}), carWith(map[string]any{"model": "civic"})),
+			)}, note: "g[1] make+model in different cars"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages[0].city", "berlin"),
+			valueFilter("garages[1].postcode", "12345"),
+			valueFilter("garages[1].cars.make", "honda"),
+			valueFilter("garages[1].cars.model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F2: garages[0].city AND garages[1].postcode AND garages[2].cars.{make,model}.
+	// Three-way split; same-car within g[2].
+	t.Run("F2_garages[0].city_AND_garages[1].postcode_AND_garages[2].cars.{make,model}", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}),
+				garage(map[string]any{"postcode": "12345"}),
+				garage(nil, carWith(map[string]any{"make": "honda", "model": "civic"})),
+			)}, note: "g[0/1/2] each satisfies its part"},
+			{id: idNoMatchSplitCars, props: map[string]any{"garages": asArr(
+				garage(map[string]any{"city": "berlin"}),
+				garage(map[string]any{"postcode": "12345"}),
+				garage(nil, carWith(map[string]any{"make": "honda"}), carWith(map[string]any{"model": "civic"})),
+			)}, note: "g[2] split cars"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages[0].city", "berlin"),
+			valueFilter("garages[1].postcode", "12345"),
+			valueFilter("garages[2].cars.make", "honda"),
+			valueFilter("garages[2].cars.model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F3: countries[0].garages.city AND countries[1].garages.postcode AND
+	// countries[1].garages.cars.{make,model}. Split at countries; within c[1]
+	// same-garage AND same-car required.
+	t.Run("F3_countries[0].garages.city_AND_countries[1].garages.postcode_AND_countries[1].cars.{make,model}", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"})),
+				country(garage(map[string]any{"postcode": "12345"}, carWith(map[string]any{"make": "honda", "model": "civic"}))),
+			)}, note: "c[0]:city; c[1]: postcode + same-car make+model"},
+			{id: idNoMatchSplitCars, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"})),
+				country(garage(map[string]any{"postcode": "12345"}, carWith(map[string]any{"make": "honda"}), carWith(map[string]any{"model": "civic"}))),
+			)}, note: "c[1] split cars"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries[0].garages.city", "berlin"),
+			valueFilter("countries[1].garages.postcode", "12345"),
+			valueFilter("countries[1].garages.cars.make", "honda"),
+			valueFilter("countries[1].garages.cars.model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F4: countries[0/1/2] three-way split. Within c[2] same-garage AND same-car.
+	t.Run("F4_countries[0].garages.city_AND_countries[1].garages.postcode_AND_countries[2].cars.{make,model}", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"})),
+				country(garage(map[string]any{"postcode": "12345"})),
+				country(garage(nil, carWith(map[string]any{"make": "honda", "model": "civic"}))),
+			)}, note: "c[0/1/2] each satisfies its part"},
+			{id: idNoMatchSplitCars, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"})),
+				country(garage(map[string]any{"postcode": "12345"})),
+				country(garage(nil, carWith(map[string]any{"make": "honda"}), carWith(map[string]any{"model": "civic"}))),
+			)}, note: "c[2] split cars"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries[0].garages.city", "berlin"),
+			valueFilter("countries[1].garages.postcode", "12345"),
+			valueFilter("countries[2].garages.cars.make", "honda"),
+			valueFilter("countries[2].garages.cars.model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F5: countries[2].garages[3].cars.{make,model} with city+postcode pinned to c[0]/c[1].
+	t.Run("F5_countries[0].garages.city_AND_countries[1].garages.postcode_AND_countries[2].garages[3].cars.{make,model}", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"})),
+				country(garage(map[string]any{"postcode": "12345"})),
+				country(
+					garage(nil), garage(nil), garage(nil),
+					garage(nil, carWith(map[string]any{"make": "honda", "model": "civic"})),
+				),
+			)}, note: "c[2].g[3] has same-car make+model"},
+			{id: idNoMatchSplitCars, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"})),
+				country(garage(map[string]any{"postcode": "12345"})),
+				country(
+					garage(nil), garage(nil), garage(nil),
+					garage(nil, carWith(map[string]any{"make": "honda"}), carWith(map[string]any{"model": "civic"})),
+				),
+			)}, note: "c[2].g[3] split cars"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries[0].garages.city", "berlin"),
+			valueFilter("countries[1].garages.postcode", "12345"),
+			valueFilter("countries[2].garages[3].cars.make", "honda"),
+			valueFilter("countries[2].garages[3].cars.model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F6: countries.garages.{city,postcode} AND cars.{make,model} — no indices.
+	// Same garage + same car required.
+	t.Run("F6_countries.garages.city_AND_postcode_AND_cars.{make,model}", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		idNoMatchSplitGarages := uuid(3)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin", "postcode": "12345"}, carWith(map[string]any{"make": "honda", "model": "civic"}))),
+			)}, note: "same garage same car has all four"},
+			{id: idNoMatchSplitCars, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin", "postcode": "12345"}, carWith(map[string]any{"make": "honda"}), carWith(map[string]any{"model": "civic"}))),
+			)}, note: "same garage but split cars"},
+			{id: idNoMatchSplitGarages, props: map[string]any{"countries": asArr(
+				country(
+					garage(map[string]any{"city": "berlin"}, carWith(map[string]any{"make": "honda", "model": "civic"})),
+					garage(map[string]any{"postcode": "12345"}),
+				),
+			)}, note: "city+cars in g[0]; postcode in g[1]"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages.city", "berlin"),
+			valueFilter("countries.garages.postcode", "12345"),
+			valueFilter("countries.garages.cars.make", "honda"),
+			valueFilter("countries.garages.cars.model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F7: countries.garages.{city,postcode} AND cars.accessories.type AND cars.tags.
+	// Same garage + same car required (accessories and tags both per-car).
+	t.Run("F7_countries.garages.city_AND_postcode_AND_cars.accessories.type_AND_cars.tags", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin", "postcode": "12345"},
+					map[string]any{"accessories": asArr(accessory("spoiler")), "tags": []any{"electric"}},
+				)),
+			)}, note: "same car has accessories + tags"},
+			{id: idNoMatchSplitCars, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin", "postcode": "12345"},
+					map[string]any{"accessories": asArr(accessory("spoiler"))},
+					map[string]any{"tags": []any{"electric"}},
+				)),
+			)}, note: "accessories in cars[0]; tags in cars[1]"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages.city", "berlin"),
+			valueFilter("countries.garages.postcode", "12345"),
+			valueFilter("countries.garages.cars.accessories.type", "spoiler"),
+			valueFilter("countries.garages.cars.tags", "electric"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F8: countries.garages.{city,postcode} AND cars.accessories.type AND cars.tires.width.
+	// Same garage + same car required; the two object[] sub-arrays' positions
+	// can differ — only the parent car must match.
+	t.Run("F8_countries.garages.city_AND_postcode_AND_cars.accessories.type_AND_cars.tires.width", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitCars := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin", "postcode": "12345"},
+					map[string]any{"accessories": asArr(accessory("spoiler")), "tires": asArr(tire("225"))},
+				)),
+			)}, note: "same car has accessories + tires"},
+			{id: idNoMatchSplitCars, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin", "postcode": "12345"},
+					map[string]any{"accessories": asArr(accessory("spoiler"))},
+					map[string]any{"tires": asArr(tire("225"))},
+				)),
+			)}, note: "accessories in cars[0]; tires in cars[1]"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages.city", "berlin"),
+			valueFilter("countries.garages.postcode", "12345"),
+			valueFilter("countries.garages.cars.accessories.type", "spoiler"),
+			valueFilter("countries.garages.cars.tires.width", "225"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F9: garages[0].cars.{tires,accessories} AND garages[1].cars.{tires,accessories}.
+	// Two compatibility groups (one per garage index); each enforces same-car
+	// for tires.width + accessories.type at that garage.
+	t.Run("F9_garages[0].cars.{tires,accessories}_AND_garages[1].cars.{tires,accessories}", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitG1Cars := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(nil, map[string]any{"tires": asArr(tire("205")), "accessories": asArr(accessory("spoiler"))}),
+				garage(nil, map[string]any{"tires": asArr(tire("225")), "accessories": asArr(accessory("sunroof"))}),
+			)}, note: "g[0].cars[0] + g[1].cars[0] both same-car"},
+			{id: idNoMatchSplitG1Cars, props: map[string]any{"garages": asArr(
+				garage(nil, map[string]any{"tires": asArr(tire("205")), "accessories": asArr(accessory("spoiler"))}),
+				garage(nil, map[string]any{"tires": asArr(tire("225"))}, map[string]any{"accessories": asArr(accessory("sunroof"))}),
+			)}, note: "g[1] split: tires in cars[0]; accessories in cars[1]"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages[0].cars.tires.width", "205"),
+			valueFilter("garages[0].cars.accessories.type", "spoiler"),
+			valueFilter("garages[1].cars.tires.width", "225"),
+			valueFilter("garages[1].cars.accessories.type", "sunroof"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F10: garages.cars[0].{tires,accessories} AND garages.cars[1].{tires,accessories}.
+	// Two compatibility groups (one per cars index); same-garage required across
+	// groups via root+docID AND.
+	t.Run("F10_garages.cars[0].{tires,accessories}_AND_garages.cars[1].{tires,accessories}", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchSplitGarages := uuid(2)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(nil,
+					map[string]any{"tires": asArr(tire("205")), "accessories": asArr(accessory("spoiler"))},
+					map[string]any{"tires": asArr(tire("225")), "accessories": asArr(accessory("sunroof"))},
+				),
+			)}, note: "g[0] has both cars[0] and cars[1] satisfied"},
+			{id: idNoMatchSplitGarages, props: map[string]any{"garages": asArr(
+				garage(nil, map[string]any{"tires": asArr(tire("205")), "accessories": asArr(accessory("spoiler"))}),
+				garage(nil, map[string]any{}, map[string]any{"tires": asArr(tire("225")), "accessories": asArr(accessory("sunroof"))}),
+			)}, note: "cars[0] in g[0], cars[1] in g[1]"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages.cars[0].tires.width", "205"),
+			valueFilter("garages.cars[0].accessories.type", "spoiler"),
+			valueFilter("garages.cars[1].tires.width", "225"),
+			valueFilter("garages.cars[1].accessories.type", "sunroof"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F11: garages[0].cars[1].make AND garages[0].cars[1].model. Single
+	// compatibility group with arr[N] at "" and "cars"; nested 1-branch SPLITs.
+	t.Run("F11_garages[0].cars[1].make_AND_garages[0].cars[1].model", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchWrongCar := uuid(2)
+		idNoMatchWrongGarage := uuid(3)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(nil, map[string]any{}, map[string]any{"make": "honda", "model": "civic"}),
+			)}, note: "g[0].cars[1] has both"},
+			{id: idNoMatchWrongCar, props: map[string]any{"garages": asArr(
+				garage(nil, map[string]any{"make": "honda", "model": "civic"}),
+			)}, note: "make+model in cars[0] (wrong index)"},
+			{id: idNoMatchWrongGarage, props: map[string]any{"garages": asArr(
+				garage(nil, map[string]any{}, map[string]any{"make": "honda"}),
+				garage(nil, map[string]any{}, map[string]any{"model": "civic"}),
+			)}, note: "make in g[0].cars[1]; model in g[1].cars[1]"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages[0].cars[1].make", "honda"),
+			valueFilter("garages[0].cars[1].model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F12: garages[0].cars[1].tires[2].width AND garages[0].cars[1].accessories[3].type.
+	// Three pinned levels per condition.
+	t.Run("F12_garages[0].cars[1].tires[2]_AND_garages[0].cars[1].accessories[3]", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchWrongTire := uuid(2)
+		idNoMatchWrongCar := uuid(3)
+		idNoMatchWrongGarage := uuid(4)
+		// Build cars[1] with the tires/accessories at the right indices.
+		matchingCar := map[string]any{
+			"tires":       asArr(tire(""), tire(""), tire("205")),                                   // tires[2].width=205
+			"accessories": asArr(accessory(""), accessory(""), accessory(""), accessory("spoiler")), // accessories[3].type=spoiler
+		}
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"garages": asArr(
+				garage(nil, map[string]any{}, matchingCar),
+			)}, note: "g[0].cars[1].tires[2] + accessories[3]"},
+			{id: idNoMatchWrongTire, props: map[string]any{"garages": asArr(
+				garage(nil, map[string]any{}, map[string]any{
+					"tires":       asArr(tire(""), tire("205")), // width at tires[1] (wrong)
+					"accessories": asArr(accessory(""), accessory(""), accessory(""), accessory("spoiler")),
+				}),
+			)}, note: "tires[1] not tires[2]"},
+			{id: idNoMatchWrongCar, props: map[string]any{"garages": asArr(
+				garage(nil,
+					map[string]any{},
+					map[string]any{"accessories": asArr(accessory(""), accessory(""), accessory(""), accessory("spoiler"))},
+					map[string]any{"tires": asArr(tire(""), tire(""), tire("205"))},
+				),
+			)}, note: "accessories in cars[1], tires in cars[2]"},
+			{id: idNoMatchWrongGarage, props: map[string]any{"garages": asArr(
+				garage(nil, map[string]any{}, map[string]any{"tires": asArr(tire(""), tire(""), tire("205"))}),
+				garage(nil, map[string]any{}, map[string]any{"accessories": asArr(accessory(""), accessory(""), accessory(""), accessory("spoiler"))}),
+			)}, note: "tires in g[0].cars[1]; accessories in g[1].cars[1]"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("garages[0].cars[1].tires[2].width", "205"),
+			valueFilter("garages[0].cars[1].accessories[3].type", "spoiler"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F14: countries.garages[0].city AND garages[1].postcode AND
+	// garages[1].cars[2].make AND garages[1].cars[3].model. Multi-group
+	// dispatch (compatibility groups always yield ≥2 groups).
+	t.Run("F14_garages[0].city_AND_garages[1].postcode_AND_garages[1].cars[2].make_AND_garages[1].cars[3].model", func(t *testing.T) {
+		idMatch := uuid(1)
+		idNoMatchCityWrongGarage := uuid(2)
+		idNoMatchMakeWrongGarage := uuid(3)
+		idNoMatchSplitCntr := uuid(4)
+		// g[1] populated with cars at indices [2] and [3]
+		g1Cars := []map[string]any{
+			{},
+			{},
+			{"make": "honda"},
+			{"model": "civic"},
+		}
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(
+					garage(map[string]any{"city": "berlin"}),
+					garage(map[string]any{"postcode": "12345"}, g1Cars...),
+				),
+			)}, note: "c[0]: city in g[0]; postcode + cars[2].make + cars[3].model in g[1]"},
+			{id: idNoMatchCityWrongGarage, props: map[string]any{"countries": asArr(
+				country(
+					garage(nil),
+					garage(map[string]any{"city": "berlin", "postcode": "12345"}, g1Cars...),
+				),
+			)}, note: "city in g[1] (must be g[0])"},
+			{id: idNoMatchMakeWrongGarage, props: map[string]any{"countries": asArr(
+				country(
+					garage(map[string]any{"city": "berlin"}),
+					garage(map[string]any{"postcode": "12345"}, []map[string]any{{}, {}, {}, {"model": "civic"}}...),
+					garage(nil, []map[string]any{{}, {}, {"make": "honda"}}...),
+				),
+			)}, note: "make in g[2].cars[2] (must be g[1])"},
+			{id: idNoMatchSplitCntr, props: map[string]any{"countries": asArr(
+				country(garage(map[string]any{"city": "berlin"})),
+				country(
+					garage(nil),
+					garage(map[string]any{"postcode": "12345"}, g1Cars...),
+				),
+			)}, note: "city in c[0]; rest in c[1]"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages[0].city", "berlin"),
+			valueFilter("countries.garages[1].postcode", "12345"),
+			valueFilter("countries.garages[1].cars[2].make", "honda"),
+			valueFilter("countries.garages[1].cars[3].model", "civic"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
+	})
+
+	// F_tags_double_value: countries.garages.cars.tags = "electric" AND
+	// countries.garages.cars.tags = "sport". Two filter conditions on the
+	// same multi-value text[] field with different values.
+	//
+	// Observed behavior: same-element correlation enforces same-car within a
+	// garage, but NOT across garages. Documented as-is — this is the current
+	// behavior of same-path multi-value AND.
+	//
+	//   - same car has both tags                         → match
+	//   - same garage, different cars                    → reject (per-car AND)
+	//   - same country, different garages, one tag each  → match (no per-garage AND)
+	//   - only one tag anywhere                          → reject (each filter must hit)
+	t.Run("F_tags_double_value_cars.tags=electric_AND_cars.tags=sport", func(t *testing.T) {
+		idMatch := uuid(1)
+		idMatchSplitGarages := uuid(2)
+		idNoMatchOnlyOne := uuid(3)
+		idNoMatchSplitCars := uuid(4)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(nil, map[string]any{"tags": []any{"electric", "sport"}})),
+			)}, note: "single car has both tags"},
+			{id: idMatchSplitGarages, props: map[string]any{"countries": asArr(
+				country(
+					garage(nil, map[string]any{"tags": []any{"electric"}}),
+					garage(nil, map[string]any{"tags": []any{"sport"}}),
+				),
+			)}, note: "tags split across g[0].cars[0]/g[1].cars[0] — currently matches"},
+			{id: idNoMatchOnlyOne, props: map[string]any{"countries": asArr(
+				country(garage(nil, map[string]any{"tags": []any{"electric"}})),
+			)}, note: "only one tag in country — fails the second filter"},
+			{id: idNoMatchSplitCars, props: map[string]any{"countries": asArr(
+				country(garage(nil,
+					map[string]any{"tags": []any{"electric"}},
+					map[string]any{"tags": []any{"sport"}},
+				)),
+			)}, note: "tags split across cars[0]/cars[1] of same garage — per-car AND rejects"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages.cars.tags", "electric"),
+			valueFilter("countries.garages.cars.tags", "sport"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch, idMatchSplitGarages})
+	})
+
+	// SameKDifferentParent_with_subs: documents a confirmed bug in same-element
+	// semantics when the executor takes the runIdxLoopRecursive path
+	// (canUseRawAndAll=false, lcaPath != "").
+	//
+	// Filter: cars.make = "honda" AND cars.tires.width = "205"
+	//   - cars.make sits at GROUP@cars (here)
+	//   - cars.tires.width sits at GROUP@cars.tires (sub)
+	//   - GROUP@cars has 1 here + 1 sub → canUseRawAndAll=false → runIdxLoopRecursive
+	//
+	// Bug: matchElementRecursive uses MaskLeafAnd, which strips leaf bits before
+	// ANDing per-condition bitmaps. When _idx.cars[K] lumps multiple physical
+	// cars (e.g., g[0].cars[0] and g[1].cars[0] both at K=0), MaskLeafAnd loses
+	// the leaf-level distinction that would have rejected cross-physical-instance
+	// matches. The doc with make in g[0].cars[0] and tires in g[1].cars[0]
+	// incorrectly matches.
+	//
+	// Asserts CURRENT (buggy) behavior so a future fix gets caught and the
+	// expected list updated to just {idMatch}.
+	t.Run("SameKDifferentParent_with_subs_make_AND_tires_BUG", func(t *testing.T) {
+		idMatch := uuid(1)
+		idBuggyMatchSplitGaragesSameK := uuid(2)
+		idNoMatchSplitCarsSameGarage := uuid(3)
+		idNoMatchOnlyMake := uuid(4)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"countries": asArr(
+				country(garage(nil, map[string]any{"make": "honda", "tires": asArr(tire("205"))})),
+			)}, note: "correct: single car has both"},
+			{id: idBuggyMatchSplitGaragesSameK, props: map[string]any{"countries": asArr(
+				country(
+					garage(nil, map[string]any{"make": "honda"}),
+					garage(nil, map[string]any{"tires": asArr(tire("205"))}),
+				),
+			)}, note: "BUG: make in g[0].cars[0]; tires in g[1].cars[0] — currently matches; should reject"},
+			{id: idNoMatchSplitCarsSameGarage, props: map[string]any{"countries": asArr(
+				country(garage(nil,
+					map[string]any{"make": "honda"},
+					map[string]any{"tires": asArr(tire("205"))},
+				)),
+			)}, note: "different K within same garage — correctly rejects"},
+			{id: idNoMatchOnlyMake, props: map[string]any{"countries": asArr(
+				country(garage(nil, map[string]any{"make": "honda"})),
+			)}, note: "only one condition — rejects"},
+		}
+		parts := []*filters.LocalFilter{
+			valueFilter("countries.garages.cars.make", "honda"),
+			valueFilter("countries.garages.cars.tires.width", "205"),
+		}
+		runOrderings(t, docs, parts, []strfmt.UUID{idMatch, idBuggyMatchSplitGaragesSameK})
+	})
+}

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -10543,3 +10543,653 @@ func TestNestedFilteringContextCancellation(t *testing.T) {
 		))
 	})
 }
+
+// TestNestedFilteringOrOfCorrelatedAnds tests `(A AND B) OR (C AND D)` shapes
+// where each AND side is a same-element correlated AND. Verifies that the
+// OR combinator correctly unions docID-level results from two independent
+// correlated AND groups — neither side's positions should bleed into the
+// other's same-element evaluation. Closes a gap noted in
+// project_correlated_and_test_followups.md.
+//
+// Two sub-tests:
+//
+//   - Same LCA: both AND groups at cars LCA. Each side picks different
+//     same-car combinations (tesla+205 vs honda+305). Doc with one car
+//     satisfying either side matches.
+//   - Different LCAs: left side at cars, right side at addresses. Each
+//     AND-group resolves at its own LCA, then the two docID sets are
+//     unioned.
+func TestNestedFilteringOrOfCorrelatedAnds(t *testing.T) {
+	const nestedClass = "OrOfCorrelatedAnds"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	rootProps := []*models.NestedProperty{
+		{
+			Name: "addresses", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{Name: "postcode", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+			},
+		},
+		{
+			Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{
+					Name: "tires", DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+					},
+				},
+			},
+		},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "doc", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	tire := func(width int) map[string]any { return map[string]any{"width": width} }
+	carWith := func(make string, width int) map[string]any {
+		out := map[string]any{}
+		if make != "" {
+			out["make"] = make
+		}
+		if width > 0 {
+			out["tires"] = asArr(tire(width))
+		}
+		return out
+	}
+	addr := func(city, postcode string) map[string]any {
+		out := map[string]any{}
+		if city != "" {
+			out["city"] = city
+		}
+		if postcode != "" {
+			out["postcode"] = postcode
+		}
+		return out
+	}
+
+	textFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	intFilter := func(path string, val int) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeInt, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+	orFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorOr, Operands: operands}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	// ----- Sub-test 1: same LCA, both AND groups at cars -----
+	// Filter: (cars.make=tesla AND cars.tires.width=205)
+	//      OR (cars.make=honda AND cars.tires.width=305)
+	// Each side requires a single car element satisfying both clauses on
+	// that side. The OR unions docID-level results from two independent
+	// correlated AND evaluations.
+	t.Run("same_LCA_cars_make_AND_width_OR_make_AND_width", func(t *testing.T) {
+		idMatchLeft := uuid(1)              // cars=[{tesla, 205}]
+		idMatchRight := uuid(2)             // cars=[{honda, 305}]
+		idMatchBoth := uuid(3)              // cars=[{tesla, 205},{honda, 305}]
+		idMatchLeftViaSecondCar := uuid(4)  // first car wrong, second satisfies left
+		idNoMatchTeslaWrongWidth := uuid(5) // cars=[{tesla, 305}] — left side wrong width
+		idNoMatchSplitLeft := uuid(6)       // cars=[{tesla},{tires:[{205}]}] — split across cars
+		idNoMatchNeither := uuid(7)         // cars=[{bmw, 225}]
+		docs := []docDef{
+			{id: idMatchLeft, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 205))}}, note: "tesla+205"},
+			{id: idMatchRight, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("honda", 305))}}, note: "honda+305"},
+			{id: idMatchBoth, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 205), carWith("honda", 305))}}, note: "both sides"},
+			{id: idMatchLeftViaSecondCar, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("bmw", 225), carWith("tesla", 205))}}, note: "[1] satisfies left"},
+			{id: idNoMatchTeslaWrongWidth, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 305))}}, note: "tesla but wrong width; not honda"},
+			{id: idNoMatchSplitLeft, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 0), carWith("", 205))}}, note: "tesla and 205 in different cars"},
+			{id: idNoMatchNeither, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("bmw", 225))}}, note: "neither side"},
+		}
+		filter := orFilter(
+			andFilter(textFilter("doc.cars.make", "tesla"), intFilter("doc.cars.tires.width", 205)),
+			andFilter(textFilter("doc.cars.make", "honda"), intFilter("doc.cars.tires.width", 305)),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchLeft, idMatchRight, idMatchBoth, idMatchLeftViaSecondCar})
+	})
+
+	// ----- Sub-test 2: different LCAs -----
+	// Filter: (cars.make=tesla AND cars.tires.width=205)
+	//      OR (addresses.city=berlin AND addresses.postcode=10115)
+	// Left side at LCA=cars (same-car semantics). Right side at LCA=addresses
+	// (same-address semantics). The OR unions docID-level results from two
+	// independent correlated AND evaluations at distinct LCAs.
+	t.Run("different_LCAs_cars_AND_OR_addresses_AND", func(t *testing.T) {
+		idMatchLeft := uuid(1)         // cars=[{tesla,205}], no berlin address
+		idMatchRight := uuid(2)        // addresses=[{berlin,10115}], no tesla car
+		idMatchBoth := uuid(3)         // satisfies both sides
+		idNoMatchSplitLeft := uuid(4)  // tesla and 205 in different cars
+		idNoMatchSplitRight := uuid(5) // berlin and 10115 in different addresses
+		idNoMatchNeither := uuid(6)
+		docs := []docDef{
+			{id: idMatchLeft, props: map[string]any{"doc": map[string]any{
+				"cars":      asArr(carWith("tesla", 205)),
+				"addresses": asArr(addr("munich", "80331")),
+			}}, note: "left side only"},
+			{id: idMatchRight, props: map[string]any{"doc": map[string]any{
+				"cars":      asArr(carWith("bmw", 225)),
+				"addresses": asArr(addr("berlin", "10115")),
+			}}, note: "right side only"},
+			{id: idMatchBoth, props: map[string]any{"doc": map[string]any{
+				"cars":      asArr(carWith("tesla", 205)),
+				"addresses": asArr(addr("berlin", "10115")),
+			}}, note: "both sides"},
+			{id: idNoMatchSplitLeft, props: map[string]any{"doc": map[string]any{
+				"cars":      asArr(carWith("tesla", 0), carWith("", 205)),
+				"addresses": asArr(addr("munich", "80331")),
+			}}, note: "left split; right absent"},
+			{id: idNoMatchSplitRight, props: map[string]any{"doc": map[string]any{
+				"cars":      asArr(carWith("bmw", 225)),
+				"addresses": asArr(addr("berlin", "00000"), addr("munich", "10115")),
+			}}, note: "right split; left absent"},
+			{id: idNoMatchNeither, props: map[string]any{"doc": map[string]any{
+				"cars":      asArr(carWith("bmw", 225)),
+				"addresses": asArr(addr("munich", "80331")),
+			}}, note: "neither side"},
+		}
+		filter := orFilter(
+			andFilter(textFilter("doc.cars.make", "tesla"), intFilter("doc.cars.tires.width", 205)),
+			andFilter(textFilter("doc.addresses.city", "berlin"), textFilter("doc.addresses.postcode", "10115")),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchLeft, idMatchRight, idMatchBoth})
+	})
+}
+
+// TestNestedFilteringNotOfCorrelatedAnd tests `NOT (A AND B)` where the
+// inner AND is a same-element correlated AND. Verifies that NOT inverts
+// the docID-level result of the AND-group: docs without any car
+// satisfying both clauses are returned; docs with at least one car
+// satisfying both are excluded.
+//
+// Two sub-tests:
+//   - NOT (cars.make=bmw AND cars.tires.width=205): basic same-element AND
+//     wrapped in NOT.
+//   - NOT (cars[0].make=tesla AND cars[1].make=bmw): NOT over a partitioned
+//     AND (conflicting arr[N] indices). Verifies NOT correctly inverts the
+//     partition result.
+func TestNestedFilteringNotOfCorrelatedAnd(t *testing.T) {
+	const nestedClass = "NotOfCorrelatedAnd"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	rootProps := []*models.NestedProperty{
+		{
+			Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{
+					Name: "tires", DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+					},
+				},
+			},
+		},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "doc", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	tire := func(width int) map[string]any { return map[string]any{"width": width} }
+	carWith := func(make string, width int) map[string]any {
+		out := map[string]any{}
+		if make != "" {
+			out["make"] = make
+		}
+		if width > 0 {
+			out["tires"] = asArr(tire(width))
+		}
+		return out
+	}
+
+	textFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	intFilter := func(path string, val int) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeInt, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+	notFilter := func(inner *filters.LocalFilter) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorNot,
+			Operands: []filters.Clause{*inner.Root},
+		}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	// ----- Sub-test 1: NOT over basic correlated AND -----
+	// Filter: NOT (cars.make=bmw AND cars.tires.width=205)
+	// Match docs where it is NOT the case that some single car has both
+	// make=bmw AND tires.width=205.
+	t.Run("NOT_make_bmw_AND_width_205_same_car", func(t *testing.T) {
+		idAndMatchSingle := uuid(1)      // single car has both → AND match → NOT excludes
+		idAndMatchInSecondCar := uuid(2) // cars[1] has both → AND match → NOT excludes
+		idBmwWrongWidth := uuid(3)       // bmw but width=225 → AND no match → NOT match
+		idCorrectWidthWrongMake := uuid(4)
+		idSplitAcrossCars := uuid(5) // bmw in cars[0], 205 in cars[1] → AND no match → NOT match
+		idNoCarsArray := uuid(6)     // empty cars array
+		idNoCarsField := uuid(7)     // no cars key
+		idMultipleCarsNeitherSatisfies := uuid(8)
+		docs := []docDef{
+			{id: idAndMatchSingle, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("bmw", 205))}}, note: "cars[0]={bmw,205}"},
+			{id: idAndMatchInSecondCar, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 225), carWith("bmw", 205))}}, note: "cars[1]={bmw,205}"},
+			{id: idBmwWrongWidth, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("bmw", 225))}}, note: "bmw,225"},
+			{id: idCorrectWidthWrongMake, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 205))}}, note: "tesla,205"},
+			{id: idSplitAcrossCars, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("bmw", 0), carWith("", 205))}}, note: "bmw and 205 in different cars"},
+			{id: idNoCarsArray, props: map[string]any{"doc": map[string]any{"cars": []any{}}}, note: "empty cars"},
+			{id: idNoCarsField, props: map[string]any{"doc": map[string]any{}}, note: "no cars field"},
+			{id: idMultipleCarsNeitherSatisfies, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("bmw", 225), carWith("tesla", 205))}}, note: "bmw+225 and tesla+205; no single car has both"},
+		}
+		filter := notFilter(andFilter(
+			textFilter("doc.cars.make", "bmw"),
+			intFilter("doc.cars.tires.width", 205),
+		))
+		runScenario(t, docs, filter, []strfmt.UUID{
+			idBmwWrongWidth, idCorrectWidthWrongMake, idSplitAcrossCars,
+			idNoCarsArray, idNoCarsField, idMultipleCarsNeitherSatisfies,
+		})
+	})
+
+	// ----- Sub-test 2: NOT over partitioned AND with conflicting arr[N] -----
+	// Filter: NOT (cars[0].make=tesla AND cars[1].make=bmw)
+	// Inner AND: cars[0] must be tesla AND cars[1] must be bmw (different
+	// physical positions enforced by arr[N] partition). NOT excludes docs
+	// satisfying that arrangement.
+	t.Run("NOT_cars[0].make_tesla_AND_cars[1].make_bmw_partition", func(t *testing.T) {
+		idAndMatch := uuid(1)                // [tesla,bmw] → AND match → NOT excludes
+		idSwapped := uuid(2)                 // [bmw,tesla] → AND no match → NOT match
+		idOnlyFirst := uuid(3)               // only [0] → no [1] → AND no match → NOT match
+		idCorrectFirstWrongSecond := uuid(4) // [tesla,volvo]
+		idEmpty := uuid(5)                   // no cars
+		idAndMatchExtraCars := uuid(6)       // [tesla,bmw,extra] → AND match → NOT excludes
+		docs := []docDef{
+			{id: idAndMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 0), carWith("bmw", 0))}}, note: "[tesla,bmw]"},
+			{id: idSwapped, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("bmw", 0), carWith("tesla", 0))}}, note: "[bmw,tesla]"},
+			{id: idOnlyFirst, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 0))}}, note: "[tesla] only"},
+			{id: idCorrectFirstWrongSecond, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 0), carWith("volvo", 0))}}, note: "[tesla,volvo]"},
+			{id: idEmpty, props: map[string]any{"doc": map[string]any{}}, note: "no cars"},
+			{id: idAndMatchExtraCars, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 0), carWith("bmw", 0), carWith("volvo", 0))}}, note: "[tesla,bmw,volvo]"},
+		}
+		filter := notFilter(andFilter(
+			textFilter("doc.cars[0].make", "tesla"),
+			textFilter("doc.cars[1].make", "bmw"),
+		))
+		runScenario(t, docs, filter, []strfmt.UUID{
+			idSwapped, idOnlyFirst, idCorrectFirstWrongSecond, idEmpty,
+		})
+	})
+
+	// ----- Sub-test 3 (regression baseline): NOT inside correlated AND -----
+	// Filter: cars.make = "tesla" AND NOT cars.tires.width = 205
+	//
+	// This locks in the *current* docID-level (universal) semantics for NOT.
+	// Two docs (idSomeTeslaWithout205 and idTwoTeslasOneHas205) discriminate
+	// between universal and per-element semantics — they would flip from "no
+	// match" to "match" if NOT inside a correlated AND were rewritten to per-
+	// element evaluation. See plan_not_per_element_semantics.md.
+	//
+	// Universal interpretation (current):
+	//   A = docs with some tesla car
+	//   B = docs where NO car has width=205
+	//   Result = A ∩ B
+	//
+	// Per-element interpretation (future, if implemented):
+	//   For each car element K: this car is tesla AND this car doesn't have width=205
+	//   Result = docs where ANY car satisfies the per-element condition
+	t.Run("regression_NOT_inside_AND_universal_docID_level", func(t *testing.T) {
+		idTeslaNo205 := uuid(1)          // single tesla car w/o 205 — both interpretations: match
+		idTeslaWith205 := uuid(2)        // single tesla car with 205 — both: no match
+		idSomeTeslaWithout205 := uuid(3) // tesla(225) + bmw(205) — universal: NO; per-element: YES
+		idTeslaWith205PlusBmw := uuid(4) // tesla(205) + bmw(225) — both: no match
+		idNoTesla := uuid(5)             // no tesla at all — both: no match
+		idTwoTeslasOneHas205 := uuid(6)  // tesla(225) + tesla(205) — universal: NO; per-element: YES
+		idEmpty := uuid(7)               // no cars — both: no match
+		docs := []docDef{
+			{id: idTeslaNo205, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 225))}}, note: "tesla,225"},
+			{id: idTeslaWith205, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 205))}}, note: "tesla,205"},
+			{id: idSomeTeslaWithout205, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 225), carWith("bmw", 205))}}, note: "tesla,225 + bmw,205 — DISCRIMINATOR"},
+			{id: idTeslaWith205PlusBmw, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 205), carWith("bmw", 225))}}, note: "tesla,205 + bmw,225"},
+			{id: idNoTesla, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("bmw", 205))}}, note: "bmw,205 — no tesla"},
+			{id: idTwoTeslasOneHas205, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 225), carWith("tesla", 205))}}, note: "tesla,225 + tesla,205 — DISCRIMINATOR"},
+			{id: idEmpty, props: map[string]any{"doc": map[string]any{}}, note: "no cars"},
+		}
+		filter := andFilter(
+			textFilter("doc.cars.make", "tesla"),
+			notFilter(intFilter("doc.cars.tires.width", 205)),
+		)
+		// Current behavior: only idTeslaNo205 matches. Two discriminator docs
+		// (idSomeTeslaWithout205, idTwoTeslasOneHas205) are excluded because
+		// some car (any car) has width=205, even though a tesla without 205
+		// also exists. If per-element NOT lands, both flip to match.
+		runScenario(t, docs, filter, []strfmt.UUID{idTeslaNo205})
+	})
+}
+
+// TestNestedFilteringNotEqualNestedRegression locks in the current
+// docID-level (universal) semantics of NotEqual on nested-leaf paths.
+// NotEqual's row-reader implementation produces a denylist: same bitmap
+// as Equal, flagged isDenyList=true. The searcher inverts at docID level,
+// giving "no element has the value" — universal/NONE-like, NOT consistent
+// with Equal's existential semantics on the same path.
+//
+// Two notable consequences locked in by this test:
+//
+//  1. A doc with mixed values (`[{bmw}, {tesla}]`) is excluded by
+//     NotEqual bmw, even though some element ≠ bmw exists. Existential
+//     interpretation would match.
+//  2. A doc with NO elements at all (no cars, or empty array) IS matched
+//     by NotEqual bmw — vacuously true under universal. Existential would
+//     exclude it (no element satisfies the predicate). This is also
+//     asymmetric with Equal: `cars.make = bmw` correctly excludes
+//     empty-cars docs.
+//
+// Discriminator docs (idMixed, idEmpty, idEmptyArr) flip from match-or-not
+// when the uniform-existential switch in
+// plan_explicit_array_quantifiers.md lands.
+//
+// Sub-test 2 mirrors regression_NOT_inside_AND_universal_docID_level for
+// NotEqual inside a correlated AND, showing that NOT and NotEqual share
+// the same per-element-vs-docID-level mismatch.
+func TestNestedFilteringNotEqualNestedRegression(t *testing.T) {
+	const nestedClass = "NotEqualRegression"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	rootProps := []*models.NestedProperty{
+		{
+			Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{
+					Name: "tires", DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+					},
+				},
+			},
+		},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "doc", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	tire := func(width int) map[string]any { return map[string]any{"width": width} }
+	carWith := func(make string, width int) map[string]any {
+		out := map[string]any{}
+		if make != "" {
+			out["make"] = make
+		}
+		if width > 0 {
+			out["tires"] = asArr(tire(width))
+		}
+		return out
+	}
+
+	textNotEqualFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorNotEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	intNotEqualFilter := func(path string, val int) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorNotEqual,
+			Value:    &filters.Value{Type: schema.DataTypeInt, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	textFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	// ----- Sub-test 1: basic NotEqual at nested leaf -----
+	// Filter: cars.make NotEqual "bmw"
+	//
+	// Universal (current): match docs where NO car has make=bmw.
+	// Existential (proposed): match docs where ANY car has make≠bmw.
+	t.Run("regression_basic_NotEqual_universal_docID_level", func(t *testing.T) {
+		idOnlyBmw := uuid(1)
+		idOnlyTesla := uuid(2)
+		idMixed := uuid(3)
+		idEmpty := uuid(4)
+		idEmptyArr := uuid(5)
+		docs := []docDef{
+			{id: idOnlyBmw, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("bmw", 0))}}, note: "bmw"},
+			{id: idOnlyTesla, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 0))}}, note: "tesla"},
+			{id: idMixed, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("bmw", 0), carWith("tesla", 0))}}, note: "[bmw,tesla] — DISCRIMINATOR"},
+			{id: idEmpty, props: map[string]any{"doc": map[string]any{}}, note: "no cars — DISCRIMINATOR"},
+			{id: idEmptyArr, props: map[string]any{"doc": map[string]any{"cars": []any{}}}, note: "cars=[] — DISCRIMINATOR"},
+		}
+		filter := textNotEqualFilter("doc.cars.make", "bmw")
+		// Current universal: idOnlyTesla + idEmpty + idEmptyArr.
+		// Existential would: idOnlyTesla + idMixed (and exclude empty docs).
+		runScenario(t, docs, filter, []strfmt.UUID{idOnlyTesla, idEmpty, idEmptyArr})
+	})
+
+	// ----- Sub-test 2: NotEqual inside correlated AND (BUG REGRESSION) -----
+	// Filter: cars.make = "tesla" AND cars.tires.width NotEqual 205
+	//
+	// **This sub-test locks in BUGGY current behavior, NOT correct behavior.**
+	//
+	// Verified by experiment: NotEqual's denylist flag is dropped (or
+	// inverted) when its bitmap is combined with another nested clause via
+	// correlated AND. The filter incorrectly matches docs where
+	// `tesla AND width=205 (same car)` — the exact OPPOSITE of what
+	// NotEqual should produce.
+	//
+	// Doc-by-doc analysis with the current bug:
+	//   idTeslaNo205    : [{tesla,225}]               → tesla yes, 205 no → bug excludes (correct expectation: include)
+	//   idTeslaWith205  : [{tesla,205}]               → same car has tesla AND 205 → bug includes (correct expectation: exclude)
+	//   idSomeTeslaWO205: [{tesla,225},{bmw,205}]     → no single car has tesla AND 205 → bug excludes
+	//   idTeslaWith205+ : [{tesla,205},{bmw,225}]     → cars[0] has tesla AND 205 → bug includes (correct expectation: exclude)
+	//   idNoTesla       : [{bmw,205}]                 → no tesla → bug excludes
+	//   idTwoTeslas1@205: [{tesla,225},{tesla,205}]   → cars[1] has tesla AND 205 → bug includes (correct expectation: exclude)
+	//   idEmpty         : (no cars)                   → bug excludes (universal-correct expectation: include)
+	//
+	// When the bug is fixed (whether to universal denylist or the proposed
+	// uniform-existential semantics), this test will fail and the expected
+	// list must be updated:
+	//   - Universal-correct fix: [idTeslaNo205, idEmpty]
+	//   - Uniform-existential fix: [idTeslaNo205, idSomeTeslaWO205, idTwoTeslas1@205]
+	//
+	// Filed alongside plan_explicit_array_quantifiers.md as a separate bug
+	// requiring fix regardless of the existential-semantics direction.
+	t.Run("regression_BUG_NotEqual_inside_AND_treated_as_Equal", func(t *testing.T) {
+		idTeslaNo205 := uuid(1)
+		idTeslaWith205 := uuid(2)
+		idSomeTeslaWithout205 := uuid(3)
+		idTeslaWith205PlusBmw := uuid(4)
+		idNoTesla := uuid(5)
+		idTwoTeslasOneHas205 := uuid(6)
+		idEmpty := uuid(7)
+		docs := []docDef{
+			{id: idTeslaNo205, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 225))}}, note: "tesla,225"},
+			{id: idTeslaWith205, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 205))}}, note: "tesla,205"},
+			{id: idSomeTeslaWithout205, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 225), carWith("bmw", 205))}}, note: "tesla,225 + bmw,205"},
+			{id: idTeslaWith205PlusBmw, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 205), carWith("bmw", 225))}}, note: "tesla,205 + bmw,225"},
+			{id: idNoTesla, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("bmw", 205))}}, note: "bmw,205"},
+			{id: idTwoTeslasOneHas205, props: map[string]any{"doc": map[string]any{"cars": asArr(carWith("tesla", 225), carWith("tesla", 205))}}, note: "tesla,225 + tesla,205"},
+			{id: idEmpty, props: map[string]any{"doc": map[string]any{}}, note: "no cars"},
+		}
+		filter := andFilter(
+			textFilter("doc.cars.make", "tesla"),
+			intNotEqualFilter("doc.cars.tires.width", 205),
+		)
+		// BUG: NotEqual is treated as Equal in correlated AND. The matches
+		// below are docs where `tesla AND width=205 (same car)` — the
+		// opposite of what NotEqual should produce.
+		runScenario(t, docs, filter, []strfmt.UUID{
+			idTeslaWith205, idTeslaWith205PlusBmw, idTwoTeslasOneHas205,
+		})
+	})
+}

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -9896,3 +9896,501 @@ func TestNestedFilteringTokenizationFollowups(t *testing.T) {
 		runScenario(t, docs, filter, []strfmt.UUID{idAllFourTokens})
 	})
 }
+
+// TestNestedFilteringSamePathMultiValueTokenized ports the 4 BUG sub-tests
+// of lower-level TestResolveNestedCorrelatedAnd (plain-object LCA and
+// object[] LCA × independent=1 / independent>1). These exercise a specific
+// pattern not otherwise covered: same path with multiple value clauses where
+// at least one is multi-token and one or more are single-token, plus a
+// sibling clause on a different path.
+//
+// At the lower level, the bug was that combinePositions produced empty
+// results when mixing MASKED (from token AndAll) and RAW (from independent)
+// bitmaps. The DB-level port verifies the user-visible behavior is correct
+// regardless of how the internal bitmaps are combined.
+func TestNestedFilteringSamePathMultiValueTokenized(t *testing.T) {
+	const nestedClass = "MultiValueTokenized"
+	vTrue := true
+	word := models.NestedPropertyTokenizationWord
+
+	textFilter := func(class, path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: schema.ClassName(class), Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	tagsAny := func(tags ...string) []any {
+		out := make([]any, len(tags))
+		for i, t := range tags {
+			out[i] = t
+		}
+		return out
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	// ----- Variant 1: plain-object LCA, text[] tags, multi-token + 1 single -----
+	// Filter: addresses.owner.tags = "new york" AND addresses.owner.tags = "berlin"
+	//         AND addresses.owner.name = "alice"
+	// LCA = addresses.owner (plain-object inside addresses[]). owner has tags
+	// (text[]) and name (text). Single address must satisfy all three clauses.
+	t.Run("plain_obj_LCA_tags_multi_token_plus_single_AND_name", func(t *testing.T) {
+		class := &models.Class{
+			Class:             nestedClass,
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{{
+				Name:     "addresses",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{{
+					Name:     "owner",
+					DataType: schema.DataTypeObject.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+						{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+					},
+				}},
+			}},
+		}
+		idMatch := uuid(1)            // addresses[0].owner.tags=["new york","berlin"], owner.name="alice"
+		idNoMatchSplit := uuid(2)     // tags split: addresses[0]=["new york"], addresses[1]=["berlin"]
+		idNoMatchWrongName := uuid(3) // addresses[0] has both tags but owner.name != alice
+		idNoMatchPartial := uuid(4)   // addresses[0] has only "new york"; missing "berlin"
+		docs := []struct {
+			id    strfmt.UUID
+			props map[string]any
+		}{
+			{id: idMatch, props: map[string]any{"addresses": asArr(map[string]any{
+				"owner": map[string]any{"tags": tagsAny("new york", "berlin"), "name": "alice"},
+			})}},
+			{id: idNoMatchSplit, props: map[string]any{"addresses": asArr(
+				map[string]any{"owner": map[string]any{"tags": tagsAny("new york"), "name": "alice"}},
+				map[string]any{"owner": map[string]any{"tags": tagsAny("berlin"), "name": "alice"}},
+			)}},
+			{id: idNoMatchWrongName, props: map[string]any{"addresses": asArr(map[string]any{
+				"owner": map[string]any{"tags": tagsAny("new york", "berlin"), "name": "bob"},
+			})}},
+			{id: idNoMatchPartial, props: map[string]any{"addresses": asArr(map[string]any{
+				"owner": map[string]any{"tags": tagsAny("new york"), "name": "alice"},
+			})}},
+		}
+
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{Class: nestedClass, ID: d.id, Properties: d.props}, nil, nil, nil, nil, 0))
+		}
+		filter := andFilter(
+			textFilter(nestedClass, "addresses.owner.tags", "new york"),
+			textFilter(nestedClass, "addresses.owner.tags", "berlin"),
+			textFilter(nestedClass, "addresses.owner.name", "alice"),
+		)
+		res, err := db.Search(ctx, dto.GetParams{ClassName: nestedClass, Pagination: &filters.Pagination{Limit: 100}, Filters: filter})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, []strfmt.UUID{idMatch}, got)
+	})
+
+	// ----- Variant 2: plain-object LCA, text title, multi-token + 2 singles -----
+	// Filter: addresses.owner.title = "new york" AND .title = "berlin" AND .title = "tech"
+	//         AND addresses.owner.name = "alice"
+	// title is text (single-valued); to satisfy three same-path clauses the
+	// title's tokenization must contain all of [new, york, berlin, tech] at the
+	// same position. With word tokenization, a value like "new york berlin tech"
+	// produces all four tokens at the same leaf.
+	t.Run("plain_obj_LCA_title_multi_token_plus_2_singles_AND_name", func(t *testing.T) {
+		class2 := &models.Class{
+			Class:             nestedClass + "2",
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{{
+				Name:     "addresses",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{{
+					Name:     "owner",
+					DataType: schema.DataTypeObject.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "title", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+						{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+					},
+				}},
+			}},
+		}
+		idMatch := uuid(1)            // title="new york berlin tech", name="alice"
+		idNoMatchPartial := uuid(2)   // title="new york berlin" — missing tech
+		idNoMatchWrongName := uuid(3) // title has all 4 but name=bob
+		idNoMatchSplitAddr := uuid(4) // tokens spread across two addresses
+		docs := []struct {
+			id    strfmt.UUID
+			props map[string]any
+		}{
+			{id: idMatch, props: map[string]any{"addresses": asArr(map[string]any{
+				"owner": map[string]any{"title": "new york berlin tech", "name": "alice"},
+			})}},
+			{id: idNoMatchPartial, props: map[string]any{"addresses": asArr(map[string]any{
+				"owner": map[string]any{"title": "new york berlin", "name": "alice"},
+			})}},
+			{id: idNoMatchWrongName, props: map[string]any{"addresses": asArr(map[string]any{
+				"owner": map[string]any{"title": "new york berlin tech", "name": "bob"},
+			})}},
+			{id: idNoMatchSplitAddr, props: map[string]any{"addresses": asArr(
+				map[string]any{"owner": map[string]any{"title": "new york", "name": "alice"}},
+				map[string]any{"owner": map[string]any{"title": "berlin tech", "name": "alice"}},
+			)}},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class2)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{Class: class2.Class, ID: d.id, Properties: d.props}, nil, nil, nil, nil, 0))
+		}
+		filter := andFilter(
+			textFilter(class2.Class, "addresses.owner.title", "new york"),
+			textFilter(class2.Class, "addresses.owner.title", "berlin"),
+			textFilter(class2.Class, "addresses.owner.title", "tech"),
+			textFilter(class2.Class, "addresses.owner.name", "alice"),
+		)
+		res, err := db.Search(ctx, dto.GetParams{ClassName: class2.Class, Pagination: &filters.Pagination{Limit: 100}, Filters: filter})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, []strfmt.UUID{idMatch}, got)
+	})
+
+	// ----- Variant 3: object[] LCA (cars), text[] tags, multi-token + 1 single -----
+	// Filter: garages.cars.tags = "new york" AND garages.cars.tags = "berlin"
+	//         AND garages.cars.make = "tesla"
+	// LCA = cars (object[]). Same car must have both tag values (multi-token "new
+	// york" at one leaf, "berlin" at another leaf within the same cars element)
+	// AND make=tesla.
+	t.Run("objArr_LCA_cars.tags_multi_token_plus_single_AND_make", func(t *testing.T) {
+		class3 := &models.Class{
+			Class:             nestedClass + "3",
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{{
+				Name:     "garages",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{{
+					Name:     "cars",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+						{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+					},
+				}},
+			}},
+		}
+		idMatch := uuid(1)               // cars[0].tags=["new york","berlin"], make="tesla"
+		idNoMatchSplitCars := uuid(2)    // tags split across cars; one has make
+		idNoMatchPartialTags := uuid(3)  // cars[0].tags=["new york"] only, make="tesla"
+		idNoMatchWrongMake := uuid(4)    // cars[0] has both tags but make != tesla
+		idNoMatchSplitGarages := uuid(5) // tags+make across separate garages
+		docs := []struct {
+			id    strfmt.UUID
+			props map[string]any
+		}{
+			{id: idMatch, props: map[string]any{"garages": asArr(map[string]any{
+				"cars": asArr(map[string]any{"tags": tagsAny("new york", "berlin"), "make": "tesla"}),
+			})}},
+			{id: idNoMatchSplitCars, props: map[string]any{"garages": asArr(map[string]any{
+				"cars": asArr(
+					map[string]any{"tags": tagsAny("new york"), "make": "tesla"},
+					map[string]any{"tags": tagsAny("berlin"), "make": "tesla"},
+				),
+			})}},
+			{id: idNoMatchPartialTags, props: map[string]any{"garages": asArr(map[string]any{
+				"cars": asArr(map[string]any{"tags": tagsAny("new york"), "make": "tesla"}),
+			})}},
+			{id: idNoMatchWrongMake, props: map[string]any{"garages": asArr(map[string]any{
+				"cars": asArr(map[string]any{"tags": tagsAny("new york", "berlin"), "make": "bmw"}),
+			})}},
+			{id: idNoMatchSplitGarages, props: map[string]any{"garages": asArr(
+				map[string]any{"cars": asArr(map[string]any{"tags": tagsAny("new york", "berlin")})},
+				map[string]any{"cars": asArr(map[string]any{"make": "tesla"})},
+			)}},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class3)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{Class: class3.Class, ID: d.id, Properties: d.props}, nil, nil, nil, nil, 0))
+		}
+		filter := andFilter(
+			textFilter(class3.Class, "garages.cars.tags", "new york"),
+			textFilter(class3.Class, "garages.cars.tags", "berlin"),
+			textFilter(class3.Class, "garages.cars.make", "tesla"),
+		)
+		res, err := db.Search(ctx, dto.GetParams{ClassName: class3.Class, Pagination: &filters.Pagination{Limit: 100}, Filters: filter})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, []strfmt.UUID{idMatch}, got)
+	})
+
+	// ----- Variant 4: object[] LCA (cars), text make, multi-token + 2 singles -----
+	// Filter: garages.cars.make = "new york" AND .make = "berlin" AND .make = "tech"
+	//         AND garages.cars.model = "s"
+	// make is text (single-valued per car), so all 4 make-tokens must come from
+	// one make value (e.g. "new york berlin tech") on the same car as model="s".
+	t.Run("objArr_LCA_cars.make_multi_token_plus_2_singles_AND_model", func(t *testing.T) {
+		class4 := &models.Class{
+			Class:             nestedClass + "4",
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{{
+				Name:     "garages",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{{
+					Name:     "cars",
+					DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+						{Name: "model", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+					},
+				}},
+			}},
+		}
+		idMatch := uuid(1)            // make="new york berlin tech", model="s"
+		idNoMatchSplitCars := uuid(2) // make tokens spread across cars
+		idNoMatchWrongModel := uuid(3)
+		idNoMatchPartial := uuid(4) // make="new york berlin" missing tech
+		docs := []struct {
+			id    strfmt.UUID
+			props map[string]any
+		}{
+			{id: idMatch, props: map[string]any{"garages": asArr(map[string]any{
+				"cars": asArr(map[string]any{"make": "new york berlin tech", "model": "s"}),
+			})}},
+			{id: idNoMatchSplitCars, props: map[string]any{"garages": asArr(map[string]any{
+				"cars": asArr(
+					map[string]any{"make": "new york", "model": "s"},
+					map[string]any{"make": "berlin tech", "model": "s"},
+				),
+			})}},
+			{id: idNoMatchWrongModel, props: map[string]any{"garages": asArr(map[string]any{
+				"cars": asArr(map[string]any{"make": "new york berlin tech", "model": "x"}),
+			})}},
+			{id: idNoMatchPartial, props: map[string]any{"garages": asArr(map[string]any{
+				"cars": asArr(map[string]any{"make": "new york berlin", "model": "s"}),
+			})}},
+		}
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class4)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{Class: class4.Class, ID: d.id, Properties: d.props}, nil, nil, nil, nil, 0))
+		}
+		filter := andFilter(
+			textFilter(class4.Class, "garages.cars.make", "new york"),
+			textFilter(class4.Class, "garages.cars.make", "berlin"),
+			textFilter(class4.Class, "garages.cars.make", "tech"),
+			textFilter(class4.Class, "garages.cars.model", "s"),
+		)
+		res, err := db.Search(ctx, dto.GetParams{ClassName: class4.Class, Pagination: &filters.Pagination{Limit: 100}, Filters: filter})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, []strfmt.UUID{idMatch}, got)
+	})
+}
+
+// TestNestedFilteringSamePathMultiValueNonTokenized closes a gap identified
+// in the Tier 2 re-audit: lower-level TestResolveNestedCorrelatedAnd #7,
+// #19, #20, #25 cover the non-tokenized variant of "same-path multi-value
+// at object[] LCA combined with another path's clause". This shape is
+// distinct from:
+//
+//   - TestNestedFilteringSamePathMultiValueTokenized — tokenized values in
+//     the same-path clauses (different combinePositions branch)
+//   - F_tags_double_value — same-path multi-value alone, no cross-path
+//   - TestNestedFilteringComprehensive — cross-path scalar AND but no
+//     same-path multi-value
+//
+// Both sub-tests use single-token (field-tokenized) text[] values so the
+// dispatch goes through the all-independents branch of combinePositions.
+func TestNestedFilteringSamePathMultiValueNonTokenized(t *testing.T) {
+	const nestedClass = "MultiValueNonTokenized"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	tagsAny := func(tags ...string) []any {
+		out := make([]any, len(tags))
+		for i, t := range tags {
+			out[i] = t
+		}
+		return out
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	textFilter := func(class, path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: schema.ClassName(class), Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+	}
+	runDocs := func(t *testing.T, class *models.Class, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{Class: class.Class, ID: d.id, Properties: d.props}, nil, nil, nil, nil, 0))
+		}
+		res, err := db.Search(ctx, dto.GetParams{ClassName: class.Class, Pagination: &filters.Pagination{Limit: 100}, Filters: filter})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	// ----- Sub-test 1: same-path multi-value + cross-path scalar -----
+	// Filter: cars.tags = "electric" AND cars.tags = "sport" AND cars.make = "tesla"
+	// Same car must have both tags AND the make. Tests combinePositions for
+	// cars.tags producing a leaf-masked bitmap (multi-independents) that then
+	// ANDs with the raw cars.make bitmap at the same LCA.
+	t.Run("same_path_multi_value_AND_cross_path_scalar", func(t *testing.T) {
+		class := &models.Class{
+			Class:             nestedClass,
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{{
+				Name:     "cars",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+					{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				},
+			}},
+		}
+		idMatch := uuid(1)
+		idNoMatchSplitTags := uuid(2)
+		idNoMatchSplitTagsMake := uuid(3)
+		idNoMatchPartialTags := uuid(4)
+		idNoMatchWrongMake := uuid(5)
+		idMatchSecondCar := uuid(6)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"cars": asArr(map[string]any{"tags": tagsAny("electric", "sport"), "make": "tesla"})}},
+			{id: idNoMatchSplitTags, props: map[string]any{"cars": asArr(
+				map[string]any{"tags": tagsAny("electric"), "make": "tesla"},
+				map[string]any{"tags": tagsAny("sport"), "make": "tesla"},
+			)}},
+			{id: idNoMatchSplitTagsMake, props: map[string]any{"cars": asArr(
+				map[string]any{"tags": tagsAny("electric", "sport")},
+				map[string]any{"make": "tesla"},
+			)}},
+			{id: idNoMatchPartialTags, props: map[string]any{"cars": asArr(map[string]any{"tags": tagsAny("electric"), "make": "tesla"})}},
+			{id: idNoMatchWrongMake, props: map[string]any{"cars": asArr(map[string]any{"tags": tagsAny("electric", "sport"), "make": "bmw"})}},
+			{id: idMatchSecondCar, props: map[string]any{"cars": asArr(
+				map[string]any{"tags": tagsAny("electric"), "make": "bmw"},
+				map[string]any{"tags": tagsAny("electric", "sport"), "make": "tesla"},
+			)}},
+		}
+		filter := andFilter(
+			textFilter(nestedClass, "cars.tags", "electric"),
+			textFilter(nestedClass, "cars.tags", "sport"),
+			textFilter(nestedClass, "cars.make", "tesla"),
+		)
+		runDocs(t, class, docs, filter, []strfmt.UUID{idMatch, idMatchSecondCar})
+	})
+
+	// ----- Sub-test 2: two same-path multi-value paths (each text[]) -----
+	// Filter: cars.tags = "electric" AND cars.tags = "sport"
+	//         AND cars.labels = "red"  AND cars.labels = "blue"
+	// Same car must have all four — both pairs of multi-values must coexist
+	// at the same physical car. Both path bitmaps are leaf-masked
+	// (multi-value), so the AND combines two MASKED bitmaps at the cars LCA.
+	t.Run("two_same_path_multi_value_paths", func(t *testing.T) {
+		class2 := &models.Class{
+			Class:             nestedClass + "2",
+			VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+			Properties: []*models.Property{{
+				Name:     "cars",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+					{Name: "labels", DataType: schema.DataTypeTextArray.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				},
+			}},
+		}
+		idMatch := uuid(1)
+		idNoMatchSplitTags := uuid(2)
+		idNoMatchSplitLabels := uuid(3)
+		idNoMatchSplitBoth := uuid(4)
+		idNoMatchPartialTags := uuid(5)
+		idNoMatchPartialLabels := uuid(6)
+		idMatchSecondCar := uuid(7)
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"cars": asArr(map[string]any{
+				"tags": tagsAny("electric", "sport"), "labels": tagsAny("red", "blue"),
+			})}},
+			{id: idNoMatchSplitTags, props: map[string]any{"cars": asArr(
+				map[string]any{"tags": tagsAny("electric"), "labels": tagsAny("red", "blue")},
+				map[string]any{"tags": tagsAny("sport"), "labels": tagsAny("red", "blue")},
+			)}},
+			{id: idNoMatchSplitLabels, props: map[string]any{"cars": asArr(
+				map[string]any{"tags": tagsAny("electric", "sport"), "labels": tagsAny("red")},
+				map[string]any{"labels": tagsAny("blue")},
+			)}},
+			{id: idNoMatchSplitBoth, props: map[string]any{"cars": asArr(
+				map[string]any{"tags": tagsAny("electric", "sport")},
+				map[string]any{"labels": tagsAny("red", "blue")},
+			)}},
+			{id: idNoMatchPartialTags, props: map[string]any{"cars": asArr(map[string]any{
+				"tags": tagsAny("electric"), "labels": tagsAny("red", "blue"),
+			})}},
+			{id: idNoMatchPartialLabels, props: map[string]any{"cars": asArr(map[string]any{
+				"tags": tagsAny("electric", "sport"), "labels": tagsAny("red"),
+			})}},
+			{id: idMatchSecondCar, props: map[string]any{"cars": asArr(
+				map[string]any{"tags": tagsAny("electric"), "labels": tagsAny("red")},
+				map[string]any{"tags": tagsAny("electric", "sport"), "labels": tagsAny("red", "blue")},
+			)}},
+		}
+		filter := andFilter(
+			textFilter(class2.Class, "cars.tags", "electric"),
+			textFilter(class2.Class, "cars.tags", "sport"),
+			textFilter(class2.Class, "cars.labels", "red"),
+			textFilter(class2.Class, "cars.labels", "blue"),
+		)
+		runDocs(t, class2, docs, filter, []strfmt.UUID{idMatch, idMatchSecondCar})
+	})
+}

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -9303,3 +9303,392 @@ func TestNestedFilteringScalarArrayIndex(t *testing.T) {
 		runScenario(t, docs, filter, []strfmt.UUID{})
 	})
 }
+
+// TestNestedFilteringComprehensive ports the lower-level
+// TestNestedFilteringComprehensive smoke test to the DB level. It exercises
+// basic filters, simple/complex AND with same-element enforcement, OR
+// (no same-element), nested AND/OR mix, and deep nesting (cars.tires.bolts)
+// — all driven through the production write+search pipeline. Two root
+// variants (DataTypeObject "doc" and DataTypeObjectArray "docs") share
+// the same nested shape but differ on doc3, which has data within a
+// single root for "doc" and split across two roots for "docs".
+//
+// Doc setup (per variant):
+//   - d1: addresses, tags=premium, cars[0]={bmw, tires=[width:205,bolts.size=10], accessories=[sunroof]}
+//   - d2: cars=[{bmw}, {tires:[width:205], accessories:[sunroof]}] — bmw and tires/acc in different cars; no bolts
+//   - d3 (doc):  addresses + cars[0]={bmw} — same root, no tires/acc/bolts
+//   - d3 (docs): docs[0]={cars:[{bmw}]}, docs[1]={addresses, cars:[{tires:[width:205], accessories:[sunroof]}]} — cross-root split
+//   - d4: addresses, cars[0]={honda, tires:[width:205], accessories:[sunroof]} — wrong make, no bolts
+func TestNestedFilteringComprehensive(t *testing.T) {
+	const nestedClass = "ComprehensiveNested"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	rootProps := []*models.NestedProperty{
+		{
+			Name: "addresses", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{Name: "postcode", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+			},
+		},
+		{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{
+			Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{
+					Name: "tires", DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+						{
+							Name: "bolts", DataType: schema.DataTypeObjectArray.PropString(),
+							NestedProperties: []*models.NestedProperty{
+								{Name: "size", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+							},
+						},
+					},
+				},
+				{
+					Name: "accessories", DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "type", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+					},
+				},
+			},
+		},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "doc", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+			{Name: "docs", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	tagsAny := func(tags ...string) []any {
+		out := make([]any, len(tags))
+		for i, t := range tags {
+			out[i] = t
+		}
+		return out
+	}
+	addr := func(city, postcode string) map[string]any {
+		return map[string]any{"city": city, "postcode": postcode}
+	}
+	bolt := func(size int) map[string]any { return map[string]any{"size": size} }
+	tireSimple := func(width int) map[string]any {
+		return map[string]any{"width": width}
+	}
+	tireWithBolts := func(width int, bolts ...map[string]any) map[string]any {
+		anyBolts := make([]any, len(bolts))
+		for i, b := range bolts {
+			anyBolts[i] = b
+		}
+		return map[string]any{"width": width, "bolts": anyBolts}
+	}
+	accessory := func(type_ string) map[string]any { return map[string]any{"type": type_} }
+
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	textFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	intFilter := func(path string, val int) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeInt, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+	orFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorOr, Operands: operands}}
+	}
+
+	type variantSpec struct {
+		name    string
+		propKey string
+		// d3Props returns doc3's variant-specific props.
+		d3Props func() map[string]any
+		// wrap takes the body (addresses/tags/cars) and produces top-level Properties.
+		wrap func(body map[string]any) map[string]any
+	}
+
+	variants := []variantSpec{
+		{
+			name:    "doc_object",
+			propKey: "doc",
+			d3Props: func() map[string]any {
+				return map[string]any{"doc": map[string]any{
+					"addresses": asArr(addr("berlin", "10115")),
+					"cars":      asArr(map[string]any{"make": "bmw"}),
+				}}
+			},
+			wrap: func(body map[string]any) map[string]any { return map[string]any{"doc": body} },
+		},
+		{
+			name:    "docs_array",
+			propKey: "docs",
+			d3Props: func() map[string]any {
+				return map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(map[string]any{"make": "bmw"})},
+					map[string]any{
+						"addresses": asArr(addr("berlin", "10115")),
+						"cars":      asArr(map[string]any{"tires": asArr(tireSimple(205)), "accessories": asArr(accessory("sunroof"))}),
+					},
+				)}
+			},
+			wrap: func(body map[string]any) map[string]any { return map[string]any{"docs": asArr(body)} },
+		},
+	}
+
+	for _, v := range variants {
+		v := v
+		t.Run(v.name, func(t *testing.T) {
+			db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+			ctx := context.Background()
+
+			d1 := uuid(1)
+			d2 := uuid(2)
+			d3 := uuid(3)
+			d4 := uuid(4)
+
+			d1Body := map[string]any{
+				"addresses": asArr(addr("berlin", "10115")),
+				"tags":      tagsAny("premium"),
+				"cars": asArr(map[string]any{
+					"make":        "bmw",
+					"tires":       asArr(tireWithBolts(205, bolt(10))),
+					"accessories": asArr(accessory("sunroof")),
+				}),
+			}
+			d2Body := map[string]any{
+				"cars": asArr(
+					map[string]any{"make": "bmw"},
+					map[string]any{"tires": asArr(tireSimple(205)), "accessories": asArr(accessory("sunroof"))},
+				),
+			}
+			d4Body := map[string]any{
+				"addresses": asArr(addr("berlin", "10115")),
+				"cars": asArr(map[string]any{
+					"make":        "honda",
+					"tires":       asArr(tireSimple(205)),
+					"accessories": asArr(accessory("sunroof")),
+				}),
+			}
+
+			require.NoError(t, db.PutObject(ctx, &models.Object{Class: nestedClass, ID: d1, Properties: v.wrap(d1Body)}, nil, nil, nil, nil, 0), "put d1")
+			require.NoError(t, db.PutObject(ctx, &models.Object{Class: nestedClass, ID: d2, Properties: v.wrap(d2Body)}, nil, nil, nil, nil, 0), "put d2")
+			require.NoError(t, db.PutObject(ctx, &models.Object{Class: nestedClass, ID: d3, Properties: v.d3Props()}, nil, nil, nil, nil, 0), "put d3")
+			require.NoError(t, db.PutObject(ctx, &models.Object{Class: nestedClass, ID: d4, Properties: v.wrap(d4Body)}, nil, nil, nil, nil, 0), "put d4")
+
+			runFilter := func(t *testing.T, filter *filters.LocalFilter, want []strfmt.UUID) {
+				t.Helper()
+				res, err := db.Search(ctx, dto.GetParams{
+					ClassName:  nestedClass,
+					Pagination: &filters.Pagination{Limit: 100},
+					Filters:    filter,
+				})
+				require.NoError(t, err)
+				got := make([]strfmt.UUID, len(res))
+				for i, r := range res {
+					got[i] = r.ID
+				}
+				assert.ElementsMatch(t, want, got)
+			}
+			want := func(forDoc, forDocs []strfmt.UUID) []strfmt.UUID {
+				if v.name == "doc_object" {
+					return forDoc
+				}
+				return forDocs
+			}
+			pk := v.propKey
+
+			// ----- Basic single-condition filters -----
+			t.Run("basic_cars.make_eq_bmw", func(t *testing.T) {
+				runFilter(t, textFilter(pk+".cars.make", "bmw"), []strfmt.UUID{d1, d2, d3})
+			})
+			t.Run("basic_cars.make_eq_honda", func(t *testing.T) {
+				runFilter(t, textFilter(pk+".cars.make", "honda"), []strfmt.UUID{d4})
+			})
+			t.Run("basic_cars.tires.width_eq_205", func(t *testing.T) {
+				// doc:  d3 has no tires → [d1,d2,d4]
+				// docs: d3 has tires in docs[1] → [d1,d2,d3,d4]
+				runFilter(t, intFilter(pk+".cars.tires.width", 205),
+					want([]strfmt.UUID{d1, d2, d4}, []strfmt.UUID{d1, d2, d3, d4}))
+			})
+			t.Run("basic_addresses.city_eq_berlin", func(t *testing.T) {
+				runFilter(t, textFilter(pk+".addresses.city", "berlin"), []strfmt.UUID{d1, d3, d4})
+			})
+			t.Run("basic_tags_eq_premium", func(t *testing.T) {
+				runFilter(t, textFilter(pk+".tags", "premium"), []strfmt.UUID{d1})
+			})
+
+			// ----- Simple AND with same-element enforcement -----
+			t.Run("AND_make_bmw_AND_tires.width_205_same_car", func(t *testing.T) {
+				// d1 only — d2's bmw is in cars[0], tires in cars[1].
+				runFilter(t, andFilter(textFilter(pk+".cars.make", "bmw"), intFilter(pk+".cars.tires.width", 205)),
+					[]strfmt.UUID{d1})
+			})
+			t.Run("AND_make_bmw_AND_accessories_sunroof_same_car", func(t *testing.T) {
+				runFilter(t, andFilter(textFilter(pk+".cars.make", "bmw"), textFilter(pk+".cars.accessories.type", "sunroof")),
+					[]strfmt.UUID{d1})
+			})
+			t.Run("AND_tires.width_AND_accessories_sunroof_same_car", func(t *testing.T) {
+				// doc:  d3 has no tires → [d1,d2,d4]
+				// docs: d3 has both in docs[1].cars[0] → [d1,d2,d3,d4]
+				runFilter(t, andFilter(intFilter(pk+".cars.tires.width", 205), textFilter(pk+".cars.accessories.type", "sunroof")),
+					want([]strfmt.UUID{d1, d2, d4}, []strfmt.UUID{d1, d2, d3, d4}))
+			})
+			t.Run("AND_3clause_make_tires_accessories_same_car", func(t *testing.T) {
+				runFilter(t, andFilter(
+					textFilter(pk+".cars.make", "bmw"),
+					intFilter(pk+".cars.tires.width", 205),
+					textFilter(pk+".cars.accessories.type", "sunroof"),
+				), []strfmt.UUID{d1})
+			})
+			t.Run("AND_make_bmw_AND_addresses.city_berlin_same_root", func(t *testing.T) {
+				// doc:  d3 has bmw+berlin in same root → [d1,d3]
+				// docs: d3 has bmw in docs[0], berlin in docs[1] (cross-root) → [d1]
+				runFilter(t, andFilter(textFilter(pk+".cars.make", "bmw"), textFilter(pk+".addresses.city", "berlin")),
+					want([]strfmt.UUID{d1, d3}, []strfmt.UUID{d1}))
+			})
+			t.Run("AND_addresses.city_AND_postcode_same_address", func(t *testing.T) {
+				runFilter(t, andFilter(textFilter(pk+".addresses.city", "berlin"), textFilter(pk+".addresses.postcode", "10115")),
+					[]strfmt.UUID{d1, d3, d4})
+			})
+			t.Run("AND_make_AND_address_pair_same_root", func(t *testing.T) {
+				runFilter(t, andFilter(
+					textFilter(pk+".cars.make", "bmw"),
+					textFilter(pk+".addresses.city", "berlin"),
+					textFilter(pk+".addresses.postcode", "10115"),
+				), want([]strfmt.UUID{d1, d3}, []strfmt.UUID{d1}))
+			})
+			t.Run("AND_tags_premium_AND_make_bmw_same_root", func(t *testing.T) {
+				runFilter(t, andFilter(textFilter(pk+".tags", "premium"), textFilter(pk+".cars.make", "bmw")),
+					[]strfmt.UUID{d1})
+			})
+			t.Run("AND_tires_AND_accessories_AND_address_pair", func(t *testing.T) {
+				// doc:  d3 no tires/acc → [d1,d4]
+				// docs: d3 docs[1] has all → [d1,d3,d4]
+				runFilter(t, andFilter(
+					intFilter(pk+".cars.tires.width", 205),
+					textFilter(pk+".cars.accessories.type", "sunroof"),
+					textFilter(pk+".addresses.city", "berlin"),
+					textFilter(pk+".addresses.postcode", "10115"),
+				), want([]strfmt.UUID{d1, d4}, []strfmt.UUID{d1, d3, d4}))
+			})
+
+			// ----- Simple OR -----
+			t.Run("OR_make_bmw_OR_make_honda", func(t *testing.T) {
+				runFilter(t, orFilter(textFilter(pk+".cars.make", "bmw"), textFilter(pk+".cars.make", "honda")),
+					[]strfmt.UUID{d1, d2, d3, d4})
+			})
+			t.Run("OR_make_bmw_OR_tires.width_205", func(t *testing.T) {
+				runFilter(t, orFilter(textFilter(pk+".cars.make", "bmw"), intFilter(pk+".cars.tires.width", 205)),
+					[]strfmt.UUID{d1, d2, d3, d4})
+			})
+			t.Run("OR_tags_premium_OR_addresses.city_berlin", func(t *testing.T) {
+				runFilter(t, orFilter(textFilter(pk+".tags", "premium"), textFilter(pk+".addresses.city", "berlin")),
+					[]strfmt.UUID{d1, d3, d4})
+			})
+			t.Run("OR_make_bmw_OR_addresses.city_paris_absent", func(t *testing.T) {
+				runFilter(t, orFilter(textFilter(pk+".cars.make", "bmw"), textFilter(pk+".addresses.city", "paris")),
+					[]strfmt.UUID{d1, d2, d3})
+			})
+
+			// ----- Complex multi-condition AND/OR mix -----
+			t.Run("complex_AND_make_tires_OR_make_honda", func(t *testing.T) {
+				runFilter(t, orFilter(
+					andFilter(textFilter(pk+".cars.make", "bmw"), intFilter(pk+".cars.tires.width", 205)),
+					textFilter(pk+".cars.make", "honda"),
+				), []strfmt.UUID{d1, d4})
+			})
+			t.Run("complex_make_bmw_AND_OR_tires_OR_accessories", func(t *testing.T) {
+				runFilter(t, andFilter(
+					textFilter(pk+".cars.make", "bmw"),
+					orFilter(intFilter(pk+".cars.tires.width", 205), textFilter(pk+".cars.accessories.type", "sunroof")),
+				), want([]strfmt.UUID{d1, d2}, []strfmt.UUID{d1, d2, d3}))
+			})
+			t.Run("complex_make_AND_tires_AND_addresses_all_same_root", func(t *testing.T) {
+				runFilter(t, andFilter(
+					textFilter(pk+".cars.make", "bmw"),
+					intFilter(pk+".cars.tires.width", 205),
+					textFilter(pk+".addresses.city", "berlin"),
+				), []strfmt.UUID{d1})
+			})
+			t.Run("complex_OR_makes_AND_addresses", func(t *testing.T) {
+				runFilter(t, andFilter(
+					orFilter(textFilter(pk+".cars.make", "bmw"), textFilter(pk+".cars.make", "honda")),
+					textFilter(pk+".addresses.city", "berlin"),
+				), []strfmt.UUID{d1, d3, d4})
+			})
+			t.Run("complex_4clause_tags_make_tires_accessories", func(t *testing.T) {
+				runFilter(t, andFilter(
+					textFilter(pk+".tags", "premium"),
+					textFilter(pk+".cars.make", "bmw"),
+					intFilter(pk+".cars.tires.width", 205),
+					textFilter(pk+".cars.accessories.type", "sunroof"),
+				), []strfmt.UUID{d1})
+			})
+
+			// ----- Deep nesting (cars.tires.bolts) — only d1 has bolts -----
+			t.Run("deep_bolts.size_alone", func(t *testing.T) {
+				runFilter(t, intFilter(pk+".cars.tires.bolts.size", 10), []strfmt.UUID{d1})
+			})
+			t.Run("deep_bolts.size_AND_tires.width_same_tires", func(t *testing.T) {
+				runFilter(t, andFilter(
+					intFilter(pk+".cars.tires.bolts.size", 10),
+					intFilter(pk+".cars.tires.width", 205),
+				), []strfmt.UUID{d1})
+			})
+			t.Run("deep_bolts.size_AND_tires.width_AND_make_bmw", func(t *testing.T) {
+				runFilter(t, andFilter(
+					intFilter(pk+".cars.tires.bolts.size", 10),
+					intFilter(pk+".cars.tires.width", 205),
+					textFilter(pk+".cars.make", "bmw"),
+				), []strfmt.UUID{d1})
+			})
+
+			// ----- Edge cases -----
+			// Same-path AND on different values: a single value at the same path
+			// can't equal two distinct constants, so the result must be empty
+			// regardless of doc shape.
+			t.Run("edge_same_path_contradiction_make_bmw_AND_make_honda", func(t *testing.T) {
+				runFilter(t, andFilter(
+					textFilter(pk+".cars.make", "bmw"),
+					textFilter(pk+".cars.make", "honda"),
+				), []strfmt.UUID{})
+			})
+			// Filter on a value no doc carries — verifies empty-bitmap handling.
+			t.Run("edge_empty_result_make_ferrari", func(t *testing.T) {
+				runFilter(t, textFilter(pk+".cars.make", "ferrari"), []strfmt.UUID{})
+			})
+		})
+	}
+}

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -4644,3 +4644,336 @@ func TestNestedFilteringIsNullWithArrNInCorrelatedAnd(t *testing.T) {
 		runScenario(t, docs, filter, []strfmt.UUID{idMatchMakeOnly, idMatchMakeAtCars1})
 	})
 }
+
+// TestNestedFilteringIsNullStandalone exercises IS NULL / IS NOT NULL filters
+// outside of correlated AND, end-to-end through the production write+search
+// pipeline.
+//
+// Coverage:
+//   - For both DataTypeObject (top-level "nested") and DataTypeObjectArray
+//     (top-level "nestedArray") root properties.
+//   - IsNull on the top-level nested property itself (e.g. "nested" or
+//     "nestedArray") — checks whether the nested object/array exists at all.
+//   - IsNull on a direct nested-array property of the root (e.g. "nested.addresses")
+//     — checks whether that array exists.
+//   - IsNull on a scalar leaf inside a nested array (e.g. "nested.addresses.city")
+//     — universal semantics under the current resolver.
+//   - IsNull on a scalar-array leaf (e.g. "nested.addresses.tags") — same
+//     universal semantics, but exercises a different write-path code branch
+//     (walkScalarArray instead of walkObject).
+//   - For nestedArray: aggregation across multiple top-level array elements.
+//   - Docs that don't set the top-level nested property at all.
+//
+// This documents the current universal IsNull-on-deep-path behaviour. The
+// existential-semantics plan (memory: plan_isnull_existential_semantics.md)
+// would change some of these assertions before release.
+func TestNestedFilteringIsNullStandalone(t *testing.T) {
+	const nestedClass = "Article"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	addressesProps := []*models.NestedProperty{
+		{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+		{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+	}
+	rootProps := []*models.NestedProperty{
+		{
+			Name:             "addresses",
+			DataType:         schema.DataTypeObjectArray.PropString(),
+			NestedProperties: addressesProps,
+		},
+	}
+
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "nested", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+			{Name: "nestedArray", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	addrCity := func(city string) map[string]any { return map[string]any{"city": city} }
+	addrTags := func(tags ...string) map[string]any {
+		anyTags := make([]any, len(tags))
+		for i, t := range tags {
+			anyTags[i] = t
+		}
+		return map[string]any{"tags": anyTags}
+	}
+	addrCityAndTags := func(city string, tags ...string) map[string]any {
+		anyTags := make([]any, len(tags))
+		for i, t := range tags {
+			anyTags[i] = t
+		}
+		return map[string]any{"city": city, "tags": anyTags}
+	}
+	addrEmpty := func() map[string]any { return map[string]any{} }
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+
+	isNullFilter := func(path string, isNull bool) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorIsNull,
+			Value:    &filters.Value{Type: schema.DataTypeBoolean, Value: isNull},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id,
+				Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	// ----- DataTypeObject (top-level "nested") -----
+	t.Run("nested_object", func(t *testing.T) {
+		idAddrWithCity := uuid(1)
+		idAddrNoCity := uuid(2)
+		idMixedCities := uuid(3)
+		idEmptyAddresses := uuid(4)
+		idNoAddresses := uuid(5)
+		idNoNestedProp := uuid(6)
+		idAddrWithTags := uuid(7)
+		idAddrCityAndTags := uuid(8)
+		idMixedTagsAndCities := uuid(9)
+
+		docs := []docDef{
+			{id: idAddrWithCity, props: map[string]any{
+				"nested": map[string]any{"addresses": asArr(addrCity("berlin"))},
+			}, note: "nested.addresses=[{city:berlin}]"},
+			{id: idAddrNoCity, props: map[string]any{
+				"nested": map[string]any{"addresses": asArr(addrEmpty())},
+			}, note: "nested.addresses=[{}] — no city, no tags"},
+			{id: idMixedCities, props: map[string]any{
+				"nested": map[string]any{"addresses": asArr(addrCity("munich"), addrEmpty(), addrCity("paris"))},
+			}, note: "mixed addresses with city, no tags"},
+			{id: idEmptyAddresses, props: map[string]any{
+				"nested": map[string]any{"addresses": []any{}},
+			}, note: "nested.addresses=[]"},
+			{id: idNoAddresses, props: map[string]any{
+				"nested": map[string]any{},
+			}, note: "nested={} — no addresses field"},
+			{id: idNoNestedProp, props: map[string]any{}, note: "props={} — no nested prop at all"},
+			{id: idAddrWithTags, props: map[string]any{
+				"nested": map[string]any{"addresses": asArr(addrTags("foo", "bar"))},
+			}, note: "addresses=[{tags:[foo,bar]}] — tags present, no city"},
+			{id: idAddrCityAndTags, props: map[string]any{
+				"nested": map[string]any{"addresses": asArr(addrCityAndTags("madrid", "x"))},
+			}, note: "addresses=[{city:madrid, tags:[x]}] — both present"},
+			{id: idMixedTagsAndCities, props: map[string]any{
+				"nested": map[string]any{"addresses": asArr(addrCity("munich"), addrTags("a"), addrEmpty())},
+			}, note: "mixed: city in [0], tags in [1], empty in [2]"},
+		}
+
+		t.Run("nested_is_not_null", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nested", false),
+				[]strfmt.UUID{
+					idAddrWithCity, idAddrNoCity, idMixedCities,
+					idEmptyAddresses, idNoAddresses,
+					idAddrWithTags, idAddrCityAndTags, idMixedTagsAndCities,
+				})
+		})
+
+		t.Run("nested_is_null", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nested", true),
+				[]strfmt.UUID{idNoNestedProp})
+		})
+
+		t.Run("addresses_is_not_null", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nested.addresses", false),
+				[]strfmt.UUID{
+					idAddrWithCity, idAddrNoCity, idMixedCities,
+					idAddrWithTags, idAddrCityAndTags, idMixedTagsAndCities,
+				})
+		})
+
+		t.Run("addresses_is_null", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nested.addresses", true),
+				[]strfmt.UUID{idEmptyAddresses, idNoAddresses, idNoNestedProp})
+		})
+
+		t.Run("addresses_city_is_not_null", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nested.addresses.city", false),
+				[]strfmt.UUID{
+					idAddrWithCity, idMixedCities,
+					idAddrCityAndTags, idMixedTagsAndCities,
+				})
+		})
+
+		t.Run("addresses_city_is_null_universal", func(t *testing.T) {
+			// Universal: matches docs where city is absent everywhere within
+			// nested.addresses. idMixedCities and idMixedTagsAndCities both have
+			// at least one address with city, so they are NOT returned — the
+			// existential plan would change this.
+			runScenario(t, docs, isNullFilter("nested.addresses.city", true),
+				[]strfmt.UUID{
+					idAddrNoCity, idEmptyAddresses, idNoAddresses, idNoNestedProp,
+					idAddrWithTags,
+				})
+		})
+
+		t.Run("addresses_tags_is_not_null", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nested.addresses.tags", false),
+				[]strfmt.UUID{idAddrWithTags, idAddrCityAndTags, idMixedTagsAndCities})
+		})
+
+		t.Run("addresses_tags_is_null_universal", func(t *testing.T) {
+			// Universal: matches docs with no tags anywhere. idMixedTagsAndCities
+			// has tags in one address, so NOT returned (existential would).
+			runScenario(t, docs, isNullFilter("nested.addresses.tags", true),
+				[]strfmt.UUID{
+					idAddrWithCity, idAddrNoCity, idMixedCities,
+					idEmptyAddresses, idNoAddresses, idNoNestedProp,
+				})
+		})
+	})
+
+	// ----- DataTypeObjectArray (top-level "nestedArray") -----
+	t.Run("nested_array", func(t *testing.T) {
+		idArrAddrWithCity := uuid(1)
+		idArrAddrNoCity := uuid(2)
+		idArrMixedAcrossElems := uuid(3)
+		idArrCityInSecondElem := uuid(4)
+		idArrEmptyAddresses := uuid(5)
+		idArrNoAddresses := uuid(6)
+		idArrEmptyTopLevel := uuid(7)
+		idArrNoNestedArrayProp := uuid(8)
+		idArrAddrWithTags := uuid(9)
+		idArrAddrCityAndTags := uuid(10)
+		idArrTagsInSecondElem := uuid(11)
+
+		docs := []docDef{
+			{id: idArrAddrWithCity, props: map[string]any{
+				"nestedArray": asArr(map[string]any{"addresses": asArr(addrCity("berlin"))}),
+			}, note: "single root with addresses+city"},
+			{id: idArrAddrNoCity, props: map[string]any{
+				"nestedArray": asArr(map[string]any{"addresses": asArr(addrEmpty())}),
+			}, note: "single root with addresses (no city, no tags)"},
+			{id: idArrMixedAcrossElems, props: map[string]any{
+				"nestedArray": asArr(
+					map[string]any{"addresses": asArr(addrCity("paris"))},
+					map[string]any{"addresses": asArr(addrEmpty())},
+				),
+			}, note: "two roots: first with city, second without"},
+			{id: idArrCityInSecondElem, props: map[string]any{
+				"nestedArray": asArr(
+					map[string]any{},
+					map[string]any{"addresses": asArr(addrCity("madrid"))},
+				),
+			}, note: "city in nestedArray[1] only — cross-root-element aggregation"},
+			{id: idArrEmptyAddresses, props: map[string]any{
+				"nestedArray": asArr(map[string]any{"addresses": []any{}}),
+			}, note: "single root with addresses=[]"},
+			{id: idArrNoAddresses, props: map[string]any{
+				"nestedArray": asArr(map[string]any{}),
+			}, note: "single root without addresses field"},
+			{id: idArrEmptyTopLevel, props: map[string]any{
+				"nestedArray": []any{},
+			}, note: "nestedArray=[] — empty top-level array"},
+			{id: idArrNoNestedArrayProp, props: map[string]any{}, note: "props={} — no nestedArray prop"},
+			{id: idArrAddrWithTags, props: map[string]any{
+				"nestedArray": asArr(map[string]any{"addresses": asArr(addrTags("foo"))}),
+			}, note: "addresses=[{tags:[foo]}] — tags only"},
+			{id: idArrAddrCityAndTags, props: map[string]any{
+				"nestedArray": asArr(map[string]any{"addresses": asArr(addrCityAndTags("oslo", "y"))}),
+			}, note: "addresses=[{city:oslo, tags:[y]}]"},
+			{id: idArrTagsInSecondElem, props: map[string]any{
+				"nestedArray": asArr(
+					map[string]any{},
+					map[string]any{"addresses": asArr(addrTags("z"))},
+				),
+			}, note: "tags only in nestedArray[1] — cross-root-element"},
+		}
+
+		t.Run("nestedArray_is_not_null", func(t *testing.T) {
+			// Empty top-level array and missing prop produce no _exists positions
+			// for "nestedArray" so they don't show up here.
+			runScenario(t, docs, isNullFilter("nestedArray", false),
+				[]strfmt.UUID{
+					idArrAddrWithCity, idArrAddrNoCity, idArrMixedAcrossElems, idArrCityInSecondElem,
+					idArrEmptyAddresses, idArrNoAddresses,
+					idArrAddrWithTags, idArrAddrCityAndTags, idArrTagsInSecondElem,
+				})
+		})
+
+		t.Run("nestedArray_is_null", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nestedArray", true),
+				[]strfmt.UUID{idArrEmptyTopLevel, idArrNoNestedArrayProp})
+		})
+
+		t.Run("addresses_is_not_null", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nestedArray.addresses", false),
+				[]strfmt.UUID{
+					idArrAddrWithCity, idArrAddrNoCity, idArrMixedAcrossElems, idArrCityInSecondElem,
+					idArrAddrWithTags, idArrAddrCityAndTags, idArrTagsInSecondElem,
+				})
+		})
+
+		t.Run("addresses_is_null", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nestedArray.addresses", true),
+				[]strfmt.UUID{idArrEmptyAddresses, idArrNoAddresses, idArrEmptyTopLevel, idArrNoNestedArrayProp})
+		})
+
+		t.Run("addresses_city_is_not_null", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nestedArray.addresses.city", false),
+				[]strfmt.UUID{
+					idArrAddrWithCity, idArrMixedAcrossElems, idArrCityInSecondElem,
+					idArrAddrCityAndTags,
+				})
+		})
+
+		t.Run("addresses_city_is_null_universal", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nestedArray.addresses.city", true),
+				[]strfmt.UUID{
+					idArrAddrNoCity, idArrEmptyAddresses, idArrNoAddresses, idArrEmptyTopLevel, idArrNoNestedArrayProp,
+					idArrAddrWithTags, idArrTagsInSecondElem,
+				})
+		})
+
+		t.Run("addresses_tags_is_not_null", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nestedArray.addresses.tags", false),
+				[]strfmt.UUID{idArrAddrWithTags, idArrAddrCityAndTags, idArrTagsInSecondElem})
+		})
+
+		t.Run("addresses_tags_is_null_universal", func(t *testing.T) {
+			runScenario(t, docs, isNullFilter("nestedArray.addresses.tags", true),
+				[]strfmt.UUID{
+					idArrAddrWithCity, idArrAddrNoCity, idArrMixedAcrossElems, idArrCityInSecondElem,
+					idArrEmptyAddresses, idArrNoAddresses, idArrEmptyTopLevel, idArrNoNestedArrayProp,
+				})
+		})
+	})
+}

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -7656,3 +7656,846 @@ func TestNestedFilteringCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 		runOrderings(t, docs, parts, []strfmt.UUID{idMatch})
 	})
 }
+
+// TestNestedFilteringArrayIndexAccess exercises arr[N] positional filters
+// end-to-end through the production write+search pipeline, mirroring the
+// lower-level TestNestedFilteringArrayIndex coverage:
+//
+//   - basic positional: addresses[1].city = "berlin" — matches docs whose
+//     second address element has the value
+//   - out-of-range: addresses[5].city = "berlin" — returns empty when the
+//     index is beyond the array length
+//   - arr[N] in correlated AND: cars[1].make = "bmw" AND
+//     cars[1].tires.width = 205 — both conditions pinned to the same car
+//     index; rejects docs that don't have a cars[1]
+//   - multi-root (object[] variant only): docs[K].addresses[1].city —
+//     verifies arr[N] resolves correctly across multiple root elements
+//
+// Run under both DataTypeObject (top-level "doc") and DataTypeObjectArray
+// (top-level "docs") root properties to cover both encodings.
+func TestNestedFilteringArrayIndexAccess(t *testing.T) {
+	const nestedClass = "ArrIdxAccess"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	rootProps := []*models.NestedProperty{
+		{
+			Name: "addresses", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{Name: "postcode", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+			},
+		},
+		{
+			Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{
+					Name: "tires", DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+					},
+				},
+			},
+		},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "doc", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+			{Name: "docs", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	addr := func(props ...any) map[string]any {
+		out := map[string]any{}
+		for i := 0; i < len(props); i += 2 {
+			out[props[i].(string)] = props[i+1]
+		}
+		return out
+	}
+	tire := func(width int) map[string]any { return map[string]any{"width": width} }
+	car := func(props ...any) map[string]any {
+		out := map[string]any{}
+		for i := 0; i < len(props); i += 2 {
+			out[props[i].(string)] = props[i+1]
+		}
+		return out
+	}
+
+	textFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	intFilter := func(path string, val int) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeInt, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: operands,
+		}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	// ---------- DataTypeObject (top-level "doc") ----------
+	t.Run("doc_object", func(t *testing.T) {
+		// Sub-test 1: addresses[1].city = "berlin"
+		t.Run("addresses[1].city_berlin", func(t *testing.T) {
+			idMatch := uuid(1)
+			idNoMatchSecondAddrWrongCity := uuid(2)
+			idNoMatchSecondAddrAbsent := uuid(3)
+			idNoMatchFirstIsBerlin := uuid(4)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"doc": map[string]any{"addresses": asArr(
+					addr("city", "paris"), addr("city", "berlin", "postcode", "10115"),
+				)}}, note: "addresses[1] = berlin"},
+				{id: idNoMatchSecondAddrWrongCity, props: map[string]any{"doc": map[string]any{"addresses": asArr(
+					addr("city", "paris"), addr("city", "munich"),
+				)}}, note: "addresses[1] = munich"},
+				{id: idNoMatchSecondAddrAbsent, props: map[string]any{"doc": map[string]any{"addresses": asArr(
+					addr("city", "berlin"),
+				)}}, note: "only addresses[0]; no addresses[1]"},
+				{id: idNoMatchFirstIsBerlin, props: map[string]any{"doc": map[string]any{"addresses": asArr(
+					addr("city", "berlin"), addr("city", "munich"),
+				)}}, note: "addresses[0]=berlin but [1]=munich"},
+			}
+			runScenario(t, docs, textFilter("doc.addresses[1].city", "berlin"), []strfmt.UUID{idMatch})
+		})
+
+		// Sub-test 2: addresses[5].city = "berlin" (out of range — no doc has 6+ addresses)
+		t.Run("addresses[5].city_out_of_range", func(t *testing.T) {
+			idDoc := uuid(1)
+			docs := []docDef{
+				{id: idDoc, props: map[string]any{"doc": map[string]any{"addresses": asArr(
+					addr("city", "berlin"), addr("city", "paris"),
+				)}}, note: "only 2 addresses"},
+			}
+			runScenario(t, docs, textFilter("doc.addresses[5].city", "berlin"), []strfmt.UUID{})
+		})
+
+		// Sub-test 3: cars[1].make = "bmw" AND cars[1].tires.width = 205
+		t.Run("cars[1]_make_AND_cars[1].tires.width", func(t *testing.T) {
+			idMatch := uuid(1)
+			idNoMatchSecondCarAbsent := uuid(2)
+			idNoMatchWrongMake := uuid(3)
+			idNoMatchSplitCars := uuid(4)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					car("make", "tesla"),
+					car("make", "bmw", "tires", asArr(tire(205))),
+				)}}, note: "cars[1] has both make=bmw and tires.width=205"},
+				{id: idNoMatchSecondCarAbsent, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					car("make", "bmw", "tires", asArr(tire(205))),
+				)}}, note: "only cars[0]; satisfies neither pinned cars[1] condition"},
+				{id: idNoMatchWrongMake, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					car("make", "tesla"),
+					car("make", "tesla", "tires", asArr(tire(205))),
+				)}}, note: "cars[1] has tires.width=205 but make=tesla, not bmw"},
+				{id: idNoMatchSplitCars, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					car("make", "bmw"),
+					car("make", "tesla", "tires", asArr(tire(205))),
+				)}}, note: "make=bmw in cars[0]; width=205 in cars[1] — different cars"},
+			}
+			filter := andFilter(
+				textFilter("doc.cars[1].make", "bmw"),
+				intFilter("doc.cars[1].tires.width", 205),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch})
+		})
+
+		// Sub-test 4: arr[N] against an empty intermediate array or absent
+		// property — neither should match (no element exists at index N).
+		t.Run("cars[0].make_empty_or_absent", func(t *testing.T) {
+			idEmptyArr := uuid(1)   // cars: []
+			idAbsentCars := uuid(2) // cars key omitted entirely
+			idMatch := uuid(3)
+			docs := []docDef{
+				{id: idEmptyArr, props: map[string]any{"doc": map[string]any{"cars": []any{}}}, note: "cars=[]"},
+				{id: idAbsentCars, props: map[string]any{"doc": map[string]any{}}, note: "no cars key"},
+				{id: idMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(car("make", "bmw"))}}, note: "cars[0]=bmw"},
+			}
+			runScenario(t, docs, textFilter("doc.cars[0].make", "bmw"), []strfmt.UUID{idMatch})
+		})
+	})
+
+	// ---------- DataTypeObjectArray (top-level "docs") ----------
+	t.Run("docs_array", func(t *testing.T) {
+		// Sub-test 1: docs.addresses[1].city = "berlin" (same shape as object variant,
+		// but the root is an object[] so we also test arr[N] across multiple root elements)
+		t.Run("docs.addresses[1].city_berlin", func(t *testing.T) {
+			idMatchSingleRoot := uuid(1)
+			idMatchSecondRoot := uuid(2)
+			idNoMatchAbsent := uuid(3)
+			docs := []docDef{
+				{id: idMatchSingleRoot, props: map[string]any{"docs": asArr(
+					map[string]any{"addresses": asArr(addr("city", "paris"), addr("city", "berlin"))},
+				)}, note: "single root; addresses[1] = berlin"},
+				{id: idMatchSecondRoot, props: map[string]any{"docs": asArr(
+					map[string]any{"addresses": asArr(addr("city", "munich"))},
+					map[string]any{"addresses": asArr(addr("city", "paris"), addr("city", "berlin"))},
+				)}, note: "second root has matching addresses[1]"},
+				{id: idNoMatchAbsent, props: map[string]any{"docs": asArr(
+					map[string]any{"addresses": asArr(addr("city", "berlin"))},
+				)}, note: "no addresses[1] anywhere"},
+			}
+			runScenario(t, docs, textFilter("docs.addresses[1].city", "berlin"), []strfmt.UUID{idMatchSingleRoot, idMatchSecondRoot})
+		})
+
+		// Sub-test 2: out-of-range arr[N]
+		t.Run("docs.addresses[5].city_out_of_range", func(t *testing.T) {
+			idDoc := uuid(1)
+			docs := []docDef{
+				{id: idDoc, props: map[string]any{"docs": asArr(
+					map[string]any{"addresses": asArr(addr("city", "berlin"), addr("city", "paris"))},
+				)}, note: "only 2 addresses"},
+			}
+			runScenario(t, docs, textFilter("docs.addresses[5].city", "berlin"), []strfmt.UUID{})
+		})
+
+		// Sub-test 3: arr[N] in correlated AND, also exercising root_idx disambiguation
+		t.Run("docs.cars[1]_make_AND_cars[1].tires.width", func(t *testing.T) {
+			idMatch := uuid(1)
+			idMatchInSecondRoot := uuid(2)
+			idNoMatchSplitRoots := uuid(3)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(
+						car("make", "tesla"),
+						car("make", "bmw", "tires", asArr(tire(205))),
+					)},
+				)}, note: "cars[1] in single root has both"},
+				{id: idMatchInSecondRoot, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "tesla"))},
+					map[string]any{"cars": asArr(
+						car("make", "tesla"),
+						car("make", "bmw", "tires", asArr(tire(205))),
+					)},
+				)}, note: "second root's cars[1] has both"},
+				{id: idNoMatchSplitRoots, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(
+						car("make", "tesla"),
+						car("make", "bmw"),
+					)},
+					map[string]any{"cars": asArr(
+						car("make", "tesla"),
+						car("make", "tesla", "tires", asArr(tire(205))),
+					)},
+				)}, note: "make=bmw in root[0].cars[1]; width=205 in root[1].cars[1] — different roots"},
+			}
+			filter := andFilter(
+				textFilter("docs.cars[1].make", "bmw"),
+				intFilter("docs.cars[1].tires.width", 205),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchInSecondRoot})
+		})
+	})
+}
+
+// TestNestedFilteringArrayIndexLevels exercises positional arr[N] access at
+// different nesting levels (root, mid-1, mid-2) and the dispatch behavior of
+// AND / OR over conditions pinned to *different* arr[N] indices at the same
+// LCA. Same-element AND on the same index is covered by
+// TestNestedFilteringArrayIndexAccess; this test focuses on
+//   - levels: root[N], cars[N], cars.tires[N]
+//   - combinations: AND with conflicting indices (partitioned via
+//     groupChildrenByArrayIndicesKey) and OR (per-clause union).
+func TestNestedFilteringArrayIndexLevels(t *testing.T) {
+	const nestedClass = "ArrIdxLevels"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	rootProps := []*models.NestedProperty{
+		{
+			Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{
+					Name: "tires", DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "width", DataType: schema.DataTypeInt.PropString(), IndexFilterable: &vTrue},
+					},
+				},
+			},
+		},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "doc", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+			{Name: "docs", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	tire := func(width int) map[string]any { return map[string]any{"width": width} }
+	car := func(props ...any) map[string]any {
+		out := map[string]any{}
+		for i := 0; i < len(props); i += 2 {
+			out[props[i].(string)] = props[i+1]
+		}
+		return out
+	}
+
+	textFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	intFilter := func(path string, val int) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeInt, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+	orFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorOr, Operands: operands}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	// ---------- DataTypeObject (top-level "doc") ----------
+	t.Run("doc_object", func(t *testing.T) {
+		// Mid-1 positional: doc.cars[N].make
+		t.Run("mid1_cars[N].make_positional", func(t *testing.T) {
+			id1 := uuid(1) // cars=[tesla,bmw]
+			id2 := uuid(2) // cars=[bmw]
+			id3 := uuid(3) // cars=[bmw,tesla]
+			docs := []docDef{
+				{id: id1, props: map[string]any{"doc": map[string]any{"cars": asArr(car("make", "tesla"), car("make", "bmw"))}}, note: "[tesla,bmw]"},
+				{id: id2, props: map[string]any{"doc": map[string]any{"cars": asArr(car("make", "bmw"))}}, note: "[bmw]"},
+				{id: id3, props: map[string]any{"doc": map[string]any{"cars": asArr(car("make", "bmw"), car("make", "tesla"))}}, note: "[bmw,tesla]"},
+			}
+			t.Run("cars[0].make=bmw", func(t *testing.T) {
+				runScenario(t, docs, textFilter("doc.cars[0].make", "bmw"), []strfmt.UUID{id2, id3})
+			})
+			t.Run("cars[1].make=bmw", func(t *testing.T) {
+				runScenario(t, docs, textFilter("doc.cars[1].make", "bmw"), []strfmt.UUID{id1})
+			})
+		})
+
+		// Mid-2 positional: doc.cars.tires[N].width (cars unindexed; only tires pinned)
+		t.Run("mid2_tires[N].width_positional", func(t *testing.T) {
+			id1 := uuid(1) // tires=[205,305]
+			id2 := uuid(2) // tires=[205]
+			id3 := uuid(3) // tires=[305,205]
+			docs := []docDef{
+				{id: id1, props: map[string]any{"doc": map[string]any{"cars": asArr(car("tires", asArr(tire(205), tire(305))))}}, note: "tires=[205,305]"},
+				{id: id2, props: map[string]any{"doc": map[string]any{"cars": asArr(car("tires", asArr(tire(205))))}}, note: "tires=[205]"},
+				{id: id3, props: map[string]any{"doc": map[string]any{"cars": asArr(car("tires", asArr(tire(305), tire(205))))}}, note: "tires=[305,205]"},
+			}
+			t.Run("tires[0].width=205", func(t *testing.T) {
+				runScenario(t, docs, intFilter("doc.cars.tires[0].width", 205), []strfmt.UUID{id1, id2})
+			})
+			t.Run("tires[1].width=205", func(t *testing.T) {
+				runScenario(t, docs, intFilter("doc.cars.tires[1].width", 205), []strfmt.UUID{id3})
+			})
+		})
+
+		// AND with conflicting cars[N] indices: groupChildrenByArrayIndicesKey
+		// partitions the two clauses into independent groups (each pinned to a
+		// different K), then ANDs at docID level.
+		t.Run("AND_cars[0]=tesla_AND_cars[1]=bmw", func(t *testing.T) {
+			idMatch := uuid(1)            // cars=[tesla,bmw]
+			idNoMatchSwapped := uuid(2)   // cars=[bmw,tesla]
+			idNoMatchOnlyFirst := uuid(3) // cars=[tesla]
+			idNoMatchSecondCarOnly := uuid(4)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(car("make", "tesla"), car("make", "bmw"))}}, note: "[tesla,bmw]"},
+				{id: idNoMatchSwapped, props: map[string]any{"doc": map[string]any{"cars": asArr(car("make", "bmw"), car("make", "tesla"))}}, note: "[bmw,tesla] swapped"},
+				{id: idNoMatchOnlyFirst, props: map[string]any{"doc": map[string]any{"cars": asArr(car("make", "tesla"))}}, note: "[tesla] only"},
+				{id: idNoMatchSecondCarOnly, props: map[string]any{"doc": map[string]any{"cars": asArr(car("make", "volvo"), car("make", "bmw"))}}, note: "[volvo,bmw] cars[0]≠tesla"},
+			}
+			filter := andFilter(
+				textFilter("doc.cars[0].make", "tesla"),
+				textFilter("doc.cars[1].make", "bmw"),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch})
+		})
+
+		// OR with conflicting cars[N] indices: each clause resolved independently
+		// and unioned at docID level (no partitioning needed).
+		t.Run("OR_cars[0]=tesla_OR_cars[1]=bmw", func(t *testing.T) {
+			id1 := uuid(1) // [tesla,bmw] — matches via either side
+			id2 := uuid(2) // [tesla] — matches via cars[0]
+			id3 := uuid(3) // [volvo,bmw] — matches via cars[1]
+			id4 := uuid(4) // [volvo] — no match
+			docs := []docDef{
+				{id: id1, props: map[string]any{"doc": map[string]any{"cars": asArr(car("make", "tesla"), car("make", "bmw"))}}, note: "[tesla,bmw]"},
+				{id: id2, props: map[string]any{"doc": map[string]any{"cars": asArr(car("make", "tesla"))}}, note: "[tesla]"},
+				{id: id3, props: map[string]any{"doc": map[string]any{"cars": asArr(car("make", "volvo"), car("make", "bmw"))}}, note: "[volvo,bmw]"},
+				{id: id4, props: map[string]any{"doc": map[string]any{"cars": asArr(car("make", "volvo"))}}, note: "[volvo]"},
+			}
+			filter := orFilter(
+				textFilter("doc.cars[0].make", "tesla"),
+				textFilter("doc.cars[1].make", "bmw"),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{id1, id2, id3})
+		})
+
+		// Multi-level pin in a single clause: doc.cars[0].tires[1].width=205.
+		// Both `cars` and `tires` indices are pinned in one path → stacked
+		// IdxKey constraints on the same chain. Different from 1a's
+		// cars[1].tires.width (only cars pinned) and 1b's tires[N].width
+		// (only tires pinned).
+		t.Run("multi_level_pin_cars[0].tires[1].width", func(t *testing.T) {
+			idMatch := uuid(1)              // cars[0].tires=[305,205]
+			idNoMatchTires0Is205 := uuid(2) // cars[0].tires=[205,305] — match in tires[0] not tires[1]
+			idNoMatchSingleTire := uuid(3)  // cars[0].tires=[205] — no tires[1]
+			idNoMatchSplitCars := uuid(4)   // cars[0].tires=[305], cars[1].tires=[305,205]
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(car("tires", asArr(tire(305), tire(205))))}}, note: "cars[0].tires[1]=205"},
+				{id: idNoMatchTires0Is205, props: map[string]any{"doc": map[string]any{"cars": asArr(car("tires", asArr(tire(205), tire(305))))}}, note: "cars[0].tires[0]=205"},
+				{id: idNoMatchSingleTire, props: map[string]any{"doc": map[string]any{"cars": asArr(car("tires", asArr(tire(205))))}}, note: "cars[0] only has tires[0]"},
+				{id: idNoMatchSplitCars, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					car("tires", asArr(tire(305))),
+					car("tires", asArr(tire(305), tire(205))),
+				)}}, note: "match in cars[1].tires[1] not cars[0].tires[1]"},
+			}
+			runScenario(t, docs, intFilter("doc.cars[0].tires[1].width", 205), []strfmt.UUID{idMatch})
+		})
+
+		// Three-clause AND with overlapping indices:
+		//   cars[0].make=tesla AND cars[1].make=bmw AND cars[1].tires.width=205
+		// Partitioner groups the two cars[1] clauses together (correlated AND
+		// over the same physical car at index 1) and ANDs that with the
+		// independent cars[0] group at docID level.
+		t.Run("AND_three_clause_partitioned_cars[0]_AND_cars[1]_pair", func(t *testing.T) {
+			idMatch := uuid(1) // [tesla, bmw+tires205]
+			idNoMatchCars1MissingWidth := uuid(2)
+			idNoMatchCars0Wrong := uuid(3)
+			idNoMatchSplitWidth := uuid(4) // tires.width=205 in cars[0] not cars[1]
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					car("make", "tesla"),
+					car("make", "bmw", "tires", asArr(tire(205))),
+				)}}, note: "cars[0]=tesla, cars[1]=bmw+tires205"},
+				{id: idNoMatchCars1MissingWidth, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					car("make", "tesla"),
+					car("make", "bmw"),
+				)}}, note: "cars[1] missing tires"},
+				{id: idNoMatchCars0Wrong, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					car("make", "volvo"),
+					car("make", "bmw", "tires", asArr(tire(205))),
+				)}}, note: "cars[0]=volvo not tesla"},
+				{id: idNoMatchSplitWidth, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					car("make", "tesla", "tires", asArr(tire(205))),
+					car("make", "bmw"),
+				)}}, note: "tires.width=205 in cars[0] not cars[1]"},
+			}
+			filter := andFilter(
+				textFilter("doc.cars[0].make", "tesla"),
+				textFilter("doc.cars[1].make", "bmw"),
+				intFilter("doc.cars[1].tires.width", 205),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch})
+		})
+	})
+
+	// ---------- DataTypeObjectArray (top-level "docs") ----------
+	t.Run("docs_array", func(t *testing.T) {
+		// Root positional: docs[N].cars.make — exercises root_idx encoding.
+		t.Run("root_docs[N].cars.make_positional", func(t *testing.T) {
+			id1 := uuid(1) // docs=[{tesla},{bmw}]
+			id2 := uuid(2) // docs=[{bmw}]
+			id3 := uuid(3) // docs=[{bmw},{tesla}]
+			docs := []docDef{
+				{id: id1, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "tesla"))},
+					map[string]any{"cars": asArr(car("make", "bmw"))},
+				)}, note: "[{tesla},{bmw}]"},
+				{id: id2, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "bmw"))},
+				)}, note: "[{bmw}]"},
+				{id: id3, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "bmw"))},
+					map[string]any{"cars": asArr(car("make", "tesla"))},
+				)}, note: "[{bmw},{tesla}]"},
+			}
+			t.Run("docs[0].cars.make=bmw", func(t *testing.T) {
+				runScenario(t, docs, textFilter("docs[0].cars.make", "bmw"), []strfmt.UUID{id2, id3})
+			})
+			t.Run("docs[1].cars.make=bmw", func(t *testing.T) {
+				runScenario(t, docs, textFilter("docs[1].cars.make", "bmw"), []strfmt.UUID{id1})
+			})
+		})
+
+		// AND with conflicting docs[N] indices (root level partitioning).
+		t.Run("AND_docs[0]=tesla_AND_docs[1]=bmw", func(t *testing.T) {
+			idMatch := uuid(1)
+			idNoMatchSwapped := uuid(2)
+			idNoMatchOnlyFirst := uuid(3)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "tesla"))},
+					map[string]any{"cars": asArr(car("make", "bmw"))},
+				)}, note: "[{tesla},{bmw}]"},
+				{id: idNoMatchSwapped, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "bmw"))},
+					map[string]any{"cars": asArr(car("make", "tesla"))},
+				)}, note: "[{bmw},{tesla}] swapped"},
+				{id: idNoMatchOnlyFirst, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "tesla"))},
+				)}, note: "[{tesla}] only"},
+			}
+			filter := andFilter(
+				textFilter("docs[0].cars.make", "tesla"),
+				textFilter("docs[1].cars.make", "bmw"),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch})
+		})
+
+		// OR with conflicting docs[N] indices: per-clause union.
+		t.Run("OR_docs[0]=tesla_OR_docs[1]=bmw", func(t *testing.T) {
+			id1 := uuid(1) // [{tesla},{bmw}] — both
+			id2 := uuid(2) // [{tesla}] — docs[0]
+			id3 := uuid(3) // [{volvo},{bmw}] — docs[1]
+			id4 := uuid(4) // [{volvo}] — no match
+			docs := []docDef{
+				{id: id1, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "tesla"))},
+					map[string]any{"cars": asArr(car("make", "bmw"))},
+				)}, note: "[{tesla},{bmw}]"},
+				{id: id2, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "tesla"))},
+				)}, note: "[{tesla}]"},
+				{id: id3, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "volvo"))},
+					map[string]any{"cars": asArr(car("make", "bmw"))},
+				)}, note: "[{volvo},{bmw}]"},
+				{id: id4, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "volvo"))},
+				)}, note: "[{volvo}]"},
+			}
+			filter := orFilter(
+				textFilter("docs[0].cars.make", "tesla"),
+				textFilter("docs[1].cars.make", "bmw"),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{id1, id2, id3})
+		})
+
+		// Combined root + intermediate pin in a single clause:
+		// docs[1].cars[0].make=bmw — both root_idx and intermediate IdxKey
+		// applied to the same path simultaneously.
+		t.Run("multi_level_pin_docs[1].cars[0].make", func(t *testing.T) {
+			idMatch := uuid(1)             // docs=[{tesla},{bmw}] → docs[1].cars[0]=bmw
+			idNoMatchDocs1Tesla := uuid(2) // docs=[{bmw},{tesla}] → docs[1].cars[0]=tesla
+			idNoMatchSingleRoot := uuid(3) // docs=[{bmw}] → no docs[1]
+			idNoMatchCarsAt1 := uuid(4)    // docs=[{tesla},{tesla,bmw}] → docs[1].cars[0]=tesla, cars[1]=bmw
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "tesla"))},
+					map[string]any{"cars": asArr(car("make", "bmw"))},
+				)}, note: "docs[1].cars[0]=bmw"},
+				{id: idNoMatchDocs1Tesla, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "bmw"))},
+					map[string]any{"cars": asArr(car("make", "tesla"))},
+				)}, note: "docs[1].cars[0]=tesla"},
+				{id: idNoMatchSingleRoot, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "bmw"))},
+				)}, note: "single root, no docs[1]"},
+				{id: idNoMatchCarsAt1, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(car("make", "tesla"))},
+					map[string]any{"cars": asArr(car("make", "tesla"), car("make", "bmw"))},
+				)}, note: "docs[1].cars[1]=bmw but cars[0]=tesla"},
+			}
+			runScenario(t, docs, textFilter("docs[1].cars[0].make", "bmw"), []strfmt.UUID{idMatch})
+		})
+	})
+}
+
+// TestNestedFilteringMixedArrayIndexConstraints exercises correlated AND when
+// clauses at the same LCA have *different* arr[N] constraint sets — one
+// unconstrained, the other pinned. Compatibility grouping treats {} and {N}
+// as compatible (same compatibility key) → both clauses share the same
+// resolveNestedCorrelatedGroup call, and same-element semantics force the
+// unconstrained side to match the same physical element pinned by the [N]
+// side. This is the cross-cutting case between Levels (1b) and the basic
+// arr[N] same-K AND in Access (1a).
+func TestNestedFilteringMixedArrayIndexConstraints(t *testing.T) {
+	const nestedClass = "ArrIdxMixed"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	rootProps := []*models.NestedProperty{
+		{
+			Name: "addresses", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+			},
+		},
+		{
+			Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+				{Name: "color", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+			},
+		},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "doc", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+			{Name: "docs", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	obj := func(props ...any) map[string]any {
+		out := map[string]any{}
+		for i := 0; i < len(props); i += 2 {
+			out[props[i].(string)] = props[i+1]
+		}
+		return out
+	}
+
+	textFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	// ---------- DataTypeObject (top-level "doc") ----------
+	t.Run("doc_object", func(t *testing.T) {
+		// Intermediate-level mix: doc.cars.color=red (unconstrained) AND
+		// doc.cars[1].make=bmw (pinned to cars[1]). Same-car semantics: the
+		// unconstrained color must be satisfied at the *same* car element as the
+		// pinned make → only docs whose cars[1] has BOTH red and bmw match.
+		t.Run("intermediate_color_AND_cars[1].make", func(t *testing.T) {
+			idMatch := uuid(1)         // cars=[{green},{red,bmw}] — cars[1] has both
+			idNoMatchSplit := uuid(2)  // cars=[{red},{bmw}] — different cars
+			idNoMatchNoRed := uuid(3)  // cars=[{green},{green,bmw}] — no red anywhere
+			idNoMatchSingle := uuid(4) // cars=[{red,bmw}] — only cars[0]; no cars[1]
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					obj("color", "green"),
+					obj("color", "red", "make", "bmw"),
+				)}}, note: "cars[1] has color=red AND make=bmw"},
+				{id: idNoMatchSplit, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					obj("color", "red"),
+					obj("make", "bmw"),
+				)}}, note: "red in cars[0]; bmw in cars[1]"},
+				{id: idNoMatchNoRed, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					obj("color", "green"),
+					obj("color", "green", "make", "bmw"),
+				)}}, note: "no red anywhere"},
+				{id: idNoMatchSingle, props: map[string]any{"doc": map[string]any{"cars": asArr(
+					obj("color", "red", "make", "bmw"),
+				)}}, note: "only cars[0]; no cars[1] to satisfy pinned make"},
+			}
+			filter := andFilter(
+				textFilter("doc.cars.color", "red"),
+				textFilter("doc.cars[1].make", "bmw"),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch})
+		})
+	})
+
+	// ---------- DataTypeObjectArray (top-level "docs") ----------
+	t.Run("docs_array", func(t *testing.T) {
+		// Root-level mix: docs.addresses.city=berlin (unconstrained) AND
+		// docs[1].cars.make=bmw (pinned to root[1]). Same-root-element semantics:
+		// the unconstrained city must be satisfied in the *same* root element as
+		// the pinned make → only docs whose root[1] has BOTH berlin and bmw match.
+		t.Run("root_addresses.city_AND_docs[1].cars.make", func(t *testing.T) {
+			idMatch := uuid(1)        // root[1] has berlin AND bmw
+			idNoMatchSplit := uuid(2) // berlin in root[0]; bmw in root[1] — different roots
+			idNoMatchNoBerlin := uuid(3)
+			idNoMatchSingleRoot := uuid(4) // only root[0]; no root[1]
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"docs": asArr(
+					obj("addresses", asArr(obj("city", "munich")), "cars", asArr(obj("make", "tesla"))),
+					obj("addresses", asArr(obj("city", "berlin")), "cars", asArr(obj("make", "bmw"))),
+				)}, note: "root[1] has berlin and bmw"},
+				{id: idNoMatchSplit, props: map[string]any{"docs": asArr(
+					obj("addresses", asArr(obj("city", "berlin")), "cars", asArr(obj("make", "tesla"))),
+					obj("addresses", asArr(obj("city", "munich")), "cars", asArr(obj("make", "bmw"))),
+				)}, note: "berlin in root[0]; bmw in root[1]"},
+				{id: idNoMatchNoBerlin, props: map[string]any{"docs": asArr(
+					obj("addresses", asArr(obj("city", "munich")), "cars", asArr(obj("make", "bmw"))),
+					obj("addresses", asArr(obj("city", "paris")), "cars", asArr(obj("make", "bmw"))),
+				)}, note: "no berlin anywhere"},
+				{id: idNoMatchSingleRoot, props: map[string]any{"docs": asArr(
+					obj("addresses", asArr(obj("city", "berlin")), "cars", asArr(obj("make", "bmw"))),
+				)}, note: "only root[0]; no root[1] to satisfy pinned make"},
+			}
+			filter := andFilter(
+				textFilter("docs.addresses.city", "berlin"),
+				textFilter("docs[1].cars.make", "bmw"),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch})
+		})
+
+		// Intermediate-level mix: same as doc_object intermediate test but with
+		// object[] root. Exercises the same compatibility-grouping logic when the
+		// LCA is at cars and root is object[].
+		t.Run("intermediate_color_AND_docs.cars[1].make", func(t *testing.T) {
+			idMatch := uuid(1)
+			idNoMatchSplitCars := uuid(2)
+			idNoMatchSplitRoots := uuid(3)
+			docs := []docDef{
+				{id: idMatch, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(obj("color", "green"), obj("color", "red", "make", "bmw"))},
+				)}, note: "single root, cars[1] has both"},
+				{id: idNoMatchSplitCars, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(obj("color", "red"), obj("make", "bmw"))},
+				)}, note: "single root, red in cars[0], bmw in cars[1]"},
+				{id: idNoMatchSplitRoots, props: map[string]any{"docs": asArr(
+					map[string]any{"cars": asArr(obj("color", "red"))},
+					map[string]any{"cars": asArr(obj("color", "green"), obj("make", "bmw"))},
+				)}, note: "red in root[0].cars[0]; bmw in root[1].cars[1] — different cars"},
+			}
+			filter := andFilter(
+				textFilter("docs.cars.color", "red"),
+				textFilter("docs.cars[1].make", "bmw"),
+			)
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch})
+		})
+	})
+}

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -9692,3 +9692,207 @@ func TestNestedFilteringComprehensive(t *testing.T) {
 		})
 	}
 }
+
+// TestNestedFilteringTokenizationFollowups closes three coverage gaps in the
+// tokenization cluster left open by TestNestedFilteringTokenizationCorrelatedAnd:
+//
+//  1. Multi-token text combined with arr[N] —
+//     `addresses[0].city = "new york" AND addresses[0].postcode = "10115"`.
+//     Verifies that arr[N] restriction applies to all token-leaf positions,
+//     not just the wrapper's first leaf.
+//  2. Multi-token text at a deeper LCA — `cars.tires.description = "new york"
+//     AND cars.tires.brand = "high speed"`. Existing tokenization tests use
+//     LCA=addresses (L1); this verifies the same machinery at LCA=cars.tires
+//     (L2) where the token wrapper sits at a deeper path.
+//  3. Multi-token same-path contradiction — `addresses.city = "new york" AND
+//     addresses.city = "munich oslo"`. Both clauses are token wrappers; AndAll
+//     collapses to require all four tokens (new, york, munich, oslo) at the
+//     same leaf. Documents the actual edge-case behavior — should match only
+//     docs whose city literally contains all four tokens at one address.
+func TestNestedFilteringTokenizationFollowups(t *testing.T) {
+	const nestedClass = "TokenizationFollowups"
+	vTrue := true
+	word := models.NestedPropertyTokenizationWord
+
+	rootProps := []*models.NestedProperty{
+		{
+			Name: "addresses", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+				{Name: "postcode", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+			},
+		},
+		{
+			Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: []*models.NestedProperty{
+				{
+					Name: "tires", DataType: schema.DataTypeObjectArray.PropString(),
+					NestedProperties: []*models.NestedProperty{
+						{Name: "description", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+						{Name: "brand", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+					},
+				},
+			},
+		},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "doc", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootProps},
+		},
+	}
+
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+	addr := func(props ...any) map[string]any {
+		out := map[string]any{}
+		for i := 0; i < len(props); i += 2 {
+			out[props[i].(string)] = props[i+1]
+		}
+		return out
+	}
+	tireDB := func(desc, brand string) map[string]any {
+		out := map[string]any{}
+		if desc != "" {
+			out["description"] = desc
+		}
+		if brand != "" {
+			out["brand"] = brand
+		}
+		return out
+	}
+	carWithTires := func(tires ...map[string]any) map[string]any {
+		anyTires := make([]any, len(tires))
+		for i, t := range tires {
+			anyTires[i] = t
+		}
+		return map[string]any{"tires": anyTires}
+	}
+
+	textFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(parts ...*filters.LocalFilter) *filters.LocalFilter {
+		operands := make([]filters.Clause, len(parts))
+		for i, p := range parts {
+			operands[i] = *p.Root
+		}
+		return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: operands}}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	// ----- 1. Multi-token + arr[N] -----
+	// `addresses[0].city = "new york" AND addresses[0].postcode = "10115"`
+	t.Run("arrN_addresses[0].city_new_york_AND_postcode", func(t *testing.T) {
+		idMatch := uuid(1)               // addresses[0] has city="new york" + postcode="10115"
+		idMatchExtraToken := uuid(2)     // addresses[0] city="new york city" — extra token at same leaf
+		idNoMatchInSecond := uuid(3)     // addresses[0]={}, addresses[1] satisfies — pin to [0] excludes
+		idNoMatchSplitTokens := uuid(4)  // addresses[0]={city:"new",postcode:"10115"}, [1]={city:"york"} — tokens split
+		idNoMatchOnlyOne := uuid(5)      // addresses[0] has only one of the two clauses
+		idNoMatchSplitClauses := uuid(6) // city in [0], postcode in [1] — same-element forces both at [0]
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("city", "new york", "postcode", "10115"))}}, note: "[0] has both"},
+			{id: idMatchExtraToken, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("city", "new york city", "postcode", "10115"))}}, note: "[0].city has extra token"},
+			{id: idNoMatchInSecond, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr(), addr("city", "new york", "postcode", "10115"))}}, note: "match only at [1]; pinned to [0]"},
+			{id: idNoMatchSplitTokens, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("city", "new", "postcode", "10115"), addr("city", "york"))}}, note: "city tokens split across addresses"},
+			{id: idNoMatchOnlyOne, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("city", "new york"))}}, note: "[0] has city but no postcode"},
+			{id: idNoMatchSplitClauses, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("city", "new york"), addr("postcode", "10115"))}}, note: "city at [0], postcode at [1]"},
+		}
+		filter := andFilter(
+			textFilter("doc.addresses[0].city", "new york"),
+			textFilter("doc.addresses[0].postcode", "10115"),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchExtraToken})
+	})
+
+	// ----- 2. Multi-token at deeper LCA -----
+	// LCA = cars.tires (L2 from root); both clauses are multi-token at the same
+	// LCA. Same-tire correlation requires the same physical tire to satisfy
+	// both `description` and `brand`.
+	t.Run("deeper_LCA_cars.tires.description_AND_brand_multi_token", func(t *testing.T) {
+		idMatch := uuid(1)                   // tires=[{description:"new york",brand:"high speed"}]
+		idMatchSecondTire := uuid(2)         // tires=[{},{description:"new york",brand:"high speed"}]
+		idNoMatchSplitAcrossTires := uuid(3) // description in tires[0], brand in tires[1]
+		idNoMatchPartialClause := uuid(4)    // tires[0].description has only "new"
+		idNoMatchWrongBrand := uuid(5)       // tires[0] correct desc but brand="low speed"
+		idMatchExtraTokens := uuid(6)        // description="new york city", brand="very high speed" — extra tokens
+		docs := []docDef{
+			{id: idMatch, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithTires(tireDB("new york", "high speed")))}}, note: "tires[0] has both at same tire"},
+			{id: idMatchSecondTire, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithTires(tireDB("", ""), tireDB("new york", "high speed")))}}, note: "tires[1] has both"},
+			{id: idNoMatchSplitAcrossTires, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithTires(tireDB("new york", ""), tireDB("", "high speed")))}}, note: "different tires"},
+			{id: idNoMatchPartialClause, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithTires(tireDB("new", "high speed")))}}, note: "missing 'york' token"},
+			{id: idNoMatchWrongBrand, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithTires(tireDB("new york", "low speed")))}}, note: "wrong brand"},
+			{id: idMatchExtraTokens, props: map[string]any{"doc": map[string]any{"cars": asArr(carWithTires(tireDB("new york city", "very high speed")))}}, note: "extra tokens at same tire"},
+		}
+		filter := andFilter(
+			textFilter("doc.cars.tires.description", "new york"),
+			textFilter("doc.cars.tires.brand", "high speed"),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchSecondTire, idMatchExtraTokens})
+	})
+
+	// ----- 3. Multi-token same-path contradiction -----
+	// `addresses.city = "new york" AND addresses.city = "munich oslo"` — both
+	// clauses target the same path with disjoint multi-token values. AndAll
+	// over the token leaves requires [new, york, munich, oslo] all at the
+	// same address element. Edge case: documents the actual behavior, ensures
+	// no crash, and verifies a doc that *does* contain all four tokens at one
+	// address is matched.
+	t.Run("same_path_multi_token_contradiction", func(t *testing.T) {
+		idNoMatchOnlyFirst := uuid(1)  // city="new york"
+		idNoMatchOnlySecond := uuid(2) // city="munich oslo"
+		idNoMatchSplit := uuid(3)      // city="new york" in [0], city="munich oslo" in [1] — different addresses
+		idAllFourTokens := uuid(4)     // city="new york munich oslo" — all four tokens at one address
+		docs := []docDef{
+			{id: idNoMatchOnlyFirst, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("city", "new york"))}}, note: "city has [new,york]; missing munich,oslo"},
+			{id: idNoMatchOnlySecond, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("city", "munich oslo"))}}, note: "city has [munich,oslo]; missing new,york"},
+			{id: idNoMatchSplit, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("city", "new york"), addr("city", "munich oslo"))}}, note: "split across addresses"},
+			{id: idAllFourTokens, props: map[string]any{"doc": map[string]any{"addresses": asArr(addr("city", "new york munich oslo"))}}, note: "all four tokens at same address"},
+		}
+		filter := andFilter(
+			textFilter("doc.addresses.city", "new york"),
+			textFilter("doc.addresses.city", "munich oslo"),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idAllFourTokens})
+	})
+}

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -7624,7 +7624,7 @@ func TestNestedFilteringCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 	// canUseRawAndAll false (multi-sub at GROUP@cars), flat-AndAll bails on
 	// multi-sub → runIdxLoopRecursive. The wrapping GROUP@garages must be
 	// kept (not collapsed away) so its _idx.garages[K_g] iteration provides
-	// per-garage parentScope to the inner GROUP@cars's _idx.cars[K_c]
+	// per-garage parentScope to the inner GROUP@cars' _idx.cars[K_c]
 	// iteration, disambiguating same-K-different-parent physical cars.
 	//
 	// Discriminating shapes:

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -15,6 +15,7 @@ package db
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -3693,4 +3694,953 @@ func TestNestedFilteringF17DeeperCorrelatedAndDifferentCarsSameGarage(t *testing
 		idCntrMatchHeterogeneous,
 	}
 	assert.ElementsMatch(t, want, got)
+}
+
+// TestNestedFilteringIsNullWithArrNInCorrelatedAnd exercises correlated AND
+// filters where one condition pins to a specific array index (arr[N]) and the
+// other is an IsNull check on a property in the same scope. Coverage spans
+// three arr[N] depths (root countries[N], intermediate garages[N], deepest
+// cars[N]) crossed with IsNull polarity (true/false), plus dual-IsNull
+// patterns (no positive value condition).
+//
+// At each constraint level multiple IsNull depths are exercised where they
+// make sense: IsNull on a leaf, on the intermediate object[] (e.g. cars), and
+// on the outer intermediate object[] (e.g. garages). This probes _exists key
+// generation across arr[N]-restricted scopes and the resolver's ability to
+// combine arr[N] restriction with both leaf-level and intermediate-level
+// IsNull.
+func TestNestedFilteringIsNullWithArrNInCorrelatedAnd(t *testing.T) {
+	const nestedClass = "IsNullArrN"
+	vTrue := true
+	tok := models.NestedPropertyTokenizationField
+
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{
+				Name:     "countries",
+				DataType: schema.DataTypeObjectArray.PropString(),
+				NestedProperties: []*models.NestedProperty{
+					{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+					{
+						Name:     "garages",
+						DataType: schema.DataTypeObjectArray.PropString(),
+						NestedProperties: []*models.NestedProperty{
+							{Name: "city", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+							{
+								Name:     "cars",
+								DataType: schema.DataTypeObjectArray.PropString(),
+								NestedProperties: []*models.NestedProperty{
+									{Name: "make", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+									{Name: "model", DataType: schema.DataTypeText.PropString(), Tokenization: tok, IndexFilterable: &vTrue},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	car := func(props ...string) map[string]any {
+		out := map[string]any{}
+		for i := 0; i < len(props); i += 2 {
+			out[props[i]] = props[i+1]
+		}
+		return out
+	}
+	asArr := func(items ...map[string]any) []any {
+		out := make([]any, len(items))
+		for i, item := range items {
+			out[i] = item
+		}
+		return out
+	}
+
+	valueFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	isNullFilter := func(path string, isNull bool) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorIsNull,
+			Value:    &filters.Value{Type: schema.DataTypeBoolean, Value: isNull},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(a, b *filters.LocalFilter) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: []filters.Clause{*a.Root, *b.Root},
+		}}
+	}
+
+	type docDef struct {
+		id        strfmt.UUID
+		countries []any
+		note      string
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id,
+				Properties: map[string]any{"countries": d.countries},
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	// uuids returns sub-test-scoped UUIDs starting from 0x01.
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	// Reusable filler car: non-matching make and model populated.
+	fillerCar := func() map[string]any { return car("make", "toyota", "model", "corolla") }
+
+	// ----- Constraint at countries[1] -----
+
+	// 1a: countries[1].name = "germany" AND countries[1].garages.cars.model IS NULL
+	t.Run("1a_countries_value_and_isNull_cars_model", func(t *testing.T) {
+		idMatch := uuid(1)
+		idMatchNoGarages := uuid(2)
+		idMatchEmptyGarages := uuid(3)
+		idMatchGarageNoCars := uuid(4)
+		idMatchModelOnlyInOtherCntr := uuid(5)
+		idNoMatchModelInCntr1 := uuid(6)
+		idNoMatchModelInOtherGarage := uuid(7)
+		idNoMatchWrongName := uuid(8)
+		idNoMatchGermanyAtCntr0 := uuid(9)
+		idAbsentCntr1Empty := uuid(10)
+		idAbsentOneCountry := uuid(11)
+
+		fillerCntr := func() map[string]any {
+			return map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(fillerCar())})}
+		}
+
+		docs := []docDef{
+			{id: idMatch, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})},
+			}, note: "countries[1].name=germany; one car with only make field — no model anywhere → match"},
+			{id: idMatchNoGarages, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany"},
+			}, note: "countries[1].name=germany; no garages → no model anywhere → match"},
+			{id: idMatchEmptyGarages, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": []any{}},
+			}, note: "countries[1].name=germany; garages=[] → match"},
+			{id: idMatchGarageNoCars, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})},
+			}, note: "countries[1].name=germany; garage with city only, no cars → match"},
+			{id: idMatchModelOnlyInOtherCntr, countries: []any{
+				map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})},
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})},
+			}, note: "model in countries[0] but countries[1] has no model → match (IsNull restricted to countries[1])"},
+			{id: idNoMatchModelInCntr1, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})},
+			}, note: "countries[1] has model present → no match"},
+			{id: idNoMatchModelInOtherGarage, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(
+					map[string]any{"cars": asArr(car("make", "x"))},
+					map[string]any{"cars": asArr(car("model", "y"))},
+				)},
+			}, note: "countries[1] g0 no model, but g1 has model → no match (IsNull is per countries[1] scope)"},
+			{id: idNoMatchWrongName, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})},
+			}, note: "countries[1].name=france ≠ germany → no match"},
+			{id: idNoMatchGermanyAtCntr0, countries: []any{
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})},
+				map[string]any{"name": "france"},
+			}, note: "germany at countries[0]; countries[1].name=france → no match"},
+			{id: idAbsentCntr1Empty, countries: []any{
+				fillerCntr(),
+				map[string]any{},
+			}, note: "countries[1] is empty {} (no name) → no match"},
+			{id: idAbsentOneCountry, countries: []any{
+				map[string]any{"name": "germany"},
+			}, note: "only countries[0]; countries[1] missing → no match"},
+		}
+
+		filter := andFilter(
+			valueFilter("countries[1].name", "germany"),
+			isNullFilter("countries[1].garages.cars.model", true),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchNoGarages, idMatchEmptyGarages, idMatchGarageNoCars, idMatchModelOnlyInOtherCntr})
+	})
+
+	// 1b: countries[1].name = "germany" AND countries[1].garages.cars IS NULL
+	t.Run("1b_countries_value_and_isNull_cars", func(t *testing.T) {
+		idMatchNoGarages := uuid(1)
+		idMatchEmptyGarages := uuid(2)
+		idMatchGarageNoCars := uuid(3)
+		idMatchEmptyCarsArray := uuid(4)
+		idMatchCarsOnlyInOtherCntr := uuid(5)
+		idNoMatchCarsPresent := uuid(6)
+		idNoMatchCarsInOtherGarage := uuid(7)
+		idNoMatchWrongName := uuid(8)
+		idAbsentCntr1Empty := uuid(9)
+
+		fillerCntr := func() map[string]any {
+			return map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(fillerCar())})}
+		}
+
+		docs := []docDef{
+			{id: idMatchNoGarages, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany"},
+			}, note: "countries[1].name=germany; no garages → no cars → match"},
+			{id: idMatchEmptyGarages, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": []any{}},
+			}, note: "countries[1].name=germany; garages=[] → no cars → match"},
+			{id: idMatchGarageNoCars, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})},
+			}, note: "garage with no cars field → match"},
+			{id: idMatchEmptyCarsArray, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": []any{}})},
+			}, note: "garage with cars=[] → no cars → match"},
+			{id: idMatchCarsOnlyInOtherCntr, countries: []any{
+				map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(fillerCar())})},
+				map[string]any{"name": "germany"},
+			}, note: "cars in countries[0] but countries[1] has no cars → match"},
+			{id: idNoMatchCarsPresent, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(fillerCar())})},
+			}, note: "countries[1] has cars → no match"},
+			{id: idNoMatchCarsInOtherGarage, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(
+					map[string]any{"city": "berlin"},
+					map[string]any{"cars": asArr(fillerCar())},
+				)},
+			}, note: "countries[1] g0 has no cars but g1 does → no match (cars exist within countries[1])"},
+			{id: idNoMatchWrongName, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "france"},
+			}, note: "countries[1].name=france → no match"},
+			{id: idAbsentCntr1Empty, countries: []any{
+				fillerCntr(),
+				map[string]any{},
+			}, note: "countries[1] empty (no name) → no match"},
+		}
+
+		filter := andFilter(
+			valueFilter("countries[1].name", "germany"),
+			isNullFilter("countries[1].garages.cars", true),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchNoGarages, idMatchEmptyGarages, idMatchGarageNoCars, idMatchEmptyCarsArray, idMatchCarsOnlyInOtherCntr})
+	})
+
+	// 1c: countries[1].name = "germany" AND countries[1].garages IS NULL
+	t.Run("1c_countries_value_and_isNull_garages", func(t *testing.T) {
+		idMatchNoGarages := uuid(1)
+		idMatchEmptyGarages := uuid(2)
+		idMatchGaragesOnlyInOtherCntr := uuid(3)
+		idNoMatchGaragesPresent := uuid(4)
+		idNoMatchGaragesNoCars := uuid(5)
+		idNoMatchWrongName := uuid(6)
+		idAbsentCntr1Empty := uuid(7)
+
+		fillerCntr := func() map[string]any {
+			return map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(fillerCar())})}
+		}
+
+		docs := []docDef{
+			{id: idMatchNoGarages, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany"},
+			}, note: "countries[1] has no garages field → match"},
+			{id: idMatchEmptyGarages, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": []any{}},
+			}, note: "countries[1] has garages=[] → no garages elements → match"},
+			{id: idMatchGaragesOnlyInOtherCntr, countries: []any{
+				map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(fillerCar())})},
+				map[string]any{"name": "germany"},
+			}, note: "garages in countries[0] only → match"},
+			{id: idNoMatchGaragesPresent, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})},
+			}, note: "countries[1] has garage → no match"},
+			{id: idNoMatchGaragesNoCars, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{})},
+			}, note: "countries[1] has empty garage element → no match (garage exists)"},
+			{id: idNoMatchWrongName, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "france"},
+			}, note: "countries[1].name=france → no match"},
+			{id: idAbsentCntr1Empty, countries: []any{
+				fillerCntr(),
+				map[string]any{},
+			}, note: "countries[1] empty → no match"},
+		}
+
+		filter := andFilter(
+			valueFilter("countries[1].name", "germany"),
+			isNullFilter("countries[1].garages", true),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchNoGarages, idMatchEmptyGarages, idMatchGaragesOnlyInOtherCntr})
+	})
+
+	// 2a: countries[1].name = "germany" AND countries[1].garages.cars.model IS NOT NULL
+	t.Run("2a_countries_value_and_isNotNull_cars_model", func(t *testing.T) {
+		idMatchModelInCntr1 := uuid(1)
+		idMatchModelInG1 := uuid(2)
+		idMatchModelInCars2 := uuid(3)
+		idMatchCrossConfusion := uuid(4)
+		idNoMatchNoModel := uuid(5)
+		idNoMatchModelOnlyInOtherCntr := uuid(6)
+		idNoMatchWrongName := uuid(7)
+		idNoMatchNoGarages := uuid(8)
+		idAbsentCntr1Empty := uuid(9)
+
+		fillerCntr := func() map[string]any {
+			return map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(fillerCar())})}
+		}
+
+		docs := []docDef{
+			{id: idMatchModelInCntr1, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})},
+			}, note: "countries[1] has model present → match"},
+			{id: idMatchModelInG1, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(
+					map[string]any{"cars": asArr(car("make", "x"))},
+					map[string]any{"cars": asArr(car("model", "y"))},
+				)},
+			}, note: "countries[1] g1 has model → match (model exists somewhere in countries[1])"},
+			{id: idMatchModelInCars2, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"), car("make", "y"), car("model", "z"))})},
+			}, note: "countries[1] cars[2] has model → match"},
+			{id: idMatchCrossConfusion, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "civic", "model", "honda"))})},
+			}, note: "model present (value 'honda' on model field) → match (IsNotNull only checks presence)"},
+			{id: idNoMatchNoModel, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})},
+			}, note: "countries[1] has no model anywhere → no match"},
+			{id: idNoMatchModelOnlyInOtherCntr, countries: []any{
+				map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})},
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})},
+			}, note: "model in countries[0] only → no match (IsNotNull restricted to countries[1])"},
+			{id: idNoMatchWrongName, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})},
+			}, note: "countries[1].name=france → no match"},
+			{id: idNoMatchNoGarages, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany"},
+			}, note: "germany but no garages → no model → no match"},
+			{id: idAbsentCntr1Empty, countries: []any{
+				fillerCntr(),
+				map[string]any{},
+			}, note: "countries[1] empty → no match"},
+		}
+
+		filter := andFilter(
+			valueFilter("countries[1].name", "germany"),
+			isNullFilter("countries[1].garages.cars.model", false),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchModelInCntr1, idMatchModelInG1, idMatchModelInCars2, idMatchCrossConfusion})
+	})
+
+	// 2b: countries[1].name = "germany" AND countries[1].garages.cars IS NOT NULL
+	t.Run("2b_countries_value_and_isNotNull_cars", func(t *testing.T) {
+		idMatchCarsPresent := uuid(1)
+		idMatchCarsInG1 := uuid(2)
+		idNoMatchNoCars := uuid(3)
+		idNoMatchEmptyCars := uuid(4)
+		idNoMatchCarsOnlyInOtherCntr := uuid(5)
+		idNoMatchWrongName := uuid(6)
+		idAbsentCntr1Empty := uuid(7)
+
+		fillerCntr := func() map[string]any {
+			return map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(fillerCar())})}
+		}
+
+		docs := []docDef{
+			{id: idMatchCarsPresent, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": asArr(fillerCar())})},
+			}, note: "countries[1] has cars → match"},
+			{id: idMatchCarsInG1, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(
+					map[string]any{"city": "berlin"},
+					map[string]any{"cars": asArr(fillerCar())},
+				)},
+			}, note: "countries[1] g0 no cars; g1 has cars → match"},
+			{id: idNoMatchNoCars, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})},
+			}, note: "garages have no cars → no match"},
+			{id: idNoMatchEmptyCars, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"cars": []any{}})},
+			}, note: "garages have cars=[] → no match (no car elements)"},
+			{id: idNoMatchCarsOnlyInOtherCntr, countries: []any{
+				map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(fillerCar())})},
+				map[string]any{"name": "germany"},
+			}, note: "cars in countries[0] only → no match"},
+			{id: idNoMatchWrongName, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "france"},
+			}, note: "wrong name → no match"},
+			{id: idAbsentCntr1Empty, countries: []any{
+				fillerCntr(),
+				map[string]any{},
+			}, note: "empty countries[1] → no match"},
+		}
+
+		filter := andFilter(
+			valueFilter("countries[1].name", "germany"),
+			isNullFilter("countries[1].garages.cars", false),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchCarsPresent, idMatchCarsInG1})
+	})
+
+	// 2c: countries[1].name = "germany" AND countries[1].garages IS NOT NULL
+	t.Run("2c_countries_value_and_isNotNull_garages", func(t *testing.T) {
+		idMatchGaragePresent := uuid(1)
+		idMatchEmptyGarageElement := uuid(2)
+		idNoMatchNoGarages := uuid(3)
+		idNoMatchEmptyGarages := uuid(4)
+		idNoMatchGaragesOnlyInOtherCntr := uuid(5)
+		idNoMatchWrongName := uuid(6)
+		idAbsentCntr1Empty := uuid(7)
+
+		fillerCntr := func() map[string]any {
+			return map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(fillerCar())})}
+		}
+
+		docs := []docDef{
+			{id: idMatchGaragePresent, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{"city": "berlin"})},
+			}, note: "countries[1] has garage → match"},
+			{id: idMatchEmptyGarageElement, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": asArr(map[string]any{})},
+			}, note: "countries[1] has empty garage element → match (garage element exists)"},
+			{id: idNoMatchNoGarages, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany"},
+			}, note: "no garages field → no match"},
+			{id: idNoMatchEmptyGarages, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "germany", "garages": []any{}},
+			}, note: "garages=[] → no garage elements → no match"},
+			{id: idNoMatchGaragesOnlyInOtherCntr, countries: []any{
+				map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(fillerCar())})},
+				map[string]any{"name": "germany"},
+			}, note: "garages in countries[0] only → no match"},
+			{id: idNoMatchWrongName, countries: []any{
+				fillerCntr(),
+				map[string]any{"name": "france"},
+			}, note: "wrong name → no match"},
+			{id: idAbsentCntr1Empty, countries: []any{
+				fillerCntr(),
+				map[string]any{},
+			}, note: "empty countries[1] → no match"},
+		}
+
+		filter := andFilter(
+			valueFilter("countries[1].name", "germany"),
+			isNullFilter("countries[1].garages", false),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchGaragePresent, idMatchEmptyGarageElement})
+	})
+
+	// 7: countries[1].garages.cars.make IS NOT NULL AND countries[1].garages.cars.model IS NULL
+	//
+	// Semantics note: both conditions reference paths that share the same
+	// unconstrained deepest ancestor (garages.cars) below the constrained
+	// countries[1]. Same-element correlation therefore lands at cars level —
+	// the filter matches when SOME car within countries[1] has make present and
+	// model absent at THAT same car. Compare sub-test 1a where the value
+	// condition lives at countries[1] direct (no shared unconstrained ancestor
+	// with the IsNull condition); there same-element falls back to countries[1]
+	// level and IsNull becomes "no model anywhere within countries[1]".
+	t.Run("7_countries_dual_isNull_make_present_model_absent", func(t *testing.T) {
+		idMatchMakeOnly := uuid(1)
+		idMatchMakeMultiCars := uuid(2)
+		idMatchMakeInG0NoModel := uuid(3)
+		idMatchSwapAcrossCntrs := uuid(4)
+		idNoMatchModelPresent := uuid(5)
+		idNoMatchNoMake := uuid(6)
+		idNoMatchNoCars := uuid(7)
+		idNoMatchEveryCarHasModel := uuid(8)
+		idAbsentCntr1Empty := uuid(9)
+
+		fillerCntr := func() map[string]any {
+			return map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})}
+		}
+
+		docs := []docDef{
+			{id: idMatchMakeOnly, countries: []any{
+				fillerCntr(),
+				map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})},
+			}, note: "cars[0] in countries[1] has make, no model → match (per-cars same-element)"},
+			{id: idMatchMakeMultiCars, countries: []any{
+				fillerCntr(),
+				map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "x"), car("make", "y"))})},
+			}, note: "multiple cars in countries[1] each have make+nomodel → match"},
+			{id: idMatchMakeInG0NoModel, countries: []any{
+				fillerCntr(),
+				map[string]any{"garages": asArr(
+					map[string]any{"cars": asArr(car("make", "x"))},
+					map[string]any{"cars": asArr(car("model", "y"))},
+				)},
+			}, note: "g0.cars[0] has make+nomodel (satisfies per-cars); g1.cars[0]'s model excludes only that specific car → match"},
+			{id: idMatchSwapAcrossCntrs, countries: []any{
+				map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("model", "y"))})},
+				map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})},
+			}, note: "countries[0] has model, countries[1] has make+nomodel car → match"},
+			{id: idNoMatchModelPresent, countries: []any{
+				fillerCntr(),
+				map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "x", "model", "y"))})},
+			}, note: "single car has both make and model → exclude removes that car; no other cars → no match"},
+			{id: idNoMatchNoMake, countries: []any{
+				fillerCntr(),
+				map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("model", "y"))})},
+			}, note: "only model, no make anywhere → make IS NOT NULL fails at every car → no match"},
+			{id: idNoMatchNoCars, countries: []any{
+				fillerCntr(),
+				map[string]any{"garages": asArr(map[string]any{"city": "berlin"})},
+			}, note: "no cars → no car-element to satisfy → no match"},
+			{id: idNoMatchEveryCarHasModel, countries: []any{
+				fillerCntr(),
+				map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+					car("make", "x", "model", "y"),
+					car("make", "a", "model", "b"),
+				)})},
+			}, note: "every car in countries[1] has both make and model → exclude removes every car → no match"},
+			{id: idAbsentCntr1Empty, countries: []any{
+				fillerCntr(),
+				map[string]any{},
+			}, note: "empty countries[1] → no match"},
+		}
+
+		filter := andFilter(
+			isNullFilter("countries[1].garages.cars.make", false),
+			isNullFilter("countries[1].garages.cars.model", true),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchMakeOnly, idMatchMakeMultiCars, idMatchMakeInG0NoModel, idMatchSwapAcrossCntrs})
+	})
+
+	// ----- Constraint at countries.garages[1] -----
+
+	// 3a: countries.garages[1].city = "berlin" AND countries.garages[1].cars.model IS NULL
+	t.Run("3a_garages_value_and_isNull_cars_model", func(t *testing.T) {
+		idMatchMinimal := uuid(1)
+		idMatchNoCars := uuid(2)
+		idMatchEmptyCars := uuid(3)
+		idMatchModelOnlyInG0 := uuid(4)
+		idNoMatchModelInG1 := uuid(5)
+		idNoMatchWrongCity := uuid(6)
+		idNoMatchBerlinAtG0 := uuid(7)
+		idAbsentG1Empty := uuid(8)
+
+		docs := []docDef{
+			{id: idMatchMinimal, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin", "cars": asArr(car("make", "x"))},
+			)}}, note: "garages[1]: city=berlin, cars only have make → match"},
+			{id: idMatchNoCars, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin"},
+			)}}, note: "garages[1]: city=berlin, no cars → match"},
+			{id: idMatchEmptyCars, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin", "cars": []any{}},
+			)}}, note: "garages[1]: city=berlin, cars=[] → match"},
+			{id: idMatchModelOnlyInG0, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich", "cars": asArr(car("make", "x", "model", "y"))},
+				map[string]any{"city": "berlin", "cars": asArr(car("make", "x"))},
+			)}}, note: "model only in garages[0]; garages[1] has no model → match (IsNull restricted to garages[1])"},
+			{id: idNoMatchModelInG1, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin", "cars": asArr(car("make", "x", "model", "y"))},
+			)}}, note: "garages[1].cars[0].model present → no match"},
+			{id: idNoMatchWrongCity, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "paris", "cars": asArr(car("make", "x"))},
+			)}}, note: "garages[1].city=paris → no match"},
+			{id: idNoMatchBerlinAtG0, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "berlin"},
+				map[string]any{"city": "paris", "cars": asArr(car("make", "x"))},
+			)}}, note: "berlin at garages[0]; garages[1].city=paris → no match"},
+			{id: idAbsentG1Empty, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{},
+			)}}, note: "garages[1] empty (no city) → no match"},
+		}
+
+		filter := andFilter(
+			valueFilter("countries.garages[1].city", "berlin"),
+			isNullFilter("countries.garages[1].cars.model", true),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchMinimal, idMatchNoCars, idMatchEmptyCars, idMatchModelOnlyInG0})
+	})
+
+	// 3b: countries.garages[1].city = "berlin" AND countries.garages[1].cars IS NULL
+	t.Run("3b_garages_value_and_isNull_cars", func(t *testing.T) {
+		idMatchNoCars := uuid(1)
+		idMatchEmptyCars := uuid(2)
+		idMatchCarsOnlyInG0 := uuid(3)
+		idNoMatchCarsPresent := uuid(4)
+		idNoMatchWrongCity := uuid(5)
+		idAbsentG1Empty := uuid(6)
+
+		docs := []docDef{
+			{id: idMatchNoCars, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin"},
+			)}}, note: "garages[1]: berlin, no cars → match"},
+			{id: idMatchEmptyCars, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin", "cars": []any{}},
+			)}}, note: "garages[1]: berlin, cars=[] → match"},
+			{id: idMatchCarsOnlyInG0, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich", "cars": asArr(fillerCar())},
+				map[string]any{"city": "berlin"},
+			)}}, note: "cars only in garages[0]; garages[1] has no cars → match"},
+			{id: idNoMatchCarsPresent, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin", "cars": asArr(fillerCar())},
+			)}}, note: "garages[1] has cars → no match"},
+			{id: idNoMatchWrongCity, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "paris"},
+			)}}, note: "wrong city → no match"},
+			{id: idAbsentG1Empty, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{},
+			)}}, note: "garages[1] empty → no match"},
+		}
+
+		filter := andFilter(
+			valueFilter("countries.garages[1].city", "berlin"),
+			isNullFilter("countries.garages[1].cars", true),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchNoCars, idMatchEmptyCars, idMatchCarsOnlyInG0})
+	})
+
+	// 4a: countries.garages[1].city = "berlin" AND countries.garages[1].cars.model IS NOT NULL
+	t.Run("4a_garages_value_and_isNotNull_cars_model", func(t *testing.T) {
+		idMatchModelInG1 := uuid(1)
+		idMatchModelInDeepCar := uuid(2)
+		idMatchCrossConfusion := uuid(3)
+		idNoMatchNoModel := uuid(4)
+		idNoMatchNoCars := uuid(5)
+		idNoMatchModelOnlyInG0 := uuid(6)
+		idNoMatchWrongCity := uuid(7)
+		idAbsentG1Empty := uuid(8)
+
+		docs := []docDef{
+			{id: idMatchModelInG1, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin", "cars": asArr(car("make", "x", "model", "y"))},
+			)}}, note: "garages[1] has model → match"},
+			{id: idMatchModelInDeepCar, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin", "cars": asArr(car("make", "x"), car("make", "y"), car("model", "z"))},
+			)}}, note: "garages[1].cars[2] has model → match"},
+			{id: idMatchCrossConfusion, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin", "cars": asArr(car("make", "civic", "model", "honda"))},
+			)}}, note: "garages[1] has model field present (with value 'honda') → match"},
+			{id: idNoMatchNoModel, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin", "cars": asArr(car("make", "x"))},
+			)}}, note: "garages[1] has no model → no match"},
+			{id: idNoMatchNoCars, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin"},
+			)}}, note: "garages[1] has no cars → no model → no match"},
+			{id: idNoMatchModelOnlyInG0, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich", "cars": asArr(car("make", "x", "model", "y"))},
+				map[string]any{"city": "berlin", "cars": asArr(car("make", "x"))},
+			)}}, note: "model only in garages[0]; garages[1] has no model → no match"},
+			{id: idNoMatchWrongCity, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "paris", "cars": asArr(car("make", "x", "model", "y"))},
+			)}}, note: "wrong city → no match"},
+			{id: idAbsentG1Empty, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{},
+			)}}, note: "garages[1] empty → no match"},
+		}
+
+		filter := andFilter(
+			valueFilter("countries.garages[1].city", "berlin"),
+			isNullFilter("countries.garages[1].cars.model", false),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchModelInG1, idMatchModelInDeepCar, idMatchCrossConfusion})
+	})
+
+	// 4b: countries.garages[1].city = "berlin" AND countries.garages[1].cars IS NOT NULL
+	t.Run("4b_garages_value_and_isNotNull_cars", func(t *testing.T) {
+		idMatchCarsPresent := uuid(1)
+		idNoMatchNoCars := uuid(2)
+		idNoMatchEmptyCars := uuid(3)
+		idNoMatchCarsOnlyInG0 := uuid(4)
+		idNoMatchWrongCity := uuid(5)
+		idAbsentG1Empty := uuid(6)
+
+		docs := []docDef{
+			{id: idMatchCarsPresent, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin", "cars": asArr(fillerCar())},
+			)}}, note: "garages[1] has cars → match"},
+			{id: idNoMatchNoCars, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin"},
+			)}}, note: "garages[1] no cars → no match"},
+			{id: idNoMatchEmptyCars, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "berlin", "cars": []any{}},
+			)}}, note: "garages[1] cars=[] → no match"},
+			{id: idNoMatchCarsOnlyInG0, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich", "cars": asArr(fillerCar())},
+				map[string]any{"city": "berlin"},
+			)}}, note: "cars in garages[0] only → no match"},
+			{id: idNoMatchWrongCity, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{"city": "paris", "cars": asArr(fillerCar())},
+			)}}, note: "wrong city → no match"},
+			{id: idAbsentG1Empty, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"city": "munich"},
+				map[string]any{},
+			)}}, note: "garages[1] empty → no match"},
+		}
+
+		filter := andFilter(
+			valueFilter("countries.garages[1].city", "berlin"),
+			isNullFilter("countries.garages[1].cars", false),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchCarsPresent})
+	})
+
+	// 8: countries.garages[1].cars.make IS NOT NULL AND countries.garages[1].cars.model IS NULL
+	t.Run("8_garages_dual_isNull_make_present_model_absent", func(t *testing.T) {
+		idMatchMakeOnly := uuid(1)
+		idMatchMakeAndModelInG0 := uuid(2)
+		idNoMatchModelInG1 := uuid(3)
+		idNoMatchNoMake := uuid(4)
+		idNoMatchNoCars := uuid(5)
+		idAbsentG1Empty := uuid(6)
+
+		docs := []docDef{
+			{id: idMatchMakeOnly, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"cars": asArr(fillerCar())},
+				map[string]any{"cars": asArr(car("make", "x"))},
+			)}}, note: "garages[1].cars: make present, no model → match"},
+			{id: idMatchMakeAndModelInG0, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"cars": asArr(car("make", "x", "model", "y"))},
+				map[string]any{"cars": asArr(car("make", "x"))},
+			)}}, note: "model in garages[0] only; garages[1] has only make → match"},
+			{id: idNoMatchModelInG1, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"cars": asArr(fillerCar())},
+				map[string]any{"cars": asArr(car("make", "x", "model", "y"))},
+			)}}, note: "garages[1] has both → no match (model present)"},
+			{id: idNoMatchNoMake, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"cars": asArr(fillerCar())},
+				map[string]any{"cars": asArr(car("model", "y"))},
+			)}}, note: "garages[1]: only model, no make → no match"},
+			{id: idNoMatchNoCars, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"cars": asArr(fillerCar())},
+				map[string]any{"city": "berlin"},
+			)}}, note: "garages[1] no cars → make IS NOT NULL fails → no match"},
+			{id: idAbsentG1Empty, countries: []any{map[string]any{"garages": asArr(
+				map[string]any{"cars": asArr(fillerCar())},
+				map[string]any{},
+			)}}, note: "garages[1] empty → no match"},
+		}
+
+		filter := andFilter(
+			isNullFilter("countries.garages[1].cars.make", false),
+			isNullFilter("countries.garages[1].cars.model", true),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchMakeOnly, idMatchMakeAndModelInG0})
+	})
+
+	// ----- Constraint at countries.garages.cars[1] -----
+
+	// 5: cars[1].make = "honda" AND cars[1].model IS NULL
+	t.Run("5_cars_value_and_isNull_model", func(t *testing.T) {
+		idMatchMinimal := uuid(1)
+		idMatchExtraCar := uuid(2)
+		idNoMatchModelPresent := uuid(3)
+		idNoMatchWrongMake := uuid(4)
+		idNoMatchHondaAtCars0 := uuid(5)
+		idNoMatchCrossConfusion := uuid(6)
+		idNoMatchSplitMakeModel := uuid(7)
+		idAbsentCars1Missing := uuid(8)
+		idAbsentNoCars := uuid(9)
+
+		docs := []docDef{
+			{id: idMatchMinimal, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "x"),
+				car("make", "honda"),
+			)})}}, note: "cars[1]: make=honda, no model → match"},
+			{id: idMatchExtraCar, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "x"),
+				car("make", "honda"),
+				car("make", "y", "model", "z"),
+			)})}}, note: "cars[1] satisfies; cars[2]'s model doesn't matter → match"},
+			{id: idNoMatchModelPresent, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "x"),
+				car("make", "honda", "model", "civic"),
+			)})}}, note: "cars[1] has model → no match"},
+			{id: idNoMatchWrongMake, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "x"),
+				car("make", "toyota"),
+			)})}}, note: "cars[1].make=toyota → no match"},
+			{id: idNoMatchHondaAtCars0, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "honda"),
+				car("make", "toyota"),
+			)})}}, note: "honda at cars[0]; cars[1] doesn't satisfy → no match"},
+			{id: idNoMatchCrossConfusion, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "x"),
+				car("make", "civic", "model", "honda"),
+			)})}}, note: "cars[1]: values swapped on fields (make=civic, model=honda) → no match (make≠honda + model present)"},
+			{id: idNoMatchSplitMakeModel, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "honda"),
+				car("model", "civic"),
+			)})}}, note: "cars[0] has honda, cars[1] has model → no match (cars[1].make≠honda)"},
+			{id: idAbsentCars1Missing, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "honda"),
+			)})}}, note: "cars=[honda] only — cars[1] missing → no match"},
+			{id: idAbsentNoCars, countries: []any{map[string]any{"garages": asArr(map[string]any{"city": "berlin"})}}, note: "no cars → no match"},
+		}
+
+		filter := andFilter(
+			valueFilter("countries.garages.cars[1].make", "honda"),
+			isNullFilter("countries.garages.cars[1].model", true),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchMinimal, idMatchExtraCar})
+	})
+
+	// 6: cars[1].make = "honda" AND cars[1].model IS NOT NULL
+	t.Run("6_cars_value_and_isNotNull_model", func(t *testing.T) {
+		idMatchMinimal := uuid(1)
+		idMatchExtraField := uuid(2)
+		idNoMatchModelAbsent := uuid(3)
+		idNoMatchWrongMake := uuid(4)
+		idNoMatchHondaAtCars0 := uuid(5)
+		idNoMatchModelAtCars0Only := uuid(6)
+		idAbsentCars1Missing := uuid(7)
+
+		docs := []docDef{
+			{id: idMatchMinimal, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "x"),
+				car("make", "honda", "model", "civic"),
+			)})}}, note: "cars[1]: make=honda, model present → match"},
+			{id: idMatchExtraField, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				fillerCar(),
+				car("make", "honda", "model", "any-value"),
+				fillerCar(),
+			)})}}, note: "cars[1] satisfies, surrounded by fillers → match"},
+			{id: idNoMatchModelAbsent, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "x"),
+				car("make", "honda"),
+			)})}}, note: "cars[1] has make=honda but no model → no match"},
+			{id: idNoMatchWrongMake, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "x"),
+				car("make", "toyota", "model", "civic"),
+			)})}}, note: "cars[1].make=toyota → no match"},
+			{id: idNoMatchHondaAtCars0, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "honda", "model", "civic"),
+				car("make", "toyota"),
+			)})}}, note: "honda+model at cars[0]; cars[1] doesn't satisfy → no match"},
+			{id: idNoMatchModelAtCars0Only, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "x", "model", "y"),
+				car("make", "honda"),
+			)})}}, note: "model at cars[0]; cars[1].model absent → no match"},
+			{id: idAbsentCars1Missing, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "honda", "model", "civic"),
+			)})}}, note: "cars[1] missing → no match"},
+		}
+
+		filter := andFilter(
+			valueFilter("countries.garages.cars[1].make", "honda"),
+			isNullFilter("countries.garages.cars[1].model", false),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchMinimal, idMatchExtraField})
+	})
+
+	// 9: cars[1].make IS NOT NULL AND cars[1].model IS NULL
+	t.Run("9_cars_dual_isNull_make_present_model_absent", func(t *testing.T) {
+		idMatchMakeOnly := uuid(1)
+		idMatchMakeAtCars1 := uuid(2)
+		idNoMatchModelPresent := uuid(3)
+		idNoMatchNoMake := uuid(4)
+		idNoMatchSwapAcrossCars := uuid(5)
+		idAbsentCars1Missing := uuid(6)
+		idAbsentNoCars := uuid(7)
+
+		docs := []docDef{
+			{id: idMatchMakeOnly, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "x", "model", "y"),
+				car("make", "honda"),
+			)})}}, note: "cars[1]: make present, no model → match"},
+			{id: idMatchMakeAtCars1, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("model", "y"),
+				car("make", "z"),
+			)})}}, note: "cars[1]: make present, no model; cars[0] has model but doesn't matter → match"},
+			{id: idNoMatchModelPresent, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				fillerCar(),
+				car("make", "x", "model", "y"),
+			)})}}, note: "cars[1] has both → no match (model present)"},
+			{id: idNoMatchNoMake, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				fillerCar(),
+				car("model", "y"),
+			)})}}, note: "cars[1]: only model, no make → no match"},
+			{id: idNoMatchSwapAcrossCars, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "x"),
+				car("model", "y"),
+			)})}}, note: "make at cars[0], model at cars[1] → cars[1] has no make → no match"},
+			{id: idAbsentCars1Missing, countries: []any{map[string]any{"garages": asArr(map[string]any{"cars": asArr(
+				car("make", "x"),
+			)})}}, note: "cars[1] missing → no match"},
+			{id: idAbsentNoCars, countries: []any{map[string]any{"garages": asArr(map[string]any{"city": "berlin"})}}, note: "no cars → no match"},
+		}
+
+		filter := andFilter(
+			isNullFilter("countries.garages.cars[1].make", false),
+			isNullFilter("countries.garages.cars[1].model", true),
+		)
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchMakeOnly, idMatchMakeAtCars1})
+	})
 }


### PR DESCRIPTION
### Nested object filtering — Part 13                                                                                     
                                                                                                                            
  Thirteenth PR in the nested object filtering series, building on Part 12 (recursive plan/executor and same-element-at-LCA semantics). Ports the lower-level integration test matrix to the DB-level write+search pipeline, fixes a same-element correctness bug discovered during the port, and documents three remaining known-buggy behaviors that flip when later PRs land.                                                                                                                     
                                                                                                                          
  **Bug fix: same-K-different-parent**                                                                                      
   
  `runIdxLoopRecursive` uses `MaskLeafAnd` in `matchElementRecursive`, which strips leaf bits before ANDing per-condition bitmaps. When `_idx.{lcaPath}[K]` lumps multiple physical instances at the same K under different parents (e.g. `g[0].cars[0]` and `g[1].cars[0]`), `MaskLeaf` erases the only leaf-level distinction that would have rejected cross-instance matches.                                                                                                 
                                                                                                                          
  Fix adds a flat raw-AndAll path in `evalGroup`: when the subtree is a chain of `recGroupNode`s with unique `here` paths, no scalar-array terminals, and at most one deeper group with `here` conditions, fold the entire subtree into one raw `AndAll`. Same-element semantics holds via the analyzer's Phase-3 scalar inheritance (`elementPositions = descendants`), so leaves coincide within a single physical instance and diverge across instances. This avoids the expensive idx loop for filters where the encoding already enforces same-element semantics naturally.                                             

  The executor now receives the root prop's nested schema via `withProps` to identify scalar-array terminals (`text[]`, `int[]`, …), which use distinct leaves per element from `walkScalarArray` and break the inheritance bridge.
                                                                                                                            
  Six lower-level fixtures (`C3/C4/C5`, `F1/F3/F6`) were updated to assign leaves in DFS order per the walker — they had been forgiving under the `MaskLeaf` path but raw `AndAll` requires accurate leaves.
                                                                                                                            
  **DB-level test matrix port**                                                                                             
   
  Tests ported from the lower-level `TestResolveNestedCorrelatedAnd` / `TestCorrelatedAndFilterExamplesIndexed` / `TestPlanCasesIntegration` to the production write+search pipeline:                                                     
                                                                                                                            
  - **G1-G10 / C1-C10** correlated AND examples (each `Cn` mirrors `Gn` with `countries` prepended for two-depth coverage; gap-fills for unconstrained deep correlation, same-`arr[N]`-index on both sides, three-way multi-bucket splits)
  - **F1-F12, F14** four-condition indexed filter examples (forward and reverse orderings)                                  
  - **IsNull cluster** — standalone, IsNull-in-correlated-AND (28 sub-tests), IsNull+`arr[N]` at root/mid/deep, multi-level pinned IsNull, scalar-array positional IsNull, IsNull on multi-level `object[]`, `text[]` IsNull with `arr[N]`            
  - **`arr[N]` cluster** — positional access, level coverage (root/mid-1/mid-2), mixed constrained/unconstrained,           
  multi-level pin, three-clause overlap, partition vs union                                                                 
  - **Scalar-array positional** — basic, multi-level pin, partition with different parent indices, deeper-nested          
  (`cars.tires.tags[N]`), same-position contradiction                                                                       
  - **Tokenization follow-ups** — multi-token text + `arr[N]`, multi-token at deeper LCA (`cars.tires.*`), same-path      
  tokenized contradiction                                                                                                   
  - **Same-path multi-value** — tokenized and non-tokenized BUG ports (plain-object LCA × `object[]` LCA, `independent=1` vs `>1`)                                                                                                                    
  - **Comprehensive smoke test** — 28 sub-tests across both `DataTypeObject` and `DataTypeObjectArray` roots covering single-condition, AND, OR, parenthesized AND/OR mix, three-level deep nesting, and contradiction edge cases               
  - **Context cancellation** — four sub-tests exercising `canUseRawAndAll`, `runIdxLoopRecursive`, `rootAnchor`, and SPLIT executor entry paths                                                                                                      
                                                                                                                          
  **Negation regression coverage**                                                                                          
                                                                                                                          
  Three new test families lock in current behavior for negation on nested fields:                                           
  - `TestNestedFilteringOrOfCorrelatedAnds` — OR over two same-element AND groups
  - `TestNestedFilteringNotOfCorrelatedAnd` — NOT wrapping a correlated AND, with a regression sub-test pinning today's docID-level NOT semantics (flips to per-element in a later PR)                                                            
  - `TestNestedFilteringNotEqualNestedRegression` — locks in current universal `NotEqual` at top level and captures a discovered correctness bug: `NotEqual` inside a nested correlated AND is treated as `Equal` (denylist flag dropped); sub-test name flagged with `BUG` so the assertion is obviously locking buggy behavior                                   
                                                                                                                            
  **Test plan**                                                                                                           
  - [ ] `go test ./adapters/repos/db/inverted/...`
  - [ ] `go test -tags integrationTest ./adapters/repos/db/inverted/...`                                                    
  - [ ] `go test -tags integrationTest ./adapters/repos/db/...`  