### PR TITLE
[FIX] - gh-11335 preserve hybrid aggregate multi-target vectors

### DIFF
--- a/usecases/traverser/traverser_aggregate.go
+++ b/usecases/traverser/traverser_aggregate.go
@@ -77,10 +77,7 @@ func (t *Traverser) Aggregate(ctx context.Context, principal *models.Principal, 
 	}
 
 	if params.Hybrid != nil {
-		var targetVectors []string
-		if len(params.Hybrid.TargetVectors) == 1 {
-			targetVectors = params.Hybrid.TargetVectors[:1]
-		}
+		targetVectors := params.Hybrid.TargetVectors
 		targetVectors, err := t.targetVectorParamHelper.GetTargetVectorOrDefault(t.schemaGetter.GetSchemaSkipAuth(), params.ClassName.String(), targetVectors)
 		if err != nil {
 			return nil, err

--- a/usecases/traverser/traverser_aggregate_test.go
+++ b/usecases/traverser/traverser_aggregate_test.go
@@ -329,6 +329,51 @@ func Test_Traverser_Aggregate(t *testing.T) {
 		require.Nil(t, err)
 		assert.Equal(t, &agg, res)
 	})
+
+	t.Run("with hybrid search and multiple target vectors", func(t *testing.T) {
+		params := aggregation.Params{
+			ClassName: "MyClassNamedVectors",
+			Properties: []aggregation.ParamProperty{
+				{
+					Name:        "number",
+					Aggregators: []aggregation.Aggregator{aggregation.SumAggregator},
+				},
+			},
+			IncludeMetaCount: true,
+			Hybrid: &searchparams.HybridSearch{
+				Type:          "hybrid",
+				Alpha:         0.5,
+				Query:         "some query",
+				Vector:        []float32{1, 2, 3},
+				TargetVectors: []string{"title_vec", "body_vec"},
+			},
+		}
+
+		expectedParams := params
+		expectedParams.TargetVector = "title_vec"
+
+		agg := aggregation.Result{
+			Groups: []aggregation.Group{
+				{
+					Properties: map[string]aggregation.Property{
+						"number": {
+							Type: aggregation.PropertyTypeNumerical,
+							NumericalAggregations: map[string]interface{}{
+								"sum": 200,
+							},
+						},
+					},
+				},
+			},
+		}
+
+		vectorRepo.On("Aggregate", expectedParams).Return(&agg, nil).Once()
+		res, err := traverser.Aggregate(context.Background(), principal, &params)
+		require.NoError(t, err)
+		assert.Equal(t, "title_vec", params.TargetVector)
+		assert.Equal(t, []string{"title_vec", "body_vec"}, params.Hybrid.TargetVectors)
+		assert.Equal(t, &agg, res)
+	})
 }
 
 var aggregateTestSchema = schema.Schema{
@@ -360,6 +405,29 @@ var aggregateTestSchema = schema.Schema{
 					{
 						Name:     "a ref",
 						DataType: []string{"AnotherClass"},
+					},
+				},
+			},
+			{
+				Class: "MyClassNamedVectors",
+				Properties: []*models.Property{
+					{
+						Name:     "number",
+						DataType: []string{string(schema.DataTypeInt)},
+					},
+				},
+				VectorConfig: map[string]models.VectorConfig{
+					"title_vec": {
+						Vectorizer: map[string]interface{}{
+							"none": map[string]interface{}{},
+						},
+						VectorIndexType: "hnsw",
+					},
+					"body_vec": {
+						Vectorizer: map[string]interface{}{
+							"none": map[string]interface{}{},
+						},
+						VectorIndexType: "hnsw",
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

Fix aggregate hybrid on named-vector collections so valid multi-target `targetVectors` are preserved instead of being collapsed before target-vector resolution.

Fixes #11335

## What changed

- preserve all `params.Hybrid.TargetVectors` in aggregate traversal
- keep `params.TargetVector` set to the first resolved target vector for downstream aggregate behavior
- add a regression test covering hybrid aggregate with multiple named vectors

## Testing

- `env GOTOOLCHAIN=auto go test ./usecases/traverser -run Test_Traverser_Aggregate -count=1`
- `env GOTOOLCHAIN=auto go test ./usecases/traverser -count=1`