### PR TITLE
perf(hnsw): drop per-batch fsync from commit log Flush() — #199 regression

### DIFF
--- a/adapters/repos/db/vector/hnsw/commit_logger.go
+++ b/adapters/repos/db/vector/hnsw/commit_logger.go
@@ -596,8 +596,12 @@ func (l *hnswCommitLogger) Flush() error {
 	l.Lock()
 	defer l.Unlock()
 
-	if err := l.currentWriter.Flush(); err != nil {
-		return errors.Wrap(err, "flush commit log buffer")
-	}
-	return l.currentFile.Sync()
+	// Buffered writer flush is sufficient here: the OS page cache absorbs the
+	// bytes and the per-batch durability the fsync used to provide isn't
+	// load-bearing for HNSW (the index is rebuilt from the object store on
+	// any unclean shutdown). The fsync is retained on `switchCommitLogs`
+	// (file rotation) and on backup/snapshot paths. Per-batch fsync was the
+	// dominant contributor to the ~15-30% import time regression on slow
+	// disks observed in weaviate/0-weaviate-issues#199.
+	return l.currentWriter.Flush()
 }


### PR DESCRIPTION
## Why

Per [weaviate/0-weaviate-issues#199](https://github.com/weaviate/0-weaviate-issues/issues/199) — closed, but the regression persists on `hnsw-compact-v2`.

Empirical on a slow GCP Standard PD (150 GB), `dbpedia-100k-openai-ada002` ingest, single shard, `--maxConnections 32 --bq`:

| build | Total load time |
|---|---|
| `origin/main` (dc99bd6598) | **38.4s** / 40.3s |
| `origin/hnsw-compact-v2` (f84ccb9cf5) | **49.4s** / 54.1s |
| this PR | **41.1s** ← closes 8.3 of 11 s; residual within main run-variance |

## Root cause

`hnswCommitLogger.Flush()` at `adapters/repos/db/vector/hnsw/commit_logger.go:602` was calling `l.currentFile.Sync()` (= `fsync(2)`) on every invocation. `Flush()` is the per-batch durability hook on the import hot path:

```
shard_write_batch_objects.go:84  batcher.flushWALs(ctx)
shard_write_batch_objects.go:484   queue.Flush()
vector_index_queue.go:270           iq.vectorIndex.Flush()
index.go:784                         h.commitLog.Flush()
commit_logger.go:602                  l.currentFile.Sync()  ← per-batch fsync
```

100k objects / 1000-object batches = 100 calls. At ~80 ms/fsync on this disk, that's ~8 s of stall — exactly what the measurement shows.

The fsync was added in commit `4973b6ddf3e` ("quick n dirty integration"). It is **retained** on `switchCommitLogs()` (file rotation, line 523) and on the backup/snapshot paths, where durability is actually required.

## Why removing per-batch fsync is safe

- `Flush()` here is called from `flushWALs` after the LSM **object store** has accepted the batch (and the LSM has its own durability story).
- On unclean shutdown, the HNSW index is rebuilt from the object store on the next startup — there is no operator-visible data loss path that depends on per-batch HNSW commit-log durability.
- `switchCommitLogs()` still fsyncs at file rotation, so file boundaries remain crash-consistent.

## Diagnostic chain

What the symptoms looked like and what was ruled out — all empirically:

1. CPU profile (pprof CPU): **identical** on main and branch (`findAndConnectNeighbors` 58% on both). → not on-CPU work.
2. fgprof (wallclock + I/O wait): branch has **+18 s** more goroutine-time blocked on mutex contention and **+5 s** more in `syscall.Syscall` over a 30 s window.
3. Mutex profile: branch has **3.2× more** contention on `putObjectLSM` (`shard_write_put.go:301`). `shard_write_put.go` is functionally identical between branches.
4. Ruled out: bufio buffer size (already 32 K on both); per-field `WALWriter.Write*` API calls (batched all of them, no effect); `compactor.RunCycle` disabled entirely (no effect).
5. fsync drains the shared block-device I/O queue while the HNSW commit log file is fsync'd, stalling the concurrent LSM bucket writes that batches issue in parallel — explains the mutex contention symptom, identical CPU profiles, and why none of the other patches helped.

## Test plan

- [x] Local benchmark on slow GCP PD: 49.4 s → 41.1 s (this commit)
- [ ] CI green (this PR — draft for that signal)
- [ ] No new failures in `hnsw_acceptance`, `recovery`, or `backup` shards
- [ ] Sanity recheck on John's `trengr-slow-disk` machine post-CI

Draft because (a) I want CI to surface anything I haven't thought of (especially recovery/backup interactions), and (b) the parent PR is itself unmerged.
