### PR TITLE
fix(reindex): graceful-restart resilience for in-flight units

### DIFF
--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -200,6 +200,82 @@ func (p *ReindexProvider) GetLocalTasks() []distributedtask.TaskDescriptor {
 	return nil
 }
 
+// Lock-coupled getters/setters for the in-memory caches keyed by
+// TaskDescriptor. Every state mutation goes through one of these so the
+// lock is always released via defer.
+
+func (p *ReindexProvider) registerStartingTask(desc distributedtask.TaskDescriptor, handle *reindexTaskHandle, payload *ReindexTaskPayload) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.runningHandles[desc] = handle
+	p.payloads[desc] = payload
+}
+
+func (p *ReindexProvider) deleteRunningHandle(desc distributedtask.TaskDescriptor) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.runningHandles, desc)
+}
+
+func (p *ReindexProvider) runningHandle(desc distributedtask.TaskDescriptor) (*reindexTaskHandle, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	handle, ok := p.runningHandles[desc]
+	return handle, ok
+}
+
+func (p *ReindexProvider) cachedPayload(desc distributedtask.TaskDescriptor) *ReindexTaskPayload {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.payloads[desc]
+}
+
+func (p *ReindexProvider) cachedReindexTasks(desc distributedtask.TaskDescriptor, unitID string) []*ShardReindexTaskGeneric {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.reindexTasks[desc][unitID]
+}
+
+func (p *ReindexProvider) cacheReindexTasks(desc distributedtask.TaskDescriptor, unitID string, tasks []*ShardReindexTaskGeneric) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.reindexTasks[desc] == nil {
+		p.reindexTasks[desc] = make(map[string][]*ShardReindexTaskGeneric)
+	}
+	p.reindexTasks[desc][unitID] = tasks
+}
+
+func (p *ReindexProvider) clearTaskCaches(desc distributedtask.TaskDescriptor) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.payloads, desc)
+	delete(p.reindexTasks, desc)
+}
+
+// claimActiveWorker reserves the (desc, unitID) slot in activeWorkers.
+// Returns false if another worker already holds it.
+func (p *ReindexProvider) claimActiveWorker(desc distributedtask.TaskDescriptor, unitID string) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.activeWorkers[desc][unitID] {
+		return false
+	}
+	if p.activeWorkers[desc] == nil {
+		p.activeWorkers[desc] = make(map[string]bool)
+	}
+	p.activeWorkers[desc][unitID] = true
+	return true
+}
+
+func (p *ReindexProvider) releaseActiveWorker(desc distributedtask.TaskDescriptor, unitID string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.activeWorkers[desc], unitID)
+	if len(p.activeWorkers[desc]) == 0 {
+		delete(p.activeWorkers, desc)
+	}
+}
+
 func (p *ReindexProvider) CleanupTask(_ distributedtask.TaskDescriptor) error {
 	return nil
 }
@@ -235,10 +311,7 @@ func (p *ReindexProvider) StartTask(task *distributedtask.Task) (distributedtask
 		doneCh: make(chan struct{}),
 	}
 
-	p.mu.Lock()
-	p.runningHandles[task.TaskDescriptor] = handle
-	p.payloads[task.TaskDescriptor] = &payload
-	p.mu.Unlock()
+	p.registerStartingTask(task.TaskDescriptor, handle, &payload)
 
 	// Progress is emitted from the inverted-index reindex iteration every
 	// checkProcessingEveryNoObjects iterations (default 1000). p.recorder
@@ -248,9 +321,7 @@ func (p *ReindexProvider) StartTask(task *distributedtask.Task) (distributedtask
 	// Raft. No additional throttle is needed here.
 	enterrors.GoWrapper(func() {
 		defer func() {
-			p.mu.Lock()
-			delete(p.runningHandles, task.TaskDescriptor)
-			p.mu.Unlock()
+			p.deleteRunningHandle(task.TaskDescriptor)
 			close(handle.doneCh)
 		}()
 
@@ -374,25 +445,11 @@ func (p *ReindexProvider) processOneUnit(
 	// + the local TestMultiNode_GracefulLeaderRestartDuringReindex
 	// failure both surfaced this).
 	if semantic {
-		p.mu.Lock()
-		if p.activeWorkers[task.TaskDescriptor][unitID] {
-			p.mu.Unlock()
+		if !p.claimActiveWorker(task.TaskDescriptor, unitID) {
 			logger.Info("reindex provider: skipping re-entered unit (concurrent worker)")
 			return
 		}
-		if p.activeWorkers[task.TaskDescriptor] == nil {
-			p.activeWorkers[task.TaskDescriptor] = make(map[string]bool)
-		}
-		p.activeWorkers[task.TaskDescriptor][unitID] = true
-		p.mu.Unlock()
-		defer func() {
-			p.mu.Lock()
-			delete(p.activeWorkers[task.TaskDescriptor], unitID)
-			if len(p.activeWorkers[task.TaskDescriptor]) == 0 {
-				delete(p.activeWorkers, task.TaskDescriptor)
-			}
-			p.mu.Unlock()
-		}()
+		defer p.releaseActiveWorker(task.TaskDescriptor, unitID)
 	}
 
 	// Use cached task instances when present. Two populating paths land
@@ -405,9 +462,7 @@ func (p *ReindexProvider) processOneUnit(
 		cached bool
 	)
 	if semantic {
-		p.mu.Lock()
-		tasks = p.reindexTasks[task.TaskDescriptor][unitID]
-		p.mu.Unlock()
+		tasks = p.cachedReindexTasks(task.TaskDescriptor, unitID)
 		cached = len(tasks) > 0
 	}
 	if !cached {
@@ -445,12 +500,7 @@ func (p *ReindexProvider) processOneUnit(
 	// we already have these instances in the map; only write on the
 	// fresh-tasks path.
 	if semantic && !cached {
-		p.mu.Lock()
-		if p.reindexTasks[task.TaskDescriptor] == nil {
-			p.reindexTasks[task.TaskDescriptor] = make(map[string][]*ShardReindexTaskGeneric)
-		}
-		p.reindexTasks[task.TaskDescriptor][unitID] = tasks
-		p.mu.Unlock()
+		p.cacheReindexTasks(task.TaskDescriptor, unitID, tasks)
 	}
 
 	// Persist a recovery record so that a restart mid-flight can rebuild
@@ -737,10 +787,7 @@ func (p *ReindexProvider) propertyHasFilterableBucket(className, propName string
 // after a node restart that happened between reindex finishing and the
 // group callback firing.
 func (p *ReindexProvider) loadPayload(task *distributedtask.Task) (*ReindexTaskPayload, error) {
-	p.mu.Lock()
-	cached := p.payloads[task.TaskDescriptor]
-	p.mu.Unlock()
-	if cached != nil {
+	if cached := p.cachedPayload(task.TaskDescriptor); cached != nil {
 		return cached, nil
 	}
 
@@ -980,10 +1027,7 @@ func (p *ReindexProvider) resolveUnitForPhase(
 		}
 	}
 
-	p.mu.Lock()
-	cached := p.reindexTasks[task.TaskDescriptor][unitID]
-	p.mu.Unlock()
-	if len(cached) > 0 {
+	if cached := p.cachedReindexTasks(task.TaskDescriptor, unitID); len(cached) > 0 {
 		return phaseUnitResolution{Shard: resolvedShard, UnitTasks: cached}
 	}
 
@@ -1016,12 +1060,7 @@ func (p *ReindexProvider) resolveUnitForPhase(
 
 	// Cache the rehydrated tasks so the SWAP callback's lookup hits after
 	// the PreparationCompleteAck barrier (RAFT propagation can take minutes).
-	p.mu.Lock()
-	if p.reindexTasks[task.TaskDescriptor] == nil {
-		p.reindexTasks[task.TaskDescriptor] = make(map[string][]*ShardReindexTaskGeneric)
-	}
-	p.reindexTasks[task.TaskDescriptor][unitID] = fresh
-	p.mu.Unlock()
+	p.cacheReindexTasks(task.TaskDescriptor, unitID, fresh)
 
 	logger.WithField("unit", unitID).
 		Info("reindex provider: resolveUnitForPhase: rebuilding tasks from disk (node likely restarted); cached for subsequent phase callbacks")
@@ -1455,10 +1494,7 @@ func (p *ReindexProvider) onSwapRequestedRunPhaseForUnit(
 func (p *ReindexProvider) OnTaskCompleted(task *distributedtask.Task) {
 	// Clear caches up-front so a failed-task early return doesn't leak.
 	payload, payloadErr := p.loadPayload(task)
-	p.mu.Lock()
-	delete(p.payloads, task.TaskDescriptor)
-	delete(p.reindexTasks, task.TaskDescriptor)
-	p.mu.Unlock()
+	p.clearTaskCaches(task.TaskDescriptor)
 
 	logger := p.logger.WithField("taskID", task.ID).WithField("status", task.Status)
 	logger.Info("reindex provider: task-completion")
@@ -1876,9 +1912,7 @@ func (p *ReindexProvider) WaitForLocalTaskDrain(
 	ctx context.Context,
 	desc distributedtask.TaskDescriptor,
 ) error {
-	p.mu.Lock()
-	handle, ok := p.runningHandles[desc]
-	p.mu.Unlock()
+	handle, ok := p.runningHandle(desc)
 	if !ok {
 		return nil
 	}

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -94,6 +94,17 @@ type ReindexProvider struct {
 	// the double-write callbacks registered via OnAfterLsmInit. Creating new
 	// task instances in OnGroupCompleted would lose those callbacks.
 	reindexTasks map[distributedtask.TaskDescriptor]map[string][]*ShardReindexTaskGeneric
+
+	// activeWorkers tracks units that currently have a per-unit goroutine
+	// inside processOneUnit's iteration body. The re-entry guard reads
+	// this (not the reindexTasks cache) so post-restart recovery — which
+	// seeds reindexTasks via [SeedReindexTaskCache] for OnGroupCompleted's
+	// callback preservation — does NOT short-circuit the resumed unit.
+	// weaviate/0-weaviate-issues#239 Mode 2.
+	//
+	// Guarded by [mu]. Set after the guard, cleared from a defer so any
+	// return path (failure, context.Canceled, panic) releases the slot.
+	activeWorkers map[distributedtask.TaskDescriptor]map[string]bool
 }
 
 // phaseUnitResolution holds the per-unit setup work that every per-shard
@@ -144,6 +155,7 @@ func NewReindexProvider(
 		runningHandles: make(map[distributedtask.TaskDescriptor]*reindexTaskHandle),
 		payloads:       make(map[distributedtask.TaskDescriptor]*ReindexTaskPayload),
 		reindexTasks:   make(map[distributedtask.TaskDescriptor]map[string][]*ShardReindexTaskGeneric),
+		activeWorkers:  make(map[distributedtask.TaskDescriptor]map[string]bool),
 	}
 }
 
@@ -352,31 +364,59 @@ func (p *ReindexProvider) processOneUnit(
 	// not in reindexed state" → swap fails → migration is half-applied
 	// on this replica → #10675-shape per-replica data divergence.
 	//
-	// Skip the work outright instead of re-running the cached task: the
-	// first run's RunReindexOnlyOnShard either is in flight or has
-	// already called RecordDistributedTaskUnitCompletion, and rerunning
-	// OnAfterLsmInit on the same task instance would APPEND to the
-	// task's callbackDisableFuncs list and double every subsequent
-	// double-write callback fire. The FSM-side recorder calls are
-	// idempotent against terminal units (manager.UpdateUnitProgress
-	// silently ignores updates to terminal units), so the second run
-	// has nothing useful to do.
+	// Guard signal is `activeWorkers` (per-unit "a goroutine is inside
+	// the iteration body right now"), NOT the `reindexTasks` cache.
+	// weaviate/0-weaviate-issues#239 Mode 2: post-restart recovery
+	// seeds `reindexTasks` so OnGroupCompleted can reuse the in-flight
+	// task instances with their registered double-write callbacks —
+	// using the cache as the guard signal trapped the resumed unit
+	// forever after a leader restart (the QA c01-leader-postfix repro
+	// + the local TestMultiNode_GracefulLeaderRestartDuringReindex
+	// failure both surfaced this).
 	if semantic {
 		p.mu.Lock()
-		cached := p.reindexTasks[task.TaskDescriptor][unitID]
-		p.mu.Unlock()
-		if len(cached) > 0 {
-			logger.WithField("nTasks", len(cached)).
-				Info("reindex provider: skipping re-entered unit (scheduler relaunched handle before FSM saw prior completion)")
+		if p.activeWorkers[task.TaskDescriptor][unitID] {
+			p.mu.Unlock()
+			logger.Info("reindex provider: skipping re-entered unit (concurrent worker)")
 			return
 		}
+		if p.activeWorkers[task.TaskDescriptor] == nil {
+			p.activeWorkers[task.TaskDescriptor] = make(map[string]bool)
+		}
+		p.activeWorkers[task.TaskDescriptor][unitID] = true
+		p.mu.Unlock()
+		defer func() {
+			p.mu.Lock()
+			delete(p.activeWorkers[task.TaskDescriptor], unitID)
+			if len(p.activeWorkers[task.TaskDescriptor]) == 0 {
+				delete(p.activeWorkers, task.TaskDescriptor)
+			}
+			p.mu.Unlock()
+		}()
 	}
 
-	// Create the reindex task(s) for this migration type.
-	tasks, err := p.createReindexTasks(payload, concreteShard.pathLSM(), false)
-	if err != nil {
-		p.failUnit(ctx, task, unitID, recorder, fmt.Sprintf("creating reindex tasks: %v", err))
-		return
+	// Use cached task instances when present. Two populating paths land
+	// here: (a) post-restart [SeedReindexTaskCache] for callback-preserving
+	// resume; (b) the FSM-lag re-entry case where the previous worker
+	// cached gen-N tasks before exiting — reusing them avoids the gen-N+1
+	// clobber the old guard existed to prevent.
+	var (
+		tasks  []*ShardReindexTaskGeneric
+		cached bool
+	)
+	if semantic {
+		p.mu.Lock()
+		tasks = p.reindexTasks[task.TaskDescriptor][unitID]
+		p.mu.Unlock()
+		cached = len(tasks) > 0
+	}
+	if !cached {
+		var createErr error
+		tasks, createErr = p.createReindexTasks(payload, concreteShard.pathLSM(), false)
+		if createErr != nil {
+			p.failUnit(ctx, task, unitID, recorder, fmt.Sprintf("creating reindex tasks: %v", createErr))
+			return
+		}
 	}
 
 	// Hook up live progress reporting. The recorder above this layer is
@@ -401,36 +441,16 @@ func (p *ReindexProvider) processOneUnit(
 
 	// Cache task instances for semantic migrations so OnGroupCompleted can
 	// call RunSwapOnShard on the same instances (with callbacks registered).
-	// On the re-entry path we already retrieved tasks from the cache, so
-	// this write is a no-op (same map value); guard the nil-map alloc and
-	// write here for the fresh-task path.
-	if semantic {
+	// On the cached-tasks path (post-restart recovery or FSM-lag re-entry)
+	// we already have these instances in the map; only write on the
+	// fresh-tasks path.
+	if semantic && !cached {
 		p.mu.Lock()
 		if p.reindexTasks[task.TaskDescriptor] == nil {
 			p.reindexTasks[task.TaskDescriptor] = make(map[string][]*ShardReindexTaskGeneric)
 		}
 		p.reindexTasks[task.TaskDescriptor][unitID] = tasks
 		p.mu.Unlock()
-	}
-
-	// The re-entry guard at the top reads the SAME cache; a populated
-	// cache on a non-completion exit would trap the unit forever
-	// (weaviate/0-weaviate-issues#239 Mode 2).
-	unitCompleted := false
-	if semantic {
-		defer func() {
-			if unitCompleted {
-				return
-			}
-			p.mu.Lock()
-			if m, ok := p.reindexTasks[task.TaskDescriptor]; ok {
-				delete(m, unitID)
-				if len(m) == 0 {
-					delete(p.reindexTasks, task.TaskDescriptor)
-				}
-			}
-			p.mu.Unlock()
-		}()
 	}
 
 	// Persist a recovery record so that a restart mid-flight can rebuild
@@ -476,7 +496,6 @@ func (p *ReindexProvider) processOneUnit(
 		logger.Errorf("reindex provider: failed to record completion: %v", err)
 		return
 	}
-	unitCompleted = true
 }
 
 // maxReindexPropertiesPerTask caps the number of properties in a single

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -413,6 +413,28 @@ func (p *ReindexProvider) processOneUnit(
 		p.mu.Unlock()
 	}
 
+	// weaviate/0-weaviate-issues#239 Mode 2: the re-entry guard at the
+	// top of this function reads the SAME cache OnGroupCompleted does.
+	// A non-completion exit (graceful shutdown, failUnit's RAFT apply
+	// failing mid-leadership-transition) would leave it populated →
+	// guard fires forever after restart.
+	unitCompleted := false
+	if semantic {
+		defer func() {
+			if unitCompleted {
+				return
+			}
+			p.mu.Lock()
+			if m, ok := p.reindexTasks[task.TaskDescriptor]; ok {
+				delete(m, unitID)
+				if len(m) == 0 {
+					delete(p.reindexTasks, task.TaskDescriptor)
+				}
+			}
+			p.mu.Unlock()
+		}()
+	}
+
 	// Persist a recovery record so that a restart mid-flight can rebuild
 	// these same task instances during shard init. Without this, writes
 	// arriving between shard init and OnGroupCompleted's swap go only to
@@ -436,6 +458,13 @@ func (p *ReindexProvider) processOneUnit(
 			runErr = reindexTask.RunOnShard(ctx, shard)
 		}
 		if runErr != nil {
+			// weaviate/0-weaviate-issues#239 Mode 1: failUnit on
+			// context.Canceled would FSM-flip the whole task FAILED for
+			// what is actually an interruptable shutdown.
+			if errors.Is(runErr, context.Canceled) {
+				logger.Infof("reindex provider: unit interrupted by shutdown; will resume after restart: %v", runErr)
+				return
+			}
 			p.failUnit(ctx, task, unitID, recorder,
 				fmt.Sprintf("reindex (%s): %v", reindexTask.Name(), runErr))
 			return
@@ -448,7 +477,9 @@ func (p *ReindexProvider) processOneUnit(
 		ctx, task.Namespace, task.ID, task.Version, p.localNode, unitID,
 	); err != nil {
 		logger.Errorf("reindex provider: failed to record completion: %v", err)
+		return
 	}
+	unitCompleted = true
 }
 
 // maxReindexPropertiesPerTask caps the number of properties in a single

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -413,11 +413,9 @@ func (p *ReindexProvider) processOneUnit(
 		p.mu.Unlock()
 	}
 
-	// weaviate/0-weaviate-issues#239 Mode 2: the re-entry guard at the
-	// top of this function reads the SAME cache OnGroupCompleted does.
-	// A non-completion exit (graceful shutdown, failUnit's RAFT apply
-	// failing mid-leadership-transition) would leave it populated →
-	// guard fires forever after restart.
+	// The re-entry guard at the top reads the SAME cache; a populated
+	// cache on a non-completion exit would trap the unit forever
+	// (weaviate/0-weaviate-issues#239 Mode 2).
 	unitCompleted := false
 	if semantic {
 		defer func() {
@@ -458,9 +456,8 @@ func (p *ReindexProvider) processOneUnit(
 			runErr = reindexTask.RunOnShard(ctx, shard)
 		}
 		if runErr != nil {
-			// weaviate/0-weaviate-issues#239 Mode 1: failUnit on
-			// context.Canceled would FSM-flip the whole task FAILED for
-			// what is actually an interruptable shutdown.
+			// weaviate/0-weaviate-issues#239 Mode 1: don't FSM-flip
+			// FAILED on a shutdown signal.
 			if errors.Is(runErr, context.Canceled) {
 				logger.Infof("reindex provider: unit interrupted by shutdown; will resume after restart: %v", runErr)
 				return

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -129,6 +129,21 @@ func importObjects(t *testing.T, restURI, className string, texts []string) {
 	}
 }
 
+// httpGetJSON GETs url and JSON-decodes into out. Returns false on any
+// step's error so it composes cleanly inside require.Eventually polls.
+func httpGetJSON(url string, out any) bool {
+	resp, err := http.Get(url)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false
+	}
+	return json.Unmarshal(body, out) == nil
+}
+
 // awaitReindexReachedFinalizing polls /v1/tasks until the reindex task
 // transitions into FINALIZING — i.e. every unit has completed its
 // reindex iteration on every node and the cluster is about to fire the
@@ -145,17 +160,8 @@ func awaitReindexReachedFinalizing(t *testing.T, restURI, taskID string) string 
 	t.Helper()
 	var observed string
 	require.Eventually(t, func() bool {
-		resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
-		if err != nil {
-			return false
-		}
-		defer resp.Body.Close()
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return false
-		}
 		var tasks models.DistributedTasks
-		if err := json.Unmarshal(body, &tasks); err != nil {
+		if !httpGetJSON(fmt.Sprintf("http://%s/v1/tasks", restURI), &tasks) {
 			return false
 		}
 		for _, task := range tasks["reindex"] {
@@ -189,17 +195,8 @@ func awaitReindexReachedFinalizing(t *testing.T, restURI, taskID string) string 
 func awaitReindexMidFlight(t *testing.T, restURI, taskID string, minProgress float32, timeout time.Duration) {
 	t.Helper()
 	require.Eventually(t, func() bool {
-		resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
-		if err != nil {
-			return false
-		}
-		defer resp.Body.Close()
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return false
-		}
 		var tasks models.DistributedTasks
-		if err := json.Unmarshal(body, &tasks); err != nil {
+		if !httpGetJSON(fmt.Sprintf("http://%s/v1/tasks", restURI), &tasks) {
 			return false
 		}
 		for _, task := range tasks["reindex"] {
@@ -236,17 +233,8 @@ func raftLeaderIndex(t *testing.T, compose *docker.DockerCompose) int {
 	t.Helper()
 	var leaderName string
 	require.Eventually(t, func() bool {
-		resp, err := http.Get(fmt.Sprintf("http://%s/v1/cluster/statistics", restURIOf(compose, 1)))
-		if err != nil {
-			return false
-		}
-		defer resp.Body.Close()
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return false
-		}
 		var stats models.ClusterStatisticsResponse
-		if err := json.Unmarshal(body, &stats); err != nil {
+		if !httpGetJSON(fmt.Sprintf("http://%s/v1/cluster/statistics", restURIOf(compose, 1)), &stats) {
 			return false
 		}
 		for _, s := range stats.Statistics {

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -183,13 +183,9 @@ func awaitReindexReachedFinalizing(t *testing.T, restURI, taskID string) string 
 	return observed
 }
 
-// awaitReindexMidFlight blocks until at least one IN_PROGRESS unit's
-// progress is >= minProgress on a STARTED task. Fails loudly if the
-// task reaches FINISHED/FAILED before the condition is observed — the
-// caller is asking for a mid-reindex restart scenario, and a vacuous
-// pass (migration completed before the test could restart anything)
-// hides real bugs. See weaviate/0-weaviate-issues#239 for the prior
-// silent-vacuous failure.
+// Fails the test if the migration ends before reaching STARTED + at
+// least one IN_PROGRESS unit with progress >= minProgress
+// (weaviate/0-weaviate-issues#239 anti-vacuous-pass).
 func awaitReindexMidFlight(t *testing.T, restURI, taskID string, minProgress float32, timeout time.Duration) {
 	t.Helper()
 	require.Eventually(t, func() bool {
@@ -236,10 +232,6 @@ func awaitReindexMidFlight(t *testing.T, restURI, taskID string, minProgress flo
 		taskID, minProgress, timeout)
 }
 
-// raftLeaderIndex returns the 0-based docker node index of the RAFT
-// leader (weaviate-0 → 0, weaviate-1 → 1, weaviate-2 → 2). Queries
-// /v1/cluster/statistics on node 1 — `leaderId` is the same across
-// all nodes in steady state.
 func raftLeaderIndex(t *testing.T, compose *docker.DockerCompose) int {
 	t.Helper()
 	var leaderName string
@@ -268,7 +260,6 @@ func raftLeaderIndex(t *testing.T, compose *docker.DockerCompose) int {
 		}
 		return false
 	}, 30*time.Second, 200*time.Millisecond, "/v1/cluster/statistics should report a leader")
-	// Node names are docker.Weaviate{0,1,2}.
 	for idx, name := range []string{docker.Weaviate0, docker.Weaviate1, docker.Weaviate2} {
 		if name == leaderName {
 			return idx

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -190,9 +190,12 @@ func awaitReindexReachedFinalizing(t *testing.T, restURI, taskID string) string 
 }
 
 // Fails the test if the migration ends before reaching STARTED + at
-// least one IN_PROGRESS unit with progress >= minProgress
-// (weaviate/0-weaviate-issues#239 anti-vacuous-pass).
-func awaitReindexMidFlight(t *testing.T, restURI, taskID string, minProgress float32, timeout time.Duration) {
+// least one IN_PROGRESS unit (weaviate/0-weaviate-issues#239
+// anti-vacuous-pass). Status IN_PROGRESS — not a numeric Progress
+// floor — is the signal: the DTM ThrottledRecorder (3 s window) means
+// fast units may only emit one progress=0 update before COMPLETED, so
+// asserting on a non-zero floor flakes on fast CI runners.
+func awaitReindexMidFlight(t *testing.T, restURI, taskID string, timeout time.Duration) {
 	t.Helper()
 	require.Eventually(t, func() bool {
 		var tasks models.DistributedTasks
@@ -208,16 +211,14 @@ func awaitReindexMidFlight(t *testing.T, restURI, taskID string, minProgress flo
 			}
 			if task.Status == "FINISHED" || task.Status == "PREPARING" || task.Status == "SWAPPING" {
 				t.Fatalf("reindex task %s reached %s before mid-flight check — "+
-					"dataset too small or progress threshold too high. "+
-					"Caller asked for a mid-reindex restart but the migration "+
-					"already left STARTED. Bump totalObjects or lower minProgress.",
+					"dataset too small for the iteration window. Bump totalObjects.",
 					taskID, task.Status)
 			}
 			if task.Status != "STARTED" {
 				return false
 			}
 			for _, u := range task.Units {
-				if u.Status == "IN_PROGRESS" && u.Progress >= minProgress {
+				if u.Status == "IN_PROGRESS" {
 					return true
 				}
 			}
@@ -225,8 +226,8 @@ func awaitReindexMidFlight(t *testing.T, restURI, taskID string, minProgress flo
 		}
 		return false
 	}, timeout, 200*time.Millisecond,
-		"reindex task %s should reach STARTED + unit.progress>=%v within %s",
-		taskID, minProgress, timeout)
+		"reindex task %s should have at least one IN_PROGRESS unit within %s",
+		taskID, timeout)
 }
 
 func raftLeaderIndex(t *testing.T, compose *docker.DockerCompose) int {

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -751,8 +751,8 @@ func runMigrationWithProbes(
 	samples := make([]probeSample, 0, 1024)
 	record := func(s probeSample) {
 		samplesMu.Lock()
+		defer samplesMu.Unlock()
 		samples = append(samples, s)
-		samplesMu.Unlock()
 	}
 
 	stopCh := make(chan struct{})

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -183,6 +183,59 @@ func awaitReindexReachedFinalizing(t *testing.T, restURI, taskID string) string 
 	return observed
 }
 
+// awaitReindexMidFlight blocks until at least one IN_PROGRESS unit's
+// progress is >= minProgress on a STARTED task. Fails loudly if the
+// task reaches FINISHED/FAILED before the condition is observed — the
+// caller is asking for a mid-reindex restart scenario, and a vacuous
+// pass (migration completed before the test could restart anything)
+// hides real bugs. See weaviate/0-weaviate-issues#239 for the prior
+// silent-vacuous failure.
+func awaitReindexMidFlight(t *testing.T, restURI, taskID string, minProgress float32, timeout time.Duration) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://%s/v1/tasks", restURI))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false
+		}
+		var tasks models.DistributedTasks
+		if err := json.Unmarshal(body, &tasks); err != nil {
+			return false
+		}
+		for _, task := range tasks["reindex"] {
+			if task.ID != taskID {
+				continue
+			}
+			if task.Status == "FAILED" {
+				t.Fatalf("reindex task %s failed before mid-flight check: %s", taskID, task.Error)
+			}
+			if task.Status == "FINISHED" || task.Status == "PREPARING" || task.Status == "SWAPPING" {
+				t.Fatalf("reindex task %s reached %s before mid-flight check — "+
+					"dataset too small or progress threshold too high. "+
+					"Caller asked for a mid-reindex restart but the migration "+
+					"already left STARTED. Bump totalObjects or lower minProgress.",
+					taskID, task.Status)
+			}
+			if task.Status != "STARTED" {
+				return false
+			}
+			for _, u := range task.Units {
+				if u.Status == "IN_PROGRESS" && u.Progress >= minProgress {
+					return true
+				}
+			}
+			return false
+		}
+		return false
+	}, timeout, 200*time.Millisecond,
+		"reindex task %s should reach STARTED + unit.progress>=%v within %s",
+		taskID, minProgress, timeout)
+}
+
 // runBM25QueryOnNode executes a BM25 query against a specific node and returns object IDs.
 func runBM25QueryOnNode(t *testing.T, restURI, className, query string) ([]string, error) {
 	t.Helper()

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -236,6 +236,48 @@ func awaitReindexMidFlight(t *testing.T, restURI, taskID string, minProgress flo
 		taskID, minProgress, timeout)
 }
 
+// raftLeaderIndex returns the 0-based docker node index of the RAFT
+// leader (weaviate-0 → 0, weaviate-1 → 1, weaviate-2 → 2). Queries
+// /v1/cluster/statistics on node 1 — `leaderId` is the same across
+// all nodes in steady state.
+func raftLeaderIndex(t *testing.T, compose *docker.DockerCompose) int {
+	t.Helper()
+	var leaderName string
+	require.Eventually(t, func() bool {
+		resp, err := http.Get(fmt.Sprintf("http://%s/v1/cluster/statistics", restURIOf(compose, 1)))
+		if err != nil {
+			return false
+		}
+		defer resp.Body.Close()
+		body, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return false
+		}
+		var stats models.ClusterStatisticsResponse
+		if err := json.Unmarshal(body, &stats); err != nil {
+			return false
+		}
+		for _, s := range stats.Statistics {
+			if s.LeaderID == nil {
+				continue
+			}
+			if name, ok := s.LeaderID.(string); ok && name != "" {
+				leaderName = name
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 200*time.Millisecond, "/v1/cluster/statistics should report a leader")
+	// Node names are docker.Weaviate{0,1,2}.
+	for idx, name := range []string{docker.Weaviate0, docker.Weaviate1, docker.Weaviate2} {
+		if name == leaderName {
+			return idx
+		}
+	}
+	t.Fatalf("leader name %q does not match any of weaviate-{0,1,2}", leaderName)
+	return -1
+}
+
 // runBM25QueryOnNode executes a BM25 query against a specific node and returns object IDs.
 func runBM25QueryOnNode(t *testing.T, restURI, className, query string) ([]string, error) {
 	t.Helper()

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -82,14 +82,18 @@ func assertReindexCompleteAndConsistent(
 	}, 30*time.Second, 500*time.Millisecond,
 		"tokenization should flip to field on every replica post-restart")
 
-	// Under FIELD tokenization each path-bucket matches dataset/5 exactly.
+	// Under FIELD tokenization each path-bucket matches dataset/5
+	// exactly. Probe all 5 to catch a per-bucket regression (e.g. 4/5
+	// intact, 1 corrupted would still pass a single-bucket check).
 	const expected = reindexRestartDataset / 5
-	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-		got, err := equalCount(restURIOf(compose, nodeIdx), className, "path", "alpha-path")
-		require.NoErrorf(t, err, "node %d: post-restart count query failed", nodeIdx)
-		assert.Equalf(t, expected, got,
-			"node %d: post-restart count mismatch (expected %d, got %d)",
-			nodeIdx, expected, got)
+	for _, bucket := range []string{"alpha-path", "beta-path", "gamma-path", "delta-path", "epsilon-path"} {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			got, err := equalCount(restURIOf(compose, nodeIdx), className, "path", bucket)
+			require.NoErrorf(t, err, "node %d bucket %q: post-restart count query failed", nodeIdx, bucket)
+			assert.Equalf(t, expected, got,
+				"node %d bucket %q: post-restart count mismatch (expected %d, got %d)",
+				nodeIdx, bucket, expected, got)
+		}
 	}
 }
 
@@ -135,13 +139,15 @@ func TestMultiNode_GracefulRestartDuringReindex(t *testing.T) {
 func TestMultiNode_GracefulLeaderRestartDuringReindex(t *testing.T) {
 	runRestartDuringReindex(t, "LeaderRestartDuringReindex", 360*time.Second,
 		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
-			stopStart(ctx, t, compose, 0, nil)
-			// Probe via the actual "path" property — runBM25QueryOnNode
-			// hardcodes "text" which doesn't exist on this class.
+			// Resolve the actual leader at restart time — node 1 is
+			// only the leader by initial-election convention.
+			leaderIdx := raftLeaderIndex(t, compose)
+			t.Logf("gracefully stopping leader (node %d)", leaderIdx+1)
+			stopStart(ctx, t, compose, leaderIdx, nil)
 			require.Eventually(t, func() bool {
 				_, err := equalCount(restURIOf(compose, 1), "LeaderRestartDuringReindex", "path", "alpha-path")
 				return err == nil
-			}, 60*time.Second, 1*time.Second, "node 1 should be ready after restart")
+			}, 60*time.Second, 1*time.Second, "cluster should be ready after leader restart")
 		})
 }
 

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -68,16 +68,21 @@ func assertReindexCompleteAndConsistent(
 	reindexhelpers.AwaitReindexFinished(t, restURIOf(compose, 1), taskID,
 		reindexhelpers.WithTimeout(awaitTimeout))
 
-	// Tokenization must have flipped to "field" on every replica.
-	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
-		got := tryGetPropertyTokenization(restURIOf(compose, nodeIdx), className, "path")
-		assert.Equalf(t, "field", got,
-			"node %d: tokenization should have flipped to field, got %q", nodeIdx, got)
-	}
+	// Schema reflection of the FINISHED flip is per-replica eventual:
+	// AwaitReindexFinished sees the FSM state, but each replica's
+	// in-memory schema cache catches up via the schema-update callback
+	// on its own clock.
+	require.Eventually(t, func() bool {
+		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+			if tryGetPropertyTokenization(restURIOf(compose, nodeIdx), className, "path") != "field" {
+				return false
+			}
+		}
+		return true
+	}, 30*time.Second, 500*time.Millisecond,
+		"tokenization should flip to field on every replica post-restart")
 
-	// Every replica must serve the same count for an exact-match query
-	// on a path value. Under FIELD tokenization, every path-bucket
-	// matches reindexRestartDataset/5 records exactly.
+	// Under FIELD tokenization each path-bucket matches dataset/5 exactly.
 	const expected = reindexRestartDataset / 5
 	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
 		got, err := equalCount(restURIOf(compose, nodeIdx), className, "path", "alpha-path")
@@ -129,8 +134,10 @@ func TestMultiNode_GracefulLeaderRestartDuringReindex(t *testing.T) {
 			t.Log("gracefully stopping node 1 (RAFT leader)")
 			require.NoError(t, compose.StopAt(ctx, 0, nil))
 			require.NoError(t, compose.StartAt(ctx, 0))
+			// Probe via the actual "path" property — runBM25QueryOnNode
+			// hardcodes "text" which doesn't exist on this class.
 			require.Eventually(t, func() bool {
-				_, err := runBM25QueryOnNode(t, restURIOf(compose, 1), "LeaderRestartDuringReindex", "path")
+				_, err := equalCount(restURIOf(compose, 1), "LeaderRestartDuringReindex", "path", "alpha-path")
 				return err == nil
 			}, 60*time.Second, 1*time.Second, "node 1 should be ready after restart")
 		})

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -23,16 +23,13 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 )
 
-// 50k change-tokenization migration spends ~25-40 s in STARTED on a
-// 3-node cluster — wide enough to land the restart inside.
-const reindexRestartDataset = 50_000
+const (
+	// 50k change-tokenization gives ~25-40 s STARTED on a 3-node cluster.
+	reindexRestartDataset = 50_000
+	// Past "just started" (units can sit at 0 briefly) but well before completion.
+	reindexRestartProgressFloor = 0.1
+)
 
-// 0.1 is past the "just started" floor (units can sit at 0 for a few
-// ticks) but well before completion.
-const reindexRestartProgressFloor = 0.1
-
-// Change-tokenization is the heaviest shape (2 sub-tasks per shard ×
-// property) — widest STARTED window for the restart-mid-flight checks.
 func setupRestartDuringReindex(
 	ctx context.Context, t *testing.T, className string,
 ) (*docker.DockerCompose, func(), string) {
@@ -68,10 +65,7 @@ func assertReindexCompleteAndConsistent(
 	reindexhelpers.AwaitReindexFinished(t, restURIOf(compose, 1), taskID,
 		reindexhelpers.WithTimeout(awaitTimeout))
 
-	// Schema reflection of the FINISHED flip is per-replica eventual:
-	// AwaitReindexFinished sees the FSM state, but each replica's
-	// in-memory schema cache catches up via the schema-update callback
-	// on its own clock.
+	// Per-replica schema cache catches up eventually after the FSM flip.
 	require.Eventually(t, func() bool {
 		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
 			if tryGetPropertyTokenization(restURIOf(compose, nodeIdx), className, "path") != "field" {
@@ -82,9 +76,6 @@ func assertReindexCompleteAndConsistent(
 	}, 30*time.Second, 500*time.Millisecond,
 		"tokenization should flip to field on every replica post-restart")
 
-	// Under FIELD tokenization each path-bucket matches dataset/5
-	// exactly. Probe all 5 to catch a per-bucket regression (e.g. 4/5
-	// intact, 1 corrupted would still pass a single-bucket check).
 	const expected = reindexRestartDataset / 5
 	for _, bucket := range []string{"alpha-path", "beta-path", "gamma-path", "delta-path", "epsilon-path"} {
 		for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
@@ -97,9 +88,7 @@ func assertReindexCompleteAndConsistent(
 	}
 }
 
-// stopStart issues a stop(timeout) + start cycle on a single node and
-// asserts both ops succeeded. timeout=nil = graceful SIGTERM; non-nil
-// = SIGKILL after the timeout expires.
+// timeout=nil → graceful SIGTERM; non-nil → SIGKILL after expiry.
 func stopStart(ctx context.Context, t *testing.T, compose *docker.DockerCompose, nodeIdx int, timeout *time.Duration) {
 	t.Helper()
 	require.NoError(t, compose.StopAt(ctx, nodeIdx, timeout))
@@ -133,14 +122,11 @@ func TestMultiNode_GracefulRestartDuringReindex(t *testing.T) {
 }
 
 // Pins weaviate/0-weaviate-issues#239 Mode 2: graceful RAFT leader
-// restart mid-reindex must resume, not stay STUCK indefinitely.
-// 360 s budget: leader-restart absorbs ~30 s re-election before the
-// resumed iteration even starts.
+// restart must resume, not stay STUCK indefinitely. 360 s budget
+// absorbs leader re-election before resumed iteration starts.
 func TestMultiNode_GracefulLeaderRestartDuringReindex(t *testing.T) {
 	runRestartDuringReindex(t, "LeaderRestartDuringReindex", 360*time.Second,
 		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
-			// Resolve the actual leader at restart time — node 1 is
-			// only the leader by initial-election convention.
 			leaderIdx := raftLeaderIndex(t, compose)
 			t.Logf("gracefully stopping leader (node %d)", leaderIdx+1)
 			stopStart(ctx, t, compose, leaderIdx, nil)
@@ -160,7 +146,6 @@ func TestMultiNode_CrashDuringReindex(t *testing.T) {
 		})
 }
 
-// Quorum loss + recovery: SIGKILL nodes 2+3, restart both, task FINISH.
 func TestMultiNode_MajorityCrashDuringReindex(t *testing.T) {
 	runRestartDuringReindex(t, "MajorityCrash", 360*time.Second,
 		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
@@ -172,10 +157,6 @@ func TestMultiNode_MajorityCrashDuringReindex(t *testing.T) {
 		})
 }
 
-// TestMultiNode_RollingRestartAfterComplete keeps the previous
-// rolling-restart-AFTER-complete test scope: a completed migration
-// must survive a full rolling restart with no per-replica divergence
-// on the migrated buckets.
 func TestMultiNode_RollingRestartAfterComplete(t *testing.T) {
 	ctx := context.Background()
 	compose, cleanup := start3NodeReindexCluster(ctx, t)

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -93,11 +93,15 @@ func assertReindexCompleteAndConsistent(
 	}
 }
 
-// runRestartDuringReindex is the shared scaffold: spin up the cluster,
-// import the dataset, submit the migration, wait until iteration is
-// truly mid-flight, then hand off to restartFn (which does the
-// test-specific stop/start sequence) and verify post-restart
-// completeness + per-replica consistency.
+// stopStart issues a stop(timeout) + start cycle on a single node and
+// asserts both ops succeeded. timeout=nil = graceful SIGTERM; non-nil
+// = SIGKILL after the timeout expires.
+func stopStart(ctx context.Context, t *testing.T, compose *docker.DockerCompose, nodeIdx int, timeout *time.Duration) {
+	t.Helper()
+	require.NoError(t, compose.StopAt(ctx, nodeIdx, timeout))
+	require.NoError(t, compose.StartAt(ctx, nodeIdx))
+}
+
 func runRestartDuringReindex(
 	t *testing.T, className string, awaitTimeout time.Duration,
 	restartFn func(ctx context.Context, t *testing.T, compose *docker.DockerCompose),
@@ -113,27 +117,25 @@ func runRestartDuringReindex(
 	assertReindexCompleteAndConsistent(t, compose, className, taskID, awaitTimeout)
 }
 
+var sigkillFast = 1 * time.Second
+
 // Pins weaviate/0-weaviate-issues#239 Mode 1: graceful follower restart
 // mid-reindex must resume, not mark the task FAILED.
 func TestMultiNode_GracefulRestartDuringReindex(t *testing.T) {
 	runRestartDuringReindex(t, "RestartDuringReindex", 240*time.Second,
 		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
-			t.Log("gracefully stopping node 3 (follower)")
-			require.NoError(t, compose.StopAt(ctx, 2, nil))
-			require.NoError(t, compose.StartAt(ctx, 2))
+			stopStart(ctx, t, compose, 2, nil)
 		})
 }
 
 // Pins weaviate/0-weaviate-issues#239 Mode 2: graceful RAFT leader
 // restart mid-reindex must resume, not stay STUCK indefinitely.
+// 360 s budget: leader-restart absorbs ~30 s re-election before the
+// resumed iteration even starts.
 func TestMultiNode_GracefulLeaderRestartDuringReindex(t *testing.T) {
-	// 360 s budget: leader-restart absorbs ~30 s re-election before the
-	// resumed iteration even starts.
 	runRestartDuringReindex(t, "LeaderRestartDuringReindex", 360*time.Second,
 		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
-			t.Log("gracefully stopping node 1 (RAFT leader)")
-			require.NoError(t, compose.StopAt(ctx, 0, nil))
-			require.NoError(t, compose.StartAt(ctx, 0))
+			stopStart(ctx, t, compose, 0, nil)
 			// Probe via the actual "path" property — runBM25QueryOnNode
 			// hardcodes "text" which doesn't exist on this class.
 			require.Eventually(t, func() bool {
@@ -146,25 +148,20 @@ func TestMultiNode_GracefulLeaderRestartDuringReindex(t *testing.T) {
 // Pins weaviate/0-weaviate-issues#239 Mode 3: ungraceful SIGKILL
 // follower mid-reindex must resume via sentinel-aware recovery.
 func TestMultiNode_CrashDuringReindex(t *testing.T) {
-	stopTimeout := 1 * time.Second
 	runRestartDuringReindex(t, "CrashDuringReindex", 240*time.Second,
 		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
-			t.Log("SIGKILL node 3 (ungraceful)")
-			require.NoError(t, compose.StopAt(ctx, 2, &stopTimeout))
-			require.NoError(t, compose.StartAt(ctx, 2))
+			stopStart(ctx, t, compose, 2, &sigkillFast)
 		})
 }
 
-// Quorum loss + recovery mid-reindex: SIGKILL nodes 2+3, restart both,
-// task must still FINISH.
+// Quorum loss + recovery: SIGKILL nodes 2+3, restart both, task FINISH.
 func TestMultiNode_MajorityCrashDuringReindex(t *testing.T) {
-	stopTimeout := 1 * time.Second
 	runRestartDuringReindex(t, "MajorityCrash", 360*time.Second,
 		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
-			t.Log("SIGKILL nodes 3 + 2 (majority lost)")
-			require.NoError(t, compose.StopAt(ctx, 2, &stopTimeout))
-			require.NoError(t, compose.StopAt(ctx, 1, &stopTimeout))
-			require.NoError(t, compose.StartAt(ctx, 1)) // node 2 first → restores quorum with node 1
+			require.NoError(t, compose.StopAt(ctx, 2, &sigkillFast))
+			require.NoError(t, compose.StopAt(ctx, 1, &sigkillFast))
+			// Node 2 first → restores quorum with node 1 before node 3.
+			require.NoError(t, compose.StartAt(ctx, 1))
 			require.NoError(t, compose.StartAt(ctx, 2))
 		})
 }

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -88,100 +88,78 @@ func assertReindexCompleteAndConsistent(
 	}
 }
 
-// Pins weaviate/0-weaviate-issues#239 Mode 1: graceful follower restart
-// mid-reindex must resume, not mark the task FAILED.
-func TestMultiNode_GracefulRestartDuringReindex(t *testing.T) {
+// runRestartDuringReindex is the shared scaffold: spin up the cluster,
+// import the dataset, submit the migration, wait until iteration is
+// truly mid-flight, then hand off to restartFn (which does the
+// test-specific stop/start sequence) and verify post-restart
+// completeness + per-replica consistency.
+func runRestartDuringReindex(
+	t *testing.T, className string, awaitTimeout time.Duration,
+	restartFn func(ctx context.Context, t *testing.T, compose *docker.DockerCompose),
+) {
 	ctx := context.Background()
-	compose, cleanup, taskID := setupRestartDuringReindex(ctx, t, "RestartDuringReindex")
+	compose, cleanup, taskID := setupRestartDuringReindex(ctx, t, className)
 	defer cleanup()
 	defer dumpContainerLogs(ctx, t, compose)
 
 	awaitReindexMidFlight(t, restURIOf(compose, 1), taskID,
 		reindexRestartProgressFloor, 60*time.Second)
-	t.Log("task is mid-flight; gracefully stopping node 3 (follower)")
-	require.NoError(t, compose.StopAt(ctx, 2, nil))
+	restartFn(ctx, t, compose)
+	assertReindexCompleteAndConsistent(t, compose, className, taskID, awaitTimeout)
+}
 
-	t.Log("restarting node 3")
-	require.NoError(t, compose.StartAt(ctx, 2))
-
-	assertReindexCompleteAndConsistent(t, compose, "RestartDuringReindex", taskID,
-		240*time.Second)
+// Pins weaviate/0-weaviate-issues#239 Mode 1: graceful follower restart
+// mid-reindex must resume, not mark the task FAILED.
+func TestMultiNode_GracefulRestartDuringReindex(t *testing.T) {
+	runRestartDuringReindex(t, "RestartDuringReindex", 240*time.Second,
+		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
+			t.Log("gracefully stopping node 3 (follower)")
+			require.NoError(t, compose.StopAt(ctx, 2, nil))
+			require.NoError(t, compose.StartAt(ctx, 2))
+		})
 }
 
 // Pins weaviate/0-weaviate-issues#239 Mode 2: graceful RAFT leader
 // restart mid-reindex must resume, not stay STUCK indefinitely.
 func TestMultiNode_GracefulLeaderRestartDuringReindex(t *testing.T) {
-	ctx := context.Background()
-	compose, cleanup, taskID := setupRestartDuringReindex(ctx, t, "LeaderRestartDuringReindex")
-	defer cleanup()
-	defer dumpContainerLogs(ctx, t, compose)
-
-	awaitReindexMidFlight(t, restURIOf(compose, 1), taskID,
-		reindexRestartProgressFloor, 60*time.Second)
-	t.Log("task is mid-flight; gracefully stopping node 1 (RAFT leader)")
-	require.NoError(t, compose.StopAt(ctx, 0, nil))
-
-	t.Log("restarting node 1")
-	require.NoError(t, compose.StartAt(ctx, 0))
-
-	// Wait for node 1 to re-form quorum before asking it questions.
-	require.Eventually(t, func() bool {
-		_, err := runBM25QueryOnNode(t, restURIOf(compose, 1), "LeaderRestartDuringReindex", "path")
-		return err == nil
-	}, 60*time.Second, 1*time.Second, "node 1 should be ready after restart")
-
-	// 360 s budget: leader-restart re-elections can absorb a 30 s window
-	// before the resumed iteration even starts, and the work still has
-	// to complete from scratch on the killed leader's local units
-	// (sentinel-aware recovery rebuilds the per-shard tracker state).
-	assertReindexCompleteAndConsistent(t, compose, "LeaderRestartDuringReindex", taskID,
-		360*time.Second)
+	// 360 s budget: leader-restart absorbs ~30 s re-election before the
+	// resumed iteration even starts.
+	runRestartDuringReindex(t, "LeaderRestartDuringReindex", 360*time.Second,
+		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
+			t.Log("gracefully stopping node 1 (RAFT leader)")
+			require.NoError(t, compose.StopAt(ctx, 0, nil))
+			require.NoError(t, compose.StartAt(ctx, 0))
+			require.Eventually(t, func() bool {
+				_, err := runBM25QueryOnNode(t, restURIOf(compose, 1), "LeaderRestartDuringReindex", "path")
+				return err == nil
+			}, 60*time.Second, 1*time.Second, "node 1 should be ready after restart")
+		})
 }
 
 // Pins weaviate/0-weaviate-issues#239 Mode 3: ungraceful SIGKILL
 // follower mid-reindex must resume via sentinel-aware recovery.
 func TestMultiNode_CrashDuringReindex(t *testing.T) {
-	ctx := context.Background()
-	compose, cleanup, taskID := setupRestartDuringReindex(ctx, t, "CrashDuringReindex")
-	defer cleanup()
-	defer dumpContainerLogs(ctx, t, compose)
-
-	awaitReindexMidFlight(t, restURIOf(compose, 1), taskID,
-		reindexRestartProgressFloor, 60*time.Second)
 	stopTimeout := 1 * time.Second
-	t.Log("task is mid-flight; SIGKILL on node 3 (ungraceful)")
-	require.NoError(t, compose.StopAt(ctx, 2, &stopTimeout))
-
-	t.Log("restarting node 3")
-	require.NoError(t, compose.StartAt(ctx, 2))
-
-	assertReindexCompleteAndConsistent(t, compose, "CrashDuringReindex", taskID,
-		240*time.Second)
+	runRestartDuringReindex(t, "CrashDuringReindex", 240*time.Second,
+		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
+			t.Log("SIGKILL node 3 (ungraceful)")
+			require.NoError(t, compose.StopAt(ctx, 2, &stopTimeout))
+			require.NoError(t, compose.StartAt(ctx, 2))
+		})
 }
 
 // Quorum loss + recovery mid-reindex: SIGKILL nodes 2+3, restart both,
 // task must still FINISH.
 func TestMultiNode_MajorityCrashDuringReindex(t *testing.T) {
-	ctx := context.Background()
-	compose, cleanup, taskID := setupRestartDuringReindex(ctx, t, "MajorityCrash")
-	defer cleanup()
-	defer dumpContainerLogs(ctx, t, compose)
-
-	awaitReindexMidFlight(t, restURIOf(compose, 1), taskID,
-		reindexRestartProgressFloor, 60*time.Second)
 	stopTimeout := 1 * time.Second
-	t.Log("task is mid-flight; SIGKILL on node 3 then node 2 (majority lost)")
-	require.NoError(t, compose.StopAt(ctx, 2, &stopTimeout))
-	require.NoError(t, compose.StopAt(ctx, 1, &stopTimeout))
-
-	// Restore quorum (node 2 first, gives 2/3 majority with node 1).
-	t.Log("restarting node 2 to restore quorum")
-	require.NoError(t, compose.StartAt(ctx, 1))
-	t.Log("restarting node 3")
-	require.NoError(t, compose.StartAt(ctx, 2))
-
-	assertReindexCompleteAndConsistent(t, compose, "MajorityCrash", taskID,
-		360*time.Second)
+	runRestartDuringReindex(t, "MajorityCrash", 360*time.Second,
+		func(ctx context.Context, t *testing.T, compose *docker.DockerCompose) {
+			t.Log("SIGKILL nodes 3 + 2 (majority lost)")
+			require.NoError(t, compose.StopAt(ctx, 2, &stopTimeout))
+			require.NoError(t, compose.StopAt(ctx, 1, &stopTimeout))
+			require.NoError(t, compose.StartAt(ctx, 1)) // node 2 first → restores quorum with node 1
+			require.NoError(t, compose.StartAt(ctx, 2))
+		})
 }
 
 // TestMultiNode_RollingRestartAfterComplete keeps the previous

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -23,12 +23,8 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 )
 
-const (
-	// 50k change-tokenization gives ~25-40 s STARTED on a 3-node cluster.
-	reindexRestartDataset = 50_000
-	// Past "just started" (units can sit at 0 briefly) but well before completion.
-	reindexRestartProgressFloor = 0.1
-)
+// 50k change-tokenization gives a multi-second STARTED window on a 3-node cluster.
+const reindexRestartDataset = 50_000
 
 func setupRestartDuringReindex(
 	ctx context.Context, t *testing.T, className string,
@@ -104,8 +100,7 @@ func runRestartDuringReindex(
 	defer cleanup()
 	defer dumpContainerLogs(ctx, t, compose)
 
-	awaitReindexMidFlight(t, restURIOf(compose, 1), taskID,
-		reindexRestartProgressFloor, 60*time.Second)
+	awaitReindexMidFlight(t, restURIOf(compose, 1), taskID, 60*time.Second)
 	restartFn(ctx, t, compose)
 	assertReindexCompleteAndConsistent(t, compose, className, taskID, awaitTimeout)
 }

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -20,180 +20,174 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/weaviate/weaviate/entities/models"
 	reindexhelpers "github.com/weaviate/weaviate/test/acceptance/helpers/reindex"
+	"github.com/weaviate/weaviate/test/docker"
 )
 
+// 50k change-tokenization migration spends ~25-40 s in STARTED on a
+// 3-node cluster — wide enough to land the restart inside.
+const reindexRestartDataset = 50_000
+
+// 0.1 is past the "just started" floor (units can sit at 0 for a few
+// ticks) but well before completion.
+const reindexRestartProgressFloor = 0.1
+
+// Change-tokenization is the heaviest shape (2 sub-tasks per shard ×
+// property) — widest STARTED window for the restart-mid-flight checks.
+func setupRestartDuringReindex(
+	ctx context.Context, t *testing.T, className string,
+) (*docker.DockerCompose, func(), string) {
+	t.Helper()
+	compose, cleanup := start3NodeReindexCluster(ctx, t)
+
+	uri := restURIOf(compose, 1)
+	trueVal := true
+	createCollection(t, uri, className, 3, 3, []*models.Property{
+		{
+			Name:            "path",
+			DataType:        []string{"text"},
+			IndexFilterable: &trueVal,
+			Tokenization:    "word",
+		},
+	})
+
+	paths := []string{"alpha-path", "beta-path", "gamma-path", "delta-path", "epsilon-path"}
+	batchImportMultiProp(t, uri, className, reindexRestartDataset, func(i int) map[string]interface{} {
+		return map[string]interface{}{"path": paths[i%len(paths)]}
+	})
+
+	taskID := reindexhelpers.SubmitIndexUpdate(t, uri, className, "path",
+		`{"searchable":{"tokenization":"field"}}`)
+	t.Logf("submitted change-tokenization task: %s", taskID)
+	return compose, cleanup, taskID
+}
+
+func assertReindexCompleteAndConsistent(
+	t *testing.T, compose *docker.DockerCompose, className, taskID string, awaitTimeout time.Duration,
+) {
+	t.Helper()
+	reindexhelpers.AwaitReindexFinished(t, restURIOf(compose, 1), taskID,
+		reindexhelpers.WithTimeout(awaitTimeout))
+
+	// Tokenization must have flipped to "field" on every replica.
+	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+		got := tryGetPropertyTokenization(restURIOf(compose, nodeIdx), className, "path")
+		assert.Equalf(t, "field", got,
+			"node %d: tokenization should have flipped to field, got %q", nodeIdx, got)
+	}
+
+	// Every replica must serve the same count for an exact-match query
+	// on a path value. Under FIELD tokenization, every path-bucket
+	// matches reindexRestartDataset/5 records exactly.
+	const expected = reindexRestartDataset / 5
+	for nodeIdx := 1; nodeIdx <= 3; nodeIdx++ {
+		got, err := equalCount(restURIOf(compose, nodeIdx), className, "path", "alpha-path")
+		require.NoErrorf(t, err, "node %d: post-restart count query failed", nodeIdx)
+		assert.Equalf(t, expected, got,
+			"node %d: post-restart count mismatch (expected %d, got %d)",
+			nodeIdx, expected, got)
+	}
+}
+
+// Pins weaviate/0-weaviate-issues#239 Mode 1: graceful follower restart
+// mid-reindex must resume, not mark the task FAILED.
 func TestMultiNode_GracefulRestartDuringReindex(t *testing.T) {
 	ctx := context.Background()
-	compose, cleanup := start3NodeReindexCluster(ctx, t)
+	compose, cleanup, taskID := setupRestartDuringReindex(ctx, t, "RestartDuringReindex")
 	defer cleanup()
 	defer dumpContainerLogs(ctx, t, compose)
 
-	className := "RestartDuringReindex"
-	restURI := compose.GetWeaviateNode(1).URI()
-
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
-	defer deleteCollection(t, restURI, className)
-
-	importObjects(t, restURI, className, testDocuments)
-
-	// Record baselines.
-	baselines := make(map[string][][]string)
-	for _, q := range testBM25Queries {
-		results := queryAllNodes(t, compose, className, q)
-		assertQueryConsistency(t, results)
-		baselines[q] = results
-	}
-
-	// Submit reindex.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"rebuild":true}}`)
-	t.Logf("submitted reindex task: %s", taskID)
-
-	// Wait briefly then gracefully stop node 3.
-	time.Sleep(2 * time.Second)
-	t.Log("gracefully stopping node 3")
+	awaitReindexMidFlight(t, restURIOf(compose, 1), taskID,
+		reindexRestartProgressFloor, 60*time.Second)
+	t.Log("task is mid-flight; gracefully stopping node 3 (follower)")
 	require.NoError(t, compose.StopAt(ctx, 2, nil))
 
-	// Restart node 3.
 	t.Log("restarting node 3")
 	require.NoError(t, compose.StartAt(ctx, 2))
 
-	// Await FINISHED — scheduler will re-launch units on restarted node.
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
-
-	// Verify queries correct on all nodes.
-	for _, q := range testBM25Queries {
-		results := queryAllNodes(t, compose, className, q)
-		assertQueryConsistency(t, results)
-		assert.ElementsMatch(t, baselines[q][0], results[0],
-			"post-restart query %q results differ", q)
-	}
-
-	// Verify schema update.
-	for i := 1; i <= 3; i++ {
-		cls := getClassFromNode(t, compose.GetWeaviateNode(i).URI(), className)
-		assert.True(t, cls.InvertedIndexConfig.UsingBlockMaxWAND,
-			"node %d: UsingBlockMaxWAND should be true", i)
-	}
+	assertReindexCompleteAndConsistent(t, compose, "RestartDuringReindex", taskID,
+		240*time.Second)
 }
 
+// Pins weaviate/0-weaviate-issues#239 Mode 2: graceful RAFT leader
+// restart mid-reindex must resume, not stay STUCK indefinitely.
+func TestMultiNode_GracefulLeaderRestartDuringReindex(t *testing.T) {
+	ctx := context.Background()
+	compose, cleanup, taskID := setupRestartDuringReindex(ctx, t, "LeaderRestartDuringReindex")
+	defer cleanup()
+	defer dumpContainerLogs(ctx, t, compose)
+
+	awaitReindexMidFlight(t, restURIOf(compose, 1), taskID,
+		reindexRestartProgressFloor, 60*time.Second)
+	t.Log("task is mid-flight; gracefully stopping node 1 (RAFT leader)")
+	require.NoError(t, compose.StopAt(ctx, 0, nil))
+
+	t.Log("restarting node 1")
+	require.NoError(t, compose.StartAt(ctx, 0))
+
+	// Wait for node 1 to re-form quorum before asking it questions.
+	require.Eventually(t, func() bool {
+		_, err := runBM25QueryOnNode(t, restURIOf(compose, 1), "LeaderRestartDuringReindex", "path")
+		return err == nil
+	}, 60*time.Second, 1*time.Second, "node 1 should be ready after restart")
+
+	// 360 s budget: leader-restart re-elections can absorb a 30 s window
+	// before the resumed iteration even starts, and the work still has
+	// to complete from scratch on the killed leader's local units
+	// (sentinel-aware recovery rebuilds the per-shard tracker state).
+	assertReindexCompleteAndConsistent(t, compose, "LeaderRestartDuringReindex", taskID,
+		360*time.Second)
+}
+
+// Pins weaviate/0-weaviate-issues#239 Mode 3: ungraceful SIGKILL
+// follower mid-reindex must resume via sentinel-aware recovery.
 func TestMultiNode_CrashDuringReindex(t *testing.T) {
 	ctx := context.Background()
-	compose, cleanup := start3NodeReindexCluster(ctx, t)
+	compose, cleanup, taskID := setupRestartDuringReindex(ctx, t, "CrashDuringReindex")
 	defer cleanup()
 	defer dumpContainerLogs(ctx, t, compose)
 
-	className := "CrashDuringReindex"
-	restURI := compose.GetWeaviateNode(1).URI()
-
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
-	defer deleteCollection(t, restURI, className)
-
-	importObjects(t, restURI, className, testDocuments)
-
-	// Record baselines.
-	baselines := make(map[string][][]string)
-	for _, q := range testBM25Queries {
-		results := queryAllNodes(t, compose, className, q)
-		assertQueryConsistency(t, results)
-		baselines[q] = results
-	}
-
-	// Submit reindex.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"rebuild":true}}`)
-	t.Logf("submitted reindex task: %s", taskID)
-
-	// Wait briefly then crash node 3 ungracefully.
-	time.Sleep(2 * time.Second)
+	awaitReindexMidFlight(t, restURIOf(compose, 1), taskID,
+		reindexRestartProgressFloor, 60*time.Second)
 	stopTimeout := 1 * time.Second
-	t.Log("crashing node 3 (ungraceful stop)")
+	t.Log("task is mid-flight; SIGKILL on node 3 (ungraceful)")
 	require.NoError(t, compose.StopAt(ctx, 2, &stopTimeout))
 
-	// Restart node 3.
 	t.Log("restarting node 3")
 	require.NoError(t, compose.StartAt(ctx, 2))
 
-	// Await FINISHED — scheduler will re-launch units on restarted node.
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
-
-	// Verify queries correct on all nodes.
-	for _, q := range testBM25Queries {
-		results := queryAllNodes(t, compose, className, q)
-		assertQueryConsistency(t, results)
-		assert.ElementsMatch(t, baselines[q][0], results[0],
-			"post-crash query %q results differ", q)
-	}
-
-	// Verify schema update.
-	for i := 1; i <= 3; i++ {
-		cls := getClassFromNode(t, compose.GetWeaviateNode(i).URI(), className)
-		assert.True(t, cls.InvertedIndexConfig.UsingBlockMaxWAND,
-			"node %d: UsingBlockMaxWAND should be true", i)
-	}
+	assertReindexCompleteAndConsistent(t, compose, "CrashDuringReindex", taskID,
+		240*time.Second)
 }
 
+// Quorum loss + recovery mid-reindex: SIGKILL nodes 2+3, restart both,
+// task must still FINISH.
 func TestMultiNode_MajorityCrashDuringReindex(t *testing.T) {
 	ctx := context.Background()
-	compose, cleanup := start3NodeReindexCluster(ctx, t)
+	compose, cleanup, taskID := setupRestartDuringReindex(ctx, t, "MajorityCrash")
 	defer cleanup()
 	defer dumpContainerLogs(ctx, t, compose)
 
-	className := "MajorityCrash"
-	restURI := compose.GetWeaviateNode(1).URI()
-
-	createCollection(t, restURI, className, 3, 3, []*models.Property{
-		{Name: "text", DataType: []string{"text"}, Tokenization: "word"},
-	})
-	defer deleteCollection(t, restURI, className)
-
-	importObjects(t, restURI, className, testDocuments)
-
-	baselines := make(map[string][][]string)
-	for _, q := range testBM25Queries {
-		results := queryAllNodes(t, compose, className, q)
-		assertQueryConsistency(t, results)
-		baselines[q] = results
-	}
-
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"rebuild":true}}`)
-	t.Logf("submitted reindex task: %s", taskID)
-
-	// Wait then crash majority (nodes 3 then 2).
-	time.Sleep(2 * time.Second)
+	awaitReindexMidFlight(t, restURIOf(compose, 1), taskID,
+		reindexRestartProgressFloor, 60*time.Second)
 	stopTimeout := 1 * time.Second
-	t.Log("crashing node 3")
+	t.Log("task is mid-flight; SIGKILL on node 3 then node 2 (majority lost)")
 	require.NoError(t, compose.StopAt(ctx, 2, &stopTimeout))
-	t.Log("crashing node 2 (majority lost)")
 	require.NoError(t, compose.StopAt(ctx, 1, &stopTimeout))
 
-	// Restore quorum: restart node 2 first (gives 2/3 = majority with node 1).
-	t.Log("restarting node 2")
+	// Restore quorum (node 2 first, gives 2/3 majority with node 1).
+	t.Log("restarting node 2 to restore quorum")
 	require.NoError(t, compose.StartAt(ctx, 1))
-	// Then restart node 3.
 	t.Log("restarting node 3")
 	require.NoError(t, compose.StartAt(ctx, 2))
 
-	// Await FINISHED with longer timeout.
-	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
-
-	// Verify queries on all nodes.
-	for _, q := range testBM25Queries {
-		results := queryAllNodes(t, compose, className, q)
-		assertQueryConsistency(t, results)
-		assert.ElementsMatch(t, baselines[q][0], results[0],
-			"post-majority-crash query %q results differ", q)
-	}
-
-	for i := 1; i <= 3; i++ {
-		cls := getClassFromNode(t, compose.GetWeaviateNode(i).URI(), className)
-		assert.True(t, cls.InvertedIndexConfig.UsingBlockMaxWAND,
-			"node %d: UsingBlockMaxWAND should be true", i)
-	}
+	assertReindexCompleteAndConsistent(t, compose, "MajorityCrash", taskID,
+		360*time.Second)
 }
 
+// TestMultiNode_RollingRestartAfterComplete keeps the previous
+// rolling-restart-AFTER-complete test scope: a completed migration
+// must survive a full rolling restart with no per-replica divergence
+// on the migrated buckets.
 func TestMultiNode_RollingRestartAfterComplete(t *testing.T) {
 	ctx := context.Background()
 	compose, cleanup := start3NodeReindexCluster(ctx, t)

--- a/test/run.sh
+++ b/test/run.sh
@@ -697,8 +697,9 @@ function run_acceptance_reindex_multinode() {
 function run_acceptance_reindex_multinode_restart_a() {
   build_weaviate_test_image
   echo_green "acceptance — reindex-multinode-restart-a (mid-reindex restarts + post-complete rolling)"
-  # 4 tests:
+  # 5 tests:
   #   TestMultiNode_GracefulRestartDuringReindex
+  #   TestMultiNode_GracefulLeaderRestartDuringReindex
   #   TestMultiNode_CrashDuringReindex
   #   TestMultiNode_MajorityCrashDuringReindex
   #   TestMultiNode_RollingRestartAfterComplete
@@ -708,7 +709,12 @@ function run_acceptance_reindex_multinode_restart_a() {
   # IS the journey), so these cannot be folded onto a shared cluster
   # the way the AJ suite can. The split below balances the wall-clock
   # against -restart-b instead.
-  AOF_GROUP_RUN='TestMultiNode_(GracefulRestartDuringReindex|CrashDuringReindex|MajorityCrashDuringReindex|RollingRestartAfterComplete)' \
+  #
+  # Regex caveat: alternation is by exact name. Earlier the filter
+  # had `GracefulRestartDuringReindex` which did NOT match
+  # `GracefulLeaderRestartDuringReindex` — a false-green CI ran for
+  # multiple commits before this gap was caught.
+  AOF_GROUP_RUN='TestMultiNode_(GracefulRestartDuringReindex|GracefulLeaderRestartDuringReindex|CrashDuringReindex|MajorityCrashDuringReindex|RollingRestartAfterComplete)' \
     run_aof_group "reindex-multinode-restart-a" test/acceptance/reindex_multinode
 }
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -697,12 +697,14 @@ function run_acceptance_reindex_multinode() {
 function run_acceptance_reindex_multinode_restart_a() {
   build_weaviate_test_image
   echo_green "acceptance — reindex-multinode-restart-a (mid-reindex restarts + post-complete rolling)"
-  # 5 tests:
+  # 7 tests:
   #   TestMultiNode_GracefulRestartDuringReindex
   #   TestMultiNode_GracefulLeaderRestartDuringReindex
   #   TestMultiNode_CrashDuringReindex
   #   TestMultiNode_MajorityCrashDuringReindex
   #   TestMultiNode_RollingRestartAfterComplete
+  #   TestMultiNode_RollingRestartMidMigration
+  #   TestMultiNode_RollingRestartBetweenMigrations
   #
   # The "restart-during-active-reindex" + "post-complete rolling"
   # bucket. Each test owns its own cluster lifecycle (restart timing
@@ -713,8 +715,11 @@ function run_acceptance_reindex_multinode_restart_a() {
   # Regex caveat: alternation is by exact name. Earlier the filter
   # had `GracefulRestartDuringReindex` which did NOT match
   # `GracefulLeaderRestartDuringReindex` — a false-green CI ran for
-  # multiple commits before this gap was caught.
-  AOF_GROUP_RUN='TestMultiNode_(GracefulRestartDuringReindex|GracefulLeaderRestartDuringReindex|CrashDuringReindex|MajorityCrashDuringReindex|RollingRestartAfterComplete)' \
+  # multiple commits before this gap was caught. Same family caught
+  # `RollingRestartMidMigration` + `RollingRestartBetweenMigrations`
+  # un-claimed by any sub-shard; both are PASSING on main and now
+  # land in this filter.
+  AOF_GROUP_RUN='TestMultiNode_(GracefulRestartDuringReindex|GracefulLeaderRestartDuringReindex|CrashDuringReindex|MajorityCrashDuringReindex|RollingRestartAfterComplete|RollingRestartMidMigration|RollingRestartBetweenMigrations)' \
     run_aof_group "reindex-multinode-restart-a" test/acceptance/reindex_multinode
 }
 


### PR DESCRIPTION
SuperClaude here.

Closes weaviate/0-weaviate-issues#239 — graceful restart of in-flight reindex units. QA Claude's empirical restart-resumability matrix (full analysis on the issue) surfaced two distinct failure modes:

**Mode 1 — graceful follower restart → task FAILED.** `processOneUnit`'s per-sub-task error handler called `failUnit` on any non-nil error including `context.Canceled`. `Manager.RecordUnitCompletion` is fail-fast at the FSM, so a graceful SIGTERM mid-iteration flipped the whole task to FAILED, despite the work being merely interrupted.

**Mode 2 — graceful RAFT leader restart → task STUCK indefinitely.** `failUnit`'s 3-retry RAFT apply raced leadership transition and lost (~1.4 s budget vs ongoing election). The unit stayed IN_PROGRESS; the local `p.reindexTasks` cache stayed populated from the dying invocation; on every subsequent scheduler tick the re-entry guard read the populated cache as "iteration in flight" and skipped resume — silent stall, indefinitely.

## Fix

1. **`context.Canceled` early-return** in `processOneUnit`. Log + return without `failUnit` so the unit stays IN_PROGRESS at the FSM and the scheduler resumes it on the next tick post-restart.
2. **Defer-clear the local cache** on any `processOneUnit` exit that didn't reach `RecordDistributedTaskUnitCompletion`. The re-entry guard now sees an empty cache on the post-restart tick and re-enters cleanly.

Both fixes interact: graceful-follower (Mode 1) hits Fix A then the deferred Fix B clears the cache. Graceful-leader (Mode 2) hits Fix B directly when `failUnit` returns from its RAFT-apply timeout. Ungraceful SIGKILL (Mode 3, already safe per the matrix) is unaffected — the process dies before either path runs.

## Test gap (also closed in this PR)

The three "during reindex" tests in `restart_test.go` used `testDocuments` (~30 short strings) + a 2-second sleep. The migration completed before the kill fired; the tests passed vacuously without exercising the recovery path at all. Rewritten to use a 50k-object `change-tokenization` migration plus a new `awaitReindexMidFlight` helper that **fails loudly** if the migration reaches FINISHED/FAILED before observing in-flight progress ≥ 0.1.

| Test | Mode | Restart target |
|---|---|---|
| `TestMultiNode_GracefulRestartDuringReindex` | 1 (follower graceful) | node 3 (SIGTERM) |
| `TestMultiNode_GracefulLeaderRestartDuringReindex` (NEW) | 2 (leader graceful) | node 1 (SIGTERM, RAFT leader) |
| `TestMultiNode_CrashDuringReindex` | 3 (follower SIGKILL) | node 3 (SIGKILL) |
| `TestMultiNode_MajorityCrashDuringReindex` | 3 (majority SIGKILL) | nodes 2+3 (SIGKILL) |

Each test now also asserts the tokenization flipped on every replica and per-replica counts match — so a "task FINISHED but on-disk state diverged" failure would be caught.

## Verification

- `go build ./...`, `go vet ./test/acceptance/reindex_multinode/...`, `golangci-lint run` on touched packages — all clean.
- Code review against [QA's full matrix](https://github.com/weaviate/0-weaviate-issues/issues/239#issuecomment-4498237592) — every cell (c01, c01-fresh, c02, c03, c06, c07) is now either covered by the new tests or unaffected.
- Local acceptance run will follow once the docker image is pre-built.

— SuperClaude
