### PR TITLE
fix(reindex): short-circuit OnGroupCompleted on past-terminal tasks (0-weaviate-issues#217)

### DIFF
--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -885,6 +885,28 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 	logger := p.logger.WithField("taskID", task.ID).WithField("groupID", groupID).
 		WithField("localGroupUnitIDs", localGroupUnitIDs)
 
+	// Recovery-replay short-circuit. The scheduler can invoke
+	// OnGroupCompleted for a task whose terminal state was reached in a
+	// prior process lifetime — FINISHED, FAILED, or CANCELLED tasks
+	// rehydrated during startup recovery, or replayed when a node rejoins
+	// the cluster with a stale RAFT log. For semantic migrations the swap
+	// dirs are long gone by then (markTidied + the per-shard
+	// trimOlderGenerations call removed them), so any attempt to re-run
+	// runtimeSwap would error with "reindex bucket %q not found" — noise
+	// only since the ack barrier in [Manager.RecordPostCompletionAck]
+	// drops acks on terminal tasks (correctness unaffected), but every
+	// operator restart spams an ERROR log entry per local unit that
+	// looks like a real problem.
+	//
+	// Returning nil here mirrors the format-only-migration short-circuit
+	// below: no-op for a request the system is not in a position to act
+	// on. See 0-weaviate-issues#217 (spillover from #214 A5).
+	if task.Status.IsTerminal() {
+		logger.WithField("status", task.Status).
+			Debug("reindex provider: OnGroupCompleted: skipping replay on past-terminal task")
+		return nil
+	}
+
 	payload, err := p.loadPayload(task)
 	if err != nil {
 		logger.WithError(err).Error("reindex provider: OnGroupCompleted: failed to load payload")

--- a/adapters/repos/db/reindex_provider_on_group_completed_test.go
+++ b/adapters/repos/db/reindex_provider_on_group_completed_test.go
@@ -1,0 +1,91 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/cluster/distributedtask"
+)
+
+// TestOnGroupCompleted_TerminalStatusShortCircuit pins the recovery-replay
+// short-circuit at the top of [ReindexProvider.OnGroupCompleted]. When
+// the scheduler invokes OnGroupCompleted for a task whose status is
+// already terminal (FINISHED / FAILED / CANCELLED) — e.g. a startup
+// recovery replay of a long-finished migration — the function must
+// return nil immediately without attempting to load the payload or
+// dispatch to RunSwapOnShard. Without this guard, the dispatch falls
+// through to runtimeSwap which errors with "reindex bucket %q not
+// found" because the swap dirs were trimmed at migration completion,
+// spamming every node restart with bogus ERROR-level log entries.
+//
+// See 0-weaviate-issues#217 (spillover from 0-weaviate-issues#214 A5).
+//
+// The test exercises every status value defined in
+// [distributedtask.TaskStatus] to make the boundary explicit: STARTED
+// and FINALIZING continue the dispatch (returning an error from a
+// missing payload — proves we got past the short-circuit), while the
+// terminal trio returns nil without touching the payload loader.
+func TestOnGroupCompleted_TerminalStatusShortCircuit(t *testing.T) {
+	tests := []struct {
+		status       distributedtask.TaskStatus
+		shortCircuit bool
+	}{
+		{distributedtask.TaskStatusStarted, false},
+		{distributedtask.TaskStatusFinalizing, false},
+		{distributedtask.TaskStatusFinished, true},
+		{distributedtask.TaskStatusFailed, true},
+		{distributedtask.TaskStatusCancelled, true},
+	}
+
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			p, hook := newTestProvider(t)
+			task := newFailUnitTestTask()
+			task.Status = tc.status
+			// Intentionally do NOT set Payload — if the short-circuit
+			// doesn't fire, loadPayload errors and OnGroupCompleted
+			// returns a non-nil error. That's how we observe whether
+			// the short-circuit fired.
+
+			err := p.OnGroupCompleted(task, "", []string{"unit-1"})
+
+			if tc.shortCircuit {
+				require.NoError(t, err,
+					"OnGroupCompleted should short-circuit (return nil) for terminal status %q",
+					tc.status)
+				// Should have logged a Debug line about skipping —
+				// loose check so the log message can evolve.
+				var sawSkip bool
+				for _, entry := range hook.AllEntries() {
+					if entry.Message == "reindex provider: OnGroupCompleted: skipping replay on past-terminal task" {
+						sawSkip = true
+						break
+					}
+				}
+				require.True(t, sawSkip,
+					"expected debug log about skipping past-terminal task for status %q",
+					tc.status)
+			} else {
+				// Non-terminal: dispatch falls through to loadPayload
+				// which fails because we didn't populate Payload. That
+				// failure proves the short-circuit did NOT fire — which
+				// is exactly the correctness assertion we want for
+				// STARTED/FINALIZING.
+				require.Error(t, err,
+					"OnGroupCompleted should NOT short-circuit for non-terminal status %q (expected payload load error)",
+					tc.status)
+			}
+		})
+	}
+}

--- a/cluster/distributedtask/types.go
+++ b/cluster/distributedtask/types.go
@@ -352,6 +352,24 @@ func (t TaskStatus) String() string {
 	return string(t)
 }
 
+// IsTerminal reports whether this status is a terminal state. A task in
+// a terminal state is not transitioning further: it has reached
+// [TaskStatusFinished], [TaskStatusFailed], or [TaskStatusCancelled]
+// and the scheduler will not invoke any more per-unit or per-task
+// callbacks for it via the normal in-flight path. Recovery replays on
+// startup can still observe terminal tasks — providers that own
+// destructive side-effects (per-shard swaps, file moves) should
+// short-circuit on terminal status to avoid running them again. See
+// 0-weaviate-issues#217 for a concrete instance.
+func (t TaskStatus) IsTerminal() bool {
+	switch t {
+	case TaskStatusFinished, TaskStatusFailed, TaskStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
 // TaskDescriptor is a struct identifying a task execution under a certain task namespace.
 type TaskDescriptor struct {
 	// ID is the identifier of the task in the namespace.

--- a/cluster/distributedtask/types_test.go
+++ b/cluster/distributedtask/types_test.go
@@ -1,0 +1,47 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package distributedtask
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestTaskStatus_IsTerminal pins the terminal-status classification used
+// by providers' recovery-replay short-circuit (see e.g.
+// [ReindexProvider.OnGroupCompleted] in
+// adapters/repos/db/reindex_provider.go and 0-weaviate-issues#217).
+// Adding a new TaskStatus value should require an explicit decision
+// here; the default-case below ensures unknown values are non-terminal.
+func TestTaskStatus_IsTerminal(t *testing.T) {
+	tests := []struct {
+		status   TaskStatus
+		terminal bool
+	}{
+		{TaskStatusStarted, false},
+		{TaskStatusFinalizing, false},
+		{TaskStatusFinished, true},
+		{TaskStatusFailed, true},
+		{TaskStatusCancelled, true},
+		// Unknown / future statuses default to non-terminal so providers
+		// don't accidentally skip work they're meant to do.
+		{TaskStatus("UNKNOWN_FUTURE_STATE"), false},
+		{TaskStatus(""), false},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.status), func(t *testing.T) {
+			assert.Equal(t, tc.terminal, tc.status.IsTerminal(),
+				"%q.IsTerminal() should be %v", tc.status, tc.terminal)
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Closes 0-weaviate-issues#217. Spillover from the #214 Gap A landing in #10694 (A5 in QA Claude's TL;DR).

When the scheduler invokes [`ReindexProvider.OnGroupCompleted`](https://github.com/weaviate/weaviate/blob/main/adapters/repos/db/reindex_provider.go) for a task whose terminal state was reached in a prior process lifetime — startup-recovery replays of FINISHED/FAILED/CANCELLED tasks, or stale-RAFT-log replays on node rejoin — the dispatch falls through to `runtimeSwap` step 1. That errors with `reindex bucket %q not found` because the swap dirs were trimmed at migration completion. Noise only (the ack barrier in `Manager.RecordPostCompletionAck` drops acks for past-terminal tasks), but every operator restart spams an ERROR-level log entry per local unit that reads like a real failure.

## Changes

1. **`TaskStatus.IsTerminal()` helper** (`cluster/distributedtask/types.go`). Classifies FINISHED / FAILED / CANCELLED as terminal; default-case for unknown future statuses is non-terminal so new states don't accidentally trigger skip-the-work behavior.

2. **OnGroupCompleted short-circuit** (`adapters/repos/db/reindex_provider.go`). Returns nil immediately when `task.Status.IsTerminal()`, mirroring the format-only-migration short-circuit pattern. Sits before the payload load so terminal replays don't even touch disk.

## Tests

- `TestTaskStatus_IsTerminal`: pins all 5 statuses + empty + unknown-future-state.
- `TestOnGroupCompleted_TerminalStatusShortCircuit`: exercises every status. Terminal triggers the short-circuit (nil return, debug log fires); STARTED/FINALIZING fall through to the payload loader and error — proves the short-circuit did NOT fire for non-terminal states.

## Dependency

This PR's branch (`fix-217-...`) is currently based on `runtime-reindex-wip` (the PR #10694 branch). The diff below includes #10694's changes; once #10694 merges to main, this branch will be rebased and the diff will narrow to the four files listed above.

**Merge order:** #10694 (Gap A) first → this PR (A5 noise cleanup) second.

## Test plan

- [x] `go test ./cluster/distributedtask/ ./adapters/repos/db/` green locally
- [x] `golangci-lint run ./cluster/distributedtask/... ./adapters/repos/db/...` clean
- [x] Goroutine linter clean
- [ ] CI green
- [ ] QA confirmation: no more `OnGroupCompleted ... reindex bucket not found` spam in startup logs of a freshly-restarted post-FINISHED migration cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)