### PR TITLE
Namespaces: Response stripping

### DIFF
--- a/adapters/handlers/grpc/v1/parse_search_request.go
+++ b/adapters/handlers/grpc/v1/parse_search_request.go
@@ -59,17 +59,14 @@ type generativeParser interface {
 type Parser struct {
 	generative         generativeParser
 	authorizedGetClass classGetterWithAuthzFunc
-	aliasGetter        aliasGetter
 }
 
 func NewParser(uses127Api bool,
 	authorizedGetClass classGetterWithAuthzFunc,
-	aliasGetter aliasGetter,
 ) *Parser {
 	return &Parser{
 		generative:         generative.NewParser(uses127Api),
 		authorizedGetClass: authorizedGetClass,
-		aliasGetter:        aliasGetter,
 	}
 }
 
@@ -80,7 +77,6 @@ func (p *Parser) Search(req *pb.SearchRequest, config *config.Config) (dto.GetPa
 		return out, err
 	}
 
-	out.Alias = p.aliasGetter(req.Collection)
 	out.ClassName = class.Class
 	out.ReplicationProperties = extractReplicationProperties(req.ConsistencyLevel)
 

--- a/adapters/handlers/grpc/v1/parse_search_request_test.go
+++ b/adapters/handlers/grpc/v1/parse_search_request_test.go
@@ -2782,7 +2782,7 @@ func TestGRPCSearchRequest(t *testing.T) {
 		},
 	}
 
-	parser := NewParser(false, getClass, getAlias)
+	parser := NewParser(false, getClass)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			out, err := parser.Search(tt.req, &config.Config{QueryDefaults: config.QueryDefaults{Limit: 10}})
@@ -2807,10 +2807,6 @@ func getClass(name string) (*models.Class, error) {
 		return nil, fmt.Errorf("class %s not found", name)
 	}
 	return class, nil
-}
-
-func getAlias(name string) string {
-	return ""
 }
 
 func sortNamedVecs(vecs []string) {

--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -536,7 +536,7 @@ func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[stri
 	if err != nil {
 		return nil, err
 	}
-	props.TargetCollection = namespacing.StripOwnNS(r.principal, className)
+	props.TargetCollection = namespacing.StripOwnNamespace(r.principal, className)
 	return props, nil
 }
 

--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -33,6 +33,7 @@ import (
 	"github.com/weaviate/weaviate/entities/dto"
 	"github.com/weaviate/weaviate/entities/search"
 	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 type mapper interface {
@@ -48,6 +49,7 @@ type generativeReplier interface {
 type Replier struct {
 	generative generativeReplier
 	mapper     mapper
+	principal  *models.Principal
 	logger     logrus.FieldLogger
 }
 
@@ -62,11 +64,13 @@ type generativeQueryParams interface {
 func NewReplier(
 	uses127 bool,
 	generativeQueryParams generativeQueryParams,
+	principal *models.Principal,
 	logger logrus.FieldLogger,
 ) *Replier {
 	return &Replier{
 		generative: generative.NewReplier(logger, generativeQueryParams, uses127),
 		mapper:     &Mapper{},
+		principal:  principal,
 		logger:     logger,
 	}
 }
@@ -524,7 +528,36 @@ func (r *Replier) extractGroup(raw any, searchParams dto.GetParams, scheme schem
 	return ret, groupedGenerativeResults, nil
 }
 
+// extractPropertiesAnswer fills the top-level result for one hit. alias is
+// already stripped upstream, so it's echoed as-is; className is stripped here.
 func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[string]interface{}, properties search.SelectProperties, className, alias string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
+	props, err := r.buildPropertiesResult(scheme, results, properties, className, additionalPropsParams)
+	if err != nil {
+		return nil, err
+	}
+	if alias != "" {
+		props.TargetCollection = alias
+	} else {
+		props.TargetCollection = namespacing.StripOwnNS(r.principal, className)
+	}
+	return props, nil
+}
+
+// extractRefPropertiesAnswer fills the result for a nested reference hit.
+// The ref's qualified class name is echoed verbatim — ref-shape stripping
+// lives in a later slice.
+func (r *Replier) extractRefPropertiesAnswer(scheme schema.Schema, results map[string]interface{}, properties search.SelectProperties, className string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
+	props, err := r.buildPropertiesResult(scheme, results, properties, className, additionalPropsParams)
+	if err != nil {
+		return nil, err
+	}
+	props.TargetCollection = className
+	return props, nil
+}
+
+// buildPropertiesResult assembles the per-hit non-ref + ref properties.
+// TargetCollection is set by the calling wrapper.
+func (r *Replier) buildPropertiesResult(scheme schema.Schema, results map[string]interface{}, properties search.SelectProperties, className string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
 	nonRefProps := &pb.Properties{
 		Fields: make(map[string]*pb.Value, 0),
 	}
@@ -580,7 +613,7 @@ func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[stri
 			if !ok {
 				continue
 			}
-			extractedRefProp, err := r.extractPropertiesAnswer(scheme, refLocal.Fields, prop.Refs[0].RefProperties, refLocal.Class, "", additionalPropsParams)
+			extractedRefProp, err := r.extractRefPropertiesAnswer(scheme, refLocal.Fields, prop.Refs[0].RefProperties, refLocal.Class, additionalPropsParams)
 			if err != nil {
 				continue
 			}
@@ -598,7 +631,7 @@ func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[stri
 		refProp := pb.RefPropertiesResult{PropName: prop.Name, Properties: extractedRefProps}
 		refProps = append(refProps, &refProp)
 	}
-	props := pb.PropertiesResult{}
+	props := &pb.PropertiesResult{}
 	if len(nonRefProps.Fields) != 0 {
 		props.NonRefProps = nonRefProps
 	}
@@ -606,12 +639,7 @@ func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[stri
 		props.RefProps = refProps
 	}
 	props.RefPropsRequested = properties.HasRefs()
-	if alias != "" {
-		props.TargetCollection = alias
-	} else {
-		props.TargetCollection = className
-	}
-	return &props, nil
+	return props, nil
 }
 
 func extractGenerateResult(additionalPropertiesMap map[string]interface{}) (*additionalModels.GenerateResult, error) {

--- a/adapters/handlers/grpc/v1/prepare_reply.go
+++ b/adapters/handlers/grpc/v1/prepare_reply.go
@@ -163,7 +163,7 @@ func (r *Replier) extractObjectsToResults(res []interface{}, searchParams dto.Ge
 		var props *pb.PropertiesResult
 		var err error
 
-		props, err = r.extractPropertiesAnswer(scheme, asMap, searchParams.Properties, searchParams.ClassName, searchParams.Alias, searchParams.AdditionalProperties)
+		props, err = r.extractPropertiesAnswer(scheme, asMap, searchParams.Properties, searchParams.ClassName, searchParams.AdditionalProperties)
 		if err != nil {
 			return nil, "", nil, err
 		}
@@ -528,18 +528,15 @@ func (r *Replier) extractGroup(raw any, searchParams dto.GetParams, scheme schem
 	return ret, groupedGenerativeResults, nil
 }
 
-// extractPropertiesAnswer fills the top-level result for one hit. alias is
-// already stripped upstream, so it's echoed as-is; className is stripped here.
-func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[string]interface{}, properties search.SelectProperties, className, alias string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
+// extractPropertiesAnswer fills the top-level result for one hit.
+// TargetCollection is the resolved class name, stripped of the caller's own
+// namespace prefix.
+func (r *Replier) extractPropertiesAnswer(scheme schema.Schema, results map[string]interface{}, properties search.SelectProperties, className string, additionalPropsParams additional.Properties) (*pb.PropertiesResult, error) {
 	props, err := r.buildPropertiesResult(scheme, results, properties, className, additionalPropsParams)
 	if err != nil {
 		return nil, err
 	}
-	if alias != "" {
-		props.TargetCollection = alias
-	} else {
-		props.TargetCollection = namespacing.StripOwnNS(r.principal, className)
-	}
+	props.TargetCollection = namespacing.StripOwnNS(r.principal, className)
 	return props, nil
 }
 

--- a/adapters/handlers/grpc/v1/prepare_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_reply_test.go
@@ -1373,8 +1373,8 @@ func (f fakeGenerativeParams) ReturnDebugForGrouped() bool {
 	return false
 }
 
-// TestTargetCollectionStripping: alias wins if set, else className stripped
-// to the caller's namespace; globals/nil principals pass through raw.
+// TestTargetCollectionStripping: className is stripped to the caller's
+// namespace; global/nil principals pass through raw.
 func TestTargetCollectionStripping(t *testing.T) {
 	namespaced := &models.Principal{Username: "u", Namespace: "customer1"}
 	global := &models.Principal{Username: "admin", IsGlobalOperator: true}
@@ -1392,49 +1392,30 @@ func TestTargetCollectionStripping(t *testing.T) {
 		name      string
 		principal *models.Principal
 		className string
-		alias     string // pre-stripped upstream
 		want      string
 	}{
 		{
-			name:      "namespaced caller, no alias: class stripped to short form",
+			name:      "namespaced caller: class stripped to short form",
 			principal: namespaced,
 			className: "customer1:Movies",
-			alias:     "",
 			want:      "Movies",
 		},
 		{
-			name:      "namespaced caller, alias set: alias echoed verbatim",
-			principal: namespaced,
-			className: "customer1:Movies",
-			alias:     "Films",
-			want:      "Films",
-		},
-		{
-			name:      "global caller, no alias: raw qualified class echoed",
+			name:      "global caller: raw qualified class echoed",
 			principal: global,
 			className: "customer1:Movies",
-			alias:     "",
 			want:      "customer1:Movies",
 		},
 		{
-			name:      "global caller, alias set: alias echoed verbatim",
-			principal: global,
-			className: "customer1:Movies",
-			alias:     "customer1:Films",
-			want:      "customer1:Films",
-		},
-		{
-			name:      "nil principal, no alias: passthrough",
+			name:      "nil principal: passthrough",
 			principal: nil,
 			className: "Movies",
-			alias:     "",
 			want:      "Movies",
 		},
 		{
 			name:      "namespaced caller, foreign-NS class: prefix preserved",
 			principal: namespaced,
 			className: "customer2:Movies",
-			alias:     "",
 			want:      "customer2:Movies",
 		},
 	}
@@ -1446,7 +1427,6 @@ func TestTargetCollectionStripping(t *testing.T) {
 				map[string]interface{}{},
 				search.SelectProperties{}, // no properties → no schema walk needed
 				tc.className,
-				tc.alias,
 				additional.Properties{},
 			)
 			require.NoError(t, err)

--- a/adapters/handlers/grpc/v1/prepare_reply_test.go
+++ b/adapters/handlers/grpc/v1/prepare_reply_test.go
@@ -1327,7 +1327,7 @@ func TestGRPCReply(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		replier := NewReplier(false, fakeGenerativeParams{}, nil)
+		replier := NewReplier(false, fakeGenerativeParams{}, nil, nil)
 		t.Run(tt.name, func(t *testing.T) {
 			out, err := replier.Search(tt.res, time.Now(), tt.searchParams, scheme)
 			if tt.hasError {
@@ -1371,4 +1371,87 @@ func (f fakeGenerativeParams) ReturnDebugForSingle() bool {
 
 func (f fakeGenerativeParams) ReturnDebugForGrouped() bool {
 	return false
+}
+
+// TestTargetCollectionStripping: alias wins if set, else className stripped
+// to the caller's namespace; globals/nil principals pass through raw.
+func TestTargetCollectionStripping(t *testing.T) {
+	namespaced := &models.Principal{Username: "u", Namespace: "customer1"}
+	global := &models.Principal{Username: "admin", IsGlobalOperator: true}
+
+	scheme := schema.Schema{
+		Objects: &models.Schema{
+			Classes: []*models.Class{
+				{Class: "customer1:Movies"},
+				{Class: "Movies"},
+			},
+		},
+	}
+
+	cases := []struct {
+		name      string
+		principal *models.Principal
+		className string
+		alias     string // pre-stripped upstream
+		want      string
+	}{
+		{
+			name:      "namespaced caller, no alias: class stripped to short form",
+			principal: namespaced,
+			className: "customer1:Movies",
+			alias:     "",
+			want:      "Movies",
+		},
+		{
+			name:      "namespaced caller, alias set: alias echoed verbatim",
+			principal: namespaced,
+			className: "customer1:Movies",
+			alias:     "Films",
+			want:      "Films",
+		},
+		{
+			name:      "global caller, no alias: raw qualified class echoed",
+			principal: global,
+			className: "customer1:Movies",
+			alias:     "",
+			want:      "customer1:Movies",
+		},
+		{
+			name:      "global caller, alias set: alias echoed verbatim",
+			principal: global,
+			className: "customer1:Movies",
+			alias:     "customer1:Films",
+			want:      "customer1:Films",
+		},
+		{
+			name:      "nil principal, no alias: passthrough",
+			principal: nil,
+			className: "Movies",
+			alias:     "",
+			want:      "Movies",
+		},
+		{
+			name:      "namespaced caller, foreign-NS class: prefix preserved",
+			principal: namespaced,
+			className: "customer2:Movies",
+			alias:     "",
+			want:      "customer2:Movies",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			replier := NewReplier(false, fakeGenerativeParams{}, tc.principal, nil)
+			got, err := replier.extractPropertiesAnswer(
+				scheme,
+				map[string]interface{}{},
+				search.SelectProperties{}, // no properties → no schema walk needed
+				tc.className,
+				tc.alias,
+				additional.Properties{},
+			)
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Equal(t, tc.want, got.TargetCollection)
+		})
+	}
 }

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -285,18 +285,19 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	}
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
-	if req.Collection, _, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {
+	var originalAlias string
+	if req.Collection, originalAlias, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {
 		return nil, err
 	}
 
 	parser := NewParser(
 		req.Uses_127Api,
 		s.classGetterWithAuthzFunc(ctx, principal, req.Tenant),
-		s.aliasGetter(),
 	)
 	replier := NewReplier(
 		req.Uses_127Api,
 		parser.generative,
+		principal,
 		s.logger,
 	)
 
@@ -304,6 +305,9 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	if err != nil {
 		return nil, err
 	}
+	// Resolve returns the qualified alias used for lookup; strip back to
+	// the caller's short form for the reply. Empty for non-alias requests.
+	searchParams.Alias = namespacing.StripOwnNS(principal, originalAlias)
 
 	if err := s.validateClassAndProperty(searchParams); err != nil {
 		return nil, err
@@ -358,17 +362,6 @@ func (s *Service) classGetterWithAuthzFunc(ctx context.Context, principal *model
 			return nil, fmt.Errorf("could not find class %s in schema", name)
 		}
 		return class, nil
-	}
-}
-
-type aliasGetter func(string) string
-
-func (s *Service) aliasGetter() aliasGetter {
-	return func(name string) string {
-		if cls := s.schemaManager.ResolveAlias(name); cls != "" {
-			return name // name is an alias
-		}
-		return ""
 	}
 }
 

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -285,8 +285,7 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	}
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
-	var qualifiedAlias string
-	if req.Collection, qualifiedAlias, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {
+	if req.Collection, _, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {
 		return nil, err
 	}
 
@@ -305,9 +304,6 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	if err != nil {
 		return nil, err
 	}
-	// Strip back to the caller's short form for the reply. Empty for
-	// non-alias requests.
-	searchParams.Alias = namespacing.StripOwnNS(principal, qualifiedAlias)
 
 	if err := s.validateClassAndProperty(searchParams); err != nil {
 		return nil, err

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -285,8 +285,8 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	}
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
-	var originalAlias string
-	if req.Collection, originalAlias, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {
+	var qualifiedAlias string
+	if req.Collection, qualifiedAlias, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {
 		return nil, err
 	}
 
@@ -305,9 +305,9 @@ func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	if err != nil {
 		return nil, err
 	}
-	// Resolve returns the qualified alias used for lookup; strip back to
-	// the caller's short form for the reply. Empty for non-alias requests.
-	searchParams.Alias = namespacing.StripOwnNS(principal, originalAlias)
+	// Strip back to the caller's short form for the reply. Empty for
+	// non-alias requests.
+	searchParams.Alias = namespacing.StripOwnNS(principal, qualifiedAlias)
 
 	if err := s.validateClassAndProperty(searchParams); err != nil {
 		return nil, err

--- a/adapters/handlers/mcp/read/collections.go
+++ b/adapters/handlers/mcp/read/collections.go
@@ -56,12 +56,20 @@ func (r *WeaviateReader) GetCollectionConfig(ctx context.Context, req mcp.CallTo
 	if args.CollectionName != "" {
 		for _, class := range res.Objects.Classes {
 			if class.Class == args.CollectionName {
-				return &GetCollectionConfigResp{Collections: []*models.Class{class}}, nil
+				return &GetCollectionConfigResp{Collections: []*models.Class{namespacing.StripClassResponse(principal, class)}}, nil
 			}
 		}
 		return nil, fmt.Errorf("collection %q not found", args.CollectionName)
 	}
 
 	// Return all collections
-	return &GetCollectionConfigResp{Collections: res.Objects.Classes}, nil
+	collections := res.Objects.Classes
+	if principal != nil && principal.Namespace != "" && len(collections) > 0 {
+		stripped := make([]*models.Class, len(collections))
+		for i, c := range collections {
+			stripped[i] = namespacing.StripClassResponse(principal, c)
+		}
+		collections = stripped
+	}
+	return &GetCollectionConfigResp{Collections: collections}, nil
 }

--- a/adapters/handlers/mcp/read/collections_test.go
+++ b/adapters/handlers/mcp/read/collections_test.go
@@ -122,11 +122,11 @@ func TestGetCollectionConfig_NamespaceResolution(t *testing.T) {
 		want              wantResp
 	}{
 		{
-			name:              "namespaced principal, short name resolves",
+			name:              "namespaced principal, short name resolves and response is stripped",
 			principal:         &models.Principal{Namespace: "customer1"},
 			namespacesEnabled: true,
 			args:              GetCollectionConfigArgs{CollectionName: "Movies"},
-			want:              wantResp{classes: []string{"customer1:Movies"}},
+			want:              wantResp{classes: []string{"Movies"}},
 		},
 		{
 			name:              "namespaced principal, own-namespace qualified is rejected",
@@ -157,18 +157,21 @@ func TestGetCollectionConfig_NamespaceResolution(t *testing.T) {
 			want:              wantResp{errSubstr: "not found"},
 		},
 		{
-			name:              "namespaced principal, alias resolves to qualified target",
+			name:              "namespaced principal, alias resolves to qualified target and response is stripped",
 			principal:         &models.Principal{Namespace: "customer1"},
 			namespacesEnabled: true,
 			args:              GetCollectionConfigArgs{CollectionName: "Films"},
-			want:              wantResp{classes: []string{"customer1:Movies"}},
+			want:              wantResp{classes: []string{"Movies"}},
 		},
 		{
-			name:              "list-all branch skips resolution",
+			// Own-NS prefixes are stripped; foreign prefixes survive (RBAC would
+			// have filtered them out upstream — this test wires no RBAC, so the
+			// foreign class still appears qualified).
+			name:              "list-all branch skips resolution and strips own namespace",
 			principal:         &models.Principal{Namespace: "customer1"},
 			namespacesEnabled: true,
 			args:              GetCollectionConfigArgs{},
-			want:              wantResp{classes: []string{"customer1:Movies", "customer2:Movies", "Global"}},
+			want:              wantResp{classes: []string{"Movies", "customer2:Movies", "Global"}},
 		},
 		{
 			name:              "namespaces disabled, short name flows through",

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1191,7 +1191,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	db_users.SetupHandlers(api, appState.ClusterService.Raft, appState.Authorizer, appState.ServerConfig.Config.Authentication, appState.ServerConfig.Config.Authorization, remoteDbUsers, appState.SchemaManager, appState.ServerConfig.Config.Namespaces.Enabled, appState.NamespacesController, appState.Logger)
 	rest_namespaces.SetupHandlers(appState.ServerConfig.Config.Namespaces.Enabled, api, appState.ClusterService.Raft, appState.Authorizer, appState.Logger)
 
-	setupSchemaHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger, appState.ClusterService.Raft, appState.ReindexSubmitLocks)
+	setupSchemaHandlers(api, appState.SchemaManager, appState.ServerConfig.Config.Namespaces.Enabled, appState.Metrics, appState.Logger, appState.ClusterService.Raft, appState.ReindexSubmitLocks)
 	setupIndexesHandlers(api, appState)
 	setupTokenizeHandlers(api, appState.SchemaManager, appState.ServerConfig.Config.Namespaces.Enabled, appState.Logger)
 	setupAliasesHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger)

--- a/adapters/handlers/rest/configure_api.go
+++ b/adapters/handlers/rest/configure_api.go
@@ -1191,7 +1191,7 @@ func configureAPI(api *operations.WeaviateAPI) http.Handler {
 	db_users.SetupHandlers(api, appState.ClusterService.Raft, appState.Authorizer, appState.ServerConfig.Config.Authentication, appState.ServerConfig.Config.Authorization, remoteDbUsers, appState.SchemaManager, appState.ServerConfig.Config.Namespaces.Enabled, appState.NamespacesController, appState.Logger)
 	rest_namespaces.SetupHandlers(appState.ServerConfig.Config.Namespaces.Enabled, api, appState.ClusterService.Raft, appState.Authorizer, appState.Logger)
 
-	setupSchemaHandlers(api, appState.SchemaManager, appState.ServerConfig.Config.Namespaces.Enabled, appState.Metrics, appState.Logger, appState.ClusterService.Raft, appState.ReindexSubmitLocks)
+	setupSchemaHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger, appState.ClusterService.Raft, appState.ReindexSubmitLocks)
 	setupIndexesHandlers(api, appState)
 	setupTokenizeHandlers(api, appState.SchemaManager, appState.ServerConfig.Config.Namespaces.Enabled, appState.Logger)
 	setupAliasesHandlers(api, appState.SchemaManager, appState.Metrics, appState.Logger)

--- a/adapters/handlers/rest/handlers_aliases.go
+++ b/adapters/handlers/rest/handlers_aliases.go
@@ -25,6 +25,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	uco "github.com/weaviate/weaviate/usecases/objects"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 type aliasesHandlers struct {
@@ -56,6 +57,13 @@ func (s *aliasesHandlers) getAliases(params schema.AliasesGetParams,
 		}
 	}
 
+	if principal != nil && principal.Namespace != "" && len(aliases) > 0 {
+		stripped := make([]*models.Alias, len(aliases))
+		for i, a := range aliases {
+			stripped[i] = namespacing.StripAliasResponse(principal, a)
+		}
+		aliases = stripped
+	}
 	aliasesResponse := &models.AliasResponse{Aliases: aliases}
 
 	s.metricRequestsTotal.logOk(className)
@@ -87,7 +95,7 @@ func (s *aliasesHandlers) getAlias(params schema.AliasesGetAliasParams,
 	}
 
 	s.metricRequestsTotal.logOk("")
-	return schema.NewAliasesGetAliasOK().WithPayload(alias)
+	return schema.NewAliasesGetAliasOK().WithPayload(namespacing.StripAliasResponse(principal, alias))
 }
 
 func (s *aliasesHandlers) addAlias(params schema.AliasesCreateParams,
@@ -111,7 +119,7 @@ func (s *aliasesHandlers) addAlias(params schema.AliasesCreateParams,
 	}
 
 	s.metricRequestsTotal.logOk(params.Body.Class)
-	return schema.NewAliasesCreateOK().WithPayload(params.Body)
+	return schema.NewAliasesCreateOK().WithPayload(namespacing.StripAliasResponse(principal, params.Body))
 }
 
 func (s *aliasesHandlers) updateAlias(params schema.AliasesUpdateParams,
@@ -138,7 +146,7 @@ func (s *aliasesHandlers) updateAlias(params schema.AliasesUpdateParams,
 	}
 
 	s.metricRequestsTotal.logOk(params.Body.Class)
-	return schema.NewAliasesUpdateOK().WithPayload(alias)
+	return schema.NewAliasesUpdateOK().WithPayload(namespacing.StripAliasResponse(principal, alias))
 }
 
 func (s *aliasesHandlers) deleteAlias(params schema.AliasesDeleteParams, principal *models.Principal) middleware.Responder {

--- a/adapters/handlers/rest/handlers_authn.go
+++ b/adapters/handlers/rest/handlers_authn.go
@@ -23,6 +23,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzConv "github.com/weaviate/weaviate/usecases/auth/authorization/conv"
 	"github.com/weaviate/weaviate/usecases/auth/authorization/rbac/rbacconf"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 type authNHandlers struct {
@@ -78,9 +79,101 @@ func (h *authNHandlers) getOwnInfo(_ users.GetOwnInfoParams, principal *models.P
 		"user":      principal.Username,
 	}).Info("own info requested")
 
+	username := namespacing.StripOwnNS(principal, principal.Username)
 	return users.NewGetOwnInfoOK().WithPayload(&models.UserOwnInfo{
 		Groups:   principal.Groups,
-		Roles:    roles,
-		Username: &principal.Username,
+		Roles:    stripRolesForCaller(principal, roles),
+		Username: &username,
 	})
+}
+
+// stripRolesForCaller returns roles with each permission's namespace-bearing
+// resource string stripped of the caller's own namespace prefix. It never
+// mutates the input or its sub-structs in place: PoliciesToPermission may
+// point sub-structs at package-level singletons (authorization.AllCollections,
+// etc.), and mutating those would corrupt every other caller. Phase-1 stored
+// `p`/`g` policies are unqualified templates, so this is usually a no-op
+// today; doing the strip anyway keeps Phase-2 namespaced roles safe to expose
+// without revisiting this handler.
+func stripRolesForCaller(principal *models.Principal, roles []*models.Role) []*models.Role {
+	if principal == nil || principal.Namespace == "" || len(roles) == 0 {
+		return roles
+	}
+	out := make([]*models.Role, len(roles))
+	for i, role := range roles {
+		if role == nil {
+			continue
+		}
+		copied := *role
+		if len(role.Permissions) > 0 {
+			perms := make([]*models.Permission, len(role.Permissions))
+			for j, p := range role.Permissions {
+				perms[j] = stripPermissionForCaller(principal, p)
+			}
+			copied.Permissions = perms
+		}
+		out[i] = &copied
+	}
+	return out
+}
+
+// stripPermissionForCaller returns a permission with its namespace-bearing
+// sub-structs replaced (not mutated) by fresh copies that strip the caller's
+// own namespace prefix. Strip set: collection/alias only;
+// users/roles/tenants/replicate.shard/groups/namespaces fields untouched.
+func stripPermissionForCaller(principal *models.Principal, p *models.Permission) *models.Permission {
+	if p == nil {
+		return nil
+	}
+	out := *p
+	if p.Collections != nil && p.Collections.Collection != nil {
+		stripped := namespacing.StripOwnNS(principal, *p.Collections.Collection)
+		out.Collections = &models.PermissionCollections{Collection: &stripped}
+	}
+	if p.Data != nil && p.Data.Collection != nil {
+		stripped := namespacing.StripOwnNS(principal, *p.Data.Collection)
+		fresh := *p.Data
+		fresh.Collection = &stripped
+		out.Data = &fresh
+	}
+	if p.Nodes != nil && p.Nodes.Collection != nil {
+		stripped := namespacing.StripOwnNS(principal, *p.Nodes.Collection)
+		fresh := *p.Nodes
+		fresh.Collection = &stripped
+		out.Nodes = &fresh
+	}
+	if p.Tenants != nil && p.Tenants.Collection != nil {
+		stripped := namespacing.StripOwnNS(principal, *p.Tenants.Collection)
+		fresh := *p.Tenants
+		fresh.Collection = &stripped
+		out.Tenants = &fresh
+	}
+	if p.Backups != nil && p.Backups.Collection != nil {
+		stripped := namespacing.StripOwnNS(principal, *p.Backups.Collection)
+		out.Backups = &models.PermissionBackups{Collection: &stripped}
+	}
+	if p.Replicate != nil && p.Replicate.Collection != nil {
+		stripped := namespacing.StripOwnNS(principal, *p.Replicate.Collection)
+		fresh := *p.Replicate
+		fresh.Collection = &stripped
+		out.Replicate = &fresh
+	}
+	if p.Aliases != nil {
+		aliases := *p.Aliases
+		changed := false
+		if p.Aliases.Collection != nil {
+			stripped := namespacing.StripOwnNS(principal, *p.Aliases.Collection)
+			aliases.Collection = &stripped
+			changed = true
+		}
+		if p.Aliases.Alias != nil {
+			stripped := namespacing.StripOwnNS(principal, *p.Aliases.Alias)
+			aliases.Alias = &stripped
+			changed = true
+		}
+		if changed {
+			out.Aliases = &aliases
+		}
+	}
+	return &out
 }

--- a/adapters/handlers/rest/handlers_authn.go
+++ b/adapters/handlers/rest/handlers_authn.go
@@ -79,7 +79,7 @@ func (h *authNHandlers) getOwnInfo(_ users.GetOwnInfoParams, principal *models.P
 		"user":      principal.Username,
 	}).Info("own info requested")
 
-	username := namespacing.StripOwnNS(principal, principal.Username)
+	username := namespacing.StripOwnNamespace(principal, principal.Username)
 	return users.NewGetOwnInfoOK().WithPayload(&models.UserOwnInfo{
 		Groups:   principal.Groups,
 		Roles:    stripRolesForCaller(principal, roles),
@@ -127,33 +127,33 @@ func stripPermissionForCaller(principal *models.Principal, p *models.Permission)
 	}
 	out := *p
 	if p.Collections != nil && p.Collections.Collection != nil {
-		stripped := namespacing.StripOwnNS(principal, *p.Collections.Collection)
+		stripped := namespacing.StripOwnNamespace(principal, *p.Collections.Collection)
 		out.Collections = &models.PermissionCollections{Collection: &stripped}
 	}
 	if p.Data != nil && p.Data.Collection != nil {
-		stripped := namespacing.StripOwnNS(principal, *p.Data.Collection)
+		stripped := namespacing.StripOwnNamespace(principal, *p.Data.Collection)
 		fresh := *p.Data
 		fresh.Collection = &stripped
 		out.Data = &fresh
 	}
 	if p.Nodes != nil && p.Nodes.Collection != nil {
-		stripped := namespacing.StripOwnNS(principal, *p.Nodes.Collection)
+		stripped := namespacing.StripOwnNamespace(principal, *p.Nodes.Collection)
 		fresh := *p.Nodes
 		fresh.Collection = &stripped
 		out.Nodes = &fresh
 	}
 	if p.Tenants != nil && p.Tenants.Collection != nil {
-		stripped := namespacing.StripOwnNS(principal, *p.Tenants.Collection)
+		stripped := namespacing.StripOwnNamespace(principal, *p.Tenants.Collection)
 		fresh := *p.Tenants
 		fresh.Collection = &stripped
 		out.Tenants = &fresh
 	}
 	if p.Backups != nil && p.Backups.Collection != nil {
-		stripped := namespacing.StripOwnNS(principal, *p.Backups.Collection)
+		stripped := namespacing.StripOwnNamespace(principal, *p.Backups.Collection)
 		out.Backups = &models.PermissionBackups{Collection: &stripped}
 	}
 	if p.Replicate != nil && p.Replicate.Collection != nil {
-		stripped := namespacing.StripOwnNS(principal, *p.Replicate.Collection)
+		stripped := namespacing.StripOwnNamespace(principal, *p.Replicate.Collection)
 		fresh := *p.Replicate
 		fresh.Collection = &stripped
 		out.Replicate = &fresh
@@ -162,12 +162,12 @@ func stripPermissionForCaller(principal *models.Principal, p *models.Permission)
 		aliases := *p.Aliases
 		changed := false
 		if p.Aliases.Collection != nil {
-			stripped := namespacing.StripOwnNS(principal, *p.Aliases.Collection)
+			stripped := namespacing.StripOwnNamespace(principal, *p.Aliases.Collection)
 			aliases.Collection = &stripped
 			changed = true
 		}
 		if p.Aliases.Alias != nil {
-			stripped := namespacing.StripOwnNS(principal, *p.Aliases.Alias)
+			stripped := namespacing.StripOwnNamespace(principal, *p.Aliases.Alias)
 			aliases.Alias = &stripped
 			changed = true
 		}

--- a/adapters/handlers/rest/handlers_authn_test.go
+++ b/adapters/handlers/rest/handlers_authn_test.go
@@ -1,0 +1,329 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package rest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/auth/authorization"
+)
+
+var (
+	authnNamespacedPrincipal = &models.Principal{Username: "u", Namespace: "customer1"}
+	authnGlobalPrincipal     = &models.Principal{Username: "admin", IsGlobalOperator: true}
+	authnEmptyNSPrincipal    = &models.Principal{Username: "u"}
+)
+
+// fullPermission returns a permission populated with one own-NS value per
+// strip-set field plus a few untouched fields, so a single fixture can
+// exercise the whole strip surface in one row.
+func fullPermission() *models.Permission {
+	return &models.Permission{
+		Action:      strPtr("read_collections"),
+		Collections: &models.PermissionCollections{Collection: strPtr("customer1:Movies")},
+		Data:        &models.PermissionData{Collection: strPtr("customer1:Movies"), Tenant: strPtr("t1"), Object: strPtr("o1")},
+		Nodes:       &models.PermissionNodes{Collection: strPtr("customer1:Movies"), Verbosity: strPtr("minimal")},
+		Tenants:     &models.PermissionTenants{Collection: strPtr("customer1:Movies"), Tenant: strPtr("t1")},
+		Backups:     &models.PermissionBackups{Collection: strPtr("customer1:Movies")},
+		Replicate:   &models.PermissionReplicate{Collection: strPtr("customer1:Movies"), Shard: strPtr("s1")},
+		Aliases:     &models.PermissionAliases{Collection: strPtr("customer1:Movies"), Alias: strPtr("customer1:Films")},
+		Users:       &models.PermissionUsers{Users: strPtr("customer1:apiuser")},
+		Roles:       &models.PermissionRoles{Role: strPtr("customer1:editor")},
+		Groups:      &models.PermissionGroups{Group: strPtr("customer1:engineers")},
+		Namespaces:  &models.PermissionNamespaces{Namespace: strPtr("customer1")},
+	}
+}
+
+func fullPermissionStripped() *models.Permission {
+	return &models.Permission{
+		Action:      strPtr("read_collections"),
+		Collections: &models.PermissionCollections{Collection: strPtr("Movies")},
+		Data:        &models.PermissionData{Collection: strPtr("Movies"), Tenant: strPtr("t1"), Object: strPtr("o1")},
+		Nodes:       &models.PermissionNodes{Collection: strPtr("Movies"), Verbosity: strPtr("minimal")},
+		Tenants:     &models.PermissionTenants{Collection: strPtr("Movies"), Tenant: strPtr("t1")},
+		Backups:     &models.PermissionBackups{Collection: strPtr("Movies")},
+		Replicate:   &models.PermissionReplicate{Collection: strPtr("Movies"), Shard: strPtr("s1")},
+		Aliases:     &models.PermissionAliases{Collection: strPtr("Movies"), Alias: strPtr("Films")},
+		// Untouched sub-structs are preserved by value.
+		Users:      &models.PermissionUsers{Users: strPtr("customer1:apiuser")},
+		Roles:      &models.PermissionRoles{Role: strPtr("customer1:editor")},
+		Groups:     &models.PermissionGroups{Group: strPtr("customer1:engineers")},
+		Namespaces: &models.PermissionNamespaces{Namespace: strPtr("customer1")},
+	}
+}
+
+func TestStripPermissionForCaller(t *testing.T) {
+	cases := []struct {
+		name      string
+		principal *models.Principal
+		in        *models.Permission
+		want      *models.Permission
+	}{
+		{
+			name:      "namespaced principal: every strip-set field stripped, untouched fields preserved",
+			principal: authnNamespacedPrincipal,
+			in:        fullPermission(),
+			want:      fullPermissionStripped(),
+		},
+		{
+			name:      "foreign prefix preserved on Collections",
+			principal: authnNamespacedPrincipal,
+			in:        &models.Permission{Collections: &models.PermissionCollections{Collection: strPtr("customer2:Movies")}},
+			want:      &models.Permission{Collections: &models.PermissionCollections{Collection: strPtr("customer2:Movies")}},
+		},
+		{
+			name:      "wildcard `*` preserved on Aliases",
+			principal: authnNamespacedPrincipal,
+			in:        &models.Permission{Aliases: &models.PermissionAliases{Collection: strPtr("*"), Alias: strPtr("*")}},
+			want:      &models.Permission{Aliases: &models.PermissionAliases{Collection: strPtr("*"), Alias: strPtr("*")}},
+		},
+		{
+			name:      "aliases sub-struct with only Alias set",
+			principal: authnNamespacedPrincipal,
+			in:        &models.Permission{Aliases: &models.PermissionAliases{Alias: strPtr("customer1:Films")}},
+			want:      &models.Permission{Aliases: &models.PermissionAliases{Alias: strPtr("Films")}},
+		},
+		{
+			name:      "action only — all resource sub-structs nil",
+			principal: authnNamespacedPrincipal,
+			in:        &models.Permission{Action: strPtr("read_collections")},
+			want:      &models.Permission{Action: strPtr("read_collections")},
+		},
+		{
+			name:      "sub-struct present but Collection nil — passes through untouched",
+			principal: authnNamespacedPrincipal,
+			in:        &models.Permission{Collections: &models.PermissionCollections{}},
+			want:      &models.Permission{Collections: &models.PermissionCollections{}},
+		},
+		{
+			name:      "global principal: stripping is a no-op even when called directly",
+			principal: authnGlobalPrincipal,
+			in:        &models.Permission{Collections: &models.PermissionCollections{Collection: strPtr("customer1:Movies")}},
+			want:      &models.Permission{Collections: &models.PermissionCollections{Collection: strPtr("customer1:Movies")}},
+		},
+		{
+			name:      "nil principal: stripping is a no-op even when called directly",
+			principal: nil,
+			in:        &models.Permission{Collections: &models.PermissionCollections{Collection: strPtr("customer1:Movies")}},
+			want:      &models.Permission{Collections: &models.PermissionCollections{Collection: strPtr("customer1:Movies")}},
+		},
+		{
+			name:      "principal with empty namespace: stripping is a no-op",
+			principal: authnEmptyNSPrincipal,
+			in:        &models.Permission{Collections: &models.PermissionCollections{Collection: strPtr("customer1:Movies")}},
+			want:      &models.Permission{Collections: &models.PermissionCollections{Collection: strPtr("customer1:Movies")}},
+		},
+		{
+			name:      "nil permission returns nil",
+			principal: authnNamespacedPrincipal,
+			in:        nil,
+			want:      nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot := tc.in
+			got := stripPermissionForCaller(tc.principal, tc.in)
+			assert.Equal(t, tc.want, got)
+			// Input must not have been mutated.
+			assert.Equal(t, snapshot, tc.in)
+		})
+	}
+
+	// Pointer-identity invariants — verified once each, not table-driven, so
+	// the rest of the table can stay value-only.
+	t.Run("stripped sub-structs are freshly allocated, not aliases of the input", func(t *testing.T) {
+		in := fullPermission()
+		got := stripPermissionForCaller(authnNamespacedPrincipal, in)
+		require.NotSame(t, in, got)
+		assert.NotSame(t, in.Collections, got.Collections)
+		assert.NotSame(t, in.Data, got.Data)
+		assert.NotSame(t, in.Nodes, got.Nodes)
+		assert.NotSame(t, in.Tenants, got.Tenants)
+		assert.NotSame(t, in.Backups, got.Backups)
+		assert.NotSame(t, in.Replicate, got.Replicate)
+		assert.NotSame(t, in.Aliases, got.Aliases)
+	})
+
+	t.Run("untouched sub-structs keep their input pointer identity", func(t *testing.T) {
+		in := fullPermission()
+		got := stripPermissionForCaller(authnNamespacedPrincipal, in)
+		// Strip set excludes users/roles/groups/namespaces — reused as-is.
+		assert.Same(t, in.Users, got.Users)
+		assert.Same(t, in.Roles, got.Roles)
+		assert.Same(t, in.Groups, got.Groups)
+		assert.Same(t, in.Namespaces, got.Namespaces)
+	})
+
+	// Singleton safety: PoliciesToPermission's `*authorization.All` branch
+	// points sub-structs at package-level singletons. Mutating them would
+	// corrupt every other caller in the process. Verify each strip-set
+	// singleton is replaced, not mutated.
+	singletonCases := []struct {
+		name        string
+		mkInput     func() *models.Permission
+		originalPtr any
+		check       func(t *testing.T, got *models.Permission)
+	}{
+		{
+			name: "AllCollections singleton not mutated",
+			mkInput: func() *models.Permission {
+				return &models.Permission{Collections: authorization.AllCollections}
+			},
+			originalPtr: authorization.AllCollections,
+			check: func(t *testing.T, got *models.Permission) {
+				assert.NotSame(t, authorization.AllCollections, got.Collections)
+			},
+		},
+		{
+			name: "AllAliases singleton not mutated",
+			mkInput: func() *models.Permission {
+				return &models.Permission{Aliases: authorization.AllAliases}
+			},
+			originalPtr: authorization.AllAliases,
+			check: func(t *testing.T, got *models.Permission) {
+				assert.NotSame(t, authorization.AllAliases, got.Aliases)
+			},
+		},
+	}
+	for _, tc := range singletonCases {
+		t.Run(tc.name, func(t *testing.T) {
+			before := tc.originalPtr
+			got := stripPermissionForCaller(authnNamespacedPrincipal, tc.mkInput())
+			tc.check(t, got)
+			// Underlying singleton pointer still points at the same address.
+			switch tc.name {
+			case "AllCollections singleton not mutated":
+				assert.Same(t, before, authorization.AllCollections)
+			case "AllAliases singleton not mutated":
+				assert.Same(t, before, authorization.AllAliases)
+			}
+		})
+	}
+}
+
+func TestStripRolesForCaller(t *testing.T) {
+	makeRoles := func() []*models.Role {
+		name1 := "viewer"
+		name2 := "editor"
+		return []*models.Role{
+			{
+				Name: &name1,
+				Permissions: []*models.Permission{
+					{
+						Action:      strPtr("read_collections"),
+						Collections: &models.PermissionCollections{Collection: strPtr("customer1:Movies")},
+					},
+					{
+						Action:  strPtr("read_aliases"),
+						Aliases: &models.PermissionAliases{Collection: strPtr("customer1:Movies"), Alias: strPtr("customer1:Films")},
+					},
+				},
+			},
+			{Name: &name2}, // role with no permissions
+		}
+	}
+
+	makeStrippedRoles := func() []*models.Role {
+		name1 := "viewer"
+		name2 := "editor"
+		return []*models.Role{
+			{
+				Name: &name1,
+				Permissions: []*models.Permission{
+					{
+						Action:      strPtr("read_collections"),
+						Collections: &models.PermissionCollections{Collection: strPtr("Movies")},
+					},
+					{
+						Action:  strPtr("read_aliases"),
+						Aliases: &models.PermissionAliases{Collection: strPtr("Movies"), Alias: strPtr("Films")},
+					},
+				},
+			},
+			{Name: &name2},
+		}
+	}
+
+	cases := []struct {
+		name      string
+		principal *models.Principal
+		in        []*models.Role
+		want      []*models.Role
+		wantSame  bool // true when the helper is expected to return the input slice unchanged (pass-through)
+	}{
+		{
+			name:      "namespaced principal strips each permission",
+			principal: authnNamespacedPrincipal,
+			in:        makeRoles(),
+			want:      makeStrippedRoles(),
+		},
+		{
+			name:      "global principal: input slice returned unchanged",
+			principal: authnGlobalPrincipal,
+			in:        makeRoles(),
+			want:      makeRoles(),
+			wantSame:  true,
+		},
+		{
+			name:      "nil principal: input slice returned unchanged",
+			principal: nil,
+			in:        makeRoles(),
+			want:      makeRoles(),
+			wantSame:  true,
+		},
+		{
+			name:      "empty namespace: input slice returned unchanged",
+			principal: authnEmptyNSPrincipal,
+			in:        makeRoles(),
+			want:      makeRoles(),
+			wantSame:  true,
+		},
+		{
+			name:      "nil roles: nil out",
+			principal: authnNamespacedPrincipal,
+			in:        nil,
+			want:      nil,
+			wantSame:  true,
+		},
+		{
+			name:      "empty roles: passes through",
+			principal: authnNamespacedPrincipal,
+			in:        []*models.Role{},
+			want:      []*models.Role{},
+			wantSame:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot := tc.in
+			got := stripRolesForCaller(tc.principal, tc.in)
+			assert.Equal(t, tc.want, got)
+			// Input slice itself must not have been mutated.
+			assert.Equal(t, snapshot, tc.in)
+			if tc.wantSame && tc.in != nil {
+				// Pass-through path: same backing slice header.
+				require.Len(t, got, len(tc.in))
+				if len(tc.in) > 0 {
+					assert.Same(t, tc.in[0], got[0])
+				}
+			} else if !tc.wantSame && len(tc.in) > 0 {
+				// Strip path: each role is a fresh allocation.
+				assert.NotSame(t, tc.in[0], got[0])
+			}
+		})
+	}
+}

--- a/adapters/handlers/rest/handlers_batch_objects.go
+++ b/adapters/handlers/rest/handlers_batch_objects.go
@@ -234,7 +234,7 @@ func (h *batchObjectHandlers) objectsDeleteResponse(principal *models.Principal,
 
 	response := &models.BatchDeleteResponse{
 		Match: &models.BatchDeleteResponseMatch{
-			Class: namespacing.StripOwnNS(principal, input.Match.Class),
+			Class: namespacing.StripOwnNamespace(principal, input.Match.Class),
 			Where: input.Match.Where,
 		},
 		DeletionTimeUnixMilli: &deletionTimeUnixMilli,

--- a/adapters/handlers/rest/handlers_batch_objects.go
+++ b/adapters/handlers/rest/handlers_batch_objects.go
@@ -26,6 +26,7 @@ import (
 	autherrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	"github.com/weaviate/weaviate/usecases/objects"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 	"github.com/weaviate/weaviate/usecases/usagelimits"
 )
 
@@ -71,10 +72,10 @@ func (h *batchObjectHandlers) addObjects(params batch.BatchObjectsCreateParams,
 
 	h.metricRequestsTotal.logOk("")
 	return batch.NewBatchObjectsCreateOK().
-		WithPayload(h.objectsResponse(objs))
+		WithPayload(h.objectsResponse(principal, objs))
 }
 
-func (h *batchObjectHandlers) objectsResponse(input objects.BatchObjects) []*models.ObjectsGetResponse {
+func (h *batchObjectHandlers) objectsResponse(principal *models.Principal, input objects.BatchObjects) []*models.ObjectsGetResponse {
 	response := make([]*models.ObjectsGetResponse, len(input))
 	for i, object := range input {
 		var errorResponse *models.ErrorResponse
@@ -85,6 +86,7 @@ func (h *batchObjectHandlers) objectsResponse(input objects.BatchObjects) []*mod
 		}
 
 		object.Object.ID = object.UUID
+		namespacing.StripObjectResponseClass(principal, object.Object)
 		response[i] = &models.ObjectsGetResponse{
 			Object: *object.Object,
 			Result: &models.ObjectsGetResponseAO2Result{
@@ -193,10 +195,10 @@ func (h *batchObjectHandlers) deleteObjects(params batch.BatchObjectsDeleteParam
 
 	h.metricRequestsTotal.logOk("")
 	return batch.NewBatchObjectsDeleteOK().
-		WithPayload(h.objectsDeleteResponse(res))
+		WithPayload(h.objectsDeleteResponse(principal, res))
 }
 
-func (h *batchObjectHandlers) objectsDeleteResponse(input *objects.BatchDeleteResponse) *models.BatchDeleteResponse {
+func (h *batchObjectHandlers) objectsDeleteResponse(principal *models.Principal, input *objects.BatchDeleteResponse) *models.BatchDeleteResponse {
 	var successful, failed int64
 	output := input.Output
 	var objects []*models.BatchDeleteResponseResultsObjectsItems0
@@ -232,7 +234,7 @@ func (h *batchObjectHandlers) objectsDeleteResponse(input *objects.BatchDeleteRe
 
 	response := &models.BatchDeleteResponse{
 		Match: &models.BatchDeleteResponseMatch{
-			Class: input.Match.Class,
+			Class: namespacing.StripOwnNS(principal, input.Match.Class),
 			Where: input.Match.Where,
 		},
 		DeletionTimeUnixMilli: &deletionTimeUnixMilli,

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -379,11 +379,6 @@ func (h *objectHandlers) updateObject(params objects.ObjectsClassPutParams,
 	principal *models.Principal,
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
-	// Realign Body.Class with the raw path class so a stripped GET → PUT
-	// round-trip works regardless of which form the caller's body carries.
-	if params.Body != nil {
-		params.Body.Class = params.ClassName
-	}
 	className := getClassName(params.Body)
 	repl, err := getReplicationProperties(params.ConsistencyLevel, nil)
 	if err != nil {

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -31,6 +31,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/config"
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	uco "github.com/weaviate/weaviate/usecases/objects"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 	"github.com/weaviate/weaviate/usecases/usagelimits"
 )
 
@@ -116,6 +117,7 @@ func (h *objectHandlers) addObject(params objects.ObjectsCreateParams,
 		object.Properties = h.extendPropertiesWithAPILinks(propertiesMap)
 	}
 
+	namespacing.StripObjectResponseClass(principal, object)
 	h.metricRequestsTotal.logOk(className)
 	return objects.NewObjectsCreateOK().WithPayload(object)
 }
@@ -219,6 +221,7 @@ func (h *objectHandlers) getObject(params objects.ObjectsClassGetParams,
 		object.Properties = h.extendPropertiesWithAPILinks(propertiesMap)
 	}
 
+	namespacing.StripObjectResponseClass(principal, object)
 	h.metricRequestsTotal.logOk(getClassName(object))
 	return objects.NewObjectsClassGetOK().WithPayload(object)
 }
@@ -265,6 +268,7 @@ func (h *objectHandlers) getObjects(params objects.ObjectsListParams,
 		if ok {
 			list[i].Properties = h.extendPropertiesWithAPILinks(propertiesMap)
 		}
+		namespacing.StripObjectResponseClass(principal, list[i])
 	}
 
 	h.metricRequestsTotal.logOk("")
@@ -322,6 +326,7 @@ func (h *objectHandlers) query(params objects.ObjectsListParams,
 		if ok {
 			resultSet[i].Properties = h.extendPropertiesWithAPILinks(propertiesMap)
 		}
+		namespacing.StripObjectResponseClass(principal, resultSet[i])
 	}
 
 	h.metricRequestsTotal.logOk(req.Class)
@@ -374,6 +379,11 @@ func (h *objectHandlers) updateObject(params objects.ObjectsClassPutParams,
 	principal *models.Principal,
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
+	// Realign Body.Class with the raw path class so a stripped GET → PUT
+	// round-trip works regardless of which form the caller's body carries.
+	if params.Body != nil {
+		params.Body.Class = params.ClassName
+	}
 	className := getClassName(params.Body)
 	repl, err := getReplicationProperties(params.ConsistencyLevel, nil)
 	if err != nil {
@@ -406,6 +416,7 @@ func (h *objectHandlers) updateObject(params objects.ObjectsClassPutParams,
 		object.Properties = h.extendPropertiesWithAPILinks(propertiesMap)
 	}
 
+	namespacing.StripObjectResponseClass(principal, object)
 	h.metricRequestsTotal.logOk(className)
 	return objects.NewObjectsClassPutOK().WithPayload(object)
 }

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -32,6 +32,7 @@ import (
 	"github.com/weaviate/weaviate/usecases/monitoring"
 	uco "github.com/weaviate/weaviate/usecases/objects"
 	schemaUC "github.com/weaviate/weaviate/usecases/schema"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 	"github.com/weaviate/weaviate/usecases/usagelimits"
 )
 
@@ -66,6 +67,7 @@ type reindexSubmitLockProvider interface {
 
 type schemaHandlers struct {
 	manager             *schemaUC.Manager
+	namespacesEnabled   bool
 	metricRequestsTotal restApiRequestsTotal
 	reindexTaskLister   reindexInFlightChecker
 	reindexSubmitLocks  reindexSubmitLockProvider
@@ -94,13 +96,26 @@ func (s *schemaHandlers) addClass(params schema.SchemaObjectsCreateParams,
 	}
 
 	s.metricRequestsTotal.logOk(params.ObjectClass.Class)
-	return schema.NewSchemaObjectsCreateOK().WithPayload(params.ObjectClass)
+	return schema.NewSchemaObjectsCreateOK().WithPayload(namespacing.StripClassResponse(principal, params.ObjectClass))
 }
 
 func (s *schemaHandlers) updateClass(params schema.SchemaObjectsUpdateParams,
 	principal *models.Principal,
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
+
+	// Realign Body.Class with the qualified path so immutable-field
+	// validation passes on a stripped GET → PUT round-trip.
+	if params.ObjectClass != nil {
+		qualifiedPath, err := namespacing.QualifyClass(principal, s.namespacesEnabled, params.ClassName)
+		if err != nil {
+			s.metricRequestsTotal.logError(params.ClassName, err)
+			return schema.NewSchemaObjectsUpdateUnprocessableEntity().
+				WithPayload(errPayloadFromSingleErr(err))
+		}
+		params.ObjectClass.Class = qualifiedPath
+	}
+
 	err := s.manager.UpdateClass(ctx, principal, params.ClassName,
 		params.ObjectClass)
 	if err != nil {
@@ -120,7 +135,7 @@ func (s *schemaHandlers) updateClass(params schema.SchemaObjectsUpdateParams,
 	}
 
 	s.metricRequestsTotal.logOk(params.ClassName)
-	return schema.NewSchemaObjectsUpdateOK().WithPayload(params.ObjectClass)
+	return schema.NewSchemaObjectsUpdateOK().WithPayload(namespacing.StripClassResponse(principal, params.ObjectClass))
 }
 
 func (s *schemaHandlers) getClass(params schema.SchemaObjectsGetParams,
@@ -149,7 +164,7 @@ func (s *schemaHandlers) getClass(params schema.SchemaObjectsGetParams,
 	}
 
 	s.metricRequestsTotal.logOk(params.ClassName)
-	return schema.NewSchemaObjectsGetOK().WithPayload(class)
+	return schema.NewSchemaObjectsGetOK().WithPayload(namespacing.StripClassResponse(principal, class))
 }
 
 func (s *schemaHandlers) deleteClass(params schema.SchemaObjectsDeleteParams, principal *models.Principal) middleware.Responder {
@@ -187,7 +202,7 @@ func (s *schemaHandlers) addClassProperty(params schema.SchemaObjectsPropertiesA
 	}
 
 	s.metricRequestsTotal.logOk(params.ClassName)
-	return schema.NewSchemaObjectsPropertiesAddOK().WithPayload(params.Body)
+	return schema.NewSchemaObjectsPropertiesAddOK().WithPayload(namespacing.StripPropertyResponse(principal, params.Body))
 }
 
 func (s *schemaHandlers) deleteClassPropertyIndex(params schema.SchemaObjectsPropertiesDeleteParams,
@@ -360,6 +375,15 @@ func (s *schemaHandlers) getSchema(params schema.SchemaDumpParams, principal *mo
 	}
 
 	payload := dbSchema.Objects
+	if principal != nil && principal.Namespace != "" && payload != nil && len(payload.Classes) > 0 {
+		stripped := make([]*models.Class, len(payload.Classes))
+		for i, c := range payload.Classes {
+			stripped[i] = namespacing.StripClassResponse(principal, c)
+		}
+		copyPayload := *payload
+		copyPayload.Classes = stripped
+		payload = &copyPayload
+	}
 
 	s.metricRequestsTotal.logOk("")
 	return schema.NewSchemaDumpOK().WithPayload(payload)
@@ -563,9 +587,10 @@ func (s *schemaHandlers) tenantExists(params schema.TenantExistsParams, principa
 	return schema.NewTenantExistsOK()
 }
 
-func setupSchemaHandlers(api *operations.WeaviateAPI, manager *schemaUC.Manager, metrics *monitoring.PrometheusMetrics, logger logrus.FieldLogger, reindexTaskLister reindexInFlightChecker, reindexSubmitLocks reindexSubmitLockProvider) {
+func setupSchemaHandlers(api *operations.WeaviateAPI, manager *schemaUC.Manager, namespacesEnabled bool, metrics *monitoring.PrometheusMetrics, logger logrus.FieldLogger, reindexTaskLister reindexInFlightChecker, reindexSubmitLocks reindexSubmitLockProvider) {
 	h := &schemaHandlers{
 		manager:             manager,
+		namespacesEnabled:   namespacesEnabled,
 		metricRequestsTotal: newSchemaRequestsTotal(metrics, logger),
 		reindexTaskLister:   reindexTaskLister,
 		reindexSubmitLocks:  reindexSubmitLocks,

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -67,7 +67,6 @@ type reindexSubmitLockProvider interface {
 
 type schemaHandlers struct {
 	manager             *schemaUC.Manager
-	namespacesEnabled   bool
 	metricRequestsTotal restApiRequestsTotal
 	reindexTaskLister   reindexInFlightChecker
 	reindexSubmitLocks  reindexSubmitLockProvider
@@ -103,19 +102,6 @@ func (s *schemaHandlers) updateClass(params schema.SchemaObjectsUpdateParams,
 	principal *models.Principal,
 ) middleware.Responder {
 	ctx := restCtx.AddPrincipalToContext(params.HTTPRequest.Context(), principal)
-
-	// Realign Body.Class with the qualified path so immutable-field
-	// validation passes on a stripped GET → PUT round-trip.
-	if params.ObjectClass != nil {
-		qualifiedPath, err := namespacing.QualifyClass(principal, s.namespacesEnabled, params.ClassName)
-		if err != nil {
-			s.metricRequestsTotal.logError(params.ClassName, err)
-			return schema.NewSchemaObjectsUpdateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
-		}
-		params.ObjectClass.Class = qualifiedPath
-	}
-
 	err := s.manager.UpdateClass(ctx, principal, params.ClassName,
 		params.ObjectClass)
 	if err != nil {
@@ -587,10 +573,9 @@ func (s *schemaHandlers) tenantExists(params schema.TenantExistsParams, principa
 	return schema.NewTenantExistsOK()
 }
 
-func setupSchemaHandlers(api *operations.WeaviateAPI, manager *schemaUC.Manager, namespacesEnabled bool, metrics *monitoring.PrometheusMetrics, logger logrus.FieldLogger, reindexTaskLister reindexInFlightChecker, reindexSubmitLocks reindexSubmitLockProvider) {
+func setupSchemaHandlers(api *operations.WeaviateAPI, manager *schemaUC.Manager, metrics *monitoring.PrometheusMetrics, logger logrus.FieldLogger, reindexTaskLister reindexInFlightChecker, reindexSubmitLocks reindexSubmitLockProvider) {
 	h := &schemaHandlers{
 		manager:             manager,
-		namespacesEnabled:   namespacesEnabled,
 		metricRequestsTotal: newSchemaRequestsTotal(metrics, logger),
 		reindexTaskLister:   reindexTaskLister,
 		reindexSubmitLocks:  reindexSubmitLocks,

--- a/test/acceptance/authz/namespaces_oidc_test.go
+++ b/test/acceptance/authz/namespaces_oidc_test.go
@@ -72,11 +72,11 @@ func TestNamespacesOIDC(t *testing.T) {
 	helper.CreateNamespace(t, "customer1", adminKey)
 	defer helper.DeleteNamespace(t, "customer1", adminKey)
 
-	t.Run("classification: namespaced token gets prefixed username", func(t *testing.T) {
+	t.Run("classification: namespaced token gets stripped username", func(t *testing.T) {
 		token, _ := docker.GetTokensFromMockOIDCWithHelperFor(t, helperURI, "oidc-namespaced-customer1")
 		info := helper.GetInfoForOwnUser(t, token)
 		require.NotNil(t, info.Username)
-		assert.Equal(t, "customer1:oidc-namespaced-customer1", *info.Username)
+		assert.Equal(t, "oidc-namespaced-customer1", *info.Username)
 	})
 
 	t.Run("classification: global-principal token gets bare username", func(t *testing.T) {
@@ -220,14 +220,16 @@ func TestNamespacesOIDC(t *testing.T) {
 		customer1OIDCToken, _ := docker.GetTokensFromMockOIDCWithHelperFor(t, helperURI, sharedSubject)
 
 		// Both auth paths produce the same principal username — the OIDC
-		// namespace prefix matches what the user-creation API stores.
+		// namespace prefix matches what the user-creation API stores. The
+		// own-info response strips the caller's own namespace, so both
+		// paths surface the short subject back.
 		dbInfo := helper.GetInfoForOwnUser(t, customer1Key)
 		require.NotNil(t, dbInfo.Username)
-		assert.Equal(t, customer1ID, *dbInfo.Username)
+		assert.Equal(t, sharedSubject, *dbInfo.Username)
 
 		oidcInfo := helper.GetInfoForOwnUser(t, customer1OIDCToken)
 		require.NotNil(t, oidcInfo.Username)
-		assert.Equal(t, customer1ID, *oidcInfo.Username)
+		assert.Equal(t, sharedSubject, *oidcInfo.Username)
 
 		// customer1's user creates a collection via the DB API key —
 		// matcher-specialized to customer1:Books. Title is defined
@@ -245,10 +247,11 @@ func TestNamespacesOIDC(t *testing.T) {
 		assert.Equal(t, "customer1:Books", stored.Class)
 
 		// customer1's user via OIDC reads the same class: requests "Books",
-		// resolver prefixes to customer1:Books. Confirms OIDC and DB paths
-		// share the matcher specialization.
+		// resolver prefixes to customer1:Books, response stripping returns
+		// the short name. Confirms OIDC and DB paths share the matcher
+		// specialization and the response-stripping path.
 		viaOIDC := helper.GetClassAuth(t, "Books", customer1OIDCToken)
-		assert.Equal(t, "customer1:Books", viaOIDC.Class)
+		assert.Equal(t, "Books", viaOIDC.Class)
 
 		// Narrowed admin → DENIED on namespace management (cluster-only).
 		_, err = helper.Client(t).Namespaces.DeleteNamespace(
@@ -320,7 +323,6 @@ func TestNamespacesOIDC(t *testing.T) {
 	t.Run("narrowed admin via OIDC group binding", func(t *testing.T) {
 		const groupName = "AllUsers"
 		const bobSubject = "oidc-customer1-group-member"
-		const bobUsername = "customer1:" + bobSubject
 
 		helper.AssignRoleToGroup(t, adminKey, authorization.Admin, groupName)
 		defer helper.RevokeRoleFromGroup(t, adminKey, authorization.Admin, groupName)
@@ -329,7 +331,7 @@ func TestNamespacesOIDC(t *testing.T) {
 
 		info := helper.GetInfoForOwnUser(t, token)
 		require.NotNil(t, info.Username)
-		assert.Equal(t, bobUsername, *info.Username)
+		assert.Equal(t, bobSubject, *info.Username)
 		assert.Contains(t, info.Groups, groupName, "OIDC token must carry the group claim")
 
 		// Bob has no direct admin assignment. If group binding works,

--- a/test/acceptance/authz/namespaces_test.go
+++ b/test/acceptance/authz/namespaces_test.go
@@ -191,14 +191,15 @@ func TestAuthzNamespaces(t *testing.T) {
 	defer helper.DeleteUser(t, ns2+":u2", adminKey)
 
 	// Namespaced DB users start with no permissions. Grant both a single
-	// namespace-relative create_collections role; the matcher specializes the
-	// unqualified `*` template per caller, so each user can only create within
-	// their own namespace.
+	// namespace-relative role covering create_collections and create_aliases;
+	// the matcher specializes the unqualified `*` template per caller, so each
+	// user can only create within their own namespace.
 	const bootstrapRole = "ns-bootstrap-create"
 	helper.CreateRole(t, adminKey, &models.Role{
 		Name: String(bootstrapRole),
 		Permissions: []*models.Permission{
 			helper.NewCollectionsPermission().WithAction(authorization.CreateCollections).WithCollection("*").Permission(),
+			helper.NewAliasesPermission().WithAction(authorization.CreateAliases).WithCollection("*").WithAlias("*").Permission(),
 		},
 	})
 	defer helper.DeleteRole(t, adminKey, bootstrapRole)

--- a/test/acceptance/authz/namespaces_test.go
+++ b/test/acceptance/authz/namespaces_test.go
@@ -231,7 +231,7 @@ func TestAuthzNamespaces(t *testing.T) {
 		helper.AssignRoleToUser(t, adminKey, role, ns1+":u1")
 		defer helper.RevokeRoleFromUser(t, adminKey, role, ns1+":u1")
 
-		assert.Equal(t, ns1+":Movies", helper.GetClassAuth(t, "Movies", user1Key).Class)
+		assert.Equal(t, "Movies", helper.GetClassAuth(t, "Movies", user1Key).Class)
 	})
 
 	t.Run("read_collections regex scope (Movies*): matches in own namespace only", func(t *testing.T) {
@@ -246,8 +246,8 @@ func TestAuthzNamespaces(t *testing.T) {
 		helper.AssignRoleToUser(t, adminKey, role, ns1+":u1")
 		defer helper.RevokeRoleFromUser(t, adminKey, role, ns1+":u1")
 
-		assert.Equal(t, ns1+":Movies", helper.GetClassAuth(t, "Movies", user1Key).Class)
-		assert.Equal(t, ns1+":MoviesArchive", helper.GetClassAuth(t, "MoviesArchive", user1Key).Class)
+		assert.Equal(t, "Movies", helper.GetClassAuth(t, "Movies", user1Key).Class)
+		assert.Equal(t, "MoviesArchive", helper.GetClassAuth(t, "MoviesArchive", user1Key).Class)
 
 		_, err := helper.Client(t).Schema.SchemaObjectsGet(
 			schema.NewSchemaObjectsGetParams().WithClassName("Music"),
@@ -268,7 +268,7 @@ func TestAuthzNamespaces(t *testing.T) {
 		helper.AssignRoleToUser(t, adminKey, role, ns1+":u1")
 		defer helper.RevokeRoleFromUser(t, adminKey, role, ns1+":u1")
 
-		assert.Equal(t, ns1+":Movies", helper.GetClassAuth(t, "Movies", user1Key).Class)
+		assert.Equal(t, "Movies", helper.GetClassAuth(t, "Movies", user1Key).Class)
 
 		_, err := helper.Client(t).Schema.SchemaObjectsGet(
 			schema.NewSchemaObjectsGetParams().WithClassName("MoviesArchive"),
@@ -292,8 +292,8 @@ func TestAuthzNamespaces(t *testing.T) {
 		resp, err := helper.Client(t).Schema.SchemaDump(schema.NewSchemaDumpParams(), helper.CreateAuth(user1Key))
 		require.NoError(t, err)
 		got := classNames(resp.Payload.Classes)
-		assert.ElementsMatch(t, []string{ns1 + ":Movies", ns1 + ":MoviesArchive", ns1 + ":Music"}, got,
-			"namespaced caller must only see own-namespace classes in schema dump")
+		assert.ElementsMatch(t, []string{"Movies", "MoviesArchive", "Music"}, got,
+			"namespaced caller must only see own-namespace classes in schema dump, stripped to short names")
 	})
 
 	t.Run("global operator sees both namespaces in schema dump by qualified name", func(t *testing.T) {
@@ -304,6 +304,52 @@ func TestAuthzNamespaces(t *testing.T) {
 			ns1 + ":Movies", ns1 + ":MoviesArchive", ns1 + ":Music",
 			ns2 + ":Movies", ns2 + ":Music",
 		}, got)
+	})
+
+	t.Run("alias list filters to own namespace for namespaced caller", func(t *testing.T) {
+		// Each namespace gets the same short alias name pointing at its own
+		// Movies class. RBAC scopes the list to entries the caller can READ;
+		// stripping returns short forms to namespaced callers.
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "Films", Class: "Movies"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, ns1+":Films", helper.CreateAuth(adminKey))
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "Films", Class: "Movies"}, user2Key)
+		defer helper.DeleteAliasWithAuthz(t, ns2+":Films", helper.CreateAuth(adminKey))
+
+		const role = "read-aliases-all"
+		helper.CreateRole(t, adminKey, &models.Role{
+			Name: String(role),
+			Permissions: []*models.Permission{
+				helper.NewAliasesPermission().WithAction(authorization.ReadAliases).WithCollection("*").WithAlias("*").Permission(),
+			},
+		})
+		defer helper.DeleteRole(t, adminKey, role)
+		helper.AssignRoleToUser(t, adminKey, role, ns1+":u1")
+		defer helper.RevokeRoleFromUser(t, adminKey, role, ns1+":u1")
+
+		resp, err := helper.GetAliasesAuthWithReturn(t, nil, user1Key)
+		require.NoError(t, err)
+		seenAlias := map[string]string{}
+		for _, a := range resp.Payload.Aliases {
+			seenAlias[a.Alias] = a.Class
+		}
+		assert.Equal(t, "Movies", seenAlias["Films"], "namespaced caller sees own alias in short form")
+		assert.NotContains(t, seenAlias, ns2+":Films", "namespaced caller must not see foreign-namespace alias")
+	})
+
+	t.Run("global operator sees both namespaces in alias list by qualified name", func(t *testing.T) {
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "Songs", Class: "Music"}, user1Key)
+		defer helper.DeleteAliasWithAuthz(t, ns1+":Songs", helper.CreateAuth(adminKey))
+		helper.CreateAliasAuth(t, &models.Alias{Alias: "Songs", Class: "Music"}, user2Key)
+		defer helper.DeleteAliasWithAuthz(t, ns2+":Songs", helper.CreateAuth(adminKey))
+
+		resp, err := helper.GetAliasesAuthWithReturn(t, nil, adminKey)
+		require.NoError(t, err)
+		seenAlias := map[string]string{}
+		for _, a := range resp.Payload.Aliases {
+			seenAlias[a.Alias] = a.Class
+		}
+		assert.Equal(t, ns1+":Music", seenAlias[ns1+":Songs"], "admin sees ns1 alias raw")
+		assert.Equal(t, ns2+":Music", seenAlias[ns2+":Songs"], "admin sees ns2 alias raw")
 	})
 
 	t.Run("role with namespace-qualified resource path is rejected at create time", func(t *testing.T) {

--- a/test/acceptance/authz/namespaces_test.go
+++ b/test/acceptance/authz/namespaces_test.go
@@ -352,6 +352,56 @@ func TestAuthzNamespaces(t *testing.T) {
 		assert.Equal(t, ns2+":Music", seenAlias[ns2+":Songs"], "admin sees ns2 alias raw")
 	})
 
+	t.Run("own-info strips username and lets wildcard permission resources pass through", func(t *testing.T) {
+		// Role creation rejects qualified resource paths for now
+		const role = "own-info-strip"
+		helper.CreateRole(t, adminKey, &models.Role{
+			Name: String(role),
+			Permissions: []*models.Permission{
+				helper.NewCollectionsPermission().WithAction(authorization.ReadCollections).WithCollection("*").Permission(),
+				helper.NewAliasesPermission().WithAction(authorization.ReadAliases).WithCollection("*").WithAlias("*").Permission(),
+			},
+		})
+		defer helper.DeleteRole(t, adminKey, role)
+		helper.AssignRoleToUser(t, adminKey, role, ns1+":u1")
+		defer helper.RevokeRoleFromUser(t, adminKey, role, ns1+":u1")
+
+		info := helper.GetInfoForOwnUser(t, user1Key)
+		require.NotNil(t, info.Username)
+		assert.Equal(t, "u1", *info.Username, "namespaced caller's username must be stripped")
+
+		// Find the assigned role on the principal and assert wildcard
+		// permissions pass through unchanged (StripOwnNS is a no-op on `*`).
+		var found *models.Role
+		for _, r := range info.Roles {
+			if r.Name != nil && *r.Name == role {
+				found = r
+				break
+			}
+		}
+		require.NotNil(t, found, "role must be present on own-info response")
+		require.NotEmpty(t, found.Permissions)
+		sawCollectionsStar := false
+		sawAliasesStar := false
+		for _, p := range found.Permissions {
+			if p.Collections != nil && p.Collections.Collection != nil && *p.Collections.Collection == "*" {
+				sawCollectionsStar = true
+			}
+			if p.Aliases != nil && p.Aliases.Collection != nil && *p.Aliases.Collection == "*" &&
+				p.Aliases.Alias != nil && *p.Aliases.Alias == "*" {
+				sawAliasesStar = true
+			}
+		}
+		assert.True(t, sawCollectionsStar, "wildcard collection must pass through unchanged")
+		assert.True(t, sawAliasesStar, "wildcard alias must pass through unchanged")
+	})
+
+	t.Run("own-info: global admin sees raw username", func(t *testing.T) {
+		info := helper.GetInfoForOwnUser(t, adminKey)
+		require.NotNil(t, info.Username)
+		assert.Equal(t, adminUser, *info.Username)
+	})
+
 	t.Run("role with namespace-qualified resource path is rejected at create time", func(t *testing.T) {
 		const role = "qualified-path-role"
 		_, err := helper.Client(t).Authz.CreateRole(

--- a/test/acceptance/authz/namespaces_test.go
+++ b/test/acceptance/authz/namespaces_test.go
@@ -372,7 +372,7 @@ func TestAuthzNamespaces(t *testing.T) {
 		assert.Equal(t, "u1", *info.Username, "namespaced caller's username must be stripped")
 
 		// Find the assigned role on the principal and assert wildcard
-		// permissions pass through unchanged (StripOwnNS is a no-op on `*`).
+		// permissions pass through unchanged (StripOwnNamespace is a no-op on `*`).
 		var found *models.Role
 		for _, r := range info.Roles {
 			if r.Name != nil && *r.Name == role {

--- a/test/acceptance/namespace/auto_schema_test.go
+++ b/test/acceptance/namespace/auto_schema_test.go
@@ -45,10 +45,10 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 		}, user1Key)
 		require.NoError(t, err)
 
-		// Namespaced principal sees the qualified class on read-back.
+		// Namespaced principal sees the short class on read-back (response stripping).
 		got, err := helper.GetObjectAuth(t, class, id, user1Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+class, got.Class)
+		assert.Equal(t, class, got.Class)
 		assert.Equal(t, "Inception", got.Properties.(map[string]any)["title"])
 
 		// Admin's raw schema view confirms a single-qualified class exists.
@@ -85,7 +85,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 
 		got, err := helper.GetObjectAuth(t, class, id, user1Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+class, got.Class)
+		assert.Equal(t, class, got.Class)
 		props := got.Properties.(map[string]any)
 		assert.Equal(t, "Tenet", props["title"])
 		assert.NotNil(t, props["runtime"])
@@ -173,7 +173,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 
 		got, err := helper.GetObjectAuthWithTenant(t, class, id, "tenantA", user1Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+class, got.Class)
+		assert.Equal(t, class, got.Class)
 		assert.Equal(t, "tenantA", got.Tenant)
 	})
 
@@ -191,10 +191,10 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 
 		got1, err := helper.GetObjectAuthWithTenant(t, class, id1, "tenantB", user1Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+class, got1.Class)
+		assert.Equal(t, class, got1.Class)
 		got2, err := helper.GetObjectAuthWithTenant(t, class, id2, "tenantC", user1Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+class, got2.Class)
+		assert.Equal(t, class, got2.Class)
 	})
 
 	t.Run("auto-activate cold tenant on insert", func(t *testing.T) {
@@ -223,7 +223,7 @@ func TestNamespaces_AutoSchema(t *testing.T) {
 
 		got, err := helper.GetObjectAuthWithTenant(t, class, id, "tenantD", user1Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+class, got.Class)
+		assert.Equal(t, class, got.Class)
 	})
 
 	t.Run("global principal auto-create rejected with 403", func(t *testing.T) {

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -155,9 +155,10 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		require.NotEmpty(t, obj.ID)
 
 		// user1 reads it back via the alias — Resolve qualifies + maps alias → target.
+		// Response is stripped to the short class name.
 		got, err := helper.GetObjectAuth(t, "E2EFilmsAlias", obj.ID, user1Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:E2EFilmsTarget", got.Class)
+		assert.Equal(t, "E2EFilmsTarget", got.Class)
 		assert.Equal(t, obj.ID, got.ID)
 		propsGot, ok := got.Properties.(map[string]any)
 		require.True(t, ok)
@@ -516,11 +517,12 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasShortGet", Class: "AliasShortGetTarget"}, user1Key)
 		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasShortGet", helper.CreateAuth(adminKey))
 
-		// Short name is qualified with the principal's namespace.
+		// Short name is qualified with the principal's namespace, and the
+		// response is stripped back to the short form for namespaced callers.
 		resp, err := helper.GetAliasAuthWithReturn(t, "AliasShortGet", user1Key)
 		require.NoError(t, err)
-		require.Equal(t, "customer1:AliasShortGet", resp.Payload.Alias)
-		require.Equal(t, "customer1:AliasShortGetTarget", resp.Payload.Class)
+		require.Equal(t, "AliasShortGet", resp.Payload.Alias)
+		require.Equal(t, "AliasShortGetTarget", resp.Payload.Class)
 	})
 
 	t.Run("global admin alias get with wrong-case namespace prefix returns 422", func(t *testing.T) {
@@ -564,6 +566,7 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasListByClassB", helper.CreateAuth(adminKey))
 
 		// Short class filter must be qualified to customer1:AliasListByClass.
+		// Response is stripped back to short names for the namespaced caller.
 		class := "AliasListByClass"
 		resp, err := helper.GetAliasesAuthWithReturn(t, &class, user1Key)
 		require.NoError(t, err)
@@ -572,8 +575,8 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		for _, a := range resp.Payload.Aliases {
 			gotAliases[a.Alias] = a.Class
 		}
-		assert.Equal(t, "customer1:AliasListByClass", gotAliases["customer1:AliasListByClassA"])
-		assert.Equal(t, "customer1:AliasListByClass", gotAliases["customer1:AliasListByClassB"])
+		assert.Equal(t, "AliasListByClass", gotAliases["AliasListByClassA"])
+		assert.Equal(t, "AliasListByClass", gotAliases["AliasListByClassB"])
 	})
 
 	t.Run("global admin alias list with wrong-case class filter returns 422", func(t *testing.T) {
@@ -588,29 +591,6 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		var unproc *schema.AliasesGetUnprocessableEntity
 		require.True(t, errors.As(err, &unproc), "expected AliasesGetUnprocessableEntity, got %T: %v", err, err)
 		assert.Contains(t, unproc.Payload.Error[0].Message, "invalid namespace prefix")
-	})
-
-	t.Run("alias list is namespace-isolated when both namespaces share a short alias name", func(t *testing.T) {
-		for _, key := range []string{user1Key, user2Key} {
-			helper.CreateClassAuth(t, &models.Class{Class: "AliasListIsoTarget"}, key)
-			helper.CreateAliasAuth(t, &models.Alias{Alias: "AliasListIso", Class: "AliasListIsoTarget"}, key)
-		}
-		defer helper.DeleteClassAuth(t, "customer1:AliasListIsoTarget", adminKey)
-		defer helper.DeleteClassAuth(t, "customer2:AliasListIsoTarget", adminKey)
-		defer helper.DeleteAliasWithAuthz(t, "customer1:AliasListIso", helper.CreateAuth(adminKey))
-		defer helper.DeleteAliasWithAuthz(t, "customer2:AliasListIso", helper.CreateAuth(adminKey))
-
-		// user1 lists without a class filter and only sees their namespace's
-		// alias. The schema layer is namespace-agnostic, so this exercises
-		// the usecase-level namespace filter (RBAC is off in this suite).
-		resp, err := helper.GetAliasesAuthWithReturn(t, nil, user1Key)
-		require.NoError(t, err)
-		seen := map[string]bool{}
-		for _, a := range resp.Payload.Aliases {
-			seen[a.Alias] = true
-		}
-		assert.True(t, seen["customer1:AliasListIso"], "user1 should see its own alias")
-		assert.False(t, seen["customer2:AliasListIso"], "user1 should not see customer2's alias")
 	})
 
 	t.Run("global admin lists aliases across namespaces", func(t *testing.T) {

--- a/test/acceptance/namespace/collection_alias_test.go
+++ b/test/acceptance/namespace/collection_alias_test.go
@@ -257,10 +257,10 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		helper.CreateClassAuth(t, &models.Class{Class: "UpdateMe", Description: "v1"}, user1Key)
 		defer helper.DeleteClassAuth(t, "customer1:UpdateMe", adminKey)
 
-		// GET returns the qualified class; modify the description and PUT
-		// with the short name in the path.
-		got := helper.GetClassAuth(t, "customer1:UpdateMe", adminKey)
-		require.Equal(t, "customer1:UpdateMe", got.Class)
+		// GET as the namespaced caller returns the stripped (short) class
+		// name; round-trip the same short name through both URL and body.
+		got := helper.GetClassAuth(t, "UpdateMe", user1Key)
+		require.Equal(t, "UpdateMe", got.Class)
 		got.Description = "v2"
 
 		helper.UpdateClassAuth(t, "UpdateMe", got, user1Key)
@@ -277,7 +277,9 @@ func TestNamespaces_CollectionAndAlias(t *testing.T) {
 		defer helper.DeleteClassAuth(t, "customer2:SharedUpdate", adminKey)
 
 		// user1's short-name update must only touch customer1:SharedUpdate.
-		toUpdate := helper.GetClassAuth(t, "customer1:SharedUpdate", adminKey)
+		// GET as the namespaced caller so the round-tripped body carries
+		// the stripped short class name.
+		toUpdate := helper.GetClassAuth(t, "SharedUpdate", user1Key)
 		toUpdate.Description = "v2"
 		helper.UpdateClassAuth(t, "SharedUpdate", toUpdate, user1Key)
 

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -405,10 +405,10 @@ func TestNamespaces_GRPC(t *testing.T) {
 				return err
 			})
 			assert.Len(t, searchResp.Results, 2)
-			// target_collection echoes the alias the caller actually typed
-			// (short form for the namespaced caller).
-			assert.Equal(t, aliasName, searchResp.Results[0].Properties.TargetCollection)
-			assert.Equal(t, aliasName, searchResp.Results[1].Properties.TargetCollection)
+			// target_collection is the resolved class name, stripped to the
+			// caller's namespace — never the alias the caller typed.
+			assert.Equal(t, class, searchResp.Results[0].Properties.TargetCollection)
+			assert.Equal(t, class, searchResp.Results[1].Properties.TargetCollection)
 
 			aggResp, err := grpcClient.Aggregate(authCtx(key), &pb.AggregateRequest{
 				Collection:   aliasName,

--- a/test/acceptance/namespace/grpc_test.go
+++ b/test/acceptance/namespace/grpc_test.go
@@ -115,12 +115,12 @@ func TestNamespaces_GRPC(t *testing.T) {
 		// respective qualified class names.
 		got1, err := helper.GetObjectAuth(t, class, id1, user1Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+class, got1.Class)
+		assert.Equal(t, class, got1.Class)
 		assert.Equal(t, "ns1-The Matrix", got1.Properties.(map[string]any)["title"])
 
 		got2, err := helper.GetObjectAuth(t, class, id1, user2Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer2:"+class, got2.Class)
+		assert.Equal(t, class, got2.Class)
 		assert.Equal(t, "ns2-Memento", got2.Properties.(map[string]any)["title"])
 	})
 
@@ -305,6 +305,9 @@ func TestNamespaces_GRPC(t *testing.T) {
 			resp1.Results[1].Properties.NonRefProps.Fields["title"].GetTextValue(),
 		}
 		assert.ElementsMatch(t, []string{"ns1-The Matrix", "ns1-Inception"}, titles1)
+		// target_collection: namespaced caller sees the short class name.
+		assert.Equal(t, class, resp1.Results[0].Properties.TargetCollection)
+		assert.Equal(t, class, resp1.Results[1].Properties.TargetCollection)
 
 		resp2, err := req(user2Key)
 		require.NoError(t, err)
@@ -314,6 +317,8 @@ func TestNamespaces_GRPC(t *testing.T) {
 			resp2.Results[1].Properties.NonRefProps.Fields["title"].GetTextValue(),
 		}
 		assert.ElementsMatch(t, []string{"ns2-Memento", "ns2-Tenet"}, titles2)
+		assert.Equal(t, class, resp2.Results[0].Properties.TargetCollection)
+		assert.Equal(t, class, resp2.Results[1].Properties.TargetCollection)
 	})
 
 	t.Run("Search by filter is namespace-scoped", func(t *testing.T) {
@@ -400,6 +405,10 @@ func TestNamespaces_GRPC(t *testing.T) {
 				return err
 			})
 			assert.Len(t, searchResp.Results, 2)
+			// target_collection echoes the alias the caller actually typed
+			// (short form for the namespaced caller).
+			assert.Equal(t, aliasName, searchResp.Results[0].Properties.TargetCollection)
+			assert.Equal(t, aliasName, searchResp.Results[1].Properties.TargetCollection)
 
 			aggResp, err := grpcClient.Aggregate(authCtx(key), &pb.AggregateRequest{
 				Collection:   aliasName,
@@ -450,6 +459,9 @@ func TestNamespaces_GRPC(t *testing.T) {
 		searchResp, err := qualifiedReq()
 		require.NoError(t, err)
 		assert.Len(t, searchResp.Results, 2)
+		// Admin sees the raw qualified class name in target_collection.
+		assert.Equal(t, "customer1:"+class, searchResp.Results[0].Properties.TargetCollection)
+		assert.Equal(t, "customer1:"+class, searchResp.Results[1].Properties.TargetCollection)
 
 		_, err = grpcClient.Aggregate(authCtx(adminKey), &pb.AggregateRequest{
 			Collection:   class,
@@ -577,12 +589,12 @@ func TestNamespaces_GRPC(t *testing.T) {
 		// Verify the rows landed under their respective qualified class names.
 		got1, err := helper.GetObjectAuth(t, streamClass, streamID1, user1Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+streamClass, got1.Class)
+		assert.Equal(t, streamClass, got1.Class)
 		assert.Equal(t, "ns1-stream", got1.Properties.(map[string]any)["title"])
 
 		got2, err := helper.GetObjectAuth(t, streamClass, streamID1, user2Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer2:"+streamClass, got2.Class)
+		assert.Equal(t, streamClass, got2.Class)
 		assert.Equal(t, "ns2-stream", got2.Properties.(map[string]any)["title"])
 
 		// user2's second UUID exists in ns2 only.
@@ -645,12 +657,12 @@ func TestNamespaces_GRPC(t *testing.T) {
 		// The alias resolved to each namespace's own copy of the class.
 		got1, err := helper.GetObjectAuth(t, streamClass, id1, user1Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+streamClass, got1.Class)
+		assert.Equal(t, streamClass, got1.Class)
 		assert.Equal(t, "ns1-alias-stream", got1.Properties.(map[string]any)["title"])
 
 		got2, err := helper.GetObjectAuth(t, streamClass, id2, user2Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer2:"+streamClass, got2.Class)
+		assert.Equal(t, streamClass, got2.Class)
 		assert.Equal(t, "ns2-alias-stream", got2.Properties.(map[string]any)["title"])
 
 		// And cross-namespace lookups miss — user2 cannot see user1's row.

--- a/test/acceptance/namespace/mcp_test.go
+++ b/test/acceptance/namespace/mcp_test.go
@@ -66,13 +66,14 @@ func TestNamespaces_MCP(t *testing.T) {
 		require.NotNil(t, got)
 		assert.Equal(t, qualNs1, got.Class)
 
-		// get-config (specific)
+		// get-config (specific) — namespaced principals see the short name in the
+		// response; the qualified prefix is stripped before serialization.
 		var cfg *read.GetCollectionConfigResp
 		err = helper.CallToolOnce(t.Context(), t, mcpToolGetConfig,
 			&read.GetCollectionConfigArgs{CollectionName: short}, &cfg, user1Key)
 		require.NoError(t, err)
 		require.Len(t, cfg.Collections, 1)
-		assert.Equal(t, qualNs1, cfg.Collections[0].Class)
+		assert.Equal(t, short, cfg.Collections[0].Class)
 
 		// hybrid (BM25-only to avoid needing a vectorizer)
 		var hybridResp *search.QueryHybridResp
@@ -173,6 +174,8 @@ func TestNamespaces_MCP(t *testing.T) {
 	})
 
 	t.Run("global admin, qualified input succeeds", func(t *testing.T) {
+		// Global principals carry no namespace, so stripping is a no-op and the
+		// qualified name flows through unchanged.
 		var cfg *read.GetCollectionConfigResp
 		err := helper.CallToolOnce(t.Context(), t, mcpToolGetConfig,
 			&read.GetCollectionConfigArgs{CollectionName: qualNs1}, &cfg, adminKey)

--- a/test/acceptance/namespace/objects_test.go
+++ b/test/acceptance/namespace/objects_test.go
@@ -106,6 +106,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 		// "<namespace>:E2emovies".
 		const (
 			short      = "e2emovies"
+			shortClass = "E2emovies"
 			qualified1 = "customer1:E2emovies"
 			qualified2 = "customer2:E2emovies"
 		)
@@ -114,14 +115,15 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 		id := strfmt.UUID("11111111-2222-3333-4444-555555555555")
 		seedTwo(t, short, id, "The Matrix", "Inception", user1Key, user2Key)
 
+		// Namespaced caller sees the short class name (stripped).
 		got1, err := helper.GetObjectAuth(t, short, id, user1Key)
 		require.NoError(t, err)
-		assert.Equal(t, qualified1, got1.Class)
+		assert.Equal(t, shortClass, got1.Class)
 		assert.Equal(t, "The Matrix", got1.Properties.(map[string]any)["title"])
 
 		got2, err := helper.GetObjectAuth(t, short, id, user2Key)
 		require.NoError(t, err)
-		assert.Equal(t, qualified2, got2.Class)
+		assert.Equal(t, shortClass, got2.Class)
 		assert.Equal(t, "Inception", got2.Properties.(map[string]any)["title"])
 
 		// Admin's raw schema view shows both qualified names exist.
@@ -215,7 +217,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Len(t, listResp1.Payload.Objects, 1)
-		assert.Equal(t, "customer1:"+class, listResp1.Payload.Objects[0].Class)
+		assert.Equal(t, class, listResp1.Payload.Objects[0].Class)
 		assert.Equal(t, "list-ns1", listResp1.Payload.Objects[0].Properties.(map[string]any)["title"])
 
 		listResp2, err := helper.Client(t).Objects.ObjectsList(
@@ -224,7 +226,7 @@ func TestNamespaces_ObjectLifecycle(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.Len(t, listResp2.Payload.Objects, 1)
-		assert.Equal(t, "customer2:"+class, listResp2.Payload.Objects[0].Class)
+		assert.Equal(t, class, listResp2.Payload.Objects[0].Class)
 		assert.Equal(t, "list-ns2", listResp2.Payload.Objects[0].Properties.(map[string]any)["title"])
 	})
 
@@ -333,12 +335,12 @@ func TestNamespaces_BatchOperations(t *testing.T) {
 
 		got1a, err := helper.GetObjectAuth(t, class, id1, user1Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer1:"+class, got1a.Class)
+		assert.Equal(t, class, got1a.Class)
 		assert.Equal(t, "ns1-a", got1a.Properties.(map[string]any)["title"])
 
 		got2b, err := helper.GetObjectAuth(t, class, id2, user2Key)
 		require.NoError(t, err)
-		assert.Equal(t, "customer2:"+class, got2b.Class)
+		assert.Equal(t, class, got2b.Class)
 		assert.Equal(t, "ns2-b", got2b.Properties.(map[string]any)["title"])
 	})
 

--- a/test/acceptance/namespace/response_stripping_test.go
+++ b/test/acceptance/namespace/response_stripping_test.go
@@ -1,0 +1,272 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespace
+
+import (
+	"testing"
+
+	"github.com/go-openapi/strfmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/client/batch"
+	"github.com/weaviate/weaviate/client/objects"
+	"github.com/weaviate/weaviate/client/users"
+	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// TestNamespaces_ResponseStripping_REST pins the response-stripping contract:
+// every namespaced-caller success response surfaces short names while the
+// global admin keeps the raw qualified form. Round-trip tests assert that a
+// stripped GET response can be PUT/PATCHed back unchanged.
+func TestNamespaces_ResponseStripping_REST(t *testing.T) {
+	user1Key, user2Key := twoNamespaces(t)
+
+	t.Run("AddClass response strips Class", func(t *testing.T) {
+		// DataType cross-ref stripping cannot be exercised end-to-end on
+		// Phase-1: inline `DataType: ["Target"]` isn't auto-qualified on
+		// the way in, so the cross-ref target doesn't resolve. The strip
+		// mechanics are covered by the namespacing resolver unit tests.
+		const name = "AddClassStripped"
+		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+name, adminKey) })
+
+		resp, err := helper.CreateClassAuthWithReturn(t, &models.Class{
+			Class: name,
+			Properties: []*models.Property{
+				{Name: "title", DataType: []string{"text"}},
+			},
+		}, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, name, resp.Payload.Class)
+
+		// Admin sees the raw qualified class via direct GET.
+		assert.Equal(t, "customer1:"+name, helper.GetClassAuth(t, "customer1:"+name, adminKey).Class)
+	})
+
+	t.Run("schema GET → PUT round-trip on real class path succeeds with stripped body", func(t *testing.T) {
+		// Round-trip safety: the namespaced GET returns Class="RoundTripMe";
+		// the PUT body therefore carries the short class name. The handler
+		// must realign Class with the qualified path before UpdateClass so
+		// the immutable-field validator sees the qualified form on both
+		// sides.
+		const name = "RoundTripMe"
+		helper.CreateClassAuth(t, &models.Class{Class: name, Description: "v1"}, user1Key)
+		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+name, adminKey) })
+
+		// GET by short path — response is stripped.
+		got, err := helper.GetClassAuthWithReturn(t, name, user1Key)
+		require.NoError(t, err)
+		require.Equal(t, name, got.Payload.Class)
+
+		// Modify a non-immutable field and PUT the stripped body back.
+		got.Payload.Description = "v2"
+		putResp, err := helper.UpdateClassAuthWithReturn(t, name, got.Payload, user1Key)
+		require.NoError(t, err)
+		// PUT response is itself stripped.
+		assert.Equal(t, name, putResp.Payload.Class)
+
+		// Confirm via admin: underlying class updated.
+		after := helper.GetClassAuth(t, "customer1:"+name, adminKey)
+		assert.Equal(t, "v2", after.Description)
+	})
+
+	t.Run("AddAlias response strips Alias and Class", func(t *testing.T) {
+		const class = "AliasCreateTarget"
+		const alias = "AliasCreateName"
+		setupClassInNs1(t, class, user1Key)
+		t.Cleanup(func() {
+			helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+		})
+
+		resp, err := helper.CreateAliasAuthWithReturn(t, &models.Alias{Alias: alias, Class: class}, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, alias, resp.Payload.Alias)
+		assert.Equal(t, class, resp.Payload.Class)
+	})
+
+	t.Run("UpdateAlias response strips Alias and Class", func(t *testing.T) {
+		const classA = "AliasUpdateA"
+		const classB = "AliasUpdateB"
+		const alias = "AliasUpdateName"
+		setupClassInNs1(t, classA, user1Key)
+		helper.CreateClassAuth(t, &models.Class{Class: classB}, user1Key)
+		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+classB, adminKey) })
+		helper.CreateAliasAuth(t, &models.Alias{Alias: alias, Class: classA}, user1Key)
+		t.Cleanup(func() {
+			helper.DeleteAliasWithAuthz(t, "customer1:"+alias, helper.CreateAuth(adminKey))
+		})
+
+		resp, err := helper.UpdateAliasAuthWithReturn(t, alias, classB, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, alias, resp.Payload.Alias)
+		assert.Equal(t, classB, resp.Payload.Class)
+	})
+
+	t.Run("AddObject response is stripped", func(t *testing.T) {
+		const class = "AddObjStripped"
+		setupClassInNs1(t, class, user1Key)
+		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			Class: class, Properties: map[string]any{"title": "first"},
+		}, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, class, obj.Class)
+	})
+
+	t.Run("object GET → PUT round-trip succeeds with stripped body", func(t *testing.T) {
+		const class = "ObjPutRoundTrip"
+		setupClassInNs1(t, class, user1Key)
+
+		id := strfmt.UUID("aaaa1111-2222-3333-4444-aaaa11112222")
+		obj, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			ID: id, Class: class, Properties: map[string]any{"title": "v1"},
+		}, user1Key)
+		require.NoError(t, err)
+		require.Equal(t, class, obj.Class)
+
+		// Fetch via short name; mutate a property; PUT the stripped body back.
+		got, err := helper.GetObjectAuth(t, class, id, user1Key)
+		require.NoError(t, err)
+		require.Equal(t, class, got.Class)
+
+		got.Properties = map[string]any{"title": "v2"}
+		putResp, err := helper.Client(t).Objects.ObjectsClassPut(
+			objects.NewObjectsClassPutParams().WithClassName(class).WithID(id).WithBody(got),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		// PUT response is itself stripped.
+		assert.Equal(t, class, putResp.Payload.Class)
+
+		after, err := helper.GetObjectAuth(t, class, id, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "v2", after.Properties.(map[string]any)["title"])
+	})
+
+	t.Run("object GET → PATCH round-trip succeeds with stripped body", func(t *testing.T) {
+		const class = "ObjPatchRoundTrip"
+		setupClassInNs1(t, class, user1Key)
+
+		id := strfmt.UUID("bbbb2222-3333-4444-5555-bbbb22223333")
+		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			ID: id, Class: class, Properties: map[string]any{"title": "v1"},
+		}, user1Key)
+		require.NoError(t, err)
+
+		got, err := helper.GetObjectAuth(t, class, id, user1Key)
+		require.NoError(t, err)
+		require.Equal(t, class, got.Class)
+
+		// Derive the PATCH body from the stripped GET payload.
+		got.Properties = map[string]any{"title": "v2", "extra": "added"}
+		_, err = helper.Client(t).Objects.ObjectsClassPatch(
+			objects.NewObjectsClassPatchParams().WithClassName(class).WithID(id).WithBody(got),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+
+		after, err := helper.GetObjectAuth(t, class, id, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, "v2", after.Properties.(map[string]any)["title"])
+	})
+
+	t.Run("batch create response strips per-item Class", func(t *testing.T) {
+		const class = "BatchCreateStrip"
+		setupClassInNs1(t, class, user1Key)
+
+		resp, err := helper.Client(t).Batch.BatchObjectsCreate(
+			batch.NewBatchObjectsCreateParams().WithBody(batch.BatchObjectsCreateBody{
+				Objects: []*models.Object{
+					{Class: class, Properties: map[string]any{"title": "a"}},
+					{Class: class, Properties: map[string]any{"title": "b"}},
+				},
+			}),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		require.Len(t, resp.Payload, 2)
+		assert.Equal(t, class, resp.Payload[0].Class)
+		assert.Equal(t, class, resp.Payload[1].Class)
+	})
+
+	t.Run("batch delete response strips Match.Class", func(t *testing.T) {
+		const class = "BatchDeleteStrip"
+		setupClassInNs1(t, class, user1Key)
+		id := strfmt.UUID("cccc3333-4444-5555-6666-cccc33334444")
+		_, err := helper.CreateObjectWithResponseAuth(t, &models.Object{
+			ID: id, Class: class, Properties: map[string]any{"title": "kill"},
+		}, user1Key)
+		require.NoError(t, err)
+
+		killText := "kill"
+		resp, err := helper.Client(t).Batch.BatchObjectsDelete(
+			batch.NewBatchObjectsDeleteParams().WithBody(&models.BatchDelete{
+				Match: &models.BatchDeleteMatch{
+					Class: class,
+					Where: &models.WhereFilter{
+						Operator:  "Equal",
+						Path:      []string{"title"},
+						ValueText: &killText,
+					},
+				},
+			}),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload.Match)
+		assert.Equal(t, class, resp.Payload.Match.Class)
+	})
+
+	t.Run("cross-NS isolation: same short class name in both namespaces, each sees only own", func(t *testing.T) {
+		const class = "CrossNSStrip"
+		setupClassInBothNamespaces(t, class, user1Key, user2Key)
+
+		// Each namespaced caller GETs by short name and sees only their own
+		// short form; admin sees both qualified forms exist.
+		c1 := helper.GetClassAuth(t, class, user1Key)
+		assert.Equal(t, class, c1.Class)
+		c2 := helper.GetClassAuth(t, class, user2Key)
+		assert.Equal(t, class, c2.Class)
+
+		assert.Equal(t, "customer1:"+class, helper.GetClassAuth(t, "customer1:"+class, adminKey).Class)
+		assert.Equal(t, "customer2:"+class, helper.GetClassAuth(t, "customer2:"+class, adminKey).Class)
+	})
+}
+
+// TestNamespaces_ResponseStripping_OwnInfoUsername pins the Username strip
+// contract: namespaced DB users carry "customer1:apiuser" internally, and
+// /users/own-info must echo that as the short form. Role/permission strip
+// requires RBAC and is covered in the authz acceptance suite.
+func TestNamespaces_ResponseStripping_OwnInfoUsername(t *testing.T) {
+	user1Key, _ := twoNamespaces(t)
+
+	t.Run("namespaced DB user sees short username", func(t *testing.T) {
+		resp, err := helper.Client(t).Users.GetOwnInfo(
+			users.NewGetOwnInfoParams(), helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload.Username)
+		assert.Equal(t, "u1", *resp.Payload.Username,
+			"namespaced caller's stored username is customer1:u1; response must strip")
+	})
+
+	t.Run("global admin sees raw username", func(t *testing.T) {
+		resp, err := helper.Client(t).Users.GetOwnInfo(
+			users.NewGetOwnInfoParams(), helper.CreateAuth(adminKey),
+		)
+		require.NoError(t, err)
+		require.NotNil(t, resp.Payload.Username)
+		// Admin's username does not carry a namespace prefix, so it
+		// passes through unchanged.
+		assert.Equal(t, adminUser, *resp.Payload.Username)
+	})
+}

--- a/usecases/auth/authorization/rbac/manager.go
+++ b/usecases/auth/authorization/rbac/manager.go
@@ -503,7 +503,7 @@ func prettyPermissionsResources(principal *models.Principal, perm *models.Permis
 		return ""
 	}
 
-	strip := func(s string) string { return namespacing.StripOwnNS(principal, s) }
+	strip := func(s string) string { return namespacing.StripOwnNamespace(principal, s) }
 
 	if perm.Backups != nil {
 		s := fmt.Sprintf("Domain: %s,", authorization.BackupsDomain)

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -118,7 +118,7 @@ func (m *AutoSchemaManager) autoSchema(ctx context.Context, principal *models.Pr
 
 		if schemaClass == nil {
 			// it returns the newly created class and version
-			schemaClass, schemaVersion, err = m.createClass(ctx, principal, namespacing.StripOwnNS(principal, object.Class), properties)
+			schemaClass, schemaVersion, err = m.createClass(ctx, principal, namespacing.StripOwnNamespace(principal, object.Class), properties)
 			if err != nil {
 				return 0, fmt.Errorf("auto-schema: create collection: %w", err)
 			}
@@ -129,7 +129,7 @@ func (m *AutoSchemaManager) autoSchema(ctx context.Context, principal *models.Pr
 			if newProperties := schema.DedupProperties(schemaClass.Properties, properties); len(newProperties) > 0 {
 				var err error
 				schemaClass, schemaVersion, err = m.schemaManager.AddClassProperty(ctx,
-					principal, namespacing.StripOwnNS(principal, schemaClass.Class), true, newProperties...)
+					principal, namespacing.StripOwnNamespace(principal, schemaClass.Class), true, newProperties...)
 				if err != nil {
 					return 0, fmt.Errorf("auto-schema: update collection: %w", err)
 				}
@@ -571,7 +571,7 @@ func (m *AutoSchemaManager) addTenants(ctx context.Context, principal *models.Pr
 		return 0, fmt.Errorf(
 			"tenants must be included for multitenant-enabled class %q", class)
 	}
-	version, err := m.schemaManager.AddTenants(ctx, principal, namespacing.StripOwnNS(principal, class), tenants)
+	version, err := m.schemaManager.AddTenants(ctx, principal, namespacing.StripOwnNamespace(principal, class), tenants)
 	if err != nil {
 		return 0, err
 	}

--- a/usecases/objects/batch_manager.go
+++ b/usecases/objects/batch_manager.go
@@ -74,6 +74,6 @@ func NewBatchManager(vectorRepo BatchVectorRepo, modulesProvider ModulesProvider
 
 // resolveNS qualifies name with the principal's namespace (if enabled)
 // and resolves any alias to its underlying class.
-func (b *BatchManager) resolveNS(principal *models.Principal, name string) (class, originalAlias string, err error) {
+func (b *BatchManager) resolveNS(principal *models.Principal, name string) (class, qualifiedAlias string, err error) {
 	return namespacing.Resolve(principal, b.schemaManager, b.config.Config.Namespaces.Enabled, name)
 }

--- a/usecases/objects/manager.go
+++ b/usecases/objects/manager.go
@@ -198,7 +198,7 @@ func (m *Manager) resolveAlias(class string) (className, aliasName string) {
 
 // resolveNS qualifies name with the principal's namespace (if enabled)
 // and resolves any alias to its underlying class.
-func (m *Manager) resolveNS(principal *models.Principal, name string) (class, originalAlias string, err error) {
+func (m *Manager) resolveNS(principal *models.Principal, name string) (class, qualifiedAlias string, err error) {
 	return namespacing.Resolve(principal, m.schemaManager, m.config.Config.Namespaces.Enabled, name)
 }
 

--- a/usecases/schema/alias.go
+++ b/usecases/schema/alias.go
@@ -45,19 +45,6 @@ func (h *Handler) GetAliases(ctx context.Context, principal *models.Principal, a
 		return nil, err
 	}
 
-	// Namespaced principals see only aliases in their own namespace. The
-	// schema layer is namespace-agnostic, and on NS-enabled clusters with
-	// RBAC off this is the only thing keeping the list scoped.
-	if principal != nil && principal.Namespace != "" {
-		filtered := aliases[:0]
-		for _, a := range aliases {
-			if namespacing.NamespaceFromQualified(a.Alias) == principal.Namespace {
-				filtered = append(filtered, a)
-			}
-		}
-		aliases = filtered
-	}
-
 	filteredAliases := filter.New[*models.Alias](h.Authorizer, h.config.Authorization.Rbac).Filter(
 		ctx,
 		h.logger,

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -370,6 +370,20 @@ func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 		return err
 	}
 
+	// Namespaced callers send the stripped (short) class name in the body
+	// after a GET. Qualify it and require it to match the path so a
+	// mismatch surfaces explicitly instead of being silently overwritten.
+	if updated != nil && principal != nil && principal.Namespace != "" {
+		qualifiedBody, err := namespacing.QualifyClass(principal, h.config.Namespaces.Enabled, updated.Class)
+		if err != nil {
+			return fmt.Errorf("%w: %w", ErrValidation, err)
+		}
+		if qualifiedBody != className {
+			return fmt.Errorf("%w: class name in body %q does not match path %q", ErrValidation, updated.Class, namespacing.StripOwnNS(principal, className))
+		}
+		updated.Class = qualifiedBody
+	}
+
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil || updated == nil {
 		return err
 	}

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -379,7 +379,7 @@ func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 			return fmt.Errorf("%w: %w", ErrValidation, err)
 		}
 		if qualifiedBody != className {
-			return fmt.Errorf("%w: class name in body %q does not match path %q", ErrValidation, updated.Class, namespacing.StripOwnNS(principal, className))
+			return fmt.Errorf("%w: class name in body %q does not match path %q", ErrValidation, updated.Class, namespacing.StripOwnNamespace(principal, className))
 		}
 		updated.Class = qualifiedBody
 	}

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -105,13 +105,13 @@ func QualifyClass(principal *models.Principal, namespacesEnabled bool, name stri
 	return qualified, nil
 }
 
-// StripOwnNS removes the principal's own namespace prefix from name when
-// present. Returns name unchanged when principal.Namespace is empty (global
-// principal; also the case on NS-disabled clusters, where principals never
-// carry a namespace) or when the prefix does not match (foreign prefix or
-// short input). A foreign prefix is left intact so downstream
+// StripOwnNamespace removes the principal's own namespace prefix from name
+// when present. Returns name unchanged when principal.Namespace is empty
+// (global principal; also the case on NS-disabled clusters, where principals
+// never carry a namespace) or when the prefix does not match (foreign prefix
+// or short input). A foreign prefix is left intact so downstream
 // ValidateClassName fails closed on the embedded ":".
-func StripOwnNS(principal *models.Principal, name string) string {
+func StripOwnNamespace(principal *models.Principal, name string) string {
 	if principal == nil || principal.Namespace == "" {
 		return name
 	}
@@ -129,7 +129,7 @@ func StripClassResponse(principal *models.Principal, src *models.Class) *models.
 		return src
 	}
 	out := *src
-	out.Class = StripOwnNS(principal, src.Class)
+	out.Class = StripOwnNamespace(principal, src.Class)
 	if len(src.Properties) > 0 {
 		out.Properties = make([]*models.Property, len(src.Properties))
 		for i, p := range src.Properties {
@@ -142,7 +142,7 @@ func StripClassResponse(principal *models.Principal, src *models.Class) *models.
 // StripPropertyResponse returns a shallow copy of src with every DataType
 // entry and nested-property DataType entry stripped of the principal's own
 // namespace prefix. Primitive types (text, int, …) never carry a namespace
-// prefix, so StripOwnNS is a no-op on them. The input is never mutated.
+// prefix, so StripOwnNamespace is a no-op on them. The input is never mutated.
 func StripPropertyResponse(principal *models.Principal, src *models.Property) *models.Property {
 	if src == nil || principal == nil || principal.Namespace == "" {
 		return src
@@ -179,7 +179,7 @@ func stripDataTypes(principal *models.Principal, src []string) []string {
 	}
 	out := make([]string, len(src))
 	for i, dt := range src {
-		out[i] = StripOwnNS(principal, dt)
+		out[i] = StripOwnNamespace(principal, dt)
 	}
 	return out
 }
@@ -193,8 +193,8 @@ func StripAliasResponse(principal *models.Principal, src *models.Alias) *models.
 		return src
 	}
 	out := *src
-	out.Alias = StripOwnNS(principal, src.Alias)
-	out.Class = StripOwnNS(principal, src.Class)
+	out.Alias = StripOwnNamespace(principal, src.Alias)
+	out.Class = StripOwnNamespace(principal, src.Class)
 	return &out
 }
 
@@ -206,5 +206,5 @@ func StripObjectResponseClass(principal *models.Principal, obj *models.Object) {
 	if obj == nil || principal == nil || principal.Namespace == "" {
 		return
 	}
-	obj.Class = StripOwnNS(principal, obj.Class)
+	obj.Class = StripOwnNamespace(principal, obj.Class)
 }

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -68,11 +68,11 @@ func qualify(principal *models.Principal, name string) string {
 //  4. Look the (possibly qualified) name up as an alias via the existing
 //     in-memory resolver; if it matches an alias, return the alias target.
 //
-// Returns (class, originalAlias, err). originalAlias is the qualified alias
-// name used for lookup when an alias was hit (i.e. namespace-prefixed for
-// namespaced principals, raw for global principals), "" otherwise — used by
-// the objects layer to preserve existing alias-aware flows.
-func Resolve(principal *models.Principal, sm SchemaManager, namespacesEnabled bool, name string) (class, originalAlias string, err error) {
+// Returns (class, qualifiedAlias, err). qualifiedAlias is the
+// namespace-prefixed alias used for lookup when an alias was hit (raw for
+// global principals), "" otherwise — used by the objects layer to preserve
+// existing alias-aware flows.
+func Resolve(principal *models.Principal, sm SchemaManager, namespacesEnabled bool, name string) (class, qualifiedAlias string, err error) {
 	if err := ValidateNamespacePrefix(principal, namespacesEnabled, name, "class"); err != nil {
 		return "", "", err
 	}

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -117,3 +117,94 @@ func StripOwnNS(principal *models.Principal, name string) string {
 	}
 	return strings.TrimPrefix(name, principal.Namespace+schema.NamespaceSeparator)
 }
+
+// StripClassResponse returns a shallow copy of src with the top-level Class
+// name and every property/nested-property DataType entry stripped of the
+// principal's own namespace prefix. Returns src unchanged when the principal
+// has no namespace, so global callers (and NS-disabled clusters) get a
+// pass-through. The input is never mutated: callers can safely pass cached
+// schema pointers without affecting concurrent readers.
+func StripClassResponse(principal *models.Principal, src *models.Class) *models.Class {
+	if src == nil || principal == nil || principal.Namespace == "" {
+		return src
+	}
+	out := *src
+	out.Class = StripOwnNS(principal, src.Class)
+	if len(src.Properties) > 0 {
+		out.Properties = make([]*models.Property, len(src.Properties))
+		for i, p := range src.Properties {
+			out.Properties[i] = StripPropertyResponse(principal, p)
+		}
+	}
+	return &out
+}
+
+// StripPropertyResponse returns a shallow copy of src with every DataType
+// entry and nested-property DataType entry stripped of the principal's own
+// namespace prefix. Primitive types (text, int, …) never carry a namespace
+// prefix, so StripOwnNS is a no-op on them. The input is never mutated.
+func StripPropertyResponse(principal *models.Principal, src *models.Property) *models.Property {
+	if src == nil || principal == nil || principal.Namespace == "" {
+		return src
+	}
+	out := *src
+	out.DataType = stripDataTypes(principal, src.DataType)
+	if len(src.NestedProperties) > 0 {
+		out.NestedProperties = make([]*models.NestedProperty, len(src.NestedProperties))
+		for i, np := range src.NestedProperties {
+			out.NestedProperties[i] = stripNestedPropertyResponse(principal, np)
+		}
+	}
+	return &out
+}
+
+func stripNestedPropertyResponse(principal *models.Principal, src *models.NestedProperty) *models.NestedProperty {
+	if src == nil {
+		return nil
+	}
+	out := *src
+	out.DataType = stripDataTypes(principal, src.DataType)
+	if len(src.NestedProperties) > 0 {
+		out.NestedProperties = make([]*models.NestedProperty, len(src.NestedProperties))
+		for i, np := range src.NestedProperties {
+			out.NestedProperties[i] = stripNestedPropertyResponse(principal, np)
+		}
+	}
+	return &out
+}
+
+func stripDataTypes(principal *models.Principal, src []string) []string {
+	if len(src) == 0 {
+		return src
+	}
+	out := make([]string, len(src))
+	for i, dt := range src {
+		out[i] = StripOwnNS(principal, dt)
+	}
+	return out
+}
+
+// StripAliasResponse returns a shallow copy of src with both Alias and Class
+// stripped of the principal's own namespace prefix. The input is never
+// mutated: callers can safely pass cached schema pointers without affecting
+// concurrent readers.
+func StripAliasResponse(principal *models.Principal, src *models.Alias) *models.Alias {
+	if src == nil || principal == nil || principal.Namespace == "" {
+		return src
+	}
+	out := *src
+	out.Alias = StripOwnNS(principal, src.Alias)
+	out.Class = StripOwnNS(principal, src.Class)
+	return &out
+}
+
+// StripObjectResponseClass mutates obj.Class in place to remove the
+// principal's own namespace prefix. Objects flow per-request from the
+// objects manager — there are no shared pointers to protect — so in-place
+// mutation is safe.
+func StripObjectResponseClass(principal *models.Principal, obj *models.Object) {
+	if obj == nil || principal == nil || principal.Namespace == "" {
+		return
+	}
+	obj.Class = StripOwnNS(principal, obj.Class)
+}

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -379,6 +379,289 @@ func TestResolve_RejectsInvalidNamespacePrefix(t *testing.T) {
 	}
 }
 
+var (
+	namespacedPrincipal  = &models.Principal{Username: "u", Namespace: "customer1"}
+	globalPrincipal      = &models.Principal{Username: "admin", IsGlobalOperator: true}
+	noNamespacePrincipal = &models.Principal{Username: "u"}
+)
+
+// fullyNestedClass returns a class with every namespace-strippable surface
+// covered: own-NS class name, properties with own-NS / foreign / mixed /
+// primitive DataType, and recursive NestedProperties.
+func fullyNestedClass() *models.Class {
+	return &models.Class{
+		Class: "customer1:Movies",
+		Properties: []*models.Property{
+			{Name: "title", DataType: []string{"text"}},
+			{Name: "director", DataType: []string{"customer1:Person"}},
+			{Name: "foreign", DataType: []string{"customer2:Person"}},
+			{Name: "multi", DataType: []string{"customer1:Person", "customer2:Person", "text"}},
+			{
+				Name: "details", DataType: []string{"object"},
+				NestedProperties: []*models.NestedProperty{
+					{Name: "studio", DataType: []string{"customer1:Studio"}},
+					{
+						Name: "deep", DataType: []string{"object"},
+						NestedProperties: []*models.NestedProperty{
+							{Name: "city", DataType: []string{"customer1:City"}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func fullyNestedClassStripped() *models.Class {
+	return &models.Class{
+		Class: "Movies",
+		Properties: []*models.Property{
+			{Name: "title", DataType: []string{"text"}},
+			{Name: "director", DataType: []string{"Person"}},
+			{Name: "foreign", DataType: []string{"customer2:Person"}},
+			{Name: "multi", DataType: []string{"Person", "customer2:Person", "text"}},
+			{
+				Name: "details", DataType: []string{"object"},
+				NestedProperties: []*models.NestedProperty{
+					{Name: "studio", DataType: []string{"Studio"}},
+					{
+						Name: "deep", DataType: []string{"object"},
+						NestedProperties: []*models.NestedProperty{
+							{Name: "city", DataType: []string{"City"}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestStripClassResponse(t *testing.T) {
+	cases := []struct {
+		name      string
+		principal *models.Principal
+		in        *models.Class
+		want      *models.Class
+		wantSame  bool // result should be the same pointer as in (pass-through path)
+	}{
+		{
+			name:      "namespaced principal strips class + recursive datatypes; foreign prefix preserved",
+			principal: namespacedPrincipal,
+			in:        fullyNestedClass(),
+			want:      fullyNestedClassStripped(),
+		},
+		{
+			name:      "class without own prefix returns short-named copy",
+			principal: namespacedPrincipal,
+			in:        &models.Class{Class: "Movies"},
+			want:      &models.Class{Class: "Movies"},
+		},
+		{
+			name:      "global principal passes through",
+			principal: globalPrincipal,
+			in:        &models.Class{Class: "customer1:Movies"},
+			want:      &models.Class{Class: "customer1:Movies"},
+			wantSame:  true,
+		},
+		{
+			name:      "nil principal passes through",
+			principal: nil,
+			in:        &models.Class{Class: "customer1:Movies"},
+			want:      &models.Class{Class: "customer1:Movies"},
+			wantSame:  true,
+		},
+		{
+			name:      "empty namespace passes through",
+			principal: noNamespacePrincipal,
+			in:        &models.Class{Class: "customer1:Movies"},
+			want:      &models.Class{Class: "customer1:Movies"},
+			wantSame:  true,
+		},
+		{
+			name:      "nil src returns nil",
+			principal: namespacedPrincipal,
+			in:        nil,
+			want:      nil,
+			wantSame:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Snapshot input to verify it is not mutated.
+			snapshot := tc.in
+			got := StripClassResponse(tc.principal, tc.in)
+			assert.Equal(t, tc.want, got)
+			if tc.wantSame {
+				assert.Same(t, tc.in, got)
+			} else if tc.in != nil {
+				assert.NotSame(t, tc.in, got)
+			}
+			// Input must not have been mutated.
+			assert.Equal(t, snapshot, tc.in)
+		})
+	}
+}
+
+func TestStripPropertyResponse(t *testing.T) {
+	cases := []struct {
+		name      string
+		principal *models.Principal
+		in        *models.Property
+		want      *models.Property
+		wantSame  bool
+	}{
+		{
+			name:      "namespaced principal strips datatypes recursively",
+			principal: namespacedPrincipal,
+			in: &models.Property{
+				Name:     "owner",
+				DataType: []string{"customer1:Person", "customer2:Person", "text"},
+				NestedProperties: []*models.NestedProperty{
+					{Name: "deep", DataType: []string{"customer1:Studio"}},
+				},
+			},
+			want: &models.Property{
+				Name:     "owner",
+				DataType: []string{"Person", "customer2:Person", "text"},
+				NestedProperties: []*models.NestedProperty{
+					{Name: "deep", DataType: []string{"Studio"}},
+				},
+			},
+		},
+		{
+			name:      "global principal passes through",
+			principal: globalPrincipal,
+			in:        &models.Property{Name: "p", DataType: []string{"customer1:Person"}},
+			want:      &models.Property{Name: "p", DataType: []string{"customer1:Person"}},
+			wantSame:  true,
+		},
+		{
+			name:      "nil principal passes through",
+			principal: nil,
+			in:        &models.Property{Name: "p", DataType: []string{"customer1:Person"}},
+			want:      &models.Property{Name: "p", DataType: []string{"customer1:Person"}},
+			wantSame:  true,
+		},
+		{
+			name:      "nil src returns nil",
+			principal: namespacedPrincipal,
+			in:        nil,
+			want:      nil,
+			wantSame:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot := tc.in
+			got := StripPropertyResponse(tc.principal, tc.in)
+			assert.Equal(t, tc.want, got)
+			if tc.wantSame {
+				assert.Same(t, tc.in, got)
+			} else if tc.in != nil {
+				assert.NotSame(t, tc.in, got)
+			}
+			assert.Equal(t, snapshot, tc.in)
+		})
+	}
+}
+
+func TestStripAliasResponse(t *testing.T) {
+	cases := []struct {
+		name      string
+		principal *models.Principal
+		in        *models.Alias
+		want      *models.Alias
+		wantSame  bool
+	}{
+		{
+			name:      "namespaced principal strips alias and class",
+			principal: namespacedPrincipal,
+			in:        &models.Alias{Alias: "customer1:Films", Class: "customer1:Movies"},
+			want:      &models.Alias{Alias: "Films", Class: "Movies"},
+		},
+		{
+			name:      "foreign prefix preserved on both fields",
+			principal: namespacedPrincipal,
+			in:        &models.Alias{Alias: "customer2:Films", Class: "customer2:Movies"},
+			want:      &models.Alias{Alias: "customer2:Films", Class: "customer2:Movies"},
+		},
+		{
+			name:      "global principal passes through",
+			principal: globalPrincipal,
+			in:        &models.Alias{Alias: "customer1:Films", Class: "customer1:Movies"},
+			want:      &models.Alias{Alias: "customer1:Films", Class: "customer1:Movies"},
+			wantSame:  true,
+		},
+		{
+			name:      "nil src returns nil",
+			principal: namespacedPrincipal,
+			in:        nil,
+			want:      nil,
+			wantSame:  true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			snapshot := tc.in
+			got := StripAliasResponse(tc.principal, tc.in)
+			assert.Equal(t, tc.want, got)
+			if tc.wantSame {
+				assert.Same(t, tc.in, got)
+			} else if tc.in != nil {
+				assert.NotSame(t, tc.in, got)
+			}
+			assert.Equal(t, snapshot, tc.in)
+		})
+	}
+}
+
+func TestStripObjectResponseClass(t *testing.T) {
+	cases := []struct {
+		name      string
+		principal *models.Principal
+		in        *models.Object
+		want      string // expected obj.Class after the call ("" when in == nil)
+	}{
+		{
+			name:      "in-place strip of own prefix",
+			principal: namespacedPrincipal,
+			in:        &models.Object{Class: "customer1:Movies"},
+			want:      "Movies",
+		},
+		{
+			name:      "foreign prefix left intact",
+			principal: namespacedPrincipal,
+			in:        &models.Object{Class: "customer2:Movies"},
+			want:      "customer2:Movies",
+		},
+		{
+			name:      "global principal no-op",
+			principal: globalPrincipal,
+			in:        &models.Object{Class: "customer1:Movies"},
+			want:      "customer1:Movies",
+		},
+		{
+			name:      "nil principal no-op",
+			principal: nil,
+			in:        &models.Object{Class: "customer1:Movies"},
+			want:      "customer1:Movies",
+		},
+		{
+			name:      "nil obj no-op",
+			principal: namespacedPrincipal,
+			in:        nil,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			StripObjectResponseClass(tc.principal, tc.in)
+			if tc.in != nil {
+				assert.Equal(t, tc.want, tc.in.Class)
+			}
+		})
+	}
+}
+
 func TestStripOwnNS(t *testing.T) {
 	cases := []struct {
 		testName  string

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -662,7 +662,7 @@ func TestStripObjectResponseClass(t *testing.T) {
 	}
 }
 
-func TestStripOwnNS(t *testing.T) {
+func TestStripOwnNamespace(t *testing.T) {
 	cases := []struct {
 		testName  string
 		principal *models.Principal
@@ -720,7 +720,7 @@ func TestStripOwnNS(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.testName, func(t *testing.T) {
-			got := StripOwnNS(tc.principal, tc.input)
+			got := StripOwnNamespace(tc.principal, tc.input)
 			assert.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION
### What's being changed:

This strips namespaces form all structured responses (excluding references)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
