### PR TITLE
Support named vectors in default vector index

### DIFF
--- a/test/acceptance/schema/default_vector_index_test.go
+++ b/test/acceptance/schema/default_vector_index_test.go
@@ -67,6 +67,42 @@ func TestDefaultVectorIndexEmpty(t *testing.T) {
 		got := helper.GetClass(t, cls.Class)
 		require.Equal(t, "hnsw", got.VectorConfig["my_vector"].VectorIndexType)
 	})
+
+	t.Run("empty string vectorIndexType defaults to hnsw", func(t *testing.T) {
+		cls := &models.Class{
+			Class:             "EmptyVectorIndexType",
+			VectorIndexType:   "",
+			Vectorizer:        "none",
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+		}
+
+		helper.DeleteClass(t, cls.Class)
+		helper.CreateClass(t, cls)
+
+		got := helper.GetClass(t, cls.Class)
+		require.Equal(t, "hnsw", got.VectorIndexType)
+	})
+
+	t.Run("empty string vectorIndexType defaults to hnsw for named vectors", func(t *testing.T) {
+		cls := &models.Class{
+			Class: "NamedVectorEmptyIndexType",
+			VectorConfig: map[string]models.VectorConfig{
+				"my_vector": {
+					VectorIndexType: "",
+					Vectorizer: map[string]interface{}{
+						"none": map[string]interface{}{},
+					},
+				},
+			},
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+		}
+
+		helper.DeleteClass(t, cls.Class)
+		helper.CreateClass(t, cls)
+
+		got := helper.GetClass(t, cls.Class)
+		require.Equal(t, "hnsw", got.VectorConfig["my_vector"].VectorIndexType)
+	})
 }
 
 func TestDefaultVectorIndexHfresh(t *testing.T) {

--- a/test/acceptance/schema/default_vector_index_test.go
+++ b/test/acceptance/schema/default_vector_index_test.go
@@ -47,6 +47,26 @@ func TestDefaultVectorIndexEmpty(t *testing.T) {
 		got := helper.GetClass(t, cls.Class)
 		require.Equal(t, "hnsw", got.VectorIndexType)
 	})
+
+	t.Run("no env defaults to hnsw for named vectors", func(t *testing.T) {
+		cls := &models.Class{
+			Class: "NamedVectorDefault",
+			VectorConfig: map[string]models.VectorConfig{
+				"my_vector": {
+					Vectorizer: map[string]interface{}{
+						"none": map[string]interface{}{},
+					},
+				},
+			},
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+		}
+
+		helper.DeleteClass(t, cls.Class)
+		helper.CreateClass(t, cls)
+
+		got := helper.GetClass(t, cls.Class)
+		require.Equal(t, "hnsw", got.VectorConfig["my_vector"].VectorIndexType)
+	})
 }
 
 func TestDefaultVectorIndexHfresh(t *testing.T) {
@@ -74,5 +94,25 @@ func TestDefaultVectorIndexHfresh(t *testing.T) {
 
 		got := helper.GetClass(t, cls.Class)
 		require.Equal(t, "hfresh", got.VectorIndexType)
+	})
+
+	t.Run("env set to hfresh defaults to hfresh for named vectors", func(t *testing.T) {
+		cls := &models.Class{
+			Class: "NamedVectorHfresh",
+			VectorConfig: map[string]models.VectorConfig{
+				"my_vector": {
+					Vectorizer: map[string]interface{}{
+						"none": map[string]interface{}{},
+					},
+				},
+			},
+			ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+		}
+
+		helper.DeleteClass(t, cls.Class)
+		helper.CreateClass(t, cls)
+
+		got := helper.GetClass(t, cls.Class)
+		require.Equal(t, "hfresh", got.VectorConfig["my_vector"].VectorIndexType)
 	})
 }

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -491,6 +491,18 @@ func (h *Handler) setClassDefaults(class *models.Class, globalCfg replication.Gl
 		}
 	}
 
+	// apply default vector index type to named vectors
+	for name, vectorConfig := range class.VectorConfig {
+		if vectorConfig.VectorIndexType == "" {
+			if v := h.config.DefaultVectorIndexType.Get(); v != "" {
+				vectorConfig.VectorIndexType = v
+			} else {
+				vectorConfig.VectorIndexType = vectorindex.DefaultVectorIndexType
+			}
+			class.VectorConfig[name] = vectorConfig
+		}
+	}
+
 	setInvertedConfigDefaults(class)
 	for _, prop := range class.Properties {
 		setPropertyDefaults(prop)

--- a/usecases/schema/class_test.go
+++ b/usecases/schema/class_test.go
@@ -2979,6 +2979,63 @@ func Test_SetClassDefaults_DefaultVectorIndexType(t *testing.T) {
 	}
 }
 
+func Test_SetClassDefaults_DefaultVectorIndexType_NamedVectors(t *testing.T) {
+	t.Parallel()
+	globalCfg := replication.GlobalConfig{MinimumFactor: 1}
+
+	tests := []struct {
+		name              string
+		defaultIndexType  string
+		vectorIndexType   string
+		expectedIndexType string
+	}{
+		{
+			name:              "no env, no vector type => hnsw default",
+			defaultIndexType:  "",
+			vectorIndexType:   "",
+			expectedIndexType: vectorindex.VectorIndexTypeHNSW,
+		},
+		{
+			name:              "env set to hfresh, no vector type => hfresh",
+			defaultIndexType:  vectorindex.VectorIndexTypeHFresh,
+			vectorIndexType:   "",
+			expectedIndexType: vectorindex.VectorIndexTypeHFresh,
+		},
+		{
+			name:              "env set to flat, no vector type => flat",
+			defaultIndexType:  vectorindex.VectorIndexTypeFLAT,
+			vectorIndexType:   "",
+			expectedIndexType: vectorindex.VectorIndexTypeFLAT,
+		},
+		{
+			name:              "env set to flat, vector explicitly hnsw => hnsw preserved",
+			defaultIndexType:  vectorindex.VectorIndexTypeFLAT,
+			vectorIndexType:   vectorindex.VectorIndexTypeHNSW,
+			expectedIndexType: vectorindex.VectorIndexTypeHNSW,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler, _ := newTestHandler(t, &fakeDB{})
+			handler.config.DefaultVectorIndexType = runtime.NewDynamicValue(tt.defaultIndexType)
+
+			class := &models.Class{
+				VectorConfig: map[string]models.VectorConfig{
+					"my_vector": {
+						VectorIndexType: tt.vectorIndexType,
+						Vectorizer:      map[string]interface{}{"none": map[string]interface{}{}},
+					},
+				},
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+			}
+			err := handler.setClassDefaults(class, globalCfg)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedIndexType, class.VectorConfig["my_vector"].VectorIndexType)
+		})
+	}
+}
+
 func Test_GetConsistentClass_WithAlias(t *testing.T) {
 	t.Parallel()
 	ctx := context.Background()


### PR DESCRIPTION
### What's being changed:
- Named vectors were missed from https://github.com/weaviate/weaviate/pull/11042

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
