### PR TITLE
Nested object filtering — Part 15: position-level evaluation across operator subtrees      

### DIFF
--- a/adapters/repos/db/inverted/nested/bitmap.go
+++ b/adapters/repos/db/inverted/nested/bitmap.go
@@ -225,26 +225,27 @@ func (o *BitmapOps) OrAll(raws []*sroar.Bitmap, maxConcurrency int) (raw *sroar.
 	return raw, release
 }
 
-// CopresenceByMaskAll returns the union of values from all input bitmaps
-// whose (value & mask) projection appears in every input. Result is
-// allocated in a pool buffer sized to the largest input. Returns an empty
+// CrossLeafCopresenceAll returns the union of values from all input
+// bitmaps whose (root, docID) projection appears in every input — leaf
+// differences across inputs are tolerated. Equivalent to
+// sroar.CopresenceByMask with mask=zeroLeafBits. Result is allocated in
+// a pool buffer sized to the largest input. Returns an empty
 // (non-pooled) bitmap when raws is empty.
 //
-// Mask shape requirement: mask & 0xFFFF == 0xFFFF (sroar constraint).
-// Other shapes silently yield incorrect results.
-//
-// Use case: cross-disjoint-leaf AND under position-level evaluation —
-// each input is a raw position bitmap containing positions where one
-// operand holds, and the mask zeroes leaf bits so co-presence groups
-// by (root, docID). The returned raw bitmap composes with further raw
-// operations within the same nested root.
+// Use case: cross-disjoint-leaf AND under position-level evaluation.
+// When operands sit at different leaves of the same element (sibling
+// sub-arrays without a Phase 3 scalar bridge), raw AndAll gives ∅ even
+// when the same physical element satisfies every operand. This op keeps
+// the contributing leaf positions while filtering by (root, doc)
+// co-presence, so the result composes raw with further within-root
+// operations.
 //
 // TODO aliszka:nested_filtering: revisit buffer sizing. max(LenInBytes)
 // is usually adequate since the AND step at the heart of copresence can
 // only shrink contributions, but heavy overlap with disjoint groupings
 // could still grow the result above max. Sum of input sizes is the safe
 // upper bound. Profile to pick the sweet spot.
-func (o *BitmapOps) CopresenceByMaskAll(raws []*sroar.Bitmap, mask uint64) (raw *sroar.Bitmap, release func()) {
+func (o *BitmapOps) CrossLeafCopresenceAll(raws []*sroar.Bitmap) (raw *sroar.Bitmap, release func()) {
 	if len(raws) == 0 {
 		return sroar.NewBitmap(), func() {}
 	}
@@ -255,5 +256,5 @@ func (o *BitmapOps) CopresenceByMaskAll(raws []*sroar.Bitmap, mask uint64) (raw 
 		}
 	}
 	buf, release := o.pool.Get(maxLen)
-	return sroar.CopresenceByMaskToBuf(raws, mask, buf), release
+	return sroar.CopresenceByMaskToBuf(raws, zeroLeafBits, buf), release
 }

--- a/adapters/repos/db/inverted/nested/bitmap.go
+++ b/adapters/repos/db/inverted/nested/bitmap.go
@@ -111,24 +111,24 @@ func NewBitmapOps(pool roaringset.BitmapBufPool) *BitmapOps {
 // allocate internally, but for typical use (result ⊆ some known upper bound)
 // the hint avoids that reallocation.
 func (o *BitmapOps) NewEmpty(minCap int) (result *sroar.Bitmap, release func()) {
-	buf, put := o.pool.Get(minCap)
-	return sroar.NewBitmapToBuf(buf), put
+	buf, release := o.pool.Get(minCap)
+	return sroar.NewBitmapToBuf(buf), release
 }
 
 // MaskLeaf zeroes the leaf bits of raw and returns the rootDoc bitmap in a
 // pool buffer. The caller must invoke release() when the result is no longer
 // needed.
 func (o *BitmapOps) MaskLeaf(raw *sroar.Bitmap) (rootDoc *sroar.Bitmap, release func()) {
-	buf, put := o.pool.Get(raw.LenInBytes())
-	return raw.MaskedToBuf(zeroLeafBits, buf), put
+	buf, release := o.pool.Get(raw.LenInBytes())
+	return raw.MaskedToBuf(zeroLeafBits, buf), release
 }
 
 // MaskRootLeaf zeroes both root and leaf bits of positions, returning only
 // docIDs in a pool buffer. Use as the final step to extract plain document
 // IDs. positions may be raw or rootDoc.
 func (o *BitmapOps) MaskRootLeaf(positions *sroar.Bitmap) (doc *sroar.Bitmap, release func()) {
-	buf, put := o.pool.Get(positions.LenInBytes())
-	return positions.MaskedToBuf(zeroRootBits&zeroLeafBits, buf), put
+	buf, release := o.pool.Get(positions.LenInBytes())
+	return positions.MaskedToBuf(zeroRootBits&zeroLeafBits, buf), release
 }
 
 // AndAll returns the intersection of all raw position bitmaps in a pool
@@ -157,15 +157,15 @@ func (o *BitmapOps) AndAllMaskLeaf(raws []*sroar.Bitmap, maxConcurrency int) (ro
 	if len(raws) == 0 {
 		return sroar.NewBitmap(), func() {}
 	}
-	buf, put := o.pool.Get(raws[0].LenInBytes())
+	buf, release := o.pool.Get(raws[0].LenInBytes())
 	rootDoc = raws[0].MaskedToBuf(zeroLeafBits, buf)
 	for _, bm := range raws[1:] {
 		rootDoc.AndMaskedConc(bm, zeroLeafBits, maxConcurrency)
 		if rootDoc.IsEmpty() {
-			return rootDoc, put
+			return rootDoc, release
 		}
 	}
-	return rootDoc, put
+	return rootDoc, release
 }
 
 // MaskLeafAnd intersects rawA and rawB on raw positions, zeroes the leaf bits
@@ -174,8 +174,8 @@ func (o *BitmapOps) AndAllMaskLeaf(raws []*sroar.Bitmap, maxConcurrency int) (ro
 //
 // Both inputs must be raw position bitmaps (non-zero leaf bits).
 func (o *BitmapOps) MaskLeafAnd(rawA, rawB *sroar.Bitmap) (rootDoc *sroar.Bitmap, release func()) {
-	buf, put := o.pool.Get(min(rawA.LenInBytes(), rawB.LenInBytes()))
-	return sroar.MaskedAndToBuf(rawA, rawB, zeroLeafBits, buf), put
+	buf, release := o.pool.Get(min(rawA.LenInBytes(), rawB.LenInBytes()))
+	return sroar.MaskedAndToBuf(rawA, rawB, zeroLeafBits, buf), release
 }
 
 // IntersectsMaskedLeaf reports whether rootDoc and raw share at least one
@@ -184,4 +184,76 @@ func (o *BitmapOps) MaskLeafAnd(rawA, rawB *sroar.Bitmap) (rootDoc *sroar.Bitmap
 // running the full per-element intersection.
 func (o *BitmapOps) IntersectsMaskedLeaf(rootDoc, raw *sroar.Bitmap) bool {
 	return rootDoc.IntersectsMasked(raw, zeroLeafBits)
+}
+
+// OrAll returns the union of all raw position bitmaps in a pool buffer.
+// The largest input is cloned as the accumulator and the rest are folded
+// in — avoiding one OrConc pass and starting from a pre-populated
+// container structure (typically faster than growing an empty buffer
+// through repeated ORs). Returns an empty (non-pooled) bitmap when raws
+// is empty.
+//
+// TODO aliszka:nested_filtering: revisit buffer sizing. Cloning the
+// largest input still under-sizes the accumulator when the remaining
+// inputs contain disjoint values — internal growth fires. Sum of input
+// sizes is the safe upper bound but wastes pool capacity in the common
+// overlapping case. Profile the nested-filter workload to pick the
+// sweet spot.
+//
+// TODO aliszka:nested_filtering: consider sorting the remaining inputs
+// in descending order by LenInBytes before folding them in. OR is
+// commutative so correctness is unaffected; the question is whether
+// accumulator-growth cost dominates enough for sort order to matter.
+// Profile before adding the sort cost.
+func (o *BitmapOps) OrAll(raws []*sroar.Bitmap, maxConcurrency int) (raw *sroar.Bitmap, release func()) {
+	if len(raws) == 0 {
+		return sroar.NewBitmap(), func() {}
+	}
+	largestIdx := 0
+	for i := 1; i < len(raws); i++ {
+		if raws[i].LenInBytes() > raws[largestIdx].LenInBytes() {
+			largestIdx = i
+		}
+	}
+	raw, release = o.pool.CloneToBuf(raws[largestIdx])
+	for i, bm := range raws {
+		if i == largestIdx {
+			continue
+		}
+		raw.OrConc(bm, maxConcurrency)
+	}
+	return raw, release
+}
+
+// CopresenceByMaskAll returns the union of values from all input bitmaps
+// whose (value & mask) projection appears in every input. Result is
+// allocated in a pool buffer sized to the largest input. Returns an empty
+// (non-pooled) bitmap when raws is empty.
+//
+// Mask shape requirement: mask & 0xFFFF == 0xFFFF (sroar constraint).
+// Other shapes silently yield incorrect results.
+//
+// Use case: cross-disjoint-leaf AND under position-level evaluation —
+// each input is a raw position bitmap containing positions where one
+// operand holds, and the mask zeroes leaf bits so co-presence groups
+// by (root, docID). The returned raw bitmap composes with further raw
+// operations within the same nested root.
+//
+// TODO aliszka:nested_filtering: revisit buffer sizing. max(LenInBytes)
+// is usually adequate since the AND step at the heart of copresence can
+// only shrink contributions, but heavy overlap with disjoint groupings
+// could still grow the result above max. Sum of input sizes is the safe
+// upper bound. Profile to pick the sweet spot.
+func (o *BitmapOps) CopresenceByMaskAll(raws []*sroar.Bitmap, mask uint64) (raw *sroar.Bitmap, release func()) {
+	if len(raws) == 0 {
+		return sroar.NewBitmap(), func() {}
+	}
+	maxLen := 0
+	for _, bm := range raws {
+		if l := bm.LenInBytes(); l > maxLen {
+			maxLen = l
+		}
+	}
+	buf, release := o.pool.Get(maxLen)
+	return sroar.CopresenceByMaskToBuf(raws, mask, buf), release
 }

--- a/adapters/repos/db/inverted/nested/bitmap_test.go
+++ b/adapters/repos/db/inverted/nested/bitmap_test.go
@@ -521,3 +521,530 @@ func TestBitmapOps_IntersectsMaskedLeaf(t *testing.T) {
 		assert.Equal(t, origRaw, raw.ToArray())
 	})
 }
+
+func TestBitmapOps_OrAll(t *testing.T) {
+	ops := newTrackingOps(t)
+
+	t.Run("empty input returns empty bitmap", func(t *testing.T) {
+		result, release := ops.OrAll(nil, 1)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("single bitmap returns its values", func(t *testing.T) {
+		bm := sroar.NewBitmap()
+		bm.SetMany([]uint64{1, 2, 3})
+		result, release := ops.OrAll([]*sroar.Bitmap{bm}, 1)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{1, 2, 3}, result.ToArray())
+		// result is not the input — mutating must not affect the original
+		result.Set(99)
+		assert.Equal(t, []uint64{1, 2, 3}, bm.ToArray())
+	})
+
+	t.Run("union of two overlapping bitmaps", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.SetMany([]uint64{1, 2, 3})
+		b := sroar.NewBitmap()
+		b.SetMany([]uint64{2, 3, 4})
+		result, release := ops.OrAll([]*sroar.Bitmap{a, b}, 1)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{1, 2, 3, 4}, result.ToArray())
+		// inputs unmodified
+		assert.Equal(t, []uint64{1, 2, 3}, a.ToArray())
+		assert.Equal(t, []uint64{2, 3, 4}, b.ToArray())
+	})
+
+	t.Run("union of disjoint bitmaps", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.SetMany([]uint64{1, 2})
+		b := sroar.NewBitmap()
+		b.SetMany([]uint64{10, 20})
+		result, release := ops.OrAll([]*sroar.Bitmap{a, b}, 1)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{1, 2, 10, 20}, result.ToArray())
+	})
+
+	t.Run("union of three bitmaps", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.SetMany([]uint64{1, 2})
+		b := sroar.NewBitmap()
+		b.SetMany([]uint64{3})
+		c := sroar.NewBitmap()
+		c.SetMany([]uint64{2, 4, 5})
+		result, release := ops.OrAll([]*sroar.Bitmap{a, b, c}, 1)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{1, 2, 3, 4, 5}, result.ToArray())
+	})
+
+	t.Run("union with an empty input among many", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.SetMany([]uint64{1, 2})
+		empty := sroar.NewBitmap()
+		c := sroar.NewBitmap()
+		c.SetMany([]uint64{3, 4})
+		result, release := ops.OrAll([]*sroar.Bitmap{a, empty, c}, 1)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{1, 2, 3, 4}, result.ToArray())
+	})
+
+	t.Run("union of position-encoded bitmaps preserves leaves", func(t *testing.T) {
+		// B = cars.tires.width=205 → leaf 2 in doc 100
+		// C = cars.colors=red      → leaf 3 in doc 100
+		b := sroar.NewBitmap()
+		b.Set(Encode(1, 2, 100))
+		c := sroar.NewBitmap()
+		c.Set(Encode(1, 3, 100))
+		result, release := ops.OrAll([]*sroar.Bitmap{b, c}, 1)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{Encode(1, 2, 100), Encode(1, 3, 100)}, result.ToArray())
+	})
+}
+
+func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
+	ops := newTrackingOps(t)
+
+	// Co-presence groups by (root, doc) via the package-level zeroLeafBits
+	// mask, which satisfies sroar's mask shape requirement (low 16 bits
+	// inside the docID region are all set).
+
+	t.Run("empty input returns empty bitmap", func(t *testing.T) {
+		result, release := ops.CopresenceByMaskAll(nil, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("single input is clone", func(t *testing.T) {
+		bm := sroar.NewBitmap()
+		bm.Set(Encode(1, 1, 100))
+		bm.Set(Encode(1, 2, 100))
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{bm}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{Encode(1, 1, 100), Encode(1, 2, 100)}, result.ToArray())
+	})
+
+	t.Run("one input empty returns empty", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 1, 100))
+		empty := sroar.NewBitmap()
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, empty}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("single car satisfies all — union of contributing leaves", func(t *testing.T) {
+		// A_in_car = spoiler accessory leaf;
+		// OR_in_car = 205 tire leaf + red color leaf.
+		// All in same (root=1, doc=1). Co-presence = {(1, 0, 1)}.
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 1, 1))
+		or := sroar.NewBitmap()
+		or.Set(Encode(1, 2, 1))
+		or.Set(Encode(1, 3, 1))
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{
+			Encode(1, 1, 1), Encode(1, 2, 1), Encode(1, 3, 1),
+		}, result.ToArray())
+	})
+
+	t.Run("cross-country split — different root_idx, no co-presence", func(t *testing.T) {
+		// A in country 0 (root=1); OR in country 1 (root=2). Same doc.
+		// Co-presence on (root, doc): {(1,0,8)} ∩ {(2,0,8)} = ∅.
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 1, 8))
+		or := sroar.NewBitmap()
+		or.Set(Encode(2, 1, 8))
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("cross-doc — same root different docs, no co-presence", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 1, 1))
+		or := sroar.NewBitmap()
+		or.Set(Encode(1, 2, 2))
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("multi-doc — only co-present (root, doc) pairs survive", func(t *testing.T) {
+		// A in docs 1, 2, 3. OR only in doc 2. Only doc 2 co-presents.
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 1, 1))
+		a.Set(Encode(1, 1, 2))
+		a.Set(Encode(1, 1, 3))
+		or := sroar.NewBitmap()
+		or.Set(Encode(1, 2, 2))
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{Encode(1, 1, 2), Encode(1, 2, 2)}, result.ToArray())
+	})
+
+	t.Run("two countries both co-present — both contribute", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 1, 1))
+		a.Set(Encode(2, 1, 1))
+		or := sroar.NewBitmap()
+		or.Set(Encode(1, 2, 1))
+		or.Set(Encode(2, 2, 1))
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{
+			Encode(1, 1, 1), Encode(1, 2, 1),
+			Encode(2, 1, 1), Encode(2, 2, 1),
+		}, result.ToArray())
+	})
+
+	t.Run("two countries, only one co-present — filter drops the other", func(t *testing.T) {
+		// A in countries 1, 2. OR only in country 2.
+		// Co-presence = {(2, 0, 9)}. (1, 1, 9) drops.
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 1, 9))
+		a.Set(Encode(2, 1, 9))
+		or := sroar.NewBitmap()
+		or.Set(Encode(2, 2, 9))
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{Encode(2, 1, 9), Encode(2, 2, 9)}, result.ToArray())
+	})
+
+	t.Run("27-car doc K=0 L=1 — co-presence only via root=3", func(t *testing.T) {
+		// Mirrors the iteration trace from the 27-car doc 100 walkthrough.
+		// A_in_car = country 2's spoiler at (3, 3, 100).
+		// OR_in_car = country 0's 205 tire at (1, 5, 100) + country 2's red
+		// color at (3, 4, 100). Only (3, 0, 100) is co-present.
+		// (1, 5, 100) drops out.
+		a := sroar.NewBitmap()
+		a.Set(Encode(3, 3, 100))
+		or := sroar.NewBitmap()
+		or.Set(Encode(1, 5, 100))
+		or.Set(Encode(3, 4, 100))
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{Encode(3, 3, 100), Encode(3, 4, 100)}, result.ToArray())
+	})
+
+	t.Run("three-way — all inputs at same (root, doc)", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 1, 5))
+		b := sroar.NewBitmap()
+		b.Set(Encode(1, 2, 5))
+		c := sroar.NewBitmap()
+		c.Set(Encode(1, 3, 5))
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, b, c}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{
+			Encode(1, 1, 5), Encode(1, 2, 5), Encode(1, 3, 5),
+		}, result.ToArray())
+	})
+
+	t.Run("three-way — one input at wrong root, no co-presence", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 1, 5))
+		b := sroar.NewBitmap()
+		b.Set(Encode(1, 2, 5))
+		c := sroar.NewBitmap()
+		c.Set(Encode(2, 3, 5))
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, b, c}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("three-way — partial co-presence, only complete group survives", func(t *testing.T) {
+		// Country 1 has all three operands. Country 2 missing the third.
+		// Only (1, 0, 5) is co-present in all three; (2, 0, 5) drops.
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 1, 5))
+		a.Set(Encode(2, 1, 5))
+		b := sroar.NewBitmap()
+		b.Set(Encode(1, 2, 5))
+		b.Set(Encode(2, 2, 5))
+		c := sroar.NewBitmap()
+		c.Set(Encode(1, 3, 5))
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, b, c}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, []uint64{
+			Encode(1, 1, 5), Encode(1, 2, 5), Encode(1, 3, 5),
+		}, result.ToArray())
+	})
+
+	t.Run("batch of 5 docs, only docs 2 and 4 co-present", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		for _, doc := range []uint64{1, 2, 3, 4, 5} {
+			a.Set(Encode(1, 1, doc))
+		}
+		or := sroar.NewBitmap()
+		or.Set(Encode(1, 2, 2))
+		or.Set(Encode(1, 2, 4))
+		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		defer release()
+		requireBitmapValid(t, result)
+		// ToArray returns values in ascending uint64 order. With leaf bits at
+		// positions 49-36 and docID at 35-0, all leaf=1 positions precede all
+		// leaf=2 positions.
+		assert.Equal(t, []uint64{
+			Encode(1, 1, 2), Encode(1, 1, 4),
+			Encode(1, 2, 2), Encode(1, 2, 4),
+		}, result.ToArray())
+	})
+
+	t.Run("inputs unmodified", func(t *testing.T) {
+		a := sroar.NewBitmap()
+		a.Set(Encode(1, 1, 1))
+		aBefore := a.ToArray()
+		or := sroar.NewBitmap()
+		or.Set(Encode(1, 2, 1))
+		orBefore := or.ToArray()
+		_, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		defer release()
+		assert.Equal(t, aBefore, a.ToArray())
+		assert.Equal(t, orBefore, or.ToArray())
+	})
+}
+
+// TestBitmapOps_CopresenceByMaskAll_IdxLoopSimulation simulates the
+// position-level eval cars-level AND combining step end-to-end. For
+// each (garage K, car L) iteration, it narrows the per-condition raw
+// bitmaps by car_scope = _idx.garages.cars[L] ∩ _idx.garages[K] and
+// applies CopresenceByMaskAll. Per-iteration results are OR'd into the
+// accumulator. Scenarios mirror the doc walkthroughs from the
+// position-level eval discussion.
+func TestBitmapOps_CopresenceByMaskAll_IdxLoopSimulation(t *testing.T) {
+	ops := newTrackingOps(t)
+	// Co-presence groups by (root, doc) via the package-level zeroLeafBits.
+
+	docID := uint64(100)
+	// pos packs a (root, leaf, doc=100) position for human-readable test data.
+	pos := func(root, leaf uint16) uint64 { return Encode(root, leaf, docID) }
+
+	// narrow simulates car_scope = idxKey ∩ garageScope. Returns a fresh
+	// bitmap; inputs are unmodified.
+	narrow := func(idxKey, garageScope *sroar.Bitmap) *sroar.Bitmap {
+		clone := idxKey.Clone()
+		clone.And(garageScope)
+		return clone
+	}
+
+	// simulate runs the cars idx-loop. For each car_scope iteration, it
+	// narrows each condition by car_scope (raw AND) and feeds the narrowed
+	// bitmaps to CopresenceByMaskAll. Per-iteration results are OR'd into
+	// the accumulator. Returns the accumulator's values.
+	simulate := func(t *testing.T, conds []*sroar.Bitmap, carScopes []*sroar.Bitmap) []uint64 {
+		t.Helper()
+		accumulator := sroar.NewBitmap()
+		for _, carScope := range carScopes {
+			narrowed := make([]*sroar.Bitmap, len(conds))
+			for i, cond := range conds {
+				clone := cond.Clone()
+				clone.And(carScope)
+				narrowed[i] = clone
+			}
+			result, release := ops.CopresenceByMaskAll(narrowed, zeroLeafBits)
+			accumulator.Or(result)
+			release()
+		}
+		out := accumulator.ToArray()
+		if out == nil {
+			return []uint64{}
+		}
+		return out
+	}
+
+	t.Run("2x2x2 doc, rotation pattern — every car has A-only or OR-only, no match", func(t *testing.T) {
+		// Country 1 (root=1) leaves:
+		//   c1.g0.cars[0]: A → leaf 1
+		//   c1.g0.cars[1]: OR → leaf 2
+		//   c1.g1.cars[0]: OR → leaf 3
+		//   c1.g1.cars[1]: A → leaf 4
+		// Country 2 (root=2) leaves reset:
+		//   c2.g0.cars[0]: OR → leaf 1
+		//   c2.g0.cars[1]: A → leaf 2
+		//   c2.g1.cars[0]: A → leaf 3
+		//   c2.g1.cars[1]: OR → leaf 4
+		aRaw := roaringset.NewBitmap(pos(1, 1), pos(1, 4), pos(2, 2), pos(2, 3))
+		orRaw := roaringset.NewBitmap(pos(1, 2), pos(1, 3), pos(2, 1), pos(2, 4))
+
+		garage0 := roaringset.NewBitmap(pos(1, 1), pos(1, 2), pos(2, 1), pos(2, 2))
+		garage1 := roaringset.NewBitmap(pos(1, 3), pos(1, 4), pos(2, 3), pos(2, 4))
+		car0 := roaringset.NewBitmap(pos(1, 1), pos(1, 3), pos(2, 1), pos(2, 3))
+		car1 := roaringset.NewBitmap(pos(1, 2), pos(1, 4), pos(2, 2), pos(2, 4))
+
+		carScopes := []*sroar.Bitmap{
+			narrow(car0, garage0), // K=0, L=0
+			narrow(car1, garage0), // K=0, L=1
+			narrow(car0, garage1), // K=1, L=0
+			narrow(car1, garage1), // K=1, L=1
+		}
+
+		result := simulate(t, []*sroar.Bitmap{aRaw, orRaw}, carScopes)
+		assert.Empty(t, result, "no single car has both A and OR; result must be empty")
+	})
+
+	t.Run("same 2x2x2 doc with c2.g1.cars[1] changed to A AND OR — single car flips it to match", func(t *testing.T) {
+		// c2.g1.cars[1] now contains both spoiler (A) and 205 tire (B in OR).
+		// Updated country 2 leaves:
+		//   c2.g0.cars[0]: OR → leaf 1
+		//   c2.g0.cars[1]: A → leaf 2
+		//   c2.g1.cars[0]: A → leaf 3
+		//   c2.g1.cars[1]: A AND OR → A at leaf 4, OR at leaf 5
+		aRaw := roaringset.NewBitmap(pos(1, 1), pos(1, 4), pos(2, 2), pos(2, 3), pos(2, 4))
+		orRaw := roaringset.NewBitmap(pos(1, 2), pos(1, 3), pos(2, 1), pos(2, 5))
+
+		garage0 := roaringset.NewBitmap(pos(1, 1), pos(1, 2), pos(2, 1), pos(2, 2))
+		// c2.garages[1] descendants now span leaves 3, 4, 5
+		garage1 := roaringset.NewBitmap(pos(1, 3), pos(1, 4), pos(2, 3), pos(2, 4), pos(2, 5))
+		car0 := roaringset.NewBitmap(pos(1, 1), pos(1, 3), pos(2, 1), pos(2, 3))
+		// c2.cars[1] in garages[1] occupies leaves 4 and 5
+		car1 := roaringset.NewBitmap(pos(1, 2), pos(1, 4), pos(2, 2), pos(2, 4), pos(2, 5))
+
+		carScopes := []*sroar.Bitmap{
+			narrow(car0, garage0),
+			narrow(car1, garage0),
+			narrow(car0, garage1),
+			narrow(car1, garage1), // matching iteration
+		}
+
+		result := simulate(t, []*sroar.Bitmap{aRaw, orRaw}, carScopes)
+		// Co-presence at (2, 0, 100) in the K=1 L=1 iteration yields both
+		// leaves of c2.g1.cars[1].
+		assert.Equal(t, []uint64{pos(2, 4), pos(2, 5)}, result)
+	})
+
+	t.Run("cross-country split at same (K, L) — co-presence on (root, doc) rejects", func(t *testing.T) {
+		// A only in c1.g0.cars[0] (root=1); OR only in c2.g0.cars[0] (root=2).
+		// Both at L=0 in their respective country's garage[0]. Within the
+		// single (K=0, L=0) iteration, both A_in_car and OR_in_car are
+		// non-empty — but they project to different (root, doc) keys, so
+		// co-presence is empty.
+		aRaw := roaringset.NewBitmap(pos(1, 1))
+		orRaw := roaringset.NewBitmap(pos(2, 1))
+		garage0 := roaringset.NewBitmap(pos(1, 1), pos(2, 1))
+		car0 := roaringset.NewBitmap(pos(1, 1), pos(2, 1))
+
+		carScopes := []*sroar.Bitmap{narrow(car0, garage0)}
+
+		result := simulate(t, []*sroar.Bitmap{aRaw, orRaw}, carScopes)
+		assert.Empty(t, result, "different root_idx in same iteration must not co-present")
+	})
+
+	t.Run("cross-garage split (same country, same L) — parent garage scope rejects", func(t *testing.T) {
+		// A only in c1.g0.cars[0]; OR only in c1.g1.cars[0]. Both at L=0
+		// but different garages. The parent garage idx-loop narrows each
+		// K's iteration to one physical garage, so each cars-level
+		// iteration sees only one side.
+		aRaw := roaringset.NewBitmap(pos(1, 1))  // c1.g0.cars[0]
+		orRaw := roaringset.NewBitmap(pos(1, 3)) // c1.g1.cars[0]
+		garage0 := roaringset.NewBitmap(pos(1, 1))
+		garage1 := roaringset.NewBitmap(pos(1, 3))
+		car0 := roaringset.NewBitmap(pos(1, 1), pos(1, 3)) // _idx.cars[0] mixes both garages' cars[0]
+
+		carScopes := []*sroar.Bitmap{
+			narrow(car0, garage0), // K=0, L=0 — only A holds
+			narrow(car0, garage1), // K=1, L=0 — only OR holds
+		}
+
+		result := simulate(t, []*sroar.Bitmap{aRaw, orRaw}, carScopes)
+		assert.Empty(t, result, "different garages must not produce a co-presence match — parent scope narrows")
+	})
+
+	t.Run("cross-car within same garage — different L iterations reject", func(t *testing.T) {
+		// A only in c1.g0.cars[0]; OR only in c1.g0.cars[1]. Same country,
+		// same garage, different cars. The cars idx-loop visits each L
+		// separately so neither iteration has both.
+		aRaw := roaringset.NewBitmap(pos(1, 1))
+		orRaw := roaringset.NewBitmap(pos(1, 2))
+		garage0 := roaringset.NewBitmap(pos(1, 1), pos(1, 2))
+		car0 := roaringset.NewBitmap(pos(1, 1))
+		car1 := roaringset.NewBitmap(pos(1, 2))
+
+		carScopes := []*sroar.Bitmap{
+			narrow(car0, garage0),
+			narrow(car1, garage0),
+		}
+
+		result := simulate(t, []*sroar.Bitmap{aRaw, orRaw}, carScopes)
+		assert.Empty(t, result)
+	})
+
+	t.Run("two matching cars in same doc — each contributes its leaves", func(t *testing.T) {
+		// Two cars satisfy A AND OR in the same doc:
+		//   c1.g0.cars[0]: spoiler (leaf 1) + 205 tire (leaf 2)
+		//   c2.g1.cars[1]: spoiler (leaf 4) + 205 tire (leaf 5)
+		// Other cars have nothing — get their own leaves via Phase 2.
+		// Country 1 layout: c1.g0.cars[0]=A+OR(1,2); c1.g0.cars[1]=∅(3);
+		//                   c1.g1.cars[0]=∅(4); c1.g1.cars[1]=∅(5)
+		// Country 2 layout: c2.g0.cars[0]=∅(1); c2.g0.cars[1]=∅(2);
+		//                   c2.g1.cars[0]=∅(3); c2.g1.cars[1]=A+OR(4,5)
+		aRaw := roaringset.NewBitmap(pos(1, 1), pos(2, 4))
+		orRaw := roaringset.NewBitmap(pos(1, 2), pos(2, 5))
+		garage0 := roaringset.NewBitmap(pos(1, 1), pos(1, 2), pos(1, 3), pos(2, 1), pos(2, 2))
+		garage1 := roaringset.NewBitmap(pos(1, 4), pos(1, 5), pos(2, 3), pos(2, 4), pos(2, 5))
+		car0 := roaringset.NewBitmap(pos(1, 1), pos(1, 2), pos(1, 4), pos(2, 1), pos(2, 3))
+		car1 := roaringset.NewBitmap(pos(1, 3), pos(1, 5), pos(2, 2), pos(2, 4), pos(2, 5))
+
+		carScopes := []*sroar.Bitmap{
+			narrow(car0, garage0), // c1.g0.cars[0] matches; c2.g0.cars[0] empty
+			narrow(car1, garage0), // c1.g0.cars[1] and c2.g0.cars[1] both empty
+			narrow(car0, garage1), // c1.g1.cars[0] and c2.g1.cars[0] both empty
+			narrow(car1, garage1), // c1.g1.cars[1] empty; c2.g1.cars[1] matches
+		}
+
+		result := simulate(t, []*sroar.Bitmap{aRaw, orRaw}, carScopes)
+		assert.Equal(t, []uint64{
+			pos(1, 1), pos(1, 2), // c1.g0.cars[0]'s contributing leaves
+			pos(2, 4), pos(2, 5), // c2.g1.cars[1]'s contributing leaves
+		}, result)
+	})
+
+	t.Run("three-way AND simulating sibling sub-arrays — same car wins, cross-car loses", func(t *testing.T) {
+		// Three operands (e.g., accessories, tires, colors). One car has
+		// all three; another country's car has two of three.
+		// Country 1: c1.g0.cars[0] has all three (leaves 1, 2, 3)
+		// Country 2: c2.g0.cars[0] has only A and B (leaves 1, 2); missing C
+		// Country 2: c2.g0.cars[1] has only C (leaf 3) — different car
+		//
+		// Only c1.g0.cars[0] should match at K=0, L=0.
+		aRaw := roaringset.NewBitmap(pos(1, 1), pos(2, 1))
+		bRaw := roaringset.NewBitmap(pos(1, 2), pos(2, 2))
+		cRaw := roaringset.NewBitmap(pos(1, 3), pos(2, 3))
+
+		garage0 := roaringset.NewBitmap(pos(1, 1), pos(1, 2), pos(1, 3), pos(2, 1), pos(2, 2), pos(2, 3))
+		car0 := roaringset.NewBitmap(pos(1, 1), pos(1, 2), pos(1, 3), pos(2, 1), pos(2, 2))
+		car1 := roaringset.NewBitmap(pos(2, 3))
+
+		carScopes := []*sroar.Bitmap{
+			narrow(car0, garage0), // K=0, L=0
+			narrow(car1, garage0), // K=0, L=1
+		}
+
+		result := simulate(t, []*sroar.Bitmap{aRaw, bRaw, cRaw}, carScopes)
+		// c1.g0.cars[0] has all three at root=1; that's the only co-presence.
+		// At L=0, c2.g0.cars[0] has A and B but not C — co-presence on
+		// (2, 0, 100) fails because cRaw has no value at root=2 with leaf
+		// inside car_scope.
+		assert.Equal(t, []uint64{pos(1, 1), pos(1, 2), pos(1, 3)}, result)
+	})
+}

--- a/adapters/repos/db/inverted/nested/bitmap_test.go
+++ b/adapters/repos/db/inverted/nested/bitmap_test.go
@@ -608,7 +608,7 @@ func TestBitmapOps_OrAll(t *testing.T) {
 	})
 }
 
-func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
+func TestBitmapOps_CrossLeafCopresenceAll(t *testing.T) {
 	ops := newTrackingOps(t)
 
 	// Co-presence groups by (root, doc) via the package-level zeroLeafBits
@@ -616,7 +616,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 	// inside the docID region are all set).
 
 	t.Run("empty input returns empty bitmap", func(t *testing.T) {
-		result, release := ops.CopresenceByMaskAll(nil, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll(nil)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
@@ -626,7 +626,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		bm := sroar.NewBitmap()
 		bm.Set(Encode(1, 1, 100))
 		bm.Set(Encode(1, 2, 100))
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{bm}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{bm})
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{Encode(1, 1, 100), Encode(1, 2, 100)}, result.ToArray())
@@ -636,7 +636,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		a := sroar.NewBitmap()
 		a.Set(Encode(1, 1, 100))
 		empty := sroar.NewBitmap()
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, empty}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, empty})
 		defer release()
 		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
@@ -651,7 +651,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		or := sroar.NewBitmap()
 		or.Set(Encode(1, 2, 1))
 		or.Set(Encode(1, 3, 1))
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, or})
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{
@@ -666,7 +666,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		a.Set(Encode(1, 1, 8))
 		or := sroar.NewBitmap()
 		or.Set(Encode(2, 1, 8))
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, or})
 		defer release()
 		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
@@ -677,7 +677,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		a.Set(Encode(1, 1, 1))
 		or := sroar.NewBitmap()
 		or.Set(Encode(1, 2, 2))
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, or})
 		defer release()
 		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
@@ -691,7 +691,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		a.Set(Encode(1, 1, 3))
 		or := sroar.NewBitmap()
 		or.Set(Encode(1, 2, 2))
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, or})
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{Encode(1, 1, 2), Encode(1, 2, 2)}, result.ToArray())
@@ -704,7 +704,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		or := sroar.NewBitmap()
 		or.Set(Encode(1, 2, 1))
 		or.Set(Encode(2, 2, 1))
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, or})
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{
@@ -721,7 +721,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		a.Set(Encode(2, 1, 9))
 		or := sroar.NewBitmap()
 		or.Set(Encode(2, 2, 9))
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, or})
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{Encode(2, 1, 9), Encode(2, 2, 9)}, result.ToArray())
@@ -738,7 +738,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		or := sroar.NewBitmap()
 		or.Set(Encode(1, 5, 100))
 		or.Set(Encode(3, 4, 100))
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, or})
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{Encode(3, 3, 100), Encode(3, 4, 100)}, result.ToArray())
@@ -751,7 +751,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		b.Set(Encode(1, 2, 5))
 		c := sroar.NewBitmap()
 		c.Set(Encode(1, 3, 5))
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, b, c}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, b, c})
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{
@@ -766,7 +766,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		b.Set(Encode(1, 2, 5))
 		c := sroar.NewBitmap()
 		c.Set(Encode(2, 3, 5))
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, b, c}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, b, c})
 		defer release()
 		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
@@ -783,7 +783,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		b.Set(Encode(2, 2, 5))
 		c := sroar.NewBitmap()
 		c.Set(Encode(1, 3, 5))
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, b, c}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, b, c})
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{
@@ -799,7 +799,7 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		or := sroar.NewBitmap()
 		or.Set(Encode(1, 2, 2))
 		or.Set(Encode(1, 2, 4))
-		result, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		result, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, or})
 		defer release()
 		requireBitmapValid(t, result)
 		// ToArray returns values in ascending uint64 order. With leaf bits at
@@ -818,21 +818,21 @@ func TestBitmapOps_CopresenceByMaskAll(t *testing.T) {
 		or := sroar.NewBitmap()
 		or.Set(Encode(1, 2, 1))
 		orBefore := or.ToArray()
-		_, release := ops.CopresenceByMaskAll([]*sroar.Bitmap{a, or}, zeroLeafBits)
+		_, release := ops.CrossLeafCopresenceAll([]*sroar.Bitmap{a, or})
 		defer release()
 		assert.Equal(t, aBefore, a.ToArray())
 		assert.Equal(t, orBefore, or.ToArray())
 	})
 }
 
-// TestBitmapOps_CopresenceByMaskAll_IdxLoopSimulation simulates the
+// TestBitmapOps_CrossLeafCopresenceAll_IdxLoopSimulation simulates the
 // position-level eval cars-level AND combining step end-to-end. For
 // each (garage K, car L) iteration, it narrows the per-condition raw
 // bitmaps by car_scope = _idx.garages.cars[L] ∩ _idx.garages[K] and
-// applies CopresenceByMaskAll. Per-iteration results are OR'd into the
+// applies CrossLeafCopresenceAll. Per-iteration results are OR'd into the
 // accumulator. Scenarios mirror the doc walkthroughs from the
 // position-level eval discussion.
-func TestBitmapOps_CopresenceByMaskAll_IdxLoopSimulation(t *testing.T) {
+func TestBitmapOps_CrossLeafCopresenceAll_IdxLoopSimulation(t *testing.T) {
 	ops := newTrackingOps(t)
 	// Co-presence groups by (root, doc) via the package-level zeroLeafBits.
 
@@ -850,7 +850,7 @@ func TestBitmapOps_CopresenceByMaskAll_IdxLoopSimulation(t *testing.T) {
 
 	// simulate runs the cars idx-loop. For each car_scope iteration, it
 	// narrows each condition by car_scope (raw AND) and feeds the narrowed
-	// bitmaps to CopresenceByMaskAll. Per-iteration results are OR'd into
+	// bitmaps to CrossLeafCopresenceAll. Per-iteration results are OR'd into
 	// the accumulator. Returns the accumulator's values.
 	simulate := func(t *testing.T, conds []*sroar.Bitmap, carScopes []*sroar.Bitmap) []uint64 {
 		t.Helper()
@@ -862,7 +862,7 @@ func TestBitmapOps_CopresenceByMaskAll_IdxLoopSimulation(t *testing.T) {
 				clone.And(carScope)
 				narrowed[i] = clone
 			}
-			result, release := ops.CopresenceByMaskAll(narrowed, zeroLeafBits)
+			result, release := ops.CrossLeafCopresenceAll(narrowed)
 			accumulator.Or(result)
 			release()
 		}

--- a/adapters/repos/db/inverted/nested/bitmap_test.go
+++ b/adapters/repos/db/inverted/nested/bitmap_test.go
@@ -826,12 +826,12 @@ func TestBitmapOps_CrossLeafCopresenceAll(t *testing.T) {
 }
 
 // TestBitmapOps_CrossLeafCopresenceAll_IdxLoopSimulation simulates the
-// position-level eval cars-level AND combining step end-to-end. For
+// position-level evaluation cars-level AND combining step end-to-end. For
 // each (garage K, car L) iteration, it narrows the per-condition raw
 // bitmaps by car_scope = _idx.garages.cars[L] ∩ _idx.garages[K] and
 // applies CrossLeafCopresenceAll. Per-iteration results are OR'd into the
 // accumulator. Scenarios mirror the doc walkthroughs from the
-// position-level eval discussion.
+// position-level evaluation discussion.
 func TestBitmapOps_CrossLeafCopresenceAll_IdxLoopSimulation(t *testing.T) {
 	ops := newTrackingOps(t)
 	// Co-presence groups by (root, doc) via the package-level zeroLeafBits.

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -59,8 +59,8 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 
 	// Correlated nested AND created during extraction: all children target the
 	// same root property (stored in pv.prop) and require same-element semantics.
-	if pv.nested.isCorrelated {
-		return pv.resolveNestedCorrelated(ctx, s)
+	if pv.nested.isWithinRootSubtree {
+		return pv.resolveNestedSubtree(ctx, s)
 	}
 
 	// All nested-specific dispatch: IsNull, value filters, and correlated AND

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -27,7 +27,7 @@ import (
 // nestedInfo groups fields that are only relevant for nested (object/object[])
 // property filters. The zero value represents a non-nested node.
 //
-// isNested and isCorrelated are mutually exclusive — a node is either a leaf
+// isNested and isWithinRootSubtree are mutually exclusive — a node is either a leaf
 // or a group, never both:
 //
 // When isNested is set (leaf node):
@@ -37,7 +37,7 @@ import (
 //     (e.g. "city" or "owner.firstname")
 //   - the result bitmap contains positions that are stripped to docIDs
 //
-// When isCorrelated is set (AND group node):
+// When isWithinRootSubtree is set (AND group node):
 //   - prop on the parent propValuePair is the root property name
 //   - all children require position-aware same-element resolution
 //   - childrenFromTokenization marks a compound AND from multi-token text;
@@ -45,7 +45,7 @@ import (
 type nestedInfo struct {
 	isNested                 bool
 	relPath                  string
-	isCorrelated             bool
+	isWithinRootSubtree      bool
 	childrenFromTokenization bool
 	arrayIndices             arrayIndices
 }
@@ -102,7 +102,7 @@ func (pv *propValuePair) fetchNestedIsNull(s *Searcher) (*docBitmap, error) {
 // fetchNestedPositions fetches the raw position bitmap for a nested value
 // filter and applies any arr[N] index constraints. Positions are not stripped
 // to docIDs — callers that need docIDs use fetchNestedDocIDs instead; the
-// correlated resolution path (resolveNestedCorrelated) uses this directly.
+// correlated resolution path (resolveNestedSubtree) uses this directly.
 func (pv *propValuePair) fetchNestedPositions(ctx context.Context, s *Searcher, limit int) (*docBitmap, error) {
 	raw, err := pv.readFromBucket(ctx, s, limit)
 	if err != nil {
@@ -178,10 +178,10 @@ func (pv *propValuePair) fetchNestedExistsPositions(s *Searcher) (*sroar.Bitmap,
 	return restricted.docIDs, restricted.release, nil
 }
 
-// resolveNestedCorrelated resolves a correlated AND filter using position-aware
+// resolveNestedSubtree resolves a correlated AND filter using position-aware
 // same-element semantics. Children are grouped by arr[N] compatibility, then:
 //
-//   - Single group: resolved directly via resolveNestedCorrelatedGroup.
+//   - Single group: resolved directly via resolveNestedSubtreeGroup.
 //   - All groups root-constrained (all first arr[N] have RelPath=""): the user
 //     is explicitly querying different root elements → docID-level AND.
 //   - Otherwise: resolve each group to root+docID positions and AND them so all
@@ -191,13 +191,13 @@ func (pv *propValuePair) fetchNestedExistsPositions(s *Searcher) (*sroar.Bitmap,
 // intermediate arr[N] constraints with unconstrained conditions at the same
 // level in filter validation. Until that lands, unconstrained items in that
 // shape are silently dropped during plan construction.
-func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searcher) (*docBitmap, error) {
+func (pv *propValuePair) resolveNestedSubtree(ctx context.Context, s *Searcher) (*docBitmap, error) {
 	groups, allRootConstrained := groupChildrenByArrayIndicesKey(pv.children)
 	switch len(groups) {
 	case 0:
 		return nil, fmt.Errorf("nested correlated AND: no condition groups for %q", pv.prop)
 	case 1:
-		return pv.resolveNestedCorrelatedGroup(ctx, s, groups[0])
+		return pv.resolveNestedSubtreeGroup(ctx, s, groups[0])
 	}
 
 	if allRootConstrained {
@@ -215,7 +215,7 @@ func (pv *propValuePair) resolveNestedCorrelated(ctx context.Context, s *Searche
 // plain docID results. Correct when all groups explicitly target different root
 // elements (allGroupsRootConstrained).
 func (pv *propValuePair) resolveMultiGroupDocIDLevelAnd(ctx context.Context, s *Searcher, groups [][]*propValuePair) (*docBitmap, error) {
-	dbm, err := pv.resolveNestedCorrelatedGroup(ctx, s, groups[0])
+	dbm, err := pv.resolveNestedSubtreeGroup(ctx, s, groups[0])
 	if err != nil {
 		return nil, err
 	}
@@ -226,7 +226,7 @@ func (pv *propValuePair) resolveMultiGroupDocIDLevelAnd(ctx context.Context, s *
 		}
 	}()
 	for _, group := range groups[1:] {
-		groupDbm, err := pv.resolveNestedCorrelatedGroup(ctx, s, group)
+		groupDbm, err := pv.resolveNestedSubtreeGroup(ctx, s, group)
 		if err != nil {
 			return nil, err
 		}
@@ -274,11 +274,11 @@ func (pv *propValuePair) resolveMultiGroupRootDocIDAnd(ctx context.Context, s *S
 	return &docBitmap{docIDs: docIDs, release: docRelease}, nil
 }
 
-// resolveNestedCorrelatedGroup resolves a single set of children using
+// resolveNestedSubtreeGroup resolves a single set of children using
 // position-aware same-element correlation through the recursive plan + executor.
 // The raw position bitmap returned by the executor is stripped to docIDs via
 // MaskRootLeaf.
-func (pv *propValuePair) resolveNestedCorrelatedGroup(ctx context.Context, s *Searcher, children []*propValuePair) (*docBitmap, error) {
+func (pv *propValuePair) resolveNestedSubtreeGroup(ctx context.Context, s *Searcher, children []*propValuePair) (*docBitmap, error) {
 	raw, rawRelease, err := pv.resolveGroupRaw(ctx, s, children)
 	if err != nil {
 		return nil, err
@@ -291,7 +291,7 @@ func (pv *propValuePair) resolveNestedCorrelatedGroup(ctx context.Context, s *Se
 // resolveGroupRaw resolves children to a raw position bitmap through the
 // recursive plan + executor. Used directly by resolveMultiGroupRootDocIDAnd
 // to combine groups via CrossLeafCopresenceAll before stripping to docIDs,
-// and indirectly by resolveNestedCorrelatedGroup which strips immediately.
+// and indirectly by resolveNestedSubtreeGroup which strips immediately.
 func (pv *propValuePair) resolveGroupRaw(ctx context.Context, s *Searcher, children []*propValuePair) (*sroar.Bitmap, func(), error) {
 	plan, executor, releases, err := pv.buildRecGroupExecutor(ctx, s, children)
 	if err != nil {

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -372,10 +372,15 @@ func (pv *propValuePair) fetchRootAnchor(s *Searcher, metaBucket *lsmkv.Bucket, 
 // ---------------------------------------------------------------------------
 
 // childRelPath returns the relative path of a child, handling both direct leaf
-// conditions and tokenization compound AND children.
+// conditions and tokenization compound AND children. OR/NOT operator items
+// have no single representative path — their structure is planned recursively;
+// returning "" defers placement to the OR/NOT-aware dispatch in buildGroup.
 func childRelPath(child *propValuePair) string {
 	if child.nested.isNested {
 		return child.nested.relPath
+	}
+	if child.operator == filters.OperatorOr || child.operator == filters.OperatorNot {
+		return ""
 	}
 	if len(child.children) > 0 {
 		return child.children[0].nested.relPath
@@ -383,10 +388,17 @@ func childRelPath(child *propValuePair) string {
 	return ""
 }
 
-// childArrayIndices returns the arr[N] constraints of a child.
+// childArrayIndices returns the arr[N] constraints of a child. OR/NOT
+// operator items are not subject to outer arr[N] dispatch — their pins are
+// internal (lifted into recNotNode for universe restriction, or carried by
+// each OR child's own plan). Returning nil keeps the outer planner from
+// wrapping an OR/NOT in a SPLIT based on inner-leaf pins.
 func childArrayIndices(child *propValuePair) arrayIndices {
 	if child.nested.isNested {
 		return child.nested.arrayIndices
+	}
+	if child.operator == filters.OperatorOr || child.operator == filters.OperatorNot {
+		return nil
 	}
 	if len(child.children) > 0 {
 		return child.children[0].nested.arrayIndices

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -195,7 +195,7 @@ func (pv *propValuePair) resolveNestedSubtree(ctx context.Context, s *Searcher) 
 	groups, allRootConstrained := groupChildrenByArrayIndicesKey(pv.children)
 	switch len(groups) {
 	case 0:
-		return nil, fmt.Errorf("nested correlated AND: no condition groups for %q", pv.prop)
+		return nil, fmt.Errorf("nested subtree: no condition groups for %q", pv.prop)
 	case 1:
 		return pv.resolveNestedSubtreeGroup(ctx, s, groups[0])
 	}
@@ -307,7 +307,7 @@ func (pv *propValuePair) resolveGroupRaw(ctx context.Context, s *Searcher, child
 	// consider deriving it from the request context or shard-level config.
 	raw, rawRelease, err := executor.execute(ctx, plan)
 	if err != nil {
-		return nil, nil, fmt.Errorf("nested correlated AND: execute for %q: %w", pv.prop, err)
+		return nil, nil, fmt.Errorf("nested subtree: execute for %q: %w", pv.prop, err)
 	}
 	return raw, rawRelease, nil
 }

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -20,7 +20,6 @@ import (
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
-	"github.com/weaviate/weaviate/entities/concurrency"
 	"github.com/weaviate/weaviate/entities/filters"
 	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 )
@@ -237,11 +236,16 @@ func (pv *propValuePair) resolveMultiGroupDocIDLevelAnd(ctx context.Context, s *
 	return dbm, nil
 }
 
-// resolveMultiGroupRootDocIDAnd resolves each group to root+docID positions and
-// AND's them so all conditions must land in the same root element. Applied when
-// groups have conflicting intermediate constraints or no common intermediate LCA.
+// resolveMultiGroupRootDocIDAnd resolves each group to a raw position bitmap
+// and combines them via CrossLeafCopresenceAll so all conditions must land in
+// the same root element. Applied when groups have conflicting intermediate
+// constraints or no common intermediate LCA — different groups' leaves are
+// disjoint by construction, so plain raw AndAll would give ∅. The leaf-zeroed
+// (root, doc) co-presence check across groups keeps positions whose root
+// element contains a passing element in every group.
 func (pv *propValuePair) resolveMultiGroupRootDocIDAnd(ctx context.Context, s *Searcher, groups [][]*propValuePair) (*docBitmap, error) {
-	var releases []func()
+	rawBitmaps := make([]*sroar.Bitmap, 0, len(groups))
+	releases := make([]func(), 0, len(groups))
 	succeeded := false
 	defer func() {
 		if !succeeded {
@@ -251,22 +255,18 @@ func (pv *propValuePair) resolveMultiGroupRootDocIDAnd(ctx context.Context, s *S
 		}
 	}()
 
-	masked, rel, err := pv.resolveGroupMasked(ctx, s, groups[0])
-	if err != nil {
-		return nil, err
-	}
-	releases = append(releases, rel)
-
-	for _, group := range groups[1:] {
-		groupMasked, groupRel, err := pv.resolveGroupMasked(ctx, s, group)
+	for _, group := range groups {
+		raw, rel, err := pv.resolveGroupRaw(ctx, s, group)
 		if err != nil {
 			return nil, err
 		}
-		releases = append(releases, groupRel)
-		masked.AndConc(groupMasked, concurrency.SROAR_MERGE)
+		rawBitmaps = append(rawBitmaps, raw)
+		releases = append(releases, rel)
 	}
 
-	docIDs, docRelease := s.nestedBitmapOps.MaskRootLeaf(masked)
+	combined, combinedRel := s.nestedBitmapOps.CrossLeafCopresenceAll(rawBitmaps)
+	docIDs, docRelease := s.nestedBitmapOps.MaskRootLeaf(combined)
+	combinedRel()
 	succeeded = true
 	for _, rel := range releases {
 		rel()
@@ -276,30 +276,23 @@ func (pv *propValuePair) resolveMultiGroupRootDocIDAnd(ctx context.Context, s *S
 
 // resolveNestedCorrelatedGroup resolves a single set of children using
 // position-aware same-element correlation through the recursive plan + executor.
+// The raw position bitmap returned by the executor is stripped to docIDs via
+// MaskRootLeaf.
 func (pv *propValuePair) resolveNestedCorrelatedGroup(ctx context.Context, s *Searcher, children []*propValuePair) (*docBitmap, error) {
-	plan, executor, releases, err := pv.buildRecGroupExecutor(ctx, s, children)
+	raw, rawRelease, err := pv.resolveGroupRaw(ctx, s, children)
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		for _, rel := range releases {
-			rel()
-		}
-	}()
-
-	// TODO aliszka:nested_filtering concurrency.SROAR_MERGE is a fixed budget;
-	// consider deriving it from the request context or shard-level config.
-	docIDs, release, err := executor.execute(ctx, plan)
-	if err != nil {
-		return nil, fmt.Errorf("nested correlated AND: execute for %q: %w", pv.prop, err)
-	}
+	defer rawRelease()
+	docIDs, release := s.nestedBitmapOps.MaskRootLeaf(raw)
 	return &docBitmap{docIDs: docIDs, release: release}, nil
 }
 
-// resolveGroupMasked resolves children to root+docID positions (leaf bits zeroed)
-// instead of plain docIDs by toggling returnMasked on the recursive executor.
-// Used by resolveMultiGroupRootDocIDAnd to AND groups at root+docID level.
-func (pv *propValuePair) resolveGroupMasked(ctx context.Context, s *Searcher, children []*propValuePair) (*sroar.Bitmap, func(), error) {
+// resolveGroupRaw resolves children to a raw position bitmap through the
+// recursive plan + executor. Used directly by resolveMultiGroupRootDocIDAnd
+// to combine groups via CrossLeafCopresenceAll before stripping to docIDs,
+// and indirectly by resolveNestedCorrelatedGroup which strips immediately.
+func (pv *propValuePair) resolveGroupRaw(ctx context.Context, s *Searcher, children []*propValuePair) (*sroar.Bitmap, func(), error) {
 	plan, executor, releases, err := pv.buildRecGroupExecutor(ctx, s, children)
 	if err != nil {
 		return nil, nil, err
@@ -310,12 +303,13 @@ func (pv *propValuePair) resolveGroupMasked(ctx context.Context, s *Searcher, ch
 		}
 	}()
 
-	executor.withReturnMasked(true)
-	masked, maskedRelease, err := executor.execute(ctx, plan)
+	// TODO aliszka:nested_filtering concurrency.SROAR_MERGE is a fixed budget;
+	// consider deriving it from the request context or shard-level config.
+	raw, rawRelease, err := executor.execute(ctx, plan)
 	if err != nil {
-		return nil, nil, fmt.Errorf("nested correlated AND: execute masked for %q: %w", pv.prop, err)
+		return nil, nil, fmt.Errorf("nested correlated AND: execute for %q: %w", pv.prop, err)
 	}
-	return masked, maskedRelease, nil
+	return raw, rawRelease, nil
 }
 
 // fetchRootAnchor returns the bitmap of element positions used as the starting

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -5866,7 +5866,12 @@ func TestIsNullWithArrNInCorrelatedAnd(t *testing.T) {
 	t.Run("root arr[N] IsNull=true — garages[1].city=berlin AND cars.make absent", func(t *testing.T) {
 		// Both conditions carry {RelPath:"", Index:1} so they resolve in the same group.
 		// doc1: garages[1] = {city:"berlin", no cars.make} → match
-		// doc2: garages[1] = {city:"berlin", cars.make present} → no match
+		// doc2: garages[1] = {city:"berlin", cars.make present} →
+		//   Phase 2 per-element IsNull: city's leaf (2) and cars.make's
+		//   existence leaf (1) are different leaves of the same garages[1].
+		//   The city position survives raw AndNot because cars.make doesn't
+		//   exist at THAT leaf. Pre-Phase 2 used universal-at-rootDoc
+		//   semantics which dropped doc2 entirely.
 		searcher, vb, mb := newIsNullCorrelationSearcher(t, "garages")
 		class := isNullCorrelationClass()
 
@@ -5888,7 +5893,7 @@ func TestIsNullWithArrNInCorrelatedAnd(t *testing.T) {
 		require.NoError(t, err)
 		defer result.release()
 		requireBitmapValid(t, result.docIDs)
-		assert.Equal(t, []uint64{doc1}, result.docIDs.ToArray())
+		assert.Equal(t, []uint64{doc1, doc2}, result.docIDs.ToArray())
 	})
 
 	// Test 4: garages[1].cars.make IS NOT NULL — root arr[N], IsNull=false

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -7194,8 +7194,10 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 	//
 	// Two compatibility groups — {cars[0]} and {cars[1]} — conflict at
 	// RelPath="cars", so allRootConstrained is false and dispatch goes through
-	// resolveMultiGroupRootDocIDAnd (returnMasked=true → AND at root+docID
-	// level → MaskRootLeaf). Within each group the plan is SPLIT@"cars"[idx]
+	// resolveMultiGroupRootDocIDAnd: each group resolves to a raw position
+	// bitmap and the per-group raw bitmaps are combined via
+	// CrossLeafCopresenceAll before MaskRootLeaf. Within each group the
+	// plan is SPLIT@"cars"[idx]
 	// → GROUP@"cars" with two deeper subs (tires + accessories), exercising
 	// runIdxLoopRecursive at lcaPath="cars" inside the per-group execution.
 	//
@@ -7432,9 +7434,9 @@ func TestCorrelatedAndFilterExamplesIndexed(t *testing.T) {
 	// Compatibility grouping always yields three groups (for ABCD order it is
 	// {A}, {B, C}, {D}; for DACB order it is {D, B}, {A}, {C}). In both cases
 	// allRootConstrained=false (outermost RelPath="garages") so dispatch goes
-	// through resolveMultiGroupRootDocIDAnd: each group resolves with
-	// returnMasked=true, and the per-group root+docID outputs are AndAll'd
-	// before MaskRootLeaf.
+	// through resolveMultiGroupRootDocIDAnd: each group resolves to a raw
+	// position bitmap and the per-group raw bitmaps are combined via
+	// CrossLeafCopresenceAll before MaskRootLeaf.
 	//
 	// Per-group plans (ABCD order):
 	//   {A}     SPLIT@"garages"[0] → GROUP@"garages" here=[city]

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -1625,10 +1625,11 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 	// intermediate (intermediate ObjectArray LCA).
 	// -----------------------------------------------------------------------
 
-	// tokenCompound builds a non-isNested compound AND whose children are
-	// routed as tokens by resolveNestedSubtree. The outer correlated pvp's
-	// childrenFromTokenization is false, so this non-isNested child enters the
-	// else branch and its grandchildren become tokens for the given relPath.
+	// tokenCompound models the production tokenization wrapper from
+	// buildNestedTextFilterPair: childrenFromTokenization=true keeps the
+	// planner from unwrapping the AND as an associative compound, and
+	// normalizeRecGroup AndAlls the token grandchildren into one virtual
+	// leaf bitmap.
 	tokenCompound := func(class *models.Class, prop, relPath string, terms ...string) *propValuePair {
 		children := make([]*propValuePair, len(terms))
 		for i, term := range terms {
@@ -1636,7 +1637,7 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		}
 		return &propValuePair{
 			operator: filters.OperatorAnd,
-			nested:   nestedInfo{}, // isNested=false → grandchildren become tokens
+			nested:   nestedInfo{childrenFromTokenization: true},
 			children: children,
 			Class:    class,
 		}

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -3780,14 +3780,14 @@ func TestNestedFilteringComprehensive(t *testing.T) {
 			})
 
 			t.Run("complex — cars.make=bmw AND (cars.tires.width=205 OR cars.accessories.type=sunroof)", func(t *testing.T) {
-				// Outer AND groups all into one correlated node. OR children resolve to docIDs independently.
-				// bmw: [d1,d2,d3]. OR(tires,acc): [d1,d2,d3(nestedArray)/d1,d2,d4(nested)].
-				// nested: OR(tires,acc)=[d1,d2,d4]; ∩ bmw=[d1,d2,d3] → [d1,d2]
-				// nestedArray: OR(tires,acc)=[d1,d2,d3,d4]; ∩ bmw=[d1,d2,d3] → [d1,d2,d3]
+				// Same-cars-element AND: a single car must satisfy bmw
+				// AND (205 OR sunroof). d2 (bmw in cars[0], OR in
+				// cars[1]) drops in both variants; d3 in nestedArray
+				// (bmw in root=1, OR in root=2) also drops.
 				run(t, and(
 					textFlt(prop+".cars.make", "bmw"),
 					*or(intFlt(prop+".cars.tires.width", 205), textFlt(prop+".cars.accessories.type", "sunroof")),
-				), want([]uint64{d1, d2}, []uint64{d1, d2, d3}))
+				), []uint64{d1})
 			})
 
 			t.Run("complex — cars.make=bmw AND cars.tires.width=205 AND addresses.city=berlin", func(t *testing.T) {
@@ -3801,11 +3801,14 @@ func TestNestedFilteringComprehensive(t *testing.T) {
 			})
 
 			t.Run("complex — (cars.make=bmw OR cars.make=honda) AND addresses.city=berlin", func(t *testing.T) {
-				// OR(bmw,honda)=[d1,d2,d3,d4]; berlin=[d1,d3,d4]. Intersection=[d1,d3,d4].
+				// Same-root-element AND: a single root entry must have
+				// (bmw OR honda) AND berlin. nested d3 (single root with
+				// bmw + berlin) stays in; nestedArray d3 (bmw in root=1,
+				// berlin in root=2) drops out.
 				run(t, and(
 					*or(textFlt(prop+".cars.make", "bmw"), textFlt(prop+".cars.make", "honda")),
 					textFlt(prop+".addresses.city", "berlin"),
-				), []uint64{d1, d3, d4})
+				), want([]uint64{d1, d3, d4}, []uint64{d1, d4}))
 			})
 
 			t.Run("complex — tags=premium AND cars.make=bmw AND cars.tires.width=205 AND cars.accessories.type=sunroof", func(t *testing.T) {

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -39,7 +39,7 @@ import (
 // ---------------------------------------------------------------------------
 
 // correlationTestClass returns a minimal class with nested object-array
-// properties used across resolveNestedCorrelated tests.
+// properties used across resolveNestedSubtree tests.
 //
 //	addresses: object[] { city text, postcode text }
 //	cars:      object[] { make text, tires object[]{width int}, accessories object[]{type text} }
@@ -133,11 +133,11 @@ func makeLeafPvp(class *models.Class, prop, relPath, term string) *propValuePair
 	}
 }
 
-// makeCorrelatedPvp wraps children in an isCorrelatedNested AND node for prop.
+// makeCorrelatedPvp wraps children in an isWithinRootSubtree AND node for prop.
 func makeCorrelatedPvp(class *models.Class, prop string, children ...*propValuePair) *propValuePair {
 	return &propValuePair{
 		operator: filters.OperatorAnd,
-		nested:   nestedInfo{isCorrelated: true},
+		nested:   nestedInfo{isWithinRootSubtree: true},
 		prop:     prop,
 		children: children,
 		Class:    class,
@@ -333,7 +333,7 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		addrVb := store.Bucket(addrBucketName)
 		writeNestedValue(t, addrVb, "city", "berlin", []uint64{invnested.Encode(1, 1, doc5)})
 
-		// groupNestedByProp creates one isCorrelatedNested node per prop;
+		// groupNestedByProp creates one isWithinRootSubtree node per prop;
 		// here we build the same structure directly.
 		pv := makeAndPvp(class,
 			makeCorrelatedPvp(class, "cars",
@@ -520,7 +520,7 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 		//
 		// Both conditions hit the same relPath "cars.tags" and land in
 		// positionsByPath["cars.tags"].independent. "cars" is a DataTypeObjectArray
-		// within garages, so the fix in resolveNestedCorrelated detects this and
+		// within garages, so the fix in resolveNestedSubtree detects this and
 		// calls runIdxLoop("cars", [germanBm, electricBm]) before plan building.
 		// This enforces same-car semantics, not just same-garage semantics.
 		//
@@ -838,7 +838,7 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 
 		pv := &propValuePair{
 			operator: filters.OperatorAnd,
-			nested:   nestedInfo{isCorrelated: true, childrenFromTokenization: true},
+			nested:   nestedInfo{isWithinRootSubtree: true, childrenFromTokenization: true},
 			prop:     "addresses",
 			children: []*propValuePair{
 				makeLeafPvp(class, "addresses", "city", "new"),
@@ -1626,7 +1626,7 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 	// -----------------------------------------------------------------------
 
 	// tokenCompound builds a non-isNested compound AND whose children are
-	// routed as tokens by resolveNestedCorrelated. The outer correlated pvp's
+	// routed as tokens by resolveNestedSubtree. The outer correlated pvp's
 	// childrenFromTokenization is false, so this non-isNested child enters the
 	// else branch and its grandchildren become tokens for the given relPath.
 	tokenCompound := func(class *models.Class, prop, relPath string, terms ...string) *propValuePair {
@@ -1960,7 +1960,7 @@ func TestResolveNestedCorrelatedAnd(t *testing.T) {
 
 		valueBucketName := helpers.BucketNestedFromPropNameLSM("cars")
 		metaBucketName := helpers.BucketNestedMetaFromPropNameLSM("cars")
-		// Meta bucket is required by resolveNestedCorrelated, but intentionally left
+		// Meta bucket is required by resolveNestedSubtree, but intentionally left
 		// empty — this test proves that no _idx entries are accessed or needed.
 		searcher, store := newNestedTestSearcher(t, valueBucketName, metaBucketName)
 		class := correlationTestClass()
@@ -3298,7 +3298,7 @@ func TestPlanCasesIntegration(t *testing.T) {
 
 		// -----------------------------------------------------------------------
 		// Single-condition cases — each produces one leaf pvp resolved via
-		// fetchNestedDocIDs (not resolveNestedCorrelated). These verify that the
+		// fetchNestedDocIDs (not resolveNestedSubtree). These verify that the
 		// basic bucket read + MaskRootLeaf path works correctly at every nesting
 		// depth and for every leaf type.
 		//
@@ -4765,7 +4765,7 @@ func TestNestedFilteringMixedArrayIndexConstraints(t *testing.T) {
 	// Root-level: nestedArray.addresses.city="berlin" AND nestedArray[1].cars.make="bmw"
 	//
 	// city ({}) and make ({[1]}) are compatible → same group → single
-	// resolveNestedCorrelatedGroup call. Plan: two sub-groups (addresses and cars
+	// resolveNestedSubtreeGroup call. Plan: two sub-groups (addresses and cars
 	// byFirst), resolved with AndAllMaskLeaf → same root element required.
 	//
 	// doc5: nestedArray[1] has berlin(root=2,leaf=1) AND bmw(root=2,leaf=2)
@@ -4824,7 +4824,7 @@ func TestNestedFilteringMixedArrayIndexConstraints(t *testing.T) {
 	// Intermediate-level: nested.cars.colors="red" AND nested.cars[1].make="bmw"
 	//
 	// colors ({}) and make ({cars:1}) are compatible → same group → single
-	// resolveNestedCorrelatedGroup call. Plan: LCA="cars", groupAndAll — ANDs raw
+	// resolveNestedSubtreeGroup call. Plan: LCA="cars", groupAndAll — ANDs raw
 	// position bitmaps. make is restricted to cars[1] (leaf=2); colors spans all
 	// cars (leaf=1 for cars[0], leaf=2 for cars[1]). AND requires same leaf →
 	// both must be satisfied by cars[1].
@@ -5459,7 +5459,7 @@ func TestIsNullInCorrelatedAnd(t *testing.T) {
 
 		makeTokenNode := &propValuePair{
 			operator: filters.OperatorAnd,
-			nested:   nestedInfo{isCorrelated: true, childrenFromTokenization: true},
+			nested:   nestedInfo{isWithinRootSubtree: true, childrenFromTokenization: true},
 			prop:     "cars",
 			children: []*propValuePair{
 				makeLeafPvp(class, "cars", "make", "honda"),
@@ -5494,7 +5494,7 @@ func TestIsNullInCorrelatedAnd(t *testing.T) {
 
 		makeTokenNode := &propValuePair{
 			operator: filters.OperatorAnd,
-			nested:   nestedInfo{isCorrelated: true, childrenFromTokenization: true},
+			nested:   nestedInfo{isWithinRootSubtree: true, childrenFromTokenization: true},
 			prop:     "cars",
 			children: []*propValuePair{
 				makeLeafPvp(class, "cars", "make", "honda"),

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_integration_test.go
@@ -153,6 +153,24 @@ func makeAndPvp(class *models.Class, children ...*propValuePair) *propValuePair 
 	}
 }
 
+// makeOrPvp wraps children in an OR propValuePair.
+func makeOrPvp(class *models.Class, children ...*propValuePair) *propValuePair {
+	return &propValuePair{
+		operator: filters.OperatorOr,
+		children: children,
+		Class:    class,
+	}
+}
+
+// makeNotPvp wraps a single operand in a NOT propValuePair.
+func makeNotPvp(class *models.Class, operand *propValuePair) *propValuePair {
+	return &propValuePair{
+		operator: filters.OperatorNot,
+		children: []*propValuePair{operand},
+		Class:    class,
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
@@ -121,8 +121,15 @@ func normalizeRecGroup(
 		return input, nil
 	}
 
-	// Pattern 2 (and the mainstream non-tokenized case): each child is either a
-	// direct leaf (isNested) or a tokenization wrapper containing token leaves.
+	// Pattern 2 (and the mainstream non-tokenized case): each child is one of
+	//   - direct nested leaf (isNested): routeDirectLeaf.
+	//   - tokenization wrapper (childrenFromTokenization=true): AndAll the
+	//     token grandchildren into one virtual leaf bitmap.
+	//   - operator subtree (AND/OR/NOT containing nested leaves) introduced
+	//     by recursive same-root grouping: recursively pre-fetch a value
+	//     bitmap for every nested leaf inside the subtree. The operator pvp
+	//     itself is added to positives so the planner sees it and builds
+	//     recOrNode / recNotNode / nested recGroupNode as needed.
 	for _, child := range children {
 		if child.nested.isNested {
 			if err := routeDirectLeaf(ctx, child, fetcher, input); err != nil {
@@ -133,13 +140,25 @@ func normalizeRecGroup(
 		if len(child.children) == 0 {
 			return nil, fmt.Errorf("normalizeRecGroup: non-nested child %p has no grandchildren", child)
 		}
-		combined, releases, err := fetchAndAndAllTokens(ctx, child.children, fetcher, bitmapOps, maxConcurrency)
-		if err != nil {
-			return nil, err
+		if child.nested.childrenFromTokenization {
+			combined, releases, err := fetchAndAndAllTokens(ctx, child.children, fetcher, bitmapOps, maxConcurrency)
+			if err != nil {
+				return nil, err
+			}
+			input.releases = append(input.releases, releases...)
+			input.positives = append(input.positives, child)
+			input.rawsByCond[child] = combined
+			continue
 		}
-		input.releases = append(input.releases, releases...)
-		input.positives = append(input.positives, child)
-		input.rawsByCond[child] = combined
+		switch child.operator {
+		case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot:
+			if err := fetchOperatorSubtreeBitmaps(ctx, child, fetcher, input); err != nil {
+				return nil, err
+			}
+			input.positives = append(input.positives, child)
+		default:
+			return nil, fmt.Errorf("normalizeRecGroup: unsupported non-nested child operator %q", child.operator.Name())
+		}
 	}
 
 	if len(input.positives) == 0 && len(input.excludePositions) > 0 {
@@ -184,6 +203,47 @@ func routeDirectLeaf(ctx context.Context, leaf *propValuePair, fetcher recBitmap
 	input.positives = append(input.positives, leaf)
 	input.rawsByCond[leaf] = bm
 	return nil
+}
+
+// fetchOperatorSubtreeBitmaps walks an AND/OR/NOT subtree rooted at node and
+// pre-fetches a raw position bitmap for every nested leaf it reaches. Bitmaps
+// land in input.rawsByCond keyed by the leaf pvp; the operator nodes
+// themselves don't go to rawsByCond — the planner walks them via
+// buildOr/buildNot/buildGroup and reads bitmaps for the leaves at evaluation.
+//
+// IsNull leaves inside operator subtrees are not yet supported; if encountered
+// the function returns an error so callers can detect the gap rather than
+// produce silent wrong results. Mixing IsNull with same-element OR/NOT
+// semantics will be addressed alongside the IsNull validation step.
+func fetchOperatorSubtreeBitmaps(
+	ctx context.Context,
+	node *propValuePair,
+	fetcher recBitmapFetcher,
+	input *recGroupInput,
+) error {
+	if node.nested.isNested {
+		if node.operator == filters.OperatorIsNull {
+			return fmt.Errorf("normalizeRecGroup: IsNull leaf inside operator subtree not yet supported (%q)", node.nested.relPath)
+		}
+		bm, rel, err := fetcher.fetchValue(ctx, node)
+		if err != nil {
+			return fmt.Errorf("normalizeRecGroup: fetch value for %q: %w", node.nested.relPath, err)
+		}
+		input.releases = append(input.releases, rel)
+		input.rawsByCond[node] = bm
+		return nil
+	}
+	switch node.operator {
+	case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot:
+		for _, child := range node.children {
+			if err := fetchOperatorSubtreeBitmaps(ctx, child, fetcher, input); err != nil {
+				return err
+			}
+		}
+		return nil
+	default:
+		return fmt.Errorf("normalizeRecGroup: unsupported node in operator subtree (operator=%q, isNested=%v)", node.operator.Name(), node.nested.isNested)
+	}
 }
 
 // fetchAndAndAllTokens fetches every token's raw position bitmap and ANDs them

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive_integration_test.go
@@ -35,12 +35,14 @@ func writeExistsAt(t *testing.T, mb *lsmkv.Bucket, relPath string, positions []u
 }
 
 // makeTokenizationWrapper wraps tokens of a single multi-token text value.
-// The outer pv has childrenFromTokenization=false but isNested=false; tokens
-// are direct leaves at the same path. Used to model Pattern 2 tokenization.
+// Production tokenization wrappers from buildNestedTextFilterPair set
+// childrenFromTokenization=true; this is the discriminator that keeps the
+// planner from unwrapping AND children of the wrapper.
 func makeTokenizationWrapper(class *models.Class, tokens ...*propValuePair) *propValuePair {
 	return &propValuePair{
 		operator: filters.OperatorAnd,
 		children: tokens,
+		nested:   nestedInfo{childrenFromTokenization: true},
 		Class:    class,
 	}
 }

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive_integration_test.go
@@ -193,11 +193,17 @@ func TestRecGroupExecutorTokenizationAndIsNull(t *testing.T) {
 		runRec(t, s, pv, []uint64{docMatch})
 	})
 
-	t.Run("isnull_true_with_positive_excludes_at_rootDoc_level", func(t *testing.T) {
-		// addresses.postcode = "10115" AND addresses.city IS NULL — match docs
-		// that have an address with postcode 10115 AND have NO city anywhere.
-		// docMatch: postcode=10115 AND no city present at all.
-		// docNoMatch: postcode=10115 AND has a city in some address → excluded.
+	t.Run("isnull_true_with_positive_excludes_at_raw_level", func(t *testing.T) {
+		// addresses.postcode = "10115" AND addresses.city IS NULL.
+		// docMatch: postcode=10115 at leaf 1, no city anywhere.
+		// docNoMatch: postcode=10115 at leaf 1, city exists at leaf 2 (a
+		// different address than the postcode hit).
+		//
+		// Phase 2 per-element IsNull: AndNot at raw level subtracts only
+		// positions where city exists AT THE SAME LEAF as postcode. doc2's
+		// city is at leaf 2 (a different address element) so the postcode
+		// position at leaf 1 survives — both docs match. Pre-Phase 2 used
+		// universal-at-rootDoc semantics, dropping doc2 entirely.
 		const (
 			docMatch   = uint64(51)
 			docNoMatch = uint64(52)
@@ -217,7 +223,7 @@ func TestRecGroupExecutorTokenizationAndIsNull(t *testing.T) {
 			makeLeafPvp(class, "addresses", "postcode", "10115"),
 			makeIsNullPvp(class, "addresses", "city", true),
 		)
-		runRec(t, s, pv, []uint64{docMatch})
+		runRec(t, s, pv, []uint64{docMatch, docNoMatch})
 	})
 
 	t.Run("isnull_true_only_uses_rootAnchor_seed", func(t *testing.T) {

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive_integration_test.go
@@ -67,8 +67,10 @@ func TestRecGroupExecutorTokenizationAndIsNull(t *testing.T) {
 				rel()
 			}
 		}()
-		docs, docRel, err := exec.execute(context.Background(), plan)
+		raw, rawRel, err := exec.execute(context.Background(), plan)
 		require.NoError(t, err)
+		defer rawRel()
+		docs, docRel := s.nestedBitmapOps.MaskRootLeaf(raw)
 		defer docRel()
 		requireBitmapValid(t, docs)
 		assert.Equal(t, want, docs.ToArray())

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive_integration_test.go
@@ -155,7 +155,7 @@ func TestRecGroupExecutorTokenizationAndIsNull(t *testing.T) {
 
 		pv := &propValuePair{
 			operator: filters.OperatorAnd,
-			nested:   nestedInfo{isCorrelated: true, childrenFromTokenization: true},
+			nested:   nestedInfo{isWithinRootSubtree: true, childrenFromTokenization: true},
 			prop:     "addresses",
 			children: []*propValuePair{
 				makeLeafPvp(class, "addresses", "city", "new"),

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive_test.go
@@ -141,12 +141,15 @@ func tokenWrapperOuter(tokens ...*propValuePair) *propValuePair {
 }
 
 // tokenWrapperInner builds a non-nested wrapper child whose grandchildren are
-// tokens of a single value at the same path. Models Pattern 2.
+// tokens of a single value at the same path. Models Pattern 2: production
+// buildNestedTextFilterPair sets childrenFromTokenization=true, which is
+// how normalizeRecGroup distinguishes tokenization wrappers from same-root
+// operator subtrees.
 func tokenWrapperInner(tokens ...*propValuePair) *propValuePair {
 	return &propValuePair{
 		prop:     "addresses",
 		operator: filters.OperatorAnd,
-		// isNested defaults to false → routed through the wrapper branch.
+		nested:   nestedInfo{childrenFromTokenization: true},
 		children: tokens,
 	}
 }

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive_test.go
@@ -135,7 +135,7 @@ func tokenWrapperOuter(tokens ...*propValuePair) *propValuePair {
 	return &propValuePair{
 		prop:     "addresses",
 		operator: filters.OperatorAnd,
-		nested:   nestedInfo{isCorrelated: true, childrenFromTokenization: true},
+		nested:   nestedInfo{isWithinRootSubtree: true, childrenFromTokenization: true},
 		children: tokens,
 	}
 }
@@ -156,7 +156,7 @@ func outerCorrelated(children ...*propValuePair) *propValuePair {
 	return &propValuePair{
 		prop:     "addresses",
 		operator: filters.OperatorAnd,
-		nested:   nestedInfo{isCorrelated: true},
+		nested:   nestedInfo{isWithinRootSubtree: true},
 		children: children,
 	}
 }

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_test.go
@@ -232,10 +232,12 @@ func TestGroupNestedByProp(t *testing.T) {
 		},
 
 		// output:
-		// ├── addresses.city         ← single-child group, no wrapper
-		// └── OR(addresses.postcode) ← flat: not an AND node
+		// └── correlated(addresses)
+		//     ├── city
+		//     └── OR(postcode)  ← OR-of-same-root folds into the subtree
+		// Recursive nestedRootProp recognises the OR as addresses-rooted.
 		{
-			name: "non-AND compound child goes to flat",
+			name: "OR with same-root child folds into subtree",
 			children: []*propValuePair{
 				nestedPvp("addresses", "city"),
 				{
@@ -243,10 +245,144 @@ func TestGroupNestedByProp(t *testing.T) {
 					children: []*propValuePair{nestedPvp("addresses", "postcode")},
 				},
 			},
+			want: []wantChild{{correlatedProp: "addresses", groupSize: 2}},
+		},
+
+		// output:
+		// └── correlated(addresses)
+		//     ├── city
+		//     └── OR(postcode, country)  ← all same-root, folds in
+		{
+			name: "OR with multiple same-root children folds into subtree",
+			children: []*propValuePair{
+				nestedPvp("addresses", "city"),
+				{
+					operator: filters.OperatorOr,
+					children: []*propValuePair{
+						nestedPvp("addresses", "postcode"),
+						nestedPvp("addresses", "country"),
+					},
+				},
+			},
+			want: []wantChild{{correlatedProp: "addresses", groupSize: 2}},
+		},
+
+		// output:
+		// ├── addresses.city                  ← single-child group, no wrapper
+		// └── OR(addresses.postcode, cars.x)  ← mixed-root OR stays opaque
+		{
+			name: "OR with mixed-root children stays opaque",
+			children: []*propValuePair{
+				nestedPvp("addresses", "city"),
+				{
+					operator: filters.OperatorOr,
+					children: []*propValuePair{
+						nestedPvp("addresses", "postcode"),
+						nestedPvp("cars", "make"),
+					},
+				},
+			},
 			want: []wantChild{
 				{isPlain: true},
 				{isPlain: true},
 			},
+		},
+
+		// output:
+		// ├── addresses.city               ← single-child group, no wrapper
+		// └── OR(addresses.postcode, flat) ← OR with flat stays opaque
+		{
+			name: "OR with flat child stays opaque",
+			children: []*propValuePair{
+				nestedPvp("addresses", "city"),
+				{
+					operator: filters.OperatorOr,
+					children: []*propValuePair{
+						nestedPvp("addresses", "postcode"),
+						flatPvp(),
+					},
+				},
+			},
+			want: []wantChild{
+				{isPlain: true},
+				{isPlain: true},
+			},
+		},
+
+		// output:
+		// └── correlated(addresses)
+		//     ├── city
+		//     └── NOT(postcode)  ← NOT-of-same-root folds in
+		{
+			name: "NOT with same-root child folds into subtree",
+			children: []*propValuePair{
+				nestedPvp("addresses", "city"),
+				{
+					operator: filters.OperatorNot,
+					children: []*propValuePair{nestedPvp("addresses", "postcode")},
+				},
+			},
+			want: []wantChild{{correlatedProp: "addresses", groupSize: 2}},
+		},
+
+		// output:
+		// ├── addresses.city            ← single-child group, no wrapper
+		// └── NOT(cars.make)            ← different root, stays opaque
+		{
+			name: "NOT with different-root child stays opaque",
+			children: []*propValuePair{
+				nestedPvp("addresses", "city"),
+				{
+					operator: filters.OperatorNot,
+					children: []*propValuePair{nestedPvp("cars", "make")},
+				},
+			},
+			want: []wantChild{
+				{isPlain: true},
+				{isPlain: true},
+			},
+		},
+
+		// output:
+		// └── correlated(addresses)
+		//     ├── city
+		//     └── AND(postcode, country)  ← AND-of-same-root folds in
+		// Recognises a user-written AND of same-root leaves as a same-root
+		// subtree (in contrast to the existing test for AND with mixed roots
+		// or AND with flat children which stay opaque).
+		{
+			name: "AND with multiple same-root nested leaves folds into subtree",
+			children: []*propValuePair{
+				nestedPvp("addresses", "city"),
+				userNestedAndPvp(
+					nestedPvp("addresses", "postcode"),
+					nestedPvp("addresses", "country"),
+				),
+			},
+			want: []wantChild{{correlatedProp: "addresses", groupSize: 2}},
+		},
+
+		// output:
+		// └── correlated(addresses)
+		//     ├── city
+		//     └── AND(postcode, OR(country, region))  ← deep nesting all same-root
+		// Recursive analysis crosses multiple levels of operator nesting.
+		{
+			name: "deeply nested same-root operators fold into subtree",
+			children: []*propValuePair{
+				nestedPvp("addresses", "city"),
+				userNestedAndPvp(
+					nestedPvp("addresses", "postcode"),
+					&propValuePair{
+						operator: filters.OperatorOr,
+						children: []*propValuePair{
+							nestedPvp("addresses", "country"),
+							nestedPvp("addresses", "region"),
+						},
+					},
+				),
+			},
+			want: []wantChild{{correlatedProp: "addresses", groupSize: 2}},
 		},
 
 		// output:

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_test.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_test.go
@@ -26,14 +26,14 @@ func nestedPvp(prop, relPath string) *propValuePair {
 }
 
 // compoundAndPvp builds a compound AND propValuePair as produced by multi-token
-// text tokenization (childrenFromTokenization=true, isCorrelatedNested=true).
+// text tokenization (childrenFromTokenization=true, isWithinRootSubtree=true).
 // prop is derived from the first child, mirroring buildNestedTextFilterPair.
 func compoundAndPvp(children ...*propValuePair) *propValuePair {
 	var prop string
 	if len(children) > 0 {
 		prop = children[0].prop
 	}
-	return &propValuePair{operator: filters.OperatorAnd, children: children, nested: nestedInfo{isCorrelated: true, childrenFromTokenization: true}, prop: prop}
+	return &propValuePair{operator: filters.OperatorAnd, children: children, nested: nestedInfo{isWithinRootSubtree: true, childrenFromTokenization: true}, prop: prop}
 }
 
 // userNestedAndPvp builds a compound AND propValuePair as produced by user
@@ -46,7 +46,7 @@ func userNestedAndPvp(children ...*propValuePair) *propValuePair {
 // wantChild describes one expected element in the groupNestedByProp output.
 type wantChild struct {
 	// correlatedProp is non-empty when the output child should be an
-	// isCorrelatedNested=true AND node wrapping conditions for that prop.
+	// isWithinRootSubtree=true AND node wrapping conditions for that prop.
 	correlatedProp string
 	// groupSize is the number of children inside the correlated group.
 	// Only inspected when correlatedProp is non-empty.
@@ -293,12 +293,12 @@ func TestGroupNestedByProp(t *testing.T) {
 			for i, wc := range tt.want {
 				child := result[i]
 				if wc.correlatedProp != "" {
-					assert.True(t, child.nested.isCorrelated, "child[%d] should be correlated", i)
+					assert.True(t, child.nested.isWithinRootSubtree, "child[%d] should be correlated", i)
 					assert.Equal(t, filters.OperatorAnd, child.operator, "child[%d] operator", i)
 					assert.Equal(t, wc.correlatedProp, child.prop, "child[%d] prop", i)
 					assert.Len(t, child.children, wc.groupSize, "child[%d] group size", i)
 				} else {
-					assert.False(t, child.nested.isCorrelated, "child[%d] should not be correlated", i)
+					assert.False(t, child.nested.isWithinRootSubtree, "child[%d] should not be correlated", i)
 				}
 			}
 		})

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -333,6 +333,12 @@ func (s *Searcher) docIDs(ctx context.Context, filter *filters.LocalFilter,
 	return helpers.NewAllowListCloseableFromBitmap(dbm.docIDs, dbm.release), nil
 }
 
+// extractPropValuePair is the entry point. It delegates type-dispatched
+// construction of the propValuePair tree to buildPropValuePair, then
+// runs a single post-order pass over the tree to group same-root
+// subtrees at every AND node. Recursive calls from
+// extractPropValuePairs go directly to buildPropValuePair to avoid
+// re-grouping during construction.
 func (s *Searcher) extractPropValuePair(
 	ctx context.Context, filter *filters.Clause, className schema.ClassName,
 ) (*propValuePair, error) {
@@ -340,6 +346,58 @@ func (s *Searcher) extractPropValuePair(
 	if class == nil {
 		return nil, fmt.Errorf("class %q not found", className)
 	}
+	out, err := s.buildPropValuePair(ctx, filter, className, class)
+	if err != nil {
+		return nil, err
+	}
+	return groupNestedSubtrees(out, class), nil
+}
+
+// groupNestedSubtrees walks pv's tree post-order and applies the
+// same-root grouping rule of groupNestedByProp at every AND node it
+// finds. OR / NOT / leaf nodes pass through; their children are still
+// walked so AND nodes deeper in the tree get grouped. Pre-marked
+// wrappers (isWithinRootSubtree=true, e.g. tokenization wrappers from
+// buildNestedTextFilterPair) are skipped — their children are already
+// the leaves of one same-root subtree and need no further grouping.
+//
+// When grouping collapses every child of an AND into a single same-root
+// wrapper, the AND is promoted in place: its own isWithinRootSubtree
+// flag and prop are set, and the redundant single-child wrapping level
+// is elided. Mixed-root ANDs keep the per-group wrappers as separate
+// children.
+func groupNestedSubtrees(pv *propValuePair, class *models.Class) *propValuePair {
+	if pv == nil || len(pv.children) == 0 {
+		return pv
+	}
+	for i := range pv.children {
+		pv.children[i] = groupNestedSubtrees(pv.children[i], class)
+	}
+	if pv.operator != filters.OperatorAnd || pv.nested.isWithinRootSubtree {
+		return pv
+	}
+	grouped := groupNestedByProp(pv.children, class)
+	if len(grouped) == 1 && grouped[0].nested.isWithinRootSubtree {
+		// Collapse: every child landed in one same-root wrapper.
+		// Promote pv to be that wrapper instead of holding it as a
+		// useless single-child outer AND.
+		w := grouped[0]
+		pv.nested.isWithinRootSubtree = true
+		pv.prop = w.prop
+		pv.children = w.children
+		return pv
+	}
+	pv.children = grouped
+	return pv
+}
+
+// buildPropValuePair constructs the propValuePair from filter without
+// applying the same-root grouping pass. Used recursively by
+// extractPropValuePairs; the top-level extractPropValuePair wrapper
+// invokes groupNestedSubtrees once on the final tree.
+func (s *Searcher) buildPropValuePair(
+	ctx context.Context, filter *filters.Clause, className schema.ClassName, class *models.Class,
+) (*propValuePair, error) {
 	out, err := newPropValuePair(class)
 	if err != nil {
 		return nil, fmt.Errorf("new prop value pair: %w", err)
@@ -349,9 +407,6 @@ func (s *Searcher) extractPropValuePair(
 		children, err := s.extractPropValuePairs(ctx, filter.Operands, filter.Operator, className)
 		if err != nil {
 			return nil, err
-		}
-		if filter.Operator == filters.OperatorAnd {
-			children = groupNestedByProp(children, class)
 		}
 		out.children = children
 		out.operator = filter.Operator
@@ -428,9 +483,19 @@ func (s *Searcher) extractPropValuePair(
 	return s.extractPrimitiveProp(property, filter.Value.Type, filter.Value.Value, filter.Operator, class)
 }
 
+// extractPropValuePairs extracts each operand recursively via
+// buildPropValuePair (not the public extractPropValuePair wrapper) so
+// the same-root grouping pass runs only once at the outermost call.
+// The top-level groupNestedSubtrees pass walks the full tree post-order
+// and groups every AND node — including those nested inside OR/NOT —
+// so this recursion model doesn't miss any AND nodes.
 func (s *Searcher) extractPropValuePairs(ctx context.Context,
 	operands []filters.Clause, operator filters.Operator, className schema.ClassName,
 ) ([]*propValuePair, error) {
+	class := s.getClass(className.String())
+	if class == nil {
+		return nil, fmt.Errorf("class %q not found", className)
+	}
 	children := make([]*propValuePair, len(operands))
 	eg := enterrors.NewErrorGroupWrapper(s.logger)
 	outerConcurrencyLimit := concurrency.BudgetFromCtx(ctx, concurrency.GOMAXPROCS)
@@ -442,7 +507,7 @@ func (s *Searcher) extractPropValuePairs(ctx context.Context,
 		i, clause := i, clause
 		eg.Go(func() error {
 			ctx := concurrency.ContextWithFractionalBudget(ctx, concurrencyReductionFactor, concurrency.GOMAXPROCS)
-			child, err := s.extractPropValuePair(ctx, &clause, className)
+			child, err := s.buildPropValuePair(ctx, &clause, className, class)
 			// check for stopword errors on ContainsAny operator only at the end
 			if err != nil && errors.Is(err, ErrOnlyStopwords) && operator == filters.ContainsAny {
 				return nil
@@ -884,6 +949,10 @@ func (s *Searcher) extractContains(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
+	// No same-root grouping here. ContainsAll desugars to an AND that
+	// the outermost extractPropValuePair wrapper normalizes via
+	// groupNestedByProp; ContainsAny / ContainsNone desugar to OR /
+	// NOT(OR) which the wrapper deliberately leaves ungrouped.
 	out, err := newPropValuePair(class)
 	if err != nil {
 		return nil, fmt.Errorf("new prop value pair: %w", err)

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -138,7 +138,7 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, propName, f
 	case 1:
 		return pvps[0], nil
 	default:
-		return &propValuePair{operator: filters.OperatorAnd, children: pvps, nested: nestedInfo{isCorrelated: true, childrenFromTokenization: true}, prop: propName, Class: class}, nil
+		return &propValuePair{operator: filters.OperatorAnd, children: pvps, nested: nestedInfo{isWithinRootSubtree: true, childrenFromTokenization: true}, prop: propName, Class: class}, nil
 	}
 }
 
@@ -207,10 +207,10 @@ func (s *Searcher) buildNestedIsNullPair(filter *filters.Clause, propName, relPa
 // nestedRootProp returns the root property name for a child eligible for
 // correlated grouping, or "" if the child is flat and should pass through.
 // Eligible children are direct nested leaves (nested.isNested) or
-// tokenization compound ANDs (nested.isCorrelated).
+// tokenization compound ANDs (nested.isWithinRootSubtree).
 // For "garages.cars.tags", the root property name is "garages".
 func nestedRootProp(child *propValuePair) string {
-	if child.nested.isNested || child.nested.isCorrelated {
+	if child.nested.isNested || child.nested.isWithinRootSubtree {
 		return child.prop
 	}
 	return ""
@@ -218,13 +218,13 @@ func nestedRootProp(child *propValuePair) string {
 
 // groupNestedByProp rewrites a flat slice of AND children so that conditions
 // targeting the same root nested property are grouped into a single
-// isCorrelated AND node that the resolver will handle with position-aware
+// isWithinRootSubtree AND node that the resolver will handle with position-aware
 // same-element semantics. Flat (non-nested) conditions and nested conditions
 // from different props are returned unchanged in their original order.
 //
 // A child is eligible for grouping when it is:
 //   - a direct nested leaf (nested.isNested == true), or
-//   - a tokenization-produced compound AND (nested.isCorrelated == true)
+//   - a tokenization-produced compound AND (nested.isWithinRootSubtree == true)
 //
 // If no nested children are found, the original slice is returned as-is.
 // Single-child groups are kept as plain children (no wrapper node created).
@@ -238,7 +238,7 @@ func nestedRootProp(child *propValuePair) string {
 //
 // the result is:
 //
-//	isCorrelated(addresses) [city="Berlin", postcode="10115"]
+//	isWithinRootSubtree(addresses) [city="Berlin", postcode="10115"]
 //	age > 30
 //	cars.make = "BMW"
 func groupNestedByProp(children []*propValuePair, class *models.Class) []*propValuePair {
@@ -260,7 +260,7 @@ func groupNestedByProp(children []*propValuePair, class *models.Class) []*propVa
 	}
 
 	// Second pass: reconstruct the children slice, replacing multi-condition
-	// nested groups with a single isCorrelated AND node. Single-condition
+	// nested groups with a single isWithinRootSubtree AND node. Single-condition
 	// groups are kept as plain children. Flat conditions retain their position.
 	result := make([]*propValuePair, 0, len(children))
 	emitted := make(map[string]bool, len(propOrder))
@@ -280,7 +280,7 @@ func groupNestedByProp(children []*propValuePair, class *models.Class) []*propVa
 		} else {
 			result = append(result, &propValuePair{
 				operator: filters.OperatorAnd,
-				nested:   nestedInfo{isCorrelated: true},
+				nested:   nestedInfo{isWithinRootSubtree: true},
 				prop:     prop,
 				children: group,
 				Class:    class,

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -204,16 +204,44 @@ func (s *Searcher) buildNestedIsNullPair(filter *filters.Clause, propName, relPa
 	}, nil
 }
 
-// nestedRootProp returns the root property name for a child eligible for
-// correlated grouping, or "" if the child is flat and should pass through.
-// Eligible children are direct nested leaves (nested.isNested) or
-// tokenization compound ANDs (nested.isWithinRootSubtree).
-// For "garages.cars.tags", the root property name is "garages".
+// nestedRootProp returns the root property name if child's entire subtree
+// consists of nested conditions on a single root nested prop, or "" if it
+// contains any flat property, mixed-root nested leaves, or has no nested
+// content. Used by groupNestedByProp to decide which children fold into a
+// same-root subtree wrapper.
+//
+// Terminating cases:
+//   - direct nested leaf (nested.isNested): returns child.prop.
+//   - already-marked subtree (nested.isWithinRootSubtree): returns child.prop.
+//
+// Recursive cases — for AND/OR/NOT operator children, all descendants must
+// agree on a single root for the subtree to be eligible:
+//   - AND/OR with N≥1 children: all children must return the same non-empty root.
+//   - NOT with 1 child: returns whatever the operand returns.
+//
+// A flat leaf, mixed-root subtree, or empty operator returns "".
 func nestedRootProp(child *propValuePair) string {
 	if child.nested.isNested || child.nested.isWithinRootSubtree {
 		return child.prop
 	}
-	return ""
+	switch child.operator {
+	case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot:
+		if len(child.children) == 0 {
+			return ""
+		}
+		first := nestedRootProp(child.children[0])
+		if first == "" {
+			return ""
+		}
+		for _, gc := range child.children[1:] {
+			if nestedRootProp(gc) != first {
+				return ""
+			}
+		}
+		return first
+	default:
+		return ""
+	}
 }
 
 // groupNestedByProp rewrites a flat slice of AND children so that conditions

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
@@ -175,18 +175,26 @@ func (e *recExecutor) execute(ctx context.Context, plan recPlanNode) (*sroar.Bit
 		return nil, nil, err
 	}
 
+	// Apply non-plan-consumed excludes at raw level. bm is raw under Phase 2;
+	// excludes are raw _exists.{path} bitmaps. AndNot is leaf-precise,
+	// preserving per-element semantics — a sibling element at the same LCA
+	// without the absent property's existence survives.
 	for _, excl := range e.excludes {
 		if e.excludeConsumedByPlan(excl) {
 			continue
 		}
-		maskedExcl, relExcl := e.bitmapOps.MaskLeaf(excl.bitmap)
-		bm.AndNotConc(maskedExcl, e.maxConcurrency)
-		relExcl()
+		bm.AndNotConc(excl.bitmap, e.maxConcurrency)
 	}
 
 	if e.returnMasked {
-		// Caller takes ownership of bm — its release is the returned release.
-		return bm, release, nil
+		// returnMasked callers (multi-group fallback) expect a leaf-zeroed
+		// bitmap for cross-group AndConc. Apply MaskLeaf to preserve the
+		// Phase 1 contract; switching the contract to "skip MaskRootLeaf,
+		// return raw" is a Phase 2c follow-up that would also require
+		// resolveMultiGroupRootDocIDAnd to use CrossLeafCopresenceAll.
+		masked, maskedRel := e.bitmapOps.MaskLeaf(bm)
+		release()
+		return masked, maskedRel, nil
 	}
 	defer release()
 	docs, docRel := e.bitmapOps.MaskRootLeaf(bm)
@@ -403,9 +411,7 @@ func (e *recExecutor) evalFlatRawAndAll(ctx context.Context, flat *flatSubtree, 
 			anded.AndNotConc(excl.bitmap, e.maxConcurrency)
 		}
 	}
-	result, resultRel := e.bitmapOps.MaskLeaf(anded)
-	andedRel()
-	return result, resultRel, nil
+	return anded, andedRel, nil
 }
 
 // evalGroupRoot collects raw bitmaps for here conditions and rootDoc bitmaps
@@ -466,26 +472,29 @@ func (e *recExecutor) evalGroupRoot(ctx context.Context, g *recGroupNode, parent
 	if e.canUseRawAndAll(g) {
 		anded, andedRel := e.bitmapOps.AndAll(bitmaps, e.maxConcurrency)
 		// Apply matching excludes (lcaPath == g.lca) at raw level — the
-		// anded bitmap is still raw-shape (leaf-precise) here, so AndNot'ing a
-		// raw _exists.{path} bitmap removes only the exact same-element leaf
-		// position that carries the absent property's existence. This is the
-		// §8.5 sibling-element semantics: a sibling element at the same LCA
+		// anded bitmap is raw-shape (leaf-precise), so AndNot'ing a raw
+		// _exists.{path} bitmap removes only the exact same-element leaf
+		// position that carries the absent property's existence. §8.5
+		// sibling-element semantics: a sibling element at the same LCA
 		// without the absent property's existence survives.
 		for _, excl := range e.excludes {
 			if e.excludeMatchesGroup(excl, g) {
 				anded.AndNotConc(excl.bitmap, e.maxConcurrency)
 			}
 		}
-		result, resultRel := e.bitmapOps.MaskLeaf(anded)
-		andedRel()
 		succeeded = true
 		for _, rel := range releases {
 			rel()
 		}
-		return result, resultRel, nil
+		return anded, andedRel, nil
 	}
 
-	result, resultRel := e.bitmapOps.AndAllMaskLeaf(bitmaps, e.maxConcurrency)
+	// Non-bridged path: Phase 3 inheritance doesn't span the group's
+	// operands (multi-sub, dup paths, or sub-result mixed with here-raws).
+	// CrossLeafCopresenceAll keeps positions whose (root, doc) co-presents
+	// across every operand and preserves the contributing leaves for
+	// downstream raw composition.
+	result, resultRel := e.bitmapOps.CrossLeafCopresenceAll(bitmaps)
 	succeeded = true
 	for _, rel := range releases {
 		rel()
@@ -639,62 +648,67 @@ func (e *recExecutor) applyMatchingExcludes(g *recGroupNode, effective *sroar.Bi
 	return cloned, clonedRel
 }
 
-// matchElementRecursive computes the per-element rootDoc as the intersection of
-// all here MaskLeafAnd results and all sub plan results, evaluated under
-// effective. On any empty intermediate it short-circuits and the element is
-// skipped. On success the per-element rootDoc is OR'd into result.
+// matchElementRecursive gathers per-condition raw bitmaps for the element
+// represented by effective, combines them via CrossLeafCopresenceAll, and
+// ORs the result into the accumulator.
+//
+// Each here leaf contributes raw AndAll(rawLeaf, effective) — positions of
+// that condition inside the element. Each sub-plan contributes its raw
+// output (Phase 2 architecture: subs emit raw). Cross-condition combining
+// uses CrossLeafCopresenceAll so positions co-presenting on (root, doc)
+// are kept regardless of leaf alignment — correct for the non-bridged path
+// (Phase 3 inheritance doesn't span the group's operands; that's why
+// evalGroup routed here instead of canUseRawAndAll or evalFlatRawAndAll).
+// Empty inputs short-circuit the element entirely.
 func (e *recExecutor) matchElementRecursive(ctx context.Context, g *recGroupNode, effective, result *sroar.Bitmap) error {
-	var partial *sroar.Bitmap
-	var partialRel func()
-	releasePartial := func() {
-		if partialRel != nil {
-			partialRel()
+	bitmaps := make([]*sroar.Bitmap, 0, len(g.here)+len(g.subs))
+	releases := make([]func(), 0, len(g.here)+len(g.subs))
+	releaseAll := func() {
+		for _, rel := range releases {
+			rel()
 		}
-	}
-
-	addRootDoc := func(bm *sroar.Bitmap, rel func()) (empty bool) {
-		if partial == nil {
-			partial = bm
-			partialRel = rel
-			return partial.IsEmpty()
-		}
-		partial.AndConc(bm, e.maxConcurrency)
-		rel()
-		return partial.IsEmpty()
 	}
 
 	for _, leaf := range g.here {
 		rawLeaf, ok := e.rawsByCond[leaf]
 		if !ok {
-			releasePartial()
+			releaseAll()
 			return fmt.Errorf("matchElementRecursive: no raw bitmap for leaf %q", childRelPath(leaf))
 		}
-		bm, rel := e.bitmapOps.MaskLeafAnd(rawLeaf, effective)
-		if addRootDoc(bm, rel) {
-			releasePartial()
+		bm, rel := e.bitmapOps.AndAll([]*sroar.Bitmap{rawLeaf, effective}, e.maxConcurrency)
+		if bm.IsEmpty() {
+			rel()
+			releaseAll()
 			return nil
 		}
+		bitmaps = append(bitmaps, bm)
+		releases = append(releases, rel)
 	}
 
 	for _, sub := range g.subs {
 		subResult, subRelease, err := e.evalNode(ctx, sub, effective)
 		if err != nil {
-			releasePartial()
+			releaseAll()
 			return err
 		}
-		if addRootDoc(subResult, subRelease) {
-			releasePartial()
+		if subResult.IsEmpty() {
+			subRelease()
+			releaseAll()
 			return nil
 		}
+		bitmaps = append(bitmaps, subResult)
+		releases = append(releases, subRelease)
 	}
 
-	if partial == nil {
+	if len(bitmaps) == 0 {
 		// A group with no here and no subs is a builder bug. Treat as no match.
 		return nil
 	}
 
-	result.OrConc(partial, e.maxConcurrency)
-	releasePartial()
+	combined, combinedRel := e.bitmapOps.CrossLeafCopresenceAll(bitmaps)
+	result.OrConc(combined, e.maxConcurrency)
+	combinedRel()
+	releaseAll()
 	return nil
 }
 
@@ -749,7 +763,13 @@ func (e *recExecutor) evalSplit(ctx context.Context, n *recSplitNode, parentScop
 	if n.lca == "" {
 		return e.andBranchesAtDocID(branchResults, branchReleases, &succeeded)
 	}
-	result, resultRel := e.bitmapOps.AndAll(branchResults, e.maxConcurrency)
+	// Non-root multi-branch: branches pin to different arr[N] slices of
+	// the same intermediate scope. Each branch returns raw positions in
+	// its pinned slice; different branches' leaves are disjoint by
+	// construction (different elements at the lca). CrossLeafCopresenceAll
+	// keeps positions whose (root, doc) co-presents across every branch —
+	// i.e. the same root contains a passing element in every pinned slice.
+	result, resultRel := e.bitmapOps.CrossLeafCopresenceAll(branchResults)
 	succeeded = true
 	for _, rel := range branchReleases {
 		rel()
@@ -952,14 +972,11 @@ func (e *recExecutor) evalNot(ctx context.Context, n *recNotNode, parentScope *s
 	}
 	defer operandRel()
 
-	// 6. AndNot universe ∖ operand. Under Phase 1 the operand returns
-	// rootDoc, so MaskLeaf the universe to match before subtraction. Phase 2
-	// will refactor the operand path to return raw and the MaskLeaf step
-	// here becomes unnecessary.
-	universeMatched, universeMatchedRel := e.bitmapOps.MaskLeaf(universe)
-	universeRel()
-	universeMatched.AndNotConc(operand, e.maxConcurrency)
+	// 6. AndNot at raw level: universe ∖ operand. Both are raw position
+	// bitmaps; AndNot is leaf-precise, giving existential per-element NOT
+	// semantics — "this element does not satisfy operand".
+	universe.AndNotConc(operand, e.maxConcurrency)
 
 	succeeded = true
-	return universeMatched, universeMatchedRel, nil
+	return universe, universeRel, nil
 }

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
@@ -229,6 +229,10 @@ func (e *recExecutor) evalNode(ctx context.Context, node recPlanNode, parentScop
 		return e.evalGroup(ctx, n, parentScope)
 	case *recSplitNode:
 		return e.evalSplit(ctx, n, parentScope)
+	case *recOrNode:
+		return e.evalOr(ctx, n, parentScope)
+	case *recNotNode:
+		return e.evalNot(ctx, n, parentScope)
 	default:
 		return nil, nil, fmt.Errorf("recExecutor: unknown node type %T", node)
 	}
@@ -797,4 +801,153 @@ func (e *recExecutor) intersectScope(scope, parentScope *sroar.Bitmap) (*sroar.B
 		return scope, func() {}
 	}
 	return e.bitmapOps.AndAll([]*sroar.Bitmap{scope, parentScope}, e.maxConcurrency)
+}
+
+// evalOr evaluates each child of an OR node and returns their union via OrAll.
+// Output shape matches the children's shape — OrAll preserves position bits, so
+// the OR works regardless of whether children return raw or rootDoc bitmaps
+// (transitional during the position-level eval rollout: Phase 1 inner functions
+// still emit rootDoc; Phase 2 flips them to raw and OR semantics are unchanged).
+//
+// parentScope is passed through to each child's evalNode unchanged. Children's
+// own evaluation logic applies the scope; the OR doesn't need to re-apply.
+func (e *recExecutor) evalOr(ctx context.Context, n *recOrNode, parentScope *sroar.Bitmap) (*sroar.Bitmap, func(), error) {
+	if err := ctxExpired(ctx); err != nil {
+		return nil, nil, err
+	}
+	if len(n.children) == 0 {
+		return nil, nil, fmt.Errorf("evalOr: OR with zero children at lca=%q", n.lca)
+	}
+
+	bitmaps := make([]*sroar.Bitmap, 0, len(n.children))
+	releases := make([]func(), 0, len(n.children))
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			for _, rel := range releases {
+				rel()
+			}
+		}
+	}()
+
+	for _, child := range n.children {
+		bm, rel, err := e.evalNode(ctx, child, parentScope)
+		if err != nil {
+			return nil, nil, err
+		}
+		bitmaps = append(bitmaps, bm)
+		releases = append(releases, rel)
+	}
+
+	result, resultRel := e.bitmapOps.OrAll(bitmaps, e.maxConcurrency)
+	succeeded = true
+	for _, rel := range releases {
+		rel()
+	}
+	return result, resultRel, nil
+}
+
+// evalNot inverts its operand at the operand's natural LCA against the
+// per-LCA universe (`_exists.{lca}`). pins (when present) intersect the
+// universe with `_idx.{pin.RelPath}[pin.Index]` slices — for example, pins
+// for `NOT cars.tires[1].width=205` restrict the universe to tire-position
+// entries at index 1. parentScope further narrows the universe so per-element
+// inversion respects an enclosing idx-loop's effective scope.
+//
+// The output shape matches the operand's shape (transitional during Phase 1:
+// operands return rootDoc, so this method MaskLeaf's the universe to match
+// before AndNot. Phase 2 will refactor the rest of the executor to emit raw;
+// the MaskLeaf step in evalNot can be dropped then, and the universe stays
+// raw end-to-end).
+func (e *recExecutor) evalNot(ctx context.Context, n *recNotNode, parentScope *sroar.Bitmap) (*sroar.Bitmap, func(), error) {
+	if err := ctxExpired(ctx); err != nil {
+		return nil, nil, err
+	}
+	if e.metaBucket == nil {
+		return nil, nil, fmt.Errorf("evalNot: meta bucket is nil at lca=%q", n.lca)
+	}
+
+	// 1. Read the universe of positions at the operand's LCA. Empty universe
+	// means the operand can't match anything in any element — NOT result is
+	// also empty (existential per-element: no element exists to satisfy
+	// "this element does not satisfy operand").
+	universeBucket, universeBucketRel, err := e.metaBucket.RoaringSetGet(invnested.ExistsKey(n.lca))
+	if err != nil {
+		return nil, nil, fmt.Errorf("evalNot: read _exists for %q: %w", n.lca, err)
+	}
+	if universeBucket == nil || universeBucket.IsEmpty() {
+		if universeBucketRel != nil {
+			universeBucketRel()
+		}
+		empty, emptyRel := e.bitmapOps.NewEmpty(0)
+		return empty, emptyRel, nil
+	}
+
+	// 2. Clone the universe into a pool buffer so subsequent steps can mutate
+	// it without disturbing the bucket-owned bitmap. We can release the
+	// bucket entry as soon as the clone is made.
+	universe, universeRel := e.bitmapOps.AndAll([]*sroar.Bitmap{universeBucket}, e.maxConcurrency)
+	universeBucketRel()
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			universeRel()
+		}
+	}()
+
+	// 3. Apply pin restrictions. Each pin intersects the universe with the
+	// _idx slice for that arr[N] tuple.
+	var keyBuf [invnested.IdxKeySize]byte
+	for _, pin := range n.pins {
+		pinBm, pinRel, err := e.metaBucket.RoaringSetGet(
+			invnested.IdxKeyToBuf(pin.RelPath, pin.Index, keyBuf[:]))
+		if err != nil {
+			return nil, nil, fmt.Errorf("evalNot: read _idx for pin %q[%d]: %w", pin.RelPath, pin.Index, err)
+		}
+		if pinBm == nil {
+			if pinRel != nil {
+				pinRel()
+			}
+			// Pin slice not present in any doc — universe becomes empty.
+			empty, emptyRel := e.bitmapOps.NewEmpty(0)
+			succeeded = true
+			universeRel()
+			return empty, emptyRel, nil
+		}
+		universe.AndConc(pinBm, e.maxConcurrency)
+		pinRel()
+		if universe.IsEmpty() {
+			succeeded = true
+			return universe, universeRel, nil
+		}
+	}
+
+	// 4. Apply parentScope. parentScope is a raw bitmap from an enclosing
+	// idx-loop; AND'ing narrows the universe to that loop's element scope.
+	if parentScope != nil {
+		universe.AndConc(parentScope, e.maxConcurrency)
+		if universe.IsEmpty() {
+			succeeded = true
+			return universe, universeRel, nil
+		}
+	}
+
+	// 5. Evaluate operand under parentScope. Operand evaluation handles its
+	// own scope restrictions internally.
+	operand, operandRel, err := e.evalNode(ctx, n.operand, parentScope)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer operandRel()
+
+	// 6. AndNot universe ∖ operand. Under Phase 1 the operand returns
+	// rootDoc, so MaskLeaf the universe to match before subtraction. Phase 2
+	// will refactor the operand path to return raw and the MaskLeaf step
+	// here becomes unnecessary.
+	universeMatched, universeMatchedRel := e.bitmapOps.MaskLeaf(universe)
+	universeRel()
+	universeMatched.AndNotConc(operand, e.maxConcurrency)
+
+	succeeded = true
+	return universeMatched, universeMatchedRel, nil
 }

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
@@ -33,8 +33,10 @@ type recExclude struct {
 	lcaPath string
 }
 
-// recExecutor evaluates a recPlanNode tree to produce the docID bitmap of
-// matching documents.
+// recExecutor evaluates a recPlanNode tree to produce a raw position bitmap.
+// Callers strip to docIDs via bitmapOps.MaskRootLeaf when needed — the
+// executor itself stays position-level so multi-group fallback can combine
+// raw bitmaps via CrossLeafCopresenceAll before stripping.
 //
 // Each leaf condition in the plan (a *propValuePair appearing in some
 // recGroupNode.here) maps to a raw position bitmap via rawsByCond. The
@@ -47,10 +49,9 @@ type recExclude struct {
 // LCA. When the LCA matches a group's lcaPath in the plan (planLCAs), the
 // exclude is subtracted raw-level inside that group — preserving leaf-precise
 // per-element semantics for §8.5 sibling-element negation. Otherwise it is
-// subtracted at rootDoc level via MaskLeaf+AndNot in execute(). rootAnchor is
+// subtracted at raw level by execute() after evalNode returns. rootAnchor is
 // the seed for the no-positive path: when plan is nil, the executor clones
-// the anchor, AndNots excludes at raw level (preserving leaf alignment), then
-// MaskLeaf to produce a rootDoc bitmap.
+// the anchor and AndNots excludes at raw level (preserving leaf alignment).
 //
 // Position lifecycle: every bitmap returned to a caller comes with a release
 // function. Internal intermediates are released before this method returns.
@@ -62,7 +63,6 @@ type recExecutor struct {
 	metaBucket     *lsmkv.Bucket
 	bitmapOps      *invnested.BitmapOps
 	maxConcurrency int
-	returnMasked   bool
 	// props is the nested schema of the root property the executor operates
 	// on. Used by collectFlatSubtree to identify scalar-array (text[], int[],
 	// uuid[], …) here paths — those values get distinct leaves per element
@@ -131,15 +131,6 @@ func (e *recExecutor) withRootAnchor(anchor *sroar.Bitmap) *recExecutor {
 	return e
 }
 
-// withReturnMasked toggles masked-output mode. When true, execute returns a
-// root+docID position bitmap (leaf bits zeroed) instead of plain docIDs — i.e.
-// it skips the trailing MaskRootLeaf. Used by resolveMultiGroupRootDocIDAnd to
-// AND multiple groups at root+docID level before stripping root bits.
-func (e *recExecutor) withReturnMasked(returnMasked bool) *recExecutor {
-	e.returnMasked = returnMasked
-	return e
-}
-
 // withProps attaches the root property's nested schema. Required for the
 // flat raw-AndAll path in evalGroup to detect scalar-array (narrow-leaf)
 // here paths.
@@ -148,20 +139,17 @@ func (e *recExecutor) withProps(props []*models.NestedProperty) *recExecutor {
 	return e
 }
 
-// execute runs the plan and returns either the final docID bitmap (root and
-// leaf bits stripped) or the intermediate root+docID position bitmap when
-// returnMasked is set. The caller must invoke the returned release.
+// execute runs the plan and returns a raw position bitmap. The caller is
+// responsible for stripping to docIDs via bitmapOps.MaskRootLeaf when needed
+// and must invoke the returned release.
 //
-// When plan is nil the executor takes the rootAnchor path: clone the anchor,
-// AndNot each exclude at raw position level (preserves leaf alignment with the
-// anchor's positions), MaskLeaf to a rootDoc bitmap, then MaskRootLeaf (skipped
-// if returnMasked).
+// When plan is nil the executor takes the rootAnchor path: clone the anchor
+// and AndNot each exclude at raw level (preserves leaf alignment).
 //
-// When plan is non-nil: evalNode produces a rootDoc bitmap; each exclude that
-// is NOT consumed inside the plan tree is MaskLeaf'd and AndNot'd from it
-// (root+docID-level subtraction). Excludes with lcaPath ∈ planLCAs were already
-// applied raw-level inside the matching group(s) — see §8.5. MaskRootLeaf
-// produces the final docID set (skipped if returnMasked).
+// When plan is non-nil: evalNode produces a raw bitmap; each exclude that
+// is NOT consumed inside the plan tree is AndNot'd at raw level (leaf-precise
+// per-element subtraction). Excludes with lcaPath ∈ planLCAs were already
+// applied raw-level inside the matching group(s) — see §8.5.
 func (e *recExecutor) execute(ctx context.Context, plan recPlanNode) (*sroar.Bitmap, func(), error) {
 	if err := ctxExpired(ctx); err != nil {
 		return nil, nil, err
@@ -175,43 +163,24 @@ func (e *recExecutor) execute(ctx context.Context, plan recPlanNode) (*sroar.Bit
 		return nil, nil, err
 	}
 
-	// Apply non-plan-consumed excludes at raw level. bm is raw under Phase 2;
-	// excludes are raw _exists.{path} bitmaps. AndNot is leaf-precise,
-	// preserving per-element semantics — a sibling element at the same LCA
-	// without the absent property's existence survives.
+	// Apply non-plan-consumed excludes at raw level. bm is raw; excludes are
+	// raw _exists.{path} bitmaps. AndNot is leaf-precise, preserving
+	// per-element semantics — a sibling element at the same LCA without the
+	// absent property's existence survives.
 	for _, excl := range e.excludes {
 		if e.excludeConsumedByPlan(excl) {
 			continue
 		}
 		bm.AndNotConc(excl.bitmap, e.maxConcurrency)
 	}
-
-	if e.returnMasked {
-		// returnMasked callers (multi-group fallback) expect a leaf-zeroed
-		// bitmap for cross-group AndConc. Apply MaskLeaf to preserve the
-		// Phase 1 contract; switching the contract to "skip MaskRootLeaf,
-		// return raw" is a Phase 2c follow-up that would also require
-		// resolveMultiGroupRootDocIDAnd to use CrossLeafCopresenceAll.
-		masked, maskedRel := e.bitmapOps.MaskLeaf(bm)
-		release()
-		return masked, maskedRel, nil
-	}
-	defer release()
-	docs, docRel := e.bitmapOps.MaskRootLeaf(bm)
-	return docs, docRel, nil
+	return bm, release, nil
 }
 
 // executeRootAnchor handles the no-positive path. The anchor is the universe
-// of element positions (from _exists.{scope}); excludes are subtracted at raw
-// level so leaf-position alignment with the anchor is preserved. The trailing
-// MaskRootLeaf produces docIDs (skipped when returnMasked is set, in which
-// case the caller receives a leaf-precise raw bitmap and is responsible for
-// collapsing to docIDs itself).
-//
-// Phase 2a of the position-level eval rollout: dropped the prior MaskLeaf
-// step before MaskRootLeaf — it was redundant since MaskRootLeaf zeros both
-// root and leaf, and removing it lets the raw bitmap flow through to the
-// boundary unchanged.
+// of element positions (from _exists.{scope}); excludes are subtracted at
+// raw level so leaf-position alignment with the anchor is preserved. Returns
+// the resulting raw position bitmap — callers strip to docIDs via
+// bitmapOps.MaskRootLeaf when needed.
 func (e *recExecutor) executeRootAnchor() (*sroar.Bitmap, func(), error) {
 	if e.rootAnchor == nil {
 		return nil, nil, fmt.Errorf("recExecutor.execute: nil plan requires a non-nil rootAnchor")
@@ -222,17 +191,7 @@ func (e *recExecutor) executeRootAnchor() (*sroar.Bitmap, func(), error) {
 	for _, excl := range e.excludes {
 		raw.AndNotConc(excl.bitmap, e.maxConcurrency)
 	}
-	if e.returnMasked {
-		// returnMasked callers expect a leaf-zeroed bitmap. Apply MaskLeaf
-		// here to preserve that contract until Step 4 phase 2b refactors
-		// returnMasked to mean "skip MaskRootLeaf, return raw".
-		masked, maskedRel := e.bitmapOps.MaskLeaf(raw)
-		rawRel()
-		return masked, maskedRel, nil
-	}
-	defer rawRel()
-	docs, docRel := e.bitmapOps.MaskRootLeaf(raw)
-	return docs, docRel, nil
+	return raw, rawRel, nil
 }
 
 // evalNode dispatches by node type. parentScope (a raw position bitmap) limits

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
@@ -797,7 +797,7 @@ func (e *recExecutor) intersectScope(scope, parentScope *sroar.Bitmap) (*sroar.B
 // evalOr evaluates each child of an OR node and returns their union via OrAll.
 // Output shape matches the children's shape — OrAll preserves position bits, so
 // the OR works regardless of whether children return raw or rootDoc bitmaps
-// (transitional during the position-level eval rollout: Phase 1 inner functions
+// (transitional during the position-level evaluation rollout: Phase 1 inner functions
 // still emit rootDoc; Phase 2 flips them to raw and OR semantics are unchanged).
 //
 // parentScope is passed through to each child's evalNode unchanged. Children's

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
@@ -106,11 +106,11 @@ func (e *recExecutor) withPlanLCAs(lcas map[string]struct{}) *recExecutor {
 
 // excludeMatchesGroup reports whether the given exclude must be subtracted
 // inside this group at raw level. True iff exclude.lcaPath is non-empty and
-// equals g.lcaPath. The caller still has to be in a code path that can mix
+// equals g.lca. The caller still has to be in a code path that can mix
 // raw-shape exclude bitmaps with raw-shape inputs (canUseRawAndAll path or
 // runIdxLoopRecursive); other paths fall back to rootDoc subtraction.
 func (e *recExecutor) excludeMatchesGroup(excl recExclude, g *recGroupNode) bool {
-	return excl.lcaPath != "" && excl.lcaPath == g.lcaPath
+	return excl.lcaPath != "" && excl.lcaPath == g.lca
 }
 
 // excludeConsumedByPlan reports whether the exclude is subtracted somewhere
@@ -261,7 +261,7 @@ func (e *recExecutor) evalNode(ctx context.Context, node recPlanNode, parentScop
 // The here=0, subs=1 case is collapsed away by the planner so it does not
 // reach evalGroup (see buildGroup).
 func (e *recExecutor) evalGroup(ctx context.Context, g *recGroupNode, parentScope *sroar.Bitmap) (*sroar.Bitmap, func(), error) {
-	if e.canUseRawAndAll(g) || g.lcaPath == "" {
+	if e.canUseRawAndAll(g) || g.lca == "" {
 		return e.evalGroupRoot(ctx, g, parentScope)
 	}
 	if flat, ok := e.collectFlatSubtree(g); ok {
@@ -326,7 +326,7 @@ func (e *recExecutor) collectFlatSubtree(g *recGroupNode) (*flatSubtree, bool) {
 				return false
 			}
 		}
-		out.lcaPaths[grp.lcaPath] = struct{}{}
+		out.lcaPaths[grp.lca] = struct{}{}
 		for _, leaf := range grp.here {
 			path := childRelPath(leaf)
 			if _, dup := seen[path]; dup {
@@ -444,12 +444,12 @@ func (e *recExecutor) evalGroupRoot(ctx context.Context, g *recGroupNode, parent
 		bitmaps = append(bitmaps, parentScope)
 	}
 	if len(bitmaps) == 0 {
-		return nil, nil, fmt.Errorf("evalGroupRoot: no inputs for group at lcaPath=%q", g.lcaPath)
+		return nil, nil, fmt.Errorf("evalGroupRoot: no inputs for group at lcaPath=%q", g.lca)
 	}
 
 	if e.canUseRawAndAll(g) {
 		anded, andedRel := e.bitmapOps.AndAll(bitmaps, e.maxConcurrency)
-		// Apply matching excludes (lcaPath == g.lcaPath) at raw level — the
+		// Apply matching excludes (lcaPath == g.lca) at raw level — the
 		// anded bitmap is still raw-shape (leaf-precise) here, so AndNot'ing a
 		// raw _exists.{path} bitmap removes only the exact same-element leaf
 		// position that carries the absent property's existence. This is the
@@ -529,13 +529,13 @@ func (e *recExecutor) canUseRawAndAll(g *recGroupNode) bool {
 // into the accumulator.
 func (e *recExecutor) runIdxLoopRecursive(ctx context.Context, g *recGroupNode, parentScope *sroar.Bitmap) (*sroar.Bitmap, func(), error) {
 	if e.metaBucket == nil {
-		return nil, nil, fmt.Errorf("runIdxLoopRecursive: meta bucket is nil for %q", g.lcaPath)
+		return nil, nil, fmt.Errorf("runIdxLoopRecursive: meta bucket is nil for %q", g.lca)
 	}
 	if err := ctxExpired(ctx); err != nil {
 		return nil, nil, err
 	}
 
-	idxPrefix := invnested.PathPrefix("_idx." + g.lcaPath)
+	idxPrefix := invnested.PathPrefix("_idx." + g.lca)
 
 	capHint := 64
 	for _, leaf := range g.here {
@@ -557,7 +557,7 @@ func (e *recExecutor) runIdxLoopRecursive(ctx context.Context, g *recGroupNode, 
 	c := e.metaBucket.CursorRoaringSet()
 	defer c.Close()
 
-	for k, elemBitmap := c.Seek(invnested.IdxKey(g.lcaPath, 0)); k != nil; k, elemBitmap = c.Next() {
+	for k, elemBitmap := c.Seek(invnested.IdxKey(g.lca, 0)); k != nil; k, elemBitmap = c.Next() {
 		if err := ctxExpired(ctx); err != nil {
 			return nil, nil, err
 		}
@@ -573,7 +573,7 @@ func (e *recExecutor) runIdxLoopRecursive(ctx context.Context, g *recGroupNode, 
 			effRelease()
 			continue
 		}
-		// Apply matching excludes (lcaPath == g.lcaPath) at raw level on a
+		// Apply matching excludes (lcaPath == g.lca) at raw level on a
 		// per-element copy of effective. AndNot'ing the raw _exists.{path}
 		// bitmap removes leaf positions that carry the absent property's
 		// existence, so matchElementRecursive only intersects positives
@@ -696,10 +696,10 @@ func (e *recExecutor) matchElementRecursive(ctx context.Context, g *recGroupNode
 //     root, so a plain rootDoc AND gives the correct same-root semantics.
 func (e *recExecutor) evalSplit(ctx context.Context, n *recSplitNode, parentScope *sroar.Bitmap) (*sroar.Bitmap, func(), error) {
 	if e.metaBucket == nil {
-		return nil, nil, fmt.Errorf("evalSplit: meta bucket is nil for %q", n.lcaPath)
+		return nil, nil, fmt.Errorf("evalSplit: meta bucket is nil for %q", n.lca)
 	}
 	if len(n.branches) == 0 {
-		return nil, nil, fmt.Errorf("evalSplit: split with no branches at %q", n.lcaPath)
+		return nil, nil, fmt.Errorf("evalSplit: split with no branches at %q", n.lca)
 	}
 
 	branchResults := make([]*sroar.Bitmap, 0, len(n.branches))
@@ -717,7 +717,7 @@ func (e *recExecutor) evalSplit(ctx context.Context, n *recSplitNode, parentScop
 		if err := ctxExpired(ctx); err != nil {
 			return nil, nil, err
 		}
-		bm, rel, err := e.evalSplitBranch(ctx, n.lcaPath, br, parentScope)
+		bm, rel, err := e.evalSplitBranch(ctx, n.lca, br, parentScope)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -730,7 +730,7 @@ func (e *recExecutor) evalSplit(ctx context.Context, n *recSplitNode, parentScop
 		return branchResults[0], branchReleases[0], nil
 	}
 
-	if n.lcaPath == "" {
+	if n.lca == "" {
 		return e.andBranchesAtDocID(branchResults, branchReleases, &succeeded)
 	}
 	result, resultRel := e.bitmapOps.AndAll(branchResults, e.maxConcurrency)

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
@@ -195,23 +195,35 @@ func (e *recExecutor) execute(ctx context.Context, plan recPlanNode) (*sroar.Bit
 
 // executeRootAnchor handles the no-positive path. The anchor is the universe
 // of element positions (from _exists.{scope}); excludes are subtracted at raw
-// level so leaf-position alignment with the anchor is preserved before the
-// per-element MaskLeaf collapses the result to (root, 0, docID). The trailing
-// MaskRootLeaf is skipped when returnMasked is set.
+// level so leaf-position alignment with the anchor is preserved. The trailing
+// MaskRootLeaf produces docIDs (skipped when returnMasked is set, in which
+// case the caller receives a leaf-precise raw bitmap and is responsible for
+// collapsing to docIDs itself).
+//
+// Phase 2a of the position-level eval rollout: dropped the prior MaskLeaf
+// step before MaskRootLeaf — it was redundant since MaskRootLeaf zeros both
+// root and leaf, and removing it lets the raw bitmap flow through to the
+// boundary unchanged.
 func (e *recExecutor) executeRootAnchor() (*sroar.Bitmap, func(), error) {
 	if e.rootAnchor == nil {
 		return nil, nil, fmt.Errorf("recExecutor.execute: nil plan requires a non-nil rootAnchor")
 	}
-	anchor := e.rootAnchor.Clone()
+	// Clone the anchor into a pool buffer so AndNot mutations don't disturb
+	// the shared rootAnchor; the clone becomes the result.
+	raw, rawRel := e.bitmapOps.AndAll([]*sroar.Bitmap{e.rootAnchor}, e.maxConcurrency)
 	for _, excl := range e.excludes {
-		anchor.AndNotConc(excl.bitmap, e.maxConcurrency)
+		raw.AndNotConc(excl.bitmap, e.maxConcurrency)
 	}
-	masked, maskedRel := e.bitmapOps.MaskLeaf(anchor)
 	if e.returnMasked {
+		// returnMasked callers expect a leaf-zeroed bitmap. Apply MaskLeaf
+		// here to preserve that contract until Step 4 phase 2b refactors
+		// returnMasked to mean "skip MaskRootLeaf, return raw".
+		masked, maskedRel := e.bitmapOps.MaskLeaf(raw)
+		rawRel()
 		return masked, maskedRel, nil
 	}
-	defer maskedRel()
-	docs, docRel := e.bitmapOps.MaskRootLeaf(masked)
+	defer rawRel()
+	docs, docRel := e.bitmapOps.MaskRootLeaf(raw)
 	return docs, docRel, nil
 }
 

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive.go
@@ -197,11 +197,13 @@ func (e *recExecutor) executeRootAnchor() (*sroar.Bitmap, func(), error) {
 // evalNode dispatches by node type. parentScope (a raw position bitmap) limits
 // evaluation to positions within those array elements; nil means no restriction.
 //
-// The returned bitmap is a position bitmap with leaf bits zeroed. Most nodes
-// return a rootDoc bitmap (root_idx + docID). The single exception is a
-// recSplitNode at lcaPath="" — its branches must be ANDed at docID level
-// because they pin to different root_idx values, so the result has both root
-// and leaf bits zeroed. MaskRootLeaf in execute is idempotent in that case.
+// Most nodes return a raw position bitmap (root_idx | leaf_idx | docID) with
+// leaves intact so downstream operands can keep composing on raw positions; the
+// caller strips to docIDs via MaskRootLeaf when docIDs are needed. The single
+// exception is a recSplitNode at lcaPath="" — its branches pin to different
+// root_idx values, so andBranchesAtDocID MaskRootLeaf's each branch and ANDs
+// them at docID level; the result is a doc-only bitmap. A caller-side
+// MaskRootLeaf is idempotent on that doc-only result.
 func (e *recExecutor) evalNode(ctx context.Context, node recPlanNode, parentScope *sroar.Bitmap) (*sroar.Bitmap, func(), error) {
 	switch n := node.(type) {
 	case *recGroupNode:

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
@@ -1387,7 +1387,7 @@ func TestRecExecutorRunIdxLoopRecursiveCursor(t *testing.T) {
 			leaves[i] = newLeaf("cars.x")
 			raws[leaves[i]] = bm
 		}
-		g := &recGroupNode{lcaPath: "cars", here: leaves}
+		g := &recGroupNode{lca: "cars", here: leaves}
 		exec := newRecExecutor(raws, bucket, ops, concurrency.SROAR_MERGE)
 		result, release, err := exec.runIdxLoopRecursive(context.Background(), g, nil)
 		require.NoError(t, err)
@@ -1407,7 +1407,7 @@ func TestRecExecutorRunIdxLoopRecursiveCursor(t *testing.T) {
 			leaves[i] = newLeaf("cars.x")
 			raws[leaves[i]] = bm
 		}
-		g := &recGroupNode{lcaPath: "cars", here: leaves}
+		g := &recGroupNode{lca: "cars", here: leaves}
 		exec := newRecExecutor(raws, bucket, ops, concurrency.SROAR_MERGE)
 		result, release, err := exec.runIdxLoopRecursive(context.Background(), g, nil)
 		require.NoError(t, err)

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
@@ -1478,7 +1478,7 @@ func TestRecExecutorRunIdxLoopRecursiveCursor(t *testing.T) {
 // TestRecExecutorEvalOr exercises evalOr against hand-constructed OR plans.
 // The planner produces recOrNode for OR-operator pvps (Step 3); evalOr unions
 // child results via the OrAll primitive. Output shape matches children's
-// shape — under Phase 1 of position-level eval, children return rootDoc, so
+// shape — under Phase 1 of position-level evaluation, children return rootDoc, so
 // the OR result is rootDoc. execute() then MaskRootLeaf's to docIDs.
 func TestRecExecutorEvalOr(t *testing.T) {
 	class := filterExamplesClass()

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/sroar"
-	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	invnested "github.com/weaviate/weaviate/adapters/repos/db/inverted/nested"
 	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
 	"github.com/weaviate/weaviate/adapters/repos/db/roaringset"
@@ -51,8 +50,10 @@ func TestRecExecutorFilterExamples(t *testing.T) {
 		ops := newLifecycleOps(t)
 		plan := newRecPlanBuilder(props).build(pv.children)
 		exec := newRecExecutor(rawsByCond, mb, ops, concurrency.SROAR_MERGE)
-		result, release, err := exec.execute(context.Background(), plan)
+		raw, rawRel, err := exec.execute(context.Background(), plan)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, want, result.ToArray())
@@ -726,8 +727,10 @@ func TestRecExecutorFilterExamples(t *testing.T) {
 		ops := newLifecycleOps(t)
 		plan := newRecPlanBuilder(props).build(pv.children)
 		exec := newRecExecutor(rawsByCond, mb, ops, concurrency.SROAR_MERGE)
-		result, release, err := exec.execute(context.Background(), plan)
+		raw, rawRel, err := exec.execute(context.Background(), plan)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		assert.Empty(t, result.ToArray())
 	}
@@ -815,125 +818,16 @@ func TestRecExecutorFilterExamples(t *testing.T) {
 	})
 }
 
-// TestRecExecutorReturnMasked exercises withReturnMasked across both execute
-// paths. It runs the same scenario twice — once unmasked (final docIDs), once
-// masked (root+docID positions) — and asserts that MaskRootLeaf'ing the masked
-// output produces the same docID set as the unmasked output. This is the
-// invariant resolveMultiGroupRootDocIDAnd relies on when ANDing groups at
-// root+docID level before stripping root bits.
-func TestRecExecutorReturnMasked(t *testing.T) {
-	enc := func(root, leaf uint16, docID uint64) uint64 { return invnested.Encode(root, leaf, docID) }
-
-	t.Run("normal_path_returnMasked_then_MaskRootLeaf_equals_unmasked", func(t *testing.T) {
-		const (
-			docMatch   = uint64(101)
-			docNoMatch = uint64(102)
-		)
-		valueBucket := helpers.BucketNestedFromPropNameLSM("addresses")
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
-		s, store := newNestedTestSearcher(t, valueBucket, metaBucket)
-		class := correlationTestClass()
-
-		vb := store.Bucket(valueBucket)
-		writeNestedValue(t, vb, "city", "berlin", []uint64{enc(1, 1, docMatch), enc(1, 1, docNoMatch)})
-		writeNestedValue(t, vb, "postcode", "10115", []uint64{enc(1, 1, docMatch), enc(1, 2, docNoMatch)})
-
-		pv := makeCorrelatedPvp(class, "addresses",
-			makeLeafPvp(class, "addresses", "city", "berlin"),
-			makeLeafPvp(class, "addresses", "postcode", "10115"),
-		)
-
-		// Unmasked: plain docIDs.
-		planU, execU, relsU, err := pv.buildRecGroupExecutor(context.Background(), s, pv.children)
-		require.NoError(t, err)
-		docs, docsRel, err := execU.execute(context.Background(), planU)
-		require.NoError(t, err)
-		unmaskedDocs := docs.ToArray()
-		docsRel()
-		for _, rel := range relsU {
-			rel()
-		}
-
-		// Masked: root+docID positions. MaskRootLeaf'ing must give the same docs.
-		planM, execM, relsM, err := pv.buildRecGroupExecutor(context.Background(), s, pv.children)
-		require.NoError(t, err)
-		execM.withReturnMasked(true)
-		masked, maskedRel, err := execM.execute(context.Background(), planM)
-		require.NoError(t, err)
-		ops := newLifecycleOps(t)
-		fromMasked, fromMaskedRel := ops.MaskRootLeaf(masked)
-		assert.Equal(t, unmaskedDocs, fromMasked.ToArray(),
-			"MaskRootLeaf(returnMasked output) must equal unmasked output")
-		fromMaskedRel()
-		maskedRel()
-		for _, rel := range relsM {
-			rel()
-		}
-	})
-
-	t.Run("root_anchor_path_returnMasked_then_MaskRootLeaf_equals_unmasked", func(t *testing.T) {
-		// addresses.city IS NULL — no positives, only excludes; execute takes the
-		// rootAnchor branch in both modes. Same MaskRootLeaf invariant must hold.
-		const (
-			docMatch   = uint64(111)
-			docNoMatch = uint64(112)
-		)
-		valueBucket := helpers.BucketNestedFromPropNameLSM("addresses")
-		metaBucket := helpers.BucketNestedMetaFromPropNameLSM("addresses")
-		s, store := newNestedTestSearcher(t, valueBucket, metaBucket)
-		class := correlationTestClass()
-
-		mb := store.Bucket(metaBucket)
-		require.NoError(t, mb.RoaringSetAddList(invnested.ExistsKey(""), []uint64{
-			enc(1, 1, docMatch), enc(1, 1, docNoMatch),
-		}))
-		require.NoError(t, mb.RoaringSetAddList(invnested.ExistsKey("city"), []uint64{
-			enc(1, 1, docNoMatch),
-		}))
-
-		pv := makeCorrelatedPvp(class, "addresses",
-			makeIsNullPvp(class, "addresses", "city", true),
-		)
-
-		planU, execU, relsU, err := pv.buildRecGroupExecutor(context.Background(), s, pv.children)
-		require.NoError(t, err)
-		docs, docsRel, err := execU.execute(context.Background(), planU)
-		require.NoError(t, err)
-		unmaskedDocs := docs.ToArray()
-		docsRel()
-		for _, rel := range relsU {
-			rel()
-		}
-
-		planM, execM, relsM, err := pv.buildRecGroupExecutor(context.Background(), s, pv.children)
-		require.NoError(t, err)
-		execM.withReturnMasked(true)
-		masked, maskedRel, err := execM.execute(context.Background(), planM)
-		require.NoError(t, err)
-		assert.Nil(t, planM, "rootAnchor scenario yields nil plan")
-		ops := newLifecycleOps(t)
-		fromMasked, fromMaskedRel := ops.MaskRootLeaf(masked)
-		assert.Equal(t, unmaskedDocs, fromMasked.ToArray(),
-			"MaskRootLeaf(returnMasked rootAnchor output) must equal unmasked output")
-		fromMaskedRel()
-		maskedRel()
-		for _, rel := range relsM {
-			rel()
-		}
-	})
-}
-
 // TestRecExecutorRootAnchor exercises the executeRootAnchor path of execute()
 // — the branch taken when plan==nil. The path applies for correlated AND
 // filters that contain only IsNull conditions: there is no positive anchor, so
 // the executor uses _exists.{scope} as the element universe. Each exclude (a
 // raw _exists.{path} position bitmap) is AndNot'd at raw level (preserving
-// leaf alignment with the anchor), then MaskLeaf collapses to rootDoc, then
-// MaskRootLeaf to docIDs.
+// leaf alignment with the anchor); the caller strips to docIDs via
+// MaskRootLeaf when needed.
 //
-// TestRecExecutorReturnMasked already proves the masked-vs-unmasked invariant
-// for this path. This test exercises absolute-result and lifecycle invariants:
-// single vs. multiple excludes, partial-element subtraction (one element of a
+// This test exercises absolute-result and lifecycle invariants: single vs.
+// multiple excludes, partial-element subtraction (one element of a
 // multi-element doc excluded while another survives), and the nil-anchor
 // error.
 func TestRecExecutorRootAnchor(t *testing.T) {
@@ -950,8 +844,10 @@ func TestRecExecutorRootAnchor(t *testing.T) {
 			withRootAnchor(anchor).
 			withExcludes([]recExclude{{bitmap: exclude}})
 
-		result, release, err := exec.execute(context.Background(), nil)
+		raw, rawRel, err := exec.execute(context.Background(), nil)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{101}, result.ToArray())
@@ -972,8 +868,10 @@ func TestRecExecutorRootAnchor(t *testing.T) {
 			withRootAnchor(anchor).
 			withExcludes([]recExclude{{bitmap: excl1}, {bitmap: excl2}})
 
-		result, release, err := exec.execute(context.Background(), nil)
+		raw, rawRel, err := exec.execute(context.Background(), nil)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{200, 202, 204}, result.ToArray())
@@ -998,8 +896,10 @@ func TestRecExecutorRootAnchor(t *testing.T) {
 			withRootAnchor(anchor).
 			withExcludes([]recExclude{{bitmap: exclude}})
 
-		result, release, err := exec.execute(context.Background(), nil)
+		raw, rawRel, err := exec.execute(context.Background(), nil)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{300}, result.ToArray())
@@ -1058,8 +958,10 @@ func TestRecExecutorExcludePositions(t *testing.T) {
 		exec := newRecExecutor(map[*propValuePair]*sroar.Bitmap{city: rawCity}, nil, ops, concurrency.SROAR_MERGE).
 			withExcludes([]recExclude{{bitmap: excludeZip}, {bitmap: excludeAge}})
 
-		result, release, err := exec.execute(context.Background(), plan)
+		raw, rawRel, err := exec.execute(context.Background(), plan)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{1}, result.ToArray())
@@ -1080,8 +982,10 @@ func TestRecExecutorExcludePositions(t *testing.T) {
 		exec := newRecExecutor(map[*propValuePair]*sroar.Bitmap{city: rawCity}, nil, ops, concurrency.SROAR_MERGE).
 			withExcludes([]recExclude{{bitmap: excludeZip}})
 
-		result, release, err := exec.execute(context.Background(), plan)
+		raw, rawRel, err := exec.execute(context.Background(), plan)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{500}, result.ToArray())
@@ -1113,8 +1017,10 @@ func TestRecExecutorExcludePositions(t *testing.T) {
 			withExcludes([]recExclude{{bitmap: excludeZip, lcaPath: "garages"}}).
 			withPlanLCAs(collectPlanLCAs(plan))
 
-		result, release, err := exec.execute(context.Background(), plan)
+		raw, rawRel, err := exec.execute(context.Background(), plan)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{1}, result.ToArray())
@@ -1147,44 +1053,13 @@ func TestRecExecutorExcludePositions(t *testing.T) {
 			withExcludes([]recExclude{{bitmap: excludeZip, lcaPath: "garages.cars"}}).
 			withPlanLCAs(collectPlanLCAs(plan))
 
-		result, release, err := exec.execute(context.Background(), plan)
+		raw, rawRel, err := exec.execute(context.Background(), plan)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, []uint64{1}, result.ToArray(), "raw AndNot preserves doc1 via the surviving leaf-5 city position")
-	})
-
-	t.Run("returnMasked_keeps_rootDoc_after_excludes", func(t *testing.T) {
-		// With returnMasked=true, execute returns the post-AndNot rootDoc
-		// bitmap directly — MaskRootLeaf is skipped. Verify the equivalence
-		// invariant: MaskRootLeaf'ing the masked result equals the unmasked
-		// docID set. Confirms the exclude loop runs identically in both modes
-		// (the returnMasked check happens after the loop, not before).
-		city := makeLeafPvp(class, "countries", "garages.city", "berlin")
-		rawCity := roaringset.NewBitmap(enc(1, 1, 700), enc(2, 1, 701))
-		excludeZip := roaringset.NewBitmap(enc(2, 5, 701))
-
-		opsU := newLifecycleOps(t)
-		planU := newRecPlanBuilder(props).build([]*propValuePair{city})
-		execU := newRecExecutor(map[*propValuePair]*sroar.Bitmap{city: rawCity}, nil, opsU, concurrency.SROAR_MERGE).
-			withExcludes([]recExclude{{bitmap: excludeZip}})
-		unmasked, unmaskedRel, err := execU.execute(context.Background(), planU)
-		require.NoError(t, err)
-		unmaskedDocs := unmasked.ToArray()
-		unmaskedRel()
-
-		opsM := newLifecycleOps(t)
-		planM := newRecPlanBuilder(props).build([]*propValuePair{city})
-		execM := newRecExecutor(map[*propValuePair]*sroar.Bitmap{city: rawCity}, nil, opsM, concurrency.SROAR_MERGE).
-			withExcludes([]recExclude{{bitmap: excludeZip}}).
-			withReturnMasked(true)
-		masked, maskedRel, err := execM.execute(context.Background(), planM)
-		require.NoError(t, err)
-		ops := newLifecycleOps(t)
-		fromMasked, fromMaskedRel := ops.MaskRootLeaf(masked)
-		assert.Equal(t, unmaskedDocs, fromMasked.ToArray())
-		fromMaskedRel()
-		maskedRel()
 	})
 }
 
@@ -1615,8 +1490,10 @@ func TestRecExecutorEvalOr(t *testing.T) {
 		ops := newLifecycleOps(t)
 		plan := newRecPlanBuilder(props).build([]*propValuePair{pv})
 		exec := newRecExecutor(raws, mb, ops, concurrency.SROAR_MERGE)
-		result, release, err := exec.execute(context.Background(), plan)
+		raw, rawRel, err := exec.execute(context.Background(), plan)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, want, result.ToArray())
@@ -1672,8 +1549,10 @@ func TestRecExecutorEvalOr(t *testing.T) {
 		ops := newLifecycleOps(t)
 		plan := newRecPlanBuilder(props).build([]*propValuePair{makeOrPvp(class, makeBm, modelBm)})
 		exec := newRecExecutor(raws, mb, ops, concurrency.SROAR_MERGE)
-		result, release, err := exec.execute(context.Background(), plan)
+		raw, rawRel, err := exec.execute(context.Background(), plan)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
@@ -1719,8 +1598,10 @@ func TestRecExecutorEvalNot(t *testing.T) {
 		ops := newLifecycleOps(t)
 		plan := newRecPlanBuilder(props).build([]*propValuePair{pv})
 		exec := newRecExecutor(raws, mb, ops, concurrency.SROAR_MERGE)
-		result, release, err := exec.execute(context.Background(), plan)
+		raw, rawRel, err := exec.execute(context.Background(), plan)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.Equal(t, want, result.ToArray())
@@ -1819,8 +1700,10 @@ func TestRecExecutorEvalNot(t *testing.T) {
 		ops := newLifecycleOps(t)
 		plan := newRecPlanBuilder(props).build([]*propValuePair{makeNotPvp(class, makeBm)})
 		exec := newRecExecutor(raws, mb, ops, concurrency.SROAR_MERGE)
-		result, release, err := exec.execute(context.Background(), plan)
+		raw, rawRel, err := exec.execute(context.Background(), plan)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())
@@ -1857,8 +1740,10 @@ func TestRecExecutorEvalNot(t *testing.T) {
 		ops := newLifecycleOps(t)
 		plan := newRecPlanBuilder(props).build([]*propValuePair{makeNotPvp(class, makeBm)})
 		exec := newRecExecutor(raws, mb, ops, concurrency.SROAR_MERGE)
-		result, release, err := exec.execute(context.Background(), plan)
+		raw, rawRel, err := exec.execute(context.Background(), plan)
 		require.NoError(t, err)
+		defer rawRel()
+		result, release := ops.MaskRootLeaf(raw)
 		defer release()
 		requireBitmapValid(t, result)
 		assert.True(t, result.IsEmpty())

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
@@ -1594,3 +1594,272 @@ func TestRecExecutorRunIdxLoopRecursiveCursor(t *testing.T) {
 		assert.Equal(t, []uint64{doc5}, runLoop(t, bucket, condA, condB))
 	})
 }
+
+// TestRecExecutorEvalOr exercises evalOr against hand-constructed OR plans.
+// The planner produces recOrNode for OR-operator pvps (Step 3); evalOr unions
+// child results via the OrAll primitive. Output shape matches children's
+// shape — under Phase 1 of position-level eval, children return rootDoc, so
+// the OR result is rootDoc. execute() then MaskRootLeaf's to docIDs.
+func TestRecExecutorEvalOr(t *testing.T) {
+	class := filterExamplesClass()
+	props := rootNestedProps(t, class, "countries")
+	enc := func(root, leaf uint16, docID uint64) uint64 { return invnested.Encode(root, leaf, docID) }
+
+	runRec := func(t *testing.T, pv *propValuePair, mb *lsmkv.Bucket, raws map[*propValuePair]*sroar.Bitmap, want []uint64) {
+		t.Helper()
+		ops := newLifecycleOps(t)
+		plan := newRecPlanBuilder(props).build([]*propValuePair{pv})
+		exec := newRecExecutor(raws, mb, ops, concurrency.SROAR_MERGE)
+		result, release, err := exec.execute(context.Background(), plan)
+		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, want, result.ToArray())
+	}
+
+	t.Run("OR_of_two_leaves_union_docIDs", func(t *testing.T) {
+		// OR(make=tesla, model=civic): docs where either holds.
+		const (
+			docTesla = uint64(1) // make=tesla only
+			docCivic = uint64(2) // model=civic only
+			docBoth  = uint64(3) // both
+			docNone  = uint64(4) // neither
+		)
+		mb := newIdxBucket(t)
+
+		makeBm := makeLeafPvp(class, "countries", "garages.cars.make", "tesla")
+		modelBm := makeLeafPvp(class, "countries", "garages.cars.model", "civic")
+		raws := map[*propValuePair]*sroar.Bitmap{
+			makeBm:  roaringset.NewBitmap(enc(1, 1, docTesla), enc(1, 1, docBoth)),
+			modelBm: roaringset.NewBitmap(enc(1, 1, docCivic), enc(1, 1, docBoth)),
+		}
+
+		runRec(t, makeOrPvp(class, makeBm, modelBm), mb, raws,
+			[]uint64{docTesla, docCivic, docBoth})
+	})
+
+	t.Run("OR_with_one_empty_operand_returns_other", func(t *testing.T) {
+		const (
+			docMatch = uint64(1)
+		)
+		mb := newIdxBucket(t)
+
+		makeBm := makeLeafPvp(class, "countries", "garages.cars.make", "tesla")
+		modelBm := makeLeafPvp(class, "countries", "garages.cars.model", "civic")
+		raws := map[*propValuePair]*sroar.Bitmap{
+			makeBm:  roaringset.NewBitmap(enc(1, 1, docMatch)),
+			modelBm: sroar.NewBitmap(), // empty
+		}
+
+		runRec(t, makeOrPvp(class, makeBm, modelBm), mb, raws, []uint64{docMatch})
+	})
+
+	t.Run("OR_with_all_empty_operands_returns_empty", func(t *testing.T) {
+		mb := newIdxBucket(t)
+
+		makeBm := makeLeafPvp(class, "countries", "garages.cars.make", "tesla")
+		modelBm := makeLeafPvp(class, "countries", "garages.cars.model", "civic")
+		raws := map[*propValuePair]*sroar.Bitmap{
+			makeBm:  sroar.NewBitmap(),
+			modelBm: sroar.NewBitmap(),
+		}
+
+		ops := newLifecycleOps(t)
+		plan := newRecPlanBuilder(props).build([]*propValuePair{makeOrPvp(class, makeBm, modelBm)})
+		exec := newRecExecutor(raws, mb, ops, concurrency.SROAR_MERGE)
+		result, release, err := exec.execute(context.Background(), plan)
+		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("OR_of_three_leaves", func(t *testing.T) {
+		const (
+			doc1 = uint64(1) // make=tesla
+			doc2 = uint64(2) // model=civic
+			doc3 = uint64(3) // color=red
+			doc4 = uint64(4) // none
+		)
+		mb := newIdxBucket(t)
+
+		makeBm := makeLeafPvp(class, "countries", "garages.cars.make", "tesla")
+		modelBm := makeLeafPvp(class, "countries", "garages.cars.model", "civic")
+		colorBm := makeLeafPvp(class, "countries", "garages.cars.color", "red")
+		raws := map[*propValuePair]*sroar.Bitmap{
+			makeBm:  roaringset.NewBitmap(enc(1, 1, doc1)),
+			modelBm: roaringset.NewBitmap(enc(1, 1, doc2)),
+			colorBm: roaringset.NewBitmap(enc(1, 1, doc3)),
+		}
+
+		runRec(t, makeOrPvp(class, makeBm, modelBm, colorBm), mb, raws,
+			[]uint64{doc1, doc2, doc3})
+	})
+}
+
+// TestRecExecutorEvalNot exercises evalNot against hand-constructed NOT plans.
+// The planner produces recNotNode for NOT-operator pvps (Step 3); evalNot
+// inverts at the operand's natural LCA against `_exists.{lca}`. Pin
+// restrictions narrow the universe; parentScope further narrows when an
+// enclosing idx-loop is active. Output shape: rootDoc under Phase 1 (the
+// MaskLeaf step inside evalNot reconciles the raw universe with the operand's
+// rootDoc shape; Phase 2 will drop the MaskLeaf and the universe stays raw).
+func TestRecExecutorEvalNot(t *testing.T) {
+	class := filterExamplesClass()
+	props := rootNestedProps(t, class, "countries")
+	enc := func(root, leaf uint16, docID uint64) uint64 { return invnested.Encode(root, leaf, docID) }
+
+	runRec := func(t *testing.T, pv *propValuePair, mb *lsmkv.Bucket, raws map[*propValuePair]*sroar.Bitmap, want []uint64) {
+		t.Helper()
+		ops := newLifecycleOps(t)
+		plan := newRecPlanBuilder(props).build([]*propValuePair{pv})
+		exec := newRecExecutor(raws, mb, ops, concurrency.SROAR_MERGE)
+		result, release, err := exec.execute(context.Background(), plan)
+		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.Equal(t, want, result.ToArray())
+	}
+
+	t.Run("NOT_of_leaf_universe_minus_operand", func(t *testing.T) {
+		// NOT garages.cars.make=tesla:
+		// universe = _exists.garages.cars
+		// operand  = positions where make=tesla
+		// result   = (per-element NOT) positions of cars where make != tesla
+		const (
+			docTesla    = uint64(1) // one car, make=tesla — excluded under both semantics
+			docCivic    = uint64(2) // one car, make=civic — included under both
+			docMixedCar = uint64(3) // cars[0]=tesla, cars[1]=civic
+			//                        — universal-NOT (Phase 1): excluded (has a tesla)
+			//                        — per-element NOT (Phase 2): included (civic car satisfies)
+		)
+		mb := newIdxBucket(t)
+
+		// _exists.garages.cars: every car position in every doc.
+		writeExistsAt(t, mb, "garages.cars", []uint64{
+			enc(1, 1, docTesla),                            // docTesla cars[0]
+			enc(1, 1, docCivic),                            // docCivic cars[0]
+			enc(1, 1, docMixedCar), enc(1, 2, docMixedCar), // docMixedCar cars[0] and cars[1]
+		})
+
+		makeBm := makeLeafPvp(class, "countries", "garages.cars.make", "tesla")
+		raws := map[*propValuePair]*sroar.Bitmap{
+			makeBm: roaringset.NewBitmap(
+				enc(1, 1, docTesla),    // make=tesla in docTesla
+				enc(1, 1, docMixedCar), // make=tesla in cars[0] of docMixedCar
+			),
+		}
+
+		// TODO aliszka:nested_filtering: locks in Phase 1's universal-at-rootDoc
+		// NOT semantics — evalNot's MaskLeaf step collapses per-element
+		// distinctions, so docMixedCar (one tesla car + one civic car) is
+		// excluded. Under Phase 2 (executor refactor to raw outputs), per-element
+		// NOT will include docMixedCar via the civic car's position. Expected
+		// list flips to {docCivic, docMixedCar} when Phase 2 lands.
+		runRec(t, makeNotPvp(class, makeBm), mb, raws, []uint64{docCivic})
+	})
+
+	t.Run("NOT_with_root_pin_restricts_universe_to_pinned_root", func(t *testing.T) {
+		// NOT countries[1].garages.cars.make=tesla:
+		// universe restricted to root_idx=2's cars-positions.
+		// NOT.lca = "" (root SPLIT), but in this Phase 1 test we use a leaf
+		// operand directly to keep the universe at garages.cars LCA.
+		//
+		// Use intermediate pin instead, more representative of pin handling:
+		t.Skip("covered by NOT_with_intermediate_pin test")
+	})
+
+	t.Run("NOT_with_intermediate_pin_restricts_universe_to_pinned_subarray", func(t *testing.T) {
+		// NOT cars.tires[1].width=205:
+		// universe = _exists.garages.cars.tires ∩ _idx.garages.cars.tires[1]
+		// operand  = positions where width=205 (at tires-leaves)
+		// result   = positions of tires[1] elements where width != 205
+		const (
+			docMatch1 = uint64(1) // tires[1] exists, width != 205 — included
+			docMatch2 = uint64(2) // tires[1] exists, width = 205 — excluded
+		)
+		mb := newIdxBucket(t)
+
+		// _exists.garages.cars.tires for both docs.
+		writeExistsAt(t, mb, "garages.cars.tires", []uint64{
+			enc(1, 1, docMatch1), enc(1, 2, docMatch1), // tires[0], tires[1]
+			enc(1, 3, docMatch2), enc(1, 4, docMatch2), // tires[0], tires[1]
+		})
+		// _idx.garages.cars.tires[1]: only the tires[1] entries.
+		writeIdx(t, mb, "garages.cars.tires", 1, []uint64{
+			enc(1, 2, docMatch1),
+			enc(1, 4, docMatch2),
+		})
+
+		pin := filnested.ArrayIndex{RelPath: "garages.cars.tires", Index: 1}
+		width := makeLeafPvpWithIdx(class, "countries", "garages.cars.tires.width", "205", pin)
+		raws := map[*propValuePair]*sroar.Bitmap{
+			width: roaringset.NewBitmap(enc(1, 4, docMatch2)), // width=205 only in docMatch2's tires[1]
+		}
+
+		// docMatch1 has tires[1] with width!=205 → included.
+		// docMatch2 has tires[1] with width=205 → excluded.
+		runRec(t, makeNotPvp(class, width), mb, raws, []uint64{docMatch1})
+	})
+
+	t.Run("NOT_when_operand_exhausts_universe_returns_empty", func(t *testing.T) {
+		// Every car in every doc has make=tesla. NOT must produce empty
+		// because the operand result covers the full universe.
+		const docID = uint64(1)
+		mb := newIdxBucket(t)
+
+		writeExistsAt(t, mb, "garages.cars", []uint64{enc(1, 1, docID)})
+
+		makeBm := makeLeafPvp(class, "countries", "garages.cars.make", "tesla")
+		raws := map[*propValuePair]*sroar.Bitmap{
+			makeBm: roaringset.NewBitmap(enc(1, 1, docID)),
+		}
+
+		ops := newLifecycleOps(t)
+		plan := newRecPlanBuilder(props).build([]*propValuePair{makeNotPvp(class, makeBm)})
+		exec := newRecExecutor(raws, mb, ops, concurrency.SROAR_MERGE)
+		result, release, err := exec.execute(context.Background(), plan)
+		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.True(t, result.IsEmpty())
+	})
+
+	t.Run("NOT_when_operand_empty_returns_full_universe", func(t *testing.T) {
+		// No car has make=tesla. NOT covers the entire universe.
+		const (
+			doc1 = uint64(1)
+			doc2 = uint64(2)
+		)
+		mb := newIdxBucket(t)
+
+		writeExistsAt(t, mb, "garages.cars", []uint64{enc(1, 1, doc1), enc(1, 1, doc2)})
+
+		makeBm := makeLeafPvp(class, "countries", "garages.cars.make", "tesla")
+		raws := map[*propValuePair]*sroar.Bitmap{
+			makeBm: sroar.NewBitmap(),
+		}
+
+		runRec(t, makeNotPvp(class, makeBm), mb, raws, []uint64{doc1, doc2})
+	})
+
+	t.Run("NOT_with_empty_universe_returns_empty", func(t *testing.T) {
+		// No _exists.{path} entry in the meta bucket → universe is empty.
+		// NOT result is also empty (nothing to invert).
+		mb := newIdxBucket(t)
+
+		makeBm := makeLeafPvp(class, "countries", "garages.cars.make", "tesla")
+		raws := map[*propValuePair]*sroar.Bitmap{
+			makeBm: sroar.NewBitmap(),
+		}
+
+		ops := newLifecycleOps(t)
+		plan := newRecPlanBuilder(props).build([]*propValuePair{makeNotPvp(class, makeBm)})
+		exec := newRecExecutor(raws, mb, ops, concurrency.SROAR_MERGE)
+		result, release, err := exec.execute(context.Background(), plan)
+		require.NoError(t, err)
+		defer release()
+		requireBitmapValid(t, result)
+		assert.True(t, result.IsEmpty())
+	})
+}

--- a/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_executor_recursive_integration_test.go
@@ -1024,18 +1024,19 @@ func TestRecExecutorExcludePositions(t *testing.T) {
 	class := filterExamplesClass()
 	props := rootNestedProps(t, class, "countries")
 
-	t.Run("multi_exclude_loop_subtracts_at_rootDoc_level", func(t *testing.T) {
+	t.Run("multi_exclude_loop_subtracts_at_raw_level", func(t *testing.T) {
 		// Plan-driven path: single positive condition `garages.city=berlin`
-		// produces GROUP@"garages" here=[garages.city]. canUseRawAndAll runs
-		// AndAll([raw_city]) → MaskLeaf → bm at rootDoc shape. The exclude
-		// loop in execute() then MaskLeafs each exclude (collapsing leaf bits)
-		// and AndNots from bm. Two excludes, one applying to two docs each
-		// (with overlap on doc4), verify the loop iterates and accumulates.
+		// produces GROUP@"garages" here=[garages.city]. canUseRawAndAll
+		// returns raw bm. The exclude loop in execute() AndNots each
+		// exclude at raw level (Phase 2: no MaskLeaf collapse). Verifies
+		// the loop iterates and accumulates across multiple excludes.
 		//
-		// doc1: city only — kept.
-		// doc2: city + zip exists in a different leaf — excludeZip drops it.
-		// doc3: city + age exists — excludeAge drops it.
-		// doc4: city + zip + age — both excludes apply (idempotent AndNot).
+		// Excludes overlap positives at the same leaf so raw AndNot fires:
+		//   doc1: city at leaf 1, no excludes — kept.
+		//   doc2: city at leaf 1, excludeZip at leaf 1 — excludeZip drops it.
+		//   doc3: city at leaf 1, excludeAge at leaf 1 — excludeAge drops it.
+		//   doc4: city at leaf 1, both excludes at leaf 1 — both drop it
+		//     (idempotent AndNot for the second exclude).
 		city := makeLeafPvp(class, "countries", "garages.city", "berlin")
 		rawCity := roaringset.NewBitmap(
 			enc(1, 1, 1),
@@ -1044,12 +1045,12 @@ func TestRecExecutorExcludePositions(t *testing.T) {
 			enc(4, 1, 4),
 		)
 		excludeZip := roaringset.NewBitmap(
-			enc(2, 5, 2),
-			enc(4, 5, 4),
+			enc(2, 1, 2),
+			enc(4, 1, 4),
 		)
 		excludeAge := roaringset.NewBitmap(
-			enc(3, 7, 3),
-			enc(4, 7, 4),
+			enc(3, 1, 3),
+			enc(4, 1, 4),
 		)
 
 		ops := newLifecycleOps(t)
@@ -1119,13 +1120,17 @@ func TestRecExecutorExcludePositions(t *testing.T) {
 		assert.Equal(t, []uint64{1}, result.ToArray())
 	})
 
-	t.Run("non_matching_lcaPath_falls_through_to_rootDoc_subtract", func(t *testing.T) {
+	t.Run("non_matching_lcaPath_subtracts_at_raw_level", func(t *testing.T) {
 		// When the exclude's lcaPath is NOT in planLCAs, execute() applies
-		// rootDoc-level subtraction (MaskLeaf+AndNot). Same data layout as the
-		// §8.5 raw test, but lcaPath="garages.cars" is below the plan's only
-		// group lcaPath "garages" — so the exclude collapses to rootDoc shape
-		// (per-garage element) and drops doc1 entirely (root_idx=1 has zip in
-		// some leaf), reproducing the pre-fix behavior for that combination.
+		// the subtraction at raw level (Phase 2: bm is raw throughout, so
+		// AndNot is leaf-precise and preserves per-element semantics).
+		//
+		// doc1 has city at leaves 3 and 5 but zip only at leaf 3 — leaf 5
+		// survives the AndNot, so doc1 is included. doc2 has city and zip
+		// both at leaf 3 — drops.
+		//
+		// Pre-Phase-2 the exclude was MaskLeaf'd then AndNot'd at rootDoc,
+		// which dropped both docs at (root, doc) granularity.
 		city := makeLeafPvp(class, "countries", "garages.city", "berlin")
 		rawCity := roaringset.NewBitmap(
 			enc(1, 3, 1), enc(1, 5, 1),
@@ -1146,7 +1151,7 @@ func TestRecExecutorExcludePositions(t *testing.T) {
 		require.NoError(t, err)
 		defer release()
 		requireBitmapValid(t, result)
-		assert.Empty(t, result.ToArray(), "rootDoc subtract drops both docs at (root,docID) granularity")
+		assert.Equal(t, []uint64{1}, result.ToArray(), "raw AndNot preserves doc1 via the surviving leaf-5 city position")
 	})
 
 	t.Run("returnMasked_keeps_rootDoc_after_excludes", func(t *testing.T) {
@@ -1750,13 +1755,9 @@ func TestRecExecutorEvalNot(t *testing.T) {
 			),
 		}
 
-		// TODO aliszka:nested_filtering: locks in Phase 1's universal-at-rootDoc
-		// NOT semantics — evalNot's MaskLeaf step collapses per-element
-		// distinctions, so docMixedCar (one tesla car + one civic car) is
-		// excluded. Under Phase 2 (executor refactor to raw outputs), per-element
-		// NOT will include docMixedCar via the civic car's position. Expected
-		// list flips to {docCivic, docMixedCar} when Phase 2 lands.
-		runRec(t, makeNotPvp(class, makeBm), mb, raws, []uint64{docCivic})
+		// Per-element NOT: docMixedCar's civic car satisfies "this car is
+		// not tesla", so the doc is included alongside docCivic.
+		runRec(t, makeNotPvp(class, makeBm), mb, raws, []uint64{docCivic, docMixedCar})
 	})
 
 	t.Run("NOT_with_root_pin_restricts_universe_to_pinned_root", func(t *testing.T) {

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
@@ -93,7 +93,7 @@ func (o *recOrNode) lcaPath() string    { return o.lca }
 func (n *recNotNode) lcaPath() string   { return n.lca }
 
 // recPlanBuilder builds a recPlanNode tree from the children of an
-// isCorrelated AND. Only the root property's nested schema is required; all
+// isWithinRootSubtree AND. Only the root property's nested schema is required; all
 // per-condition state lives on the propValuePair children.
 type recPlanBuilder struct {
 	props []*models.NestedProperty
@@ -103,7 +103,7 @@ func newRecPlanBuilder(props []*models.NestedProperty) *recPlanBuilder {
 	return &recPlanBuilder{props: props}
 }
 
-// build is the entry point. children are the conditions of an isCorrelated
+// build is the entry point. children are the conditions of an isWithinRootSubtree
 // AND. The returned plan starts from the root property scope ("").
 func (b *recPlanBuilder) build(children []*propValuePair) recPlanNode {
 	return b.buildPlan(children, "")

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
@@ -16,6 +16,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/weaviate/weaviate/entities/filters"
 	filnested "github.com/weaviate/weaviate/entities/filters/nested"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/entities/schema"
@@ -36,16 +37,20 @@ import (
 type recPlanNode interface {
 	isRecPlanNode()
 	describeLines() []string
+	// lcaPath returns the node's logical LCA scope. Used by parents to compute
+	// their own LCA (e.g. recOrNode's deepest-common-LCA across children) and
+	// for plan-shape tests.
+	lcaPath() string
 }
 
 type recGroupNode struct {
-	lcaPath string
-	here    []*propValuePair
-	subs    []recPlanNode
+	lca  string
+	here []*propValuePair
+	subs []recPlanNode
 }
 
 type recSplitNode struct {
-	lcaPath  string
+	lca      string
 	branches []recSplitBranch
 }
 
@@ -54,8 +59,38 @@ type recSplitBranch struct {
 	plan  recPlanNode
 }
 
+// recOrNode is a position-level OR over arbitrary recPlanNode children.
+// Each child evaluates raw at its own lcaPath; the OR returns the raw
+// union. The lcaPath field is the deepest common ancestor of the
+// children's lcaPaths and serves as the OR result's logical scope for
+// parent-side combining. Not yet produced by the planner in production
+// (step 5 dispatch refactor will enable that); validated by unit tests.
+type recOrNode struct {
+	lca      string
+	children []recPlanNode
+}
+
+// recNotNode inverts its operand at the operand's natural LCA against
+// the per-LCA universe (`_exists.{lca}`). pins, when non-empty, restrict
+// the universe to the specified arr[N] slice — for example, pins for
+// `NOT cars.tires[1].width=205` are `[{path:"tires", idx:1}]`, so the
+// inversion universe is `_exists.cars.tires ∩ _idx.cars.tires[1]`.
+// Not yet produced by the planner in production.
+type recNotNode struct {
+	lca     string
+	pins    arrayIndices
+	operand recPlanNode
+}
+
 func (*recGroupNode) isRecPlanNode() {}
 func (*recSplitNode) isRecPlanNode() {}
+func (*recOrNode) isRecPlanNode()    {}
+func (*recNotNode) isRecPlanNode()   {}
+
+func (g *recGroupNode) lcaPath() string { return g.lca }
+func (s *recSplitNode) lcaPath() string { return s.lca }
+func (o *recOrNode) lcaPath() string    { return o.lca }
+func (n *recNotNode) lcaPath() string   { return n.lca }
 
 // recPlanBuilder builds a recPlanNode tree from the children of an
 // isCorrelated AND. Only the root property's nested schema is required; all
@@ -112,7 +147,7 @@ func (b *recPlanBuilder) buildPlan(items []*propValuePair, scope string) recPlan
 		merged := append([]*propValuePair{}, constrained[idx]...)
 		merged = append(merged, unconstrained...)
 		return &recSplitNode{
-			lcaPath: scope,
+			lca: scope,
 			branches: []recSplitBranch{{
 				index: idx,
 				plan:  b.buildGroup(merged, scope),
@@ -127,16 +162,29 @@ func (b *recPlanBuilder) buildPlan(items []*propValuePair, scope string) recPlan
 			plan:  b.buildGroup(constrained[idx], scope),
 		})
 	}
-	return &recSplitNode{lcaPath: scope, branches: branches}
+	return &recSplitNode{lca: scope, branches: branches}
 }
 
 // buildGroup partitions items at scope into here (terminating at the scope
-// LCA) and one sub-plan per next-deeper ObjectArray. An empty here with a
-// single sub collapses to the sub directly so trees stay tight.
+// LCA), one sub-plan per next-deeper ObjectArray (for leaf items), and one
+// sub-plan per OR/NOT operator item (planned recursively from its natural
+// scope). An empty here with a single sub collapses to the sub directly so
+// trees stay tight.
 func (b *recPlanBuilder) buildGroup(items []*propValuePair, scope string) recPlanNode {
 	var here []*propValuePair
 	subsByPath := map[string][]*propValuePair{}
+	var operatorSubs []recPlanNode
 	for _, it := range items {
+		switch it.operator {
+		case filters.OperatorOr:
+			operatorSubs = append(operatorSubs, b.buildOr(it))
+			continue
+		case filters.OperatorNot:
+			operatorSubs = append(operatorSubs, b.buildNot(it))
+			continue
+		default:
+			// Fall through to leaf-or-correlated-AND path below.
+		}
 		rp := childRelPath(it)
 		if b.lastIntermediateObjectArray(rp) == scope {
 			here = append(here, it)
@@ -156,15 +204,120 @@ func (b *recPlanBuilder) buildGroup(items []*propValuePair, scope string) recPla
 	}
 	sort.Strings(nextPaths)
 
-	subs := make([]recPlanNode, 0, len(nextPaths))
+	subs := make([]recPlanNode, 0, len(nextPaths)+len(operatorSubs))
 	for _, p := range nextPaths {
 		subs = append(subs, b.buildPlan(subsByPath[p], p))
 	}
+	// Operator subs (OR/NOT) appear after path-grouped subs. Stable order
+	// preserves the user-written filter sequence for plan-shape tests.
+	subs = append(subs, operatorSubs...)
 
 	if len(here) == 0 && len(subs) == 1 && !b.needsWrappingGroup(scope, subs[0]) {
 		return subs[0]
 	}
-	return &recGroupNode{lcaPath: scope, here: here, subs: subs}
+	return &recGroupNode{lca: scope, here: here, subs: subs}
+}
+
+// buildOr plans each child of an OR operator at its own natural scope and
+// wraps the children in a recOrNode whose lca is the deepest common
+// ancestor of the children's lcas. Filter validation rejects OR with zero
+// children; we assert defensively to surface validation gaps loudly. See
+// step 7 (validation) in the position-level eval implementation plan.
+func (b *recPlanBuilder) buildOr(orPv *propValuePair) recPlanNode {
+	if len(orPv.children) == 0 {
+		panic("recPlanBuilder.buildOr: OR with zero children — filter validation gap")
+	}
+	childPlans := make([]recPlanNode, 0, len(orPv.children))
+	childLCAs := make([]string, 0, len(orPv.children))
+	for _, c := range orPv.children {
+		plan := b.planSingleItem(c)
+		childPlans = append(childPlans, plan)
+		childLCAs = append(childLCAs, plan.lcaPath())
+	}
+	return &recOrNode{lca: deepestCommonLCA(childLCAs), children: childPlans}
+}
+
+// buildNot plans the single operand of a NOT operator and wraps it in a
+// recNotNode whose lca is the operand's natural LCA. arr[N] pins are
+// lifted from the operand for universe restriction during evaluation —
+// today this is best-effort: leaf operands' arrayIndices are propagated
+// directly, and compound operands (e.g. NOT(A AND B)) leave pins empty
+// (universe unrestricted; correct but loose).
+//
+// Filter validation rejects NOT with !=1 children; we assert defensively.
+// See step 7 (validation) for the broader operator-arity check.
+func (b *recPlanBuilder) buildNot(notPv *propValuePair) recPlanNode {
+	if len(notPv.children) != 1 {
+		panic(fmt.Sprintf("recPlanBuilder.buildNot: NOT with %d children — filter validation gap", len(notPv.children)))
+	}
+	operand := notPv.children[0]
+	plan := b.planSingleItem(operand)
+	return &recNotNode{
+		lca:     plan.lcaPath(),
+		pins:    liftArrayIndicesFromOperand(operand),
+		operand: plan,
+	}
+}
+
+// planSingleItem plans one item from the root scope. Used by buildOr /
+// buildNot to plan their child operands without inheriting the parent's
+// scope (each operand's plan must reflect its own path's natural scope).
+func (b *recPlanBuilder) planSingleItem(it *propValuePair) recPlanNode {
+	return b.buildPlan([]*propValuePair{it}, "")
+}
+
+// liftArrayIndicesFromOperand extracts arr[N] pins from a NOT operand
+// for universe restriction. For a leaf operand the pins come from the
+// operand's nested.arrayIndices directly. For a compound operand
+// (sub-operator like AND/OR/NOT), pin handling is deferred — returning
+// empty falls back to an unrestricted universe at evaluation time, which
+// is correct but may evaluate over more positions than strictly needed.
+//
+// TODO aliszka:nested_filtering: extend lift to compound operands when
+// all leaves share a common pin (e.g. NOT(cars[1].make=tesla AND
+// cars[1].color=red) could lift pins=[{path:"", idx:1}]). Today leaves
+// this as the unrestricted universe.
+func liftArrayIndicesFromOperand(pv *propValuePair) arrayIndices {
+	if pv.nested.isNested {
+		return pv.nested.arrayIndices
+	}
+	return nil
+}
+
+// deepestCommonLCA returns the longest dot-segment-aligned common prefix
+// of the provided LCA paths. Used by buildOr to compute its lca from
+// children's lcas. Returns "" if the list is empty, no common prefix
+// exists, or any input is "".
+//
+// Examples:
+//
+//	deepestCommonLCA(["cars.tires", "cars"])                = "cars"
+//	deepestCommonLCA(["cars.tires", "cars.accessories"])   = "cars"
+//	deepestCommonLCA(["cars.tires", "garages.cars"])       = ""
+//	deepestCommonLCA(["cars.tires", "cars.tires"])         = "cars.tires"
+//	deepestCommonLCA(["cars.tires.brand", "cars", "cars.colors"]) = "cars"
+func deepestCommonLCA(paths []string) string {
+	if len(paths) == 0 {
+		return ""
+	}
+	segs := filnested.SplitPath(paths[0])
+	for _, p := range paths[1:] {
+		other := filnested.SplitPath(p)
+		// Truncate segs to the common prefix with other.
+		limit := len(segs)
+		if len(other) < limit {
+			limit = len(other)
+		}
+		i := 0
+		for i < limit && segs[i] == other[i] {
+			i++
+		}
+		segs = segs[:i]
+		if len(segs) == 0 {
+			return ""
+		}
+	}
+	return filnested.JoinPath(segs)
 }
 
 // needsWrappingGroup reports whether the wrapping GROUP at scope must be kept
@@ -224,7 +377,7 @@ func (b *recPlanBuilder) needsWrappingGroup(scope string, sub recPlanNode) bool 
 //   - It has ≥1 scalar-array here AND ≥1 sub — collectFlatSubtree bails on
 //     scalar-array, canUseRawAndAll bails on subs.
 func (b *recPlanBuilder) groupSubtreeNeedsOuterScope(g *recGroupNode) bool {
-	if g.lcaPath != "" && (len(g.subs) >= 2 || hasDuplicateHerePaths(g) || b.groupNeedsIdxLoop(g)) {
+	if g.lca != "" && (len(g.subs) >= 2 || hasDuplicateHerePaths(g) || b.groupNeedsIdxLoop(g)) {
 		return true
 	}
 	for _, sub := range g.subs {
@@ -386,7 +539,7 @@ func collectPlanLCAs(node recPlanNode) map[string]struct{} {
 	walk = func(n recPlanNode) {
 		switch t := n.(type) {
 		case *recGroupNode:
-			out[t.lcaPath] = struct{}{}
+			out[t.lca] = struct{}{}
 			for _, sub := range t.subs {
 				walk(sub)
 			}
@@ -411,7 +564,7 @@ func describePlan(node recPlanNode) string {
 }
 
 func (g *recGroupNode) describeLines() []string {
-	lines := []string{fmt.Sprintf("GROUP lcaPath=%q", g.lcaPath)}
+	lines := []string{fmt.Sprintf("GROUP lcaPath=%q", g.lca)}
 	paths := make([]string, len(g.here))
 	for i, c := range g.here {
 		paths[i] = childRelPath(c)
@@ -432,7 +585,7 @@ func (g *recGroupNode) describeLines() []string {
 
 func (s *recSplitNode) describeLines() []string {
 	lines := []string{
-		fmt.Sprintf("SPLIT lcaPath=%q", s.lcaPath),
+		fmt.Sprintf("SPLIT lcaPath=%q", s.lca),
 		"  branches:",
 	}
 	for _, br := range s.branches {
@@ -440,6 +593,34 @@ func (s *recSplitNode) describeLines() []string {
 		for _, l := range br.plan.describeLines() {
 			lines = append(lines, "      "+l)
 		}
+	}
+	return lines
+}
+
+func (o *recOrNode) describeLines() []string {
+	lines := []string{
+		fmt.Sprintf("OR lcaPath=%q", o.lca),
+		"  children:",
+	}
+	for _, c := range o.children {
+		for _, l := range c.describeLines() {
+			lines = append(lines, "    "+l)
+		}
+	}
+	return lines
+}
+
+func (n *recNotNode) describeLines() []string {
+	pinStrs := make([]string, 0, len(n.pins))
+	for _, p := range n.pins {
+		pinStrs = append(pinStrs, fmt.Sprintf("%s[%d]", p.RelPath, p.Index))
+	}
+	lines := []string{
+		fmt.Sprintf("NOT lcaPath=%q pins=[%s]", n.lca, strings.Join(pinStrs, ",")),
+		"  operand:",
+	}
+	for _, l := range n.operand.describeLines() {
+		lines = append(lines, "    "+l)
 	}
 	return lines
 }

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
@@ -165,25 +165,53 @@ func (b *recPlanBuilder) buildPlan(items []*propValuePair, scope string) recPlan
 	return &recSplitNode{lca: scope, branches: branches}
 }
 
-// buildGroup partitions items at scope into here (terminating at the scope
-// LCA), one sub-plan per next-deeper ObjectArray (for leaf items), and one
-// sub-plan per OR/NOT operator item (planned recursively from its natural
-// scope). An empty here with a single sub collapses to the sub directly so
-// trees stay tight.
+// buildGroup partitions items at scope into:
+//   - `here`: leaves (and tokenization wrappers) whose natural LCA equals scope.
+//   - `subsByPath[next]`: items whose natural LCA is a descendant of scope; the
+//     descendant `next` is the first ObjectArray segment from scope toward
+//     the item's LCA, recursing into buildPlan at that scope.
+//   - `operatorSubs`: OR/NOT operator items whose natural LCA equals scope —
+//     planned in place via buildOrAtScope / buildNotAtScope so their operands
+//     are planned within `scope` and share leaf alignment with sibling leaves.
+//
+// Non-tokenization AND operator items (introduced by groupNestedByProp's
+// recursive same-root wrapping or by user-written `A AND (B AND C)`) are
+// unwrapped: their children are treated as direct items at the same scope.
+// AND is associative, so this preserves semantics and lets the planner reach
+// the leaves at their natural depth.
+//
+// An empty here with a single sub collapses to the sub directly so trees
+// stay tight.
 func (b *recPlanBuilder) buildGroup(items []*propValuePair, scope string) recPlanNode {
+	// Flatten non-tokenization AND wrappers so their leaves participate at
+	// `scope` directly. Tokenization wrappers (childrenFromTokenization=true)
+	// remain — the normalizer collapses their tokens into a virtual leaf
+	// bitmap and the planner treats them as leaves.
+	items = flattenAndOperators(items)
+
 	var here []*propValuePair
 	subsByPath := map[string][]*propValuePair{}
 	var operatorSubs []recPlanNode
 	for _, it := range items {
 		switch it.operator {
-		case filters.OperatorOr:
-			operatorSubs = append(operatorSubs, b.buildOr(it))
-			continue
-		case filters.OperatorNot:
-			operatorSubs = append(operatorSubs, b.buildNot(it))
+		case filters.OperatorOr, filters.OperatorNot:
+			lca := b.naturalLCA(it)
+			if lca == scope {
+				if it.operator == filters.OperatorOr {
+					operatorSubs = append(operatorSubs, b.buildOrAtScope(it, scope))
+				} else {
+					operatorSubs = append(operatorSubs, b.buildNotAtScope(it, scope))
+				}
+				continue
+			}
+			// Natural LCA is deeper than scope — bucket as a deeper sub
+			// so the OR/NOT is planned inside the deeper recGroupNode and
+			// its operands share leaf alignment with siblings at that scope.
+			next := b.nextObjectArrayAfter(scope, lca)
+			subsByPath[next] = append(subsByPath[next], it)
 			continue
 		default:
-			// Fall through to leaf-or-correlated-AND path below.
+			// Other operators fall through to the leaf/correlated-AND path below.
 		}
 		rp := childRelPath(it)
 		if b.lastIntermediateObjectArray(rp) == scope {
@@ -218,52 +246,92 @@ func (b *recPlanBuilder) buildGroup(items []*propValuePair, scope string) recPla
 	return &recGroupNode{lca: scope, here: here, subs: subs}
 }
 
-// buildOr plans each child of an OR operator at its own natural scope and
-// wraps the children in a recOrNode whose lca is the deepest common
-// ancestor of the children's lcas. Filter validation rejects OR with zero
-// children; we assert defensively to surface validation gaps loudly. See
-// step 7 (validation) in the position-level eval implementation plan.
-func (b *recPlanBuilder) buildOr(orPv *propValuePair) recPlanNode {
+// flattenAndOperators unwraps non-tokenization AND wrappers in items. AND is
+// associative, so `[A, AND(B, C)]` is logically the same as `[A, B, C]` and
+// the planner can treat them identically. Tokenization wrappers
+// (childrenFromTokenization=true) are NOT unwrapped — they behave as single
+// virtual leaves at normalize time.
+func flattenAndOperators(items []*propValuePair) []*propValuePair {
+	hasFlattenable := false
+	for _, it := range items {
+		if it.operator == filters.OperatorAnd && !it.nested.childrenFromTokenization && !it.nested.isNested {
+			hasFlattenable = true
+			break
+		}
+	}
+	if !hasFlattenable {
+		return items
+	}
+	out := make([]*propValuePair, 0, len(items))
+	for _, it := range items {
+		if it.operator == filters.OperatorAnd && !it.nested.childrenFromTokenization && !it.nested.isNested {
+			out = append(out, flattenAndOperators(it.children)...)
+			continue
+		}
+		out = append(out, it)
+	}
+	return out
+}
+
+// naturalLCA returns the deepest LCA at which all leaves of pv's subtree
+// coincide. For a single nested leaf it's lastIntermediateObjectArray of the
+// leaf's relPath. For an operator (AND/OR/NOT) it's the deepest common LCA
+// of all reachable leaves. The result is the scope at which a position-level
+// combine over pv's subtree enforces same-element correlation.
+func (b *recPlanBuilder) naturalLCA(pv *propValuePair) string {
+	if pv.nested.isNested {
+		return b.lastIntermediateObjectArray(pv.nested.relPath)
+	}
+	// Compound: gather all reachable leaves' natural LCAs and reduce.
+	if len(pv.children) == 0 {
+		return ""
+	}
+	lcas := make([]string, 0, len(pv.children))
+	for _, c := range pv.children {
+		lcas = append(lcas, b.naturalLCA(c))
+	}
+	return deepestCommonLCA(lcas)
+}
+
+// buildOrAtScope plans each child of an OR operator from `scope` and wraps
+// them in a recOrNode whose lca is the deepest common ancestor of the
+// children's lcas. The scope argument lets buildGroup plant the OR inside a
+// deeper recGroupNode so its operands share leaf alignment with siblings at
+// that scope (enabling same-deepest-LCA-element correlation across the
+// enclosing AND). Filter validation rejects OR with zero children; we
+// assert defensively to surface validation gaps loudly.
+func (b *recPlanBuilder) buildOrAtScope(orPv *propValuePair, scope string) recPlanNode {
 	if len(orPv.children) == 0 {
-		panic("recPlanBuilder.buildOr: OR with zero children — filter validation gap")
+		panic("recPlanBuilder.buildOrAtScope: OR with zero children — filter validation gap")
 	}
 	childPlans := make([]recPlanNode, 0, len(orPv.children))
 	childLCAs := make([]string, 0, len(orPv.children))
 	for _, c := range orPv.children {
-		plan := b.planSingleItem(c)
+		plan := b.buildPlan([]*propValuePair{c}, scope)
 		childPlans = append(childPlans, plan)
 		childLCAs = append(childLCAs, plan.lcaPath())
 	}
 	return &recOrNode{lca: deepestCommonLCA(childLCAs), children: childPlans}
 }
 
-// buildNot plans the single operand of a NOT operator and wraps it in a
-// recNotNode whose lca is the operand's natural LCA. arr[N] pins are
-// lifted from the operand for universe restriction during evaluation —
-// today this is best-effort: leaf operands' arrayIndices are propagated
-// directly, and compound operands (e.g. NOT(A AND B)) leave pins empty
-// (universe unrestricted; correct but loose).
-//
-// Filter validation rejects NOT with !=1 children; we assert defensively.
-// See step 7 (validation) for the broader operator-arity check.
-func (b *recPlanBuilder) buildNot(notPv *propValuePair) recPlanNode {
+// buildNotAtScope plans the single operand of a NOT operator from `scope`
+// and wraps it in a recNotNode whose lca is the operand's plan LCA. arr[N]
+// pins are lifted from the operand for universe restriction during
+// evaluation — leaf operands propagate their arrayIndices directly;
+// compound operands leave pins empty (universe unrestricted; correct but
+// loose). Filter validation rejects NOT with !=1 children; we assert
+// defensively.
+func (b *recPlanBuilder) buildNotAtScope(notPv *propValuePair, scope string) recPlanNode {
 	if len(notPv.children) != 1 {
-		panic(fmt.Sprintf("recPlanBuilder.buildNot: NOT with %d children — filter validation gap", len(notPv.children)))
+		panic(fmt.Sprintf("recPlanBuilder.buildNotAtScope: NOT with %d children — filter validation gap", len(notPv.children)))
 	}
 	operand := notPv.children[0]
-	plan := b.planSingleItem(operand)
+	plan := b.buildPlan([]*propValuePair{operand}, scope)
 	return &recNotNode{
 		lca:     plan.lcaPath(),
 		pins:    liftArrayIndicesFromOperand(operand),
 		operand: plan,
 	}
-}
-
-// planSingleItem plans one item from the root scope. Used by buildOr /
-// buildNot to plan their child operands without inheriting the parent's
-// scope (each operand's plan must reflect its own path's natural scope).
-func (b *recPlanBuilder) planSingleItem(it *propValuePair) recPlanNode {
-	return b.buildPlan([]*propValuePair{it}, "")
 }
 
 // liftArrayIndicesFromOperand extracts arr[N] pins from a NOT operand

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
@@ -444,13 +444,24 @@ func (b *recPlanBuilder) needsWrappingGroup(scope string, sub recPlanNode) bool 
 //     canUseRawAndAll bails and collectFlatSubtree bails on scalar-array.
 //   - It has ≥1 scalar-array here AND ≥1 sub — collectFlatSubtree bails on
 //     scalar-array, canUseRawAndAll bails on subs.
+//   - It has an operator sub (recOrNode / recNotNode). canUseRawAndAll
+//     bails on any sub; collectFlatSubtree bails on non-recGroupNode
+//     subs. So an operator sub forces runIdxLoopRecursive too, and the
+//     idx loop needs outer scope to disambiguate same-K-different-parent
+//     instances at every intermediate object[] level above the group's
+//     LCA — root_idx alone only disambiguates the outermost level.
 func (b *recPlanBuilder) groupSubtreeNeedsOuterScope(g *recGroupNode) bool {
 	if g.lca != "" && (len(g.subs) >= 2 || hasDuplicateHerePaths(g) || b.groupNeedsIdxLoop(g)) {
 		return true
 	}
 	for _, sub := range g.subs {
-		if grp, ok := sub.(*recGroupNode); ok {
-			if b.groupSubtreeNeedsOuterScope(grp) {
+		switch s := sub.(type) {
+		case *recOrNode, *recNotNode:
+			if g.lca != "" {
+				return true
+			}
+		case *recGroupNode:
+			if b.groupSubtreeNeedsOuterScope(s) {
 				return true
 			}
 		}

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive_integration_test.go
@@ -520,3 +520,331 @@ func TestRecPlanBuilderBucketingRules(t *testing.T) {
 			makeCorrelatedPvp(class, "countries", carsMake, postcode, city))
 	})
 }
+
+// TestRecPlanBuilderOrShape covers the recOrNode plan-shape: OR children
+// are planned at their own natural scope and wrapped under an OR node
+// whose lcaPath is the deepest common ancestor of children's lcaPaths.
+//
+// These cases aren't produced by the planner today (step 5 dispatch
+// refactor will start passing OR/NOT into the planner). The tests
+// exercise the planner directly with hand-constructed OR propValuePairs.
+func TestRecPlanBuilderOrShape(t *testing.T) {
+	class := filterExamplesClass()
+	props := rootNestedProps(t, class, "countries")
+	builder := newRecPlanBuilder(props)
+
+	t.Run("OR_of_two_leaves_at_same_LCA_under_cars", func(t *testing.T) {
+		// OR(make=tesla, model=civic) — both at garages.cars LCA.
+		orPv := makeOrPvp(class,
+			makeLeafPvp(class, "countries", "garages.cars.make", "tesla"),
+			makeLeafPvp(class, "countries", "garages.cars.model", "civic"),
+		)
+		want := `OR lcaPath="garages.cars"
+  children:
+    GROUP lcaPath="garages.cars"
+      here=[garages.cars.make]
+      subs=[]
+    GROUP lcaPath="garages.cars"
+      here=[garages.cars.model]
+      subs=[]`
+		assert.Equal(t, want, describePlan(builder.build([]*propValuePair{orPv})))
+	})
+
+	t.Run("OR_of_leaves_at_different_LCAs_picks_common_ancestor", func(t *testing.T) {
+		// OR(garages.city=berlin, garages.cars.make=tesla) — operands at
+		// different LCAs (garages vs garages.cars). Common ancestor: garages.
+		orPv := makeOrPvp(class,
+			makeLeafPvp(class, "countries", "garages.city", "berlin"),
+			makeLeafPvp(class, "countries", "garages.cars.make", "tesla"),
+		)
+		want := `OR lcaPath="garages"
+  children:
+    GROUP lcaPath="garages"
+      here=[garages.city]
+      subs=[]
+    GROUP lcaPath="garages.cars"
+      here=[garages.cars.make]
+      subs=[]`
+		assert.Equal(t, want, describePlan(builder.build([]*propValuePair{orPv})))
+	})
+
+	t.Run("OR_inside_correlated_AND_alongside_leaf", func(t *testing.T) {
+		// make=tesla AND (color=red OR model=civic). All at garages.cars.
+		// Root recGroupNode wraps the leaf-derived sub and the OR sub.
+		orPv := makeOrPvp(class,
+			makeLeafPvp(class, "countries", "garages.cars.color", "red"),
+			makeLeafPvp(class, "countries", "garages.cars.model", "civic"),
+		)
+		want := `GROUP lcaPath=""
+  here=[]
+  subs:
+    GROUP lcaPath="garages.cars"
+      here=[garages.cars.make]
+      subs=[]
+    OR lcaPath="garages.cars"
+      children:
+        GROUP lcaPath="garages.cars"
+          here=[garages.cars.color]
+          subs=[]
+        GROUP lcaPath="garages.cars"
+          here=[garages.cars.model]
+          subs=[]`
+		assert.Equal(t, want, describePlan(builder.build(
+			[]*propValuePair{
+				makeLeafPvp(class, "countries", "garages.cars.make", "tesla"),
+				orPv,
+			},
+		)))
+	})
+
+	t.Run("nested_OR_of_OR_preserved_not_flattened", func(t *testing.T) {
+		// OR(make=tesla, OR(model=civic, color=red)) — nested as written.
+		// Flattening is a possible later optimization; Step 3 keeps the
+		// structure as the user wrote it.
+		innerOr := makeOrPvp(class,
+			makeLeafPvp(class, "countries", "garages.cars.model", "civic"),
+			makeLeafPvp(class, "countries", "garages.cars.color", "red"),
+		)
+		outerOr := makeOrPvp(class,
+			makeLeafPvp(class, "countries", "garages.cars.make", "tesla"),
+			innerOr,
+		)
+		want := `OR lcaPath="garages.cars"
+  children:
+    GROUP lcaPath="garages.cars"
+      here=[garages.cars.make]
+      subs=[]
+    OR lcaPath="garages.cars"
+      children:
+        GROUP lcaPath="garages.cars"
+          here=[garages.cars.model]
+          subs=[]
+        GROUP lcaPath="garages.cars"
+          here=[garages.cars.color]
+          subs=[]`
+		assert.Equal(t, want, describePlan(builder.build([]*propValuePair{outerOr})))
+	})
+
+	t.Run("OR_of_leaves_at_different_depths_through_garages_chain", func(t *testing.T) {
+		// OR(tires.width=205, accessories.type=spoiler) — both deeper than
+		// garages.cars; common ancestor is garages.cars.
+		orPv := makeOrPvp(class,
+			makeLeafPvp(class, "countries", "garages.cars.tires.width", "205"),
+			makeLeafPvp(class, "countries", "garages.cars.accessories.type", "spoiler"),
+		)
+		want := `OR lcaPath="garages.cars"
+  children:
+    GROUP lcaPath="garages.cars.tires"
+      here=[garages.cars.tires.width]
+      subs=[]
+    GROUP lcaPath="garages.cars.accessories"
+      here=[garages.cars.accessories.type]
+      subs=[]`
+		assert.Equal(t, want, describePlan(builder.build([]*propValuePair{orPv})))
+	})
+}
+
+// TestRecPlanBuilderNotShape covers the recNotNode plan-shape: the
+// operand is planned recursively at its own scope and wrapped in a NOT
+// node whose lcaPath is the operand's natural LCA. arr[N] pins on a
+// leaf operand are lifted into the NOT node for universe restriction.
+func TestRecPlanBuilderNotShape(t *testing.T) {
+	class := filterExamplesClass()
+	props := rootNestedProps(t, class, "countries")
+	builder := newRecPlanBuilder(props)
+
+	t.Run("NOT_of_leaf", func(t *testing.T) {
+		notPv := makeNotPvp(class,
+			makeLeafPvp(class, "countries", "garages.cars.make", "tesla"),
+		)
+		want := `NOT lcaPath="garages.cars" pins=[]
+  operand:
+    GROUP lcaPath="garages.cars"
+      here=[garages.cars.make]
+      subs=[]`
+		assert.Equal(t, want, describePlan(builder.build([]*propValuePair{notPv})))
+	})
+
+	t.Run("NOT_inside_correlated_AND_alongside_leaf", func(t *testing.T) {
+		notPv := makeNotPvp(class,
+			makeLeafPvp(class, "countries", "garages.cars.tires.width", "205"),
+		)
+		want := `GROUP lcaPath=""
+  here=[]
+  subs:
+    GROUP lcaPath="garages.cars"
+      here=[garages.cars.make]
+      subs=[]
+    NOT lcaPath="garages.cars.tires" pins=[]
+      operand:
+        GROUP lcaPath="garages.cars.tires"
+          here=[garages.cars.tires.width]
+          subs=[]`
+		assert.Equal(t, want, describePlan(builder.build(
+			[]*propValuePair{
+				makeLeafPvp(class, "countries", "garages.cars.make", "tesla"),
+				notPv,
+			},
+		)))
+	})
+
+	t.Run("NOT_of_leaf_with_root_arrN_pin", func(t *testing.T) {
+		// NOT countries[1].garages.cars.make=tesla — pin at root scope.
+		// The operand plan is a root-level SPLIT, so the NOT inherits
+		// lcaPath="" from the operand. Universe restriction at evaluation
+		// time uses _exists."" (root positions) ∩ _idx.""[1] = cars-element
+		// positions of root index 1.
+		pin := filnested.ArrayIndex{RelPath: "", Index: 1}
+		operand := makeLeafPvpWithIdx(class, "countries", "garages.cars.make", "tesla", pin)
+		notPv := makeNotPvp(class, operand)
+		want := `NOT lcaPath="" pins=[[1]]
+  operand:
+    SPLIT lcaPath=""
+      branches:
+        index=1
+          GROUP lcaPath="garages.cars"
+            here=[garages.cars.make]
+            subs=[]`
+		assert.Equal(t, want, describePlan(builder.build([]*propValuePair{notPv})))
+	})
+
+	t.Run("NOT_of_leaf_with_intermediate_arrN_pin", func(t *testing.T) {
+		// NOT cars.tires[1].width=205 — pin at "tires" relpath (not lifted
+		// to root). Verifies multi-level pin propagation.
+		pin := filnested.ArrayIndex{RelPath: "garages.cars.tires", Index: 1}
+		operand := makeLeafPvpWithIdx(class, "countries", "garages.cars.tires.width", "205", pin)
+		notPv := makeNotPvp(class, operand)
+		want := `NOT lcaPath="garages.cars.tires" pins=[garages.cars.tires[1]]
+  operand:
+    SPLIT lcaPath="garages.cars.tires"
+      branches:
+        index=1
+          GROUP lcaPath="garages.cars.tires"
+            here=[garages.cars.tires.width]
+            subs=[]`
+		assert.Equal(t, want, describePlan(builder.build([]*propValuePair{notPv})))
+	})
+
+	// NOTE: NOT of a nested correlated AND is intentionally not tested here.
+	// The planner treats the inner correlated AND as a single opaque item
+	// (using its first child's path for placement), which is the existing
+	// behavior for compound items and is outside Step 3's scope. NOT-of-OR
+	// (covered by TestRecPlanBuilderOrNotMixed/OR_inside_NOT) exercises the
+	// compound-operand path that Step 3 does extend.
+}
+
+// TestRecPlanBuilderOrNotMixed exercises filters with OR and NOT
+// combined inside correlated AND, including NOT inside OR and OR inside
+// NOT. Confirms recursive planning composes the new node types
+// correctly without unintended interactions with the AND-side dispatch.
+func TestRecPlanBuilderOrNotMixed(t *testing.T) {
+	class := filterExamplesClass()
+	props := rootNestedProps(t, class, "countries")
+	builder := newRecPlanBuilder(props)
+
+	t.Run("AND_with_leaf_OR_NOT_at_same_LCA", func(t *testing.T) {
+		// make=tesla AND (color=red OR model=civic) AND NOT tires.width=205.
+		orPv := makeOrPvp(class,
+			makeLeafPvp(class, "countries", "garages.cars.color", "red"),
+			makeLeafPvp(class, "countries", "garages.cars.model", "civic"),
+		)
+		notPv := makeNotPvp(class,
+			makeLeafPvp(class, "countries", "garages.cars.tires.width", "205"),
+		)
+		want := `GROUP lcaPath=""
+  here=[]
+  subs:
+    GROUP lcaPath="garages.cars"
+      here=[garages.cars.make]
+      subs=[]
+    OR lcaPath="garages.cars"
+      children:
+        GROUP lcaPath="garages.cars"
+          here=[garages.cars.color]
+          subs=[]
+        GROUP lcaPath="garages.cars"
+          here=[garages.cars.model]
+          subs=[]
+    NOT lcaPath="garages.cars.tires" pins=[]
+      operand:
+        GROUP lcaPath="garages.cars.tires"
+          here=[garages.cars.tires.width]
+          subs=[]`
+		assert.Equal(t, want, describePlan(builder.build(
+			[]*propValuePair{
+				makeLeafPvp(class, "countries", "garages.cars.make", "tesla"),
+				orPv,
+				notPv,
+			},
+		)))
+	})
+
+	t.Run("NOT_inside_OR", func(t *testing.T) {
+		// OR(make=tesla, NOT color=red)
+		notPv := makeNotPvp(class,
+			makeLeafPvp(class, "countries", "garages.cars.color", "red"),
+		)
+		orPv := makeOrPvp(class,
+			makeLeafPvp(class, "countries", "garages.cars.make", "tesla"),
+			notPv,
+		)
+		want := `OR lcaPath="garages.cars"
+  children:
+    GROUP lcaPath="garages.cars"
+      here=[garages.cars.make]
+      subs=[]
+    NOT lcaPath="garages.cars" pins=[]
+      operand:
+        GROUP lcaPath="garages.cars"
+          here=[garages.cars.color]
+          subs=[]`
+		assert.Equal(t, want, describePlan(builder.build([]*propValuePair{orPv})))
+	})
+
+	t.Run("OR_inside_NOT", func(t *testing.T) {
+		// NOT (make=tesla OR color=red)
+		orPv := makeOrPvp(class,
+			makeLeafPvp(class, "countries", "garages.cars.make", "tesla"),
+			makeLeafPvp(class, "countries", "garages.cars.color", "red"),
+		)
+		notPv := makeNotPvp(class, orPv)
+		want := `NOT lcaPath="garages.cars" pins=[]
+  operand:
+    OR lcaPath="garages.cars"
+      children:
+        GROUP lcaPath="garages.cars"
+          here=[garages.cars.make]
+          subs=[]
+        GROUP lcaPath="garages.cars"
+          here=[garages.cars.color]
+          subs=[]`
+		assert.Equal(t, want, describePlan(builder.build([]*propValuePair{notPv})))
+	})
+}
+
+// TestDeepestCommonLCA exercises the LCA-computing helper directly.
+// Covers boundary cases that aren't easily exercised through the higher-
+// level OR-plan tests.
+func TestDeepestCommonLCA(t *testing.T) {
+	cases := []struct {
+		name  string
+		paths []string
+		want  string
+	}{
+		{name: "empty list returns empty", paths: nil, want: ""},
+		{name: "single path returns itself", paths: []string{"cars.tires"}, want: "cars.tires"},
+		{name: "two identical paths", paths: []string{"cars.tires", "cars.tires"}, want: "cars.tires"},
+		{name: "one is prefix of other", paths: []string{"cars", "cars.tires"}, want: "cars"},
+		{name: "sibling sub-arrays share parent", paths: []string{"cars.tires", "cars.accessories"}, want: "cars"},
+		{name: "no common prefix returns empty", paths: []string{"cars.tires", "garages.city"}, want: ""},
+		{name: "empty path forces empty common", paths: []string{"cars.tires", ""}, want: ""},
+		{name: "three paths converge at deepest", paths: []string{"cars.tires.width", "cars.tires.brand", "cars.tires"}, want: "cars.tires"},
+		{name: "three paths converge at parent", paths: []string{"cars.tires.width", "cars.accessories.type", "cars.model"}, want: "cars"},
+		{name: "segment boundary not character prefix", paths: []string{"cars.tires", "cars.tirestore"}, want: "cars"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, deepestCommonLCA(tc.paths))
+		})
+	}
+}

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive_integration_test.go
@@ -570,17 +570,17 @@ func TestRecPlanBuilderOrShape(t *testing.T) {
 
 	t.Run("OR_inside_correlated_AND_alongside_leaf", func(t *testing.T) {
 		// make=tesla AND (color=red OR model=civic). All at garages.cars.
-		// Root recGroupNode wraps the leaf-derived sub and the OR sub.
+		// The OR's natural LCA matches the leaf's natural LCA, so the OR is
+		// pushed into the garages.cars subgroup as a sibling of the make
+		// leaf. Same-cars-element correlation now holds across the AND —
+		// see plan_planner_operator_subgroup_lca.md.
 		orPv := makeOrPvp(class,
 			makeLeafPvp(class, "countries", "garages.cars.color", "red"),
 			makeLeafPvp(class, "countries", "garages.cars.model", "civic"),
 		)
-		want := `GROUP lcaPath=""
-  here=[]
+		want := `GROUP lcaPath="garages.cars"
+  here=[garages.cars.make]
   subs:
-    GROUP lcaPath="garages.cars"
-      here=[garages.cars.make]
-      subs=[]
     OR lcaPath="garages.cars"
       children:
         GROUP lcaPath="garages.cars"
@@ -666,15 +666,17 @@ func TestRecPlanBuilderNotShape(t *testing.T) {
 	})
 
 	t.Run("NOT_inside_correlated_AND_alongside_leaf", func(t *testing.T) {
+		// make=tesla AND NOT tires.width=205. The NOT's natural LCA is
+		// garages.cars.tires (deeper than the leaf's garages.cars). Both
+		// items pivot through the garages.cars subgroup; the NOT is placed
+		// as a sub of garages.cars, planned at scope garages.cars so its
+		// operand's deeper sub appears under garages.cars.tires.
 		notPv := makeNotPvp(class,
 			makeLeafPvp(class, "countries", "garages.cars.tires.width", "205"),
 		)
-		want := `GROUP lcaPath=""
-  here=[]
+		want := `GROUP lcaPath="garages.cars"
+  here=[garages.cars.make]
   subs:
-    GROUP lcaPath="garages.cars"
-      here=[garages.cars.make]
-      subs=[]
     NOT lcaPath="garages.cars.tires" pins=[]
       operand:
         GROUP lcaPath="garages.cars.tires"
@@ -690,21 +692,21 @@ func TestRecPlanBuilderNotShape(t *testing.T) {
 
 	t.Run("NOT_of_leaf_with_root_arrN_pin", func(t *testing.T) {
 		// NOT countries[1].garages.cars.make=tesla — pin at root scope.
-		// The operand plan is a root-level SPLIT, so the NOT inherits
-		// lcaPath="" from the operand. Universe restriction at evaluation
-		// time uses _exists."" (root positions) ∩ _idx.""[1] = cars-element
-		// positions of root index 1.
+		// The NOT's natural LCA is the operand's LCA (garages.cars), so
+		// NOT plants at lcaPath="garages.cars" and the operand is planned
+		// at scope garages.cars (where the root pin doesn't apply, so no
+		// SPLIT around the operand). The pin is lifted onto the NOT node
+		// and applied at evaluation time as universe ∩ _idx."[1]" — same
+		// result as the previous SPLIT-wrapped-operand shape but with a
+		// flatter plan tree.
 		pin := filnested.ArrayIndex{RelPath: "", Index: 1}
 		operand := makeLeafPvpWithIdx(class, "countries", "garages.cars.make", "tesla", pin)
 		notPv := makeNotPvp(class, operand)
-		want := `NOT lcaPath="" pins=[[1]]
+		want := `NOT lcaPath="garages.cars" pins=[[1]]
   operand:
-    SPLIT lcaPath=""
-      branches:
-        index=1
-          GROUP lcaPath="garages.cars"
-            here=[garages.cars.make]
-            subs=[]`
+    GROUP lcaPath="garages.cars"
+      here=[garages.cars.make]
+      subs=[]`
 		assert.Equal(t, want, describePlan(builder.build([]*propValuePair{notPv})))
 	})
 
@@ -744,6 +746,13 @@ func TestRecPlanBuilderOrNotMixed(t *testing.T) {
 
 	t.Run("AND_with_leaf_OR_NOT_at_same_LCA", func(t *testing.T) {
 		// make=tesla AND (color=red OR model=civic) AND NOT tires.width=205.
+		// OR's natural LCA is "garages.cars" (deeper than root "") so it is
+		// pushed into the garages.cars subgroup alongside the leaf make
+		// condition. NOT's natural LCA is "garages.cars.tires", also pushed
+		// down through the same subgroup chain, ending up as a sub of the
+		// garages.cars group. The outer GROUP at "garages" wraps because the
+		// deeper garages.cars carries multi-subs (needs outer scope to
+		// disambiguate parents per needsWrappingGroup).
 		orPv := makeOrPvp(class,
 			makeLeafPvp(class, "countries", "garages.cars.color", "red"),
 			makeLeafPvp(class, "countries", "garages.cars.model", "civic"),
@@ -751,25 +760,25 @@ func TestRecPlanBuilderOrNotMixed(t *testing.T) {
 		notPv := makeNotPvp(class,
 			makeLeafPvp(class, "countries", "garages.cars.tires.width", "205"),
 		)
-		want := `GROUP lcaPath=""
+		want := `GROUP lcaPath="garages"
   here=[]
   subs:
     GROUP lcaPath="garages.cars"
       here=[garages.cars.make]
-      subs=[]
-    OR lcaPath="garages.cars"
-      children:
-        GROUP lcaPath="garages.cars"
-          here=[garages.cars.color]
-          subs=[]
-        GROUP lcaPath="garages.cars"
-          here=[garages.cars.model]
-          subs=[]
-    NOT lcaPath="garages.cars.tires" pins=[]
-      operand:
-        GROUP lcaPath="garages.cars.tires"
-          here=[garages.cars.tires.width]
-          subs=[]`
+      subs:
+        NOT lcaPath="garages.cars.tires" pins=[]
+          operand:
+            GROUP lcaPath="garages.cars.tires"
+              here=[garages.cars.tires.width]
+              subs=[]
+        OR lcaPath="garages.cars"
+          children:
+            GROUP lcaPath="garages.cars"
+              here=[garages.cars.color]
+              subs=[]
+            GROUP lcaPath="garages.cars"
+              here=[garages.cars.model]
+              subs=[]`
 		assert.Equal(t, want, describePlan(builder.build(
 			[]*propValuePair{
 				makeLeafPvp(class, "countries", "garages.cars.make", "tesla"),

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive_integration_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive_integration_test.go
@@ -572,23 +572,32 @@ func TestRecPlanBuilderOrShape(t *testing.T) {
 		// make=tesla AND (color=red OR model=civic). All at garages.cars.
 		// The OR's natural LCA matches the leaf's natural LCA, so the OR is
 		// pushed into the garages.cars subgroup as a sibling of the make
-		// leaf. Same-cars-element correlation now holds across the AND —
-		// see plan_planner_operator_subgroup_lca.md.
+		// leaf. Same-cars-element correlation now holds across the AND.
+		//
+		// The outer GROUP at "garages" is kept by needsWrappingGroup —
+		// the cars group has an OR sub, which forces runIdxLoopRecursive
+		// at cars[], and that idx loop needs parentScope from the
+		// enclosing garages[] iteration to disambiguate same-K-different-
+		// garage cars (otherwise tesla in garages[0].cars[0] and a sibling
+		// non-tesla in garages[1].cars[0] would mix at K=0).
 		orPv := makeOrPvp(class,
 			makeLeafPvp(class, "countries", "garages.cars.color", "red"),
 			makeLeafPvp(class, "countries", "garages.cars.model", "civic"),
 		)
-		want := `GROUP lcaPath="garages.cars"
-  here=[garages.cars.make]
+		want := `GROUP lcaPath="garages"
+  here=[]
   subs:
-    OR lcaPath="garages.cars"
-      children:
-        GROUP lcaPath="garages.cars"
-          here=[garages.cars.color]
-          subs=[]
-        GROUP lcaPath="garages.cars"
-          here=[garages.cars.model]
-          subs=[]`
+    GROUP lcaPath="garages.cars"
+      here=[garages.cars.make]
+      subs:
+        OR lcaPath="garages.cars"
+          children:
+            GROUP lcaPath="garages.cars"
+              here=[garages.cars.color]
+              subs=[]
+            GROUP lcaPath="garages.cars"
+              here=[garages.cars.model]
+              subs=[]`
 		assert.Equal(t, want, describePlan(builder.build(
 			[]*propValuePair{
 				makeLeafPvp(class, "countries", "garages.cars.make", "tesla"),
@@ -671,17 +680,26 @@ func TestRecPlanBuilderNotShape(t *testing.T) {
 		// items pivot through the garages.cars subgroup; the NOT is placed
 		// as a sub of garages.cars, planned at scope garages.cars so its
 		// operand's deeper sub appears under garages.cars.tires.
+		//
+		// The outer GROUP at "garages" is kept by needsWrappingGroup —
+		// the cars group has a NOT sub, which forces
+		// runIdxLoopRecursive at cars[], and that idx loop needs
+		// parentScope from the enclosing garages[] iteration to
+		// disambiguate same-K-different-garage cars.
 		notPv := makeNotPvp(class,
 			makeLeafPvp(class, "countries", "garages.cars.tires.width", "205"),
 		)
-		want := `GROUP lcaPath="garages.cars"
-  here=[garages.cars.make]
+		want := `GROUP lcaPath="garages"
+  here=[]
   subs:
-    NOT lcaPath="garages.cars.tires" pins=[]
-      operand:
-        GROUP lcaPath="garages.cars.tires"
-          here=[garages.cars.tires.width]
-          subs=[]`
+    GROUP lcaPath="garages.cars"
+      here=[garages.cars.make]
+      subs:
+        NOT lcaPath="garages.cars.tires" pins=[]
+          operand:
+            GROUP lcaPath="garages.cars.tires"
+              here=[garages.cars.tires.width]
+              subs=[]`
 		assert.Equal(t, want, describePlan(builder.build(
 			[]*propValuePair{
 				makeLeafPvp(class, "countries", "garages.cars.make", "tesla"),

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -349,27 +349,28 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 	t.Run("multi-token nested text alongside scalar nested condition", func(t *testing.T) {
 		// input:  AND(nested.title = "hello world", nested.city = "berlin")
 		// output:
-		// └── correlated(nested)        ← nested.isWithinRootSubtree=true, nested.childrenFromTokenization=false
-		//     ├── correlated(nested)    ← nested.isWithinRootSubtree=true, nested.childrenFromTokenization=true (title tokens)
+		// └── AND {isWithinRootSubtree=true, prop=nested}  ← outer AND collapsed
+		//     ├── AND {isWithinRootSubtree=true, fromTok}   (title tokens)
 		//     │   ├── title:"hello"
 		//     │   └── title:"world"
 		//     └── city:"berlin"
+		//
+		// The outer AND has both same-root children landing in one group, so
+		// groupNestedSubtrees promotes the outer AND in place rather than producing
+		// a redundant AND-with-single-wrapper-child layer.
 		pv, err := s.extractPropValuePair(t.Context(),
 			andClause(leaf("nested.title", "hello world"), leaf("nested.city", "berlin")),
 			"Article")
 		require.NoError(t, err)
 
 		assert.Equal(t, filters.OperatorAnd, pv.operator)
-		require.Len(t, pv.children, 1, "both conditions grouped under one correlated(nested) node")
-
-		group := pv.children[0]
-		assert.True(t, group.nested.isWithinRootSubtree)
-		assert.False(t, group.nested.childrenFromTokenization)
-		assert.Equal(t, "nested", group.prop)
-		require.Len(t, group.children, 2)
+		assert.True(t, pv.nested.isWithinRootSubtree, "outer AND collapsed into the same-root wrapper")
+		assert.False(t, pv.nested.childrenFromTokenization)
+		assert.Equal(t, "nested", pv.prop)
+		require.Len(t, pv.children, 2)
 
 		// first child: the tokenization compound AND for "hello world"
-		tokenAnd := group.children[0]
+		tokenAnd := pv.children[0]
 		assert.True(t, tokenAnd.nested.isWithinRootSubtree)
 		assert.True(t, tokenAnd.nested.childrenFromTokenization)
 		assert.Equal(t, filters.OperatorAnd, tokenAnd.operator)
@@ -378,11 +379,306 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		assert.Equal(t, []byte("world"), tokenAnd.children[1].value)
 
 		// second child: the scalar city leaf
-		cityLeaf := group.children[1]
+		cityLeaf := pv.children[1]
 		assert.True(t, cityLeaf.nested.isNested)
 		assert.False(t, cityLeaf.nested.isWithinRootSubtree)
 		assert.Equal(t, []byte("berlin"), cityLeaf.value)
 		assert.Equal(t, "city", cityLeaf.nested.relPath)
+	})
+
+	orClause := func(operands ...filters.Clause) *filters.Clause {
+		return &filters.Clause{Operator: filters.OperatorOr, Operands: operands}
+	}
+	notClause := func(operand filters.Clause) *filters.Clause {
+		return &filters.Clause{Operator: filters.OperatorNot, Operands: []filters.Clause{operand}}
+	}
+	intLeaf := func(path string, value int) filters.Clause {
+		return *makeNestedFilterClause(path, filters.OperatorEqual, schema.DataTypeInt, value)
+	}
+
+	// assertNestedLeaf asserts the pvp is a nested leaf at relPath with value.
+	assertNestedLeaf := func(t *testing.T, pv *propValuePair, relPath string, value []byte) {
+		t.Helper()
+		assert.True(t, pv.nested.isNested, "expected nested leaf")
+		assert.False(t, pv.nested.isWithinRootSubtree, "leaf should not be marked as wrapper")
+		assert.Equal(t, relPath, pv.nested.relPath)
+		assert.Equal(t, value, pv.value)
+	}
+
+	t.Run("AND of two same-root scalars collapses outer AND", func(t *testing.T) {
+		// input:  AND(nested.city=berlin, nested.title=hello)
+		// output (collapsed — no redundant outer AND level):
+		// └── AND {isWRS:nested}
+		//     ├── city:berlin
+		//     └── title:hello  (single token — no tokenization wrapper)
+		pv, err := s.extractPropValuePair(t.Context(),
+			andClause(leaf("nested.city", "berlin"), leaf("nested.title", "hello")),
+			"Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorAnd, pv.operator)
+		assert.True(t, pv.nested.isWithinRootSubtree)
+		assert.Equal(t, "nested", pv.prop)
+		require.Len(t, pv.children, 2)
+		assertNestedLeaf(t, pv.children[0], "city", []byte("berlin"))
+		assertNestedLeaf(t, pv.children[1], "title", []byte("hello"))
+	})
+
+	t.Run("AND with OR(same-root) inside wraps outer AND", func(t *testing.T) {
+		// input:  AND(nested.city=berlin, OR(nested.title=alpha, nested.title=beta))
+		// output (outer AND collapses; inner OR passes through unwrapped):
+		// └── AND {isWRS:nested}
+		//     ├── city:berlin
+		//     └── OR
+		//         ├── title:alpha
+		//         └── title:beta
+		pv, err := s.extractPropValuePair(t.Context(),
+			andClause(
+				leaf("nested.city", "berlin"),
+				*orClause(leaf("nested.title", "alpha"), leaf("nested.title", "beta")),
+			),
+			"Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorAnd, pv.operator)
+		assert.True(t, pv.nested.isWithinRootSubtree)
+		assert.Equal(t, "nested", pv.prop)
+		require.Len(t, pv.children, 2)
+
+		assertNestedLeaf(t, pv.children[0], "city", []byte("berlin"))
+
+		orChild := pv.children[1]
+		assert.Equal(t, filters.OperatorOr, orChild.operator)
+		assert.False(t, orChild.nested.isWithinRootSubtree, "OR is not wrapped")
+		require.Len(t, orChild.children, 2)
+		assertNestedLeaf(t, orChild.children[0], "title", []byte("alpha"))
+		assertNestedLeaf(t, orChild.children[1], "title", []byte("beta"))
+	})
+
+	t.Run("parenthesized AND nested in same-root AND wraps both levels", func(t *testing.T) {
+		// input:  AND(nested.city=berlin, AND(nested.title=alpha, nested.count=1))
+		// output (outer AND collapses; inner AND also collapses):
+		// └── AND {isWRS:nested}
+		//     ├── city:berlin
+		//     └── AND {isWRS:nested}     ← inner AND collapsed; flattenAndOperators
+		//         ├── title:alpha       removes this layer at plan time
+		//         └── count:1
+		pv, err := s.extractPropValuePair(t.Context(),
+			andClause(
+				leaf("nested.city", "berlin"),
+				*andClause(leaf("nested.title", "alpha"), intLeaf("nested.count", 1)),
+			),
+			"Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorAnd, pv.operator)
+		assert.True(t, pv.nested.isWithinRootSubtree)
+		assert.Equal(t, "nested", pv.prop)
+		require.Len(t, pv.children, 2)
+
+		assertNestedLeaf(t, pv.children[0], "city", []byte("berlin"))
+
+		innerAnd := pv.children[1]
+		assert.Equal(t, filters.OperatorAnd, innerAnd.operator)
+		assert.True(t, innerAnd.nested.isWithinRootSubtree, "inner AND also collapsed")
+		assert.Equal(t, "nested", innerAnd.prop)
+		require.Len(t, innerAnd.children, 2)
+		assertNestedLeaf(t, innerAnd.children[0], "title", []byte("alpha"))
+		assert.True(t, innerAnd.children[1].nested.isNested)
+		assert.Equal(t, "count", innerAnd.children[1].nested.relPath)
+	})
+
+	t.Run("OR(AND(A,B), leaf) — outer OR pass-through, inner AND collapses", func(t *testing.T) {
+		// input:  OR(AND(nested.city=berlin, nested.title=alpha), nested.title=beta)
+		// output:
+		// └── OR
+		//     ├── AND {isWRS:nested}  ← inner AND collapsed
+		//     │   ├── city:berlin
+		//     │   └── title:alpha
+		//     └── title:beta
+		pv, err := s.extractPropValuePair(t.Context(),
+			orClause(
+				*andClause(leaf("nested.city", "berlin"), leaf("nested.title", "alpha")),
+				leaf("nested.title", "beta"),
+			),
+			"Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorOr, pv.operator)
+		assert.False(t, pv.nested.isWithinRootSubtree, "outer OR is not wrapped")
+		require.Len(t, pv.children, 2)
+
+		innerAnd := pv.children[0]
+		assert.Equal(t, filters.OperatorAnd, innerAnd.operator)
+		assert.True(t, innerAnd.nested.isWithinRootSubtree, "inner AND collapsed into a wrapper")
+		assert.Equal(t, "nested", innerAnd.prop)
+		require.Len(t, innerAnd.children, 2)
+		assertNestedLeaf(t, innerAnd.children[0], "city", []byte("berlin"))
+		assertNestedLeaf(t, innerAnd.children[1], "title", []byte("alpha"))
+
+		assertNestedLeaf(t, pv.children[1], "title", []byte("beta"))
+	})
+
+	t.Run("top-level ContainsAll on int[] collapses to same-root wrapper", func(t *testing.T) {
+		// input:  ContainsAll(nested.numbers, [1, 2])
+		// output:
+		// └── AND {isWRS:nested}    ← desugared AND collapsed
+		//     ├── numbers=1
+		//     └── numbers=2
+		clause := &filters.Clause{
+			Operator: filters.ContainsAll,
+			Value:    &filters.Value{Type: schema.DataTypeIntArray, Value: []int{1, 2}},
+			On:       &filters.Path{Class: "Article", Property: "nested.numbers"},
+		}
+		pv, err := s.extractPropValuePair(t.Context(), clause, "Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorAnd, pv.operator)
+		assert.True(t, pv.nested.isWithinRootSubtree, "ContainsAll's AND collapses into a wrapper")
+		assert.Equal(t, "nested", pv.prop)
+		require.Len(t, pv.children, 2)
+		assert.True(t, pv.children[0].nested.isNested)
+		assert.Equal(t, "numbers", pv.children[0].nested.relPath)
+	})
+
+	t.Run("top-level ContainsAny passes through unwrapped", func(t *testing.T) {
+		// input:  ContainsAny(nested.numbers, [1, 2])
+		// output (OR — no wrap; OR-of-same-root has identical docID
+		// semantics at docID and position levels):
+		// └── OR
+		//     ├── numbers=1
+		//     └── numbers=2
+		clause := &filters.Clause{
+			Operator: filters.ContainsAny,
+			Value:    &filters.Value{Type: schema.DataTypeIntArray, Value: []int{1, 2}},
+			On:       &filters.Path{Class: "Article", Property: "nested.numbers"},
+		}
+		pv, err := s.extractPropValuePair(t.Context(), clause, "Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorOr, pv.operator)
+		assert.False(t, pv.nested.isWithinRootSubtree, "OR is not wrapped")
+		require.Len(t, pv.children, 2)
+		assert.True(t, pv.children[0].nested.isNested)
+	})
+
+	t.Run("top-level ContainsNone passes through unwrapped", func(t *testing.T) {
+		// input:  ContainsNone(nested.numbers, [1, 2])
+		// output (NOT(OR) — neither layer is wrapped):
+		// └── NOT
+		//     └── OR
+		//         ├── numbers=1
+		//         └── numbers=2
+		clause := &filters.Clause{
+			Operator: filters.ContainsNone,
+			Value:    &filters.Value{Type: schema.DataTypeIntArray, Value: []int{1, 2}},
+			On:       &filters.Path{Class: "Article", Property: "nested.numbers"},
+		}
+		pv, err := s.extractPropValuePair(t.Context(), clause, "Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorNot, pv.operator)
+		assert.False(t, pv.nested.isWithinRootSubtree)
+		require.Len(t, pv.children, 1)
+
+		inner := pv.children[0]
+		assert.Equal(t, filters.OperatorOr, inner.operator)
+		assert.False(t, inner.nested.isWithinRootSubtree)
+		require.Len(t, inner.children, 2)
+	})
+
+	t.Run("ContainsAny inside AND wraps outer AND via recursive nestedRootProp", func(t *testing.T) {
+		// input:  AND(nested.city=berlin, ContainsAny(nested.numbers, [1, 2]))
+		// output (outer AND collapses; inner OR passes through. Phase B's
+		// recursive nestedRootProp recognises the OR's leaves as same-root
+		// and includes the OR in the outer wrap):
+		// └── AND {isWRS:nested}
+		//     ├── city:berlin
+		//     └── OR
+		//         ├── numbers=1
+		//         └── numbers=2
+		containsAny := filters.Clause{
+			Operator: filters.ContainsAny,
+			Value:    &filters.Value{Type: schema.DataTypeIntArray, Value: []int{1, 2}},
+			On:       &filters.Path{Class: "Article", Property: "nested.numbers"},
+		}
+		pv, err := s.extractPropValuePair(t.Context(),
+			andClause(leaf("nested.city", "berlin"), containsAny),
+			"Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorAnd, pv.operator)
+		assert.True(t, pv.nested.isWithinRootSubtree)
+		assert.Equal(t, "nested", pv.prop)
+		require.Len(t, pv.children, 2)
+
+		assertNestedLeaf(t, pv.children[0], "city", []byte("berlin"))
+
+		orChild := pv.children[1]
+		assert.Equal(t, filters.OperatorOr, orChild.operator)
+		assert.False(t, orChild.nested.isWithinRootSubtree)
+		require.Len(t, orChild.children, 2)
+	})
+
+	t.Run("standalone OR of same-root leaves is not wrapped", func(t *testing.T) {
+		// input:  OR(nested.city=berlin, nested.title=alpha)
+		// output (OR-of-same-root has identical docID semantics at docID
+		// and position levels, so no wrapping):
+		// └── OR
+		//     ├── city:berlin
+		//     └── title:alpha
+		pv, err := s.extractPropValuePair(t.Context(),
+			orClause(leaf("nested.city", "berlin"), leaf("nested.title", "alpha")),
+			"Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorOr, pv.operator)
+		assert.False(t, pv.nested.isWithinRootSubtree)
+		require.Len(t, pv.children, 2)
+		assertNestedLeaf(t, pv.children[0], "city", []byte("berlin"))
+		assertNestedLeaf(t, pv.children[1], "title", []byte("alpha"))
+	})
+
+	t.Run("standalone NOT of nested leaf is not wrapped", func(t *testing.T) {
+		// input:  NOT(nested.city=berlin)
+		// output:
+		// └── NOT
+		//     └── city:berlin
+		pv, err := s.extractPropValuePair(t.Context(),
+			notClause(leaf("nested.city", "berlin")),
+			"Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorNot, pv.operator)
+		assert.False(t, pv.nested.isWithinRootSubtree)
+		require.Len(t, pv.children, 1)
+		assertNestedLeaf(t, pv.children[0], "city", []byte("berlin"))
+	})
+
+	t.Run("AND with NOT(leaf) inside wraps outer AND via recursive nestedRootProp", func(t *testing.T) {
+		// input:  AND(nested.city=berlin, NOT(nested.title=alpha))
+		// output (outer AND collapses; inner NOT passes through):
+		// └── AND {isWRS:nested}
+		//     ├── city:berlin
+		//     └── NOT
+		//         └── title:alpha
+		pv, err := s.extractPropValuePair(t.Context(),
+			andClause(leaf("nested.city", "berlin"), *notClause(leaf("nested.title", "alpha"))),
+			"Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorAnd, pv.operator)
+		assert.True(t, pv.nested.isWithinRootSubtree)
+		assert.Equal(t, "nested", pv.prop)
+		require.Len(t, pv.children, 2)
+
+		assertNestedLeaf(t, pv.children[0], "city", []byte("berlin"))
+
+		notChild := pv.children[1]
+		assert.Equal(t, filters.OperatorNot, notChild.operator)
+		assert.False(t, notChild.nested.isWithinRootSubtree)
+		require.Len(t, notChild.children, 1)
+		assertNestedLeaf(t, notChild.children[0], "title", []byte("alpha"))
 	})
 }
 

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -123,11 +123,11 @@ func TestExtractNestedProp(t *testing.T) {
 			valueType: schema.DataTypeText, value: "hello world",
 			verify: func(t *testing.T, pv *propValuePair) {
 				// output:
-				// └── correlated(nested) ← nested.isCorrelated=true, nested.childrenFromTokenization=true
+				// └── correlated(nested) ← nested.isWithinRootSubtree=true, nested.childrenFromTokenization=true
 				//     ├── title:"hello"
 				//     └── title:"world"
 				require.Equal(t, filters.OperatorAnd, pv.operator)
-				assert.True(t, pv.nested.isCorrelated, "compound AND should be marked nested.isCorrelated")
+				assert.True(t, pv.nested.isWithinRootSubtree, "compound AND should be marked nested.isWithinRootSubtree")
 				assert.True(t, pv.nested.childrenFromTokenization, "compound AND should be marked nested.childrenFromTokenization")
 				assert.Equal(t, "nested", pv.prop)
 				require.Len(t, pv.children, 2)
@@ -316,7 +316,7 @@ func TestExtractNestedProp(t *testing.T) {
 
 // TestExtractPropValuePairNestedGrouping verifies that extractPropValuePair
 // correctly groups nested AND children via groupNestedByProp, with special
-// attention to multi-token text conditions (nested.isCorrelated + nested.childrenFromTokenization).
+// attention to multi-token text conditions (nested.isWithinRootSubtree + nested.childrenFromTokenization).
 func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 	s := newTestSearcher()
 
@@ -330,7 +330,7 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 	t.Run("standalone multi-token nested text", func(t *testing.T) {
 		// input:  nested.title = "hello world"
 		// output:
-		// └── correlated(nested)  ← nested.isCorrelated=true, nested.childrenFromTokenization=true
+		// └── correlated(nested)  ← nested.isWithinRootSubtree=true, nested.childrenFromTokenization=true
 		//     ├── title:"hello"
 		//     └── title:"world"
 		clause := makeNestedFilterClause("nested.title", filters.OperatorEqual, schema.DataTypeText, "hello world")
@@ -338,7 +338,7 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, filters.OperatorAnd, pv.operator)
-		assert.True(t, pv.nested.isCorrelated)
+		assert.True(t, pv.nested.isWithinRootSubtree)
 		assert.True(t, pv.nested.childrenFromTokenization)
 		assert.Equal(t, "nested", pv.prop)
 		require.Len(t, pv.children, 2)
@@ -349,8 +349,8 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 	t.Run("multi-token nested text alongside scalar nested condition", func(t *testing.T) {
 		// input:  AND(nested.title = "hello world", nested.city = "berlin")
 		// output:
-		// └── correlated(nested)        ← nested.isCorrelated=true, nested.childrenFromTokenization=false
-		//     ├── correlated(nested)    ← nested.isCorrelated=true, nested.childrenFromTokenization=true (title tokens)
+		// └── correlated(nested)        ← nested.isWithinRootSubtree=true, nested.childrenFromTokenization=false
+		//     ├── correlated(nested)    ← nested.isWithinRootSubtree=true, nested.childrenFromTokenization=true (title tokens)
 		//     │   ├── title:"hello"
 		//     │   └── title:"world"
 		//     └── city:"berlin"
@@ -363,14 +363,14 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		require.Len(t, pv.children, 1, "both conditions grouped under one correlated(nested) node")
 
 		group := pv.children[0]
-		assert.True(t, group.nested.isCorrelated)
+		assert.True(t, group.nested.isWithinRootSubtree)
 		assert.False(t, group.nested.childrenFromTokenization)
 		assert.Equal(t, "nested", group.prop)
 		require.Len(t, group.children, 2)
 
 		// first child: the tokenization compound AND for "hello world"
 		tokenAnd := group.children[0]
-		assert.True(t, tokenAnd.nested.isCorrelated)
+		assert.True(t, tokenAnd.nested.isWithinRootSubtree)
 		assert.True(t, tokenAnd.nested.childrenFromTokenization)
 		assert.Equal(t, filters.OperatorAnd, tokenAnd.operator)
 		require.Len(t, tokenAnd.children, 2)
@@ -380,7 +380,7 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		// second child: the scalar city leaf
 		cityLeaf := group.children[1]
 		assert.True(t, cityLeaf.nested.isNested)
-		assert.False(t, cityLeaf.nested.isCorrelated)
+		assert.False(t, cityLeaf.nested.isWithinRootSubtree)
 		assert.Equal(t, []byte("berlin"), cityLeaf.value)
 		assert.Equal(t, "city", cityLeaf.nested.relPath)
 	})

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -8382,7 +8382,7 @@ func TestNestedFilteringArrayIndexLevels(t *testing.T) {
 // clauses at the same LCA have *different* arr[N] constraint sets — one
 // unconstrained, the other pinned. Compatibility grouping treats {} and {N}
 // as compatible (same compatibility key) → both clauses share the same
-// resolveNestedCorrelatedGroup call, and same-element semantics force the
+// resolveNestedSubtreeGroup call, and same-element semantics force the
 // unconstrained side to match the same physical element pinned by the [N]
 // side. This is the cross-cutting case between Levels (1b) and the basic
 // arr[N] same-K AND in Access (1a).
@@ -13644,7 +13644,7 @@ func TestNestedFilteringAndShapeFlatVsAndOfAnd(t *testing.T) {
 	}
 
 	// Flat: AND(f1, f2, f3, f4) — groupNestedByProp folds all four leaves
-	// into one isCorrelated wrapper at LCA cars. The executor enforces
+	// into one isWithinRootSubtree wrapper at LCA cars. The executor enforces
 	// same-element AND across all four — ONE car must satisfy every leaf.
 	t.Run("flat_AND_requires_single_car_for_all_four", func(t *testing.T) {
 		runScenario(t, andFilter(f1, f2, f3, f4),
@@ -13652,7 +13652,7 @@ func TestNestedFilteringAndShapeFlatVsAndOfAnd(t *testing.T) {
 	})
 
 	// Nested: AND(AND(f1,f2), AND(f3,f4)) — each inner AND becomes its own
-	// isCorrelated wrapper at LCA cars. The outer AND combines the two
+	// isWithinRootSubtree wrapper at LCA cars. The outer AND combines the two
 	// inner results at docID level. So a doc matches when SOME car has
 	// (make+year) AND SOME — possibly different — car has (color+fuel).
 	//

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -3896,7 +3896,10 @@ func TestNestedFilteringIsNullWithArrNInCorrelatedAnd(t *testing.T) {
 			valueFilter("countries[1].name", "germany"),
 			isNullFilter("countries[1].garages.cars.model", true),
 		)
-		runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchNoGarages, idMatchEmptyGarages, idMatchGarageNoCars, idMatchModelOnlyInOtherCntr})
+		// Phase 2 per-element IsNull: idNoMatchModelInOtherGarage flips to
+		// match because the no-model leaf in garages[0] satisfies the
+		// existential per-element IsNull on countries[1].garages.cars.model.
+		runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchNoGarages, idMatchEmptyGarages, idMatchGarageNoCars, idMatchModelOnlyInOtherCntr, idNoMatchModelInOtherGarage})
 	})
 
 	// 1b: countries[1].name = "germany" AND countries[1].garages.cars IS NULL
@@ -3961,7 +3964,10 @@ func TestNestedFilteringIsNullWithArrNInCorrelatedAnd(t *testing.T) {
 			valueFilter("countries[1].name", "germany"),
 			isNullFilter("countries[1].garages.cars", true),
 		)
-		runScenario(t, docs, filter, []strfmt.UUID{idMatchNoGarages, idMatchEmptyGarages, idMatchGarageNoCars, idMatchEmptyCarsArray, idMatchCarsOnlyInOtherCntr})
+		// Phase 2 per-element IsNull: idNoMatchCarsInOtherGarage flips to
+		// match because the no-cars leaf in garages[0] satisfies the
+		// existential per-element IsNull on countries[1].garages.cars.
+		runScenario(t, docs, filter, []strfmt.UUID{idMatchNoGarages, idMatchEmptyGarages, idMatchGarageNoCars, idMatchEmptyCarsArray, idMatchCarsOnlyInOtherCntr, idNoMatchCarsInOtherGarage})
 	})
 
 	// 1c: countries[1].name = "germany" AND countries[1].garages IS NULL
@@ -5380,7 +5386,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongName, props: map[string]any{"country": map[string]any{"name": "france", "garages": asArr(map[string]any{"cars": asArr(car("make", "x"))})}}, note: "wrong name"},
 			}
 			filter := andFilter(valueFilter("country.name", "germany"), isNullFilter("country.garages.cars.model", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchEmpty, idMatchNoCarsAtAll})
+			// Phase 2 per-element IsNull: idNoMatchModelInOtherGarage flips to
+			// match — the no-model leaf in the first garage's car survives
+			// raw AndNot against the existing-model leaf in the second garage.
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchEmpty, idMatchNoCarsAtAll, idNoMatchModelInOtherGarage})
 		})
 
 		// Sub-test 11 (cross-level): country.name = "germany" AND country.garages.cars.model IS NOT NULL
@@ -5428,7 +5437,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongCity, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "munich"})}}, note: "wrong city"},
 			}
 			filter := andFilter(valueFilter("country.garages.city", "berlin"), isNullFilter("country.garages.cars.make", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchEmptyCars})
+			// Phase 2 per-element IsNull: idNoMatchMakeInOtherGarage flips —
+			// berlin's leaf survives raw AndNot because the make-existence
+			// is at a different garage's leaf.
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchEmptyCars, idNoMatchMakeInOtherGarage})
 		})
 
 		// Sub-test 13 (no-positive / rootAnchor path):
@@ -5548,7 +5560,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongName, props: map[string]any{"country": map[string]any{"name": "france"}}, note: "wrong name"},
 			}
 			filter := andFilter(valueFilter("country.name", "germany"), isNullFilter("country.garages.cars", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatchNoCarsAnywhere, idMatchNoGarages, idMatchAllGaragesNoCars})
+			// Phase 2 per-element IsNull: idNoMatchCarsInOtherGarage flips —
+			// the no-cars leaf in garages[0] (berlin) survives raw AndNot
+			// against the cars-existence leaf in garages[1].
+			runScenario(t, docs, filter, []strfmt.UUID{idMatchNoCarsAnywhere, idMatchNoGarages, idMatchAllGaragesNoCars, idNoMatchCarsInOtherGarage})
 		})
 
 		// Sub-test 18 (inverse cross-level): country.garages.cars.make = "honda"
@@ -5594,7 +5609,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongMake, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota"))})}}, note: "wrong make"},
 			}
 			filter := andFilter(valueFilter("country.garages.cars.make", "honda"), isNullFilter("country.garages.postcode", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchHondaInSecondGarage})
+			// Phase 2 per-element IsNull: idNoMatchPostcodeInOtherGarage flips —
+			// honda's leaf in garages[0] survives raw AndNot against the
+			// postcode-existence leaf in garages[1].
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchHondaInSecondGarage, idNoMatchPostcodeInOtherGarage})
 		})
 
 		// Sub-test 20 (no-positive / rootAnchor with three excludes):
@@ -5646,7 +5664,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongCity, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "munich"})}}, note: "wrong city"},
 			}
 			filter := andFilter(valueFilter("country.garages.city", "berlin"), isNullFilter("country.garages.cars", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultipleGarages})
+			// Phase 2 per-element IsNull: idNoMatchHasCarsOtherGarage flips —
+			// berlin's leaf in garages[0] survives raw AndNot against the
+			// cars-existence leaf in garages[1].
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultipleGarages, idNoMatchHasCarsOtherGarage})
 		})
 
 		// Sub-test 22: country.garages.cars.make = "honda" AND
@@ -5675,7 +5696,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongMake, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota"))})}}, note: "wrong make"},
 			}
 			filter := andFilter(valueFilter("country.garages.cars.make", "honda"), isNullFilter("country.garages.cars.tires", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultipleCars})
+			// Phase 2 per-element IsNull: idNoMatchHasTiresOtherCar flips —
+			// honda's leaf in cars[0] survives raw AndNot against the
+			// tires-existence leaf in cars[1].
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultipleCars, idNoMatchHasTiresOtherCar})
 		})
 
 		// Sub-test 23 (cross-level L1+L2): country.garages.city = "berlin" AND
@@ -5700,7 +5724,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongCity, props: map[string]any{"country": map[string]any{"garages": asArr(map[string]any{"city": "munich"})}}, note: "wrong city"},
 			}
 			filter := andFilter(valueFilter("country.garages.city", "berlin"), isNullFilter("country.garages.cars.tires", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchCarsNoTires})
+			// Phase 2 per-element IsNull: idNoMatchTiresInOtherGarage flips —
+			// berlin's leaf in garages[0] survives raw AndNot against the
+			// tires-existence leaf in garages[1].
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchCarsNoTires, idNoMatchTiresInOtherGarage})
 		})
 	})
 
@@ -6000,7 +6027,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongName, props: map[string]any{"countries": asArr(map[string]any{"name": "france"})}, note: "wrong name"},
 			}
 			filter := andFilter(valueFilter("countries.name", "germany"), isNullFilter("countries.garages.cars.model", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchModelInOtherCntr, idMatchEmptyCntr, idMatchNoCarsAtAll})
+			// Phase 2 per-element IsNull: idNoMatchModelInDeepCar flips —
+			// the no-model leaf in g[0] survives raw AndNot against the
+			// model-existence leaf in g[1].
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchModelInOtherCntr, idMatchEmptyCntr, idMatchNoCarsAtAll, idNoMatchModelInDeepCar})
 		})
 
 		// Sub-test 11 (cross-level): countries.name = "germany" AND countries.garages.cars.model IS NOT NULL
@@ -6060,7 +6090,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongCity, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "munich"})})}, note: "wrong city"},
 			}
 			filter := andFilter(valueFilter("countries.garages.city", "berlin"), isNullFilter("countries.garages.cars.make", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchEmptyCars, idMatchInSecondCntr, idMatchSplitAcrossCountries})
+			// Phase 2 per-element IsNull: idNoMatchMakeInOtherGarageSameCntr
+			// flips — berlin's leaf in garages[0] survives raw AndNot
+			// against the make-existence leaf in garages[1].
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchEmptyCars, idMatchInSecondCntr, idMatchSplitAcrossCountries, idNoMatchMakeInOtherGarageSameCntr})
 		})
 
 		// Sub-test 13 (no-positive / rootAnchor path):
@@ -6194,7 +6227,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongName, props: map[string]any{"countries": asArr(map[string]any{"name": "france"})}, note: "wrong name"},
 			}
 			filter := andFilter(valueFilter("countries.name", "germany"), isNullFilter("countries.garages.cars", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchNoGarages, idMatchCarsInOtherCntr})
+			// Phase 2 per-element IsNull: idNoMatchCarsInOtherGarage flips —
+			// berlin's leaf in garages[0] survives raw AndNot against the
+			// cars-existence leaf in garages[1].
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchNoGarages, idMatchCarsInOtherCntr, idNoMatchCarsInOtherGarage})
 		})
 
 		// Sub-test 18 (inverse cross-level): countries.garages.cars.make = "honda"
@@ -6305,7 +6341,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongCity, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "munich"})})}, note: "wrong city"},
 			}
 			filter := andFilter(valueFilter("countries.garages.city", "berlin"), isNullFilter("countries.garages.cars", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultipleGarages, idMatchInSecondCntr})
+			// Phase 2 per-element IsNull: idNoMatchHasCarsOtherGarageSameCntr
+			// flips — berlin's leaf in garages[0] survives raw AndNot against
+			// the cars-existence leaf in garages[1].
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultipleGarages, idMatchInSecondCntr, idNoMatchHasCarsOtherGarageSameCntr})
 		})
 
 		// Sub-test 22: countries.garages.cars.make = "honda" AND
@@ -6338,7 +6377,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongMake, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"cars": asArr(car("make", "toyota"))})})}, note: "wrong make"},
 			}
 			filter := andFilter(valueFilter("countries.garages.cars.make", "honda"), isNullFilter("countries.garages.cars.tires", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultipleCars, idMatchInSecondCntr})
+			// Phase 2 per-element IsNull: idNoMatchHasTiresOtherCarSameCntr
+			// flips — honda's leaf in cars[0] survives raw AndNot against
+			// the tires-existence leaf in cars[1].
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchMultipleCars, idMatchInSecondCntr, idNoMatchHasTiresOtherCarSameCntr})
 		})
 
 		// Sub-test 23 (cross-level L1+L2): countries.garages.city = "berlin" AND
@@ -6368,7 +6410,10 @@ func TestNestedFilteringIsNullInCorrelatedAnd(t *testing.T) {
 				{id: idNoMatchWrongCity, props: map[string]any{"countries": asArr(map[string]any{"garages": asArr(map[string]any{"city": "munich"})})}, note: "wrong city"},
 			}
 			filter := andFilter(valueFilter("countries.garages.city", "berlin"), isNullFilter("countries.garages.cars.tires", true))
-			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchCarsNoTires, idMatchInSecondCntr})
+			// Phase 2 per-element IsNull: idNoMatchTiresInOtherGarageSameCntr
+			// flips — berlin's leaf in garages[0] survives raw AndNot against
+			// the tires-existence leaf in garages[1].
+			runScenario(t, docs, filter, []strfmt.UUID{idMatch, idMatchCarsNoTires, idMatchInSecondCntr, idNoMatchTiresInOtherGarageSameCntr})
 		})
 	})
 }

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -9718,20 +9718,16 @@ func TestNestedFilteringComprehensive(t *testing.T) {
 					textFilter(pk+".cars.make", "honda"),
 				), []strfmt.UUID{d1, d4})
 			})
-			// TODO aliszka:nested_filtering: this sub-test asserts CURRENT
-			// docID-level AND-of-OR behavior. The d2 expectation (cars[0]=bmw
-			// alone, cars[1]=tires+accessories alone) depends on AND not
-			// propagating same-element correlation across the OR boundary.
-			// When OR distribution lands (OR-in-AND distribution rewrite),
-			// d2 will no longer match — only docs with a single car satisfying
-			// (bmw AND 205) or (bmw AND sunroof) would match.
-			// See TestNestedFilteringAndOfOrRegression for a dedicated
-			// discriminator test.
+			// Same-cars-element AND of OR: a single car must satisfy bmw
+			// AND (205 OR sunroof). d2 (bmw in cars[0], tires/acc in
+			// cars[1]) and d3 in docs_array (bmw in docs[0], tires/acc
+			// in docs[1]) drop. See TestNestedFilteringAndOfOrRegression
+			// for a dedicated discriminator test.
 			t.Run("complex_make_bmw_AND_OR_tires_OR_accessories", func(t *testing.T) {
 				runFilter(t, andFilter(
 					textFilter(pk+".cars.make", "bmw"),
 					orFilter(intFilter(pk+".cars.tires.width", 205), textFilter(pk+".cars.accessories.type", "sunroof")),
-				), want([]strfmt.UUID{d1, d2}, []strfmt.UUID{d1, d2, d3}))
+				), []strfmt.UUID{d1})
 			})
 			t.Run("complex_make_AND_tires_AND_addresses_all_same_root", func(t *testing.T) {
 				runFilter(t, andFilter(
@@ -9740,19 +9736,17 @@ func TestNestedFilteringComprehensive(t *testing.T) {
 					textFilter(pk+".addresses.city", "berlin"),
 				), []strfmt.UUID{d1})
 			})
-			// TODO aliszka:nested_filtering: this sub-test asserts CURRENT
-			// docID-level AND-of-OR behavior. d3 in docs_array variant has
-			// bmw in docs[0] and berlin in docs[1] (cross-root) — currently
-			// matches via docID-level intersection. When OR distribution
-			// lands (OR-in-AND distribution rewrite), the
-			// rewritten filter `(bmw AND berlin) OR (honda AND berlin)`
-			// requires same-root for each branch, so d3 (docs_array) would
-			// no longer match. doc_object expectation unchanged (single root).
+			// Same-element AND of (bmw OR honda) with berlin requires
+			// single doc-body (doc_object) or single docs[N]
+			// (docs_array) to have both. doc_object's d3 has bmw+berlin
+			// in one body so it stays in; docs_array's d3 has bmw and
+			// berlin in different docs[N] so it drops out. doc_object
+			// expectation unchanged (single root).
 			t.Run("complex_OR_makes_AND_addresses", func(t *testing.T) {
 				runFilter(t, andFilter(
 					orFilter(textFilter(pk+".cars.make", "bmw"), textFilter(pk+".cars.make", "honda")),
 					textFilter(pk+".addresses.city", "berlin"),
-				), []strfmt.UUID{d1, d3, d4})
+				), want([]strfmt.UUID{d1, d3, d4}, []strfmt.UUID{d1, d4}))
 			})
 			t.Run("complex_4clause_tags_make_tires_accessories", func(t *testing.T) {
 				runFilter(t, andFilter(
@@ -11703,28 +11697,17 @@ func TestNestedFilteringOrOfCorrelatedAndsWithArrN(t *testing.T) {
 	})
 }
 
-// TestNestedFilteringAndOfOrRegression locks in the *current* docID-level
-// semantics of `A AND (B OR C)` for nested-leaf paths. Today the OR child
-// resolves to a docID set independently and the outer AND intersects at
-// docID level — same-element correlation does NOT propagate across the OR
-// boundary. See OR-in-AND distribution rewrite for the proposed
-// fix (distribute OR over AND at extractPropValuePair time, giving same-
-// element semantics per DNF branch).
-//
-// The discriminator docs (idDiscriminator*) currently MATCH because the
-// dispatch only requires "honda exists somewhere AND (205 or 225 exists
-// somewhere)". Under per-element AND-of-OR (the proposed direction), they
-// would NOT match because no single car satisfies (honda AND 205) or
-// (honda AND 225).
-//
-// When OR distribution lands, this test will fail and the expected list
-// must flip from [idSameCarMatch, idSameCarMatchAlt, idDiscriminatorSplit*,
-// idDiscriminatorAcrossCars] (current docID-level) to
-// [idSameCarMatch, idSameCarMatchAlt] (per-element).
+// TestNestedFilteringAndOfOrRegression verifies the per-element semantics
+// of `A AND (B OR C)` for nested-leaf paths. Same-element correlation
+// propagates across the OR boundary via the planner's LCA pushdown: the
+// OR is planted inside the same cars[] subgroup as the AND's other leg,
+// so the AND demands a single car satisfying make=honda together with
+// width=205 or width=225 in that same car. Discriminator docs (with
+// honda and 205/225 in different cars) do NOT match.
 //
 // A companion sub-test in TestNestedFilteringComprehensive
-// (`complex_make_bmw_AND_OR_tires_OR_accessories`) carries an inline
-// cross-reference comment pointing back to this regression test.
+// (`complex_make_bmw_AND_OR_tires_OR_accessories`) follows the same
+// per-element rule.
 func TestNestedFilteringAndOfOrRegression(t *testing.T) {
 	const nestedClass = "AndOfOrRegression"
 	vTrue := true
@@ -11827,20 +11810,10 @@ func TestNestedFilteringAndOfOrRegression(t *testing.T) {
 
 	// Filter: cars.make = "honda" AND (cars.tires.width = 205 OR cars.tires.width = 225)
 	//
-	// Current (docID-level): match if SOME car has honda AND SOME car has
-	// (205 or 225) — honda and width may be in different cars.
-	//
-	// Per-element (proposed): match if SOME car has both honda AND (205 or
-	// 225) at that same car. Equivalent to distributing the OR:
-	//   (cars.make=honda AND cars.tires.width=205)
-	//      OR (cars.make=honda AND cars.tires.width=225)
-	//
-	// TODO aliszka:nested_filtering: locks in CURRENT docID-level AND-of-OR
-	// behavior. Flips when OR distribution lands
-	// (OR-in-AND distribution rewrite) — discriminator docs
-	// (idDiscriminatorSplit205, idDiscriminatorSplit225,
-	// idDiscriminatorAcrossCars) stop matching, expected list shrinks to
-	// [idSameCarMatch, idSameCarMatchAlt] (per-element same-car).
+	// Per-element: match if SOME car has both honda AND (205 or 225) at
+	// that same car. The discriminator docs (honda and 205/225 in
+	// different cars) do not match because no single car satisfies both
+	// legs of the AND.
 	t.Run("regression_AND_of_OR_universal_docID_level_simple", func(t *testing.T) {
 		idSameCarMatch := uuid(1)            // [{honda,205}] — both interpretations: match
 		idSameCarMatchAlt := uuid(2)         // [{honda,225}] — both: match
@@ -11867,12 +11840,12 @@ func TestNestedFilteringAndOfOrRegression(t *testing.T) {
 				intFilter("doc.cars.tires.width", 225),
 			),
 		)
-		// Current: discriminators match (docID-level intersection succeeds).
-		// Per-element (after distribution): only the same-car matches survive.
-		// Expected list must flip if OR distribution lands.
+		// Per-element same-car: only the docs whose single car satisfies
+		// both legs survive. Discriminator docs (idDiscriminatorSplit205,
+		// idDiscriminatorSplit225, idDiscriminatorAcrossCars) stay in the
+		// doc set to prove the AND does not propagate across cars.
 		runScenario(t, docs, filter, []strfmt.UUID{
 			idSameCarMatch, idSameCarMatchAlt,
-			idDiscriminatorSplit205, idDiscriminatorSplit225, idDiscriminatorAcrossCars,
 		})
 	})
 
@@ -12586,16 +12559,13 @@ func TestNestedFilteringDeeplyNestedAndOrTree(t *testing.T) {
 	// countries (object[]) root
 	// =========================================================================
 
-	// TODO aliszka:nested_filtering: locks in CURRENT docID-level AND-of-OR
-	// behavior at the outer-AND boundary across multiple root elements.
-	// Two discriminator docs (idTeslaWithBerlinInSecondCountry,
-	// idTeslaInOneCountryBerlinInAnother) currently match because the
-	// outer AND treats the OR as a docID-level set — tesla in one
-	// country and berlin in another satisfies docID-level intersection.
-	// Under the planned OR-in-AND distribution rewrite, both would stop
-	// matching: each distributed branch (`tesla AND berlin`,
-	// `tesla AND munich AND 80331`) requires same-country semantics.
-	// Same root cause as regression_AND_of_OR_universal_docID_level_simple.
+	// regression_countries_array_3level_AND_OR_innerAND — same-element
+	// AND at countries[]: a single countries entry must have tesla AND
+	// satisfy the OR (berlin OR (munich AND 80331)). Discriminator docs
+	// (tesla in one country, berlin in another) drop OUT because no
+	// single country satisfies both legs. Same root cause as
+	// TestNestedFilteringAndOfOrRegression's same-car semantics, applied
+	// at the countries[] LCA.
 	t.Run("regression_countries_array_3level_AND_OR_innerAND", func(t *testing.T) {
 		idTeslaPlusBerlin := uuid(1)
 		idTeslaPlusMunich80331 := uuid(2)
@@ -12633,9 +12603,11 @@ func TestNestedFilteringDeeplyNestedAndOrTree(t *testing.T) {
 				),
 			),
 		)
+		// idTeslaWithBerlinInSecondCountry and
+		// idTeslaInOneCountryBerlinInAnother drop OUT — no single
+		// country has tesla AND satisfies the OR.
 		runScenario(t, docs, filter, []strfmt.UUID{
 			idTeslaPlusBerlin, idTeslaPlusMunich80331,
-			idTeslaWithBerlinInSecondCountry, idTeslaInOneCountryBerlinInAnother,
 		})
 	})
 }
@@ -12849,17 +12821,12 @@ func TestNestedFilteringOperatorSweep(t *testing.T) {
 //   - ContainsAny  → OR  of Equal clauses
 //   - ContainsNone → NOT(OR of Equal clauses)
 //
-// CURRENT BEHAVIOR — OBSERVED 2026-05-07:
-//
-// ContainsAll on a nested array path performs **docID-level AND** — it
-// intersects the "doc has A anywhere" set with "doc has B anywhere".
-// This means a doc whose nested elements collectively cover both values
-// matches even if no single element contains both. Sub-tests where the
-// path traverses one or more object[] levels are marked
-// regression_ContainsAll: under a future planner improvement that
-// recognizes same-path AND as a correlated AND, these would tighten to
-// same-element AND and the discriminator docs would stop matching. See
-// plan_contains_all_same_element_semantics for the fix direction.
+// ContainsAll on a nested array path performs **same-element AND** at
+// the deepest-LCA element: it requires a single element of that LCA to
+// contain every listed value. Sub-tests where the path traverses one or
+// more object[] levels are kept under the regression_ContainsAll name
+// (they were the discriminators that flipped when the same-path AND
+// correlation landed) and now lock in the per-element contract.
 //
 // ContainsAny resolves at docID level (matches if any element has any
 // listed value) — natural existential semantics, no regression marker.
@@ -13079,16 +13046,12 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				)), note: "g0.tags=[muscle]"},
 				{id: d5, props: map[string]any{"country": map[string]any{}}, note: "empty country"},
 			}
-			// TODO aliszka:nested_filtering: locks in CURRENT docID-level AND
-			// for ContainsAll on a same-path pair where the array prop sits
-			// inside one object[] level (garages). d2 (split-garages within
-			// the single country) currently matches because the doc has both
-			// 'sport' and 'luxury' somewhere; under the planned same-path
-			// correlated-AND fix, only d1 (single garage with both) would
-			// match.
+			// regression_ContainsAll — same-element AND at garages[]:
+			// requires a single garage to contain both 'sport' and
+			// 'luxury'. d2 (split-garages) flips out.
 			t.Run("regression_ContainsAll", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.garages.tags", filters.ContainsAll, "sport", "luxury"),
-					[]strfmt.UUID{d1, d2})
+					[]strfmt.UUID{d1})
 			})
 			t.Run("ContainsAny", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.garages.tags", filters.ContainsAny, "sport", "luxury"),
@@ -13126,14 +13089,13 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				)), note: "g0.city='boston'"},
 				{id: d5, props: map[string]any{"country": map[string]any{}}, note: "empty country"},
 			}
-			// TODO aliszka:nested_filtering: same shape as L1_garages_tags
-			// regression_ContainsAll — locks in CURRENT docID-level AND
-			// under one object[] level. d2 (split tokens across garages)
-			// currently matches; under same-path correlated-AND fix only d1
-			// (both tokens in single garage's city) would match.
+			// regression_ContainsAll — same shape as L1_garages_tags
+			// regression_ContainsAll, applied to word-tokenized text:
+			// both tokens must live in a single garage's city. d2
+			// (split tokens across garages) flips out.
 			t.Run("regression_ContainsAll", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.garages.city", filters.ContainsAll, "new", "york"),
-					[]strfmt.UUID{d1, d2})
+					[]strfmt.UUID{d1})
 			})
 			t.Run("ContainsAny", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.garages.city", filters.ContainsAny, "new", "york"),
@@ -13172,14 +13134,12 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				)), note: "g0.cars[0].tags=[muscle]"},
 				{id: d6, props: map[string]any{"country": map[string]any{}}, note: "empty country"},
 			}
-			// TODO aliszka:nested_filtering: locks in CURRENT docID-level AND
-			// for ContainsAll under two object[] levels. d2 (split-cars in
-			// single garage) and d3 (split-garages in single country) match
-			// because the doc has both values somewhere; under same-path
-			// correlated-AND fix only d1 (single car with both) would match.
+			// regression_ContainsAll — same-element AND at cars[]:
+			// requires a single car to contain both tags. d2 (split-
+			// cars in single garage) and d3 (split-garages) flip out.
 			t.Run("regression_ContainsAll", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.garages.cars.tags", filters.ContainsAll, "sport", "luxury"),
-					[]strfmt.UUID{d1, d2, d3})
+					[]strfmt.UUID{d1})
 			})
 			t.Run("ContainsAny", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.garages.cars.tags", filters.ContainsAny, "sport", "luxury"),
@@ -13217,13 +13177,13 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				)), note: "make='boston' (neither)"},
 				{id: d6, props: map[string]any{"country": map[string]any{}}, note: "empty country"},
 			}
-			// TODO aliszka:nested_filtering: same shape as L2_cars_tags
-			// regression_ContainsAll — locks in CURRENT docID-level AND
-			// under two object[] levels. Splits across cars/garages match
-			// today; same-path correlated-AND fix would tighten to d1 only.
+			// regression_ContainsAll — same shape as L2_cars_tags
+			// regression_ContainsAll, applied to word-tokenized text:
+			// both tokens must live in a single car's make field. d2
+			// (split-cars) and d3 (split-garages) flip out.
 			t.Run("regression_ContainsAll", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.garages.cars.make", filters.ContainsAll, "new", "york"),
-					[]strfmt.UUID{d1, d2, d3})
+					[]strfmt.UUID{d1})
 			})
 			t.Run("ContainsAny", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.garages.cars.make", filters.ContainsAny, "new", "york"),
@@ -13257,14 +13217,12 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				{id: d4, props: wrapCountries(countryBody("", []string{"muscle"})), note: "[muscle]"},
 				{id: d5, props: map[string]any{"countries": []any{}}, note: "empty countries"},
 			}
-			// TODO aliszka:nested_filtering: locks in CURRENT docID-level AND
-			// for ContainsAll under one object[] level (countries). d2
-			// (split-countries) currently matches because the doc has both
-			// 'sport' and 'luxury' somewhere; under same-path correlated-AND
-			// fix only d1 (single country with both tags) would match.
+			// regression_ContainsAll — same-element AND at countries[]:
+			// requires a single country to contain both tags. d2
+			// (split-countries) flips out.
 			t.Run("regression_ContainsAll", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("countries.tags", filters.ContainsAll, "sport", "luxury"),
-					[]strfmt.UUID{d1, d2})
+					[]strfmt.UUID{d1})
 			})
 			t.Run("ContainsAny", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("countries.tags", filters.ContainsAny, "sport", "luxury"),
@@ -13293,13 +13251,13 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				{id: d4, props: wrapCountries(countryBody("boston", nil)), note: "boston"},
 				{id: d5, props: map[string]any{"countries": []any{}}, note: "empty countries"},
 			}
-			// TODO aliszka:nested_filtering: same shape as L0_tags
-			// regression_ContainsAll — docID-level AND under one object[]
-			// level. d2 (split-countries) currently matches; fix would
-			// tighten to d1 only.
+			// regression_ContainsAll — same shape as L0_tags
+			// regression_ContainsAll, applied to word-tokenized text:
+			// both tokens must live in a single country's name. d2
+			// (split-countries) flips out.
 			t.Run("regression_ContainsAll", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("countries.name", filters.ContainsAll, "new", "york"),
-					[]strfmt.UUID{d1, d2})
+					[]strfmt.UUID{d1})
 			})
 			t.Run("ContainsAny", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("countries.name", filters.ContainsAny, "new", "york"),
@@ -13337,13 +13295,13 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				)), note: "[muscle]"},
 				{id: d6, props: map[string]any{"countries": []any{}}, note: "empty countries"},
 			}
-			// TODO aliszka:nested_filtering: locks in CURRENT docID-level AND
-			// for ContainsAll under two object[] levels. d2 (split-garages
-			// in single country) and d3 (split-countries) currently match;
-			// fix to same-path correlated-AND would tighten to d1 only.
+			// regression_ContainsAll — same-element AND at garages[]:
+			// requires a single garage to contain both tags. d2
+			// (split-garages in single country) and d3 (split-countries)
+			// flip out.
 			t.Run("regression_ContainsAll", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("countries.garages.tags", filters.ContainsAll, "sport", "luxury"),
-					[]strfmt.UUID{d1, d2, d3})
+					[]strfmt.UUID{d1})
 			})
 			t.Run("ContainsAny", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("countries.garages.tags", filters.ContainsAny, "sport", "luxury"),
@@ -13375,13 +13333,13 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				{id: d5, props: wrapCountries(countryBody("", nil, garage("boston", nil))), note: "boston"},
 				{id: d6, props: map[string]any{"countries": []any{}}, note: "empty countries"},
 			}
-			// TODO aliszka:nested_filtering: same shape as L1_garages_tags
-			// regression_ContainsAll — docID-level AND under two object[]
-			// levels. Splits across garages or countries currently match;
-			// fix tightens to single-garage matches only.
+			// regression_ContainsAll — same shape as L1_garages_tags
+			// regression_ContainsAll, applied to word-tokenized text:
+			// both tokens must live in a single garage's city. d2
+			// (split-garages) and d3 (split-countries) flip out.
 			t.Run("regression_ContainsAll", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("countries.garages.city", filters.ContainsAll, "new", "york"),
-					[]strfmt.UUID{d1, d2, d3})
+					[]strfmt.UUID{d1})
 			})
 			t.Run("ContainsAny", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("countries.garages.city", filters.ContainsAny, "new", "york"),
@@ -13421,14 +13379,13 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				)), note: "[muscle]"},
 				{id: d7, props: map[string]any{"countries": []any{}}, note: "empty countries"},
 			}
-			// TODO aliszka:nested_filtering: locks in CURRENT docID-level AND
-			// for ContainsAll under three object[] levels. All three split
-			// shapes (split-cars, split-garages, split-countries) currently
-			// match; fix to same-path correlated-AND would tighten to d1
-			// only (single car with both tags).
+			// regression_ContainsAll — same-element AND at cars[]:
+			// requires a single car to contain both tags. d2
+			// (split-cars), d3 (split-garages), d4 (split-countries)
+			// all flip out.
 			t.Run("regression_ContainsAll", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("countries.garages.cars.tags", filters.ContainsAll, "sport", "luxury"),
-					[]strfmt.UUID{d1, d2, d3, d4})
+					[]strfmt.UUID{d1})
 			})
 			t.Run("ContainsAny", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("countries.garages.cars.tags", filters.ContainsAny, "sport", "luxury"),
@@ -13469,13 +13426,14 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				)), note: "make='boston' (neither)"},
 				{id: d7, props: map[string]any{"countries": []any{}}, note: "empty countries"},
 			}
-			// TODO aliszka:nested_filtering: same shape as L2_cars_tags
-			// regression_ContainsAll — docID-level AND under three object[]
-			// levels. Splits across cars/garages/countries match today; fix
-			// would tighten to d1 only.
+			// regression_ContainsAll — same shape as L2_cars_tags
+			// regression_ContainsAll, applied to word-tokenized text:
+			// both tokens must live in a single car's make field.
+			// d2 (split-cars), d3 (split-garages), d4 (split-countries)
+			// all flip out.
 			t.Run("regression_ContainsAll", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("countries.garages.cars.make", filters.ContainsAll, "new", "york"),
-					[]strfmt.UUID{d1, d2, d3, d4})
+					[]strfmt.UUID{d1})
 			})
 			t.Run("ContainsAny", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("countries.garages.cars.make", filters.ContainsAny, "new", "york"),
@@ -13490,28 +13448,19 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 	})
 }
 
-// TestNestedFilteringAndShapeFlatVsAndOfAnd contrasts two AND shapes that
-// are logically equivalent under classical boolean associativity but
-// produce DIFFERENT results in the nested-filter dispatch:
+// TestNestedFilteringAndShapeFlatVsAndOfAnd verifies that two AND shapes
+// equivalent under classical boolean associativity produce IDENTICAL
+// results in the nested-filter dispatch:
 //
 //	flat:   AND(f1, f2, f3, f4)
 //	nested: AND(AND(f1, f2), AND(f3, f4))
 //
-// All four leaf filters target the same nested root (cars). The dispatch
-// runs `groupNestedByProp` at each AND level, scoping same-element
-// correlation to that AND's children. Sibling ANDs are then combined at
-// docID level, never crossed.
-//
-// Effect on the same data:
-//
-//   - Flat: ONE car must satisfy all four leaves.
-//   - Nested: ONE car must satisfy (f1 AND f2); some — possibly different —
-//     car must satisfy (f3 AND f4).
-//
-// Verified 2026-05-07. Same root cause family as the OR-in-AND
-// distribution gap (plan_or_in_correlated_and_distribution): correlation
-// doesn't cross combinator boundaries, even associatively-equivalent
-// ones.
+// All four leaf filters target the same nested root (cars). The planner's
+// `flattenAndOperators` collapses non-tokenization, non-isWithinRootSubtree
+// AND wrappers into a single AND at the same scope, and a single post-order
+// `groupNestedSubtrees` pass folds the four leaves into one
+// `isWithinRootSubtree` wrapper at LCA cars. Both shapes therefore require
+// ONE car to satisfy all four leaves.
 func TestNestedFilteringAndShapeFlatVsAndOfAnd(t *testing.T) {
 	const nestedClass = "AndShapeFlatVsAndOfAnd"
 	vTrue := true
@@ -13651,19 +13600,17 @@ func TestNestedFilteringAndShapeFlatVsAndOfAnd(t *testing.T) {
 			[]strfmt.UUID{idAllOneCar})
 	})
 
-	// Nested: AND(AND(f1,f2), AND(f3,f4)) — each inner AND becomes its own
-	// isWithinRootSubtree wrapper at LCA cars. The outer AND combines the two
-	// inner results at docID level. So a doc matches when SOME car has
-	// (make+year) AND SOME — possibly different — car has (color+fuel).
-	//
-	// idSplitPairs and idGroupedDiffMakes are the contrast docs: they
-	// match the nested shape but NOT the flat shape, demonstrating that
-	// parenthesization scopes same-element correlation.
-	t.Run("nested_AND_of_AND_allows_split_across_cars", func(t *testing.T) {
+	// Nested: AND(AND(f1,f2), AND(f3,f4)) — flattenAndOperators unwraps the
+	// inner ANDs at the outer AND's scope, and groupNestedSubtrees folds all
+	// four leaves into one isWithinRootSubtree wrapper at LCA cars. The
+	// executor enforces same-element AND across all four, matching the flat
+	// shape exactly. idSplitPairs and idGroupedDiffMakes split the leaves
+	// across cars and therefore do NOT match — no single car has all four.
+	t.Run("nested_AND_of_AND_collapses_to_flat", func(t *testing.T) {
 		runScenario(t, andFilter(
 			andFilter(f1, f2),
 			andFilter(f3, f4),
-		), []strfmt.UUID{idAllOneCar, idSplitPairs, idGroupedDiffMakes})
+		), []strfmt.UUID{idAllOneCar})
 	})
 }
 
@@ -13799,13 +13746,13 @@ func TestNestedFilteringNotInsideAnd3Levels(t *testing.T) {
 			assert.ElementsMatch(t, want, got)
 		}
 
-		// TODO aliszka:nested_filtering: locks in CURRENT docID-level NOT
-		// behavior for "<path>.make=tesla AND NOT <path>.tires.width=205".
-		// Under scope-aware NOT (NOT inverts at operand's natural LCA =
-		// <path>.tires), the expected list flips to existential
-		// per-element semantics: doc matches if some tesla car has at
-		// least one non-205 tire (with same-element correlation across
-		// the AND).
+		// regression_gap3_NOT_inside_AND_cross_LCA_siblings —
+		// scope-aware NOT at <path>.tires (operand LCA, existential
+		// per-element) inside same-cars-element AND. Doc matches when
+		// at least one tesla car has at least one non-205 tire.
+		// Tesla-no-tires docs drop (vacuous existential); mixed-tires
+		// and cross-car split docs (tesla(non-205) + bmw(205)) flip
+		// to match.
 		t.Run("regression_gap3_NOT_inside_AND_cross_LCA_siblings", func(t *testing.T) {
 			runScenario(t, andF(
 				textF(makePath, "tesla"),
@@ -13865,21 +13812,19 @@ func TestNestedFilteringNotInsideAnd3Levels(t *testing.T) {
 		runLevel(t, className, class,
 			"cars.make", "cars.tires.width",
 			docs,
-			// gap #3 today
-			[]strfmt.UUID{idTeslaNo205, idTeslaNoTires},
-			// expected after scope-aware NOT:
-			// []strfmt.UUID{idTeslaNo205, idTeslaMixed, idSplitTeslaBmw}
-			//   (idTeslaNoTires drops — vacuous; idTeslaMixed and
-			//   idSplitTeslaBmw flip to match — tesla car has at least one
-			//   non-205 tire.)
+			// gap #3 — scope-aware NOT, existential per-element.
+			// idTeslaNoTires drops (vacuous); idTeslaMixed (mixed
+			// tires on a single tesla car) and idSplitTeslaBmw (tesla
+			// car with non-205 tire) flip to match.
+			[]strfmt.UUID{idTeslaNo205, idTeslaMixed, idSplitTeslaBmw},
 
-			// gap #9 today
+			// gap #9 — still locks in CURRENT docID-level NOT of a
+			// compound AND. TODO aliszka:nested_filtering: under
+			// scope-aware NOT applied to compound operands (not yet
+			// landed), expectation flips to
+			// []strfmt.UUID{idTeslaNo205, idTeslaNoTires,
+			//               idSplitTeslaBmw, idTeslaPlusOther, idBmwOnly}.
 			[]strfmt.UUID{idTeslaNo205, idTeslaNoTires, idSplitTeslaBmw, idBmwOnly, idEmpty},
-			// expected after scope-aware NOT:
-			// []strfmt.UUID{idTeslaNo205, idTeslaNoTires, idSplitTeslaBmw,
-			//               idTeslaPlusOther, idBmwOnly}
-			//   (idEmpty drops — vacuous; idTeslaPlusOther flips to match —
-			//   cars[1] (bmw,225) is in the inverted set.)
 		)
 	})
 
@@ -13942,30 +13887,32 @@ func TestNestedFilteringNotInsideAnd3Levels(t *testing.T) {
 		runLevel(t, className, class,
 			"garages.cars.make", "garages.cars.tires.width",
 			docs,
-			// gap #3 today
-			[]strfmt.UUID{idTeslaNo205, idTeslaNoTires},
-			// expected after scope-aware NOT:
-			// []strfmt.UUID{idTeslaNo205, idTeslaMixed,
-			//               idSplitTeslaBmwSameGarage,
-			//               idSplitAcrossGarages, idTwoTeslasOneSatisfiesG}
-			//   (idTeslaNoTires drops — vacuous; mixed-tires, split-cars,
-			//   split-across-garages, and two-tesla-one-satisfies all flip
-			//   to match — tesla car has at least one non-205 tire.)
-
-			// gap #9 today
+			// gap #3 — scope-aware NOT, existential per-element.
+			// Tesla-no-tires drops (vacuous); mixed-tires,
+			// split-cars-same-garage, split-across-garages, and
+			// two-teslas-one-satisfies all flip to match.
 			[]strfmt.UUID{
-				idTeslaNo205, idTeslaNoTires, idSplitTeslaBmwSameGarage,
-				idBmwOnly, idEmpty, idSplitAcrossGarages,
+				idTeslaNo205, idTeslaMixed,
+				idSplitTeslaBmwSameGarage,
+				idSplitAcrossGarages, idTwoTeslasOneSatisfiesG,
 			},
-			// expected after scope-aware NOT:
+
+			// gap #9 — still locks in CURRENT docID-level NOT of
+			// compound AND. TODO aliszka:nested_filtering: under
+			// scope-aware compound NOT (top-level NOT-of-compound),
+			// expectation flips to
 			// []strfmt.UUID{idTeslaNo205, idTeslaNoTires,
 			//               idSplitTeslaBmwSameGarage,
 			//               idTeslaPlusOtherSameGarage, idBmwOnly,
 			//               idSplitAcrossGarages, idTeslaG0PlusOtherG1,
 			//               idTwoTeslasOneSatisfiesG}
-			//   (idEmpty drops — vacuous; tesla+other-same-garage,
-			//   tesla-g0-plus-other-g1, and two-teslas-one-satisfies flip
-			//   to match — at least one car not in inner-AND positive.)
+			//   (idEmpty drops — no cars universe; tesla+other-same-
+			//   garage, tesla-g0-plus-other-g1, and two-teslas-one-
+			//   satisfies flip in.)
+			[]strfmt.UUID{
+				idTeslaNo205, idTeslaNoTires, idSplitTeslaBmwSameGarage,
+				idBmwOnly, idEmpty, idSplitAcrossGarages,
+			},
 		)
 	})
 
@@ -14021,25 +13968,28 @@ func TestNestedFilteringNotInsideAnd3Levels(t *testing.T) {
 		runLevel(t, className, class,
 			"garage.cars.make", "garage.cars.tires.width",
 			docs,
-			// gap #3 today
-			[]strfmt.UUID{idTeslaNo205, idTeslaNoTires},
-			// expected after scope-aware NOT:
-			// []strfmt.UUID{idTeslaNo205, idTeslaMixed,
-			//               idSplitTeslaBmwSameGarage}
-			//   (idTeslaNoTires drops — vacuous; mixed-tires and
-			//   split-cars-same-garage flip to match.)
+			// gap #3 — scope-aware NOT, existential per-element.
+			// Tesla-no-tires drops; mixed-tires and split-cars-same-
+			// garage flip to match. No split-across-garages variant
+			// because the root is a single object, not an array.
+			[]strfmt.UUID{
+				idTeslaNo205, idTeslaMixed,
+				idSplitTeslaBmwSameGarage,
+			},
 
-			// gap #9 today
+			// gap #9 — still locks in CURRENT docID-level NOT of
+			// compound AND. TODO aliszka:nested_filtering: under
+			// scope-aware compound NOT, expectation flips to
+			// []strfmt.UUID{idTeslaNo205, idTeslaNoTires,
+			//               idSplitTeslaBmwSameGarage,
+			//               idTeslaPlusOtherSameGarage, idBmwOnly}
+			//   (idEmptyDoc and idEmptyGarage drop — no cars universe;
+			//   tesla+other-same-garage flips in. No split-across-
+			//   garages variant because the root is a single object.)
 			[]strfmt.UUID{
 				idTeslaNo205, idTeslaNoTires, idSplitTeslaBmwSameGarage,
 				idBmwOnly, idEmptyDoc, idEmptyGarage,
 			},
-			// expected after scope-aware NOT:
-			// []strfmt.UUID{idTeslaNo205, idTeslaNoTires,
-			//               idSplitTeslaBmwSameGarage,
-			//               idTeslaPlusOtherSameGarage, idBmwOnly}
-			//   (idEmptyDoc, idEmptyGarage drop — vacuous;
-			//   tesla+other-same-garage flips to match.)
 		)
 	})
 
@@ -14098,36 +14048,34 @@ func TestNestedFilteringNotInsideAnd3Levels(t *testing.T) {
 			{id: idTwoTeslasAcrossCountries, props: wrapC(country(garage(car("tesla", tire(225)))), country(garage(car("tesla", tire(205))))), note: "tesla in both c[0],c[1]; only c[1] has 205 — DISCRIM L2 the multi-element / multi-leaf encoding gap"},
 		}
 
-		// Today's expected at L2:
-		// gap #3: tesla AND no 205 anywhere. d2, d4 match.
-		// gap #9: all docs without a (tesla AND has-205) car.
 		runLevel(t, className, class,
 			"countries.garages.cars.make", "countries.garages.cars.tires.width",
 			docs,
-			// gap #3 today
-			[]strfmt.UUID{idTeslaNo205, idTeslaNoTires},
-			// expected after scope-aware NOT:
-			// []strfmt.UUID{idTeslaNo205, idTeslaMixed,
-			//               idSplitTeslaBmwSameGarage,
-			//               idSplitAcrossGarages, idSplitAcrossCountries,
-			//               idTwoTeslasAcrossCountries}
-			//   (idTeslaNoTires drops — vacuous; mixed-tires, split-cars,
-			//   split-across-garages, split-across-countries, and
-			//   two-teslas-across-countries flip to match.)
-
-			// gap #9 today
+			// gap #3 — scope-aware NOT, existential per-element.
+			// Tesla-no-tires drops (vacuous); mixed-tires, split-cars-
+			// same-garage, split-across-garages, split-across-countries,
+			// and two-teslas-across-countries all flip to match.
 			[]strfmt.UUID{
-				idTeslaNo205, idTeslaNoTires, idSplitTeslaBmwSameGarage,
-				idBmwOnly, idEmpty, idSplitAcrossGarages, idSplitAcrossCountries,
+				idTeslaNo205, idTeslaMixed,
+				idSplitTeslaBmwSameGarage,
+				idSplitAcrossGarages, idSplitAcrossCountries,
+				idTwoTeslasAcrossCountries,
 			},
-			// expected after scope-aware NOT:
+
+			// gap #9 — still locks in CURRENT docID-level NOT of
+			// compound AND. TODO aliszka:nested_filtering: under
+			// scope-aware compound NOT, expectation flips to
 			// []strfmt.UUID{idTeslaNo205, idTeslaNoTires,
 			//               idSplitTeslaBmwSameGarage,
 			//               idTeslaPlusOtherSameGarage, idBmwOnly,
 			//               idSplitAcrossGarages, idSplitAcrossCountries,
 			//               idTwoTeslasAcrossCountries}
-			//   (idEmpty drops — vacuous; tesla+other-same-garage and
-			//   two-teslas-across-countries flip to match.)
+			//   (idEmpty drops; tesla+other-same-garage and
+			//   two-teslas-across-countries flip in.)
+			[]strfmt.UUID{
+				idTeslaNo205, idTeslaNoTires, idSplitTeslaBmwSameGarage,
+				idBmwOnly, idEmpty, idSplitAcrossGarages, idSplitAcrossCountries,
+			},
 		)
 	})
 
@@ -14191,27 +14139,29 @@ func TestNestedFilteringNotInsideAnd3Levels(t *testing.T) {
 		runLevel(t, className, class,
 			"country.garages.cars.make", "country.garages.cars.tires.width",
 			docs,
-			// gap #3 today
-			[]strfmt.UUID{idTeslaNo205, idTeslaNoTires},
-			// expected after scope-aware NOT:
-			// []strfmt.UUID{idTeslaNo205, idTeslaMixed,
-			//               idSplitTeslaBmwSameGarage, idSplitAcrossGarages}
-			//   (idTeslaNoTires drops — vacuous; mixed-tires, split-cars,
-			//   split-across-garages flip to match.)
-
-			// gap #9 today
+			// gap #3 — scope-aware NOT, existential per-element.
+			// Tesla-no-tires drops (vacuous); mixed-tires, split-cars-
+			// same-garage, and split-across-garages flip to match. No
+			// split-across-countries variant because the root is a
+			// single object, not an array.
 			[]strfmt.UUID{
-				idTeslaNo205, idTeslaNoTires, idSplitTeslaBmwSameGarage,
-				idBmwOnly, idEmptyDoc, idEmptyCountry, idSplitAcrossGarages,
+				idTeslaNo205, idTeslaMixed,
+				idSplitTeslaBmwSameGarage, idSplitAcrossGarages,
 			},
-			// expected after scope-aware NOT:
+
+			// gap #9 — still locks in CURRENT docID-level NOT of
+			// compound AND. TODO aliszka:nested_filtering: under
+			// scope-aware compound NOT, expectation flips to
 			// []strfmt.UUID{idTeslaNo205, idTeslaNoTires,
 			//               idSplitTeslaBmwSameGarage,
 			//               idTeslaPlusOtherSameGarage, idBmwOnly,
 			//               idSplitAcrossGarages, idTeslaG0PlusOtherG1}
-			//   (idEmptyDoc, idEmptyCountry drop — vacuous;
-			//   tesla+other-same-garage and tesla-g0-plus-other-g1 flip to
-			//   match.)
+			//   (idEmptyDoc and idEmptyCountry drop; tesla+other-same-
+			//   garage and tesla-g0-plus-other-g1 flip in.)
+			[]strfmt.UUID{
+				idTeslaNo205, idTeslaNoTires, idSplitTeslaBmwSameGarage,
+				idBmwOnly, idEmptyDoc, idEmptyCountry, idSplitAcrossGarages,
+			},
 		)
 	})
 }
@@ -14707,10 +14657,10 @@ func TestNestedFilteringNotPin3Levels(t *testing.T) {
 	})
 }
 
-// TestNestedFilteringNotShapeAMultiVsCompound covers gaps #10 and #11
-// for "Shape A": both NOT operands at a deeper LCA than the positive
-// sibling, comparing the multi-NOT form `A AND NOT B AND NOT C`
-// against the compound-NOT form `A AND NOT(B AND C)`.
+// TestNestedFilteringNotShapeAMultiVsCompound covers "Shape A": both
+// NOT operands at a deeper LCA than the positive sibling, comparing
+// the multi-NOT form `A AND NOT B AND NOT C` against the compound-NOT
+// form `A AND NOT(B AND C)`.
 //
 // Filters per level:
 //
@@ -14721,9 +14671,11 @@ func TestNestedFilteringNotPin3Levels(t *testing.T) {
 //	          NOT(<chain>.cars.tires.brand=michelin AND
 //	              <chain>.cars.tires.width=205)
 //
-// By De Morgan, multi ≡ NOT(B OR C) and compound ≡ (NOT B) OR (NOT C),
-// so the two forms produce different results today already, and shift
-// independently under scope-aware NOT.
+// Under scope-aware NOT both forms inherit per-tire semantics (both
+// NOT operands share LCA cars.tires; AND-ing at that LCA forces same-
+// tire correlation). By De Morgan, multi ≡ NOT(B OR C) reads as
+// "∃ tire that is neither michelin nor 205", while compound reads as
+// "∃ tire that is not (michelin AND 205)" — strictly more permissive.
 //
 // Three nesting levels: L0_root_cars, L1_garages_cars (object[]),
 // L2_countries_garages_cars (object[]). Object-root variants are
@@ -14843,13 +14795,10 @@ func TestNestedFilteringNotShapeAMultiVsCompound(t *testing.T) {
 			assert.ElementsMatch(t, want, got)
 		}
 
-		// TODO aliszka:nested_filtering: multi-NOT form locks in CURRENT
-		// docID-level NOT behavior. Each NOT inverts independently at
-		// docID. Under scope-aware NOT (each NOT inverts at its operand's
-		// LCA = cars.tires, projects up to cars), the form becomes
-		// "tesla cars where (some tire ≠ michelin) AND (some tire ≠ 205)"
-		// — both conditions must hold for a single car (different tires
-		// can satisfy each).
+		// regression_multi_NOT_shapeA — both NOTs share LCA cars.tires,
+		// AND-ing at that LCA forces same-tire correlation. By De Morgan
+		// (multi ≡ NOT(B OR C)) the predicate is "tesla car with
+		// ∃ tire that is neither michelin nor 205".
 		t.Run("regression_multi_NOT_shapeA", func(t *testing.T) {
 			runScenario(t, andF(
 				textF(makePath, "tesla"),
@@ -14858,13 +14807,11 @@ func TestNestedFilteringNotShapeAMultiVsCompound(t *testing.T) {
 			), multiWant)
 		})
 
-		// TODO aliszka:nested_filtering: compound-NOT form locks in CURRENT
-		// behavior. Inner AND is a same-tire correlated AND (tires where
-		// brand=michelin AND width=205). NOT inverts at docID. Under
-		// scope-aware NOT, NOT inverts at the inner AND's LCA =
-		// cars.tires; result becomes "tesla cars with at least one tire
-		// that is NOT (michelin AND 205)" — strictly more permissive
-		// than the multi-NOT form.
+		// regression_compound_NOT_shapeA — inner AND is same-tire
+		// correlated (both operands at cars.tires); NOT inverts at
+		// cars.tires per-tire. Predicate: "tesla car with ∃ tire that
+		// is NOT (michelin AND 205)" — strictly more permissive than
+		// the multi-NOT form.
 		t.Run("regression_compound_NOT_shapeA", func(t *testing.T) {
 			runScenario(t, andF(
 				textF(makePath, "tesla"),
@@ -14914,25 +14861,21 @@ func TestNestedFilteringNotShapeAMultiVsCompound(t *testing.T) {
 		runLevel(t, className, class,
 			"cars.make", "cars.tires.brand", "cars.tires.width",
 			docs,
-			// multi-NOT today: tesla AND no michelin tire AND no 205 tire.
-			[]strfmt.UUID{idTeslaGoodyear100, idTeslaNoTires},
-			// expected after scope-aware NOT (multi):
-			// []strfmt.UUID{idTeslaMixedTires, idTeslaGoodyear100}
-			//   (idTeslaNoTires drops — vacuous; idTeslaMixedTires flips
-			//   to match — tesla car has at least one non-michelin tire
-			//   AND at least one non-205 tire.)
+			// multi — same-tire correlation (De Morgan: NOT(michelin
+			// OR 205) per tire). Only idTeslaGoodyear100's single tire
+			// is neither michelin nor 205. idTeslaMixedTires drops:
+			// tire0 fails ≠michelin, tire1 fails ≠205, no single tire
+			// satisfies both.
+			[]strfmt.UUID{idTeslaGoodyear100},
 
-			// compound-NOT today: tesla AND no (michelin AND 205) tire.
+			// compound — per-tire ∃ NOT(michelin AND 205). All tesla
+			// docs with at least one non-(michelin&205) tire match.
+			// idTeslaSingleMichelin205 (only tire is michelin&205) and
+			// idTeslaNoTires (vacuous) drop.
 			[]strfmt.UUID{
 				idTeslaSingleMichelin, idTeslaSingle205, idTeslaMixedTires,
-				idTeslaGoodyear100, idTeslaNoTires, idTeslaPlusBmw,
+				idTeslaGoodyear100, idTeslaPlusBmw,
 			},
-			// expected after scope-aware NOT (compound):
-			// []strfmt.UUID{idTeslaSingleMichelin, idTeslaSingle205,
-			//               idTeslaMixedTires, idTeslaGoodyear100,
-			//               idTeslaPlusBmw}
-			//   (idTeslaNoTires drops — vacuous, no tire-positions in the
-			//   inverted bitmap.)
 		)
 	})
 
@@ -14981,25 +14924,20 @@ func TestNestedFilteringNotShapeAMultiVsCompound(t *testing.T) {
 		runLevel(t, className, class,
 			"garages.cars.make", "garages.cars.tires.brand", "garages.cars.tires.width",
 			docs,
-			// multi-NOT today
-			[]strfmt.UUID{idTeslaGoodyear100, idTeslaNoTires},
-			// expected after scope-aware NOT (multi):
-			// []strfmt.UUID{idTeslaMixedTires, idTeslaGoodyear100}
-			//   (idTeslaNoTires drops — vacuous; idTeslaMixedTires flips
-			//   to match. Other docs without a single car satisfying both
-			//   non-michelin AND non-205 stay excluded.)
+			// multi — same-tire correlation. Only idTeslaGoodyear100
+			// has a single tire that is neither michelin nor 205.
+			// Splits across garages don't help — no single tesla car
+			// has a tire satisfying both NOTs simultaneously.
+			[]strfmt.UUID{idTeslaGoodyear100},
 
-			// compound-NOT today
+			// compound — per-tire ∃ NOT(michelin AND 205). All tesla
+			// docs with at least one non-(michelin&205) tire match,
+			// including the split-across-garages discriminator.
 			[]strfmt.UUID{
 				idTeslaSingleMichelin, idTeslaSingle205, idTeslaMixedTires,
-				idTeslaGoodyear100, idTeslaNoTires, idTeslaPlusBmwSameGarage,
+				idTeslaGoodyear100, idTeslaPlusBmwSameGarage,
 				idSplitAcrossGarages,
 			},
-			// expected after scope-aware NOT (compound):
-			// []strfmt.UUID{idTeslaSingleMichelin, idTeslaSingle205,
-			//               idTeslaMixedTires, idTeslaGoodyear100,
-			//               idTeslaPlusBmwSameGarage, idSplitAcrossGarages}
-			//   (idTeslaNoTires drops — vacuous.)
 		)
 	})
 
@@ -15055,26 +14993,20 @@ func TestNestedFilteringNotShapeAMultiVsCompound(t *testing.T) {
 		runLevel(t, className, class,
 			"countries.garages.cars.make", "countries.garages.cars.tires.brand", "countries.garages.cars.tires.width",
 			docs,
-			// multi-NOT today
-			[]strfmt.UUID{idTeslaGoodyear100, idTeslaNoTires},
-			// expected after scope-aware NOT (multi):
-			// []strfmt.UUID{idTeslaMixedTires, idTeslaGoodyear100}
-			//   (idTeslaNoTires drops; idTeslaMixedTires flips. Splits
-			//   across garages or countries don't help multi because no
-			//   single car has both non-michelin AND non-205 tires.)
+			// multi — same-tire correlation. Only idTeslaGoodyear100
+			// has a single tire that is neither michelin nor 205.
+			// Splits across garages or countries don't help.
+			[]strfmt.UUID{idTeslaGoodyear100},
 
-			// compound-NOT today
+			// compound — per-tire ∃ NOT(michelin AND 205). All tesla
+			// docs with at least one non-(michelin&205) tire match,
+			// including split-across-garages and split-across-countries
+			// discriminators.
 			[]strfmt.UUID{
 				idTeslaSingleMichelin, idTeslaSingle205, idTeslaMixedTires,
-				idTeslaGoodyear100, idTeslaNoTires, idTeslaPlusBmwSameGarage,
+				idTeslaGoodyear100, idTeslaPlusBmwSameGarage,
 				idSplitAcrossGarages, idSplitAcrossCountries,
 			},
-			// expected after scope-aware NOT (compound):
-			// []strfmt.UUID{idTeslaSingleMichelin, idTeslaSingle205,
-			//               idTeslaMixedTires, idTeslaGoodyear100,
-			//               idTeslaPlusBmwSameGarage,
-			//               idSplitAcrossGarages, idSplitAcrossCountries}
-			//   (idTeslaNoTires drops — vacuous.)
 		)
 	})
 }
@@ -15202,10 +15134,10 @@ func TestNestedFilteringNotShapeBMultiVsCompound(t *testing.T) {
 			assert.ElementsMatch(t, want, got)
 		}
 
-		// TODO aliszka:nested_filtering: multi-NOT form. Today's docID-level
-		// NOT inverts each clause independently. Under scope-aware NOT,
-		// each NOT inverts at cars (operand LCA = surrounding scope LCA),
-		// giving same-car AND of (tesla AND year≠2020 AND color≠red).
+		// regression_multi_NOT_shapeB — all operands at cars LCA; each
+		// NOT inverts at cars (existential per-car). By De Morgan
+		// (multi ≡ NOT(year=2020 OR color=red)) the predicate is
+		// "∃ tesla car with year≠2020 AND color≠red on the same car".
 		t.Run("regression_multi_NOT_shapeB", func(t *testing.T) {
 			runScenario(t, andF(
 				textF(makePath, "tesla"),
@@ -15214,10 +15146,11 @@ func TestNestedFilteringNotShapeBMultiVsCompound(t *testing.T) {
 			), multiWant)
 		})
 
-		// TODO aliszka:nested_filtering: compound-NOT form. Inner AND is
-		// same-car correlated AND. NOT inverts at docID today. Under
-		// scope-aware NOT, NOT inverts at cars (inner AND's LCA): tesla
-		// cars where NOT (year=2020 AND color=red).
+		// regression_compound_NOT_shapeB — inner AND same-car correlated
+		// at cars; NOT inverts at cars per-car. Predicate: "∃ tesla car
+		// NOT (year=2020 AND color=red)" — strictly more permissive
+		// than multi-NOT (a 2020-but-not-red car or a red-but-not-2020
+		// car satisfies compound but fails multi).
 		t.Run("regression_compound_NOT_shapeB", func(t *testing.T) {
 			runScenario(t, andF(
 				textF(makePath, "tesla"),
@@ -15268,23 +15201,18 @@ func TestNestedFilteringNotShapeBMultiVsCompound(t *testing.T) {
 		runLevel(t, className, class,
 			"cars.make", "cars.year", "cars.color",
 			docs,
-			// multi-NOT today: tesla AND no 2020 AND no red anywhere.
-			[]strfmt.UUID{idTesla2018Blue},
-			// expected after scope-aware NOT (multi):
-			// []strfmt.UUID{idTesla2018Blue, idGoodTeslaPlusBadBmw}
-			//   (idGoodTeslaPlusBadBmw flips to match — cars[0] is tesla
-			//   AND year≠2020 AND color≠red.)
+			// multi — same-car AND of (tesla AND year≠2020 AND color≠red).
+			// idGoodTeslaPlusBadBmw flips in (cars[0] tesla 2018 blue
+			// satisfies all three on the same car).
+			[]strfmt.UUID{idTesla2018Blue, idGoodTeslaPlusBadBmw},
 
-			// compound-NOT today: tesla AND no car has (2020 AND red).
+			// compound — ∃ tesla car NOT (year=2020 AND color=red).
+			// idGoodTeslaPlusBadBmw flips in (cars[0] not in inner-AND
+			// positive set).
 			[]strfmt.UUID{
-				idTesla2020Blue, idTesla2018Red, idTesla2018Blue, idSplitTeslas,
+				idTesla2020Blue, idTesla2018Red, idTesla2018Blue,
+				idGoodTeslaPlusBadBmw, idSplitTeslas,
 			},
-			// expected after scope-aware NOT (compound):
-			// []strfmt.UUID{idTesla2020Blue, idTesla2018Red,
-			//               idTesla2018Blue, idGoodTeslaPlusBadBmw,
-			//               idSplitTeslas}
-			//   (idGoodTeslaPlusBadBmw flips to match — cars[0] not in
-			//   inner-AND positive, in inverted set.)
 		)
 	})
 
@@ -15334,24 +15262,20 @@ func TestNestedFilteringNotShapeBMultiVsCompound(t *testing.T) {
 		runLevel(t, className, class,
 			"garages.cars.make", "garages.cars.year", "garages.cars.color",
 			docs,
-			// multi-NOT today
-			[]strfmt.UUID{idTesla2018Blue},
-			// expected after scope-aware NOT (multi):
-			// []strfmt.UUID{idTesla2018Blue, idGoodTeslaPlusBadBmw,
-			//               idGoodTeslaSplitGarages}
-			//   (idGoodTeslaPlusBadBmw and idGoodTeslaSplitGarages flip —
-			//   each has a tesla car satisfying year≠2020 AND color≠red.)
-
-			// compound-NOT today
+			// multi — same-car AND of (tesla AND year≠2020 AND color≠red).
+			// idGoodTeslaPlusBadBmw and idGoodTeslaSplitGarages flip in
+			// — each has a tesla car satisfying all three.
 			[]strfmt.UUID{
-				idTesla2020Blue, idTesla2018Red, idTesla2018Blue, idSplitTeslas,
+				idTesla2018Blue, idGoodTeslaPlusBadBmw, idGoodTeslaSplitGarages,
 			},
-			// expected after scope-aware NOT (compound):
-			// []strfmt.UUID{idTesla2020Blue, idTesla2018Red,
-			//               idTesla2018Blue, idGoodTeslaPlusBadBmw,
-			//               idSplitTeslas, idGoodTeslaSplitGarages}
-			//   (idGoodTeslaPlusBadBmw and idGoodTeslaSplitGarages flip —
-			//   tesla car not in inner-AND positive, in inverted set.)
+
+			// compound — ∃ tesla car NOT (year=2020 AND color=red).
+			// idGoodTeslaPlusBadBmw and idGoodTeslaSplitGarages flip in
+			// — each has a tesla car outside the inner-AND positive set.
+			[]strfmt.UUID{
+				idTesla2020Blue, idTesla2018Red, idTesla2018Blue,
+				idGoodTeslaPlusBadBmw, idSplitTeslas, idGoodTeslaSplitGarages,
+			},
 		)
 	})
 
@@ -15408,26 +15332,22 @@ func TestNestedFilteringNotShapeBMultiVsCompound(t *testing.T) {
 		runLevel(t, className, class,
 			"countries.garages.cars.make", "countries.garages.cars.year", "countries.garages.cars.color",
 			docs,
-			// multi-NOT today
-			[]strfmt.UUID{idTesla2018Blue},
-			// expected after scope-aware NOT (multi):
-			// []strfmt.UUID{idTesla2018Blue, idGoodTeslaPlusBadBmw,
-			//               idGoodTeslaSplitGarages, idGoodTeslaSplitCountries}
-			//   (the three split-good-tesla docs all flip — each has at
-			//   least one tesla car satisfying all three conditions
-			//   simultaneously.)
-
-			// compound-NOT today
+			// multi — same-car AND of (tesla AND year≠2020 AND color≠red).
+			// All three split-good-tesla docs flip in — each has at
+			// least one tesla car satisfying all three on the same car.
 			[]strfmt.UUID{
-				idTesla2020Blue, idTesla2018Red, idTesla2018Blue, idSplitTeslas,
+				idTesla2018Blue, idGoodTeslaPlusBadBmw,
+				idGoodTeslaSplitGarages, idGoodTeslaSplitCountries,
 			},
-			// expected after scope-aware NOT (compound):
-			// []strfmt.UUID{idTesla2020Blue, idTesla2018Red,
-			//               idTesla2018Blue, idGoodTeslaPlusBadBmw,
-			//               idSplitTeslas, idGoodTeslaSplitGarages,
-			//               idGoodTeslaSplitCountries}
-			//   (split docs flip — at least one tesla car not in
-			//   inner-AND positive.)
+
+			// compound — ∃ tesla car NOT (year=2020 AND color=red).
+			// Split docs flip in — each has at least one tesla car
+			// outside the inner-AND positive set.
+			[]strfmt.UUID{
+				idTesla2020Blue, idTesla2018Red, idTesla2018Blue,
+				idGoodTeslaPlusBadBmw, idSplitTeslas,
+				idGoodTeslaSplitGarages, idGoodTeslaSplitCountries,
+			},
 		)
 	})
 }
@@ -15561,11 +15481,11 @@ func TestNestedFilteringNotShapeCMultiVsCompound(t *testing.T) {
 			assert.ElementsMatch(t, want, got)
 		}
 
-		// TODO aliszka:nested_filtering: multi-NOT form. Today's docID-level
-		// NOT inverts each clause independently. Under scope-aware NOT,
-		// NOT B (cars.color) inverts at cars; NOT C (cars.tires.width)
-		// inverts at cars.tires (and projects up). AND at cars: tesla
-		// cars where color≠red AND has at least one non-205 tire.
+		// regression_multi_NOT_shapeC — mixed LCAs. NOT B (cars.color)
+		// inverts at cars per-car; NOT C (cars.tires.width) inverts at
+		// cars.tires per-tire and projects to cars (∃ tire≠205). Outer
+		// AND same-car at cars: "∃ tesla car with color≠red AND ∃ non-205
+		// tire on the same car". Tesla-no-tires drops (vacuous ∃ tire).
 		t.Run("regression_multi_NOT_shapeC", func(t *testing.T) {
 			runScenario(t, andF(
 				textF(makePath, "tesla"),
@@ -15574,10 +15494,11 @@ func TestNestedFilteringNotShapeCMultiVsCompound(t *testing.T) {
 			), multiWant)
 		})
 
-		// TODO aliszka:nested_filtering: compound-NOT form. Inner AND is
-		// same-car correlated AND (deepest common LCA = cars). NOT
-		// inverts at docID today. Under scope-aware NOT, NOT inverts at
-		// cars: tesla cars where NOT (color=red AND has 205 tire).
+		// regression_compound_NOT_shapeC — inner AND has LCA cars
+		// (same-car correlation: cars where color=red AND ∃ tire=205);
+		// NOT inverts at cars per-car. Predicate: "∃ tesla car NOT
+		// (color=red AND ∃ tire=205)" — strictly more permissive than
+		// multi. Tesla-no-tires stays (vacuous inner AND ⇒ NOT true).
 		t.Run("regression_compound_NOT_shapeC", func(t *testing.T) {
 			runScenario(t, andF(
 				textF(makePath, "tesla"),
@@ -15632,26 +15553,20 @@ func TestNestedFilteringNotShapeCMultiVsCompound(t *testing.T) {
 		runLevel(t, className, class,
 			"cars.make", "cars.color", "cars.tires.width",
 			docs,
-			// multi-NOT today: tesla AND no red car AND no 205 tire.
-			[]strfmt.UUID{idTeslaBlue225, idTeslaBlueNoTires},
-			// expected after scope-aware NOT (multi):
-			// []strfmt.UUID{idTeslaBlue225, idTeslaBlueMixed,
-			//               idGoodPlusBadCars}
-			//   (idTeslaBlueNoTires drops — vacuous, no tire-positions
-			//   for NOT C projection; idTeslaBlueMixed and
-			//   idGoodPlusBadCars flip to match.)
+			// multi — same-car AND of (tesla AND color≠red AND ∃ tire≠205).
+			// idTeslaBlueNoTires drops (vacuous ∃ tire); idTeslaBlueMixed
+			// and idGoodPlusBadCars flip in (tesla car has color≠red AND
+			// a non-205 tire).
+			[]strfmt.UUID{idTeslaBlue225, idTeslaBlueMixed, idGoodPlusBadCars},
 
-			// compound-NOT today: tesla AND no car has (color=red AND has 205).
+			// compound — ∃ tesla car NOT (color=red AND ∃ tire=205).
+			// idGoodPlusBadCars flips in (tesla car blue,225 is outside
+			// inner-AND positive). idTeslaBlueNoTires stays (vacuous
+			// inner AND).
 			[]strfmt.UUID{
 				idTeslaRed225, idTeslaBlue205, idTeslaBlue225, idTeslaBlueMixed,
-				idTeslaBlueNoTires, idTwoTeslasNeither,
+				idTeslaBlueNoTires, idGoodPlusBadCars, idTwoTeslasNeither,
 			},
-			// expected after scope-aware NOT (compound):
-			// []strfmt.UUID{idTeslaRed225, idTeslaBlue205,
-			//               idTeslaBlue225, idTeslaBlueMixed,
-			//               idTeslaBlueNoTires, idGoodPlusBadCars,
-			//               idTwoTeslasNeither}
-			//   (idGoodPlusBadCars flips to match.)
 		)
 	})
 
@@ -15705,26 +15620,21 @@ func TestNestedFilteringNotShapeCMultiVsCompound(t *testing.T) {
 		runLevel(t, className, class,
 			"garages.cars.make", "garages.cars.color", "garages.cars.tires.width",
 			docs,
-			// multi-NOT today
-			[]strfmt.UUID{idTeslaBlue225, idTeslaBlueNoTires},
-			// expected after scope-aware NOT (multi):
-			// []strfmt.UUID{idTeslaBlue225, idTeslaBlueMixed,
-			//               idGoodPlusBadSameGarage,
-			//               idGoodPlusBadSplitGarages}
-			//   (idTeslaBlueNoTires drops; mixed-tires and split-cars
-			//   docs flip — tesla car has color≠red AND non-205 tire.)
+			// multi — same-car AND of (tesla AND color≠red AND ∃ tire≠205).
+			// idTeslaBlueNoTires drops; mixed-tires, same-garage, and
+			// split-garage discriminators all flip in.
+			[]strfmt.UUID{
+				idTeslaBlue225, idTeslaBlueMixed,
+				idGoodPlusBadSameGarage, idGoodPlusBadSplitGarages,
+			},
 
-			// compound-NOT today
+			// compound — ∃ tesla car NOT (color=red AND ∃ tire=205).
+			// idGoodPlusBad* flip in. idTeslaBlueNoTires stays.
 			[]strfmt.UUID{
 				idTeslaRed225, idTeslaBlue205, idTeslaBlue225, idTeslaBlueMixed,
-				idTeslaBlueNoTires, idTwoTeslasNeither,
+				idTeslaBlueNoTires, idGoodPlusBadSameGarage,
+				idTwoTeslasNeither, idGoodPlusBadSplitGarages,
 			},
-			// expected after scope-aware NOT (compound):
-			// []strfmt.UUID{idTeslaRed225, idTeslaBlue205,
-			//               idTeslaBlue225, idTeslaBlueMixed,
-			//               idTeslaBlueNoTires, idGoodPlusBadSameGarage,
-			//               idTwoTeslasNeither, idGoodPlusBadSplitGarages}
-			//   (idGoodPlusBad* flip — tesla car not in inner-AND positive.)
 		)
 	})
 
@@ -15785,29 +15695,23 @@ func TestNestedFilteringNotShapeCMultiVsCompound(t *testing.T) {
 		runLevel(t, className, class,
 			"countries.garages.cars.make", "countries.garages.cars.color", "countries.garages.cars.tires.width",
 			docs,
-			// multi-NOT today
-			[]strfmt.UUID{idTeslaBlue225, idTeslaBlueNoTires},
-			// expected after scope-aware NOT (multi):
-			// []strfmt.UUID{idTeslaBlue225, idTeslaBlueMixed,
-			//               idGoodPlusBadSameGarage,
-			//               idGoodPlusBadSplitGarages,
-			//               idGoodPlusBadSplitCountries}
-			//   (idTeslaBlueNoTires drops; mixed-tires and split-cars/
-			//   garages/countries docs flip.)
+			// multi — same-car AND of (tesla AND color≠red AND ∃ tire≠205).
+			// idTeslaBlueNoTires drops; mixed-tires, same-garage, split-
+			// garage, and split-country discriminators all flip in.
+			[]strfmt.UUID{
+				idTeslaBlue225, idTeslaBlueMixed,
+				idGoodPlusBadSameGarage,
+				idGoodPlusBadSplitGarages, idGoodPlusBadSplitCountries,
+			},
 
-			// compound-NOT today
+			// compound — ∃ tesla car NOT (color=red AND ∃ tire=205).
+			// idGoodPlusBad* flip in. idTeslaBlueNoTires stays.
 			[]strfmt.UUID{
 				idTeslaRed225, idTeslaBlue205, idTeslaBlue225, idTeslaBlueMixed,
-				idTeslaBlueNoTires, idTwoTeslasNeither,
+				idTeslaBlueNoTires, idGoodPlusBadSameGarage,
+				idTwoTeslasNeither,
+				idGoodPlusBadSplitGarages, idGoodPlusBadSplitCountries,
 			},
-			// expected after scope-aware NOT (compound):
-			// []strfmt.UUID{idTeslaRed225, idTeslaBlue205,
-			//               idTeslaBlue225, idTeslaBlueMixed,
-			//               idTeslaBlueNoTires, idGoodPlusBadSameGarage,
-			//               idTwoTeslasNeither,
-			//               idGoodPlusBadSplitGarages,
-			//               idGoodPlusBadSplitCountries}
-			//   (split docs flip — tesla car not in inner-AND positive.)
 		)
 	})
 }
@@ -15935,11 +15839,12 @@ func TestNestedFilteringNotShapeDMultiVsCompound(t *testing.T) {
 			assert.ElementsMatch(t, want, got)
 		}
 
-		// TODO aliszka:nested_filtering: multi-NOT form with no positive
-		// sibling. Today's docID-level NOT inverts each clause. Under
-		// scope-aware NOT, NOT B inverts at cars; NOT C inverts at
-		// cars.tires (and projects up). AND at cars: cars where color≠red
-		// AND has at least one non-205 tire. Then project to docID.
+		// regression_multi_NOT_shapeD — no positive sibling. NOT B
+		// inverts at cars per-car (color≠red); NOT C inverts at
+		// cars.tires per-tire and projects to cars existentially
+		// (∃ tire≠205). Outer AND same-car at cars: "∃ car with
+		// color≠red AND ∃ non-205 tire on the same car". Cars with no
+		// tires and empty docs drop (vacuous ∃ tire).
 		t.Run("regression_multi_NOT_shapeD", func(t *testing.T) {
 			runScenario(t, andF(
 				notF(textF(colorPath, "red")),
@@ -15947,10 +15852,11 @@ func TestNestedFilteringNotShapeDMultiVsCompound(t *testing.T) {
 			), multiWant)
 		})
 
-		// TODO aliszka:nested_filtering: compound-NOT form. Inner AND has
-		// deepest common LCA = cars. NOT inverts at docID today. Under
-		// scope-aware NOT, NOT inverts at cars: cars where NOT (color=red
-		// AND has 205 tire). Project to docID.
+		// TODO aliszka:nested_filtering: compound-NOT form locks in
+		// CURRENT docID-level NOT of a top-level compound AND (no outer
+		// AND anchor). Under scope-aware top-level NOT-of-compound (not
+		// yet landed), inner AND inverts at cars per-car (cars where
+		// NOT (color=red AND ∃ tire=205)); empty docs drop.
 		t.Run("regression_compound_NOT_shapeD", func(t *testing.T) {
 			runScenario(t, notF(andF(
 				textF(colorPath, "red"),
@@ -16000,25 +15906,24 @@ func TestNestedFilteringNotShapeDMultiVsCompound(t *testing.T) {
 		runLevel(t, className, class,
 			"cars.color", "cars.tires.width",
 			docs,
-			// multi-NOT today: no red car AND no 205 tire (anywhere).
-			[]strfmt.UUID{idBlue225, idBlueNoTires, idEmpty},
-			// expected after scope-aware NOT (multi):
-			// []strfmt.UUID{idBlue225, idBlueMixed, idGoodPlusBad}
-			//   (idBlueNoTires drops — no tire-positions for NOT C
-			//   projection; idEmpty drops — no cars universe;
-			//   idBlueMixed and idGoodPlusBad flip to match — at least
-			//   one car has color≠red AND has non-205 tire.)
+			// multi — same-car AND of (color≠red AND ∃ tire≠205).
+			// idBlueNoTires and idEmpty drop (vacuous ∃ tire);
+			// idBlueMixed and idGoodPlusBad flip in.
+			[]strfmt.UUID{idBlue225, idBlueMixed, idGoodPlusBad},
 
-			// compound-NOT today: no car has (color=red AND has 205).
+			// compound — still locks in CURRENT docID-level NOT of a
+			// top-level compound AND (no outer AND anchor). TODO
+			// aliszka:nested_filtering: under scope-aware top-level
+			// NOT-of-compound (not yet landed), expectation flips to
+			// []strfmt.UUID{idRed225, idBlue205, idBlue225,
+			//               idBlueMixed, idBlueNoTires,
+			//               idGoodPlusBad, idAttrSplit}
+			//   (idEmpty drops — no cars universe; idGoodPlusBad
+			//   flips in — cars[0] not in inner-AND positive set.)
 			[]strfmt.UUID{
 				idRed225, idBlue205, idBlue225, idBlueMixed, idBlueNoTires,
 				idAttrSplit, idEmpty,
 			},
-			// expected after scope-aware NOT (compound):
-			// []strfmt.UUID{idRed225, idBlue205, idBlue225, idBlueMixed,
-			//               idBlueNoTires, idGoodPlusBad, idAttrSplit}
-			//   (idEmpty drops — no cars universe; idGoodPlusBad flips
-			//   to match — cars[0] not in inner-AND positive.)
 		)
 	})
 
@@ -16070,26 +15975,28 @@ func TestNestedFilteringNotShapeDMultiVsCompound(t *testing.T) {
 		runLevel(t, className, class,
 			"garages.cars.color", "garages.cars.tires.width",
 			docs,
-			// multi-NOT today
-			[]strfmt.UUID{idBlue225, idBlueNoTires, idEmpty},
-			// expected after scope-aware NOT (multi):
-			// []strfmt.UUID{idBlue225, idBlueMixed,
-			//               idGoodPlusBadSameGarage,
-			//               idGoodPlusBadSplitGarages}
-			//   (idBlueNoTires and idEmpty drop — vacuous; mixed and
-			//   split docs flip — at least one car has color≠red AND
-			//   non-205 tire.)
+			// multi — same-car AND of (color≠red AND ∃ tire≠205).
+			// idBlueNoTires and idEmpty drop (vacuous ∃ tire);
+			// mixed-tires, good+bad same garage, and good+bad split
+			// garages all flip in.
+			[]strfmt.UUID{
+				idBlue225, idBlueMixed,
+				idGoodPlusBadSameGarage, idGoodPlusBadSplitGarages,
+			},
 
-			// compound-NOT today
+			// compound — still locks in CURRENT docID-level NOT of a
+			// top-level compound AND. TODO aliszka:nested_filtering:
+			// under scope-aware top-level NOT-of-compound, expectation
+			// flips to
+			// []strfmt.UUID{idRed225, idBlue205, idBlue225,
+			//               idBlueMixed, idBlueNoTires,
+			//               idGoodPlusBadSameGarage, idAttrSplit,
+			//               idGoodPlusBadSplitGarages}
+			//   (idEmpty drops; good+bad docs flip in.)
 			[]strfmt.UUID{
 				idRed225, idBlue205, idBlue225, idBlueMixed, idBlueNoTires,
 				idAttrSplit, idEmpty,
 			},
-			// expected after scope-aware NOT (compound):
-			// []strfmt.UUID{idRed225, idBlue205, idBlue225, idBlueMixed,
-			//               idBlueNoTires, idGoodPlusBadSameGarage,
-			//               idAttrSplit, idGoodPlusBadSplitGarages}
-			//   (idEmpty drops; good+bad docs flip.)
 		)
 	})
 
@@ -16148,27 +16055,30 @@ func TestNestedFilteringNotShapeDMultiVsCompound(t *testing.T) {
 		runLevel(t, className, class,
 			"countries.garages.cars.color", "countries.garages.cars.tires.width",
 			docs,
-			// multi-NOT today
-			[]strfmt.UUID{idBlue225, idBlueNoTires, idEmpty},
-			// expected after scope-aware NOT (multi):
-			// []strfmt.UUID{idBlue225, idBlueMixed,
-			//               idGoodPlusBadSameGarage,
+			// multi — same-car AND of (color≠red AND ∃ tire≠205).
+			// idBlueNoTires and idEmpty drop (vacuous ∃ tire);
+			// mixed-tires, good+bad same garage, good+bad split garages,
+			// and good+bad split countries all flip in.
+			[]strfmt.UUID{
+				idBlue225, idBlueMixed,
+				idGoodPlusBadSameGarage,
+				idGoodPlusBadSplitGarages, idGoodPlusBadSplitCountries,
+			},
+
+			// compound — still locks in CURRENT docID-level NOT of a
+			// top-level compound AND. TODO aliszka:nested_filtering:
+			// under scope-aware top-level NOT-of-compound, expectation
+			// flips to
+			// []strfmt.UUID{idRed225, idBlue205, idBlue225,
+			//               idBlueMixed, idBlueNoTires,
+			//               idGoodPlusBadSameGarage, idAttrSplit,
 			//               idGoodPlusBadSplitGarages,
 			//               idGoodPlusBadSplitCountries}
-			//   (idBlueNoTires and idEmpty drop; mixed and split docs
-			//   flip — at least one car has color≠red AND non-205 tire.)
-
-			// compound-NOT today
+			//   (idEmpty drops; good+bad docs flip in.)
 			[]strfmt.UUID{
 				idRed225, idBlue205, idBlue225, idBlueMixed, idBlueNoTires,
 				idAttrSplit, idEmpty,
 			},
-			// expected after scope-aware NOT (compound):
-			// []strfmt.UUID{idRed225, idBlue205, idBlue225, idBlueMixed,
-			//               idBlueNoTires, idGoodPlusBadSameGarage,
-			//               idAttrSplit, idGoodPlusBadSplitGarages,
-			//               idGoodPlusBadSplitCountries}
-			//   (idEmpty drops; good+bad docs flip.)
 		)
 	})
 }
@@ -16321,11 +16231,10 @@ func TestNestedFilteringNotInsideOrInsideAnd3Levels(t *testing.T) {
 			assert.ElementsMatch(t, want, got)
 		}
 
-		// TODO aliszka:nested_filtering: Shape 1 — NOT operand and OR
-		// siblings all at cars LCA. Today's docID-level OR satisfies
-		// "no 2022 car" via vacuous absence elsewhere; under scope-aware
-		// NOT, OR is per-car: cars where (color=red OR year≠2022),
-		// AND'd with cars.make=tesla at cars.
+		// regression_shape1_NOT_in_OR_same_LCA — NOT operand and OR
+		// siblings all at cars LCA. NOT inverts at cars (year≠2022 per
+		// car); OR per-car: cars where (color=red OR year≠2022). Outer
+		// AND with make=tesla at cars: ∃ tesla car satisfying the OR.
 		t.Run("regression_shape1_NOT_in_OR_same_LCA", func(t *testing.T) {
 			runScenario(t, andF(
 				textF(makePath, "tesla"),
@@ -16336,10 +16245,12 @@ func TestNestedFilteringNotInsideOrInsideAnd3Levels(t *testing.T) {
 			), shape1Want)
 		})
 
-		// TODO aliszka:nested_filtering: Shape 2 — NOT operand at deeper
-		// LCA (cars.tires) than OR's other branch (cars). Under
-		// scope-aware NOT, NOT inverts at cars.tires, projects to cars.
-		// OR per-car: cars where (color=red OR has non-205 tire).
+		// regression_shape2_NOT_in_OR_deeper_LCA — NOT operand at deeper
+		// LCA (cars.tires) than OR's other branch (cars). NOT inverts at
+		// cars.tires per-tire and projects to cars existentially (∃ tire
+		// ≠205). OR per-car: cars where (color=red OR ∃ non-205 tire).
+		// Outer AND with make=tesla at cars: ∃ tesla car satisfying the
+		// OR. Cars with no tires drop the NOT branch (vacuous).
 		t.Run("regression_shape2_NOT_in_OR_deeper_LCA", func(t *testing.T) {
 			runScenario(t, andF(
 				textF(makePath, "tesla"),
@@ -16394,33 +16305,23 @@ func TestNestedFilteringNotInsideOrInsideAnd3Levels(t *testing.T) {
 		runLevel(t, className, class,
 			"cars.make", "cars.color", "cars.year", "cars.tires.width",
 			docs,
-			// Shape 1 today: tesla AND (has red car OR no 2022 car).
+			// Shape 1 — per-car OR: ∃ tesla car (color=red OR year≠2022).
+			// idTeslaBadPlusBmwRed drops (red is on bmw, not tesla);
+			// idTeslaBadPlusGood flips in (cars[1] tesla, year=2018≠2022).
 			[]strfmt.UUID{
 				idTeslaRed2022_205, idTeslaRed2018_225, idTeslaBlue2018_225,
-				idTeslaBadPlusBmwRed, idTeslaMixed, idTeslaBlueNoAttrs,
+				idTeslaBadPlusGood, idTeslaMixed, idTeslaBlueNoAttrs,
 			},
-			// expected after scope-aware NOT (Shape 1):
-			// []strfmt.UUID{idTeslaRed2022_205, idTeslaRed2018_225,
-			//               idTeslaBlue2018_225, idTeslaBadPlusGood,
-			//               idTeslaMixed, idTeslaBlueNoAttrs}
-			//   (idTeslaBadPlusBmwRed flips to excl — no single tesla
-			//   car satisfies (red OR year≠2022); idTeslaBadPlusGood
-			//   flips to match — cars[1] is tesla AND year≠2022.)
 
-			// Shape 2 today: tesla AND (has red car OR no 205 tire).
+			// Shape 2 — per-car OR: ∃ tesla car (color=red OR ∃ non-205
+			// tire). idTeslaBadPlusBmwRed drops; idTeslaBadPlusGood flips
+			// in (cars[1] tesla, tire 225≠205); idTeslaMixed flips in
+			// (tire 225≠205 on the tesla car); idTeslaBlueNoAttrs drops
+			// (no tires for ∃ projection, no red color).
 			[]strfmt.UUID{
 				idTeslaRed2022_205, idTeslaRed2018_225, idTeslaBlue2018_225,
-				idTeslaBadPlusBmwRed, idTeslaBlueNoAttrs,
+				idTeslaBadPlusGood, idTeslaMixed,
 			},
-			// expected after scope-aware NOT (Shape 2):
-			// []strfmt.UUID{idTeslaRed2022_205, idTeslaRed2018_225,
-			//               idTeslaBlue2018_225, idTeslaBadPlusGood,
-			//               idTeslaMixed}
-			//   (idTeslaBadPlusBmwRed flips to excl; idTeslaBadPlusGood
-			//   flips to match — cars[1] is tesla AND has 225 (non-205)
-			//   tire; idTeslaMixed flips to match — cars[0] has both
-			//   tires; idTeslaBlueNoAttrs flips to excl — no tires for
-			//   the NOT-tires projection to qualify.)
 		)
 	})
 
@@ -16474,34 +16375,22 @@ func TestNestedFilteringNotInsideOrInsideAnd3Levels(t *testing.T) {
 		runLevel(t, className, class,
 			"garages.cars.make", "garages.cars.color", "garages.cars.year", "garages.cars.tires.width",
 			docs,
-			// Shape 1 today
+			// Shape 1 — per-car OR: ∃ tesla car (color=red OR year≠2022).
+			// idTeslaBadPlusBmwRed and idSplitAcrossGarages drop (red on
+			// bmw, no good tesla); idTeslaBadPlusGood flips in (cars[1]
+			// tesla, year≠2022).
 			[]strfmt.UUID{
 				idTeslaRed2022_205, idTeslaRed2018_225, idTeslaBlue2018_225,
-				idTeslaBadPlusBmwRed, idTeslaMixed, idTeslaBlueNoAttrs,
-				idSplitAcrossGarages,
+				idTeslaBadPlusGood, idTeslaMixed, idTeslaBlueNoAttrs,
 			},
-			// expected after scope-aware NOT (Shape 1):
-			// []strfmt.UUID{idTeslaRed2022_205, idTeslaRed2018_225,
-			//               idTeslaBlue2018_225, idTeslaBadPlusGood,
-			//               idTeslaMixed, idTeslaBlueNoAttrs}
-			//   (idTeslaBadPlusBmwRed and idSplitAcrossGarages flip to
-			//   excl — no single tesla car satisfies (red OR year≠2022);
-			//   idTeslaBadPlusGood flips to match — cars[1] is tesla AND
-			//   year≠2022.)
 
-			// Shape 2 today
+			// Shape 2 — per-car OR. idTeslaBadPlusBmwRed and
+			// idSplitAcrossGarages drop; idTeslaBadPlusGood and
+			// idTeslaMixed flip in; idTeslaBlueNoAttrs drops (no tires).
 			[]strfmt.UUID{
 				idTeslaRed2022_205, idTeslaRed2018_225, idTeslaBlue2018_225,
-				idTeslaBadPlusBmwRed, idTeslaBlueNoAttrs,
-				idSplitAcrossGarages,
+				idTeslaBadPlusGood, idTeslaMixed,
 			},
-			// expected after scope-aware NOT (Shape 2):
-			// []strfmt.UUID{idTeslaRed2022_205, idTeslaRed2018_225,
-			//               idTeslaBlue2018_225, idTeslaBadPlusGood,
-			//               idTeslaMixed}
-			//   (idTeslaBadPlusBmwRed and idSplitAcrossGarages flip to
-			//   excl; idTeslaBadPlusGood and idTeslaMixed flip to match;
-			//   idTeslaBlueNoAttrs flips to excl — no tires.)
 		)
 	})
 
@@ -16562,32 +16451,21 @@ func TestNestedFilteringNotInsideOrInsideAnd3Levels(t *testing.T) {
 		runLevel(t, className, class,
 			"countries.garages.cars.make", "countries.garages.cars.color", "countries.garages.cars.year", "countries.garages.cars.tires.width",
 			docs,
-			// Shape 1 today
+			// Shape 1 — per-car OR. Split-garages and split-countries
+			// drop (no single tesla car satisfies the OR);
+			// idTeslaBadPlusGood flips in.
 			[]strfmt.UUID{
 				idTeslaRed2022_205, idTeslaRed2018_225, idTeslaBlue2018_225,
-				idTeslaBadPlusBmwRed, idTeslaMixed, idTeslaBlueNoAttrs,
-				idSplitAcrossGarages, idSplitAcrossCountries,
+				idTeslaBadPlusGood, idTeslaMixed, idTeslaBlueNoAttrs,
 			},
-			// expected after scope-aware NOT (Shape 1):
-			// []strfmt.UUID{idTeslaRed2022_205, idTeslaRed2018_225,
-			//               idTeslaBlue2018_225, idTeslaBadPlusGood,
-			//               idTeslaMixed, idTeslaBlueNoAttrs}
-			//   (split docs flip to excl — no single tesla car satisfies
-			//   the OR; idTeslaBadPlusGood flips to match.)
 
-			// Shape 2 today
+			// Shape 2 — per-car OR. Split docs drop;
+			// idTeslaBadPlusGood and idTeslaMixed flip in;
+			// idTeslaBlueNoAttrs drops (no tires).
 			[]strfmt.UUID{
 				idTeslaRed2022_205, idTeslaRed2018_225, idTeslaBlue2018_225,
-				idTeslaBadPlusBmwRed, idTeslaBlueNoAttrs,
-				idSplitAcrossGarages, idSplitAcrossCountries,
+				idTeslaBadPlusGood, idTeslaMixed,
 			},
-			// expected after scope-aware NOT (Shape 2):
-			// []strfmt.UUID{idTeslaRed2022_205, idTeslaRed2018_225,
-			//               idTeslaBlue2018_225, idTeslaBadPlusGood,
-			//               idTeslaMixed}
-			//   (split docs flip to excl; idTeslaBadPlusGood and
-			//   idTeslaMixed flip to match; idTeslaBlueNoAttrs flips to
-			//   excl — no tires.)
 		)
 	})
 }
@@ -16601,18 +16479,14 @@ func TestNestedFilteringNotInsideOrInsideAnd3Levels(t *testing.T) {
 //	(<chain>.cars.color=red OR
 //	 (<chain>.cars.year=2022 AND NOT <chain>.cars.tires.width=205))
 //
-// Today's dispatch: docID-level for the OR boundary and the NOT.
-// Inner AND `(year=2022 AND NOT tires.width=205)` resolves at docID:
-// doc has 2022 car AND doc has no 205 tire (anywhere). Outer OR with
-// `color=red` at docID: doc has (red car) OR (2022 car AND no 205 tire).
-// Outer AND with tesla: doc has tesla AND that disjunction.
-//
-// Future scope-aware NOT + position-level OR within single root: NOT D
-// inverts at cars.tires (operand LCA), projects to cars (cars with
-// non-205 tire). Inner AND at cars: cars where year=2022 AND has
-// non-205 tire. Outer OR at cars: cars where color=red OR (year=2022
-// AND non-205 tire). Outer AND with tesla at cars: tesla cars
-// satisfying that disjunction. Per-car evaluation throughout.
+// The entire expression evaluates per-car at cars[] LCA: NOT inverts
+// at cars.tires (operand LCA) and projects to cars (cars with at
+// least one non-205 tire); inner AND at cars (cars where year=2022
+// AND has a non-205 tire); outer OR at cars (cars where color=red OR
+// inner-AND); outer AND with tesla at cars (tesla cars satisfying
+// that disjunction). Cross-cars docs that today satisfy via different
+// cars (e.g. red on a non-tesla car) flip OUT; mixed-tires and
+// good-tesla-sibling docs that today fail the doc-level NOT flip IN.
 //
 // Three nesting levels with object[] roots: L0_root_cars,
 // L1_garages_cars, L2_countries_garages_cars.
@@ -16740,13 +16614,12 @@ func TestNestedFilteringDeeplyNestedAndOrNotSameRoot3Levels(t *testing.T) {
 			assert.ElementsMatch(t, want, got)
 		}
 
-		// TODO aliszka:nested_filtering: locks in CURRENT docID-level
-		// dispatch for the 3-level AND/OR/AND/NOT structure. Inner AND
-		// resolves at docID; OR combines at docID; outer AND combines
-		// at docID. Under scope-aware NOT + position-level OR within a
-		// single root, the entire expression evaluates per-cars-element
-		// at cars LCA, giving stricter (or sometimes more permissive)
-		// results depending on doc shape.
+		// regression_AND_OR_AND_NOT_3level — same-cars-element AND
+		// through the OR, with scope-aware NOT at cars.tires. The
+		// entire 3-level AND/OR/AND/NOT evaluates per tesla car.
+		// Bad-tesla-plus-red-on-non-tesla docs flip OUT; mixed-tires
+		// (has both 205 and non-205 on one car) and bad-plus-good-
+		// tesla docs flip IN.
 		t.Run("regression_AND_OR_AND_NOT_3level", func(t *testing.T) {
 			runScenario(t, andF(
 				textF(makePath, "tesla"),
@@ -16801,23 +16674,18 @@ func TestNestedFilteringDeeplyNestedAndOrNotSameRoot3Levels(t *testing.T) {
 			{id: idEmpty, props: emptyDoc(), note: "no cars"},
 		}
 
+		// idTeslaBadPlusBmwRed (red on non-tesla car) flips to excl;
+		// idTeslaBlue2022Mixed (mixed tires on a single car) and
+		// idTeslaBadPlusGoodTesla (good-tesla sibling) flip to
+		// match — per-car evaluation throughout.
 		runLevel(t, className, class,
 			"cars.make", "cars.color", "cars.year", "cars.tires.width",
 			docs,
-			// today: tesla AND (red car OR (2022 car AND no 205 tire)).
 			[]strfmt.UUID{
-				idTeslaRed2022_205, idTeslaBlue2022_225, idTeslaRed2018_225,
-				idTeslaBadPlusBmwRed,
+				idTeslaRed2022_205, idTeslaBlue2022_225,
+				idTeslaBlue2022Mixed, idTeslaRed2018_225,
+				idTeslaBadPlusGoodTesla,
 			},
-			// expected after scope-aware NOT + position-level OR:
-			// []strfmt.UUID{idTeslaRed2022_205, idTeslaBlue2022_225,
-			//               idTeslaBlue2022Mixed, idTeslaRed2018_225,
-			//               idTeslaBadPlusGoodTesla}
-			//   (idTeslaBadPlusBmwRed flips to excl — no single tesla
-			//   car satisfies (red OR (2022 AND non-205 tire));
-			//   idTeslaBlue2022Mixed and idTeslaBadPlusGoodTesla flip
-			//   to match — at least one tesla car has 2022 AND has a
-			//   non-205 tire same-car.)
 		)
 	})
 
@@ -16870,21 +16738,18 @@ func TestNestedFilteringDeeplyNestedAndOrNotSameRoot3Levels(t *testing.T) {
 			{id: idSplitGaragesBadPlusGoodTesla, props: wrapG(garage(car("tesla", "blue", 2022, tire(205))), garage(car("tesla", "blue", 2022, tire(225)))), note: "g[0]=tesla bad; g[1]=tesla good — L1 KEY"},
 		}
 
+		// bad+bmw-red docs flip to excl regardless of whether the
+		// bmw is in the same garage or a different garage; mixed-
+		// tires and bad+good-tesla docs flip to match likewise.
 		runLevel(t, className, class,
 			"garages.cars.make", "garages.cars.color", "garages.cars.year", "garages.cars.tires.width",
 			docs,
-			// today
 			[]strfmt.UUID{
-				idTeslaRed2022_205, idTeslaBlue2022_225, idTeslaRed2018_225,
-				idTeslaBadPlusBmwRedSameGarage, idSplitGaragesBadPlusBmwRed,
+				idTeslaRed2022_205, idTeslaBlue2022_225,
+				idTeslaBlue2022Mixed, idTeslaRed2018_225,
+				idTeslaBadPlusGoodTeslaSameGarage,
+				idSplitGaragesBadPlusGoodTesla,
 			},
-			// expected after scope-aware NOT + position-level OR:
-			// []strfmt.UUID{idTeslaRed2022_205, idTeslaBlue2022_225,
-			//               idTeslaBlue2022Mixed, idTeslaRed2018_225,
-			//               idTeslaBadPlusGoodTeslaSameGarage,
-			//               idSplitGaragesBadPlusGoodTesla}
-			//   (bad+bmw-red docs flip to excl; mixed-tires and
-			//   bad+good-tesla docs flip to match.)
 		)
 	})
 
@@ -16946,23 +16811,20 @@ func TestNestedFilteringDeeplyNestedAndOrNotSameRoot3Levels(t *testing.T) {
 			{id: idSplitCountriesBadPlusGoodTesla, props: wrapC(country(garage(car("tesla", "blue", 2022, tire(205)))), country(garage(car("tesla", "blue", 2022, tire(225))))), note: "split countries bad+good tesla — L2 KEY"},
 		}
 
+		// bad+bmw-red docs flip to excl across every split layout
+		// (same garage, different garages, different countries);
+		// mixed-tires and bad+good-tesla docs flip to match
+		// likewise.
 		runLevel(t, className, class,
 			"countries.garages.cars.make", "countries.garages.cars.color", "countries.garages.cars.year", "countries.garages.cars.tires.width",
 			docs,
-			// today
 			[]strfmt.UUID{
-				idTeslaRed2022_205, idTeslaBlue2022_225, idTeslaRed2018_225,
-				idTeslaBadPlusBmwRedSameGarage, idSplitGaragesBadPlusBmwRed,
-				idSplitCountriesBadPlusBmwRed,
+				idTeslaRed2022_205, idTeslaBlue2022_225,
+				idTeslaBlue2022Mixed, idTeslaRed2018_225,
+				idTeslaBadPlusGoodTeslaSameGarage,
+				idSplitGaragesBadPlusGoodTesla,
+				idSplitCountriesBadPlusGoodTesla,
 			},
-			// expected after scope-aware NOT + position-level OR:
-			// []strfmt.UUID{idTeslaRed2022_205, idTeslaBlue2022_225,
-			//               idTeslaBlue2022Mixed, idTeslaRed2018_225,
-			//               idTeslaBadPlusGoodTeslaSameGarage,
-			//               idSplitGaragesBadPlusGoodTesla,
-			//               idSplitCountriesBadPlusGoodTesla}
-			//   (bad+bmw-red docs at all splits flip to excl; mixed and
-			//   bad+good-tesla docs at all splits flip to match.)
 		)
 	})
 }
@@ -16977,19 +16839,13 @@ func TestNestedFilteringDeeplyNestedAndOrNotSameRoot3Levels(t *testing.T) {
 //	<chain>.cars.make=tesla
 //
 // The OR branches target two sibling sub-arrays (accessories, tires)
-// under cars. They have NO common ancestor below cars — diverging at
-// the cars level.
-//
-// Today (docID-level OR): each branch resolves to a docID set;
-// OR unions; AND with tesla intersects at docID. Doc matches when
-// it has a tesla car AND (sunroof somewhere OR 205 tire somewhere) —
-// the OR can be satisfied by ANY car, not necessarily a tesla.
-//
-// Future (position-level OR within single root): both branches
-// project up to cars LCA; OR at cars (cars where some accessory is
-// sunroof OR some tire is 205); AND with tesla at cars (tesla cars
-// satisfying the OR). Per-tesla-car evaluation — strictly tighter
-// than today when the OR is satisfied via a non-tesla car.
+// under cars; their deepest common LCA is cars. The planner plants
+// the OR inside the cars subgroup so the outer AND with
+// cars.make=tesla correlates same-element at cars[]: a single tesla
+// car must satisfy the OR. Cross-car docs (where the OR is satisfied
+// via a non-tesla car) drop out, regardless of whether the non-tesla
+// car is in the same garage, a different garage, or a different
+// country.
 //
 // Three nesting levels with object[] roots: L0_root_cars,
 // L1_garages_cars, L2_countries_garages_cars.
@@ -17113,17 +16969,10 @@ func TestNestedFilteringDisjointSubArraysOrInAnd3Levels(t *testing.T) {
 			assert.ElementsMatch(t, want, got)
 		}
 
-		// TODO aliszka:nested_filtering: locks in CURRENT docID-level OR
-		// for disjoint sibling sub-arrays. Branches at cars.accessories
-		// and cars.tires resolve independently to docID sets and union
-		// at docID. AND with cars.make=tesla intersects at docID. Doc
-		// matches when tesla car exists AND OR satisfied by any car.
-		//
-		// Under position-level OR within a single root, both branches
-		// project up to cars LCA, OR per-cars-element, AND with tesla
-		// at cars. Doc matches only when a tesla car itself satisfies
-		// the OR. Discriminator docs where the OR is satisfied via a
-		// non-tesla car flip to excl.
+		// regression_OR_disjoint_sub_arrays_in_AND — same-element AND at
+		// cars[]: a single tesla car must satisfy the OR. Discriminator
+		// docs (cross-car splits) drop out — the non-tesla car
+		// satisfying the OR doesn't count.
 		t.Run("regression_OR_disjoint_sub_arrays_in_AND", func(t *testing.T) {
 			runScenario(t, andF(
 				orF(
@@ -17171,20 +17020,16 @@ func TestNestedFilteringDisjointSubArraysOrInAnd3Levels(t *testing.T) {
 			{id: idEmpty, props: emptyDoc(), note: "no cars"},
 		}
 
+		// Same-element AND at cars[]: only tesla cars that themselves
+		// satisfy the OR match. idTeslaNothingPlusBmwSunroof /
+		// idTeslaNothingPlusBmw205 drop out — their tesla cars are
+		// empty; the bmw car satisfies the OR but isn't tesla.
 		runLevel(t, className, class,
 			"cars.make", "cars.accessories.type", "cars.tires.width",
 			docs,
-			// today: tesla AND (sunroof somewhere OR 205 somewhere).
 			[]strfmt.UUID{
 				idTeslaSunroof205, idTeslaSunroofOnly, idTesla205Only,
-				idTeslaNothingPlusBmwSunroof, idTeslaNothingPlusBmw205,
 			},
-			// expected after position-level OR within single root:
-			// []strfmt.UUID{idTeslaSunroof205, idTeslaSunroofOnly,
-			//               idTesla205Only}
-			//   (idTeslaNothingPlusBmwSunroof and idTeslaNothingPlusBmw205
-			//   flip to excl — no tesla car satisfies the OR; the
-			//   non-tesla car satisfies OR but isn't tesla.)
 		)
 	})
 
@@ -17231,21 +17076,15 @@ func TestNestedFilteringDisjointSubArraysOrInAnd3Levels(t *testing.T) {
 			{id: idSplitGaragesTeslaPlusBmwSunroof, props: wrapG(garage(car("tesla", nil, nil)), garage(car("bmw", []map[string]any{accessory("sunroof")}, nil))), note: "g[0]=tesla nothing; g[1]=bmw sunroof — L1 KEY"},
 		}
 
+		// Same-element AND at cars[]: cross-car docs drop out regardless
+		// of whether the non-tesla car is in the same garage as the
+		// tesla or a different one (idSplitGaragesTeslaPlusBmwSunroof).
 		runLevel(t, className, class,
 			"garages.cars.make", "garages.cars.accessories.type", "garages.cars.tires.width",
 			docs,
-			// today
 			[]strfmt.UUID{
 				idTeslaSunroof205, idTeslaSunroofOnly, idTesla205Only,
-				idTeslaNothingPlusBmwSunroofSameGarage,
-				idTeslaNothingPlusBmw205SameGarage,
-				idSplitGaragesTeslaPlusBmwSunroof,
 			},
-			// expected after position-level OR within single root:
-			// []strfmt.UUID{idTeslaSunroof205, idTeslaSunroofOnly,
-			//               idTesla205Only}
-			//   (cross-car docs flip to excl regardless of whether the
-			//   non-tesla car is in the same garage or a different one.)
 		)
 	})
 
@@ -17299,23 +17138,17 @@ func TestNestedFilteringDisjointSubArraysOrInAnd3Levels(t *testing.T) {
 			{id: idSplitCountriesTeslaPlusBmwSunroof, props: wrapC(country(garage(car("tesla", nil, nil))), country(garage(car("bmw", []map[string]any{accessory("sunroof")}, nil)))), note: "split across countries — L2 KEY"},
 		}
 
+		// Same-element AND at cars[]: cross-car docs drop out regardless
+		// of whether the non-tesla car is in the same garage, a
+		// different garage, or a different country
+		// (idSplitGaragesTeslaPlusBmwSunroof /
+		// idSplitCountriesTeslaPlusBmwSunroof).
 		runLevel(t, className, class,
 			"countries.garages.cars.make", "countries.garages.cars.accessories.type", "countries.garages.cars.tires.width",
 			docs,
-			// today
 			[]strfmt.UUID{
 				idTeslaSunroof205, idTeslaSunroofOnly, idTesla205Only,
-				idTeslaNothingPlusBmwSunroofSameGarage,
-				idTeslaNothingPlusBmw205SameGarage,
-				idSplitGaragesTeslaPlusBmwSunroof,
-				idSplitCountriesTeslaPlusBmwSunroof,
 			},
-			// expected after position-level OR within single root:
-			// []strfmt.UUID{idTeslaSunroof205, idTeslaSunroofOnly,
-			//               idTesla205Only}
-			//   (cross-car docs flip to excl regardless of whether the
-			//   non-tesla car is same garage, different garage, or
-			//   different country.)
 		)
 	})
 }
@@ -18693,34 +18526,24 @@ func TestNestedFilteringAndParenthesization3Levels(t *testing.T) {
 			assert.ElementsMatch(t, want, got)
 		}
 
-		// TODO aliszka:nested_filtering: locks in CURRENT flat 3-AND
-		// behavior — same-element correlation across all three
-		// operands at one cars[] LCA. Only docs with a single car
-		// satisfying make=tesla AND year=2020 AND color=red match.
-		// Under associative AND flattening this is the canonical
-		// result that all three forms collapse to.
+		// flat 3-AND: same-element correlation across all three operands
+		// at one cars[] LCA. Only docs with a single car satisfying
+		// make=tesla AND year=2020 AND color=red match.
 		t.Run("regression_flat_3_and", func(t *testing.T) {
 			runScenario(t, andF(makeF(), yearF(), colorF()), wantFlat)
 		})
 
-		// TODO aliszka:nested_filtering: locks in CURRENT
-		// left-grouped behavior — inner (make AND year) correlates
-		// at cars[], producing a docID set; outer AND with color=red
-		// intersects at docID. Cars satisfying inner and cars with
-		// color=red can be different elements. Under associative
-		// AND flattening this collapses to the flat plan.
+		// left-grouped: (make AND year) AND color. The planner's
+		// associative AND flattening collapses this to the flat plan,
+		// so the result matches regression_flat_3_and (same-element
+		// correlation across all three operands at cars[] LCA).
 		t.Run("regression_left_grouped_and", func(t *testing.T) {
 			runScenario(t, andF(andF(makeF(), yearF()), colorF()), wantLeft)
 		})
 
-		// TODO aliszka:nested_filtering: locks in CURRENT
-		// right-grouped behavior — inner (year AND color) correlates
-		// at cars[]; outer AND with make=tesla intersects at docID.
-		// Different from left-grouped on docs where the inner pair
-		// can only be satisfied by one shape (e.g., year+color in a
-		// non-tesla car) but the outer leaf is satisfied by another
-		// car. Under associative AND flattening this collapses to
-		// the flat plan.
+		// right-grouped: make AND (year AND color). Same AND associative
+		// flattening as left-grouped — collapses to the flat plan and
+		// produces the same most-restrictive result.
 		t.Run("regression_right_grouped_and", func(t *testing.T) {
 			runScenario(t, andF(makeF(), andF(yearF(), colorF())), wantRight)
 		})
@@ -18771,20 +18594,17 @@ func TestNestedFilteringAndParenthesization3Levels(t *testing.T) {
 			{id: idEmpty, props: map[string]any{}, note: "no cars"},
 		}
 
+		// Per associative AND flattening at the planner, all three forms
+		// (flat, left-grouped, right-grouped) collapse to the same
+		// single-car-satisfies-all result. The discriminator docs (
+		// idSplitTeslaYearVsRed / idLeftOnly / idRightOnly) are kept
+		// to prove no form leaks them.
 		runLevel(t, className, class,
 			"cars.make", "cars.year", "cars.color",
 			docs,
-			// today flat: only single-car-all-3.
-			[]strfmt.UUID{idAllInOne},
-			// today left-grouped: inner (tesla AND 2020) correlated;
-			// outer AND color=red docID-intersect. Mixed docs where
-			// some car has tesla+2020 AND some car has red satisfy.
-			[]strfmt.UUID{idAllInOne, idSplitTeslaYearVsRed, idLeftOnly},
-			// today right-grouped: inner (2020 AND red) correlated;
-			// outer AND make=tesla docID-intersect.
-			[]strfmt.UUID{idAllInOne, idSplitTeslaYearVsRed, idRightOnly},
-			// expected after AND associative flattening: all three
-			// forms collapse to the flat plan -> []strfmt.UUID{idAllInOne}.
+			[]strfmt.UUID{idAllInOne}, // flat
+			[]strfmt.UUID{idAllInOne}, // left — flattens to flat
+			[]strfmt.UUID{idAllInOne}, // right — flattens to flat
 		)
 	})
 
@@ -18828,19 +18648,15 @@ func TestNestedFilteringAndParenthesization3Levels(t *testing.T) {
 			{id: idSplitTeslaYearVsRedSplitGarages, props: wrapG(garage(car("tesla", 2020, "blue")), garage(car("bmw", 2020, "red"))), note: "g[0]=[tesla,2020]; g[1]=[bmw,red]"},
 		}
 
+		// All three forms collapse to the flat plan; discriminator docs
+		// (split-same-garage / left-only / right-only / split-garages)
+		// stay in the doc set to prove no form leaks them.
 		runLevel(t, className, class,
 			"garages.cars.make", "garages.cars.year", "garages.cars.color",
 			docs,
-			// today flat: single-car all 3 (anywhere in any garage).
-			[]strfmt.UUID{idAllInOne},
-			// today left-grouped: inner (make AND year) correlates
-			// at the cars LCA; outer AND color=red docID. Mixed
-			// satisfies regardless of garage split.
-			[]strfmt.UUID{idAllInOne, idSplitTeslaYearVsRedSameGarage, idLeftOnlySameGarage, idSplitTeslaYearVsRedSplitGarages},
-			// today right-grouped.
-			[]strfmt.UUID{idAllInOne, idSplitTeslaYearVsRedSameGarage, idRightOnlySameGarage, idSplitTeslaYearVsRedSplitGarages},
-			// expected after AND associative flattening:
-			// []strfmt.UUID{idAllInOne}.
+			[]strfmt.UUID{idAllInOne}, // flat
+			[]strfmt.UUID{idAllInOne}, // left — flattens to flat
+			[]strfmt.UUID{idAllInOne}, // right — flattens to flat
 		)
 	})
 
@@ -18891,20 +18707,16 @@ func TestNestedFilteringAndParenthesization3Levels(t *testing.T) {
 			{id: idSplitTeslaYearVsRedSplitCountries, props: wrapC(country(garage(car("tesla", 2020, "blue"))), country(garage(car("bmw", 2020, "red")))), note: "split across countries — L2 KEY"},
 		}
 
+		// All three forms collapse to the flat plan; discriminator docs
+		// (split-same-garage / left-only / right-only / split-garages /
+		// split-countries) stay in the doc set to prove no form leaks
+		// them.
 		runLevel(t, className, class,
 			"countries.garages.cars.make", "countries.garages.cars.year", "countries.garages.cars.color",
 			docs,
-			// today flat
-			[]strfmt.UUID{idAllInOne},
-			// today left-grouped: docID intersection ignores the
-			// cross-country split.
-			[]strfmt.UUID{idAllInOne, idSplitTeslaYearVsRedSameGarage, idLeftOnlySameGarage, idSplitTeslaYearVsRedSplitGarages, idSplitTeslaYearVsRedSplitCountries},
-			// today right-grouped
-			[]strfmt.UUID{idAllInOne, idSplitTeslaYearVsRedSameGarage, idRightOnlySameGarage, idSplitTeslaYearVsRedSplitGarages, idSplitTeslaYearVsRedSplitCountries},
-			// expected after AND associative flattening:
-			// []strfmt.UUID{idAllInOne} — at all 3 levels the three
-			// forms agree on the most restrictive (single-car-
-			// all-3) result.
+			[]strfmt.UUID{idAllInOne}, // flat
+			[]strfmt.UUID{idAllInOne}, // left — flattens to flat
+			[]strfmt.UUID{idAllInOne}, // right — flattens to flat
 		)
 	})
 }
@@ -19081,11 +18893,10 @@ func TestNestedFilteringNotContextSensitivity3Levels(t *testing.T) {
 			runScenario(t, notF(colorRedF()), want.standalone)
 		})
 
-		// TODO aliszka:nested_filtering: Context 2 — sibling at SAME
-		// root. Enclosing AND's LCA = cars[]. Today's contribution
-		// of NOT is doc-level. per-element inversion and universal-within-scope inversion both invert at
-		// cars[] (operand's natural LCA = enclosing LCA), so they
-		// agree here.
+		// ctx2_AND_same_root_sibling — sibling at SAME root.
+		// Enclosing AND's LCA = cars[]. NOT inverts at cars[]
+		// (operand's natural LCA = enclosing LCA). Option A and
+		// Option B agree here.
 		t.Run("ctx2_AND_same_root_sibling", func(t *testing.T) {
 			runScenario(t, andF(makeF(), notF(colorRedF())), want.andSameRoot)
 		})
@@ -19177,38 +18988,33 @@ func TestNestedFilteringNotContextSensitivity3Levels(t *testing.T) {
 			"cars.make", "cars.year", "cars.color", "owner",
 			docs,
 			wantSet{
-				// ctx1 standalone: NOT_today = no red anywhere.
-				// {d2, d4, d5, d7}.
+				// ctx1 standalone — TODO aliszka:nested_filtering:
+				// locks in CURRENT root-universe NOT.
+				//   Option A: {d2,d4,d5,d6} — d6 in, d7 out.
+				//   Option B: {d2,d4,d5,d7} — same as today (no
+				//             enclosing combinator).
 				standalone: []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idEmpty},
-				// ctx2 AND same-root: T ∩ NOT_today = {d2, d5}.
-				andSameRoot: []strfmt.UUID{idTesla2020Blue, idTesla1990Blue},
-				// ctx3 AND outer-scope: O ∩ NOT_today = {d2,d4,d5}.
+				// ctx2 AND same-root — option A and option B agree:
+				// per-cars-element NOT. idMixed (d6) flips in.
+				andSameRoot: []strfmt.UUID{idTesla2020Blue, idTesla1990Blue, idMixed},
+				// ctx3 AND outer-scope — TODO aliszka:nested_filtering:
+				// locks in CURRENT docID-level NOT. THIS is the A vs B
+				// discriminator.
+				//   Option A: {d2,d4,d5,d6} — d6 in.
+				//   Option B: {d2,d4,d5} — same as today (enclosing
+				//             LCA = doc).
 				andOuterScope: []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue},
-				// ctx4 OR same-root: T ∪ NOT_today =
-				// {d1,d2,d4,d5,d6,d7,d8}.
+				// ctx4 OR same-root — TODO aliszka:nested_filtering:
+				// locks in CURRENT root-universe NOT (top-level OR
+				// doesn't trigger scope-aware NOT yet).
+				//   Option A: {d1,d2,d4,d5,d6,d8} — d6 in, d7 out.
+				//   Option B: same as Option A (enclosing OR's LCA =
+				//             cars = operand LCA).
 				orSameRoot: []strfmt.UUID{idTesla2020Red, idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idMixed, idEmpty, idTesla2020RedOwnerBob},
-				// ctx5 mix: T ∩ (Y ∪ NOT_today) =
-				// {d1,d2,d5,d6,d8}.
+				// ctx5 mix — passes under today, option A, and option B.
+				// The OR positive branch (Y) absorbs the discriminators.
 				andOrMix: []strfmt.UUID{idTesla2020Red, idTesla2020Blue, idTesla1990Blue, idMixed, idTesla2020RedOwnerBob},
 			},
-			// expected after option A (per-element NOT, context-free):
-			//   ctx1: {d2,d4,d5,d6}        — d6 in, d7 out
-			//   ctx2: {d2,d5,d6}           — d6 in
-			//   ctx3: {d2,d4,d5,d6}        — d6 in
-			//   ctx4: {d1,d2,d4,d5,d6,d8}  — d6 in, d7 out
-			//   ctx5: {d1,d2,d5,d6,d8}     — same as today (the
-			//                                 union absorbs the
-			//                                 difference at d2,d4,
-			//                                 d5,d6 since these
-			//                                 appear in Y too)
-			//
-			// expected after option B (NOT at enclosing-scope LCA):
-			//   ctx1: same as today (no enclosing combinator)
-			//   ctx2: same as option A (enclosing LCA = cars[])
-			//   ctx3: same as today (enclosing LCA = doc)
-			//          — THIS is the A vs B discriminator
-			//   ctx4: same as option A
-			//   ctx5: same as option A
 		)
 	})
 
@@ -19271,29 +19077,28 @@ func TestNestedFilteringNotContextSensitivity3Levels(t *testing.T) {
 			"garages.cars.make", "garages.cars.year", "garages.cars.color", "owner",
 			docs,
 			wantSet{
-				// ctx1 standalone NOT_today
+				// ctx1 standalone — TODO aliszka:nested_filtering:
+				// locks in CURRENT root-universe NOT.
+				//   Option A: {d2,d4,d5,d6,d9}.
+				//   Option B: {d2,d4,d5,d7} — same as today.
 				standalone: []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idEmpty},
-				// ctx2 T ∩ NOT_today
-				andSameRoot: []strfmt.UUID{idTesla2020Blue, idTesla1990Blue},
-				// ctx3 O ∩ NOT_today
+				// ctx2 AND same-root — option A and option B agree.
+				// idMixedSameGarage and idMixedSplitGarages flip in.
+				andSameRoot: []strfmt.UUID{idTesla2020Blue, idTesla1990Blue, idMixedSameGarage, idMixedSplitGarages},
+				// ctx3 AND outer-scope — TODO aliszka:nested_filtering:
+				// locks in CURRENT docID-level NOT. THIS is the A vs B
+				// discriminator.
+				//   Option A: {d2,d4,d5,d6,d9}.
+				//   Option B: {d2,d4,d5} — same as today.
 				andOuterScope: []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue},
-				// ctx4 T ∪ NOT_today
+				// ctx4 OR same-root — TODO aliszka:nested_filtering:
+				// locks in CURRENT root-universe NOT.
+				//   Option A: {d1,d2,d4,d5,d6,d8,d9}.
+				//   Option B: same as Option A.
 				orSameRoot: []strfmt.UUID{idTesla2020Red, idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idMixedSameGarage, idEmpty, idTesla2020RedOwnerBob, idMixedSplitGarages},
-				// ctx5 T ∩ (Y ∪ NOT_today)
+				// ctx5 mix — passes under today, option A, and option B.
 				andOrMix: []strfmt.UUID{idTesla2020Red, idTesla2020Blue, idTesla1990Blue, idMixedSameGarage, idTesla2020RedOwnerBob, idMixedSplitGarages},
 			},
-			// expected after option A:
-			//   NOT_optA = exists garages.cars with color!=red =
-			//   {d2,d4,d5,d6,d9} (mixed docs flip IN, idEmpty
-			//   flips OUT).
-			//   ctx1: {d2,d4,d5,d6,d9}
-			//   ctx2: {d2,d5,d6,d9}
-			//   ctx3: {d2,d4,d5,d6,d9}
-			//   ctx4: {d1,d2,d4,d5,d6,d8,d9}
-			//   ctx5: {d1,d2,d5,d6,d8,d9} (same as today)
-			//
-			// option B: ctx1 and ctx3 collapse to today; ctx2/4/5
-			// match option A.
 		)
 	})
 
@@ -19358,46 +19163,42 @@ func TestNestedFilteringNotContextSensitivity3Levels(t *testing.T) {
 			"countries.garages.cars.make", "countries.garages.cars.year", "countries.garages.cars.color", "owner",
 			docs,
 			wantSet{
-				// today T = {d1,d2,d5,d6,d8,d9,d10}
-				// Y = {d1,d2,d3,d4,d6,d8,d9,d10}
-				// O = {d1,d2,d3,d4,d5,d6,d9,d10}
-				// NOT_today = {d2,d4,d5,d7}
-				standalone:    []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idEmpty},
-				andSameRoot:   []strfmt.UUID{idTesla2020Blue, idTesla1990Blue},
+				// ctx1 standalone — TODO aliszka:nested_filtering:
+				// locks in CURRENT root-universe NOT.
+				//   Option A: {d2,d4,d5,d6,d9,d10}.
+				//   Option B: {d2,d4,d5,d7} — same as today.
+				standalone: []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idEmpty},
+				// ctx2 AND same-root — option A and option B agree.
+				// All mixed-layout docs (same garage, split garages,
+				// split countries) flip in.
+				andSameRoot: []strfmt.UUID{idTesla2020Blue, idTesla1990Blue, idMixedSameGarage, idMixedSplitGarages, idMixedSplitCountries},
+				// ctx3 AND outer-scope — TODO aliszka:nested_filtering:
+				// locks in CURRENT docID-level NOT. THIS is the A vs B
+				// discriminator.
+				//   Option A: {d2,d4,d5,d6,d9,d10}.
+				//   Option B: {d2,d4,d5} — same as today.
 				andOuterScope: []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue},
-				orSameRoot:    []strfmt.UUID{idTesla2020Red, idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idMixedSameGarage, idEmpty, idTesla2020RedOwnerBob, idMixedSplitGarages, idMixedSplitCountries},
-				andOrMix:      []strfmt.UUID{idTesla2020Red, idTesla2020Blue, idTesla1990Blue, idMixedSameGarage, idTesla2020RedOwnerBob, idMixedSplitGarages, idMixedSplitCountries},
+				// ctx4 OR same-root — TODO aliszka:nested_filtering:
+				// locks in CURRENT root-universe NOT.
+				//   Option A: {d1,d2,d4,d5,d6,d8,d9,d10}.
+				//   Option B: same as Option A.
+				orSameRoot: []strfmt.UUID{idTesla2020Red, idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idMixedSameGarage, idEmpty, idTesla2020RedOwnerBob, idMixedSplitGarages, idMixedSplitCountries},
+				// ctx5 mix — passes under today, option A, and option B.
+				// Cross-country split docs flip alongside cross-garage
+				// ones — uniformly per-element regardless of where in
+				// the nested chain the mixed elements live.
+				andOrMix: []strfmt.UUID{idTesla2020Red, idTesla2020Blue, idTesla1990Blue, idMixedSameGarage, idTesla2020RedOwnerBob, idMixedSplitGarages, idMixedSplitCountries},
 			},
-			// expected after option A:
-			//   NOT_optA = {d2,d4,d5,d6,d9,d10} (every mixed-layout
-			//   doc flips IN; idEmpty flips OUT).
-			//   ctx1: {d2,d4,d5,d6,d9,d10}
-			//   ctx2: {d2,d5,d6,d9,d10}
-			//   ctx3: {d2,d4,d5,d6,d9,d10}
-			//   ctx4: {d1,d2,d4,d5,d6,d8,d9,d10}
-			//   ctx5: {d1,d2,d5,d6,d8,d9,d10} (same as today)
-			//
-			// option B: ctx1 and ctx3 fall back to today; ctx2/4/5
-			// match option A. The cross-country split docs flip
-			// alongside the cross-garage ones — option A is
-			// uniformly per-element regardless of where in the
-			// nested chain the mixed elements live.
 		)
 	})
 }
 
 // TestNestedFilteringContainsAllOrCrossElement3Levels covers gap #7:
-// `cars.tags ContainsAll ["a","b"] OR cars.color=red` — locks in
-// today's docID-level ContainsAll (synthesized AND of same-path
-// Equals resolves at docID, so the two values can come from
-// different cars) combined with docID-level OR.
-//
-// Under the planned "correlated ContainsAll" rewrite, ContainsAll's
-// synthesized AND inherits the parent's same-element grouping
-// rule — both values must live on a single cars element. Docs that
-// satisfy ContainsAll only via cross-element splits flip OUT of the
-// ContainsAll branch; the OR with color=red still admits docs that
-// have red anywhere.
+// `cars.tags ContainsAll ["a","b"] OR cars.color=red`. The ContainsAll
+// branch correlates same-element at cars[] — both values must live on
+// a single car. Docs that satisfy ContainsAll only via cross-element
+// splits no longer match through the ContainsAll branch; the OR with
+// color=red still admits docs that have red anywhere.
 func TestNestedFilteringContainsAllOrCrossElement3Levels(t *testing.T) {
 	vTrue := true
 	tok := models.NestedPropertyTokenizationField
@@ -19477,16 +19278,11 @@ func TestNestedFilteringContainsAllOrCrossElement3Levels(t *testing.T) {
 			return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorOr, Operands: ops}}
 		}
 
-		// TODO aliszka:nested_filtering: locks in CURRENT
-		// ContainsAll-as-docID-level-AND combined with OR. The
-		// ContainsAll branch matches docs that have both tag values
-		// somewhere across the cars hierarchy (potentially in
-		// different cars or different garages/countries). The OR
-		// adds docs whose cars contain color=red. Under correlated
-		// ContainsAll, only docs with a single car having BOTH tags
-		// satisfy the ContainsAll branch — cross-element split docs
-		// flip OUT of that branch and only stay in the result if
-		// the OR's color=red branch admits them.
+		// regression_ContainsAll_OR_cross_element — ContainsAll
+		// requires both tags on a single car (same-element AND at
+		// cars[]). Cross-element split docs no longer satisfy the
+		// ContainsAll branch; they remain only if the OR's
+		// color=red branch admits them.
 		t.Run("regression_ContainsAll_OR_cross_element", func(t *testing.T) {
 			db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
 			ctx := context.Background()
@@ -19545,22 +19341,19 @@ func TestNestedFilteringContainsAllOrCrossElement3Levels(t *testing.T) {
 			{id: idSplitTagsButRed, props: wrap(car("blue", "a"), car("red", "b")), note: "tags split, red in cars[1]"},
 		}
 
+		// ContainsAll(cars.tags, [a,b]) same-element at cars[]:
+		// only single-car-with-both matches via the ContainsAll
+		// branch. The OR's color=red branch independently admits
+		// docs that have red anywhere. idSplitTagsAcrossCars
+		// (split tags, no red) flips OUT; idSplitTagsButRed
+		// stays IN via the OR branch.
 		runLevel(t, className, class,
 			"cars.tags", "cars.color",
 			docs,
-			// today: ContainsAll docID-level (a anywhere AND b
-			// anywhere) ∪ red anywhere.
 			[]strfmt.UUID{
-				idSingleCarBothTags, idSplitTagsAcrossCars,
-				idOnlyAWithRed, idSingleCarBothTagsRed, idSplitTagsButRed,
+				idSingleCarBothTags, idOnlyAWithRed,
+				idSingleCarBothTagsRed, idSplitTagsButRed,
 			},
-			// expected after correlated ContainsAll:
-			// []strfmt.UUID{idSingleCarBothTags, idOnlyAWithRed,
-			//               idSingleCarBothTagsRed,
-			//               idSplitTagsButRed}
-			//   (idSplitTagsAcrossCars flips OUT — no single car
-			//   has both tags AND no red. idSplitTagsButRed stays
-			//   IN via the OR's red branch.)
 		)
 	})
 
@@ -19604,24 +19397,19 @@ func TestNestedFilteringContainsAllOrCrossElement3Levels(t *testing.T) {
 			{id: idSplitTagsAcrossGarages, props: wrapG(garage(car("blue", "a")), garage(car("blue", "b"))), note: "g0={a}; g1={b} — L1 KEY"},
 		}
 
+		// ContainsAll(garages.cars.tags, [a,b]) same-element at
+		// cars[]. idSplitTagsSameGarage (split-cars within one
+		// garage) and idSplitTagsAcrossGarages (split across
+		// garages) both flip OUT — no single car has both tags.
+		// idSplitTagsSameGarageButRed stays IN via the OR's
+		// color=red branch.
 		runLevel(t, className, class,
 			"garages.cars.tags", "garages.cars.color",
 			docs,
-			// today: ContainsAll docID across all cars regardless
-			// of garage layout.
 			[]strfmt.UUID{
-				idSingleCarBothTags, idSplitTagsSameGarage,
-				idOnlyAWithRed, idSingleCarBothTagsRed,
-				idSplitTagsSameGarageButRed, idSplitTagsAcrossGarages,
+				idSingleCarBothTags, idOnlyAWithRed,
+				idSingleCarBothTagsRed, idSplitTagsSameGarageButRed,
 			},
-			// expected after correlated ContainsAll:
-			// []strfmt.UUID{idSingleCarBothTags, idOnlyAWithRed,
-			//               idSingleCarBothTagsRed,
-			//               idSplitTagsSameGarageButRed}
-			//   (idSplitTagsSameGarage and idSplitTagsAcrossGarages
-			//   flip OUT — neither has a single car with both
-			//   tags. idSplitTagsSameGarageButRed stays IN via
-			//   red.)
 		)
 	})
 
@@ -19672,26 +19460,18 @@ func TestNestedFilteringContainsAllOrCrossElement3Levels(t *testing.T) {
 			{id: idSplitTagsAcrossCountries, props: wrapC(country(garage(car("blue", "a"))), country(garage(car("blue", "b")))), note: "split across countries — L2 KEY"},
 		}
 
+		// ContainsAll(countries.garages.cars.tags, [a,b]) same-element
+		// at cars[]. Every cross-car split — same garage, different
+		// garages, different countries — flips OUT. Only the
+		// single-car-with-both-tags docs and the docs admitted by
+		// the OR's color=red branch survive.
 		runLevel(t, className, class,
 			"countries.garages.cars.tags", "countries.garages.cars.color",
 			docs,
-			// today: ContainsAll docID-level across the entire
-			// countries.garages.cars hierarchy regardless of
-			// layout.
 			[]strfmt.UUID{
-				idSingleCarBothTags, idSplitTagsSameGarage,
-				idOnlyAWithRed, idSingleCarBothTagsRed,
-				idSplitTagsSameGarageButRed, idSplitTagsAcrossGarages,
-				idSplitTagsAcrossCountries,
+				idSingleCarBothTags, idOnlyAWithRed,
+				idSingleCarBothTagsRed, idSplitTagsSameGarageButRed,
 			},
-			// expected after correlated ContainsAll:
-			// []strfmt.UUID{idSingleCarBothTags, idOnlyAWithRed,
-			//               idSingleCarBothTagsRed,
-			//               idSplitTagsSameGarageButRed}
-			//   (every cross-car split — same garage, different
-			//   garages, or different countries — flips OUT.
-			//   Only docs whose single car has both tags or has
-			//   color=red survive.)
 		)
 	})
 }
@@ -19703,17 +19483,11 @@ func TestNestedFilteringContainsAllOrCrossElement3Levels(t *testing.T) {
 //
 //	cars.make=tesla AND (cars.color=red OR cars.accessories.type=sunroof)
 //
-// Today's OR resolves at docID — the two branches each compute a
-// docID set independently and union — so same-cars-element
-// correlation does not propagate across the OR. A doc whose tesla
-// car has neither red nor sunroof but a non-tesla sibling supplies
-// red or sunroof still matches.
-//
-// Under position-level OR within a single nested root, the two OR
-// branches project up to their deepest common ancestor (cars[]) and
-// OR per cars element. The outer AND with cars.make=tesla then
-// requires the same cars element to satisfy both make=tesla and
-// (color=red OR has-sunroof-accessory). Cross-cars docs flip OUT.
+// The planner plants the OR at cars[] (deepest common LCA of color
+// and accessories). The outer AND with cars.make=tesla then
+// correlates same-element at cars[]: a single tesla car must satisfy
+// both make=tesla and (color=red OR has-sunroof-accessory). Cross-
+// cars docs (where the OR is satisfied via a non-tesla car) drop out.
 //
 // This is a parent-child-depth variant of gap #4 (sibling sub-array
 // depths). The flip pattern is the same; the test exists to prove
@@ -19804,17 +19578,14 @@ func TestNestedFilteringOrInAndDifferentSubArrayDepths3Levels(t *testing.T) {
 			return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorOr, Operands: ops}}
 		}
 
-		// TODO aliszka:nested_filtering: locks in CURRENT
-		// docID-level OR with operands at different sub-array
-		// depths (cars[] vs cars.accessories[]). The OR's branches
-		// independently produce docID sets that union, so the
-		// surrounding AND with cars.make=tesla intersects at docID
-		// without enforcing same-cars-element correlation across
-		// the OR. Under position-level OR within a single nested
-		// root, both branches project to cars[] LCA and OR
-		// per-element; the outer AND then requires the same car to
-		// satisfy both make=tesla and (color=red OR has-sunroof
-		// accessory). Cross-cars docs flip OUT.
+		// regression_OR_in_AND_different_sub_array_depths — same-element
+		// AND at cars[]: a single tesla car must satisfy both legs of
+		// the OR (color=red OR has-sunroof-accessory). The depth
+		// difference between the OR's branches (cars[] vs
+		// cars.accessories[]) is resolved by the planner planting the
+		// OR at cars[] — their deepest common LCA — so cross-cars docs
+		// drop out regardless of which OR branch the non-tesla car
+		// satisfies.
 		t.Run("regression_OR_in_AND_different_sub_array_depths", func(t *testing.T) {
 			db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
 			ctx := context.Background()
@@ -19876,21 +19647,15 @@ func TestNestedFilteringOrInAndDifferentSubArrayDepths3Levels(t *testing.T) {
 			{id: idEmpty, props: map[string]any{}, note: "no cars"},
 		}
 
+		// Same-element AND at cars[]: only tesla cars that themselves
+		// satisfy the OR match. idTeslaBlueBmwRed (color branch
+		// satisfied via bmw) and idTeslaBlueBmwSunroof (accessory
+		// branch satisfied via bmw) both drop — the different-depth
+		// branches collapse to the same per-car contract.
 		runLevel(t, className, class,
 			"cars.make", "cars.color", "cars.accessories.type",
 			docs,
-			// today: tesla anywhere AND (red anywhere OR sunroof
-			// in any accessory anywhere).
-			[]strfmt.UUID{idTeslaRed, idTeslaSunroof, idTeslaBlueBmwRed, idTeslaBlueBmwSunroof},
-			// expected after position-level OR within single root:
-			// []strfmt.UUID{idTeslaRed, idTeslaSunroof}
-			//   (idTeslaBlueBmwRed flips OUT — tesla car has no
-			//   red and no sunroof; bmw has red but isn't tesla.
-			//   idTeslaBlueBmwSunroof flips OUT — tesla car has
-			//   no sunroof in its accessories; bmw has sunroof
-			//   but isn't tesla. Different-depth branch
-			//   (accessories) collapses the same way as the
-			//   sibling-depth branch (color).)
+			[]strfmt.UUID{idTeslaRed, idTeslaSunroof},
 		)
 	})
 
@@ -19936,20 +19701,13 @@ func TestNestedFilteringOrInAndDifferentSubArrayDepths3Levels(t *testing.T) {
 			{id: idTeslaBlueBmwSunroofSplitGarages, props: wrapG(garage(car("tesla", "blue")), garage(car("bmw", "blue", accessory("sunroof")))), note: "g0=tesla; g1=bmw with sunroof — split accessory"},
 		}
 
+		// Every cross-car split — same garage or different garages,
+		// color-branch or accessory-branch — drops out. Only docs
+		// whose tesla car itself satisfies the OR survive.
 		runLevel(t, className, class,
 			"garages.cars.make", "garages.cars.color", "garages.cars.accessories.type",
 			docs,
-			// today
-			[]strfmt.UUID{
-				idTeslaRed, idTeslaSunroof,
-				idTeslaBlueBmwRedSameGarage, idTeslaBlueBmwSunroofSameGarage,
-				idTeslaBlueBmwRedSplitGarages, idTeslaBlueBmwSunroofSplitGarages,
-			},
-			// expected after position-level OR:
-			// []strfmt.UUID{idTeslaRed, idTeslaSunroof}
-			//   (every cross-car split — same garage or different
-			//   garages, color-branch or accessory-branch — flips
-			//   OUT. Only single-car satisfaction survives.)
+			[]strfmt.UUID{idTeslaRed, idTeslaSunroof},
 		)
 	})
 
@@ -20004,26 +19762,15 @@ func TestNestedFilteringOrInAndDifferentSubArrayDepths3Levels(t *testing.T) {
 			{id: idTeslaBlueBmwSunroofSplitCountries, props: wrapC(country(garage(car("tesla", "blue"))), country(garage(car("bmw", "blue", accessory("sunroof"))))), note: "split across countries — accessory"},
 		}
 
+		// Position-level OR within cars[] LCA combined with same-cars-
+		// element AND semantics is uniform regardless of where in the
+		// nested hierarchy the mixed elements live: same garage,
+		// different garages, or different countries — every cross-car
+		// split drops out via either branch.
 		runLevel(t, className, class,
 			"countries.garages.cars.make", "countries.garages.cars.color", "countries.garages.cars.accessories.type",
 			docs,
-			// today: docID-level OR + AND across the entire
-			// countries.garages.cars hierarchy regardless of
-			// layout.
-			[]strfmt.UUID{
-				idTeslaRed, idTeslaSunroof,
-				idTeslaBlueBmwRedSameGarage, idTeslaBlueBmwSunroofSameGarage,
-				idTeslaBlueBmwRedSplitGarages, idTeslaBlueBmwSunroofSplitGarages,
-				idTeslaBlueBmwRedSplitCountries, idTeslaBlueBmwSunroofSplitCountries,
-			},
-			// expected after position-level OR:
-			// []strfmt.UUID{idTeslaRed, idTeslaSunroof}
-			//   (all cross-car splits — same garage, different
-			//   garages, different countries; color or accessory
-			//   branch — flip OUT. Position-level OR within
-			//   cars[] LCA combined with same-cars-element AND
-			//   semantics is uniform regardless of where in the
-			//   nested hierarchy the mixed elements live.)
+			[]strfmt.UUID{idTeslaRed, idTeslaSunroof},
 		)
 	})
 }
@@ -20147,15 +19894,12 @@ func TestNestedFilteringAndDeepWithOrThreeDepths3Levels(t *testing.T) {
 			return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorOr, Operands: ops}}
 		}
 
-		// TODO aliszka:nested_filtering: locks in CURRENT docID-level
-		// OR + AND with operands at three different sub-array depths
-		// inside cars[]. Today the OR's two branches independently
-		// produce docID sets and the outer AND with the depth-2
-		// accessories sibling intersects at docID — no same-cars-
-		// element correlation across the OR boundary or across the
-		// depth-1/depth-2 sibling boundary. Under position-level
-		// evaluation, all three operands project to cars[] LCA and
-		// combine per cars element; cross-cars docs flip OUT.
+		// regression_AND_deep_with_OR_three_depths — same-element AND
+		// at cars[]. Operands at three different sub-array depths
+		// (cars.accessories[], cars.tires[], cars.colors as text[])
+		// all project to cars[] LCA. A single car must satisfy the
+		// outer AND's spoiler accessory together with either 205-tire
+		// or red-color leg of the OR. Cross-cars docs drop out.
 		t.Run("regression_AND_deep_with_OR_three_depths", func(t *testing.T) {
 			db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
 			ctx := context.Background()
@@ -20223,17 +19967,12 @@ func TestNestedFilteringAndDeepWithOrThreeDepths3Levels(t *testing.T) {
 			{id: idEmpty, props: map[string]any{}, note: "no cars"},
 		}
 
+		// Cross-cars docs drop out — no single car has spoiler AND
+		// (205 or red).
 		runLevel(t, className, class,
 			"cars.accessories.type", "cars.tires.width", "cars.colors",
 			docs,
-			// today: spoiler anywhere AND (205 anywhere OR red
-			// anywhere).
-			[]strfmt.UUID{idSpoilerWith205, idSpoilerWithRed, idSplitSpoilerVs205, idSplitSpoilerVsRed},
-			// expected after position-level evaluation:
-			// []strfmt.UUID{idSpoilerWith205, idSpoilerWithRed}
-			//   (idSplitSpoilerVs205 and idSplitSpoilerVsRed flip
-			//   OUT — neither has a single car with spoiler AND
-			//   either 205 or red.)
+			[]strfmt.UUID{idSpoilerWith205, idSpoilerWithRed},
 		)
 	})
 
@@ -20286,19 +20025,12 @@ func TestNestedFilteringAndDeepWithOrThreeDepths3Levels(t *testing.T) {
 			), note: "g0=spoiler,200; g1=205 — split garages KEY"},
 		}
 
+		// All cross-car splits — same garage or different garages —
+		// drop out.
 		runLevel(t, className, class,
 			"garages.cars.accessories.type", "garages.cars.tires.width", "garages.cars.colors",
 			docs,
-			// today
-			[]strfmt.UUID{
-				idSpoilerWith205, idSpoilerWithRed,
-				idSplitSpoilerVs205SameGarage, idSplitSpoilerVsRedSameGarage,
-				idSplitSpoilerVs205SplitGarages,
-			},
-			// expected after position-level evaluation:
-			// []strfmt.UUID{idSpoilerWith205, idSpoilerWithRed}
-			//   (every cross-car split — same garage or different
-			//   garages — flips OUT.)
+			[]strfmt.UUID{idSpoilerWith205, idSpoilerWithRed},
 		)
 	})
 
@@ -20361,19 +20093,12 @@ func TestNestedFilteringAndDeepWithOrThreeDepths3Levels(t *testing.T) {
 			), note: "split across countries — L2 KEY"},
 		}
 
+		// All cross-car splits — same garage, different garages,
+		// different countries — drop out.
 		runLevel(t, className, class,
 			"countries.garages.cars.accessories.type", "countries.garages.cars.tires.width", "countries.garages.cars.colors",
 			docs,
-			// today
-			[]strfmt.UUID{
-				idSpoilerWith205, idSpoilerWithRed,
-				idSplitSpoilerVs205SameGarage, idSplitSpoilerVsRedSameGarage,
-				idSplitSpoilerVs205SplitGarages, idSplitSpoilerVs205SplitCountries,
-			},
-			// expected after position-level evaluation:
-			// []strfmt.UUID{idSpoilerWith205, idSpoilerWithRed}
-			//   (all cross-car splits — same garage, different
-			//   garages, different countries — flip OUT.)
+			[]strfmt.UUID{idSpoilerWith205, idSpoilerWithRed},
 		)
 	})
 }
@@ -20492,14 +20217,12 @@ func TestNestedFilteringAndDeepNotDeepSiblings3Levels(t *testing.T) {
 			return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorAnd, Operands: ops}}
 		}
 
-		// TODO aliszka:nested_filtering: locks in CURRENT root-
-		// universe NOT combined with same-cars AND across sibling
-		// deep sub-arrays. Today: doc has spoiler accessory anywhere
-		// AND has no tire of width 205 anywhere. Under scope-aware
-		// NOT (operand-LCA), NOT inverts at cars.tires[]: exists
-		// tire with width!=205. Combined with same-cars correlation
-		// under outer AND, doc satisfies iff some single car has
-		// spoiler accessory AND some tire with width!=205.
+		// regression_AND_deep_NOT_deep_sibling_subarrays — A and B at
+		// sibling deep sub-arrays (cars.accessories vs cars.tires).
+		// NOT inverts at cars.tires per-tire (∃ tire≠205), projects to
+		// cars existentially. Positive accessories.type=spoiler projects
+		// to cars existentially. Outer AND same-car at cars: "∃ car
+		// with spoiler accessory AND ∃ non-205 tire on the same car".
 		t.Run("regression_AND_deep_NOT_deep_sibling_subarrays", func(t *testing.T) {
 			db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
 			ctx := context.Background()
@@ -20564,20 +20287,12 @@ func TestNestedFilteringAndDeepNotDeepSiblings3Levels(t *testing.T) {
 		runLevel(t, className, class,
 			"cars.accessories.type", "cars.tires.width",
 			docs,
-			// today: spoiler anywhere AND (no tire of 205
-			// anywhere). Empty/no-tires docs vacuously satisfy
-			// NOT.
-			[]strfmt.UUID{idSpoilerOnly200, idSpoilerNoTires, idSplitSpoilerVs200},
-			// expected after scope-aware NOT + same-cars AND:
-			// []strfmt.UUID{idSpoilerOnly200, idSpoilerMixed}
-			//   - idSpoilerMixed flips IN — single car has
-			//     spoiler AND has tire 200 (≠205) → satisfies
-			//     same-car NOT.
-			//   - idSpoilerNoTires flips OUT — single car has
-			//     spoiler but no tire to satisfy "exists tire
-			//     ≠205".
-			//   - idSplitSpoilerVs200 flips OUT — no single car
-			//     has both spoiler AND a non-205 tire.
+			// scope-aware NOT + same-cars AND.
+			// idSpoilerMixed flips in (single car has spoiler AND
+			// non-205 tire); idSpoilerNoTires flips out (vacuous ∃
+			// tire); idSplitSpoilerVs200 flips out (no single car
+			// has both spoiler AND a non-205 tire).
+			[]strfmt.UUID{idSpoilerOnly200, idSpoilerMixed},
 		)
 	})
 
@@ -20630,12 +20345,10 @@ func TestNestedFilteringAndDeepNotDeepSiblings3Levels(t *testing.T) {
 		runLevel(t, className, class,
 			"garages.cars.accessories.type", "garages.cars.tires.width",
 			docs,
-			// today
-			[]strfmt.UUID{idSpoilerOnly200, idSpoilerNoTires, idSplitSpoilerVs200SameGarage, idSplitSpoilerVs200SplitGarages},
-			// expected after scope-aware NOT + same-cars AND:
-			// []strfmt.UUID{idSpoilerOnly200, idSpoilerMixed}
-			//   (same flips as L0; cross-garage and same-garage
-			//   splits both flip OUT; idSpoilerNoTires flips OUT.)
+			// scope-aware NOT + same-cars AND. idSpoilerMixed flips in.
+			// idSpoilerNoTires, same-garage split, and split-garages all
+			// flip out — no single car has both spoiler AND non-205 tire.
+			[]strfmt.UUID{idSpoilerOnly200, idSpoilerMixed},
 		)
 	})
 
@@ -20698,19 +20411,11 @@ func TestNestedFilteringAndDeepNotDeepSiblings3Levels(t *testing.T) {
 		runLevel(t, className, class,
 			"countries.garages.cars.accessories.type", "countries.garages.cars.tires.width",
 			docs,
-			// today
-			[]strfmt.UUID{
-				idSpoilerOnly200, idSpoilerNoTires,
-				idSplitSpoilerVs200SameGarage,
-				idSplitSpoilerVs200SplitGarages,
-				idSplitSpoilerVs200SplitCountries,
-			},
-			// expected after scope-aware NOT + same-cars AND:
-			// []strfmt.UUID{idSpoilerOnly200, idSpoilerMixed}
-			//   (every cross-cars split — same garage, different
-			//   garages, different countries — flips OUT;
-			//   idSpoilerNoTires flips OUT; idSpoilerMixed flips
-			//   IN.)
+			// scope-aware NOT + same-cars AND. idSpoilerMixed flips in.
+			// Every cross-cars split — same garage, different garages,
+			// different countries — flips out; idSpoilerNoTires flips
+			// out.
+			[]strfmt.UUID{idSpoilerOnly200, idSpoilerMixed},
 		)
 	})
 }
@@ -20834,15 +20539,13 @@ func TestNestedFilteringIntraSubArrayOrCrossSubArrayAnd3Levels(t *testing.T) {
 			return &filters.LocalFilter{Root: &filters.Clause{Operator: filters.OperatorOr, Operands: ops}}
 		}
 
-		// TODO aliszka:nested_filtering: locks in CURRENT docID-level
-		// OR with both branches at the same deep sub-array
-		// (cars.tires) combined with cross-sub-array AND
-		// (cars.accessories). Today the OR returns a docID set; the
-		// outer AND intersects at docID without enforcing same-
-		// cars-element correlation across the OR boundary. Under
-		// position-level evaluation, the cars.tires OR is per-tire,
-		// projects up to cars[], and the outer AND requires the
-		// same car to have a matching tire AND a spoiler accessory.
+		// regression_intra_subarray_OR_cross_subarray_AND —
+		// same-element AND at cars[]. The OR's branches (both at
+		// cars.tires[]) project up to cars[], and the outer AND with
+		// cars.accessories.type=spoiler requires the same car to
+		// have both a matching tire and a spoiler accessory. Cross-
+		// cars docs (spoiler in one car, qualifying tire in another)
+		// drop out.
 		t.Run("regression_intra_subarray_OR_cross_subarray_AND", func(t *testing.T) {
 			db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
 			ctx := context.Background()
@@ -20910,16 +20613,12 @@ func TestNestedFilteringIntraSubArrayOrCrossSubArrayAnd3Levels(t *testing.T) {
 			{id: idEmpty, props: map[string]any{}, note: "no cars"},
 		}
 
+		// Cross-cars splits drop out — no single car has spoiler
+		// AND a 205-or-pirelli tire.
 		runLevel(t, className, class,
 			"cars.accessories.type", "cars.tires.width", "cars.tires.brand",
 			docs,
-			// today: (205 anywhere OR pirelli anywhere) AND
-			// spoiler anywhere.
-			[]strfmt.UUID{idSpoiler205, idSpoilerPirelli, idSplitSpoilerVs205, idSplitSpoilerVsPirelli},
-			// expected after position-level evaluation:
-			// []strfmt.UUID{idSpoiler205, idSpoilerPirelli}
-			//   (both cross-cars splits flip OUT — no single car
-			//   has spoiler AND a 205-or-pirelli tire.)
+			[]strfmt.UUID{idSpoiler205, idSpoilerPirelli},
 		)
 	})
 
@@ -20972,19 +20671,12 @@ func TestNestedFilteringIntraSubArrayOrCrossSubArrayAnd3Levels(t *testing.T) {
 			), note: "split garages — KEY"},
 		}
 
+		// All cross-cars splits — same garage or different garages —
+		// drop out.
 		runLevel(t, className, class,
 			"garages.cars.accessories.type", "garages.cars.tires.width", "garages.cars.tires.brand",
 			docs,
-			// today
-			[]strfmt.UUID{
-				idSpoiler205, idSpoilerPirelli,
-				idSplitSpoilerVs205SameGarage, idSplitSpoilerVsPirelliSameGarage,
-				idSplitSpoilerVs205SplitGarages,
-			},
-			// expected after position-level evaluation:
-			// []strfmt.UUID{idSpoiler205, idSpoilerPirelli}
-			//   (all cross-cars splits — same garage or different
-			//   garages — flip OUT.)
+			[]strfmt.UUID{idSpoiler205, idSpoilerPirelli},
 		)
 	})
 
@@ -21047,19 +20739,12 @@ func TestNestedFilteringIntraSubArrayOrCrossSubArrayAnd3Levels(t *testing.T) {
 			), note: "split across countries — L2 KEY"},
 		}
 
+		// All cross-cars splits — same garage, different garages,
+		// different countries — drop out.
 		runLevel(t, className, class,
 			"countries.garages.cars.accessories.type", "countries.garages.cars.tires.width", "countries.garages.cars.tires.brand",
 			docs,
-			// today
-			[]strfmt.UUID{
-				idSpoiler205, idSpoilerPirelli,
-				idSplitSpoilerVs205SameGarage, idSplitSpoilerVsPirelliSameGarage,
-				idSplitSpoilerVs205SplitGarages, idSplitSpoilerVs205SplitCountries,
-			},
-			// expected after position-level evaluation:
-			// []strfmt.UUID{idSpoiler205, idSpoilerPirelli}
-			//   (all cross-cars splits — same garage, different
-			//   garages, different countries — flip OUT.)
+			[]strfmt.UUID{idSpoiler205, idSpoilerPirelli},
 		)
 	})
 }

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -18895,8 +18895,8 @@ func TestNestedFilteringNotContextSensitivity3Levels(t *testing.T) {
 
 		// ctx2_AND_same_root_sibling — sibling at SAME root.
 		// Enclosing AND's LCA = cars[]. NOT inverts at cars[]
-		// (operand's natural LCA = enclosing LCA). Option A and
-		// Option B agree here.
+		// (operand's natural LCA = enclosing LCA). per-element inversion and
+		// universal-within-scope inversion agree here.
 		t.Run("ctx2_AND_same_root_sibling", func(t *testing.T) {
 			runScenario(t, andF(makeF(), notF(colorRedF())), want.andSameRoot)
 		})
@@ -18990,8 +18990,8 @@ func TestNestedFilteringNotContextSensitivity3Levels(t *testing.T) {
 			wantSet{
 				// ctx1 standalone — TODO aliszka:nested_filtering:
 				// locks in CURRENT root-universe NOT.
-				//   Option A: {d2,d4,d5,d6} — d6 in, d7 out.
-				//   Option B: {d2,d4,d5,d7} — same as today (no
+				//   per-element inversion: {d2,d4,d5,d6} — d6 in, d7 out.
+				//   universal-within-scope inversion: {d2,d4,d5,d7} — same as today (no
 				//             enclosing combinator).
 				standalone: []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idEmpty},
 				// ctx2 AND same-root — option A and option B agree:
@@ -19000,15 +19000,15 @@ func TestNestedFilteringNotContextSensitivity3Levels(t *testing.T) {
 				// ctx3 AND outer-scope — TODO aliszka:nested_filtering:
 				// locks in CURRENT docID-level NOT. THIS is the A vs B
 				// discriminator.
-				//   Option A: {d2,d4,d5,d6} — d6 in.
-				//   Option B: {d2,d4,d5} — same as today (enclosing
+				//   per-element inversion: {d2,d4,d5,d6} — d6 in.
+				//   universal-within-scope inversion: {d2,d4,d5} — same as today (enclosing
 				//             LCA = doc).
 				andOuterScope: []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue},
 				// ctx4 OR same-root — TODO aliszka:nested_filtering:
 				// locks in CURRENT root-universe NOT (top-level OR
 				// doesn't trigger scope-aware NOT yet).
-				//   Option A: {d1,d2,d4,d5,d6,d8} — d6 in, d7 out.
-				//   Option B: same as Option A (enclosing OR's LCA =
+				//   per-element inversion: {d1,d2,d4,d5,d6,d8} — d6 in, d7 out.
+				//   universal-within-scope inversion: same as per-element inversion (enclosing OR's LCA =
 				//             cars = operand LCA).
 				orSameRoot: []strfmt.UUID{idTesla2020Red, idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idMixed, idEmpty, idTesla2020RedOwnerBob},
 				// ctx5 mix — passes under today, option A, and option B.
@@ -19079,8 +19079,8 @@ func TestNestedFilteringNotContextSensitivity3Levels(t *testing.T) {
 			wantSet{
 				// ctx1 standalone — TODO aliszka:nested_filtering:
 				// locks in CURRENT root-universe NOT.
-				//   Option A: {d2,d4,d5,d6,d9}.
-				//   Option B: {d2,d4,d5,d7} — same as today.
+				//   per-element inversion: {d2,d4,d5,d6,d9}.
+				//   universal-within-scope inversion: {d2,d4,d5,d7} — same as today.
 				standalone: []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idEmpty},
 				// ctx2 AND same-root — option A and option B agree.
 				// idMixedSameGarage and idMixedSplitGarages flip in.
@@ -19088,13 +19088,13 @@ func TestNestedFilteringNotContextSensitivity3Levels(t *testing.T) {
 				// ctx3 AND outer-scope — TODO aliszka:nested_filtering:
 				// locks in CURRENT docID-level NOT. THIS is the A vs B
 				// discriminator.
-				//   Option A: {d2,d4,d5,d6,d9}.
-				//   Option B: {d2,d4,d5} — same as today.
+				//   per-element inversion: {d2,d4,d5,d6,d9}.
+				//   universal-within-scope inversion: {d2,d4,d5} — same as today.
 				andOuterScope: []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue},
 				// ctx4 OR same-root — TODO aliszka:nested_filtering:
 				// locks in CURRENT root-universe NOT.
-				//   Option A: {d1,d2,d4,d5,d6,d8,d9}.
-				//   Option B: same as Option A.
+				//   per-element inversion: {d1,d2,d4,d5,d6,d8,d9}.
+				//   universal-within-scope inversion: same as per-element inversion.
 				orSameRoot: []strfmt.UUID{idTesla2020Red, idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idMixedSameGarage, idEmpty, idTesla2020RedOwnerBob, idMixedSplitGarages},
 				// ctx5 mix — passes under today, option A, and option B.
 				andOrMix: []strfmt.UUID{idTesla2020Red, idTesla2020Blue, idTesla1990Blue, idMixedSameGarage, idTesla2020RedOwnerBob, idMixedSplitGarages},
@@ -19165,8 +19165,8 @@ func TestNestedFilteringNotContextSensitivity3Levels(t *testing.T) {
 			wantSet{
 				// ctx1 standalone — TODO aliszka:nested_filtering:
 				// locks in CURRENT root-universe NOT.
-				//   Option A: {d2,d4,d5,d6,d9,d10}.
-				//   Option B: {d2,d4,d5,d7} — same as today.
+				//   per-element inversion: {d2,d4,d5,d6,d9,d10}.
+				//   universal-within-scope inversion: {d2,d4,d5,d7} — same as today.
 				standalone: []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idEmpty},
 				// ctx2 AND same-root — option A and option B agree.
 				// All mixed-layout docs (same garage, split garages,
@@ -19175,13 +19175,13 @@ func TestNestedFilteringNotContextSensitivity3Levels(t *testing.T) {
 				// ctx3 AND outer-scope — TODO aliszka:nested_filtering:
 				// locks in CURRENT docID-level NOT. THIS is the A vs B
 				// discriminator.
-				//   Option A: {d2,d4,d5,d6,d9,d10}.
-				//   Option B: {d2,d4,d5} — same as today.
+				//   per-element inversion: {d2,d4,d5,d6,d9,d10}.
+				//   universal-within-scope inversion: {d2,d4,d5} — same as today.
 				andOuterScope: []strfmt.UUID{idTesla2020Blue, idBmw2020Blue, idTesla1990Blue},
 				// ctx4 OR same-root — TODO aliszka:nested_filtering:
 				// locks in CURRENT root-universe NOT.
-				//   Option A: {d1,d2,d4,d5,d6,d8,d9,d10}.
-				//   Option B: same as Option A.
+				//   per-element inversion: {d1,d2,d4,d5,d6,d8,d9,d10}.
+				//   universal-within-scope inversion: same as per-element inversion.
 				orSameRoot: []strfmt.UUID{idTesla2020Red, idTesla2020Blue, idBmw2020Blue, idTesla1990Blue, idMixedSameGarage, idEmpty, idTesla2020RedOwnerBob, idMixedSplitGarages, idMixedSplitCountries},
 				// ctx5 mix — passes under today, option A, and option B.
 				// Cross-country split docs flip alongside cross-garage

--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/weaviate/fgprof v0.0.1
 	github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2
 	github.com/weaviate/s5cmd/v2 v2.0.1
-	github.com/weaviate/sroar v0.0.14-0.20260425092300-c79995b0f0ba
+	github.com/weaviate/sroar v0.0.14-0.20260511125437-5d49ac3cb4c0
 	github.com/weaviate/tiktoken-go v0.0.3
 	go.etcd.io/bbolt v1.4.3
 	go.opentelemetry.io/otel v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -687,8 +687,8 @@ github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2 h1:lJpPgu+7Vx9K2
 github.com/weaviate/mockoidc v0.0.0-20250611114324-56bff60d94c2/go.mod h1:6cErcTSXUX3sGQEY+FQlxBztdlzVPoArKdMRNq6XKlE=
 github.com/weaviate/s5cmd/v2 v2.0.1 h1:NLsBemDEeUa1pcqVAGl5Y2quKH8EFpkz/Z8n4s620hg=
 github.com/weaviate/s5cmd/v2 v2.0.1/go.mod h1:JEoBF8SXVwK8qoaRKi0fPA4qi4OFmr+iVgc4XO3l/Zs=
-github.com/weaviate/sroar v0.0.14-0.20260425092300-c79995b0f0ba h1:ZVaa77mn6lSiMuHT3euZ/Xa7EinjJnB9iBi3CURyPC8=
-github.com/weaviate/sroar v0.0.14-0.20260425092300-c79995b0f0ba/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
+github.com/weaviate/sroar v0.0.14-0.20260511125437-5d49ac3cb4c0 h1:aQv9zppxi/PHT2StZoZBpBtZ8zQE9NnvFTuCixt2hPE=
+github.com/weaviate/sroar v0.0.14-0.20260511125437-5d49ac3cb4c0/go.mod h1:VgBRWPKPHRV/k9ABnD5w7QgdH9xe4RACzDzkrrK977g=
 github.com/weaviate/tiktoken-go v0.0.3 h1:05QrZ0un7zoGyLYBWVK4HuxVHfpdbbdRfQokvxBNtXg=
 github.com/weaviate/tiktoken-go v0.0.3/go.mod h1:u47qSckEGSi4sOcVJmUnd3xoHpDV9/5FDDi3KUCFUq4=
 github.com/willf/bitset v1.1.11 h1:N7Z7E9UvjW+sGsEl7k/SJrvY2reP1A07MrGuCjIOjRE=


### PR DESCRIPTION
### Nested object filtering — Part 15                                                                                   
                                                                                                                            
  Fifteenth PR in the nested object filtering series, building on Part 14 (regression baseline test sweep). Switches the   recursive executor to raw position bitmaps throughout, adds OR/NOT plan nodes, and extends same-element correlation across AND / OR / NOT / `Contains*` operator subtrees within a single nested root. Part 14's `regression_` baselines flip to their post-fix expected lists.                                                                                          

  **New `BitmapOps` wrappers**

  `OrAll(bitmaps)` clones the largest input as the accumulator. `CrossLeafCopresenceAll(bitmaps)` wraps a new sroar primitive reporting `(root, doc)` co-presence after zeroing leaf bits, with `zeroLeafBits` hardcoded. Requires a sroar dependency bump.                                                                                                          
                                                                                                                          
  **Plan tree and executor: raw outputs throughout**

  New `recOrNode` and `recNotNode` types; `lcaPath` field renamed to `lca` to free the `recPlanNode.lcaPath()` interface method. Every inner emitter drops trailing `MaskLeaf` and emits raw position bitmaps: `evalGroupRoot`, `evalFlatRawAndAll`, `matchElementRecursive` (now gathers raws + `CrossLeafCopresence` with empty short-circuit), `evalSplit` non-root branches, `evalNot` and `execute()` excludes (`AndNot raw vs raw` gives per-element NOT / IsNull semantics). `MaskRootLeaf` moves out of the executor; `resolveGroupRaw` is the single wrapper, composed by `resolveNestedCorrelatedGroup`. `evalOr` and `evalNot` are added and wired in.

  **Extraction: same-root operator subtrees**

  `groupNestedByProp` walks AND/OR/NOT subtrees and recognizes those where every reachable leaf shares one root prop. `normalizeRecGroup`'s new `fetchOperatorSubtreeBitmaps` pre-fetches raw bitmaps per leaf; the operator pvp goes into positives so the planner places it at its natural LCA. `extractPropValuePair` runs one post-order grouping pass over the tree, promoting collapsed AND-into-single-wrapper levels in place. Planner pushdown routes OR/NOT operator children to their natural-LCA subgroup; AND children unwrap via `flattenAndOperators`.

  **Top-level `ContainsAll` and naming**

  `ContainsAll`'s desugared AND now folds into a same-root subtree wrapper, giving same-element correlation across values. `ContainsAny` / `ContainsNone` stay ungrouped. `isCorrelated` is renamed to `isWithinRootSubtree` throughout — it marks any same-root nested subtree, not just a correlated AND.                                                                  
                                                                                                                          
  **Tests**

  Part 14's regression baselines flip across all three nesting levels (parenthesization collapse, AND-of-OR per-element, OR-in-AND variants, `ContainsAll` same-element, multi-NOT shapes, complex AND-of-OR). Each flip was hand-traced via position encoding. Final commit rewrites `position-level eval` → `position-level evaluation` in code comments.            
                                                                                                                          
  **Test plan**
  - [ ] `go test ./adapters/repos/db/inverted/...`
  - [ ] `go test -tags integrationTest ./adapters/repos/db/inverted/...`
  - [ ] `go test -tags integrationTest ./adapters/repos/db/...`