### PR TITLE
fix(rest): acquire reindex submit lock BEFORE class read + validation (#218 follow-up)

### DIFF
--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -209,6 +209,35 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 		return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(errPayloadFromSingleErr(err))
 	}
 
+	// Acquire the per-(collection, property) submit lock EARLY — before
+	// reading the class or running any validation — so a parallel DELETE
+	// on /properties/{prop}/index/{name} cannot mutate the schema (drop
+	// the canonical bucket) between this handler's class read and its
+	// task-add RAFT call.
+	//
+	// The previous lock position (just before AddDistributedTask, after
+	// validation) was insufficient: a parallel DELETE could win the lock,
+	// flip IndexSearchable=false + drop the searchable bucket, release;
+	// meanwhile PUT was already past its `class := ReadOnlyClass(...)` +
+	// `validateTokenizationChange(targetProp)` snapshot which still
+	// observed IndexSearchable=true, so validation passed and PUT
+	// proceeded to submit a change-tok task against a no-longer-existing
+	// bucket — FilterableRetokenize/SearchableRetokenize then fails at
+	// the swap step (0-weaviate-issues#218
+	// TestParallelConflictMatrix/change_tokenization_both__delete_searchable_parallel
+	// returned RED on PR #11319 CI run 25977837049 after the lock
+	// manager was made shared but acquisition stayed late).
+	//
+	// Now: PUT holds the lock across class read + validation + RAFT
+	// task-add. A concurrent DELETE waits; when it acquires, the task
+	// is in-flight in RAFT and the apply-time MutationGuard (T1)
+	// rejects the DELETE deterministically. If DELETE wins instead,
+	// PUT's class read sees IndexSearchable=false and
+	// validateTokenizationChange rejects with 400.
+	propLock := h.submitLock(collection, propertyName)
+	propLock.Lock()
+	defer propLock.Unlock()
+
 	class := h.appState.SchemaManager.ReadOnlyClass(collection)
 	if class == nil {
 		return schema.NewSchemaObjectsIndexesUpdateNotFound()
@@ -427,17 +456,14 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 		taskID = fmt.Sprintf("%s:%s:%s:%s", collection, migrationType, properties[0], suffix)
 	}
 
-	// Serialize the conflict-check + submit critical section per
-	// (collection, property) on this node. Without the lock, two
-	// parallel HTTP requests on the same property can both pass
-	// checkReindexConflict (each runs before the other has called
-	// AddDistributedTask and registered itself in the task list) and
-	// both successfully submit — which is exactly the race the
-	// frontend hit on weaviate/weaviate#10675. See the
-	// state.ReindexSubmitLocks field godoc for the multi-node caveat.
-	propLock := h.submitLock(collection, propertyName)
-	propLock.Lock()
-	defer propLock.Unlock()
+	// Note: propLock for (collection, propertyName) was acquired at
+	// the top of this handler — before the class read and validation —
+	// so the conflict-check + AddDistributedTask + DELETE-property-
+	// index races (frontend-observed on weaviate/weaviate#10675 and
+	// the parallel-conflict-matrix Sev 1 on 0-weaviate-issues#218) are
+	// all serialized through the same lock entry. See the early-
+	// acquisition comment up top + state.ReindexSubmitLocks godoc for
+	// the multi-node caveat.
 
 	// Check for conflicting active tasks. Any two reindex migrations on
 	// the same (collection, property) tuple conflict; see typesConflict's


### PR DESCRIPTION
SuperClaude here.

## Summary

Follow-up to PR #11320. The shared submit lock collapsed the lock-manager surface between PUT `/indexes/{prop}` and DELETE `/properties/{prop}/index/{name}`, but the PUT handler still acquired the lock LATE in its flow (just before `checkReindexConflict` + `AddDistributedTask`), AFTER:

1. `class := ReadOnlyClass(collection)`
2. `targetProp` lookup
3. `validateBodyExclusivity`
4. migrationType switch (including `validateTokenizationChange(targetProp)`)
5. shard ownership lookup

A parallel DELETE that won the lock could mutate the schema (flip `IndexSearchable=false` + drop the searchable bucket) and release before PUT's late lock acquisition. PUT's already-captured class snapshot still showed `IndexSearchable=true`, validation passed, PUT then acquired the lock and submitted the change-tok task against a no-longer-existing bucket → reindex worker's `SearchableRetokenize` / `FilterableRetokenize` swap step failed → torn filterable bucket reported by `parallel_conflict_matrix_test.go:751`.

Reproduced on PR #11319 CI run [25977837049](https://github.com/weaviate/weaviate/actions/runs/25977837049) — same shape #11320 was supposed to close, returned RED.

## Fix

Move `propLock.Lock()` to the TOP of `updateIndex`, right after authorization, BEFORE the class read. PUT now holds the lock across class read + validation + RAFT task-add. A concurrent DELETE either:

- Waits for the lock — by the time it acquires, the task is in-flight in RAFT and the apply-time `MutationGuard` (T1) rejects DELETE deterministically.
- Or wins the lock first — PUT's post-lock class read then sees `IndexSearchable=false` and `validateTokenizationChange` returns 400.

Either way the filterable bucket stays consistent.

## Test plan

- [x] `go build ./...` clean
- [x] `golangci-lint run ./adapters/handlers/rest/...` clean
- [x] `go test ./adapters/handlers/rest/...` green
- [ ] `acceptance large (reindex-singlenode)` shard green on CI
- [ ] Specifically `TestParallelConflictMatrix/change_tokenization_both__delete_searchable_parallel` green

— SuperClaude