### PR TITLE
Make cache eviction inline

### DIFF
--- a/adapters/repos/db/vector/cache/cache.go
+++ b/adapters/repos/db/vector/cache/cache.go
@@ -13,10 +13,7 @@ package cache
 
 import (
 	"context"
-	"time"
 )
-
-const DefaultDeletionInterval = 3 * time.Second
 
 type MultiCache[T any] interface {
 	PreloadMulti(docID uint64, ids []uint64, vecs [][]T)

--- a/adapters/repos/db/vector/cache/sharded_lock_cache.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache.go
@@ -15,11 +15,9 @@ import (
 	"context"
 	"sync"
 	"sync/atomic"
-	"time"
 	"unsafe"
 
 	"github.com/pkg/errors"
-	enterrors "github.com/weaviate/weaviate/entities/errors"
 	"github.com/weaviate/weaviate/usecases/memwatch"
 
 	"github.com/sirupsen/logrus"
@@ -35,9 +33,7 @@ type shardedLockCache[T float32 | byte | uint64] struct {
 	normalizeOnRead        bool
 	maxSize                int64
 	count                  int64
-	cancel                 chan bool
 	logger                 logrus.FieldLogger
-	deletionInterval       time.Duration
 	allocChecker           memwatch.AllocChecker
 
 	// The maintenanceLock makes sure that only one maintenance operation, such
@@ -55,7 +51,7 @@ const (
 )
 
 func NewShardedFloat32LockCache(vecForID common.VectorForID[float32], multiVecForID common.VectorForID[[]float32], maxSize int, pageSize uint64,
-	logger logrus.FieldLogger, normalizeOnRead bool, deletionInterval time.Duration,
+	logger logrus.FieldLogger, normalizeOnRead bool,
 	allocChecker memwatch.AllocChecker,
 ) Cache[float32] {
 	vc := &shardedLockCache[float32]{
@@ -74,59 +70,50 @@ func NewShardedFloat32LockCache(vecForID common.VectorForID[float32], multiVecFo
 		normalizeOnRead:        normalizeOnRead,
 		count:                  0,
 		maxSize:                int64(maxSize),
-		cancel:                 make(chan bool),
 		logger:                 logger,
 		shardedLocks:           common.NewShardedRWLocksWithPageSize(pageSize),
 		maintenanceLock:        sync.RWMutex{},
-		deletionInterval:       deletionInterval,
 		allocChecker:           allocChecker,
 	}
 
-	vc.watchForDeletion()
 	return vc
 }
 
 func NewShardedByteLockCache(vecForID common.VectorForID[byte], maxSize int, pageSize uint64,
-	logger logrus.FieldLogger, deletionInterval time.Duration,
+	logger logrus.FieldLogger,
 	allocChecker memwatch.AllocChecker,
 ) Cache[byte] {
 	vc := &shardedLockCache[byte]{
-		vectorForID:      vecForID,
-		cache:            make([][]byte, InitialSize),
-		normalizeOnRead:  false,
-		count:            0,
-		maxSize:          int64(maxSize),
-		cancel:           make(chan bool),
-		logger:           logger,
-		shardedLocks:     common.NewShardedRWLocksWithPageSize(pageSize),
-		maintenanceLock:  sync.RWMutex{},
-		deletionInterval: deletionInterval,
-		allocChecker:     allocChecker,
+		vectorForID:     vecForID,
+		cache:           make([][]byte, InitialSize),
+		normalizeOnRead: false,
+		count:           0,
+		maxSize:         int64(maxSize),
+		logger:          logger,
+		shardedLocks:    common.NewShardedRWLocksWithPageSize(pageSize),
+		maintenanceLock: sync.RWMutex{},
+		allocChecker:    allocChecker,
 	}
 
-	vc.watchForDeletion()
 	return vc
 }
 
 func NewShardedUInt64LockCache(vecForID common.VectorForID[uint64], maxSize int, pageSize uint64,
-	logger logrus.FieldLogger, deletionInterval time.Duration,
+	logger logrus.FieldLogger,
 	allocChecker memwatch.AllocChecker,
 ) Cache[uint64] {
 	vc := &shardedLockCache[uint64]{
-		vectorForID:      vecForID,
-		cache:            make([][]uint64, InitialSize),
-		normalizeOnRead:  false,
-		count:            0,
-		maxSize:          int64(maxSize),
-		cancel:           make(chan bool),
-		logger:           logger,
-		shardedLocks:     common.NewShardedRWLocksWithPageSize(pageSize),
-		maintenanceLock:  sync.RWMutex{},
-		deletionInterval: deletionInterval,
-		allocChecker:     allocChecker,
+		vectorForID:     vecForID,
+		cache:           make([][]uint64, InitialSize),
+		normalizeOnRead: false,
+		count:           0,
+		maxSize:         int64(maxSize),
+		logger:          logger,
+		shardedLocks:    common.NewShardedRWLocksWithPageSize(pageSize),
+		maintenanceLock: sync.RWMutex{},
+		allocChecker:    allocChecker,
 	}
 
-	vc.watchForDeletion()
 	return vc
 }
 
@@ -190,6 +177,7 @@ func (s *shardedLockCache[T]) handleCacheMiss(ctx context.Context, id uint64) ([
 	}
 
 	atomic.AddInt64(&s.count, 1)
+	s.replaceIfFull()
 
 	if vec != nil {
 		s.shardedLocks.Lock(id)
@@ -349,9 +337,6 @@ func (s *shardedLockCache[T]) CountVectors() int64 {
 
 func (s *shardedLockCache[T]) Drop() {
 	s.deleteAllVectors()
-	if s.deletionInterval != 0 {
-		s.cancel <- true
-	}
 }
 
 func (s *shardedLockCache[T]) deleteAllVectors() {
@@ -365,24 +350,6 @@ func (s *shardedLockCache[T]) deleteAllVectors() {
 	}
 
 	atomic.StoreInt64(&s.count, 0)
-}
-
-func (s *shardedLockCache[T]) watchForDeletion() {
-	if s.deletionInterval != 0 {
-		f := func() {
-			t := time.NewTicker(s.deletionInterval)
-			defer t.Stop()
-			for {
-				select {
-				case <-s.cancel:
-					return
-				case <-t.C:
-					s.replaceIfFull()
-				}
-			}
-		}
-		enterrors.GoWrapper(f, s.logger)
-	}
 }
 
 func (s *shardedLockCache[T]) replaceIfFull() {
@@ -442,10 +409,7 @@ type shardedMultipleLockCache[T float32 | uint64 | byte] struct {
 	normalizeOnRead        bool
 	maxSize                int64
 	count                  int64
-	ctx                    context.Context
-	cancelFn               func()
 	logger                 logrus.FieldLogger
-	deletionInterval       time.Duration
 	allocChecker           memwatch.AllocChecker
 	vectorDocID            []CacheKeys
 	// Only used by multi vector caches
@@ -457,7 +421,7 @@ type shardedMultipleLockCache[T float32 | uint64 | byte] struct {
 }
 
 func NewShardedMultiFloat32LockCache(multipleVecForID common.VectorForID[[]float32], maxSize int,
-	logger logrus.FieldLogger, normalizeOnRead bool, deletionInterval time.Duration,
+	logger logrus.FieldLogger, normalizeOnRead bool,
 	allocChecker memwatch.AllocChecker,
 ) Cache[float32] {
 	multipleVecForIDValue := func(ctx context.Context, id uint64, relativeID uint64) ([]float32, error) {
@@ -487,19 +451,15 @@ func NewShardedMultiFloat32LockCache(multipleVecForID common.VectorForID[[]float
 		logger:                 logger,
 		shardedLocks:           common.NewDefaultShardedRWLocks(),
 		maintenanceLock:        sync.RWMutex{},
-		deletionInterval:       deletionInterval,
 		allocChecker:           allocChecker,
 		vectorDocID:            make([]CacheKeys, InitialSize),
 	}
 
-	vc.ctx, vc.cancelFn = context.WithCancel(context.Background())
-
-	vc.watchForDeletion()
 	return vc
 }
 
 func NewShardedMultiUInt64LockCache(multipleVecForID common.VectorForID[uint64], maxSize int,
-	logger logrus.FieldLogger, deletionInterval time.Duration,
+	logger logrus.FieldLogger,
 	allocChecker memwatch.AllocChecker,
 ) Cache[uint64] {
 	multipleVecForIDValue := func(ctx context.Context, id uint64, relativeID uint64) ([]uint64, error) {
@@ -520,20 +480,16 @@ func NewShardedMultiUInt64LockCache(multipleVecForID common.VectorForID[uint64],
 		logger:              logger,
 		shardedLocks:        common.NewDefaultShardedRWLocks(),
 		maintenanceLock:     sync.RWMutex{},
-		deletionInterval:    deletionInterval,
 		allocChecker:        allocChecker,
 		vectorDocID:         make([]CacheKeys, InitialSize),
 		fetchByNodeID:       true,
 	}
 
-	vc.ctx, vc.cancelFn = context.WithCancel(context.Background())
-
-	vc.watchForDeletion()
 	return vc
 }
 
 func NewShardedMultiByteLockCache(multipleVecForID common.VectorForID[byte], maxSize int,
-	logger logrus.FieldLogger, deletionInterval time.Duration,
+	logger logrus.FieldLogger,
 	allocChecker memwatch.AllocChecker,
 ) Cache[byte] {
 	multipleVecForIDValue := func(ctx context.Context, id uint64, relativeID uint64) ([]byte, error) {
@@ -554,15 +510,11 @@ func NewShardedMultiByteLockCache(multipleVecForID common.VectorForID[byte], max
 		logger:              logger,
 		shardedLocks:        common.NewDefaultShardedRWLocks(),
 		maintenanceLock:     sync.RWMutex{},
-		deletionInterval:    deletionInterval,
 		allocChecker:        allocChecker,
 		vectorDocID:         make([]CacheKeys, InitialSize),
 		fetchByNodeID:       true,
 	}
 
-	vc.ctx, vc.cancelFn = context.WithCancel(context.Background())
-
-	vc.watchForDeletion()
 	return vc
 }
 
@@ -681,6 +633,8 @@ func (s *shardedMultipleLockCache[T]) handleMultipleCacheMiss(ctx context.Contex
 	}
 
 	atomic.AddInt64(&s.count, 1)
+	s.replaceIfFull()
+
 	if len(vec) != 0 {
 		s.shardedLocks.Lock(id)
 		s.cache[id] = vec
@@ -778,9 +732,6 @@ func (s *shardedMultipleLockCache[T]) CountVectors() int64 {
 
 func (s *shardedMultipleLockCache[T]) Drop() {
 	s.deleteAllVectors()
-	if s.deletionInterval != 0 {
-		s.cancelFn()
-	}
 }
 
 func (s *shardedMultipleLockCache[T]) deleteAllVectors() {
@@ -795,24 +746,6 @@ func (s *shardedMultipleLockCache[T]) deleteAllVectors() {
 	}
 
 	atomic.StoreInt64(&s.count, 0)
-}
-
-func (s *shardedMultipleLockCache[T]) watchForDeletion() {
-	if s.deletionInterval != 0 {
-		f := func() {
-			t := time.NewTicker(s.deletionInterval)
-			defer t.Stop()
-			for {
-				select {
-				case <-s.ctx.Done():
-					return
-				case <-t.C:
-					s.replaceIfFull()
-				}
-			}
-		}
-		enterrors.GoWrapper(f, s.logger)
-	}
 }
 
 func (s *shardedMultipleLockCache[T]) replaceIfFull() {

--- a/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
+++ b/adapters/repos/db/vector/cache/sharded_lock_cache_test.go
@@ -31,7 +31,7 @@ func TestVectorCacheGrowth(t *testing.T) {
 	id := 100_000
 	expectedCount := int64(0)
 
-	vectorCache := NewShardedFloat32LockCache(vecForId, nil, 1_000_000, 1, logger, false, time.Duration(10_000), nil)
+	vectorCache := NewShardedFloat32LockCache(vecForId, nil, 1_000_000, 1, logger, false, nil)
 	initialSize := vectorCache.Len()
 	assert.Less(t, int(initialSize), id)
 	assert.Equal(t, expectedCount, vectorCache.CountVectors())
@@ -53,7 +53,7 @@ func TestCache_ParallelGrowth(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	var vecForId common.VectorForID[float32] = func(context.Context, uint64) ([]float32, error) { return nil, nil }
-	vectorCache := NewShardedFloat32LockCache(vecForId, nil, 1_000_000, 1, logger, false, time.Second, nil)
+	vectorCache := NewShardedFloat32LockCache(vecForId, nil, 1_000_000, 1, logger, false, nil)
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	count := 10_000
@@ -76,25 +76,21 @@ func TestCache_ParallelGrowth(t *testing.T) {
 
 func TestCacheCleanup(t *testing.T) {
 	logger, _ := test.NewNullLogger()
-	var vecForId common.VectorForID[float32] = nil
 
 	maxSize := 10
-	batchSize := maxSize - 1
-	deletionInterval := 200 * time.Millisecond // overwrite default deletionInterval of 3s
-	sleepDuration := deletionInterval + 100*time.Millisecond
 
-	t.Run("count is not reset on unnecessary deletion", func(t *testing.T) {
-		vectorCache := NewShardedFloat32LockCache(vecForId, nil, maxSize, 1, logger, false, deletionInterval, nil)
+	t.Run("no eviction below maxSize", func(t *testing.T) {
+		var vecForId common.VectorForID[float32] = nil
+		vectorCache := NewShardedFloat32LockCache(vecForId, nil, maxSize, 1, logger, false, nil)
 		shardedLockCache, ok := vectorCache.(*shardedLockCache[float32])
 		assert.True(t, ok)
 
-		for i := 0; i < batchSize; i++ {
+		for i := 0; i < maxSize-1; i++ {
 			shardedLockCache.Preload(uint64(i), []float32{float32(i), float32(i)})
 		}
-		time.Sleep(sleepDuration) // wait for deletion to fire
 
-		assert.Equal(t, batchSize, int(shardedLockCache.CountVectors()))
-		assert.Equal(t, batchSize, countCached(shardedLockCache))
+		assert.Equal(t, maxSize-1, int(shardedLockCache.CountVectors()))
+		assert.Equal(t, maxSize-1, countCached(shardedLockCache))
 
 		shardedLockCache.Drop()
 
@@ -102,23 +98,92 @@ func TestCacheCleanup(t *testing.T) {
 		assert.Equal(t, 0, countCached(shardedLockCache))
 	})
 
-	t.Run("deletion clears cache and counter when maxSize exceeded", func(t *testing.T) {
-		vectorCache := NewShardedFloat32LockCache(vecForId, nil, maxSize, 1, logger, false, deletionInterval, nil)
+	t.Run("eviction triggers on cache miss when at maxSize", func(t *testing.T) {
+		vecForId := func(ctx context.Context, id uint64) ([]float32, error) {
+			return []float32{float32(id)}, nil
+		}
+		vectorCache := NewShardedFloat32LockCache(vecForId, nil, maxSize, 1, logger, false, nil)
 		shardedLockCache, ok := vectorCache.(*shardedLockCache[float32])
 		assert.True(t, ok)
 
-		for b := 0; b < 2; b++ {
-			for i := 0; i < batchSize; i++ {
-				id := b*batchSize + i
-				shardedLockCache.Preload(uint64(id), []float32{float32(id), float32(id)})
-			}
-			time.Sleep(sleepDuration) // wait for deletion to fire, 2nd should clean the cache
+		// Preload to just below maxSize
+		for i := 0; i < maxSize-1; i++ {
+			shardedLockCache.Preload(uint64(i), []float32{float32(i)})
 		}
+		assert.Equal(t, maxSize-1, int(shardedLockCache.CountVectors()))
 
+		// This Get causes a cache miss, pushing count to maxSize, triggering eviction
+		vec, err := shardedLockCache.Get(context.Background(), uint64(maxSize-1))
+		assert.NoError(t, err)
+		assert.NotNil(t, vec)
+
+		// After eviction, count is reset to 0 (deleteAllVectors sets it to 0)
 		assert.Equal(t, 0, int(shardedLockCache.CountVectors()))
-		assert.Equal(t, 0, countCached(shardedLockCache))
 
 		shardedLockCache.Drop()
+	})
+
+	t.Run("concurrent cache misses near eviction boundary", func(t *testing.T) {
+		vecForId := func(ctx context.Context, id uint64) ([]float32, error) {
+			return []float32{float32(id)}, nil
+		}
+		concurrentMaxSize := 100
+		vectorCache := NewShardedFloat32LockCache(vecForId, nil, concurrentMaxSize, 1, logger, false, nil)
+
+		// Preload to just below maxSize
+		for i := 0; i < concurrentMaxSize-1; i++ {
+			vectorCache.(*shardedLockCache[float32]).Preload(uint64(i), []float32{float32(i)})
+		}
+
+		// Many goroutines trigger cache misses concurrently near the boundary
+		goroutines := 50
+		wg := new(sync.WaitGroup)
+		wg.Add(goroutines)
+		for i := 0; i < goroutines; i++ {
+			id := uint64(concurrentMaxSize + i)
+			go func(id uint64) {
+				defer wg.Done()
+				vectorCache.Grow(id)
+				vectorCache.Get(context.Background(), id)
+			}(id)
+		}
+		wg.Wait()
+
+		// No panic or deadlock means success. The cache should still be usable.
+		vec, err := vectorCache.Get(context.Background(), 0)
+		assert.NoError(t, err)
+		assert.NotNil(t, vec)
+
+		vectorCache.Drop()
+	})
+
+	t.Run("multiple eviction cycles", func(t *testing.T) {
+		vecForId := func(ctx context.Context, id uint64) ([]float32, error) {
+			return []float32{float32(id)}, nil
+		}
+		vectorCache := NewShardedFloat32LockCache(vecForId, nil, maxSize, 1, logger, false, nil)
+		c := vectorCache.(*shardedLockCache[float32])
+
+		for cycle := 0; cycle < 3; cycle++ {
+			// Fill to just below maxSize via Preload
+			base := cycle * maxSize
+			for i := 0; i < maxSize-1; i++ {
+				id := uint64(base + i)
+				c.Grow(id)
+				c.Preload(id, []float32{float32(id)})
+			}
+			assert.Equal(t, maxSize-1, int(c.CountVectors()))
+
+			// One more Get triggers eviction
+			triggerID := uint64(base + maxSize - 1)
+			c.Grow(triggerID)
+			vec, err := c.Get(context.Background(), triggerID)
+			assert.NoError(t, err)
+			assert.NotNil(t, vec)
+			assert.Equal(t, 0, int(c.CountVectors()))
+		}
+
+		c.Drop()
 	})
 }
 
@@ -142,7 +207,7 @@ func TestGetAllInCurrentLock(t *testing.T) {
 
 	t.Run("fully cached page", func(t *testing.T) {
 		// Setup a cache with some pre-loaded vectors
-		vectorCache := NewShardedFloat32LockCache(nil, nil, maxSize, pageSize, logger, false, 0, nil)
+		vectorCache := NewShardedFloat32LockCache(nil, nil, maxSize, pageSize, logger, false, nil)
 		cache := vectorCache.(*shardedLockCache[float32])
 
 		// Preload vectors for a full page
@@ -174,7 +239,7 @@ func TestGetAllInCurrentLock(t *testing.T) {
 			return []float32{float32(id * 100)}, nil
 		}
 
-		vectorCache := NewShardedFloat32LockCache(vecForID, nil, maxSize, pageSize, logger, false, 0, nil)
+		vectorCache := NewShardedFloat32LockCache(vecForID, nil, maxSize, pageSize, logger, false, nil)
 		cache := vectorCache.(*shardedLockCache[float32])
 
 		// Preload only some vectors
@@ -205,7 +270,7 @@ func TestGetAllInCurrentLock(t *testing.T) {
 	})
 
 	t.Run("page beyond cache size", func(t *testing.T) {
-		vectorCache := NewShardedFloat32LockCache(nil, nil, maxSize, pageSize, logger, false, 0, nil)
+		vectorCache := NewShardedFloat32LockCache(nil, nil, maxSize, pageSize, logger, false, nil)
 		cache := vectorCache.(*shardedLockCache[float32])
 
 		// Request vectors beyond current cache size
@@ -233,7 +298,7 @@ func TestGetAllInCurrentLock(t *testing.T) {
 			return nil, expectedErr
 		}
 
-		vectorCache := NewShardedFloat32LockCache(vecForID, nil, maxSize, pageSize, logger, false, 0, nil)
+		vectorCache := NewShardedFloat32LockCache(vecForID, nil, maxSize, pageSize, logger, false, nil)
 		cache := vectorCache.(*shardedLockCache[float32])
 
 		out := make([][]float32, pageSize)
@@ -257,7 +322,7 @@ func TestMultiVectorCacheGrowth(t *testing.T) {
 	id := 100_000
 	expectedCount := int64(0)
 
-	vectorCache := NewShardedMultiFloat32LockCache(multivecForId, 1_000_000, logger, false, time.Duration(10_000), nil)
+	vectorCache := NewShardedMultiFloat32LockCache(multivecForId, 1_000_000, logger, false, nil)
 	initialSize := vectorCache.Len()
 	assert.Less(t, int(initialSize), id)
 	assert.Equal(t, expectedCount, vectorCache.CountVectors())
@@ -279,7 +344,7 @@ func TestMultiCache_ParallelGrowth(t *testing.T) {
 
 	logger, _ := test.NewNullLogger()
 	var multivecForId common.VectorForID[[]float32] = func(context.Context, uint64) ([][]float32, error) { return nil, nil }
-	vectorCache := NewShardedMultiFloat32LockCache(multivecForId, 1_000_000, logger, false, time.Second, nil)
+	vectorCache := NewShardedMultiFloat32LockCache(multivecForId, 1_000_000, logger, false, nil)
 
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	count := 10_000
@@ -301,25 +366,21 @@ func TestMultiCache_ParallelGrowth(t *testing.T) {
 
 func TestMultiCacheCleanup(t *testing.T) {
 	logger, _ := test.NewNullLogger()
-	var multivecForId common.VectorForID[[]float32] = nil
 
 	maxSize := 10
-	batchSize := maxSize - 1
-	deletionInterval := 200 * time.Millisecond // overwrite default deletionInterval of 3s
-	sleepDuration := deletionInterval + 100*time.Millisecond
 
-	t.Run("count is not reset on unnecessary deletion", func(t *testing.T) {
-		vectorCache := NewShardedMultiFloat32LockCache(multivecForId, maxSize, logger, false, deletionInterval, nil)
+	t.Run("no eviction below maxSize", func(t *testing.T) {
+		var multivecForId common.VectorForID[[]float32] = nil
+		vectorCache := NewShardedMultiFloat32LockCache(multivecForId, maxSize, logger, false, nil)
 		shardedLockCache, ok := vectorCache.(*shardedMultipleLockCache[float32])
 		assert.True(t, ok)
 
-		for i := 0; i < batchSize; i++ {
+		for i := 0; i < maxSize-1; i++ {
 			shardedLockCache.PreloadMulti(uint64(i), []uint64{uint64(i)}, [][]float32{{float32(i), float32(i)}})
 		}
-		time.Sleep(sleepDuration) // wait for deletion to fire
 
-		assert.Equal(t, batchSize, int(shardedLockCache.CountVectors()))
-		assert.Equal(t, batchSize, countMultiCached(shardedLockCache))
+		assert.Equal(t, maxSize-1, int(shardedLockCache.CountVectors()))
+		assert.Equal(t, maxSize-1, countMultiCached(shardedLockCache))
 
 		shardedLockCache.Drop()
 
@@ -327,21 +388,31 @@ func TestMultiCacheCleanup(t *testing.T) {
 		assert.Equal(t, 0, countMultiCached(shardedLockCache))
 	})
 
-	t.Run("deletion clears cache and counter when maxSize exceeded", func(t *testing.T) {
-		vectorCache := NewShardedMultiFloat32LockCache(multivecForId, maxSize, logger, false, deletionInterval, nil)
+	t.Run("eviction triggers on cache miss when at maxSize", func(t *testing.T) {
+		multivecForId := func(ctx context.Context, id uint64) ([][]float32, error) {
+			return [][]float32{{float32(id)}}, nil
+		}
+		vectorCache := NewShardedMultiFloat32LockCache(multivecForId, maxSize, logger, false, nil)
 		shardedLockCache, ok := vectorCache.(*shardedMultipleLockCache[float32])
 		assert.True(t, ok)
 
-		for b := 0; b < 2; b++ {
-			for i := 0; i < batchSize; i++ {
-				id := b*batchSize + i
-				shardedLockCache.PreloadMulti(uint64(id), []uint64{uint64(id)}, [][]float32{{float32(id), float32(id)}})
-			}
-			time.Sleep(sleepDuration) // wait for deletion to fire, 2nd should clean the cache
+		// Preload to just below maxSize
+		for i := 0; i < maxSize-1; i++ {
+			shardedLockCache.PreloadMulti(uint64(i), []uint64{uint64(i)}, [][]float32{{float32(i)}})
 		}
+		assert.Equal(t, maxSize-1, int(shardedLockCache.CountVectors()))
 
+		// Set keys for the new ID so handleMultipleCacheMiss can fetch it
+		newID := uint64(maxSize - 1)
+		shardedLockCache.SetKeys(newID, newID, 0)
+
+		// This Get causes a cache miss, pushing count to maxSize, triggering eviction
+		vec, err := shardedLockCache.Get(context.Background(), newID)
+		assert.NoError(t, err)
+		assert.NotNil(t, vec)
+
+		// After eviction, count is reset to 0
 		assert.Equal(t, 0, int(shardedLockCache.CountVectors()))
-		assert.Equal(t, 0, countMultiCached(shardedLockCache))
 
 		shardedLockCache.Drop()
 	})
@@ -358,7 +429,7 @@ func TestGet_OutOfBounds(t *testing.T) {
 	}
 
 	t.Run("shardedLockCache grows and handles miss for out-of-bounds id", func(t *testing.T) {
-		vectorCache := NewShardedFloat32LockCache(notFoundVecForID, nil, 1_000_000, 1, logger, false, 0, nil)
+		vectorCache := NewShardedFloat32LockCache(notFoundVecForID, nil, 1_000_000, 1, logger, false, nil)
 		cache := vectorCache.(*shardedLockCache[float32])
 
 		outOfBoundsID := uint64(len(cache.cache) + 1)
@@ -371,7 +442,7 @@ func TestGet_OutOfBounds(t *testing.T) {
 	})
 
 	t.Run("shardedLockCache grows and handles miss for id exactly at cache length", func(t *testing.T) {
-		vectorCache := NewShardedFloat32LockCache(notFoundVecForID, nil, 1_000_000, 1, logger, false, 0, nil)
+		vectorCache := NewShardedFloat32LockCache(notFoundVecForID, nil, 1_000_000, 1, logger, false, nil)
 		cache := vectorCache.(*shardedLockCache[float32])
 
 		atBoundID := uint64(len(cache.cache))
@@ -384,7 +455,7 @@ func TestGet_OutOfBounds(t *testing.T) {
 
 	t.Run("shardedLockCache returns vector for valid id", func(t *testing.T) {
 		expected := []float32{1.0, 2.0, 3.0}
-		vectorCache := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, 0, nil)
+		vectorCache := NewShardedFloat32LockCache(nil, nil, 1_000_000, 1, logger, false, nil)
 		cache := vectorCache.(*shardedLockCache[float32])
 
 		cache.Preload(0, expected)
@@ -395,7 +466,7 @@ func TestGet_OutOfBounds(t *testing.T) {
 	})
 
 	t.Run("shardedMultipleLockCache grows and handles miss for out-of-bounds id", func(t *testing.T) {
-		vectorCache := NewShardedMultiFloat32LockCache(notFoundMultiVecForID, 1_000_000, logger, false, 0, nil)
+		vectorCache := NewShardedMultiFloat32LockCache(notFoundMultiVecForID, 1_000_000, logger, false, nil)
 		cache := vectorCache.(*shardedMultipleLockCache[float32])
 
 		outOfBoundsID := uint64(len(cache.cache) + 1)
@@ -407,7 +478,7 @@ func TestGet_OutOfBounds(t *testing.T) {
 	})
 
 	t.Run("shardedMultipleLockCache grows and handles miss for id exactly at cache length", func(t *testing.T) {
-		vectorCache := NewShardedMultiFloat32LockCache(notFoundMultiVecForID, 1_000_000, logger, false, 0, nil)
+		vectorCache := NewShardedMultiFloat32LockCache(notFoundMultiVecForID, 1_000_000, logger, false, nil)
 		cache := vectorCache.(*shardedMultipleLockCache[float32])
 
 		atBoundID := uint64(len(cache.cache))
@@ -421,7 +492,7 @@ func TestGet_OutOfBounds(t *testing.T) {
 	t.Run("shardedMultipleLockCache returns vector for valid id", func(t *testing.T) {
 		expected := []float32{1.0, 2.0, 3.0}
 		var multivecForId common.VectorForID[[]float32] = nil
-		vectorCache := NewShardedMultiFloat32LockCache(multivecForId, 1_000_000, logger, false, 0, nil)
+		vectorCache := NewShardedMultiFloat32LockCache(multivecForId, 1_000_000, logger, false, nil)
 		cache := vectorCache.(*shardedMultipleLockCache[float32])
 
 		cache.PreloadPassage(0, 0, 0, expected)

--- a/adapters/repos/db/vector/compressionhelpers/compression.go
+++ b/adapters/repos/db/vector/compressionhelpers/compression.go
@@ -492,7 +492,7 @@ func NewHNSWPQCompressor(
 	}
 	pqVectorsCompressor.cache = cache.NewShardedByteLockCache(
 		pqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, 1, logger,
-		0, allocChecker)
+		allocChecker)
 	pqVectorsCompressor.cache.Grow(uint64(len(data)))
 	err = quantizer.Fit(data)
 	if err != nil {
@@ -532,7 +532,7 @@ func RestoreHNSWPQCompressor(
 		return nil, err
 	}
 	pqVectorsCompressor.cache = cache.NewShardedByteLockCache(
-		pqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, 1, logger, 0,
+		pqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, 1, logger,
 		allocChecker)
 	return pqVectorsCompressor, nil
 }
@@ -569,7 +569,7 @@ func NewHNSWPQMultiCompressor(
 	}
 	pqVectorsCompressor.cache = cache.NewShardedMultiByteLockCache(
 		pqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, logger,
-		0, allocChecker)
+		allocChecker)
 	pqVectorsCompressor.cache.Grow(uint64(len(data)))
 	err = quantizer.Fit(data)
 	if err != nil {
@@ -609,7 +609,7 @@ func RestoreHNSWPQMultiCompressor(
 		return nil, err
 	}
 	pqVectorsCompressor.cache = cache.NewShardedMultiByteLockCache(
-		pqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, logger, 0,
+		pqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, logger,
 		allocChecker)
 	return pqVectorsCompressor, nil
 }
@@ -639,7 +639,7 @@ func NewBQCompressor(
 		return nil, err
 	}
 	bqVectorsCompressor.cache = cache.NewShardedUInt64LockCache(
-		bqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, 1, logger, 0,
+		bqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, 1, logger,
 		allocChecker)
 	return bqVectorsCompressor, nil
 }
@@ -669,7 +669,7 @@ func NewBQMultiCompressor(
 		return nil, err
 	}
 	bqVectorsCompressor.cache = cache.NewShardedMultiUInt64LockCache(
-		bqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, logger, 0,
+		bqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, logger,
 		allocChecker)
 	return bqVectorsCompressor, nil
 }
@@ -701,7 +701,7 @@ func NewHNSWSQCompressor(
 	}
 	sqVectorsCompressor.cache = cache.NewShardedByteLockCache(
 		sqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, 1, logger,
-		0, allocChecker)
+		allocChecker)
 	sqVectorsCompressor.cache.Grow(uint64(len(data)))
 	return sqVectorsCompressor, nil
 }
@@ -737,7 +737,7 @@ func RestoreHNSWSQCompressor(
 	}
 	sqVectorsCompressor.cache = cache.NewShardedByteLockCache(
 		sqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, 1, logger,
-		0, allocChecker)
+		allocChecker)
 	return sqVectorsCompressor, nil
 }
 
@@ -768,7 +768,7 @@ func NewHNSWSQMultiCompressor(
 	}
 	sqVectorsCompressor.cache = cache.NewShardedMultiByteLockCache(
 		sqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, logger,
-		0, allocChecker)
+		allocChecker)
 	sqVectorsCompressor.cache.Grow(uint64(len(data)))
 	return sqVectorsCompressor, nil
 }
@@ -804,7 +804,7 @@ func RestoreHNSWSQMultiCompressor(
 	}
 	sqVectorsCompressor.cache = cache.NewShardedMultiByteLockCache(
 		sqVectorsCompressor.getCompressedVectorForID, vectorCacheMaxObjects, logger,
-		0, allocChecker)
+		allocChecker)
 	return sqVectorsCompressor, nil
 }
 
@@ -842,7 +842,7 @@ func NewRQCompressor(
 		}
 		rqVectorsCompressor.(*quantizedVectorsCompressor[uint64]).cache = cache.NewShardedUInt64LockCache(
 			rqVectorsCompressor.(*quantizedVectorsCompressor[uint64]).getCompressedVectorForID, vectorCacheMaxObjects, 1, logger,
-			0, allocChecker)
+			allocChecker)
 	case 8:
 		quantizer := NewRotationalQuantizer(dim, DefaultFastRotationSeed, bits, distance)
 		rqVectorsCompressor = &quantizedVectorsCompressor[byte]{
@@ -860,7 +860,7 @@ func NewRQCompressor(
 		}
 		rqVectorsCompressor.(*quantizedVectorsCompressor[byte]).cache = cache.NewShardedByteLockCache(
 			rqVectorsCompressor.(*quantizedVectorsCompressor[byte]).getCompressedVectorForID, vectorCacheMaxObjects, 1, logger,
-			0, allocChecker)
+			allocChecker)
 	default:
 		return nil, errors.New("invalid bits value, only 1 and 8 bits are supported")
 	}
@@ -906,7 +906,7 @@ func RestoreRQCompressor(
 		}
 		rqVectorsCompressor.(*quantizedVectorsCompressor[uint64]).cache = cache.NewShardedUInt64LockCache(
 			rqVectorsCompressor.(*quantizedVectorsCompressor[uint64]).getCompressedVectorForID, vectorCacheMaxObjects, 1, logger,
-			0, allocChecker)
+			allocChecker)
 	case 8:
 		quantizer, err := RestoreRotationalQuantizer(dimensions, bits, outputDim, rounds, swaps, signs, distance)
 		if err != nil {
@@ -927,7 +927,7 @@ func RestoreRQCompressor(
 		}
 		rqVectorsCompressor.(*quantizedVectorsCompressor[byte]).cache = cache.NewShardedByteLockCache(
 			rqVectorsCompressor.(*quantizedVectorsCompressor[byte]).getCompressedVectorForID, vectorCacheMaxObjects, 1, logger,
-			0, allocChecker)
+			allocChecker)
 	default:
 		return nil, errors.New("invalid bits value, only 1 and 8 bits are supported")
 	}
@@ -968,7 +968,7 @@ func NewRQMultiCompressor(
 		}
 		rqVectorsCompressor.(*quantizedVectorsCompressor[uint64]).cache = cache.NewShardedMultiUInt64LockCache(
 			rqVectorsCompressor.(*quantizedVectorsCompressor[uint64]).getCompressedVectorForID, vectorCacheMaxObjects, logger,
-			0, allocChecker)
+			allocChecker)
 	case 8:
 		quantizer := NewRotationalQuantizer(dim, DefaultFastRotationSeed, bits, distance)
 		rqVectorsCompressor = &quantizedVectorsCompressor[byte]{
@@ -986,7 +986,7 @@ func NewRQMultiCompressor(
 		}
 		rqVectorsCompressor.(*quantizedVectorsCompressor[byte]).cache = cache.NewShardedMultiByteLockCache(
 			rqVectorsCompressor.(*quantizedVectorsCompressor[byte]).getCompressedVectorForID, vectorCacheMaxObjects, logger,
-			0, allocChecker)
+			allocChecker)
 	default:
 		return nil, errors.New("invalid bits value, only 1 and 8 bits are supported")
 	}
@@ -1032,7 +1032,7 @@ func RestoreRQMultiCompressor(
 		}
 		rqVectorsCompressor.(*quantizedVectorsCompressor[uint64]).cache = cache.NewShardedMultiUInt64LockCache(
 			rqVectorsCompressor.(*quantizedVectorsCompressor[uint64]).getCompressedVectorForID, vectorCacheMaxObjects, logger,
-			0, allocChecker)
+			allocChecker)
 	case 8:
 		quantizer, err := RestoreRotationalQuantizer(dimensions, bits, outputDim, rounds, swaps, signs, distance)
 		if err != nil {
@@ -1053,7 +1053,7 @@ func RestoreRQMultiCompressor(
 		}
 		rqVectorsCompressor.(*quantizedVectorsCompressor[byte]).cache = cache.NewShardedMultiByteLockCache(
 			rqVectorsCompressor.(*quantizedVectorsCompressor[byte]).getCompressedVectorForID, vectorCacheMaxObjects, logger,
-			0, allocChecker)
+			allocChecker)
 	default:
 		return nil, errors.New("invalid bits value, only 1 and 8 bits are supported")
 	}

--- a/adapters/repos/db/vector/flat/quantizer.go
+++ b/adapters/repos/db/vector/flat/quantizer.go
@@ -218,9 +218,9 @@ func NewCache(getUint64Vector func(ctx context.Context, id uint64) ([]uint64, er
 
 	switch quantizerType {
 	case Uint64Quantizer:
-		c.uint64Cache = cache.NewShardedUInt64LockCache(getUint64Vector, maxObjects, defaultCachePageSize, logger, 0, allocChecker)
+		c.uint64Cache = cache.NewShardedUInt64LockCache(getUint64Vector, maxObjects, defaultCachePageSize, logger, allocChecker)
 	case ByteQuantizer:
-		c.byteCache = cache.NewShardedByteLockCache(getByteVector, maxObjects, defaultCachePageSize, logger, 0, allocChecker)
+		c.byteCache = cache.NewShardedByteLockCache(getByteVector, maxObjects, defaultCachePageSize, logger, allocChecker)
 	}
 
 	return c

--- a/adapters/repos/db/vector/hnsw/index.go
+++ b/adapters/repos/db/vector/hnsw/index.go
@@ -302,7 +302,7 @@ func New(cfg Config, uc ent.UserConfig,
 	var muveraEncoder *multivector.MuveraEncoder
 	if uc.Multivector.Enabled && !uc.Multivector.MuveraConfig.Enabled {
 		vectorCache = cache.NewShardedMultiFloat32LockCache(cfg.MultiVectorForIDThunk, uc.VectorCacheMaxObjects,
-			cfg.Logger, normalizeOnRead, cache.DefaultDeletionInterval, cfg.AllocChecker)
+			cfg.Logger, normalizeOnRead, cfg.AllocChecker)
 	} else {
 		if uc.Multivector.MuveraConfig.Enabled {
 			muveraEncoder = multivector.NewMuveraEncoder(uc.Multivector.MuveraConfig, store)
@@ -319,11 +319,11 @@ func New(cfg Config, uc ent.UserConfig,
 			}
 			vectorCache = cache.NewShardedFloat32LockCache(
 				muveraVectorForID, cfg.MultiVectorForIDThunk, uc.VectorCacheMaxObjects, 1, cfg.Logger,
-				normalizeOnRead, cache.DefaultDeletionInterval, cfg.AllocChecker)
+				normalizeOnRead, cfg.AllocChecker)
 
 		} else {
 			vectorCache = cache.NewShardedFloat32LockCache(cfg.VectorForIDThunk, cfg.MultiVectorForIDThunk, uc.VectorCacheMaxObjects, 1, cfg.Logger,
-				normalizeOnRead, cache.DefaultDeletionInterval, cfg.AllocChecker)
+				normalizeOnRead, cfg.AllocChecker)
 		}
 	}
 	resetCtx, resetCtxCancel := context.WithCancel(context.Background())


### PR DESCRIPTION
### What's being changed:
- The sharded lock cache had a ticker per shard which caused a high number goroutines for MT use-cases
- This PR removes the ticker and does the eviction inline

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
