### PR TITLE
fix(backup): narrow shardCreateLocks scope to unblock queries during snapshot (#234)

### DIFF
--- a/adapters/repos/db/backup.go
+++ b/adapters/repos/db/backup.go
@@ -309,14 +309,23 @@ func (i *Index) descriptorWithHardlinks(ctx context.Context, backupID string, de
 // backupShardWithHardlinks backs up a single shard using hardlinks. Under backupLock.Lock,
 // it checks the shardMap to determine whether the shard is active (loaded in memory) or
 // inactive (on disk only), and uses the appropriate backup path.
+//
+// For active shards, shardCreateLocks is released early (after acquiring the
+// preventShutdown refcount) so concurrent queries — which RLock the same per-shard
+// key in getOptInitLocalShard — don't block for the snapshot duration. See
+// weaviate/0-weaviate-issues#234.
 func (i *Index) backupShardWithHardlinks(ctx context.Context, name string, classBaseDescrs []*backup.ClassDescriptor, stagingRoot string) (*backup.ShardDescriptor, error) {
 	shardBaseDescr := i.collectShardBaseDescrs(name, classBaseDescrs)
 
 	i.backupLock.Lock(name)
+	defer i.backupLock.Unlock(name)
+
 	i.shardCreateLocks.Lock(name)
+	shardCreateLocksHeld := true
 	defer func() {
-		i.shardCreateLocks.Unlock(name)
-		i.backupLock.Unlock(name)
+		if shardCreateLocksHeld {
+			i.shardCreateLocks.Unlock(name)
+		}
 	}()
 
 	var sd backup.ShardDescriptor
@@ -353,8 +362,18 @@ func (i *Index) backupShardWithHardlinks(ctx context.Context, name string, class
 		releaseBlock()
 	}
 
-	// Active path => shard is loaded in memory. Call through the ShardLike
-	// interface so both *Shard and loaded *LazyLoadShard work correctly.
+	// Acquire preventShutdown before releasing shardCreateLocks: UnloadLocalShard
+	// holds only shardCreateLocks (not backupLock), so without the refcount it could
+	// call Shard.Shutdown between our release and CreateBackupSnapshot.
+	release, err := shard.preventShutdown()
+	if err != nil {
+		return nil, fmt.Errorf("prevent shutdown of shard %v: %w", name, err)
+	}
+	defer release()
+
+	i.shardCreateLocks.Unlock(name)
+	shardCreateLocksHeld = false
+
 	files, err := shard.CreateBackupSnapshot(ctx, &sd, stagingRoot)
 	if err != nil {
 		return nil, fmt.Errorf("snapshot shard %v: %w", name, err)

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -750,6 +750,9 @@ func TestDescriptorHotAndColdTenants(t *testing.T) {
 		name := name
 		mockShard := NewMockShardLike(t)
 		files := hotFiles[name]
+		// preventShutdown is acquired by backupShardWithHardlinks on the active
+		// path before releasing shardCreateLocks. See weaviate/0-weaviate-issues#234.
+		mockShard.EXPECT().preventShutdown().Return(func() {}, nil)
 		mockShard.EXPECT().
 			CreateBackupSnapshot(mock.Anything, mock.Anything, mock.Anything).
 			RunAndReturn(func(_ context.Context, sd *backup.ShardDescriptor, _ string) ([]string, error) {
@@ -804,4 +807,142 @@ func TestDescriptorHotAndColdTenants(t *testing.T) {
 	for _, name := range coldTenants {
 		assert.Contains(t, restoredState.Physical, name)
 	}
+}
+
+// TestBackupShardWithHardlinks_ConcurrentRLockNotBlocked verifies that for the
+// active-shard path, backupShardWithHardlinks releases shardCreateLocks BEFORE
+// invoking CreateBackupSnapshot. This is the load-bearing invariant behind the
+// fix for weaviate/0-weaviate-issues#234: without it, concurrent queries that
+// take shardCreateLocks.RLock(name) via Index.getOptInitLocalShard block for
+// the entire snapshot duration (HaltForTransfer + flush + hardlink), which on
+// large clusters is 5-15 minutes of query stalls per backup.
+//
+// Regression guard requested by Copilot review on weaviate/weaviate#11349.
+func TestBackupShardWithHardlinks_ConcurrentRLockNotBlocked(t *testing.T) {
+	rootDir := t.TempDir()
+	className := "TestClass"
+	shardName := "test-shard"
+	ctx := context.Background()
+
+	shardState := NewMultiTenantShardingStateBuilder().
+		AddTenant(shardName, models.TenantActivityStatusHOT).
+		WithReplicationFactor(1).
+		Build()
+
+	idx := newDescriptorTestIndex(t, rootDir, className, shardState)
+
+	// Synchronization channels: CreateBackupSnapshot signals when it is
+	// in-flight, then blocks until the test releases it.
+	snapshotStarted := make(chan struct{})
+	releaseSnapshot := make(chan struct{})
+	releaseCalled := make(chan struct{})
+
+	mockShard := NewMockShardLike(t)
+	mockShard.EXPECT().preventShutdown().Return(func() {
+		close(releaseCalled)
+	}, nil)
+	mockShard.EXPECT().
+		CreateBackupSnapshot(mock.Anything, mock.Anything, mock.Anything).
+		RunAndReturn(func(_ context.Context, sd *backup.ShardDescriptor, _ string) ([]string, error) {
+			sd.Name = shardName
+			sd.Node = "node1"
+			close(snapshotStarted)
+			<-releaseSnapshot
+			return []string{}, nil
+		})
+	idx.shards.Store(shardName, mockShard)
+
+	// Drive backupShardWithHardlinks from a goroutine so the test can probe
+	// lock state while CreateBackupSnapshot is in-flight.
+	type backupResult struct {
+		sd  *backup.ShardDescriptor
+		err error
+	}
+	backupDone := make(chan backupResult, 1)
+	go func() {
+		sd, err := idx.backupShardWithHardlinks(ctx, shardName, nil, t.TempDir())
+		backupDone <- backupResult{sd: sd, err: err}
+	}()
+
+	// Wait for CreateBackupSnapshot to be in-flight.
+	select {
+	case <-snapshotStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("CreateBackupSnapshot was not invoked within 5s")
+	}
+
+	// Core assertion: shardCreateLocks must NOT be held during the snapshot.
+	// A concurrent reader (Index.getOptInitLocalShard, which RLocks the same
+	// per-shard key) must proceed without blocking.
+	require.True(t, idx.shardCreateLocks.TryRLock(shardName),
+		"shardCreateLocks must be released before CreateBackupSnapshot — "+
+			"otherwise concurrent queries block for the snapshot duration "+
+			"(weaviate/0-weaviate-issues#234)")
+	idx.shardCreateLocks.RUnlock(shardName)
+
+	// Contrast assertion: backupLock MUST still be held. Concurrent writers
+	// and dropShards (which take backupLock.RLock or backupLock.Lock) still
+	// have to be excluded for the snapshot duration.
+	require.False(t, idx.backupLock.TryRLock(shardName),
+		"backupLock must remain held during CreateBackupSnapshot")
+
+	// Release the snapshot and expect the goroutine to finish promptly.
+	close(releaseSnapshot)
+	select {
+	case res := <-backupDone:
+		require.NoError(t, res.err)
+		require.NotNil(t, res.sd)
+		assert.Equal(t, shardName, res.sd.Name)
+	case <-time.After(5 * time.Second):
+		t.Fatal("backupShardWithHardlinks did not return within 5s of releasing snapshot")
+	}
+
+	// After return, both locks must be released and the preventShutdown
+	// release callback must have run (refcount returned).
+	select {
+	case <-releaseCalled:
+	default:
+		t.Error("preventShutdown release callback was not invoked")
+	}
+	require.True(t, idx.backupLock.TryRLock(shardName),
+		"backupLock must be released after backupShardWithHardlinks returns")
+	idx.backupLock.RUnlock(shardName)
+	require.True(t, idx.shardCreateLocks.TryRLock(shardName),
+		"shardCreateLocks must remain released after backupShardWithHardlinks returns")
+	idx.shardCreateLocks.RUnlock(shardName)
+}
+
+// TestBackupShardWithHardlinks_PreventShutdownErrorReleasesLocks verifies the
+// error path: if preventShutdown fails (the shard is already shutting down),
+// backupShardWithHardlinks must still release both backupLock and
+// shardCreateLocks before returning. Regression guard for the
+// shardCreateLocksHeld bookkeeping introduced in #11349.
+func TestBackupShardWithHardlinks_PreventShutdownErrorReleasesLocks(t *testing.T) {
+	rootDir := t.TempDir()
+	className := "TestClass"
+	shardName := "test-shard"
+	ctx := context.Background()
+
+	shardState := NewMultiTenantShardingStateBuilder().
+		AddTenant(shardName, models.TenantActivityStatusHOT).
+		WithReplicationFactor(1).
+		Build()
+
+	idx := newDescriptorTestIndex(t, rootDir, className, shardState)
+
+	mockShard := NewMockShardLike(t)
+	mockShard.EXPECT().preventShutdown().Return(nil, errors.New("shard is shutting down"))
+	idx.shards.Store(shardName, mockShard)
+
+	_, err := idx.backupShardWithHardlinks(ctx, shardName, nil, t.TempDir())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "prevent shutdown")
+
+	// Both locks must be released even on the error path.
+	require.True(t, idx.backupLock.TryRLock(shardName),
+		"backupLock must be released after preventShutdown failure")
+	idx.backupLock.RUnlock(shardName)
+	require.True(t, idx.shardCreateLocks.TryRLock(shardName),
+		"shardCreateLocks must be released after preventShutdown failure")
+	idx.shardCreateLocks.RUnlock(shardName)
 }

--- a/adapters/repos/db/backup_test.go
+++ b/adapters/repos/db/backup_test.go
@@ -809,15 +809,9 @@ func TestDescriptorHotAndColdTenants(t *testing.T) {
 	}
 }
 
-// TestBackupShardWithHardlinks_ConcurrentRLockNotBlocked verifies that for the
-// active-shard path, backupShardWithHardlinks releases shardCreateLocks BEFORE
-// invoking CreateBackupSnapshot. This is the load-bearing invariant behind the
-// fix for weaviate/0-weaviate-issues#234: without it, concurrent queries that
-// take shardCreateLocks.RLock(name) via Index.getOptInitLocalShard block for
-// the entire snapshot duration (HaltForTransfer + flush + hardlink), which on
-// large clusters is 5-15 minutes of query stalls per backup.
-//
-// Regression guard requested by Copilot review on weaviate/weaviate#11349.
+// Asserts shardCreateLocks is released before CreateBackupSnapshot so concurrent
+// queries (via Index.getOptInitLocalShard) don't stall for the snapshot duration.
+// See weaviate/0-weaviate-issues#234.
 func TestBackupShardWithHardlinks_ConcurrentRLockNotBlocked(t *testing.T) {
 	rootDir := t.TempDir()
 	className := "TestClass"
@@ -831,8 +825,6 @@ func TestBackupShardWithHardlinks_ConcurrentRLockNotBlocked(t *testing.T) {
 
 	idx := newDescriptorTestIndex(t, rootDir, className, shardState)
 
-	// Synchronization channels: CreateBackupSnapshot signals when it is
-	// in-flight, then blocks until the test releases it.
 	snapshotStarted := make(chan struct{})
 	releaseSnapshot := make(chan struct{})
 	releaseCalled := make(chan struct{})
@@ -852,8 +844,6 @@ func TestBackupShardWithHardlinks_ConcurrentRLockNotBlocked(t *testing.T) {
 		})
 	idx.shards.Store(shardName, mockShard)
 
-	// Drive backupShardWithHardlinks from a goroutine so the test can probe
-	// lock state while CreateBackupSnapshot is in-flight.
 	type backupResult struct {
 		sd  *backup.ShardDescriptor
 		err error
@@ -864,29 +854,19 @@ func TestBackupShardWithHardlinks_ConcurrentRLockNotBlocked(t *testing.T) {
 		backupDone <- backupResult{sd: sd, err: err}
 	}()
 
-	// Wait for CreateBackupSnapshot to be in-flight.
 	select {
 	case <-snapshotStarted:
 	case <-time.After(5 * time.Second):
 		t.Fatal("CreateBackupSnapshot was not invoked within 5s")
 	}
 
-	// Core assertion: shardCreateLocks must NOT be held during the snapshot.
-	// A concurrent reader (Index.getOptInitLocalShard, which RLocks the same
-	// per-shard key) must proceed without blocking.
 	require.True(t, idx.shardCreateLocks.TryRLock(shardName),
-		"shardCreateLocks must be released before CreateBackupSnapshot — "+
-			"otherwise concurrent queries block for the snapshot duration "+
-			"(weaviate/0-weaviate-issues#234)")
+		"shardCreateLocks must be released before CreateBackupSnapshot")
 	idx.shardCreateLocks.RUnlock(shardName)
 
-	// Contrast assertion: backupLock MUST still be held. Concurrent writers
-	// and dropShards (which take backupLock.RLock or backupLock.Lock) still
-	// have to be excluded for the snapshot duration.
 	require.False(t, idx.backupLock.TryRLock(shardName),
 		"backupLock must remain held during CreateBackupSnapshot")
 
-	// Release the snapshot and expect the goroutine to finish promptly.
 	close(releaseSnapshot)
 	select {
 	case res := <-backupDone:
@@ -897,26 +877,19 @@ func TestBackupShardWithHardlinks_ConcurrentRLockNotBlocked(t *testing.T) {
 		t.Fatal("backupShardWithHardlinks did not return within 5s of releasing snapshot")
 	}
 
-	// After return, both locks must be released and the preventShutdown
-	// release callback must have run (refcount returned).
 	select {
 	case <-releaseCalled:
 	default:
 		t.Error("preventShutdown release callback was not invoked")
 	}
-	require.True(t, idx.backupLock.TryRLock(shardName),
-		"backupLock must be released after backupShardWithHardlinks returns")
+	require.True(t, idx.backupLock.TryRLock(shardName), "backupLock must be released after return")
 	idx.backupLock.RUnlock(shardName)
-	require.True(t, idx.shardCreateLocks.TryRLock(shardName),
-		"shardCreateLocks must remain released after backupShardWithHardlinks returns")
+	require.True(t, idx.shardCreateLocks.TryRLock(shardName), "shardCreateLocks must remain released after return")
 	idx.shardCreateLocks.RUnlock(shardName)
 }
 
-// TestBackupShardWithHardlinks_PreventShutdownErrorReleasesLocks verifies the
-// error path: if preventShutdown fails (the shard is already shutting down),
-// backupShardWithHardlinks must still release both backupLock and
-// shardCreateLocks before returning. Regression guard for the
-// shardCreateLocksHeld bookkeeping introduced in #11349.
+// Asserts both locks are released on the preventShutdown error path — guards
+// the shardCreateLocksHeld bookkeeping that supports the early-release.
 func TestBackupShardWithHardlinks_PreventShutdownErrorReleasesLocks(t *testing.T) {
 	rootDir := t.TempDir()
 	className := "TestClass"


### PR DESCRIPTION
SuperClaude here.

Draft PR for review — **not yet ready to ship.** Per Etienne's direction on [weaviate/0-weaviate-issues#234](https://github.com/weaviate/0-weaviate-issues/issues/234#issuecomment-4480463864), opening as a draft so reviewers (especially the lazy-shard / shutdown machinery owners) can look at the diff while a separable residual is still under investigation.

## Summary

Production incident: customer's billion-scale cluster shows 5–15 min query-latency spikes at backup start when a long compaction is in flight. RCA pinned the mechanism to `i.shardCreateLocks.Lock(name)` being held by `Index.backupShardWithHardlinks` (`backup.go:316`) for the entire `HaltForTransfer` wall time, including `Store.PauseCompaction`'s wait for in-flight compactions. All queries route through `Index.GetShard` → `getOptInitLocalShard` → `i.shardCreateLocks.RLock(shardName)` (`index.go:2789`); Go's RWMutex writer-starvation prevention pins every reader behind the waiting writer.

This patch releases `shardCreateLocks` early on the active (already-loaded) path, holding `shard.preventShutdown()` (existing primitive at `shard_shutdown.go:187`) instead to keep the shard reference alive through `CreateBackupSnapshot`.

## Diff

Single file, +45 -4. Lock-scope policy documented in the function godoc.

## Validation (QA Claude on a synthetic 8 M-object 3-shard cluster, `WEAVIATE_DEBUG_COMPACT_SLEEP_SECONDS=10`)

| metric | pre-fix | post-fix |
|---|---|---|
| qidx=1 max during 15 s burst window | 6108 ms | **73 ms** (~84×) |
| qidx=3 max | 6096 ms | 86 ms |
| qidx=0 max (control, empty schema-only) | 207 ms | 81 ms |
| goroutines parked on `shardCreateLocks.RLock` | 35 | **0** |
| `KeyRWLocker.Lock` writer in `backupShardWithHardlinks` | 1 | **0** |
| **spike vs `compactOnce` wall time** | **linear** | **decoupled** |

Last row is the production-critical property: under the fix, a 10 s deterministic compaction produces the same 73 ms query-latency tail as a sub-second compaction. The mechanism is broken, not just attenuated.

Full validation: [weaviate/0-weaviate-issues#234 (comment)](https://github.com/weaviate/0-weaviate-issues/issues/234#issuecomment-4480433332).

## Residual under investigation (why this is still draft)

A separable ~1.8 s latency blip occurs ~84 s after backup fire when `HaltForTransfer` reaches the second shard. The blip is **bounded** and **does not scale with `compactOnce` wall time** — it correlates with the brief WLock windows in the post-`PauseCompaction` steps (`FlushMemtables` → `b.flushLock.Lock()` in `atomicallySwitchMemtable` / `atomicallyAddDiskSegmentAndRemoveFlushing`; HNSW `PrepareForBackup` commit-log switch; possibly vector-queue `ForceSwitch`).

We're investigating which step is the dominant blocker (per-step timing instrumentation incoming). Once identified, the decision is whether to:
- combine the residual fix with this PR, or
- ship this PR and the residual fix as separate landing units.

Etienne explicitly flagged he's not opposed to two fixes, just doesn't want to rush the decision.

## Safety analysis (key questions for maintainer review)

Three things I'd like specifically eyeballed by someone with deep familiarity with the lazy-shard / shutdown / drop machinery:

1. **`shardCreateLocks` scope:** does anything beyond \"prevent concurrent shard *loading*\" depend on this lock being held during the body of `backupShardWithHardlinks`? My read: no — the explicit comment at `backup.go:334-337` names lazy loading as the reason. Readers via `getOptInitLocalShard` need RLock for the shard-map lookup, which is brief; the WLock by backup is what compounds.

2. **`preventShutdown` composition with `LazyLoadShard`:** for the active (loaded) path, `LazyLoadShard.preventShutdown` forwards to the inner `*Shard.preventShutdown`. `inUseCounter` is the refcount; `Shard.Shutdown` retries while `inUseCounter > 0` (`shard_shutdown.go:60-77`). The race window between releasing `shardCreateLocks` and acquiring `preventShutdown` is **inverted** in the patch — preventShutdown is acquired *before* the release — so `UnloadLocalShard` (which holds only `shardCreateLocks`, not `backupLock`) is blocked at its `shardCreateLocks.Lock` until our release, at which point our refcount is already held and its `Shutdown` call retries. Want a second pair of eyes on this ordering.

3. **`shard` reference stability after `shardCreateLocks` release:** `dropShards` (`index.go:3055`) takes `backupLock.RLock(name)` which our `backupLock.Lock(name)` blocks. `UnloadLocalShard` does *not* take `backupLock`, but its `Shutdown` call is gated by `preventShutdown`'s refcount. Is there any other path that could mutate `i.shards.Load(name)`'s return between our load and our `CreateBackupSnapshot` call?

## Refs

- weaviate/0-weaviate-issues#234 — primary RCA thread, mechanism + validation evidence
- This supersedes the framing in #11347 (Tommy's hotfix); see [weaviate/0-weaviate-issues#234 (comment)](https://github.com/weaviate/0-weaviate-issues/issues/234#issuecomment-4479894113) for the pivot reasoning. #11347 will get its own close-out once the residual investigation lands and we know whether the combined fix supersedes #11347 in full.

— SuperClaude