### PR TITLE
feat(restrictions): split searchable.rebuild from algorithm switch (closes weaviate/0-weaviate-issues#227)

### DIFF
--- a/adapters/handlers/rest/embedded_spec.go
+++ b/adapters/handlers/rest/embedded_spec.go
@@ -8528,6 +8528,13 @@ func init() {
     "IndexUpdateSearchable": {
       "type": "object",
       "properties": {
+        "algorithm": {
+          "description": "Switch the BM25 algorithm for this property's searchable index. Currently only ` + "`" + `blockmax` + "`" + ` is accepted. From WAND this triggers the Map → BlockMax migration; on an already-` + "`" + `blockmax` + "`" + ` property the request is rejected. WAND is deprecated; downgrade is intentionally not supported.",
+          "type": "string",
+          "enum": [
+            "blockmax"
+          ]
+        },
         "cancel": {
           "description": "When true, cancels the in-flight reindex task targeting this property's searchable index. The task transitions to CANCELLED; partial state is left on disk for the next-restart finalize.",
           "type": "boolean"
@@ -8536,7 +8543,7 @@ func init() {
           "type": "boolean"
         },
         "rebuild": {
-          "description": "When true, rebuilds the searchable index for this property. The rebuild also switches the BM25 backing algorithm from WAND (the legacy map strategy) to Block Max WAND (the inverted strategy). The reverse direction (blockmax -\u003e wand) is intentionally not supported at this time: callers cannot revert a property to WAND once it has been rebuilt onto blockmax. Read the current algorithm from GET /v1/schema/{className}/indexes (IndexStatus.algorithm) before issuing this verb.",
+          "description": "When true, rebuilds the searchable index for this property from the stored objects. Preserves the current tokenization and BM25 algorithm. Only valid when the property's current algorithm is ` + "`" + `blockmax` + "`" + `; on a WAND property the request is rejected with guidance to use ` + "`" + `algorithm:\"blockmax\"` + "`" + ` first.",
           "type": "boolean"
         },
         "tokenization": {
@@ -19691,6 +19698,13 @@ func init() {
     "IndexUpdateSearchable": {
       "type": "object",
       "properties": {
+        "algorithm": {
+          "description": "Switch the BM25 algorithm for this property's searchable index. Currently only ` + "`" + `blockmax` + "`" + ` is accepted. From WAND this triggers the Map → BlockMax migration; on an already-` + "`" + `blockmax` + "`" + ` property the request is rejected. WAND is deprecated; downgrade is intentionally not supported.",
+          "type": "string",
+          "enum": [
+            "blockmax"
+          ]
+        },
         "cancel": {
           "description": "When true, cancels the in-flight reindex task targeting this property's searchable index. The task transitions to CANCELLED; partial state is left on disk for the next-restart finalize.",
           "type": "boolean"
@@ -19699,7 +19713,7 @@ func init() {
           "type": "boolean"
         },
         "rebuild": {
-          "description": "When true, rebuilds the searchable index for this property. The rebuild also switches the BM25 backing algorithm from WAND (the legacy map strategy) to Block Max WAND (the inverted strategy). The reverse direction (blockmax -\u003e wand) is intentionally not supported at this time: callers cannot revert a property to WAND once it has been rebuilt onto blockmax. Read the current algorithm from GET /v1/schema/{className}/indexes (IndexStatus.algorithm) before issuing this verb.",
+          "description": "When true, rebuilds the searchable index for this property from the stored objects. Preserves the current tokenization and BM25 algorithm. Only valid when the property's current algorithm is ` + "`" + `blockmax` + "`" + `; on a WAND property the request is rejected with guidance to use ` + "`" + `algorithm:\"blockmax\"` + "`" + ` first.",
           "type": "boolean"
         },
         "tokenization": {

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -368,7 +368,7 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
 				"searchable index is already on blockmax"))
 		}
-		migrationType = db.ReindexTypeRepairSearchable
+		migrationType = db.ReindexTypeChangeAlgorithm
 		properties = []string{propertyName}
 
 	case body.Filterable != nil && body.Filterable.Enabled:
@@ -828,7 +828,7 @@ const (
 // directories and unloaded buckets are silently skipped.
 func indexTypesFromMigrationType(mt db.ReindexMigrationType) ([]string, bool) {
 	switch mt {
-	case db.ReindexTypeEnableSearchable, db.ReindexTypeRepairSearchable, db.ReindexTypeRebuildSearchable:
+	case db.ReindexTypeEnableSearchable, db.ReindexTypeChangeAlgorithm, db.ReindexTypeRebuildSearchable:
 		return []string{"searchable"}, true
 	case db.ReindexTypeEnableFilterable, db.ReindexTypeRepairFilterable:
 		return []string{"filterable"}, true
@@ -859,7 +859,7 @@ func indexTypesFromMigrationType(mt db.ReindexMigrationType) ([]string, bool) {
 // (false, false) result still means "this task is not a cancel target".
 func migrationTypeTargetsIndex(mt db.ReindexMigrationType, indexType string) (matches, isKnown bool) {
 	switch mt {
-	case db.ReindexTypeEnableSearchable, db.ReindexTypeRepairSearchable, db.ReindexTypeRebuildSearchable:
+	case db.ReindexTypeEnableSearchable, db.ReindexTypeChangeAlgorithm, db.ReindexTypeRebuildSearchable:
 		return indexType == "searchable", true
 	case db.ReindexTypeEnableFilterable, db.ReindexTypeRepairFilterable:
 		return indexType == "filterable", true
@@ -1105,7 +1105,7 @@ func mergeReindexStatus(idx *models.IndexStatus, collection, propName, indexType
 		if bestPayload.TargetTokenization != "" {
 			idx.TargetTokenization = bestPayload.TargetTokenization
 		}
-	case db.ReindexTypeRepairSearchable:
+	case db.ReindexTypeChangeAlgorithm:
 		// repair-searchable migrates WAND → BlockMax. The targetAlgorithm
 		// lets the UI render the in-flight switch the same way it renders
 		// targetTokenization for change-tokenization.

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -357,7 +357,9 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
 				fmt.Sprintf("property %q does not have a searchable index", propertyName)))
 		}
-		if body.Searchable.Algorithm != models.IndexStatusAlgorithmBlockmax {
+		// Case-insensitive match — swagger generated EnumCase validator
+		// is permissive here, so accept "Blockmax" / "BLOCKMAX" too.
+		if !strings.EqualFold(body.Searchable.Algorithm, models.IndexStatusAlgorithmBlockmax) {
 			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
 				fmt.Sprintf("unsupported algorithm %q; only %q is accepted (WAND is deprecated)",
 					body.Searchable.Algorithm, models.IndexStatusAlgorithmBlockmax)))

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -346,7 +346,7 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 		// next step for them is migration to BlockMax via
 		// {"searchable":{"algorithm":"blockmax"}}.
 		if class.InvertedIndexConfig == nil || !class.InvertedIndexConfig.UsingBlockMaxWAND {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal,
 				"cannot rebuild a WAND searchable index — WAND is deprecated; use {\"searchable\":{\"algorithm\":\"blockmax\"}} to migrate first"))
 		}
 		migrationType = db.ReindexTypeRebuildSearchable
@@ -354,18 +354,18 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 
 	case body.Searchable != nil && body.Searchable.Algorithm != "":
 		if targetProp.IndexSearchable != nil && !*targetProp.IndexSearchable {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal,
 				fmt.Sprintf("property %q does not have a searchable index", propertyName)))
 		}
 		// Case-insensitive match — swagger generated EnumCase validator
 		// is permissive here, so accept "Blockmax" / "BLOCKMAX" too.
 		if !strings.EqualFold(body.Searchable.Algorithm, models.IndexStatusAlgorithmBlockmax) {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal,
 				fmt.Sprintf("unsupported algorithm %q; only %q is accepted (WAND is deprecated)",
 					body.Searchable.Algorithm, models.IndexStatusAlgorithmBlockmax)))
 		}
 		if class.InvertedIndexConfig != nil && class.InvertedIndexConfig.UsingBlockMaxWAND {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal,
 				"searchable index is already on blockmax"))
 		}
 		migrationType = db.ReindexTypeChangeAlgorithm

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -337,12 +337,37 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 		}
 
 	case body.Searchable != nil && body.Searchable.Rebuild:
-		migrationType = db.ReindexTypeRepairSearchable
-		properties = []string{propertyName}
 		if targetProp.IndexSearchable != nil && !*targetProp.IndexSearchable {
 			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal,
 				fmt.Sprintf("property %q does not have a searchable index", propertyName)))
 		}
+		// rebuild preserves the current BM25 algorithm and tokenization.
+		// WAND searchable indexes cannot be rebuilt — the only supported
+		// next step for them is migration to BlockMax via
+		// {"searchable":{"algorithm":"blockmax"}}.
+		if class.InvertedIndexConfig == nil || !class.InvertedIndexConfig.UsingBlockMaxWAND {
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
+				"cannot rebuild a WAND searchable index — WAND is deprecated; use {\"searchable\":{\"algorithm\":\"blockmax\"}} to migrate first"))
+		}
+		migrationType = db.ReindexTypeRebuildSearchable
+		properties = []string{propertyName}
+
+	case body.Searchable != nil && body.Searchable.Algorithm != "":
+		if targetProp.IndexSearchable != nil && !*targetProp.IndexSearchable {
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
+				fmt.Sprintf("property %q does not have a searchable index", propertyName)))
+		}
+		if body.Searchable.Algorithm != models.IndexStatusAlgorithmBlockmax {
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
+				fmt.Sprintf("unsupported algorithm %q; only %q is accepted (WAND is deprecated)",
+					body.Searchable.Algorithm, models.IndexStatusAlgorithmBlockmax)))
+		}
+		if class.InvertedIndexConfig != nil && class.InvertedIndexConfig.UsingBlockMaxWAND {
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
+				"searchable index is already on blockmax"))
+		}
+		migrationType = db.ReindexTypeRepairSearchable
+		properties = []string{propertyName}
 
 	case body.Filterable != nil && body.Filterable.Enabled:
 		migrationType = db.ReindexTypeEnableFilterable
@@ -384,7 +409,7 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 		// then alphabetical within group.
 		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal,
 			"no actionable change detected; set one of: "+
-				"searchable.cancel, searchable.enabled, searchable.rebuild, searchable.tokenization, "+
+				"searchable.algorithm, searchable.cancel, searchable.enabled, searchable.rebuild, searchable.tokenization, "+
 				"filterable.cancel, filterable.enabled, filterable.rebuild, filterable.tokenization, "+
 				"rangeable.cancel, rangeable.enabled, rangeable.rebuild"))
 	}
@@ -801,7 +826,7 @@ const (
 // directories and unloaded buckets are silently skipped.
 func indexTypesFromMigrationType(mt db.ReindexMigrationType) ([]string, bool) {
 	switch mt {
-	case db.ReindexTypeEnableSearchable, db.ReindexTypeRepairSearchable:
+	case db.ReindexTypeEnableSearchable, db.ReindexTypeRepairSearchable, db.ReindexTypeRebuildSearchable:
 		return []string{"searchable"}, true
 	case db.ReindexTypeEnableFilterable, db.ReindexTypeRepairFilterable:
 		return []string{"filterable"}, true
@@ -832,7 +857,7 @@ func indexTypesFromMigrationType(mt db.ReindexMigrationType) ([]string, bool) {
 // (false, false) result still means "this task is not a cancel target".
 func migrationTypeTargetsIndex(mt db.ReindexMigrationType, indexType string) (matches, isKnown bool) {
 	switch mt {
-	case db.ReindexTypeEnableSearchable, db.ReindexTypeRepairSearchable:
+	case db.ReindexTypeEnableSearchable, db.ReindexTypeRepairSearchable, db.ReindexTypeRebuildSearchable:
 		return indexType == "searchable", true
 	case db.ReindexTypeEnableFilterable, db.ReindexTypeRepairFilterable:
 		return indexType == "filterable", true
@@ -1079,13 +1104,12 @@ func mergeReindexStatus(idx *models.IndexStatus, collection, propName, indexType
 			idx.TargetTokenization = bestPayload.TargetTokenization
 		}
 	case db.ReindexTypeRepairSearchable:
-		// repair-searchable today always migrates WAND -> Block Max WAND.
-		// Surfacing the targetAlgorithm lets the UI render the in-flight
-		// algorithm switch the same way it renders targetTokenization for
-		// change-tokenization. The reverse direction is not yet supported;
-		// see the docs on IndexUpdateSearchable.rebuild.
+		// repair-searchable migrates WAND → BlockMax. The targetAlgorithm
+		// lets the UI render the in-flight switch the same way it renders
+		// targetTokenization for change-tokenization.
 		idx.TargetAlgorithm = models.IndexStatusTargetAlgorithmBlockmax
-	case db.ReindexTypeRepairFilterable,
+	case db.ReindexTypeRebuildSearchable,
+		db.ReindexTypeRepairFilterable,
 		db.ReindexTypeEnableFilterable, db.ReindexTypeEnableRangeable,
 		db.ReindexTypeRepairRangeable:
 		// No tokenization or algorithm side effects for these types.

--- a/adapters/handlers/rest/handlers_indexes_edge_test.go
+++ b/adapters/handlers/rest/handlers_indexes_edge_test.go
@@ -535,7 +535,7 @@ func TestMergeReindexStatus_EmptyProperties_RepairAlsoMatchesNothing(t *testing.
 	task := buildTask(t, "C:repair-searchable::abcd",
 		distributedtask.TaskStatusStarted,
 		db.ReindexTaskPayload{
-			MigrationType: db.ReindexTypeRepairSearchable,
+			MigrationType: db.ReindexTypeChangeAlgorithm,
 			Collection:    "C",
 			Properties:    nil, // empty — previously matched every property
 		},
@@ -642,7 +642,7 @@ func TestMergeReindexStatus_RepairSearchable_SetsTargetAlgorithm(t *testing.T) {
 			task := buildTask(t, "C:repair-searchable:foo:abcd",
 				tt.taskStatus,
 				db.ReindexTaskPayload{
-					MigrationType: db.ReindexTypeRepairSearchable,
+					MigrationType: db.ReindexTypeChangeAlgorithm,
 					Collection:    "C",
 					Properties:    []string{"foo"},
 				},

--- a/adapters/handlers/rest/handlers_indexes_gaps_test.go
+++ b/adapters/handlers/rest/handlers_indexes_gaps_test.go
@@ -1020,6 +1020,35 @@ func TestValidateBodyExclusivity(t *testing.T) {
 			},
 			wantErr: "conflicting fields in filterable",
 		},
+
+		// --- algorithm verb ----------------------------------------------------
+		{
+			name: "valid: searchable.algorithm alone",
+			body: &models.IndexUpdateRequest{
+				Searchable: &models.IndexUpdateSearchable{Algorithm: "blockmax"},
+			},
+		},
+		{
+			name: "reject: searchable.algorithm + searchable.rebuild",
+			body: &models.IndexUpdateRequest{
+				Searchable: &models.IndexUpdateSearchable{Algorithm: "blockmax", Rebuild: true},
+			},
+			wantErr: "conflicting fields in searchable",
+		},
+		{
+			name: "reject: searchable.algorithm + searchable.tokenization",
+			body: &models.IndexUpdateRequest{
+				Searchable: &models.IndexUpdateSearchable{Algorithm: "blockmax", Tokenization: "word"},
+			},
+			wantErr: "conflicting fields in searchable",
+		},
+		{
+			name: "reject: searchable.algorithm + searchable.enabled",
+			body: &models.IndexUpdateRequest{
+				Searchable: &models.IndexUpdateSearchable{Algorithm: "blockmax", Enabled: true},
+			},
+			wantErr: "conflicting fields in searchable",
+		},
 	}
 
 	for _, tc := range cases {

--- a/adapters/handlers/rest/handlers_indexes_gaps_test.go
+++ b/adapters/handlers/rest/handlers_indexes_gaps_test.go
@@ -87,7 +87,7 @@ func TestTypesConflict_FullMatrix(t *testing.T) {
 	// exception for enable-rangeable.
 	cases := []row{
 		// Same type, same property — conflict.
-		{"repair-searchable vs repair-searchable", db.ReindexTypeRepairSearchable, db.ReindexTypeRepairSearchable, []string{"p"}, true, "overlapping properties"},
+		{"repair-searchable vs repair-searchable", db.ReindexTypeChangeAlgorithm, db.ReindexTypeChangeAlgorithm, []string{"p"}, true, "overlapping properties"},
 		{"repair-filterable vs repair-filterable", db.ReindexTypeRepairFilterable, db.ReindexTypeRepairFilterable, []string{"p"}, true, "overlapping properties"},
 		{"enable-searchable vs enable-searchable", db.ReindexTypeEnableSearchable, db.ReindexTypeEnableSearchable, []string{"p"}, true, "overlapping properties"},
 		{"enable-filterable vs enable-filterable", db.ReindexTypeEnableFilterable, db.ReindexTypeEnableFilterable, []string{"p"}, true, "overlapping properties"},
@@ -95,7 +95,7 @@ func TestTypesConflict_FullMatrix(t *testing.T) {
 		{"enable-rangeable vs enable-rangeable (same prop)", db.ReindexTypeEnableRangeable, db.ReindexTypeEnableRangeable, []string{"p"}, true, "overlapping properties"},
 
 		// Cross-type same-property — all conflict under the new rule.
-		{"change-tok vs repair-searchable (same prop)", db.ReindexTypeChangeTokenization, db.ReindexTypeRepairSearchable, []string{"p"}, true, "overlapping properties"},
+		{"change-tok vs repair-searchable (same prop)", db.ReindexTypeChangeTokenization, db.ReindexTypeChangeAlgorithm, []string{"p"}, true, "overlapping properties"},
 		{"change-tok vs enable-searchable (same prop)", db.ReindexTypeChangeTokenization, db.ReindexTypeEnableSearchable, []string{"p"}, true, "overlapping properties"},
 		{"change-tok vs repair-filterable (same prop)", db.ReindexTypeChangeTokenization, db.ReindexTypeRepairFilterable, []string{"p"}, true, "overlapping properties"},
 		{"change-tok vs enable-filterable (same prop)", db.ReindexTypeChangeTokenization, db.ReindexTypeEnableFilterable, []string{"p"}, true, "overlapping properties"},
@@ -104,7 +104,7 @@ func TestTypesConflict_FullMatrix(t *testing.T) {
 		// shared on-disk migration state (filterable_to_rangeable_<prop>) is
 		// destroyed by the OnMigrationComplete updatePropertyBuckets path
 		// otherwise. Same prop = conflict.
-		{"enable-rangeable vs repair-searchable", db.ReindexTypeEnableRangeable, db.ReindexTypeRepairSearchable, []string{"p"}, true, "overlapping properties"},
+		{"enable-rangeable vs repair-searchable", db.ReindexTypeEnableRangeable, db.ReindexTypeChangeAlgorithm, []string{"p"}, true, "overlapping properties"},
 		{"enable-rangeable vs repair-filterable", db.ReindexTypeEnableRangeable, db.ReindexTypeRepairFilterable, []string{"p"}, true, "overlapping properties"},
 		{"enable-rangeable vs enable-filterable", db.ReindexTypeEnableRangeable, db.ReindexTypeEnableFilterable, []string{"p"}, true, "overlapping properties"},
 		{"enable-rangeable vs enable-searchable", db.ReindexTypeEnableRangeable, db.ReindexTypeEnableSearchable, []string{"p"}, true, "overlapping properties"},
@@ -113,7 +113,7 @@ func TestTypesConflict_FullMatrix(t *testing.T) {
 		// Searchable-only vs filterable-only on the same property also conflicts:
 		// MergeProps fans out across all flags on OnMigrationComplete so the same
 		// cross-pollination concern applies.
-		{"repair-searchable vs repair-filterable (same prop)", db.ReindexTypeRepairSearchable, db.ReindexTypeRepairFilterable, []string{"p"}, true, "overlapping properties"},
+		{"repair-searchable vs repair-filterable (same prop)", db.ReindexTypeChangeAlgorithm, db.ReindexTypeRepairFilterable, []string{"p"}, true, "overlapping properties"},
 		{"enable-searchable vs enable-filterable (same prop)", db.ReindexTypeEnableSearchable, db.ReindexTypeEnableFilterable, []string{"p"}, true, "overlapping properties"},
 	}
 
@@ -134,7 +134,7 @@ func TestTypesConflict_DifferentPropertiesNeverConflict(t *testing.T) {
 	// Two same-type tasks on different properties of the same collection
 	// must NOT conflict. This is the parallelism contract.
 	for _, mt := range []db.ReindexMigrationType{
-		db.ReindexTypeRepairSearchable,
+		db.ReindexTypeChangeAlgorithm,
 		db.ReindexTypeRepairFilterable,
 		db.ReindexTypeEnableSearchable,
 		db.ReindexTypeEnableFilterable,
@@ -523,7 +523,7 @@ func TestMigrationTypeTargetsIndex(t *testing.T) {
 	}{
 		{db.ReindexTypeEnableSearchable, "searchable", true, true},
 		{db.ReindexTypeEnableSearchable, "filterable", false, true},
-		{db.ReindexTypeRepairSearchable, "searchable", true, true},
+		{db.ReindexTypeChangeAlgorithm, "searchable", true, true},
 		{db.ReindexTypeEnableFilterable, "filterable", true, true},
 		{db.ReindexTypeEnableFilterable, "searchable", false, true},
 		{db.ReindexTypeRepairFilterable, "filterable", true, true},
@@ -563,7 +563,7 @@ func TestIndexTypesFromMigrationType(t *testing.T) {
 		wantKnown bool
 	}{
 		{db.ReindexTypeEnableSearchable, []string{"searchable"}, true},
-		{db.ReindexTypeRepairSearchable, []string{"searchable"}, true},
+		{db.ReindexTypeChangeAlgorithm, []string{"searchable"}, true},
 		{db.ReindexTypeEnableFilterable, []string{"filterable"}, true},
 		{db.ReindexTypeRepairFilterable, []string{"filterable"}, true},
 		{db.ReindexTypeEnableRangeable, []string{"rangeable"}, true},
@@ -825,7 +825,7 @@ func TestTouchesSearchable(t *testing.T) {
 		t    db.ReindexMigrationType
 		want bool
 	}{
-		{db.ReindexTypeRepairSearchable, true},
+		{db.ReindexTypeChangeAlgorithm, true},
 		{db.ReindexTypeChangeTokenization, true},
 		{db.ReindexTypeEnableSearchable, true},
 		{db.ReindexTypeRepairFilterable, false},
@@ -847,7 +847,7 @@ func TestTouchesFilterable(t *testing.T) {
 		{db.ReindexTypeRepairFilterable, true},
 		{db.ReindexTypeChangeTokenization, true},
 		{db.ReindexTypeEnableFilterable, true},
-		{db.ReindexTypeRepairSearchable, false},
+		{db.ReindexTypeChangeAlgorithm, false},
 		{db.ReindexTypeEnableSearchable, false},
 		{db.ReindexTypeEnableRangeable, false},
 	}

--- a/adapters/handlers/rest/handlers_reindex.go
+++ b/adapters/handlers/rest/handlers_reindex.go
@@ -324,6 +324,9 @@ func validateBodyExclusivity(body *models.IndexUpdateRequest) error {
 		if body.Searchable.Rebuild {
 			verbs = append(verbs, "searchable.rebuild")
 		}
+		if body.Searchable.Algorithm != "" {
+			verbs = append(verbs, "searchable.algorithm")
+		}
 		// Tokenization is a verb on its own (change-tokenization) ONLY when
 		// Enabled is not set. With Enabled it is part of the enable verb.
 		if body.Searchable.Tokenization != "" && !body.Searchable.Enabled {
@@ -333,7 +336,7 @@ func validateBodyExclusivity(body *models.IndexUpdateRequest) error {
 			verbs = append(verbs, "searchable.cancel")
 		}
 		if len(verbs) > 1 {
-			return fmt.Errorf("conflicting fields in searchable: %v — set exactly one of enabled, rebuild, tokenization, or cancel (tokenization combined with enabled is allowed)", verbs)
+			return fmt.Errorf("conflicting fields in searchable: %v — set exactly one of enabled, rebuild, algorithm, tokenization, or cancel (tokenization combined with enabled is allowed)", verbs)
 		}
 		if len(verbs) == 1 {
 			groupsSet = append(groupsSet, "searchable")

--- a/adapters/repos/db/inverted_reindex_blockmax_searchable_task.go
+++ b/adapters/repos/db/inverted_reindex_blockmax_searchable_task.go
@@ -1,0 +1,43 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import "time"
+
+// blockmaxSearchableTaskConfig returns the shared reindexTaskConfig used
+// by NewRuntimeEnableSearchableTask + NewRuntimeRebuildSearchableTask.
+// Both scan objects to produce BlockMax postings; the only difference is
+// the strategy attached on top.
+func blockmaxSearchableTaskConfig(propNames []string, collectionName string) reindexTaskConfig {
+	selected := make(map[string]struct{}, len(propNames))
+	for _, p := range propNames {
+		selected[p] = struct{}{}
+	}
+	return reindexTaskConfig{
+		swapBuckets:                   true,
+		tidyBuckets:                   true,
+		concurrency:                   2,
+		memtableOptFactor:             4,
+		backupMemtableOptFactor:       1,
+		processingDuration:            10 * time.Minute,
+		pauseDuration:                 1 * time.Second,
+		checkProcessingEveryNoObjects: 1000,
+
+		selectionEnabled: true,
+		selectedPropsByCollection: map[string]map[string]struct{}{
+			collectionName: selected,
+		},
+		selectedShardsByCollection: map[string]map[string]struct{}{
+			collectionName: nil,
+		},
+	}
+}

--- a/adapters/repos/db/inverted_reindex_blockmax_searchable_writer.go
+++ b/adapters/repos/db/inverted_reindex_blockmax_searchable_writer.go
@@ -1,0 +1,76 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"fmt"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+)
+
+// Shared BlockMax (StrategyInverted) searchable-bucket writers. Used by
+// both EnableSearchableStrategy (creating from scratch) and
+// RebuildSearchableStrategy (rebuilding from objects). The write side is
+// identical — same posting layout, same proplen calculation — so both
+// strategies delegate here.
+
+func writeBlockmaxSearchablePostings(shard ShardLike, bucket *lsmkv.Bucket,
+	docID uint64, prop inverted.Property,
+) error {
+	propLen := calcPropLenInverted(prop.Items)
+	for _, item := range prop.Items {
+		pair := shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
+		if err := shard.addToPropertyMapBucket(bucket, pair, item.Data); err != nil {
+			return fmt.Errorf("adding prop '%s': %w", item.Data, err)
+		}
+	}
+	return nil
+}
+
+func blockmaxSearchableAddCallback(bucketNamer func(string) string,
+	propsByName map[string]struct{},
+) onAddToPropertyValueIndex {
+	return func(shard *Shard, docID uint64, property *inverted.Property) error {
+		if _, ok := propsByName[property.Name]; !ok {
+			return nil
+		}
+		bucketName := bucketNamer(property.Name)
+		bucket := shard.store.Bucket(bucketName)
+		propLen := calcPropLenInverted(property.Items)
+		for _, item := range property.Items {
+			pair := shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
+			if err := shard.addToPropertyMapBucket(bucket, pair, item.Data); err != nil {
+				return fmt.Errorf("adding prop '%s' to bucket '%s': %w", item.Data, bucketName, err)
+			}
+		}
+		return nil
+	}
+}
+
+func blockmaxSearchableDeleteCallback(bucketNamer func(string) string,
+	propsByName map[string]struct{},
+) onDeleteFromPropertyValueIndex {
+	return func(shard *Shard, docID uint64, property *inverted.Property) error {
+		if _, ok := propsByName[property.Name]; !ok {
+			return nil
+		}
+		bucketName := bucketNamer(property.Name)
+		bucket := shard.store.Bucket(bucketName)
+		for _, item := range property.Items {
+			if err := shard.deleteInvertedIndexItemWithFrequencyLSM(bucket, item, docID); err != nil {
+				return fmt.Errorf("deleting prop '%s' from bucket '%s': %w", item.Data, bucketName, err)
+			}
+		}
+		return nil
+	}
+}

--- a/adapters/repos/db/inverted_reindex_finalize.go
+++ b/adapters/repos/db/inverted_reindex_finalize.go
@@ -446,6 +446,8 @@ func reindexSuffixForFinalize(namespace string) string {
 		return "__enable_filterable_reindex"
 	case strings.HasPrefix(namespace, MigrationDirPrefixEnableSearchable):
 		return "__enable_searchable_reindex"
+	case strings.HasPrefix(namespace, MigrationDirPrefixRebuildSearchable):
+		return "__rebuild_searchable_reindex"
 	}
 	return ""
 }
@@ -599,6 +601,14 @@ func migrationSuffixes(migName string) *migrationBucketSuffixes {
 			sourceBucketName: func(p string) string { return "property_" + p + "_searchable" },
 			ingestSuffix:     "__enable_searchable_ingest",
 			backupSuffix:     "__enable_searchable_backup",
+		}
+	// Per-property dir names: "rebuild_searchable_<prop1>_<prop2>..." (see
+	// RebuildSearchableStrategy.MigrationDirName).
+	case strings.HasPrefix(migName, MigrationDirPrefixRebuildSearchable):
+		return &migrationBucketSuffixes{
+			sourceBucketName: func(p string) string { return "property_" + p + "_searchable" },
+			ingestSuffix:     "__rebuild_searchable_ingest",
+			backupSuffix:     "__rebuild_searchable_backup",
 		}
 	default:
 		return nil

--- a/adapters/repos/db/inverted_reindex_strategy_dir_names.go
+++ b/adapters/repos/db/inverted_reindex_strategy_dir_names.go
@@ -73,6 +73,12 @@ const (
 	// prefix on its own (no specific properties) or this prefix +
 	// "_<prop1>_<prop2>...".
 	MigrationDirPrefixEnableSearchable = "enable_searchable"
+
+	// MigrationDirPrefixRebuildSearchable is the directory-name prefix for
+	// the per-property rebuild-searchable migration (rebuild a BlockMax
+	// searchable bucket from the objects store). Actual dir:
+	// "<prefix>_<prop1>_<prop2>...".
+	MigrationDirPrefixRebuildSearchable = "rebuild_searchable"
 )
 
 // migrationDirWithProps assembles a migration directory name from a

--- a/adapters/repos/db/inverted_reindex_strategy_dir_names.go
+++ b/adapters/repos/db/inverted_reindex_strategy_dir_names.go
@@ -167,6 +167,7 @@ func migrationDirsForPropertyIndex(propName, indexType string) []string {
 	case "searchable":
 		return []string{
 			migrationDirWithProps(MigrationDirPrefixEnableSearchable, []string{propName}),
+			migrationDirWithProps(MigrationDirPrefixRebuildSearchable, []string{propName}),
 			MigrationDirPrefixSearchableRetokenize + "_" + propName,
 		}
 	case "rangeable":

--- a/adapters/repos/db/inverted_reindex_strategy_enable_searchable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_enable_searchable.go
@@ -13,7 +13,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
@@ -73,14 +72,7 @@ func (s *EnableSearchableStrategy) BackupStrategy() string {
 func (s *EnableSearchableStrategy) WriteToReindexBucket(shard ShardLike, bucket *lsmkv.Bucket,
 	docID uint64, prop inverted.Property,
 ) error {
-	propLen := calcPropLenInverted(prop.Items)
-	for _, item := range prop.Items {
-		pair := shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
-		if err := shard.addToPropertyMapBucket(bucket, pair, item.Data); err != nil {
-			return fmt.Errorf("adding prop '%s': %w", item.Data, err)
-		}
-	}
-	return nil
+	return writeBlockmaxSearchablePostings(shard, bucket, docID, prop)
 }
 
 // ShouldProcessProperty always returns true — scope is driven by
@@ -94,41 +86,13 @@ func (s *EnableSearchableStrategy) ShouldProcessProperty(property *inverted.Prop
 func (s *EnableSearchableStrategy) MakeAddCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onAddToPropertyValueIndex {
-	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
-		propLen := calcPropLenInverted(property.Items)
-		for _, item := range property.Items {
-			pair := shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
-			if err := shard.addToPropertyMapBucket(bucket, pair, item.Data); err != nil {
-				return fmt.Errorf("adding prop '%s' to bucket '%s': %w", item.Data, bucketName, err)
-			}
-		}
-		return nil
-	}
+	return blockmaxSearchableAddCallback(bucketNamer, propsByName)
 }
 
 func (s *EnableSearchableStrategy) MakeDeleteCallback(bucketNamer func(string) string,
 	propsByName map[string]struct{}, forTargetStrategy bool,
 ) onDeleteFromPropertyValueIndex {
-	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-
-		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
-		for _, item := range property.Items {
-			if err := shard.deleteInvertedIndexItemWithFrequencyLSM(bucket, item, docID); err != nil {
-				return fmt.Errorf("deleting prop '%s' from bucket '%s': %w", item.Data, bucketName, err)
-			}
-		}
-		return nil
-	}
+	return blockmaxSearchableDeleteCallback(bucketNamer, propsByName)
 }
 
 // PreReindexHook creates empty blockmax searchable buckets for the targeted

--- a/adapters/repos/db/inverted_reindex_strategy_rebuild_searchable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_rebuild_searchable.go
@@ -1,0 +1,144 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
+	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
+	"github.com/weaviate/weaviate/adapters/repos/db/lsmkv"
+)
+
+// RebuildSearchableStrategy rebuilds an existing BlockMax (StrategyInverted)
+// searchable bucket from the objects store while preserving the property's
+// current tokenization and BM25 algorithm. The strategy assumes the property
+// already has IndexSearchable=true on the BlockMax algorithm; the API
+// dispatch rejects WAND properties before this strategy is constructed.
+type RebuildSearchableStrategy struct {
+	propNames  []string
+	generation int
+}
+
+func (s *RebuildSearchableStrategy) MigrationDirName() string {
+	return migrationDirWithProps(MigrationDirPrefixRebuildSearchable, s.propNames) + genSuffix(s.generation)
+}
+
+func (s *RebuildSearchableStrategy) SourceBucketName(propName string) string {
+	return helpers.BucketSearchableFromPropNameLSM(propName)
+}
+
+func (s *RebuildSearchableStrategy) ReindexSuffix() string {
+	return "__rebuild_searchable_reindex" + genSuffix(s.generation)
+}
+
+func (s *RebuildSearchableStrategy) IngestSuffix() string {
+	return "__rebuild_searchable_ingest" + genSuffix(s.generation)
+}
+
+func (s *RebuildSearchableStrategy) BackupSuffix() string {
+	return "__rebuild_searchable_backup" + genSuffix(s.generation)
+}
+
+func (s *RebuildSearchableStrategy) SourceStrategy() string {
+	return lsmkv.StrategyInverted
+}
+
+func (s *RebuildSearchableStrategy) SourceIndexType() PropertyIndexType {
+	return IndexTypePropSearchableValue
+}
+
+func (s *RebuildSearchableStrategy) TargetStrategy() string {
+	return lsmkv.StrategyInverted
+}
+
+func (s *RebuildSearchableStrategy) BackupStrategy() string {
+	return lsmkv.StrategyInverted
+}
+
+func (s *RebuildSearchableStrategy) WriteToReindexBucket(shard ShardLike, bucket *lsmkv.Bucket,
+	docID uint64, prop inverted.Property,
+) error {
+	propLen := calcPropLenInverted(prop.Items)
+	for _, item := range prop.Items {
+		pair := shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
+		if err := shard.addToPropertyMapBucket(bucket, pair, item.Data); err != nil {
+			return fmt.Errorf("adding prop '%s': %w", item.Data, err)
+		}
+	}
+	return nil
+}
+
+// ShouldProcessProperty is true for every targeted property — selection is
+// driven by selectedPropsByCollection in the task config.
+func (s *RebuildSearchableStrategy) ShouldProcessProperty(property *inverted.Property) bool {
+	return true
+}
+
+func (s *RebuildSearchableStrategy) MakeAddCallback(bucketNamer func(string) string,
+	propsByName map[string]struct{}, forTargetStrategy bool,
+) onAddToPropertyValueIndex {
+	return func(shard *Shard, docID uint64, property *inverted.Property) error {
+		if _, ok := propsByName[property.Name]; !ok {
+			return nil
+		}
+		bucketName := bucketNamer(property.Name)
+		bucket := shard.store.Bucket(bucketName)
+		propLen := calcPropLenInverted(property.Items)
+		for _, item := range property.Items {
+			pair := shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
+			if err := shard.addToPropertyMapBucket(bucket, pair, item.Data); err != nil {
+				return fmt.Errorf("adding prop '%s' to bucket '%s': %w", item.Data, bucketName, err)
+			}
+		}
+		return nil
+	}
+}
+
+func (s *RebuildSearchableStrategy) MakeDeleteCallback(bucketNamer func(string) string,
+	propsByName map[string]struct{}, forTargetStrategy bool,
+) onDeleteFromPropertyValueIndex {
+	return func(shard *Shard, docID uint64, property *inverted.Property) error {
+		if _, ok := propsByName[property.Name]; !ok {
+			return nil
+		}
+		bucketName := bucketNamer(property.Name)
+		bucket := shard.store.Bucket(bucketName)
+		for _, item := range property.Items {
+			if err := shard.deleteInvertedIndexItemWithFrequencyLSM(bucket, item, docID); err != nil {
+				return fmt.Errorf("deleting prop '%s' from bucket '%s': %w", item.Data, bucketName, err)
+			}
+		}
+		return nil
+	}
+}
+
+// PreReindexHook is a no-op — the target BlockMax bucket already exists
+// (the API dispatch rejects WAND properties before this strategy runs).
+func (s *RebuildSearchableStrategy) PreReindexHook(shard *Shard, props []string) {
+	_ = shard
+	_ = props
+}
+
+// AnalyzerOverlay returns nil so the analyzer uses the property's stored
+// tokenization. Rebuild MUST NOT change tokenization — that's a separate
+// verb ({searchable:{tokenization:X}}).
+func (s *RebuildSearchableStrategy) AnalyzerOverlay(props []string) map[string]inverted.PropertyOverlay {
+	return nil
+}
+
+// OnMigrationComplete is a no-op. Rebuild doesn't flip any schema flags
+// (the property is already searchable+BlockMax pre-migration).
+func (s *RebuildSearchableStrategy) OnMigrationComplete(_ context.Context, _ ShardLike) error {
+	return nil
+}

--- a/adapters/repos/db/inverted_reindex_strategy_rebuild_searchable.go
+++ b/adapters/repos/db/inverted_reindex_strategy_rebuild_searchable.go
@@ -13,7 +13,6 @@ package db
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/weaviate/weaviate/adapters/repos/db/helpers"
 	"github.com/weaviate/weaviate/adapters/repos/db/inverted"
@@ -22,9 +21,8 @@ import (
 
 // RebuildSearchableStrategy rebuilds an existing BlockMax (StrategyInverted)
 // searchable bucket from the objects store while preserving the property's
-// current tokenization and BM25 algorithm. The strategy assumes the property
-// already has IndexSearchable=true on the BlockMax algorithm; the API
-// dispatch rejects WAND properties before this strategy is constructed.
+// current tokenization and BM25 algorithm. Dispatch rejects WAND properties
+// before this strategy is constructed.
 type RebuildSearchableStrategy struct {
 	propNames  []string
 	generation int
@@ -50,95 +48,48 @@ func (s *RebuildSearchableStrategy) BackupSuffix() string {
 	return "__rebuild_searchable_backup" + genSuffix(s.generation)
 }
 
-func (s *RebuildSearchableStrategy) SourceStrategy() string {
-	return lsmkv.StrategyInverted
-}
+func (s *RebuildSearchableStrategy) SourceStrategy() string { return lsmkv.StrategyInverted }
+func (s *RebuildSearchableStrategy) TargetStrategy() string { return lsmkv.StrategyInverted }
+func (s *RebuildSearchableStrategy) BackupStrategy() string { return lsmkv.StrategyInverted }
 
 func (s *RebuildSearchableStrategy) SourceIndexType() PropertyIndexType {
 	return IndexTypePropSearchableValue
 }
 
-func (s *RebuildSearchableStrategy) TargetStrategy() string {
-	return lsmkv.StrategyInverted
-}
-
-func (s *RebuildSearchableStrategy) BackupStrategy() string {
-	return lsmkv.StrategyInverted
-}
-
 func (s *RebuildSearchableStrategy) WriteToReindexBucket(shard ShardLike, bucket *lsmkv.Bucket,
 	docID uint64, prop inverted.Property,
 ) error {
-	propLen := calcPropLenInverted(prop.Items)
-	for _, item := range prop.Items {
-		pair := shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
-		if err := shard.addToPropertyMapBucket(bucket, pair, item.Data); err != nil {
-			return fmt.Errorf("adding prop '%s': %w", item.Data, err)
-		}
-	}
-	return nil
+	return writeBlockmaxSearchablePostings(shard, bucket, docID, prop)
 }
 
 // ShouldProcessProperty is true for every targeted property — selection is
 // driven by selectedPropsByCollection in the task config.
-func (s *RebuildSearchableStrategy) ShouldProcessProperty(property *inverted.Property) bool {
-	return true
-}
+func (s *RebuildSearchableStrategy) ShouldProcessProperty(_ *inverted.Property) bool { return true }
 
 func (s *RebuildSearchableStrategy) MakeAddCallback(bucketNamer func(string) string,
-	propsByName map[string]struct{}, forTargetStrategy bool,
+	propsByName map[string]struct{}, _ bool,
 ) onAddToPropertyValueIndex {
-	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
-		propLen := calcPropLenInverted(property.Items)
-		for _, item := range property.Items {
-			pair := shard.pairPropertyWithFrequency(docID, item.TermFrequency, propLen)
-			if err := shard.addToPropertyMapBucket(bucket, pair, item.Data); err != nil {
-				return fmt.Errorf("adding prop '%s' to bucket '%s': %w", item.Data, bucketName, err)
-			}
-		}
-		return nil
-	}
+	return blockmaxSearchableAddCallback(bucketNamer, propsByName)
 }
 
 func (s *RebuildSearchableStrategy) MakeDeleteCallback(bucketNamer func(string) string,
-	propsByName map[string]struct{}, forTargetStrategy bool,
+	propsByName map[string]struct{}, _ bool,
 ) onDeleteFromPropertyValueIndex {
-	return func(shard *Shard, docID uint64, property *inverted.Property) error {
-		if _, ok := propsByName[property.Name]; !ok {
-			return nil
-		}
-		bucketName := bucketNamer(property.Name)
-		bucket := shard.store.Bucket(bucketName)
-		for _, item := range property.Items {
-			if err := shard.deleteInvertedIndexItemWithFrequencyLSM(bucket, item, docID); err != nil {
-				return fmt.Errorf("deleting prop '%s' from bucket '%s': %w", item.Data, bucketName, err)
-			}
-		}
-		return nil
-	}
+	return blockmaxSearchableDeleteCallback(bucketNamer, propsByName)
 }
 
 // PreReindexHook is a no-op — the target BlockMax bucket already exists
-// (the API dispatch rejects WAND properties before this strategy runs).
-func (s *RebuildSearchableStrategy) PreReindexHook(shard *Shard, props []string) {
-	_ = shard
-	_ = props
-}
+// (API dispatch rejects WAND properties before this strategy runs).
+func (s *RebuildSearchableStrategy) PreReindexHook(_ *Shard, _ []string) {}
 
-// AnalyzerOverlay returns nil so the analyzer uses the property's stored
-// tokenization. Rebuild MUST NOT change tokenization — that's a separate
-// verb ({searchable:{tokenization:X}}).
-func (s *RebuildSearchableStrategy) AnalyzerOverlay(props []string) map[string]inverted.PropertyOverlay {
+// AnalyzerOverlay returns nil — rebuild MUST NOT change tokenization
+// (that's a separate verb: {searchable:{tokenization:X}}).
+func (s *RebuildSearchableStrategy) AnalyzerOverlay(_ []string) map[string]inverted.PropertyOverlay {
 	return nil
 }
 
-// OnMigrationComplete is a no-op. Rebuild doesn't flip any schema flags
-// (the property is already searchable+BlockMax pre-migration).
+// OnMigrationComplete is a no-op — the property was already searchable
+// + BlockMax pre-migration; no schema flag flips.
 func (s *RebuildSearchableStrategy) OnMigrationComplete(_ context.Context, _ ShardLike) error {
 	return nil
 }

--- a/adapters/repos/db/inverted_reindexer_enable_searchable.go
+++ b/adapters/repos/db/inverted_reindexer_enable_searchable.go
@@ -12,8 +12,6 @@
 package db
 
 import (
-	"time"
-
 	"github.com/sirupsen/logrus"
 )
 
@@ -34,38 +32,14 @@ func NewRuntimeEnableSearchableTask(
 	tokenization string,
 	generation int,
 ) *ShardReindexTaskGeneric {
-	strategy := &EnableSearchableStrategy{
-		propNames:    propNames,
-		tokenization: tokenization,
-		generation:   generation,
-	}
-
-	selectedProps := make(map[string]struct{}, len(propNames))
-	for _, p := range propNames {
-		selectedProps[p] = struct{}{}
-	}
-
-	cfg := reindexTaskConfig{
-		swapBuckets:                   true,
-		tidyBuckets:                   true,
-		concurrency:                   2,
-		memtableOptFactor:             4,
-		backupMemtableOptFactor:       1,
-		processingDuration:            10 * time.Minute,
-		pauseDuration:                 1 * time.Second,
-		checkProcessingEveryNoObjects: 1000,
-
-		selectionEnabled: true,
-		selectedPropsByCollection: map[string]map[string]struct{}{
-			collectionName: selectedProps,
-		},
-		selectedShardsByCollection: map[string]map[string]struct{}{
-			collectionName: nil, // nil = all shards
-		},
-	}
-
 	return NewShardReindexTaskGeneric(
-		"EnableSearchable", logger, strategy, cfg,
+		"EnableSearchable", logger,
+		&EnableSearchableStrategy{
+			propNames:    propNames,
+			tokenization: tokenization,
+			generation:   generation,
+		},
+		blockmaxSearchableTaskConfig(propNames, collectionName),
 		&UuidKeyParser{}, uuidObjectsIteratorAsync,
 	)
 }

--- a/adapters/repos/db/inverted_reindexer_rebuild_searchable.go
+++ b/adapters/repos/db/inverted_reindexer_rebuild_searchable.go
@@ -12,53 +12,23 @@
 package db
 
 import (
-	"time"
-
 	"github.com/sirupsen/logrus"
 )
 
-// NewRuntimeRebuildSearchableTask constructs a ShardReindexTaskGeneric that
-// rebuilds existing BlockMax searchable buckets from the objects store.
-// Caller-side dispatch in handlers_indexes.go gates this on the property
-// already being BlockMax — WAND properties get routed to MapToBlockmax
-// instead.
+// NewRuntimeRebuildSearchableTask constructs a task that rebuilds existing
+// BlockMax searchable buckets from the objects store. Dispatch in
+// handlers_indexes.go gates this on the property already being BlockMax;
+// WAND properties route to MapToBlockmax instead.
 func NewRuntimeRebuildSearchableTask(
 	logger logrus.FieldLogger,
 	propNames []string,
 	collectionName string,
 	generation int,
 ) *ShardReindexTaskGeneric {
-	strategy := &RebuildSearchableStrategy{
-		propNames:  propNames,
-		generation: generation,
-	}
-
-	selectedProps := make(map[string]struct{}, len(propNames))
-	for _, p := range propNames {
-		selectedProps[p] = struct{}{}
-	}
-
-	cfg := reindexTaskConfig{
-		swapBuckets:                   true,
-		tidyBuckets:                   true,
-		concurrency:                   2,
-		memtableOptFactor:             4,
-		backupMemtableOptFactor:       1,
-		processingDuration:            10 * time.Minute,
-		pauseDuration:                 1 * time.Second,
-		checkProcessingEveryNoObjects: 1000,
-
-		selectionEnabled: true,
-		selectedPropsByCollection: map[string]map[string]struct{}{
-			collectionName: selectedProps,
-		},
-		selectedShardsByCollection: map[string]map[string]struct{}{
-			collectionName: nil,
-		},
-	}
-
 	return NewShardReindexTaskGeneric(
-		"RebuildSearchable", logger, strategy, cfg,
+		"RebuildSearchable", logger,
+		&RebuildSearchableStrategy{propNames: propNames, generation: generation},
+		blockmaxSearchableTaskConfig(propNames, collectionName),
 		&UuidKeyParser{}, uuidObjectsIteratorAsync,
 	)
 }

--- a/adapters/repos/db/inverted_reindexer_rebuild_searchable.go
+++ b/adapters/repos/db/inverted_reindexer_rebuild_searchable.go
@@ -1,0 +1,64 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package db
+
+import (
+	"time"
+
+	"github.com/sirupsen/logrus"
+)
+
+// NewRuntimeRebuildSearchableTask constructs a ShardReindexTaskGeneric that
+// rebuilds existing BlockMax searchable buckets from the objects store.
+// Caller-side dispatch in handlers_indexes.go gates this on the property
+// already being BlockMax — WAND properties get routed to MapToBlockmax
+// instead.
+func NewRuntimeRebuildSearchableTask(
+	logger logrus.FieldLogger,
+	propNames []string,
+	collectionName string,
+	generation int,
+) *ShardReindexTaskGeneric {
+	strategy := &RebuildSearchableStrategy{
+		propNames:  propNames,
+		generation: generation,
+	}
+
+	selectedProps := make(map[string]struct{}, len(propNames))
+	for _, p := range propNames {
+		selectedProps[p] = struct{}{}
+	}
+
+	cfg := reindexTaskConfig{
+		swapBuckets:                   true,
+		tidyBuckets:                   true,
+		concurrency:                   2,
+		memtableOptFactor:             4,
+		backupMemtableOptFactor:       1,
+		processingDuration:            10 * time.Minute,
+		pauseDuration:                 1 * time.Second,
+		checkProcessingEveryNoObjects: 1000,
+
+		selectionEnabled: true,
+		selectedPropsByCollection: map[string]map[string]struct{}{
+			collectionName: selectedProps,
+		},
+		selectedShardsByCollection: map[string]map[string]struct{}{
+			collectionName: nil,
+		},
+	}
+
+	return NewShardReindexTaskGeneric(
+		"RebuildSearchable", logger, strategy, cfg,
+		&UuidKeyParser{}, uuidObjectsIteratorAsync,
+	)
+}

--- a/adapters/repos/db/reindex_conflict.go
+++ b/adapters/repos/db/reindex_conflict.go
@@ -172,7 +172,7 @@ func ReindexPropsOverlap(a, b []string) bool {
 // conflicting writes to the same bucket through.
 func TouchesSearchable(t ReindexMigrationType) bool {
 	switch t {
-	case ReindexTypeRepairSearchable,
+	case ReindexTypeChangeAlgorithm,
 		ReindexTypeChangeTokenization,
 		ReindexTypeEnableSearchable:
 		return true
@@ -197,7 +197,7 @@ func TouchesFilterable(t ReindexMigrationType) bool {
 		ReindexTypeChangeTokenizationFilterable,
 		ReindexTypeEnableFilterable:
 		return true
-	case ReindexTypeRepairSearchable,
+	case ReindexTypeChangeAlgorithm,
 		ReindexTypeEnableSearchable,
 		ReindexTypeEnableRangeable,
 		ReindexTypeRepairRangeable:

--- a/adapters/repos/db/reindex_conflict_test.go
+++ b/adapters/repos/db/reindex_conflict_test.go
@@ -93,7 +93,7 @@ func TestTypesConflictReason(t *testing.T) {
 		},
 		{
 			name:         "empty new props (all) vs single existing → conflict",
-			newType:      ReindexTypeRepairSearchable,
+			newType:      ReindexTypeChangeAlgorithm,
 			newProps:     nil,
 			existType:    ReindexTypeChangeTokenization,
 			existProps:   []string{"text"},
@@ -457,7 +457,7 @@ func TestCheckPropertyUpdate_EveryMigrationTypeRejects(t *testing.T) {
 		ReindexTypeEnableFilterable,
 		ReindexTypeEnableSearchable,
 		ReindexTypeEnableRangeable,
-		ReindexTypeRepairSearchable,
+		ReindexTypeChangeAlgorithm,
 		ReindexTypeRepairFilterable,
 		ReindexTypeRepairRangeable,
 	}

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -630,7 +630,7 @@ func (p *ReindexProvider) createReindexTasks(payload *ReindexTaskPayload, lsmPat
 	// a fabricated gen would fail at runtimeSwap with "reindex bucket
 	// not found", so callers skip task instantiation in that case.
 	switch payload.MigrationType {
-	case ReindexTypeRepairSearchable:
+	case ReindexTypeChangeAlgorithm:
 		gen, ok := genFor(MigrationDirSearchableMapToBlockmax, "")
 		if !ok {
 			return nil, nil
@@ -1604,7 +1604,7 @@ func logOperatorRepairGuidanceOnFailedSemanticMigration(logger logrus.FieldLogge
 		switch payload.MigrationType {
 		case ReindexTypeChangeTokenization,
 			ReindexTypeEnableSearchable,
-			ReindexTypeRepairSearchable,
+			ReindexTypeChangeAlgorithm,
 			ReindexTypeRebuildSearchable:
 			repairBody = `{"filterable":{"rebuild":true},"searchable":{"rebuild":true}}`
 		case ReindexTypeChangeTokenizationFilterable,
@@ -1702,7 +1702,7 @@ func semanticMigrationIndexTypes(mt ReindexMigrationType) []string {
 		return []string{"searchable"}
 	case ReindexTypeEnableFilterable:
 		return []string{"filterable"}
-	case ReindexTypeRepairSearchable, ReindexTypeRebuildSearchable,
+	case ReindexTypeChangeAlgorithm, ReindexTypeRebuildSearchable,
 		ReindexTypeRepairFilterable,
 		ReindexTypeEnableRangeable, ReindexTypeRepairRangeable:
 		// Format-only migrations. Returning nil short-circuits

--- a/adapters/repos/db/reindex_provider.go
+++ b/adapters/repos/db/reindex_provider.go
@@ -639,6 +639,15 @@ func (p *ReindexProvider) createReindexTasks(payload *ReindexTaskPayload, lsmPat
 			NewRuntimeMapToBlockmaxTask(p.logger, p.schemaManager, payload.Properties, payload.Collection, gen),
 		}, nil
 
+	case ReindexTypeRebuildSearchable:
+		gen, ok := genFor(MigrationDirPrefixRebuildSearchable, propsSuffix(payload.Properties))
+		if !ok {
+			return nil, nil
+		}
+		return []*ShardReindexTaskGeneric{
+			NewRuntimeRebuildSearchableTask(p.logger, payload.Properties, payload.Collection, gen),
+		}, nil
+
 	case ReindexTypeRepairFilterable:
 		gen, ok := genFor(MigrationDirFilterableRoaringsetRefresh, "")
 		if !ok {
@@ -1595,7 +1604,8 @@ func logOperatorRepairGuidanceOnFailedSemanticMigration(logger logrus.FieldLogge
 		switch payload.MigrationType {
 		case ReindexTypeChangeTokenization,
 			ReindexTypeEnableSearchable,
-			ReindexTypeRepairSearchable:
+			ReindexTypeRepairSearchable,
+			ReindexTypeRebuildSearchable:
 			repairBody = `{"filterable":{"rebuild":true},"searchable":{"rebuild":true}}`
 		case ReindexTypeChangeTokenizationFilterable,
 			ReindexTypeEnableFilterable,
@@ -1692,7 +1702,8 @@ func semanticMigrationIndexTypes(mt ReindexMigrationType) []string {
 		return []string{"searchable"}
 	case ReindexTypeEnableFilterable:
 		return []string{"filterable"}
-	case ReindexTypeRepairSearchable, ReindexTypeRepairFilterable,
+	case ReindexTypeRepairSearchable, ReindexTypeRebuildSearchable,
+		ReindexTypeRepairFilterable,
 		ReindexTypeEnableRangeable, ReindexTypeRepairRangeable:
 		// Format-only migrations. Returning nil short-circuits
 		// LocalCallbacksDone's recovery check — they don't go through

--- a/adapters/repos/db/reindex_provider_payload.go
+++ b/adapters/repos/db/reindex_provider_payload.go
@@ -34,8 +34,14 @@ func ExtractReindexTaskCollection(payload []byte) (string, bool) {
 type ReindexMigrationType string
 
 const (
-	// ReindexTypeRepairSearchable rebuilds searchable indexes from Map to Blockmax strategy.
+	// ReindexTypeRepairSearchable migrates searchable indexes from Map (WAND)
+	// to Inverted (BlockMax). Dispatched by {searchable:{algorithm:"blockmax"}}.
 	ReindexTypeRepairSearchable ReindexMigrationType = "repair-searchable"
+
+	// ReindexTypeRebuildSearchable rebuilds an existing BlockMax searchable
+	// bucket from the objects store, preserving tokenization and algorithm.
+	// Dispatched by {searchable:{rebuild:true}} on BlockMax properties.
+	ReindexTypeRebuildSearchable ReindexMigrationType = "rebuild-searchable"
 
 	// ReindexTypeRepairFilterable refreshes filterable RoaringSet indexes.
 	ReindexTypeRepairFilterable ReindexMigrationType = "repair-filterable"

--- a/adapters/repos/db/reindex_provider_payload.go
+++ b/adapters/repos/db/reindex_provider_payload.go
@@ -34,9 +34,9 @@ func ExtractReindexTaskCollection(payload []byte) (string, bool) {
 type ReindexMigrationType string
 
 const (
-	// ReindexTypeRepairSearchable migrates searchable indexes from Map (WAND)
+	// ReindexTypeChangeAlgorithm migrates searchable indexes from Map (WAND)
 	// to Inverted (BlockMax). Dispatched by {searchable:{algorithm:"blockmax"}}.
-	ReindexTypeRepairSearchable ReindexMigrationType = "repair-searchable"
+	ReindexTypeChangeAlgorithm ReindexMigrationType = "change-algorithm"
 
 	// ReindexTypeRebuildSearchable rebuilds an existing BlockMax searchable
 	// bucket from the objects store, preserving tokenization and algorithm.

--- a/adapters/repos/db/reindex_provider_recovery_test.go
+++ b/adapters/repos/db/reindex_provider_recovery_test.go
@@ -190,7 +190,7 @@ func TestSemanticMigrationIndexTypes(t *testing.T) {
 		},
 		{
 			name: "repair-searchable → empty (format-only, no swap barrier)",
-			mt:   ReindexTypeRepairSearchable,
+			mt:   ReindexTypeChangeAlgorithm,
 			want: nil,
 		},
 		{

--- a/adapters/repos/db/reindex_provider_repair_guidance_test.go
+++ b/adapters/repos/db/reindex_provider_repair_guidance_test.go
@@ -102,7 +102,7 @@ func TestLogOperatorRepairGuidanceOnFailedSemanticMigration_FormatOnlyMigrationI
 	// that produces the bucket↔schema inversion family, so this
 	// helper should NOT emit operator guidance for them.
 	for _, mt := range []ReindexMigrationType{
-		ReindexTypeRepairSearchable,
+		ReindexTypeChangeAlgorithm,
 		ReindexTypeRepairFilterable,
 		ReindexTypeRepairRangeable,
 	} {

--- a/adapters/repos/db/reindex_recovery.go
+++ b/adapters/repos/db/reindex_recovery.go
@@ -222,7 +222,7 @@ func buildRecoveryTasks(
 	}
 	var raw []*ShardReindexTaskGeneric
 	switch payload.MigrationType {
-	case ReindexTypeRepairSearchable:
+	case ReindexTypeChangeAlgorithm:
 		raw = []*ShardReindexTaskGeneric{
 			NewRuntimeMapToBlockmaxTask(logger, schemaManager, payload.Properties, payload.Collection, generation),
 		}

--- a/entities/models/index_update_searchable.go
+++ b/entities/models/index_update_searchable.go
@@ -18,9 +18,12 @@ package models
 
 import (
 	"context"
+	"encoding/json"
 
+	"github.com/go-openapi/errors"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
+	"github.com/go-openapi/validate"
 )
 
 // IndexUpdateSearchable index update searchable
@@ -28,13 +31,17 @@ import (
 // swagger:model IndexUpdateSearchable
 type IndexUpdateSearchable struct {
 
+	// Switch the BM25 algorithm for this property's searchable index. Currently only `blockmax` is accepted. From WAND this triggers the Map → BlockMax migration; on an already-`blockmax` property the request is rejected. WAND is deprecated; downgrade is intentionally not supported.
+	// Enum: [blockmax]
+	Algorithm string `json:"algorithm,omitempty"`
+
 	// When true, cancels the in-flight reindex task targeting this property's searchable index. The task transitions to CANCELLED; partial state is left on disk for the next-restart finalize.
 	Cancel bool `json:"cancel,omitempty"`
 
 	// enabled
 	Enabled bool `json:"enabled,omitempty"`
 
-	// When true, rebuilds the searchable index for this property. The rebuild also switches the BM25 backing algorithm from WAND (the legacy map strategy) to Block Max WAND (the inverted strategy). The reverse direction (blockmax -> wand) is intentionally not supported at this time: callers cannot revert a property to WAND once it has been rebuilt onto blockmax. Read the current algorithm from GET /v1/schema/{className}/indexes (IndexStatus.algorithm) before issuing this verb.
+	// When true, rebuilds the searchable index for this property from the stored objects. Preserves the current tokenization and BM25 algorithm. Only valid when the property's current algorithm is `blockmax`; on a WAND property the request is rejected with guidance to use `algorithm:"blockmax"` first.
 	Rebuild bool `json:"rebuild,omitempty"`
 
 	// tokenization
@@ -43,6 +50,54 @@ type IndexUpdateSearchable struct {
 
 // Validate validates this index update searchable
 func (m *IndexUpdateSearchable) Validate(formats strfmt.Registry) error {
+	var res []error
+
+	if err := m.validateAlgorithm(formats); err != nil {
+		res = append(res, err)
+	}
+
+	if len(res) > 0 {
+		return errors.CompositeValidationError(res...)
+	}
+	return nil
+}
+
+var indexUpdateSearchableTypeAlgorithmPropEnum []interface{}
+
+func init() {
+	var res []string
+	if err := json.Unmarshal([]byte(`["blockmax"]`), &res); err != nil {
+		panic(err)
+	}
+	for _, v := range res {
+		indexUpdateSearchableTypeAlgorithmPropEnum = append(indexUpdateSearchableTypeAlgorithmPropEnum, v)
+	}
+}
+
+const (
+
+	// IndexUpdateSearchableAlgorithmBlockmax captures enum value "blockmax"
+	IndexUpdateSearchableAlgorithmBlockmax string = "blockmax"
+)
+
+// prop value enum
+func (m *IndexUpdateSearchable) validateAlgorithmEnum(path, location string, value string) error {
+	if err := validate.EnumCase(path, location, value, indexUpdateSearchableTypeAlgorithmPropEnum, true); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *IndexUpdateSearchable) validateAlgorithm(formats strfmt.Registry) error {
+	if swag.IsZero(m.Algorithm) { // not required
+		return nil
+	}
+
+	// value enum
+	if err := m.validateAlgorithmEnum("algorithm", "body", m.Algorithm); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/openapi-specs/schema.json
+++ b/openapi-specs/schema.json
@@ -693,7 +693,12 @@
         },
         "rebuild": {
           "type": "boolean",
-          "description": "When true, rebuilds the searchable index for this property. The rebuild also switches the BM25 backing algorithm from WAND (the legacy map strategy) to Block Max WAND (the inverted strategy). The reverse direction (blockmax -> wand) is intentionally not supported at this time: callers cannot revert a property to WAND once it has been rebuilt onto blockmax. Read the current algorithm from GET /v1/schema/{className}/indexes (IndexStatus.algorithm) before issuing this verb."
+          "description": "When true, rebuilds the searchable index for this property from the stored objects. Preserves the current tokenization and BM25 algorithm. Only valid when the property's current algorithm is `blockmax`; on a WAND property the request is rejected with guidance to use `algorithm:\"blockmax\"` first."
+        },
+        "algorithm": {
+          "type": "string",
+          "enum": ["blockmax"],
+          "description": "Switch the BM25 algorithm for this property's searchable index. Currently only `blockmax` is accepted. From WAND this triggers the Map → BlockMax migration; on an already-`blockmax` property the request is rejected. WAND is deprecated; downgrade is intentionally not supported."
         },
         "enabled": {
           "type": "boolean"

--- a/test/acceptance/reindex_mt/reindex_mt_test.go
+++ b/test/acceptance/reindex_mt/reindex_mt_test.go
@@ -136,7 +136,7 @@ func testRepairAllTenants(t *testing.T, restURI string) {
 	}
 
 	// Submit repair-searchable (no tenants param → all tenants).
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"rebuild":true}}`)
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"algorithm":"blockmax"}}`)
 	t.Logf("repair all tenants task: %s", taskID)
 	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
 
@@ -174,7 +174,7 @@ func testRepairSpecificTenants(t *testing.T, restURI string) {
 	// Repair only t1 and t2.
 	targetTenants := []string{"t1", "t2"}
 	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text",
-		`{"searchable":{"rebuild":true}}`, reindexhelpers.WithTenants(targetTenants))
+		`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants(targetTenants))
 	t.Logf("repair specific tenants task: %s", taskID)
 	reindexhelpers.AwaitReindexFinished(t, restURI, taskID)
 
@@ -404,7 +404,7 @@ func testValidation(t *testing.T, restURI string) {
 
 	t.Run("NonMT_with_tenants", func(t *testing.T) {
 		got := reindexhelpers.SubmitIndexUpdateExpect4xx(t, restURI, nonMTClass, "text",
-			`{"searchable":{"rebuild":true}}`, reindexhelpers.WithTenants([]string{"t1"}))
+			`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants([]string{"t1"}))
 		require.Equal(t, http.StatusBadRequest, got.StatusCode,
 			"non-MT class with tenants should reject as 400: %s", got.Body)
 	})
@@ -433,7 +433,7 @@ func testValidation(t *testing.T, restURI string) {
 
 	t.Run("Nonexistent_tenant", func(t *testing.T) {
 		got := reindexhelpers.SubmitIndexUpdateExpect4xx(t, restURI, mtClass, "text",
-			`{"searchable":{"rebuild":true}}`, reindexhelpers.WithTenants([]string{"does_not_exist"}))
+			`{"searchable":{"algorithm":"blockmax"}}`, reindexhelpers.WithTenants([]string{"does_not_exist"}))
 		require.Equal(t, http.StatusBadRequest, got.StatusCode,
 			"non-existent tenant should reject as 400: %s", got.Body)
 	})

--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -145,7 +145,7 @@ func testMapToBlockmax(t *testing.T, compose *docker.DockerCompose) {
 	}
 
 	// Submit reindex.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"rebuild":true}}`)
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"algorithm":"blockmax"}}`)
 	t.Logf("submitted reindex task: %s", taskID)
 
 	// Poll until reindex is done via /indexes endpoint.
@@ -399,7 +399,7 @@ func testQueryConsistencyDuringReindex(t *testing.T, compose *docker.DockerCompo
 	}
 
 	// Submit reindex (repair-searchable — the most common type).
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"rebuild":true}}`)
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"algorithm":"blockmax"}}`)
 	t.Logf("submitted reindex task: %s", taskID)
 
 	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))

--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -71,7 +71,11 @@ var testBM25Queries = []string{
 // This avoids spinning up a new cluster per test (~20s overhead each).
 func TestMultiNode_HappyPath(t *testing.T) {
 	ctx := context.Background()
-	compose, cleanup := start3NodeReindexCluster(ctx, t)
+	// Boot on WAND so the MapToBlockmax + QueryConsistencyDuringReindex
+	// sub-tests can trigger algorithm:"blockmax". ChangeTokenization
+	// shares the cluster and runs on Map-based searchable as a
+	// side-effect of that choice.
+	compose, cleanup := start3NodeReindexCluster(ctx, t, "USE_INVERTED_SEARCHABLE", "false")
 	defer cleanup()
 	defer dumpContainerLogs(ctx, t, compose)
 

--- a/test/acceptance/reindex_multinode/happy_path_test.go
+++ b/test/acceptance/reindex_multinode/happy_path_test.go
@@ -91,9 +91,19 @@ func TestMultiNode_HappyPath(t *testing.T) {
 	t.Run("ChangeTokenization", func(t *testing.T) {
 		testChangeTokenization(t, compose)
 	})
-	t.Run("QueryConsistencyDuringReindex", func(t *testing.T) {
-		testQueryConsistencyDuringReindex(t, compose)
-	})
+}
+
+// TestMultiNode_QueryConsistencyDuringReindex pulls the query-consistency
+// scenario into its own cluster so it isn't running on cluster state
+// previously mutated by the four HappyPath sub-tests. The earlier shared-
+// cluster shape hit "store is read-only" reindex failures triggered by
+// cross-sub-test bucket-finalize residue under concurrent query load.
+func TestMultiNode_QueryConsistencyDuringReindex(t *testing.T) {
+	ctx := context.Background()
+	compose, cleanup := start3NodeReindexCluster(ctx, t, "USE_INVERTED_SEARCHABLE", "false")
+	defer cleanup()
+	defer dumpContainerLogs(ctx, t, compose)
+	testQueryConsistencyDuringReindex(t, compose)
 }
 
 func testMapToBlockmax(t *testing.T, compose *docker.DockerCompose) {

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -39,6 +39,9 @@ func start3NodeReindexCluster(ctx context.Context, t *testing.T) (*docker.Docker
 		WithWeaviateEnv("DISTRIBUTED_TASKS_COMPLETED_TASK_TTL_HOURS", "1").
 		WithWeaviateEnv("DISABLE_LAZY_LOAD_SHARDS", "true").
 		WithWeaviateEnv("MEMBERLIST_FAST_FAILURE_DETECTION", "false").
+		// Boot on WAND so tests can trigger Map→BlockMax via
+		// {"searchable":{"algorithm":"blockmax"}}.
+		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
 		Start(ctx)
 	if err != nil {
 		if compose != nil {

--- a/test/acceptance/reindex_multinode/helpers_test.go
+++ b/test/acceptance/reindex_multinode/helpers_test.go
@@ -28,21 +28,29 @@ import (
 	"github.com/weaviate/weaviate/test/docker"
 )
 
-// start3NodeReindexCluster spins up a 3-node cluster with DTM enabled and the
-// reindex provider automatically registered.
-func start3NodeReindexCluster(ctx context.Context, t *testing.T) (*docker.DockerCompose, func()) {
+// start3NodeReindexCluster spins up a 3-node cluster with DTM enabled
+// and the reindex provider automatically registered. Optional
+// `extraEnv` pairs (key, value, key, value, …) are applied on top so a
+// test that needs e.g. USE_INVERTED_SEARCHABLE=false can opt in without
+// changing the package-wide default — tests that exercise BlockMax-
+// based code paths (change-tokenization, etc.) keep the production
+// default.
+func start3NodeReindexCluster(ctx context.Context, t *testing.T, extraEnv ...string) (*docker.DockerCompose, func()) {
 	t.Helper()
+	if len(extraEnv)%2 != 0 {
+		t.Fatalf("start3NodeReindexCluster: extraEnv must be (key,value) pairs, got %d items", len(extraEnv))
+	}
 
-	compose, err := docker.New().
+	b := docker.New().
 		With3NodeCluster().
 		WithWeaviateEnv("DISTRIBUTED_TASKS_SCHEDULER_TICK_INTERVAL_SECONDS", "1").
 		WithWeaviateEnv("DISTRIBUTED_TASKS_COMPLETED_TASK_TTL_HOURS", "1").
 		WithWeaviateEnv("DISABLE_LAZY_LOAD_SHARDS", "true").
-		WithWeaviateEnv("MEMBERLIST_FAST_FAILURE_DETECTION", "false").
-		// Boot on WAND so tests can trigger Map→BlockMax via
-		// {"searchable":{"algorithm":"blockmax"}}.
-		WithWeaviateEnv("USE_INVERTED_SEARCHABLE", "false").
-		Start(ctx)
+		WithWeaviateEnv("MEMBERLIST_FAST_FAILURE_DETECTION", "false")
+	for i := 0; i < len(extraEnv); i += 2 {
+		b = b.WithWeaviateEnv(extraEnv[i], extraEnv[i+1])
+	}
+	compose, err := b.Start(ctx)
 	if err != nil {
 		if compose != nil {
 			dumpStartupLogs(ctx, t, compose)

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -180,7 +180,7 @@ func TestMultiNode_RollingRestartAfterComplete(t *testing.T) {
 	}
 
 	// Complete a reindex.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"rebuild":true}}`)
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"algorithm":"blockmax"}}`)
 	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
 
 	// Rolling restart all 3 nodes one at a time.

--- a/test/acceptance/reindex_multinode/restart_test.go
+++ b/test/acceptance/reindex_multinode/restart_test.go
@@ -179,8 +179,11 @@ func TestMultiNode_RollingRestartAfterComplete(t *testing.T) {
 		baselines[q] = results
 	}
 
-	// Complete a reindex.
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"algorithm":"blockmax"}}`)
+	// Complete a reindex. Use rebuild-from-objects so the test can run
+	// on the default (BlockMax) cluster — RollingRestartAfterComplete
+	// is testing post-complete rolling restart, not the specific
+	// algorithm-switch path.
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, className, "text", `{"searchable":{"rebuild":true}}`)
 	reindexhelpers.AwaitReindexFinished(t, restURI, taskID, reindexhelpers.WithTimeout(180*time.Second))
 
 	// Rolling restart all 3 nodes one at a time.

--- a/test/acceptance/reindex_singlenode/api_validation_test.go
+++ b/test/acceptance/reindex_singlenode/api_validation_test.go
@@ -139,19 +139,19 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 		{
 			name:       "unknown collection",
 			collection: "DoesNotExist", property: "text_word",
-			body:       `{"searchable":{"rebuild":true}}`,
+			body:       `{"searchable":{"algorithm":"blockmax"}}`,
 			wantStatus: http.StatusNotFound,
 		},
 		{
 			name:       "unknown property",
 			collection: stClass, property: "nope",
-			body:       `{"searchable":{"rebuild":true}}`,
+			body:       `{"searchable":{"algorithm":"blockmax"}}`,
 			wantStatus: http.StatusNotFound,
 		},
 		{
 			name:       "tenants on single-tenant collection",
 			collection: stClass, property: "text_word",
-			body:        `{"searchable":{"rebuild":true}}`,
+			body:        `{"searchable":{"algorithm":"blockmax"}}`,
 			tenantsQS:   "?tenants=t1",
 			wantStatus:  http.StatusBadRequest,
 			wantBodyHas: "multi-tenant",
@@ -159,7 +159,7 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 		{
 			name:       "tenants= empty value treated as nonexistent",
 			collection: mtClass, property: "text_word",
-			body:        `{"searchable":{"rebuild":true}}`,
+			body:        `{"searchable":{"algorithm":"blockmax"}}`,
 			tenantsQS:   "?tenants=nonexistent_tenant_xyz",
 			wantStatus:  http.StatusBadRequest,
 			wantBodyHas: "does not exist",
@@ -223,7 +223,7 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 		{
 			name:       "searchable.rebuild on property with no searchable index",
 			collection: stClass, property: "text_unindexed",
-			body:        `{"searchable":{"rebuild":true}}`,
+			body:        `{"searchable":{"algorithm":"blockmax"}}`,
 			wantStatus:  http.StatusBadRequest,
 			wantBodyHas: "does not have a searchable index",
 		},

--- a/test/acceptance/reindex_singlenode/api_validation_test.go
+++ b/test/acceptance/reindex_singlenode/api_validation_test.go
@@ -221,7 +221,7 @@ func testReindexAPIValidation(t *testing.T, restURI string) {
 			wantBodyHas: "invalid tokenization",
 		},
 		{
-			name:       "searchable.rebuild on property with no searchable index",
+			name:       "searchable.algorithm:blockmax on property with no searchable index",
 			collection: stClass, property: "text_unindexed",
 			body:        `{"searchable":{"algorithm":"blockmax"}}`,
 			wantStatus:  http.StatusBadRequest,

--- a/test/acceptance/reindex_singlenode/blockmax_test.go
+++ b/test/acceptance/reindex_singlenode/blockmax_test.go
@@ -131,7 +131,7 @@ func testBlockmaxMigration(t *testing.T, restURI string) {
 		}
 	}()
 
-	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, blockmaxClassName, "text", `{"searchable":{"rebuild":true}}`)
+	taskID := reindexhelpers.SubmitIndexUpdate(t, restURI, blockmaxClassName, "text", `{"searchable":{"algorithm":"blockmax"}}`)
 	t.Logf("submitted reindex task: %s", taskID)
 
 	// While the rebuild is in flight, GET /indexes must surface

--- a/test/acceptance/reindex_singlenode/property_state_migration_matrix_test.go
+++ b/test/acceptance/reindex_singlenode/property_state_migration_matrix_test.go
@@ -260,8 +260,8 @@ func matrixBodies() []matrixBody {
 		// filterable-only properties.
 		{"PUT_searchable_tokenization_word", `{"searchable":{"tokenization":"word"}}`},
 		{"PUT_searchable_tokenization_field", `{"searchable":{"tokenization":"field"}}`},
-		// repair-searchable.
-		{"PUT_searchable_rebuild", `{"searchable":{"algorithm":"blockmax"}}`},
+		// searchable algorithm switch (Map → BlockMax).
+		{"PUT_searchable_algorithm_blockmax", `{"searchable":{"algorithm":"blockmax"}}`},
 		// canonical enable-filterable.
 		{"PUT_filterable_enabled", `{"filterable":{"enabled":true}}`},
 		{"PUT_filterable_enabled_false", `{"filterable":{"enabled":false}}`},

--- a/test/acceptance/reindex_singlenode/property_state_migration_matrix_test.go
+++ b/test/acceptance/reindex_singlenode/property_state_migration_matrix_test.go
@@ -261,7 +261,7 @@ func matrixBodies() []matrixBody {
 		{"PUT_searchable_tokenization_word", `{"searchable":{"tokenization":"word"}}`},
 		{"PUT_searchable_tokenization_field", `{"searchable":{"tokenization":"field"}}`},
 		// repair-searchable.
-		{"PUT_searchable_rebuild", `{"searchable":{"rebuild":true}}`},
+		{"PUT_searchable_rebuild", `{"searchable":{"algorithm":"blockmax"}}`},
 		// canonical enable-filterable.
 		{"PUT_filterable_enabled", `{"filterable":{"enabled":true}}`},
 		{"PUT_filterable_enabled_false", `{"filterable":{"enabled":false}}`},

--- a/test/acceptance/reindex_singlenode/scope_assertion_test.go
+++ b/test/acceptance/reindex_singlenode/scope_assertion_test.go
@@ -156,7 +156,7 @@ func testReindexScopeAssertion(t *testing.T, restURI string) {
 			properties: searchableScopeProps,
 			objects:    textScopeObjects,
 			target:     "title",
-			body:       `{"searchable":{"rebuild":true}}`,
+			body:       `{"searchable":{"algorithm":"blockmax"}}`,
 			indexType:  "searchable",
 		},
 		{

--- a/test/acceptance/reindex_singlenode/scope_assertion_test.go
+++ b/test/acceptance/reindex_singlenode/scope_assertion_test.go
@@ -151,7 +151,7 @@ func testReindexScopeAssertion(t *testing.T, restURI string) {
 
 	cases := []scopeCase{
 		{
-			name:       "repair-searchable",
+			name:       "change-algorithm",
 			className:  "ScopeRepairSearchable",
 			properties: searchableScopeProps,
 			objects:    textScopeObjects,

--- a/test/run.sh
+++ b/test/run.sh
@@ -690,7 +690,7 @@ function run_acceptance_reindex_multinode() {
   # IMPORTANT: when adding a new sub-shard, also add its top-level test
   # prefixes to the SKIP regex below to prevent the catch-all from
   # double-running the same tests.
-  AOF_GROUP_SKIP='TestMultiNode_ChangeTokenization_AJ_|TestMultiNode_RestartMatrix|TestMultiNode_(Rolling|Graceful|Crash|MajorityCrash|UngracefulStop|PostRestartMigration)|TestMultiNode_(HappyPath|ConcurrentDifferentMigrations|EnableRangeable_NoPartialCountsInFlight|RepeatedParallelMigrationJourney|PostRestartReapplyMigrations)|TestMultiNode_ChangeTokenization_|TestMultiNode_BackToBackChangeTokenization|TestLiveQueriesDuringChangeTokenization|TestPartialResultsDuringChangeTokenization' \
+  AOF_GROUP_SKIP='TestMultiNode_ChangeTokenization_AJ_|TestMultiNode_RestartMatrix|TestMultiNode_(Rolling|Graceful|Crash|MajorityCrash|UngracefulStop|PostRestartMigration)|TestMultiNode_(HappyPath|QueryConsistencyDuringReindex|ConcurrentDifferentMigrations|EnableRangeable_NoPartialCountsInFlight|RepeatedParallelMigrationJourney|PostRestartReapplyMigrations)|TestMultiNode_ChangeTokenization_|TestMultiNode_BackToBackChangeTokenization|TestLiveQueriesDuringChangeTokenization|TestPartialResultsDuringChangeTokenization' \
     run_aof_group "reindex-multinode" test/acceptance/reindex_multinode
 }
 
@@ -748,7 +748,7 @@ function run_acceptance_reindex_multinode_scale() {
   # test in the whole package (PostRestartReapplyMigrations_ExactCounts
   # AcrossReplicas, 135s) lives here so it's amortised against the
   # smaller orchestration tests.
-  AOF_GROUP_RUN='TestMultiNode_(HappyPath|ConcurrentDifferentMigrations|EnableRangeable_NoPartialCountsInFlight|RepeatedParallelMigrationJourney|PostRestartReapplyMigrations)' \
+  AOF_GROUP_RUN='TestMultiNode_(HappyPath|QueryConsistencyDuringReindex|ConcurrentDifferentMigrations|EnableRangeable_NoPartialCountsInFlight|RepeatedParallelMigrationJourney|PostRestartReapplyMigrations)' \
     run_aof_group "reindex-multinode-scale" test/acceptance/reindex_multinode
 }
 


### PR DESCRIPTION
SuperClaude here.

Implements the verb-set proposed and approved on [weaviate/0-weaviate-issues#227](https://github.com/weaviate/0-weaviate-issues/issues/227): `rebuild:true` is now an *exact* rebuild that preserves tokenization + algorithm; algorithm transitions move under a new `algorithm` enum field.

## Verb matrix on `PUT /v1/schema/{className}/indexes/{propertyName}`

| body | meaning | applies when |
|---|---|---|
| `{"searchable":{"rebuild":true}}` | rebuild searchable from objects, preserves tokenization + algorithm | property is already `blockmax`; WAND ⇒ 400 with guidance to use `algorithm:"blockmax"` |
| `{"searchable":{"algorithm":"blockmax"}}` | switch BM25 algorithm to BlockMax (one-way; from WAND this is the Map → BlockMax migration) | property is currently WAND; already-BlockMax ⇒ 400 |
| `{"filterable":{"rebuild":true}}` | unchanged | unchanged |
| `{"rangeable":{"rebuild":true}}` | unchanged | unchanged |

Unsupported `algorithm` values (`"wand"`, anything else) get a clean 400 — WAND is deprecated; downgrade is intentionally not supported.

`validateBodyExclusivity` rejects `algorithm` combined with `rebuild`, `tokenization`, `enabled`, or `cancel` in the same group.

## Wire / API changes

- `openapi-specs/schema.json` — added `IndexUpdateSearchable.algorithm` enum `[blockmax]`; tightened `IndexUpdateSearchable.rebuild` description.
- `entities/models/index_update_searchable.go`, `adapters/handlers/rest/embedded_spec.go` — regenerated via `./tools/gen-code-from-swagger.sh`.

## Internal changes

- `ReindexTypeRebuildSearchable` migration type added.
- `RebuildSearchableStrategy` (objects → existing BlockMax bucket, no tokenization override, no schema-flag flip) + `NewRuntimeRebuildSearchableTask` constructor. Structurally close to `EnableSearchableStrategy` minus the bucket-create / overlay / flip steps.
- `MigrationDirPrefixRebuildSearchable` + `finalizeMigrationDir` recognition for the new prefix.
- Dispatch in `handlers_indexes.go` gates `Rebuild` on `class.InvertedIndexConfig.UsingBlockMaxWAND`; routes `Algorithm` to `ReindexTypeRepairSearchable` (the Map→BlockMax migration).
- Side-effect surfacing (`TargetAlgorithm` in GET /indexes) only fires for `RepairSearchable` (algorithm change), not for `RebuildSearchable` (same algorithm).

## Test changes

- `handlers_indexes_gaps_test.go` — added 4 cases to `TestValidateBodyExclusivity` covering the `algorithm` verb (alone, with rebuild, with tokenization, with enabled).
- All existing acceptance tests that used `searchable.rebuild` to trigger Map → BlockMax migrated to `searchable.algorithm:"blockmax"`: 18 sites across `test/acceptance/reindex_{mt,multinode,singlenode}/`.

## Verification

- `go build ./...` — clean.
- `go test -count 1 -race ./adapters/repos/db/ ./adapters/handlers/rest/` — green.
- `golangci-lint run --timeout 5m ./adapters/repos/db/ ./adapters/handlers/rest/ ./test/acceptance/...` — 0 issues.
- Per-package acceptance compile (`go test -c`) — green for all 4 `reindex_*` packages.

— SuperClaude