### PR TITLE
Fix flaky TestMakeUnboundedChannel_CapShrink

### DIFF
--- a/adapters/repos/db/vector/common/unbounded_channel_test.go
+++ b/adapters/repos/db/vector/common/unbounded_channel_test.go
@@ -14,6 +14,7 @@ package common
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -56,17 +57,20 @@ func TestMakeUnboundedChannel_CapShrink(t *testing.T) {
 	ch.mu.RUnlock()
 	require.GreaterOrEqual(t, c, 2000)
 
-	// read > 75% items
-	for i := range 1600 {
+	// drain almost all items so the internal buffer becomes heavily underused
+	for i := range 1900 {
 		v := <-ch.Out()
 		require.Equal(t, i, v)
 	}
 
-	ch.mu.RLock()
-	c = cap(ch.q)
-	ch.mu.RUnlock()
-
-	require.LessOrEqual(t, c, 1024)
+	// pop() shrinks the internal buffer lazily on the background goroutine,
+	// so the capacity settles asynchronously after the reads above. Poll
+	// until it has shrunk back down.
+	require.Eventually(t, func() bool {
+		ch.mu.RLock()
+		defer ch.mu.RUnlock()
+		return cap(ch.q) <= 1024
+	}, 5*time.Second, time.Millisecond)
 
 	ch.Close(t.Context())
 }


### PR DESCRIPTION
## Summary

`TestMakeUnboundedChannel_CapShrink` is flaky — it failed on CI with `"1025" is not less than or equal to "1024"`.

The test pushed 2000 items, drained 75% of them, then asserted `cap(q) <= 1024` with a single check. Two independent issues made that assertion non-deterministic:

- **Off-by-a-bit threshold.** `pop()` halves the buffer capacity only while `cap > 1024`. Go's slice growth does not guarantee power-of-two capacities (size classes), so `append` can leave an odd capacity like `2050`, whose half is `1025`. With ~25% of the items still buffered, the shrink legitimately stops at `1025` — just above the asserted bound.
- **Async shrink.** The shrink runs inside `pop()` on the background drain goroutine, so the capacity settles asynchronously. The single `cap` check could race ahead of the goroutine.

## Fix

- Drain almost all items (1900 of 2000) so the internal buffer is heavily underused — the shrink is then guaranteed to reach `<= 1024`.
- Poll with `require.Eventually` to wait for the asynchronous shrink to settle, instead of checking once.

No production code changed — `UnboundedChannel` itself behaves correctly; only the test's assumptions were too strict.

## Test plan

- [x] `go test -run TestMakeUnboundedChannel -count 200 ./adapters/repos/db/vector/common/` — 200/200 pass
- [x] `go test -race -run TestMakeUnboundedChannel -count 40 ./adapters/repos/db/vector/common/` — pass
- [x] `golangci-lint run ./adapters/repos/db/vector/common/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)