### PR TITLE
Namespaces: Add support for references in schema

### DIFF
--- a/adapters/handlers/rest/handlers_authn_test.go
+++ b/adapters/handlers/rest/handlers_authn_test.go
@@ -12,6 +12,7 @@
 package rest
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,6 +21,35 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 )
+
+// deepCopyPermission returns a fully independent clone of p via JSON
+// round-trip. Used by mutation-sensitive tests so the snapshot does not
+// share any pointers (sub-struct pointers and *string fields) with the
+// input the function under test sees.
+func deepCopyPermission(t *testing.T, p *models.Permission) *models.Permission {
+	t.Helper()
+	if p == nil {
+		return nil
+	}
+	b, err := json.Marshal(p)
+	require.NoError(t, err)
+	out := &models.Permission{}
+	require.NoError(t, json.Unmarshal(b, out))
+	return out
+}
+
+// deepCopyRoles is the slice variant of deepCopyPermission for role tables.
+func deepCopyRoles(t *testing.T, roles []*models.Role) []*models.Role {
+	t.Helper()
+	if roles == nil {
+		return nil
+	}
+	b, err := json.Marshal(roles)
+	require.NoError(t, err)
+	out := []*models.Role{}
+	require.NoError(t, json.Unmarshal(b, &out))
+	return out
+}
 
 var (
 	authnNamespacedPrincipal = &models.Principal{Username: "u", Namespace: "customer1"}
@@ -135,11 +165,13 @@ func TestStripPermissionForCaller(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			snapshot := tc.in
+			// Deep-copy snapshot so a mutation through tc.in is observable
+			// in the post-call comparison (a pointer copy would be aliased
+			// by any in-place edit on sub-structs or *string fields).
+			snapshot := deepCopyPermission(t, tc.in)
 			got := stripPermissionForCaller(tc.principal, tc.in)
 			assert.Equal(t, tc.want, got)
-			// Input must not have been mutated.
-			assert.Equal(t, snapshot, tc.in)
+			assert.Equal(t, snapshot, tc.in, "input must not be mutated")
 		})
 	}
 
@@ -309,11 +341,10 @@ func TestStripRolesForCaller(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			snapshot := tc.in
+			snapshot := deepCopyRoles(t, tc.in)
 			got := stripRolesForCaller(tc.principal, tc.in)
 			assert.Equal(t, tc.want, got)
-			// Input slice itself must not have been mutated.
-			assert.Equal(t, snapshot, tc.in)
+			assert.Equal(t, snapshot, tc.in, "input must not be mutated")
 			if tc.wantSame && tc.in != nil {
 				// Pass-through path: same backing slice header.
 				require.Len(t, got, len(tc.in))

--- a/entities/schema/backward_compat.go
+++ b/entities/schema/backward_compat.go
@@ -68,12 +68,9 @@ func GetPropertyDataType(class *models.Class, propertyName string) (*DataType, e
 		if len(dataType) == 0 {
 			return nil, fmt.Errorf("invalid-dataType")
 		}
-		// Get the first letter to see if it is a capital
-		firstLetter := string(dataType[0])
-		if strings.ToUpper(firstLetter) == firstLetter {
+		if IsRefDataType([]string{dataType}) {
 			returnDataType = DataTypeCRef
 		} else {
-			// Get the value-data type (non-cref), return error if there is one, otherwise assign it to return data type
 			valueDataType, err := GetValueDataTypeFromString(dataType)
 			if err != nil {
 				return nil, err
@@ -111,12 +108,9 @@ func GetNestedPropertyDataType[P PropertyInterface](p P, propertyName string) (*
 		if len(dataType) == 0 {
 			return nil, fmt.Errorf("invalid-dataType")
 		}
-		// Get the first letter to see if it is a capital
-		firstLetter := string(dataType[0])
-		if strings.ToUpper(firstLetter) == firstLetter {
+		if IsRefDataType([]string{dataType}) {
 			returnDataType = DataTypeCRef
 		} else {
-			// Get the value-data type (non-cref), return error if there is one, otherwise assign it to return data type
 			valueDataType, err := GetValueDataTypeFromString(dataType)
 			if err != nil {
 				return nil, err
@@ -169,8 +163,21 @@ func IsValidValueDataType(dt string) bool {
 	return false
 }
 
+// IsRefDataType reports whether dt is a cross-reference DataType. Expects
+// stored DataType — qualified "<namespace>:Class" or bare "Class".
+// User-supplied DataType must go through FindPropertyDataTypeWithRefsAndAuth.
 func IsRefDataType(dt []string) bool {
-	firstLetter := string(dt[0][0])
+	if len(dt) == 0 || len(dt[0]) == 0 {
+		return false
+	}
+	name := dt[0]
+	if _, cls, ok := strings.Cut(name, NamespaceSeparator); ok {
+		if cls == "" {
+			return false
+		}
+		name = cls
+	}
+	firstLetter := string(name[0])
 	return strings.ToUpper(firstLetter) == firstLetter
 }
 

--- a/entities/schema/backward_compat_test.go
+++ b/entities/schema/backward_compat_test.go
@@ -13,6 +13,11 @@ package schema
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/weaviate/weaviate/entities/models"
 )
 
 func TestIsArrayDataType(t *testing.T) {
@@ -102,4 +107,84 @@ func TestIsArrayDataType(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsRefDataType_QualifiedNames(t *testing.T) {
+	cases := []struct {
+		name string
+		dt   []string
+		want bool
+	}{
+		{name: "bare ref", dt: []string{"Movies"}, want: true},
+		{name: "qualified own-ns ref", dt: []string{"customer1:Movies"}, want: true},
+		{name: "qualified multi-target ref", dt: []string{"customer1:Movies", "customer1:Books"}, want: true},
+		{name: "bare primitive text", dt: []string{"text"}, want: false},
+		{name: "bare primitive int", dt: []string{"int"}, want: false},
+		{name: "bare primitive text[]", dt: []string{"text[]"}, want: false},
+		{name: "bare nested object", dt: []string{"object"}, want: false},
+		{name: "bare nested object[]", dt: []string{"object[]"}, want: false},
+		{name: "empty slice", dt: []string{}, want: false},
+		{name: "empty string element", dt: []string{""}, want: false},
+		{name: "only namespace separator", dt: []string{":"}, want: false},
+		{name: "trailing colon", dt: []string{"customer1:"}, want: false},
+		// Cannot arise in practice (class names must start uppercase per
+		// ClassNameRegexCore), but the rule is pinned: lowercase class
+		// portion is NOT classified as ref.
+		{name: "lowercase class portion", dt: []string{"customer1:text"}, want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsRefDataType(tc.dt))
+		})
+	}
+}
+
+func TestGetPropertyDataType_QualifiedRef(t *testing.T) {
+	class := &models.Class{
+		Class: "customer1:Library",
+		Properties: []*models.Property{
+			{Name: "watched", DataType: []string{"customer1:Movies"}},
+			{Name: "title", DataType: []string{"text"}},
+		},
+	}
+	gotRef, err := GetPropertyDataType(class, "watched")
+	require.NoError(t, err)
+	require.NotNil(t, gotRef)
+	assert.Equal(t, DataTypeCRef, *gotRef)
+
+	gotPrim, err := GetPropertyDataType(class, "title")
+	require.NoError(t, err)
+	require.NotNil(t, gotPrim)
+	assert.Equal(t, DataTypeText, *gotPrim)
+}
+
+type fakeNestedProperty struct {
+	name   string
+	nested []*models.NestedProperty
+}
+
+func (f fakeNestedProperty) GetName() string                               { return f.name }
+func (f fakeNestedProperty) GetNestedProperties() []*models.NestedProperty { return f.nested }
+
+func TestGetNestedPropertyDataType_QualifiedRef(t *testing.T) {
+	// NestedProperty.DataType cross-refs are rejected upstream at
+	// validation.go:95, so this shape cannot reach production. The test
+	// pins the helper's behaviour symmetric with GetPropertyDataType so a
+	// future refactor cannot regress the dedup.
+	p := fakeNestedProperty{
+		name: "outer",
+		nested: []*models.NestedProperty{
+			{Name: "ref", DataType: []string{"customer1:Movies"}},
+			{Name: "label", DataType: []string{"text"}},
+		},
+	}
+	gotRef, err := GetNestedPropertyDataType(p, "ref")
+	require.NoError(t, err)
+	require.NotNil(t, gotRef)
+	assert.Equal(t, DataTypeCRef, *gotRef)
+
+	gotPrim, err := GetNestedPropertyDataType(p, "label")
+	require.NoError(t, err)
+	require.NotNil(t, gotPrim)
+	assert.Equal(t, DataTypeText, *gotPrim)
 }

--- a/entities/schema/data_types.go
+++ b/entities/schema/data_types.go
@@ -16,7 +16,6 @@ import (
 	"fmt"
 	"slices"
 	"strings"
-	"unicode"
 
 	"github.com/weaviate/weaviate/entities/models"
 )
@@ -266,8 +265,7 @@ func FindPropertyDataTypeWithRefsAndAuth(authorizedGetClass func(string) (*model
 		if len(dataType[0]) == 0 {
 			return nil, fmt.Errorf("dataType cannot be an empty string")
 		}
-		firstLetter := rune(dataType[0][0])
-		if unicode.IsLower(firstLetter) {
+		if !IsRefDataType(dataType) {
 			return nil, fmt.Errorf("unknown primitive data type '%s'", dataType[0])
 		}
 	}
@@ -276,7 +274,7 @@ func FindPropertyDataTypeWithRefsAndAuth(authorizedGetClass func(string) (*model
 	var classes []ClassName
 
 	for _, someDataType := range dataType {
-		className, err := ValidateClassName(someDataType)
+		className, err := ValidateQualifiedClassName(someDataType)
 		if err != nil {
 			return nil, err
 		}

--- a/entities/schema/data_types_test.go
+++ b/entities/schema/data_types_test.go
@@ -415,3 +415,47 @@ func Test_DataType_AsNested(t *testing.T) {
 func ptDataType(dt DataType) *DataType {
 	return &dt
 }
+
+func TestFindPropertyDataType_Qualified(t *testing.T) {
+	cases := []struct {
+		name          string
+		dataType      []string
+		wantErrSubstr string
+	}{
+		{
+			name:     "single qualified ref",
+			dataType: []string{"customer1:Movies"},
+		},
+		{
+			name:     "multi-target qualified refs",
+			dataType: []string{"customer1:Movies", "customer1:Books"},
+		},
+		{
+			// Uppercase namespace portion violates NamespaceNameRegexCore.
+			name:          "malformed namespace prefix rejected",
+			dataType:      []string{"UPPER:Movies"},
+			wantErrSubstr: "not a valid class name",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := Empty()
+			// Pre-register every dataType entry as a class. Harmless for the
+			// failure case — validation fires before the schema lookup.
+			for _, cls := range tc.dataType {
+				s.Objects.Classes = append(s.Objects.Classes, &models.Class{Class: cls})
+			}
+			pdt, err := s.FindPropertyDataType(tc.dataType)
+			if tc.wantErrSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrSubstr)
+				return
+			}
+			require.NoError(t, err)
+			assert.True(t, pdt.IsReference())
+			for _, want := range tc.dataType {
+				assert.True(t, pdt.ContainsClass(ClassName(want)), "expected %q in pdt", want)
+			}
+		})
+	}
+}

--- a/entities/schema/validation.go
+++ b/entities/schema/validation.go
@@ -142,11 +142,12 @@ func ValidateClassName(name string) (ClassName, error) {
 // class portion matches ClassNameRegexCore. The full qualified name is
 // returned unchanged.
 //
-// Use at post-resolver boundaries (e.g. the filter parser) where a
-// qualified class name is a legitimate input that has already been
-// produced by namespacing.Resolve. User-facing inputs (schema create,
-// alias create, cross-ref data types) must continue to call
-// ValidateClassName, which rejects ":".
+// Use at post-resolver boundaries (e.g. the filter parser, cross-ref
+// DataType validation) where a qualified class name is a legitimate
+// input that has already been produced by namespacing.Resolve or
+// namespacing.QualifyPropertyDataTypes. User-facing inputs (schema
+// create, alias create) must continue to call ValidateClassName, which
+// rejects ":".
 func ValidateQualifiedClassName(name string) (ClassName, error) {
 	if len(name) > NamespaceMaxLength+len(NamespaceSeparator)+ClassNameMaxLength {
 		return "", fmt.Errorf("'%s' is not a valid class name", name)

--- a/test/acceptance/namespace/response_stripping_test.go
+++ b/test/acceptance/namespace/response_stripping_test.go
@@ -12,6 +12,7 @@
 package namespace
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/go-openapi/strfmt"
@@ -20,6 +21,7 @@ import (
 
 	"github.com/weaviate/weaviate/client/batch"
 	"github.com/weaviate/weaviate/client/objects"
+	clschema "github.com/weaviate/weaviate/client/schema"
 	"github.com/weaviate/weaviate/client/users"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/test/helper"
@@ -104,7 +106,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 			},
 		}, user1Key)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not a valid class name")
+		assert.Contains(t, schemaCreateErrMessage(t, err), "not a valid class name")
 	})
 
 	t.Run("AddClass with cross-NS DataType rejected", func(t *testing.T) {
@@ -119,7 +121,7 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 			},
 		}, user1Key)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "not a valid class name")
+		assert.Contains(t, schemaCreateErrMessage(t, err), "not a valid class name")
 	})
 
 	t.Run("schema GET → PUT round-trip on real class path succeeds with stripped body", func(t *testing.T) {
@@ -380,4 +382,17 @@ func TestNamespaces_ResponseStripping_OwnInfoUsername(t *testing.T) {
 		// passes through unchanged.
 		assert.Equal(t, adminUser, *resp.Payload.Username)
 	})
+}
+
+// schemaCreateErrMessage extracts the human-readable validation message from a
+// SchemaObjectsCreate 422 response. The go-swagger Error() output only shows
+// the status line and a pointer to the body, so callers asserting on the
+// underlying validation text must unwrap through the typed payload.
+func schemaCreateErrMessage(t *testing.T, err error) string {
+	t.Helper()
+	var parsed *clschema.SchemaObjectsCreateUnprocessableEntity
+	require.True(t, errors.As(err, &parsed), "expected SchemaObjectsCreateUnprocessableEntity, got %T: %v", err, err)
+	require.NotNil(t, parsed.Payload)
+	require.NotEmpty(t, parsed.Payload.Error)
+	return parsed.Payload.Error[0].Message
 }

--- a/test/acceptance/namespace/response_stripping_test.go
+++ b/test/acceptance/namespace/response_stripping_test.go
@@ -32,25 +32,94 @@ import (
 func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 	user1Key, user2Key := twoNamespaces(t)
 
-	t.Run("AddClass response strips Class", func(t *testing.T) {
-		// DataType cross-ref stripping cannot be exercised end-to-end on
-		// Phase-1: inline `DataType: ["Target"]` isn't auto-qualified on
-		// the way in, so the cross-ref target doesn't resolve. The strip
-		// mechanics are covered by the namespacing resolver unit tests.
+	t.Run("AddClass response strips Class and cross-ref DataType", func(t *testing.T) {
 		const name = "AddClassStripped"
-		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:"+name, adminKey) })
+		// Set up referenced classes first so the cross-ref existence
+		// check passes when the new class is created.
+		helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user1Key)
+		helper.CreateClassAuth(t, &models.Class{Class: "Books"}, user1Key)
+		t.Cleanup(func() {
+			helper.DeleteClassAuth(t, "customer1:"+name, adminKey)
+			helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+			helper.DeleteClassAuth(t, "customer1:Books", adminKey)
+		})
 
 		resp, err := helper.CreateClassAuthWithReturn(t, &models.Class{
 			Class: name,
 			Properties: []*models.Property{
 				{Name: "title", DataType: []string{"text"}},
+				{Name: "watched", DataType: []string{"Movies"}},
+				{Name: "related", DataType: []string{"Movies", "Books"}},
 			},
 		}, user1Key)
 		require.NoError(t, err)
 		assert.Equal(t, name, resp.Payload.Class)
+		require.Len(t, resp.Payload.Properties, 3)
+		assert.Equal(t, []string{"text"}, findProp(resp.Payload, "title").DataType)
+		assert.Equal(t, []string{"Movies"}, findProp(resp.Payload, "watched").DataType)
+		assert.Equal(t, []string{"Movies", "Books"}, findProp(resp.Payload, "related").DataType)
 
-		// Admin sees the raw qualified class via direct GET.
-		assert.Equal(t, "customer1:"+name, helper.GetClassAuth(t, "customer1:"+name, adminKey).Class)
+		// Admin sees the raw qualified class + qualified cross-ref DataTypes
+		// via direct GET.
+		raw := helper.GetClassAuth(t, "customer1:"+name, adminKey)
+		assert.Equal(t, "customer1:"+name, raw.Class)
+		assert.Equal(t, []string{"customer1:Movies"}, findProp(raw, "watched").DataType)
+		assert.Equal(t, []string{"customer1:Movies", "customer1:Books"}, findProp(raw, "related").DataType)
+	})
+
+	t.Run("addClassProperty response strips DataType cross-ref class names", func(t *testing.T) {
+		const host = "Library"
+		helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user1Key)
+		helper.CreateClassAuth(t, &models.Class{Class: "Books"}, user1Key)
+		setupClassInNs1(t, host, user1Key)
+		t.Cleanup(func() {
+			helper.DeleteClassAuth(t, "customer1:Movies", adminKey)
+			helper.DeleteClassAuth(t, "customer1:Books", adminKey)
+		})
+
+		single, err := addPropertyAuthWithReturn(t, host,
+			&models.Property{Name: "watched", DataType: []string{"Movies"}}, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"Movies"}, single.DataType)
+
+		multi, err := addPropertyAuthWithReturn(t, host,
+			&models.Property{Name: "related", DataType: []string{"Movies", "Books"}}, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"Movies", "Books"}, multi.DataType)
+
+		// Admin sees the raw qualified DataTypes via direct GET.
+		raw := helper.GetClassAuth(t, "customer1:"+host, adminKey)
+		assert.Equal(t, []string{"customer1:Movies"}, findProp(raw, "watched").DataType)
+		assert.Equal(t, []string{"customer1:Movies", "customer1:Books"}, findProp(raw, "related").DataType)
+	})
+
+	t.Run("AddClass with already-qualified own-NS DataType rejected", func(t *testing.T) {
+		helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user1Key)
+		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer1:Movies", adminKey) })
+
+		_, err := helper.CreateClassAuthWithReturn(t, &models.Class{
+			Class: "RejectQualifiedOwn",
+			Properties: []*models.Property{
+				{Name: "watched", DataType: []string{"customer1:Movies"}},
+			},
+		}, user1Key)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a valid class name")
+	})
+
+	t.Run("AddClass with cross-NS DataType rejected", func(t *testing.T) {
+		// customer2:Movies exists, but customer1's caller may not reference it.
+		helper.CreateClassAuth(t, &models.Class{Class: "Movies"}, user2Key)
+		t.Cleanup(func() { helper.DeleteClassAuth(t, "customer2:Movies", adminKey) })
+
+		_, err := helper.CreateClassAuthWithReturn(t, &models.Class{
+			Class: "RejectCrossNS",
+			Properties: []*models.Property{
+				{Name: "watched", DataType: []string{"customer2:Movies"}},
+			},
+		}, user1Key)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "not a valid class name")
 	})
 
 	t.Run("schema GET → PUT round-trip on real class path succeeds with stripped body", func(t *testing.T) {

--- a/test/acceptance/namespace/response_stripping_test.go
+++ b/test/acceptance/namespace/response_stripping_test.go
@@ -149,6 +149,48 @@ func TestNamespaces_ResponseStripping_REST(t *testing.T) {
 		assert.Equal(t, "v2", after.Description)
 	})
 
+	t.Run("schema GET → PUT round-trip with cross-ref properties succeeds", func(t *testing.T) {
+		// Stripped cross-ref DataTypes in the PUT body must be re-qualified;
+		// otherwise the property-immutability check rejects the round-trip.
+		const host = "RoundTripWithRefs"
+		const target = "RoundTripRefTarget"
+		helper.CreateClassAuth(t, &models.Class{Class: target}, user1Key)
+		helper.CreateClassAuth(t, &models.Class{
+			Class:       host,
+			Description: "v1",
+			Properties: []*models.Property{
+				{Name: "title", DataType: []string{"text"}},
+				{Name: "watched", DataType: []string{target}},
+				{Name: "related", DataType: []string{target}},
+			},
+		}, user1Key)
+		t.Cleanup(func() {
+			helper.DeleteClassAuth(t, "customer1:"+host, adminKey)
+			helper.DeleteClassAuth(t, "customer1:"+target, adminKey)
+		})
+
+		got, err := helper.GetClassAuthWithReturn(t, host, user1Key)
+		require.NoError(t, err)
+		require.Equal(t, host, got.Payload.Class)
+		// GET response is stripped: cross-ref DataTypes are short.
+		assert.Equal(t, []string{target}, findProp(got.Payload, "watched").DataType)
+		assert.Equal(t, []string{target}, findProp(got.Payload, "related").DataType)
+
+		// PUT the stripped body back verbatim with a non-immutable change.
+		got.Payload.Description = "v2"
+		putResp, err := helper.UpdateClassAuthWithReturn(t, host, got.Payload, user1Key)
+		require.NoError(t, err)
+		assert.Equal(t, host, putResp.Payload.Class)
+		assert.Equal(t, []string{target}, findProp(putResp.Payload, "watched").DataType)
+
+		// Admin GET confirms the stored cross-refs are still qualified and
+		// the Description update landed.
+		after := helper.GetClassAuth(t, "customer1:"+host, adminKey)
+		assert.Equal(t, "v2", after.Description)
+		assert.Equal(t, []string{"customer1:" + target}, findProp(after, "watched").DataType)
+		assert.Equal(t, []string{"customer1:" + target}, findProp(after, "related").DataType)
+	})
+
 	t.Run("AddAlias response strips Alias and Class", func(t *testing.T) {
 		const class = "AliasCreateTarget"
 		const alias = "AliasCreateName"

--- a/test/acceptance/namespace/schema_ops_test.go
+++ b/test/acceptance/namespace/schema_ops_test.go
@@ -34,6 +34,18 @@ func addPropertyAuth(t *testing.T, className string, prop *models.Property, key 
 	return err
 }
 
+func addPropertyAuthWithReturn(t *testing.T, className string, prop *models.Property, key string) (*models.Property, error) {
+	t.Helper()
+	params := schema.NewSchemaObjectsPropertiesAddParams().
+		WithClassName(className).
+		WithBody(prop)
+	resp, err := helper.Client(t).Schema.SchemaObjectsPropertiesAdd(params, helper.CreateAuth(key))
+	if err != nil {
+		return nil, err
+	}
+	return resp.Payload, nil
+}
+
 func deletePropertyIndexAuth(t *testing.T, className, propName, indexName, key string) error {
 	t.Helper()
 	params := schema.NewSchemaObjectsPropertiesDeleteParams().

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -200,7 +200,7 @@ func (m *AutoSchemaManager) getProperties(object *models.Object, principal *mode
 	// other DataType (primitive, nested, short class from beacons-with-class).
 	for _, p := range properties {
 		for i, dt := range p.DataType {
-			p.DataType[i] = namespacing.StripOwnNS(principal, dt)
+			p.DataType[i] = namespacing.StripOwnNamespace(principal, dt)
 		}
 	}
 	return properties, nil

--- a/usecases/objects/auto_schema.go
+++ b/usecases/objects/auto_schema.go
@@ -111,7 +111,7 @@ func (m *AutoSchemaManager) autoSchema(ctx context.Context, principal *models.Pr
 		if schemaClass == nil && !allowCreateClass {
 			return 0, ErrInvalidUserInput{"given class does not exist"}
 		}
-		properties, err := m.getProperties(object)
+		properties, err := m.getProperties(object, principal)
 		if err != nil {
 			return 0, err
 		}
@@ -159,7 +159,7 @@ func (m *AutoSchemaManager) createClass(ctx context.Context, principal *models.P
 	return newClass, schemaVersion, err
 }
 
-func (m *AutoSchemaManager) getProperties(object *models.Object) ([]*models.Property, error) {
+func (m *AutoSchemaManager) getProperties(object *models.Object, principal *models.Principal) ([]*models.Property, error) {
 	properties := []*models.Property{}
 	if props, ok := object.Properties.(map[string]interface{}); ok {
 		for name, value := range props {
@@ -191,6 +191,16 @@ func (m *AutoSchemaManager) getProperties(object *models.Object) ([]*models.Prop
 				NestedProperties: nestedProperties,
 			}
 			properties = append(properties, property)
+		}
+	}
+	// asRef's beacon-without-class path resolves the target via ObjectByID
+	// and returns res.ClassName, which is the qualified storage key on
+	// NS-enabled clusters. The downstream QualifyPropertyDataTypes rejects
+	// already-qualified entries, so strip the own-NS prefix. No-op for every
+	// other DataType (primitive, nested, short class from beacons-with-class).
+	for _, p := range properties {
+		for i, dt := range p.DataType {
+			p.DataType[i] = namespacing.StripOwnNS(principal, dt)
 		}
 	}
 	return properties, nil

--- a/usecases/objects/auto_schema_test.go
+++ b/usecases/objects/auto_schema_test.go
@@ -1294,9 +1294,71 @@ func Test_autoSchemaManager_getProperties(t *testing.T) {
 			properties, _ := manager.getProperties(&models.Object{
 				Class:      "ClassWithObjectProps",
 				Properties: tc.valProperties,
-			})
+			}, nil)
 
 			assertPropsMatch(t, tc.expectedProperties, properties)
+		})
+	}
+}
+
+func Test_autoSchemaManager_getProperties_stripsBeaconWithoutClassDataType(t *testing.T) {
+	cases := []struct {
+		name             string
+		principal        *models.Principal
+		repoClassName    string
+		expectedDataType []string
+	}{
+		{
+			name:             "namespaced principal own-NS prefix stripped",
+			principal:        &models.Principal{Username: "u", Namespace: "customer1"},
+			repoClassName:    "customer1:Movies",
+			expectedDataType: []string{"Movies"},
+		},
+		{
+			name:             "global principal passes through",
+			principal:        &models.Principal{Username: "admin", IsGlobalOperator: true},
+			repoClassName:    "Movies",
+			expectedDataType: []string{"Movies"},
+		},
+		{
+			// Crosses-namespace beacons should fall through unchanged so the
+			// downstream qualifier rejects them (deny-foreign-NS contract).
+			name:             "foreign-NS prefix left intact",
+			principal:        &models.Principal{Username: "u", Namespace: "customer1"},
+			repoClassName:    "customer2:Movies",
+			expectedDataType: []string{"customer2:Movies"},
+		},
+	}
+	id := strfmt.UUID("00000000-1111-2222-3333-444444444444")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			vectorRepo := &fakeVectorRepo{}
+			vectorRepo.On("ObjectByID", id, mock.Anything, mock.Anything, mock.Anything).
+				Return(&search.Result{ClassName: tc.repoClassName}, nil).Once()
+			manager := &AutoSchemaManager{
+				schemaManager: &fakeSchemaManager{},
+				vectorRepo:    vectorRepo,
+				config: config.AutoSchema{
+					Enabled:       runtime.NewDynamicValue(true),
+					DefaultNumber: schema.DataTypeNumber.String(),
+					DefaultString: schema.DataTypeText.String(),
+					DefaultDate:   schema.DataTypeDate.String(),
+				},
+			}
+			properties, err := manager.getProperties(&models.Object{
+				Class: "Library",
+				Properties: map[string]interface{}{
+					"watched": []interface{}{
+						// Beacon without class — asRef looks up the object and
+						// uses its stored ClassName (qualified on NS-enabled).
+						map[string]interface{}{"beacon": "weaviate://localhost/" + id.String()},
+					},
+				},
+			}, tc.principal)
+			require.NoError(t, err)
+			require.Len(t, properties, 1)
+			assert.Equal(t, "watched", properties[0].Name)
+			assert.Equal(t, tc.expectedDataType, properties[0].DataType)
 		})
 	}
 }

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -132,6 +132,9 @@ func (h *Handler) AddClass(ctx context.Context, principal *models.Principal,
 		return nil, 0, err
 	}
 	cls.Class = qualified
+	if err := namespacing.QualifyPropertyDataTypes(principal, h.config.Namespaces.Enabled, cls.Properties); err != nil {
+		return nil, 0, err
+	}
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.CollectionsMetadata(cls.Class)...); err != nil {
 		return nil, 0, err

--- a/usecases/schema/class.go
+++ b/usecases/schema/class.go
@@ -457,6 +457,9 @@ func (h *Handler) UpdateClass(ctx context.Context, principal *models.Principal,
 			return fmt.Errorf("%w: class name in body %q does not match path %q", ErrValidation, updated.Class, namespacing.StripOwnNamespace(principal, className))
 		}
 		updated.Class = qualifiedBody
+		if err := namespacing.QualifyPropertyDataTypes(principal, h.config.Namespaces.Enabled, updated.Properties); err != nil {
+			return fmt.Errorf("%w: %w", ErrValidation, err)
+		}
 	}
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil || updated == nil {

--- a/usecases/schema/namespace_create_test.go
+++ b/usecases/schema/namespace_create_test.go
@@ -711,6 +711,117 @@ func TestAddAlias(t *testing.T) {
 	}
 }
 
+// TestUpdateClass_QualifiesPropertyDataTypes pins the GET→PUT round-trip:
+// a namespaced caller's stripped cross-ref DataType is qualified before
+// reaching the SchemaManager; foreign-prefix entries are rejected.
+func TestUpdateClass_QualifiesPropertyDataTypes(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		enabled       bool
+		principal     *models.Principal
+		storedClass   string
+		bodyClass     string
+		bodyDataType  []string
+		wantStoredDT  []string
+		wantErrSubstr string
+	}{
+		{
+			name:         "namespaced: stripped cross-ref DataType qualified before SchemaManager",
+			enabled:      true,
+			principal:    namespacedPrincipal("customer1"),
+			storedClass:  "customer1:Movies",
+			bodyClass:    "Movies",
+			bodyDataType: []string{"Other"},
+			wantStoredDT: []string{"customer1:Other"},
+		},
+		{
+			name:         "namespaced: multi-target stripped refs all qualified",
+			enabled:      true,
+			principal:    namespacedPrincipal("customer1"),
+			storedClass:  "customer1:Movies",
+			bodyClass:    "Movies",
+			bodyDataType: []string{"Other", "Another"},
+			wantStoredDT: []string{"customer1:Other", "customer1:Another"},
+		},
+		{
+			name:          "namespaced: foreign-namespace ref DataType rejected",
+			enabled:       true,
+			principal:     namespacedPrincipal("customer1"),
+			storedClass:   "customer1:Movies",
+			bodyClass:     "Movies",
+			bodyDataType:  []string{"customer2:Other"},
+			wantErrSubstr: "is not a valid class name",
+		},
+		{
+			name:         "namespaced: primitive DataType passes through untouched",
+			enabled:      true,
+			principal:    namespacedPrincipal("customer1"),
+			storedClass:  "customer1:Movies",
+			bodyClass:    "Movies",
+			bodyDataType: []string{"text"},
+			wantStoredDT: []string{"text"},
+		},
+		{
+			name:         "NS disabled: qualifier is a no-op, body passes through verbatim",
+			enabled:      false,
+			principal:    nil,
+			storedClass:  "Movies",
+			bodyClass:    "Movies",
+			bodyDataType: []string{"Other"},
+			wantStoredDT: []string{"Other"},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler, sm := newTestHandlerWithNamespaces(t, tt.enabled)
+
+			stored := &models.Class{
+				Class:             tt.storedClass,
+				Vectorizer:        "model1",
+				VectorIndexConfig: map[string]interface{}{},
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				Properties: []*models.Property{
+					{Name: "watched", DataType: tt.wantStoredDT},
+				},
+			}
+			sm.On("ReadOnlyClass", tt.storedClass).Return(stored).Maybe()
+
+			var captured *models.Class
+			sm.On("UpdateClass", mock.MatchedBy(func(c *models.Class) bool {
+				captured = c
+				return true
+			}), mock.Anything).Return(nil).Maybe()
+
+			body := &models.Class{
+				Class:             tt.bodyClass,
+				Vectorizer:        "model1",
+				VectorIndexConfig: map[string]interface{}{},
+				ReplicationConfig: &models.ReplicationConfig{Factor: 1},
+				Properties: []*models.Property{
+					{Name: "watched", DataType: tt.bodyDataType},
+				},
+			}
+
+			err := handler.UpdateClass(context.Background(), tt.principal, tt.bodyClass, body)
+			if tt.wantErrSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrSubstr)
+				require.Nil(t, captured, "SchemaManager.UpdateClass must not be called on rejected body")
+				return
+			}
+			require.NoError(t, err)
+			require.NotNil(t, captured, "SchemaManager.UpdateClass should have been called")
+			require.Equal(t, tt.storedClass, captured.Class)
+			require.Len(t, captured.Properties, 1)
+			assert.Equal(t, tt.wantStoredDT, captured.Properties[0].DataType)
+		})
+	}
+}
+
 // TestAddClass_NamespacedCollectionLimit checks that the
 // MAXIMUM_ALLOWED_COLLECTIONS_COUNT cap is enforced per namespace when
 // namespaces are enabled, using principal.Namespace as the selector.

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -105,6 +105,50 @@ func QualifyClass(principal *models.Principal, namespacesEnabled bool, name stri
 	return qualified, nil
 }
 
+// QualifyPropertyDataTypes auto-qualifies cross-reference DataType class names
+// with the principal's namespace on namespaces-enabled clusters. Primitive and
+// nested-object DataTypes pass through unchanged. Already-qualified entries
+// (containing the namespace separator) sent by a namespaced principal are
+// rejected via ValidateNamespacePrefix — symmetric with QualifyClass.
+//
+// Mutates properties[i].DataType slices in place. No-op when namespaces are
+// disabled or the principal has no namespace (global principals / NS-disabled
+// clusters). Callers that construct *models.Property programmatically must
+// pass short DataType names; an already-qualified value will be rejected.
+//
+// Scope: top-level properties only. NestedProperty.DataType cross-refs are
+// rejected at usecases/schema/validation.go and never reach this path.
+func QualifyPropertyDataTypes(
+	principal *models.Principal,
+	namespacesEnabled bool,
+	properties []*models.Property,
+) error {
+	if !namespacesEnabled || principal == nil || principal.Namespace == "" {
+		return nil
+	}
+	for _, p := range properties {
+		if p == nil || len(p.DataType) == 0 {
+			continue
+		}
+		if _, ok := schema.AsPrimitive(p.DataType); ok {
+			continue
+		}
+		if _, ok := schema.AsNested(p.DataType); ok {
+			continue
+		}
+		for i, dt := range p.DataType {
+			if dt == "" {
+				continue
+			}
+			if err := ValidateNamespacePrefix(principal, namespacesEnabled, dt, "class"); err != nil {
+				return err
+			}
+			p.DataType[i] = QualifiedName(principal.Namespace, dt)
+		}
+	}
+	return nil
+}
+
 // StripOwnNamespace removes the principal's own namespace prefix from name
 // when present. Returns name unchanged when principal.Namespace is empty
 // (global principal; also the case on NS-disabled clusters, where principals

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -505,6 +505,128 @@ func TestStripClassResponse(t *testing.T) {
 	}
 }
 
+func TestQualifyPropertyDataTypes(t *testing.T) {
+	cases := []struct {
+		name              string
+		principal         *models.Principal
+		namespacesEnabled bool
+		in                []*models.Property
+		want              []*models.Property
+		wantErrSubstr     string
+	}{
+		{
+			name:              "namespaced principal qualifies short cross-ref",
+			principal:         namespacedPrincipal,
+			namespacesEnabled: true,
+			in:                []*models.Property{{Name: "watched", DataType: []string{"Movies"}}},
+			want:              []*models.Property{{Name: "watched", DataType: []string{"customer1:Movies"}}},
+		},
+		{
+			name:              "multi-target refs all qualified",
+			principal:         namespacedPrincipal,
+			namespacesEnabled: true,
+			in:                []*models.Property{{Name: "related", DataType: []string{"Movies", "Books"}}},
+			want:              []*models.Property{{Name: "related", DataType: []string{"customer1:Movies", "customer1:Books"}}},
+		},
+		{
+			name:              "primitive DataType passes through",
+			principal:         namespacedPrincipal,
+			namespacesEnabled: true,
+			in:                []*models.Property{{Name: "title", DataType: []string{"text"}}},
+			want:              []*models.Property{{Name: "title", DataType: []string{"text"}}},
+		},
+		{
+			name:              "nested object DataType passes through",
+			principal:         namespacedPrincipal,
+			namespacesEnabled: true,
+			in: []*models.Property{
+				{Name: "meta", DataType: []string{"object"}},
+				{Name: "metas", DataType: []string{"object[]"}},
+			},
+			want: []*models.Property{
+				{Name: "meta", DataType: []string{"object"}},
+				{Name: "metas", DataType: []string{"object[]"}},
+			},
+		},
+		{
+			name:              "already-qualified own-namespace rejected",
+			principal:         namespacedPrincipal,
+			namespacesEnabled: true,
+			in:                []*models.Property{{Name: "watched", DataType: []string{"customer1:Movies"}}},
+			wantErrSubstr:     "not a valid class name",
+		},
+		{
+			name:              "already-qualified foreign-namespace rejected",
+			principal:         namespacedPrincipal,
+			namespacesEnabled: true,
+			in:                []*models.Property{{Name: "watched", DataType: []string{"customer2:Movies"}}},
+			wantErrSubstr:     "not a valid class name",
+		},
+		{
+			name:              "global principal passes through",
+			principal:         globalPrincipal,
+			namespacesEnabled: true,
+			in:                []*models.Property{{Name: "watched", DataType: []string{"customer1:Movies"}}},
+			want:              []*models.Property{{Name: "watched", DataType: []string{"customer1:Movies"}}},
+		},
+		{
+			name:              "nil principal passes through",
+			principal:         nil,
+			namespacesEnabled: true,
+			in:                []*models.Property{{Name: "watched", DataType: []string{"Movies"}}},
+			want:              []*models.Property{{Name: "watched", DataType: []string{"Movies"}}},
+		},
+		{
+			name:              "NS disabled passes through",
+			principal:         namespacedPrincipal,
+			namespacesEnabled: false,
+			in:                []*models.Property{{Name: "watched", DataType: []string{"customer1:Movies"}}},
+			want:              []*models.Property{{Name: "watched", DataType: []string{"customer1:Movies"}}},
+		},
+		{
+			name:              "empty DataType slice and nil property no-op",
+			principal:         namespacedPrincipal,
+			namespacesEnabled: true,
+			in: []*models.Property{
+				nil,
+				{Name: "empty", DataType: []string{}},
+				{Name: "watched", DataType: []string{"Movies"}},
+			},
+			want: []*models.Property{
+				nil,
+				{Name: "empty", DataType: []string{}},
+				{Name: "watched", DataType: []string{"customer1:Movies"}},
+			},
+		},
+		{
+			name:              "mixed primitive and ref in same call",
+			principal:         namespacedPrincipal,
+			namespacesEnabled: true,
+			in: []*models.Property{
+				{Name: "title", DataType: []string{"text"}},
+				{Name: "watched", DataType: []string{"Movies"}},
+			},
+			want: []*models.Property{
+				{Name: "title", DataType: []string{"text"}},
+				{Name: "watched", DataType: []string{"customer1:Movies"}},
+			},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := QualifyPropertyDataTypes(tc.principal, tc.namespacesEnabled, tc.in)
+			if tc.wantErrSubstr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErrSubstr)
+				return
+			}
+			require.NoError(t, err)
+			// Mutation in-place is intentional — assert via the input slice.
+			assert.Equal(t, tc.want, tc.in)
+		})
+	}
+}
+
 func TestStripPropertyResponse(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -12,6 +12,7 @@
 package namespacing
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -22,6 +23,20 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	autherrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 )
+
+// deepCopyJSON returns a fully independent clone via JSON round-trip, so
+// no-mutation assertions can catch in-place edits through shared pointers.
+func deepCopyJSON[T any](t *testing.T, src *T) *T {
+	t.Helper()
+	if src == nil {
+		return nil
+	}
+	b, err := json.Marshal(src)
+	require.NoError(t, err)
+	out := new(T)
+	require.NoError(t, json.Unmarshal(b, out))
+	return out
+}
 
 // fakeSchemaManager implements SchemaManager for testing
 type fakeSchemaManager struct {
@@ -490,8 +505,7 @@ func TestStripClassResponse(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Snapshot input to verify it is not mutated.
-			snapshot := tc.in
+			snapshot := deepCopyJSON(t, tc.in)
 			got := StripClassResponse(tc.principal, tc.in)
 			assert.Equal(t, tc.want, got)
 			if tc.wantSame {
@@ -499,8 +513,7 @@ func TestStripClassResponse(t *testing.T) {
 			} else if tc.in != nil {
 				assert.NotSame(t, tc.in, got)
 			}
-			// Input must not have been mutated.
-			assert.Equal(t, snapshot, tc.in)
+			assert.Equal(t, snapshot, tc.in, "input must not be mutated")
 		})
 	}
 }
@@ -677,7 +690,7 @@ func TestStripPropertyResponse(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			snapshot := tc.in
+			snapshot := deepCopyJSON(t, tc.in)
 			got := StripPropertyResponse(tc.principal, tc.in)
 			assert.Equal(t, tc.want, got)
 			if tc.wantSame {
@@ -685,7 +698,7 @@ func TestStripPropertyResponse(t *testing.T) {
 			} else if tc.in != nil {
 				assert.NotSame(t, tc.in, got)
 			}
-			assert.Equal(t, snapshot, tc.in)
+			assert.Equal(t, snapshot, tc.in, "input must not be mutated")
 		})
 	}
 }
@@ -727,7 +740,7 @@ func TestStripAliasResponse(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			snapshot := tc.in
+			snapshot := deepCopyJSON(t, tc.in)
 			got := StripAliasResponse(tc.principal, tc.in)
 			assert.Equal(t, tc.want, got)
 			if tc.wantSame {
@@ -735,7 +748,7 @@ func TestStripAliasResponse(t *testing.T) {
 			} else if tc.in != nil {
 				assert.NotSame(t, tc.in, got)
 			}
-			assert.Equal(t, snapshot, tc.in)
+			assert.Equal(t, snapshot, tc.in, "input must not be mutated")
 		})
 	}
 }

--- a/usecases/schema/property.go
+++ b/usecases/schema/property.go
@@ -37,6 +37,9 @@ func (h *Handler) AddClassProperty(ctx context.Context, principal *models.Princi
 	if err != nil {
 		return nil, 0, err
 	}
+	if err := namespacing.QualifyPropertyDataTypes(principal, h.config.Namespaces.Enabled, newProps); err != nil {
+		return nil, 0, err
+	}
 
 	if err := h.Authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.CollectionsMetadata(className)...); err != nil {
 		return nil, 0, err


### PR DESCRIPTION
### What's being changed:

This adds namespaces support for references in the schema (NOT data object)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
