### PR TITLE
Nested object filtering — Part 17: Contains* operators as first-class on nested paths

### DIFF
--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -63,7 +63,7 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 		return pv.resolveNestedSubtree(ctx, s)
 	}
 
-	// Nested ContainsNone is a first-class operator (Route 1) with the
+	// Nested ContainsNone is a first-class operator (first-class-operator approach) with the
 	// scalar-array path on pv.nested.relPath. Dispatch BEFORE the isNested
 	// check because the ContainsNone wrapper itself is not a leaf — its
 	// children are the per-value pvps.

--- a/adapters/repos/db/inverted/prop_value_pairs.go
+++ b/adapters/repos/db/inverted/prop_value_pairs.go
@@ -63,6 +63,14 @@ func (pv *propValuePair) resolveDocIDs(ctx context.Context, s *Searcher, limit i
 		return pv.resolveNestedSubtree(ctx, s)
 	}
 
+	// Nested ContainsNone is a first-class operator (Route 1) with the
+	// scalar-array path on pv.nested.relPath. Dispatch BEFORE the isNested
+	// check because the ContainsNone wrapper itself is not a leaf — its
+	// children are the per-value pvps.
+	if pv.operator == filters.ContainsNone && pv.nested.relPath != "" {
+		return pv.fetchNestedContainsNone(ctx, s)
+	}
+
 	// All nested-specific dispatch: IsNull, value filters, and correlated AND
 	// are all routed here so nested logic stays out of the flat fetch path.
 	if pv.nested.isNested {

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -452,11 +452,13 @@ func (pv *propValuePair) fetchNestedExistsPositions(s *Searcher) (*sroar.Bitmap,
 // level in filter validation. Until that lands, unconstrained items in that
 // shape are silently dropped during plan construction.
 func (pv *propValuePair) resolveNestedSubtree(ctx context.Context, s *Searcher) (*docBitmap, error) {
-	if pv.operator == filters.OperatorOr || pv.operator == filters.OperatorNot {
+	if pv.operator == filters.OperatorOr || pv.operator == filters.OperatorNot ||
+		pv.operator == filters.ContainsAny {
 		// Single-group fast path: the planner's buildOrAtScope /
 		// buildNotAtScope handle per-child arr[N] pins internally;
 		// top-level partitioning would fan out into single-child groups
-		// and lose leaf bitmap references.
+		// and lose leaf bitmap references. ContainsAny is an OR alias
+		// under Route 1 — same path as OperatorOr.
 		return pv.resolveNestedSubtreeGroup(ctx, s, pv.children)
 	}
 

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -458,7 +458,7 @@ func (pv *propValuePair) resolveNestedSubtree(ctx context.Context, s *Searcher) 
 		// buildNotAtScope handle per-child arr[N] pins internally;
 		// top-level partitioning would fan out into single-child groups
 		// and lose leaf bitmap references. ContainsAny is an OR alias
-		// under Route 1 — same path as OperatorOr.
+		// under first-class-operator approach — same path as OperatorOr.
 		return pv.resolveNestedSubtreeGroup(ctx, s, pv.children)
 	}
 

--- a/adapters/repos/db/inverted/prop_value_pairs_nested.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested.go
@@ -160,6 +160,145 @@ func (pv *propValuePair) fetchNestedIsNull(s *Searcher) (*docBitmap, error) {
 	return &docBitmap{docIDs: docIDs, release: docIDsRel}, nil
 }
 
+// fetchNestedContainsNone resolves a ContainsNone filter on a nested
+// scalar-array path (text[], int[], etc.) or single-value scalar. Strict
+// existential semantics: a doc matches iff ∃ a position at the operand's
+// path whose value is NOT in the listed set.
+//
+// Implementation: read `_exists.{relPath}` as the universe (restricted by
+// any arr[N] pins on this pv); compute operand = OR over each value's
+// bitmap (with multi-token text values AndAll'd through their tokenization
+// wrapper child); strict-existential = universe AndNot operand; strip to
+// docIDs.
+//
+// The universe is the operand's own scalar-array path — `_exists.tags` for
+// `country.tags`, never `_exists.""`. This means sibling-branch leaves
+// (e.g. `cities`) and phantom leaves from empty containers cannot leak
+// through the AndNot.
+func (pv *propValuePair) fetchNestedContainsNone(ctx context.Context, s *Searcher) (*docBitmap, error) {
+	metaBucket := s.store.Bucket(helpers.BucketNestedMetaFromPropNameLSM(pv.prop))
+	if metaBucket == nil {
+		return nil, errors.Errorf("nested ContainsNone: meta bucket for %q not found", pv.prop)
+	}
+	if len(pv.children) == 0 {
+		return nil, errors.Errorf("nested ContainsNone: no values for %q", pv.prop)
+	}
+
+	operand, operandRel, err := pv.collectNestedContainsOperand(ctx, s)
+	if err != nil {
+		return nil, err
+	}
+	defer operandRel()
+
+	universeRaw, universeRel, err := metaBucket.RoaringSetGet(invnested.ExistsKey(pv.nested.relPath))
+	if err != nil {
+		return nil, fmt.Errorf("nested ContainsNone: read exists key for %q: %w", pv.nested.relPath, err)
+	}
+	universe, err := pv.restrictByNestedIdx(s, &docBitmap{docIDs: universeRaw, release: universeRel})
+	if err != nil {
+		return nil, err
+	}
+	defer universe.release()
+
+	positive, positiveRel := s.nestedBitmapOps.AndNot(universe.docIDs, operand, concurrency.SROAR_MERGE)
+	defer positiveRel()
+
+	docIDs, docIDsRel := s.nestedBitmapOps.MaskRootLeaf(positive)
+	return &docBitmap{docIDs: docIDs, release: docIDsRel}, nil
+}
+
+// collectNestedContainsOperand fetches each ContainsNone child's position
+// bitmap and OR-s them. Children come from extractContains and are either:
+//
+//   - Single-token value leaves (`isNested=true`, `operator=Equal`): one
+//     fetchNestedPositions read.
+//   - Tokenization wrappers (`childrenFromTokenization=true`): AndAll over
+//     grandchildren tokens so all tokens land on the same leaf (multi-token
+//     text value semantics).
+//
+// Returns a borrowed bitmap and a release that cleans up all intermediates.
+func (pv *propValuePair) collectNestedContainsOperand(ctx context.Context, s *Searcher) (*sroar.Bitmap, func(), error) {
+	releases := make([]func(), 0, len(pv.children))
+	cleanup := func() {
+		for _, rel := range releases {
+			rel()
+		}
+	}
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			cleanup()
+		}
+	}()
+
+	perValue := make([]*sroar.Bitmap, 0, len(pv.children))
+	for _, child := range pv.children {
+		bm, rel, err := pv.fetchContainsChildBitmap(ctx, s, child)
+		if err != nil {
+			return nil, nil, err
+		}
+		releases = append(releases, rel)
+		perValue = append(perValue, bm)
+	}
+
+	if len(perValue) == 1 {
+		succeeded = true
+		return perValue[0], cleanup, nil
+	}
+	or, orRel := s.nestedBitmapOps.OrAll(perValue, concurrency.SROAR_MERGE)
+	releases = append(releases, orRel)
+	succeeded = true
+	return or, cleanup, nil
+}
+
+// fetchContainsChildBitmap returns the position bitmap for one ContainsNone
+// child value. Multi-token values (childrenFromTokenization=true) AndAll
+// their grandchildren tokens so all tokens of the same value land on the
+// same leaf.
+func (pv *propValuePair) fetchContainsChildBitmap(ctx context.Context, s *Searcher, child *propValuePair) (*sroar.Bitmap, func(), error) {
+	if child.nested.childrenFromTokenization {
+		if len(child.children) == 0 {
+			return nil, nil, errors.Errorf("nested ContainsNone: tokenization wrapper with no tokens for %q", pv.prop)
+		}
+		tokenBitmaps := make([]*sroar.Bitmap, 0, len(child.children))
+		releases := make([]func(), 0, len(child.children))
+		succeeded := false
+		defer func() {
+			if !succeeded {
+				for _, rel := range releases {
+					rel()
+				}
+			}
+		}()
+		for _, gc := range child.children {
+			dbm, err := gc.fetchNestedPositions(ctx, s, 0)
+			if err != nil {
+				return nil, nil, err
+			}
+			tokenBitmaps = append(tokenBitmaps, dbm.docIDs)
+			releases = append(releases, dbm.release)
+		}
+		if len(tokenBitmaps) == 1 {
+			succeeded = true
+			return tokenBitmaps[0], releases[0], nil
+		}
+		anded, andedRel := s.nestedBitmapOps.AndAll(tokenBitmaps, concurrency.SROAR_MERGE)
+		releases = append(releases, andedRel)
+		cleanup := func() {
+			for _, rel := range releases {
+				rel()
+			}
+		}
+		succeeded = true
+		return anded, cleanup, nil
+	}
+	dbm, err := child.fetchNestedPositions(ctx, s, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	return dbm.docIDs, dbm.release, nil
+}
+
 // isNullOperandLCA returns the operand's natural LCA for an IS NULL filter on
 // a sub-property (pv.nested.relPath != ""). Result is the deepest object[]
 // segment strictly above relPath, or "" if the field is at the top level of

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
@@ -150,7 +150,7 @@ func normalizeRecGroup(
 		case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot,
 			filters.ContainsAll, filters.ContainsAny:
 			// ContainsAll / ContainsAny are AND / OR aliases on nested
-			// paths (Route 1); same fetch path as OperatorAnd/Or — the
+			// paths (first-class-operator approach); same fetch path as OperatorAnd/Or — the
 			// planner reads them as operator subtrees and either flattens
 			// (ContainsAll → AND) or plans an OR scope (ContainsAny).
 			if err := fetchOperatorSubtreeBitmaps(ctx, child, fetcher, bitmapOps, maxConcurrency, input); err != nil {
@@ -339,7 +339,7 @@ func fetchOperatorSubtreeBitmaps(
 	switch node.operator {
 	case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot,
 		filters.ContainsAll, filters.ContainsAny:
-		// ContainsAll / ContainsAny treated as AND / OR aliases (Route 1).
+		// ContainsAll / ContainsAny treated as AND / OR aliases (first-class-operator approach).
 		for _, child := range node.children {
 			if err := fetchOperatorSubtreeBitmaps(ctx, child, fetcher, bitmapOps, maxConcurrency, input); err != nil {
 				return err

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
@@ -147,7 +147,12 @@ func normalizeRecGroup(
 			continue
 		}
 		switch child.operator {
-		case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot:
+		case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot,
+			filters.ContainsAll, filters.ContainsAny:
+			// ContainsAll / ContainsAny are AND / OR aliases on nested
+			// paths (Route 1); same fetch path as OperatorAnd/Or — the
+			// planner reads them as operator subtrees and either flattens
+			// (ContainsAll → AND) or plans an OR scope (ContainsAny).
 			if err := fetchOperatorSubtreeBitmaps(ctx, child, fetcher, bitmapOps, maxConcurrency, input); err != nil {
 				return nil, err
 			}
@@ -332,7 +337,9 @@ func fetchOperatorSubtreeBitmaps(
 		return nil
 	}
 	switch node.operator {
-	case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot:
+	case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot,
+		filters.ContainsAll, filters.ContainsAny:
+		// ContainsAll / ContainsAny treated as AND / OR aliases (Route 1).
 		for _, child := range node.children {
 			if err := fetchOperatorSubtreeBitmaps(ctx, child, fetcher, bitmapOps, maxConcurrency, input); err != nil {
 				return err
@@ -461,12 +468,12 @@ func (pv *propValuePair) buildRecGroupExecutor(
 	// Dispatch on outer operator. Wrapping for all shapes is decided
 	// at extraction time by groupNestedSubtrees; here we just plant
 	// the right plan node.
-	//   AND-of-same-root → recGroupNode (same-element correlation).
-	//   OR-of-same-root → recOrNode (union at deepest common LCA).
-	//   NOT-of-same-root → recNotNode (invert at operand LCA).
+	//   AND / ContainsAll → recGroupNode (same-element correlation).
+	//   OR / ContainsAny  → recOrNode (union at deepest common LCA).
+	//   NOT               → recNotNode (invert at operand LCA).
 	var plan recPlanNode
 	switch pv.operator {
-	case filters.OperatorOr:
+	case filters.OperatorOr, filters.ContainsAny:
 		plan = builder.buildOrAtScope(pv, "")
 	case filters.OperatorNot:
 		plan = builder.buildNotAtScope(pv, "")

--- a/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
+++ b/adapters/repos/db/inverted/prop_value_pairs_nested_recursive.go
@@ -152,6 +152,18 @@ func normalizeRecGroup(
 				return nil, err
 			}
 			input.positives = append(input.positives, child)
+		case filters.ContainsNone:
+			// First-class ContainsNone inside a correlated AND. Materialize
+			// the strict-existential result (universe at operand path AndNot
+			// OR-of-value-bitmaps) as a raw position bitmap, stored in
+			// rawsByCond keyed by the ContainsNone pvp. The planner places
+			// the pvp at its natural LCA (via childRelPath → operand path)
+			// and the executor correlates it with sibling leaves at root
+			// scope via the existing same-element AndAll path.
+			if err := materializeNestedContainsNone(ctx, child, fetcher, bitmapOps, maxConcurrency, input); err != nil {
+				return nil, err
+			}
+			input.positives = append(input.positives, child)
 		default:
 			return nil, fmt.Errorf("normalizeRecGroup: unsupported non-nested child operator %q", child.operator.Name())
 		}
@@ -159,6 +171,69 @@ func normalizeRecGroup(
 
 	succeeded = true
 	return input, nil
+}
+
+// materializeNestedContainsNone computes a ContainsNone leaf's strict-
+// existential bitmap for use inside a correlated AND or operator subtree.
+// Mirrors fetchNestedContainsNone's algorithm but builds the result inline
+// against the recBitmapFetcher abstraction so it composes with the rest of
+// normalizeRecGroup. Children may be value leaves or tokenization wrappers
+// (multi-token text values).
+func materializeNestedContainsNone(
+	ctx context.Context,
+	pv *propValuePair,
+	fetcher recBitmapFetcher,
+	bitmapOps *invnested.BitmapOps,
+	maxConcurrency int,
+	input *recGroupInput,
+) error {
+	if len(pv.children) == 0 {
+		return fmt.Errorf("materializeNestedContainsNone: no values for %q", pv.prop)
+	}
+
+	// Operand: OR over each forbidden value's position bitmap. Multi-token
+	// text values AndAll their tokens at the leaf level (same as standalone
+	// fetchNestedContainsNone) before contributing to the OR.
+	perValue := make([]*sroar.Bitmap, 0, len(pv.children))
+	for _, child := range pv.children {
+		if child.nested.childrenFromTokenization {
+			combined, releases, err := fetchAndAndAllTokens(ctx, child.children, fetcher, bitmapOps, maxConcurrency)
+			if err != nil {
+				return fmt.Errorf("materializeNestedContainsNone: tokens for %q: %w", pv.prop, err)
+			}
+			input.releases = append(input.releases, releases...)
+			perValue = append(perValue, combined)
+			continue
+		}
+		bm, rel, err := fetcher.fetchValue(ctx, child)
+		if err != nil {
+			return fmt.Errorf("materializeNestedContainsNone: fetch value for %q: %w", pv.prop, err)
+		}
+		input.releases = append(input.releases, rel)
+		perValue = append(perValue, bm)
+	}
+
+	var operand *sroar.Bitmap
+	if len(perValue) == 1 {
+		operand = perValue[0]
+	} else {
+		var operandRel func()
+		operand, operandRel = bitmapOps.OrAll(perValue, maxConcurrency)
+		input.releases = append(input.releases, operandRel)
+	}
+
+	// Universe at the operand's scalar-array scope, restricted by any
+	// arr[N] pins carried on the ContainsNone pvp itself.
+	universe, universeRel, err := fetcher.fetchExistsAtPath(pv, pv.nested.relPath)
+	if err != nil {
+		return fmt.Errorf("materializeNestedContainsNone: fetch exists at %q: %w", pv.nested.relPath, err)
+	}
+	input.releases = append(input.releases, universeRel)
+
+	result, resultRel := bitmapOps.AndNot(universe, operand, maxConcurrency)
+	input.releases = append(input.releases, resultRel)
+	input.rawsByCond[pv] = result
+	return nil
 }
 
 // routeDirectLeaf classifies a single isNested child and appends to the right
@@ -264,6 +339,11 @@ func fetchOperatorSubtreeBitmaps(
 			}
 		}
 		return nil
+	case filters.ContainsNone:
+		// First-class ContainsNone inside an operator subtree (OR/NOT/AND).
+		// Materialize the strict-existential bitmap inline, same as the
+		// correlated-AND child case in normalizeRecGroup.
+		return materializeNestedContainsNone(ctx, node, fetcher, bitmapOps, maxConcurrency, input)
 	default:
 		return fmt.Errorf("normalizeRecGroup: unsupported node in operator subtree (operator=%q, isNested=%v)", node.operator.Name(), node.nested.isNested)
 	}

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -386,7 +386,7 @@ func groupNestedSubtrees(pv *propValuePair, class *models.Class) *propValuePair 
 	switch pv.operator {
 	case filters.OperatorAnd, filters.OperatorOr, filters.ContainsAll, filters.ContainsAny:
 		// ContainsAll / ContainsAny are AND / OR aliases on a nested path
-		// (Route 1 — operator identity preserved by extractContains).
+		// (first-class-operator approach — operator identity preserved by extractContains).
 		grouped := groupNestedByProp(pv.children, class, pv.operator)
 		if len(grouped) == 1 && grouped[0].nested.isWithinRootSubtree {
 			// Collapse: every child landed in one same-root wrapper.
@@ -1007,7 +1007,7 @@ func (s *Searcher) extractContains(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	// Route 1: on a nested path each Contains* operator keeps its operator
+	// first-class-operator approach: on a nested path each Contains* operator keeps its operator
 	// identity instead of desugaring to AND / OR / NOT(OR). Downstream
 	// switches treat ContainsAll as an AND alias and ContainsAny as an OR
 	// alias; ContainsNone has dedicated dispatch (a first-class resolver

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -1012,9 +1012,9 @@ func (s *Searcher) extractContains(ctx context.Context,
 	// switches treat ContainsAll as an AND alias and ContainsAny as an OR
 	// alias; ContainsNone has dedicated dispatch (a first-class resolver
 	// that reads `_exists.{relPath}` as the inversion universe so sibling-
-	// branch leaves and phantom leaves cannot leak through the AndNot —
-	// see project_containsnone_universe_leak.md). Non-nested (flat) paths
-	// keep the old desugared shapes which the flat resolver handles.
+	// branch leaves and phantom leaves cannot leak through the AndNot).
+	// Non-nested (flat) paths keep the old desugared shapes which the flat
+	// resolver handles.
 	out, err := newPropValuePair(class)
 	if err != nil {
 		return nil, fmt.Errorf("new prop value pair: %w", err)
@@ -1023,7 +1023,13 @@ func (s *Searcher) extractContains(ctx context.Context,
 	out.children = children
 	out.Class = class
 
-	nested := len(children) > 0 && children[0].nested.isNested
+	// Nested detection covers both direct leaves (isNested=true) and tokenization
+	// wrappers produced by buildNestedTextFilterPair for multi-token text values
+	// (isWithinRootSubtree=true, childrenFromTokenization=true, isNested=false).
+	// Without the isWithinRootSubtree branch, a nested ContainsAll/Any/None on a
+	// multi-token text value would misclassify as non-nested and lose operator
+	// identity / reintroduce the ContainsNone universe-leak.
+	nested := len(children) > 0 && (children[0].nested.isNested || children[0].nested.isWithinRootSubtree)
 
 	switch operator {
 	case filters.ContainsAll:

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -1009,6 +1009,15 @@ func (s *Searcher) extractContains(ctx context.Context,
 	// the outermost extractPropValuePair wrapper normalizes via
 	// groupNestedByProp; ContainsAny / ContainsNone desugar to OR /
 	// NOT(OR) which the wrapper deliberately leaves ungrouped.
+	//
+	// Route 1 exception: ContainsNone on a nested path keeps its operator
+	// identity instead of desugaring to NOT(OR(...)). This preserves the
+	// scalar-array operand path on the pvp so the resolver / planner can
+	// use `_exists.{relPath}` as the inversion universe (rather than
+	// `_exists.{LCA}` which falls through to the root prop when the path
+	// has no DataTypeObjectArray ancestor). Without this, sibling-branch
+	// leaves and phantom leaves from empty containers leak past the AndNot
+	// — see project_containsnone_universe_leak.md.
 	out, err := newPropValuePair(class)
 	if err != nil {
 		return nil, fmt.Errorf("new prop value pair: %w", err)
@@ -1023,6 +1032,19 @@ func (s *Searcher) extractContains(ctx context.Context,
 	case filters.ContainsAny:
 		out.operator = filters.OperatorOr
 	case filters.ContainsNone:
+		if len(children) > 0 && children[0].nested.isNested {
+			// Nested path: keep ContainsNone as a first-class operator. The
+			// pvp carries the operand relPath (from the children, which all
+			// share it by construction) and the children list as values.
+			out.operator = filters.ContainsNone
+			out.prop = children[0].prop
+			out.nested.relPath = children[0].nested.relPath
+			// Note: out.nested.isNested stays false — this is a compound
+			// operator node, not a leaf; the value-leaves live as children.
+			return out, nil
+		}
+		// Non-nested path: keep the desugared NOT(OR(...)) shape. The
+		// existing flat resolver handles it.
 		out.operator = filters.OperatorOr
 
 		parent, err := newPropValuePair(class)

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -1039,6 +1039,11 @@ func (s *Searcher) extractContains(ctx context.Context,
 			out.operator = filters.ContainsNone
 			out.prop = children[0].prop
 			out.nested.relPath = children[0].nested.relPath
+			// arr[N] pins are propagated from any child — all children of a
+			// single ContainsNone clause share the same pins by construction
+			// (extracted from the same Path). The resolver uses them to
+			// restrict the `_exists.{relPath}` universe lookup.
+			out.nested.arrayIndices = children[0].nested.arrayIndices
 			// Note: out.nested.isNested stays false — this is a compound
 			// operator node, not a leaf; the value-leaves live as children.
 			return out, nil

--- a/adapters/repos/db/inverted/searcher.go
+++ b/adapters/repos/db/inverted/searcher.go
@@ -384,13 +384,15 @@ func groupNestedSubtrees(pv *propValuePair, class *models.Class) *propValuePair 
 		return pv
 	}
 	switch pv.operator {
-	case filters.OperatorAnd, filters.OperatorOr:
+	case filters.OperatorAnd, filters.OperatorOr, filters.ContainsAll, filters.ContainsAny:
+		// ContainsAll / ContainsAny are AND / OR aliases on a nested path
+		// (Route 1 — operator identity preserved by extractContains).
 		grouped := groupNestedByProp(pv.children, class, pv.operator)
 		if len(grouped) == 1 && grouped[0].nested.isWithinRootSubtree {
 			// Collapse: every child landed in one same-root wrapper.
 			// Promote pv to be that wrapper instead of holding it as a
 			// useless single-child outer node. pv keeps its operator
-			// (AND or OR), so the planner sees the right shape.
+			// (AND/OR or ContainsAll/Any), so the planner sees the right shape.
 			w := grouped[0]
 			pv.nested.isWithinRootSubtree = true
 			pv.prop = w.prop
@@ -1005,19 +1007,14 @@ func (s *Searcher) extractContains(ctx context.Context,
 	if err != nil {
 		return nil, err
 	}
-	// No same-root grouping here. ContainsAll desugars to an AND that
-	// the outermost extractPropValuePair wrapper normalizes via
-	// groupNestedByProp; ContainsAny / ContainsNone desugar to OR /
-	// NOT(OR) which the wrapper deliberately leaves ungrouped.
-	//
-	// Route 1 exception: ContainsNone on a nested path keeps its operator
-	// identity instead of desugaring to NOT(OR(...)). This preserves the
-	// scalar-array operand path on the pvp so the resolver / planner can
-	// use `_exists.{relPath}` as the inversion universe (rather than
-	// `_exists.{LCA}` which falls through to the root prop when the path
-	// has no DataTypeObjectArray ancestor). Without this, sibling-branch
-	// leaves and phantom leaves from empty containers leak past the AndNot
-	// — see project_containsnone_universe_leak.md.
+	// Route 1: on a nested path each Contains* operator keeps its operator
+	// identity instead of desugaring to AND / OR / NOT(OR). Downstream
+	// switches treat ContainsAll as an AND alias and ContainsAny as an OR
+	// alias; ContainsNone has dedicated dispatch (a first-class resolver
+	// that reads `_exists.{relPath}` as the inversion universe so sibling-
+	// branch leaves and phantom leaves cannot leak through the AndNot —
+	// see project_containsnone_universe_leak.md). Non-nested (flat) paths
+	// keep the old desugared shapes which the flat resolver handles.
 	out, err := newPropValuePair(class)
 	if err != nil {
 		return nil, fmt.Errorf("new prop value pair: %w", err)
@@ -1026,13 +1023,34 @@ func (s *Searcher) extractContains(ctx context.Context,
 	out.children = children
 	out.Class = class
 
+	nested := len(children) > 0 && children[0].nested.isNested
+
 	switch operator {
 	case filters.ContainsAll:
+		if nested {
+			// Single-value Contains is semantically the bare Equal leaf;
+			// return it directly so we don't end up with an unwrapped
+			// ContainsAll compound (which groupNestedSubtrees can't promote
+			// to isWithinRootSubtree and resolveDocIDs would route through
+			// fetchDocIDs on an empty prop).
+			if len(children) == 1 {
+				return children[0], nil
+			}
+			out.operator = filters.ContainsAll
+			return out, nil
+		}
 		out.operator = filters.OperatorAnd
 	case filters.ContainsAny:
+		if nested {
+			if len(children) == 1 {
+				return children[0], nil
+			}
+			out.operator = filters.ContainsAny
+			return out, nil
+		}
 		out.operator = filters.OperatorOr
 	case filters.ContainsNone:
-		if len(children) > 0 && children[0].nested.isNested {
+		if nested {
 			// Nested path: keep ContainsNone as a first-class operator. The
 			// pvp carries the operand relPath (from the children, which all
 			// share it by construction) and the children list as values.

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -228,7 +228,7 @@ func nestedRootProp(child *propValuePair) string {
 	case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot,
 		filters.ContainsAll, filters.ContainsAny:
 		// ContainsAll / ContainsAny are AND / OR aliases on a nested path
-		// (Route 1 — operator identity preserved by extractContains).
+		// (first-class-operator approach — operator identity preserved by extractContains).
 		if len(child.children) == 0 {
 			return ""
 		}

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -138,7 +138,22 @@ func (s *Searcher) buildNestedTextFilterPair(filter *filters.Clause, propName, f
 	case 1:
 		return pvps[0], nil
 	default:
-		return &propValuePair{operator: filters.OperatorAnd, children: pvps, nested: nestedInfo{isWithinRootSubtree: true, childrenFromTokenization: true}, prop: propName, Class: class}, nil
+		// Propagate relPath and arrayIndices onto the wrapper so callers that
+		// inspect the wrapper directly (e.g. extractContains' first-class
+		// ContainsNone path) see the same operand metadata as the inner
+		// per-token leaves.
+		return &propValuePair{
+			operator: filters.OperatorAnd,
+			children: pvps,
+			nested: nestedInfo{
+				isWithinRootSubtree:      true,
+				childrenFromTokenization: true,
+				relPath:                  relPath,
+				arrayIndices:             arrayIndices,
+			},
+			prop:  propName,
+			Class: class,
+		}, nil
 	}
 }
 
@@ -226,9 +241,13 @@ func nestedRootProp(child *propValuePair) string {
 	}
 	switch child.operator {
 	case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot,
-		filters.ContainsAll, filters.ContainsAny:
-		// ContainsAll / ContainsAny are AND / OR aliases on a nested path
-		// (first-class-operator approach — operator identity preserved by extractContains).
+		filters.ContainsAll, filters.ContainsAny, filters.ContainsNone:
+		// ContainsAll / ContainsAny / ContainsNone are AND / OR / NOT(OR) aliases
+		// on a nested path (first-class-operator approach — operator identity
+		// preserved by extractContains). Including ContainsNone here lets
+		// groupNestedByProp same-root-wrap `AND(name=…, ContainsNone(tags,…))`
+		// so the correlated-AND path enforces same-element semantics across
+		// the two predicates.
 		if len(child.children) == 0 {
 			return ""
 		}

--- a/adapters/repos/db/inverted/searcher_nested.go
+++ b/adapters/repos/db/inverted/searcher_nested.go
@@ -225,7 +225,10 @@ func nestedRootProp(child *propValuePair) string {
 		return child.prop
 	}
 	switch child.operator {
-	case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot:
+	case filters.OperatorAnd, filters.OperatorOr, filters.OperatorNot,
+		filters.ContainsAll, filters.ContainsAny:
+		// ContainsAll / ContainsAny are AND / OR aliases on a nested path
+		// (Route 1 — operator identity preserved by extractContains).
 		if len(child.children) == 0 {
 			return ""
 		}

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
@@ -195,7 +195,7 @@ func (b *recPlanBuilder) buildGroup(items []*propValuePair, scope string) recPla
 	for _, it := range items {
 		switch it.operator {
 		case filters.OperatorOr, filters.OperatorNot, filters.ContainsAny:
-			// ContainsAny is an OR alias on a nested path (Route 1).
+			// ContainsAny is an OR alias on a nested path (first-class-operator approach).
 			lca := b.naturalLCA(it)
 			if lca == scope {
 				if it.operator == filters.OperatorOr || it.operator == filters.ContainsAny {
@@ -250,7 +250,7 @@ func (b *recPlanBuilder) buildGroup(items []*propValuePair, scope string) recPla
 // flattenAndOperators unwraps non-tokenization AND wrappers in items. AND is
 // associative, so `[A, AND(B, C)]` is logically the same as `[A, B, C]` and
 // the planner can treat them identically. ContainsAll is treated as an AND
-// alias here under Route 1 — its semantics is identical to AND-of-values-
+// alias here under first-class-operator approach — its semantics is identical to AND-of-values-
 // at-same-element, so unwrapping puts its value leaves at the same scope as
 // sibling conditions. Tokenization wrappers (childrenFromTokenization=true)
 // are NOT unwrapped — they behave as single virtual leaves at normalize time.

--- a/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
+++ b/adapters/repos/db/inverted/searcher_nested_plan_recursive.go
@@ -194,10 +194,11 @@ func (b *recPlanBuilder) buildGroup(items []*propValuePair, scope string) recPla
 	var operatorSubs []recPlanNode
 	for _, it := range items {
 		switch it.operator {
-		case filters.OperatorOr, filters.OperatorNot:
+		case filters.OperatorOr, filters.OperatorNot, filters.ContainsAny:
+			// ContainsAny is an OR alias on a nested path (Route 1).
 			lca := b.naturalLCA(it)
 			if lca == scope {
-				if it.operator == filters.OperatorOr {
+				if it.operator == filters.OperatorOr || it.operator == filters.ContainsAny {
 					operatorSubs = append(operatorSubs, b.buildOrAtScope(it, scope))
 				} else {
 					operatorSubs = append(operatorSubs, b.buildNotAtScope(it, scope))
@@ -248,13 +249,15 @@ func (b *recPlanBuilder) buildGroup(items []*propValuePair, scope string) recPla
 
 // flattenAndOperators unwraps non-tokenization AND wrappers in items. AND is
 // associative, so `[A, AND(B, C)]` is logically the same as `[A, B, C]` and
-// the planner can treat them identically. Tokenization wrappers
-// (childrenFromTokenization=true) are NOT unwrapped — they behave as single
-// virtual leaves at normalize time.
+// the planner can treat them identically. ContainsAll is treated as an AND
+// alias here under Route 1 — its semantics is identical to AND-of-values-
+// at-same-element, so unwrapping puts its value leaves at the same scope as
+// sibling conditions. Tokenization wrappers (childrenFromTokenization=true)
+// are NOT unwrapped — they behave as single virtual leaves at normalize time.
 func flattenAndOperators(items []*propValuePair) []*propValuePair {
 	hasFlattenable := false
 	for _, it := range items {
-		if it.operator == filters.OperatorAnd && !it.nested.childrenFromTokenization && !it.nested.isNested {
+		if isAndFlattenable(it) {
 			hasFlattenable = true
 			break
 		}
@@ -264,13 +267,25 @@ func flattenAndOperators(items []*propValuePair) []*propValuePair {
 	}
 	out := make([]*propValuePair, 0, len(items))
 	for _, it := range items {
-		if it.operator == filters.OperatorAnd && !it.nested.childrenFromTokenization && !it.nested.isNested {
+		if isAndFlattenable(it) {
 			out = append(out, flattenAndOperators(it.children)...)
 			continue
 		}
 		out = append(out, it)
 	}
 	return out
+}
+
+// isAndFlattenable reports whether it is a non-leaf AND-shaped operator
+// wrapper that can be inlined into its parent. OperatorAnd and ContainsAll
+// share AND semantics (same-element at LCA). Tokenization wrappers
+// (childrenFromTokenization=true) stay intact — they collapse to a single
+// virtual leaf during normalization.
+func isAndFlattenable(it *propValuePair) bool {
+	if it.nested.childrenFromTokenization || it.nested.isNested {
+		return false
+	}
+	return it.operator == filters.OperatorAnd || it.operator == filters.ContainsAll
 }
 
 // naturalLCA returns the deepest LCA at which all leaves of pv's subtree

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -567,14 +567,13 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		assert.True(t, pv.children[0].nested.isNested)
 	})
 
-	t.Run("top-level ContainsNone wraps both NOT and inner OR", func(t *testing.T) {
+	t.Run("top-level nested ContainsNone is a first-class operator", func(t *testing.T) {
 		// input:  ContainsNone(nested.numbers, [1, 2])
-		// output (NOT(OR) — inner OR same-root wraps under OR-of-same-root wrapping
-		// and outer NOT same-root operand wraps under top-level NOT wrapping):
-		// └── NOT {isWRS:nested}
-		//     └── OR {isWRS:nested}
-		//         ├── numbers=1
-		//         └── numbers=2
+		// output (Route 1: no desugar to NOT(OR), single ContainsNone pvp
+		// carrying the operand relPath and the per-value children):
+		// └── ContainsNone {prop:nested, relPath:numbers}
+		//     ├── numbers=1
+		//     └── numbers=2
 		clause := &filters.Clause{
 			Operator: filters.ContainsNone,
 			Value:    &filters.Value{Type: schema.DataTypeIntArray, Value: []int{1, 2}},
@@ -583,16 +582,18 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		pv, err := s.extractPropValuePair(t.Context(), clause, "Article")
 		require.NoError(t, err)
 
-		assert.Equal(t, filters.OperatorNot, pv.operator)
-		assert.True(t, pv.nested.isWithinRootSubtree, "outer NOT wraps under top-level NOT wrapping")
+		assert.Equal(t, filters.ContainsNone, pv.operator,
+			"nested ContainsNone preserves operator identity (Route 1)")
 		assert.Equal(t, "nested", pv.prop)
-		require.Len(t, pv.children, 1)
-
-		inner := pv.children[0]
-		assert.Equal(t, filters.OperatorOr, inner.operator)
-		assert.True(t, inner.nested.isWithinRootSubtree, "inner OR same-root wraps")
-		assert.Equal(t, "nested", inner.prop)
-		require.Len(t, inner.children, 2)
+		assert.Equal(t, "numbers", pv.nested.relPath,
+			"operand path carried on the wrapper so the resolver / planner can read _exists.numbers as universe")
+		assert.False(t, pv.nested.isNested, "compound operator node, not a leaf")
+		assert.False(t, pv.nested.isWithinRootSubtree, "not a same-root AND group")
+		require.Len(t, pv.children, 2, "one child per forbidden value")
+		for _, child := range pv.children {
+			assert.True(t, child.nested.isNested)
+			assert.Equal(t, "numbers", child.nested.relPath)
+		}
 	})
 
 	t.Run("ContainsAny inside AND wraps both levels", func(t *testing.T) {

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -525,8 +525,10 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 
 	t.Run("top-level ContainsAll on int[] collapses to same-root wrapper", func(t *testing.T) {
 		// input:  ContainsAll(nested.numbers, [1, 2])
-		// output:
-		// └── AND {isWRS:nested}    ← desugared AND collapsed
+		// output (Route 1: operator identity preserved; same-root wrapping
+		// still collapses since ContainsAll is treated as an AND alias by
+		// groupNestedSubtrees / planner):
+		// └── ContainsAll {isWRS:nested}
 		//     ├── numbers=1
 		//     └── numbers=2
 		clause := &filters.Clause{
@@ -537,8 +539,9 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		pv, err := s.extractPropValuePair(t.Context(), clause, "Article")
 		require.NoError(t, err)
 
-		assert.Equal(t, filters.OperatorAnd, pv.operator)
-		assert.True(t, pv.nested.isWithinRootSubtree, "ContainsAll's AND collapses into a wrapper")
+		assert.Equal(t, filters.ContainsAll, pv.operator,
+			"nested ContainsAll preserves operator identity (Route 1)")
+		assert.True(t, pv.nested.isWithinRootSubtree, "ContainsAll same-root wraps")
 		assert.Equal(t, "nested", pv.prop)
 		require.Len(t, pv.children, 2)
 		assert.True(t, pv.children[0].nested.isNested)
@@ -547,9 +550,10 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 
 	t.Run("top-level ContainsAny collapses to same-root OR wrapper", func(t *testing.T) {
 		// input:  ContainsAny(nested.numbers, [1, 2])
-		// output (desugared OR collapses under OR-of-same-root wrapping; OR-of-same-root
-		// wraps so the planner evaluates per-element at the nested LCA):
-		// └── OR {isWRS:nested}
+		// output (Route 1: operator identity preserved; same-root wrapping
+		// still collapses since ContainsAny is treated as an OR alias by
+		// groupNestedSubtrees / planner):
+		// └── ContainsAny {isWRS:nested}
 		//     ├── numbers=1
 		//     └── numbers=2
 		clause := &filters.Clause{
@@ -560,11 +564,50 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		pv, err := s.extractPropValuePair(t.Context(), clause, "Article")
 		require.NoError(t, err)
 
-		assert.Equal(t, filters.OperatorOr, pv.operator)
-		assert.True(t, pv.nested.isWithinRootSubtree, "ContainsAny's OR same-root wraps")
+		assert.Equal(t, filters.ContainsAny, pv.operator,
+			"nested ContainsAny preserves operator identity (Route 1)")
+		assert.True(t, pv.nested.isWithinRootSubtree, "ContainsAny same-root wraps")
 		assert.Equal(t, "nested", pv.prop)
 		require.Len(t, pv.children, 2)
 		assert.True(t, pv.children[0].nested.isNested)
+	})
+
+	t.Run("single-value nested ContainsAll collapses to bare leaf", func(t *testing.T) {
+		// input:  ContainsAll(nested.numbers, [1])
+		// output (single-value Contains ≡ Equal — return the leaf directly
+		// so resolveDocIDs sees a nested leaf, not an unbacked compound):
+		// └── numbers=1
+		clause := &filters.Clause{
+			Operator: filters.ContainsAll,
+			Value:    &filters.Value{Type: schema.DataTypeIntArray, Value: []int{1}},
+			On:       &filters.Path{Class: "Article", Property: "nested.numbers"},
+		}
+		pv, err := s.extractPropValuePair(t.Context(), clause, "Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorEqual, pv.operator,
+			"single-value Contains collapses to the bare Equal leaf")
+		assert.True(t, pv.nested.isNested)
+		assert.Equal(t, "nested", pv.prop)
+		assert.Equal(t, "numbers", pv.nested.relPath)
+	})
+
+	t.Run("single-value nested ContainsAny collapses to bare leaf", func(t *testing.T) {
+		// input:  ContainsAny(nested.numbers, [1])
+		// output: same shape as ContainsAll single-value.
+		clause := &filters.Clause{
+			Operator: filters.ContainsAny,
+			Value:    &filters.Value{Type: schema.DataTypeIntArray, Value: []int{1}},
+			On:       &filters.Path{Class: "Article", Property: "nested.numbers"},
+		}
+		pv, err := s.extractPropValuePair(t.Context(), clause, "Article")
+		require.NoError(t, err)
+
+		assert.Equal(t, filters.OperatorEqual, pv.operator,
+			"single-value Contains collapses to the bare Equal leaf")
+		assert.True(t, pv.nested.isNested)
+		assert.Equal(t, "nested", pv.prop)
+		assert.Equal(t, "numbers", pv.nested.relPath)
 	})
 
 	t.Run("top-level nested ContainsNone is a first-class operator", func(t *testing.T) {
@@ -598,11 +641,12 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 
 	t.Run("ContainsAny inside AND wraps both levels", func(t *testing.T) {
 		// input:  AND(nested.city=berlin, ContainsAny(nested.numbers, [1, 2]))
-		// output (outer AND collapses; inner OR also collapses under
-		// OR-of-same-root wrapping — both same-root wrappers):
+		// output (outer AND collapses; inner ContainsAny also collapses
+		// under sub-rule 1 — both same-root wrappers, ContainsAny keeps
+		// its operator identity under Route 1):
 		// └── AND {isWRS:nested}
 		//     ├── city:berlin
-		//     └── OR {isWRS:nested}
+		//     └── ContainsAny {isWRS:nested}
 		//         ├── numbers=1
 		//         └── numbers=2
 		containsAny := filters.Clause{
@@ -622,11 +666,12 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 
 		assertNestedLeaf(t, pv.children[0], "city", []byte("berlin"))
 
-		orChild := pv.children[1]
-		assert.Equal(t, filters.OperatorOr, orChild.operator)
-		assert.True(t, orChild.nested.isWithinRootSubtree, "inner OR same-root wraps")
-		assert.Equal(t, "nested", orChild.prop)
-		require.Len(t, orChild.children, 2)
+		anyChild := pv.children[1]
+		assert.Equal(t, filters.ContainsAny, anyChild.operator,
+			"inner ContainsAny preserves operator identity (Route 1)")
+		assert.True(t, anyChild.nested.isWithinRootSubtree, "inner ContainsAny same-root wraps")
+		assert.Equal(t, "nested", anyChild.prop)
+		require.Len(t, anyChild.children, 2)
 	})
 
 	t.Run("standalone OR of same-root leaves wraps and collapses", func(t *testing.T) {

--- a/adapters/repos/db/inverted/searcher_nested_test.go
+++ b/adapters/repos/db/inverted/searcher_nested_test.go
@@ -525,7 +525,7 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 
 	t.Run("top-level ContainsAll on int[] collapses to same-root wrapper", func(t *testing.T) {
 		// input:  ContainsAll(nested.numbers, [1, 2])
-		// output (Route 1: operator identity preserved; same-root wrapping
+		// output (first-class-operator approach: operator identity preserved; same-root wrapping
 		// still collapses since ContainsAll is treated as an AND alias by
 		// groupNestedSubtrees / planner):
 		// └── ContainsAll {isWRS:nested}
@@ -540,7 +540,7 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, filters.ContainsAll, pv.operator,
-			"nested ContainsAll preserves operator identity (Route 1)")
+			"nested ContainsAll preserves operator identity (first-class-operator approach)")
 		assert.True(t, pv.nested.isWithinRootSubtree, "ContainsAll same-root wraps")
 		assert.Equal(t, "nested", pv.prop)
 		require.Len(t, pv.children, 2)
@@ -550,7 +550,7 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 
 	t.Run("top-level ContainsAny collapses to same-root OR wrapper", func(t *testing.T) {
 		// input:  ContainsAny(nested.numbers, [1, 2])
-		// output (Route 1: operator identity preserved; same-root wrapping
+		// output (first-class-operator approach: operator identity preserved; same-root wrapping
 		// still collapses since ContainsAny is treated as an OR alias by
 		// groupNestedSubtrees / planner):
 		// └── ContainsAny {isWRS:nested}
@@ -565,7 +565,7 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, filters.ContainsAny, pv.operator,
-			"nested ContainsAny preserves operator identity (Route 1)")
+			"nested ContainsAny preserves operator identity (first-class-operator approach)")
 		assert.True(t, pv.nested.isWithinRootSubtree, "ContainsAny same-root wraps")
 		assert.Equal(t, "nested", pv.prop)
 		require.Len(t, pv.children, 2)
@@ -612,7 +612,7 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 
 	t.Run("top-level nested ContainsNone is a first-class operator", func(t *testing.T) {
 		// input:  ContainsNone(nested.numbers, [1, 2])
-		// output (Route 1: no desugar to NOT(OR), single ContainsNone pvp
+		// output (first-class-operator approach: no desugar to NOT(OR), single ContainsNone pvp
 		// carrying the operand relPath and the per-value children):
 		// └── ContainsNone {prop:nested, relPath:numbers}
 		//     ├── numbers=1
@@ -626,7 +626,7 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, filters.ContainsNone, pv.operator,
-			"nested ContainsNone preserves operator identity (Route 1)")
+			"nested ContainsNone preserves operator identity (first-class-operator approach)")
 		assert.Equal(t, "nested", pv.prop)
 		assert.Equal(t, "numbers", pv.nested.relPath,
 			"operand path carried on the wrapper so the resolver / planner can read _exists.numbers as universe")
@@ -642,8 +642,8 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 	t.Run("ContainsAny inside AND wraps both levels", func(t *testing.T) {
 		// input:  AND(nested.city=berlin, ContainsAny(nested.numbers, [1, 2]))
 		// output (outer AND collapses; inner ContainsAny also collapses
-		// under sub-rule 1 — both same-root wrappers, ContainsAny keeps
-		// its operator identity under Route 1):
+		// under OR-of-same-root wrapping — both same-root wrappers, ContainsAny keeps
+		// its operator identity under first-class-operator approach):
 		// └── AND {isWRS:nested}
 		//     ├── city:berlin
 		//     └── ContainsAny {isWRS:nested}
@@ -668,7 +668,7 @@ func TestExtractPropValuePairNestedGrouping(t *testing.T) {
 
 		anyChild := pv.children[1]
 		assert.Equal(t, filters.ContainsAny, anyChild.operator,
-			"inner ContainsAny preserves operator identity (Route 1)")
+			"inner ContainsAny preserves operator identity (first-class-operator approach)")
 		assert.True(t, anyChild.nested.isWithinRootSubtree, "inner ContainsAny same-root wraps")
 		assert.Equal(t, "nested", anyChild.prop)
 		require.Len(t, anyChild.children, 2)

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -514,7 +514,7 @@ func TestNestedFilteringViaShardWritePath(t *testing.T) {
 			matchesObjectDel: e, matchesArrayDel: e,
 			matchesObjectUpd: e, matchesArrayUpd: e,
 		},
-		// Route 1: ContainsNone is now a first-class operator using
+		// first-class-operator approach: ContainsNone is now a first-class operator using
 		// `_exists.{relPath}` as the inversion universe. For doc125Data
 		// (tags=["electric"]) the only tag IS in the listed set, so no
 		// qualifying tag exists → drops. Array case (id999=[doc124, doc125])
@@ -13243,7 +13243,7 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.tags", filters.ContainsAny, "sport", "luxury"),
 					[]strfmt.UUID{d1, d2, d3})
 			})
-			// Route 1: ContainsNone is now a first-class operator with
+			// first-class-operator approach: ContainsNone is now a first-class operator with
 			// `_exists.tags` as the inversion universe. d2/d3/d4 have at
 			// least one tag outside [sport, luxury] → match. d5 (empty
 			// country, no tags) has no tag positions → universe empty →
@@ -13273,7 +13273,7 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.name", filters.ContainsAny, "new", "york"),
 					[]strfmt.UUID{d1, d2, d3})
 			})
-			// Route 1: ContainsNone is now first-class with universe =
+			// first-class-operator approach: ContainsNone is now first-class with universe =
 			// `_exists.name`. d4 (boston, no "new"/"york" tokens) matches;
 			// d5 (empty country, no name) has no position in the universe
 			// → drops.
@@ -13712,7 +13712,7 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 }
 
 // TestNestedFilteringContainsNoneSiblingScalarArrayLeak regression-locks
-// the Route 1 fix for the ContainsNone universe leak. ContainsNone on a
+// the first-class-operator approach fix for the ContainsNone universe leak. ContainsNone on a
 // nested path is now a first-class operator (no longer desugared to
 // NOT(OR(...))) and uses `_exists.{relPath}` as the inversion universe —
 // the scalar-array path itself, not the broader LCA.
@@ -13819,7 +13819,7 @@ func TestNestedFilteringContainsNoneSiblingScalarArrayLeak(t *testing.T) {
 				"cities": asTextArr("berlin"),
 			}}, note: "no tags at all; only cities sibling — vacuous case"},
 		}
-		// Route 1: ContainsNone is now a first-class operator with universe
+		// first-class-operator approach: ContainsNone is now a first-class operator with universe
 		// = `_exists.tags`. d1 (only-electric tag) and d3 (no tags at all)
 		// both correctly drop. d2 (sport tag, not in listed set) matches.
 		runScenario(t, docs, containsFilter("country.tags", filters.ContainsNone, "electric"),
@@ -13847,7 +13847,7 @@ func TestNestedFilteringContainsNoneSiblingScalarArrayLeak(t *testing.T) {
 				},
 			}}, note: "no tags, only cities — vacuous"},
 		}
-		// Route 1: same as country_object — encoding is bit-identical for
+		// first-class-operator approach: same as country_object — encoding is bit-identical for
 		// DataTypeObject and DataTypeObjectArray with one element, so the
 		// same fix applies regardless of root prop type.
 		runScenario(t, docs, containsFilter("countries.tags", filters.ContainsNone, "electric"),
@@ -13865,7 +13865,7 @@ func TestNestedFilteringContainsNoneSiblingScalarArrayLeak(t *testing.T) {
 // set.
 //
 // The schema includes a sibling `cities: text[]` to exercise the
-// sibling-leak shape inside the correlated AND. Without Route 1's
+// sibling-leak shape inside the correlated AND. Without first-class-operator approach's
 // first-class operator handling, the inside-AND ContainsNone would use
 // `_exists.""` as universe and the cities-leaf would survive AndNot —
 // docs would leak through identically to the standalone case
@@ -14039,7 +14039,7 @@ func TestNestedFilteringContainsNoneInsideCorrelatedAnd(t *testing.T) {
 // flattenAndOperators) so the executor requires the same root to have ALL
 // listed tags AND the matching name.
 //
-// Sibling `cities: text[]` is kept in the schema to confirm Route 1 does
+// Sibling `cities: text[]` is kept in the schema to confirm first-class-operator approach does
 // not introduce a sibling-leak shape on positive operators (none expected;
 // ContainsAll doesn't read the inversion universe).
 //

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -14030,6 +14030,875 @@ func TestNestedFilteringContainsNoneInsideCorrelatedAnd(t *testing.T) {
 	})
 }
 
+// TestNestedFilteringContainsAllInsideCorrelatedAnd exercises the post-
+// Route-1 correlated-AND handler for ContainsAll. Two root prop shapes; in
+// each: AND(name=<value>, ContainsAll(tags, [a, b])) — both children
+// target the same root prop so same-root grouping triggers the correlated-
+// AND path. ContainsAll is treated as an AND alias by the planner: its
+// value leaves are flattened into the outer recGroupNode (via
+// flattenAndOperators) so the executor requires the same root to have ALL
+// listed tags AND the matching name.
+//
+// Sibling `cities: text[]` is kept in the schema to confirm Route 1 does
+// not introduce a sibling-leak shape on positive operators (none expected;
+// ContainsAll doesn't read the inversion universe).
+//
+// Schema:
+//
+//	country:   DataTypeObject       { name: text/field, tags: text[]/field, cities: text[]/field }
+//	countries: DataTypeObjectArray  { name: text/field, tags: text[]/field, cities: text[]/field }
+//
+// Filter: AND(<root>.name="germany", ContainsAll(<root>.tags, ["sport", "luxury"]))
+//
+// Docs:
+//
+//	d1: name="germany", tags=[sport, luxury, electric], cities=[paris]  — matches (both present + sibling)
+//	d2: name="germany", tags=[sport],                   cities=[paris]  — drops (missing luxury)
+//	d3: name="germany", tags=[sport, luxury],           cities=[london] — matches (both present)
+//	d4: name="germany", tags=[sport, luxury]                            — matches (both present, no sibling)
+//	d5: name="france",  tags=[sport, luxury],           cities=[paris]  — drops (wrong name)
+//	d6: name="germany",                                 cities=[paris]  — drops (no tags — vacuous)
+//	d7: name="germany", tags=[luxury, electric]                         — drops (missing sport)
+func TestNestedFilteringContainsAllInsideCorrelatedAnd(t *testing.T) {
+	const nestedClass = "ContainsAllInsideAnd"
+	vTrue := true
+	field := models.NestedPropertyTokenizationField
+
+	rootInner := []*models.NestedProperty{
+		{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "cities", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "country", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootInner},
+			{Name: "countries", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootInner},
+		},
+	}
+
+	asTextArr := func(vals ...string) []any {
+		out := make([]any, len(vals))
+		for i, v := range vals {
+			out[i] = v
+		}
+		return out
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	valueFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	containsFilter := func(path string, op filters.Operator, vals ...string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: op,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: vals},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(a, b *filters.LocalFilter) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: []filters.Clause{*a.Root, *b.Root},
+		}}
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	t.Run("country_object", func(t *testing.T) {
+		d1, d2, d3, d4, d5, d6, d7 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport", "luxury", "electric"), "cities": asTextArr("paris"),
+			}}, note: "germany; both required + extra + sibling"},
+			{id: d2, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport"), "cities": asTextArr("paris"),
+			}}, note: "germany; missing luxury"},
+			{id: d3, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport", "luxury"), "cities": asTextArr("london"),
+			}}, note: "germany; both required + sibling"},
+			{id: d4, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport", "luxury"),
+			}}, note: "germany; both required, no sibling"},
+			{id: d5, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("sport", "luxury"), "cities": asTextArr("paris"),
+			}}, note: "wrong name"},
+			{id: d6, props: map[string]any{"country": map[string]any{
+				"name": "germany", "cities": asTextArr("paris"),
+			}}, note: "germany; no tags — vacuous"},
+			{id: d7, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("luxury", "electric"),
+			}}, note: "germany; missing sport"},
+		}
+		f := andFilter(
+			valueFilter("country.name", "germany"),
+			containsFilter("country.tags", filters.ContainsAll, "sport", "luxury"),
+		)
+		runScenario(t, docs, f, []strfmt.UUID{d1, d3, d4})
+	})
+
+	t.Run("countries_array", func(t *testing.T) {
+		d1, d2, d3, d4, d5, d6, d7 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport", "luxury", "electric"), "cities": asTextArr("paris")},
+			}}, note: "germany; both required + extra + sibling"},
+			{id: d2, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport"), "cities": asTextArr("paris")},
+			}}, note: "germany; missing luxury"},
+			{id: d3, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport", "luxury"), "cities": asTextArr("london")},
+			}}, note: "germany; both required + sibling"},
+			{id: d4, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport", "luxury")},
+			}}, note: "germany; both required, no sibling"},
+			{id: d5, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("sport", "luxury"), "cities": asTextArr("paris")},
+			}}, note: "wrong name"},
+			{id: d6, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "cities": asTextArr("paris")},
+			}}, note: "germany; no tags — vacuous"},
+			{id: d7, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("luxury", "electric")},
+			}}, note: "germany; missing sport"},
+		}
+		f := andFilter(
+			valueFilter("countries.name", "germany"),
+			containsFilter("countries.tags", filters.ContainsAll, "sport", "luxury"),
+		)
+		runScenario(t, docs, f, []strfmt.UUID{d1, d3, d4})
+	})
+}
+
+// TestNestedFilteringContainsAnyInsideCorrelatedAnd exercises the post-
+// Route-1 correlated-AND handler for ContainsAny. ContainsAny is treated
+// as an OR alias by the planner: buildRecGroupExecutor / buildGroup route
+// the ContainsAny subtree through buildOrAtScope and the executor unions
+// its value leaves at the operand LCA — matching docs whose tags array
+// contains AT LEAST ONE of the listed values AND the matching name.
+//
+// Same schema + sibling cities as the ContainsAll companion test.
+//
+// Schema:
+//
+//	country:   DataTypeObject       { name: text/field, tags: text[]/field, cities: text[]/field }
+//	countries: DataTypeObjectArray  { name: text/field, tags: text[]/field, cities: text[]/field }
+//
+// Filter: AND(<root>.name="germany", ContainsAny(<root>.tags, ["sport", "luxury"]))
+//
+// Docs:
+//
+//	d1: name="germany", tags=[sport, luxury, electric], cities=[paris]  — matches (both present)
+//	d2: name="germany", tags=[sport],                   cities=[paris]  — matches (sport qualifies)
+//	d3: name="germany", tags=[luxury],                  cities=[london] — matches (luxury qualifies)
+//	d4: name="germany", tags=[electric]                                 — drops (no listed tag)
+//	d5: name="france",  tags=[sport, luxury]                            — drops (wrong name)
+//	d6: name="germany",                                 cities=[paris]  — drops (no tags)
+//	d7: name="germany", tags=[electric],                cities=[paris]  — drops (sibling alone doesn't count)
+func TestNestedFilteringContainsAnyInsideCorrelatedAnd(t *testing.T) {
+	const nestedClass = "ContainsAnyInsideAnd"
+	vTrue := true
+	field := models.NestedPropertyTokenizationField
+
+	rootInner := []*models.NestedProperty{
+		{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "cities", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "country", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootInner},
+			{Name: "countries", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootInner},
+		},
+	}
+
+	asTextArr := func(vals ...string) []any {
+		out := make([]any, len(vals))
+		for i, v := range vals {
+			out[i] = v
+		}
+		return out
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	valueFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	containsFilter := func(path string, op filters.Operator, vals ...string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: op,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: vals},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(a, b *filters.LocalFilter) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: []filters.Clause{*a.Root, *b.Root},
+		}}
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	t.Run("country_object", func(t *testing.T) {
+		d1, d2, d3, d4, d5, d6, d7 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport", "luxury", "electric"), "cities": asTextArr("paris"),
+			}}, note: "germany; both qualifying + extra + sibling"},
+			{id: d2, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport"), "cities": asTextArr("paris"),
+			}}, note: "germany; sport qualifies"},
+			{id: d3, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("luxury"), "cities": asTextArr("london"),
+			}}, note: "germany; luxury qualifies"},
+			{id: d4, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("electric"),
+			}}, note: "germany; no listed tag"},
+			{id: d5, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("sport", "luxury"),
+			}}, note: "wrong name"},
+			{id: d6, props: map[string]any{"country": map[string]any{
+				"name": "germany", "cities": asTextArr("paris"),
+			}}, note: "germany; no tags"},
+			{id: d7, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("electric"), "cities": asTextArr("paris"),
+			}}, note: "germany; wrong tag + sibling"},
+		}
+		f := andFilter(
+			valueFilter("country.name", "germany"),
+			containsFilter("country.tags", filters.ContainsAny, "sport", "luxury"),
+		)
+		runScenario(t, docs, f, []strfmt.UUID{d1, d2, d3})
+	})
+
+	t.Run("countries_array", func(t *testing.T) {
+		d1, d2, d3, d4, d5, d6, d7 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport", "luxury", "electric"), "cities": asTextArr("paris")},
+			}}, note: "germany; both qualifying + extra + sibling"},
+			{id: d2, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport"), "cities": asTextArr("paris")},
+			}}, note: "germany; sport qualifies"},
+			{id: d3, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("luxury"), "cities": asTextArr("london")},
+			}}, note: "germany; luxury qualifies"},
+			{id: d4, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("electric")},
+			}}, note: "germany; no listed tag"},
+			{id: d5, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("sport", "luxury")},
+			}}, note: "wrong name"},
+			{id: d6, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "cities": asTextArr("paris")},
+			}}, note: "germany; no tags"},
+			{id: d7, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("electric"), "cities": asTextArr("paris")},
+			}}, note: "germany; wrong tag + sibling"},
+		}
+		f := andFilter(
+			valueFilter("countries.name", "germany"),
+			containsFilter("countries.tags", filters.ContainsAny, "sport", "luxury"),
+		)
+		runScenario(t, docs, f, []strfmt.UUID{d1, d2, d3})
+	})
+}
+
+// TestNestedFilteringContainsNoneInsideOr — companion to the inside-AND
+// test, but with OR as the outer operator. ContainsNone is not folded
+// into same-root grouping (it's absent from nestedRootProp's switch), so
+// the outer OR resolves at docID level — each child resolves to a docID
+// bitmap and they are unioned.
+//
+// Semantics: doc matches iff name="germany" OR (∃ tag-element whose value
+// is NOT in the listed set). Strict-existential ContainsNone is supplied
+// by the standalone fetchNestedContainsNone path.
+//
+// Schema:
+//
+//	country:   DataTypeObject       { name: text/field, tags: text[]/field, cities: text[]/field }
+//	countries: DataTypeObjectArray  { name: text/field, tags: text[]/field, cities: text[]/field }
+//
+// Filter: OR(<root>.name="germany", ContainsNone(<root>.tags, ["electric"]))
+//
+// Docs:
+//
+//	d1: name="germany", tags=[electric]                                — matches (name)
+//	d2: name="germany", tags=[sport, electric]                         — matches (both)
+//	d3: name="france",  tags=[sport]                                   — matches (ContainsNone — sport qualifies)
+//	d4: name="france",  tags=[electric]                                — drops (wrong name + no qualifying tag)
+//	d5: name="france"                                                  — drops (no tags — vacuous + wrong name)
+//	d6: name="germany"                                                 — matches (name; tags vacuous doesn't matter)
+//	d7: name="france",  tags=[sport, electric], cities=[paris]         — matches (ContainsNone)
+//	d8: name="france",  tags=[electric, electric], cities=[paris]      — drops (no qualifying tag, sibling alone doesn't count)
+func TestNestedFilteringContainsNoneInsideOr(t *testing.T) {
+	const nestedClass = "ContainsNoneInsideOr"
+	vTrue := true
+	field := models.NestedPropertyTokenizationField
+
+	rootInner := []*models.NestedProperty{
+		{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "cities", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "country", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootInner},
+			{Name: "countries", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootInner},
+		},
+	}
+
+	asTextArr := func(vals ...string) []any {
+		out := make([]any, len(vals))
+		for i, v := range vals {
+			out[i] = v
+		}
+		return out
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	valueFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	containsFilter := func(path string, op filters.Operator, vals ...string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: op,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: vals},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	orFilter := func(a, b *filters.LocalFilter) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorOr,
+			Operands: []filters.Clause{*a.Root, *b.Root},
+		}}
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	t.Run("country_object", func(t *testing.T) {
+		d1, d2, d3, d4, d5, d6, d7, d8 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7), uuid(8)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("electric"),
+			}}, note: "germany; only-listed (name matches)"},
+			{id: d2, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport", "electric"),
+			}}, note: "germany; mixed (both reasons)"},
+			{id: d3, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("sport"),
+			}}, note: "france; ContainsNone qualifies"},
+			{id: d4, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("electric"),
+			}}, note: "wrong name + only-listed"},
+			{id: d5, props: map[string]any{"country": map[string]any{
+				"name": "france",
+			}}, note: "wrong name + no tags"},
+			{id: d6, props: map[string]any{"country": map[string]any{
+				"name": "germany",
+			}}, note: "germany; no tags (name matches)"},
+			{id: d7, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("sport", "electric"), "cities": asTextArr("paris"),
+			}}, note: "france; mixed + sibling — ContainsNone qualifies"},
+			{id: d8, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("electric", "electric"), "cities": asTextArr("paris"),
+			}}, note: "france; only-listed + sibling — neither qualifies (the leak shape)"},
+		}
+		f := orFilter(
+			valueFilter("country.name", "germany"),
+			containsFilter("country.tags", filters.ContainsNone, "electric"),
+		)
+		runScenario(t, docs, f, []strfmt.UUID{d1, d2, d3, d6, d7})
+	})
+
+	t.Run("countries_array", func(t *testing.T) {
+		d1, d2, d3, d4, d5, d6, d7, d8 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7), uuid(8)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("electric")},
+			}}, note: "germany; only-listed (name matches)"},
+			{id: d2, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport", "electric")},
+			}}, note: "germany; mixed (both reasons)"},
+			{id: d3, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("sport")},
+			}}, note: "france; ContainsNone qualifies"},
+			{id: d4, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("electric")},
+			}}, note: "wrong name + only-listed"},
+			{id: d5, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france"},
+			}}, note: "wrong name + no tags"},
+			{id: d6, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany"},
+			}}, note: "germany; no tags"},
+			{id: d7, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("sport", "electric"), "cities": asTextArr("paris")},
+			}}, note: "france; mixed + sibling"},
+			{id: d8, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("electric", "electric"), "cities": asTextArr("paris")},
+			}}, note: "france; only-listed + sibling — neither qualifies"},
+		}
+		f := orFilter(
+			valueFilter("countries.name", "germany"),
+			containsFilter("countries.tags", filters.ContainsNone, "electric"),
+		)
+		runScenario(t, docs, f, []strfmt.UUID{d1, d2, d3, d6, d7})
+	})
+}
+
+// TestNestedFilteringContainsAllInsideOr — companion to the inside-AND
+// test, but with OR as the outer operator. ContainsAll is recognized as
+// an AND alias by nestedRootProp, so both children of the OR are folded
+// into a single same-root OR wrapper (isWithinRootSubtree=true). The
+// recursive planner plans the ContainsAll subtree via buildPlan →
+// buildGroup, where flattenAndOperators unwraps it into its value leaves
+// at the operand LCA. The recOrNode unions the two children's raw
+// bitmaps.
+//
+// Semantics: doc matches iff name="germany" OR (tags ⊇ [sport, luxury]).
+//
+// Schema:
+//
+//	country:   DataTypeObject       { name: text/field, tags: text[]/field, cities: text[]/field }
+//	countries: DataTypeObjectArray  { name: text/field, tags: text[]/field, cities: text[]/field }
+//
+// Filter: OR(<root>.name="germany", ContainsAll(<root>.tags, ["sport", "luxury"]))
+//
+// Docs:
+//
+//	d1: name="germany", tags=[sport, luxury, electric], cities=[paris] — matches (both reasons)
+//	d2: name="germany", tags=[sport]                                   — matches (name only)
+//	d3: name="france",  tags=[sport, luxury], cities=[london]          — matches (ContainsAll only)
+//	d4: name="france",  tags=[sport]                                   — drops (neither)
+//	d5: name="france",  tags=[luxury]                                  — drops (neither)
+//	d6: name="germany",                                  cities=[paris] — matches (name only)
+//	d7: name="france"                                                   — drops (wrong name + no tags)
+//	d8: name="france",  tags=[sport, luxury]                            — matches (ContainsAll only)
+func TestNestedFilteringContainsAllInsideOr(t *testing.T) {
+	const nestedClass = "ContainsAllInsideOr"
+	vTrue := true
+	field := models.NestedPropertyTokenizationField
+
+	rootInner := []*models.NestedProperty{
+		{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "cities", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "country", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootInner},
+			{Name: "countries", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootInner},
+		},
+	}
+
+	asTextArr := func(vals ...string) []any {
+		out := make([]any, len(vals))
+		for i, v := range vals {
+			out[i] = v
+		}
+		return out
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	valueFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	containsFilter := func(path string, op filters.Operator, vals ...string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: op,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: vals},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	orFilter := func(a, b *filters.LocalFilter) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorOr,
+			Operands: []filters.Clause{*a.Root, *b.Root},
+		}}
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	t.Run("country_object", func(t *testing.T) {
+		d1, d2, d3, d4, d5, d6, d7, d8 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7), uuid(8)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport", "luxury", "electric"), "cities": asTextArr("paris"),
+			}}, note: "germany; both required + extra + sibling"},
+			{id: d2, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport"),
+			}}, note: "germany; name only"},
+			{id: d3, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("sport", "luxury"), "cities": asTextArr("london"),
+			}}, note: "france; ContainsAll only"},
+			{id: d4, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("sport"),
+			}}, note: "wrong name; partial tag"},
+			{id: d5, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("luxury"),
+			}}, note: "wrong name; partial tag"},
+			{id: d6, props: map[string]any{"country": map[string]any{
+				"name": "germany", "cities": asTextArr("paris"),
+			}}, note: "germany; name only (no tags)"},
+			{id: d7, props: map[string]any{"country": map[string]any{
+				"name": "france",
+			}}, note: "wrong name; no tags"},
+			{id: d8, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("sport", "luxury"),
+			}}, note: "france; ContainsAll only (no sibling)"},
+		}
+		f := orFilter(
+			valueFilter("country.name", "germany"),
+			containsFilter("country.tags", filters.ContainsAll, "sport", "luxury"),
+		)
+		runScenario(t, docs, f, []strfmt.UUID{d1, d2, d3, d6, d8})
+	})
+
+	t.Run("countries_array", func(t *testing.T) {
+		d1, d2, d3, d4, d5, d6, d7, d8 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7), uuid(8)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport", "luxury", "electric"), "cities": asTextArr("paris")},
+			}}, note: "germany; both required + extra + sibling"},
+			{id: d2, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport")},
+			}}, note: "germany; name only"},
+			{id: d3, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("sport", "luxury"), "cities": asTextArr("london")},
+			}}, note: "france; ContainsAll only"},
+			{id: d4, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("sport")},
+			}}, note: "wrong name; partial tag"},
+			{id: d5, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("luxury")},
+			}}, note: "wrong name; partial tag"},
+			{id: d6, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "cities": asTextArr("paris")},
+			}}, note: "germany; name only (no tags)"},
+			{id: d7, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france"},
+			}}, note: "wrong name; no tags"},
+			{id: d8, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("sport", "luxury")},
+			}}, note: "france; ContainsAll only"},
+		}
+		f := orFilter(
+			valueFilter("countries.name", "germany"),
+			containsFilter("countries.tags", filters.ContainsAll, "sport", "luxury"),
+		)
+		runScenario(t, docs, f, []strfmt.UUID{d1, d2, d3, d6, d8})
+	})
+}
+
+// TestNestedFilteringContainsAnyInsideOr — companion to the inside-AND
+// test, but with OR as the outer operator. ContainsAny is recognized as
+// an OR alias by nestedRootProp; both children of the OR fold into a
+// single same-root OR wrapper. buildRecGroupExecutor plans the outer OR
+// via buildOrAtScope, which builds a recOrNode whose children are the
+// recursively-planned name leaf and the ContainsAny OR-of-values
+// subtree.
+//
+// Semantics: doc matches iff name="germany" OR (∃ tag ∈ [sport, luxury]).
+//
+// Schema:
+//
+//	country:   DataTypeObject       { name: text/field, tags: text[]/field, cities: text[]/field }
+//	countries: DataTypeObjectArray  { name: text/field, tags: text[]/field, cities: text[]/field }
+//
+// Filter: OR(<root>.name="germany", ContainsAny(<root>.tags, ["sport", "luxury"]))
+//
+// Docs:
+//
+//	d1: name="germany", tags=[sport]                                   — matches (both reasons)
+//	d2: name="germany", tags=[other]                                   — matches (name only)
+//	d3: name="france",  tags=[sport]                                   — matches (ContainsAny — sport qualifies)
+//	d4: name="france",  tags=[luxury], cities=[paris]                  — matches (ContainsAny — luxury qualifies)
+//	d5: name="france",  tags=[electric]                                — drops (no listed tag, wrong name)
+//	d6: name="germany"                                                 — matches (name; no tags doesn't matter)
+//	d7: name="france"                                                  — drops (wrong name + no tags)
+//	d8: name="france",  tags=[sport, electric], cities=[paris]         — matches (ContainsAny + sibling)
+func TestNestedFilteringContainsAnyInsideOr(t *testing.T) {
+	const nestedClass = "ContainsAnyInsideOr"
+	vTrue := true
+	field := models.NestedPropertyTokenizationField
+
+	rootInner := []*models.NestedProperty{
+		{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "cities", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "country", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootInner},
+			{Name: "countries", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootInner},
+		},
+	}
+
+	asTextArr := func(vals ...string) []any {
+		out := make([]any, len(vals))
+		for i, v := range vals {
+			out[i] = v
+		}
+		return out
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	valueFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	containsFilter := func(path string, op filters.Operator, vals ...string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: op,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: vals},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	orFilter := func(a, b *filters.LocalFilter) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorOr,
+			Operands: []filters.Clause{*a.Root, *b.Root},
+		}}
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	t.Run("country_object", func(t *testing.T) {
+		d1, d2, d3, d4, d5, d6, d7, d8 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7), uuid(8)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport"),
+			}}, note: "germany; sport (both reasons)"},
+			{id: d2, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("other"),
+			}}, note: "germany; non-listed tag (name only)"},
+			{id: d3, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("sport"),
+			}}, note: "france; sport qualifies"},
+			{id: d4, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("luxury"), "cities": asTextArr("paris"),
+			}}, note: "france; luxury + sibling"},
+			{id: d5, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("electric"),
+			}}, note: "wrong name + non-listed"},
+			{id: d6, props: map[string]any{"country": map[string]any{
+				"name": "germany",
+			}}, note: "germany; no tags (name only)"},
+			{id: d7, props: map[string]any{"country": map[string]any{
+				"name": "france",
+			}}, note: "wrong name + no tags"},
+			{id: d8, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("sport", "electric"), "cities": asTextArr("paris"),
+			}}, note: "france; sport + extra + sibling"},
+		}
+		f := orFilter(
+			valueFilter("country.name", "germany"),
+			containsFilter("country.tags", filters.ContainsAny, "sport", "luxury"),
+		)
+		runScenario(t, docs, f, []strfmt.UUID{d1, d2, d3, d4, d6, d8})
+	})
+
+	t.Run("countries_array", func(t *testing.T) {
+		d1, d2, d3, d4, d5, d6, d7, d8 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7), uuid(8)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport")},
+			}}, note: "germany; sport (both reasons)"},
+			{id: d2, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("other")},
+			}}, note: "germany; non-listed tag"},
+			{id: d3, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("sport")},
+			}}, note: "france; sport qualifies"},
+			{id: d4, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("luxury"), "cities": asTextArr("paris")},
+			}}, note: "france; luxury + sibling"},
+			{id: d5, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("electric")},
+			}}, note: "wrong name + non-listed"},
+			{id: d6, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany"},
+			}}, note: "germany; no tags"},
+			{id: d7, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france"},
+			}}, note: "wrong name + no tags"},
+			{id: d8, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("sport", "electric"), "cities": asTextArr("paris")},
+			}}, note: "france; sport + extra + sibling"},
+		}
+		f := orFilter(
+			valueFilter("countries.name", "germany"),
+			containsFilter("countries.tags", filters.ContainsAny, "sport", "luxury"),
+		)
+		runScenario(t, docs, f, []strfmt.UUID{d1, d2, d3, d4, d6, d8})
+	})
+}
+
 // TestNestedFilteringAndShapeFlatVsAndOfAnd verifies that two AND shapes
 // equivalent under classical boolean associativity produce IDENTICAL
 // results in the nested-filter dispatch:

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -13855,6 +13855,327 @@ func TestNestedFilteringContainsNoneSiblingScalarArrayLeak(t *testing.T) {
 	})
 }
 
+// TestNestedFilteringContainsNoneMultiTokenWrapper regression-locks that
+// extractContains correctly classifies a nested Contains* as "nested" when
+// its query value tokenizes into multiple terms (and therefore produces a
+// tokenization wrapper, not a direct nested leaf, as children[0]).
+//
+// buildNestedTextFilterPair returns a propValuePair with
+// `nested.isWithinRootSubtree=true, childrenFromTokenization=true,
+// isNested=false` whenever the query value tokenizes into >1 term.
+// extractContains's nested-detection initially only checked
+// `children[0].nested.isNested`, so multi-token nested ContainsNone
+// (e.g. ContainsNone(tags, ["new york"]) under word tokenization) was
+// misclassified as non-nested and desugared to NOT(OR(...)) — which
+// reintroduces the ContainsNone universe leak the first-class operator
+// path was added to fix.
+//
+// Filter: ContainsNone(<root>.tags, ["new york"])  under word tokenization
+//
+// Docs (sibling-leak shape mirroring
+// TestNestedFilteringContainsNoneSiblingScalarArrayLeak, but with the
+// query value tokenizing into multiple terms):
+//
+//	d1: tags=["sport"],     cities=["paris"]  — no token matches; control
+//	d2: tags=["new york"],  cities=["paris"]  — both tokens at same position
+//	                                              (phrase match) → must drop
+//	d3:                     cities=["berlin"] — no tags; pre-fix universe-leaks
+//	                                              via cities leaf → must drop
+//
+// Post-fix: ContainsNone takes the first-class path, universe is
+// `_exists.tags`, only d1 matches.
+// Pre-fix: misclassified as non-nested → desugared NOT(OR(tags="new",
+// tags="york")) over `_exists.""` → d3 leaks via cities leaf.
+func TestNestedFilteringContainsNoneMultiTokenWrapper(t *testing.T) {
+	const nestedClass = "ContainsNoneMultiTokenWrapper"
+	vTrue := true
+	word := models.NestedPropertyTokenizationWord
+
+	rootInner := []*models.NestedProperty{
+		{Name: "tags", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+		{Name: "cities", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "country", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootInner},
+			{Name: "countries", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootInner},
+		},
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	containsFilter := func(path string, op filters.Operator, vals ...string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: op,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: vals},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	t.Run("country_object", func(t *testing.T) {
+		d1, d2, d3 := uuid(1), uuid(2), uuid(3)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"country": map[string]any{
+				"tags": "sport", "cities": "paris",
+			}}, note: "tags=sport (no token match); control"},
+			{id: d2, props: map[string]any{"country": map[string]any{
+				"tags": "new york", "cities": "paris",
+			}}, note: "tags=\"new york\" — both query tokens at same position"},
+			{id: d3, props: map[string]any{"country": map[string]any{
+				"cities": "berlin",
+			}}, note: "no tags, only sibling cities — pre-fix leaks via cities leaf"},
+		}
+		runScenario(t, docs, containsFilter("country.tags", filters.ContainsNone, "new york"),
+			[]strfmt.UUID{d1})
+	})
+
+	t.Run("countries_array", func(t *testing.T) {
+		d1, d2, d3 := uuid(1), uuid(2), uuid(3)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"countries": []any{
+				map[string]any{"tags": "sport", "cities": "paris"},
+			}}, note: "tags=sport (control)"},
+			{id: d2, props: map[string]any{"countries": []any{
+				map[string]any{"tags": "new york", "cities": "paris"},
+			}}, note: "tags=\"new york\" — both tokens at same position"},
+			{id: d3, props: map[string]any{"countries": []any{
+				map[string]any{"cities": "berlin"},
+			}}, note: "no tags, only cities — pre-fix universe-leak shape"},
+		}
+		runScenario(t, docs, containsFilter("countries.tags", filters.ContainsNone, "new york"),
+			[]strfmt.UUID{d1})
+	})
+}
+
+// TestNestedFilteringContainsNoneMultiTokenArrNPin regression-locks that
+// buildNestedTextFilterPair's tokenization wrapper carries relPath and
+// arrayIndices onto itself, so the first-class ContainsNone path sees the
+// pinned operand scope. Without this propagation the multi-token wrapper
+// is created with empty `relPath`/`arrayIndices`, and extractContains's
+// first-class path silently drops the arr[N] pin — the query then
+// evaluates over the unpinned universe instead of `_exists.{relPath} ∩
+// _idx.<pinPath>[N]`.
+//
+// Schema: garages (object[]) > cars (object[]) > tags (text[]/word).
+// Filter: ContainsNone(garages.cars[1].tags, "new york")
+//
+// Docs:
+//
+//	d1: cars=[{tags:[new york]}, {tags:[sport]}]  — cars[1].tags=[sport]
+//	                                                  → ∃ tag without "new york"
+//	                                                  → match
+//	d2: cars=[{tags:[sport]}, {tags:[new york]}]  — cars[1].tags=[new york]
+//	                                                  → no qualifying tag in cars[1]
+//	                                                  → drop
+//	d3: cars=[{tags:[sport]}]                     — cars[1] doesn't exist
+//	                                                  → vacuous at the pinned LCA
+//	                                                  → drop
+//
+// With the pin honored: only d1 matches.
+// Without the pin (pre-Fix 1b): the universe ignores cars[1] and "sport"
+// in cars[0] qualifies for d2 and d3 too — both leak through.
+func TestNestedFilteringContainsNoneMultiTokenArrNPin(t *testing.T) {
+	const nestedClass = "ContainsNoneMultiTokenArrNPin"
+	vTrue := true
+	word := models.NestedPropertyTokenizationWord
+
+	carInner := []*models.NestedProperty{
+		{Name: "tags", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+	}
+	garagesInner := []*models.NestedProperty{
+		{
+			Name: "cars", DataType: schema.DataTypeObjectArray.PropString(),
+			NestedProperties: carInner,
+		},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "garages", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: garagesInner},
+		},
+	}
+
+	asArr := func(items ...any) []any { return items }
+	car := func(tag string) map[string]any {
+		if tag == "" {
+			return map[string]any{}
+		}
+		return map[string]any{"tags": tag}
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	containsFilter := func(path string, op filters.Operator, vals ...string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: op,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: vals},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+
+	d1, d2, d3 := uuid(1), uuid(2), uuid(3)
+	docs := []docDef{
+		{id: d1, props: map[string]any{"garages": asArr(
+			map[string]any{"cars": asArr(car("new york"), car("sport"))},
+		)}, note: "cars[1].tags=sport (qualifies for pinned scope)"},
+		{id: d2, props: map[string]any{"garages": asArr(
+			map[string]any{"cars": asArr(car("sport"), car("new york"))},
+		)}, note: "cars[1].tags=new york (does NOT qualify)"},
+		{id: d3, props: map[string]any{"garages": asArr(
+			map[string]any{"cars": asArr(car("sport"))},
+		)}, note: "no cars[1] — vacuous at pinned LCA"},
+	}
+
+	db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+	ctx := context.Background()
+	for _, d := range docs {
+		require.NoError(t, db.PutObject(ctx, &models.Object{
+			Class: nestedClass, ID: d.id, Properties: d.props,
+		}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+	}
+	res, err := db.Search(ctx, dto.GetParams{
+		ClassName:  nestedClass,
+		Pagination: &filters.Pagination{Limit: 100},
+		Filters:    containsFilter("garages.cars[1].tags", filters.ContainsNone, "new york"),
+	})
+	require.NoError(t, err)
+	got := make([]strfmt.UUID, len(res))
+	for i, r := range res {
+		got[i] = r.ID
+	}
+	assert.ElementsMatch(t, []strfmt.UUID{d1}, got)
+}
+
+// TestNestedFilteringContainsAllAnyMultiTokenWrapper regression-locks that
+// extractContains correctly classifies a nested ContainsAll / ContainsAny
+// as "nested" when its query value tokenizes into multiple terms (the
+// children[0] is a tokenization wrapper, not a direct nested leaf). The
+// bug surface for ContainsAll/Any without Fix 1 is different from
+// ContainsNone (no universe leak), but the misclassification still
+// produces the wrong dispatch shape — the OUT pvp becomes OperatorAnd /
+// OperatorOr which flattenAndOperators may unwrap, exposing the inner
+// tokenization wrappers and breaking same-element correlation under any
+// surrounding AND.
+//
+// Schema: country.tags (text/word).
+// Filter A: ContainsAll(country.tags, "new york")  — single multi-token value
+// Filter B: ContainsAny(country.tags, "new york")  — same shape, OR operator
+//
+// Single multi-token value collapses to the inner tokenization wrapper
+// (per extractContains' len(children)==1 shortcut), so the regression
+// here is that the wrapper carries the same answer pre and post fix.
+// Verifies the nested detection at extractContains is symmetric across
+// the three Contains* operators.
+func TestNestedFilteringContainsAllAnyMultiTokenWrapper(t *testing.T) {
+	const nestedClass = "ContainsAllAnyMultiTokenWrapper"
+	vTrue := true
+	word := models.NestedPropertyTokenizationWord
+
+	rootInner := []*models.NestedProperty{
+		{Name: "tags", DataType: schema.DataTypeText.PropString(), Tokenization: word, IndexFilterable: &vTrue},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "country", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootInner},
+		},
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	containsFilter := func(path string, op filters.Operator, vals ...string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: op,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: vals},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	d1, d2, d3 := uuid(1), uuid(2), uuid(3)
+	docs := []docDef{
+		{id: d1, props: map[string]any{"country": map[string]any{"tags": "new york"}}, note: "tags=new york (phrase match)"},
+		{id: d2, props: map[string]any{"country": map[string]any{"tags": "new orleans"}}, note: "tags=new orleans (only new token)"},
+		{id: d3, props: map[string]any{"country": map[string]any{"tags": "sport"}}, note: "tags=sport (no overlap)"},
+	}
+
+	t.Run("ContainsAll", func(t *testing.T) {
+		// ContainsAll(tags, "new york") — single multi-token value requires both
+		// tokens to co-occur at the same tag value. Only d1 matches.
+		runScenario(t, docs, containsFilter("country.tags", filters.ContainsAll, "new york"),
+			[]strfmt.UUID{d1})
+	})
+	t.Run("ContainsAny", func(t *testing.T) {
+		// ContainsAny(tags, "new york") — single value; equivalent to
+		// ContainsAll in this single-value case. Only d1 has both tokens.
+		runScenario(t, docs, containsFilter("country.tags", filters.ContainsAny, "new york"),
+			[]strfmt.UUID{d1})
+	})
+}
+
 // TestNestedFilteringContainsNoneInsideCorrelatedAnd exercises the
 // post-Route-1 correlated-AND handler for ContainsNone (materialized
 // inline via normalizeRecGroup's ContainsNone case). Two root prop
@@ -13998,7 +14319,7 @@ func TestNestedFilteringContainsNoneInsideCorrelatedAnd(t *testing.T) {
 	})
 
 	t.Run("countries_array", func(t *testing.T) {
-		d1, d2, d3, d4, d5, d6, d7 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7)
+		d1, d2, d3, d4, d5, d6, d7, d8 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7), uuid(8)
 		docs := []docDef{
 			{id: d1, props: map[string]any{"countries": []any{
 				map[string]any{"name": "germany", "tags": asTextArr("sport", "electric"), "cities": asTextArr("paris")},
@@ -14021,6 +14342,17 @@ func TestNestedFilteringContainsNoneInsideCorrelatedAnd(t *testing.T) {
 			{id: d7, props: map[string]any{"countries": []any{
 				map[string]any{"name": "germany", "tags": asTextArr("sport"), "cities": asTextArr("london")},
 			}}, note: "germany; qualifying tag + sibling"},
+			// d8 — multi-element discriminator: countries[0] has name=germany but
+			// only-listed tags; countries[1] has qualifying tags but wrong name.
+			// Under same-element correlated-AND semantics (Route 1 grouping
+			// includes ContainsNone), no single country satisfies both predicates,
+			// so the doc must drop. Pre-Route-1 (or if ContainsNone is left out
+			// of nestedRootProp's switch) the dispatch combines at docID level
+			// and the doc would erroneously match.
+			{id: d8, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("electric")},
+				map[string]any{"name": "france", "tags": asTextArr("sport")},
+			}}, note: "split across countries: germany has only-listed tags; sport tag is in france"},
 		}
 		f := andFilter(
 			valueFilter("countries.name", "germany"),
@@ -14170,7 +14502,7 @@ func TestNestedFilteringContainsAllInsideCorrelatedAnd(t *testing.T) {
 	})
 
 	t.Run("countries_array", func(t *testing.T) {
-		d1, d2, d3, d4, d5, d6, d7 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7)
+		d1, d2, d3, d4, d5, d6, d7, d8 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7), uuid(8)
 		docs := []docDef{
 			{id: d1, props: map[string]any{"countries": []any{
 				map[string]any{"name": "germany", "tags": asTextArr("sport", "luxury", "electric"), "cities": asTextArr("paris")},
@@ -14193,6 +14525,16 @@ func TestNestedFilteringContainsAllInsideCorrelatedAnd(t *testing.T) {
 			{id: d7, props: map[string]any{"countries": []any{
 				map[string]any{"name": "germany", "tags": asTextArr("luxury", "electric")},
 			}}, note: "germany; missing sport"},
+			// d8 — multi-element discriminator: countries[0] has name=germany but
+			// tags=[sport]; countries[1] has tags=[sport, luxury] but name=france.
+			// Same-element correlated-AND (ContainsAll same-root grouped with the
+			// name leaf) requires ONE country to satisfy both predicates → no
+			// match. Pre-grouping (docID-level combination) would erroneously
+			// match d8 (germany name in [0], all required tags in [1]).
+			{id: d8, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport")},
+				map[string]any{"name": "france", "tags": asTextArr("sport", "luxury")},
+			}}, note: "split across countries: germany lacks luxury; required tags are in france"},
 		}
 		f := andFilter(
 			valueFilter("countries.name", "germany"),
@@ -14338,7 +14680,7 @@ func TestNestedFilteringContainsAnyInsideCorrelatedAnd(t *testing.T) {
 	})
 
 	t.Run("countries_array", func(t *testing.T) {
-		d1, d2, d3, d4, d5, d6, d7 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7)
+		d1, d2, d3, d4, d5, d6, d7, d8 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7), uuid(8)
 		docs := []docDef{
 			{id: d1, props: map[string]any{"countries": []any{
 				map[string]any{"name": "germany", "tags": asTextArr("sport", "luxury", "electric"), "cities": asTextArr("paris")},
@@ -14361,6 +14703,16 @@ func TestNestedFilteringContainsAnyInsideCorrelatedAnd(t *testing.T) {
 			{id: d7, props: map[string]any{"countries": []any{
 				map[string]any{"name": "germany", "tags": asTextArr("electric"), "cities": asTextArr("paris")},
 			}}, note: "germany; wrong tag + sibling"},
+			// d8 — multi-element discriminator: countries[0] has name=germany but
+			// no qualifying tag; countries[1] has qualifying tag but wrong name.
+			// Same-element correlated-AND (ContainsAny same-root grouped with the
+			// name leaf) requires ONE country to satisfy both predicates → no
+			// match. Pre-grouping (docID-level combination) would erroneously
+			// match d8 (germany name in [0], qualifying tag in [1]).
+			{id: d8, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("electric")},
+				map[string]any{"name": "france", "tags": asTextArr("sport")},
+			}}, note: "split across countries: germany lacks qualifying tag; sport tag is in france"},
 		}
 		f := andFilter(
 			valueFilter("countries.name", "germany"),
@@ -14371,10 +14723,11 @@ func TestNestedFilteringContainsAnyInsideCorrelatedAnd(t *testing.T) {
 }
 
 // TestNestedFilteringContainsNoneInsideOr — companion to the inside-AND
-// test, but with OR as the outer operator. ContainsNone is not folded
-// into same-root grouping (it's absent from nestedRootProp's switch), so
-// the outer OR resolves at docID level — each child resolves to a docID
-// bitmap and they are unioned.
+// test, but with OR as the outer operator. ContainsNone participates in
+// same-root grouping (it's in nestedRootProp's switch), so the OR is
+// wrapped under isWithinRootSubtree and the planner builds a
+// position-level recOrNode at the deepest common LCA; the two operand
+// bitmaps are unioned there.
 //
 // Semantics: doc matches iff name="germany" OR (∃ tag-element whose value
 // is NOT in the listed set). Strict-existential ContainsNone is supplied

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -514,36 +514,23 @@ func TestNestedFilteringViaShardWritePath(t *testing.T) {
 			matchesObjectDel: e, matchesArrayDel: e,
 			matchesObjectUpd: e, matchesArrayUpd: e,
 		},
-		// ContainsNone is NOT(OR of Equal clauses). OR-of-same-root wrapping
-		// (OR grouping) + top-level NOT wrapping (top-level NOT marking) dispatch the
-		// NOT to the scope-aware planner; it inverts at the operand's
-		// natural LCA (the tags array path) giving per-tag-element
-		// existential. The id125/id201 (=doc125Data, tags=["electric"])
-		// rows leak through today because of a single-object-root +
-		// text[] vacuous-drop bug — same root cause as
-		// TestNestedFilteringContainsOperators/country_object/L0_tags.
-		// TODO aliszka:nested_filtering: after vacuous-drop fix for
-		// single-object-root with text[] property, expected per-element inversion is:
-		//   [electric, sedan]:
-		//     matchesObjectAdd: {id123, id124}    matchesArrayAdd: {id998, id999}
-		//     matchesObjectDel: {id124}           matchesArrayDel: {id999}
-		//     matchesObjectUpd: {id200}           matchesArrayUpd: {id300}
-		//   [premium, electric]:
-		//     matchesObjectAdd: {id123, id124}    matchesArrayAdd: {id998, id999}
-		//     matchesObjectDel: {id124}           matchesArrayDel: {id999}
-		//     matchesObjectUpd: {id200}           matchesArrayUpd: {id300}
-		//   (d125-only rows drop under proper vacuous-element handling.)
+		// Route 1: ContainsNone is now a first-class operator using
+		// `_exists.{relPath}` as the inversion universe. For doc125Data
+		// (tags=["electric"]) the only tag IS in the listed set, so no
+		// qualifying tag exists → drops. Array case (id999=[doc124, doc125])
+		// still matches because doc124 has tags=[german, japanese, sedan]
+		// of which german/japanese qualify.
 		{
 			name: "tags ContainsNone [electric, sedan]", filter: f("tags", filters.ContainsNone, schema.DataTypeText, []string{"electric", "sedan"}),
-			matchesObjectAdd: []strfmt.UUID{id123, id124, id125}, matchesArrayAdd: []strfmt.UUID{id998, id999},
-			matchesObjectDel: []strfmt.UUID{id124, id125}, matchesArrayDel: []strfmt.UUID{id999},
-			matchesObjectUpd: []strfmt.UUID{id200, id201}, matchesArrayUpd: []strfmt.UUID{id300},
+			matchesObjectAdd: []strfmt.UUID{id123, id124}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
 		},
 		{
 			name: "tags ContainsNone [premium, electric]", filter: f("tags", filters.ContainsNone, schema.DataTypeText, []string{"premium", "electric"}),
-			matchesObjectAdd: []strfmt.UUID{id123, id124, id125}, matchesArrayAdd: []strfmt.UUID{id998, id999},
-			matchesObjectDel: []strfmt.UUID{id124, id125}, matchesArrayDel: []strfmt.UUID{id999},
-			matchesObjectUpd: []strfmt.UUID{id200, id201}, matchesArrayUpd: []strfmt.UUID{id300},
+			matchesObjectAdd: []strfmt.UUID{id123, id124}, matchesArrayAdd: []strfmt.UUID{id998, id999},
+			matchesObjectDel: []strfmt.UUID{id124}, matchesArrayDel: []strfmt.UUID{id999},
+			matchesObjectUpd: []strfmt.UUID{id200}, matchesArrayUpd: []strfmt.UUID{id300},
 		},
 		{
 			// NotEqual under existential per-element semantics (materialized
@@ -13256,25 +13243,14 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.tags", filters.ContainsAny, "sport", "luxury"),
 					[]strfmt.UUID{d1, d2, d3})
 			})
-			// OR-of-same-root wrapping marks OR-of-same-root (the two
-			// country.tags=value branches) as scope-aware. The wrapping
-			// NOT then inverts at the operand's natural LCA = country.tags
-			// (the tag array), giving per-tag-element existential
-			// semantics instead of the per-country semantics the test
-			// author originally assumed under "single root object,
-			// ContainsNone unambiguous". d2 ([sport,cargo]) and d3
-			// ([luxury,cargo]) flip in because they have a cargo tag that
-			// is none of [sport,luxury]. d5 (empty country) leaks in
-			// today — under per-element inversion's vacuous-element rule it should
-			// drop.
-			// TODO aliszka:nested_filtering: after vacuous-drop fix for
-			// single-object-root with empty array prop, expected per-element inversion:
-			//   []strfmt.UUID{d2, d3, d4}
-			//   (d5 drops; per-tag-element existential: ∃ tag not in
-			//   [sport,luxury].)
+			// Route 1: ContainsNone is now a first-class operator with
+			// `_exists.tags` as the inversion universe. d2/d3/d4 have at
+			// least one tag outside [sport, luxury] → match. d5 (empty
+			// country, no tags) has no tag positions → universe empty →
+			// drops correctly.
 			t.Run("ContainsNone", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.tags", filters.ContainsNone, "sport", "luxury"),
-					[]strfmt.UUID{d2, d3, d4, d5})
+					[]strfmt.UUID{d2, d3, d4})
 			})
 		})
 
@@ -13297,9 +13273,13 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.name", filters.ContainsAny, "new", "york"),
 					[]strfmt.UUID{d1, d2, d3})
 			})
+			// Route 1: ContainsNone is now first-class with universe =
+			// `_exists.name`. d4 (boston, no "new"/"york" tokens) matches;
+			// d5 (empty country, no name) has no position in the universe
+			// → drops.
 			t.Run("ContainsNone", func(t *testing.T) {
 				runScenario(t, docs, containsFilter("country.name", filters.ContainsNone, "new", "york"),
-					[]strfmt.UUID{d4, d5})
+					[]strfmt.UUID{d4})
 			})
 		})
 
@@ -13728,6 +13708,150 @@ func TestNestedFilteringContainsOperators(t *testing.T) {
 					[]strfmt.UUID{d6})
 			})
 		})
+	})
+}
+
+// TestNestedFilteringContainsNoneSiblingScalarArrayLeak regression-locks
+// the Route 1 fix for the ContainsNone universe leak. ContainsNone on a
+// nested path is now a first-class operator (no longer desugared to
+// NOT(OR(...))) and uses `_exists.{relPath}` as the inversion universe —
+// the scalar-array path itself, not the broader LCA.
+//
+// Pre-fix the leak applied for both DataTypeObject and DataTypeObjectArray
+// roots because the writer encodes them identically — only test fixture
+// quirks (`[]` vs `{}` for "empty") sidestepped it elsewhere. With the
+// fix in place the bug surfaces in neither root form.
+//
+// Schema (both variants share `rootInner`):
+//
+//	country:   DataTypeObject       { tags: text[], cities: text[] }
+//	countries: DataTypeObjectArray  { tags: text[], cities: text[] }
+//
+// Filter: ContainsNone(<root>.tags, ["electric"])  — strict existential:
+// ∃ a tag NOT in {electric}.
+//
+// Docs (same shape for both roots, only wrapping differs):
+//
+//	d1: tags=[electric], cities=[paris]   — only tag is in listed set;
+//	                                         pre-fix leaked via cities leaf
+//	d2: tags=[sport],    cities=[london]  — control: tag NOT in listed set
+//	d3:                  cities=[berlin]  — vacuous: no tags; pre-fix
+//	                                         leaked via cities leaf
+//
+// Expected (post-Route-1): only d2 matches for both variants.
+func TestNestedFilteringContainsNoneSiblingScalarArrayLeak(t *testing.T) {
+	const nestedClass = "ContainsNoneSiblingLeak"
+	vTrue := true
+	field := models.NestedPropertyTokenizationField
+
+	rootInner := []*models.NestedProperty{
+		{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "cities", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "country", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootInner},
+			{Name: "countries", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootInner},
+		},
+	}
+
+	asTextArr := func(vals ...string) []any {
+		out := make([]any, len(vals))
+		for i, v := range vals {
+			out[i] = v
+		}
+		return out
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+
+	containsFilter := func(path string, op filters.Operator, vals ...string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: op,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: vals},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	t.Run("country_object", func(t *testing.T) {
+		d1, d2, d3 := uuid(1), uuid(2), uuid(3)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"country": map[string]any{
+				"tags":   asTextArr("electric"),
+				"cities": asTextArr("paris"),
+			}}, note: "only tag is electric (in listed set); cities=[paris] sibling"},
+			{id: d2, props: map[string]any{"country": map[string]any{
+				"tags":   asTextArr("sport"),
+				"cities": asTextArr("london"),
+			}}, note: "tag=sport (not in listed set); control"},
+			{id: d3, props: map[string]any{"country": map[string]any{
+				"cities": asTextArr("berlin"),
+			}}, note: "no tags at all; only cities sibling — vacuous case"},
+		}
+		// Route 1: ContainsNone is now a first-class operator with universe
+		// = `_exists.tags`. d1 (only-electric tag) and d3 (no tags at all)
+		// both correctly drop. d2 (sport tag, not in listed set) matches.
+		runScenario(t, docs, containsFilter("country.tags", filters.ContainsNone, "electric"),
+			[]strfmt.UUID{d2})
+	})
+
+	t.Run("countries_array", func(t *testing.T) {
+		d1, d2, d3 := uuid(1), uuid(2), uuid(3)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"countries": []any{
+				map[string]any{
+					"tags":   asTextArr("electric"),
+					"cities": asTextArr("paris"),
+				},
+			}}, note: "only tag is electric; cities=[paris] sibling"},
+			{id: d2, props: map[string]any{"countries": []any{
+				map[string]any{
+					"tags":   asTextArr("sport"),
+					"cities": asTextArr("london"),
+				},
+			}}, note: "tag=sport (control)"},
+			{id: d3, props: map[string]any{"countries": []any{
+				map[string]any{
+					"cities": asTextArr("berlin"),
+				},
+			}}, note: "no tags, only cities — vacuous"},
+		}
+		// Route 1: same as country_object — encoding is bit-identical for
+		// DataTypeObject and DataTypeObjectArray with one element, so the
+		// same fix applies regardless of root prop type.
+		runScenario(t, docs, containsFilter("countries.tags", filters.ContainsNone, "electric"),
+			[]strfmt.UUID{d2})
 	})
 }
 

--- a/adapters/repos/db/nested_filtering_db_integration_test.go
+++ b/adapters/repos/db/nested_filtering_db_integration_test.go
@@ -13855,6 +13855,181 @@ func TestNestedFilteringContainsNoneSiblingScalarArrayLeak(t *testing.T) {
 	})
 }
 
+// TestNestedFilteringContainsNoneInsideCorrelatedAnd exercises the
+// post-Route-1 correlated-AND handler for ContainsNone (materialized
+// inline via normalizeRecGroup's ContainsNone case). Two root prop
+// shapes; in each: AND(name=<value>, ContainsNone(tags, [...])) — both
+// children target the same root prop so same-root grouping triggers the
+// correlated-AND path. Each doc's outcome must match strict-existential:
+// the matching name AND ∃ a tag-element whose value is NOT in the listed
+// set.
+//
+// The schema includes a sibling `cities: text[]` to exercise the
+// sibling-leak shape inside the correlated AND. Without Route 1's
+// first-class operator handling, the inside-AND ContainsNone would use
+// `_exists.""` as universe and the cities-leaf would survive AndNot —
+// docs would leak through identically to the standalone case
+// (see TestNestedFilteringContainsNoneSiblingScalarArrayLeak).
+//
+// Schema:
+//
+//	country:   DataTypeObject       { name: text/field, tags: text[]/field, cities: text[]/field }
+//	countries: DataTypeObjectArray  { name: text/field, tags: text[]/field, cities: text[]/field }
+//
+// Filter: AND(<root>.name="germany", ContainsNone(<root>.tags, ["electric"]))
+//
+// Docs:
+//
+//	d1: name="germany", tags=[sport, electric], cities=[paris]   — matches (sport qualifies)
+//	d2: name="germany", tags=[electric],        cities=[paris]   — drops (only-listed + sibling cities — the leak shape)
+//	d3: name="germany",                         cities=[paris]   — drops (no tags + sibling cities, vacuous)
+//	d4: name="germany", tags=[electric]                          — drops (only-listed, no sibling)
+//	d5: name="france",  tags=[sport],           cities=[london]  — drops (wrong name)
+//	d6: name="germany", tags=[sport]                             — matches (control, no sibling)
+//	d7: name="germany", tags=[sport],           cities=[london]  — matches (control, with sibling)
+func TestNestedFilteringContainsNoneInsideCorrelatedAnd(t *testing.T) {
+	const nestedClass = "ContainsNoneInsideAnd"
+	vTrue := true
+	field := models.NestedPropertyTokenizationField
+
+	rootInner := []*models.NestedProperty{
+		{Name: "name", DataType: schema.DataTypeText.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "tags", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+		{Name: "cities", DataType: schema.DataTypeTextArray.PropString(), Tokenization: field, IndexFilterable: &vTrue},
+	}
+	class := &models.Class{
+		Class:             nestedClass,
+		VectorIndexConfig: enthnsw.UserConfig{Skip: true},
+		Properties: []*models.Property{
+			{Name: "country", DataType: schema.DataTypeObject.PropString(), NestedProperties: rootInner},
+			{Name: "countries", DataType: schema.DataTypeObjectArray.PropString(), NestedProperties: rootInner},
+		},
+	}
+
+	asTextArr := func(vals ...string) []any {
+		out := make([]any, len(vals))
+		for i, v := range vals {
+			out[i] = v
+		}
+		return out
+	}
+
+	type docDef struct {
+		id    strfmt.UUID
+		props map[string]any
+		note  string
+	}
+	uuid := func(n int) strfmt.UUID {
+		return strfmt.UUID(fmt.Sprintf("00000000-0000-0000-0000-%012x", n))
+	}
+	valueFilter := func(path, val string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorEqual,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: val},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	containsFilter := func(path string, op filters.Operator, vals ...string) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: op,
+			Value:    &filters.Value{Type: schema.DataTypeText, Value: vals},
+			On:       &filters.Path{Class: nestedClass, Property: schema.PropertyName(path)},
+		}}
+	}
+	andFilter := func(a, b *filters.LocalFilter) *filters.LocalFilter {
+		return &filters.LocalFilter{Root: &filters.Clause{
+			Operator: filters.OperatorAnd,
+			Operands: []filters.Clause{*a.Root, *b.Root},
+		}}
+	}
+
+	runScenario := func(t *testing.T, docs []docDef, filter *filters.LocalFilter, want []strfmt.UUID) {
+		t.Helper()
+		db := createTestDatabaseWithClass(t, monitoring.GetMetrics(), class)
+		ctx := context.Background()
+		for _, d := range docs {
+			require.NoError(t, db.PutObject(ctx, &models.Object{
+				Class: nestedClass, ID: d.id, Properties: d.props,
+			}, nil, nil, nil, nil, 0), "put %s (%s)", d.id, d.note)
+		}
+		res, err := db.Search(ctx, dto.GetParams{
+			ClassName:  nestedClass,
+			Pagination: &filters.Pagination{Limit: 100},
+			Filters:    filter,
+		})
+		require.NoError(t, err)
+		got := make([]strfmt.UUID, len(res))
+		for i, r := range res {
+			got[i] = r.ID
+		}
+		assert.ElementsMatch(t, want, got)
+	}
+
+	t.Run("country_object", func(t *testing.T) {
+		d1, d2, d3, d4, d5, d6, d7 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport", "electric"), "cities": asTextArr("paris"),
+			}}, note: "germany; mixed tags + sibling cities (sport qualifies)"},
+			{id: d2, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("electric"), "cities": asTextArr("paris"),
+			}}, note: "germany; only-listed tag + sibling cities — the inside-AND leak shape"},
+			{id: d3, props: map[string]any{"country": map[string]any{
+				"name": "germany", "cities": asTextArr("paris"),
+			}}, note: "germany; no tags but sibling cities — vacuous"},
+			{id: d4, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("electric"),
+			}}, note: "germany; only-listed tag, no sibling"},
+			{id: d5, props: map[string]any{"country": map[string]any{
+				"name": "france", "tags": asTextArr("sport"), "cities": asTextArr("london"),
+			}}, note: "wrong name"},
+			{id: d6, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport"),
+			}}, note: "germany; qualifying tag, no sibling"},
+			{id: d7, props: map[string]any{"country": map[string]any{
+				"name": "germany", "tags": asTextArr("sport"), "cities": asTextArr("london"),
+			}}, note: "germany; qualifying tag + sibling cities"},
+		}
+		f := andFilter(
+			valueFilter("country.name", "germany"),
+			containsFilter("country.tags", filters.ContainsNone, "electric"),
+		)
+		runScenario(t, docs, f, []strfmt.UUID{d1, d6, d7})
+	})
+
+	t.Run("countries_array", func(t *testing.T) {
+		d1, d2, d3, d4, d5, d6, d7 := uuid(1), uuid(2), uuid(3), uuid(4), uuid(5), uuid(6), uuid(7)
+		docs := []docDef{
+			{id: d1, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport", "electric"), "cities": asTextArr("paris")},
+			}}, note: "germany; mixed tags + sibling cities"},
+			{id: d2, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("electric"), "cities": asTextArr("paris")},
+			}}, note: "germany; only-listed + sibling — leak shape"},
+			{id: d3, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "cities": asTextArr("paris")},
+			}}, note: "germany; no tags + sibling — vacuous"},
+			{id: d4, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("electric")},
+			}}, note: "germany; only-listed, no sibling"},
+			{id: d5, props: map[string]any{"countries": []any{
+				map[string]any{"name": "france", "tags": asTextArr("sport"), "cities": asTextArr("london")},
+			}}, note: "wrong name"},
+			{id: d6, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport")},
+			}}, note: "germany; qualifying tag, no sibling"},
+			{id: d7, props: map[string]any{"countries": []any{
+				map[string]any{"name": "germany", "tags": asTextArr("sport"), "cities": asTextArr("london")},
+			}}, note: "germany; qualifying tag + sibling"},
+		}
+		f := andFilter(
+			valueFilter("countries.name", "germany"),
+			containsFilter("countries.tags", filters.ContainsNone, "electric"),
+		)
+		runScenario(t, docs, f, []strfmt.UUID{d1, d6, d7})
+	})
+}
+
 // TestNestedFilteringAndShapeFlatVsAndOfAnd verifies that two AND shapes
 // equivalent under classical boolean associativity produce IDENTICAL
 // results in the nested-filter dispatch:


### PR DESCRIPTION
### Nested object filtering — Part 17                                                                                   
                                                                                                                            
  Seventeenth PR in the nested object filtering series, building on Part 16 (scope-aware NOT and IsNull). Closes a `ContainsNone` correctness leak by preserving `Contains*` operators as first-class on nested paths instead of desugaring them to `NOT(OR(...))` / `OR(...)` / `AND(...)` of same-path Equals.                                                      
                                                                                                                          
  **`ContainsNone` universe leak (bug fix)**

  `ContainsNone(path, [v1, …])` on a nested path was desugared to `NOT(OR(path=v1, …))`, and the wrapping NOT went through scope-aware NOT inversion at the operand's LCA. For paths with no `DataTypeObjectArray` ancestor (e.g. `country.tags`), LCA fell through to `""` and the universe `_exists.""` aggregated positions from every property branch under the root — sibling-property leaves and phantom leaves from empty containers survived the inversion, leaking the doc.               

  Fix: `extractContains` keeps `ContainsNone` as a first-class operator. New `fetchNestedContainsNone` reads `_exists.{relPath}` (restricted by any `arr[N]` pins) as the universe, ORs per-value bitmaps as the operand, AndNots, strips to docIDs. Multi-token text values AndAll their tokens at the leaf level. Non-nested `ContainsNone` still desugars.
                                                                                                                          
  **`ContainsNone` inside correlated AND / operator subtree**                                                               
   
  The first-class dispatch only handled standalone `ContainsNone`; as a child of a same-root correlated AND (or inside an OR / NOT subtree under one) it reached `normalizeRecGroup`'s default case and errored. Adds explicit cases to `normalizeRecGroup` and `fetchOperatorSubtreeBitmaps`, both routed through a shared `materializeNestedContainsNone` helper. `extractContains` propagates `arr[N]` indices from children so the universe lookup honors pins.                 

  **`ContainsAll` / `ContainsAny` extended for consistency**                                                                
   
  `ContainsAll` and `ContainsAny` keep their operator identity through `extractContains`; downstream pipeline switches treat `ContainsAll` as an AND alias and `ContainsAny` as an OR alias. `flattenAndOperators` unwraps `ContainsAll` wrappers. Single-value `Contains*` collapses to the bare Equal leaf. No semantic change — existing tests pass unchanged.            
                                                                                                                          
  **Test impact and cleanup**

  - `TestNestedFilteringContainsNoneSiblingScalarArrayLeak` locks the leak shape (sibling `tags`/`cities` `text[]`)         
  - 12 `ViaShardWritePath` object-type `ContainsNone` sub-tests + 2 `ContainsOperators/country_object/L0_*` sub-tests flip to post-fix expected lists                                                                                                
  - 5 new regression tests cover each `Contains*` operator as a sibling of a value filter under AND and OR outer operators, with a `text[]` leak discriminator                                                                                        
  - 1 unit-test reshape + 2 new asserts for the single-value-collapse path                                                
                                                                                                                            
  Final commit rewrites internal jargon (route labels, residual gap / sub-rule / position-level eval references) — 26 lines across 8 files, no code logic touched.
                                                                                                                            
  **Test plan**                                                                                                           
  - [ ] `go test ./adapters/repos/db/inverted/...`
  - [ ] `go test -tags integrationTest ./adapters/repos/db/inverted/...`
  - [ ] `go test -tags integrationTest ./adapters/repos/db/...`  