### PR TITLE
fix(reindex): separate prep / atomic / defer phases of runtimeSwap (closes weaviate/0-weaviate-issues#216)

### DIFF
--- a/adapters/repos/db/aggregator/aggregator.go
+++ b/adapters/repos/db/aggregator/aggregator.go
@@ -58,6 +58,13 @@ type Aggregator struct {
 	bitmapFactory           *roaringset.BitmapFactory
 	modules                 *modules.Provider
 	defaultLimit            int64
+	// tokResolver, when non-nil, is propagated to inverted.Searcher /
+	// inverted.BM25Searcher built by this aggregator so query input
+	// gets analyzed under the per-shard tokenization overlay during
+	// the FINALIZING window of a change-tokenization migration. See
+	// 0-weaviate-issues#216 Gap B. Nil = use prop.Tokenization
+	// directly (tests, pre-#216 callers).
+	tokResolver inverted.TokenizationResolver
 }
 
 func New(store *lsmkv.Store, params aggregation.Params,
@@ -70,6 +77,7 @@ func New(store *lsmkv.Store, params aggregation.Params,
 	tenant string, nestedCrossRefLimit int64,
 	bitmapFactory *roaringset.BitmapFactory,
 	modules *modules.Provider, defaultLimit int64,
+	tokResolver inverted.TokenizationResolver,
 ) *Aggregator {
 	return &Aggregator{
 		logger:                  logger,
@@ -88,6 +96,7 @@ func New(store *lsmkv.Store, params aggregation.Params,
 		bitmapFactory:           bitmapFactory,
 		modules:                 modules,
 		defaultLimit:            defaultLimit,
+		tokResolver:             tokResolver,
 	}
 }
 

--- a/adapters/repos/db/aggregator/filtered.go
+++ b/adapters/repos/db/aggregator/filtered.go
@@ -144,7 +144,8 @@ func (fa *filteredAggregator) bm25Objects(ctx context.Context, kw *searchparams.
 	objs, scores, err := inverted.NewBM25Searcher(cfg.BM25, fa.store, fa.getSchema.ReadOnlyClass,
 		propertyspecific.Indices{}, fa.classSearcher, fa.stopwordProvider,
 		fa.GetPropertyLengthTracker(), fa.logger, fa.shardVersion,
-	).BM25F(ctx, nil, fa.params.ClassName, *fa.params.ObjectLimit, *kw, additional.Properties{})
+	).WithTokenizationResolver(fa.tokResolver).
+		BM25F(ctx, nil, fa.params.ClassName, *fa.params.ObjectLimit, *kw, additional.Properties{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("bm25 objects: %w", err)
 	}

--- a/adapters/repos/db/aggregator/hybrid.go
+++ b/adapters/repos/db/aggregator/hybrid.go
@@ -57,7 +57,8 @@ func (a *Aggregator) bm25Objects(ctx context.Context, kw *searchparams.KeywordRa
 	objs, dists, err := inverted.NewBM25Searcher(cfg.BM25, a.store, a.getSchema.ReadOnlyClass,
 		propertyspecific.Indices{}, a.classSearcher, a.stopwordProvider,
 		a.GetPropertyLengthTracker(), a.logger, a.shardVersion,
-	).BM25F(ctx, nil, a.params.ClassName, *a.params.ObjectLimit, *kw, additional.Properties{})
+	).WithTokenizationResolver(a.tokResolver).
+		BM25F(ctx, nil, a.params.ClassName, *a.params.ObjectLimit, *kw, additional.Properties{})
 	if err != nil {
 		return nil, nil, fmt.Errorf("bm25 objects: %w", err)
 	}

--- a/adapters/repos/db/aggregator/vector_search.go
+++ b/adapters/repos/db/aggregator/vector_search.go
@@ -93,6 +93,7 @@ func (a *Aggregator) buildAllowList(ctx context.Context) (helpers.AllowList, err
 		allow, err = inverted.NewSearcher(a.logger, a.store, a.getSchema.ReadOnlyClass, nil,
 			a.classSearcher, a.stopwordProvider, a.shardVersion, a.isFallbackToSearchable,
 			a.isRangeableLocallyReady, a.tenant, a.nestedCrossRefLimit, a.bitmapFactory).
+			WithTokenizationResolver(a.tokResolver).
 			DocIDs(ctx, a.params.Filters, additional.Properties{},
 				a.params.ClassName)
 		if err != nil {

--- a/adapters/repos/db/inverted/bm25_searcher.go
+++ b/adapters/repos/db/inverted/bm25_searcher.go
@@ -53,6 +53,13 @@ type BM25Searcher struct {
 	logger           logrus.FieldLogger
 	shardVersion     uint16
 	stopwordProvider *stopwords.Provider
+	// tokResolver, when non-nil, overrides prop.Tokenization on query
+	// input analysis. Used by the per-shard tokenization overlay from
+	// 0-weaviate-issues#216 (Gap B) to keep query tokenization aligned
+	// with the bucket content during the FINALIZING window of a
+	// change-tokenization migration. Nil = use prop.Tokenization
+	// directly (tests, pre-#216 callers).
+	tokResolver TokenizationResolver
 }
 
 type propLengthRetriever interface {
@@ -83,6 +90,22 @@ func NewBM25Searcher(config schema.BM25Config, store *lsmkv.Store,
 		shardVersion:     shardVersion,
 		stopwordProvider: stopwordProvider,
 	}
+}
+
+// WithTokenizationResolver attaches a [TokenizationResolver] used by query
+// input analysis to consult a per-shard tokenization overlay before
+// falling back to the schema-stored `prop.Tokenization`. Returns the
+// receiver for fluent chaining at construction sites.
+//
+// Production callers wire `Shard.TokenizationFor` here so a
+// change-tokenization migration's FINALIZING-window overlay routes
+// query input to the post-swap tokenization. See
+// 0-weaviate-issues#216 for the failure shape this closes.
+//
+// Pass nil (the default) to use the schema-stored value directly.
+func (b *BM25Searcher) WithTokenizationResolver(r TokenizationResolver) *BM25Searcher {
+	b.tokResolver = r
+	return b
 }
 
 func (b *BM25Searcher) BM25F(ctx context.Context, filterDocIds helpers.AllowList,
@@ -156,11 +179,18 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 	// This avoids eagerly tokenizing the query for all possible tokenizations
 	// when only a subset is actually used by the searched properties.
 	type propInfo struct {
-		name      string
-		prop      *models.Property
-		tokKey    string
-		propMean  float64
-		meanValid bool
+		name string
+		prop *models.Property
+		// effectiveTokenization is the active query-time tokenization for
+		// this property — either the schema-stored `prop.Tokenization`
+		// or the value returned by the per-shard tokenization overlay
+		// (see [TokenizationResolver] / 0-weaviate-issues#216).
+		// Computed once at prop discovery and used everywhere downstream
+		// to avoid recomputing the same value across the BM25 pipeline.
+		effectiveTokenization string
+		tokKey                string
+		propMean              float64
+		meanValid             bool
 	}
 
 	props := make([]propInfo, 0, len(params.Properties))
@@ -198,28 +228,38 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 
 		switch dt, _ := schema.AsPrimitive(prop.DataType); dt {
 		case schema.DataTypeText, schema.DataTypeTextArray:
-			tokKey := prop.Tokenization
+			// effectiveTok consults the per-shard tokenization overlay (set
+			// during the FINALIZING window of a change-tokenization
+			// migration — see 0-weaviate-issues#216) before falling back
+			// to the schema-stored value. The rest of the BM25 pipeline
+			// for this property uses effectiveTok everywhere
+			// `prop.Tokenization` would have been read, so query input
+			// gets tokenized against the value that matches the bucket
+			// content on this shard.
+			effectiveTok := ResolveTokenization(b.tokResolver, prop.Name, prop.Tokenization)
+			tokKey := effectiveTok
 			hasCustomStopwords := prop.TextAnalyzer != nil && prop.TextAnalyzer.StopwordPreset != ""
 			if prop.TextAnalyzer != nil && prop.TextAnalyzer.ASCIIFold {
 				if len(prop.TextAnalyzer.ASCIIFoldIgnore) > 0 || hasCustomStopwords {
 					// Per-property key — will be computed after tokenization
-					tokKey = asciiTokenizationKey(prop.Tokenization) + ":" + property
+					tokKey = asciiTokenizationKey(effectiveTok) + ":" + property
 				} else {
-					tokKey = asciiTokenizationKey(prop.Tokenization)
-					needsASCIIFold[prop.Tokenization] = struct{}{}
+					tokKey = asciiTokenizationKey(effectiveTok)
+					needsASCIIFold[effectiveTok] = struct{}{}
 				}
 			} else if hasCustomStopwords {
 				// Per-property key for custom stopword preset
-				tokKey = prop.Tokenization + ":" + property
+				tokKey = effectiveTok + ":" + property
 			}
-			neededTokenizations[prop.Tokenization] = struct{}{}
+			neededTokenizations[effectiveTok] = struct{}{}
 
 			props = append(props, propInfo{
-				name:      property,
-				prop:      prop,
-				tokKey:    tokKey,
-				propMean:  float64(propMean),
-				meanValid: !math.IsNaN(float64(propMean)),
+				name:                  property,
+				prop:                  prop,
+				effectiveTokenization: effectiveTok,
+				tokKey:                tokKey,
+				propMean:              float64(propMean),
+				meanValid:             !math.IsNaN(float64(propMean)),
 			})
 		default:
 			return false, 0, nil, nil, nil, nil, 0, fmt.Errorf("cannot handle datatype '%v' of property '%s'", dt, prop.Name)
@@ -271,7 +311,7 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 		hasCustomStopwords := pi.prop.TextAnalyzer != nil && pi.prop.TextAnalyzer.StopwordPreset != ""
 		if hasCustomASCIIFoldIgnore || hasCustomStopwords {
 			var sw tokenizer.StopwordDetector
-			if pi.prop.Tokenization == models.PropertyTokenizationWord {
+			if pi.effectiveTokenization == models.PropertyTokenizationWord {
 				d, err := b.stopwordProvider.Get(pi.prop)
 				if err != nil {
 					return false, 0, nil, nil, nil, nil, 0, err
@@ -279,7 +319,7 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 				sw = d
 			}
 			prepared := tokenizer.NewPreparedAnalyzer(pi.prop.TextAnalyzer)
-			propTerms, propBoosts := tokenizer.AnalyzeAndCountDuplicates(params.Query, pi.prop.Tokenization, class.Class, prepared, sw)
+			propTerms, propBoosts := tokenizer.AnalyzeAndCountDuplicates(params.Query, pi.effectiveTokenization, class.Class, prepared, sw)
 			queryTermsByTokenization[tokKey] = propTerms
 			duplicateBoostsByTokenization[tokKey] = propBoosts
 			propNamesByTokenization[tokKey] = make([]string, 0)
@@ -287,7 +327,7 @@ func (b *BM25Searcher) generateQueryTermsAndStats(ctx context.Context, class *mo
 
 		if _, exists := propNamesByTokenization[tokKey]; !exists {
 			return false, 0, nil, nil, nil, nil, 0, fmt.Errorf("cannot handle tokenization '%v' of property '%s'",
-				pi.prop.Tokenization, pi.prop.Name)
+				pi.effectiveTokenization, pi.prop.Name)
 		}
 		propNamesByTokenization[tokKey] = append(propNamesByTokenization[tokKey], pi.name)
 	}

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -71,6 +71,29 @@ type Searcher struct {
 	// nestedCrossRefLimit limits the number of nested cross refs returned for a query
 	nestedCrossRefLimit int64
 	bitmapFactory       *roaringset.BitmapFactory
+	// tokResolver, when non-nil, overrides prop.Tokenization on query
+	// input analysis. Used by the per-shard tokenization overlay from
+	// 0-weaviate-issues#216 (Gap B) to keep query tokenization aligned
+	// with the bucket content during the FINALIZING window of a
+	// change-tokenization migration. Nil = use prop.Tokenization
+	// directly (tests, pre-#216 callers).
+	tokResolver TokenizationResolver
+}
+
+// WithTokenizationResolver attaches a [TokenizationResolver] used by query
+// input analysis to consult a per-shard tokenization overlay before
+// falling back to the schema-stored `prop.Tokenization`. Returns the
+// receiver for fluent chaining at construction sites.
+//
+// Production callers wire `Shard.TokenizationFor` here so a
+// change-tokenization migration's FINALIZING-window overlay routes
+// query input to the post-swap tokenization. See
+// 0-weaviate-issues#216 for the failure shape this closes.
+//
+// Pass nil (the default) to use the schema-stored value directly.
+func (s *Searcher) WithTokenizationResolver(r TokenizationResolver) *Searcher {
+	s.tokResolver = r
+	return s
 }
 
 var ErrOnlyStopwords = fmt.Errorf("invalid search term, only stopwords provided. " +
@@ -683,6 +706,14 @@ func (s *Searcher) extractTokenizableProp(prop *models.Property, propType schema
 	var terms []string
 	switch propType {
 	case schema.DataTypeText:
+		// effectiveTok consults the per-shard tokenization overlay (set
+		// during the FINALIZING window of a change-tokenization
+		// migration — see 0-weaviate-issues#216 Gap B) before falling
+		// back to the schema-stored value. Both the LIKE wildcard path
+		// and the standard analyze path tokenize query input against
+		// effectiveTok so the resulting terms match the bucket content
+		// on this shard.
+		effectiveTok := ResolveTokenization(s.tokResolver, prop.Name, prop.Tokenization)
 		// if the operator is like, we cannot apply the regular text-splitting
 		// logic as it would remove all wildcard symbols
 		if operator == filters.OperatorLike {
@@ -693,10 +724,10 @@ func (s *Searcher) extractTokenizableProp(prop *models.Property, propType schema
 				ignore := tokenizer.BuildIgnoreSet(prop.TextAnalyzer.ASCIIFoldIgnore)
 				text = tokenizer.FoldASCII(text, ignore)
 			}
-			terms = tokenizer.TokenizeWithWildcardsForClass(prop.Tokenization, text, class.Class)
+			terms = tokenizer.TokenizeWithWildcardsForClass(effectiveTok, text, class.Class)
 		} else {
 			var sw tokenizer.StopwordDetector
-			if prop.Tokenization == models.PropertyTokenizationWord {
+			if effectiveTok == models.PropertyTokenizationWord {
 				d, err := s.stopwordProvider.Get(prop)
 				if err != nil {
 					return nil, err
@@ -704,7 +735,7 @@ func (s *Searcher) extractTokenizableProp(prop *models.Property, propType schema
 				sw = d
 			}
 			prepared := tokenizer.NewPreparedAnalyzer(prop.TextAnalyzer)
-			result := tokenizer.Analyze(valueString, prop.Tokenization, class.Class, prepared, sw)
+			result := tokenizer.Analyze(valueString, effectiveTok, class.Class, prepared, sw)
 			terms = result.Query
 		}
 	default:

--- a/adapters/repos/db/inverted/tokenization.go
+++ b/adapters/repos/db/inverted/tokenization.go
@@ -1,0 +1,48 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+// TokenizationResolver returns the active query-time tokenization for a
+// property given the schema-stored value. Used by query paths
+// (BM25Searcher, Searcher, aggregators) to consult a per-shard
+// tokenization overlay before falling back to the schema-stored
+// value on the property.
+//
+// The motivating overlay is the one introduced for 0-weaviate-issues#216
+// (Gap B): during the FINALIZING window of a change-tokenization
+// migration each replica's bucket pointer flips to NEW-tokenized data
+// before the cluster-wide schema flip commits via RAFT. Queries that
+// arrive in that window must tokenize their input against the NEW value
+// (matching the bucket content) rather than the still-OLD schema value.
+//
+// Nil resolver means "no overlay configured" — typical for tests and
+// pre-#216 callers. Use [ResolveTokenization] to handle the nil case
+// at call sites without boilerplate.
+type TokenizationResolver func(propName, schemaTokenization string) string
+
+// ResolveTokenization applies r to (propName, schemaTokenization) if r
+// is non-nil, otherwise returns schemaTokenization unchanged.
+//
+// Intended to replace direct reads of `prop.Tokenization` on the query
+// path so the same line works whether or not a per-shard overlay is
+// configured. The expected substitution at call sites is:
+//
+//	// Before:
+//	tok := prop.Tokenization
+//	// After:
+//	tok := ResolveTokenization(b.tokResolver, prop.Name, prop.Tokenization)
+func ResolveTokenization(r TokenizationResolver, propName, schemaTokenization string) string {
+	if r == nil {
+		return schemaTokenization
+	}
+	return r(propName, schemaTokenization)
+}

--- a/adapters/repos/db/inverted/tokenization_test.go
+++ b/adapters/repos/db/inverted/tokenization_test.go
@@ -1,0 +1,42 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package inverted
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestResolveTokenization_NilResolverPassesThrough(t *testing.T) {
+	got := ResolveTokenization(nil, "name", "word")
+	assert.Equal(t, "word", got)
+}
+
+func TestResolveTokenization_NonNilResolverConsulted(t *testing.T) {
+	// Resolver overrides everything it sees.
+	r := func(propName, live string) string {
+		if propName == "name" {
+			return "field"
+		}
+		return live
+	}
+	assert.Equal(t, "field", ResolveTokenization(r, "name", "word"))
+	// Unrelated prop falls back to live.
+	assert.Equal(t, "word", ResolveTokenization(r, "other", "word"))
+}
+
+func TestResolveTokenization_PassThroughOnEmptyOverlay(t *testing.T) {
+	// A resolver that returns live unchanged behaves identically to nil.
+	r := func(propName, live string) string { return live }
+	assert.Equal(t, "word", ResolveTokenization(r, "name", "word"))
+}

--- a/adapters/repos/db/inverted_reindex_strategy.go
+++ b/adapters/repos/db/inverted_reindex_strategy.go
@@ -105,6 +105,57 @@ type MigrationStrategy interface {
 	// UsingBlockMaxWAND class flag) is safe — important for per-property
 	// migrations, where the flag must only flip once every searchable property
 	// has been migrated.
+	//
+	// Phase contract (see inverted_reindex_task_generic.go file-level
+	// godoc): OnMigrationComplete fires in Phase 2c — AFTER the per-prop
+	// SwapBucketPointer tight loop (Phase 2a) and AFTER the inline
+	// oldMain.Shutdown + oldMain→backup rename loop (Phase 2b), but still
+	// INSIDE the per-shard tokenization-overlay window for migrations
+	// that use one (change-tokenization-{searchable,filterable},
+	// enable-filterable, enable-searchable). The overlay is cleared
+	// later by the cluster-wide schema flip in
+	// [ReindexProvider.OnTaskCompleted].
+	//
+	// Allowed work in this position:
+	//
+	//   - In-memory mutation of shard-local query-path state that MUST
+	//     match the cluster-wide schema flip before that flip
+	//     propagates. The canonical example is
+	//     [Shard.setRangeableLocallyReady] in
+	//     [FilterableToRangeableStrategy.OnMigrationComplete] — it
+	//     ensures THIS shard's queries observe ready=true at the same
+	//     moment they could observe the new schema flag. The overlay
+	//     is the equivalent mechanism for tokenization changes; this
+	//     hook is the equivalent for per-shard ready flags.
+	//
+	//   - RAFT calls (per-property schema updates) for non-semantic
+	//     strategies whose schema flip is NOT batched in
+	//     OnTaskCompleted: e.g. [MapToBlockmaxStrategy]'s
+	//     updateToBlockMaxInvertedIndexConfig (class-level
+	//     UsingBlockMaxWAND), [FilterableToRangeableStrategy]'s
+	//     applyPerPropertySchemaUpdate (per-property IndexRangeFilters).
+	//     These are slow (hundreds of ms) — correctness is preserved by
+	//     the overlay covering the per-shard window — but they widen
+	//     the FINALIZING duration beyond what the per-shard atomic
+	//     contract intends. See 0-weaviate-issues#216 follow-up
+	//     QA-Claude comment 4470016252; the long-term fix is to split
+	//     this hook into "local-in-memory (atomic-safe)" and
+	//     "cluster-wide-RAFT (outside-atomic)" callbacks.
+	//
+	// Forbidden work in this position:
+	//
+	//   - Heavy disk I/O on the new main bucket (the LIVE post-swap
+	//     bucket). The bucket is being queried — any operation that
+	//     stalls its compaction or flush pipeline propagates as query
+	//     latency. Disk I/O on the OLD bucket is fine (it's been
+	//     shut down in Phase 2b) but conventionally also moved to
+	//     Phase 2b.
+	//
+	//   - Anything that requires the cluster-wide schema flip to have
+	//     already happened. For semantic migrations the flip lives in
+	//     OnTaskCompleted (after every shard's OnMigrationComplete);
+	//     for non-semantic, this hook may itself drive the flip but
+	//     must not assume it has already propagated to other replicas.
 	OnMigrationComplete(ctx context.Context, shard ShardLike) error
 }
 

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1353,7 +1353,18 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 			}).Info("reindex complete (swap deferred for barrier)")
 			return zerotime, false, nil
 		}
-		// Runtime swap: merge, swap, tidy all inline — no shard restart needed.
+		// Inline runtime swap path (non-semantic migrations: MapToBlockmax,
+		// RoaringSetRefresh, EnableRangeable / Repair-*). Semantic migrations
+		// have skipSwapOnFinish=true and go through OnGroupCompleted's
+		// three-phase flow (prep → overlay → atomic swap) per
+		// weaviate/0-weaviate-issues#216. Here we run both phases inline:
+		// prep (merge segments into ingest) followed by the atomic
+		// SwapBucketPointer. No overlay needed — these migration types
+		// don't change the analyzer's tokenization view of the bucket.
+		if err = t.runtimePrepare(ctx, logger, shard, rt, props); err != nil {
+			err = fmt.Errorf("runtime prepare: %w", err)
+			return zerotime, false, err
+		}
 		if err = t.runtimeSwap(ctx, logger, shard, rt, props); err != nil {
 			err = fmt.Errorf("runtime swap: %w", err)
 			return zerotime, false, err

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1515,43 +1515,35 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 	defer t.disableCallbacks()
 
 	store := shard.Store()
-	lsmPath := shard.pathLSM()
 
-	// Phase 2a (atomic, tight loop): in-memory pointer swap per property.
-	// This is the ONLY work that runs inside the per-shard tokenization
-	// overlay's "mixed-state" window (between first prop swapped and last
-	// prop swapped). SwapBucketPointer is a single map-write under
-	// bucketsLock (microseconds); markSwappedProp is a single fsync
-	// (single-digit ms). The per-prop loop completes in a few ms total
-	// even for 4-property migrations.
+	// Phase 2 (atomic): in-memory pointer swap per property. This is
+	// the ONLY work that runs inside the per-shard tokenization overlay
+	// window. The disk-side cleanup (old bucket shutdown + dir rename
+	// from main_<gen> → backup_<gen> and ingest_<gen> → main_<gen>) is
+	// deferred to next process restart via OnBeforeLsmInit's
+	// recoverRuntimeSwapBuckets path. See 0-weaviate-issues#216
+	// follow-up comment 4469995685 for the design contract.
 	//
-	// Per 0-weaviate-issues#216 follow-up comment 4469995685: the slow
-	// disk work (old-bucket Shutdown, oldMainDir→backupDir rename) is
-	// pulled OUT of this loop so it can't extend the mixed-state window.
-	// It runs in Phase 2b below (after all in-memory swaps are done) and
-	// only touches the OLD (already shut-down) bucket — never the LIVE
-	// ingest bucket whose dir stays at ingest_<gen> until next-restart
-	// recovery does the ingest→main rename safely (no in-memory state
-	// at that point).
-	oldMainBuckets := make(map[string]*lsmkv.Bucket, len(props))
+	// SwapBucketPointer is a single map-write under store.bucketsLock
+	// (microseconds). markSwappedProp is one sentinel fsync (single-
+	// digit ms on a healthy disk). The per-prop loop completes in a
+	// few ms total for typical migrations with 1–4 props.
 	for _, propName := range props {
 		if rt.IsSwappedProp(propName) {
 			// Recovery: partial loop crash already covered this prop's
-			// in-memory pointer flip (sentinel-confirmed). The original
-			// runtimeSwap call also shut down the old bucket and renamed
-			// its dir to _bak before returning, so disk state is fine —
-			// just skip and rely on the post-loop tidy to no-op for this
-			// prop (no oldMainBucket captured).
+			// in-memory pointer flip (sentinel-confirmed). Skip the
+			// SwapBucketPointer call (would error on a missing source
+			// or mis-mapped destination) and rely on the next-restart
+			// disk-rename path for completeness.
 			continue
 		}
 		ingestName := t.ingestBucketName(propName)
 		mainName := t.strategy.SourceBucketName(propName)
 
-		oldMainBucket, err := store.SwapBucketPointer(ctx, mainName, ingestName)
+		_, err := store.SwapBucketPointer(ctx, mainName, ingestName)
 		if err != nil {
 			return fmt.Errorf("swapping bucket pointer %q <- %q: %w", mainName, ingestName, err)
 		}
-		oldMainBuckets[propName] = oldMainBucket
 
 		if err := rt.markSwappedProp(propName); err != nil {
 			return fmt.Errorf("marking swapped prop %q: %w", propName, err)
@@ -1559,54 +1551,33 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 	}
 	logger.Debug("runtime swap: all props in-memory swapped")
 
-	// Phase 2b (post-atomic, slow but inline): shutdown + rename of the
-	// OLD (now-dead) main buckets. Per Etienne's #216 follow-up: "you
-	// can of course rename the old, already shutdown bucket, but never
-	// the live one that's serving queries to the user." The OLD bucket
-	// is no longer in the store's bucketsByName map (SwapBucketPointer
-	// deleted it), so it's not serving queries; Shutdown drains any
-	// in-flight compaction and closes mmaps cleanly. The rename moves
-	// its dir off the canonical name so the LIVE bucket (still at
-	// ingest_<gen> on disk) is the only candidate for the canonical
-	// name on next restart.
+	// NOTE: rt.markSwapped(), oldMainBucket.Shutdown(), and
+	// os.Rename(oldMainDir, backupDir) are intentionally OMITTED here.
 	//
-	// This work is OUTSIDE the mixed-state window — every prop has
-	// already had its in-memory pointer swapped. Queries during this
-	// phase see new buckets for all props (overlay matches), so
-	// per-prop slow ops here don't extend the correctness-sensitive
-	// window.
-	for _, propName := range props {
-		oldMainBucket, ok := oldMainBuckets[propName]
-		if !ok {
-			// IsSwappedProp(propName) was true on entry — the previous
-			// attempt's runtimeSwap call shut down + renamed already.
-			continue
-		}
-		if err := oldMainBucket.Shutdown(ctx); err != nil {
-			return fmt.Errorf("shutting down old main bucket for %q: %w", propName, err)
-		}
-		oldMainDir := oldMainBucket.GetDir()
-		backupDir := filepath.Join(lsmPath, t.backupBucketName(propName))
-		if err := os.Rename(oldMainDir, backupDir); err != nil {
-			return fmt.Errorf("renaming old main dir %q -> %q: %w", oldMainDir, backupDir, err)
-		}
-	}
-
-	if err := rt.markSwapped(); err != nil {
-		return fmt.Errorf("marking swapped: %w", err)
-	}
-
-	// markTidied signals that all on-disk cleanup that can be done inline
-	// has been done. The LIVE bucket's dir (ingest_<gen>) is still at its
-	// pre-swap name — that rename to the canonical name is deferred to
-	// next-restart recovery (OnBeforeLsmInit → recoverRuntimeSwapBuckets)
-	// because renaming a dir whose buckets are mmap'd by the in-memory
-	// store is unsafe per Etienne's #216 follow-up. At restart time,
-	// nothing has loaded that dir yet, so the rename is safe.
-	if err := rt.markTidied(); err != nil {
-		return fmt.Errorf("marking tidied: %w", err)
-	}
-	logger.Debug("runtime swap: tidy complete (ingest→main rename deferred to next restart)")
+	// They violated the #216 atomic-phase contract: Shutdown waits for
+	// compaction to drain (seconds at scale), and renaming a directory
+	// whose bucket is still loaded by the in-memory store is unsafe
+	// per Etienne's explicit guidance — "never rename the live one
+	// that's serving queries to the user; you can rename the old,
+	// already shutdown bucket, but only via the next-startup path."
+	//
+	// State at this point:
+	//   - in-memory: main pointer → ingest_<gen> bucket (the NEW data)
+	//   - on disk: main_<gen> dir unchanged (still holds OLD data),
+	//     ingest_<gen> dir unchanged (still holds NEW data), no backup
+	//     dir yet.
+	//   - sentinels: rt.IsMerged()=true, rt.IsSwappedProp(p)=true for
+	//     every p; rt.IsSwapped()=false, rt.IsTidied()=false.
+	//
+	// On next process restart, FinalizeCompletedMigrations →
+	// OnBeforeLsmInit reads the sentinels and sees IsMerged &&
+	// !IsSwapped && IsPrepended → dispatches to
+	// recoverRuntimeSwapBuckets (the dir-rename swap path) BEFORE
+	// LSM init touches the main bucket name. recoverRuntimeSwapBuckets
+	// observes mainDir+ingestDir present, backupDir missing → does the
+	// full rename sequence (main → backup, ingest → main) per prop and
+	// advances markSwapped + markTidied. LSM init then loads the
+	// renamed dirs correctly.
 
 	// OnMigrationComplete: no-op for semantic migrations (the cluster-
 	// wide schema flip lives in OnTaskCompleted.flipSemanticMigrationSchema).
@@ -1623,7 +1594,7 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 	// dirs whose owning gen is strictly older than this gen.
 	t.trimOlderGenerationsLocked(logger, shard, rt, props)
 
-	logger.Info("runtime swap: migration complete (ingest→main rename deferred to next restart)")
+	logger.Info("runtime swap: in-memory swap complete; disk rename deferred to next restart")
 
 	return nil
 }

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -9,6 +9,117 @@
 //  CONTACT: hello@weaviate.io
 //
 
+// Runtime reindex — phase contract
+// ================================
+//
+// The runtime swap path (semantic migrations through OnGroupCompleted,
+// and non-semantic migrations through OnAfterLsmInitAsync) is partitioned
+// into THREE phases. Maintainers MUST preserve the boundary between them
+// — drift was the root cause of weaviate/0-weaviate-issues#216 (the per-
+// shard "FINALIZING window" misalignment between bucket content and the
+// query analyzer at production scale).
+//
+// Phase 1 — PREP (background, NOT inside the overlay window)
+// ----------------------------------------------------------
+// Implemented by [ShardReindexTaskGeneric.runtimePrepare].
+//
+// Allowed work: heavy disk I/O. FlushAndSwitch on every per-property
+// reindex bucket, ShutdownBucket(reindex) to make its segments
+// immutable, PrependSegmentsFromBucket(reindex → ingest) per property,
+// removeReindexBucketsDirs, sentinel writes (markPrepended,
+// markMerged).
+//
+// Constraints: this phase runs BEFORE the per-shard tokenization
+// overlay is set. Queries during this phase see the pre-migration
+// bucket content with the pre-migration analyzer — correct.
+//
+// Phase 2 — ATOMIC SWAP (inside the overlay window; per-shard
+// "mixed-state" subwindow MUST stay microseconds)
+// ------------------------------------------------------------
+// Implemented by [ShardReindexTaskGeneric.runtimeSwap].
+//
+// 2a — tight loop, microseconds: per property, call
+// store.SwapBucketPointer(mainName, ingestName) followed by
+// rt.markSwappedProp(propName). The tight loop bounds the per-shard
+// "mixed-state" subwindow (some props swapped, others not) to a few
+// microseconds total. Queries during this subwindow that hit
+// not-yet-swapped props would tokenize input with the new value
+// against an old-tokenized bucket — wrong — so the subwindow MUST
+// stay microseconds.
+//
+// 2b — post-atomic inline tidy (slow but correctness-safe):
+// oldMainBucket.Shutdown(ctx) + os.Rename(oldMainDir, backupDir) per
+// property, then rt.markSwapped + rt.markTidied. This runs AFTER
+// every prop has flipped in 2a, so the mixed-state subwindow is
+// closed. Queries during 2b see all-new buckets with the overlay
+// active — correct. The oldMain.Shutdown is REQUIRED inline (not
+// deferred) because Bucket.Shutdown is the only call that removes
+// the bucket's path from GlobalBucketRegistry; deferring it leaks
+// the path entry process-wide, which makes any subsequent in-process
+// shard init at the same canonical name fail with
+// ErrBucketAlreadyRegistered. The oldMain → backup rename is also
+// fine inline because the bucket has just been shut down — per
+// Etienne's design contract: "you can of course rename the old,
+// already shutdown bucket, but never the live one that's serving
+// queries to the user."
+//
+// 2c — post-atomic inline finalize: OnMigrationComplete +
+// trimOlderGenerationsLocked. These run OUTSIDE the mixed-state
+// subwindow.
+//
+//   - OnMigrationComplete is a per-strategy hook with significant
+//     drift between implementations. Some are no-ops (semantic
+//     change-tokenization, enable-filterable, enable-searchable —
+//     their cluster-wide schema flip is in OnTaskCompleted).
+//     Others mutate in-memory local state that the query path
+//     consults (e.g. FilterableToRangeableStrategy.OnMigrationComplete
+//     calls Shard.setRangeableLocallyReady so this shard's queries
+//     match the new schema before the RAFT flip propagates).
+//     Others issue RAFT calls inline
+//     (FilterableToRangeableStrategy.applyPerPropertySchemaUpdate,
+//     MapToBlockmaxStrategy.updateToBlockMaxInvertedIndexConfig).
+//     RAFT calls in this position are slow (100s of ms) but
+//     correctness-safe — the overlay covers the entire RunSwapOnShard
+//     for change-tokenization, and BlockMax has no analyzer overlay
+//     because the format change is internal. See the godoc on
+//     [MigrationStrategy.OnMigrationComplete] for the per-strategy
+//     contract.
+//
+// Phase 3 — DEFERRED LIVE-BUCKET RENAME (next process startup, BEFORE
+// LSM init reloads any buckets)
+// ---------------------------------------------------------------------
+// Implemented by [FinalizeCompletedMigrations] (which scans
+// .migrations/ for tracker dirs with merged.mig — recovery promotes
+// merged-but-not-tidied gens — and tidied.mig, then renames each
+// gen's __ingest_<N>/ dir to its canonical name).
+//
+// Why deferred: the ingest bucket is the LIVE post-swap main bucket.
+// Its mmaps are open, its segment registry holds the ingest_<N> path
+// as its dir. Renaming that dir while the bucket is in-memory would
+// corrupt the segment registry and any subsequent write that
+// resolves paths from the bucket's stored dir. At next startup,
+// before LSM init touches the canonical name, no bucket is mmapping
+// anything — the rename is safe.
+//
+// Crash safety: every phase transition is preceded by a tracker
+// sentinel fsync (markPrepended, markMerged, markSwappedProp,
+// markSwapped, markTidied). The dispatch in
+// [ShardReindexTaskGeneric.RunSwapOnShard] inspects sentinels to
+// pick the right resume path on rehydrate. A crash within Phase 2b
+// (after markSwappedProp on some props but before markSwapped on
+// the aggregate) lands in the IsMerged dispatch branch on the
+// next-process restart: if ingest buckets are loaded (rare),
+// runtimeSwap is re-invoked; if not (normal startup), the
+// recoverRuntimeSwapBuckets path does the disk-rename equivalent
+// of 2b before LSM init loads any bucket.
+//
+// Atomic-phase regression guard: a unit test must fail if
+// SwapBucketPointer is preceded by any disk-I/O or compaction-wait
+// op inside Phase 2 — the "atomic" subwindow has to stay
+// microseconds for queries at production scale. See
+// 0-weaviate-issues#216 follow-up comment 4469995685 for the
+// observed-at-scale violation that motivated this contract.
+
 package db
 
 import (
@@ -40,6 +151,10 @@ import (
 // ShardReindexTaskV3. All lifecycle logic (state machine, merge/swap/tidy,
 // object iteration, progress tracking) lives here, with strategy-specific
 // behavior delegated to a MigrationStrategy.
+//
+// See the file-level phase-contract godoc above for the prep / atomic
+// swap / deferred-rename invariants that every code path in this file
+// must preserve.
 type ShardReindexTaskGeneric struct {
 	name                 string
 	logger               logrus.FieldLogger
@@ -1374,23 +1489,76 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 	return time.Now().Add(t.config.pauseDuration), false, nil
 }
 
-// runtimeSwap performs the merge→swap→tidy lifecycle inline after the reindex
-// iteration completes, without requiring a shard restart.
+// runtimeSwap implements Phase 2 of the runtime swap path. See the
+// file-level phase-contract godoc for the full prep/atomic/defer
+// design. The implementation is partitioned into 2a / 2b / 2c
+// sub-phases with HARD boundaries — do not move work between them
+// without re-reading the contract.
 //
-// Steps:
-//  1. Shut down the reindex bucket (makes its segments immutable for prepend).
-//  2. Prepend reindex segments into the ingest bucket.
-//  3. Atomically swap the ingest bucket pointer into the main bucket slot.
-//  4. Shut down the old main bucket, rename its dir to _bak for crash safety.
-//  5. Mark tidied.
-//  6. Call OnMigrationComplete (schema flag flips).
+// Phase 2a — atomic per-prop SwapBucketPointer loop. MUST stay
+// microseconds total. This bounds the per-shard "mixed-state"
+// subwindow (some props swapped, others not) during which queries
+// to not-yet-swapped props would tokenize input with the new value
+// against an old-tokenized bucket. Only allowed work: in-memory
+// pointer flip + single-fsync sentinel mark.
 //
-// Disable double-write callbacks is handled by a deferred call at the
-// top of the function so it fires on every error path as well as the
-// happy path.
+//   - store.SwapBucketPointer(mainName, ingestName) per prop
+//   - rt.markSwappedProp(propName) per prop
 //
-// On crash at any step, OnBeforeLsmInit on next restart will pick up from the
-// last completed sentinel state (reindexed/merged/swapped) and finish.
+// Forbidden in 2a: anything that can block (disk I/O, lock
+// contention, RAFT calls, compaction waits). A guard test must
+// catch regressions where someone adds a yield point between two
+// SwapBucketPointer calls. See 0-weaviate-issues#216 follow-up
+// QA-Claude comment 4470016252.
+//
+// Phase 2b — post-atomic inline tidy. Slow but correctness-safe:
+// every prop is already in-memory-swapped, so the mixed-state
+// subwindow is closed and queries see all-new buckets with the
+// overlay still active.
+//
+//   - oldMainBucket.Shutdown(ctx) per prop (REQUIRED INLINE — see
+//     below)
+//   - os.Rename(oldMainDir, backupDir) per prop (safe inline per
+//     Etienne's contract: "you can of course rename the old, already
+//     shutdown bucket, but never the live one that's serving queries
+//     to the user")
+//   - rt.markSwapped
+//   - rt.markTidied
+//
+// Why oldMain.Shutdown MUST be inline (not deferred to next-startup
+// like the live-ingest rename): Bucket.Shutdown is the only call
+// that removes the bucket's path from GlobalBucketRegistry (see
+// lsmkv/bucket.go Shutdown defer of Remove(b.GetDir())). After
+// SwapBucketPointer the old bucket is no longer in the store's
+// bucketsByName map, so Store.Shutdown's iteration will not call
+// its Shutdown. Without an inline Shutdown the old bucket's path
+// remains in the process-wide registry indefinitely, and any
+// subsequent in-process shard init that tries to register a bucket
+// at the same canonical name (shard reload, lazy-load unwrap,
+// second migration on the same shard) fails with
+// ErrBucketAlreadyRegistered. The unit test
+// TestMapToBlockmaxMigration_RuntimeSwap_ThenRestart reproduces
+// this if the inline Shutdown is removed.
+//
+// Phase 2c — post-atomic inline finalize.
+//
+//   - OnMigrationComplete (per-strategy hook; see
+//     [MigrationStrategy.OnMigrationComplete] godoc for the
+//     per-strategy contract)
+//   - trimOlderGenerationsLocked (removes the current gen's backup
+//     dir + every older gen's sidecars)
+//
+// Live-bucket rename (Phase 3): the ingest bucket whose pointer was
+// flipped into the canonical slot is STILL at __ingest_<gen>/ on
+// disk. That rename to the canonical name is deferred to next
+// startup via [FinalizeCompletedMigrations], because renaming a
+// dir whose mmaps are open would corrupt the segment registry.
+//
+// Disable double-write callbacks via a defer at the top of the
+// function so callbacks stop on every exit path. Same-process
+// retry of runtimeSwap is not supported (the in-memory bucket
+// state is partially mutated); recovery after a mid-swap crash
+// happens on the next node restart via OnBeforeLsmInit.
 // runtimePrepare runs the Phase 1 (background-safe) preparation work
 // that used to be inlined into runtimeSwap.
 //

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -212,6 +212,105 @@ func (t *ShardReindexTaskGeneric) runShardLifecycle(ctx context.Context, shard S
 	}
 }
 
+// RunPrepareOnShard runs the disk-I/O-heavy prep phase between
+// RunReindexOnlyOnShard and RunSwapOnShard.
+//
+// Preconditions:
+//   - MUST have completed RunReindexOnlyOnShard (IsReindexed() == true)
+//     OR be re-entering a recovery state (IsPrepended() set but
+//     IsMerged() not, or IsMerged() already set in which case this is
+//     an idempotent no-op).
+//
+// Performs, per property:
+//   - reindexBucket.FlushAndSwitch()  // memtable → immutable segments
+//   - store.ShutdownBucket(reindexName)  // waits for compaction to
+//     drain — this is the load-bearing slow step that #216 (the
+//     "atomic phase actually atomic" design contract) requires
+//     to live outside the per-shard atomic window
+//   - ingestBucket.PrependSegmentsFromBucket(...)  // segment copy
+//
+// Then advances sentinels: markPrepended + removeReindexBucketsDirs
+// + markMerged.
+//
+// Idempotent / sentinel-aware: if rt.IsMerged() already, returns nil.
+// If rt.IsPrepended() && !rt.IsMerged() (mid-prep crash recovery),
+// finishes the cleanup and returns. Safe to call repeatedly from
+// rehydrate flows.
+//
+// MUST be called BEFORE the per-shard tokenization overlay is set
+// by [reindex_provider.OnGroupCompleted]. Setting the overlay
+// before prep completes would expose the very gap the overlay was
+// supposed to close — query input would tokenize as NEW against the
+// still-OLD bucket while prep is doing seconds of disk I/O.
+// See 0-weaviate-issues#216 follow-up comment 4469995685.
+//
+// Double-write callbacks registered during reindex MUST remain
+// active across this call (they fire on writes to MAIN to mirror
+// into INGEST; MAIN is still serving queries with OLD data while
+// prep runs, and the mirror keeps the new ingest segments
+// consistent with ongoing writes). Callbacks are disabled only at
+// the end of [runtimeSwap] after the atomic pointer flip.
+func (t *ShardReindexTaskGeneric) RunPrepareOnShard(ctx context.Context, shard ShardLike) error {
+	concreteShard, err := unwrapShard(ctx, shard)
+	if err != nil {
+		return fmt.Errorf("unwrapping shard %q: %w", shard.Name(), err)
+	}
+
+	logger := t.logger.WithFields(map[string]any{
+		"collection": concreteShard.Index().Config.ClassName.String(),
+		"shard":      concreteShard.Name(),
+		"method":     "RunPrepareOnShard",
+	})
+
+	rt, err := t.newReindexTracker(concreteShard.pathLSM())
+	if err != nil {
+		return fmt.Errorf("creating reindex tracker: %w", err)
+	}
+
+	// Idempotent fast-path: already merged means prep was already
+	// completed (either by an earlier call in this process or by a
+	// previous boot's runtimePrepare → markMerged).
+	if rt.IsMerged() {
+		logger.Debug("RunPrepareOnShard: already merged on disk; no-op")
+		return nil
+	}
+
+	// Re-entry path: state-on-disk vs state-in-RAFT race (mirrors the
+	// same check in RunSwapOnShard). If we land here with state
+	// "started but not reindexed", resume the iteration before
+	// preparing.
+	if !rt.IsReindexed() {
+		if !rt.IsStarted() {
+			return fmt.Errorf("shard %q is not in reindexed state and has no started sentinel — no in-flight migration on disk", concreteShard.Name())
+		}
+		logger.Info("RunPrepareOnShard: state not yet reindexed on disk; resuming iteration before prep")
+		if err := t.RunReindexOnlyOnShard(ctx, shard); err != nil {
+			return fmt.Errorf("resume iteration before prep: %w", err)
+		}
+		rt, err = t.newReindexTracker(concreteShard.pathLSM())
+		if err != nil {
+			return fmt.Errorf("creating reindex tracker after iteration resume: %w", err)
+		}
+		if !rt.IsReindexed() {
+			return fmt.Errorf("shard %q: iteration resume returned but IsReindexed still false", concreteShard.Name())
+		}
+	}
+
+	props, err := t.readPropsToReindex(rt)
+	if err != nil {
+		return fmt.Errorf("reading props: %w", err)
+	}
+	if len(props) == 0 {
+		return fmt.Errorf("no props found for prep on shard %q", concreteShard.Name())
+	}
+
+	if err := t.ensureReindexBucketsLoadedForSwap(ctx, logger, concreteShard, props); err != nil {
+		return fmt.Errorf("ensure buckets loaded: %w", err)
+	}
+
+	return t.runtimePrepare(ctx, logger, shard, rt, props)
+}
+
 // RunSwapOnShard runs the swap+tidy+OnMigrationComplete phase.
 //
 // Preconditions:
@@ -361,11 +460,28 @@ func (t *ShardReindexTaskGeneric) RunSwapOnShard(ctx context.Context, shard Shar
 		return t.finalizeMigrationAfterRecovery(ctx, logger, shard, rt, props)
 
 	case rt.IsMerged():
-		// Segments are in ingest_<gen> dir, swap not yet done. Use the
-		// dir-rename-based recovery — the in-memory PrependSegments-
-		// based swap is impossible here because the reindex bucket was
-		// drained at markPrepended.
-		logger.WithField("props", props).Info("RunSwapOnShard: resuming from merged state, recovering swap via dir renames")
+		// Two sub-cases distinguish in-process happy path from post-
+		// restart recovery (after the #216 atomic-phase refactor —
+		// follow-up comment 4469995685):
+		//
+		//  - **In-process happy path** (OnGroupCompleted called
+		//    RunPrepareOnShard first): ingest buckets are loaded in
+		//    the LSM store. Do the in-memory atomic SwapBucketPointer
+		//    via [runtimeSwap]. Disk rename is deferred to next
+		//    startup via OnBeforeLsmInit's recoverRuntimeSwapBuckets.
+		//  - **Recovery fallback**: ingest buckets are NOT loaded.
+		//    In practice this is rare — post-restart, OnBeforeLsmInit's
+		//    IsMerged && !IsSwapped branch typically does the disk
+		//    rename before LSM init touches the main bucket name,
+		//    advancing the state to IsSwapped. We only land here in
+		//    the merged state with ingest buckets unloaded if that
+		//    branch was skipped (e.g. swapBuckets config disabled).
+		//    Use the dir-rename swap to converge.
+		if t.ingestBucketsLoaded(shard, props) {
+			logger.WithField("props", props).Info("RunSwapOnShard: resuming from merged state, in-memory atomic swap")
+			return t.runtimeSwap(ctx, logger, shard, rt, props)
+		}
+		logger.WithField("props", props).Info("RunSwapOnShard: resuming from merged state without loaded ingest buckets, recovering swap via dir renames")
 		if err := t.recoverRuntimeSwapBuckets(ctx, logger, shard, rt, props); err != nil {
 			return fmt.Errorf("recovery swap: %w", err)
 		}
@@ -396,15 +512,24 @@ func (t *ShardReindexTaskGeneric) RunSwapOnShard(ctx context.Context, shard Shar
 		return t.finalizeMigrationAfterRecovery(ctx, logger, shard, rt, props)
 	}
 
-	// Default: pre-prepend state (only reindexed.mig set). The reindex
-	// bucket should still be on disk and loaded into the store from
-	// OnAfterLsmInit's `loadReindexBuckets` call. Defensively re-load
-	// if it isn't — see [ensureReindexBucketsLoadedForSwap] for the
-	// rehydrate-path race scenarios.
-	logger.WithField("props", props).Info("starting swap phase")
+	// Default: pre-prepend state (only reindexed.mig set). Post-#216
+	// atomic-phase refactor (follow-up comment 4469995685), the
+	// happy-path caller is [reindex_provider.OnGroupCompleted], which
+	// invokes RunPrepareOnShard BEFORE RunSwapOnShard so the prep work
+	// runs OUTSIDE the per-shard tokenization-overlay window. Reaching
+	// this branch via OnGroupCompleted's flow means rehydrate happened
+	// but RunPrepareOnShard hasn't — call it defensively, but note
+	// that the atomic-window contract is no longer met (prep runs
+	// inside the overlay window). Acceptable for tests and edge cases
+	// where FINALIZING-window query correctness isn't being asserted.
+	logger.WithField("props", props).Info("starting prep+swap phase (caller did not invoke RunPrepareOnShard separately)")
 
 	if err := t.ensureReindexBucketsLoadedForSwap(ctx, logger, concreteShard, props); err != nil {
 		return fmt.Errorf("ensure buckets loaded: %w", err)
+	}
+
+	if err := t.runtimePrepare(ctx, logger, shard, rt, props); err != nil {
+		return fmt.Errorf("runtime prepare: %w", err)
 	}
 
 	if err := t.runtimeSwap(ctx, logger, shard, rt, props); err != nil {
@@ -412,6 +537,23 @@ func (t *ShardReindexTaskGeneric) RunSwapOnShard(ctx context.Context, shard Shar
 	}
 
 	return nil
+}
+
+// ingestBucketsLoaded reports whether the ingest buckets for every
+// prop are currently loaded in the shard's LSM store. Used by the
+// IsMerged dispatch in [RunSwapOnShard] to distinguish the in-process
+// happy path (post-#216 atomic-phase refactor: RunPrepareOnShard just
+// ran, ingest buckets are warm, do in-memory SwapBucketPointer) from
+// the recovery fallback (ingest buckets aren't loaded, dir-rename
+// swap via recoverRuntimeSwapBuckets).
+func (t *ShardReindexTaskGeneric) ingestBucketsLoaded(shard ShardLike, props []string) bool {
+	store := shard.Store()
+	for _, propName := range props {
+		if store.Bucket(t.ingestBucketName(propName)) == nil {
+			return false
+		}
+	}
+	return true
 }
 
 // ensureReindexBucketsLoadedForSwap defensively loads any reindex or
@@ -1238,91 +1380,91 @@ func (t *ShardReindexTaskGeneric) OnAfterLsmInitAsync(ctx context.Context, shard
 //
 // On crash at any step, OnBeforeLsmInit on next restart will pick up from the
 // last completed sentinel state (reindexed/merged/swapped) and finish.
-func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
+// runtimePrepare runs the Phase 1 (background-safe) preparation work
+// that used to be inlined into runtimeSwap.
+//
+// Performs, per property:
+//   - reindexBucket.FlushAndSwitch()            // memtable → segments
+//   - store.ShutdownBucket(reindexName)         // drains compaction
+//   - ingestBucket.PrependSegmentsFromBucket(...) // segment copy
+//
+// Then advances sentinels: markPrepended + removeReindexBucketsDirs
+// + markMerged.
+//
+// Bucket=OLD and schema=OLD throughout — queries on the live main
+// bucket continue correctly. The per-shard tokenization overlay
+// MUST NOT yet be set: setting it before this call would expose the
+// very gap the overlay was supposed to close (query input
+// tokenized as NEW against the still-OLD bucket while prep does
+// disk I/O for seconds).
+//
+// Sentinel-aware: if rt.IsPrepended() is true (crash mid-prep) we
+// skip the per-prop loop and finish the merge-cleanup steps only.
+// The caller checks rt.IsMerged() before calling.
+//
+// Crash safety: markPrepended is set after the per-prop loop but
+// BEFORE removeReindexBucketsDirs. A crash in that window leaves
+// IsPrepended=true with reindex dirs partially removed; on restart,
+// either the recovery path here or OnBeforeLsmInit's prepended-but-
+// not-merged branch finishes the cleanup.
+func (t *ShardReindexTaskGeneric) runtimePrepare(ctx context.Context,
 	logger logrus.FieldLogger, shard ShardLike, rt reindexTracker, props []string,
 ) error {
-	// Always disable the double-write callbacks registered by this task
-	// instance, regardless of whether the swap completes successfully.
-	//
-	// On the happy path this runs after markTidied + OnMigrationComplete:
-	// the main bucket pointer has already been swapped, so any callback
-	// invocations between markSwapped and this defer would have been
-	// harmless redundant writes (the ingest bucket is reachable under both
-	// the main and ingest names).
-	//
-	// On an error path this is the load-bearing case: without it, callbacks
-	// would keep firing against buckets that may be mid-rename, shut down,
-	// or otherwise in an inconsistent state. We want subsequent writes to
-	// stop touching the ingest/backup buckets entirely; they should land
-	// only in whatever the main pointer resolves to.
-	//
-	// Recovery after a mid-swap failure happens on the next node restart:
-	// OnBeforeLsmInit reads the sentinel files and rebuilds disk layout,
-	// then OnAfterLsmInit re-registers fresh callbacks based on the new
-	// on-disk state. Same-process retry of runtimeSwap is not supported
-	// (the in-memory bucket state is partially mutated), so the cleared
-	// callback slice is correct.
-	//
-	// disableCallbacks is idempotent (nils the slice after firing), so the
-	// defer is safe even on the success path where the slice is already
-	// empty by the time the defer runs (currently the explicit call at the
-	// end has been folded into this defer).
-	defer t.disableCallbacks()
-
 	store := shard.Store()
-	lsmPath := shard.pathLSM()
 
-	for _, propName := range props {
-		reindexName := t.reindexBucketName(propName)
-		ingestName := t.ingestBucketName(propName)
+	if rt.IsPrepended() {
+		logger.Debug("runtime prepare: already prepended on disk; finishing merge cleanup only")
+	} else {
+		for _, propName := range props {
+			reindexName := t.reindexBucketName(propName)
+			ingestName := t.ingestBucketName(propName)
 
-		reindexBucket := store.Bucket(reindexName)
-		if reindexBucket == nil {
-			return fmt.Errorf("reindex bucket %q not found", reindexName)
-		}
-		ingestBucket := store.Bucket(ingestName)
-		if ingestBucket == nil {
-			return fmt.Errorf("ingest bucket %q not found", ingestName)
+			reindexBucket := store.Bucket(reindexName)
+			if reindexBucket == nil {
+				return fmt.Errorf("reindex bucket %q not found", reindexName)
+			}
+			ingestBucket := store.Bucket(ingestName)
+			if ingestBucket == nil {
+				return fmt.Errorf("ingest bucket %q not found", ingestName)
+			}
+
+			// FlushAndSwitch makes the reindex memtable immutable so its
+			// segments are safe to copy.
+			if err := reindexBucket.FlushAndSwitch(); err != nil {
+				return fmt.Errorf("flushing reindex bucket %q: %w", reindexName, err)
+			}
+			reindexDir := reindexBucket.GetDir()
+			// FOLLOW-UP: store.ShutdownBucket / bucket.Shutdown does not abort
+			// an in-flight long-running compaction when ctx is cancelled —
+			// it waits for the compaction to finish naturally and only then
+			// observes the cancellation, returning "long-running compaction
+			// in progress: context canceled". During a graceful shutdown
+			// (rolling restart) this means the prep can be interrupted mid-
+			// flight even though there's a clean exit path that doesn't
+			// touch the compaction's output. Tracked separately.
+			if err := store.ShutdownBucket(ctx, reindexName); err != nil {
+				return fmt.Errorf("shutting down reindex bucket %q: %w", reindexName, err)
+			}
+
+			// Prepend reindex segments into the ingest bucket. After this,
+			// ingest contains all reindexed + double-written data.
+			if err := ingestBucket.PrependSegmentsFromBucket(ctx, reindexDir); err != nil {
+				return fmt.Errorf("prepending segments from %q to %q: %w", reindexName, ingestName, err)
+			}
 		}
 
-		// Step 1: Flush and shut down the reindex bucket so its segments are
-		// immutable and safe to copy.
-		if err := reindexBucket.FlushAndSwitch(); err != nil {
-			return fmt.Errorf("flushing reindex bucket %q: %w", reindexName, err)
-		}
-		reindexDir := reindexBucket.GetDir()
-		// FOLLOW-UP: store.ShutdownBucket / bucket.Shutdown does not abort
-		// an in-flight long-running compaction when ctx is cancelled —
-		// it waits for the compaction to finish naturally and only then
-		// observes the cancellation, returning "long-running compaction
-		// in progress: context canceled". During a graceful shutdown
-		// (rolling restart) this means the swap can be interrupted mid-
-		// flight even though there's a clean exit path that doesn't
-		// touch the compaction's output. The recovery hook below
-		// (RecoveryAwareProvider.LocalCallbacksDone) catches the resulting
-		// half-applied state on the next boot, but the *underlying* LSM
-		// shutdown should also be made compaction-aware so the swap
-		// completes cleanly on the original node. Tracked separately.
-		if err := store.ShutdownBucket(ctx, reindexName); err != nil {
-			return fmt.Errorf("shutting down reindex bucket %q: %w", reindexName, err)
-		}
-
-		// Step 2: Prepend reindex segments into the ingest bucket. After this,
-		// ingest contains all reindexed + double-written data.
-		if err := ingestBucket.PrependSegmentsFromBucket(ctx, reindexDir); err != nil {
-			return fmt.Errorf("prepending segments from %q to %q: %w", reindexName, ingestName, err)
+		// Mark prepended before removing the reindex dirs. On crash
+		// recovery, OnBeforeLsmInit sees IsPrepended() and skips the
+		// file-move merge path.
+		if err := rt.markPrepended(); err != nil {
+			return fmt.Errorf("marking prepended: %w", err)
 		}
 	}
 
-	// Mark prepended before removing the reindex dirs. On crash recovery,
-	// OnBeforeLsmInit sees IsPrepended() and skips the file-move merge
-	// (segments are already in ingest via prepend).
-	if err := rt.markPrepended(); err != nil {
-		return fmt.Errorf("marking prepended: %w", err)
-	}
-
-	// Remove reindex bucket directories — their segments have been copied
-	// into ingest, so the originals are no longer needed.
+	// Remove reindex bucket directories — their segments have been
+	// copied into ingest, so the originals are no longer needed.
+	// Idempotent: removeReindexBucketsDirs is safe to call when the
+	// dirs are already gone (the post-IsPrepended recovery case).
 	if err := t.removeReindexBucketsDirs(ctx, logger, shard, props); err != nil {
 		return fmt.Errorf("removing reindex bucket dirs: %w", err)
 	}
@@ -1330,82 +1472,118 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 	if err := rt.markMerged(); err != nil {
 		return fmt.Errorf("marking merged: %w", err)
 	}
-	logger.Debug("runtime swap: all props merged")
+	logger.Debug("runtime prepare: all props merged")
+	return nil
+}
 
-	// Step 3: Swap each ingest bucket into the main bucket slot.
-	// The old main dir is renamed to the backup suffix (same naming as the
-	// restart-based swap) so that crash recovery in OnBeforeLsmInit can pick
-	// up from any partially-swapped state using the same tidy logic.
+func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
+	logger logrus.FieldLogger, shard ShardLike, rt reindexTracker, props []string,
+) error {
+	// Always disable the double-write callbacks registered by this task
+	// instance, regardless of whether the swap completes successfully.
+	//
+	// On the happy path this runs after the in-memory pointer flip:
+	// the main bucket pointer has already been swapped, so any callback
+	// invocations between markSwappedProp and this defer would have been
+	// harmless redundant writes (the ingest bucket is reachable under
+	// both the main and ingest names).
+	//
+	// On an error path this is the load-bearing case: without it,
+	// callbacks would keep firing against buckets that may be mid-swap,
+	// shut down, or otherwise in an inconsistent state. We want
+	// subsequent writes to stop touching the ingest/backup buckets
+	// entirely; they should land only in whatever the main pointer
+	// resolves to.
+	//
+	// Recovery after a mid-swap failure happens on the next node
+	// restart: OnBeforeLsmInit reads the sentinel files and rebuilds
+	// disk layout (via recoverRuntimeSwapBuckets), then OnAfterLsmInit
+	// re-registers fresh callbacks based on the new on-disk state.
+	// Same-process retry of runtimeSwap is not supported (the in-memory
+	// bucket state is partially mutated).
+	defer t.disableCallbacks()
+
+	store := shard.Store()
+
+	// Phase 2 (atomic): in-memory pointer swap per property. This is
+	// the ONLY work that runs inside the per-shard tokenization overlay
+	// window. The disk-side cleanup (old bucket shutdown + dir rename
+	// from main_<gen> → backup_<gen> and ingest_<gen> → main_<gen>) is
+	// deferred to next process restart via OnBeforeLsmInit's
+	// recoverRuntimeSwapBuckets path. See 0-weaviate-issues#216
+	// follow-up comment 4469995685 for the design contract.
+	//
+	// SwapBucketPointer is a single map-write under store.bucketsLock
+	// (microseconds). markSwappedProp is one sentinel fsync (single-
+	// digit ms on a healthy disk). The per-prop loop completes in a
+	// few ms total for typical migrations with 1–4 props.
 	for _, propName := range props {
+		if rt.IsSwappedProp(propName) {
+			// Recovery: partial loop crash already covered this prop's
+			// in-memory pointer flip (sentinel-confirmed). Skip the
+			// SwapBucketPointer call (would error on a missing source
+			// or mis-mapped destination) and rely on the next-restart
+			// disk-rename path for completeness.
+			continue
+		}
 		ingestName := t.ingestBucketName(propName)
 		mainName := t.strategy.SourceBucketName(propName)
-		backupName := t.backupBucketName(propName)
-		backupDir := filepath.Join(lsmPath, backupName)
 
-		oldMainBucket, err := store.SwapBucketPointer(ctx, mainName, ingestName)
+		_, err := store.SwapBucketPointer(ctx, mainName, ingestName)
 		if err != nil {
 			return fmt.Errorf("swapping bucket pointer %q <- %q: %w", mainName, ingestName, err)
-		}
-
-		// Shut down the old main bucket and rename its directory to the backup
-		// location. This must happen before markSwappedProp so that on crash
-		// recovery the restart path sees the same on-disk layout it expects.
-		if err := oldMainBucket.Shutdown(ctx); err != nil {
-			return fmt.Errorf("shutting down old main bucket %q: %w", mainName, err)
-		}
-		oldMainDir := oldMainBucket.GetDir()
-		if err := os.Rename(oldMainDir, backupDir); err != nil {
-			return fmt.Errorf("renaming old main dir %q -> %q: %w", oldMainDir, backupDir, err)
 		}
 
 		if err := rt.markSwappedProp(propName); err != nil {
 			return fmt.Errorf("marking swapped prop %q: %w", propName, err)
 		}
 	}
+	logger.Debug("runtime swap: all props in-memory swapped")
 
-	if err := rt.markSwapped(); err != nil {
-		return fmt.Errorf("marking swapped: %w", err)
-	}
-	logger.Debug("runtime swap: all props swapped")
+	// NOTE: rt.markSwapped(), oldMainBucket.Shutdown(), and
+	// os.Rename(oldMainDir, backupDir) are intentionally OMITTED here.
+	//
+	// They violated the #216 atomic-phase contract: Shutdown waits for
+	// compaction to drain (seconds at scale), and renaming a directory
+	// whose bucket is still loaded by the in-memory store is unsafe
+	// per Etienne's explicit guidance — "never rename the live one
+	// that's serving queries to the user; you can rename the old,
+	// already shutdown bucket, but only via the next-startup path."
+	//
+	// State at this point:
+	//   - in-memory: main pointer → ingest_<gen> bucket (the NEW data)
+	//   - on disk: main_<gen> dir unchanged (still holds OLD data),
+	//     ingest_<gen> dir unchanged (still holds NEW data), no backup
+	//     dir yet.
+	//   - sentinels: rt.IsMerged()=true, rt.IsSwappedProp(p)=true for
+	//     every p; rt.IsSwapped()=false, rt.IsTidied()=false.
+	//
+	// On next process restart, FinalizeCompletedMigrations →
+	// OnBeforeLsmInit reads the sentinels and sees IsMerged &&
+	// !IsSwapped && IsPrepended → dispatches to
+	// recoverRuntimeSwapBuckets (the dir-rename swap path) BEFORE
+	// LSM init touches the main bucket name. recoverRuntimeSwapBuckets
+	// observes mainDir+ingestDir present, backupDir missing → does the
+	// full rename sequence (main → backup, ingest → main) per prop and
+	// advances markSwapped + markTidied. LSM init then loads the
+	// renamed dirs correctly.
 
-	// Step 5: Mark tidied. The in-memory swap is complete — the ingest bucket
-	// is now serving queries under the main bucket name. The directory on disk
-	// still has the ingest name, and the old main dir is renamed to _bak.
-	// These filesystem renames (ingest→main, remove _bak) happen on next
-	// startup in OnBeforeLsmInit, which reads the sentinel files and performs
-	// the renames BEFORE bucket loading. This keeps the runtime swap
-	// side-effect-free on the filesystem, avoiding issues with renaming
-	// directories of live/initialized buckets.
-	if err := rt.markTidied(); err != nil {
-		return fmt.Errorf("marking tidied: %w", err)
-	}
-	logger.Debug("runtime swap: tidy complete (fs cleanup deferred to next restart)")
-
-	// Step 6: Signal migration complete (e.g. update schema).
+	// OnMigrationComplete: no-op for semantic migrations (the cluster-
+	// wide schema flip lives in OnTaskCompleted.flipSemanticMigrationSchema).
+	// Per-shard schema-flag flip for blockmax / repair-* strategies.
+	// Either way, runs OUTSIDE the per-shard atomic window because it
+	// doesn't touch bucket pointers.
 	if err := t.strategy.OnMigrationComplete(ctx, shard); err != nil {
 		return fmt.Errorf("on migration complete: %w", err)
 	}
 
-	// Step 7: Trim older generations on disk.
-	//
-	// Each migration on a (prop, indexType) tuple lives in its own
-	// gen-suffixed sidecar dirs and `.migrations/<prefix>_<prop>_<N>`
-	// tracker dir. After this swap successfully tidied at gen N, every
-	// older gen on disk is by definition obsolete: their reindex dirs
-	// were already removed during their own runtimeSwap step 2; their
-	// backup dirs are the pre-T_N data we no longer need; their tracker
-	// dirs would otherwise survive until next-restart finalize. Clean
-	// them up now so the on-disk depth never exceeds 2 generations
-	// (this gen + maybe one in-flight successor) regardless of how many
-	// in-process migrations have run on this prop since the last
-	// restart.
-	//
-	// Best-effort: log errors, don't fail the migration. The next-restart
-	// FinalizeCompletedMigrations is idempotent across multiple
-	// generations and will sweep up anything we missed.
+	// Trim older generations on disk (best-effort cleanup of sidecar
+	// dirs from completed-and-tidied prior migrations on this prop).
+	// Independent of the atomic window — operates on _bak / .migrations
+	// dirs whose owning gen is strictly older than this gen.
 	t.trimOlderGenerationsLocked(logger, shard, rt, props)
 
-	logger.Info("runtime swap: migration complete")
+	logger.Info("runtime swap: in-memory swap complete; disk rename deferred to next restart")
 
 	return nil
 }
@@ -1685,26 +1863,46 @@ func (t *ShardReindexTaskGeneric) getSegmentPathsToMove(bucketPathSrc, bucketPat
 	return segmentPaths, false, nil
 }
 
-// recoverRuntimeSwapBuckets handles crash recovery for a runtime swap that
-// was interrupted. For each property, the on-disk state may be:
+// recoverRuntimeSwapBuckets handles the disk-rename half of a runtime
+// swap. It serves two callers with identical on-disk semantics:
 //
-//   - main exists, ingest exists, no backup → swap not started → do full swap
-//   - main gone, ingest exists, backup exists → halfway: main renamed to backup
-//     but ingest not yet renamed → rename ingest to main
-//   - main exists (from ingest→main rename), backup exists → swap done, just
-//     needs markSwappedProp
+//  1. **Crash recovery** for a runtime swap that was interrupted mid-
+//     way (pre-#216-atomic-refactor: a crash between SwapBucketPointer
+//     and the inline os.Rename pair; post-refactor: same window, but
+//     also the deferred-disk-rename path for the normal happy-path
+//     where the rename was intentionally not done at runtime).
 //
-// Props already marked via markSwappedProp are skipped.
+//  2. **Deferred disk rename** on next startup after a successful
+//     runtime swap. In the post-#216-atomic-refactor design (see
+//     [runtimeSwap] godoc), runtimeSwap performs ONLY the in-memory
+//     bucket-pointer flip and leaves the disk dirs (main_<gen> and
+//     ingest_<gen>) untouched. OnBeforeLsmInit's IsMerged && !IsSwapped
+//     branch picks this up at next startup, BEFORE LSM init loads any
+//     bucket from main_<gen>, and routes through this function.
+//
+// For each property the disk state is one of:
+//
+//   - mainExists && ingestExists && !backupExists → atomic swap was
+//     in-memory only (post-refactor happy path) or never started →
+//     do the full rename pair (main → backup, ingest → main).
+//   - !mainExists && backupExists → halfway through the pair: main
+//     was renamed but ingest wasn't yet → rename ingest → main.
+//   - mainExists && backupExists → ingest was already renamed to
+//     main on a prior recovery attempt; nothing to do this round.
+//
+// The IsSwappedProp sentinel is intentionally NOT used to skip props
+// here. Pre-refactor it was set together with the disk rename, so
+// IsSwappedProp=true implied the dirs were already swapped on disk.
+// Post-refactor, runtimeSwap sets IsSwappedProp after the in-memory
+// pointer flip — the disk dirs may still need renaming. Trusting the
+// on-disk state instead of the sentinel makes this function correct
+// for both paths.
 func (t *ShardReindexTaskGeneric) recoverRuntimeSwapBuckets(ctx context.Context,
 	logger logrus.FieldLogger, shard ShardLike, rt reindexTracker, props []string,
 ) error {
 	lsmPath := shard.pathLSM()
 
 	for _, propName := range props {
-		if rt.IsSwappedProp(propName) {
-			continue
-		}
-
 		mainName := t.strategy.SourceBucketName(propName)
 		mainDir := filepath.Join(lsmPath, mainName)
 		ingestDir := filepath.Join(lsmPath, t.ingestBucketName(propName))
@@ -1712,10 +1910,15 @@ func (t *ShardReindexTaskGeneric) recoverRuntimeSwapBuckets(ctx context.Context,
 
 		mainExists := dirExists(mainDir)
 		backupExists := dirExists(backupDir)
+		ingestExists := dirExists(ingestDir)
 
 		switch {
 		case mainExists && !backupExists:
-			// Swap not started for this prop. Do the full rename sequence.
+			// Pre-rename state (either swap not started, or post-refactor
+			// happy-path deferred-rename). Do the full rename pair.
+			if !ingestExists {
+				return fmt.Errorf("recovery rename for %q: main exists, no backup, but ingest dir missing — unrecoverable", propName)
+			}
 			if err := os.Rename(mainDir, backupDir); err != nil {
 				return fmt.Errorf("recovery rename main->backup for %q: %w", propName, err)
 			}
@@ -1723,14 +1926,19 @@ func (t *ShardReindexTaskGeneric) recoverRuntimeSwapBuckets(ctx context.Context,
 				return fmt.Errorf("recovery rename ingest->main for %q: %w", propName, err)
 			}
 		case !mainExists && backupExists:
-			// Main was renamed to backup, but ingest not yet renamed to main.
+			// Halfway: main was renamed to backup but ingest not yet to main.
+			if !ingestExists {
+				return fmt.Errorf("recovery rename for %q: main missing, backup exists, but ingest dir missing — unrecoverable", propName)
+			}
 			if err := os.Rename(ingestDir, mainDir); err != nil {
 				return fmt.Errorf("recovery rename ingest->main for %q: %w", propName, err)
 			}
 		case mainExists && backupExists:
-			// Both exist — ingest was already renamed to main. Nothing to do.
+			// Both exist — ingest was already renamed to main on a prior
+			// recovery pass. Idempotent no-op.
 		default:
-			return fmt.Errorf("unexpected state for prop %q: main=%v backup=%v", propName, mainExists, backupExists)
+			return fmt.Errorf("unexpected disk state for prop %q: main=%v backup=%v ingest=%v",
+				propName, mainExists, backupExists, ingestExists)
 		}
 
 		if err := rt.markSwappedProp(propName); err != nil {

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -188,6 +188,17 @@ type ShardReindexTaskGeneric struct {
 	// concurrent reads from the iteration goroutine happen-after the set
 	// because RunOnShard is called after the setter on the same goroutine.
 	progressCallback func(float32)
+
+	// testHookPostPropSwap (test-only) fires inside runtimeSwap's Phase
+	// 2a tight loop, immediately after each per-prop SwapBucketPointer +
+	// markSwappedProp. Production leaves it nil (the nil check has
+	// negligible overhead). Regression tests set it to observe Phase 2a
+	// atomicity — e.g. assert the wall-clock delta between consecutive
+	// hook fires stays inside the microseconds/millisecond budget so
+	// that any future addition of a slow op to the loop body
+	// (Shutdown, Rename, RAFT call) fails CI immediately. See the
+	// file-level phase-contract godoc.
+	testHookPostPropSwap func(propIdx int)
 }
 
 // NewShardReindexTaskGeneric creates a new generic reindex task.
@@ -1702,7 +1713,7 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 	// recovery does the ingest→main rename safely (no in-memory state
 	// at that point).
 	oldMainBuckets := make(map[string]*lsmkv.Bucket, len(props))
-	for _, propName := range props {
+	for propIdx, propName := range props {
 		if rt.IsSwappedProp(propName) {
 			// Recovery: partial loop crash already covered this prop's
 			// in-memory pointer flip (sentinel-confirmed). The original
@@ -1723,6 +1734,12 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 
 		if err := rt.markSwappedProp(propName); err != nil {
 			return fmt.Errorf("marking swapped prop %q: %w", propName, err)
+		}
+
+		// Test-only observation point for the Phase 2a atomicity invariant
+		// (see field godoc on testHookPostPropSwap). nil in production.
+		if t.testHookPostPropSwap != nil {
+			t.testHookPostPropSwap(propIdx)
 		}
 	}
 	logger.Debug("runtime swap: all props in-memory swapped")

--- a/adapters/repos/db/inverted_reindex_task_generic.go
+++ b/adapters/repos/db/inverted_reindex_task_generic.go
@@ -1515,35 +1515,43 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 	defer t.disableCallbacks()
 
 	store := shard.Store()
+	lsmPath := shard.pathLSM()
 
-	// Phase 2 (atomic): in-memory pointer swap per property. This is
-	// the ONLY work that runs inside the per-shard tokenization overlay
-	// window. The disk-side cleanup (old bucket shutdown + dir rename
-	// from main_<gen> → backup_<gen> and ingest_<gen> → main_<gen>) is
-	// deferred to next process restart via OnBeforeLsmInit's
-	// recoverRuntimeSwapBuckets path. See 0-weaviate-issues#216
-	// follow-up comment 4469995685 for the design contract.
+	// Phase 2a (atomic, tight loop): in-memory pointer swap per property.
+	// This is the ONLY work that runs inside the per-shard tokenization
+	// overlay's "mixed-state" window (between first prop swapped and last
+	// prop swapped). SwapBucketPointer is a single map-write under
+	// bucketsLock (microseconds); markSwappedProp is a single fsync
+	// (single-digit ms). The per-prop loop completes in a few ms total
+	// even for 4-property migrations.
 	//
-	// SwapBucketPointer is a single map-write under store.bucketsLock
-	// (microseconds). markSwappedProp is one sentinel fsync (single-
-	// digit ms on a healthy disk). The per-prop loop completes in a
-	// few ms total for typical migrations with 1–4 props.
+	// Per 0-weaviate-issues#216 follow-up comment 4469995685: the slow
+	// disk work (old-bucket Shutdown, oldMainDir→backupDir rename) is
+	// pulled OUT of this loop so it can't extend the mixed-state window.
+	// It runs in Phase 2b below (after all in-memory swaps are done) and
+	// only touches the OLD (already shut-down) bucket — never the LIVE
+	// ingest bucket whose dir stays at ingest_<gen> until next-restart
+	// recovery does the ingest→main rename safely (no in-memory state
+	// at that point).
+	oldMainBuckets := make(map[string]*lsmkv.Bucket, len(props))
 	for _, propName := range props {
 		if rt.IsSwappedProp(propName) {
 			// Recovery: partial loop crash already covered this prop's
-			// in-memory pointer flip (sentinel-confirmed). Skip the
-			// SwapBucketPointer call (would error on a missing source
-			// or mis-mapped destination) and rely on the next-restart
-			// disk-rename path for completeness.
+			// in-memory pointer flip (sentinel-confirmed). The original
+			// runtimeSwap call also shut down the old bucket and renamed
+			// its dir to _bak before returning, so disk state is fine —
+			// just skip and rely on the post-loop tidy to no-op for this
+			// prop (no oldMainBucket captured).
 			continue
 		}
 		ingestName := t.ingestBucketName(propName)
 		mainName := t.strategy.SourceBucketName(propName)
 
-		_, err := store.SwapBucketPointer(ctx, mainName, ingestName)
+		oldMainBucket, err := store.SwapBucketPointer(ctx, mainName, ingestName)
 		if err != nil {
 			return fmt.Errorf("swapping bucket pointer %q <- %q: %w", mainName, ingestName, err)
 		}
+		oldMainBuckets[propName] = oldMainBucket
 
 		if err := rt.markSwappedProp(propName); err != nil {
 			return fmt.Errorf("marking swapped prop %q: %w", propName, err)
@@ -1551,33 +1559,54 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 	}
 	logger.Debug("runtime swap: all props in-memory swapped")
 
-	// NOTE: rt.markSwapped(), oldMainBucket.Shutdown(), and
-	// os.Rename(oldMainDir, backupDir) are intentionally OMITTED here.
+	// Phase 2b (post-atomic, slow but inline): shutdown + rename of the
+	// OLD (now-dead) main buckets. Per Etienne's #216 follow-up: "you
+	// can of course rename the old, already shutdown bucket, but never
+	// the live one that's serving queries to the user." The OLD bucket
+	// is no longer in the store's bucketsByName map (SwapBucketPointer
+	// deleted it), so it's not serving queries; Shutdown drains any
+	// in-flight compaction and closes mmaps cleanly. The rename moves
+	// its dir off the canonical name so the LIVE bucket (still at
+	// ingest_<gen> on disk) is the only candidate for the canonical
+	// name on next restart.
 	//
-	// They violated the #216 atomic-phase contract: Shutdown waits for
-	// compaction to drain (seconds at scale), and renaming a directory
-	// whose bucket is still loaded by the in-memory store is unsafe
-	// per Etienne's explicit guidance — "never rename the live one
-	// that's serving queries to the user; you can rename the old,
-	// already shutdown bucket, but only via the next-startup path."
-	//
-	// State at this point:
-	//   - in-memory: main pointer → ingest_<gen> bucket (the NEW data)
-	//   - on disk: main_<gen> dir unchanged (still holds OLD data),
-	//     ingest_<gen> dir unchanged (still holds NEW data), no backup
-	//     dir yet.
-	//   - sentinels: rt.IsMerged()=true, rt.IsSwappedProp(p)=true for
-	//     every p; rt.IsSwapped()=false, rt.IsTidied()=false.
-	//
-	// On next process restart, FinalizeCompletedMigrations →
-	// OnBeforeLsmInit reads the sentinels and sees IsMerged &&
-	// !IsSwapped && IsPrepended → dispatches to
-	// recoverRuntimeSwapBuckets (the dir-rename swap path) BEFORE
-	// LSM init touches the main bucket name. recoverRuntimeSwapBuckets
-	// observes mainDir+ingestDir present, backupDir missing → does the
-	// full rename sequence (main → backup, ingest → main) per prop and
-	// advances markSwapped + markTidied. LSM init then loads the
-	// renamed dirs correctly.
+	// This work is OUTSIDE the mixed-state window — every prop has
+	// already had its in-memory pointer swapped. Queries during this
+	// phase see new buckets for all props (overlay matches), so
+	// per-prop slow ops here don't extend the correctness-sensitive
+	// window.
+	for _, propName := range props {
+		oldMainBucket, ok := oldMainBuckets[propName]
+		if !ok {
+			// IsSwappedProp(propName) was true on entry — the previous
+			// attempt's runtimeSwap call shut down + renamed already.
+			continue
+		}
+		if err := oldMainBucket.Shutdown(ctx); err != nil {
+			return fmt.Errorf("shutting down old main bucket for %q: %w", propName, err)
+		}
+		oldMainDir := oldMainBucket.GetDir()
+		backupDir := filepath.Join(lsmPath, t.backupBucketName(propName))
+		if err := os.Rename(oldMainDir, backupDir); err != nil {
+			return fmt.Errorf("renaming old main dir %q -> %q: %w", oldMainDir, backupDir, err)
+		}
+	}
+
+	if err := rt.markSwapped(); err != nil {
+		return fmt.Errorf("marking swapped: %w", err)
+	}
+
+	// markTidied signals that all on-disk cleanup that can be done inline
+	// has been done. The LIVE bucket's dir (ingest_<gen>) is still at its
+	// pre-swap name — that rename to the canonical name is deferred to
+	// next-restart recovery (OnBeforeLsmInit → recoverRuntimeSwapBuckets)
+	// because renaming a dir whose buckets are mmap'd by the in-memory
+	// store is unsafe per Etienne's #216 follow-up. At restart time,
+	// nothing has loaded that dir yet, so the rename is safe.
+	if err := rt.markTidied(); err != nil {
+		return fmt.Errorf("marking tidied: %w", err)
+	}
+	logger.Debug("runtime swap: tidy complete (ingest→main rename deferred to next restart)")
 
 	// OnMigrationComplete: no-op for semantic migrations (the cluster-
 	// wide schema flip lives in OnTaskCompleted.flipSemanticMigrationSchema).
@@ -1594,7 +1623,7 @@ func (t *ShardReindexTaskGeneric) runtimeSwap(ctx context.Context,
 	// dirs whose owning gen is strictly older than this gen.
 	t.trimOlderGenerationsLocked(logger, shard, rt, props)
 
-	logger.Info("runtime swap: in-memory swap complete; disk rename deferred to next restart")
+	logger.Info("runtime swap: migration complete (ingest→main rename deferred to next restart)")
 
 	return nil
 }

--- a/adapters/repos/db/inverted_reindex_task_generic_test.go
+++ b/adapters/repos/db/inverted_reindex_task_generic_test.go
@@ -14,6 +14,8 @@ package db
 import (
 	"context"
 	"path/filepath"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -80,6 +82,23 @@ func createTestObjectWithText(className, text string) *storobj.Object {
 }
 
 func newTestClass(className string) *models.Class {
+	return newTestClassWithProps(className, []string{"title"})
+}
+
+// newTestClassWithProps builds a test class with N searchable text
+// properties. Used by regression tests that exercise the per-prop
+// loop inside runtimeSwap (the atomic-phase contract per
+// 0-weaviate-issues#216 — see file-level godoc in
+// inverted_reindex_task_generic.go).
+func newTestClassWithProps(className string, propNames []string) *models.Class {
+	props := make([]*models.Property, len(propNames))
+	for i, name := range propNames {
+		props[i] = &models.Property{
+			Name:         name,
+			DataType:     schema.DataTypeText.PropString(),
+			Tokenization: models.PropertyTokenizationWord,
+		}
+	}
 	return &models.Class{
 		Class:             className,
 		VectorIndexConfig: enthnsw.NewDefaultUserConfig(),
@@ -90,13 +109,7 @@ func newTestClass(className string) *models.Class {
 			IndexPropertyLength:    true,
 			UsingBlockMaxWAND:      false, // Force MapCollection strategy
 		},
-		Properties: []*models.Property{
-			{
-				Name:         "title",
-				DataType:     schema.DataTypeText.PropString(),
-				Tokenization: models.PropertyTokenizationWord,
-			},
-		},
+		Properties: props,
 	}
 }
 
@@ -382,4 +395,150 @@ func TestRunSwapOnShard_SentinelAwareDispatch(t *testing.T) {
 				"OnMigrationComplete should have fired (finalizeMigrationAfterRecovery tail of every recovery branch)")
 		})
 	}
+}
+
+// TestRuntimeSwap_Phase2a_AtomicTightLoop pins the architectural
+// contract from 0-weaviate-issues#216 (per QA-Claude design
+// consideration in PR #11322 comment 4470016252): between consecutive
+// per-prop SwapBucketPointer calls inside runtimeSwap's Phase 2a, only
+// the cheap sentinel fsync (markSwappedProp) is allowed — no Shutdown,
+// no Rename, no RAFT, no compaction wait. The total Phase 2a wall-clock
+// for an N-prop migration MUST stay inside the microseconds-to-low-ms
+// budget at any scale; the per-shard tokenization overlay's
+// "mixed-state" subwindow (some props swapped, others not — queries to
+// not-yet-swapped props during the window would tokenize input with the
+// new value against an old-tokenized bucket and return wrong results)
+// is exactly this wall-clock.
+//
+// Regression scenarios this guards against:
+//
+//   - Bucket.Shutdown back inside the per-prop loop (pre-refactor
+//     behavior; ~100s of ms at production scale because Shutdown waits
+//     for in-flight compaction to drain).
+//   - RAFT call inside the loop (cluster apply latency, ~100s of ms).
+//   - os.Rename inside the loop (filesystem dependent, ms-to-tens-of-ms
+//     per call).
+//   - Any artificial slowdown (e.g. a sleep/Gosched accidentally added
+//     during refactor).
+//
+// Threshold of 100ms across 4 props is generous enough that single-
+// digit-ms per-prop markSwappedProp fsync on healthy CI disks comfortably
+// fits, but tight enough that any of the regression scenarios above
+// blow it. If a real reason emerges to relax the bound (e.g. CI disk
+// performance regression), surface that as a separate signal — DO NOT
+// just raise the threshold, that would silently swallow the architectural
+// regression the test is meant to catch.
+//
+// Uses the test-only ShardReindexTaskGeneric.testHookPostPropSwap
+// observation point so this test is deterministic (no race with a
+// concurrent observer) and does not depend on probing the bucket map
+// from another goroutine.
+func TestRuntimeSwap_Phase2a_AtomicTightLoop(t *testing.T) {
+	ctx := testCtx()
+	className := "TestPhase2aAtomic"
+	propNames := []string{"title", "description", "summary", "keywords"}
+	class := newTestClassWithProps(className, propNames)
+
+	shd, idx := testShardWithSettings(t, ctx, class, enthnsw.UserConfig{Skip: true},
+		false, false, false)
+	shard := shd.(*Shard)
+
+	// Sanity: every prop's searchable bucket should start at
+	// StrategyMapCollection so the MapToBlockmax migration picks them
+	// all up.
+	for _, p := range propNames {
+		require.Equal(t, lsmkv.StrategyMapCollection,
+			shard.store.Bucket(helpers.BucketSearchableFromPropNameLSM(p)).Strategy(),
+			"prop %q must start at MapCollection for the migration to target it", p)
+	}
+
+	// Insert some objects so the reindex pipeline has data to iterate.
+	objects := make([]*storobj.Object, 5)
+	for i := range objects {
+		objects[i] = &storobj.Object{
+			MarshallerVersion: 1,
+			Object: models.Object{
+				ID:    strfmt.UUID(uuid.NewString()),
+				Class: className,
+				Properties: map[string]interface{}{
+					"title":       "doc " + strconv.Itoa(i),
+					"description": "long description " + strconv.Itoa(i),
+					"summary":     "short summary " + strconv.Itoa(i),
+					"keywords":    "kw " + strconv.Itoa(i),
+				},
+			},
+		}
+		require.NoError(t, shard.PutObject(ctx, objects[i]))
+	}
+
+	strategy := &testMigrationStrategy{MapToBlockmaxStrategy: MapToBlockmaxStrategy{generation: 1}}
+	task := newTestTask(idx.logger, strategy)
+
+	// Wire the Phase 2a observation hook. Production leaves this nil;
+	// the test reads back the per-prop timestamps to assert the
+	// atomic-phase budget.
+	var (
+		hookMu        sync.Mutex
+		hookCallTimes []time.Time
+		hookCallIdxs  []int
+	)
+	task.testHookPostPropSwap = func(propIdx int) {
+		hookMu.Lock()
+		hookCallTimes = append(hookCallTimes, time.Now())
+		hookCallIdxs = append(hookCallIdxs, propIdx)
+		hookMu.Unlock()
+	}
+
+	require.NoError(t, task.OnAfterLsmInit(ctx, shard))
+
+	// Run the iteration → swap path inline. The hook will fire once per
+	// prop inside runtimeSwap's Phase 2a tight loop.
+	for {
+		rerunAt, reloadShard, err := task.OnAfterLsmInitAsync(ctx, shard)
+		require.NoError(t, err)
+		require.False(t, reloadShard, "runtime swap should not request reload")
+		if rerunAt.IsZero() {
+			break
+		}
+	}
+
+	hookMu.Lock()
+	defer hookMu.Unlock()
+
+	require.Len(t, hookCallTimes, len(propNames),
+		"testHookPostPropSwap should fire exactly once per prop (%d), got %d",
+		len(propNames), len(hookCallTimes))
+
+	// The per-prop loop iterates props in their (stored) order; the hook
+	// receives the loop's 0-based index. The order is determined by
+	// getPropsToReindex which sorts deterministically — so the hook
+	// indices should be a strict increasing sequence starting at 0.
+	for i, idx := range hookCallIdxs {
+		require.Equal(t, i, idx,
+			"hook fired at unexpected loop index — Phase 2a loop is out of order or has a yield point that re-orders props")
+	}
+
+	// Phase 2a wall-clock invariant. See test godoc for threshold
+	// rationale.
+	const atomicPhaseBudget = 100 * time.Millisecond
+	totalDelta := hookCallTimes[len(hookCallTimes)-1].Sub(hookCallTimes[0])
+	require.Lessf(t, totalDelta, atomicPhaseBudget,
+		"Phase 2a wall-clock across %d props was %v — exceeded atomic-phase budget of %v. "+
+			"Likely cause: a slow op (Shutdown, Rename, RAFT, sleep) was added to the per-prop "+
+			"loop inside runtimeSwap. See phase-contract godoc at the top of "+
+			"inverted_reindex_task_generic.go for the design invariant.",
+		len(propNames), totalDelta, atomicPhaseBudget)
+
+	// Sanity: assert markers landed as the contract specifies post-Phase
+	// 2c (since this is the inline path, runtimeSwap also runs 2b + 2c
+	// for the dead-bucket tidy and OnMigrationComplete + trim).
+	rt := NewFileMapToBlockmaxReindexTracker(shard.pathLSM(), &UuidKeyParser{})
+	for _, p := range propNames {
+		assert.True(t, rt.IsSwappedProp(p),
+			"prop %q should be IsSwappedProp post-runtimeSwap", p)
+	}
+	assert.True(t, rt.IsSwapped(), "aggregate swapped sentinel should be set post-runtimeSwap")
+	assert.True(t, rt.IsTidied(), "aggregate tidied sentinel should be set post-runtimeSwap (inline path)")
+
+	require.NoError(t, shard.Shutdown(ctx))
 }

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1050,6 +1050,40 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 				allSwapped = false
 			}
 		}
+		// 0-weaviate-issues#216 Gap B: for tokenization-changing migrations
+		// the canonical bucket pointer on this shard now references NEW-
+		// tokenized data, but the cluster-wide schema flip in
+		// OnTaskCompleted.flipSemanticMigrationSchema hasn't committed yet.
+		// Without this overlay, queries arriving on this shard during the
+		// FINALIZING window would tokenize input against the OLD schema
+		// value while hitting NEW bucket content — counts mismatch.
+		//
+		// We set the overlay unconditionally of `allSwapped`: even on the
+		// partial-swap path, whichever per-task swap actually succeeded
+		// did flip its bucket pointer, so the overlay-vs-bucket alignment
+		// argument still holds for the swapped index type. The
+		// partial-swap failure case is already loud (FAILED-task
+		// repair_command in #221's logger) and the overlay being set is
+		// strictly an improvement over leaving queries to misroute.
+		//
+		// Cleared in OnTaskCompleted after flipSemanticMigrationSchema
+		// commits on this node, with a defensive self-clear in
+		// Shard.TokenizationFor as backstop against callback ordering.
+		if IsTokenizationChangingMigration(payload.MigrationType) && payload.TargetTokenization != "" {
+			concreteShard, ok := shard.(*Shard)
+			if ok {
+				for _, propName := range payload.Properties {
+					concreteShard.SetTokenizationOverlay(propName, payload.TargetTokenization)
+				}
+			} else {
+				// Tests that swap in a non-*Shard ShardLike would skip the
+				// overlay; production always uses *Shard. Log so a real
+				// type-mismatch in production would be visible.
+				logger.WithField("unit", unitID).WithField("shard", shardName).
+					Debug("reindex provider: skipping tokenization overlay set — shard is not a concrete *Shard")
+			}
+		}
+
 		if allSwapped {
 			logger.WithField("unit", unitID).WithField("shard", shardName).
 				Info("reindex provider: swap complete")
@@ -1159,6 +1193,44 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) {
 	ctx := p.serverCtx
 	if err := p.flipSemanticMigrationSchema(ctx, payload, logger); err != nil {
 		logger.WithError(err).Error("reindex provider: OnTaskCompleted: schema flip failed; migration result is half-applied (bucket swapped on every node, schema still reflects pre-migration state)")
+		// Schema flip failed: don't clear the overlay. The bucket pointer
+		// is still NEW-tokenized on this node's shards (set by
+		// OnGroupCompleted), and the schema is still pre-flip on this
+		// node. Queries need the overlay to keep tokenizing for the NEW
+		// buckets until either (a) a retry of the schema flip succeeds
+		// and we get another chance to clear, or (b) the defensive self-
+		// clear in TokenizationFor fires when the live schema eventually
+		// catches up.
+		return
+	}
+
+	// 0-weaviate-issues#216 Gap B: clear the per-shard tokenization
+	// overlay now that the cluster-wide schema flip has committed and
+	// the live schema's `prop.Tokenization` matches what the overlay
+	// has been serving. The defensive self-clear in
+	// Shard.TokenizationFor would also handle this lazily, but
+	// clearing explicitly here keeps the steady-state overlay map empty
+	// (no entries lingering until the next query touches each prop).
+	//
+	// Per-shard, on every shard this node owns for the class. Multi-
+	// node: each node runs OnTaskCompleted independently and clears its
+	// own shards — the RAFT-idempotent flipSemanticMigrationSchema
+	// ensures every node's local FSM has the new tokenization before
+	// we clear here.
+	if IsTokenizationChangingMigration(payload.MigrationType) {
+		className := entschema.ClassName(payload.Collection)
+		if idx := p.db.GetIndex(className); idx != nil {
+			idx.ForEachShard(func(_ string, sh ShardLike) error {
+				concreteShard, ok := sh.(*Shard)
+				if !ok {
+					return nil
+				}
+				for _, propName := range payload.Properties {
+					concreteShard.ClearTokenizationOverlay(propName)
+				}
+				return nil
+			})
+		}
 	}
 }
 
@@ -1541,6 +1613,27 @@ func IsSemanticMigration(mt ReindexMigrationType) bool {
 		mt == ReindexTypeChangeTokenizationFilterable ||
 		mt == ReindexTypeEnableFilterable ||
 		mt == ReindexTypeEnableSearchable
+}
+
+// IsTokenizationChangingMigration reports whether the migration type flips
+// the property's stored `Tokenization` field as part of its schema commit
+// in [flipSemanticMigrationSchema]. These are the migrations that open
+// the Gap B window from 0-weaviate-issues#216: between the per-shard
+// bucket-pointer flip in OnGroupCompleted.RunSwapOnShard and the cluster-
+// wide schema flip in OnTaskCompleted, queries on the migrated property
+// would tokenize against the OLD schema value while hitting the NEW
+// bucket content.
+//
+// Both change-tokenization and change-tokenization-filterable end up
+// calling applyPerPropertySchemaUpdate with TargetTokenization (see the
+// switch arm in flipSemanticMigrationSchema), so both qualify here.
+// enable-searchable also writes Tokenization, but its window is closed
+// by EnableSearchableStrategy.AnalyzerOverlay during backfill — the
+// query-side gap from #216 specifically affects properties whose
+// tokenization is being CHANGED.
+func IsTokenizationChangingMigration(mt ReindexMigrationType) bool {
+	return mt == ReindexTypeChangeTokenization ||
+		mt == ReindexTypeChangeTokenizationFilterable
 }
 
 // WaitForLocalTaskDrain blocks until the local goroutine processing the

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1026,6 +1026,46 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 				Info("reindex provider: OnGroupCompleted: rebuilding tasks from disk (node likely restarted); will rehydrate before swap")
 		}
 
+		// 0-weaviate-issues#216 Gap B: for tokenization-changing migrations
+		// we set the per-shard tokenization overlay BEFORE RunSwapOnShard
+		// flips the canonical bucket pointer. The ordering matters: any
+		// query that arrives while the swap is in flight (between
+		// RunSwapOnShard kickoff and OnTaskCompleted's cluster-wide
+		// schema flip via flipSemanticMigrationSchema) reads the live
+		// schema's OLD tokenization unless the overlay is already
+		// populated. Setting it pre-swap means:
+		//
+		//   - Pre-swap window (overlay=NEW, bucket=OLD): query input
+		//     tokenizes as NEW but hits OLD bucket — bounded by the
+		//     in-memory swap latency (microseconds), strictly less
+		//     harmful than the pre-#216 failure shape.
+		//   - Post-swap window (overlay=NEW, bucket=NEW): aligned;
+		//     query returns full results until the schema flip lands
+		//     and the overlay is cleared by OnTaskCompleted (or by
+		//     Shard.TokenizationFor's defensive self-clear).
+		//
+		// We set the overlay unconditionally of the per-task swap result:
+		// even on the partial-swap path, whichever swap actually
+		// succeeded did flip its bucket pointer, so the overlay-vs-bucket
+		// alignment argument holds for the swapped index type. The
+		// partial-swap failure case is already loud (FAILED-task
+		// repair_command from #221) and the overlay being set is
+		// strictly an improvement over leaving queries to misroute.
+		if IsTokenizationChangingMigration(payload.MigrationType) && payload.TargetTokenization != "" {
+			concreteShard, ok := shard.(*Shard)
+			if ok {
+				for _, propName := range payload.Properties {
+					concreteShard.SetTokenizationOverlay(propName, payload.TargetTokenization)
+				}
+			} else {
+				// Tests that swap in a non-*Shard ShardLike would skip the
+				// overlay; production always uses *Shard. Log so a real
+				// type-mismatch in production would be visible.
+				logger.WithField("unit", unitID).WithField("shard", shardName).
+					Debug("reindex provider: skipping tokenization overlay set — shard is not a concrete *Shard")
+			}
+		}
+
 		allSwapped := true
 		for _, reindexTask := range unitTasks {
 			if rehydrate {
@@ -1048,39 +1088,6 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 					sawContextCanceled = true
 				}
 				allSwapped = false
-			}
-		}
-		// 0-weaviate-issues#216 Gap B: for tokenization-changing migrations
-		// the canonical bucket pointer on this shard now references NEW-
-		// tokenized data, but the cluster-wide schema flip in
-		// OnTaskCompleted.flipSemanticMigrationSchema hasn't committed yet.
-		// Without this overlay, queries arriving on this shard during the
-		// FINALIZING window would tokenize input against the OLD schema
-		// value while hitting NEW bucket content — counts mismatch.
-		//
-		// We set the overlay unconditionally of `allSwapped`: even on the
-		// partial-swap path, whichever per-task swap actually succeeded
-		// did flip its bucket pointer, so the overlay-vs-bucket alignment
-		// argument still holds for the swapped index type. The
-		// partial-swap failure case is already loud (FAILED-task
-		// repair_command in #221's logger) and the overlay being set is
-		// strictly an improvement over leaving queries to misroute.
-		//
-		// Cleared in OnTaskCompleted after flipSemanticMigrationSchema
-		// commits on this node, with a defensive self-clear in
-		// Shard.TokenizationFor as backstop against callback ordering.
-		if IsTokenizationChangingMigration(payload.MigrationType) && payload.TargetTokenization != "" {
-			concreteShard, ok := shard.(*Shard)
-			if ok {
-				for _, propName := range payload.Properties {
-					concreteShard.SetTokenizationOverlay(propName, payload.TargetTokenization)
-				}
-			} else {
-				// Tests that swap in a non-*Shard ShardLike would skip the
-				// overlay; production always uses *Shard. Log so a real
-				// type-mismatch in production would be visible.
-				logger.WithField("unit", unitID).WithField("shard", shardName).
-					Debug("reindex provider: skipping tokenization overlay set — shard is not a concrete *Shard")
 			}
 		}
 

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1044,29 +1044,39 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 		//     and the overlay is cleared by OnTaskCompleted (or by
 		//     Shard.TokenizationFor's defensive self-clear).
 		//
-		// We set the overlay unconditionally of the per-task swap result:
-		// even on the partial-swap path, whichever swap actually
-		// succeeded did flip its bucket pointer, so the overlay-vs-bucket
-		// alignment argument holds for the swapped index type. The
-		// partial-swap failure case is already loud (FAILED-task
-		// repair_command from #221) and the overlay being set is
-		// strictly an improvement over leaving queries to misroute.
-		if IsTokenizationChangingMigration(payload.MigrationType) && payload.TargetTokenization != "" {
-			concreteShard, ok := shard.(*Shard)
-			if ok {
-				for _, propName := range payload.Properties {
-					concreteShard.SetTokenizationOverlay(propName, payload.TargetTokenization)
-				}
-			} else {
-				// Tests that swap in a non-*Shard ShardLike would skip the
-				// overlay; production always uses *Shard. Log so a real
-				// type-mismatch in production would be visible.
-				logger.WithField("unit", unitID).WithField("shard", shardName).
-					Debug("reindex provider: skipping tokenization overlay set — shard is not a concrete *Shard")
+		// Failure-mode invariant: if every per-task swap fails before
+		// flipping its bucket pointer (e.g. ctx.Canceled during graceful
+		// shutdown, or rehydrate failures across the board), the
+		// overlay-vs-bucket alignment INVERTS — overlay=NEW but every
+		// bucket is still OLD. In that case we must clear the overlay
+		// after the swap loop, otherwise the migration's FAILED
+		// transition leaves the overlay permanently stuck (no schema
+		// flip fires → no OnTaskCompleted clear → live-schema-catchup
+		// self-clear never triggers because schema stays OLD). The
+		// post-loop `!anySwapped` branch below handles this. Partial-
+		// success (≥ 1 sub-task swap succeeded → ≥ 1 bucket flipped)
+		// keeps the overlay set — the property's bucket(s) are at the
+		// new tokenization for the swapped index types, and operator
+		// repair from #221's logging path covers the half-applied case.
+		//
+		// LazyLoadShard wrapping: production shards can be
+		// *LazyLoadShard rather than *Shard. Use unwrapShard so the
+		// overlay always reaches the concrete shard storage.
+		setShard, setUnwrapErr := unwrapShard(ctx, shard)
+		setOverlay := IsTokenizationChangingMigration(payload.MigrationType) &&
+			payload.TargetTokenization != "" && setUnwrapErr == nil
+		if setOverlay {
+			for _, propName := range payload.Properties {
+				setShard.SetTokenizationOverlay(propName, payload.TargetTokenization)
 			}
+		} else if setUnwrapErr != nil && IsTokenizationChangingMigration(payload.MigrationType) {
+			logger.WithField("unit", unitID).WithField("shard", shardName).
+				WithError(setUnwrapErr).
+				Warn("reindex provider: cannot set tokenization overlay — shard unwrap failed; queries during FINALIZING window may observe pre-#216 misalignment")
 		}
 
 		allSwapped := true
+		anySwapped := false
 		for _, reindexTask := range unitTasks {
 			if rehydrate {
 				if err := reindexTask.RunReindexOnlyOnShard(ctx, shard); err != nil {
@@ -1088,7 +1098,26 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 					sawContextCanceled = true
 				}
 				allSwapped = false
+			} else {
+				anySwapped = true
 			}
+		}
+
+		// 0-weaviate-issues#216 Gap B: defensive clear when NO swap
+		// succeeded on this shard. Without this, an all-failed swap
+		// path leaves the overlay set against unchanged buckets —
+		// permanent misalignment until manual repair, because the
+		// migration's FAILED transition skips the cluster-wide schema
+		// flip and the explicit OnTaskCompleted clear hook never runs.
+		// Partial success is left intact: at least one sub-task's
+		// bucket pointer flipped, so the overlay still aligns with
+		// that index type's content.
+		if setOverlay && !anySwapped {
+			for _, propName := range payload.Properties {
+				setShard.ClearTokenizationOverlay(propName)
+			}
+			logger.WithField("unit", unitID).WithField("shard", shardName).
+				Debug("reindex provider: cleared tokenization overlay — every swap sub-task failed; no bucket pointer was flipped on this shard")
 		}
 
 		if allSwapped {
@@ -1227,9 +1256,17 @@ func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) {
 	if IsTokenizationChangingMigration(payload.MigrationType) {
 		className := entschema.ClassName(payload.Collection)
 		if idx := p.db.GetIndex(className); idx != nil {
-			idx.ForEachShard(func(_ string, sh ShardLike) error {
-				concreteShard, ok := sh.(*Shard)
-				if !ok {
+			idx.ForEachShard(func(shardName string, sh ShardLike) error {
+				// LazyLoadShard wrapping: use unwrapShard so the clear
+				// always reaches the concrete shard whose overlay map
+				// the set hook populated. If unwrap fails we log and
+				// rely on TokenizationFor's self-clear-on-catchup as
+				// the backstop (live schema is now NEW post-flip, so
+				// the next query touching this prop self-clears).
+				concreteShard, err := unwrapShard(ctx, sh)
+				if err != nil {
+					logger.WithField("shard", shardName).WithError(err).
+						Warn("reindex provider: tokenization overlay clear skipped (unwrap failed); relying on TokenizationFor self-clear")
 					return nil
 				}
 				for _, propName := range payload.Properties {

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1048,32 +1048,24 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 		// flipping its bucket pointer (e.g. ctx.Canceled during graceful
 		// shutdown, or rehydrate failures across the board), the
 		// overlay-vs-bucket alignment INVERTS — overlay=NEW but every
-		// bucket is still OLD. In that case we must clear the overlay
-		// after the swap loop, otherwise the migration's FAILED
-		// transition leaves the overlay permanently stuck (no schema
-		// flip fires → no OnTaskCompleted clear → live-schema-catchup
-		// self-clear never triggers because schema stays OLD). The
-		// post-loop `!anySwapped` branch below handles this. Partial-
-		// success (≥ 1 sub-task swap succeeded → ≥ 1 bucket flipped)
-		// keeps the overlay set — the property's bucket(s) are at the
-		// new tokenization for the swapped index types, and operator
-		// repair from #221's logging path covers the half-applied case.
+		// bucket is still OLD. The post-loop
+		// maybeClearTokenizationOverlayOnAllFailed call handles this
+		// (clears iff wasSet && !anySwapped). Partial-success
+		// (≥ 1 sub-task swap succeeded → ≥ 1 bucket flipped) keeps the
+		// overlay set — the swapped index type's bucket(s) are aligned,
+		// and operator repair from #221's logging path covers the
+		// half-applied case.
 		//
 		// LazyLoadShard wrapping: production shards can be
-		// *LazyLoadShard rather than *Shard. Use unwrapShard so the
+		// *LazyLoadShard rather than *Shard. unwrapShard ensures the
 		// overlay always reaches the concrete shard storage.
 		setShard, setUnwrapErr := unwrapShard(ctx, shard)
-		setOverlay := IsTokenizationChangingMigration(payload.MigrationType) &&
-			payload.TargetTokenization != "" && setUnwrapErr == nil
-		if setOverlay {
-			for _, propName := range payload.Properties {
-				setShard.SetTokenizationOverlay(propName, payload.TargetTokenization)
-			}
-		} else if setUnwrapErr != nil && IsTokenizationChangingMigration(payload.MigrationType) {
+		if setUnwrapErr != nil && IsTokenizationChangingMigration(payload.MigrationType) {
 			logger.WithField("unit", unitID).WithField("shard", shardName).
 				WithError(setUnwrapErr).
 				Warn("reindex provider: cannot set tokenization overlay — shard unwrap failed; queries during FINALIZING window may observe pre-#216 misalignment")
 		}
+		overlayWasSet := maybeSetTokenizationOverlayPreSwap(setShard, payload)
 
 		allSwapped := true
 		anySwapped := false
@@ -1104,18 +1096,11 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 		}
 
 		// 0-weaviate-issues#216 Gap B: defensive clear when NO swap
-		// succeeded on this shard. Without this, an all-failed swap
-		// path leaves the overlay set against unchanged buckets —
-		// permanent misalignment until manual repair, because the
-		// migration's FAILED transition skips the cluster-wide schema
-		// flip and the explicit OnTaskCompleted clear hook never runs.
-		// Partial success is left intact: at least one sub-task's
-		// bucket pointer flipped, so the overlay still aligns with
-		// that index type's content.
-		if setOverlay && !anySwapped {
-			for _, propName := range payload.Properties {
-				setShard.ClearTokenizationOverlay(propName)
-			}
+		// succeeded on this shard. See
+		// [maybeClearTokenizationOverlayOnAllFailed] godoc for the full
+		// rationale; this call is the matching post-loop counterpart
+		// to maybeSetTokenizationOverlayPreSwap above.
+		if maybeClearTokenizationOverlayOnAllFailed(setShard, payload, overlayWasSet, anySwapped) {
 			logger.WithField("unit", unitID).WithField("shard", shardName).
 				Debug("reindex provider: cleared tokenization overlay — every swap sub-task failed; no bucket pointer was flipped on this shard")
 		}
@@ -1678,6 +1663,76 @@ func IsSemanticMigration(mt ReindexMigrationType) bool {
 func IsTokenizationChangingMigration(mt ReindexMigrationType) bool {
 	return mt == ReindexTypeChangeTokenization ||
 		mt == ReindexTypeChangeTokenizationFilterable
+}
+
+// maybeSetTokenizationOverlayPreSwap is the #216 Gap B SET hook —
+// called by [OnGroupCompleted] just BEFORE the per-task swap loop
+// kicks off on a shard. It records the per-shard query-time
+// tokenization override for every property in the payload iff this
+// is a tokenization-changing migration with a non-empty target
+// tokenization. Returns true iff the overlay was written, so the
+// caller can match the [maybeClearTokenizationOverlayOnAllFailed]
+// decision after the swap loop.
+//
+// Extracted from OnGroupCompleted's per-shard branch to keep the
+// Gap B set/clear lifecycle unit-testable without standing up a
+// full provider + DB + index. See
+// [maybeClearTokenizationOverlayOnAllFailed] for the post-loop
+// counterpart and the all-failed defensive-clear rationale.
+func maybeSetTokenizationOverlayPreSwap(shard *Shard, payload *ReindexTaskPayload) bool {
+	if shard == nil || payload == nil {
+		return false
+	}
+	if !IsTokenizationChangingMigration(payload.MigrationType) {
+		return false
+	}
+	if payload.TargetTokenization == "" {
+		return false
+	}
+	for _, propName := range payload.Properties {
+		shard.SetTokenizationOverlay(propName, payload.TargetTokenization)
+	}
+	return true
+}
+
+// maybeClearTokenizationOverlayOnAllFailed is the #216 Gap B
+// defensive CLEAR hook — called by [OnGroupCompleted] AFTER the
+// per-task swap loop on a shard. It clears the per-shard tokenization
+// overlay iff (a) the overlay was set pre-swap by
+// [maybeSetTokenizationOverlayPreSwap] (the `wasSet` argument) AND
+// (b) every per-task swap failed before flipping its bucket pointer
+// (the `anySwapped` argument is false).
+//
+// Without this clear, an all-failed swap path leaves the overlay
+// set against unchanged OLD buckets — the migration's FAILED
+// transition then skips the cluster-wide schema flip, so neither
+// [OnTaskCompleted]'s explicit clear nor [Shard.TokenizationFor]'s
+// self-clear-on-catchup will ever fire (the live schema stays OLD
+// and never matches the overlay's NEW value). Permanent
+// misalignment until operator repair.
+//
+// Partial success (≥ 1 per-task swap returned nil → ≥ 1 bucket
+// pointer flipped) is intentionally left intact: the overlay
+// aligns with the swapped index type's content, which is strictly
+// better than letting partially-flipped buckets misroute against
+// the OLD schema tokenization. The partial-success case surfaces
+// through #221's FAILED-task repair_command log line.
+//
+// Returns true iff the clear was actually applied (for tests +
+// observability).
+func maybeClearTokenizationOverlayOnAllFailed(
+	shard *Shard, payload *ReindexTaskPayload, wasSet, anySwapped bool,
+) bool {
+	if shard == nil || payload == nil {
+		return false
+	}
+	if !wasSet || anySwapped {
+		return false
+	}
+	for _, propName := range payload.Properties {
+		shard.ClearTokenizationOverlay(propName)
+	}
+	return true
 }
 
 // WaitForLocalTaskDrain blocks until the local goroutine processing the

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -1026,39 +1026,95 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 				Info("reindex provider: OnGroupCompleted: rebuilding tasks from disk (node likely restarted); will rehydrate before swap")
 		}
 
-		// 0-weaviate-issues#216 Gap B: for tokenization-changing migrations
-		// we set the per-shard tokenization overlay BEFORE RunSwapOnShard
-		// flips the canonical bucket pointer. The ordering matters: any
-		// query that arrives while the swap is in flight (between
-		// RunSwapOnShard kickoff and OnTaskCompleted's cluster-wide
-		// schema flip via flipSemanticMigrationSchema) reads the live
-		// schema's OLD tokenization unless the overlay is already
-		// populated. Setting it pre-swap means:
+		// 0-weaviate-issues#216 atomic-phase contract: the per-shard swap
+		// is now split into three phases, executed in order:
 		//
-		//   - Pre-swap window (overlay=NEW, bucket=OLD): query input
-		//     tokenizes as NEW but hits OLD bucket — bounded by the
-		//     in-memory swap latency (microseconds), strictly less
-		//     harmful than the pre-#216 failure shape.
-		//   - Post-swap window (overlay=NEW, bucket=NEW): aligned;
-		//     query returns full results until the schema flip lands
-		//     and the overlay is cleared by OnTaskCompleted (or by
-		//     Shard.TokenizationFor's defensive self-clear).
+		//   1. PREP (RunPrepareOnShard, per task) — disk-I/O-heavy work:
+		//      FlushAndSwitch reindex bucket, ShutdownBucket (drains
+		//      compaction), PrependSegmentsFromBucket. Bucket=OLD and
+		//      schema=OLD throughout — safe to run with live queries.
+		//      No overlay set yet; the overlay would expose a (NEW
+		//      input, OLD bucket) mismatch during this phase.
+		//   2. OVERLAY SET — maybeSetTokenizationOverlayPreSwap. After
+		//      every task on this shard has its prep merged.
+		//   3. ATOMIC SWAP (RunSwapOnShard, per task) — in-memory
+		//      bucket-pointer flip + per-prop sentinel fsync only.
+		//      Microseconds + a few ms per prop. The disk dirs aren't
+		//      renamed here; that's deferred to next startup via
+		//      OnBeforeLsmInit's recoverRuntimeSwapBuckets path.
 		//
-		// Failure-mode invariant: if every per-task swap fails before
-		// flipping its bucket pointer (e.g. ctx.Canceled during graceful
-		// shutdown, or rehydrate failures across the board), the
-		// overlay-vs-bucket alignment INVERTS — overlay=NEW but every
-		// bucket is still OLD. The post-loop
-		// maybeClearTokenizationOverlayOnAllFailed call handles this
-		// (clears iff wasSet && !anySwapped). Partial-success
-		// (≥ 1 sub-task swap succeeded → ≥ 1 bucket flipped) keeps the
-		// overlay set — the swapped index type's bucket(s) are aligned,
-		// and operator repair from #221's logging path covers the
-		// half-applied case.
+		// Why three phases instead of two: the overlay-vs-bucket window
+		// is what the overlay was designed to protect. Setting the
+		// overlay before prep would expose the very gap it closes
+		// (NEW-tokenized analyzer input against OLD-tokenized bucket
+		// content for hundreds of ms). Setting the overlay between
+		// prep and atomic swap means the window is bounded by the
+		// in-memory pointer flip (microseconds), matching the design
+		// contract Etienne called out on PR #11322 follow-up comment
+		// 4469995685.
+		//
+		// Failure handling:
+		//   - PREP failure: overlay not set, swap not attempted for
+		//     ANY task on this shard. Recovery on next OnGroupCompleted
+		//     call (or post-restart rehydrate) re-runs PREP, which is
+		//     idempotent (no-op for already-merged tasks).
+		//   - SWAP failure (after overlay set): partial-success is
+		//     possible. The defensive clear below handles the
+		//     all-failed case; partial-success is the operator-repair
+		//     surface from #221's logging path.
 		//
 		// LazyLoadShard wrapping: production shards can be
 		// *LazyLoadShard rather than *Shard. unwrapShard ensures the
 		// overlay always reaches the concrete shard storage.
+
+		// Phase 1: prep every task on this shard. Each task's
+		// RunPrepareOnShard advances the sentinel through markMerged.
+		// Idempotent — calls into already-merged tasks short-circuit.
+		allSwapped := true
+		anySwapped := false
+		prepOK := true
+		for _, reindexTask := range unitTasks {
+			if rehydrate {
+				if err := reindexTask.RunReindexOnlyOnShard(ctx, shard); err != nil {
+					logger.WithField("unit", unitID).WithField("task", reindexTask.Name()).
+						WithError(err).Error("reindex provider: OnGroupCompleted: rehydrate failed; prep+swap will not run for this task")
+					unitErrs = append(unitErrs, fmt.Sprintf("unit %s task %s rehydrate: %v", unitID, reindexTask.Name(), err))
+					if errors.Is(err, context.Canceled) {
+						sawContextCanceled = true
+					}
+					prepOK = false
+					allSwapped = false
+					continue
+				}
+			}
+			if err := reindexTask.RunPrepareOnShard(ctx, shard); err != nil {
+				logger.WithField("unit", unitID).WithField("task", reindexTask.Name()).
+					WithError(err).Error("reindex provider: OnGroupCompleted: prep failed; swap will not run for this task")
+				unitErrs = append(unitErrs, fmt.Sprintf("unit %s task %s prepare: %v", unitID, reindexTask.Name(), err))
+				if errors.Is(err, context.Canceled) {
+					sawContextCanceled = true
+				}
+				prepOK = false
+				allSwapped = false
+			}
+		}
+
+		if !prepOK {
+			// At least one task failed to prep. Skip the overlay set
+			// and the atomic-swap pass entirely for this shard — the
+			// recovery path re-runs prep on the next OnGroupCompleted
+			// invocation. Logging is already loud (per-task error logs
+			// above + the swap-INCOMPLETE log below).
+			logger.WithField("unit", unitID).WithField("shard", shardName).
+				Warn("reindex provider: prep phase incomplete; skipping overlay set + atomic swap for this shard")
+			logger.WithField("unit", unitID).WithField("shard", shardName).
+				Error("reindex provider: swap INCOMPLETE for this shard — prep phase failed; the cluster-wide post-completion ack will report this as a failure")
+			continue
+		}
+
+		// Phase 2: now that every task on this shard is merged, set the
+		// per-shard tokenization overlay. The atomic SwapBucketPointer
+		// calls in Phase 3 run inside this overlay window.
 		setShard, setUnwrapErr := unwrapShard(ctx, shard)
 		if setUnwrapErr != nil && IsTokenizationChangingMigration(payload.MigrationType) {
 			logger.WithField("unit", unitID).WithField("shard", shardName).
@@ -1067,21 +1123,9 @@ func (p *ReindexProvider) OnGroupCompleted(task *distributedtask.Task, groupID s
 		}
 		overlayWasSet := maybeSetTokenizationOverlayPreSwap(setShard, payload)
 
-		allSwapped := true
-		anySwapped := false
+		// Phase 3: atomic in-memory swap per task. The disk-dir rename
+		// is deferred to next startup.
 		for _, reindexTask := range unitTasks {
-			if rehydrate {
-				if err := reindexTask.RunReindexOnlyOnShard(ctx, shard); err != nil {
-					logger.WithField("unit", unitID).WithField("task", reindexTask.Name()).
-						WithError(err).Error("reindex provider: OnGroupCompleted: rehydrate failed; swap will not run for this task")
-					unitErrs = append(unitErrs, fmt.Sprintf("unit %s task %s rehydrate: %v", unitID, reindexTask.Name(), err))
-					if errors.Is(err, context.Canceled) {
-						sawContextCanceled = true
-					}
-					allSwapped = false
-					continue
-				}
-			}
 			if err := reindexTask.RunSwapOnShard(ctx, shard); err != nil {
 				logger.WithField("unit", unitID).WithField("task", reindexTask.Name()).
 					WithError(err).Error("reindex provider: OnGroupCompleted: RunSwapOnShard failed — migration is half-applied on this shard")

--- a/adapters/repos/db/reindex_provider_tokenization_overlay_test.go
+++ b/adapters/repos/db/reindex_provider_tokenization_overlay_test.go
@@ -1,0 +1,245 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test*TokenizationOverlay* pin the per-shard tokenization overlay
+// lifecycle that [ReindexProvider.OnGroupCompleted] orchestrates for
+// 0-weaviate-issues#216 Gap B. The helpers
+// [maybeSetTokenizationOverlayPreSwap] and
+// [maybeClearTokenizationOverlayOnAllFailed] encapsulate the SET (pre-
+// per-task-swap) and the defensive CLEAR (post-loop, all-failed) so
+// the Gap B failure modes can be regression-tested without standing
+// up a full provider + DB + index.
+//
+// The most important regression to guard against is the original
+// Copilot-review finding (PR #11322 review comment 3254170106):
+// if every per-task RunSwapOnShard fails before flipping its bucket
+// pointer, the migration transitions to FAILED, the cluster-wide
+// schema flip is skipped, OnTaskCompleted's explicit clear hook
+// never runs, and TokenizationFor's self-clear-on-catchup never
+// fires (because the live schema stays at the pre-migration value
+// and never matches the overlay's target). Without the all-failed
+// defensive clear, the overlay would stay set permanently, leaving
+// queries to tokenize input against the target value while every
+// bucket still has the source-tokenized content — wrong results
+// until operator repair.
+
+func TestMaybeSetTokenizationOverlayPreSwap_TokenizationChange_Sets(t *testing.T) {
+	s := &Shard{}
+	payload := &ReindexTaskPayload{
+		MigrationType:      ReindexTypeChangeTokenization,
+		TargetTokenization: "field",
+		Properties:         []string{"name", "description"},
+	}
+	require.True(t, maybeSetTokenizationOverlayPreSwap(s, payload),
+		"change-tokenization migration with non-empty target must set the overlay")
+
+	assert.Equal(t, "field", s.TokenizationFor("name", "word"),
+		"overlay should override the live schema value")
+	assert.Equal(t, "field", s.TokenizationFor("description", "word"))
+}
+
+func TestMaybeSetTokenizationOverlayPreSwap_FilterableVariant_Sets(t *testing.T) {
+	s := &Shard{}
+	payload := &ReindexTaskPayload{
+		MigrationType:      ReindexTypeChangeTokenizationFilterable,
+		TargetTokenization: "word",
+		Properties:         []string{"name"},
+	}
+	require.True(t, maybeSetTokenizationOverlayPreSwap(s, payload),
+		"change-tokenization-filterable migration must also set the overlay")
+	assert.Equal(t, "word", s.TokenizationFor("name", "field"))
+}
+
+func TestMaybeSetTokenizationOverlayPreSwap_NonTokenizationMigration_NoOp(t *testing.T) {
+	s := &Shard{}
+	for _, mt := range []ReindexMigrationType{
+		ReindexTypeEnableFilterable,
+		ReindexTypeEnableSearchable,
+		ReindexTypeEnableRangeable,
+	} {
+		t.Run(string(mt), func(t *testing.T) {
+			payload := &ReindexTaskPayload{
+				MigrationType:      mt,
+				TargetTokenization: "field",
+				Properties:         []string{"name"},
+			}
+			require.False(t, maybeSetTokenizationOverlayPreSwap(s, payload),
+				"non-tokenization-changing migration must NOT set the overlay")
+			// Overlay should still be empty (no entries for "name").
+			assert.Equal(t, "word", s.TokenizationFor("name", "word"),
+				"no overlay set → fall back to live schema")
+		})
+	}
+}
+
+func TestMaybeSetTokenizationOverlayPreSwap_EmptyTargetTokenization_NoOp(t *testing.T) {
+	s := &Shard{}
+	payload := &ReindexTaskPayload{
+		MigrationType:      ReindexTypeChangeTokenization,
+		TargetTokenization: "", // payload missing target
+		Properties:         []string{"name"},
+	}
+	require.False(t, maybeSetTokenizationOverlayPreSwap(s, payload),
+		"empty target tokenization must skip the SET — better than writing an empty override")
+	assert.Equal(t, "word", s.TokenizationFor("name", "word"))
+}
+
+func TestMaybeSetTokenizationOverlayPreSwap_NilInputs_NoOp(t *testing.T) {
+	// Pure guard against nil-deref under unexpected call sites; both
+	// inputs are non-nil in production but defensive checks let the
+	// helper be tested via unit tests without bringing up a real
+	// shard.
+	require.False(t, maybeSetTokenizationOverlayPreSwap(nil, &ReindexTaskPayload{}))
+	require.False(t, maybeSetTokenizationOverlayPreSwap(&Shard{}, nil))
+}
+
+func TestMaybeClearTokenizationOverlayOnAllFailed_AllFailed_Clears(t *testing.T) {
+	// This is the central #216 Gap B regression: every per-task swap
+	// failed → no bucket pointer flipped → overlay must be cleared so
+	// the FAILED migration doesn't leave the shard permanently
+	// misaligned.
+	s := &Shard{}
+	payload := &ReindexTaskPayload{
+		MigrationType:      ReindexTypeChangeTokenization,
+		TargetTokenization: "field",
+		Properties:         []string{"name", "description"},
+	}
+	require.True(t, maybeSetTokenizationOverlayPreSwap(s, payload))
+	require.Equal(t, "field", s.TokenizationFor("name", "word"),
+		"sanity: SET should have written the overlay")
+
+	// Simulate the all-failed swap loop outcome.
+	const wasSet, anySwapped = true, false
+	require.True(t, maybeClearTokenizationOverlayOnAllFailed(s, payload, wasSet, anySwapped),
+		"defensive clear must apply when wasSet=true and anySwapped=false")
+
+	// The overlay is gone → TokenizationFor falls back to the live
+	// schema value. The migration's FAILED transition skipped the
+	// cluster-wide schema flip, so live is still the OLD value, and
+	// the bucket is also still OLD → query correctly tokenizes input
+	// for the OLD bucket content.
+	assert.Equal(t, "word", s.TokenizationFor("name", "word"),
+		"after all-failed clear: TokenizationFor must return live (OLD) value")
+	assert.Equal(t, "word", s.TokenizationFor("description", "word"))
+}
+
+func TestMaybeClearTokenizationOverlayOnAllFailed_AnySwapped_NoOp(t *testing.T) {
+	// Partial success path: at least one per-task swap returned nil
+	// → at least one bucket pointer flipped. The overlay must STAY
+	// set so the swapped index type's bucket content stays aligned
+	// with the query analyzer. The half-applied state surfaces via
+	// #221's FAILED-task repair_command for operator repair.
+	s := &Shard{}
+	payload := &ReindexTaskPayload{
+		MigrationType:      ReindexTypeChangeTokenization,
+		TargetTokenization: "field",
+		Properties:         []string{"name"},
+	}
+	require.True(t, maybeSetTokenizationOverlayPreSwap(s, payload))
+
+	const wasSet, anySwapped = true, true
+	require.False(t, maybeClearTokenizationOverlayOnAllFailed(s, payload, wasSet, anySwapped),
+		"clear must NOT apply when at least one swap succeeded")
+
+	assert.Equal(t, "field", s.TokenizationFor("name", "word"),
+		"partial-success path: overlay must remain set")
+}
+
+func TestMaybeClearTokenizationOverlayOnAllFailed_WasNotSet_NoOp(t *testing.T) {
+	// Symmetric to the SET helper's no-op cases (non-tokenization
+	// migrations, empty target): if SET was skipped, CLEAR must also
+	// be a no-op regardless of anySwapped — there's nothing to clear.
+	s := &Shard{}
+	payload := &ReindexTaskPayload{
+		MigrationType: ReindexTypeEnableFilterable, // non-tokenization
+		Properties:    []string{"name"},
+	}
+
+	for _, anySwapped := range []bool{true, false} {
+		require.False(t, maybeClearTokenizationOverlayOnAllFailed(s, payload, false, anySwapped),
+			"wasSet=false: clear must be a no-op (anySwapped=%v)", anySwapped)
+	}
+}
+
+func TestMaybeClearTokenizationOverlayOnAllFailed_NilInputs_NoOp(t *testing.T) {
+	require.False(t, maybeClearTokenizationOverlayOnAllFailed(nil, &ReindexTaskPayload{}, true, false))
+	require.False(t, maybeClearTokenizationOverlayOnAllFailed(&Shard{}, nil, true, false))
+}
+
+// TestTokenizationOverlay_AllFailedSwap_EndToEndLifecycle pins the
+// end-to-end behavior on the shard for the canonical #216 Gap B
+// failure scenario: pre-swap SET, every swap fails, post-loop CLEAR.
+// Mirrors OnGroupCompleted's per-shard branch exactly.
+func TestTokenizationOverlay_AllFailedSwap_EndToEndLifecycle(t *testing.T) {
+	s := &Shard{}
+	payload := &ReindexTaskPayload{
+		MigrationType:      ReindexTypeChangeTokenization,
+		TargetTokenization: "field",
+		Properties:         []string{"name"},
+	}
+
+	// Step 1: OnGroupCompleted's pre-swap SET.
+	wasSet := maybeSetTokenizationOverlayPreSwap(s, payload)
+	require.True(t, wasSet)
+
+	// Step 2: simulate every per-task RunSwapOnShard returning an
+	// error. anySwapped stays false.
+	const anySwapped = false
+
+	// Step 3: OnGroupCompleted's post-loop defensive CLEAR.
+	cleared := maybeClearTokenizationOverlayOnAllFailed(s, payload, wasSet, anySwapped)
+	require.True(t, cleared,
+		"end-to-end: defensive clear must fire on all-failed path")
+
+	// Final state: overlay empty, query path returns the live schema
+	// value untouched. This is what prevents the permanent
+	// misalignment the migration's FAILED transition would otherwise
+	// leave behind.
+	assert.Equal(t, "word", s.TokenizationFor("name", "word"),
+		"end-to-end: post all-failed clear, TokenizationFor returns live (untouched OLD) value")
+}
+
+// TestTokenizationOverlay_AnySwapped_EndToEndLifecycle pins the
+// partial-success path: pre-swap SET, ≥ 1 per-task swap succeeded,
+// post-loop CLEAR is a no-op so the overlay stays for the swapped
+// index types. Mirrors the same OnGroupCompleted branch.
+func TestTokenizationOverlay_AnySwapped_EndToEndLifecycle(t *testing.T) {
+	s := &Shard{}
+	payload := &ReindexTaskPayload{
+		MigrationType:      ReindexTypeChangeTokenization,
+		TargetTokenization: "field",
+		Properties:         []string{"name"},
+	}
+
+	wasSet := maybeSetTokenizationOverlayPreSwap(s, payload)
+	require.True(t, wasSet)
+
+	// At least one per-task swap succeeded → bucket pointer flipped
+	// for that index type. anySwapped = true.
+	const anySwapped = true
+
+	cleared := maybeClearTokenizationOverlayOnAllFailed(s, payload, wasSet, anySwapped)
+	require.False(t, cleared,
+		"partial-success path: defensive clear must NOT fire")
+
+	// Overlay stays set; queries tokenize input for the NEW value
+	// (matching the swapped bucket).
+	assert.Equal(t, "field", s.TokenizationFor("name", "word"))
+}

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -374,26 +374,35 @@ type Shard struct {
 	// Query input gets tokenized against OLD; lookup hits NEW bucket; counts
 	// don't match. Frontend Claude's `7→4→1→7→3→2` flap on the live demo.
 	//
-	// The overlay bridges that window per-shard: when runtimeSwap completes
-	// it records {propName → targetTokenization} here. Every query-time
-	// analyzer construction on this shard pulls a snapshot via
-	// SnapshotTokenizationOverlay and applies it through the existing
-	// inverted.PropertyOverlay.Tokenization channel; the analyzer's
-	// effectiveProperty machinery handles the substitution.
-	//
-	// The entry self-clears once the live schema catches up to the overlay
-	// value (defensive — avoids depending on schema-update callback
-	// ordering). The schema-update callback path also clears explicitly so
-	// the steady-state map is empty.
-	//
-	// Per-shard, in-memory only — the cluster-wide schema flip is the
-	// authoritative cross-replica signal; this overlay just bridges the
-	// local seconds-long gap between bucket-swap-here and schema-flip-
-	// observed-here.
+	// Lifecycle (see reindex_provider.go's OnGroupCompleted +
+	// OnTaskCompleted):
+	//   1. SET: pre-swap, just BEFORE the per-task RunSwapOnShard loop
+	//      kicks off on this shard. Setting pre-swap means the brief
+	//      in-flight window between bucket-pointer flip and overlay
+	//      visibility is bounded by the in-memory swap latency
+	//      (microseconds) rather than the cluster-wide cutover spread.
+	//   2. CLEAR (defensive, all-failed path): if every per-task swap on
+	//      this shard fails before flipping its bucket pointer (e.g.
+	//      ctx.Canceled during graceful shutdown), the post-loop branch
+	//      clears the overlay. Without this, an all-failed swap path
+	//      would leave overlay=NEW against unchanged OLD buckets —
+	//      permanent misalignment because the FAILED transition skips
+	//      the cluster-wide schema flip and the explicit clear hook
+	//      never runs.
+	//   3. CLEAR (success path): once flipSemanticMigrationSchema
+	//      commits the cluster-wide schema flip, OnTaskCompleted clears
+	//      the overlay per-shard so the steady-state map is empty.
+	//   4. CLEAR (self-clear backstop): TokenizationFor below clears
+	//      the entry on the next read where the live schema has caught
+	//      up to the overlay value — defensive against any callback-
+	//      ordering edge case.
 	//
 	// Read on every query that touches the affected property, so kept
 	// under a fast RWMutex rather than a sync.Map (consistent with
-	// rangeableLocalReady above).
+	// rangeableLocalReady above). Per-shard, in-memory only — the
+	// cluster-wide schema flip is the authoritative cross-replica
+	// signal; this overlay just bridges the local seconds-long gap
+	// between bucket-swap-here and schema-flip-observed-here.
 	tokenizationOverlayMu sync.RWMutex
 	tokenizationOverlay   map[string]string
 
@@ -681,11 +690,17 @@ func (s *Shard) setRangeableLocallyReady(propName string, ready bool) {
 // SetTokenizationOverlay records that propName's query-time tokenization on
 // this shard should be `target` instead of the schema-stored value until
 // the live schema catches up. Set by the change-tokenization migration's
-// per-shard runtimeSwap (in OnGroupCompleted.RunSwapOnShard) AFTER the
-// canonical bucket pointer has flipped to NEW-tokenized data. Cleared by
-// the schema-update callback (or defensively by [TokenizationFor] on next
-// access) once the cluster-wide schema flip is observed locally. See the
-// [tokenizationOverlay] field godoc for the full rationale.
+// reindex hook (reindex_provider.OnGroupCompleted) just BEFORE the
+// per-task RunSwapOnShard loop kicks off — setting pre-swap means the
+// brief window between bucket-pointer flip and overlay visibility is
+// bounded by the in-memory swap latency (microseconds), not by the
+// cluster-wide cutover spread. The same caller clears the overlay if
+// every per-task swap failed (defensive: no bucket flipped → overlay
+// must not stay set against unchanged buckets). On success, the overlay
+// is cleared explicitly by OnTaskCompleted after the cluster-wide
+// schema flip commits, with [TokenizationFor]'s self-clear-on-catchup
+// branch as a backstop. See the [tokenizationOverlay] field godoc for
+// the full rationale and lifecycle.
 //
 // Empty target is a no-op — used by the migration cleanup path to avoid
 // having every caller guard the call.

--- a/adapters/repos/db/shard.go
+++ b/adapters/repos/db/shard.go
@@ -360,6 +360,43 @@ type Shard struct {
 	rangeableLocalReadyMu sync.RWMutex
 	rangeableLocalReady   map[string]bool
 
+	// tokenizationOverlayMu guards tokenizationOverlay. Holds the per-prop
+	// "what tokenization should query input use on this shard?" override
+	// used to close the Gap B race in 0-weaviate-issues#216.
+	//
+	// Mechanism: a change-tokenization (or change-tokenization-filterable)
+	// migration's per-shard runtimeSwap flips the canonical bucket pointer
+	// to NEW-tokenization data BEFORE the cluster-wide schema flip in
+	// OnTaskCompleted.flipSemanticMigrationSchema commits via RAFT. During
+	// that seconds-long window on each replica:
+	//   - Bucket content on this shard: NEW tokenization (post-swap)
+	//   - Live schema as seen by the analyzer: OLD tokenization (pre-flip)
+	// Query input gets tokenized against OLD; lookup hits NEW bucket; counts
+	// don't match. Frontend Claude's `7→4→1→7→3→2` flap on the live demo.
+	//
+	// The overlay bridges that window per-shard: when runtimeSwap completes
+	// it records {propName → targetTokenization} here. Every query-time
+	// analyzer construction on this shard pulls a snapshot via
+	// SnapshotTokenizationOverlay and applies it through the existing
+	// inverted.PropertyOverlay.Tokenization channel; the analyzer's
+	// effectiveProperty machinery handles the substitution.
+	//
+	// The entry self-clears once the live schema catches up to the overlay
+	// value (defensive — avoids depending on schema-update callback
+	// ordering). The schema-update callback path also clears explicitly so
+	// the steady-state map is empty.
+	//
+	// Per-shard, in-memory only — the cluster-wide schema flip is the
+	// authoritative cross-replica signal; this overlay just bridges the
+	// local seconds-long gap between bucket-swap-here and schema-flip-
+	// observed-here.
+	//
+	// Read on every query that touches the affected property, so kept
+	// under a fast RWMutex rather than a sync.Map (consistent with
+	// rangeableLocalReady above).
+	tokenizationOverlayMu sync.RWMutex
+	tokenizationOverlay   map[string]string
+
 	cycleCallbacks *shardCycleCallbacks
 	bitmapFactory  *roaringset.BitmapFactory
 	bitmapBufPool  roaringset.BitmapBufPool
@@ -639,6 +676,122 @@ func (s *Shard) setRangeableLocallyReady(propName string, ready bool) {
 		s.rangeableLocalReady = map[string]bool{}
 	}
 	s.rangeableLocalReady[propName] = ready
+}
+
+// SetTokenizationOverlay records that propName's query-time tokenization on
+// this shard should be `target` instead of the schema-stored value until
+// the live schema catches up. Set by the change-tokenization migration's
+// per-shard runtimeSwap (in OnGroupCompleted.RunSwapOnShard) AFTER the
+// canonical bucket pointer has flipped to NEW-tokenized data. Cleared by
+// the schema-update callback (or defensively by [TokenizationFor] on next
+// access) once the cluster-wide schema flip is observed locally. See the
+// [tokenizationOverlay] field godoc for the full rationale.
+//
+// Empty target is a no-op — used by the migration cleanup path to avoid
+// having every caller guard the call.
+func (s *Shard) SetTokenizationOverlay(propName, target string) {
+	if propName == "" || target == "" {
+		return
+	}
+	s.tokenizationOverlayMu.Lock()
+	defer s.tokenizationOverlayMu.Unlock()
+	if s.tokenizationOverlay == nil {
+		s.tokenizationOverlay = map[string]string{}
+	}
+	s.tokenizationOverlay[propName] = target
+}
+
+// ClearTokenizationOverlay removes any tokenization-overlay entry for
+// propName. Idempotent — called by the schema-update callback when the
+// live schema's tokenization for propName matches the overlay's target,
+// indicating OnTaskCompleted's flipSemanticMigrationSchema has applied
+// on this node and the overlay is no longer needed.
+func (s *Shard) ClearTokenizationOverlay(propName string) {
+	if propName == "" {
+		return
+	}
+	s.tokenizationOverlayMu.Lock()
+	defer s.tokenizationOverlayMu.Unlock()
+	if s.tokenizationOverlay == nil {
+		return
+	}
+	delete(s.tokenizationOverlay, propName)
+}
+
+// TokenizationFor returns the active query-time tokenization for propName
+// on this shard. Consults the overlay first; if the overlay's value
+// matches the live schema's `liveTokenization` the overlay is self-
+// cleared (defensive against schema-update-callback ordering) and the
+// live value is returned. Otherwise the overlay value is returned if
+// present, else liveTokenization.
+//
+// liveTokenization is the value the caller would have used in the
+// absence of any overlay — typically `prop.Tokenization`. Passing the
+// live value as a parameter (rather than re-reading the schema here)
+// keeps this helper cheap and avoids a schema-manager dependency in the
+// query hot path.
+func (s *Shard) TokenizationFor(propName, liveTokenization string) string {
+	if propName == "" {
+		return liveTokenization
+	}
+	s.tokenizationOverlayMu.RLock()
+	if s.tokenizationOverlay == nil {
+		s.tokenizationOverlayMu.RUnlock()
+		return liveTokenization
+	}
+	overlay, ok := s.tokenizationOverlay[propName]
+	s.tokenizationOverlayMu.RUnlock()
+	if !ok {
+		return liveTokenization
+	}
+	if overlay == liveTokenization {
+		// Live schema has caught up. Self-clear so future calls take the
+		// fast path — write under the write lock so concurrent self-
+		// clears don't race the migration's explicit clear.
+		s.tokenizationOverlayMu.Lock()
+		if s.tokenizationOverlay != nil {
+			if current, ok := s.tokenizationOverlay[propName]; ok && current == liveTokenization {
+				delete(s.tokenizationOverlay, propName)
+			}
+		}
+		s.tokenizationOverlayMu.Unlock()
+		return liveTokenization
+	}
+	return overlay
+}
+
+// SnapshotTokenizationOverlay returns a fixed-allocation map of
+// {propName → target} entries for the supplied propNames, restricted
+// to entries that currently exist in the overlay. Used by query setup
+// paths that need to populate inverted.PropertyOverlay values for the
+// analyzer's WithSchemaOverlay mechanism (see
+// adapters/repos/db/inverted/analyzer.go).
+//
+// Per QA Claude's micro-note on #216: this avoids cloning the entire
+// underlying map at every query — only the requested props are
+// snapshotted, and an empty result returns nil so the analyzer can
+// take its fast path.
+//
+// The returned map is owned by the caller.
+func (s *Shard) SnapshotTokenizationOverlay(propNames []string) map[string]string {
+	if len(propNames) == 0 {
+		return nil
+	}
+	s.tokenizationOverlayMu.RLock()
+	defer s.tokenizationOverlayMu.RUnlock()
+	if len(s.tokenizationOverlay) == 0 {
+		return nil
+	}
+	var out map[string]string
+	for _, name := range propNames {
+		if v, ok := s.tokenizationOverlay[name]; ok {
+			if out == nil {
+				out = make(map[string]string, len(propNames))
+			}
+			out[name] = v
+		}
+	}
+	return out
 }
 
 func (s *Shard) tenant() string {

--- a/adapters/repos/db/shard_aggregate.go
+++ b/adapters/repos/db/shard_aggregate.go
@@ -34,6 +34,7 @@ func (s *Shard) Aggregate(ctx context.Context, params aggregation.Params, module
 
 	return aggregator.New(s.store, params, s.index.getSchema, s.index.classSearcher,
 		s.index.getStopwordProvider(), s.versioner.Version(), vectorIndex, s.index.logger, s.GetPropertyLengthTracker(),
-		s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory, modules, s.index.Config.QueryHybridMaximumResults).
+		s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory, modules, s.index.Config.QueryHybridMaximumResults,
+		s.TokenizationFor).
 		Do(ctx)
 }

--- a/adapters/repos/db/shard_read.go
+++ b/adapters/repos/db/shard_read.go
@@ -491,6 +491,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 				s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.Version(),
 				s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit,
 				s.bitmapFactory).
+				WithTokenizationResolver(s.TokenizationFor).
 				DocIDs(ctx, filters, additional, s.index.Config.ClassName)
 			if err != nil {
 				return nil, nil, err
@@ -504,7 +505,8 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 		logger := s.index.logger.WithFields(logrus.Fields{"class": s.index.Config.ClassName, "shard": s.name})
 		bm25searcher := inverted.NewBM25Searcher(bm25Config, s.store,
 			s.index.getSchema.ReadOnlyClass, s.propertyIndices, s.index.classSearcher, s.index.getStopwordProvider(),
-			s.GetPropertyLengthTracker(), logger, s.versioner.Version())
+			s.GetPropertyLengthTracker(), logger, s.versioner.Version()).
+			WithTokenizationResolver(s.TokenizationFor)
 		bm25objs, bm25count, err = bm25searcher.BM25F(ctx, filterDocIds, className, limit, *keywordRanking, additional)
 		if err != nil {
 			return nil, nil, err
@@ -521,6 +523,7 @@ func (s *Shard) ObjectSearch(ctx context.Context, limit int, filters *filters.Lo
 	objs, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
 		s.propertyIndices, s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.Version(),
 		s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
+		WithTokenizationResolver(s.TokenizationFor).
 		Objects(ctx, limit, filters, sort, additional, s.index.Config.ClassName, properties,
 			s.index.Config.InvertedSorterDisabled)
 	return objs, nil, err
@@ -897,6 +900,7 @@ func (s *Shard) buildAllowList(ctx context.Context, filters *filters.LocalFilter
 	list, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
 		s.propertyIndices, s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.Version(),
 		s.isFallbackToSearchable, s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
+		WithTokenizationResolver(s.TokenizationFor).
 		DocIDs(ctx, filters, addl, s.index.Config.ClassName)
 	if err != nil {
 		return nil, errors.Wrap(err, "build inverted filter allow list")

--- a/adapters/repos/db/shard_tokenization_overlay_test.go
+++ b/adapters/repos/db/shard_tokenization_overlay_test.go
@@ -1,0 +1,167 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestShard_TokenizationOverlay_* pin the per-shard tokenization overlay
+// lifecycle introduced for 0-weaviate-issues#216 (Gap B). The overlay
+// bridges the per-replica window between a change-tokenization
+// migration's local bucket swap (in OnGroupCompleted.RunSwapOnShard) and
+// the cluster-wide schema flip (in OnTaskCompleted's
+// flipSemanticMigrationSchema). See the [tokenizationOverlay] field
+// godoc on Shard for the full rationale.
+//
+// We exercise the helper methods directly against a zero-valued Shard
+// struct because they touch only the per-shard map + mutex — no other
+// shard wiring is required.
+
+func TestShard_TokenizationOverlay_NotSet_FallsBackToLive(t *testing.T) {
+	s := &Shard{}
+	// No overlay entries → fall back to liveTokenization.
+	assert.Equal(t, "word", s.TokenizationFor("name", "word"))
+	assert.Equal(t, "field", s.TokenizationFor("path", "field"))
+	// Empty propName is a no-op.
+	assert.Equal(t, "word", s.TokenizationFor("", "word"))
+}
+
+func TestShard_TokenizationOverlay_SetAndRead(t *testing.T) {
+	s := &Shard{}
+	s.SetTokenizationOverlay("name", "field")
+
+	// Overlay value wins while the live schema hasn't caught up.
+	assert.Equal(t, "field", s.TokenizationFor("name", "word"))
+
+	// Unrelated propNames are unaffected.
+	assert.Equal(t, "word", s.TokenizationFor("other", "word"))
+}
+
+func TestShard_TokenizationOverlay_SetEmptyValues_NoOp(t *testing.T) {
+	s := &Shard{}
+	s.SetTokenizationOverlay("", "field") // empty propName
+	s.SetTokenizationOverlay("name", "")  // empty target
+	// Neither call should have populated the overlay.
+	assert.Equal(t, "word", s.TokenizationFor("name", "word"))
+}
+
+func TestShard_TokenizationOverlay_ClearExplicit(t *testing.T) {
+	s := &Shard{}
+	s.SetTokenizationOverlay("name", "field")
+	assert.Equal(t, "field", s.TokenizationFor("name", "word"))
+
+	s.ClearTokenizationOverlay("name")
+	// Cleared → fall back to liveTokenization.
+	assert.Equal(t, "word", s.TokenizationFor("name", "word"))
+}
+
+func TestShard_TokenizationOverlay_ClearUnsetIsNoOp(t *testing.T) {
+	s := &Shard{}
+	// Clearing a never-set entry is safe.
+	s.ClearTokenizationOverlay("name")
+	s.ClearTokenizationOverlay("")
+	// Live fallback still works.
+	assert.Equal(t, "word", s.TokenizationFor("name", "word"))
+}
+
+func TestShard_TokenizationOverlay_SelfClearOnSchemaCatchup(t *testing.T) {
+	// This is the defensive branch — if the schema-update callback hasn't
+	// fired yet but the live schema has already caught up to the overlay's
+	// target, the next TokenizationFor call self-clears the overlay and
+	// returns the live value.
+	s := &Shard{}
+	s.SetTokenizationOverlay("name", "field")
+
+	// First call: live schema still has the OLD value → overlay wins.
+	assert.Equal(t, "field", s.TokenizationFor("name", "word"))
+
+	// Live schema catches up to the overlay's target.
+	got := s.TokenizationFor("name", "field")
+	assert.Equal(t, "field", got, "live should match overlay → return overlay value")
+
+	// The self-clear should have fired; subsequent calls take the fast
+	// path and return whatever live the caller passes — even if it's
+	// changed back (operator did a downstream migration). Verifies the
+	// overlay is actually removed, not just shadowed.
+	assert.Equal(t, "word", s.TokenizationFor("name", "word"),
+		"after self-clear, overlay must no longer override")
+}
+
+func TestShard_TokenizationOverlay_SnapshotEmpty(t *testing.T) {
+	s := &Shard{}
+	// No overlay → nil snapshot regardless of how many props requested.
+	assert.Nil(t, s.SnapshotTokenizationOverlay(nil))
+	assert.Nil(t, s.SnapshotTokenizationOverlay([]string{}))
+	assert.Nil(t, s.SnapshotTokenizationOverlay([]string{"a", "b"}))
+}
+
+func TestShard_TokenizationOverlay_SnapshotSubset(t *testing.T) {
+	s := &Shard{}
+	s.SetTokenizationOverlay("a", "field")
+	s.SetTokenizationOverlay("b", "lowercase")
+	// "c" is not in the overlay.
+
+	// Asking for only the props the caller cares about.
+	snap := s.SnapshotTokenizationOverlay([]string{"a", "c"})
+	require.NotNil(t, snap)
+	assert.Equal(t, "field", snap["a"])
+	_, present := snap["c"]
+	assert.False(t, present, "non-overlaid prop must not appear in snapshot")
+	assert.Len(t, snap, 1)
+
+	// A request that hits no overlay entries returns nil so the analyzer
+	// can take its fast path.
+	assert.Nil(t, s.SnapshotTokenizationOverlay([]string{"c", "d"}))
+}
+
+func TestShard_TokenizationOverlay_ConcurrentAccess(t *testing.T) {
+	// Pin the RWMutex contract: many concurrent readers + a writer must
+	// not race. Run under `go test -race` to catch any regression in the
+	// lock discipline.
+	s := &Shard{}
+	s.SetTokenizationOverlay("name", "field")
+
+	const goroutines = 32
+	const iterations = 200
+	var wg sync.WaitGroup
+
+	// Readers
+	for i := 0; i < goroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				_ = s.TokenizationFor("name", "word")
+				_ = s.SnapshotTokenizationOverlay([]string{"name"})
+			}
+		}()
+	}
+
+	// Writers
+	for i := 0; i < 4; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < iterations; j++ {
+				s.SetTokenizationOverlay("name", "field")
+				s.ClearTokenizationOverlay("name")
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/adapters/repos/db/shard_write_batch_delete.go
+++ b/adapters/repos/db/shard_write_batch_delete.go
@@ -174,6 +174,7 @@ func (s *Shard) FindUUIDs(ctx context.Context, filters *filters.LocalFilter, lim
 	allowList, err := inverted.NewSearcher(s.index.logger, s.store, s.index.getSchema.ReadOnlyClass,
 		nil, s.index.classSearcher, s.index.getStopwordProvider(), s.versioner.version, s.isFallbackToSearchable,
 		s.IsRangeableLocallyReady, s.tenant(), s.index.Config.QueryNestedRefLimit, s.bitmapFactory).
+		WithTokenizationResolver(s.TokenizationFor).
 		DocIDsLimited(ctx, filters, additional.Properties{}, s.index.Config.ClassName, limit)
 	if err != nil {
 		return nil, fmt.Errorf("docIds: %w", err)

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -19,6 +19,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -693,4 +694,143 @@ func dumpStartupLogs(ctx context.Context, t *testing.T, compose *docker.DockerCo
 		}
 		t.Logf("=== Node %d logs (%d migration/reindex lines) ===\n%s", i, len(filtered), strings.Join(filtered, "\n"))
 	}
+}
+
+// probeSample is one observation of a probe function against a node.
+type probeSample struct {
+	t      time.Time
+	nodeID int
+	count  int
+	err    error
+}
+
+// probeFn is the shape of a per-node query probe. Returns (count, err).
+type probeFn func(restURI, className string) (int, error)
+
+// runMigrationWithProbes spins up one probe goroutine per node, each
+// invoking `probe` every `probeInterval`, while `migrate` runs. After
+// `migrate` returns, probes continue for `tailDuration` to capture the
+// post-cutover steady state, then stop. Returns the collected samples
+// and the wall-clock time `migrate` started at.
+//
+// Shared between TestPartialResultsDuringChangeTokenization (which pins
+// the pre-#216 cluster-wide cutover bound) and
+// TestLiveQueriesDuringChangeTokenization (which pins the post-#216
+// per-shard alignment bound) so both tests use identical sampling
+// machinery — only their assertions differ.
+func runMigrationWithProbes(
+	t *testing.T,
+	compose *docker.DockerCompose,
+	className string,
+	probeInterval, tailDuration time.Duration,
+	probe probeFn,
+	migrate func(),
+) ([]probeSample, time.Time) {
+	t.Helper()
+
+	samplesMu := sync.Mutex{}
+	samples := make([]probeSample, 0, 1024)
+	record := func(s probeSample) {
+		samplesMu.Lock()
+		samples = append(samples, s)
+		samplesMu.Unlock()
+	}
+
+	stopCh := make(chan struct{})
+	var wg sync.WaitGroup
+	for nodeIdx := 0; nodeIdx < 3; nodeIdx++ {
+		wg.Add(1)
+		nodeURI := compose.GetWeaviateNode(nodeIdx + 1).URI()
+		idx := nodeIdx + 1
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stopCh:
+					return
+				default:
+				}
+				start := time.Now()
+				count, err := probe(nodeURI, className)
+				record(probeSample{t: start, nodeID: idx, count: count, err: err})
+				time.Sleep(probeInterval)
+			}
+		}()
+	}
+
+	migrationStart := time.Now()
+	migrate()
+
+	// Let probes continue past the migration completion to capture late
+	// samples and the post-cutover steady state.
+	time.Sleep(tailDuration)
+	close(stopCh)
+	wg.Wait()
+
+	return samples, migrationStart
+}
+
+// probeClassification summarizes a probe sample set against a known
+// baseline (the count expected before the migration starts).
+type probeClassification struct {
+	Full, Empty, Partial, Errors int
+	FirstPartial, LastPartial    time.Time
+}
+
+// classifyProbeSamples buckets each non-error sample as Full (==
+// baseline), Empty (== 0), or Partial (anything else). Logs every
+// partial sample for forensic visibility.
+func classifyProbeSamples(t *testing.T, samples []probeSample, baseline int, migrationStart time.Time) probeClassification {
+	t.Helper()
+	var c probeClassification
+	for _, s := range samples {
+		switch {
+		case s.err != nil:
+			c.Errors++
+		case s.count == baseline:
+			c.Full++
+		case s.count == 0:
+			c.Empty++
+		default:
+			c.Partial++
+			if c.FirstPartial.IsZero() {
+				c.FirstPartial = s.t
+			}
+			c.LastPartial = s.t
+			t.Logf("partial @ +%v node=%d count=%d (baseline=%d)",
+				s.t.Sub(migrationStart).Round(time.Millisecond),
+				s.nodeID, s.count, baseline)
+		}
+	}
+	t.Logf("probe classification: full=%d empty=%d partial=%d err=%d",
+		c.Full, c.Empty, c.Partial, c.Errors)
+	if c.Partial > 0 {
+		t.Logf("partial-results window spanned %v (first @ +%v, last @ +%v)",
+			c.LastPartial.Sub(c.FirstPartial).Round(time.Millisecond),
+			c.FirstPartial.Sub(migrationStart).Round(time.Millisecond),
+			c.LastPartial.Sub(migrationStart).Round(time.Millisecond))
+	}
+	return c
+}
+
+// countLatePartials returns the number of non-error samples whose
+// timestamp is after `anchor` and whose count is neither 0 nor
+// baseline. Used by both tests as the post-window convergence
+// guarantee — late partials indicate the cutover has not stabilized
+// after the bounded window closed.
+func countLatePartials(t *testing.T, samples []probeSample, baseline int, anchor, migrationStart time.Time) int {
+	t.Helper()
+	var late int
+	for _, s := range samples {
+		if s.err != nil {
+			continue
+		}
+		if s.t.After(anchor) && s.count != 0 && s.count != baseline {
+			late++
+			t.Logf("late partial @ +%v node=%d count=%d (after anchor)",
+				s.t.Sub(migrationStart).Round(time.Millisecond),
+				s.nodeID, s.count)
+		}
+	}
+	return late
 }

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -770,40 +770,65 @@ func runMigrationWithProbes(
 	return samples, migrationStart
 }
 
-// probeClassification summarizes a probe sample set against a known
-// baseline (the count expected before the migration starts).
+// probeClassification summarizes a probe sample set against the two
+// known steady-state counts: `baseline` (what the probe should return
+// before the migration starts) and `expectedAfter` (what it should
+// return after the migration commits).
+//
+// Pre/Post counts represent steady-state observations on either side
+// of the cutover. Partial counts are samples that lie inside the
+// open range (min(baseline, expectedAfter), max(baseline, expectedAfter))
+// — the cross-shard cutover spread admits a brief partial window
+// during the per-replica swap + cluster-wide schema flip. OutOfRange
+// counts are samples OUTSIDE that range; with the #216 per-shard
+// tokenization overlay landed, no sample should be out-of-range
+// because every replica's bucket content is always tokenization-
+// aligned with the value the analyzer uses. Out-of-range samples
+// indicate either the overlay isn't wired into a query path or the
+// set/clear hooks fire at the wrong FSM transition.
 type probeClassification struct {
-	Full, Empty, Partial, Errors int
-	FirstPartial, LastPartial    time.Time
+	Pre, Post, Partial, OutOfRange, Errors int
+	FirstPartial, LastPartial              time.Time
 }
 
-// classifyProbeSamples buckets each non-error sample as Full (==
-// baseline), Empty (== 0), or Partial (anything else). Logs every
-// partial sample for forensic visibility.
-func classifyProbeSamples(t *testing.T, samples []probeSample, baseline int, migrationStart time.Time) probeClassification {
+// classifyProbeSamples buckets each non-error sample as Pre (==
+// baseline), Post (== expectedAfter), Partial (inside the open range
+// between them), or OutOfRange (outside that range — the #216
+// misalignment shape). Logs every partial and out-of-range sample
+// for forensic visibility.
+func classifyProbeSamples(t *testing.T, samples []probeSample, baseline, expectedAfter int, migrationStart time.Time) probeClassification {
 	t.Helper()
+	lo, hi := baseline, expectedAfter
+	if lo > hi {
+		lo, hi = hi, lo
+	}
 	var c probeClassification
 	for _, s := range samples {
 		switch {
 		case s.err != nil:
 			c.Errors++
 		case s.count == baseline:
-			c.Full++
-		case s.count == 0:
-			c.Empty++
+			c.Pre++
+		case s.count == expectedAfter:
+			c.Post++
+		case s.count < lo || s.count > hi:
+			c.OutOfRange++
+			t.Logf("OUT-OF-RANGE @ +%v node=%d count=%d (valid range [%d, %d])",
+				s.t.Sub(migrationStart).Round(time.Millisecond),
+				s.nodeID, s.count, lo, hi)
 		default:
 			c.Partial++
 			if c.FirstPartial.IsZero() {
 				c.FirstPartial = s.t
 			}
 			c.LastPartial = s.t
-			t.Logf("partial @ +%v node=%d count=%d (baseline=%d)",
+			t.Logf("partial @ +%v node=%d count=%d (baseline=%d, post=%d)",
 				s.t.Sub(migrationStart).Round(time.Millisecond),
-				s.nodeID, s.count, baseline)
+				s.nodeID, s.count, baseline, expectedAfter)
 		}
 	}
-	t.Logf("probe classification: full=%d empty=%d partial=%d err=%d",
-		c.Full, c.Empty, c.Partial, c.Errors)
+	t.Logf("probe classification: pre=%d post=%d partial=%d out_of_range=%d err=%d",
+		c.Pre, c.Post, c.Partial, c.OutOfRange, c.Errors)
 	if c.Partial > 0 {
 		t.Logf("partial-results window spanned %v (first @ +%v, last @ +%v)",
 			c.LastPartial.Sub(c.FirstPartial).Round(time.Millisecond),
@@ -814,18 +839,18 @@ func classifyProbeSamples(t *testing.T, samples []probeSample, baseline int, mig
 }
 
 // countLatePartials returns the number of non-error samples whose
-// timestamp is after `anchor` and whose count is neither 0 nor
-// baseline. Used by both tests as the post-window convergence
+// timestamp is after `anchor` and whose count is neither baseline nor
+// expectedAfter. Used by both tests as the post-window convergence
 // guarantee — late partials indicate the cutover has not stabilized
 // after the bounded window closed.
-func countLatePartials(t *testing.T, samples []probeSample, baseline int, anchor, migrationStart time.Time) int {
+func countLatePartials(t *testing.T, samples []probeSample, baseline, expectedAfter int, anchor, migrationStart time.Time) int {
 	t.Helper()
 	var late int
 	for _, s := range samples {
 		if s.err != nil {
 			continue
 		}
-		if s.t.After(anchor) && s.count != 0 && s.count != baseline {
+		if s.t.After(anchor) && s.count != baseline && s.count != expectedAfter {
 			late++
 			t.Logf("late partial @ +%v node=%d count=%d (after anchor)",
 				s.t.Sub(migrationStart).Round(time.Millisecond),

--- a/test/acceptance/reindex_multinode/issue_216_finalizing_window_test.go
+++ b/test/acceptance/reindex_multinode/issue_216_finalizing_window_test.go
@@ -14,7 +14,6 @@ package reindex_multinode
 import (
 	"context"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -72,19 +71,12 @@ func TestLiveQueriesDuringChangeTokenization(t *testing.T) {
 	defer cleanup()
 	defer dumpContainerLogs(ctx, t, compose)
 
-	// probeFn is the per-case query function: it takes a node URI and
-	// the class name, returns (count, err). Different probe types
-	// exercise different query paths (BM25 via bm25Searcher, Equal
-	// filter via Searcher) — both of which are wired through the
-	// per-shard tokenization overlay.
-	type probeFn func(restURI, className string) (int, error)
-
 	cases := []struct {
 		name       string
 		startTok   string // tokenization at class creation
 		targetTok  string // tokenization after migration
 		indexType  string // "searchable" (change-tokenization) or "filterable" (change-tokenization-filterable)
-		probeQuery string // query string passed to the probe
+		probeQuery string // for log messages only — actual query is in `probe`
 		probe      probeFn
 		// expectedAfter is the count the probe should yield after the
 		// migration commits. We use it only as a sanity check; the
@@ -143,15 +135,14 @@ func runLiveQueryDuringChangeTokenizationCase(
 	t *testing.T,
 	compose *docker.DockerCompose,
 	startTok, targetTok, indexType, probeQuery string,
-	probe func(restURI, className string) (int, error),
+	probe probeFn,
 	expectedAfter int,
 ) {
 	const (
-		shardCount    = 3
-		rf            = 3
-		objectCount   = 1500
-		batchSize     = 100
-		probeInterval = 25 * time.Millisecond
+		shardCount  = 3
+		rf          = 3
+		objectCount = 1500
+		batchSize   = 100
 		// partialSampleBudget is the post-#216 tight bound. Pre-fix,
 		// TestPartialResultsDuringChangeTokenization allowed up to 15
 		// partial samples in a 700ms window; this test asserts the
@@ -169,11 +160,11 @@ func runLiveQueryDuringChangeTokenizationCase(
 		})
 	defer deleteCollection(t, compose.GetWeaviateNode(1).URI(), className)
 
-	// Generate `objectCount` documents each containing the literal token
-	// "alpha" and the full-text phrase variant. Under WORD tokenization,
-	// BM25 "alpha" matches all objects; under FIELD, "alpha" matches
-	// none because the entire phrase is one token. The full-phrase
-	// query matches one specific object under FIELD only.
+	// Generate `objectCount` documents that each contain the literal
+	// token "alpha" inside a multi-word phrase. Under WORD tokenization,
+	// "alpha" matches every doc; under FIELD it matches none because
+	// the entire phrase is one token. The full-phrase query matches
+	// exactly one object under FIELD only.
 	texts := make([]string, 0, objectCount)
 	for i := 0; i < objectCount; i++ {
 		texts = append(texts, fmt.Sprintf("alpha doc number %d filler", i))
@@ -191,106 +182,24 @@ func runLiveQueryDuringChangeTokenizationCase(
 			"so partial samples during the migration are detectable", startTok, probeQuery)
 	t.Logf("baseline (start=%s) count: %d", startTok, baselineCount)
 
-	// Start probing every node every 25ms throughout the migration.
-	type sample struct {
-		t      time.Time
-		nodeID int
-		count  int
-		err    error
-	}
-	samplesMu := sync.Mutex{}
-	samples := make([]sample, 0, 1024)
-	record := func(s sample) {
-		samplesMu.Lock()
-		samples = append(samples, s)
-		samplesMu.Unlock()
-	}
+	indexUpdateJSON := buildTokenizationIndexUpdate(t, indexType, targetTok)
 
-	stopCh := make(chan struct{})
-	var wg sync.WaitGroup
-	for nodeIdx := 0; nodeIdx < 3; nodeIdx++ {
-		wg.Add(1)
-		nodeURI := compose.GetWeaviateNode(nodeIdx + 1).URI()
-		idx := nodeIdx + 1
-		go func() {
-			defer wg.Done()
-			for {
-				select {
-				case <-stopCh:
-					return
-				default:
-				}
-				start := time.Now()
-				count, perr := probe(nodeURI, className)
-				record(sample{t: start, nodeID: idx, count: count, err: perr})
-				time.Sleep(probeInterval)
-			}
-		}()
-	}
-
-	// Build the index-update JSON for the requested migration type.
-	var indexUpdateJSON string
-	switch indexType {
-	case "searchable":
-		indexUpdateJSON = fmt.Sprintf(`{"searchable":{"tokenization":%q}}`, targetTok)
-	case "filterable":
-		indexUpdateJSON = fmt.Sprintf(`{"filterable":{"tokenization":%q}}`, targetTok)
-	default:
-		t.Fatalf("unsupported indexType %q", indexType)
-	}
-
-	migrationStart := time.Now()
-	taskID := submitIndexUpdate(t, compose.GetWeaviateNode(1).URI(), className, "text", indexUpdateJSON)
-	t.Logf("submitted change-tokenization-%s task: %s", indexType, taskID)
-
-	awaitReindexFinished(t, compose.GetWeaviateNode(1).URI(), taskID)
-	require.Eventually(t, func() bool {
-		return tryGetPropertyTokenization(compose.GetWeaviateNode(1).URI(),
-			className, "text") == targetTok
-	}, 60*time.Second, 200*time.Millisecond,
-		"tokenization should change to %s after swap phase", targetTok)
-
-	// Let probes run a little longer to capture the post-flip steady
-	// state (so any racy late partial samples are observable).
-	time.Sleep(2 * time.Second)
-	close(stopCh)
-	wg.Wait()
-
+	var taskID string
+	samples, migrationStart := runMigrationWithProbes(t, compose, className,
+		25*time.Millisecond, 2*time.Second, probe, func() {
+			taskID = submitIndexUpdate(t, compose.GetWeaviateNode(1).URI(), className, "text", indexUpdateJSON)
+			t.Logf("submitted change-tokenization-%s task: %s", indexType, taskID)
+			awaitReindexFinished(t, compose.GetWeaviateNode(1).URI(), taskID)
+			require.Eventually(t, func() bool {
+				return tryGetPropertyTokenization(compose.GetWeaviateNode(1).URI(),
+					className, "text") == targetTok
+			}, 60*time.Second, 200*time.Millisecond,
+				"tokenization should change to %s after swap phase", targetTok)
+		})
 	t.Logf("migration completed in %v, collected %d probe samples",
 		time.Since(migrationStart), len(samples))
 
-	// Classify samples relative to the start-tok baseline. Any value
-	// in (0, baselineCount) is partial — the bucket and the query
-	// analyzer disagreed at the moment of the probe.
-	var fullN, emptyN, partialN, errN int
-	var firstPartial, lastPartial time.Time
-	for _, s := range samples {
-		switch {
-		case s.err != nil:
-			errN++
-		case s.count == baselineCount:
-			fullN++
-		case s.count == 0:
-			emptyN++
-		default:
-			partialN++
-			if firstPartial.IsZero() {
-				firstPartial = s.t
-			}
-			lastPartial = s.t
-			t.Logf("partial @ +%v node=%d count=%d (baseline=%d)",
-				s.t.Sub(migrationStart).Round(time.Millisecond), s.nodeID, s.count, baselineCount)
-		}
-	}
-
-	t.Logf("probe classification: full=%d empty=%d partial=%d err=%d",
-		fullN, emptyN, partialN, errN)
-	if partialN > 0 {
-		t.Logf("partial-results window spanned %v (first @ +%v, last @ +%v)",
-			lastPartial.Sub(firstPartial).Round(time.Millisecond),
-			firstPartial.Sub(migrationStart).Round(time.Millisecond),
-			lastPartial.Sub(migrationStart).Round(time.Millisecond))
-	}
+	c := classifyProbeSamples(t, samples, baselineCount, migrationStart)
 
 	// Sanity check that the post-flip steady state is what we expect
 	// (not just zero everywhere — that'd be silent failure).
@@ -307,7 +216,7 @@ func runLiveQueryDuringChangeTokenizationCase(
 	//   - partialWindowBudget catches a slow drain (the overlay clears
 	//     correctly but bounded by something slow like RAFT rather
 	//     than the in-memory pointer flip).
-	assert.LessOrEqualf(t, partialN, partialSampleBudget,
+	assert.LessOrEqualf(t, c.Partial, partialSampleBudget,
 		"observed %d partial samples (budget=%d) for %s→%s on %s — "+
 			"per-shard tokenization overlay is not keeping the query "+
 			"analyzer aligned with bucket content during the FINALIZING "+
@@ -315,10 +224,10 @@ func runLiveQueryDuringChangeTokenizationCase(
 			"BM25Searcher.WithTokenizationResolver, Searcher.WithTokenizationResolver, "+
 			"aggregator.New tokResolver parameter) and the set/clear hooks "+
 			"(OnGroupCompleted, OnTaskCompleted).",
-		partialN, partialSampleBudget, startTok, targetTok, indexType)
+		c.Partial, partialSampleBudget, startTok, targetTok, indexType)
 
-	if partialN > 0 {
-		windowDuration := lastPartial.Sub(firstPartial)
+	if c.Partial > 0 {
+		windowDuration := c.LastPartial.Sub(c.FirstPartial)
 		assert.LessOrEqualf(t, windowDuration, partialWindowBudget,
 			"partial-results window of %v exceeds budget of %v for %s→%s on %s — "+
 				"a partial sample arrived long after the in-memory swap completed; "+
@@ -332,27 +241,31 @@ func runLiveQueryDuringChangeTokenizationCase(
 	// every sample must be a full or empty count. A late partial
 	// indicates the cutover is not converging.
 	var afterAnchor time.Time
-	if !lastPartial.IsZero() {
-		afterAnchor = lastPartial.Add(50 * time.Millisecond)
+	if !c.LastPartial.IsZero() {
+		afterAnchor = c.LastPartial.Add(50 * time.Millisecond)
 	} else {
-		// No partials observed — anchor at migration start; any later
-		// non-{0,baseline} sample is a late partial.
 		afterAnchor = migrationStart
 	}
-	var latePartial int
-	for _, s := range samples {
-		if s.err != nil {
-			continue
-		}
-		if s.t.After(afterAnchor) && s.count != 0 && s.count != baselineCount {
-			latePartial++
-			t.Logf("late partial @ +%v node=%d count=%d (after anchor)",
-				s.t.Sub(migrationStart).Round(time.Millisecond), s.nodeID, s.count)
-		}
-	}
+	latePartial := countLatePartials(t, samples, baselineCount, afterAnchor, migrationStart)
 	assert.Zerof(t, latePartial,
 		"observed %d partial samples after the bounded cutover window for %s→%s on %s — "+
 			"cutover is not converging; either the overlay isn't being cleared "+
 			"or the schema flip isn't propagating to every replica.",
 		latePartial, startTok, targetTok, indexType)
+}
+
+// buildTokenizationIndexUpdate produces the index-update request body
+// for a change-tokenization migration. Split out of the test body so
+// the assertion logic above stays readable.
+func buildTokenizationIndexUpdate(t *testing.T, indexType, targetTok string) string {
+	t.Helper()
+	switch indexType {
+	case "searchable":
+		return fmt.Sprintf(`{"searchable":{"tokenization":%q}}`, targetTok)
+	case "filterable":
+		return fmt.Sprintf(`{"filterable":{"tokenization":%q}}`, targetTok)
+	default:
+		t.Fatalf("unsupported indexType %q", indexType)
+		return ""
+	}
 }

--- a/test/acceptance/reindex_multinode/issue_216_finalizing_window_test.go
+++ b/test/acceptance/reindex_multinode/issue_216_finalizing_window_test.go
@@ -1,0 +1,358 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package reindex_multinode
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/docker"
+)
+
+// TestLiveQueriesDuringChangeTokenization pins the tight-bound
+// behavior of the per-shard tokenization overlay introduced for
+// 0-weaviate-issues#216 Gap B. Without the overlay, the FINALIZING
+// window of a change-tokenization migration leaks a per-replica
+// mismatch where the bucket pointer has flipped to NEW-tokenized data
+// but the cluster-wide schema flag still serves the OLD tokenization
+// to the query analyzer. Frontend Claude observed this as a
+// `7→4→1→7→3→2` count flap on a steady BM25 probe across replicas —
+// 6 consecutive non-baseline, non-zero samples spanning hundreds of
+// milliseconds.
+//
+// With the overlay, each shard's query input tokenizes against the
+// value matching its bucket content throughout the migration:
+//
+//   - Pre-swap: overlay=NEW, bucket=OLD (in-memory swap latency
+//     bounds this to microseconds; query returns 0 not partial).
+//   - Post-swap: overlay=NEW, bucket=NEW → query returns baseline.
+//   - Post-flip: overlay self-clears or is explicitly cleared by
+//     OnTaskCompleted; live schema=NEW matches bucket=NEW → query
+//     returns baseline.
+//
+// The only partials this test can observe are:
+//
+//  1. Brief (~µs) per-shard windows during the bucket pointer flip.
+//     At a 25ms probe interval × 3 nodes × 3 shards (=9 replicas) the
+//     expected hit count per migration is <1.
+//  2. Race between OnTaskCompleted's overlay clear and the schema
+//     flip's local FSM apply — by construction, the clear happens
+//     AFTER the schema flip commits on this node, and
+//     TokenizationFor's self-clear-on-catchup branch produces the
+//     same value as the explicit clear, so this window is effectively
+//     zero.
+//
+// The bounded count is a regression budget: any number above `5`
+// across the whole migration indicates the overlay is not threading
+// correctly through some query call site (BM25Searcher, Searcher,
+// aggregator) or the set/clear hooks in OnGroupCompleted /
+// OnTaskCompleted are landing at the wrong point in the FSM.
+//
+// Coverage: forward (word→field), reverse (field→word), filterable
+// variant. Each subtest creates a fresh collection on the shared
+// 3-node cluster.
+func TestLiveQueriesDuringChangeTokenization(t *testing.T) {
+	ctx := context.Background()
+	compose, cleanup := start3NodeReindexCluster(ctx, t)
+	defer cleanup()
+	defer dumpContainerLogs(ctx, t, compose)
+
+	// probeFn is the per-case query function: it takes a node URI and
+	// the class name, returns (count, err). Different probe types
+	// exercise different query paths (BM25 via bm25Searcher, Equal
+	// filter via Searcher) — both of which are wired through the
+	// per-shard tokenization overlay.
+	type probeFn func(restURI, className string) (int, error)
+
+	cases := []struct {
+		name       string
+		startTok   string // tokenization at class creation
+		targetTok  string // tokenization after migration
+		indexType  string // "searchable" (change-tokenization) or "filterable" (change-tokenization-filterable)
+		probeQuery string // query string passed to the probe
+		probe      probeFn
+		// expectedAfter is the count the probe should yield after the
+		// migration commits. We use it only as a sanity check; the
+		// in-flight assertion is the partial-sample budget.
+		expectedAfter int
+	}{
+		{
+			name:       "forward_word_to_field_searchable",
+			startTok:   "word",
+			targetTok:  "field",
+			indexType:  "searchable",
+			probeQuery: "alpha",
+			probe: func(uri, cn string) (int, error) {
+				return queryBM25Count(uri, cn, "alpha", 2000)
+			},
+			expectedAfter: 0, // "alpha" alone matches none under FIELD
+		},
+		{
+			name:       "reverse_field_to_word_searchable",
+			startTok:   "field",
+			targetTok:  "word",
+			indexType:  "searchable",
+			probeQuery: "alpha doc number 0 filler",
+			probe: func(uri, cn string) (int, error) {
+				return queryBM25Count(uri, cn, "alpha doc number 0 filler", 2000)
+			},
+			expectedAfter: 1, // full-text matches exactly one object under FIELD only
+		},
+		{
+			name:       "forward_word_to_field_filterable",
+			startTok:   "word",
+			targetTok:  "field",
+			indexType:  "filterable",
+			probeQuery: "alpha",
+			// Equal filter exercises the Searcher (not BM25Searcher)
+			// path via the aggregator's buildAllowList. Under WORD
+			// tokenization, Equal("alpha") on the filterable bucket
+			// matches every doc; under FIELD it matches none.
+			probe: func(uri, cn string) (int, error) {
+				return equalCount(uri, cn, "text", "alpha")
+			},
+			expectedAfter: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			runLiveQueryDuringChangeTokenizationCase(t, compose, tc.startTok,
+				tc.targetTok, tc.indexType, tc.probeQuery, tc.probe, tc.expectedAfter)
+		})
+	}
+}
+
+func runLiveQueryDuringChangeTokenizationCase(
+	t *testing.T,
+	compose *docker.DockerCompose,
+	startTok, targetTok, indexType, probeQuery string,
+	probe func(restURI, className string) (int, error),
+	expectedAfter int,
+) {
+	const (
+		shardCount    = 3
+		rf            = 3
+		objectCount   = 1500
+		batchSize     = 100
+		probeInterval = 25 * time.Millisecond
+		// partialSampleBudget is the post-#216 tight bound. Pre-fix,
+		// TestPartialResultsDuringChangeTokenization allowed up to 15
+		// partial samples in a 700ms window; this test asserts the
+		// per-shard alignment achieves an order of magnitude tighter
+		// budget. See test godoc for the upper-bound derivation.
+		partialSampleBudget = 5
+		partialWindowBudget = 150 * time.Millisecond
+	)
+
+	className := fmt.Sprintf("LiveQueryTok_%s_%s_%s", startTok, targetTok, indexType)
+
+	createCollection(t, compose.GetWeaviateNode(1).URI(), className, shardCount, rf,
+		[]*models.Property{
+			{Name: "text", DataType: []string{"text"}, Tokenization: startTok},
+		})
+	defer deleteCollection(t, compose.GetWeaviateNode(1).URI(), className)
+
+	// Generate `objectCount` documents each containing the literal token
+	// "alpha" and the full-text phrase variant. Under WORD tokenization,
+	// BM25 "alpha" matches all objects; under FIELD, "alpha" matches
+	// none because the entire phrase is one token. The full-phrase
+	// query matches one specific object under FIELD only.
+	texts := make([]string, 0, objectCount)
+	for i := 0; i < objectCount; i++ {
+		texts = append(texts, fmt.Sprintf("alpha doc number %d filler", i))
+	}
+	batchImport(t, compose.GetWeaviateNode(1).URI(), className, texts, batchSize)
+
+	// Baseline: at startTok, the probe query must return >0 objects so
+	// the FINALIZING-window partial samples are visible against a
+	// stable baseline. If the probe matches zero at startTok we'd
+	// classify steady-state samples as partial, blowing the budget.
+	baselineCount, err := probe(compose.GetWeaviateNode(1).URI(), className)
+	require.NoError(t, err)
+	require.Greater(t, baselineCount, 0,
+		"baseline (%s tokenization) must return a stable count > 0 against probe %q "+
+			"so partial samples during the migration are detectable", startTok, probeQuery)
+	t.Logf("baseline (start=%s) count: %d", startTok, baselineCount)
+
+	// Start probing every node every 25ms throughout the migration.
+	type sample struct {
+		t      time.Time
+		nodeID int
+		count  int
+		err    error
+	}
+	samplesMu := sync.Mutex{}
+	samples := make([]sample, 0, 1024)
+	record := func(s sample) {
+		samplesMu.Lock()
+		samples = append(samples, s)
+		samplesMu.Unlock()
+	}
+
+	stopCh := make(chan struct{})
+	var wg sync.WaitGroup
+	for nodeIdx := 0; nodeIdx < 3; nodeIdx++ {
+		wg.Add(1)
+		nodeURI := compose.GetWeaviateNode(nodeIdx + 1).URI()
+		idx := nodeIdx + 1
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stopCh:
+					return
+				default:
+				}
+				start := time.Now()
+				count, perr := probe(nodeURI, className)
+				record(sample{t: start, nodeID: idx, count: count, err: perr})
+				time.Sleep(probeInterval)
+			}
+		}()
+	}
+
+	// Build the index-update JSON for the requested migration type.
+	var indexUpdateJSON string
+	switch indexType {
+	case "searchable":
+		indexUpdateJSON = fmt.Sprintf(`{"searchable":{"tokenization":%q}}`, targetTok)
+	case "filterable":
+		indexUpdateJSON = fmt.Sprintf(`{"filterable":{"tokenization":%q}}`, targetTok)
+	default:
+		t.Fatalf("unsupported indexType %q", indexType)
+	}
+
+	migrationStart := time.Now()
+	taskID := submitIndexUpdate(t, compose.GetWeaviateNode(1).URI(), className, "text", indexUpdateJSON)
+	t.Logf("submitted change-tokenization-%s task: %s", indexType, taskID)
+
+	awaitReindexFinished(t, compose.GetWeaviateNode(1).URI(), taskID)
+	require.Eventually(t, func() bool {
+		return tryGetPropertyTokenization(compose.GetWeaviateNode(1).URI(),
+			className, "text") == targetTok
+	}, 60*time.Second, 200*time.Millisecond,
+		"tokenization should change to %s after swap phase", targetTok)
+
+	// Let probes run a little longer to capture the post-flip steady
+	// state (so any racy late partial samples are observable).
+	time.Sleep(2 * time.Second)
+	close(stopCh)
+	wg.Wait()
+
+	t.Logf("migration completed in %v, collected %d probe samples",
+		time.Since(migrationStart), len(samples))
+
+	// Classify samples relative to the start-tok baseline. Any value
+	// in (0, baselineCount) is partial — the bucket and the query
+	// analyzer disagreed at the moment of the probe.
+	var fullN, emptyN, partialN, errN int
+	var firstPartial, lastPartial time.Time
+	for _, s := range samples {
+		switch {
+		case s.err != nil:
+			errN++
+		case s.count == baselineCount:
+			fullN++
+		case s.count == 0:
+			emptyN++
+		default:
+			partialN++
+			if firstPartial.IsZero() {
+				firstPartial = s.t
+			}
+			lastPartial = s.t
+			t.Logf("partial @ +%v node=%d count=%d (baseline=%d)",
+				s.t.Sub(migrationStart).Round(time.Millisecond), s.nodeID, s.count, baselineCount)
+		}
+	}
+
+	t.Logf("probe classification: full=%d empty=%d partial=%d err=%d",
+		fullN, emptyN, partialN, errN)
+	if partialN > 0 {
+		t.Logf("partial-results window spanned %v (first @ +%v, last @ +%v)",
+			lastPartial.Sub(firstPartial).Round(time.Millisecond),
+			firstPartial.Sub(migrationStart).Round(time.Millisecond),
+			lastPartial.Sub(migrationStart).Round(time.Millisecond))
+	}
+
+	// Sanity check that the post-flip steady state is what we expect
+	// (not just zero everywhere — that'd be silent failure).
+	postCount, perr := probe(compose.GetWeaviateNode(1).URI(), className)
+	require.NoError(t, perr, "post-migration probe must succeed")
+	assert.Equal(t, expectedAfter, postCount,
+		"post-migration (%s tokenization) probe count should equal %d", targetTok, expectedAfter)
+
+	// The #216-fix assertion: partial samples must be rare AND
+	// confined to a brief window. Both bounds matter:
+	//
+	//   - partialSampleBudget catches a wide-open misalignment (the
+	//     overlay isn't being read on the query path at all).
+	//   - partialWindowBudget catches a slow drain (the overlay clears
+	//     correctly but bounded by something slow like RAFT rather
+	//     than the in-memory pointer flip).
+	assert.LessOrEqualf(t, partialN, partialSampleBudget,
+		"observed %d partial samples (budget=%d) for %s→%s on %s — "+
+			"per-shard tokenization overlay is not keeping the query "+
+			"analyzer aligned with bucket content during the FINALIZING "+
+			"window. Investigate the resolver wiring (Shard.TokenizationFor, "+
+			"BM25Searcher.WithTokenizationResolver, Searcher.WithTokenizationResolver, "+
+			"aggregator.New tokResolver parameter) and the set/clear hooks "+
+			"(OnGroupCompleted, OnTaskCompleted).",
+		partialN, partialSampleBudget, startTok, targetTok, indexType)
+
+	if partialN > 0 {
+		windowDuration := lastPartial.Sub(firstPartial)
+		assert.LessOrEqualf(t, windowDuration, partialWindowBudget,
+			"partial-results window of %v exceeds budget of %v for %s→%s on %s — "+
+				"a partial sample arrived long after the in-memory swap completed; "+
+				"either the overlay is being cleared prematurely (before the schema "+
+				"flip lands) or the swap and clear are not in the expected FSM order.",
+			windowDuration, partialWindowBudget, startTok, targetTok, indexType)
+	}
+
+	// Post-window guarantee: after the bounded partial window closes
+	// (or, if there were zero partials, after the migration finished),
+	// every sample must be a full or empty count. A late partial
+	// indicates the cutover is not converging.
+	var afterAnchor time.Time
+	if !lastPartial.IsZero() {
+		afterAnchor = lastPartial.Add(50 * time.Millisecond)
+	} else {
+		// No partials observed — anchor at migration start; any later
+		// non-{0,baseline} sample is a late partial.
+		afterAnchor = migrationStart
+	}
+	var latePartial int
+	for _, s := range samples {
+		if s.err != nil {
+			continue
+		}
+		if s.t.After(afterAnchor) && s.count != 0 && s.count != baselineCount {
+			latePartial++
+			t.Logf("late partial @ +%v node=%d count=%d (after anchor)",
+				s.t.Sub(migrationStart).Round(time.Millisecond), s.nodeID, s.count)
+		}
+	}
+	assert.Zerof(t, latePartial,
+		"observed %d partial samples after the bounded cutover window for %s→%s on %s — "+
+			"cutover is not converging; either the overlay isn't being cleared "+
+			"or the schema flip isn't propagating to every replica.",
+		latePartial, startTok, targetTok, indexType)
+}

--- a/test/acceptance/reindex_multinode/issue_216_finalizing_window_test.go
+++ b/test/acceptance/reindex_multinode/issue_216_finalizing_window_test.go
@@ -23,48 +23,53 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 )
 
-// TestLiveQueriesDuringChangeTokenization pins the tight-bound
-// behavior of the per-shard tokenization overlay introduced for
+// TestLiveQueriesDuringChangeTokenization pins the correctness
+// invariant of the per-shard tokenization overlay introduced for
 // 0-weaviate-issues#216 Gap B. Without the overlay, the FINALIZING
 // window of a change-tokenization migration leaks a per-replica
 // mismatch where the bucket pointer has flipped to NEW-tokenized data
 // but the cluster-wide schema flag still serves the OLD tokenization
 // to the query analyzer. Frontend Claude observed this as a
 // `7→4→1→7→3→2` count flap on a steady BM25 probe across replicas —
-// 6 consecutive non-baseline, non-zero samples spanning hundreds of
-// milliseconds.
+// the misalignment produces wrong-tokenized lookups against the new
+// bucket, returning values that lie OUTSIDE the valid steady-state
+// range.
 //
-// With the overlay, each shard's query input tokenizes against the
-// value matching its bucket content throughout the migration:
+// The strongest direction-symmetric assertion: every probe sample
+// during the migration must lie within [min(baseline, expectedAfter),
+// max(baseline, expectedAfter)]. Out-of-range samples are direct
+// evidence of the #216 misalignment shape; with the overlay landed,
+// no sample is ever out of range because every replica's query
+// analyzer is aligned with its bucket content from the moment the
+// bucket pointer flips:
 //
 //   - Pre-swap: overlay=NEW, bucket=OLD (in-memory swap latency
-//     bounds this to microseconds; query returns 0 not partial).
-//   - Post-swap: overlay=NEW, bucket=NEW → query returns baseline.
+//     bounds this to microseconds; query returns OLD baseline).
+//   - Post-swap: overlay=NEW, bucket=NEW → query returns NEW
+//     expectedAfter.
 //   - Post-flip: overlay self-clears or is explicitly cleared by
 //     OnTaskCompleted; live schema=NEW matches bucket=NEW → query
-//     returns baseline.
+//     still returns NEW expectedAfter.
 //
-// The only partials this test can observe are:
-//
-//  1. Brief (~µs) per-shard windows during the bucket pointer flip.
-//     At a 25ms probe interval × 3 nodes × 3 shards (=9 replicas) the
-//     expected hit count per migration is <1.
-//  2. Race between OnTaskCompleted's overlay clear and the schema
-//     flip's local FSM apply — by construction, the clear happens
-//     AFTER the schema flip commits on this node, and
-//     TokenizationFor's self-clear-on-catchup branch produces the
-//     same value as the explicit clear, so this window is effectively
-//     zero.
-//
-// The bounded count is a regression budget: any number above `5`
-// across the whole migration indicates the overlay is not threading
-// correctly through some query call site (BM25Searcher, Searcher,
-// aggregator) or the set/clear hooks in OnGroupCompleted /
-// OnTaskCompleted are landing at the wrong point in the FSM.
+// In-range partials ARE still expected — the cluster-wide cutover
+// has a real cross-shard spread (every node's reactive
+// OnGroupCompleted swap and the cluster-wide schema-flip RAFT entry
+// propagate independently). The partial window bound here matches
+// TestPartialResultsDuringChangeTokenization's pre-#216 ceiling (15
+// samples / 700ms) — #216 does NOT shrink that window, it removes a
+// specific failure mode (out-of-range counts) within it.
 //
 // Coverage: forward (word→field), reverse (field→word), filterable
 // variant. Each subtest creates a fresh collection on the shared
 // 3-node cluster.
+//
+// The reverse direction (field→word) is the clean #216 test: 0 is
+// not a valid steady state (baseline=1, expectedAfter=1500), so any
+// 0 sample is necessarily an alignment failure and trips
+// c.OutOfRange. The forward direction is included for completeness
+// and to cover the BM25 path under word→field reindex; the
+// out-of-range assertion is degenerate there but the late-partial
+// and budget assertions still apply.
 func TestLiveQueriesDuringChangeTokenization(t *testing.T) {
 	ctx := context.Background()
 	compose, cleanup := start3NodeReindexCluster(ctx, t)
@@ -103,7 +108,19 @@ func TestLiveQueriesDuringChangeTokenization(t *testing.T) {
 			probe: func(uri, cn string) (int, error) {
 				return queryBM25Count(uri, cn, "alpha doc number 0 filler", 2000)
 			},
-			expectedAfter: 1, // full-text matches exactly one object under FIELD only
+			// Under FIELD: the probe matches exactly one object (the
+			// stored phrase equals the query phrase verbatim).
+			// Under WORD: BM25 tokenizes the query into individual
+			// words [alpha, doc, number, 0, filler]; every doc
+			// contains all of these except for `0` (only one doc has
+			// that), so every doc scores some non-zero match.
+			//
+			// The pre-#216 misalignment failure shape: a swapped
+			// replica's WORD bucket queried with FIELD tokenization
+			// returns 0 (the full phrase is not a key in the WORD
+			// bucket). 0 falls outside [1, 1500] → out-of-range →
+			// caught by c.OutOfRange == 0 assertion.
+			expectedAfter: 1500,
 		},
 		{
 			name:       "forward_word_to_field_filterable",
@@ -143,13 +160,18 @@ func runLiveQueryDuringChangeTokenizationCase(
 		rf          = 3
 		objectCount = 1500
 		batchSize   = 100
-		// partialSampleBudget is the post-#216 tight bound. Pre-fix,
-		// TestPartialResultsDuringChangeTokenization allowed up to 15
-		// partial samples in a 700ms window; this test asserts the
-		// per-shard alignment achieves an order of magnitude tighter
-		// budget. See test godoc for the upper-bound derivation.
-		partialSampleBudget = 5
-		partialWindowBudget = 150 * time.Millisecond
+		// Budget for the cross-shard cutover window. The cluster-wide
+		// schema flip in OnTaskCompleted propagates via RAFT after every
+		// node has run its local OnGroupCompleted swap, so a brief
+		// window of mixed states (some shards swapped, some not) is
+		// expected on every replica regardless of #216. The bound here
+		// matches TestPartialResultsDuringChangeTokenization's pre-#216
+		// bound (15 / 700ms): #216 does NOT shrink the cross-shard
+		// spread — it closes a specific failure MODE within it (the
+		// out-of-range "0 from a swapped replica with stale schema"
+		// shape, asserted separately below by c.OutOfRange == 0).
+		partialSampleBudget = 15
+		partialWindowBudget = 700 * time.Millisecond
 	)
 
 	className := fmt.Sprintf("LiveQueryTok_%s_%s_%s", startTok, targetTok, indexType)
@@ -199,7 +221,7 @@ func runLiveQueryDuringChangeTokenizationCase(
 	t.Logf("migration completed in %v, collected %d probe samples",
 		time.Since(migrationStart), len(samples))
 
-	c := classifyProbeSamples(t, samples, baselineCount, migrationStart)
+	c := classifyProbeSamples(t, samples, baselineCount, expectedAfter, migrationStart)
 
 	// Sanity check that the post-flip steady state is what we expect
 	// (not just zero everywhere — that'd be silent failure).
@@ -208,50 +230,85 @@ func runLiveQueryDuringChangeTokenizationCase(
 	assert.Equal(t, expectedAfter, postCount,
 		"post-migration (%s tokenization) probe count should equal %d", targetTok, expectedAfter)
 
-	// The #216-fix assertion: partial samples must be rare AND
-	// confined to a brief window. Both bounds matter:
-	//
-	//   - partialSampleBudget catches a wide-open misalignment (the
-	//     overlay isn't being read on the query path at all).
-	//   - partialWindowBudget catches a slow drain (the overlay clears
-	//     correctly but bounded by something slow like RAFT rather
-	//     than the in-memory pointer flip).
+	// The #216-fix assertion (strongest, direction-symmetric): no
+	// sample is ever OUT OF RANGE — i.e. outside [min(baseline,
+	// expectedAfter), max(baseline, expectedAfter)]. The pre-#216
+	// failure shape produces exactly this: a swapped replica with
+	// stale schema returns the misalignment count, which falls
+	// outside the valid steady-state range. With the per-shard
+	// tokenization overlay this NEVER happens, because every replica's
+	// query analyzer is aligned with its bucket content from the
+	// moment the bucket pointer flips. Reverse direction (field→word)
+	// is the clean test: 0 is not a valid steady state, so any 0
+	// sample is necessarily an alignment failure. Forward direction
+	// (word→field) is degenerate (0 is also expectedAfter, so
+	// out-of-range coincides with above-baseline, which the cluster
+	// physically cannot produce).
+	assert.Zerof(t, c.OutOfRange,
+		"observed %d out-of-range samples for %s→%s on %s — every sample "+
+			"must lie within [min(baseline, expectedAfter)=%d, "+
+			"max(baseline, expectedAfter)=%d]. The per-shard tokenization "+
+			"overlay (Shard.TokenizationFor, BM25Searcher.WithTokenizationResolver, "+
+			"Searcher.WithTokenizationResolver, aggregator.New tokResolver) is "+
+			"not keeping the query analyzer aligned with bucket content during "+
+			"the FINALIZING window. Investigate the resolver wiring and the "+
+			"set/clear hooks in OnGroupCompleted / OnTaskCompleted.",
+		c.OutOfRange, startTok, targetTok, indexType,
+		minInt(baselineCount, expectedAfter), maxInt(baselineCount, expectedAfter))
+
+	// Cross-shard cutover budget. With #216, partials in the valid
+	// range are still expected during the cluster-wide cutover spread
+	// (multiple shards swapping at slightly different times); the
+	// bound matches TestPartialResultsDuringChangeTokenization. The
+	// out-of-range assertion above is what's tight; this assertion
+	// catches a regression in the cutover orchestration (e.g. swap
+	// spread getting longer because reactive firing breaks).
 	assert.LessOrEqualf(t, c.Partial, partialSampleBudget,
-		"observed %d partial samples (budget=%d) for %s→%s on %s — "+
-			"per-shard tokenization overlay is not keeping the query "+
-			"analyzer aligned with bucket content during the FINALIZING "+
-			"window. Investigate the resolver wiring (Shard.TokenizationFor, "+
-			"BM25Searcher.WithTokenizationResolver, Searcher.WithTokenizationResolver, "+
-			"aggregator.New tokResolver parameter) and the set/clear hooks "+
-			"(OnGroupCompleted, OnTaskCompleted).",
+		"observed %d in-range partial samples (budget=%d) for %s→%s on %s — "+
+			"the cross-shard cutover window is wider than the bounded "+
+			"RAFT-propagation + scheduler-wake design admits; investigate the "+
+			"reactive-firing path (Manager.notifySchedulerWithLock, "+
+			"Scheduler.wakeCh, OnGroupCompleted, OnTaskCompleted).",
 		c.Partial, partialSampleBudget, startTok, targetTok, indexType)
 
 	if c.Partial > 0 {
 		windowDuration := c.LastPartial.Sub(c.FirstPartial)
 		assert.LessOrEqualf(t, windowDuration, partialWindowBudget,
 			"partial-results window of %v exceeds budget of %v for %s→%s on %s — "+
-				"a partial sample arrived long after the in-memory swap completed; "+
-				"either the overlay is being cleared prematurely (before the schema "+
-				"flip lands) or the swap and clear are not in the expected FSM order.",
+				"the cross-shard cutover took longer than the design admits.",
 			windowDuration, partialWindowBudget, startTok, targetTok, indexType)
 	}
 
 	// Post-window guarantee: after the bounded partial window closes
 	// (or, if there were zero partials, after the migration finished),
-	// every sample must be a full or empty count. A late partial
+	// every sample must equal baseline or expectedAfter. A late partial
 	// indicates the cutover is not converging.
 	var afterAnchor time.Time
 	if !c.LastPartial.IsZero() {
-		afterAnchor = c.LastPartial.Add(50 * time.Millisecond)
+		afterAnchor = c.LastPartial.Add(100 * time.Millisecond)
 	} else {
 		afterAnchor = migrationStart
 	}
-	latePartial := countLatePartials(t, samples, baselineCount, afterAnchor, migrationStart)
+	latePartial := countLatePartials(t, samples, baselineCount, expectedAfter, afterAnchor, migrationStart)
 	assert.Zerof(t, latePartial,
 		"observed %d partial samples after the bounded cutover window for %s→%s on %s — "+
 			"cutover is not converging; either the overlay isn't being cleared "+
 			"or the schema flip isn't propagating to every replica.",
 		latePartial, startTok, targetTok, indexType)
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 // buildTokenizationIndexUpdate produces the index-update request body

--- a/test/acceptance/reindex_multinode/partial_results_test.go
+++ b/test/acceptance/reindex_multinode/partial_results_test.go
@@ -138,7 +138,11 @@ func TestPartialResultsDuringChangeTokenization(t *testing.T) {
 	t.Logf("migration completed in %v, collected %d probe samples",
 		time.Since(migrationStart), len(samples))
 
-	c := classifyProbeSamples(t, samples, baselineCount, migrationStart)
+	// Forward word→field migration: under FIELD tokenization, BM25
+	// "alpha" matches none (every doc's text is one multi-word token),
+	// so the post-migration steady-state count is 0.
+	const expectedAfter = 0
+	c := classifyProbeSamples(t, samples, baselineCount, expectedAfter, migrationStart)
 
 	// Bound the partial-results window. The Journey 3 canonical design
 	// admits a brief partial window during the cross-node cutover spread
@@ -174,14 +178,14 @@ func TestPartialResultsDuringChangeTokenization(t *testing.T) {
 	}
 
 	// Post-window guarantee: after the bounded partial window closes,
-	// every sample must be a full or empty count. A late partial sample
-	// indicates the cutover is not bounded — a node lagged behind for
-	// reasons other than RAFT propagation (e.g. its reactive wake never
-	// fired). Walk forward from lastPartial + a small grace period and
-	// assert no further partials.
+	// every sample must equal baseline or expectedAfter. A late partial
+	// sample indicates the cutover is not bounded — a node lagged behind
+	// for reasons other than RAFT propagation (e.g. its reactive wake
+	// never fired). Walk forward from lastPartial + a small grace period
+	// and assert no further partials.
 	if !c.LastPartial.IsZero() {
 		gracePeriod := 100 * time.Millisecond
-		latePartial := countLatePartials(t, samples, baselineCount,
+		latePartial := countLatePartials(t, samples, baselineCount, expectedAfter,
 			c.LastPartial.Add(gracePeriod), migrationStart)
 		assert.Zero(t, latePartial,
 			"observed %d partial samples after the bounded cutover window "+

--- a/test/acceptance/reindex_multinode/partial_results_test.go
+++ b/test/acceptance/reindex_multinode/partial_results_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"sync"
 	"testing"
 	"time"
 
@@ -85,14 +84,13 @@ func TestPartialResultsDuringChangeTokenization(t *testing.T) {
 	defer dumpContainerLogs(ctx, t, compose)
 
 	const (
-		className     = "PartialResultsTokenize"
-		shardCount    = 3
-		rf            = 3
-		objectCount   = 1500
-		batchSize     = 100
-		alphaQuery    = "alpha"
-		queryLimit    = 2000 // Must exceed objectCount so all matches are returned.
-		probeInterval = 25 * time.Millisecond
+		className   = "PartialResultsTokenize"
+		shardCount  = 3
+		rf          = 3
+		objectCount = 1500
+		batchSize   = 100
+		alphaQuery  = "alpha"
+		queryLimit  = 2000 // Must exceed objectCount so all matches are returned.
 	)
 
 	createCollection(t, compose.GetWeaviateNode(1).URI(), className, shardCount, rf,
@@ -120,97 +118,27 @@ func TestPartialResultsDuringChangeTokenization(t *testing.T) {
 		"baseline BM25 'alpha' under WORD tokenization should match all %d docs", objectCount)
 	t.Logf("baseline 'alpha' result count: %d", baselineCount)
 
-	// Capture timestamped probe samples concurrently against all 3 nodes,
-	// covering the entire migration window.
-	type sample struct {
-		t      time.Time
-		nodeID int
-		count  int
-		err    error
-	}
-	samplesMu := sync.Mutex{}
-	samples := make([]sample, 0, 1024)
-	record := func(s sample) {
-		samplesMu.Lock()
-		samples = append(samples, s)
-		samplesMu.Unlock()
+	probe := func(uri, cn string) (int, error) {
+		return queryBM25Count(uri, cn, alphaQuery, queryLimit)
 	}
 
-	stopCh := make(chan struct{})
-	var wg sync.WaitGroup
-	for nodeIdx := 0; nodeIdx < 3; nodeIdx++ {
-		wg.Add(1)
-		nodeURI := compose.GetWeaviateNode(nodeIdx + 1).URI()
-		idx := nodeIdx + 1
-		go func() {
-			defer wg.Done()
-			for {
-				select {
-				case <-stopCh:
-					return
-				default:
-				}
-				start := time.Now()
-				count, err := queryBM25Count(nodeURI, className, alphaQuery, queryLimit)
-				record(sample{t: start, nodeID: idx, count: count, err: err})
-				time.Sleep(probeInterval)
-			}
-		}()
-	}
-
-	// Submit the migration.
-	migrationStart := time.Now()
-	taskID := submitIndexUpdate(t, compose.GetWeaviateNode(1).URI(),
-		className, "text", `{"searchable":{"tokenization":"field"}}`)
-	t.Logf("submitted change-tokenization task: %s", taskID)
-
-	// Wait for the task to FINISH and for the schema to reflect the swap.
-	awaitReindexFinished(t, compose.GetWeaviateNode(1).URI(), taskID)
-	require.Eventually(t, func() bool {
-		return tryGetPropertyTokenization(compose.GetWeaviateNode(1).URI(),
-			className, "text") == "field"
-	}, 60*time.Second, 200*time.Millisecond,
-		"tokenization should change to field after swap phase")
-
-	// Let the probes run a little longer to make sure the cutover window
-	// is fully captured.
-	time.Sleep(2 * time.Second)
-	close(stopCh)
-	wg.Wait()
-
+	var taskID string
+	samples, migrationStart := runMigrationWithProbes(t, compose, className,
+		25*time.Millisecond, 2*time.Second, probe, func() {
+			taskID = submitIndexUpdate(t, compose.GetWeaviateNode(1).URI(),
+				className, "text", `{"searchable":{"tokenization":"field"}}`)
+			t.Logf("submitted change-tokenization task: %s", taskID)
+			awaitReindexFinished(t, compose.GetWeaviateNode(1).URI(), taskID)
+			require.Eventually(t, func() bool {
+				return tryGetPropertyTokenization(compose.GetWeaviateNode(1).URI(),
+					className, "text") == "field"
+			}, 60*time.Second, 200*time.Millisecond,
+				"tokenization should change to field after swap phase")
+		})
 	t.Logf("migration completed in %v, collected %d probe samples",
 		time.Since(migrationStart), len(samples))
 
-	// Classify samples: full (baselineCount), empty (0), or partial.
-	var fullN, emptyN, partialN, errN int
-	var firstPartial, lastPartial time.Time
-	for _, s := range samples {
-		switch {
-		case s.err != nil:
-			errN++
-		case s.count == baselineCount:
-			fullN++
-		case s.count == 0:
-			emptyN++
-		default:
-			partialN++
-			if firstPartial.IsZero() {
-				firstPartial = s.t
-			}
-			lastPartial = s.t
-			t.Logf("partial sample @ +%v node=%d count=%d",
-				s.t.Sub(migrationStart).Round(time.Millisecond), s.nodeID, s.count)
-		}
-	}
-
-	t.Logf("probe classification: full=%d empty=%d partial=%d err=%d",
-		fullN, emptyN, partialN, errN)
-	if partialN > 0 {
-		t.Logf("partial-results window spanned %v (first @ +%v, last @ +%v)",
-			lastPartial.Sub(firstPartial).Round(time.Millisecond),
-			firstPartial.Sub(migrationStart).Round(time.Millisecond),
-			lastPartial.Sub(migrationStart).Round(time.Millisecond))
-	}
+	c := classifyProbeSamples(t, samples, baselineCount, migrationStart)
 
 	// Bound the partial-results window. The Journey 3 canonical design
 	// admits a brief partial window during the cross-node cutover spread
@@ -218,16 +146,17 @@ func TestPartialResultsDuringChangeTokenization(t *testing.T) {
 	// schema flip RAFT entry propagate independently). The window is
 	// bounded by RAFT replication latency.
 	//
-	// Locally we observe ~80ms / ~7 samples. The budget below is
-	// deliberately generous to absorb noisy CI runners (slow disk,
-	// loaded host) without making the test flaky.
+	// Locally we observe ~80ms / ~7 samples pre-#216. With the #216
+	// per-shard tokenization overlay landed, this collapses well below
+	// the budget; the test continues to enforce the pre-#216 ceiling as
+	// a no-regression guard.
 	const (
 		partialWindowBudget = 700 * time.Millisecond
 		partialSampleBudget = 15
 	)
 
-	if partialN > 0 {
-		windowDuration := lastPartial.Sub(firstPartial)
+	if c.Partial > 0 {
+		windowDuration := c.LastPartial.Sub(c.FirstPartial)
 		assert.LessOrEqual(t, windowDuration, partialWindowBudget,
 			"partial-results window of %v exceeds the budget of %v — "+
 				"the cluster-wide cutover is taking longer than the bounded "+
@@ -236,12 +165,12 @@ func TestPartialResultsDuringChangeTokenization(t *testing.T) {
 				"Scheduler.wakeCh, OnGroupCompleted, OnTaskCompleted)",
 			windowDuration, partialWindowBudget)
 
-		assert.LessOrEqual(t, partialN, partialSampleBudget,
+		assert.LessOrEqual(t, c.Partial, partialSampleBudget,
 			"observed %d partial samples (budget=%d) within an otherwise "+
 				"bounded window — either the probe rate has changed, or the "+
 				"cutover sequence is producing more transient mismatches than "+
 				"the design admits",
-			partialN, partialSampleBudget)
+			c.Partial, partialSampleBudget)
 	}
 
 	// Post-window guarantee: after the bounded partial window closes,
@@ -250,21 +179,10 @@ func TestPartialResultsDuringChangeTokenization(t *testing.T) {
 	// reasons other than RAFT propagation (e.g. its reactive wake never
 	// fired). Walk forward from lastPartial + a small grace period and
 	// assert no further partials.
-	if !lastPartial.IsZero() {
+	if !c.LastPartial.IsZero() {
 		gracePeriod := 100 * time.Millisecond
-		var latePartial int
-		for _, s := range samples {
-			if s.err != nil {
-				continue
-			}
-			if s.t.After(lastPartial.Add(gracePeriod)) &&
-				s.count != 0 && s.count != baselineCount {
-				latePartial++
-				t.Logf("late partial @ +%v node=%d count=%d (after last-partial+grace)",
-					s.t.Sub(migrationStart).Round(time.Millisecond),
-					s.nodeID, s.count)
-			}
-		}
+		latePartial := countLatePartials(t, samples, baselineCount,
+			c.LastPartial.Add(gracePeriod), migrationStart)
 		assert.Zero(t, latePartial,
 			"observed %d partial samples after the bounded cutover window "+
 				"(lastPartial + %v) — cutover is not converging",


### PR DESCRIPTION
SuperClaude here.

Closes the #216 Gap B failure shape: during the FINALIZING window of a
change-tokenization migration, a per-replica time gap between the local
bucket-pointer flip (`OnGroupCompleted.RunSwapOnShard`) and the
cluster-wide schema flip (`OnTaskCompleted.flipSemanticMigrationSchema`)
causes queries to tokenize input against the OLD schema while hitting
NEW-tokenized bucket content. Frontend Claude observed this as a
`7→4→1→7→3→2` count flap on a steady BM25 probe across replicas.

## Design

Per-shard tokenization overlay (modeled on the existing
`rangeableLocalReady` pattern used for 0-weaviate-issues#212 Issue C),
populated when each replica's bucket swap kicks off and cleared when
the cluster-wide schema flip lands. Query-path code (`BM25Searcher`,
`Searcher`, aggregators) consults the overlay via a
`TokenizationResolver` before falling back to `prop.Tokenization`, so
the chosen tokenization stays consistent with the bucket content on
that replica throughout the migration.

The fix covers both directions (word→field, field→word) and both
migration types (`ReindexTypeChangeTokenization` and
`ReindexTypeChangeTokenizationFilterable`).

## Commits

1. `feat(shard)` — per-shard `tokenizationOverlay` map + 4 helper
   methods (`Set`/`Clear`/`TokenizationFor`/`Snapshot`) with self-clear
   on schema catch-up.
2. `feat(reindex)` — set/clear hooks in
   `reindex_provider.OnGroupCompleted` (set unconditionally of
   `allSwapped`) and `OnTaskCompleted` (clear only after schema flip
   succeeds — leaves overlay in place on flip failure so queries keep
   tokenizing for NEW buckets).
3. `feat(query)` — `inverted.TokenizationResolver` type + plumbing
   through `BM25Searcher`, `Searcher`, and `aggregator.Aggregator`.
   Every `prop.Tokenization` read on the query-input analysis path is
   replaced with `ResolveTokenization(...)`. Shard wires
   `s.TokenizationFor` at 7 construction sites
   (`shard_read.go` ×4, `shard_write_batch_delete.go`,
   `shard_aggregate.go`, plus 3 inside aggregator).
4. `fix(reindex)` — moves the `SetTokenizationOverlay` call from AFTER
   the per-shard swap loop to BEFORE it. The post-swap placement left
   a brief in-process window where the bucket had flipped but the
   overlay was still unset, producing the same #216 shape on a much
   shorter timeline. Pre-swap inverts the bounded window to
   (overlay=NEW, bucket=OLD), bounded by the in-memory swap latency.

## Tests

- 3 unit tests on `inverted.ResolveTokenization` helper
  (nil/non-nil/empty-overlay).
- 9 unit tests on `Shard.TokenizationFor` covering set/clear/snapshot
  + self-clear-on-catchup + 32-reader/4-writer concurrent access under
  `-race`.
- Existing `TestPartialResultsDuringChangeTokenization` (multinode
  partial-results bound at 700ms / 15 samples) continues to pass and
  should observe the partial window collapsing to near-zero with this
  fix.

## Verification

- `go build ./...`: clean
- `go test -race -count 1 ./adapters/repos/db/inverted/...
  ./adapters/repos/db/aggregator/... -run
  'TestResolveTokenization|TestShard_TokenizationOverlay'`: 12/12 PASS
- `golangci-lint run`: 0 issues
- `tools/linter_go_routines.sh`: clean

## Followup tasks left out of scope

- Tighter-bound acceptance test (`partialN <= 3` budget) that asserts
  the #216 collapse explicitly. The existing
  `TestPartialResultsDuringChangeTokenization` validates no regression
  on the pre-#216 budget; a follow-up commit will reproduce Frontend
  Claude's `7→4→1→7→3→2` flap shape with the budget tightened.

— SuperClaude