### PR TITLE
Emit log if backoff retries fails to get index locally in time

### DIFF
--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -389,7 +389,7 @@ func (db *DB) GetIndex(className schema.ClassName) *Index {
 		}
 		return nil
 	}, utils.NewBackoff()); err != nil {
-		db.logger.WithField("action", "get_index").WithField("class", className).Warning(err)
+		db.logger.WithField("action", "get_index").WithField("class", className).Info(err)
 	}
 
 	return index

--- a/adapters/repos/db/repo.go
+++ b/adapters/repos/db/repo.go
@@ -379,16 +379,18 @@ func (db *DB) GetIndex(className schema.ClassName) *Index {
 		exists bool
 	)
 	// TODO-RAFT remove backoff. Eventual consistency handled by versioning
-	backoff.Retry(func() error {
+	if err := backoff.Retry(func() error {
 		db.indexLock.RLock()
 		defer db.indexLock.RUnlock()
 
 		index, exists = db.indices[indexID(className)]
 		if !exists {
-			return fmt.Errorf("index for class %v not found locally", index)
+			return fmt.Errorf("index for class %s not found locally", className)
 		}
 		return nil
-	}, utils.NewBackoff())
+	}, utils.NewBackoff()); err != nil {
+		db.logger.WithField("action", "get_index").WithField("class", className).Warning(err)
+	}
 
 	return index
 }


### PR DESCRIPTION
### What's being changed:

Adds a warning log to `db.GetIndex(className)` in the event that the backoff retry logic does not find the index in time. This way, we will be able to discern between eventual consistency issues loading the index and genuine bugs when the index is completely missing from `db.indices`

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
