### PR TITLE
Remove `_NUMCPU`s concurrency when making snapshot hardlinks during backup

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -268,32 +268,19 @@ func (i *Index) descriptorWithHardlinks(ctx context.Context, backupID string, de
 		return fmt.Errorf("list local shards: %w", err)
 	}
 
-	eg, ctx := enterrors.NewErrorGroupWithContextWrapper(i.logger, ctx)
-	eg.SetLimit(_NUMCPU)
-	mu := sync.Mutex{}
 	shards := map[string]*backup.ShardDescriptor{}
-
 	for _, name := range shardNames {
-		eg.Go(func() error {
-			sd, err := i.backupShardWithHardlinks(ctx, name, classBaseDescrs, stagingRoot)
-			if err != nil {
-				if errors.Is(err, errShardNoLocalData) {
-					i.logger.WithField("shard", name).Debug("skipping shard with no local data")
-					return nil
-				}
-				return err
+		sd, err := i.backupShardWithHardlinks(ctx, name, classBaseDescrs, stagingRoot)
+		if err != nil {
+			if errors.Is(err, errShardNoLocalData) {
+				i.logger.WithField("shard", name).Debug("skipping shard with no local data")
+				continue
 			}
-			if sd != nil {
-				mu.Lock()
-				shards[name] = sd
-				mu.Unlock()
-			}
-			return nil
-		})
-	}
-
-	if err := eg.Wait(); err != nil {
-		return fmt.Errorf("backup shards with hardlinks: %w", err)
+			return err
+		}
+		if sd != nil {
+			shards[name] = sd
+		}
 	}
 
 	// Preserve original shard order from sharding state.


### PR DESCRIPTION
### What's being changed:


### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
