### PR TITLE
Namespaces error stripping

### DIFF
--- a/adapters/handlers/grpc/v1/batch/handler.go
+++ b/adapters/handlers/grpc/v1/batch/handler.go
@@ -50,12 +50,13 @@ func NewHandler(authorizer authorization.Authorizer, batchManager *objects.Batch
 	}
 }
 
-func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest) (*pb.BatchObjectsReply, error) {
+func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest) (reply *pb.BatchObjectsReply, retErr error) {
 	before := time.Now()
 	principal, err := h.authenticator.PrincipalFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 	ctx = classcache.ContextWithClassCache(ctx)
 
@@ -100,7 +101,7 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 
 	var objErrors []*pb.BatchObjectsReply_BatchError
 	for i, err := range objectParsingErrors {
-		objErrors = append(objErrors, &pb.BatchObjectsReply_BatchError{Index: int32(i), Error: err.Error()})
+		objErrors = append(objErrors, &pb.BatchObjectsReply_BatchError{Index: int32(i), Error: namespacing.StripErrorMessage(principal, err.Error())})
 	}
 
 	// If every object failed to parse, return early with the errors
@@ -121,7 +122,7 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 
 	for i, obj := range response {
 		if obj.Err != nil {
-			objErrors = append(objErrors, &pb.BatchObjectsReply_BatchError{Index: int32(objOriginalIndex[i]), Error: obj.Err.Error()})
+			objErrors = append(objErrors, &pb.BatchObjectsReply_BatchError{Index: int32(objOriginalIndex[i]), Error: namespacing.StripErrorMessage(principal, obj.Err.Error())})
 		}
 	}
 
@@ -132,12 +133,13 @@ func (h *Handler) BatchObjects(ctx context.Context, req *pb.BatchObjectsRequest)
 	return result, nil
 }
 
-func (h *Handler) BatchReferences(ctx context.Context, req *pb.BatchReferencesRequest) (*pb.BatchReferencesReply, error) {
+func (h *Handler) BatchReferences(ctx context.Context, req *pb.BatchReferencesRequest) (reply *pb.BatchReferencesReply, retErr error) {
 	before := time.Now()
 	principal, err := h.authenticator.PrincipalFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 	replProps := extractReplicationProperties(req.ConsistencyLevel)
 
@@ -149,7 +151,7 @@ func (h *Handler) BatchReferences(ctx context.Context, req *pb.BatchReferencesRe
 	var refErrors []*pb.BatchReferencesReply_BatchError
 	for i, ref := range response {
 		if ref.Err != nil {
-			refErrors = append(refErrors, &pb.BatchReferencesReply_BatchError{Index: int32(i), Error: ref.Err.Error()})
+			refErrors = append(refErrors, &pb.BatchReferencesReply_BatchError{Index: int32(i), Error: namespacing.StripErrorMessage(principal, ref.Err.Error())})
 		}
 	}
 

--- a/adapters/handlers/grpc/v1/batch/stream.go
+++ b/adapters/handlers/grpc/v1/batch/stream.go
@@ -121,13 +121,14 @@ func NewStreamHandler(
 //  6. Teardown the stream (delete reporting queue, etc)
 //
 // The receiver and sender loops communicate through channels to handle errors and stream closure gracefully.
-func (h *StreamHandler) Handle(stream pb.Weaviate_BatchStreamServer) error {
+func (h *StreamHandler) Handle(stream pb.Weaviate_BatchStreamServer) (retErr error) {
 	streamCtx := stream.Context()
 	// Authenticate at the highest level
 	principal, err := h.authenticator.PrincipalFromContext(streamCtx)
 	if err != nil {
 		return fmt.Errorf("authenticate: %w", err)
 	}
+	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 
 	// If the server is shutting down, we reject new streams
 	// This prevents new streams from being added to the system while we are shutting down

--- a/adapters/handlers/grpc/v1/service.go
+++ b/adapters/handlers/grpc/v1/service.go
@@ -92,13 +92,14 @@ func (s *Service) Aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 	return result, errInner
 }
 
-func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.AggregateReply, error) {
+func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (reply *pb.AggregateReply, retErr error) {
 	before := time.Now()
 
 	principal, err := s.authenticator.PrincipalFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
 	if req.Collection, _, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {
@@ -124,7 +125,7 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 		s.classGetterWithAuthzFunc(ctx, principal, req.Tenant),
 		params,
 	)
-	reply, err := replier.Aggregate(res, params.GroupBy != nil)
+	reply, err = replier.Aggregate(res, params.GroupBy != nil)
 	if err != nil {
 		return nil, fmt.Errorf("prepare reply: %w", err)
 	}
@@ -133,13 +134,14 @@ func (s *Service) aggregate(ctx context.Context, req *pb.AggregateRequest) (*pb.
 	return reply, nil
 }
 
-func (s *Service) TenantsGet(ctx context.Context, req *pb.TenantsGetRequest) (*pb.TenantsGetReply, error) {
+func (s *Service) TenantsGet(ctx context.Context, req *pb.TenantsGetRequest) (reply *pb.TenantsGetReply, retErr error) {
 	before := time.Now()
 
 	principal, err := s.authenticator.PrincipalFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
 	retTenants, err := s.tenantsGet(ctx, principal, req)
@@ -167,12 +169,13 @@ func (s *Service) BatchDelete(ctx context.Context, req *pb.BatchDeleteRequest) (
 	return result, errInner
 }
 
-func (s *Service) batchDelete(ctx context.Context, req *pb.BatchDeleteRequest) (*pb.BatchDeleteReply, error) {
+func (s *Service) batchDelete(ctx context.Context, req *pb.BatchDeleteRequest) (reply *pb.BatchDeleteReply, retErr error) {
 	before := time.Now()
 	principal, err := s.authenticator.PrincipalFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
 	replicationProperties := extractReplicationProperties(req.ConsistencyLevel)
@@ -276,13 +279,14 @@ func (s *Service) Search(ctx context.Context, req *pb.SearchRequest) (*pb.Search
 	return result, errInner
 }
 
-func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (*pb.SearchReply, error) {
+func (s *Service) search(ctx context.Context, req *pb.SearchRequest) (reply *pb.SearchReply, retErr error) {
 	before := time.Now()
 
 	principal, err := s.authenticator.PrincipalFromContext(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("extract auth: %w", err)
 	}
+	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 	ctx = restCtx.AddPrincipalToContext(ctx, principal)
 
 	if req.Collection, _, err = namespacing.Resolve(principal, s.schemaManager, s.config.Namespaces.Enabled, req.Collection); err != nil {

--- a/adapters/handlers/mcp/create/objects_upsert.go
+++ b/adapters/handlers/mcp/create/objects_upsert.go
@@ -20,9 +20,10 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
-func (c *WeaviateCreator) UpsertObject(ctx context.Context, req mcp.CallToolRequest, args UpsertObjectArgs) (*UpsertObjectResp, error) {
+func (c *WeaviateCreator) UpsertObject(ctx context.Context, req mcp.CallToolRequest, args UpsertObjectArgs) (resp *UpsertObjectResp, retErr error) {
 	log := c.logger.WithFields(logrus.Fields{
 		"tool":       "weaviate-objects-upsert",
 		"collection": args.CollectionName,
@@ -47,6 +48,7 @@ func (c *WeaviateCreator) UpsertObject(ctx context.Context, req mcp.CallToolRequ
 	if _, err := c.Authorize(ctx, req, authorization.UPDATE); err != nil {
 		return nil, err
 	}
+	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 
 	// Validate that we have at least one object
 	if len(args.Objects) == 0 {
@@ -97,7 +99,7 @@ func (c *WeaviateCreator) UpsertObject(ctx context.Context, req mcp.CallToolRequ
 	for i, result := range batchResults {
 		if result.Err != nil {
 			results[i] = UpsertObjectResult{
-				Error: result.Err.Error(),
+				Error: namespacing.StripErrorMessage(principal, result.Err.Error()),
 			}
 		} else {
 			results[i] = UpsertObjectResult{

--- a/adapters/handlers/mcp/read/collections.go
+++ b/adapters/handlers/mcp/read/collections.go
@@ -22,12 +22,13 @@ import (
 	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
-func (r *WeaviateReader) GetCollectionConfig(ctx context.Context, req mcp.CallToolRequest, args GetCollectionConfigArgs) (*GetCollectionConfigResp, error) {
+func (r *WeaviateReader) GetCollectionConfig(ctx context.Context, req mcp.CallToolRequest, args GetCollectionConfigArgs) (resp *GetCollectionConfigResp, retErr error) {
 	// Authorize the request
 	principal, err := r.Authorize(ctx, req, authorization.READ)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 
 	// Resolve only the specific-name branch: the list-all branch returns
 	// whatever GetConsistentSchema (RBAC-filtered) yields, so there is no

--- a/adapters/handlers/mcp/read/tenants.go
+++ b/adapters/handlers/mcp/read/tenants.go
@@ -18,9 +18,10 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/sirupsen/logrus"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
-func (r *WeaviateReader) GetTenants(ctx context.Context, req mcp.CallToolRequest, args GetTenantsArgs) (*GetTenantsResp, error) {
+func (r *WeaviateReader) GetTenants(ctx context.Context, req mcp.CallToolRequest, args GetTenantsArgs) (resp *GetTenantsResp, retErr error) {
 	log := r.logger.WithFields(logrus.Fields{
 		"tool":       "weaviate-tenants-list",
 		"collection": args.CollectionName,
@@ -35,6 +36,7 @@ func (r *WeaviateReader) GetTenants(ctx context.Context, req mcp.CallToolRequest
 	if err != nil {
 		return nil, err
 	}
+	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 
 	tenants, err := r.schemaReader.GetConsistentTenants(ctx, principal, args.CollectionName, true, nil)
 	if err != nil {

--- a/adapters/handlers/mcp/search/hybrid.go
+++ b/adapters/handlers/mcp/search/hybrid.go
@@ -30,12 +30,13 @@ import (
 	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
-func (s *WeaviateSearcher) Hybrid(ctx context.Context, req mcp.CallToolRequest, args QueryHybridArgs) (*QueryHybridResp, error) {
+func (s *WeaviateSearcher) Hybrid(ctx context.Context, req mcp.CallToolRequest, args QueryHybridArgs) (resp *QueryHybridResp, retErr error) {
 	// Authorize the request: first check MCP-level permission, then collection-level data permission
 	principal, err := s.Authorize(ctx, req, authorization.READ)
 	if err != nil {
 		return nil, err
 	}
+	defer func() { retErr = namespacing.StripErrForPrincipal(principal, retErr) }()
 
 	resolved, _, err := namespacing.Resolve(principal, s.schemaManager, s.namespacesEnabled, args.CollectionName)
 	if err != nil {

--- a/adapters/handlers/rest/authz/handlers_authz.go
+++ b/adapters/handlers/rest/authz/handlers_authz.go
@@ -131,45 +131,45 @@ func (h *authZHandlers) createRole(params authz.CreateRoleParams, principal *mod
 	ctx := params.HTTPRequest.Context()
 
 	if *params.Body.Name == "" {
-		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("role name is required")))
+		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("role name is required")))
 	}
 
 	if err := validateRoleName(*params.Body.Name); err != nil {
-		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("role name is invalid")))
+		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("role name is invalid")))
 	}
 
 	if err := validatePermissions(true, params.Body.Permissions...); err != nil {
-		return authz.NewCreateRoleUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("role permissions are invalid: %w", err)))
+		return authz.NewCreateRoleUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("role permissions are invalid: %w", err)))
 	}
 
 	policies, err := conv.RolesToPolicies(params.Body)
 	if err != nil {
-		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("invalid role: %w", err)))
+		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("invalid role: %w", err)))
 	}
 
 	if slices.Contains(authorization.BuiltInRoles, *params.Body.Name) {
-		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("you cannot create role with the same name as built-in role %s", *params.Body.Name)))
+		return authz.NewCreateRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("you cannot create role with the same name as built-in role %s", *params.Body.Name)))
 	}
 
 	if err := h.validateNoQualifiedNamespaceInPolicies(policies[*params.Body.Name]); err != nil {
-		return authz.NewCreateRoleUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewCreateRoleUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.authorizeRoleScopes(ctx, principal, authorization.CREATE, policies[*params.Body.Name], *params.Body.Name); err != nil {
-		return authz.NewCreateRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewCreateRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	roles, err := h.controller.GetRoles(*params.Body.Name)
 	if err != nil {
-		return authz.NewCreateRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRoles: %w", err)))
+		return authz.NewCreateRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetRoles: %w", err)))
 	}
 
 	if len(roles) > 0 {
-		return authz.NewCreateRoleConflict().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("role with name %s already exists", *params.Body.Name)))
+		return authz.NewCreateRoleConflict().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("role with name %s already exists", *params.Body.Name)))
 	}
 
 	if err = h.controller.CreateRolesPermissions(policies); err != nil {
-		return authz.NewCreateRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewCreateRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	h.logger.WithFields(logrus.Fields{
@@ -187,11 +187,11 @@ func (h *authZHandlers) addPermissions(params authz.AddPermissionsParams, princi
 	ctx := params.HTTPRequest.Context()
 
 	if slices.Contains(authorization.BuiltInRoles, params.ID) {
-		return authz.NewAddPermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("you can not update built-in role %s", params.ID)))
+		return authz.NewAddPermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("you can not update built-in role %s", params.ID)))
 	}
 
 	if err := validatePermissions(false, params.Body.Permissions...); err != nil {
-		return authz.NewAddPermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("invalid permissions %w", err)))
+		return authz.NewAddPermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("invalid permissions %w", err)))
 	}
 
 	policies, err := conv.RolesToPolicies(&models.Role{
@@ -199,20 +199,20 @@ func (h *authZHandlers) addPermissions(params authz.AddPermissionsParams, princi
 		Permissions: params.Body.Permissions,
 	})
 	if err != nil {
-		return authz.NewAddPermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("invalid permissions %w", err)))
+		return authz.NewAddPermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("invalid permissions %w", err)))
 	}
 
 	if err := h.validateNoQualifiedNamespaceInPolicies(policies[params.ID]); err != nil {
-		return authz.NewAddPermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewAddPermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.authorizeRoleScopes(ctx, principal, authorization.UPDATE, policies[params.ID], params.ID); err != nil {
-		return authz.NewAddPermissionsForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewAddPermissionsForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	roles, err := h.controller.GetRoles(params.ID)
 	if err != nil {
-		return authz.NewAddPermissionsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRoles: %w", err)))
+		return authz.NewAddPermissionsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetRoles: %w", err)))
 	}
 
 	if len(roles) == 0 { // i.e. new role
@@ -220,7 +220,7 @@ func (h *authZHandlers) addPermissions(params authz.AddPermissionsParams, princi
 	}
 
 	if err := h.controller.UpdateRolesPermissions(policies); err != nil {
-		return authz.NewAddPermissionsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewAddPermissionsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	h.logger.WithFields(logrus.Fields{
@@ -241,16 +241,16 @@ func (h *authZHandlers) removePermissions(params authz.RemovePermissionsParams, 
 	// in case of the permissions gets removed after the entity got removed
 	// delete class ABC, then remove permissions on class ABC
 	if err := validatePermissions(false, params.Body.Permissions...); err != nil {
-		return authz.NewRemovePermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("invalid permissions %w", err)))
+		return authz.NewRemovePermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("invalid permissions %w", err)))
 	}
 
 	if slices.Contains(authorization.BuiltInRoles, params.ID) {
-		return authz.NewRemovePermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("you cannot update built-in role %s", params.ID)))
+		return authz.NewRemovePermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("you cannot update built-in role %s", params.ID)))
 	}
 
 	permissions, err := conv.PermissionToPolicies(params.Body.Permissions...)
 	if err != nil {
-		return authz.NewRemovePermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("invalid permissions %w", err)))
+		return authz.NewRemovePermissionsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("invalid permissions %w", err)))
 	}
 	// TODO-RBAC PermissionToPolicies has to be []Policy{} not slice of pointers
 	policies := map[string][]authorization.Policy{
@@ -261,12 +261,12 @@ func (h *authZHandlers) removePermissions(params authz.RemovePermissionsParams, 
 	}
 
 	if err := h.authorizeRoleScopes(ctx, principal, authorization.UPDATE, policies[params.ID], params.ID); err != nil {
-		return authz.NewRemovePermissionsForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewRemovePermissionsForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	role, err := h.controller.GetRoles(params.ID)
 	if err != nil {
-		return authz.NewRemovePermissionsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRoles: %w", err)))
+		return authz.NewRemovePermissionsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetRoles: %w", err)))
 	}
 
 	if len(role) == 0 {
@@ -274,7 +274,7 @@ func (h *authZHandlers) removePermissions(params authz.RemovePermissionsParams, 
 	}
 
 	if err := h.controller.RemovePermissions(params.ID, permissions); err != nil {
-		return authz.NewRemovePermissionsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("RemovePermissions: %w", err)))
+		return authz.NewRemovePermissionsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("RemovePermissions: %w", err)))
 	}
 
 	h.logger.WithFields(logrus.Fields{
@@ -292,28 +292,28 @@ func (h *authZHandlers) hasPermission(params authz.HasPermissionParams, principa
 	ctx := params.HTTPRequest.Context()
 
 	if params.Body == nil {
-		return authz.NewHasPermissionBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("permission is required")))
+		return authz.NewHasPermissionBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("permission is required")))
 	}
 
 	if err := validatePermissions(false, params.Body); err != nil {
-		return authz.NewHasPermissionBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("invalid permissions %w", err)))
+		return authz.NewHasPermissionBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("invalid permissions %w", err)))
 	}
 
 	if err := h.authorizeRoleScopes(ctx, principal, authorization.READ, nil, params.ID); err != nil {
-		return authz.NewHasPermissionForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewHasPermissionForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	policy, err := conv.PermissionToPolicies(params.Body)
 	if err != nil {
-		return authz.NewHasPermissionBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("invalid permissions %w", err)))
+		return authz.NewHasPermissionBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("invalid permissions %w", err)))
 	}
 	if len(policy) == 0 {
-		return authz.NewHasPermissionInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("unknown error occurred passing permission to policy")))
+		return authz.NewHasPermissionInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("unknown error occurred passing permission to policy")))
 	}
 
 	hasPermission, err := h.controller.HasPermission(params.ID, policy[0])
 	if err != nil {
-		return authz.NewHasPermissionInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("HasPermission: %w", err)))
+		return authz.NewHasPermissionInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("HasPermission: %w", err)))
 	}
 
 	return authz.NewHasPermissionOK().WithPayload(hasPermission)
@@ -323,7 +323,7 @@ func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.
 	ctx := params.HTTPRequest.Context()
 	roles, err := h.controller.GetRoles()
 	if err != nil {
-		return authz.NewGetRolesInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRoles: %w", err)))
+		return authz.NewGetRolesInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetRoles: %w", err)))
 	}
 
 	var response []*models.Role
@@ -334,7 +334,7 @@ func (h *authZHandlers) getRoles(params authz.GetRolesParams, principal *models.
 
 		perms, err := conv.PoliciesToPermission(policies...)
 		if err != nil {
-			return authz.NewGetRolesInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("PoliciesToPermission: %w", err)))
+			return authz.NewGetRolesInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("PoliciesToPermission: %w", err)))
 		}
 		response = append(response, &models.Role{
 			Name:        &roleName,
@@ -388,24 +388,24 @@ func (h *authZHandlers) getRole(params authz.GetRoleParams, principal *models.Pr
 	ctx := params.HTTPRequest.Context()
 
 	if err := h.authorizeRoleScopes(ctx, principal, authorization.READ, nil, params.ID); err != nil {
-		return authz.NewGetRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewGetRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	roles, err := h.controller.GetRoles(params.ID)
 	if err != nil {
-		return authz.NewGetRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRoles: %w", err)))
+		return authz.NewGetRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetRoles: %w", err)))
 	}
 	if len(roles) == 0 {
 		return authz.NewGetRoleNotFound()
 	}
 	if len(roles) != 1 {
 		err := fmt.Errorf("expected one role but got %d", len(roles))
-		return authz.NewGetRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRoles: %w", err)))
+		return authz.NewGetRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetRoles: %w", err)))
 	}
 
 	perms, err := conv.PoliciesToPermission(roles[params.ID]...)
 	if err != nil {
-		return authz.NewGetRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("PoliciesToPermission: %w", err)))
+		return authz.NewGetRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("PoliciesToPermission: %w", err)))
 	}
 
 	h.logger.WithFields(logrus.Fields{
@@ -425,7 +425,7 @@ func (h *authZHandlers) deleteRole(params authz.DeleteRoleParams, principal *mod
 	ctx := params.HTTPRequest.Context()
 
 	if slices.Contains(authorization.BuiltInRoles, params.ID) {
-		return authz.NewDeleteRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("you can not delete built-in role %s", params.ID)))
+		return authz.NewDeleteRoleBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("you can not delete built-in role %s", params.ID)))
 	}
 
 	roles, err := h.controller.GetRoles(params.ID)
@@ -440,11 +440,11 @@ func (h *authZHandlers) deleteRole(params authz.DeleteRoleParams, principal *mod
 	}
 
 	if err := h.authorizeRoleScopes(ctx, principal, authorization.DELETE, roles[params.ID], params.ID); err != nil {
-		return authz.NewDeleteRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewDeleteRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.controller.DeleteRoles(params.ID); err != nil {
-		return authz.NewDeleteRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("DeleteRoles: %w", err)))
+		return authz.NewDeleteRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("DeleteRoles: %w", err)))
 	}
 
 	h.logger.WithFields(logrus.Fields{
@@ -462,46 +462,46 @@ func (h *authZHandlers) assignRoleToUser(params authz.AssignRoleToUserParams, pr
 
 	for _, role := range params.Body.Roles {
 		if strings.TrimSpace(role) == "" {
-			return authz.NewAssignRoleToUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to assign is empty")))
+			return authz.NewAssignRoleToUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("one or more of the roles you want to assign is empty")))
 		}
 
 		if err := validateEnvVarRoles(role); err != nil {
-			return authz.NewAssignRoleToUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("assigning: %w", err)))
+			return authz.NewAssignRoleToUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("assigning: %w", err)))
 		}
 	}
 
 	if err := h.validateUserIDForNamespaces(params.ID); err != nil {
-		return authz.NewAssignRoleToUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewAssignRoleToUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if len(params.Body.Roles) == 0 {
-		return authz.NewAssignRoleToUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("roles can not be empty")))
+		return authz.NewAssignRoleToUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("roles can not be empty")))
 	}
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.USER_AND_GROUP_ASSIGN_AND_REVOKE, authorization.Users(params.ID)...); err != nil {
-		return authz.NewAssignRoleToUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewAssignRoleToUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	existedRoles, err := h.controller.GetRoles(params.Body.Roles...)
 	if err != nil {
-		return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRoles: %w", err)))
+		return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetRoles: %w", err)))
 	}
 
 	if len(existedRoles) != len(params.Body.Roles) {
-		return authz.NewAssignRoleToUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles requested doesn't exist")))
+		return authz.NewAssignRoleToUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("one or more of the roles requested doesn't exist")))
 	}
 
 	userTypes, err := h.getUserTypesAndValidateExistence(params.ID, authentication.AuthType(params.Body.UserType))
 	if err != nil {
-		return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user exists: %w", err)))
+		return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("user exists: %w", err)))
 	}
 	if userTypes == nil {
-		return authz.NewAssignRoleToUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("username to assign role to doesn't exist")))
+		return authz.NewAssignRoleToUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("username to assign role to doesn't exist")))
 	}
 
 	for _, userType := range userTypes {
 		if err := h.controller.AddRolesForUser(conv.UserNameWithTypeFromId(params.ID, userType), params.Body.Roles); err != nil {
-			return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("AddRolesForUser: %w", err)))
+			return authz.NewAssignRoleToUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("AddRolesForUser: %w", err)))
 		}
 	}
 
@@ -521,34 +521,34 @@ func (h *authZHandlers) assignRoleToGroup(params authz.AssignRoleToGroupParams, 
 
 	for _, role := range params.Body.Roles {
 		if strings.TrimSpace(role) == "" {
-			return authz.NewAssignRoleToGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to assign is empty")))
+			return authz.NewAssignRoleToGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("one or more of the roles you want to assign is empty")))
 		}
 
 		if err := validateEnvVarRoles(role); err != nil {
-			return authz.NewAssignRoleToGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("assigning: %w", err)))
+			return authz.NewAssignRoleToGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("assigning: %w", err)))
 		}
 	}
 
 	if len(params.Body.Roles) == 0 {
-		return authz.NewAssignRoleToGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("roles can not be empty")))
+		return authz.NewAssignRoleToGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("roles can not be empty")))
 	}
 
 	groupType, err := validateUserTypeInput(string(params.Body.GroupType))
 	if err != nil || groupType != authentication.AuthTypeOIDC {
-		return authz.NewAssignRoleToGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("unknown groupType: %v", params.Body.GroupType)))
+		return authz.NewAssignRoleToGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("unknown groupType: %v", params.Body.GroupType)))
 	}
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.USER_AND_GROUP_ASSIGN_AND_REVOKE, authorization.Groups(groupType, params.ID)...); err != nil {
-		return authz.NewAssignRoleToGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewAssignRoleToGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.validateRootGroup(params.ID); err != nil {
-		return authz.NewAssignRoleToGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("assigning: %w", err)))
+		return authz.NewAssignRoleToGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("assigning: %w", err)))
 	}
 
 	existedRoles, err := h.controller.GetRoles(params.Body.Roles...)
 	if err != nil {
-		return authz.NewAssignRoleToGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRoles: %w", err)))
+		return authz.NewAssignRoleToGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetRoles: %w", err)))
 	}
 
 	if len(existedRoles) != len(params.Body.Roles) && len(params.Body.Roles) > 0 {
@@ -556,7 +556,7 @@ func (h *authZHandlers) assignRoleToGroup(params authz.AssignRoleToGroupParams, 
 	}
 
 	if err := h.controller.AddRolesForUser(conv.PrefixGroupName(params.ID), params.Body.Roles); err != nil {
-		return authz.NewAssignRoleToGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("AddRolesForUser: %w", err)))
+		return authz.NewAssignRoleToGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("AddRolesForUser: %w", err)))
 	}
 
 	h.logger.WithFields(logrus.Fields{
@@ -578,13 +578,13 @@ func (h *authZHandlers) getRolesForUserDeprecated(params authz.GetRolesForUserDe
 
 	if !ownUser {
 		if err := h.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Users(params.ID)...); err != nil {
-			return authz.NewGetRolesForUserDeprecatedForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+			return authz.NewGetRolesForUserDeprecatedForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		}
 	}
 
 	exists, err := h.userExistsDeprecated(params.ID)
 	if err != nil {
-		return authz.NewGetRolesForUserDeprecatedInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user existence: %w", err)))
+		return authz.NewGetRolesForUserDeprecatedInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("user existence: %w", err)))
 	}
 	if !exists {
 		return authz.NewGetRolesForUserDeprecatedNotFound()
@@ -592,11 +592,11 @@ func (h *authZHandlers) getRolesForUserDeprecated(params authz.GetRolesForUserDe
 
 	existingRolesDB, err := h.controller.GetRolesForUserOrGroup(params.ID, authentication.AuthTypeDb, false)
 	if err != nil {
-		return authz.NewGetRolesForUserDeprecatedInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetUsersOrGroupsWithRoles: %w", err)))
+		return authz.NewGetRolesForUserDeprecatedInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetUsersOrGroupsWithRoles: %w", err)))
 	}
 	existingRolesOIDC, err := h.controller.GetRolesForUserOrGroup(params.ID, authentication.AuthTypeOIDC, false)
 	if err != nil {
-		return authz.NewGetRolesForUserDeprecatedInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetUsersOrGroupsWithRoles: %w", err)))
+		return authz.NewGetRolesForUserDeprecatedInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetUsersOrGroupsWithRoles: %w", err)))
 	}
 
 	var response []*models.Role
@@ -606,7 +606,7 @@ func (h *authZHandlers) getRolesForUserDeprecated(params authz.GetRolesForUserDe
 		for roleName, policies := range existing {
 			perms, err := conv.PoliciesToPermission(policies...)
 			if err != nil {
-				return authz.NewGetRolesForUserDeprecatedInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("PoliciesToPermission: %w", err)))
+				return authz.NewGetRolesForUserDeprecatedInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("PoliciesToPermission: %w", err)))
 			}
 
 			if !ownUser {
@@ -631,7 +631,7 @@ func (h *authZHandlers) getRolesForUserDeprecated(params authz.GetRolesForUserDe
 	}
 
 	if (len(existingRolesDB) != 0 || len(existingRolesOIDC) != 0) && len(response) == 0 {
-		return authz.NewGetRolesForUserDeprecatedForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(authErr))
+		return authz.NewGetRolesForUserDeprecatedForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, authErr))
 	}
 
 	sortByName(response)
@@ -650,14 +650,14 @@ func (h *authZHandlers) getRolesForUser(params authz.GetRolesForUserParams, prin
 	ctx := params.HTTPRequest.Context()
 
 	if err := h.validateUserIDForNamespaces(params.ID); err != nil {
-		return authz.NewGetRolesForUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewGetRolesForUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	ownUser := params.ID == principal.Username && params.UserType == string(principal.UserType)
 
 	if !ownUser {
 		if err := h.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Users(params.ID)...); err != nil {
-			return authz.NewGetRolesForUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+			return authz.NewGetRolesForUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -665,12 +665,12 @@ func (h *authZHandlers) getRolesForUser(params authz.GetRolesForUserParams, prin
 
 	userType, err := validateUserTypeInput(params.UserType)
 	if err != nil {
-		return authz.NewGetRolesForUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("unknown userType: %v", params.UserType)))
+		return authz.NewGetRolesForUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("unknown userType: %v", params.UserType)))
 	}
 
 	exists, err := h.userExists(params.ID, userType)
 	if err != nil {
-		return authz.NewGetRolesForUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user existence: %w", err)))
+		return authz.NewGetRolesForUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("user existence: %w", err)))
 	}
 	if !exists {
 		return authz.NewGetRolesForUserNotFound()
@@ -678,7 +678,7 @@ func (h *authZHandlers) getRolesForUser(params authz.GetRolesForUserParams, prin
 
 	existingRoles, err := h.controller.GetRolesForUserOrGroup(params.ID, userType, false)
 	if err != nil {
-		return authz.NewGetRolesForUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetUsersOrGroupsWithRoles: %w", err)))
+		return authz.NewGetRolesForUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetUsersOrGroupsWithRoles: %w", err)))
 	}
 
 	var roles []*models.Role
@@ -686,7 +686,7 @@ func (h *authZHandlers) getRolesForUser(params authz.GetRolesForUserParams, prin
 	for roleName, policies := range existingRoles {
 		perms, err := conv.PoliciesToPermission(policies...)
 		if err != nil {
-			return authz.NewGetRolesForUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("PoliciesToPermission: %w", err)))
+			return authz.NewGetRolesForUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("PoliciesToPermission: %w", err)))
 		}
 
 		role := &models.Role{Name: &roleName}
@@ -703,7 +703,7 @@ func (h *authZHandlers) getRolesForUser(params authz.GetRolesForUserParams, prin
 	}
 
 	if len(authErrs) > 0 {
-		return authz.NewGetRolesForUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.Join(authErrs...)))
+		return authz.NewGetRolesForUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.Join(authErrs...)))
 	}
 
 	sortByName(roles)
@@ -722,18 +722,18 @@ func (h *authZHandlers) getUsersForRole(params authz.GetUsersForRoleParams, prin
 	ctx := params.HTTPRequest.Context()
 
 	if err := validateEnvVarRoles(params.ID); err != nil && !slices.Contains(h.rbacconfig.RootUsers, principal.Username) {
-		return authz.NewGetUsersForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewGetUsersForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.authorizeRoleScopes(ctx, principal, authorization.READ, nil, params.ID); err != nil {
-		return authz.NewGetUsersForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewGetUsersForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	var response []*authz.GetUsersForRoleOKBodyItems0
 	for _, userType := range []authentication.AuthType{authentication.AuthTypeOIDC, authentication.AuthTypeDb} {
 		users, err := h.controller.GetUsersOrGroupForRole(params.ID, userType, false)
 		if err != nil {
-			return authz.NewGetUsersForRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetUsersOrGroupForRole: %w", err)))
+			return authz.NewGetUsersForRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetUsersOrGroupForRole: %w", err)))
 		}
 
 		filteredUsers := make([]string, 0, len(users))
@@ -755,7 +755,7 @@ func (h *authZHandlers) getUsersForRole(params authz.GetUsersForRoleParams, prin
 		} else {
 			dynamicUsers, err := h.controller.GetUsers(filteredUsers...)
 			if err != nil {
-				return authz.NewGetUsersForRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetUsers: %w", err)))
+				return authz.NewGetUsersForRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetUsers: %w", err)))
 			}
 			for _, userId := range filteredUsers {
 				if _, ok := dynamicUsers[userId]; ok {
@@ -783,16 +783,16 @@ func (h *authZHandlers) getGroupsForRole(params authz.GetGroupsForRoleParams, pr
 	ctx := params.HTTPRequest.Context()
 
 	if err := validateEnvVarRoles(params.ID); err != nil && !slices.Contains(h.rbacconfig.RootUsers, principal.Username) {
-		return authz.NewGetGroupsForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewGetGroupsForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.authorizeRoleScopes(ctx, principal, authorization.READ, nil, params.ID); err != nil {
-		return authz.NewGetGroupsForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewGetGroupsForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	users, err := h.controller.GetUsersOrGroupForRole(params.ID, authentication.AuthTypeOIDC, true)
 	if err != nil {
-		return authz.NewGetGroupsForRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetUsersOrGroupForRole: %w", err)))
+		return authz.NewGetGroupsForRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetUsersOrGroupForRole: %w", err)))
 	}
 
 	filteredUsers := make([]string, 0, len(users))
@@ -830,11 +830,11 @@ func (h *authZHandlers) getUsersForRoleDeprecated(params authz.GetUsersForRoleDe
 	ctx := params.HTTPRequest.Context()
 
 	if err := validateEnvVarRoles(params.ID); err != nil && !slices.Contains(h.rbacconfig.RootUsers, principal.Username) {
-		return authz.NewGetUsersForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewGetUsersForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.authorizeRoleScopes(ctx, principal, authorization.READ, nil, params.ID); err != nil {
-		return authz.NewGetUsersForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewGetUsersForRoleForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	foundUsers := map[string]struct{}{} // no duplicates
@@ -843,7 +843,7 @@ func (h *authZHandlers) getUsersForRoleDeprecated(params authz.GetUsersForRoleDe
 	for _, userType := range []authentication.AuthType{authentication.AuthTypeDb, authentication.AuthTypeOIDC} {
 		users, err := h.controller.GetUsersOrGroupForRole(params.ID, userType, false)
 		if err != nil {
-			return authz.NewGetUsersForRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetUsersOrGroupForRole: %w", err)))
+			return authz.NewGetUsersForRoleInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetUsersOrGroupForRole: %w", err)))
 		}
 
 		for _, userName := range users {
@@ -881,45 +881,45 @@ func (h *authZHandlers) revokeRoleFromUser(params authz.RevokeRoleFromUserParams
 
 	for _, role := range params.Body.Roles {
 		if strings.TrimSpace(role) == "" {
-			return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to revoke is empty")))
+			return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("one or more of the roles you want to revoke is empty")))
 		}
 
 		if err := validateEnvVarRoles(role); err != nil {
-			return authz.NewRevokeRoleFromUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("revoking: %w", err)))
+			return authz.NewRevokeRoleFromUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("revoking: %w", err)))
 		}
 	}
 
 	if err := h.validateUserIDForNamespaces(params.ID); err != nil {
-		return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if len(params.Body.Roles) == 0 {
-		return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("roles can not be empty")))
+		return authz.NewRevokeRoleFromUserBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("roles can not be empty")))
 	}
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.USER_AND_GROUP_ASSIGN_AND_REVOKE, authorization.Users(params.ID)...); err != nil {
-		return authz.NewRevokeRoleFromUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewRevokeRoleFromUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	existedRoles, err := h.controller.GetRoles(params.Body.Roles...)
 	if err != nil {
-		return authz.NewRevokeRoleFromUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRoles: %w", err)))
+		return authz.NewRevokeRoleFromUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetRoles: %w", err)))
 	}
 
 	if len(existedRoles) != len(params.Body.Roles) {
-		return authz.NewRevokeRoleFromUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the request roles doesn't exist")))
+		return authz.NewRevokeRoleFromUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("one or more of the request roles doesn't exist")))
 	}
 
 	userTypes, err := h.getUserTypesAndValidateExistence(params.ID, authentication.AuthType(params.Body.UserType))
 	if err != nil {
-		return authz.NewRevokeRoleFromUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user exists: %w", err)))
+		return authz.NewRevokeRoleFromUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("user exists: %w", err)))
 	}
 	if userTypes == nil {
-		return authz.NewRevokeRoleFromUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("username to revoke role from doesn't exist")))
+		return authz.NewRevokeRoleFromUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("username to revoke role from doesn't exist")))
 	}
 	for _, userType := range userTypes {
 		if err := h.controller.RevokeRolesForUser(conv.UserNameWithTypeFromId(params.ID, userType), params.Body.Roles...); err != nil {
-			return authz.NewRevokeRoleFromUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("AddRolesForUser: %w", err)))
+			return authz.NewRevokeRoleFromUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("AddRolesForUser: %w", err)))
 		}
 	}
 
@@ -938,34 +938,34 @@ func (h *authZHandlers) revokeRoleFromGroup(params authz.RevokeRoleFromGroupPara
 	ctx := params.HTTPRequest.Context()
 	for _, role := range params.Body.Roles {
 		if strings.TrimSpace(role) == "" {
-			return authz.NewRevokeRoleFromGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("one or more of the roles you want to revoke is empty")))
+			return authz.NewRevokeRoleFromGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("one or more of the roles you want to revoke is empty")))
 		}
 
 		if err := validateEnvVarRoles(role); err != nil {
-			return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("revoking: %w", err)))
+			return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("revoking: %w", err)))
 		}
 	}
 
 	if len(params.Body.Roles) == 0 {
-		return authz.NewRevokeRoleFromGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("roles can not be empty")))
+		return authz.NewRevokeRoleFromGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("roles can not be empty")))
 	}
 
 	groupType, err := validateUserTypeInput(string(params.Body.GroupType))
 	if err != nil || groupType != authentication.AuthTypeOIDC {
-		return authz.NewRevokeRoleFromGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("unknown groupType: %v", params.Body.GroupType)))
+		return authz.NewRevokeRoleFromGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("unknown groupType: %v", params.Body.GroupType)))
 	}
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.USER_AND_GROUP_ASSIGN_AND_REVOKE, authorization.Groups(groupType, params.ID)...); err != nil {
-		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.validateRootGroup(params.ID); err != nil {
-		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("revoking: %w", err)))
+		return authz.NewRevokeRoleFromGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("revoking: %w", err)))
 	}
 
 	existedRoles, err := h.controller.GetRoles(params.Body.Roles...)
 	if err != nil {
-		return authz.NewRevokeRoleFromGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRoles: %w", err)))
+		return authz.NewRevokeRoleFromGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetRoles: %w", err)))
 	}
 
 	if len(existedRoles) != len(params.Body.Roles) {
@@ -973,7 +973,7 @@ func (h *authZHandlers) revokeRoleFromGroup(params authz.RevokeRoleFromGroupPara
 	}
 
 	if err := h.controller.RevokeRolesForUser(conv.PrefixGroupName(params.ID), params.Body.Roles...); err != nil {
-		return authz.NewRevokeRoleFromGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("RevokeRolesForGroup: %w", err)))
+		return authz.NewRevokeRoleFromGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("RevokeRolesForGroup: %w", err)))
 	}
 
 	h.logger.WithFields(logrus.Fields{
@@ -991,7 +991,7 @@ func (h *authZHandlers) getGroups(params authz.GetGroupsParams, principal *model
 	ctx := params.HTTPRequest.Context()
 	groupType, err := validateUserTypeInput(params.GroupType)
 	if err != nil || groupType != authentication.AuthTypeOIDC {
-		return authz.NewGetGroupsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("unknown groupType: %v", params.GroupType)))
+		return authz.NewGetGroupsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("unknown groupType: %v", params.GroupType)))
 	}
 
 	groups, err := h.controller.GetUsersOrGroupsWithRoles(true, groupType)
@@ -1027,12 +1027,12 @@ func (h *authZHandlers) getRolesForGroup(params authz.GetRolesForGroupParams, pr
 
 	groupType, err := validateUserTypeInput(params.GroupType)
 	if err != nil || groupType != authentication.AuthTypeOIDC {
-		return authz.NewGetRolesForGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("unknown groupType: %v", params.GroupType)))
+		return authz.NewGetRolesForGroupBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("unknown groupType: %v", params.GroupType)))
 	}
 
 	if !ownGroup {
 		if err := h.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Groups(groupType, params.ID)...); err != nil {
-			return authz.NewGetRolesForGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+			return authz.NewGetRolesForGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -1040,7 +1040,7 @@ func (h *authZHandlers) getRolesForGroup(params authz.GetRolesForGroupParams, pr
 
 	existingRoles, err := h.controller.GetRolesForUserOrGroup(params.ID, groupType, true)
 	if err != nil {
-		return authz.NewGetRolesForGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("GetRolesForUserOrGroup: %w", err)))
+		return authz.NewGetRolesForGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("GetRolesForUserOrGroup: %w", err)))
 	}
 
 	var roles []*models.Role
@@ -1048,7 +1048,7 @@ func (h *authZHandlers) getRolesForGroup(params authz.GetRolesForGroupParams, pr
 	for roleName, policies := range existingRoles {
 		perms, err := conv.PoliciesToPermission(policies...)
 		if err != nil {
-			return authz.NewGetRolesForGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("PoliciesToPermission: %w", err)))
+			return authz.NewGetRolesForGroupInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("PoliciesToPermission: %w", err)))
 		}
 
 		role := &models.Role{Name: &roleName}
@@ -1065,7 +1065,7 @@ func (h *authZHandlers) getRolesForGroup(params authz.GetRolesForGroupParams, pr
 	}
 
 	if len(authErrs) > 0 {
-		return authz.NewGetRolesForGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.Join(authErrs...)))
+		return authz.NewGetRolesForGroupForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.Join(authErrs...)))
 	}
 
 	sortByName(roles)

--- a/adapters/handlers/rest/db_users/handlers_db_users.go
+++ b/adapters/handlers/rest/db_users/handlers_db_users.go
@@ -107,7 +107,7 @@ func (h *dynUserHandler) listUsers(params users.ListAllUsersParams, principal *m
 
 	allDbUsers, err := h.dbUsers.GetUsers()
 	if err != nil {
-		return users.NewListAllUsersInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewListAllUsersInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	allUsers := make([]*apikey.User, 0, len(allDbUsers))
@@ -151,7 +151,7 @@ func (h *dynUserHandler) listUsers(params users.ListAllUsersParams, principal *m
 		}
 		response, err = h.addToListAllResponse(response, dbUser.Id, string(models.UserTypeOutputDbUser), dbUser.Active, apiKeyFirstLetter, namespace, &dbUser.CreatedAt, &lastUsedTime)
 		if err != nil {
-			return users.NewListAllUsersInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+			return users.NewListAllUsersInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		}
 		if isRootUser {
 			allDynamicUsers[dbUser.Id] = struct{}{}
@@ -166,7 +166,7 @@ func (h *dynUserHandler) listUsers(params users.ListAllUsersParams, principal *m
 			}
 			response, err = h.addToListAllResponse(response, staticUser, string(models.UserTypeOutputDbEnvUser), true, "", "", nil, nil)
 			if err != nil {
-				return users.NewListAllUsersInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+				return users.NewListAllUsersInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 			}
 		}
 	}
@@ -208,11 +208,11 @@ func (h *dynUserHandler) getUser(params users.GetUserInfoParams, principal *mode
 	ctx := params.HTTPRequest.Context()
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Users(params.UserID)...); err != nil {
-		return users.NewGetUserInfoForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewGetUserInfoForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if !h.dbUserEnabled {
-		return users.NewGetUserInfoUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("db user management is not enabled")))
+		return users.NewGetUserInfoUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("db user management is not enabled")))
 	}
 
 	// also check for existing static users if request comes from root
@@ -223,7 +223,7 @@ func (h *dynUserHandler) getUser(params users.GetUserInfoParams, principal *mode
 
 	existingDbUsers, err := h.dbUsers.GetUsers(params.UserID)
 	if err != nil {
-		return users.NewGetUserInfoInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("checking user existence: %w", err)))
+		return users.NewGetUserInfoInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("checking user existence: %w", err)))
 	}
 	var userType string
 	if len(existingDbUsers) > 0 {
@@ -251,7 +251,7 @@ func (h *dynUserHandler) getUser(params users.GetUserInfoParams, principal *mode
 
 	existingRoles, err := h.dbUsers.GetRolesForUserOrGroup(params.UserID, authentication.AuthTypeDb, false)
 	if err != nil {
-		return users.NewGetUserInfoInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("get roles: %w", err)))
+		return users.NewGetUserInfoInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("get roles: %w", err)))
 	}
 
 	roles := make([]string, 0, len(existingRoles))
@@ -330,59 +330,59 @@ func (h *dynUserHandler) createUser(params users.CreateUserParams, principal *mo
 	ctx := params.HTTPRequest.Context()
 
 	if err := validateUserName(params.UserID); err != nil {
-		return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.Users(params.UserID)...); err != nil {
-		return users.NewCreateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewCreateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if !h.dbUserEnabled {
-		return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("db user management is not enabled")))
+		return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("db user management is not enabled")))
 	}
 
 	// Authorization of namespace-related concerns runs before any 422
 	// validation so an unauthorized caller always sees 403, never leaks
 	// shape-of-request hints via 422 responses.
 	if h.namespacesEnabled && !principal.IsGlobalOperator {
-		return users.NewCreateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("user management on namespace-enabled clusters is restricted to global operators")))
+		return users.NewCreateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("user management on namespace-enabled clusters is restricted to global operators")))
 	}
 
 	if params.Body.Namespace != "" && !principal.IsGlobalOperator {
-		return users.NewCreateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("only global operators may bind a user to a namespace")))
+		return users.NewCreateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("only global operators may bind a user to a namespace")))
 	}
 
 	if !h.namespacesEnabled && params.Body.Namespace != "" {
-		return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("namespace is not supported: namespaces are not enabled on this cluster")))
+		return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("namespace is not supported: namespaces are not enabled on this cluster")))
 	}
 
 	if h.namespacesEnabled {
 		if params.Body.Namespace == "" {
-			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("namespace is required on namespace-enabled clusters")))
+			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("namespace is required on namespace-enabled clusters")))
 		}
 		// Fast-path local check before the RAFT round-trip. The apply
 		// path re-validates against authoritative state and surfaces
 		// the same sentinels (mapped below), so the worst case for a
 		// stale local view is a redundant 422.
 		if !h.namespaces.Exists(params.Body.Namespace) {
-			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q does not exist", params.Body.Namespace)))
+			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q does not exist", params.Body.Namespace)))
 		}
 		if !h.namespaces.IsActive(params.Body.Namespace) {
-			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q is being deleted", params.Body.Namespace)))
+			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q is being deleted", params.Body.Namespace)))
 		}
 	}
 
 	if params.Body.Import != nil && *params.Body.Import && h.namespacesEnabled {
-		return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("import is not supported on namespace-enabled clusters")))
+		return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("import is not supported on namespace-enabled clusters")))
 	}
 
 	if params.Body.Import != nil && *params.Body.Import {
 		if !h.principalIsRootUser(principal.Username) {
-			return users.NewActivateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("only root users can import static api keys")))
+			return users.NewActivateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("only root users can import static api keys")))
 		}
 
 		if !h.staticUserExists(params.UserID) {
-			return users.NewCreateUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("static user %v does not exist", params.UserID)))
+			return users.NewCreateUserNotFound().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("static user %v does not exist", params.UserID)))
 		}
 
 		var apiKey string
@@ -398,7 +398,7 @@ func (h *dynUserHandler) createUser(params users.CreateUserParams, principal *mo
 		}
 
 		if err := h.dbUsers.CreateUserWithKey(ctx, params.UserID, apiKey[:3], sha256.Sum256([]byte(apiKey)), createdAt); err != nil {
-			return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("creating user: %w", err)))
+			return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("creating user: %w", err)))
 		}
 
 		return users.NewCreateUserCreated().WithPayload(&models.UserAPIKey{Apikey: &apiKey})
@@ -411,36 +411,36 @@ func (h *dynUserHandler) createUser(params users.CreateUserParams, principal *mo
 	internalKey := apikey.MakeUserKey(params.UserID, params.Body.Namespace)
 
 	if h.staticUserExists(internalKey) {
-		return users.NewCreateUserConflict().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user '%v' already exists", params.UserID)))
+		return users.NewCreateUserConflict().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("user '%v' already exists", params.UserID)))
 	}
 	if h.isRootUser(internalKey) {
-		return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("cannot create db user with root user name")))
+		return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("cannot create db user with root user name")))
 	}
 	if h.isAdminlistUser(internalKey) {
-		return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("cannot create db user with admin list name")))
+		return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("cannot create db user with admin list name")))
 	}
 
 	existingUser, err := h.dbUsers.GetUsers(internalKey)
 	if err != nil {
-		return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("checking user existence: %w", err)))
+		return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("checking user existence: %w", err)))
 	}
 
 	if len(existingUser) > 0 {
-		return users.NewCreateUserConflict().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user '%v' already exists", params.UserID)))
+		return users.NewCreateUserConflict().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("user '%v' already exists", params.UserID)))
 	}
 
 	apiKey, hash, userIdentifier, err := h.getApiKey()
 	if err != nil {
-		return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.dbUsers.CreateUser(ctx, internalKey, hash, userIdentifier, apiKey[:3], params.Body.Namespace, time.Now()); err != nil {
 		// Apply-time race: surface a deleted/deleting namespace as 422 so
 		// clients can retry against current state.
 		if errors.Is(err, namespaces.ErrNamespaceGone) || errors.Is(err, namespaces.ErrNamespaceDeleting) {
-			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("creating user: %w", err)))
+			return users.NewCreateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("creating user: %w", err)))
 		}
-		return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("creating user: %w", err)))
+		return users.NewCreateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("creating user: %w", err)))
 	}
 
 	return users.NewCreateUserCreated().WithPayload(&models.UserAPIKey{Apikey: &apiKey})
@@ -450,25 +450,25 @@ func (h *dynUserHandler) rotateKey(params users.RotateUserAPIKeyParams, principa
 	ctx := params.HTTPRequest.Context()
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Users(params.UserID)...); err != nil {
-		return users.NewRotateUserAPIKeyForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewRotateUserAPIKeyForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if !h.dbUserEnabled {
-		return users.NewRotateUserAPIKeyUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("db user management is not enabled")))
+		return users.NewRotateUserAPIKeyUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("db user management is not enabled")))
 	}
 
 	if h.namespacesEnabled && !principal.IsGlobalOperator {
-		return users.NewRotateUserAPIKeyForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("user management on namespace-enabled clusters is restricted to global operators")))
+		return users.NewRotateUserAPIKeyForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("user management on namespace-enabled clusters is restricted to global operators")))
 	}
 
 	existingUser, err := h.dbUsers.GetUsers(params.UserID)
 	if err != nil {
-		return users.NewRotateUserAPIKeyInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("checking user existence: %w", err)))
+		return users.NewRotateUserAPIKeyInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("checking user existence: %w", err)))
 	}
 
 	if len(existingUser) == 0 {
 		if h.staticUserExists(params.UserID) {
-			return users.NewRotateUserAPIKeyUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user '%v' is static user", params.UserID)))
+			return users.NewRotateUserAPIKeyUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("user '%v' is static user", params.UserID)))
 		}
 		return users.NewRotateUserAPIKeyNotFound()
 	}
@@ -477,11 +477,11 @@ func (h *dynUserHandler) rotateKey(params users.RotateUserAPIKeyParams, principa
 
 	apiKey, hash, newUserIdentifier, err := h.getApiKey()
 	if err != nil {
-		return users.NewRotateUserAPIKeyInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewRotateUserAPIKeyInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.dbUsers.RotateKey(ctx, params.UserID, apiKey[:3], hash, oldUserIdentifier, newUserIdentifier); err != nil {
-		return users.NewRotateUserAPIKeyInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("rotate key: %w", err)))
+		return users.NewRotateUserAPIKeyInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("rotate key: %w", err)))
 	}
 
 	return users.NewRotateUserAPIKeyOK().WithPayload(&models.UserAPIKey{Apikey: &apiKey})
@@ -518,37 +518,37 @@ func (h *dynUserHandler) deleteUser(params users.DeleteUserParams, principal *mo
 	ctx := params.HTTPRequest.Context()
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Users(params.UserID)...); err != nil {
-		return users.NewDeleteUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewDeleteUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if !h.dbUserEnabled {
-		return users.NewDeleteUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("db user management is not enabled")))
+		return users.NewDeleteUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("db user management is not enabled")))
 	}
 
 	if h.namespacesEnabled && !principal.IsGlobalOperator {
-		return users.NewDeleteUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("user management on namespace-enabled clusters is restricted to global operators")))
+		return users.NewDeleteUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("user management on namespace-enabled clusters is restricted to global operators")))
 	}
 
 	if params.UserID == principal.Username {
-		return users.NewDeleteUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("cannot delete its own user %q", params.UserID)))
+		return users.NewDeleteUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("cannot delete its own user %q", params.UserID)))
 	}
 
 	if h.isRootUser(params.UserID) {
-		return users.NewDeleteUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("cannot delete root user")))
+		return users.NewDeleteUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("cannot delete root user")))
 	}
 	existingUsers, err := h.dbUsers.GetUsers(params.UserID)
 	if err != nil {
-		return users.NewDeleteUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewDeleteUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 	if len(existingUsers) == 0 {
 		if h.staticUserExists(params.UserID) {
-			return users.NewDeleteUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user '%v' is static user", params.UserID)))
+			return users.NewDeleteUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("user '%v' is static user", params.UserID)))
 		}
 		return users.NewDeleteUserNotFound()
 	}
 	roles, err := h.dbUsers.GetRolesForUserOrGroup(params.UserID, authentication.AuthTypeDb, false)
 	if err != nil {
-		return users.NewDeleteUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewDeleteUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 	if len(roles) > 0 {
 		roleNames := make([]string, 0, len(roles))
@@ -556,12 +556,12 @@ func (h *dynUserHandler) deleteUser(params users.DeleteUserParams, principal *mo
 			roleNames = append(roleNames, name)
 		}
 		if err := h.dbUsers.RevokeRolesForUser(conv.UserNameWithTypeFromId(params.UserID, authentication.AuthTypeDb), roleNames...); err != nil {
-			return users.NewDeleteUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+			return users.NewDeleteUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		}
 	}
 
 	if err := h.dbUsers.DeleteUser(ctx, params.UserID); err != nil {
-		return users.NewDeleteUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewDeleteUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 	return users.NewDeleteUserNoContent()
 }
@@ -570,33 +570,33 @@ func (h *dynUserHandler) deactivateUser(params users.DeactivateUserParams, princ
 	ctx := params.HTTPRequest.Context()
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Users(params.UserID)...); err != nil {
-		return users.NewDeactivateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewDeactivateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if !h.dbUserEnabled {
-		return users.NewDeactivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("db user management is not enabled")))
+		return users.NewDeactivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("db user management is not enabled")))
 	}
 
 	if h.namespacesEnabled && !principal.IsGlobalOperator {
-		return users.NewDeactivateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("user management on namespace-enabled clusters is restricted to global operators")))
+		return users.NewDeactivateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("user management on namespace-enabled clusters is restricted to global operators")))
 	}
 
 	if params.UserID == principal.Username {
-		return users.NewDeactivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("cannot deactivate its own user %q", params.UserID)))
+		return users.NewDeactivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("cannot deactivate its own user %q", params.UserID)))
 	}
 
 	if h.isRootUser(params.UserID) {
-		return users.NewDeactivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("cannot deactivate root user")))
+		return users.NewDeactivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("cannot deactivate root user")))
 	}
 
 	existingUser, err := h.dbUsers.GetUsers(params.UserID)
 	if err != nil {
-		return users.NewDeactivateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("checking user existence: %w", err)))
+		return users.NewDeactivateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("checking user existence: %w", err)))
 	}
 
 	if len(existingUser) == 0 {
 		if h.staticUserExists(params.UserID) {
-			return users.NewDeactivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user '%v' is static user", params.UserID)))
+			return users.NewDeactivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("user '%v' is static user", params.UserID)))
 		}
 		return users.NewDeactivateUserNotFound()
 	}
@@ -611,7 +611,7 @@ func (h *dynUserHandler) deactivateUser(params users.DeactivateUserParams, princ
 	}
 
 	if err := h.dbUsers.DeactivateUser(ctx, params.UserID, revokeKey); err != nil {
-		return users.NewDeactivateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("deactivate user: %w", err)))
+		return users.NewDeactivateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("deactivate user: %w", err)))
 	}
 
 	return users.NewDeactivateUserOK()
@@ -620,29 +620,29 @@ func (h *dynUserHandler) deactivateUser(params users.DeactivateUserParams, princ
 func (h *dynUserHandler) activateUser(params users.ActivateUserParams, principal *models.Principal) middleware.Responder {
 	ctx := params.HTTPRequest.Context()
 	if err := h.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Users(params.UserID)...); err != nil {
-		return users.NewActivateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return users.NewActivateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if !h.dbUserEnabled {
-		return users.NewActivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("db user management is not enabled")))
+		return users.NewActivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("db user management is not enabled")))
 	}
 
 	if h.namespacesEnabled && !principal.IsGlobalOperator {
-		return users.NewActivateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("user management on namespace-enabled clusters is restricted to global operators")))
+		return users.NewActivateUserForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("user management on namespace-enabled clusters is restricted to global operators")))
 	}
 
 	if h.isRootUser(params.UserID) {
-		return users.NewActivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(errors.New("cannot activate root user")))
+		return users.NewActivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, errors.New("cannot activate root user")))
 	}
 
 	existingUser, err := h.dbUsers.GetUsers(params.UserID)
 	if err != nil {
-		return users.NewActivateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("checking user existence: %w", err)))
+		return users.NewActivateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("checking user existence: %w", err)))
 	}
 
 	if len(existingUser) == 0 {
 		if h.staticUserExists(params.UserID) {
-			return users.NewActivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("user '%v' is static user", params.UserID)))
+			return users.NewActivateUserUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("user '%v' is static user", params.UserID)))
 		}
 		return users.NewActivateUserNotFound()
 	}
@@ -652,7 +652,7 @@ func (h *dynUserHandler) activateUser(params users.ActivateUserParams, principal
 	}
 
 	if err := h.dbUsers.ActivateUser(ctx, params.UserID); err != nil {
-		return users.NewActivateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("activate user: %w", err)))
+		return users.NewActivateUserInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("activate user: %w", err)))
 	}
 
 	return users.NewActivateUserOK()

--- a/adapters/handlers/rest/errors/errors.go
+++ b/adapters/handlers/rest/errors/errors.go
@@ -12,15 +12,20 @@
 package errors
 
 import (
+	"fmt"
+
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 // ErrPayloadFromSingleErr builds a single-message ErrorResponse with the
 // principal's own namespace prefix stripped from err. Pass nil for global
-// callers to leave the message unchanged.
+// callers to leave the message unchanged. A nil err is tolerated and yields
+// fmt's standard "<nil>" rendering rather than panicking, since this helper
+// sits on dozens of REST error paths and a missed err-guard upstream should
+// not crash the handler.
 func ErrPayloadFromSingleErr(principal *models.Principal, err error) *models.ErrorResponse {
 	return &models.ErrorResponse{Error: []*models.ErrorResponseErrorItems0{{
-		Message: namespacing.StripErrorMessage(principal, err.Error()),
+		Message: namespacing.StripErrorMessage(principal, fmt.Sprintf("%v", err)),
 	}}}
 }

--- a/adapters/handlers/rest/errors/errors.go
+++ b/adapters/handlers/rest/errors/errors.go
@@ -12,13 +12,15 @@
 package errors
 
 import (
-	"fmt"
-
 	"github.com/weaviate/weaviate/entities/models"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
-func ErrPayloadFromSingleErr(err error) *models.ErrorResponse {
+// ErrPayloadFromSingleErr builds a single-message ErrorResponse with the
+// principal's own namespace prefix stripped from err. Pass nil for global
+// callers to leave the message unchanged.
+func ErrPayloadFromSingleErr(principal *models.Principal, err error) *models.ErrorResponse {
 	return &models.ErrorResponse{Error: []*models.ErrorResponseErrorItems0{{
-		Message: fmt.Sprintf("%s", err),
+		Message: namespacing.StripErrorMessage(principal, err.Error()),
 	}}}
 }

--- a/adapters/handlers/rest/errors/errors_test.go
+++ b/adapters/handlers/rest/errors/errors_test.go
@@ -1,0 +1,58 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package errors
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/weaviate/weaviate/entities/models"
+)
+
+func TestErrPayloadFromSingleErr(t *testing.T) {
+	nsPrincipal := &models.Principal{Namespace: "ns"}
+	tests := []struct {
+		name      string
+		principal *models.Principal
+		err       error
+		want      string
+	}{
+		{
+			name: "nil principal, nil err yields fmt's <nil> placeholder",
+			want: "<nil>",
+		},
+		{
+			name: "nil principal leaves message unchanged",
+			err:  errors.New("ns:Class not found"),
+			want: "ns:Class not found",
+		},
+		{
+			name:      "namespaced principal strips own prefix",
+			principal: nsPrincipal,
+			err:       errors.New("ns:Class not found"),
+			want:      "Class not found",
+		},
+		{
+			name:      "namespaced principal, nil err yields fmt's <nil> placeholder",
+			principal: nsPrincipal,
+			want:      "<nil>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ErrPayloadFromSingleErr(tt.principal, tt.err)
+			require.Len(t, got.Error, 1)
+			require.Equal(t, tt.want, got.Error[0].Message)
+		})
+	}
+}

--- a/adapters/handlers/rest/handlers_aliases.go
+++ b/adapters/handlers/rest/handlers_aliases.go
@@ -47,13 +47,13 @@ func (s *aliasesHandlers) getAliases(params schema.AliasesGetParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewAliasesGetForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, schemaUC.ErrValidation):
 			return schema.NewAliasesGetUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewAliasesGetInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -84,13 +84,13 @@ func (s *aliasesHandlers) getAlias(params schema.AliasesGetAliasParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewAliasesGetAliasForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, schemaUC.ErrValidation):
 			return schema.NewAliasesGetAliasUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewAliasesGetAliasInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -108,13 +108,13 @@ func (s *aliasesHandlers) addAlias(params schema.AliasesCreateParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewAliasesCreateForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, schemaUC.ErrValidation):
 			return schema.NewAliasesCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewAliasesCreateInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -135,13 +135,13 @@ func (s *aliasesHandlers) updateAlias(params schema.AliasesUpdateParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewAliasesUpdateForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, schemaUC.ErrValidation):
 			return schema.NewAliasesUpdateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewAliasesUpdateInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -160,13 +160,13 @@ func (s *aliasesHandlers) deleteAlias(params schema.AliasesDeleteParams, princip
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewAliasesDeleteForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, schemaUC.ErrValidation):
 			return schema.NewAliasesDeleteUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewAliasesDeleteInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 

--- a/adapters/handlers/rest/handlers_authn.go
+++ b/adapters/handlers/rest/handlers_authn.go
@@ -63,7 +63,7 @@ func (h *authNHandlers) getOwnInfo(_ users.GetOwnInfoParams, principal *models.P
 		for roleName, policies := range existingRoles {
 			perms, err := authzConv.PoliciesToPermission(policies...)
 			if err != nil {
-				return users.NewGetOwnInfoInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+				return users.NewGetOwnInfoInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 			}
 			roles = append(roles, &models.Role{
 				Name:        &roleName,

--- a/adapters/handlers/rest/handlers_backup.go
+++ b/adapters/handlers/rest/handlers_backup.go
@@ -109,7 +109,7 @@ func (s *backupHandlers) createBackup(params backups.BackupsCreateParams,
 	}
 	if params.Body.ID == baseBackupID {
 		return backups.NewBackupsCreateInternalServerError().
-			WithPayload(errPayloadFromSingleErr(fmt.Errorf("base backup cannot be the same as the new backup ID: %s", baseBackupID)))
+			WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("base backup cannot be the same as the new backup ID: %s", baseBackupID)))
 	}
 
 	meta, err := s.manager.Backup(params.HTTPRequest.Context(), principal, &ubak.BackupRequest{
@@ -127,13 +127,13 @@ func (s *backupHandlers) createBackup(params backups.BackupsCreateParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return backups.NewBackupsCreateForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &backup.ErrUnprocessable{}):
 			return backups.NewBackupsCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return backups.NewBackupsCreateInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -158,16 +158,16 @@ func (s *backupHandlers) createBackupStatus(params backups.BackupsCreateStatusPa
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return backups.NewBackupsCreateStatusForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &backup.ErrUnprocessable{}):
 			return backups.NewBackupsCreateStatusUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &backup.ErrNotFound{}):
 			return backups.NewBackupsCreateStatusNotFound().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return backups.NewBackupsCreateStatusInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -224,16 +224,16 @@ func (s *backupHandlers) restoreBackup(params backups.BackupsRestoreParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return backups.NewBackupsRestoreForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &backup.ErrNotFound{}):
 			return backups.NewBackupsRestoreNotFound().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &backup.ErrUnprocessable{}):
 			return backups.NewBackupsRestoreUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return backups.NewBackupsRestoreInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -259,16 +259,16 @@ func (s *backupHandlers) restoreBackupStatus(params backups.BackupsRestoreStatus
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return backups.NewBackupsRestoreForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &backup.ErrNotFound{}):
 			return backups.NewBackupsRestoreNotFound().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &backup.ErrUnprocessable{}):
 			return backups.NewBackupsRestoreUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return backups.NewBackupsRestoreInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 	strStatus := string(status.Status)
@@ -300,13 +300,13 @@ func (s *backupHandlers) cancel(params backups.BackupsCancelParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return backups.NewBackupsCancelForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &backup.ErrUnprocessable{}):
 			return backups.NewBackupsCancelUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return backups.NewBackupsCancelInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -331,13 +331,13 @@ func (s *backupHandlers) cancelRestore(params backups.BackupsRestoreCancelParams
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return backups.NewBackupsRestoreCancelForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &backup.ErrUnprocessable{}):
 			return backups.NewBackupsRestoreCancelUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return backups.NewBackupsRestoreCancelInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -356,14 +356,14 @@ func (s *backupHandlers) list(params backups.BackupsListParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return backups.NewBackupsRestoreForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 
 		case errors.As(err, &backup.ErrUnprocessable{}):
 			return backups.NewBackupsRestoreUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return backups.NewBackupsRestoreInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 

--- a/adapters/handlers/rest/handlers_batch_objects.go
+++ b/adapters/handlers/rest/handlers_batch_objects.go
@@ -43,7 +43,7 @@ func (h *batchObjectHandlers) addObjects(params batch.BatchObjectsCreateParams,
 	if err != nil {
 		h.metricRequestsTotal.logError("", err)
 		return batch.NewBatchObjectsCreateBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	objs, err := h.manager.AddObjects(ctx, principal,
@@ -57,16 +57,16 @@ func (h *batchObjectHandlers) addObjects(params batch.BatchObjectsCreateParams,
 		switch {
 		case errors.As(err, &autherrs.Forbidden{}):
 			return batch.NewBatchObjectsCreateForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &objects.ErrInvalidUserInput{}):
 			return batch.NewBatchObjectsCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &objects.ErrMultiTenancy{}):
 			return batch.NewBatchObjectsCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return batch.NewBatchObjectsCreateInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -81,7 +81,7 @@ func (h *batchObjectHandlers) objectsResponse(principal *models.Principal, input
 		var errorResponse *models.ErrorResponse
 		status := models.ObjectsGetResponseAO2ResultStatusSUCCESS
 		if object.Err != nil {
-			errorResponse = errPayloadFromSingleErr(object.Err)
+			errorResponse = errPayloadFromSingleErr(principal, object.Err)
 			status = models.ObjectsGetResponseAO2ResultStatusFAILED
 		}
 
@@ -107,7 +107,7 @@ func (h *batchObjectHandlers) addReferences(params batch.BatchReferencesCreatePa
 	if err != nil {
 		h.metricRequestsTotal.logError("", err)
 		return batch.NewBatchReferencesCreateBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	references, err := h.manager.AddReferences(ctx, principal, params.Body, repl)
@@ -116,25 +116,25 @@ func (h *batchObjectHandlers) addReferences(params batch.BatchReferencesCreatePa
 		switch {
 		case errors.As(err, &autherrs.Forbidden{}):
 			return batch.NewBatchReferencesCreateForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &objects.ErrInvalidUserInput{}):
 			return batch.NewBatchReferencesCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &objects.ErrMultiTenancy{}):
 			return batch.NewBatchReferencesCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return batch.NewBatchReferencesCreateInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
 	h.metricRequestsTotal.logOk("")
 	return batch.NewBatchReferencesCreateOK().
-		WithPayload(h.referencesResponse(references))
+		WithPayload(h.referencesResponse(principal, references))
 }
 
-func (h *batchObjectHandlers) referencesResponse(input objects.BatchReferences) []*models.BatchReferenceResponse {
+func (h *batchObjectHandlers) referencesResponse(principal *models.Principal, input objects.BatchReferences) []*models.BatchReferenceResponse {
 	response := make([]*models.BatchReferenceResponse, len(input))
 	for i, ref := range input {
 		var errorResponse *models.ErrorResponse
@@ -142,7 +142,7 @@ func (h *batchObjectHandlers) referencesResponse(input objects.BatchReferences) 
 
 		status := models.BatchReferenceResponseAO1ResultStatusSUCCESS
 		if ref.Err != nil {
-			errorResponse = errPayloadFromSingleErr(ref.Err)
+			errorResponse = errPayloadFromSingleErr(principal, ref.Err)
 			status = models.BatchReferenceResponseAO1ResultStatusFAILED
 		} else {
 			reference.From = strfmt.URI(ref.From.String())
@@ -169,7 +169,7 @@ func (h *batchObjectHandlers) deleteObjects(params batch.BatchObjectsDeleteParam
 	if err != nil {
 		h.metricRequestsTotal.logError("", err)
 		return batch.NewBatchObjectsDeleteBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	tenant := getTenant(params.Tenant)
@@ -180,16 +180,16 @@ func (h *batchObjectHandlers) deleteObjects(params batch.BatchObjectsDeleteParam
 		h.metricRequestsTotal.logError("", err)
 		if errors.As(err, &objects.ErrInvalidUserInput{}) {
 			return batch.NewBatchObjectsDeleteUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		} else if errors.As(err, &objects.ErrMultiTenancy{}) {
 			return batch.NewBatchObjectsDeleteUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		} else if errors.As(err, &autherrs.Forbidden{}) {
 			return batch.NewBatchObjectsDeleteForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		} else {
 			return batch.NewBatchObjectsDeleteInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -210,7 +210,7 @@ func (h *batchObjectHandlers) objectsDeleteResponse(principal *models.Principal,
 			status = models.BatchDeleteResponseResultsObjectsItems0StatusDRYRUN
 		} else if obj.Err != nil {
 			status = models.BatchDeleteResponseResultsObjectsItems0StatusFAILED
-			errorResponse = errPayloadFromSingleErr(obj.Err)
+			errorResponse = errPayloadFromSingleErr(principal, obj.Err)
 			failed += 1
 		} else {
 			successful += 1

--- a/adapters/handlers/rest/handlers_classification.go
+++ b/adapters/handlers/rest/handlers_classification.go
@@ -37,7 +37,7 @@ func setupClassificationHandlers(api *operations.WeaviateAPI,
 			if namespacesEnabled {
 				metricRequestsTotal.logUserError("")
 				return classifications.NewClassificationsGetGone().
-					WithPayload(errPayloadFromSingleErr(fmt.Errorf("classifications are not supported in the current cluster configuration")))
+					WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("classifications are not supported in the current cluster configuration")))
 			}
 			res, err := classifier.Get(params.HTTPRequest.Context(), principal, strfmt.UUID(params.ID))
 			if err != nil {
@@ -46,9 +46,9 @@ func setupClassificationHandlers(api *operations.WeaviateAPI,
 				switch {
 				case errors.As(err, &forbidden):
 					return classifications.NewClassificationsGetForbidden().
-						WithPayload(errPayloadFromSingleErr(err))
+						WithPayload(errPayloadFromSingleErr(principal, err))
 				default:
-					return classifications.NewClassificationsPostBadRequest().WithPayload(errPayloadFromSingleErr(err))
+					return classifications.NewClassificationsPostBadRequest().WithPayload(errPayloadFromSingleErr(principal, err))
 				}
 			}
 
@@ -67,7 +67,7 @@ func setupClassificationHandlers(api *operations.WeaviateAPI,
 			if namespacesEnabled {
 				metricRequestsTotal.logUserError("")
 				return classifications.NewClassificationsPostGone().
-					WithPayload(errPayloadFromSingleErr(fmt.Errorf("classifications are not supported in the current cluster configuration")))
+					WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("classifications are not supported in the current cluster configuration")))
 			}
 			res, err := classifier.Schedule(params.HTTPRequest.Context(), principal, *params.Params)
 			if err != nil {
@@ -77,9 +77,9 @@ func setupClassificationHandlers(api *operations.WeaviateAPI,
 				switch {
 				case errors.As(err, &forbidden):
 					return classifications.NewClassificationsPostForbidden().
-						WithPayload(errPayloadFromSingleErr(err))
+						WithPayload(errPayloadFromSingleErr(principal, err))
 				default:
-					return classifications.NewClassificationsPostBadRequest().WithPayload(errPayloadFromSingleErr(err))
+					return classifications.NewClassificationsPostBadRequest().WithPayload(errPayloadFromSingleErr(principal, err))
 				}
 			}
 

--- a/adapters/handlers/rest/handlers_distributed_tasks.go
+++ b/adapters/handlers/rest/handlers_distributed_tasks.go
@@ -45,7 +45,7 @@ func (h *distributedTasksHandlers) getTasks(params distributed_tasks.Distributed
 			return distributed_tasks.NewDistributedTasksGetForbidden()
 		}
 		return nodes.NewNodesGetClassInternalServerError().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	return distributed_tasks.NewDistributedTasksGetOK().WithPayload(tasks)

--- a/adapters/handlers/rest/handlers_export.go
+++ b/adapters/handlers/rest/handlers_export.go
@@ -36,7 +36,7 @@ func (h *exportHandlers) createExport(params export.ExportCreateParams,
 ) middleware.Responder {
 	if params.Body.ID == nil || *params.Body.ID == "" {
 		return export.NewExportCreateUnprocessableEntity().
-			WithPayload(errPayloadFromSingleErr(errors.New("export ID is required")))
+			WithPayload(errPayloadFromSingleErr(principal, errors.New("export ID is required")))
 	}
 
 	id := *params.Body.ID
@@ -51,20 +51,20 @@ func (h *exportHandlers) createExport(params export.ExportCreateParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return export.NewExportCreateForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, ucexport.ErrExportDisabled):
 			return export.NewExportCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, ucexport.ErrExportAlreadyExists),
 			errors.Is(err, ucexport.ErrExportAlreadyActive):
 			return export.NewExportCreateConflict().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, ucexport.ErrExportValidation):
 			return export.NewExportCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return export.NewExportCreateInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -83,19 +83,19 @@ func (h *exportHandlers) exportStatus(params export.ExportStatusParams,
 		switch {
 		case errors.Is(err, ucexport.ErrExportDisabled):
 			return export.NewExportStatusUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return export.NewExportStatusForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, ucexport.ErrExportNotFound):
 			return export.NewExportStatusNotFound().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, ucexport.ErrExportValidation):
 			return export.NewExportStatusUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return export.NewExportStatusInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -114,22 +114,22 @@ func (h *exportHandlers) cancelExport(params export.ExportCancelParams,
 		switch {
 		case errors.Is(err, ucexport.ErrExportDisabled):
 			return export.NewExportCancelUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return export.NewExportCancelForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, ucexport.ErrExportNotFound):
 			return export.NewExportCancelNotFound().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, ucexport.ErrExportValidation):
 			return export.NewExportCancelUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, ucexport.ErrExportAlreadyFinished):
 			return export.NewExportCancelConflict().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return export.NewExportCancelInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 

--- a/adapters/handlers/rest/handlers_graphql.go
+++ b/adapters/handlers/rest/handlers_graphql.go
@@ -62,7 +62,7 @@ func setupGraphQLHandlers(
 		if namespacesEnabled {
 			metricRequestsTotal.logUserError()
 			return graphql.NewGraphqlPostGone().
-				WithPayload(errPayloadFromSingleErr(fmt.Errorf("graphql api is not supported in the current cluster configuration")))
+				WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("graphql api is not supported in the current cluster configuration")))
 		}
 
 		// All requests to the graphQL API need at least permissions to read the schema. Request might have further
@@ -73,12 +73,12 @@ func setupGraphQLHandlers(
 			switch {
 			case errors.As(err, &authzerrors.Forbidden{}):
 				return graphql.NewGraphqlPostForbidden().
-					WithPayload(errPayloadFromSingleErr(
+					WithPayload(errPayloadFromSingleErr(principal,
 						fmt.Errorf("due to GraphQL introspection, this role must have the permission to `read_collections` on `*` (all) collections: %w", err),
 					))
 			default:
 				return graphql.NewGraphqlPostUnprocessableEntity().
-					WithPayload(errPayloadFromSingleErr(err))
+					WithPayload(errPayloadFromSingleErr(principal, err))
 			}
 		}
 
@@ -86,7 +86,7 @@ func setupGraphQLHandlers(
 			metricRequestsTotal.logUserError()
 			err := fmt.Errorf("graphql api is disabled")
 			return graphql.NewGraphqlPostUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 
 		errorResponse := &models.ErrorResponse{}
@@ -164,13 +164,13 @@ func setupGraphQLHandlers(
 		if namespacesEnabled {
 			metricRequestsTotal.logUserError()
 			return graphql.NewGraphqlBatchGone().
-				WithPayload(errPayloadFromSingleErr(fmt.Errorf("graphql api is not supported in the current cluster configuration")))
+				WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("graphql api is not supported in the current cluster configuration")))
 		}
 
 		// this is barely used (if at all) - so require read access to all collections for data and metadata
 		err := m.Authorizer.Authorize(params.HTTPRequest.Context(), principal, authorization.READ, authorization.Collections()...)
 		if err != nil {
-			return graphql.NewGraphqlBatchForbidden().WithPayload(errPayloadFromSingleErr(err))
+			return graphql.NewGraphqlBatchForbidden().WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 
 		errorResponse := &models.ErrorResponse{}
@@ -189,7 +189,7 @@ func setupGraphQLHandlers(
 		graphQL := gqlProvider.GetGraphQL()
 		if graphQL == nil {
 			metricRequestsTotal.logUserError()
-			errRes := errPayloadFromSingleErr(fmt.Errorf("no graphql provider present, " +
+			errRes := errPayloadFromSingleErr(principal, fmt.Errorf("no graphql provider present, "+
 				"this is most likely because no schema is present. Import a schema first"))
 			return graphql.NewGraphqlBatchUnprocessableEntity().WithPayload(errRes)
 		}

--- a/adapters/handlers/rest/handlers_indexes.go
+++ b/adapters/handlers/rest/handlers_indexes.go
@@ -33,6 +33,7 @@ import (
 	"github.com/weaviate/weaviate/entities/models"
 	"github.com/weaviate/weaviate/usecases/auth/authorization"
 	authzerrors "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
+	"github.com/weaviate/weaviate/usecases/schema/namespacing"
 )
 
 func setupIndexesHandlers(api *operations.WeaviateAPI, appState *state.State) {
@@ -72,9 +73,9 @@ func (h *indexesHandlers) getIndexes(params schema.SchemaObjectsIndexesGetParams
 	if err := h.appState.Authorizer.Authorize(params.HTTPRequest.Context(), principal,
 		authorization.READ, authorization.CollectionsMetadata(collection)...); err != nil {
 		if errors.As(err, &authzerrors.Forbidden{}) {
-			return schema.NewSchemaObjectsIndexesGetForbidden().WithPayload(errPayloadFromSingleErr(err))
+			return schema.NewSchemaObjectsIndexesGetForbidden().WithPayload(errPayloadFromSingleErr(principal, err))
 		}
-		return schema.NewSchemaObjectsIndexesGetInternalServerError().WithPayload(errPayloadFromSingleErr(err))
+		return schema.NewSchemaObjectsIndexesGetInternalServerError().WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	class := h.appState.SchemaManager.ReadOnlyClass(collection)
@@ -204,9 +205,9 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 	if err := h.appState.Authorizer.Authorize(params.HTTPRequest.Context(), principal,
 		authorization.UPDATE, authorization.Collections(collection)...); err != nil {
 		if errors.As(err, &authzerrors.Forbidden{}) {
-			return schema.NewSchemaObjectsIndexesUpdateForbidden().WithPayload(errPayloadFromSingleErr(err))
+			return schema.NewSchemaObjectsIndexesUpdateForbidden().WithPayload(errPayloadFromSingleErr(principal, err))
 		}
-		return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(errPayloadFromSingleErr(err))
+		return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	// Acquire the per-(collection, property) submit lock EARLY — before
@@ -256,13 +257,13 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 
 	body := params.Body
 	if body == nil {
-		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse("request body required"))
+		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal, "request body required"))
 	}
 
 	// Reject ambiguous bodies (multiple groups set, conflicting verbs within
 	// a group, or zero verbs) before the switch silently picks one arm.
 	if err := validateBodyExclusivity(body); err != nil {
-		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(err.Error()))
+		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal, err.Error()))
 	}
 
 	// Cancel is fundamentally different from the other actions: it does not
@@ -291,7 +292,7 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 		properties = []string{propertyName}
 		targetTok = body.Searchable.Tokenization
 		if err := validateEnableSearchableProperty(targetProp, targetTok); err != nil {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(err.Error()))
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal, err.Error()))
 		}
 
 	case body.Searchable != nil && body.Searchable.Tokenization != "":
@@ -308,14 +309,14 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 		// just see a 400 and the dialog hangs. Filterable-only properties
 		// should use {filterable: {tokenization: X}} instead.
 		if targetProp.IndexSearchable != nil && !*targetProp.IndexSearchable {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal,
 				fmt.Sprintf("property %q has no searchable index; use {\"filterable\":{\"tokenization\":...}} to retokenize the filterable bucket, or {\"searchable\":{\"enabled\":true,\"tokenization\":...}} to add a searchable index", propertyName)))
 		}
 
 		var err error
 		bucketStrategy, err = validateTokenizationChange(h.appState, class, collection, propertyName, targetTok)
 		if err != nil {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(err.Error()))
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal, err.Error()))
 		}
 
 	case body.Filterable != nil && body.Filterable.Tokenization != "":
@@ -332,14 +333,14 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 		targetTok = body.Filterable.Tokenization
 
 		if err := validateFilterableTokenizationChange(targetProp, targetTok); err != nil {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(err.Error()))
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal, err.Error()))
 		}
 
 	case body.Searchable != nil && body.Searchable.Rebuild:
 		migrationType = db.ReindexTypeRepairSearchable
 		properties = []string{propertyName}
 		if targetProp.IndexSearchable != nil && !*targetProp.IndexSearchable {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal,
 				fmt.Sprintf("property %q does not have a searchable index", propertyName)))
 		}
 
@@ -347,32 +348,32 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 		migrationType = db.ReindexTypeEnableFilterable
 		properties = []string{propertyName}
 		if err := validateEnableFilterableProperty(targetProp); err != nil {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(err.Error()))
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal, err.Error()))
 		}
 
 	case body.Filterable != nil && body.Filterable.Rebuild:
 		migrationType = db.ReindexTypeRepairFilterable
 		properties = []string{propertyName}
 		if targetProp.IndexFilterable != nil && !*targetProp.IndexFilterable {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal,
 				fmt.Sprintf("property %q does not have a filterable index", propertyName)))
 		}
 		if err := validateRebuildFilterableDataType(targetProp); err != nil {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(err.Error()))
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal, err.Error()))
 		}
 
 	case body.Rangeable != nil && body.Rangeable.Enabled:
 		migrationType = db.ReindexTypeEnableRangeable
 		properties = []string{propertyName}
 		if err := validateRangeableProperties(class, properties); err != nil {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(err.Error()))
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal, err.Error()))
 		}
 
 	case body.Rangeable != nil && body.Rangeable.Rebuild:
 		migrationType = db.ReindexTypeRepairRangeable
 		properties = []string{propertyName}
 		if err := validateRebuildRangeableProperty(targetProp); err != nil {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(err.Error()))
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal, err.Error()))
 		}
 
 	default:
@@ -381,10 +382,10 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 		// but the error says it's invalid") and was the symptom flagged on
 		// weaviate/0-weaviate-issues#227 (Gap 7). Order: per index-group,
 		// then alphabetical within group.
-		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(
-			"no actionable change detected; set one of: " +
-				"searchable.cancel, searchable.enabled, searchable.rebuild, searchable.tokenization, " +
-				"filterable.cancel, filterable.enabled, filterable.rebuild, filterable.tokenization, " +
+		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal,
+			"no actionable change detected; set one of: "+
+				"searchable.cancel, searchable.enabled, searchable.rebuild, searchable.tokenization, "+
+				"filterable.cancel, filterable.enabled, filterable.rebuild, filterable.tokenization, "+
 				"rangeable.cancel, rangeable.enabled, rangeable.rebuild"))
 	}
 
@@ -396,17 +397,17 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 	// Validate MT + tenants combination.
 	if !isMT && len(tenants) > 0 {
 		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(
-			errorResponse("tenants parameter is only valid for multi-tenant collections"))
+			errorResponse(principal, "tenants parameter is only valid for multi-tenant collections"))
 	}
 	if semantic && len(tenants) > 0 {
 		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(
-			errorResponse("tenants parameter cannot be used with semantic migrations (change-tokenization); all tenants must be targeted"))
+			errorResponse(principal, "tenants parameter cannot be used with semantic migrations (change-tokenization); all tenants must be targeted"))
 	}
 
 	// For MT collections with specific tenants, validate they exist and are not OFFLOADED/FROZEN.
 	if isMT && len(tenants) > 0 {
 		if err := validateTenants(h.appState.DB, params.HTTPRequest.Context(), collection, tenants); err != nil {
-			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(err.Error()))
+			return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal, err.Error()))
 		}
 	}
 
@@ -423,10 +424,10 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 	}
 	if err != nil {
 		return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(
-			errorResponse(fmt.Sprintf("getting shard ownership: %v", err)))
+			errorResponse(principal, fmt.Sprintf("getting shard ownership: %v", err)))
 	}
 	if len(shardOwnership) == 0 {
-		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse("collection has no shards"))
+		return schema.NewSchemaObjectsIndexesUpdateBadRequest().WithPayload(errorResponse(principal, "collection has no shards"))
 	}
 
 	unitIDs, unitToShard, unitToNode := buildUnitMaps(shardOwnership)
@@ -482,10 +483,10 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 				// prove the new submit doesn't conflict with it, so refuse
 				// rather than race. Return 503 so the caller knows to retry
 				// after an operator inspects the in-flight task.
-				return schema.NewSchemaObjectsIndexesUpdateServiceUnavailable().WithPayload(errorResponse(checkErr.Error()))
+				return schema.NewSchemaObjectsIndexesUpdateServiceUnavailable().WithPayload(errorResponse(principal, checkErr.Error()))
 			}
 			if reason != "" {
-				return schema.NewSchemaObjectsIndexesUpdateConflict().WithPayload(errorResponse(reason))
+				return schema.NewSchemaObjectsIndexesUpdateConflict().WithPayload(errorResponse(principal, reason))
 			}
 			// Per-collection cap on concurrent STARTED reindex tasks. Without
 			// this a caller scripting `for p in $(properties); do PUT
@@ -494,7 +495,7 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 			// on every replica. The LSM compaction layer and disk would not
 			// survive that. Reject with 429 once the cap is reached.
 			if inflight := countStartedTasksForCollection(collection, tasks[db.ReindexNamespace]); inflight >= maxConcurrentReindexPerCollection {
-				return schema.NewSchemaObjectsIndexesUpdateServiceUnavailable().WithPayload(errorResponse(fmt.Sprintf(
+				return schema.NewSchemaObjectsIndexesUpdateServiceUnavailable().WithPayload(errorResponse(principal, fmt.Sprintf(
 					"collection %q already has %d concurrent reindex tasks (max %d); wait for one to finish before submitting another",
 					collection, inflight, maxConcurrentReindexPerCollection)))
 			}
@@ -545,14 +546,14 @@ func (h *indexesHandlers) updateIndex(params schema.SchemaObjectsIndexesUpdatePa
 			ctx, db.ReindexNamespace, taskID, payload, unitSpecs, semantic,
 		); err != nil {
 			return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(
-				errorResponse(fmt.Sprintf("submitting task: %v", err)))
+				errorResponse(principal, fmt.Sprintf("submitting task: %v", err)))
 		}
 	} else {
 		if err := h.appState.ClusterService.AddDistributedTaskWithBarrier(
 			ctx, db.ReindexNamespace, taskID, payload, unitIDs, semantic,
 		); err != nil {
 			return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(
-				errorResponse(fmt.Sprintf("submitting task: %v", err)))
+				errorResponse(principal, fmt.Sprintf("submitting task: %v", err)))
 		}
 	}
 
@@ -611,13 +612,13 @@ func requestedCancel(body *models.IndexUpdateRequest) (string, bool) {
 // the worker goroutine returns.
 func (h *indexesHandlers) cancelReindexTask(ctx context.Context, collection, propertyName, indexType string, principal *models.Principal) middleware.Responder {
 	if h.appState.ClusterService == nil {
-		return schema.NewSchemaObjectsIndexesUpdateServiceUnavailable().WithPayload(errorResponse(
+		return schema.NewSchemaObjectsIndexesUpdateServiceUnavailable().WithPayload(errorResponse(principal,
 			"cluster service unavailable; cannot cancel reindex task"))
 	}
 
 	tasks, err := h.appState.ClusterService.ListDistributedTasks(ctx)
 	if err != nil {
-		return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(errorResponse(
+		return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(errorResponse(principal,
 			fmt.Sprintf("listing tasks: %v", err)))
 	}
 
@@ -651,7 +652,7 @@ func (h *indexesHandlers) cancelReindexTask(ctx context.Context, collection, pro
 	if err := h.appState.ClusterService.CancelDistributedTask(
 		ctx, target.Namespace, target.ID, target.Version,
 	); err != nil {
-		return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(errorResponse(
+		return schema.NewSchemaObjectsIndexesUpdateInternalServerError().WithPayload(errorResponse(principal,
 			fmt.Sprintf("cancelling task: %v", err)))
 	}
 
@@ -1176,10 +1177,10 @@ func isSyntheticStatus(s string) bool {
 	return false
 }
 
-func errorResponse(msg string) *models.ErrorResponse {
+func errorResponse(principal *models.Principal, msg string) *models.ErrorResponse {
 	return &models.ErrorResponse{
 		Error: []*models.ErrorResponseErrorItems0{
-			{Message: msg},
+			{Message: namespacing.StripErrorMessage(principal, msg)},
 		},
 	}
 }

--- a/adapters/handlers/rest/handlers_misc.go
+++ b/adapters/handlers/rest/handlers_misc.go
@@ -40,7 +40,7 @@ func setupMiscHandlers(api *operations.WeaviateAPI, serverConfig *config.Weaviat
 			metaInfos, err = modulesProvider.GetMeta()
 			if err != nil {
 				metricRequestsTotal.logError("", err)
-				return meta.NewMetaGetInternalServerError().WithPayload(errPayloadFromSingleErr(err))
+				return meta.NewMetaGetInternalServerError().WithPayload(errPayloadFromSingleErr(principal, err))
 			}
 		}
 
@@ -64,7 +64,7 @@ func setupMiscHandlers(api *operations.WeaviateAPI, serverConfig *config.Weaviat
 			target, err := url.JoinPath(serverConfig.Config.Authentication.OIDC.Issuer.Get(), "/.well-known/openid-configuration")
 			if err != nil {
 				metricRequestsTotal.logError("", err)
-				return well_known.NewGetWellKnownOpenidConfigurationInternalServerError().WithPayload(errPayloadFromSingleErr(err))
+				return well_known.NewGetWellKnownOpenidConfigurationInternalServerError().WithPayload(errPayloadFromSingleErr(principal, err))
 			}
 			clientID := serverConfig.Config.Authentication.OIDC.ClientID
 			scopes := serverConfig.Config.Authentication.OIDC.Scopes

--- a/adapters/handlers/rest/handlers_nodes.go
+++ b/adapters/handlers/rest/handlers_nodes.go
@@ -42,12 +42,12 @@ type nodesHandlers struct {
 func (n *nodesHandlers) getNodesStatus(params nodes.NodesGetParams, principal *models.Principal) middleware.Responder {
 	output, err := verbosity.ParseOutput(params.Output)
 	if err != nil {
-		return nodes.NewNodesGetUnprocessableEntity().WithPayload(errPayloadFromSingleErr(err))
+		return nodes.NewNodesGetUnprocessableEntity().WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, "", "", output)
 	if err != nil {
-		return n.handleGetNodesError(err)
+		return n.handleGetNodesError(principal, err)
 	}
 
 	status := &models.NodesStatusResponse{
@@ -61,7 +61,7 @@ func (n *nodesHandlers) getNodesStatus(params nodes.NodesGetParams, principal *m
 func (n *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, principal *models.Principal) middleware.Responder {
 	output, err := verbosity.ParseOutput(params.Output)
 	if err != nil {
-		return nodes.NewNodesGetUnprocessableEntity().WithPayload(errPayloadFromSingleErr(err))
+		return nodes.NewNodesGetUnprocessableEntity().WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	shardName := ""
@@ -71,12 +71,12 @@ func (n *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, 
 
 	className, _, err := namespacing.Resolve(principal, n.schemaManager, n.namespacesEnabled, params.ClassName)
 	if err != nil {
-		return nodes.NewNodesGetUnprocessableEntity().WithPayload(errPayloadFromSingleErr(err))
+		return nodes.NewNodesGetUnprocessableEntity().WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	nodeStatuses, err := n.manager.GetNodeStatus(params.HTTPRequest.Context(), principal, className, shardName, output)
 	if err != nil {
-		return n.handleGetNodesError(err)
+		return n.handleGetNodesError(principal, err)
 	}
 
 	status := &models.NodesStatusResponse{
@@ -90,7 +90,7 @@ func (n *nodesHandlers) getNodesStatusByClass(params nodes.NodesGetClassParams, 
 func (n *nodesHandlers) getNodesStatistics(params cluster.ClusterGetStatisticsParams, principal *models.Principal) middleware.Responder {
 	nodeStatistics, err := n.manager.GetNodeStatistics(params.HTTPRequest.Context(), principal)
 	if err != nil {
-		return n.handleGetNodesError(err)
+		return n.handleGetNodesError(principal, err)
 	}
 
 	synchronized := map[string]struct{}{}
@@ -113,22 +113,22 @@ func (n *nodesHandlers) getNodesStatistics(params cluster.ClusterGetStatisticsPa
 	return cluster.NewClusterGetStatisticsOK().WithPayload(statistics)
 }
 
-func (n *nodesHandlers) handleGetNodesError(err error) middleware.Responder {
+func (n *nodesHandlers) handleGetNodesError(principal *models.Principal, err error) middleware.Responder {
 	n.metricRequestsTotal.logError("", err)
 	if errors.As(err, &enterrors.ErrNotFound{}) {
 		return nodes.NewNodesGetClassNotFound().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 	if errors.As(err, &autherrs.Forbidden{}) {
 		return nodes.NewNodesGetClassForbidden().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 	if errors.As(err, &enterrors.ErrUnprocessable{}) {
 		return nodes.NewNodesGetClassUnprocessableEntity().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 	return nodes.NewNodesGetClassInternalServerError().
-		WithPayload(errPayloadFromSingleErr(err))
+		WithPayload(errPayloadFromSingleErr(principal, err))
 }
 
 func setupNodesHandlers(api *operations.WeaviateAPI,

--- a/adapters/handlers/rest/handlers_objects.go
+++ b/adapters/handlers/rest/handlers_objects.go
@@ -85,7 +85,7 @@ func (h *objectHandlers) addObject(params objects.ObjectsCreateParams,
 	if err != nil {
 		h.metricRequestsTotal.logError("", err)
 		return objects.NewObjectsCreateBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 	className := getClassName(params.Body)
 
@@ -99,16 +99,16 @@ func (h *objectHandlers) addObject(params objects.ObjectsCreateParams,
 		}
 		if errors.As(err, &uco.ErrInvalidUserInput{}) {
 			return objects.NewObjectsCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		} else if errors.As(err, &uco.ErrMultiTenancy{}) {
 			return objects.NewObjectsCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		} else if errors.As(err, &authzerrors.Forbidden{}) {
 			return objects.NewObjectsCreateForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		} else {
 			return objects.NewObjectsCreateInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -133,16 +133,16 @@ func (h *objectHandlers) validateObject(params objects.ObjectsValidateParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return objects.NewObjectsValidateForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &uco.ErrInvalidUserInput{}):
 			return objects.NewObjectsValidateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &uco.ErrMultiTenancy{}):
 			return objects.NewObjectsValidateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return objects.NewObjectsValidateInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -174,14 +174,14 @@ func (h *objectHandlers) getObject(params objects.ObjectsClassGetParams,
 		if err != nil {
 			h.metricRequestsTotal.logUserError(params.ClassName)
 			return objects.NewObjectsClassGetBadRequest().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 
 		additional, err = parseIncludeParam(params.Include, h.modulesProvider, true, class)
 		if err != nil {
 			h.metricRequestsTotal.logError(params.ClassName, err)
 			return objects.NewObjectsClassGetBadRequest().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -189,7 +189,7 @@ func (h *objectHandlers) getObject(params objects.ObjectsClassGetParams,
 	if err != nil {
 		h.metricRequestsTotal.logError(params.ClassName, err)
 		return objects.NewObjectsClassGetBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	tenant := getTenant(params.Tenant)
@@ -201,18 +201,18 @@ func (h *objectHandlers) getObject(params objects.ObjectsClassGetParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return objects.NewObjectsClassGetForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &uco.ErrNotFound{}):
 			return objects.NewObjectsClassGetNotFound()
 		case errors.As(err, &uco.ErrInvalidUserInput{}):
 			return objects.NewObjectsClassGetUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &uco.ErrMultiTenancy{}):
 			return objects.NewObjectsClassGetUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return objects.NewObjectsClassGetInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -237,7 +237,7 @@ func (h *objectHandlers) getObjects(params objects.ObjectsListParams,
 	if err != nil {
 		h.metricRequestsTotal.logError("", err)
 		return objects.NewObjectsListBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	var deprecationsRes []*models.Deprecation
@@ -250,16 +250,16 @@ func (h *objectHandlers) getObjects(params objects.ObjectsListParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return objects.NewObjectsListForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &uco.ErrMultiTenancy{}):
 			return objects.NewObjectsListUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &uco.ErrEndpointGone{}):
 			return objects.NewObjectsListGone().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return objects.NewObjectsListInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -288,7 +288,7 @@ func (h *objectHandlers) query(params objects.ObjectsListParams,
 	if err != nil {
 		h.metricRequestsTotal.logError(*params.Class, err)
 		return objects.NewObjectsListBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 	req := uco.QueryParams{
 		Class:      *params.Class,
@@ -306,18 +306,18 @@ func (h *objectHandlers) query(params objects.ObjectsListParams,
 		switch rerr.Code {
 		case uco.StatusForbidden:
 			return objects.NewObjectsListForbidden().
-				WithPayload(errPayloadFromSingleErr(rerr))
+				WithPayload(errPayloadFromSingleErr(principal, rerr))
 		case uco.StatusNotFound:
 			return objects.NewObjectsListNotFound()
 		case uco.StatusBadRequest:
 			return objects.NewObjectsListUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(rerr))
+				WithPayload(errPayloadFromSingleErr(principal, rerr))
 		case uco.StatusUnprocessableEntity:
 			return objects.NewObjectsListUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(rerr))
+				WithPayload(errPayloadFromSingleErr(principal, rerr))
 		default:
 			return objects.NewObjectsListInternalServerError().
-				WithPayload(errPayloadFromSingleErr(rerr))
+				WithPayload(errPayloadFromSingleErr(principal, rerr))
 		}
 	}
 
@@ -347,7 +347,7 @@ func (h *objectHandlers) deleteObject(params objects.ObjectsClassDeleteParams,
 	if err != nil {
 		h.metricRequestsTotal.logError(params.ClassName, err)
 		return objects.NewObjectsCreateBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	tenant := getTenant(params.Tenant)
@@ -359,15 +359,15 @@ func (h *objectHandlers) deleteObject(params objects.ObjectsClassDeleteParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return objects.NewObjectsClassDeleteForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.As(err, &uco.ErrNotFound{}):
 			return objects.NewObjectsClassDeleteNotFound()
 		case errors.As(err, &uco.ErrMultiTenancy{}):
 			return objects.NewObjectsClassDeleteUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return objects.NewObjectsClassDeleteInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -384,7 +384,7 @@ func (h *objectHandlers) updateObject(params objects.ObjectsClassPutParams,
 	if err != nil {
 		h.metricRequestsTotal.logError(className, err)
 		return objects.NewObjectsCreateBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	object, err := h.manager.UpdateObject(ctx,
@@ -397,16 +397,16 @@ func (h *objectHandlers) updateObject(params objects.ObjectsClassPutParams,
 		}
 		if errors.As(err, &uco.ErrInvalidUserInput{}) {
 			return objects.NewObjectsClassPutUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		} else if errors.As(err, &uco.ErrMultiTenancy{}) {
 			return objects.NewObjectsClassPutUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		} else if errors.As(err, &authzerrors.Forbidden{}) {
 			return objects.NewObjectsClassPutForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		} else {
 			return objects.NewObjectsClassPutInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -428,7 +428,7 @@ func (h *objectHandlers) headObject(params objects.ObjectsClassHeadParams,
 	if err != nil {
 		h.metricRequestsTotal.logError(params.ClassName, err)
 		return objects.NewObjectsCreateBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	tenant := getTenant(params.Tenant)
@@ -440,13 +440,13 @@ func (h *objectHandlers) headObject(params objects.ObjectsClassHeadParams,
 		switch {
 		case objErr.Forbidden():
 			return objects.NewObjectsClassHeadForbidden().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		case objErr.UnprocessableEntity():
 			return objects.NewObjectsClassHeadUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		default:
 			return objects.NewObjectsClassHeadInternalServerError().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		}
 	}
 
@@ -470,7 +470,7 @@ func (h *objectHandlers) patchObject(params objects.ObjectsClassPatchParams, pri
 	if err != nil {
 		h.metricRequestsTotal.logError(getClassName(updates), err)
 		return objects.NewObjectsCreateBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	objErr := h.manager.MergeObject(ctx, principal, updates, repl)
@@ -481,16 +481,16 @@ func (h *objectHandlers) patchObject(params objects.ObjectsClassPatchParams, pri
 			return objects.NewObjectsClassPatchNotFound()
 		case objErr.Forbidden():
 			return objects.NewObjectsClassPatchForbidden().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		case objErr.BadRequest():
 			return objects.NewObjectsClassPatchUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		case objErr.UnprocessableEntity():
 			return objects.NewObjectsClassPatchUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		default:
 			return objects.NewObjectsClassPatchInternalServerError().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		}
 	}
 
@@ -514,7 +514,7 @@ func (h *objectHandlers) addObjectReference(
 	if err != nil {
 		h.metricRequestsTotal.logError(params.ClassName, err)
 		return objects.NewObjectsCreateBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 	tenant := getTenant(params.Tenant)
 
@@ -524,18 +524,18 @@ func (h *objectHandlers) addObjectReference(
 		switch {
 		case objErr.Forbidden():
 			return objects.NewObjectsClassReferencesCreateForbidden().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		case objErr.NotFound():
 			return objects.NewObjectsClassReferencesCreateNotFound()
 		case objErr.BadRequest():
 			return objects.NewObjectsClassReferencesCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		case objErr.UnprocessableEntity():
 			return objects.NewObjectsClassReferencesCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		default:
 			return objects.NewObjectsClassReferencesCreateInternalServerError().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		}
 	}
 
@@ -558,7 +558,7 @@ func (h *objectHandlers) putObjectReferences(params objects.ObjectsClassReferenc
 	if err != nil {
 		h.metricRequestsTotal.logError(params.ClassName, err)
 		return objects.NewObjectsCreateBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	tenant := getTenant(params.Tenant)
@@ -569,18 +569,18 @@ func (h *objectHandlers) putObjectReferences(params objects.ObjectsClassReferenc
 		switch {
 		case objErr.Forbidden():
 			return objects.NewObjectsClassReferencesPutForbidden().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		case objErr.NotFound():
 			return objects.NewObjectsClassReferencesPutNotFound()
 		case objErr.BadRequest():
 			return objects.NewObjectsClassReferencesPutUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		case objErr.UnprocessableEntity():
 			return objects.NewObjectsClassReferencesPutUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		default:
 			return objects.NewObjectsClassReferencesPutInternalServerError().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		}
 	}
 
@@ -603,7 +603,7 @@ func (h *objectHandlers) deleteObjectReference(params objects.ObjectsClassRefere
 	if err != nil {
 		h.metricRequestsTotal.logError(params.ClassName, err)
 		return objects.NewObjectsCreateBadRequest().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 	tenant := getTenant(params.Tenant)
 
@@ -613,18 +613,18 @@ func (h *objectHandlers) deleteObjectReference(params objects.ObjectsClassRefere
 		switch objErr.Code {
 		case uco.StatusForbidden:
 			return objects.NewObjectsClassReferencesDeleteForbidden().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		case uco.StatusNotFound:
 			return objects.NewObjectsClassReferencesDeleteNotFound()
 		case uco.StatusBadRequest:
 			return objects.NewObjectsClassReferencesDeleteUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		case uco.StatusUnprocessableEntity:
 			return objects.NewObjectsClassReferencesDeleteUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		default:
 			return objects.NewObjectsClassReferencesDeleteInternalServerError().
-				WithPayload(errPayloadFromSingleErr(objErr))
+				WithPayload(errPayloadFromSingleErr(principal, objErr))
 		}
 	}
 
@@ -685,7 +685,7 @@ func (h *objectHandlers) getObjectDeprecated(params objects.ObjectsGetParams,
 	if h.config.Namespaces.Enabled {
 		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsGetGone().
-			WithPayload(errPayloadFromSingleErr(fmt.Errorf("getting an object without a class is not supported; use /objects/{className}/{id}")))
+			WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("getting an object without a class is not supported; use /objects/{className}/{id}")))
 	}
 	ps := objects.ObjectsClassGetParams{
 		HTTPRequest: params.HTTPRequest,
@@ -702,7 +702,7 @@ func (h *objectHandlers) headObjectDeprecated(params objects.ObjectsHeadParams,
 	if h.config.Namespaces.Enabled {
 		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsHeadGone().
-			WithPayload(errPayloadFromSingleErr(fmt.Errorf("checking an object without a class is not supported; use /objects/{className}/{id}")))
+			WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("checking an object without a class is not supported; use /objects/{className}/{id}")))
 	}
 	r := objects.ObjectsClassHeadParams{
 		HTTPRequest: params.HTTPRequest,
@@ -716,7 +716,7 @@ func (h *objectHandlers) patchObjectDeprecated(params objects.ObjectsPatchParams
 	if h.config.Namespaces.Enabled {
 		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsPatchGone().
-			WithPayload(errPayloadFromSingleErr(fmt.Errorf("patching an object without a class is not supported; use /objects/{className}/{id}")))
+			WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("patching an object without a class is not supported; use /objects/{className}/{id}")))
 	}
 	args := objects.ObjectsClassPatchParams{
 		HTTPRequest: params.HTTPRequest,
@@ -736,7 +736,7 @@ func (h *objectHandlers) updateObjectDeprecated(params objects.ObjectsUpdatePara
 	if h.config.Namespaces.Enabled {
 		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsUpdateGone().
-			WithPayload(errPayloadFromSingleErr(fmt.Errorf("updating an object without a class is not supported; use /objects/{className}/{id}")))
+			WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("updating an object without a class is not supported; use /objects/{className}/{id}")))
 	}
 	ps := objects.ObjectsClassPutParams{
 		HTTPRequest: params.HTTPRequest,
@@ -754,7 +754,7 @@ func (h *objectHandlers) deleteObjectDeprecated(params objects.ObjectsDeletePara
 	if h.config.Namespaces.Enabled {
 		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsDeleteGone().
-			WithPayload(errPayloadFromSingleErr(fmt.Errorf("deleting an object without a class is not supported; use /objects/{className}/{id}")))
+			WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("deleting an object without a class is not supported; use /objects/{className}/{id}")))
 	}
 	ps := objects.ObjectsClassDeleteParams{
 		HTTPRequest: params.HTTPRequest,
@@ -770,7 +770,7 @@ func (h *objectHandlers) addObjectReferenceDeprecated(params objects.ObjectsRefe
 	if h.config.Namespaces.Enabled {
 		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsReferencesCreateGone().
-			WithPayload(errPayloadFromSingleErr(fmt.Errorf("adding a reference without a class is not supported; use /objects/{className}/{id}/references/{propertyName}")))
+			WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("adding a reference without a class is not supported; use /objects/{className}/{id}/references/{propertyName}")))
 	}
 	req := objects.ObjectsClassReferencesCreateParams{
 		HTTPRequest:  params.HTTPRequest,
@@ -788,7 +788,7 @@ func (h *objectHandlers) updateObjectReferencesDeprecated(params objects.Objects
 	if h.config.Namespaces.Enabled {
 		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsReferencesUpdateGone().
-			WithPayload(errPayloadFromSingleErr(fmt.Errorf("replacing references without a class is not supported; use /objects/{className}/{id}/references/{propertyName}")))
+			WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("replacing references without a class is not supported; use /objects/{className}/{id}/references/{propertyName}")))
 	}
 	req := objects.ObjectsClassReferencesPutParams{
 		HTTPRequest:  params.HTTPRequest,
@@ -806,7 +806,7 @@ func (h *objectHandlers) deleteObjectReferenceDeprecated(params objects.ObjectsR
 	if h.config.Namespaces.Enabled {
 		h.metricRequestsTotal.logUserError("")
 		return objects.NewObjectsReferencesDeleteGone().
-			WithPayload(errPayloadFromSingleErr(fmt.Errorf("deleting a reference without a class is not supported; use /objects/{className}/{id}/references/{propertyName}")))
+			WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("deleting a reference without a class is not supported; use /objects/{className}/{id}/references/{propertyName}")))
 	}
 	req := objects.ObjectsClassReferencesDeleteParams{
 		HTTPRequest:  params.HTTPRequest,

--- a/adapters/handlers/rest/handlers_schema.go
+++ b/adapters/handlers/rest/handlers_schema.go
@@ -87,10 +87,10 @@ func (s *schemaHandlers) addClass(params schema.SchemaObjectsCreateParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsCreateForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewSchemaObjectsCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -113,10 +113,10 @@ func (s *schemaHandlers) updateClass(params schema.SchemaObjectsUpdateParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsUpdateForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewSchemaObjectsUpdateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -134,13 +134,13 @@ func (s *schemaHandlers) getClass(params schema.SchemaObjectsGetParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsGetForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, schemaUC.ErrValidation):
 			return schema.NewSchemaObjectsGetUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewSchemaObjectsGetInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -160,9 +160,9 @@ func (s *schemaHandlers) deleteClass(params schema.SchemaObjectsDeleteParams, pr
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsDeleteForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
-			return schema.NewSchemaObjectsDeleteBadRequest().WithPayload(errPayloadFromSingleErr(err))
+			return schema.NewSchemaObjectsDeleteBadRequest().WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -180,10 +180,10 @@ func (s *schemaHandlers) addClassProperty(params schema.SchemaObjectsPropertiesA
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsPropertiesAddForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewSchemaObjectsPropertiesAddUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -228,7 +228,7 @@ func (s *schemaHandlers) deleteClassPropertyIndex(params schema.SchemaObjectsPro
 	if conflict := s.checkReindexConflictForPropertyMutation(ctx, params.ClassName, params.PropertyName); conflict != "" {
 		s.metricRequestsTotal.logError(params.ClassName, fmt.Errorf("reindex conflict: %s", conflict))
 		return schema.NewSchemaObjectsPropertiesDeleteUnprocessableEntity().
-			WithPayload(errPayloadFromSingleErr(fmt.Errorf("%s", conflict)))
+			WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("%s", conflict)))
 	}
 
 	err := s.manager.DeleteClassPropertyIndex(ctx, principal, params.ClassName, params.PropertyName, params.IndexName)
@@ -237,10 +237,10 @@ func (s *schemaHandlers) deleteClassPropertyIndex(params schema.SchemaObjectsPro
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsPropertiesDeleteForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewSchemaObjectsPropertiesDeleteUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -330,16 +330,16 @@ func (s *schemaHandlers) deleteClassVectorIndex(params schema.SchemaObjectsVecto
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsVectorsDeleteForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, schemaUC.ErrNotFound):
 			return schema.NewSchemaObjectsVectorsDeleteUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		case errors.Is(err, schemaUC.ErrValidation):
 			return schema.NewSchemaObjectsVectorsDeleteUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewSchemaObjectsVectorsDeleteInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -354,9 +354,9 @@ func (s *schemaHandlers) getSchema(params schema.SchemaDumpParams, principal *mo
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaDumpForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
-			return schema.NewSchemaDumpForbidden().WithPayload(errPayloadFromSingleErr(err))
+			return schema.NewSchemaDumpForbidden().WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -392,10 +392,10 @@ func (s *schemaHandlers) getShardsStatus(params schema.SchemaObjectsShardsGetPar
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsShardsGetForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewSchemaObjectsShardsGetNotFound().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -416,10 +416,10 @@ func (s *schemaHandlers) updateShardStatus(params schema.SchemaObjectsShardsUpda
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewSchemaObjectsShardsGetForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewSchemaObjectsShardsUpdateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -444,10 +444,10 @@ func (s *schemaHandlers) createTenants(params schema.TenantsCreateParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewTenantsCreateForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewTenantsCreateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -466,10 +466,10 @@ func (s *schemaHandlers) updateTenants(params schema.TenantsUpdateParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewTenantsUpdateForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewTenantsUpdateUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -488,10 +488,10 @@ func (s *schemaHandlers) deleteTenants(params schema.TenantsDeleteParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewTenantsDeleteForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewTenantsDeleteUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -509,10 +509,10 @@ func (s *schemaHandlers) getTenants(params schema.TenantsGetParams,
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewTenantsGetForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewTenantsGetUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 
@@ -533,21 +533,21 @@ func (s *schemaHandlers) getTenant(
 		}
 		if errors.Is(err, schemaUC.ErrUnexpectedMultiple) {
 			return schema.NewTenantsGetOneInternalServerError().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewTenantsGetOneForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewTenantsGetOneUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 	if tenant == nil {
 		s.metricRequestsTotal.logUserError(params.ClassName)
 		return schema.NewTenantsGetOneUnprocessableEntity().
-			WithPayload(errPayloadFromSingleErr(fmt.Errorf("tenant '%s' not found when it should have been", params.TenantName)))
+			WithPayload(errPayloadFromSingleErr(principal, fmt.Errorf("tenant '%s' not found when it should have been", params.TenantName)))
 	}
 	s.metricRequestsTotal.logOk(params.ClassName)
 	return schema.NewTenantsGetOneOK().WithPayload(tenant)
@@ -563,10 +563,10 @@ func (s *schemaHandlers) tenantExists(params schema.TenantExistsParams, principa
 		switch {
 		case errors.As(err, &authzerrors.Forbidden{}):
 			return schema.NewTenantExistsForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		default:
 			return schema.NewTenantExistsUnprocessableEntity().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 	}
 

--- a/adapters/handlers/rest/handlers_tokenize.go
+++ b/adapters/handlers/rest/handlers_tokenize.go
@@ -38,7 +38,7 @@ import (
 func setupTokenizeHandlers(api *operations.WeaviateAPI, schemaManager *schemaUC.Manager, namespacesEnabled bool, logger logrus.FieldLogger) {
 	api.TokenizeTokenizeHandler = tokenizeops.TokenizeHandlerFunc(
 		func(params tokenizeops.TokenizeParams, principal *models.Principal) middleware.Responder {
-			return genericTokenize(params)
+			return genericTokenize(principal, params)
 		})
 
 	api.SchemaSchemaObjectsPropertiesTokenizeHandler = schemaops.SchemaObjectsPropertiesTokenizeHandlerFunc(
@@ -47,24 +47,20 @@ func setupTokenizeHandlers(api *operations.WeaviateAPI, schemaManager *schemaUC.
 		})
 }
 
-func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
+func genericTokenize(principal *models.Principal, params tokenizeops.TokenizeParams) middleware.Responder {
 	if !slices.Contains(tokenizer.Tokenizations, *params.Body.Tokenization) {
-		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-			Error: []*models.ErrorResponseErrorItems0{{Message: "unsupported tokenization strategy: " + *params.Body.Tokenization}},
-		})
+		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(
+			errPayloadFromSingleErr(principal, fmt.Errorf("unsupported tokenization strategy: %s", *params.Body.Tokenization)))
 	}
 
 	// allow a max length of 10k characters to prevent abuse of this endpoint; the tokenizer can handle more, but it may cause performance issues
 	if len(*params.Body.Text) > 10000 {
-		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-			Error: []*models.ErrorResponseErrorItems0{{Message: "text exceeds maximum allowed length of 10,000 characters"}},
-		})
+		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(
+			errPayloadFromSingleErr(principal, errors.New("text exceeds maximum allowed length of 10,000 characters")))
 	}
 
 	if err := validateAnalyzerConfig(params.Body.AnalyzerConfig); err != nil {
-		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-			Error: []*models.ErrorResponseErrorItems0{{Message: err.Error()}},
-		})
+		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	// `stopwords` and `stopwordPresets` are mutually exclusive on this
@@ -75,9 +71,8 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 	// corner cases (e.g. stopwords.preset="en" vs stopwordPresets.en=[...]);
 	// forcing callers to pick one keeps the mental model simple.
 	if params.Body.Stopwords != nil && len(params.Body.StopwordPresets) > 0 {
-		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-			Error: []*models.ErrorResponseErrorItems0{{Message: "stopwords and stopwordPresets are mutually exclusive; pass only one"}},
-		})
+		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(
+			errPayloadFromSingleErr(principal, errors.New("stopwords and stopwordPresets are mutually exclusive; pass only one")))
 	}
 
 	// Validate stopwords/stopwordPresets with the same rules collection
@@ -92,18 +87,14 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 		StopwordPresets: params.Body.StopwordPresets,
 	}
 	if err := inverted.ValidateConfig(synthConfig); err != nil {
-		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-			Error: []*models.ErrorResponseErrorItems0{{Message: err.Error()}},
-		})
+		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	// Build the stopword Provider, mirroring the collection-level configuration
 	// the property-level endpoint inherits.
 	presetDetectors, err := stopwords.BuildPresetDetectors(params.Body.StopwordPresets)
 	if err != nil {
-		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-			Error: []*models.ErrorResponseErrorItems0{{Message: err.Error()}},
-		})
+		return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	// Collection-level fallback: stopwords is applied when
@@ -113,9 +104,8 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 	if params.Body.Stopwords != nil {
 		d, derr := stopwords.NewDetectorFromConfig(*params.Body.Stopwords)
 		if derr != nil {
-			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("invalid stopwords: %s", derr.Error())}},
-			})
+			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(
+				errPayloadFromSingleErr(principal, fmt.Errorf("invalid stopwords: %w", derr)))
 		}
 		fallback = d
 	}
@@ -136,9 +126,8 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 	case callerPreset != "":
 		d, perr := provider.Get(&models.Property{TextAnalyzer: params.Body.AnalyzerConfig})
 		if perr != nil {
-			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-				Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("unknown stopword preset %q; define it in stopwordPresets or use a built-in preset ('en', 'none')", callerPreset)}},
-			})
+			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(
+				errPayloadFromSingleErr(principal, fmt.Errorf("unknown stopword preset %q; define it in stopwordPresets or use a built-in preset ('en', 'none')", callerPreset)))
 		}
 		detector = d
 	case fallback != nil:
@@ -153,9 +142,7 @@ func genericTokenize(params tokenizeops.TokenizeParams) middleware.Responder {
 			TextAnalyzer: &models.TextAnalyzerConfig{StopwordPreset: stopwords.EnglishPreset},
 		})
 		if perr != nil {
-			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-				Error: []*models.ErrorResponseErrorItems0{{Message: perr.Error()}},
-			})
+			return tokenizeops.NewTokenizeUnprocessableEntity().WithPayload(errPayloadFromSingleErr(principal, perr))
 		}
 		detector = d
 	}
@@ -177,7 +164,7 @@ func propertyTokenize(params schemaops.SchemaObjectsPropertiesTokenizeParams,
 	className, _, err := namespacing.Resolve(principal, schemaManager, namespacesEnabled, params.ClassName)
 	if err != nil {
 		return schemaops.NewSchemaObjectsPropertiesTokenizeUnprocessableEntity().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	// Authorize: reading collection metadata (same as other schema read operations)
@@ -188,10 +175,10 @@ func propertyTokenize(params schemaops.SchemaObjectsPropertiesTokenizeParams,
 	if err != nil {
 		if errors.As(err, &authzerrors.Forbidden{}) {
 			return schemaops.NewSchemaObjectsPropertiesTokenizeForbidden().
-				WithPayload(errPayloadFromSingleErr(err))
+				WithPayload(errPayloadFromSingleErr(principal, err))
 		}
 		return schemaops.NewSchemaObjectsPropertiesTokenizeInternalServerError().
-			WithPayload(errPayloadFromSingleErr(err))
+			WithPayload(errPayloadFromSingleErr(principal, err))
 	}
 
 	class := schemaManager.ReadOnlyClass(className)
@@ -211,9 +198,8 @@ func propertyTokenize(params schemaops.SchemaObjectsPropertiesTokenizeParams,
 	}
 
 	if prop.Tokenization == "" {
-		return schemaops.NewSchemaObjectsPropertiesTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-			Error: []*models.ErrorResponseErrorItems0{{Message: "tokenization is not enabled for this property"}},
-		})
+		return schemaops.NewSchemaObjectsPropertiesTokenizeUnprocessableEntity().WithPayload(
+			errPayloadFromSingleErr(principal, errors.New("tokenization is not enabled for this property")))
 	}
 
 	// Build a Provider from the collection-level stopword config and resolve
@@ -225,9 +211,8 @@ func propertyTokenize(params schemaops.SchemaObjectsPropertiesTokenizeParams,
 		d, err := stopwords.NewDetectorFromConfig(*class.InvertedIndexConfig.Stopwords)
 		if err != nil {
 			logger.WithField("action", "create_stopword_detector").Error(err)
-			return schemaops.NewSchemaObjectsPropertiesTokenizeInternalServerError().WithPayload(&models.ErrorResponse{
-				Error: []*models.ErrorResponseErrorItems0{{Message: "failed to create stopword detector: " + err.Error()}},
-			})
+			return schemaops.NewSchemaObjectsPropertiesTokenizeInternalServerError().WithPayload(
+				errPayloadFromSingleErr(principal, fmt.Errorf("failed to create stopword detector: %w", err)))
 		}
 		fallback = d
 	}
@@ -236,9 +221,8 @@ func propertyTokenize(params schemaops.SchemaObjectsPropertiesTokenizeParams,
 		d, err := stopwords.BuildPresetDetectors(class.InvertedIndexConfig.StopwordPresets)
 		if err != nil {
 			logger.WithField("action", "create_stopword_detector").Error(err)
-			return schemaops.NewSchemaObjectsPropertiesTokenizeInternalServerError().WithPayload(&models.ErrorResponse{
-				Error: []*models.ErrorResponseErrorItems0{{Message: "failed to create stopword detector: " + err.Error()}},
-			})
+			return schemaops.NewSchemaObjectsPropertiesTokenizeInternalServerError().WithPayload(
+				errPayloadFromSingleErr(principal, fmt.Errorf("failed to create stopword detector: %w", err)))
 		}
 		presetDetectors = d
 	}
@@ -246,9 +230,8 @@ func propertyTokenize(params schemaops.SchemaObjectsPropertiesTokenizeParams,
 	detector, err := provider.Get(prop)
 	if err != nil {
 		// Property names a preset that is neither built-in nor user-defined.
-		return schemaops.NewSchemaObjectsPropertiesTokenizeUnprocessableEntity().WithPayload(&models.ErrorResponse{
-			Error: []*models.ErrorResponseErrorItems0{{Message: fmt.Sprintf("unknown stopword preset %q; must be a built-in preset ('en', 'none') or defined in invertedIndexConfig.stopwordPresets", prop.TextAnalyzer.StopwordPreset)}},
-		})
+		return schemaops.NewSchemaObjectsPropertiesTokenizeUnprocessableEntity().WithPayload(
+			errPayloadFromSingleErr(principal, fmt.Errorf("unknown stopword preset %q; must be a built-in preset ('en', 'none') or defined in invertedIndexConfig.stopwordPresets", prop.TextAnalyzer.StopwordPreset)))
 	}
 
 	prepared := tokenizer.NewPreparedAnalyzer(prop.TextAnalyzer)

--- a/adapters/handlers/rest/handlers_tokenize_test.go
+++ b/adapters/handlers/rest/handlers_tokenize_test.go
@@ -472,7 +472,7 @@ func TestHandleGenericTokenize(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := tokenizeops.TokenizeParams{Body: tt.body}
-			resp := genericTokenize(params)
+			resp := genericTokenize(nil, params)
 
 			if tt.wantOK {
 				okResp, ok := resp.(*tokenizeops.TokenizeOK)
@@ -669,7 +669,7 @@ func TestHandleGenericTokenizeGSE(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := tokenizeops.TokenizeParams{Body: tt.body}
-			resp := genericTokenize(params)
+			resp := genericTokenize(nil, params)
 
 			okResp, ok := resp.(*tokenizeops.TokenizeOK)
 			require.True(t, ok, "expected TokenizeOK response")
@@ -725,7 +725,7 @@ func TestHandleGenericTokenizeKagome(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			params := tokenizeops.TokenizeParams{Body: tt.body}
-			resp := genericTokenize(params)
+			resp := genericTokenize(nil, params)
 
 			okResp, ok := resp.(*tokenizeops.TokenizeOK)
 			require.True(t, ok, "expected TokenizeOK response")

--- a/adapters/handlers/rest/helpers.go
+++ b/adapters/handlers/rest/helpers.go
@@ -12,8 +12,7 @@
 package rest
 
 import (
-	"fmt"
-
+	cerrors "github.com/weaviate/weaviate/adapters/handlers/rest/errors"
 	"github.com/weaviate/weaviate/entities/models"
 )
 
@@ -32,8 +31,6 @@ func createErrorResponseObject(messages ...string) *models.ErrorResponse {
 	return er
 }
 
-func errPayloadFromSingleErr(err error) *models.ErrorResponse {
-	return &models.ErrorResponse{Error: []*models.ErrorResponseErrorItems0{{
-		Message: fmt.Sprintf("%s", err),
-	}}}
+func errPayloadFromSingleErr(principal *models.Principal, err error) *models.ErrorResponse {
+	return cerrors.ErrPayloadFromSingleErr(principal, err)
 }

--- a/adapters/handlers/rest/namespaces/handlers_namespaces.go
+++ b/adapters/handlers/rest/namespaces/handlers_namespaces.go
@@ -88,7 +88,7 @@ func disabledResponder() middleware.Responder {
 	return middleware.ResponderFunc(func(w http.ResponseWriter, _ runtime.Producer) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusNotFound)
-		_ = json.NewEncoder(w).Encode(cerrors.ErrPayloadFromSingleErr(errNamespacesDisabled))
+		_ = json.NewEncoder(w).Encode(cerrors.ErrPayloadFromSingleErr(nil, errNamespacesDisabled))
 	})
 }
 
@@ -101,11 +101,11 @@ func (h *namespaceHandler) createNamespace(params nsops.CreateNamespaceParams, p
 	name := params.NamespaceID
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.Namespaces(name)...); err != nil {
-		return nsops.NewCreateNamespaceForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return nsops.NewCreateNamespaceForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := usecasesNamespaces.ValidateName(name); err != nil {
-		return nsops.NewCreateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return nsops.NewCreateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	homeNode := ""
@@ -114,7 +114,7 @@ func (h *namespaceHandler) createNamespace(params nsops.CreateNamespaceParams, p
 	}
 	if homeNode != "" && !slices.Contains(h.raft.StorageCandidates(), homeNode) {
 		return nsops.NewCreateNamespaceUnprocessableEntity().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("home_node %q is not a current storage candidate", homeNode)))
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("home_node %q is not a current storage candidate", homeNode)))
 	}
 
 	// No pre-check for existence — the RAFT apply layer owns uniqueness, so
@@ -131,15 +131,15 @@ func (h *namespaceHandler) createNamespace(params nsops.CreateNamespaceParams, p
 		switch {
 		case errors.Is(err, usecasesNamespaces.ErrAlreadyExists):
 			return nsops.NewCreateNamespaceConflict().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q already exists", name)))
+				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q already exists", name)))
 		case errors.Is(err, usecasesNamespaces.ErrNamespaceDeleting):
 			return nsops.NewCreateNamespaceConflict().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q is being deleted; retry after cleanup completes", name)))
+				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q is being deleted; retry after cleanup completes", name)))
 		case errors.Is(err, usecasesNamespaces.ErrBadRequest):
-			return nsops.NewCreateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+			return nsops.NewCreateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		default:
 			return nsops.NewCreateNamespaceInternalServerError().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("creating namespace: %w", err)))
+				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("creating namespace: %w", err)))
 		}
 	}
 
@@ -159,11 +159,11 @@ func (h *namespaceHandler) updateNamespace(params nsops.UpdateNamespaceParams, p
 	name := params.NamespaceID
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Namespaces(name)...); err != nil {
-		return nsops.NewUpdateNamespaceForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return nsops.NewUpdateNamespaceForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := usecasesNamespaces.ValidateName(name); err != nil {
-		return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	homeNode := ""
@@ -172,26 +172,26 @@ func (h *namespaceHandler) updateNamespace(params nsops.UpdateNamespaceParams, p
 	}
 	if homeNode == "" {
 		return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("home_node is required")))
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("home_node is required")))
 	}
 	if !slices.Contains(h.raft.StorageCandidates(), homeNode) {
 		return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("home_node %q is not a current storage candidate", homeNode)))
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("home_node %q is not a current storage candidate", homeNode)))
 	}
 
 	if _, err := h.raft.UpdateNamespace(ctx, cmd.Namespace{Name: name, HomeNodes: []string{homeNode}}); err != nil {
 		switch {
 		case errors.Is(err, usecasesNamespaces.ErrNotFound):
 			return nsops.NewUpdateNamespaceNotFound().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q not found", name)))
+				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q not found", name)))
 		case errors.Is(err, usecasesNamespaces.ErrNamespaceDeleting):
 			return nsops.NewUpdateNamespaceConflict().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q is being deleted; home_node cannot be updated", name)))
+				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q is being deleted; home_node cannot be updated", name)))
 		case errors.Is(err, usecasesNamespaces.ErrBadRequest):
-			return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+			return nsops.NewUpdateNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		default:
 			return nsops.NewUpdateNamespaceInternalServerError().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("updating namespace: %w", err)))
+				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("updating namespace: %w", err)))
 		}
 	}
 
@@ -218,21 +218,21 @@ func (h *namespaceHandler) getNamespace(params nsops.GetNamespaceParams, princip
 	name := params.NamespaceID
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Namespaces(name)...); err != nil {
-		return nsops.NewGetNamespaceForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return nsops.NewGetNamespaceForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := usecasesNamespaces.ValidateName(name); err != nil {
-		return nsops.NewGetNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return nsops.NewGetNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	got, err := h.raft.GetNamespaces(name)
 	if err != nil {
 		return nsops.NewGetNamespaceInternalServerError().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("getting namespace: %w", err)))
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("getting namespace: %w", err)))
 	}
 	if len(got) == 0 {
 		return nsops.NewGetNamespaceNotFound().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q not found", name)))
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q not found", name)))
 	}
 
 	return nsops.NewGetNamespaceOK().WithPayload(&models.Namespace{
@@ -251,11 +251,11 @@ func (h *namespaceHandler) deleteNamespace(params nsops.DeleteNamespaceParams, p
 	name := params.NamespaceID
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Namespaces(name)...); err != nil {
-		return nsops.NewDeleteNamespaceForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return nsops.NewDeleteNamespaceForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := usecasesNamespaces.ValidateName(name); err != nil {
-		return nsops.NewDeleteNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return nsops.NewDeleteNamespaceUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	// Two-phase delete. First flip to deleting; the apply handler is
@@ -266,14 +266,14 @@ func (h *namespaceHandler) deleteNamespace(params nsops.DeleteNamespaceParams, p
 	if _, err := h.raft.ChangeNamespaceState(ctx, name, cmd.NamespaceStateDeleting); err != nil {
 		if errors.Is(err, usecasesNamespaces.ErrNotFound) {
 			return nsops.NewDeleteNamespaceNotFound().WithPayload(
-				cerrors.ErrPayloadFromSingleErr(fmt.Errorf("namespace %q not found", name)))
+				cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("namespace %q not found", name)))
 		}
 		return nsops.NewDeleteNamespaceInternalServerError().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("marking namespace for deletion: %w", err)))
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("marking namespace for deletion: %w", err)))
 	}
 	if err := h.raft.DeleteUsersInNamespace(ctx, name); err != nil {
 		return nsops.NewDeleteNamespaceInternalServerError().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("deleting users in namespace: %w", err)))
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("deleting users in namespace: %w", err)))
 	}
 
 	return nsops.NewDeleteNamespaceAccepted()
@@ -292,7 +292,7 @@ func (h *namespaceHandler) listNamespaces(params nsops.ListNamespacesParams, pri
 	all, err := h.raft.GetNamespaces()
 	if err != nil {
 		return nsops.NewListNamespacesInternalServerError().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("listing namespaces: %w", err)))
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("listing namespaces: %w", err)))
 	}
 	if len(all) == 0 {
 		return nsops.NewListNamespacesOK().WithPayload([]*models.Namespace{})
@@ -306,7 +306,7 @@ func (h *namespaceHandler) listNamespaces(params nsops.ListNamespacesParams, pri
 	allowed, err := h.authorizer.FilterAuthorizedResources(ctx, principal, authorization.READ, resources...)
 	if err != nil {
 		return nsops.NewListNamespacesInternalServerError().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("filtering authorized namespaces: %w", err)))
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("filtering authorized namespaces: %w", err)))
 	}
 
 	allowedSet := make(map[string]struct{}, len(allowed))

--- a/adapters/handlers/rest/replication/handlers_replicate.go
+++ b/adapters/handlers/rest/replication/handlers_replicate.go
@@ -30,19 +30,19 @@ import (
 
 func (h *replicationHandler) replicate(params replication.ReplicateParams, principal *models.Principal) middleware.Responder {
 	if err := params.Body.Validate(nil /* pass nil as we don't validate formatting here*/); err != nil {
-		return replication.NewReplicateBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewReplicateBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	collection := schema.UppercaseClassName(*params.Body.Collection)
 	ctx := params.HTTPRequest.Context()
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.CREATE, authorization.Replications(collection, *params.Body.Shard)); err != nil {
-		return replication.NewReplicateForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewReplicateForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	id, err := uuid.NewRandom()
 	if err != nil {
-		return replication.NewReplicateInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("could not generate uuid v4: %w", err)))
+		return replication.NewReplicateInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("could not generate uuid v4: %w", err)))
 	}
 	uuid := strfmt.UUID(id.String())
 
@@ -52,9 +52,9 @@ func (h *replicationHandler) replicate(params replication.ReplicateParams, princ
 	}
 	if err := h.replicationManager.ReplicationReplicateReplica(params.HTTPRequest.Context(), uuid, *params.Body.SourceNode, collection, *params.Body.Shard, *params.Body.TargetNode, replicationType); err != nil {
 		if errors.Is(err, replicationTypes.ErrInvalidRequest) {
-			return replication.NewReplicateUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+			return replication.NewReplicateUnprocessableEntity().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		}
-		return replication.NewReplicateInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewReplicateInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	h.logger.WithFields(logrus.Fields{
@@ -77,15 +77,15 @@ func (h *replicationHandler) getReplicationDetailsByReplicationId(params replica
 	response, err := h.replicationManager.GetReplicationDetailsByReplicationId(params.HTTPRequest.Context(), params.ID)
 	if errors.Is(err, replicationTypes.ErrReplicationOperationNotFound) {
 		if err := h.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Replications("*", "*")); err != nil {
-			return replication.NewReplicationDetailsForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+			return replication.NewReplicationDetailsForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		}
 		return h.handleOperationNotFoundError(params.ID, err)
 	} else if err != nil {
-		return h.handleInternalServerError(params.ID, err)
+		return h.handleInternalServerError(principal, params.ID, err)
 	}
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Replications(response.Collection, response.ShardId)); err != nil {
-		return replication.NewReplicationDetailsForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewReplicationDetailsForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	includeHistory := false
@@ -171,7 +171,7 @@ func (h *replicationHandler) handleOperationNotFoundError(id strfmt.UUID, err er
 	return replication.NewReplicationDetailsNotFound()
 }
 
-func (h *replicationHandler) handleInternalServerError(id strfmt.UUID, err error) middleware.Responder {
+func (h *replicationHandler) handleInternalServerError(principal *models.Principal, id strfmt.UUID, err error) middleware.Responder {
 	h.logger.WithFields(logrus.Fields{
 		"action": "replication",
 		"op":     "replication_details",
@@ -179,7 +179,7 @@ func (h *replicationHandler) handleInternalServerError(id strfmt.UUID, err error
 		"error":  err,
 	}).Error("error while retrieving replication operation details")
 
-	return replication.NewReplicationDetailsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(
+	return replication.NewReplicationDetailsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal,
 		fmt.Errorf("error while retrieving details for replication operation id '%s': %w", id, err)))
 }
 
@@ -190,11 +190,11 @@ func (h *replicationHandler) deleteReplication(params replication.DeleteReplicat
 	if errors.Is(err, replicationTypes.ErrReplicationOperationNotFound) {
 		return replication.NewDeleteReplicationNoContent()
 	} else if err != nil {
-		return replication.NewDeleteReplicationInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewDeleteReplicationInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Replications(response.Collection, response.ShardId)); err != nil {
-		return replication.NewDeleteReplicationForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewDeleteReplicationForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.replicationManager.DeleteReplication(ctx, params.ID); err != nil {
@@ -202,9 +202,9 @@ func (h *replicationHandler) deleteReplication(params replication.DeleteReplicat
 			return replication.NewDeleteReplicationNoContent()
 		}
 		if errors.Is(err, replicationTypes.ErrDeletionImpossible) {
-			return replication.NewDeleteReplicationConflict().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+			return replication.NewDeleteReplicationConflict().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		}
-		return replication.NewDeleteReplicationInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewDeleteReplicationInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	h.logger.WithFields(logrus.Fields{
@@ -219,11 +219,11 @@ func (h *replicationHandler) deleteReplication(params replication.DeleteReplicat
 func (h *replicationHandler) deleteAllReplications(params replication.DeleteAllReplicationsParams, principal *models.Principal) middleware.Responder {
 	ctx := params.HTTPRequest.Context()
 	if err := h.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Replications("*", "*")); err != nil {
-		return replication.NewDeleteAllReplicationsForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewDeleteAllReplicationsForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.replicationManager.DeleteAllReplications(ctx); err != nil {
-		return replication.NewDeleteAllReplicationsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewDeleteAllReplicationsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	h.logger.WithFields(logrus.Fields{
@@ -238,7 +238,7 @@ func (h *replicationHandler) forceDeleteReplications(params replication.ForceDel
 	ctx := params.HTTPRequest.Context()
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.DELETE, authorization.Replications("*", "*")); err != nil {
-		return replication.NewForceDeleteReplicationsForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewForceDeleteReplicationsForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	all := params.Body == nil || (params.Body.Collection == "" && params.Body.Shard == "" && params.Body.ID == "" && params.Body.Node == "")
@@ -274,10 +274,10 @@ func (h *replicationHandler) forceDeleteReplications(params replication.ForceDel
 			details, err = h.replicationManager.GetReplicationDetailsByTargetNode(params.HTTPRequest.Context(), params.Body.Node)
 		} else {
 			// This can happen if the user provides only a shard id without a collection id
-			return replication.NewForceDeleteReplicationsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("shard id provided without collection id")))
+			return replication.NewForceDeleteReplicationsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("shard id provided without collection id")))
 		}
 		if err != nil {
-			return replication.NewForceDeleteReplicationsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+			return replication.NewForceDeleteReplicationsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		}
 
 		uuids := make([]strfmt.UUID, len(details))
@@ -317,10 +317,10 @@ func (h *replicationHandler) forceDeleteReplications(params replication.ForceDel
 		err = h.replicationManager.ForceDeleteReplicationsByTargetNode(params.HTTPRequest.Context(), params.Body.Node)
 	} else {
 		// This can happen if the user provides only a shard id without a collection id
-		return replication.NewForceDeleteReplicationsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("shard id provided without collection id")))
+		return replication.NewForceDeleteReplicationsBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("shard id provided without collection id")))
 	}
 	if err != nil {
-		return replication.NewForceDeleteReplicationsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewForceDeleteReplicationsInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	h.logger.WithFields(logrus.Fields{
@@ -338,11 +338,11 @@ func (h *replicationHandler) cancelReplication(params replication.CancelReplicat
 	if errors.Is(err, replicationTypes.ErrReplicationOperationNotFound) {
 		return replication.NewCancelReplicationNoContent()
 	} else if err != nil {
-		return replication.NewCancelReplicationInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewCancelReplicationInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Replications(response.Collection, response.ShardId)); err != nil {
-		return replication.NewCancelReplicationForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewCancelReplicationForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	if err := h.replicationManager.CancelReplication(ctx, params.ID); err != nil {
@@ -350,9 +350,9 @@ func (h *replicationHandler) cancelReplication(params replication.CancelReplicat
 			return replication.NewCancelReplicationNoContent()
 		}
 		if errors.Is(err, replicationTypes.ErrCancellationImpossible) {
-			return replication.NewCancelReplicationConflict().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+			return replication.NewCancelReplicationConflict().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 		}
-		return replication.NewCancelReplicationInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewCancelReplicationInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	h.logger.WithFields(logrus.Fields{
@@ -368,7 +368,7 @@ func (h *replicationHandler) listReplication(params replication.ListReplicationP
 	ctx := params.HTTPRequest.Context()
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Replications("*", "*")); err != nil {
-		return replication.NewListReplicationForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewListReplicationForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	var response []api.ReplicationDetailsResponse
@@ -386,14 +386,14 @@ func (h *replicationHandler) listReplication(params replication.ListReplicationP
 		response, err = h.replicationManager.GetReplicationDetailsByTargetNode(params.HTTPRequest.Context(), *params.TargetNode)
 	} else {
 		// This can happen if the user provides only a shard id without a collection id
-		return replication.NewListReplicationBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("shard id provided without collection id")))
+		return replication.NewListReplicationBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("shard id provided without collection id")))
 	}
 
 	// Handle error if any
 	if errors.Is(err, replicationTypes.ErrReplicationOperationNotFound) {
 		return replication.NewListReplicationOK() // No content is returned if no replication operations are found
 	} else if err != nil {
-		return replication.NewListReplicationInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewListReplicationInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	// Parse response into the correct format and return
@@ -421,7 +421,7 @@ func (h *replicationHandler) generateShardingState(collection string, shards map
 func (h *replicationHandler) getCollectionShardingState(params replication.GetCollectionShardingStateParams, principal *models.Principal) middleware.Responder {
 	ctx := params.HTTPRequest.Context()
 	if params.Collection == nil {
-		return replication.NewGetCollectionShardingStateBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(fmt.Errorf("collection is required")))
+		return replication.NewGetCollectionShardingStateBadRequest().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("collection is required")))
 	}
 	collection := *params.Collection
 
@@ -431,7 +431,7 @@ func (h *replicationHandler) getCollectionShardingState(params replication.GetCo
 	}
 
 	if err := h.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Replications(collection, shard)); err != nil {
-		return replication.NewGetCollectionShardingStateForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewGetCollectionShardingStateForbidden().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	var shardingState api.ShardingState
@@ -445,7 +445,7 @@ func (h *replicationHandler) getCollectionShardingState(params replication.GetCo
 	if errors.Is(err, replicationTypes.ErrNotFound) {
 		return replication.NewGetCollectionShardingStateNotFound()
 	} else if err != nil {
-		return replication.NewGetCollectionShardingStateInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewGetCollectionShardingStateInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	return replication.NewGetCollectionShardingStateOK().WithPayload(
@@ -461,19 +461,19 @@ func (h *replicationHandler) getReplicationScalePlan(params replication.GetRepli
 	// Validate input
 	if params.Collection == "" {
 		return replication.NewGetReplicationScalePlanBadRequest().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("collection name must be provided")),
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("collection name must be provided")),
 		)
 	}
 	if params.ReplicationFactor <= 0 {
 		return replication.NewGetReplicationScalePlanBadRequest().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("replication factor must be greater than zero")),
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("replication factor must be greater than zero")),
 		)
 	}
 
 	// Authorize
 	if err := h.authorizer.Authorize(ctx, principal, authorization.READ, authorization.Replications(params.Collection, "*")); err != nil {
 		return replication.NewGetReplicationScalePlanForbidden().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(err),
+			cerrors.ErrPayloadFromSingleErr(principal, err),
 		)
 	}
 
@@ -481,7 +481,7 @@ func (h *replicationHandler) getReplicationScalePlan(params replication.GetRepli
 	if errors.Is(err, replicationTypes.ErrNotFound) {
 		return replication.NewGetReplicationScalePlanNotFound()
 	} else if err != nil {
-		return replication.NewGetReplicationScalePlanInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewGetReplicationScalePlanInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	modelsScalePlan := &models.ReplicationScalePlan{
@@ -516,14 +516,14 @@ func (h *replicationHandler) applyReplicationScalePlan(params replication.ApplyR
 	// Validate input non nil body and not nil scale plan
 	if modelsScalePlan == nil || modelsScalePlan.PlanID == "" || modelsScalePlan.Collection == "" {
 		return replication.NewApplyReplicationScalePlanBadRequest().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(fmt.Errorf("a valid scale plan with plan ID and collection name must be provided")),
+			cerrors.ErrPayloadFromSingleErr(principal, fmt.Errorf("a valid scale plan with plan ID and collection name must be provided")),
 		)
 	}
 
 	// Authorize
 	if err := h.authorizer.Authorize(ctx, principal, authorization.UPDATE, authorization.Replications(modelsScalePlan.Collection, "*")); err != nil {
 		return replication.NewApplyReplicationScalePlanForbidden().WithPayload(
-			cerrors.ErrPayloadFromSingleErr(err),
+			cerrors.ErrPayloadFromSingleErr(principal, err),
 		)
 	}
 
@@ -550,7 +550,7 @@ func (h *replicationHandler) applyReplicationScalePlan(params replication.ApplyR
 	if errors.Is(err, replicationTypes.ErrNotFound) {
 		return replication.NewApplyReplicationScalePlanNotFound()
 	} else if err != nil {
-		return replication.NewApplyReplicationScalePlanInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(err))
+		return replication.NewApplyReplicationScalePlanInternalServerError().WithPayload(cerrors.ErrPayloadFromSingleErr(principal, err))
 	}
 
 	return replication.NewApplyReplicationScalePlanOK().WithPayload(

--- a/test/acceptance/namespace/response_stripping_errors_test.go
+++ b/test/acceptance/namespace/response_stripping_errors_test.go
@@ -1,0 +1,244 @@
+//                           _       _
+// __      _____  __ ___   ___  __ _| |_ ___
+// \ \ /\ / / _ \/ _` \ \ / / |/ _` | __/ _ \
+//  \ V  V /  __/ (_| |\ V /| | (_| | ||  __/
+//   \_/\_/ \___|\__,_| \_/ |_|\__,_|\__\___|
+//
+//  Copyright © 2016 - 2026 Weaviate B.V. All rights reserved.
+//
+//  CONTACT: hello@weaviate.io
+//
+
+package namespace
+
+import (
+	stderrors "errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/weaviate/weaviate/adapters/handlers/mcp/create"
+	"github.com/weaviate/weaviate/adapters/handlers/mcp/search"
+	"github.com/weaviate/weaviate/client/batch"
+	"github.com/weaviate/weaviate/client/schema"
+	"github.com/weaviate/weaviate/entities/models"
+	pb "github.com/weaviate/weaviate/grpc/generated/protocol/v1"
+	"github.com/weaviate/weaviate/test/helper"
+)
+
+// TestNamespaces_ResponseStripping_Errors_REST pins the contract that REST
+// error messages surfaced to namespaced callers do not carry the caller's own
+// namespace prefix, while global admins still see qualified names.
+func TestNamespaces_ResponseStripping_Errors_REST(t *testing.T) {
+	user1Key, _ := twoNamespaces(t)
+	const class = "ErrStripREST"
+	setupClassInNs1(t, class, user1Key)
+
+	t.Run("returned error: duplicate-class create surfaces stripped message", func(t *testing.T) {
+		// Creating the class a second time returns 422 with a body whose
+		// message contains the qualified name internally; the strip must
+		// remove the "customer1:" prefix before the response leaves the
+		// handler.
+		_, err := helper.CreateClassAuthWithReturn(t, &models.Class{Class: class}, user1Key)
+		require.Error(t, err)
+		var unproc *schema.SchemaObjectsCreateUnprocessableEntity
+		require.True(t, stderrors.As(err, &unproc), "expected SchemaObjectsCreateUnprocessableEntity, got %T: %v", err, err)
+		require.NotEmpty(t, unproc.Payload.Error)
+		msg := unproc.Payload.Error[0].Message
+		assert.NotContains(t, msg, "customer1:", "namespaced caller must not see own-prefix in error: %s", msg)
+	})
+
+	t.Run("returned error: global admin sees raw qualified name (control)", func(t *testing.T) {
+		// Trigger the same duplicate via the qualified name; admin's
+		// response must keep "customer1:" intact.
+		_, err := helper.CreateClassAuthWithReturn(t, &models.Class{Class: "customer1:" + class}, adminKey)
+		require.Error(t, err)
+		var forbidden *schema.SchemaObjectsCreateForbidden
+		var unproc *schema.SchemaObjectsCreateUnprocessableEntity
+		switch {
+		case stderrors.As(err, &unproc):
+			assert.Contains(t, unproc.Payload.Error[0].Message, "customer1:", "admin must see qualified name: %s", unproc.Payload.Error[0].Message)
+		case stderrors.As(err, &forbidden):
+			// On NS-enabled clusters the admin path may be 403; the
+			// Forbidden message still contains the qualified resource.
+			assert.Contains(t, forbidden.Payload.Error[0].Message, "customer1:", "admin must see qualified name: %s", forbidden.Payload.Error[0].Message)
+		default:
+			t.Fatalf("unexpected error type %T: %v", err, err)
+		}
+	})
+
+	t.Run("batch per-item error: object referencing unknown class is stripped", func(t *testing.T) {
+		// Submit a batch where one object names a non-existent class. The
+		// per-item error lands in the success-shaped response's Result.Errors;
+		// the message must have no "customer1:" prefix.
+		const unknown = "DoesNotExistInNs1"
+		resp, err := helper.Client(t).Batch.BatchObjectsCreate(
+			batch.NewBatchObjectsCreateParams().WithBody(batch.BatchObjectsCreateBody{
+				Objects: []*models.Object{
+					{Class: class, Properties: map[string]any{"title": "ok"}},
+					{Class: unknown, Properties: map[string]any{"title": "bad"}},
+				},
+			}),
+			helper.CreateAuth(user1Key),
+		)
+		require.NoError(t, err)
+		var found bool
+		for _, r := range resp.Payload {
+			if r.Result != nil && r.Result.Errors != nil && len(r.Result.Errors.Error) > 0 {
+				msg := r.Result.Errors.Error[0].Message
+				assert.NotContains(t, msg, "customer1:", "batch per-item error must be stripped: %s", msg)
+				found = true
+			}
+		}
+		require.True(t, found, "expected at least one failed per-item entry")
+	})
+}
+
+// TestNamespaces_ResponseStripping_Errors_GRPC pins the contract for gRPC
+// unary, batch-reply per-item, and batch-stream per-item error stripping.
+// The defer-strip wrapping must preserve typed-error codes
+// (PermissionDenied/Unauthenticated) — the test asserts the status code is
+// preserved, not collapsed to Unknown.
+func TestNamespaces_ResponseStripping_Errors_GRPC(t *testing.T) {
+	user1Key, _ := twoNamespaces(t)
+	grpcClient, conn := newGrpcClient(t)
+	defer conn.Close()
+
+	const class = "ErrStripGRPC"
+	setupClassInNs1(t, class, user1Key)
+
+	t.Run("unary returned error: Search on non-existent collection stripped", func(t *testing.T) {
+		_, err := grpcClient.Search(authCtx(user1Key), searchReq("NonExistentClass", 1))
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok, "expected gRPC status error, got %T: %v", err, err)
+		// The status code must be preserved, not collapsed to Unknown by
+		// the strippedErr wrapper (Unwrap keeps the original typed error
+		// reachable for the interceptor's translateTypedError).
+		assert.NotContains(t, st.Message(), "customer1:", "namespaced caller must not see own-prefix in status message: %s", st.Message())
+	})
+
+	t.Run("batch reply per-item error: invalid object yields stripped per-item entry", func(t *testing.T) {
+		// Inject a per-item error by referencing an unknown collection so
+		// the classGetter inside BatchObjects fails for that item; the
+		// resulting BatchError must have no "customer1:" prefix.
+		resp, err := grpcClient.BatchObjects(authCtx(user1Key), &pb.BatchObjectsRequest{
+			Objects: []*pb.BatchObject{
+				{Uuid: "11111111-1111-1111-1111-111111111111", Collection: "NoSuchClass", Properties: &pb.BatchObject_Properties{
+					NonRefProperties: &structpb.Struct{Fields: map[string]*structpb.Value{
+						"title": structpb.NewStringValue("bad"),
+					}},
+				}},
+			},
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, resp.Errors)
+		for _, be := range resp.Errors {
+			assert.NotContains(t, be.Error, "customer1:", "batch reply per-item error must be stripped: %s", be.Error)
+		}
+	})
+
+	t.Run("batch-stream per-item error: invalid object yields stripped per-item entry", func(t *testing.T) {
+		stream, err := grpcClient.BatchStream(authCtx(user1Key))
+		require.NoError(t, err)
+
+		require.NoError(t, stream.Send(&pb.BatchStreamRequest{
+			Message: &pb.BatchStreamRequest_Start_{Start: &pb.BatchStreamRequest_Start{}},
+		}))
+		started, err := stream.Recv()
+		require.NoError(t, err)
+		require.NotNil(t, started.GetStarted())
+
+		require.NoError(t, stream.Send(&pb.BatchStreamRequest{
+			Message: &pb.BatchStreamRequest_Data_{Data: &pb.BatchStreamRequest_Data{
+				Objects: &pb.BatchStreamRequest_Data_Objects{Values: []*pb.BatchObject{
+					{Uuid: "22222222-2222-2222-2222-222222222222", Collection: "NoSuchStreamClass", Properties: &pb.BatchObject_Properties{
+						NonRefProperties: &structpb.Struct{Fields: map[string]*structpb.Value{
+							"title": structpb.NewStringValue("bad"),
+						}},
+					}},
+				}},
+			}},
+		}))
+		require.NoError(t, stream.Send(&pb.BatchStreamRequest{
+			Message: &pb.BatchStreamRequest_Stop_{Stop: &pb.BatchStreamRequest_Stop{}},
+		}))
+		require.NoError(t, stream.CloseSend())
+
+		var foundErr bool
+		for {
+			msg, recvErr := stream.Recv()
+			if recvErr != nil {
+				break
+			}
+			if r := msg.GetResults(); r != nil {
+				for _, e := range r.GetErrors() {
+					assert.NotContains(t, e.Error, "customer1:", "stream per-item error must be stripped: %s", e.Error)
+					foundErr = true
+				}
+			}
+		}
+		require.True(t, foundErr, "expected at least one streamed per-item error")
+	})
+
+	t.Run("control: global admin sees qualified name in unary error", func(t *testing.T) {
+		// Admin queries the qualified class form for a non-existent class —
+		// the message must keep "customer1:" intact.
+		_, err := grpcClient.Search(authCtx(adminKey), searchReq("customer1:NonExistentClass", 1))
+		require.Error(t, err)
+		st, ok := status.FromError(err)
+		require.True(t, ok)
+		assert.Contains(t, st.Message(), "customer1:", "admin must see qualified name: %s", st.Message())
+	})
+}
+
+// TestNamespaces_ResponseStripping_Errors_MCP pins the contract for MCP
+// tool-handler returned errors and per-item upsert error fields.
+func TestNamespaces_ResponseStripping_Errors_MCP(t *testing.T) {
+	user1Key, _ := twoNamespaces(t)
+	const class = "ErrStripMCP"
+	setupClassInNs1(t, class, user1Key)
+
+	t.Run("returned error: hybrid on non-existent collection is stripped", func(t *testing.T) {
+		alpha := 0.0
+		var resp *search.QueryHybridResp
+		err := helper.CallToolOnce(t.Context(), t, mcpToolHybrid, &search.QueryHybridArgs{
+			CollectionName: "NoSuchMCPClass",
+			Query:          "anything",
+			Alpha:          &alpha,
+		}, &resp, user1Key)
+		require.Error(t, err)
+		assert.NotContains(t, err.Error(), "customer1:", "namespaced caller must not see own-prefix in MCP error: %s", err.Error())
+	})
+
+	t.Run("upsert per-item error: invalid object yields stripped per-item entry", func(t *testing.T) {
+		// Mismatched UUID triggers a per-item failure; the resulting
+		// UpsertObjectResult.Error string must have no "customer1:" prefix.
+		var resp *create.UpsertObjectResp
+		err := helper.CallToolOnce(t.Context(), t, mcpToolUpsert, &create.UpsertObjectArgs{
+			CollectionName: class,
+			Objects: []create.ObjectToUpsert{
+				{UUID: "not-a-uuid", Properties: map[string]any{"title": "bad"}},
+			},
+		}, &resp, user1Key)
+		// Per-item failures with malformed UUIDs are caught at MCP-arg
+		// validation time before the batch call, returning a top-level
+		// error. Accept either shape: top-level error OR per-item Error.
+		switch {
+		case err != nil:
+			assert.NotContains(t, err.Error(), "customer1:", "top-level MCP error must be stripped: %s", err.Error())
+		case resp != nil:
+			require.NotEmpty(t, resp.Results)
+			for _, r := range resp.Results {
+				if r.Error != "" {
+					assert.NotContains(t, r.Error, "customer1:", "per-item MCP error must be stripped: %s", r.Error)
+				}
+			}
+		default:
+			t.Fatalf("expected either top-level error or per-item failure")
+		}
+	})
+}

--- a/test/acceptance/namespace/response_stripping_errors_test.go
+++ b/test/acceptance/namespace/response_stripping_errors_test.go
@@ -52,34 +52,34 @@ func TestNamespaces_ResponseStripping_Errors_REST(t *testing.T) {
 	})
 
 	t.Run("returned error: global admin sees raw qualified name (control)", func(t *testing.T) {
-		// Trigger the same duplicate via the qualified name; admin's
-		// response must keep "customer1:" intact.
-		_, err := helper.CreateClassAuthWithReturn(t, &models.Class{Class: "customer1:" + class}, adminKey)
+		// Admin adds a property whose name collides with the existing
+		// "title" prop on the qualified class. The 422 message names the
+		// qualified class, and the strip is a no-op for a global principal,
+		// so "customer1:" stays intact.
+		_, err := helper.Client(t).Schema.SchemaObjectsPropertiesAdd(
+			schema.NewSchemaObjectsPropertiesAddParams().
+				WithClassName("customer1:"+class).
+				WithBody(&models.Property{Name: "title", DataType: []string{"text"}}),
+			helper.CreateAuth(adminKey),
+		)
 		require.Error(t, err)
-		var forbidden *schema.SchemaObjectsCreateForbidden
-		var unproc *schema.SchemaObjectsCreateUnprocessableEntity
-		switch {
-		case stderrors.As(err, &unproc):
-			assert.Contains(t, unproc.Payload.Error[0].Message, "customer1:", "admin must see qualified name: %s", unproc.Payload.Error[0].Message)
-		case stderrors.As(err, &forbidden):
-			// On NS-enabled clusters the admin path may be 403; the
-			// Forbidden message still contains the qualified resource.
-			assert.Contains(t, forbidden.Payload.Error[0].Message, "customer1:", "admin must see qualified name: %s", forbidden.Payload.Error[0].Message)
-		default:
-			t.Fatalf("unexpected error type %T: %v", err, err)
-		}
+		var unproc *schema.SchemaObjectsPropertiesAddUnprocessableEntity
+		require.True(t, stderrors.As(err, &unproc), "expected SchemaObjectsPropertiesAddUnprocessableEntity, got %T: %v", err, err)
+		require.NotEmpty(t, unproc.Payload.Error)
+		assert.Contains(t, unproc.Payload.Error[0].Message, "customer1:", "admin must see qualified name: %s", unproc.Payload.Error[0].Message)
 	})
 
-	t.Run("batch per-item error: object referencing unknown class is stripped", func(t *testing.T) {
-		// Submit a batch where one object names a non-existent class. The
-		// per-item error lands in the success-shaped response's Result.Errors;
-		// the message must have no "customer1:" prefix.
-		const unknown = "DoesNotExistInNs1"
+	t.Run("batch per-item error: object with type-mismatched property is stripped", func(t *testing.T) {
+		// Number value for a text property — auto-schema can't reconcile
+		// a type conflict on an existing prop, so the validator emits a
+		// per-item error naming the qualified class. The message lands in
+		// the success-shaped response's Result.Errors with "customer1:"
+		// stripped for the namespaced caller.
 		resp, err := helper.Client(t).Batch.BatchObjectsCreate(
 			batch.NewBatchObjectsCreateParams().WithBody(batch.BatchObjectsCreateBody{
 				Objects: []*models.Object{
 					{Class: class, Properties: map[string]any{"title": "ok"}},
-					{Class: unknown, Properties: map[string]any{"title": "bad"}},
+					{Class: class, Properties: map[string]any{"title": 42}},
 				},
 			}),
 			helper.CreateAuth(user1Key),

--- a/usecases/schema/namespacing/resolver.go
+++ b/usecases/schema/namespacing/resolver.go
@@ -208,3 +208,37 @@ func StripObjectResponseClass(principal *models.Principal, obj *models.Object) {
 	}
 	obj.Class = StripOwnNamespace(principal, obj.Class)
 }
+
+// StripErrorMessage removes every occurrence of the principal's own
+// "<namespace>:" prefix from msg. Returns msg unchanged when principal is
+// nil or has no namespace.
+func StripErrorMessage(principal *models.Principal, msg string) string {
+	if principal == nil || principal.Namespace == "" {
+		return msg
+	}
+	return strings.ReplaceAll(msg, principal.Namespace+schema.NamespaceSeparator, "")
+}
+
+// StripErrForPrincipal returns an error whose Error() has the principal's
+// own namespace prefix removed. The original error is held via Unwrap so
+// errors.As keeps matching. Returns err unchanged when nothing was stripped.
+func StripErrForPrincipal(principal *models.Principal, err error) error {
+	if err == nil {
+		return nil
+	}
+	msg := err.Error()
+	stripped := StripErrorMessage(principal, msg)
+	if stripped == msg {
+		return err
+	}
+	return &strippedErr{msg: stripped, orig: err}
+}
+
+// strippedErr overrides Error() while keeping the original reachable via Unwrap.
+type strippedErr struct {
+	msg  string
+	orig error
+}
+
+func (e *strippedErr) Error() string { return e.msg }
+func (e *strippedErr) Unwrap() error { return e.orig }

--- a/usecases/schema/namespacing/resolver_test.go
+++ b/usecases/schema/namespacing/resolver_test.go
@@ -12,12 +12,15 @@
 package namespacing
 
 import (
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/weaviate/weaviate/entities/models"
+	autherrs "github.com/weaviate/weaviate/usecases/auth/authorization/errors"
 )
 
 // fakeSchemaManager implements SchemaManager for testing
@@ -657,6 +660,221 @@ func TestStripObjectResponseClass(t *testing.T) {
 			StripObjectResponseClass(tc.principal, tc.in)
 			if tc.in != nil {
 				assert.Equal(t, tc.want, tc.in.Class)
+			}
+		})
+	}
+}
+
+func TestStripErrorMessage(t *testing.T) {
+	cases := []struct {
+		name      string
+		principal *models.Principal
+		msg       string
+		want      string
+	}{
+		{
+			name:      "own prefix single occurrence",
+			principal: namespacedPrincipal,
+			msg:       "collection customer1:Movies not found",
+			want:      "collection Movies not found",
+		},
+		{
+			name:      "own prefix multiple occurrences",
+			principal: namespacedPrincipal,
+			msg:       "customer1:Movies references customer1:Person",
+			want:      "Movies references Person",
+		},
+		{
+			name:      "foreign prefix passthrough",
+			principal: namespacedPrincipal,
+			msg:       "cannot read customer2:Movies",
+			want:      "cannot read customer2:Movies",
+		},
+		{
+			name:      "mixed own and foreign",
+			principal: namespacedPrincipal,
+			msg:       "customer1:Movies cannot reference customer2:Person",
+			want:      "Movies cannot reference customer2:Person",
+		},
+		{
+			name:      "empty namespace passthrough",
+			principal: noNamespacePrincipal,
+			msg:       "customer1:Movies not found",
+			want:      "customer1:Movies not found",
+		},
+		{
+			name:      "global principal passthrough",
+			principal: globalPrincipal,
+			msg:       "customer1:Movies not found",
+			want:      "customer1:Movies not found",
+		},
+		{
+			name:      "nil principal passthrough",
+			principal: nil,
+			msg:       "customer1:Movies not found",
+			want:      "customer1:Movies not found",
+		},
+		{
+			name:      "empty message",
+			principal: namespacedPrincipal,
+			msg:       "",
+			want:      "",
+		},
+		{
+			name:      "username and resource in Forbidden.Error() shape",
+			principal: namespacedPrincipal,
+			msg:       "authorization, forbidden action: user 'customer1:apiuser' has insufficient permissions to update [data/customer1:Movies]",
+			want:      "authorization, forbidden action: user 'apiuser' has insufficient permissions to update [data/Movies]",
+		},
+		{
+			name:      "JSON-embedded class name",
+			principal: namespacedPrincipal,
+			msg:       `{"class":"customer1:Movies","id":"abc"}`,
+			want:      `{"class":"Movies","id":"abc"}`,
+		},
+		{
+			name:      "namespace as substring without separator passes through",
+			principal: namespacedPrincipal,
+			msg:       "customer1Movies is invalid",
+			want:      "customer1Movies is invalid",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, StripErrorMessage(tc.principal, tc.msg))
+		})
+	}
+}
+
+func TestStripErrForPrincipal(t *testing.T) {
+	forbiddenErr := autherrs.NewForbidden(
+		&models.Principal{Username: "customer1:apiuser"},
+		"update", "data/customer1:Movies",
+	)
+	wrappedForbidden := fmt.Errorf("doing something: %w", autherrs.NewForbidden(
+		&models.Principal{Username: "customer1:apiuser"},
+		"read", "data/customer1:Movies",
+	))
+	unauthErr := autherrs.NewUnauthenticated()
+
+	type outcome int
+	const (
+		wantNil outcome = iota
+		wantSame
+		wantStripped
+	)
+
+	cases := []struct {
+		name      string
+		principal *models.Principal
+		err       error
+		want      outcome
+		wantMsg   string // when want == wantStripped (may be empty to skip equality check)
+		extra     func(t *testing.T, got error)
+	}{
+		{
+			name:      "nil error returns nil",
+			principal: namespacedPrincipal,
+			err:       nil,
+			want:      wantNil,
+		},
+		{
+			name:      "nil principal returns original",
+			principal: nil,
+			err:       errors.New("collection customer1:Movies not found"),
+			want:      wantSame,
+		},
+		{
+			name:      "global principal returns original",
+			principal: globalPrincipal,
+			err:       errors.New("collection customer1:Movies not found"),
+			want:      wantSame,
+		},
+		{
+			name:      "empty namespace returns original",
+			principal: noNamespacePrincipal,
+			err:       errors.New("collection customer1:Movies not found"),
+			want:      wantSame,
+		},
+		{
+			name:      "no own-prefix returns original",
+			principal: namespacedPrincipal,
+			err:       errors.New("collection customer2:Movies not found"),
+			want:      wantSame,
+		},
+		{
+			name:      "own-prefix stripped",
+			principal: namespacedPrincipal,
+			err:       errors.New("collection customer1:Movies not found"),
+			want:      wantStripped,
+			wantMsg:   "collection Movies not found",
+		},
+		{
+			name:      "multiple own-prefix occurrences stripped",
+			principal: namespacedPrincipal,
+			err:       errors.New("customer1:Movies references customer1:Person"),
+			want:      wantStripped,
+			wantMsg:   "Movies references Person",
+		},
+		{
+			name:      "foreign prefix left intact",
+			principal: namespacedPrincipal,
+			err:       errors.New("customer1:Movies references customer2:Person"),
+			want:      wantStripped,
+			wantMsg:   "Movies references customer2:Person",
+		},
+		{
+			name:      "Forbidden preserved via errors.As after strip",
+			principal: namespacedPrincipal,
+			err:       forbiddenErr,
+			want:      wantStripped,
+			wantMsg:   "authorization, forbidden action: user 'apiuser' has insufficient permissions to update [data/Movies]",
+			extra: func(t *testing.T, got error) {
+				var target autherrs.Forbidden
+				require.True(t, errors.As(got, &target))
+			},
+		},
+		{
+			// Unauthenticated's message has no prefix; the function short-circuits
+			// to the original error, but errors.As must still match.
+			name:      "Unauthenticated preserved via errors.As",
+			principal: namespacedPrincipal,
+			err:       unauthErr,
+			want:      wantSame,
+			extra: func(t *testing.T, got error) {
+				var target autherrs.Unauthenticated
+				require.True(t, errors.As(got, &target))
+			},
+		},
+		{
+			name:      "wrapped Forbidden preserved via Unwrap chain",
+			principal: namespacedPrincipal,
+			err:       wrappedForbidden,
+			want:      wantStripped,
+			extra: func(t *testing.T, got error) {
+				var target autherrs.Forbidden
+				require.True(t, errors.As(got, &target))
+				assert.NotContains(t, got.Error(), "customer1:")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := StripErrForPrincipal(tc.principal, tc.err)
+			switch tc.want {
+			case wantNil:
+				assert.Nil(t, got)
+			case wantSame:
+				assert.Equal(t, tc.err, got)
+			case wantStripped:
+				require.NotNil(t, got)
+				if tc.wantMsg != "" {
+					assert.Equal(t, tc.wantMsg, got.Error())
+				}
+			}
+			if tc.extra != nil {
+				tc.extra(t, got)
 			}
 		})
 	}


### PR DESCRIPTION
### What's being changed:

Strips the errors from any namespace mentions for REST/GRPC+MCP endpoints including "structured" replies (for example individual errors for batch inserts)

### Review checklist

- [ ] Documentation has been updated, if necessary. Link to changed documentation:
- [ ] Chaos pipeline run or not necessary. Link to pipeline:
- [ ] All new code is covered by tests where it is reasonable.
- [ ] Performance tests have been run or not necessary.

<!-- Uncomment the following section if this PR requires changes in related projects (e.g., documentation, client libraries).

GitHub actions will automatically create an issue in the corresponding repository for each checked box below. (See `.github/workflows/create-cross-functional-issues.yml`)

### Cross-functional impact

- [ ] This change requires public documentation (weaviate-io) to be updated. Check the box to automatically create a corresponding issue.
- Does it require a change in the client libraries? If yes, please check the boxes for the affected client libraries.
    - [ ] Python (weaviate-python-client)
    - [ ] JavaScript/TypeScript (typescript-client)
    - [ ] Go (weaviate-go-client)
    - [ ] Java (java-client)

-->
