### PR TITLE
[FIX] - Check DB user identifier collisions in auth index

### DIFF
--- a/cluster/dynusers/dynamic_users_test.go
+++ b/cluster/dynusers/dynamic_users_test.go
@@ -205,6 +205,40 @@ func TestManager_MalformedJSON(t *testing.T) {
 	}
 }
 
+func TestManager_CheckUserIdentifierExists(t *testing.T) {
+	m, _ := newTestManager(t, newNamespacesMock(t))
+
+	_, hash, identifier, err := keys.CreateApiKeyAndHash()
+	require.NoError(t, err)
+
+	apply := &cmd.ApplyRequest{SubCommand: mustMarshalJSON(t, cmd.CreateUsersRequest{
+		UserId:         "u1",
+		SecureHash:     hash,
+		UserIdentifier: identifier,
+		CreatedAt:      time.Now(),
+	})}
+	require.NoError(t, m.CreateUser(apply))
+
+	query := &cmd.QueryRequest{SubCommand: mustMarshalJSON(t, cmd.QueryUserIdentifierExistsRequest{
+		UserIdentifier: identifier,
+	})}
+	payload, err := m.CheckUserIdentifierExists(query)
+	require.NoError(t, err)
+
+	var response cmd.QueryUserIdentifierExistsResponse
+	require.NoError(t, json.Unmarshal(payload, &response))
+	require.True(t, response.Exists)
+
+	query = &cmd.QueryRequest{SubCommand: mustMarshalJSON(t, cmd.QueryUserIdentifierExistsRequest{
+		UserIdentifier: "u1",
+	})}
+	payload, err = m.CheckUserIdentifierExists(query)
+	require.NoError(t, err)
+
+	require.NoError(t, json.Unmarshal(payload, &response))
+	require.False(t, response.Exists)
+}
+
 func TestManager_DeleteUsersInNamespace(t *testing.T) {
 	seed := func(t *testing.T, m *Manager, id, namespace string) {
 		t.Helper()

--- a/usecases/auth/authentication/apikey/db_user_test.go
+++ b/usecases/auth/authentication/apikey/db_user_test.go
@@ -174,6 +174,29 @@ func TestUpdateUser(t *testing.T) {
 	require.Less(t, tookFast, tookSlow)
 }
 
+func TestCheckUserIdentifierExists(t *testing.T) {
+	dynUsers, err := NewDBUser(t.TempDir(), true, log)
+	require.NoError(t, err)
+
+	userId := "id"
+	_, hash, identifier, err := keys.CreateApiKeyAndHash()
+	require.NoError(t, err)
+
+	exists, err := dynUsers.CheckUserIdentifierExists(identifier)
+	require.NoError(t, err)
+	require.False(t, exists)
+
+	require.NoError(t, dynUsers.CreateUser(userId, hash, identifier, "", "", time.Now()))
+
+	exists, err = dynUsers.CheckUserIdentifierExists(identifier)
+	require.NoError(t, err)
+	require.True(t, exists)
+
+	exists, err = dynUsers.CheckUserIdentifierExists(userId)
+	require.NoError(t, err)
+	require.False(t, exists)
+}
+
 func TestSnapShotAndRestore(t *testing.T) {
 	dynUsers, err := NewDBUser(t.TempDir(), true, log)
 	require.NoError(t, err)

--- a/usecases/auth/authentication/apikey/db_users.go
+++ b/usecases/auth/authentication/apikey/db_users.go
@@ -383,7 +383,7 @@ func (c *DBUser) CheckUserIdentifierExists(userIdentifier string) (bool, error) 
 	c.lock.RLock()
 	defer c.lock.RUnlock()
 
-	_, ok := c.data.Users[userIdentifier]
+	_, ok := c.data.IdentifierToId[userIdentifier]
 	return ok, nil
 }
 


### PR DESCRIPTION
### What's being changed:

#### Summary
DB user API key identifier collision checks were looking in the `Users` map, which is keyed by user ID, while dynamic API key authentication resolves identifiers through `IdentifierToId`. This changes the collision check to use `IdentifierToId` so create/rotate rejects reused identifiers at the same lookup boundary authentication uses.

#### Changes
- [usecases/auth/authentication/apikey/db_users.go](/home/kedar/OSS-contri/weaviate/usecases/auth/authentication/apikey/db_users.go)
  Switched `CheckUserIdentifierExists` from `c.data.Users[userIdentifier]` to `c.data.IdentifierToId[userIdentifier]`.
- [usecases/auth/authentication/apikey/db_user_test.go](/home/kedar/OSS-contri/weaviate/usecases/auth/authentication/apikey/db_user_test.go)
  Added `TestCheckUserIdentifierExists` to verify identifier existence is keyed by `IdentifierToId`, not by user ID.
- [cluster/dynusers/dynamic_users_test.go](/home/kedar/OSS-contri/weaviate/cluster/dynusers/dynamic_users_test.go)
  Added `TestManager_CheckUserIdentifierExists` to verify the cluster query path returns the correct identifier existence result.

#### Testing
Commands run:
- `gofumpt -w usecases/auth/authentication/apikey/db_users.go usecases/auth/authentication/apikey/db_user_test.go cluster/dynusers/dynamic_users_test.go`
- `./tools/linter_error_groups.sh`
- `./tools/linter_go_routines.sh`
- `./tools/linter_waitgroups_done.sh`
- `env GOTOOLCHAIN=auto go test ./usecases/auth/authentication/apikey ./cluster/dynusers`

New tests:
- `TestCheckUserIdentifierExists`
- `TestManager_CheckUserIdentifierExists`

Closes #11305

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [x] All new code is covered by tests where it is reasonable.
- [x] Performance tests have been run or not necessary.